### PR TITLE
system.truncated: Remove replay_position data from truncated on start

### DIFF
--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -358,6 +358,7 @@ public:
     future<> save_truncation_record(const replica::column_family&, db_clock::time_point truncated_at, db::replay_position);
     future<replay_positions> get_truncated_position(table_id);
     future<db_clock::time_point> get_truncated_at(table_id);
+    future<> drop_truncation_rp_records();
 
     /**
      * Return a map of stored tokens to IP addresses

--- a/main.cc
+++ b/main.cc
@@ -1457,6 +1457,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 }
             }
 
+            // Once stuff is replayed, we can empty RP:s from truncation records. 
+            // This ensures we can't mis-mash older records with a newer crashed run.
+            // I.e: never keep replay_positions alive across a restart cycle.
+            sys_ks.local().drop_truncation_rp_records().get();
+
             db.invoke_on_all([] (replica::database& db) {
                 db.get_tables_metadata().for_each_table([] (table_id, lw_shared_ptr<replica::table> table) {
                     replica::table& t = *table;


### PR DESCRIPTION
Refs #15354

Once we've started clean, and all replaying is done, truncation logs commit log regarding replay positions are invalid. We should exorcise them as soon as possible. Note that we cannot remove truncation data completely though, since the time stamps stored are used by things like batch log to determine if it should use or discard old batch data.