### PR TITLE
storage_service: Fixed missed notification on tablet metadata update

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5683,7 +5683,7 @@ void storage_service::on_update_tablet_metadata() {
     }
     // FIXME: Avoid reading whole tablet metadata on partial changes.
     load_tablet_metadata().get();
-    _topology_state_machine.event.signal(); // wake up load balancer.
+    _topology_state_machine.event.broadcast(); // wake up load balancer.
 }
 
 future<> storage_service::load_tablet_metadata() {


### PR DESCRIPTION
There can be 2 waiters now (coordinator and CDC generation publisher), so signal() is not enough.

Change made in c416c9ff332e385b8832a3647ae40eb46cec13f0 missed to update this site.