### PR TITLE
treewide: rename s3 credentials related variable and option names

### DIFF
--- a/docs/dev/object_storage.md
+++ b/docs/dev/object_storage.md
@@ -11,8 +11,9 @@ endpoints:
     port: $port_number
     https: optional True or False
     aws_region: optional region name, e.g. us-east-1
-    aws_key: optional AWS access key ID
-    aws_secret: optional AWS secret access key
+    aws_access_key_id: optional AWS access key ID
+    aws_secret_access_key: optional AWS secret access key
+    aws_session_token: optional AWS session token
 ```
 
 The last three items must be all present or all absent. When set the values are
@@ -55,8 +56,8 @@ endpoints:
     port: 443
     https: true
     aws_region: us-east-2
-    aws_key: AKIAIOSFODNN7EXAMPLE
-    aws_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    aws_access_key_id: AKIAIOSFODNN7EXAMPLE
+    aws_secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ```
 
 and when creating the keyspace:

--- a/main.cc
+++ b/main.cc
@@ -168,9 +168,9 @@ struct convert<::object_storage_endpoint_param> {
         if (node["aws_region"]) {
             ep.config.aws.emplace();
             ep.config.aws->region = node["aws_region"].as<std::string>();
-            ep.config.aws->key = node["aws_key"].as<std::string>();
-            ep.config.aws->secret = node["aws_secret"].as<std::string>();
-            ep.config.aws->token = node["aws_token"].as<std::string>("");
+            ep.config.aws->access_key_id = node["aws_key"].as<std::string>();
+            ep.config.aws->secret_access_key = node["aws_secret"].as<std::string>();
+            ep.config.aws->session_token = node["aws_token"].as<std::string>("");
         }
         return true;
     }

--- a/main.cc
+++ b/main.cc
@@ -168,9 +168,9 @@ struct convert<::object_storage_endpoint_param> {
         if (node["aws_region"]) {
             ep.config.aws.emplace();
             ep.config.aws->region = node["aws_region"].as<std::string>();
-            ep.config.aws->access_key_id = node["aws_key"].as<std::string>();
-            ep.config.aws->secret_access_key = node["aws_secret"].as<std::string>();
-            ep.config.aws->session_token = node["aws_token"].as<std::string>("");
+            ep.config.aws->access_key_id = node["aws_access_key_id"].as<std::string>();
+            ep.config.aws->secret_access_key = node["aws_secret_access_key"].as<std::string>();
+            ep.config.aws->session_token = node["aws_session_token"].as<std::string>("");
         }
         return true;
     }

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -41,9 +41,9 @@ s3::endpoint_config_ptr make_minio_config() {
         .port = std::stoul(tests::getenv_safe("S3_SERVER_PORT_FOR_TEST")),
         .use_https = ::getenv("AWS_DEFAULT_REGION") != nullptr,
         .aws = {{
-            .key = tests::getenv_safe("AWS_ACCESS_KEY_ID"),
-            .secret = tests::getenv_safe("AWS_SECRET_ACCESS_KEY"),
-            .token = ::getenv("AWS_SESSION_TOKEN") ? : "",
+            .access_key_id = tests::getenv_safe("AWS_ACCESS_KEY_ID"),
+            .secret_access_key = tests::getenv_safe("AWS_SECRET_ACCESS_KEY"),
+            .session_token = ::getenv("AWS_SESSION_TOKEN") ? : "",
             .region = ::getenv("AWS_DEFAULT_REGION") ? : "local",
         }},
     };

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -31,9 +31,9 @@
 //   export S3_SERVER_ADDRESS_FOR_TEST=s3.us-east-2.amazonaws.com
 //   export S3_SERVER_PORT_FOR_TEST=443
 //   export S3_BUCKET_FOR_TEST=xemul
-//   export AWS_ACCESS_KEY_ID=${aws_key}
-//   export AWS_SECRET_ACCESS_KEY=${aws_secret}
-//   export AWS_SESSION_TOKEN=${aws_token}
+//   export AWS_ACCESS_KEY_ID=${aws_access_key_id}
+//   export AWS_SECRET_ACCESS_KEY=${aws_secret_access_key}
+//   export AWS_SESSION_TOKEN=${aws_session_token}
 //   export AWS_DEFAULT_REGION="us-east-2"
 
 s3::endpoint_config_ptr make_minio_config() {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -176,9 +176,9 @@ std::unordered_map<sstring, s3::endpoint_config> make_storage_options_config(con
                 .port = std::stoul(tests::getenv_safe("S3_SERVER_PORT_FOR_TEST")),
                 .use_https = ::getenv("AWS_DEFAULT_REGION") != nullptr,
                 .aws = {{
-                    .key = tests::getenv_safe("AWS_ACCESS_KEY_ID"),
-                    .secret = tests::getenv_safe("AWS_SECRET_ACCESS_KEY"),
-                    .token = ::getenv("AWS_SESSION_TOKEN") ? : "",
+                    .access_key_id = tests::getenv_safe("AWS_ACCESS_KEY_ID"),
+                    .secret_access_key = tests::getenv_safe("AWS_SECRET_ACCESS_KEY"),
+                    .session_token = ::getenv("AWS_SESSION_TOKEN") ? : "",
                     .region = ::getenv("AWS_DEFAULT_REGION") ? : "local",
                 }},
             };

--- a/test/perf/perf_s3_client.cc
+++ b/test/perf/perf_s3_client.cc
@@ -33,10 +33,10 @@ class tester {
         cfg.port = 443;
         cfg.use_https = true;
         cfg.aws.emplace();
-        cfg.aws->key = tests::getenv_safe("AWS_ACCESS_KEY_ID");
-        cfg.aws->secret = tests::getenv_safe("AWS_SECRET_ACCESS_KEY");
+        cfg.aws->access_key_id = tests::getenv_safe("AWS_ACCESS_KEY_ID");
+        cfg.aws->secret_access_key = tests::getenv_safe("AWS_SECRET_ACCESS_KEY");
         if (auto token = ::getenv("AWS_SESSION_TOKEN"); token) {
-            cfg.aws->token = token;
+            cfg.aws->session_token = token;
         }
         cfg.aws->region = tests::getenv_safe("AWS_DEFAULT_REGION");
 

--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -154,8 +154,8 @@ class MinioServer:
         with open(path, 'w', encoding='ascii') as config_file:
             endpoint = {'name': address,
                         'port': port,
-                        'aws_key': acc_key,
-                        'aws_secret': secret_key,
+                        'aws_access_key_id': acc_key,
+                        'aws_secret_access_key': secret_key,
                         'aws_region': region,
                         }
             yaml.dump({'endpoints': [endpoint]}, config_file)

--- a/utils/s3/creds.hh
+++ b/utils/s3/creds.hh
@@ -19,11 +19,11 @@ struct endpoint_config {
 
     struct aws_config {
         // the access key of the credentials
-        std::string key;
+        std::string access_key_id;
         // the secret key of the credentials
-        std::string secret;
+        std::string secret_access_key;
         // the security token, only for session credentials
-        std::string token;
+        std::string session_token;
         std::string region;
     };
 


### PR DESCRIPTION
in this series, we rename s3 credential related variable and option names so they are more consistent with AWS's official document. this should help with the maintainability.