### PR TITLE
Fix `test_fencing.py::test_fence_hints` flakiness

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2495,7 +2495,23 @@
                ]
             }
          ]
-      }      
+      },
+      {
+         "path":"/storage_service/raft_topology/reload",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Reload Raft topology state from disk.",
+               "type":"void",
+               "nickname":"reload_raft_topology_state",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+               ]
+            }
+         ]
+      }
    ],
    "models":{
       "mapper":{

--- a/api/api.cc
+++ b/api/api.cc
@@ -102,9 +102,9 @@ future<> unset_rpc_controller(http_context& ctx) {
     return ctx.http_server.set_routes([&ctx] (routes& r) { unset_rpc_controller(ctx, r); });
 }
 
-future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss) {
-    return register_api(ctx, "storage_service", "The storage service API", [&ss] (http_context& ctx, routes& r) {
-            set_storage_service(ctx, r, ss);
+future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss, service::raft_group0_client& group0_client) {
+    return register_api(ctx, "storage_service", "The storage service API", [&ss, &group0_client] (http_context& ctx, routes& r) {
+            set_storage_service(ctx, r, ss, group0_client);
         });
 }
 

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -22,6 +22,7 @@ namespace service {
 class load_meter;
 class storage_proxy;
 class storage_service;
+class raft_group0_client;
 
 } // namespace service
 
@@ -85,7 +86,7 @@ future<> set_server_init(http_context& ctx);
 future<> set_server_config(http_context& ctx, const db::config& cfg);
 future<> set_server_snitch(http_context& ctx, sharded<locator::snitch_ptr>& snitch);
 future<> unset_server_snitch(http_context& ctx);
-future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss);
+future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss, service::raft_group0_client&);
 future<> unset_server_storage_service(http_context& ctx);
 future<> set_server_sstables_loader(http_context& ctx, sharded<sstables_loader>& sst_loader);
 future<> unset_server_sstables_loader(http_context& ctx);

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -57,7 +57,7 @@ std::vector<sstring> parse_tables(const sstring& ks_name, http_context& ctx, con
 // if the parameter is not found or is empty, returns a list of all table infos in the keyspace.
 std::vector<table_info> parse_table_infos(const sstring& ks_name, http_context& ctx, const std::unordered_map<sstring, sstring>& query_params, sstring param_name);
 
-void set_storage_service(http_context& ctx, httpd::routes& r, sharded<service::storage_service>& ss);
+void set_storage_service(http_context& ctx, httpd::routes& r, sharded<service::storage_service>& ss, service::raft_group0_client&);
 void unset_storage_service(http_context& ctx, httpd::routes& r);
 void set_sstables_loader(http_context& ctx, httpd::routes& r, sharded<sstables_loader>& sst_loader);
 void unset_sstables_loader(http_context& ctx, httpd::routes& r);

--- a/main.cc
+++ b/main.cc
@@ -1358,7 +1358,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 ss.stop().get();
             });
 
-            api::set_server_storage_service(ctx, ss).get();
+            api::set_server_storage_service(ctx, ss, group0_client).get();
             auto stop_ss_api = defer_verbose_shutdown("storage service API", [&ctx] {
                 api::unset_server_storage_service(ctx).get();
             });

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -802,10 +802,13 @@ private:
     future<> raft_check_and_repair_cdc_streams();
     future<> update_topology_with_local_metadata(raft::server&);
 
+public:
     // This is called on all nodes for each new command received through raft
     // raft_group0_client::_read_apply_mutex must be held
     // Precondition: the topology mutations were already written to disk; the function only transitions the in-memory state machine.
+    // Public for `reload_raft_topology_state` REST API.
     future<> topology_transition();
+private:
     // load topology state machine snapshot into memory
     // raft_group0_client::_read_apply_mutex must be held
     future<> topology_state_load();

--- a/test/topology_experimental_raft/test_fencing.py
+++ b/test/topology_experimental_raft/test_fencing.py
@@ -164,10 +164,10 @@ async def test_fence_hints(request, manager: ManagerClient):
     rows = await cql.run_async(select_all_stmt, host=host2)
     assert len(list(rows)) == 0
 
-    logger.info("Restarting first node with new version")
+    logger.info("Updating version on first node")
     await set_version(manager, host0, new_version)
     await set_fence_version(manager, host0, new_version)
-    await manager.server_restart(s0.server_id, wait_others=2)
+    await manager.api.client.post("/storage_service/raft_topology/reload", s0.ip_addr)
 
     logger.info(f"Waiting for sent hints on {host0}")
     async def exactly_one_hint_sent():

--- a/test/topology_experimental_raft/test_fencing.py
+++ b/test/topology_experimental_raft/test_fencing.py
@@ -112,7 +112,7 @@ async def test_fence_hints(request, manager: ManagerClient):
     logger.info("Bootstrapping cluster with three nodes")
     s0 = await manager.server_add(config={
         'error_injections_at_startup': ['decrease_hints_flush_period']
-    })
+    }, cmdline=['--logger-log-level', 'hints_manager=trace'])
     s1 = await manager.server_add()
     s2 = await manager.server_add()
 


### PR DESCRIPTION
Add a REST API to reload Raft topology state without having to restart a node and use it in `test_fence_hints`. Restarting the node has undesired side effects which cause test flakiness; more details provided in commit messages.

Refactor the test a bit while at it.

Fixes: #15285