### PR TITLE
api: storage_service: unset `reload_raft_topology_state`

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1435,6 +1435,7 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::get_ownership.unset(r);
     ss::get_effective_ownership.unset(r);
     ss::sstable_info.unset(r);
+    ss::reload_raft_topology_state.unset(r);
 }
 
 enum class scrub_status {


### PR DESCRIPTION
Every endpoint needs to be unset. Oversight in
992f1327d3749a0c021783b6febc4dbf8f9a5963.