### PR TITLE
cql-pytest.nodetool: no_autocompaction_context: support ks.tbl syntax

### DIFF
--- a/test/cql-pytest/test_tools.py
+++ b/test/cql-pytest/test_tools.py
@@ -508,11 +508,11 @@ def system_scylla_local_sstable_prepared(cql, scylla_data_dir):
     """ Prepares the system.scylla_local table for the needs of the schema loading tests.
 
     Namely:
-    * Disable auto-compaction for the system and system-schema keyspaces.
+    * Disable auto-compaction for the system-schema keyspace and system.scylla_local table.
     * Flushes said keyspaces.
     * Locates an sstable belonging to system.scylla_local and returns it.
     """
-    with nodetool.no_autocompaction_context(cql, "system", "system_schema"):
+    with nodetool.no_autocompaction_context(cql, "system.scylla_local", "system_schema"):
         # Need to flush system keyspaces whoose sstables we want to meddle
         # with, to make sure they are actually on disk.
         nodetool.flush_keyspace(cql, "system_schema")


### PR DESCRIPTION
Allow disabling auto-compaction for given table(s) using either the ks.table syntax or ks:table (as the api suggests).

The first syntax would likely be more common since the test tables we automatically create are named
as test_keyspace.test_table so we can pass that name to `no_autocompaction_context` as is.

test_tools.system_scylla_local_sstable_prepared was modified to disable auto-compaction only only
the `system.scylla_local` table rather than
the whole `system` keyspace, since it only relies
on this table. Plus, it helps test this change :)