### PR TITLE
Sanitize storage_proxy API handlers

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -193,10 +193,10 @@ future<> unset_server_messaging_service(http_context& ctx) {
     return ctx.http_server.set_routes([&ctx] (routes& r) { unset_messaging_service(ctx, r); });
 }
 
-future<> set_server_storage_proxy(http_context& ctx, sharded<service::storage_service>& ss) {
+future<> set_server_storage_proxy(http_context& ctx) {
     return register_api(ctx, "storage_proxy",
-                "The storage proxy API", [&ss] (http_context& ctx, routes& r) {
-                    set_storage_proxy(ctx, r, ss);
+                "The storage proxy API", [] (http_context& ctx, routes& r) {
+                    set_storage_proxy(ctx, r);
                 });
 }
 

--- a/api/api.cc
+++ b/api/api.cc
@@ -193,10 +193,10 @@ future<> unset_server_messaging_service(http_context& ctx) {
     return ctx.http_server.set_routes([&ctx] (routes& r) { unset_messaging_service(ctx, r); });
 }
 
-future<> set_server_storage_proxy(http_context& ctx) {
+future<> set_server_storage_proxy(http_context& ctx, sharded<service::storage_proxy>& proxy) {
     return register_api(ctx, "storage_proxy",
-                "The storage proxy API", [] (http_context& ctx, routes& r) {
-                    set_storage_proxy(ctx, r);
+                "The storage proxy API", [&proxy] (http_context& ctx, routes& r) {
+                    set_storage_proxy(ctx, r, proxy);
                 });
 }
 

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -107,7 +107,7 @@ future<> set_server_load_sstable(http_context& ctx, sharded<db::system_keyspace>
 future<> unset_server_load_sstable(http_context& ctx);
 future<> set_server_messaging_service(http_context& ctx, sharded<netw::messaging_service>& ms);
 future<> unset_server_messaging_service(http_context& ctx);
-future<> set_server_storage_proxy(http_context& ctx);
+future<> set_server_storage_proxy(http_context& ctx, sharded<service::storage_proxy>& proxy);
 future<> unset_server_storage_proxy(http_context& ctx);
 future<> set_server_stream_manager(http_context& ctx, sharded<streaming::stream_manager>& sm);
 future<> unset_server_stream_manager(http_context& ctx);

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -107,7 +107,7 @@ future<> set_server_load_sstable(http_context& ctx, sharded<db::system_keyspace>
 future<> unset_server_load_sstable(http_context& ctx);
 future<> set_server_messaging_service(http_context& ctx, sharded<netw::messaging_service>& ms);
 future<> unset_server_messaging_service(http_context& ctx);
-future<> set_server_storage_proxy(http_context& ctx, sharded<service::storage_service>& ss);
+future<> set_server_storage_proxy(http_context& ctx);
 future<> unset_server_storage_proxy(http_context& ctx);
 future<> set_server_stream_manager(http_context& ctx, sharded<streaming::stream_manager>& sm);
 future<> unset_server_stream_manager(http_context& ctx);

--- a/api/storage_proxy.cc
+++ b/api/storage_proxy.cc
@@ -10,7 +10,6 @@
 #include "service/storage_proxy.hh"
 #include "api/api-doc/storage_proxy.json.hh"
 #include "api/api-doc/utils.json.hh"
-#include "service/storage_service.hh"
 #include "db/config.hh"
 #include "utils/histogram.hh"
 #include "replica/database.hh"
@@ -184,7 +183,7 @@ sum_timer_stats_storage_proxy(distributed<proxy>& d,
     });
 }
 
-void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_service>& ss) {
+void set_storage_proxy(http_context& ctx, routes& r) {
     sp::get_total_hints.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();

--- a/api/storage_proxy.cc
+++ b/api/storage_proxy.cc
@@ -354,19 +354,6 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_se
         return sum_stats_storage_proxy(ctx.sp, &service::storage_proxy_stats::stats::read_repair_repaired_background);
     });
 
-    sp::get_schema_versions.set(r, [&ss](std::unique_ptr<http::request> req)  {
-        return ss.local().describe_schema_versions().then([] (auto result) {
-            std::vector<sp::mapper_list> res;
-            for (auto e : result) {
-                sp::mapper_list entry;
-                entry.key = std::move(e.first);
-                entry.value = std::move(e.second);
-                res.emplace_back(std::move(entry));
-            }
-            return make_ready_future<json::json_return_type>(std::move(res));
-        });
-    });
-
     sp::get_cas_read_timeouts.set(r, [&ctx](std::unique_ptr<http::request> req) {
         return sum_timed_rate_as_long(ctx.sp, &proxy::stats::cas_read_timeouts);
     });
@@ -547,7 +534,6 @@ void unset_storage_proxy(http_context& ctx, routes& r) {
     sp::get_read_repair_attempted.unset(r);
     sp::get_read_repair_repaired_blocking.unset(r);
     sp::get_read_repair_repaired_background.unset(r);
-    sp::get_schema_versions.unset(r);
     sp::get_cas_read_timeouts.unset(r);
     sp::get_cas_read_unavailables.unset(r);
     sp::get_cas_write_timeouts.unset(r);

--- a/api/storage_proxy.cc
+++ b/api/storage_proxy.cc
@@ -183,7 +183,7 @@ sum_timer_stats_storage_proxy(distributed<proxy>& d,
     });
 }
 
-void set_storage_proxy(http_context& ctx, routes& r) {
+void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_proxy>& proxy) {
     sp::get_total_hints.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();

--- a/api/storage_proxy.hh
+++ b/api/storage_proxy.hh
@@ -11,11 +11,9 @@
 #include <seastar/core/sharded.hh>
 #include "api.hh"
 
-namespace service { class storage_service; }
-
 namespace api {
 
-void set_storage_proxy(http_context& ctx, httpd::routes& r, sharded<service::storage_service>& ss);
+void set_storage_proxy(http_context& ctx, httpd::routes& r);
 void unset_storage_proxy(http_context& ctx, httpd::routes& r);
 
 }

--- a/api/storage_proxy.hh
+++ b/api/storage_proxy.hh
@@ -11,9 +11,11 @@
 #include <seastar/core/sharded.hh>
 #include "api.hh"
 
+namespace service { class storage_proxy; }
+
 namespace api {
 
-void set_storage_proxy(http_context& ctx, httpd::routes& r);
+void set_storage_proxy(http_context& ctx, httpd::routes& r, sharded<service::storage_proxy>& proxy);
 void unset_storage_proxy(http_context& ctx, httpd::routes& r);
 
 }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -42,7 +42,6 @@
 #include "thrift/controller.hh"
 #include "locator/token_metadata.hh"
 #include "cdc/generation_service.hh"
-#include "service/storage_proxy.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "sstables_loader.hh"
 #include "db/view/view_builder.hh"

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -8,6 +8,7 @@
 
 #include "storage_service.hh"
 #include "api/api-doc/storage_service.json.hh"
+#include "api/api-doc/storage_proxy.json.hh"
 #include "db/config.hh"
 #include "db/schema_tables.hh"
 #include "utils/hash.hh"
@@ -54,6 +55,7 @@ extern logging::logger apilog;
 namespace api {
 
 namespace ss = httpd::storage_service_json;
+namespace sp = httpd::storage_proxy_json;
 using namespace json;
 
 sstring validate_keyspace(http_context& ctx, sstring ks_name) {
@@ -1345,6 +1347,19 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         });
         co_return json_void();
     });
+
+    sp::get_schema_versions.set(r, [&ss](std::unique_ptr<http::request> req)  {
+        return ss.local().describe_schema_versions().then([] (auto result) {
+            std::vector<sp::mapper_list> res;
+            for (auto e : result) {
+                sp::mapper_list entry;
+                entry.key = std::move(e.first);
+                entry.value = std::move(e.second);
+                res.emplace_back(std::move(entry));
+            }
+            return make_ready_future<json::json_return_type>(std::move(res));
+        });
+    });
 }
 
 void unset_storage_service(http_context& ctx, routes& r) {
@@ -1434,6 +1449,7 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::get_ownership.unset(r);
     ss::get_effective_ownership.unset(r);
     ss::sstable_info.unset(r);
+    sp::get_schema_versions.unset(r);
 }
 
 enum class scrub_status {

--- a/main.cc
+++ b/main.cc
@@ -1062,7 +1062,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             // #293 - do not stop anything
             // engine().at_exit([&proxy] { return proxy.stop(); });
-            api::set_server_storage_proxy(ctx).get();
+            api::set_server_storage_proxy(ctx, proxy).get();
             auto stop_sp_api = defer_verbose_shutdown("storage proxy API", [&ctx] {
                 api::unset_server_storage_proxy(ctx).get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1493,7 +1493,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_snitch_api = defer_verbose_shutdown("snitch API", [&ctx] {
                 api::unset_server_snitch(ctx).get();
             });
-            api::set_server_storage_proxy(ctx, ss).get();
+            api::set_server_storage_proxy(ctx).get();
             auto stop_sp_api = defer_verbose_shutdown("storage proxy API", [&ctx] {
                 api::unset_server_storage_proxy(ctx).get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1062,6 +1062,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             // #293 - do not stop anything
             // engine().at_exit([&proxy] { return proxy.stop(); });
+            api::set_server_storage_proxy(ctx).get();
+            auto stop_sp_api = defer_verbose_shutdown("storage proxy API", [&ctx] {
+                api::unset_server_storage_proxy(ctx).get();
+            });
 
             static sharded<cql3::cql_config> cql_config;
             cql_config.start(std::ref(*cfg)).get();
@@ -1492,10 +1496,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             api::set_server_snitch(ctx, snitch).get();
             auto stop_snitch_api = defer_verbose_shutdown("snitch API", [&ctx] {
                 api::unset_server_snitch(ctx).get();
-            });
-            api::set_server_storage_proxy(ctx).get();
-            auto stop_sp_api = defer_verbose_shutdown("storage proxy API", [&ctx] {
-                api::unset_server_storage_proxy(ctx).get();
             });
             api::set_server_load_sstable(ctx, sys_ks).get();
             auto stop_cf_api = defer_verbose_shutdown("column family API", [&ctx] {


### PR DESCRIPTION
Registering API handlers for services need to
- happen next to the corresponding service's start
- use only the provided service, not any other ones (if needed, the handler's service can use its internal dependencies to do its job)
- get the service to handle requests via argument, not from http context (http context, in turn, is going _not_ to depend on anything)

The storage proxy handlers don't follow any of that rules, this PR fixes them