### PR TITLE
Do not keep excessive info on sstables::entry_descriptor

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2788,7 +2788,7 @@ future<> system_keyspace::sstables_registry_list(sstring location, sstable_regis
         auto gen = sstables::generation_type(row.get_as<utils::UUID>("generation"));
         auto ver = sstables::version_from_string(row.get_as<sstring>("version"));
         auto fmt = sstables::format_from_string(row.get_as<sstring>("format"));
-        sstables::entry_descriptor desc("", "", "", gen, ver, fmt, sstables::component_type::TOC);
+        sstables::entry_descriptor desc(gen, ver, fmt, sstables::component_type::TOC);
         co_await consumer(std::move(uuid), std::move(status), std::move(desc));
         co_return stop_iteration::no;
     });

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1905,7 +1905,7 @@ future<std::unordered_map<sstring, table::snapshot_details>> table::get_snapshot
                         // All the others should just generate an exception: there is something wrong, so don't blindly
                         // add it to the size.
                         if (name != "manifest.json" && name != "schema.cql") {
-                            sstables::entry_descriptor::make_descriptor(snapshot_dir / name);
+                            sstables::parse_path(snapshot_dir / name);
                             all_snapshots.at(snapshot_name).total += size;
                         } else {
                             size = 0;

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -36,7 +36,9 @@ struct entry_descriptor {
         : sstdir(sstdir), ks(ks), cf(cf), generation(generation), version(version), format(format), component(component) {}
 };
 
-entry_descriptor parse_path(const std::filesystem::path& sst_path);
+// Parses sstable file path extracting entry_descriptor from it. Returns the descriptor
+// and the keyspace.table pair of strings.
+std::tuple<entry_descriptor, sstring, sstring> parse_path(const std::filesystem::path& sst_path);
 
 // Use the given ks and cf and don't attempt to extract it from the dir path.
 // This allows loading sstables from any path, but the filename still has to be valid.

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -30,17 +30,17 @@ struct entry_descriptor {
     sstable_format_types format;
     component_type component;
 
-    static entry_descriptor make_descriptor(const std::filesystem::path& sst_path);
-
-    // Use the given ks and cf and don't attempt to extract it from the dir path.
-    // This allows loading sstables from any path, but the filename still has to be valid.
-    static entry_descriptor make_descriptor(const std::filesystem::path& sst_path, sstring ks, sstring cf);
-
     entry_descriptor(std::string_view sstdir, sstring ks, sstring cf, generation_type generation,
                      sstable_version_types version, sstable_format_types format,
                      component_type component)
         : sstdir(sstdir), ks(ks), cf(cf), generation(generation), version(version), format(format), component(component) {}
 };
+
+entry_descriptor parse_path(const std::filesystem::path& sst_path);
+
+// Use the given ks and cf and don't attempt to extract it from the dir path.
+// This allows loading sstables from any path, but the filename still has to be valid.
+entry_descriptor parse_path(const std::filesystem::path& sst_path, sstring ks, sstring cf);
 
 // contains data for loading a sstable using components shared by a single shard;
 // can be moved across shards

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -22,18 +22,15 @@
 namespace sstables {
 
 struct entry_descriptor {
-    sstring sstdir;
-    sstring ks;
-    sstring cf;
     generation_type generation;
     sstable_version_types version;
     sstable_format_types format;
     component_type component;
 
-    entry_descriptor(std::string_view sstdir, sstring ks, sstring cf, generation_type generation,
+    entry_descriptor(generation_type generation,
                      sstable_version_types version, sstable_format_types format,
                      component_type component)
-        : sstdir(sstdir), ks(ks), cf(cf), generation(generation), version(version), format(format), component(component) {}
+        : generation(generation), version(version), format(format), component(component) {}
 };
 
 // Parses sstable file path extracting entry_descriptor from it. Returns the descriptor

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -270,7 +270,7 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
                 break;
             }
             auto component_path = _directory / de->name;
-            auto comps = sstables::entry_descriptor::make_descriptor(component_path);
+            auto comps = sstables::parse_path(component_path);
             handle(std::move(comps), component_path);
         }
     } catch (...) {
@@ -444,7 +444,7 @@ sstable_directory::collect_output_unshared_sstables(std::vector<sstables::shared
         }
 
         dirlog.trace("Collected output SSTable {} is remote. Storing it", sst->get_filename());
-        _unshared_remote_sstables[shard].push_back(sstables::entry_descriptor::make_descriptor(_sstable_dir / sst->component_basename(component_type::Data)));
+        _unshared_remote_sstables[shard].push_back(sstables::parse_path(_sstable_dir / sst->component_basename(component_type::Data)));
         return make_ready_future<>();
     });
 }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -270,7 +270,7 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
                 break;
             }
             auto component_path = _directory / de->name;
