### PR TITLE
raft: Store snapshot update and truncate log atomically

### DIFF
--- a/service/raft/raft_sys_table_storage.hh
+++ b/service/raft/raft_sys_table_storage.hh
@@ -87,7 +87,7 @@ private:
     future<> do_store_log_entries(const std::vector<raft::log_entry_ptr>& entries);
     // Truncate all entries from the persisted log with indices <= idx
     // Called from the `store_snapshot` function.
-    future<> truncate_log_tail(raft::index_t idx);
+    future<> update_snapshot_and_truncate_log_tail(const raft::snapshot_descriptor &snap, size_t preserve_log_entries);
 
     future<> execute_with_linearization_point(std::function<future<>()> f);
 };

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -182,7 +182,7 @@ SEASTAR_TEST_CASE(test_store_snapshot_truncate_log_tail) {
 
         co_await storage.store_snapshot_descriptor(snp, preserve_log_entries);
         raft::log_entries loaded_entries = co_await storage.load_log();
-        BOOST_CHECK_EQUAL(loaded_entries.size(), 2);
+        BOOST_CHECK_EQUAL(loaded_entries.size(), preserve_log_entries);
         for (size_t i = 0, end = loaded_entries.size(); i != end; ++i) {
             BOOST_CHECK(*entries[i + 1] == *loaded_entries[i]);
         }


### PR DESCRIPTION
In case the snapshot update fails, we don't truncate commit log.

Fixes #9603