### PR TITLE
tablets: reload only changed metadata

### DIFF
--- a/auth/service.cc
+++ b/auth/service.cc
@@ -78,7 +78,7 @@ private:
     void on_update_function(const sstring& ks_name, const sstring& function_name) override {}
     void on_update_aggregate(const sstring& ks_name, const sstring& aggregate_name) override {}
     void on_update_view(const sstring& ks_name, const sstring& view_name, bool columns_changed) override {}
-    void on_update_tablet_metadata() override {}
+    void on_update_tablet_metadata(const locator::tablet_metadata_change_hint&) override {}
 
     void on_drop_keyspace(const sstring& ks_name) override {
         if (!legacy_mode(_qp)) {

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -1100,7 +1100,7 @@ void query_processor::migration_subscriber::on_update_view(
     on_update_column_family(ks_name, view_name, columns_changed);
 }
 
-void query_processor::migration_subscriber::on_update_tablet_metadata() {
+void query_processor::migration_subscriber::on_update_tablet_metadata(const locator::tablet_metadata_change_hint&) {
 }
 
 void query_processor::migration_subscriber::on_drop_keyspace(const sstring& ks_name) {

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -581,7 +581,7 @@ public:
     virtual void on_update_function(const sstring& ks_name, const sstring& function_name) override;
     virtual void on_update_aggregate(const sstring& ks_name, const sstring& aggregate_name) override;
     virtual void on_update_view(const sstring& ks_name, const sstring& view_name, bool columns_changed) override;
-    virtual void on_update_tablet_metadata() override;
+    virtual void on_update_tablet_metadata(const locator::tablet_metadata_change_hint&) override;
 
     virtual void on_drop_keyspace(const sstring& ks_name) override;
     virtual void on_drop_column_family(const sstring& ks_name, const sstring& cf_name) override;

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1560,7 +1560,7 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
         // and so that compaction groups are not destroyed altogether.
         // We must also do it before tables are created so that new tables see the tablet map.
         co_await db.invoke_on_all([&] (replica::database& db) -> future<> {
-            co_await db.get_notifier().update_tablet_metadata();
+            co_await db.get_notifier().update_tablet_metadata({});
         });
     }
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -39,6 +39,7 @@
 #include "cql3/util.hh"
 #include "types/list.hh"
 #include "types/set.hh"
+#include "replica/tablets.hh"
 
 #include "db/marshal/type_parser.hh"
 #include "db/config.hh"
@@ -157,7 +158,7 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
     std::map<table_id, schema_mutations>&& views_before,
     std::map<table_id, schema_mutations>&& views_after,
     bool reload,
-    bool has_tablet_mutations);
+    locator::tablet_metadata_change_hint tablet_hint);
 
 struct [[nodiscard]] user_types_to_drop final {
     seastar::noncopyable_function<future<> ()> drop;
@@ -1284,7 +1285,7 @@ static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, shar
     // compare before/after schemas of the affected keyspaces only
     std::set<sstring> keyspaces;
     std::unordered_map<keyspace_name, table_selector> affected_tables;
-    bool has_tablet_mutations = false;
+    locator::tablet_metadata_change_hint tablet_hint;
     for (auto&& mutation : mutations) {
         sstring keyspace_name = value_cast<sstring>(utf8_type->deserialize(mutation.key().get_component(*s, 0)));
 
@@ -1292,9 +1293,7 @@ static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, shar
             affected_tables[keyspace_name] += get_affected_tables(keyspace_name, mutation);
         }
 
-        if (mutation.schema()->id() == system_keyspace::tablets()->id()) {
-            has_tablet_mutations = true;
-        }
+        replica::update_tablet_metadata_change_hint(tablet_hint, mutation);
 
         keyspaces.emplace(std::move(keyspace_name));
         // We must force recalculation of schema version after the merge, since the resulting
@@ -1350,7 +1349,7 @@ static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, shar
     auto types_to_drop = co_await merge_types(proxy, std::move(old_types), std::move(new_types));
     co_await merge_tables_and_views(proxy, sys_ks,
         std::move(old_column_families), std::move(new_column_families),
-        std::move(old_views), std::move(new_views), reload, has_tablet_mutations);
+        std::move(old_views), std::move(new_views), reload, std::move(tablet_hint));
     co_await merge_functions(proxy, std::move(old_functions), std::move(new_functions));
     co_await merge_aggregates(proxy, std::move(old_aggregates), std::move(new_aggregates), std::move(old_scylla_aggregates), std::move(new_scylla_aggregates));
     co_await types_to_drop.drop();
@@ -1497,7 +1496,7 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
     std::map<table_id, schema_mutations>&& views_before,
     std::map<table_id, schema_mutations>&& views_after,
     bool reload,
-    bool has_tablet_mutations)
+    locator::tablet_metadata_change_hint tablet_hint)
 {
     auto tables_diff = diff_table_or_view(proxy, std::move(tables_before), std::move(tables_after), reload, [&] (schema_mutations sm, schema_diff_side) {
         return create_table_from_mutations(proxy, std::move(sm));
@@ -1554,13 +1553,13 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
         return replica::database::drop_table_on_all_shards(db, sys_ks, s.ks_name(), s.cf_name());
     });
 
-    if (has_tablet_mutations) {
+    if (tablet_hint) {
         slogger.info("Tablet metadata changed");
         // We must do it after tables are dropped so that table snapshot doesn't experience missing tablet map,
         // and so that compaction groups are not destroyed altogether.
         // We must also do it before tables are created so that new tables see the tablet map.
         co_await db.invoke_on_all([&] (replica::database& db) -> future<> {
-            co_await db.get_notifier().update_tablet_metadata({});
+            co_await db.get_notifier().update_tablet_metadata(std::move(tablet_hint));
         });
     }
 

--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -126,7 +126,7 @@ public:
             co_await populate_table(tmap, host, only_dc);
         } else {
             for (auto&& [table, tmap]: _tm->tablets().all_tables()) {
-                co_await populate_table(tmap, host, only_dc);
+                co_await populate_table(*tmap, host, only_dc);
             }
         }
 

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -349,6 +349,11 @@ void tablet_map::set_resize_decision(locator::resize_decision decision) {
     _resize_decision = std::move(decision);
 }
 
+void tablet_map::clear_tablet_transition_info(tablet_id id) {
+    check_tablet_id(id);
+    _transitions.erase(id);
+}
+
 future<> tablet_map::for_each_tablet(seastar::noncopyable_function<future<>(tablet_id, const tablet_info&)> func) const {
     std::optional<tablet_id> tid = first_tablet();
     for (const tablet_info& ti : tablets()) {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -954,3 +954,18 @@ auto fmt::formatter<locator::tablet_metadata>::format(const locator::tablet_meta
     }
     return fmt::format_to(out, "\n}}");
 }
+
+auto fmt::formatter<locator::tablet_metadata_change_hint>::format(const locator::tablet_metadata_change_hint& hint, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    auto out = ctx.out();
+    out = fmt::format_to(out, "{{");
+    bool first = true;
+    for (auto&& [table_id, table_hint] : hint.tables) {
+        if (!first) {
+            out = fmt::format_to(out, ",");
+        }
+        out = fmt::format_to(out, "\n  [{}]: {}", table_id, table_hint.tokens);
+        first = false;
+    }
+    return fmt::format_to(out, "\n}}");
+}

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -432,6 +432,7 @@ public:
     void set_tablet(tablet_id, tablet_info);
     void set_tablet_transition_info(tablet_id, tablet_transition_info);
     void set_resize_decision(locator::resize_decision);
+    void clear_tablet_transition_info(tablet_id);
     void clear_transitions();
 
     // Destroys gently.

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -23,6 +23,7 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/util/log.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
@@ -450,16 +451,15 @@ private:
 /// Copy constructor can be invoked across shards.
 class tablet_metadata {
 public:
-    // FIXME: Make cheap to copy.
     // We want both immutability and cheap updates, so we should use
     // hierarchical data structure with shared pointers and copy-on-write.
-    // Currently we have immutability but updates require full copy.
     //
     // Also, currently the copy constructor is invoked across shards, which precludes
     // using shared pointers. We should change that and use a foreign_ptr<> to
     // hold immutable tablet_metadata which lives on shard 0 only.
     // See storage_service::replicate_to_all_cores().
-    using table_to_tablet_map = std::unordered_map<table_id, tablet_map>;
+    using tablet_map_ptr = foreign_ptr<lw_shared_ptr<const tablet_map>>;
+    using table_to_tablet_map = std::unordered_map<table_id, tablet_map_ptr>;
 private:
     table_to_tablet_map _tablets;
 
@@ -469,16 +469,31 @@ public:
     bool balancing_enabled() const { return _balancing_enabled; }
     const tablet_map& get_tablet_map(table_id id) const;
     const table_to_tablet_map& all_tables() const { return _tablets; }
-    table_to_tablet_map& all_tables() { return _tablets; }
     size_t external_memory_usage() const;
     bool has_replica_on(host_id) const;
 public:
+    tablet_metadata() = default;
+    // No implicit copy, use copy()
+    tablet_metadata(tablet_metadata&) = delete;
+    tablet_metadata& operator=(tablet_metadata&) = delete;
+    future<tablet_metadata> copy() const;
+    // Move is supported.
+    tablet_metadata(tablet_metadata&&) = default;
+    tablet_metadata& operator=(tablet_metadata&&) = default;
+
     void set_balancing_enabled(bool value) { _balancing_enabled = value; }
     void set_tablet_map(table_id, tablet_map);
-    tablet_map& get_tablet_map(table_id id);
+    void drop_tablet_map(table_id);
+
+    // Allow mutating a tablet_map
+    // Uses the copy-modify-swap idiom.
+    // If func throws, no changes are done to the tablet map.
+    void mutate_tablet_map(table_id, noncopyable_function<void(tablet_map&)> func);
+    future<> mutate_tablet_map_async(table_id, noncopyable_function<future<>(tablet_map&)> func);
+
     future<> clear_gently();
 public:
-    bool operator==(const tablet_metadata&) const = default;
+    bool operator==(const tablet_metadata&) const;
     friend fmt::formatter<tablet_metadata>;
 };
 

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -535,6 +535,19 @@ public:
     std::optional<range_split_result> operator()();
 };
 
+struct tablet_metadata_change_hint {
+    struct table_hint {
+        table_id table_id;
+        std::vector<token> tokens;
+
+        bool operator==(const table_hint&) const = default;
+    };
+    std::unordered_map<table_id, table_hint> tables;
+
+    bool operator==(const tablet_metadata_change_hint&) const = default;
+    explicit operator bool() const noexcept { return !tables.empty(); }
+};
+
 }
 
 template <>
