### PR TITLE
Don't mess with table directories in distributed loader

### DIFF
--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -464,8 +464,6 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
             std::exception_ptr ex;
 
             try {
-                co_await cf.init_storage();
-
                 co_await metadata.start();
             } catch (...) {
                 std::exception_ptr eptr = std::current_exception();

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -345,11 +345,6 @@ public:
     }
 
 private:
-    fs::path get_path(sstables::sstable_state state) {
-        auto subdir = state_to_dir(state);
-        return subdir.empty() ? _base_path : _base_path / subdir;
-    }
-
     using allow_offstrategy_compaction = bool_class<struct allow_offstrategy_compaction_tag>;
     future<> populate_subdir(sstables::sstable_state state, allow_offstrategy_compaction);
 

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -357,14 +357,6 @@ private:
 };
 
 future<> table_populator::start_subdir(sstables::sstable_state state) {
-    sstring sstdir = get_path(state).native();
-    if (!co_await file_exists(sstdir)) {
-        if (state != sstables::sstable_state::quarantine) {
-            throw std::runtime_error(format("Populating {}/{} failed: {} does not exist", _ks, _cf, sstdir));
-        }
-        co_return;
-    }
-
     auto dptr = make_lw_shared<sharded<sstables::sstable_directory>>();
     auto& directory = *dptr;
     auto& global_table = _global_table;

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -208,14 +208,12 @@ future<> sstable_directory::prepare(process_flags flags) {
 }
 
 future<> sstable_directory::filesystem_components_lister::prepare(sstable_directory& dir, process_flags flags, storage& st) {
-    if (dir._state == sstable_state::quarantine) {
-        if (!co_await file_exists(_directory.native())) {
+  if (!co_await file_exists(_directory.native())) {
+        if (dir._state == sstable_state::quarantine) {
             co_return;
         }
-    } else {
         co_await io_check([this] { return recursive_touch_directory(_directory.native()); });
-    }
-
+  } else {
     // verify owner and mode on the sstables directory
     // and all its subdirectories, except for "snapshots"
     // as there could be a race with scylla-manager that might
@@ -226,6 +224,8 @@ future<> sstable_directory::filesystem_components_lister::prepare(sstable_direct
             co_await utils::directories::verify_owner_and_mode(dir / de.name, utils::directories::recursive::yes);
         }
     });
+  }
+
     if (flags.garbage_collect) {
         co_await garbage_collect(st);
     }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -212,6 +212,8 @@ future<> sstable_directory::filesystem_components_lister::prepare(sstable_direct
         if (!co_await file_exists(_directory.native())) {
             co_return;
         }
+    } else {
+        co_await io_check([this] { return recursive_touch_directory(_directory.native()); });
     }
 
     // verify owner and mode on the sstables directory

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -204,18 +204,28 @@ sstable_directory::highest_version_seen() const {
 }
 
 future<> sstable_directory::prepare(process_flags flags) {
+    return _lister->prepare(*this, flags, *_storage);
+}
+
+future<> sstable_directory::filesystem_components_lister::prepare(sstable_directory& dir, process_flags flags, storage& st) {
     // verify owner and mode on the sstables directory
     // and all its subdirectories, except for "snapshots"
     // as there could be a race with scylla-manager that might
     // delete snapshots concurrently
-    co_await utils::directories::verify_owner_and_mode(_sstable_dir, utils::directories::recursive::no);
-    co_await lister::scan_dir(_sstable_dir, lister::dir_entry_types::of<directory_entry_type::directory>(), [] (fs::path dir, directory_entry de) -> future<> {
+    co_await utils::directories::verify_owner_and_mode(_directory, utils::directories::recursive::no);
+    co_await lister::scan_dir(_directory, lister::dir_entry_types::of<directory_entry_type::directory>(), [] (fs::path dir, directory_entry de) -> future<> {
         if (de.name != sstables::snapshots_dir) {
             co_await utils::directories::verify_owner_and_mode(dir / de.name, utils::directories::recursive::yes);
         }
     });
     if (flags.garbage_collect) {
-        co_await garbage_collect();
+        co_await garbage_collect(st);
+    }
+}
+
+future<> sstable_directory::system_keyspace_components_lister::prepare(sstable_directory& dir, process_flags flags, storage& st) {
+    if (flags.garbage_collect) {
+        co_await garbage_collect(st);
     }
 }
 
@@ -600,10 +610,6 @@ future<> sstable_directory::filesystem_components_lister::replay_pending_delete_
     } catch (...) {
         sstlog.warn("Error replaying {}: {}. Ignoring.", pending_delete_log, std::current_exception());
     }
-}
-
-future<> sstable_directory::garbage_collect() {
-    return _lister->garbage_collect(*_storage);
 }
 
 future<> sstable_directory::filesystem_components_lister::garbage_collect(storage& st) {

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -208,23 +208,23 @@ future<> sstable_directory::prepare(process_flags flags) {
 }
 
 future<> sstable_directory::filesystem_components_lister::prepare(sstable_directory& dir, process_flags flags, storage& st) {
-  if (!co_await file_exists(_directory.native())) {
+    if (!co_await file_exists(_directory.native())) {
         if (dir._state == sstable_state::quarantine) {
             co_return;
         }
         co_await io_check([this] { return recursive_touch_directory(_directory.native()); });
-  } else {
-    // verify owner and mode on the sstables directory
-    // and all its subdirectories, except for "snapshots"
-    // as there could be a race with scylla-manager that might
-    // delete snapshots concurrently
-    co_await utils::directories::verify_owner_and_mode(_directory, utils::directories::recursive::no);
-    co_await lister::scan_dir(_directory, lister::dir_entry_types::of<directory_entry_type::directory>(), [] (fs::path dir, directory_entry de) -> future<> {
-        if (de.name != sstables::snapshots_dir) {
-            co_await utils::directories::verify_owner_and_mode(dir / de.name, utils::directories::recursive::yes);
-        }
-    });
-  }
+    } else {
+        // verify owner and mode on the sstables directory
+        // and all its subdirectories, except for "snapshots"
+        // as there could be a race with scylla-manager that might
+        // delete snapshots concurrently
+        co_await utils::directories::verify_owner_and_mode(_directory, utils::directories::recursive::no);
+        co_await lister::scan_dir(_directory, lister::dir_entry_types::of<directory_entry_type::directory>(), [] (fs::path dir, directory_entry de) -> future<> {
+            if (de.name != sstables::snapshots_dir) {
+                co_await utils::directories::verify_owner_and_mode(dir / de.name, utils::directories::recursive::yes);
+            }
+        });
+    }
 
     if (flags.garbage_collect) {
         co_await garbage_collect(st);


### PR DESCRIPTION
Distributed loader code still "knows" that table's datadir is a filesystem directory with some structure. For S3-backed sstables this still works because for S3 keyspaces scylla still creates and maintains empty directories in datadir. This set fixes the dist. loader assumptions about that and moves them into sstable directory's lister.

refs: #13020