### PR TITLE
tools/nodetool: implement additional commands, part 1/N

### DIFF
--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -169,4 +169,6 @@ def nodetool(request, jmx, nodetool_path, rest_api_mock_server):
         res.check_returncode()
         assert len(unconsumed_expected_requests) == 0
 
+        return res.stdout
+
     return invoker

--- a/test/nodetool/rest_api_mock.py
+++ b/test/nodetool/rest_api_mock.py
@@ -24,7 +24,7 @@ class expected_request:
                  response: Dict[str, Any] = None):
         self.method = method
         self.path = path
-        self.params = {}
+        self.params = params
         self.multiple = multiple
         self.response = response
 

--- a/test/nodetool/test_backup.py
+++ b/test/nodetool/test_backup.py
@@ -1,0 +1,27 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from rest_api_mock import expected_request
+
+
+def test_disablebackup(nodetool):
+    nodetool("disablebackup", expected_requests=[
+        expected_request("POST", "/storage_service/incremental_backups", params={"value": "false"})])
+
+
+def test_enablebackup(nodetool):
+    nodetool("enablebackup", expected_requests=[
+        expected_request("POST", "/storage_service/incremental_backups", params={"value": "true"})])
+
+
+def test_statusbackup(nodetool):
+    out = nodetool("statusbackup", expected_requests=[
+        expected_request("GET", "/storage_service/incremental_backups", response=False)])
+    assert out == "not running\n"
+
+    out = nodetool("statusbackup", expected_requests=[
+        expected_request("GET", "/storage_service/incremental_backups", response=True)])
+    assert out == "running\n"

--- a/test/nodetool/test_binary.py
+++ b/test/nodetool/test_binary.py
@@ -1,0 +1,27 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from rest_api_mock import expected_request
+
+
+def test_disablebinary(nodetool):
+    nodetool("disablebinary", expected_requests=[
+        expected_request("DELETE", "/storage_service/native_transport")])
+
+
+def test_enablebinary(nodetool):
+    nodetool("enablebinary", expected_requests=[
+        expected_request("POST", "/storage_service/native_transport")])
+
+
+def test_statusbinary(nodetool):
+    out = nodetool("statusbinary", expected_requests=[
+        expected_request("GET", "/storage_service/native_transport", response=False)])
+    assert out == "not running\n"
+
+    out = nodetool("statusbinary", expected_requests=[
+        expected_request("GET", "/storage_service/native_transport", response=True)])
+    assert out == "running\n"

--- a/test/nodetool/test_compact.py
+++ b/test/nodetool/test_compact.py
@@ -28,8 +28,8 @@ def test_nonexistent_keyspace(nodetool):
             {"expected_requests": [
                 expected_request("GET", "/storage_service/keyspaces", multiple=True, response=["system"]),
                 expected_request("POST", "/storage_service/keyspace_compaction/non_existent_ks")]},
-            "nodetool: Keyspace [non_existent_ks] does not exist.",
-            "error processing arguments: keyspace non_existent_ks does not exist")
+            ["nodetool: Keyspace [non_existent_ks] does not exist.",
+             "error processing arguments: keyspace non_existent_ks does not exist"])
 
 
 def test_table(nodetool):
@@ -68,5 +68,4 @@ def test_user_defined(nodetool, scylla_only):
             ("compact", "--user-defined", "/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/"
              "me-3g8w_11cg_4317k2ppfb6d5vgp0w-big-Data.db"),
             {},
-            None,
-            "error processing arguments: --user-defined flag is unsupported")
+            ["error processing arguments: --user-defined flag is unsupported"])

--- a/test/nodetool/test_compact.py
+++ b/test/nodetool/test_compact.py
@@ -67,14 +67,6 @@ def test_token_range_compatibility_argument(nodetool):
     nodetool("compact", "system_schema", "--start-token", "0", "--end-token", "1000", expected_requests=dummy_request)
 
 
