### PR TITLE
test/object_store: keep fd before closing it

### DIFF
--- a/test/object_store/test_basic.py
+++ b/test/object_store/test_basic.py
@@ -53,9 +53,9 @@ def run_with_dir(run_cmd_gen, run_dir):
         log = os.path.join(run_dir, 'log')
         log_fd = os.open(log, os.O_WRONLY | os.O_CREAT | os.O_APPEND, mode=0o666)
         # redirect stdout and stderr to log file
-        for output in [sys.stdout, sys.stderr]:
+        outputs = [(output, output.fileno()) for output in [sys.stdout, sys.stderr]]
+        for output, output_fd in outputs:
             output.flush()
-            output_fd = output.fileno()
             os.close(output_fd)
             os.dup2(log_fd, output_fd)
         os.setsid()


### PR DESCRIPTION
it turns out after closing an fd (1) representing stdout, "1" will be representing stderr, so the loop which is supposed to redirect both stdout *and* stderr will end up with redirecting stderr only. so in order to preserve the logging messages printed to stdout, we need to keep the fds before closing them.

so, in this change, we keep the file and corresponding fd before the loop. and use them in the loop.