### PR TITLE
Regenerate frozen toolchain for new Python driver

### DIFF
--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-38-20230919
+docker.io/scylladb/scylla-toolchain:fedora-38-20231004


### PR DESCRIPTION
Update to scylla-driver 3.26.3.