### PR TITLE
docs: nodetool compact: remove unused and unrecognized options

### DIFF
--- a/docs/operating-scylla/nodetool-commands/compact.rst
+++ b/docs/operating-scylla/nodetool-commands/compact.rst
@@ -15,26 +15,10 @@ Syntax
 -------
 .. code-block:: console
 
-   nodetool [options] compact [--partition <partition_key>] [<keyspace> [<cfnames>]...]
+   nodetool [options] compact [<keyspace> [<cfnames>]...]
 
 Options
 --------
-
-* ``-h <host>`` or  ``--host <host>`` - Node hostname or IP address.
-
-* ``-p <port>`` or ``--port <port>`` - Remote JMX agent port number.
-
-* ``--partition <partition_key>`` - String representation of the partition key.
-
-* ``-pp`` or ``--print-port`` - Operate in 4.0 mode with hosts disambiguated by port number.
-
-* ``-pw <password>`` or ``--password <password>`` - Remote JMX agent password.
-
-* ``-pwf <passwordFilePath>`` or ``--password-file <passwordFilePath>`` - Path to the JMX password file.
-
-* ``-u <username>`` or ``--username <username>`` - Remote JMX agent username.
-
-* ``--`` - Separates command-line options from the list of argument(useful when an argument might be mistaken for a command-line option).
 
 The following options are NOT supported:
 


### PR DESCRIPTION
The doc page for nodetool compact lists a bunch of JMX related options that are just distracting. These are common to all nodetool commands, no need to list them just on the page for nodetool compact. Also remove the --partition option, which is not even recognized by the current nodetool.