### PR TITLE
Sanitize storage_service API maintenance

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -108,6 +108,10 @@ future<> set_server_storage_service(http_context& ctx, sharded<service::storage_
         });
 }
 
+future<> unset_server_storage_service(http_context& ctx) {
+    return ctx.http_server.set_routes([&ctx] (routes& r) { unset_storage_service(ctx, r); });
+}
+
 future<> set_server_sstables_loader(http_context& ctx, sharded<sstables_loader>& sst_loader) {
     return ctx.http_server.set_routes([&ctx, &sst_loader] (routes& r) { set_sstables_loader(ctx, r, sst_loader); });
 }

--- a/api/api.cc
+++ b/api/api.cc
@@ -102,9 +102,9 @@ future<> unset_rpc_controller(http_context& ctx) {
     return ctx.http_server.set_routes([&ctx] (routes& r) { unset_rpc_controller(ctx, r); });
 }
 
-future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<db::system_keyspace>& sys_ks) {
-    return register_api(ctx, "storage_service", "The storage service API", [&ss, &g, &sys_ks] (http_context& ctx, routes& r) {
-            set_storage_service(ctx, r, ss, g.local(), sys_ks);
+future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss, sharded<gms::gossiper>& g) {
+    return register_api(ctx, "storage_service", "The storage service API", [&ss, &g] (http_context& ctx, routes& r) {
+            set_storage_service(ctx, r, ss, g.local());
         });
 }
 

--- a/api/api.cc
+++ b/api/api.cc
@@ -102,9 +102,9 @@ future<> unset_rpc_controller(http_context& ctx) {
     return ctx.http_server.set_routes([&ctx] (routes& r) { unset_rpc_controller(ctx, r); });
 }
 
-future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss, sharded<gms::gossiper>& g) {
-    return register_api(ctx, "storage_service", "The storage service API", [&ss, &g] (http_context& ctx, routes& r) {
-            set_storage_service(ctx, r, ss, g.local());
+future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss) {
+    return register_api(ctx, "storage_service", "The storage service API", [&ss] (http_context& ctx, routes& r) {
+            set_storage_service(ctx, r, ss);
         });
 }
 

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -86,6 +86,7 @@ future<> set_server_config(http_context& ctx, const db::config& cfg);
 future<> set_server_snitch(http_context& ctx, sharded<locator::snitch_ptr>& snitch);
 future<> unset_server_snitch(http_context& ctx);
 future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss);
+future<> unset_server_storage_service(http_context& ctx);
 future<> set_server_sstables_loader(http_context& ctx, sharded<sstables_loader>& sst_loader);
 future<> unset_server_sstables_loader(http_context& ctx);
 future<> set_server_view_builder(http_context& ctx, sharded<db::view::view_builder>& vb);

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -85,7 +85,7 @@ future<> set_server_init(http_context& ctx);
 future<> set_server_config(http_context& ctx, const db::config& cfg);
 future<> set_server_snitch(http_context& ctx, sharded<locator::snitch_ptr>& snitch);
 future<> unset_server_snitch(http_context& ctx);
-future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss, sharded<gms::gossiper>& g, sharded<db::system_keyspace>& sys_ks);
+future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss, sharded<gms::gossiper>& g);
 future<> set_server_sstables_loader(http_context& ctx, sharded<sstables_loader>& sst_loader);
 future<> unset_server_sstables_loader(http_context& ctx);
 future<> set_server_view_builder(http_context& ctx, sharded<db::view::view_builder>& vb);

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -85,7 +85,7 @@ future<> set_server_init(http_context& ctx);
 future<> set_server_config(http_context& ctx, const db::config& cfg);
 future<> set_server_snitch(http_context& ctx, sharded<locator::snitch_ptr>& snitch);
 future<> unset_server_snitch(http_context& ctx);
