### PR TITLE
doc: fix section headings that appear on page tree

### DIFF
--- a/docs/cql/secondary-indexes.rst
+++ b/docs/cql/secondary-indexes.rst
@@ -106,7 +106,7 @@ name, which may optionally specify the keyspace of the index.
 .. operation is a no-op.
 
 Additional Information
-----------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * :doc:`Global Secondary Indexes </using-scylla/secondary-indexes/>`
 * :doc:`Local Secondary Indexes </using-scylla/local-secondary-indexes/>`

--- a/docs/cql/time-to-live.rst
+++ b/docs/cql/time-to-live.rst
@@ -98,7 +98,7 @@ Notes
 
 
 Additional Information
-----------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To learn more about TTL, and see a hands-on example, check out `this lesson <https://university.scylladb.com/courses/data-modeling/lessons/advanced-data-modeling/topic/expiring-data-with-ttl-time-to-live/>`_ on Scylla University.
 


### PR DESCRIPTION
Some "Additional Information" section headings appear on the page tree in the left sidebar because of their incorrect underline.
![image](https://github.com/scylladb/scylladb/assets/37244380/a41ec5d5-6f6b-4879-9ae3-55ce814c1f31)

This commit fixes the problem by replacing the title underline with the section underline.