### PR TITLE
storage_service: increase timeout during join procedure to 3 minutes

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2594,7 +2594,7 @@ public:
 
         // Processing of the response is done in `join_node_response_handler`.
         // Wait for it to complete.
-        co_await _ss._join_node_response_done.get_shared_future(lowres_clock::now() + std::chrono::seconds(30));
+        co_await _ss._join_node_response_done.get_shared_future(lowres_clock::now() + std::chrono::minutes(3));
         slogger.info("raft topology: join: success");
         co_return true;
     }


### PR DESCRIPTION
When joining the cluster in raft topology mode, the new node asks some existing node in the cluster to put its information to the `system.topology` table. Later, the topology coordinator is supposed to contact the joining node back, telling it that it was added to group 0 and accepted, or rejected. Due to the fact that the topology coordinator might not manage to successfully contact the joining node, in order not to get stuck it might decide to give up and move the node to left state and forget about it (this not always happens as of now, but will in the future). Because of that, the joining node must use a timeout when waiting for a response because it's not guaranteed that it will ever receive it.

There is an additional complication: the topology coordinator might be busy and not notice the request to join for a long time. For example, it might be migrating tablets or joining other nodes which are in the queue before it. Therefore, it's difficult to choose a timeout which is long enough for every case and still not too long.

Such a failure was observed to happen in ARM tests in debug mode. In order to unblock the CI the timeout is increased from 30 seconds to 3 minutes. As a proper solution, the procedure will most likely have to be adjusted in a more significant way.

Fixes: #15600