-future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss, sharded<gms::gossiper>& g);
+future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss);
 future<> set_server_sstables_loader(http_context& ctx, sharded<sstables_loader>& sst_loader);
 future<> unset_server_sstables_loader(http_context& ctx);
 future<> set_server_view_builder(http_context& ctx, sharded<db::view::view_builder>& vb);

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -461,7 +461,7 @@ static future<json::json_return_type> describe_ring_as_json(sharded<service::sto
     co_return json::json_return_type(stream_range_as_array(co_await ss.local().describe_ring(keyspace), token_range_endpoints_to_json));
 }
 
-void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_service>& ss, gms::gossiper& g) {
+void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_service>& ss) {
     ss::local_hostid.set(r, [&ss](std::unique_ptr<http::request> req) {
         auto id = ss.local().get_token_metadata().get_my_id();
         return make_ready_future<json::json_return_type>(id.to_sstring());

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -461,7 +461,7 @@ static future<json::json_return_type> describe_ring_as_json(sharded<service::sto
     co_return json::json_return_type(stream_range_as_array(co_await ss.local().describe_ring(keyspace), token_range_endpoints_to_json));
 }
 
-void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_service>& ss, gms::gossiper& g, sharded<db::system_keyspace>& sys_ks) {
+void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_service>& ss, gms::gossiper& g) {
     ss::local_hostid.set(r, [&ss](std::unique_ptr<http::request> req) {
         auto id = ss.local().get_token_metadata().get_my_id();
         return make_ready_future<json::json_return_type>(id.to_sstring());

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1335,6 +1335,95 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     });
 }
 
+void unset_storage_service(http_context& ctx, routes& r) {
+    ss::local_hostid.unset(r);
+    ss::get_tokens.unset(r);
+    ss::get_node_tokens.unset(r);
+    ss::get_commitlog.unset(r);
+    ss::get_token_endpoint.unset(r);
+    ss::toppartitions_generic.unset(r);
+    ss::get_leaving_nodes.unset(r);
+    ss::get_moving_nodes.unset(r);
+    ss::get_joining_nodes.unset(r);
+    ss::get_release_version.unset(r);
+    ss::get_scylla_release_version.unset(r);
+    ss::get_schema_version.unset(r);
+    ss::get_all_data_file_locations.unset(r);
+    ss::get_saved_caches_location.unset(r);
+    ss::get_range_to_endpoint_map.unset(r);
+    ss::get_pending_range_to_endpoint_map.unset(r);
+    ss::describe_any_ring.unset(r);
+    ss::describe_ring.unset(r);
+    ss::get_host_id_map.unset(r);
+    ss::get_load.unset(r);
+    ss::get_load_map.unset(r);
+    ss::get_current_generation_number.unset(r);
+    ss::get_natural_endpoints.unset(r);
+    ss::cdc_streams_check_and_repair.unset(r);
+    ss::force_keyspace_compaction.unset(r);
+    ss::force_keyspace_cleanup.unset(r);
+    ss::perform_keyspace_offstrategy_compaction.unset(r);
+    ss::upgrade_sstables.unset(r);
+    ss::force_keyspace_flush.unset(r);
+    ss::decommission.unset(r);
+    ss::move.unset(r);
+    ss::remove_node.unset(r);
+    ss::get_removal_status.unset(r);
+    ss::force_remove_completion.unset(r);
+    ss::set_logging_level.unset(r);
+    ss::get_logging_levels.unset(r);
+    ss::get_operation_mode.unset(r);
+    ss::is_starting.unset(r);
+    ss::get_drain_progress.unset(r);
+    ss::drain.unset(r);
+    ss::truncate.unset(r);
+    ss::get_keyspaces.unset(r);
+    ss::stop_gossiping.unset(r);
+    ss::start_gossiping.unset(r);
+    ss::is_gossip_running.unset(r);
+    ss::stop_daemon.unset(r);
+    ss::is_initialized.unset(r);
+    ss::join_ring.unset(r);
+    ss::is_joined.unset(r);
+    ss::set_stream_throughput_mb_per_sec.unset(r);
+    ss::get_stream_throughput_mb_per_sec.unset(r);
+    ss::get_compaction_throughput_mb_per_sec.unset(r);
+    ss::set_compaction_throughput_mb_per_sec.unset(r);
+    ss::is_incremental_backups_enabled.unset(r);
+    ss::set_incremental_backups_enabled.unset(r);
+    ss::rebuild.unset(r);
+    ss::bulk_load.unset(r);
+    ss::bulk_load_async.unset(r);
+    ss::reschedule_failed_deletions.unset(r);
+    ss::sample_key_range.unset(r);
+    ss::reset_local_schema.unset(r);
+    ss::set_trace_probability.unset(r);
+    ss::get_trace_probability.unset(r);
+    ss::get_slow_query_info.unset(r);
+    ss::set_slow_query.unset(r);
+    ss::enable_auto_compaction.unset(r);
+    ss::disable_auto_compaction.unset(r);
+    ss::enable_tombstone_gc.unset(r);
+    ss::disable_tombstone_gc.unset(r);
+    ss::deliver_hints.unset(r);
+    ss::get_cluster_name.unset(r);
+    ss::get_partitioner_name.unset(r);
+    ss::get_tombstone_warn_threshold.unset(r);
+    ss::set_tombstone_warn_threshold.unset(r);
+    ss::get_tombstone_failure_threshold.unset(r);
+    ss::set_tombstone_failure_threshold.unset(r);
+    ss::get_batch_size_failure_threshold.unset(r);
+    ss::set_batch_size_failure_threshold.unset(r);
+    ss::set_hinted_handoff_throttle_in_kb.unset(r);
+    ss::get_metrics_load.unset(r);
+    ss::get_exceptions.unset(r);
+    ss::get_total_hints_in_progress.unset(r);
+    ss::get_total_hints.unset(r);
+    ss::get_ownership.unset(r);
+    ss::get_effective_ownership.unset(r);
+    ss::sstable_info.unset(r);
+}
+
 enum class scrub_status {
     successful = 0,
     aborted,

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -57,7 +57,7 @@ std::vector<sstring> parse_tables(const sstring& ks_name, http_context& ctx, con
 // if the parameter is not found or is empty, returns a list of all table infos in the keyspace.
 std::vector<table_info> parse_table_infos(const sstring& ks_name, http_context& ctx, const std::unordered_map<sstring, sstring>& query_params, sstring param_name);
 
-void set_storage_service(http_context& ctx, httpd::routes& r, sharded<service::storage_service>& ss, gms::gossiper& g, sharded<db::system_keyspace>& sys_ls);
+void set_storage_service(http_context& ctx, httpd::routes& r, sharded<service::storage_service>& ss, gms::gossiper& g);
 void set_sstables_loader(http_context& ctx, httpd::routes& r, sharded<sstables_loader>& sst_loader);
 void unset_sstables_loader(http_context& ctx, httpd::routes& r);
 void set_view_builder(http_context& ctx, httpd::routes& r, sharded<db::view::view_builder>& vb);

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -57,7 +57,7 @@ std::vector<sstring> parse_tables(const sstring& ks_name, http_context& ctx, con
 // if the parameter is not found or is empty, returns a list of all table infos in the keyspace.
 std::vector<table_info> parse_table_infos(const sstring& ks_name, http_context& ctx, const std::unordered_map<sstring, sstring>& query_params, sstring param_name);
 
-void set_storage_service(http_context& ctx, httpd::routes& r, sharded<service::storage_service>& ss, gms::gossiper& g);
+void set_storage_service(http_context& ctx, httpd::routes& r, sharded<service::storage_service>& ss);
 void set_sstables_loader(http_context& ctx, httpd::routes& r, sharded<sstables_loader>& sst_loader);
 void unset_sstables_loader(http_context& ctx, httpd::routes& r);
 void set_view_builder(http_context& ctx, httpd::routes& r, sharded<db::view::view_builder>& vb);

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -58,6 +58,7 @@ std::vector<sstring> parse_tables(const sstring& ks_name, http_context& ctx, con
 std::vector<table_info> parse_table_infos(const sstring& ks_name, http_context& ctx, const std::unordered_map<sstring, sstring>& query_params, sstring param_name);
 
 void set_storage_service(http_context& ctx, httpd::routes& r, sharded<service::storage_service>& ss);
+void unset_storage_service(http_context& ctx, httpd::routes& r);
 void set_sstables_loader(http_context& ctx, httpd::routes& r, sharded<sstables_loader>& sst_loader);
 void unset_sstables_loader(http_context& ctx, httpd::routes& r);
 void set_view_builder(http_context& ctx, httpd::routes& r, sharded<db::view::view_builder>& vb);

--- a/main.cc
+++ b/main.cc
@@ -1357,6 +1357,12 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_storage_service = defer_verbose_shutdown("storage_service", [&] {
                 ss.stop().get();
             });
+
+            api::set_server_storage_service(ctx, ss).get();
+            auto stop_ss_api = defer_verbose_shutdown("storage service API", [&ctx] {
+                api::unset_server_storage_service(ctx).get();
+            });
+
             supervisor::notify("initializing virtual tables");
             smp::invoke_on_all([&] {
                 return db::initialize_virtual_tables(db, ss, gossiper, raft_gr, sys_ks, *cfg);
@@ -1590,7 +1596,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_messaging_api = defer_verbose_shutdown("messaging service API", [&ctx] {
                 api::unset_server_messaging_service(ctx).get();
             });
-            api::set_server_storage_service(ctx, ss).get();
             api::set_server_repair(ctx, repair).get();
             auto stop_repair_api = defer_verbose_shutdown("repair API", [&ctx] {
                 api::unset_server_repair(ctx).get();

--- a/main.cc
+++ b/main.cc
@@ -1590,7 +1590,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_messaging_api = defer_verbose_shutdown("messaging service API", [&ctx] {
                 api::unset_server_messaging_service(ctx).get();
             });
-            api::set_server_storage_service(ctx, ss, gossiper, sys_ks).get();
+            api::set_server_storage_service(ctx, ss, gossiper).get();
             api::set_server_repair(ctx, repair).get();
             auto stop_repair_api = defer_verbose_shutdown("repair API", [&ctx] {
                 api::unset_server_repair(ctx).get();

--- a/main.cc
+++ b/main.cc
@@ -1590,7 +1590,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_messaging_api = defer_verbose_shutdown("messaging service API", [&ctx] {
                 api::unset_server_messaging_service(ctx).get();
             });
-            api::set_server_storage_service(ctx, ss, gossiper).get();
+            api::set_server_storage_service(ctx, ss).get();
             api::set_server_repair(ctx, repair).get();
             auto stop_repair_api = defer_verbose_shutdown("repair API", [&ctx] {
                 api::unset_server_repair(ctx).get();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -228,6 +228,9 @@ private:
         return _batchlog_manager;
     }
 
+    friend struct ::node_ops_ctl;
+public:
+
     const gms::gossiper& gossiper() const noexcept {
         return _gossiper;
     };
@@ -235,9 +238,6 @@ private:
     gms::gossiper& gossiper() noexcept {
         return _gossiper;
     };
-
-    friend struct ::node_ops_ctl;
-public:
 
     locator::effective_replication_map_factory& get_erm_factory() noexcept {
         return _erm_factory;


### PR DESCRIPTION
Storage service API set/unset has two flaws.

First, unset doesn't happen, so after storage service is stopped its handlers become "local is not initialized"-assertion and use-after-free landmines.

Second, setting of storage service API carry gossiper and system keyspace references, thus duplicating the knowledge about storage service dependencies.

This PR fixes both by adding the storage service API unsetting and by making the handlers use _only_ storage service instance, not any externally provided references.