-def test_partition_compatibility_argument(nodetool):
-    dummy_request = [
-            expected_request("GET", "/storage_service/keyspaces", multiple=True, response=["system", "system_schema"]),
-            expected_request("POST", "/storage_service/keyspace_compaction/system_schema")]
-
-    nodetool("compact", "system_schema", "--partition", "0", expected_requests=dummy_request)
-
-
 def test_user_defined(nodetool, scylla_only):
     with pytest.raises(subprocess.CalledProcessError) as e:
         nodetool("compact", "--user-defined", "/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/"

--- a/test/nodetool/test_gossip.py
+++ b/test/nodetool/test_gossip.py
@@ -1,0 +1,27 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from rest_api_mock import expected_request
+
+
+def test_disablegossip(nodetool):
+    nodetool("disablegossip", expected_requests=[
+        expected_request("DELETE", "/storage_service/gossiping")])
+
+
+def test_enablegossip(nodetool):
+    nodetool("enablegossip", expected_requests=[
+        expected_request("POST", "/storage_service/gossiping")])
+
+
+def test_statusgossip(nodetool):
+    out = nodetool("statusgossip", expected_requests=[
+        expected_request("GET", "/storage_service/gossiping", response=False)])
+    assert out == "not running\n"
+
+    out = nodetool("statusgossip", expected_requests=[
+        expected_request("GET", "/storage_service/gossiping", response=True)])
+    assert out == "running\n"

--- a/test/nodetool/test_help.py
+++ b/test/nodetool/test_help.py
@@ -1,0 +1,54 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import pytest
+import subprocess
+
+import utils
+
+
+# These are simple smoke tests, because automatically testing help is next to impossible.
+
+
+def test_help(nodetool):
+    out = nodetool("help")
+    assert out
+
+
+def test_help_command(nodetool):
+    out = nodetool("help", "version")
+    assert out
+
+
+def test_help_nonexistent_command(request, nodetool):
+    if request.config.getoption("nodetool") == "scylla":
+        utils.check_nodetool_fails_with(
+                nodetool,
+                ("help", "foo",),
+                {},
+                ["error processing arguments: unknown command foo"])
+    else:
+        out = nodetool("help", "foo")
+        assert out == "Unknown command foo\n\n"
+
+
+def test_help_command_too_many_args(nodetool, scylla_only):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("help", "compact", "foo", "bar"),
+            {},
+            ["error: too many positional options have been specified on the command line"])
+
+
+def test_help_consistent(nodetool, scylla_only):
+    for command in ("version", "compact", "settraceprobability"):
+        out1 = nodetool("help", command)
+        # seastar returns 1 when --help is invoked
+        with pytest.raises(subprocess.CalledProcessError) as e:
+            nodetool(command, "--help")
+        assert e.value.returncode == 1
+        out2 = e.value.stdout
+        assert out1 == out2

--- a/test/nodetool/test_traceprobability.py
+++ b/test/nodetool/test_traceprobability.py
@@ -1,0 +1,48 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from rest_api_mock import expected_request
+import utils
+
+
+def test_gettraceprobability(nodetool):
+    out = nodetool("gettraceprobability", expected_requests=[
+        expected_request("GET", "/storage_service/trace_probability", response=0.2)])
+
+    assert out == "Current trace probability: 0.2\n"
+
+
+def test_settraceprobability(nodetool):
+    nodetool("settraceprobability", "0.2", expected_requests=[
+        expected_request("POST", "/storage_service/trace_probability", params={"probability": "0.2"})])
+
+
+def test_settraceprobability_missing_param(nodetool):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("settraceprobability",),
+            {},
+            ["nodetool: Required parameters are missing: trace_probability",
+             "error processing arguments: required parameters are missing: trace_probability"])
+
+
+def test_settraceprobability_invalid_type(nodetool):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("settraceprobability", "adadad"),
+            {},
+            ["nodetool: trace_probability: can not convert \"adadad\" to a Double",
+             "error: the argument ('adadad') for option '--trace_probability' is invalid"])
+
+
+def test_settraceprobability_out_of_bounds(nodetool):
+    for value in ("-0.1", "1.1", "9000"):
+        utils.check_nodetool_fails_with(
+                nodetool,
+                ("settraceprobability", "--", value),
+                {},
+                ["nodetool: Trace probability must be between 0 and 1",
+                 "error processing arguments: trace probability must be between 0 and 1"])

--- a/test/nodetool/test_version.py
+++ b/test/nodetool/test_version.py
@@ -1,0 +1,14 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from rest_api_mock import expected_request
+
+
+def test_version(nodetool):
+    out = nodetool("version", expected_requests=[
+        expected_request("GET", "/storage_service/release_version", response="1.2.3")])
+
+    assert out == "ReleaseVersion: 1.2.3\n"

