### PR TITLE
Remove _schema field from sstable_set

### DIFF
--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -121,14 +121,12 @@ std::ostream& operator<<(std::ostream& os, const sstables::sstable_run& run) {
     return os;
 }
 
-sstable_set::sstable_set(std::unique_ptr<sstable_set_impl> impl, schema_ptr s)
+sstable_set::sstable_set(std::unique_ptr<sstable_set_impl> impl)
         : _impl(std::move(impl))
-        , _schema(std::move(s))
 {}
 
 sstable_set::sstable_set(const sstable_set& x)
         : _impl(x._impl->clone())
-        , _schema(x._schema)
 {}
 
 sstable_set::sstable_set(sstable_set&&) noexcept = default;
@@ -756,14 +754,13 @@ std::unique_ptr<sstable_set_impl> time_window_compaction_strategy::make_sstable_
 }
 
 sstable_set make_partitioned_sstable_set(schema_ptr schema, bool use_level_metadata) {
-    return sstable_set(std::make_unique<partitioned_sstable_set>(schema, use_level_metadata), schema);
+    return sstable_set(std::make_unique<partitioned_sstable_set>(schema, use_level_metadata));
 }
 
 sstable_set
 compaction_strategy::make_sstable_set(schema_ptr schema) const {
     return sstable_set(
-            _compaction_strategy_impl->make_sstable_set(schema),
-            schema);
+            _compaction_strategy_impl->make_sstable_set(schema));
 }
 
 using sstable_reader_factory_type = std::function<flat_mutation_reader_v2(shared_sstable&, const dht::partition_range& pr)>;
