### PR TITLE
querier: add more information about the read on semaphore mismatch

### DIFF
--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1197,7 +1197,7 @@ SEASTAR_TEST_CASE(multipage_range_scan_semaphore_mismatch) {
 
         read_page(default_scheduling_group(), cmd1);
         BOOST_REQUIRE_EXCEPTION(read_page(sched_groups.statement_scheduling_group, cmd2), std::runtime_error,
-                testing::exception_predicate::message_contains("looked-up reader belongs to different semaphore than the one appropriate for this query class:"));
+                testing::exception_predicate::message_contains("semaphore mismatch detected, dropping reader"));
     });
 }
 


### PR DESCRIPTION
Also rephase the messages a bit so they are more uniform. The goal of this change is to make semaphore mismatches easier to diagnose, by including the table name and the permit name in the printout.
While at it, add a test for semaphore mismatch, it didn't have one.

Refs: #15485