### PR TITLE
cql-pytest: Dont flush out/err between fork and exec

### DIFF
--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -47,10 +47,8 @@ def run_with_generated_dir(run_cmd_generator, run_dir_generator):
         # redirect stdout and stderr to log file, as in a shell's >log 2>&1:
         log = os.path.join(dir, 'log')
         fd = os.open(log, os.O_WRONLY | os.O_CREAT | os.O_APPEND, mode=0o666)
-        sys.stdout.flush()
         os.close(1)
         os.dup2(fd, 1)
-        sys.stderr.flush()
         os.close(2)
         os.dup2(fd, 2)
         # Detach child from parent's "session", so that a SIGINT will be


### PR DESCRIPTION
When fork+exec-ing a process with stdio redirection it's recommended to flush stdout/err in-memory buffers not to make child and parent processes produce buffered message twice. This recommendation applies to fork() -- this is where buffers are duplicated and have chances to get pronted twise. Flushing after fork() only makes sense to make sure anything that was printed before exec() finds its way to the descriptor, but it's not the case here.