@@ -574,4 +587,9 @@ struct fmt::formatter<locator::tablet_map> : fmt::formatter<string_view> {
 template <>
 struct fmt::formatter<locator::tablet_metadata> : fmt::formatter<string_view> {
     auto format(const locator::tablet_metadata&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<locator::tablet_metadata_change_hint> : fmt::formatter<string_view> {
+    auto format(const locator::tablet_metadata_change_hint&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -360,7 +360,7 @@ future<std::unique_ptr<token_metadata_impl>> token_metadata_impl::clone_only_tok
         ret->_sorted_tokens = _sorted_tokens;
         co_await coroutine::maybe_yield();
     }
-    ret->_tablets = _tablets;
+    ret->_tablets = co_await _tablets.copy();
     ret->_read_new = _read_new;
     co_return ret;
 }

--- a/main.cc
+++ b/main.cc
@@ -1606,7 +1606,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             supervisor::notify("loading tablet metadata");
             try {
-                ss.local().load_tablet_metadata().get();
+                ss.local().load_tablet_metadata({}).get();
             } catch (...) {
                 if (!cfg->maintenance_mode()) {
                     throw;

--- a/mutation/canonical_mutation.cc
+++ b/mutation/canonical_mutation.cc
@@ -39,6 +39,12 @@ table_id canonical_mutation::column_family_id() const {
     return mv.table_id();
 }
 
+partition_key canonical_mutation::key() const {
+    auto in = ser::as_input_stream(_data);
+    auto mv = ser::deserialize(in, boost::type<ser::canonical_mutation_view>());
+    return mv.key();
+}
+
 mutation canonical_mutation::to_mutation(schema_ptr s) const {
     auto in = ser::as_input_stream(_data);
     auto mv = ser::deserialize(in, boost::type<ser::canonical_mutation_view>());

--- a/mutation/canonical_mutation.hh
+++ b/mutation/canonical_mutation.hh
@@ -35,6 +35,8 @@ public:
     // is not intended, user should sync the schema first.
     mutation to_mutation(schema_ptr) const;
 
+    partition_key key() const;
+
     table_id column_family_id() const;
 
     const bytes_ostream& representation() const { return _data; }

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -200,7 +200,7 @@ future<> save_tablet_metadata(replica::database& db, const tablet_metadata& tm, 
         // FIXME: Should we ignore missing tables? Currently doesn't matter because this is only used in tests.
         auto s = db.find_schema(id);
         muts.emplace_back(
-                co_await tablet_map_to_mutation(tablets, id, s->ks_name(), s->cf_name(), ts));
+                co_await tablet_map_to_mutation(*tablets, id, s->ks_name(), s->cf_name(), ts));
     }
     co_await db.apply(freeze(muts), db::no_timeout);
 }

--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -61,6 +61,16 @@ mutation make_drop_tablet_map_mutation(table_id, api::timestamp_type);
 /// The timestamp must be greater than api::min_timestamp.
 future<> save_tablet_metadata(replica::database&, const locator::tablet_metadata&, api::timestamp_type);
 
+/// Extract a tablet metadata change hint from the tablet mutations.
+///
+/// Mutations which don't mutate the tablet table are ignored.
+std::optional<locator::tablet_metadata_change_hint> get_tablet_metadata_change_hint(const std::vector<canonical_mutation>&);
+
+/// Update the tablet metadata change hint, with the changes represented by the tablet mutation.
+///
+/// If the mutation belongs to another table, no updates are done.
+void update_tablet_metadata_change_hint(locator::tablet_metadata_change_hint&, const mutation&);
+
 /// Reads tablet metadata from system.tablets.
 future<locator::tablet_metadata> read_tablet_metadata(cql3::query_processor&);
 

--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -77,6 +77,12 @@ future<locator::tablet_metadata> read_tablet_metadata(cql3::query_processor&);
 /// Reads the set of hosts referenced by tablet replicas.
 future<std::unordered_set<locator::host_id>> read_required_hosts(cql3::query_processor&);
 
+/// Update tablet metadata from system.tablets, based on the provided hint.
+///
+/// The hint is used to determine what has changed and only reload the changed
+/// parts from disk, updating the passed-in metadata in-place accordingly.
+future<> update_tablet_metadata(cql3::query_processor&, locator::tablet_metadata&, const locator::tablet_metadata_change_hint&);
+
 /// Reads tablet metadata from system.tablets in the form of mutations.
 future<std::vector<canonical_mutation>> read_tablet_mutations(seastar::sharded<database>&);
 

--- a/service/migration_listener.hh
+++ b/service/migration_listener.hh
@@ -30,6 +30,9 @@ using data_type = seastar::shared_ptr<const abstract_type>;
 namespace db::functions {
 class function_name;
 }
+namespace locator {
+class tablet_metadata_change_hint;
+}
 
 #include "timestamp.hh"
 
@@ -60,7 +63,7 @@ public:
     virtual void on_update_function(const sstring& ks_name, const sstring& function_name) = 0;
     virtual void on_update_aggregate(const sstring& ks_name, const sstring& aggregate_name) = 0;
     virtual void on_update_view(const sstring& ks_name, const sstring& view_name, bool columns_changed) = 0;
-    virtual void on_update_tablet_metadata() = 0;
+    virtual void on_update_tablet_metadata(const locator::tablet_metadata_change_hint&) = 0;
 
     // The callback runs inside seastar thread
     virtual void on_drop_keyspace(const sstring& ks_name) = 0;
@@ -100,7 +103,7 @@ public:
     void on_update_user_type(const sstring& ks_name, const sstring& type_name) override {}
     void on_update_function(const sstring& ks_name, const sstring& function_name) override {}
     void on_update_aggregate(const sstring& ks_name, const sstring& aggregate_name) override {}
-    void on_update_tablet_metadata() override {}
+    void on_update_tablet_metadata(const locator::tablet_metadata_change_hint&) override {}
 
     void on_drop_keyspace(const sstring& ks_name) override {}
     void on_drop_column_family(const sstring& ks_name, const sstring& cf_name) override {}
@@ -136,7 +139,7 @@ public:
     future<> update_column_family(schema_ptr cfm, bool columns_changed);
     future<> update_user_type(user_type type);
     future<> update_view(view_ptr view, bool columns_changed);
-    future<> update_tablet_metadata();
+    future<> update_tablet_metadata(locator::tablet_metadata_change_hint);
     future<> drop_keyspace(sstring ks_name);
     future<> drop_column_family(schema_ptr cfm);
     future<> drop_user_type(user_type type);

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -513,10 +513,10 @@ future<> migration_notifier::update_view(view_ptr view, bool columns_changed) {
     });
 }
 
-future<> migration_notifier::update_tablet_metadata() {
-    return seastar::async([this] {
-        _listeners.thread_for_each([] (migration_listener* listener) {
-            listener->on_update_tablet_metadata();
+future<> migration_notifier::update_tablet_metadata(locator::tablet_metadata_change_hint hint) {
+    return seastar::async([this, hint = std::move(hint)] {
+        _listeners.thread_for_each([&hint] (migration_listener* listener) {
+            listener->on_update_tablet_metadata(hint);
         });
     });
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3016,7 +3016,7 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
         }
 
         for (auto&& [table_id, tmap]: tmptr->tablets().all_tables()) {
-            for (auto&& [tid, trinfo]: tmap.transitions()) {
+            for (auto&& [tid, trinfo]: tmap->transitions()) {
                 if (trinfo.session_id) {
                     auto id = session_id(trinfo.session_id);
                     open_sessions.insert(id);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5245,7 +5245,7 @@ future<> storage_service::keyspace_changed(const sstring& ks_name) {
     return update_topology_change_info(reason, acquire_merge_lock::no);
 }
 
-void storage_service::on_update_tablet_metadata() {
+void storage_service::on_update_tablet_metadata(const locator::tablet_metadata_change_hint& hint) {
     if (this_shard_id() != 0) {
         // replicate_to_all_cores() takes care of other shards.
         return;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -514,7 +514,7 @@ public:
     virtual void on_update_function(const sstring& ks_name, const sstring& function_name) override {}
     virtual void on_update_aggregate(const sstring& ks_name, const sstring& aggregate_name) override {}
     virtual void on_update_view(const sstring& ks_name, const sstring& view_name, bool columns_changed) override {}
-    virtual void on_update_tablet_metadata() override;
+    virtual void on_update_tablet_metadata(const locator::tablet_metadata_change_hint&) override;
 
     virtual void on_drop_keyspace(const sstring& ks_name) override { keyspace_changed(ks_name).get(); }
     virtual void on_drop_column_family(const sstring& ks_name, const sstring& cf_name) override {}

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -232,7 +232,8 @@ public:
     void init_messaging_service();
     future<> uninit_messaging_service();
 
-    future<> load_tablet_metadata();
+    // If a hint is provided, only the changed parts of the tablet metadata will be (re)loaded.
+    future<> load_tablet_metadata(const locator::tablet_metadata_change_hint& hint);
     void start_tablet_split_monitor();
 private:
     using acquire_merge_lock = bool_class<class acquire_merge_lock_tag>;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -874,11 +874,15 @@ private:
     void set_topology_change_kind(topology_change_kind kind);
 
 public:
+    struct state_change_hint {
+        std::optional<locator::tablet_metadata_change_hint> tablets_hint;
+    };
+
     // This is called on all nodes for each new command received through raft
     // raft_group0_client::_read_apply_mutex must be held
     // Precondition: the topology mutations were already written to disk; the function only transitions the in-memory state machine.
     // Public for `reload_raft_topology_state` REST API.
-    future<> topology_transition();
+    future<> topology_transition(state_change_hint hint = {});
 
 
     // Service levels cache consists of two levels: service levels cache and effective service levels cache
@@ -948,7 +952,7 @@ private:
     future<> notify_nodes_after_sync(nodes_to_notify_after_sync&& nodes_to_notify);
     // load topology state machine snapshot into memory
     // raft_group0_client::_read_apply_mutex must be held
-    future<> topology_state_load();
+    future<> topology_state_load(state_change_hint hint = {});
     // Applies received raft snapshot to local state machine persistent storage
     // raft_group0_client::_read_apply_mutex must be held
     future<> merge_topology_snapshot(raft_snapshot snp);

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -614,7 +614,7 @@ public:
         cluster_resize_load resize_load;
 
         for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
-            auto& tmap = tmap_;
+            auto& tmap = *tmap_;
 
             const auto* table_stats = load_stats_for_table(table);
             if (!table_stats) {
@@ -1763,7 +1763,7 @@ public:
         // Compute tablet load on nodes.
 
         for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
-            auto& tmap = tmap_;
+            auto& tmap = *tmap_;
 
             co_await tmap.for_each_tablet([&, table = table] (tablet_id tid, const tablet_info& ti) -> future<> {
                 auto trinfo = tmap.get_tablet_transition_info(tid);
@@ -1872,7 +1872,7 @@ public:
         _tablet_count_per_table.clear();
 
         for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
-            auto& tmap = tmap_;
+            auto& tmap = *tmap_;
             uint64_t total_load = 0;
             co_await tmap.for_each_tablet([&, table = table] (tablet_id tid, const tablet_info& ti) -> future<> {
                 auto trinfo = tmap.get_tablet_transition_info(tid);

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -576,7 +576,7 @@ public:
     virtual void on_update_function(const sstring&, const sstring&) override { ++update_function_count; }
     virtual void on_update_aggregate(const sstring&, const sstring&) override { ++update_aggregate_count; }
     virtual void on_update_view(const sstring&, const sstring&, bool) override { ++update_view_count; }
-    virtual void on_update_tablet_metadata() override { ++update_tablets; }
+    virtual void on_update_tablet_metadata(const locator::tablet_metadata_change_hint&) override { ++update_tablets; }
     virtual void on_drop_keyspace(const sstring&) override { ++drop_keyspace_count; }
     virtual void on_drop_column_family(const sstring&, const sstring&) override { ++drop_column_family_count; }
     virtual void on_drop_user_type(const sstring&, const sstring&) override { ++drop_user_type_count; }

--- a/test/perf/perf_tablets.cc
+++ b/test/perf/perf_tablets.cc
@@ -98,7 +98,7 @@ static future<> test_basic_operations(app_template& app) {
 
         tablet_metadata tm2;
         auto time_to_copy = duration_in_seconds([&] {
-            tm2 = tm;
+            tm2 = tm.copy().get();
         });
 
         testlog.info("Copied in {:.6f} [ms]", time_to_copy.count() * 1000);

--- a/test/perf/perf_tablets.cc
+++ b/test/perf/perf_tablets.cc
@@ -16,6 +16,7 @@
 #include <seastar/core/reactor.hh>
 
 #include "locator/tablets.hh"
+#include "replica/tablet_mutation_builder.hh"
 #include "replica/tablets.hh"
 #include "locator/tablet_replication_strategy.hh"
 #include "db/config.hh"
@@ -58,6 +59,7 @@ static future<> test_basic_operations(app_template& app) {
         tablet_metadata tm;
 
         auto h1 = host_id(utils::UUID_gen::get_time_UUID());
+        auto h2 = host_id(utils::UUID_gen::get_time_UUID());
 
         int nr_tables = app.configuration()["tables"].as<int>();
         int tablets_per_table = app.configuration()["tablets-per-table"].as<int>();
@@ -144,6 +146,49 @@ static future<> test_basic_operations(app_template& app) {
 
         auto&& tablets_table = e.local_db().find_column_family(db::system_keyspace::tablets());
         testlog.info("Disk space used by system.tablets: {:.6f} [MiB]", double(tablets_table.get_stats().live_disk_space_used) / MiB);
+
+        locator::tablet_metadata_change_hint hint;
+
+        // Migrate one tablet to h2
+        {
+            const auto last_table_id = ids.back();
+            const auto& tmap = tm.get_tablet_map(last_table_id);
+
+            auto ts = utils::UUID_gen::micros_timestamp(e.get_system_keyspace().local().get_last_group0_state_id().get()) + 1;
+
+            const auto tb = tmap.first_tablet();
+            replica::tablet_mutation_builder builder(ts++, last_table_id);
+            const auto token = tmap.get_last_token(tb);
+
+            builder.set_new_replicas(token,
+                tablet_replica_set {
+                    tablet_replica {h2, 0},
+                }
+            );
+            builder.set_stage(token, tablet_transition_stage::streaming);
+            builder.set_transition(token, tablet_transition_kind::migration);
+
+            std::vector<mutation> muts;
+            muts.push_back(builder.build());
+            e.local_db().apply(freeze(muts), db::no_timeout).get();
+            replica::update_tablet_metadata_change_hint(hint, muts.front());
+        }
+
+        using clk = std::chrono::high_resolution_clock;
+
+        const auto start_full_reload = clk::now();
+        const auto tm_full_reload = read_tablet_metadata(e.local_qp()).get();
+        const auto end_full_reload = clk::now();
+        const auto full_reload_duration = std::chrono::duration<double, std::milli>(end_full_reload - start_full_reload);
+
+        const auto start_partial_reload = clk::now();
+        update_tablet_metadata(e.local_qp(), tm, hint).get();
+        const auto end_partial_reload = clk::now();
+        const auto partial_reload_duration = std::chrono::duration<double, std::milli>(end_partial_reload - start_partial_reload);
+
+        assert(tm == tm_full_reload);
+
+        testlog.info("Tablet metadata reload:\nfull    {:>8.2f}ms\npartial {:>8.2f}ms", full_reload_duration.count(), partial_reload_duration.count());
     }, tablet_cql_test_config());
 }
 
@@ -154,7 +199,7 @@ int scylla_tablets_main(int argc, char** argv) {
     app_template app;
     app.add_options()
             ("tables", bpo::value<int>()->default_value(100), "Number of tables to create.")
-            ("tablets-per-table", bpo::value<int>()->default_value(10000), "Number of tablets per table.")
+            ("tablets-per-table", bpo::value<int>()->default_value(2048), "Number of tablets per table.")
             ("rf", bpo::value<int>()->default_value(3), "Number of replicas per tablet.")
             ("verbose", "Enables standard logging")
             ;

--- a/transport/event_notifier.cc
+++ b/transport/event_notifier.cc
@@ -155,7 +155,7 @@ void cql_server::event_notifier::on_update_aggregate(const sstring& ks_name, con
     elogger.warn("%s event ignored", __func__);
 }
 
-void cql_server::event_notifier::on_update_tablet_metadata() {}
+void cql_server::event_notifier::on_update_tablet_metadata(const locator::tablet_metadata_change_hint&) {}
 
 void cql_server::event_notifier::on_drop_keyspace(const sstring& ks_name)
 {

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -333,7 +333,7 @@ public:
     virtual void on_update_view(const sstring& ks_name, const sstring& view_name, bool columns_changed) override;
     virtual void on_update_function(const sstring& ks_name, const sstring& function_name) override;
     virtual void on_update_aggregate(const sstring& ks_name, const sstring& aggregate_name) override;
-    virtual void on_update_tablet_metadata() override;
+    virtual void on_update_tablet_metadata(const locator::tablet_metadata_change_hint&) override;
 
     virtual void on_drop_keyspace(const sstring& ks_name) override;
     virtual void on_drop_column_family(const sstring& ks_name, const sstring& cf_name) override;


### PR DESCRIPTION
Currently, each change to tablet metadata triggers a full metadata reload from disk. This is very wasteful, especially if the metadata change affects only a single row in the `system.tablets` table. This is the case when the tablet load balancer triggers a migration, this will affect a single row in the table, but today will trigger a full reload.
We expect tablet count to potentially grow to thousands and beyond and the overhead of this full reload can become significant.
This PR makes tablet metadata reload partial, instead of reloading all metadata on topology or schema changes, reload only the partitions that are affected by the change. Copy the rest from the in-memory state.
This is done with two passes: first the change mutations are scanned and a hint is produced. This hint is then passed down to the reload code, which will use it to only reload parts (rows/partitions) of the metadata that has actually changed.

The performance difference between full reload and partial reload is quite drastic:
```
INFO  2024-07-25 05:06:27,347 [shard 0:stat] testlog - Tablet metadata reload:
full      616.39ms
partial     0.18ms
```
This was measured with the modified (by this PR) `perf_tablets`, which creates 100 tables, each with 2K tablets. The test was modified to change a single tablet, then do a full and partial reload respectively, measuring the time it takes for reach.

Fixes: #15294

New feature, no backport needed.