### PR TITLE
reloc: strip.sh: always generate symbol list with posix format

### DIFF
--- a/scripts/strip.sh
+++ b/scripts/strip.sh
@@ -20,7 +20,7 @@ mini_debuginfo="$orig.minidebug"
 # silence "Error: Unable to find program interpreter name" warning from readelf, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1012107
 remove_sections=`readelf -W -S "$debuginfo" 2> /dev/null | awk '{ if (index($2,".debug_") != 1 && ($3 == "PROGBITS" || $3 == "NOTE" || $3 == "NOBITS") && index($8,"A") == 0) printf "--remove-section "$2" " }'`
 nm -D "$stripped" --format=posix --defined-only | awk '{ print $1 }' | sort > "$dynsyms"
-nm "$debuginfo" --format=sysv --defined-only | awk -F \| '{ if ($4 ~ "FUNC") print $1 }' | sort > "$funcsyms"
+nm "$debuginfo" --format=posix --defined-only | awk '{ if ($2 == "T" || $2 == "t" || $2 == "D") print $1 }' | sort > "$funcsyms"
 comm -13 "$dynsyms" "$funcsyms" > "$keep_symbols"
 objcopy -S $remove_sections --keep-symbols="$keep_symbols" "$debuginfo" "$mini_debuginfo"
 xz -f --threads=0 "$mini_debuginfo"


### PR DESCRIPTION
we compare the symbols lists of stripped ELF file ($orig.stripped) and
that of the one including debugging symbols ($orig.debug) to get a
an ELF file which includes only the necessary bits as the debuginfo
($orig.minidebug).

but we generate the symbol list of stripped ELF file using the
sysv format, while generate the one from the unstripped one using
posix format. the former is always padded the symbol names with spaces
so that their the length at least the same as the section name after
we split the fields with "|".

that's why the diff includes the stuff we don't expect. and hence,
we have tons of warnings like:

```
objcopy: build/node_exporter/node_exporter.keep_symbols:4910: Ignoring rubbish found on this line
```

when using objcopy to filtering the ELF file to keep only the
symbols we are interested in.

so, in this change

* use the same format when dumping the symbols from unstripped ELF
  file
* include the symbols in the text area -- the code, by checking
  "T" and "t" in the dumped symbols. this was achieved by matching
  the lines with "FUNC" before this change.
* include the the symbols in .init data section -- the global
  variables which are initialized at compile time. they could
  be also interested when debugging an application.

Fixes #15513
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>