### PR TITLE
build: extract code fragments into functions

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1602,8 +1602,6 @@ scylla_release = file.read().strip()
 file = open(f'{outdir}/SCYLLA-PRODUCT-FILE', 'r')
 scylla_product = file.read().strip()
 
-arch = platform.machine()
-
 for m, mode_config in modes.items():
     mode_config['cxxflags'] += f" -DSCYLLA_BUILD_MODE={m}"
     cxxflags = "-DSCYLLA_VERSION=\"\\\"" + scylla_version + "\\\"\" -DSCYLLA_RELEASE=\"\\\"" + scylla_release + "\\\"\""
@@ -1803,7 +1801,12 @@ if args.ragel_exec:
 else:
     ragel_exec = "ragel"
 
-with open(buildfile, 'w') as f:
+
+def write_build_file(f,
+                     arch,
+                     scylla_product,
+                     scylla_version,
+                     scylla_release):
     f.write(textwrap.dedent('''\
         configure_args = {configure_args}
         builddir = {outdir}
@@ -2342,4 +2345,12 @@ with open(buildfile, 'w') as f:
         build help: print_help | always
         ''').format(**globals()))
 
+
+with open(buildfile, 'w') as f:
+    arch = platform.machine()
+    write_build_file(f,
+                     arch,
+                     scylla_product,
+                     scylla_version,
+                     scylla_release)
 generate_compdb('compile_commands.json', buildfile, selected_modes)

--- a/configure.py
+++ b/configure.py
@@ -315,6 +315,48 @@ def generate_compdb(compdb, buildfile, modes):
             return
 
 
+def check_for_minimal_compiler_version(cxx):
+    compiler_test_src = '''
+
+// clang pretends to be gcc (defined __GNUC__), so we
+// must check it first
+#ifdef __clang__
+
+#if __clang_major__ < 10
+    #error "MAJOR"
+#endif
+
+#elif defined(__GNUC__)
+
+#if __GNUC__ < 10
+    #error "MAJOR"
+#elif __GNUC__ == 10
+    #if __GNUC_MINOR__ < 1
+        #error "MINOR"
+    #elif __GNUC_MINOR__ == 1
+        #if __GNUC_PATCHLEVEL__ < 1
+            #error "PATCHLEVEL"
+        #endif
+    #endif
+#endif
+
+#else
+
+#error "Unrecognized compiler"
+
+#endif
+
+int main() { return 0; }
+'''
+    if try_compile_and_link(compiler=cxx, source=compiler_test_src):
+        return
+    try_compile_and_link(compiler=cxx, source=compiler_test_src, verbose=True)
+    print('Wrong compiler version or incorrect flags. '
+          'Scylla needs GCC >= 10.1.1 with coroutines (-fcoroutines) or '
+          'clang >= 10.0.0 to compile.')
+    sys.exit(1)
+
+
 modes = {
     'debug': {
         'cxxflags': '-DDEBUG -DSANITIZE -DDEBUG_LSA_SANITIZER -DSCYLLA_ENABLE_ERROR_INJECTION',
@@ -1503,42 +1545,6 @@ pkgs.append('lua53' if have_pkg('lua53') else 'lua')
 pkgs.append('libsystemd')
 
 
-compiler_test_src = '''
-
-// clang pretends to be gcc (defined __GNUC__), so we
-// must check it first
-#ifdef __clang__
-
-#if __clang_major__ < 10
-    #error "MAJOR"
-#endif
-
-#elif defined(__GNUC__)
-
-#if __GNUC__ < 10
-    #error "MAJOR"
-#elif __GNUC__ == 10
-    #if __GNUC_MINOR__ < 1
-        #error "MINOR"
-    #elif __GNUC_MINOR__ == 1
-        #if __GNUC_PATCHLEVEL__ < 1
-            #error "PATCHLEVEL"
-        #endif
-    #endif
-#endif
-
-#else
-
-#error "Unrecognized compiler"
-
-#endif
-
-int main() { return 0; }
-'''
-if not try_compile_and_link(compiler=args.cxx, source=compiler_test_src):
-    try_compile_and_link(compiler=args.cxx, source=compiler_test_src, verbose=True)
-    print('Wrong compiler version or incorrect flags. Scylla needs GCC >= 10.1.1 with coroutines (-fcoroutines) or clang >= 10.0.0 to compile.')
-    sys.exit(1)
 
 if not try_compile(compiler=args.cxx, source='#include <boost/version.hpp>'):
     print('Boost not installed.  Please install {}.'.format(pkgname("boost-devel")))
@@ -2346,6 +2352,7 @@ def write_build_file(f,
         ''').format(**globals()))
 
 
+check_for_minimal_compiler_version(args.cxx)
 with open(buildfile, 'w') as f:
     arch = platform.machine()
     write_build_file(f,


### PR DESCRIPTION
more structured this way. this also allows us to quickly identify the part which should/can be reused when migrating to CMake based building system.

Refs #15379
