### PR TITLE
Track memory usage of S3 object uploads

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -984,6 +984,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             sstables::storage_manager::config stm_cfg;
+            stm_cfg.s3_clients_memory = std::clamp<size_t>(memory::stats().total_memory() * 0.01, 10 << 20, 100 << 20);
             sstm.start(std::ref(*cfg), stm_cfg).get();
             auto stop_sstm = defer_verbose_shutdown("sstables storage manager", [&sstm] {
                 sstm.stop().get();

--- a/main.cc
+++ b/main.cc
@@ -983,7 +983,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                cm.stop().get();
             });
 
-            sstm.start(std::ref(*cfg)).get();
+            sstables::storage_manager::config stm_cfg;
+            sstm.start(std::ref(*cfg), stm_cfg).get();
             auto stop_sstm = defer_verbose_shutdown("sstables storage manager", [&sstm] {
                 sstm.stop().get();
             });

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -42,7 +42,7 @@ sstables_manager::~sstables_manager() {
     assert(_undergoing_close.empty());
 }
 
-storage_manager::storage_manager(const db::config& cfg)
+storage_manager::storage_manager(const db::config& cfg, config stm_cfg)
     : _config_updater(this_shard_id() == 0 ? std::make_unique<config_updater>(cfg, *this) : nullptr)
 {
     for (auto [ep, ecfg] : cfg.object_storage_config()) {

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -43,7 +43,7 @@ sstables_manager::~sstables_manager() {
 }
 
 storage_manager::storage_manager(const db::config& cfg, config stm_cfg)
-    : _s3_clients_memory(0)
+    : _s3_clients_memory(stm_cfg.s3_clients_memory)
     , _config_updater(this_shard_id() == 0 ? std::make_unique<config_updater>(cfg, *this) : nullptr)
 {
     for (auto [ep, ecfg] : cfg.object_storage_config()) {

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -58,6 +58,7 @@ class storage_manager : public peering_sharded_service<storage_manager> {
         s3_endpoint(s3::endpoint_config_ptr c) noexcept : cfg(std::move(c)) {}
     };
 
+    semaphore _s3_clients_memory;
     std::unordered_map<sstring, s3_endpoint> _s3_endpoints;
     std::unique_ptr<config_updater> _config_updater;
 

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -66,6 +66,7 @@ class storage_manager : public peering_sharded_service<storage_manager> {
 
 public:
     struct config {
+        size_t s3_clients_memory = 16 << 20; // 16M by default
     };
 
     storage_manager(const db::config&, config cfg);

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -64,7 +64,10 @@ class storage_manager : public peering_sharded_service<storage_manager> {
     void update_config(const db::config&);
 
 public:
-    storage_manager(const db::config&);
+    struct config {
+    };
+
+    storage_manager(const db::config&, config cfg);
     shared_ptr<s3::client> get_endpoint_client(sstring endpoint);
     future<> stop();
 };

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -58,7 +58,8 @@ SEASTAR_THREAD_TEST_CASE(test_client_put_get_object) {
     const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");
-    auto cln = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config());
+    semaphore mem(0);
+    auto cln = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config(), mem);
     auto close_client = deferred_close(*cln);
 
     testlog.info("Put object {}\n", name);
@@ -103,7 +104,8 @@ void do_test_client_multipart_upload(bool with_copy_upload) {
     const sstring name(fmt::format("/{}/test{}object-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), with_copy_upload ? "jumbo" : "large", ::getpid()));
 
     testlog.info("Make client\n");
-    auto cln = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config());
+    semaphore mem(0);
+    auto cln = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config(), mem);
     auto close_client = deferred_close(*cln);
 
     testlog.info("Upload object (with copy = {})\n", with_copy_upload);
@@ -162,7 +164,8 @@ SEASTAR_THREAD_TEST_CASE(test_client_readable_file) {
     const sstring name(fmt::format("/{}/testroobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");
-    auto cln = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config());
+    semaphore mem(0);
+    auto cln = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config(), mem);
     auto close_client = deferred_close(*cln);
 
     testlog.info("Put object {}\n", name);
@@ -202,7 +205,8 @@ SEASTAR_THREAD_TEST_CASE(test_client_readable_file) {
 SEASTAR_THREAD_TEST_CASE(test_client_put_get_tagging) {
     const sstring name(fmt::format("/{}/testobject-{}",
                                    tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
-    auto client = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config());
+    semaphore mem(0);
+    auto client = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config(), mem);
     auto close_client = deferred_close(*client);
     auto data = sstring("1234567890ABCDEF").release();
     client->put_object(name, std::move(data)).get();

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -58,7 +58,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_put_get_object) {
     const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");
-    semaphore mem(0);
+    semaphore mem(16<<20);
     auto cln = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config(), mem);
     auto close_client = deferred_close(*cln);
 
@@ -104,7 +104,7 @@ void do_test_client_multipart_upload(bool with_copy_upload) {
     const sstring name(fmt::format("/{}/test{}object-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), with_copy_upload ? "jumbo" : "large", ::getpid()));
 
     testlog.info("Make client\n");
-    semaphore mem(0);
+    semaphore mem(16<<20);
     auto cln = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config(), mem);
     auto close_client = deferred_close(*cln);
 
@@ -164,7 +164,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_readable_file) {
     const sstring name(fmt::format("/{}/testroobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");
-    semaphore mem(0);
+    semaphore mem(16<<20);
     auto cln = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config(), mem);
     auto close_client = deferred_close(*cln);
 
@@ -205,7 +205,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_readable_file) {
 SEASTAR_THREAD_TEST_CASE(test_client_put_get_tagging) {
     const sstring name(fmt::format("/{}/testobject-{}",
                                    tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
-    semaphore mem(0);
+    semaphore mem(16<<20);
     auto client = s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_minio_config(), mem);
     auto close_client = deferred_close(*client);
     auto data = sstring("1234567890ABCDEF").release();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -552,7 +552,7 @@ private:
             _cm.start(std::move(get_cm_cfg), std::ref(abort_sources), std::ref(_task_manager)).get();
             auto stop_cm = deferred_stop(_cm);
 
-            _sstm.start(std::ref(*cfg)).get();
+            _sstm.start(std::ref(*cfg), sstables::storage_manager::config{}).get();
             auto stop_sstm = deferred_stop(_sstm);
 
             std::optional<wasm::startup_context> wasm_ctx;

--- a/test/perf/perf_s3_client.cc
+++ b/test/perf/perf_s3_client.cc
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/memory.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include "test/lib/test_utils.hh"
 #include "test/lib/random_utils.hh"
@@ -49,7 +50,7 @@ public:
             , _parallel(prl)
             , _object_name(fmt::format("/{}/perfobject-{}-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid(), this_shard_id()))
             , _object_size(obj_size)
-            , _mem(0)
+            , _mem(memory::stats().total_memory())
             , _client(s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_config(), _mem))
     {}
 

--- a/test/perf/perf_s3_client.cc
+++ b/test/perf/perf_s3_client.cc
@@ -22,6 +22,7 @@ class tester {
     unsigned _parallel;
     std::string _object_name;
     size_t _object_size;
+    semaphore _mem;
     shared_ptr<s3::client> _client;
     utils::estimated_histogram _reads_hist;
     unsigned _errors = 0;
@@ -48,7 +49,8 @@ public:
             , _parallel(prl)
             , _object_name(fmt::format("/{}/perfobject-{}-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid(), this_shard_id()))
             , _object_size(obj_size)
-            , _client(s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_config()))
+            , _mem(0)
+            , _client(s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_config(), _mem))
     {}
 
     future<> start() {

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -57,7 +57,7 @@ future<> ignore_reply(const http::reply& rep, input_stream<char>&& in_) {
     co_await util::skip_entire_stream(in);
 }
 
-client::client(std::string host, endpoint_config_ptr cfg, global_factory gf, private_tag)
+client::client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global_factory gf, private_tag)
         : _host(std::move(host))
         , _cfg(std::move(cfg))
         , _gf(std::move(gf))
@@ -71,8 +71,8 @@ void client::update_config(endpoint_config_ptr cfg) {
     _cfg = std::move(cfg);
 }
 
-shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, global_factory gf) {
-    return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), std::move(gf), private_tag{});
+shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, semaphore& mem, global_factory gf) {
+    return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), mem, std::move(gf), private_tag{});
 }
 
 void client::authorize(http::request& req) {

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -68,8 +68,11 @@ class client : public enable_shared_from_this<client> {
     std::unordered_map<seastar::scheduling_group, group_client> _https;
     using global_factory = std::function<shared_ptr<client>(std::string)>;
     global_factory _gf;
+    semaphore& _memory;
 
     struct private_tag {};
+
+    future<semaphore_units<>> claim_memory(size_t mem);
 
     void authorize(http::request&);
     group_client& find_or_create_client();

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -79,8 +79,8 @@ class client : public enable_shared_from_this<client> {
 
     future<> get_object_header(sstring object_name, http::experimental::client::reply_handler handler);
 public:
-    explicit client(std::string host, endpoint_config_ptr cfg, global_factory gf, private_tag);
-    static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, global_factory gf = {});
+    explicit client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global_factory gf, private_tag);
+    static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, semaphore& memory, global_factory gf = {});
 
     future<uint64_t> get_object_size(sstring object_name);
     future<stats> get_object_stats(sstring object_name);


### PR DESCRIPTION
The S3 uploading sink needs to collect buffers internally before sending them out, because the minimal upload-able part size is 5Mb. When the necessary amount of bytes is accumulated, the part uploading fibers starts in the background. On flush the sink waits for all the fibers to complete and handles failure of any.

Uploading parallelism is nowadays limited by the means of the http client max-connections parameter. However, when a part uploading fibers waits for it connection it keeps the 5Mb+ buffers on the request's body, so even though the number of uploading parts is limited, the number of _waiting_ parts is effectively not.

This PR adds a shard-wide limiter on the number of background buffers S3 clients (and theirs http clients) may use.