### PR TITLE
tools/utils: return a distinct error-code on unknown operation

### DIFF
--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -41,7 +41,7 @@ const operation& get_selected_operation(int& ac, char**& av, const std::vector<o
     const auto all_operation_names = boost::algorithm::join(operations | boost::adaptors::transformed([] (const operation op) { return op.name(); } ), ", ");
 
     fmt::print(std::cerr, "error: unrecognized {} argument: expected one of ({}), got {}\n", alias, all_operation_names, op_name);
-    exit(1);
+    exit(100);
 }
 
 // Configure seastar with defaults more appropriate for a tool.


### PR DESCRIPTION
Currently, the tools loosely follow the following convention on error-codes:
* return 1 if the error is with any of the command-line arguments
* return 2 on other errors

This patch changes the returned error-code on unknown operation/command to 100 (instead of the previous 1). The intent is to allow any wrapper script to determine that the tool failed because the operation is unrecognized and not because of something else. In particular this should enable us to write a wrapper script for scylla-nodetool, which dispatches commands still un-implemented in scylla-nodetool, to the java nodetool.
Note that the tool will still print an error message on an unknown operation. So such wrapper script would have to make sure to not let this bleed-through when it decides to forward the operation.