### PR TITLE
Sanitize tracing start-stop calls

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1093,8 +1093,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             supervisor::notify("creating tracing");
             sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
             tracing.start(sstring("trace_keyspace_helper")).get();
-            auto destroy_tracing = defer_verbose_shutdown("tracing instance", [] {
-                tracing::tracing::tracing_instance().stop().get();
+            auto destroy_tracing = defer_verbose_shutdown("tracing instance", [&tracing] {
+                tracing.stop().get();
             });
 
             with_scheduling_group(maintenance_scheduling_group, [&] {

--- a/main.cc
+++ b/main.cc
@@ -1689,7 +1689,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }).get();
 
             supervisor::notify("starting tracing");
-            tracing::tracing::start_tracing(qp, mm).get();
+            tracing.invoke_on_all(&tracing::tracing::start, std::ref(qp), std::ref(mm)).get();
             auto stop_tracing = defer_verbose_shutdown("tracing", [] {
                 tracing::tracing::stop_tracing().get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1091,7 +1091,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // });
 
             supervisor::notify("creating tracing");
-            tracing::tracing::create_tracing("trace_keyspace_helper").get();
+            sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
+            tracing.start(sstring("trace_keyspace_helper")).get();
             auto destroy_tracing = defer_verbose_shutdown("tracing instance", [] {
                 tracing::tracing::tracing_instance().stop().get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1690,8 +1690,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             supervisor::notify("starting tracing");
             tracing.invoke_on_all(&tracing::tracing::start, std::ref(qp), std::ref(mm)).get();
-            auto stop_tracing = defer_verbose_shutdown("tracing", [] {
-                tracing::tracing::stop_tracing().get();
+            auto stop_tracing = defer_verbose_shutdown("tracing", [&tracing] {
+                tracing.invoke_on_all(&tracing::tracing::shutdown).get();
             });
 
             startlog.info("SSTable data integrity checker is {}.",

--- a/test/boost/tracing_test.cc
+++ b/test/boost/tracing_test.cc
@@ -18,8 +18,7 @@ future<> do_with_tracing_env(std::function<future<>(cql_test_env&)> func, cql_te
     return do_with_cql_env_thread([func](auto &env) {
         sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
         tracing.start(sstring("trace_keyspace_helper")).get();
-
-        tracing::tracing::start_tracing(env.qp(), env.migration_manager()).get();
+        tracing.invoke_on_all(&tracing::tracing::start, std::ref(env.qp()), std::ref(env.migration_manager())).get();
 
         func(env).finally([]() {
             return tracing::tracing::tracing_instance().invoke_on_all([](tracing::tracing &local_tracing) {

--- a/test/boost/tracing_test.cc
+++ b/test/boost/tracing_test.cc
@@ -16,7 +16,8 @@
 
 future<> do_with_tracing_env(std::function<future<>(cql_test_env&)> func, cql_test_config cfg_in = {}) {
     return do_with_cql_env_thread([func](auto &env) {
-        tracing::tracing::create_tracing("trace_keyspace_helper").get();
+        sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
+        tracing.start(sstring("trace_keyspace_helper")).get();
 
         tracing::tracing::start_tracing(env.qp(), env.migration_manager()).get();
 

--- a/tracing/trace_keyspace_helper.hh
+++ b/tracing/trace_keyspace_helper.hh
@@ -62,7 +62,7 @@ public:
     // requested during the initialization phase.
     virtual future<> start(cql3::query_processor& qp, service::migration_manager& mm) override;
 
-    virtual future<> stop() override {
+    virtual future<> shutdown() override {
         return _pending_writes.close().then([this] {
             _qp_anchor = nullptr;
             _mm_anchor = nullptr;

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -68,13 +68,6 @@ tracing::tracing(sstring tracing_backend_helper_class_name)
     });
 }
 
-future<> tracing::stop_tracing() {
-    return tracing_instance().invoke_on_all([] (tracing& local_tracing) {
-        // It might have been shut down while draining
-        return local_tracing.shutdown();
-    });
-}
-
 bool tracing::may_create_new_session(const std::optional<utils::UUID>& session_id) {
     // Don't create a session if its records are likely to be dropped
     if (!have_records_budget(exp_trace_events_per_session) || _active_sessions >= max_pending_sessions + write_event_sessions_threshold) {

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -68,12 +68,6 @@ tracing::tracing(sstring tracing_backend_helper_class_name)
     });
 }
 
-future<> tracing::start_tracing(sharded<cql3::query_processor>& qp, sharded<service::migration_manager>& mm) {
-    return tracing_instance().invoke_on_all([&qp, &mm] (tracing& local_tracing) {
-        return local_tracing.start(qp.local(), mm.local());
-    });
-}
-
 future<> tracing::stop_tracing() {
     return tracing_instance().invoke_on_all([] (tracing& local_tracing) {
         // It might have been shut down while draining

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -68,10 +68,6 @@ tracing::tracing(sstring tracing_backend_helper_class_name)
     });
 }
 
-future<> tracing::create_tracing(sstring tracing_backend_class_name) {
-    return tracing_instance().start(std::move(tracing_backend_class_name));
-}
-
 future<> tracing::start_tracing(sharded<cql3::query_processor>& qp, sharded<service::migration_manager>& mm) {
     return tracing_instance().invoke_on_all([&qp, &mm] (tracing& local_tracing) {
         return local_tracing.start(qp.local(), mm.local());

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -180,7 +180,7 @@ future<> tracing::shutdown() {
     write_pending_records();
     _down = true;
     _write_timer.cancel();
-    return _tracing_backend_helper_ptr->stop().then([] {
+    return _tracing_backend_helper_ptr->shutdown().then([] {
         tracing_logger.info("Tracing is down");
     });
 }

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -420,7 +420,6 @@ public:
         return !_down;
     }
 
-    static future<> create_tracing(sstring tracing_backend_helper_class_name);
     static future<> start_tracing(sharded<cql3::query_processor>& qp, sharded<service::migration_manager>& mm);
     static future<> stop_tracing();
     tracing(sstring tracing_backend_helper_class_name);

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -420,7 +420,6 @@ public:
         return !_down;
     }
 
-    static future<> start_tracing(sharded<cql3::query_processor>& qp, sharded<service::migration_manager>& mm);
     static future<> stop_tracing();
     tracing(sstring tracing_backend_helper_class_name);
 

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -156,7 +156,7 @@ public:
     i_tracing_backend_helper(tracing& tr) : _local_tracing(tr) {}
     virtual ~i_tracing_backend_helper() {}
     virtual future<> start(cql3::query_processor& qp, service::migration_manager& mm) = 0;
-    virtual future<> stop() = 0;
+    virtual future<> shutdown() = 0;
 
     /**
      * Write a bulk of tracing records.

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -420,7 +420,6 @@ public:
         return !_down;
     }
 
-    static future<> stop_tracing();
     tracing(sstring tracing_backend_helper_class_name);
 
     // Initialize a tracing backend (e.g. tracing_keyspace or logstash)


### PR DESCRIPTION
Tracing is one of two global service left out there with its starting and stopping being pretty hairy. In order to de-globalize it and keep its start-stop under control the existing start-stop sequence is worth cleaning. This PR

 * removes create_ , start_ and stop_ wrappers to un-hide the global tracing_instance thing
 * renames tracing::stop() to shutdown() as it's in fact shutdown
 * coroutinizes start/shutdown/stop while at it

Squeezed parts from #14156 that don't reorder start-stop calls