--- a/test/nodetool/utils.py
+++ b/test/nodetool/utils.py
@@ -1,0 +1,29 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import pytest
+import subprocess
+import typing
+
+
+def check_nodetool_fails_with(
+        nodetool,
+        nodetool_args: tuple,
+        nodetool_kwargs: dict,
+        expected_errors: typing.List[str]):
+
+    with pytest.raises(subprocess.CalledProcessError) as e:
+        nodetool(*nodetool_args, **nodetool_kwargs)
+
+    err_lines = e.value.stderr.rstrip().split('\n')
+    out_lines = e.value.stdout.rstrip().split('\n')
+
+    match = False
+    for expected_error in expected_errors:
+        if expected_error in err_lines or expected_error in out_lines:
+            match = True
+
+    assert match

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -78,6 +78,11 @@ public:
     rjson::value get(sstring path, std::unordered_map<sstring, sstring> params = {}) {
         return do_request("GET", std::move(path), std::move(params));
     }
+
+    // delete is a reserved keyword, using del instead
+    rjson::value del(sstring path, std::unordered_map<sstring, sstring> params = {}) {
+        return do_request("DELETE", std::move(path), std::move(params));
+    }
 };
 
 using operation_func = void(*)(scylla_rest_client&, const bpo::variables_map&);

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -117,6 +117,19 @@ void compact_operation(scylla_rest_client& client, const bpo::variables_map& vm)
     }
 }
 
+void disablebackup_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    client.post("/storage_service/incremental_backups", {{"value", "false"}});
+}
+
+void enablebackup_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    client.post("/storage_service/incremental_backups", {{"value", "true"}});
+}
+
+void statusbackup_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    auto status = client.get("/storage_service/incremental_backups");
+    fmt::print(std::cout, "{}\n", status.GetBool() ? "running" : "not running");
+}
+
 void version_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     auto version_json = client.get("/storage_service/release_version");
     fmt::print(std::cout, "ReleaseVersion: {}\n", rjson::to_string_view(version_json));
@@ -170,6 +183,40 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
                 }
             },
             compact_operation
+        },
+        {
+            {
+                "disablebackup",
+                "Disables incremental backup",
+R"(
+Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/disablebackup.html
+)",
+            },
+            disablebackup_operation
+        },
+        {
+            {
+                "enablebackup",
+                "Enables incremental backup",
+R"(
+Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/enablebackup.html
+)",
+            },
+            enablebackup_operation
+        },
+        {
+            {
+                "statusbackup",
+                "Displays the incremental backup status",
+R"(
+Results can be one of the following: `running` or `not running`.
+
+By default, the incremental backup status is `not running`.
+
+Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/statusbackup.html
+)",
+            },
+            statusbackup_operation
         },
         {
             {

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -159,7 +159,6 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
                     typed_option<>("user-defined", "Submit listed SStable files for user-defined compaction (unused)"),
                     typed_option<int64_t>("start-token", "Specify a token at which the compaction range starts (unused)"),
                     typed_option<int64_t>("end-token", "Specify a token at which the compaction range end (unused)"),
-                    typed_option<sstring>("partition", "String representation of the partition key to compact (unused)"),
                 },
                 {
                     typed_option<std::vector<sstring>>("compaction_arg", "[<keyspace> <tables>...] or [<SStable files>...] ", -1),

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -125,12 +125,20 @@ void disablebinary_operation(scylla_rest_client& client, const bpo::variables_ma
     client.del("/storage_service/native_transport");
 }
 
+void disablegossip_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    client.del("/storage_service/gossiping");
+}
+
 void enablebackup_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     client.post("/storage_service/incremental_backups", {{"value", "true"}});
 }
 
 void enablebinary_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     client.post("/storage_service/native_transport");
+}
+
+void enablegossip_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    client.post("/storage_service/gossiping");
 }
 
 void statusbackup_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
@@ -140,6 +148,11 @@ void statusbackup_operation(scylla_rest_client& client, const bpo::variables_map
 
 void statusbinary_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     auto status = client.get("/storage_service/native_transport");
+    fmt::print(std::cout, "{}\n", status.GetBool() ? "running" : "not running");
+}
+
+void statusgossip_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    auto status = client.get("/storage_service/gossiping");
     fmt::print(std::cout, "{}\n", status.GetBool() ? "running" : "not running");
 }
 
@@ -219,6 +232,16 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
         },
         {
             {
+                "disablegossip",
+                "Disable the gossip protocol",
+R"(
+Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/disablegossip.html
+)",
+            },
+            disablegossip_operation
+        },
+        {
+            {
                 "enablebackup",
                 "Enables incremental backup",
 R"(
@@ -238,6 +261,18 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
 )",
             },
             enablebinary_operation