@@ -1212,7 +1209,7 @@ sstable_set_impl::selector_and_schema_t compound_sstable_set::make_incremental_s
 }
 
 sstable_set make_compound_sstable_set(schema_ptr schema, std::vector<lw_shared_ptr<sstable_set>> sets) {
-    return sstable_set(std::make_unique<compound_sstable_set>(schema, std::move(sets)), schema);
+    return sstable_set(std::make_unique<compound_sstable_set>(schema, std::move(sets)));
 }
 
 flat_mutation_reader_v2

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -116,10 +116,9 @@ public:
 
 class sstable_set : public enable_lw_shared_from_this<sstable_set> {
     std::unique_ptr<sstable_set_impl> _impl;
-    schema_ptr _schema;
 public:
     ~sstable_set();
-    sstable_set(std::unique_ptr<sstable_set_impl> impl, schema_ptr s);
+    sstable_set(std::unique_ptr<sstable_set_impl> impl);
     sstable_set(const sstable_set&);
     sstable_set(sstable_set&&) noexcept;
     sstable_set& operator=(const sstable_set&);

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -17,6 +17,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <type_traits>
 #include <vector>
+#include <tuple>
 
 namespace utils {
 class estimated_histogram;
@@ -97,7 +98,8 @@ public:
     uint64_t sub_bytes_on_disk(uint64_t delta) noexcept {
         return _bytes_on_disk -= delta;
     }
-    virtual std::unique_ptr<incremental_selector_impl> make_incremental_selector() const = 0;
+    using selector_and_schema_t = std::tuple<std::unique_ptr<incremental_selector_impl>, const schema&>;
+    virtual selector_and_schema_t make_incremental_selector() const = 0;
 
     virtual flat_mutation_reader_v2 create_single_key_sstable_reader(
         replica::column_family*,

--- a/sstables/sstable_set_impl.hh
+++ b/sstables/sstable_set_impl.hh
@@ -69,7 +69,7 @@ public:
     virtual bool insert(shared_sstable sst) override;
     virtual bool erase(shared_sstable sst) override;
     virtual size_t size() const noexcept override;
-    virtual std::unique_ptr<incremental_selector_impl> make_incremental_selector() const override;
+    virtual sstable_set_impl::selector_and_schema_t make_incremental_selector() const override;
     class incremental_selector;
 };
 
@@ -97,7 +97,7 @@ public:
     virtual bool insert(shared_sstable sst) override;
     virtual bool erase(shared_sstable sst) override;
     virtual size_t size() const noexcept override;
-    virtual std::unique_ptr<incremental_selector_impl> make_incremental_selector() const override;
+    virtual sstable_set_impl::selector_and_schema_t make_incremental_selector() const override;
 
     std::unique_ptr<position_reader_queue> make_position_reader_queue(
         std::function<flat_mutation_reader_v2(sstable&)> create_reader,
@@ -139,7 +139,7 @@ public:
     virtual bool erase(shared_sstable sst) override;
     virtual size_t size() const noexcept override;
     virtual uint64_t bytes_on_disk() const noexcept override;
-    virtual std::unique_ptr<incremental_selector_impl> make_incremental_selector() const override;
+    virtual sstable_set_impl::selector_and_schema_t make_incremental_selector() const override;
 
     virtual flat_mutation_reader_v2 create_single_key_sstable_reader(
             replica::column_family*,

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -20,7 +20,7 @@
 using namespace sstables;
 
 static sstables::sstable_set make_sstable_set(schema_ptr schema, lw_shared_ptr<sstable_list> all = {}, bool use_level_metadata = true) {
-    auto ret = sstables::sstable_set(std::make_unique<partitioned_sstable_set>(schema, use_level_metadata), schema);
+    auto ret = sstables::sstable_set(std::make_unique<partitioned_sstable_set>(schema, use_level_metadata));
     for (auto& sst : *all) {
         ret.insert(sst);
     }
@@ -114,7 +114,7 @@ SEASTAR_TEST_CASE(test_time_series_sstable_set_bytes_on_disk) {
         auto sst1 = make_sstable_easy(env, std::move(mr), cfg);
         auto size1 = sst1->bytes_on_disk();
 
-        auto ss1 = make_lw_shared<sstable_set>(std::make_unique<time_series_sstable_set>(ss.schema(), true), ss.schema());
+        auto ss1 = make_lw_shared<sstable_set>(std::make_unique<time_series_sstable_set>(ss.schema(), true));
         ss1->insert(sst1);
         BOOST_REQUIRE_EQUAL(ss1->bytes_on_disk(), size1);
 
@@ -129,7 +129,7 @@ SEASTAR_TEST_CASE(test_time_series_sstable_set_bytes_on_disk) {
         BOOST_REQUIRE_EQUAL(ss2->bytes_on_disk(), size1 + size2);
 
         std::vector<lw_shared_ptr<sstable_set>> sets = {ss1, ss2};
-        auto sst_set = make_lw_shared<sstable_set>(std::make_unique<compound_sstable_set>(s, std::move(sets)), ss.schema());
+        auto sst_set = make_lw_shared<sstable_set>(std::make_unique<compound_sstable_set>(s, std::move(sets)));
         BOOST_REQUIRE_EQUAL(sst_set->bytes_on_disk(), ss1->bytes_on_disk() + ss2->bytes_on_disk());
     });
 }
@@ -148,7 +148,7 @@ SEASTAR_TEST_CASE(test_partitioned_sstable_set_bytes_on_disk) {
         auto sst1 = make_sstable_easy(env, std::move(mr), cfg);
         auto size1 = sst1->bytes_on_disk();
 
-        auto ss1 = make_lw_shared<sstable_set>(std::make_unique<partitioned_sstable_set>(ss.schema(), true), ss.schema());
+        auto ss1 = make_lw_shared<sstable_set>(std::make_unique<partitioned_sstable_set>(ss.schema(), true));
         ss1->insert(sst1);
         BOOST_REQUIRE_EQUAL(ss1->bytes_on_disk(), size1);
 
@@ -163,7 +163,7 @@ SEASTAR_TEST_CASE(test_partitioned_sstable_set_bytes_on_disk) {
         BOOST_REQUIRE_EQUAL(ss2->bytes_on_disk(), size1 + size2);
 
         std::vector<lw_shared_ptr<sstable_set>> sets = {ss1, ss2};
-        auto sst_set = make_lw_shared<sstable_set>(std::make_unique<compound_sstable_set>(s, std::move(sets)), ss.schema());
+        auto sst_set = make_lw_shared<sstable_set>(std::make_unique<compound_sstable_set>(s, std::move(sets)));
         BOOST_REQUIRE_EQUAL(sst_set->bytes_on_disk(), ss1->bytes_on_disk() + ss2->bytes_on_disk());
     });
 }


### PR DESCRIPTION
All `sstable_set_impl` subclasses/implementations already keep a `schema_ptr` so we can make `sstable_set_impl::make_incremental_selector` function return both the selector and the schema that's being used by it.

That way, we can use the returned schema in `sstable_set::make_incremental_selector` function instead of `sstable_set::_schema` field which makes the field unused and allows us to remove it alltogether and reduce the memory footprint of `sstable_set` objects.