-            auto comps = sstables::parse_path(component_path);
+            auto [ comps, ks, cf ] = sstables::parse_path(component_path);
             handle(std::move(comps), component_path);
         }
     } catch (...) {
@@ -444,7 +444,8 @@ sstable_directory::collect_output_unshared_sstables(std::vector<sstables::shared
         }
 
         dirlog.trace("Collected output SSTable {} is remote. Storing it", sst->get_filename());
-        _unshared_remote_sstables[shard].push_back(sstables::parse_path(_sstable_dir / sst->component_basename(component_type::Data)));
+        auto [ desc, ks, cf ] = sstables::parse_path(_sstable_dir / sst->component_basename(component_type::Data));
+        _unshared_remote_sstables[shard].push_back(std::move(desc));
         return make_ready_future<>();
     });
 }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -444,8 +444,7 @@ sstable_directory::collect_output_unshared_sstables(std::vector<sstables::shared
         }
 
         dirlog.trace("Collected output SSTable {} is remote. Storing it", sst->get_filename());
-        auto [ desc, ks, cf ] = sstables::parse_path(_sstable_dir / sst->component_basename(component_type::Data));
-        _unshared_remote_sstables[shard].push_back(std::move(desc));
+        _unshared_remote_sstables[shard].push_back(sst->get_descriptor(component_type::Data));
         return make_ready_future<>();
     });
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2160,7 +2160,7 @@ static std::tuple<entry_descriptor, sstring, sstring> make_entry_descriptor(std:
     } else {
         throw malformed_sstable_exception(seastar::format("invalid version for file {}. Name doesn't match any known version.", fname));
     }
-    return std::make_tuple(entry_descriptor(sstdir, ks, cf, generation_type::from_string(generation), version, format_from_string(format), sstable::component_from_sstring(version, component)), ks, cf);
+    return std::make_tuple(entry_descriptor(generation_type::from_string(generation), version, format_from_string(format), sstable::component_from_sstring(version, component)), ks, cf);
 }
 
 std::tuple<entry_descriptor, sstring, sstring> parse_path(const std::filesystem::path& sst_path) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2163,11 +2163,11 @@ static entry_descriptor make_entry_descriptor(std::string_view sstdir, std::stri
     return entry_descriptor(sstdir, ks, cf, generation_type::from_string(generation), version, format_from_string(format), sstable::component_from_sstring(version, component));
 }
 
