### PR TITLE
Update tools/jmx submodule (weak dependencies for install.sh)

### DIFF
--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-38-20230919
+docker.io/scylladb/scylla-toolchain:fedora-38-20230927


### PR DESCRIPTION
* tools/jmx d107758...edf7b42 (1):
  > install-dependencies.sh: do not install weak dependencies Especially for Java, we really do not need the tens of packages and MBs it adds, just because Java apps can be built and use sound and graphics and whatnot.