### PR TITLE
build: cmake: compare CMAKE_SYSTEM_PROCESSOR using STREQUAL operator

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -22,7 +22,12 @@ function(default_target_arch arch)
   set(x86_instruction_sets i386 i686 x86_64)
   if(CMAKE_SYSTEM_PROCESSOR IN_LIST x86_instruction_sets)
     set(${arch} "westmere" PARENT_SCOPE)
-  elseif(CMAKE_SYSTEM_PROCESSOR EQUAL "aarch64")
+  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    # we always use intrinsics like vmull.p64 for speeding up crc32 calculations
+    # on the aarch64 architectures, and they require the crypto extension, so
+    # we have to add "+crypto" in the architecture flags passed to -march. the
+    # same applies to crc32 instructions, which need the ARMv8-A CRC32 extension
+    # please note, Seastar also sets -march when compiled with DPDK enabled.
     set(${arch} "armv8-a+crc+crypto" PARENT_SCOPE)
   else()
     set(${arch} "" PARENT_SCOPE)


### PR DESCRIPTION
`if (.. EQUAL ..)` is used to compare numbers so if the LHS is not a number the condition is evaluated as false, this prevents us from setting the -march when building for aarch64 targets. and because crc32 implementation in utils/ always use the crypto extension intrinsics, this also breaks the build like
```
In file included from /home/fedora/scylla/utils/gz/crc_combine.cc:40:
/home/fedora/scylla/utils/clmul.hh:60:12: error: always_inline function 'vmull_p64' requires target feature 'aes', but would be inlined into functi
on 'clmul_u32' that is compiled without support for 'aes'
    return vmull_p64(p1, p2);
           ^
```

so, in this change,

* compare two strings using `STREQUAL`.
* document the reason why we need to set the -march to the specfied argument. see also http://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html#g_t-march-and--mcpu-Feature-Modifiers