### PR TITLE
Sanitize forward-service shutdown

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1363,7 +1363,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }).get();
 
             supervisor::notify("starting forward service");
-            forward_service.start(std::ref(messaging), std::ref(proxy), std::ref(db), std::ref(token_metadata)).get();
+            forward_service.start(std::ref(messaging), std::ref(proxy), std::ref(db), std::ref(token_metadata), std::ref(stop_signal.as_sharded_abort_source())).get();
             auto stop_forward_service_handlers = defer_verbose_shutdown("forward service", [&forward_service] {
                 forward_service.stop().get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1895,11 +1895,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 ss.local().drain_on_shutdown().get();
             });
 
-            // Signal shutdown to the forward service before draining the messaging service.
-            auto shutdown_forward_service = defer_verbose_shutdown("forward service", [&forward_service] {
-                forward_service.invoke_on_all(&service::forward_service::shutdown).get();
-            });
-
             auto drain_view_builder = defer_verbose_shutdown("view builder ops", [cfg] {
                 if (cfg->view_building()) {
                     view_builder.invoke_on_all(&db::view::view_builder::drain).get();

--- a/service/forward_service.cc
+++ b/service/forward_service.cc
@@ -308,7 +308,6 @@ locator::token_metadata_ptr forward_service::get_token_metadata_ptr() const noex
 }
 
 future<> forward_service::shutdown() {
-    _shutdown = true;
     return make_ready_future<>();
 }
 

--- a/service/forward_service.cc
+++ b/service/forward_service.cc
@@ -307,10 +307,6 @@ locator::token_metadata_ptr forward_service::get_token_metadata_ptr() const noex
     return _shared_token_metadata.get();
 }
 
-future<> forward_service::shutdown() {
-    return make_ready_future<>();
-}
-
 future<> forward_service::stop() {
     return uninit_messaging_service();
 }

--- a/service/forward_service.hh
+++ b/service/forward_service.hh
@@ -131,6 +131,7 @@ class forward_service : public seastar::peering_sharded_service<forward_service>
     } _stats;
     seastar::metrics::metric_groups _metrics;
 
+    optimized_optional<abort_source::subscription> _early_abort_subscription;
     bool _shutdown = false;
 
 public:
@@ -139,7 +140,9 @@ public:
         : _messaging(ms)
         , _proxy(p)
         , _db(db)
-        , _shared_token_metadata(stm) {
+        , _shared_token_metadata(stm)
+        , _early_abort_subscription(as.subscribe([this] () noexcept { _shutdown = true; }))
+    {
         register_metrics();
         init_messaging_service();
     }

--- a/service/forward_service.hh
+++ b/service/forward_service.hh
@@ -147,7 +147,6 @@ public:
         init_messaging_service();
     }
 
-    future<> shutdown();
     future<> stop();
 
     // Splits given `forward_request` and distributes execution of resulting

--- a/service/forward_service.hh
+++ b/service/forward_service.hh
@@ -135,7 +135,7 @@ class forward_service : public seastar::peering_sharded_service<forward_service>
 
 public:
     forward_service(netw::messaging_service& ms, service::storage_proxy& p, distributed<replica::database> &db,
-        const locator::shared_token_metadata& stm)
+        const locator::shared_token_metadata& stm, abort_source& as)
         : _messaging(ms)
         , _proxy(p)
         , _db(db)

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -704,7 +704,7 @@ private:
                 return fs.enable(fs.supported_feature_set());
             }).get();
 
-            _forward_service.start(std::ref(_ms), std::ref(_proxy), std::ref(_db), std::ref(_token_metadata)).get();
+            _forward_service.start(std::ref(_ms), std::ref(_proxy), std::ref(_db), std::ref(_token_metadata), std::ref(abort_sources)).get();
             auto stop_forward_service =  defer([this] { _forward_service.stop().get(); });
 
             // gropu0 client exists only on shard 0


### PR DESCRIPTION
There's a dedicated forward_service::shutdown() method that's defer-scheduled in main for very early invocation. That's not nice, the fwd service start-shutdown-stop sequence can be made "canonical" by moving the shutting down code into abort source subscription. Similar thing was done for view updates generator in 3b95f4f107d28248f024d876284ab00e3e2d1412

refs: #2737
refs: #4384