+        },
+        {
+            {
+                "enablegossip",
+                "Enables the gossip protocol",
+R"(
+The gossip protocol is enabled by default.
+
+Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/enablegossip.html
+)",
+            },
+            enablegossip_operation
         },
         {
             {
@@ -269,6 +304,21 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
 )",
             },
             statusbinary_operation
+        },
+        {
+            {
+                "statusgossip",
+                "Displays the gossip status",
+R"(
+Provides the status of gossip.
+Results can be one of the following: `running` or `not running`.
+
+By default, the gossip protocol is `running`.
+
+Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/statusgossip.html
+)",
+            },
+            statusgossip_operation
         },
         {
             {

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -191,7 +191,7 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
                     typed_option<sstring>("partition", "String representation of the partition key to compact (unused)"),
                 },
                 {
-                    {"compaction_arg", bpo::value<std::vector<sstring>>(), "[<keyspace> <tables>...] or [<SStable files>...] ", -1},
+                    typed_option<std::vector<sstring>>("compaction_arg", "[<keyspace> <tables>...] or [<SStable files>...] ", -1),
                 }
             },
             compact_operation

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -117,6 +117,11 @@ void compact_operation(scylla_rest_client& client, const bpo::variables_map& vm)
     }
 }
 
+void version_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    auto version_json = client.get("/storage_service/release_version");
+    fmt::print(std::cout, "ReleaseVersion: {}\n", rjson::to_string_view(version_json));
+}
+
 const std::vector<operation_option> global_options{
     typed_option<sstring>("host,h", "localhost", "the hostname or ip address of the ScyllaDB node"),
     typed_option<uint16_t>("port,p", 10000, "the port of the REST API of the ScyllaDB node"),
@@ -165,6 +170,20 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
                 }
             },
             compact_operation
+        },
+        {
+            {
+                "version",
+                "Displays the Apache Cassandra version which your version of Scylla is most compatible with",
+R"(
+Displays the Apache Cassandra version which your version of Scylla is most
+compatible with, not your current Scylla version. To display the Scylla version,
+run `scylla --version`.
+
+For more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/version.html
+)",
+            },
+            version_operation
         },
     };
 

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -82,47 +82,6 @@ public:
 
 using operation_func = void(*)(scylla_rest_client&, const bpo::variables_map&);
 
-enum class json_type {
-    null, boolean, object, array, string, number
-};
-
-const rjson::value& check_json_type(const rjson::value& value, json_type type) {
-    bool ok = false;
-    sstring type_name = "unknown";
-    switch (type) {
-        case json_type::null:
-            ok = value.IsNull();
-            type_name = "null";
-            break;
-        case json_type::boolean:
-            ok = value.IsBool();
-            type_name = "bool";
-            break;
-        case json_type::object:
-            ok = value.IsObject();
-            type_name = "object";
-            break;
-        case json_type::array:
-            ok = value.IsArray();
-            type_name = "array";
-            break;
-        case json_type::string:
-            ok = value.IsString();
-            type_name = "string";
-            break;
-        case json_type::number:
-            ok = value.IsNumber();
-            type_name = "number";
-            break;
-        default:
-            throw std::runtime_error(fmt::format("check_json_type(): unknown type: {}", static_cast<int>(type)));
-    }
-    if (!ok) {
-        throw std::runtime_error(fmt::format("check_json_type(): json value is not of the expected type: {}", type_name));
-    }
-    return value;
-}
-
 void compact_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     if (vm.count("user-defined")) {
         throw std::invalid_argument("--user-defined flag is unsupported");
@@ -130,8 +89,8 @@ void compact_operation(scylla_rest_client& client, const bpo::variables_map& vm)
 
     auto keyspaces_json = client.get("/storage_service/keyspaces", {});
     std::vector<sstring> all_keyspaces;
-    for (const auto& keyspace_json : check_json_type(keyspaces_json, json_type::array).GetArray()) {
-        all_keyspaces.emplace_back(rjson::to_string_view(check_json_type(keyspace_json, json_type::string)));
+    for (const auto& keyspace_json : keyspaces_json.GetArray()) {
+        all_keyspaces.emplace_back(rjson::to_string_view(keyspace_json));
     }
 
     if (vm.count("compaction_arg")) {

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -121,12 +121,25 @@ void disablebackup_operation(scylla_rest_client& client, const bpo::variables_ma
     client.post("/storage_service/incremental_backups", {{"value", "false"}});
 }
 
+void disablebinary_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    client.del("/storage_service/native_transport");
+}
+
 void enablebackup_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     client.post("/storage_service/incremental_backups", {{"value", "true"}});
 }
 
+void enablebinary_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    client.post("/storage_service/native_transport");
+}
+
 void statusbackup_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     auto status = client.get("/storage_service/incremental_backups");