-entry_descriptor entry_descriptor::make_descriptor(const std::filesystem::path& sst_path) {
+entry_descriptor parse_path(const std::filesystem::path& sst_path) {
     return make_entry_descriptor(sst_path.parent_path().native(), sst_path.filename().native(), nullptr, nullptr);
 }
 
-entry_descriptor entry_descriptor::make_descriptor(const std::filesystem::path& sst_path, sstring ks, sstring cf) {
+entry_descriptor parse_path(const std::filesystem::path& sst_path, sstring ks, sstring cf) {
     return make_entry_descriptor(sst_path.parent_path().native(), sst_path.filename().native(), &ks, &cf);
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2163,8 +2163,9 @@ static entry_descriptor make_entry_descriptor(std::string_view sstdir, std::stri
     return entry_descriptor(sstdir, ks, cf, generation_type::from_string(generation), version, format_from_string(format), sstable::component_from_sstring(version, component));
 }
 
-entry_descriptor parse_path(const std::filesystem::path& sst_path) {
-    return make_entry_descriptor(sst_path.parent_path().native(), sst_path.filename().native(), nullptr, nullptr);
+std::tuple<entry_descriptor, sstring, sstring> parse_path(const std::filesystem::path& sst_path) {
+    auto desc = make_entry_descriptor(sst_path.parent_path().native(), sst_path.filename().native(), nullptr, nullptr);
+    return std::make_tuple(desc, desc.ks, desc.cf);
 }
 
 entry_descriptor parse_path(const std::filesystem::path& sst_path, sstring ks, sstring cf) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1445,6 +1445,10 @@ future<foreign_sstable_open_info> sstable::get_open_info() & {
     });
 }
 
+entry_descriptor sstable::get_descriptor(component_type c) const {
+    return entry_descriptor(_generation, _version, _format, c);
+}
+
 future<>
 sstable::load_owner_shards(const dht::sharder& sharder) {
     if (!_shards.empty()) {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -885,6 +885,7 @@ public:
     // get sstable open info from a loaded sstable, which can be used to quickly open a sstable
     // at another shard.
     future<foreign_sstable_open_info> get_open_info() &;
+    entry_descriptor get_descriptor(component_type c) const;
 
     sstables_stats& get_stats() {
         return _stats;

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -488,7 +488,7 @@ future<> s3_storage::ensure_remote_prefix(const sstable& sst) {
 
 void s3_storage::open(sstable& sst) {
     auto uuid = utils::UUID_gen::get_time_UUID();
-    entry_descriptor desc("", "", "", sst._generation, sst._version, sst._format, component_type::TOC);
+    entry_descriptor desc(sst._generation, sst._version, sst._format, component_type::TOC);
     sst.manager().system_keyspace().sstables_registry_create_entry(_location, uuid, status_creating, std::move(desc)).get();
     _remote_prefix = uuid.to_sstring();
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -221,12 +221,12 @@ std::optional<schema_with_source> try_load_schema_autodetect(const bpo::variable
             // Detect whether sstable is in root table directory, or in a sub-directory
             // The last component is "" due to the trailing "/" left by "remove_filename()" above.
             // So we need to go back 2 more, to find the supposed keyspace component.
-            if (ed.ks == std::prev(sst_dir_path.end(), 3)->native()) {
+            if (ks == std::prev(sst_dir_path.end(), 3)->native()) {
                 data_dir_path = sst_dir_path / ".." / "..";
             } else {
                 data_dir_path = sst_dir_path / ".." / ".." / "..";
             }
-            return schema_with_source{.schema = tools::load_schema_from_schema_tables(data_dir_path, ed.ks, ed.cf).get(),
+            return schema_with_source{.schema = tools::load_schema_from_schema_tables(data_dir_path, ks, cf).get(),
                 .source = "schema-tables",
                 .path = data_dir_path,
                 .obtained_from = format("sstable path ({})", sst_path)};

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -215,7 +215,7 @@ std::optional<schema_with_source> try_load_schema_autodetect(const bpo::variable
     if (app_config.count("sstables")) {
         try {
             auto sst_path = std::filesystem::path(app_config["sstables"].as<std::vector<sstring>>().front());
-            auto ed = sstables::parse_path(sst_path);
+            auto [ed, ks, cf] = sstables::parse_path(sst_path);
             const auto sst_dir_path = std::filesystem::path(sst_path).remove_filename();
             std::filesystem::path data_dir_path;
             // Detect whether sstable is in root table directory, or in a sub-directory

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -215,7 +215,7 @@ std::optional<schema_with_source> try_load_schema_autodetect(const bpo::variable
     if (app_config.count("sstables")) {
         try {
             auto sst_path = std::filesystem::path(app_config["sstables"].as<std::vector<sstring>>().front());
-            auto ed = sstables::entry_descriptor::make_descriptor(sst_path);
+            auto ed = sstables::parse_path(sst_path);
             const auto sst_dir_path = std::filesystem::path(sst_path).remove_filename();
             std::filesystem::path data_dir_path;
             // Detect whether sstable is in root table directory, or in a sub-directory
@@ -291,7 +291,7 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
         }
 
 
-        auto ed = sstables::entry_descriptor::make_descriptor(sst_path, schema->ks_name(), schema->cf_name());
+        auto ed = sstables::parse_path(sst_path, schema->ks_name(), schema->cf_name());
         const auto dir_path = sst_path.parent_path();
         data_dictionary::storage_options local;
         auto sst = sst_man.make_sstable(schema, dir_path.c_str(), local, ed.generation, sstables::sstable_state::normal, ed.version, ed.format);


### PR DESCRIPTION
The descriptor in question is used to parse sstable's file path and return back the result. Parser, among "relevant" info, also parses sstable directory and keyspace+table names. However, there are no code (almost) that needs those strings. And the need to construct descriptor with those makes some places obscurely use empty strings.

The PR removes sstable's directory, keyspace and table names from descriptor and, while at it, relaxes the sstable directory code that makes descriptor out of a real sstable object by (!) parsing its Data file path back.