### PR TITLE
cql3: Fix invalid JSON parsing for JSON objects with ASCII keys

### DIFF
--- a/test/cql-pytest/test_json.py
+++ b/test/cql-pytest/test_json.py
@@ -243,12 +243,10 @@ def test_fromjson_null_prepared(cql, table1):
 # Test that fromJson can parse a map<ascii,int>. Strangely Scylla had a bug
 # setting a map<ascii,int> with fromJson(), while map<text,int> worked well.
 # Reproduces #7949.
-@pytest.mark.xfail(reason="issue #7949")
 def test_fromjson_map_ascii_unprepared(cql, table1):
     p = unique_key_int()
     cql.execute("INSERT INTO " + table1 + " (p, mai) VALUES (" + str(p) + ", fromJson('{\"a\": 1, \"b\": 2}'))")
     assert list(cql.execute(f"SELECT p, mai from {table1} where p = {p}")) == [(p, {'a': 1, 'b': 2})]
-@pytest.mark.xfail(reason="issue #7949")
 def test_fromjson_map_ascii_prepared(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, mai) VALUES (?, fromJson(?))")

--- a/utils/rjson.cc
+++ b/utils/rjson.cc
@@ -109,7 +109,9 @@ public:
         rapidjson::GenericReader<encoding, encoding, allocator> reader(&the_allocator);
         reader.Parse(stream, *this);
         if (reader.HasParseError()) {
-            throw rjson::error(format("Parsing JSON failed: {}", rapidjson::GetParseError_En(reader.GetParseErrorCode())));
+            throw rjson::error(
+                format("Parsing JSON failed: {} at {}",
+                    rapidjson::GetParseError_En(reader.GetParseErrorCode()), reader.GetErrorOffset()));
         }
         //NOTICE: The handler has parsed the string, but in case of rapidjson::GenericDocument
         // the data now resides in an internal stack_ variable, which is private instead of
@@ -308,7 +310,8 @@ rjson::value parse(std::string_view str, size_t max_nested_level) {
     guarded_yieldable_json_handler<document, false> d(max_nested_level);
     d.Parse(str.data(), str.size());
     if (d.HasParseError()) {
-        throw rjson::error(format("Parsing JSON failed: {}", GetParseError_En(d.GetParseError())));
+        throw rjson::error(format("Parsing JSON failed: {} at {}",
+            GetParseError_En(d.GetParseError()), d.GetErrorOffset()));
     }
     rjson::value& v = d;
     return std::move(v);
@@ -318,7 +321,8 @@ rjson::value parse(chunked_content&& content, size_t max_nested_level) {
     guarded_yieldable_json_handler<document, false> d(max_nested_level);
     d.Parse(std::move(content));
     if (d.HasParseError()) {
-        throw rjson::error(format("Parsing JSON failed: {}", GetParseError_En(d.GetParseError())));
+        throw rjson::error(format("Parsing JSON failed: {} at {}",
+            GetParseError_En(d.GetParseError()), d.GetErrorOffset()));
     }
     rjson::value& v = d;
     return std::move(v);
@@ -342,7 +346,8 @@ rjson::value parse_yieldable(std::string_view str, size_t max_nested_level) {
     guarded_yieldable_json_handler<document, true> d(max_nested_level);
     d.Parse(str.data(), str.size());
     if (d.HasParseError()) {
-        throw rjson::error(format("Parsing JSON failed: {}", GetParseError_En(d.GetParseError())));
+        throw rjson::error(format("Parsing JSON failed: {} at {}",
+            GetParseError_En(d.GetParseError()), d.GetErrorOffset()));
     }
     rjson::value& v = d;
     return std::move(v);
@@ -352,7 +357,8 @@ rjson::value parse_yieldable(chunked_content&& content, size_t max_nested_level)
     guarded_yieldable_json_handler<document, true> d(max_nested_level);
     d.Parse(std::move(content));
     if (d.HasParseError()) {
-        throw rjson::error(format("Parsing JSON failed: {}", GetParseError_En(d.GetParseError())));
+        throw rjson::error(format("Parsing JSON failed: {} at {}",
+            GetParseError_En(d.GetParseError()), d.GetErrorOffset()));
     }
     rjson::value& v = d;
     return std::move(v);


### PR DESCRIPTION
For JSON objects represented as map<ascii, int>, don't treat ASCII keys
as a nested JSON string. We were doing that prior to the patch, which
led to parsing errors.

Included the error offset where JSON parsing failed for
rjson::parse related functions to help identify parsing errors
better.

Fixes: https://github.com/scylladb/scylladb/issues/7949