+    fmt::print(std::cout, "{}\n", status.GetBool() ? "running" : "not running");
+}
+
+void statusbinary_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    auto status = client.get("/storage_service/native_transport");
     fmt::print(std::cout, "{}\n", status.GetBool() ? "running" : "not running");
 }
 
@@ -196,6 +209,16 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
         },
         {
             {
+                "disablebinary",
+                "Disable the CQL native protocol",
+R"(
+Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/disablebinary.html
+)",
+            },
+            disablebinary_operation
+        },
+        {
+            {
                 "enablebackup",
                 "Enables incremental backup",
 R"(
@@ -203,6 +226,18 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
 )",
             },
             enablebackup_operation
+        },
+        {
+            {
+                "enablebinary",
+                "Enables the CQL native protocol",
+R"(
+The native protocol is enabled by default.
+
+Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/enablebinary.html
+)",
+            },
+            enablebinary_operation
         },
         {
             {
@@ -217,6 +252,23 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
 )",
             },
             statusbackup_operation
+        },
+        {
+            {
+                "statusbinary",
+                "Displays the incremental backup status",
+R"(
+Provides the status of native transport - CQL (binary protocol).
+In case that you don’t want to use CQL you can disable it using the disablebinary
+command.
+Results can be one of the following: `running` or `not running`.
+
+By default, the native transport is `running`.
+
+Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/statusbinary.html
+)",
+            },
+            statusbinary_operation
         },
         {
             {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2529,12 +2529,9 @@ const std::vector<operation_option> global_options {
     typed_option<sstring>("scylla-data-dir", "path to the scylla data dir (usually /var/lib/scylla/data), to read the schema tables from"),
 };
 
-static auto get_global_positional_options() {
-    static const std::vector<app_template::positional_option> options = {
-        {"sstables", bpo::value<std::vector<sstring>>(), "sstable(s) to process for operations that have sstable inputs, can also be provided as positional arguments", -1},
-    };
-    return &options;
-}
+const std::vector<operation_option> global_positional_options{
+    typed_option<std::vector<sstring>>("sstables", "sstable(s) to process for operations that have sstable inputs, can also be provided as positional arguments", -1),
+};
 
 const std::map<operation, operation_func> operations_with_func{
 /* dump-data */
@@ -2891,7 +2888,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
             .lsa_segment_pool_backend_size_mb = 100,
             .operations = std::move(operations),
             .global_options = &global_options,
-            .global_positional_options = get_global_positional_options()};
+            .global_positional_options = &global_positional_options};
     tool_app_template app(std::move(app_cfg));
 
     return app.run_async(argc, argv, [] (const operation& operation, const bpo::variables_map& app_config) {

--- a/tools/scylla-types.cc
+++ b/tools/scylla-types.cc
@@ -245,12 +245,9 @@ const std::vector<operation_option> global_options{
     typed_option<unsigned>("ignore-msb-bits", 12u, "number of shards (only relevant for shardof action)"),
 };
 
-static auto get_global_positional_options() {
-    static const std::vector<app_template::positional_option> options{
-        {"value", bpo::value<std::vector<sstring>>(), "value(s) to process, can also be provided as positional arguments", -1}
-    };
-    return &options;
-}
+const std::vector<operation_option> global_positional_options{
+    typed_option<std::vector<sstring>>("value", "value(s) to process, can also be provided as positional arguments", -1),
+};
 
 const std::map<operation, operation_func_variant> operations_with_func = {
     {{"serialize", "serialize the value and print it in hex encoded form",
@@ -380,7 +377,7 @@ $ scylla types {{action}} --help
                 [] (const operation& op) { return format("* {} - {}", op.name(), op.summary()); } ), "\n")),
         .operations = std::move(operations),
         .global_options = &global_options,
-        .global_positional_options = get_global_positional_options(),
+        .global_positional_options = &global_positional_options,
     };
     tool_app_template app(std::move(app_cfg));
 

--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -15,6 +15,10 @@
 
 namespace tools::utils {
 
+bool operation::matches(std::string_view name) const {
+    return _name == name || std::ranges::find(_aliases, name) != _aliases.end();
+}
+
 namespace {
 
 // Extract the operation from the argv.
@@ -30,7 +34,7 @@ const operation& get_selected_operation(int& ac, char**& av, const std::vector<o
 
     const char* op_name = av[1];
     if (auto found = std::ranges::find_if(operations, [op_name] (auto& op) {
-                         return op.name() == op_name;
+            return op.matches(op_name);
         });
         found != operations.end()) {
         std::shift_left(av + 1, av + ac, 1);
@@ -38,7 +42,13 @@ const operation& get_selected_operation(int& ac, char**& av, const std::vector<o
         return *found;
     }
 
-    const auto all_operation_names = boost::algorithm::join(operations | boost::adaptors::transformed([] (const operation op) { return op.name(); } ), ", ");
+    std::vector<std::string_view> all_operation_names;
+    for (const auto& op : operations) {
+        all_operation_names.push_back(op.name());
+        for (const auto& alias : op.aliases()) {
+            all_operation_names.push_back(alias);
+        }
+    }
 
     fmt::print(std::cerr, "error: unrecognized {} argument: expected one of ({}), got {}\n", alias, all_operation_names, op_name);
     exit(100);

--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -107,7 +107,7 @@ int tool_app_template::run_async(int argc, char** argv, noncopyable_function<int
     }
     if (_cfg.global_positional_options) {
         for (const auto& gpo : *_cfg.global_positional_options) {
-            app.add_positional_options({gpo});
+            app.add_positional_options({gpo.to_positional_option()});
         }
     }
 
@@ -117,7 +117,7 @@ int tool_app_template::run_async(int argc, char** argv, noncopyable_function<int
             opt.add_option(op_desc);
         }
         for (const auto& opt : found_op->positional_options()) {
-            app.add_positional_options({opt});
+            app.add_positional_options({opt.to_positional_option()});
         }
         if (!found_op->options().empty()) {
             app.get_options_description().add(op_desc);

--- a/tools/utils.hh
+++ b/tools/utils.hh
@@ -65,6 +65,7 @@ public:
 
 class operation {
     std::string _name;
+    std::vector<std::string> _aliases;
     std::string _summary;
     std::string _description;
     std::vector<operation_option> _options;
@@ -73,22 +74,37 @@ class operation {
 public:
     operation(
             std::string name,
+            std::vector<std::string> aliases,
             std::string summary,
             std::string description,
             std::vector<operation_option> options = {},
             std::vector<app_template::positional_option> positional_options = {})
         : _name(std::move(name))
+        , _aliases(std::move(aliases))
         , _summary(std::move(summary))
         , _description(std::move(description))
         , _options(std::move(options))
         , _positional_options(std::move(positional_options)) {
     }
 
+    operation(
+            std::string name,
+            std::string summary,
+            std::string description,
+            std::vector<operation_option> options = {},
+            std::vector<app_template::positional_option> positional_options = {})
+        : operation(std::move(name), {}, std::move(summary), std::move(description), std::move(options), std::move(positional_options))
+    {}
+
     const std::string& name() const { return _name; }
+    const std::vector<std::string> aliases() const { return _aliases; }
     const std::string& summary() const { return _summary; }
     const std::string& description() const { return _description; }
     const std::vector<operation_option>& options() const { return _options; }
     const std::vector<app_template::positional_option>& positional_options() const { return _positional_options; }
+
+    // Does the name or any of the aliases matches the provided name?
+    bool matches(std::string_view name) const;
 };
 
 inline bool operator<(const operation& a, const operation& b) {

--- a/tools/utils.hh
+++ b/tools/utils.hh
@@ -143,6 +143,8 @@ public:
         : _cfg(std::move(cfg))
     { }
 
+    const config& get_config() const { return _cfg; }
+
     int run_async(int argc, char** argv, noncopyable_function<int(const operation&, const boost::program_options::variables_map&)> main_func);
 };
 


### PR DESCRIPTION
The following new commands are implemented:
* disablebackup
* disablebinary
* disablegossip
* enablebackup
* enablebinary
* enablegossip
* gettraceprobability
* help
* settraceprobability
* statusbackup
* statusbinary
* statusgossip
* version

All are associated with tests. All tests (both old and new) pass with both the scylla-native and the cassandra nodetool implementation.

Refs: https://github.com/scylladb/scylladb/issues/15588