### PR TITLE
db/hints: Modernize manager

### DIFF
--- a/db/hints/internal/hint_endpoint_manager.cc
+++ b/db/hints/internal/hint_endpoint_manager.cc
@@ -43,7 +43,7 @@ bool hint_endpoint_manager::store_hint(schema_ptr s, lw_shared_ptr<const frozen_
             return with_shared(file_update_mutex(), [this, fm, s, tr_state] () mutable -> future<> {
                 return get_or_load().then([this, fm = std::move(fm), s = std::move(s), tr_state] (hints_store_ptr log_ptr) mutable {
                     commitlog_entry_writer cew(s, *fm, db::commitlog::force_sync::no);
-                    return log_ptr->add_entry(s->id(), cew, db::timeout_clock::now() + _shard_manager.hint_file_write_timeout);
+                    return log_ptr->add_entry(s->id(), cew, db::timeout_clock::now() + _shard_manager.HINT_FILE_WRITE_TIMEOUT);
                 }).then([this, tr_state] (db::rp_handle rh) {
                     auto rp = rh.release();
                     if (_last_written_rp < rp) {

--- a/db/hints/internal/hint_endpoint_manager.cc
+++ b/db/hints/internal/hint_endpoint_manager.cc
@@ -285,6 +285,11 @@ future<> hint_endpoint_manager::flush_current_hints() noexcept {
     return make_ready_future<>();
 }
 
+future<> hint_endpoint_manager::with_file_update_mutex(noncopyable_function<future<> ()> func) {
+    return with_lock(*_file_update_mutex_ptr, std::move(func)).finally(
+            [lock_ptr = _file_update_mutex_ptr] {/* extend lifetime of the lock */});
+}
+
 bool hint_endpoint_manager::replay_allowed() const noexcept {
     return _shard_manager.replay_allowed();
 }

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -73,17 +73,18 @@ public:
 public:
     future<> ensure_created_and_verified() {
         if (_state != state::uninitialized) {
-            return make_ready_future<>();
+            co_return;
         }
 
-        return with_semaphore(_lock, 1, [this] () {
-            utils::directories::set dir_set;
-            dir_set.add_sharded(_hints_directory);
-            return _dirs.create_and_verify(std::move(dir_set)).then([this] {
-                manager_logger.debug("Creating and validating hint directories: {}", _hints_directory);
-                _state = state::created_and_validated;
-            });
-        });
+        const auto units = co_await seastar::get_units(_lock, 1);
+        
+        utils::directories::set dir_set;
+        dir_set.add_sharded(_hints_directory);
+        
+        co_await _dirs.create_and_verify(std::move(dir_set));
+        
+        manager_logger.debug("Creating and validating hint directories: {}", _hints_directory);
+        _state = state::created_and_validated;
     }
 
     future<> ensure_rebalanced() {

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -49,8 +49,6 @@
 #include <algorithm>
 #include <exception>
 
-using namespace std::literals::chrono_literals;
-
 namespace db::hints {
 
 using namespace internal;

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -52,9 +52,9 @@ using namespace internal;
 
 class directory_initializer::impl {
     enum class state {
-        uninitialized = 0,
-        created_and_validated = 1,
-        rebalanced = 2,
+        uninitialized,
+        created_and_validated,
+        rebalanced
     };
 
     utils::directories& _dirs;
@@ -69,7 +69,7 @@ public:
     { }
 
     future<> ensure_created_and_verified() {
-        if (_state > state::uninitialized) {
+        if (_state != state::uninitialized) {
             return make_ready_future<>();
         }
 
@@ -84,11 +84,11 @@ public:
     }
 
     future<> ensure_rebalanced() {
-        if (_state < state::created_and_validated) {
+        if (_state == state::uninitialized) {
             return make_exception_future<>(std::logic_error("hints directory needs to be created and validated before rebalancing"));
         }
 
-        if (_state > state::created_and_validated) {
+        if (_state == state::rebalanced) {
             return make_ready_future<>();
         }
 

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -148,10 +148,6 @@ manager::manager(service::storage_proxy& proxy, sstring hints_directory, host_fi
     }
 }
 
-manager::~manager() {
-    assert(_ep_managers.empty());
-}
-
 void manager::register_metrics(const sstring& group_name) {
     namespace sm = seastar::metrics;
 

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -110,9 +110,6 @@ directory_initializer::directory_initializer(std::shared_ptr<directory_initializ
         : _impl(std::move(impl))
 { }
 
-directory_initializer::~directory_initializer()
-{ }
-
 directory_initializer directory_initializer::make_dummy() {
     return directory_initializer{nullptr};
 }

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -234,7 +234,9 @@ future<> manager::compute_hints_dir_device_id() {
 }
 
 void manager::allow_hints() {
-    boost::for_each(_ep_managers, [] (auto& pair) { pair.second.allow_hints(); });
+    for (auto& [_, ep_man] : _ep_managers) {
+        ep_man.allow_hints();
+    }
 }
 
 void manager::forbid_hints() {

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -350,7 +350,7 @@ bool manager::store_hint(endpoint_id ep, schema_ptr s, lw_shared_ptr<const froze
 bool manager::too_many_in_flight_hints_for(endpoint_id ep) const noexcept {
     // There is no need to check the DC here because if there is an in-flight hint for this end point then this means that
     // its DC has already been checked and found to be ok.
-    return _stats.size_of_hints_in_progress > max_size_of_hints_in_progress && !utils::fb_utilities::is_me(ep) && hints_in_progress_for(ep) > 0 && local_gossiper().get_endpoint_downtime(ep) <= _max_hint_window_us;
+    return _stats.size_of_hints_in_progress > MAX_SIZE_OF_HINTS_IN_PROGRESS && !utils::fb_utilities::is_me(ep) && hints_in_progress_for(ep) > 0 && local_gossiper().get_endpoint_downtime(ep) <= _max_hint_window_us;
 }
 
 bool manager::can_hint_for(endpoint_id ep) const noexcept {
@@ -367,7 +367,7 @@ bool manager::can_hint_for(endpoint_id ep) const noexcept {
     // hints is more than the maximum allowed value.
     //
     // In the worst case there's going to be (_max_size_of_hints_in_progress + N - 1) in-flight hints, where N is the total number Nodes in the cluster.
-    if (_stats.size_of_hints_in_progress > max_size_of_hints_in_progress && hints_in_progress_for(ep) > 0) {
+    if (_stats.size_of_hints_in_progress > MAX_SIZE_OF_HINTS_IN_PROGRESS && hints_in_progress_for(ep) > 0) {
         manager_logger.trace("size_of_hints_in_progress {} hints_in_progress_for({}) {}", _stats.size_of_hints_in_progress, ep, hints_in_progress_for(ep));
         return false;
     }

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -7,33 +7,42 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <algorithm>
-#include <seastar/core/future.hh>
-#include <seastar/core/seastar.hh>
-#include <seastar/core/sleep.hh>
-#include <seastar/core/gate.hh>
+#include "db/hints/manager.hh"
+
+// Seastar features.
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
+
+// Boost features.
 #include <boost/range/adaptors.hpp>
-#include "utils/div_ceil.hh"
+
+// Scylla includes.
+#include "db/hints/internal/hint_logger.hh"
 #include "db/extensions.hh"
-#include "service/storage_proxy.hh"
-#include "gms/versioned_value.hh"
-#include "gms/gossiper.hh"
-#include "seastarx.hh"
-#include "converting_mutation_partition_applier.hh"
-#include "utils/disk-error-handler.hh"
-#include "utils/lister.hh"
 #include "db/timeout_clock.hh"
-#include "replica/database.hh"
-#include "service_permit.hh"
-#include "utils/directories.hh"
+#include "gms/gossiper.hh"
+#include "gms/versioned_value.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "mutation/mutation_partition_view.hh"
-#include "utils/runtime.hh"
+#include "replica/database.hh"
+#include "service/storage_proxy.hh"
+#include "utils/directories.hh"
+#include "utils/disk-error-handler.hh"
+#include "utils/div_ceil.hh"
 #include "utils/error_injection.hh"
-#include "db/hints/internal/hint_logger.hh"
+#include "utils/lister.hh"
+#include "utils/runtime.hh"
+#include "converting_mutation_partition_applier.hh"
+#include "seastarx.hh"
+#include "service_permit.hh"
+
+// STD.
+#include <algorithm>
 
 using namespace std::literals::chrono_literals;
 

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -359,9 +359,12 @@ bool manager::store_hint(endpoint_id ep, schema_ptr s, lw_shared_ptr<const froze
 }
 
 bool manager::too_many_in_flight_hints_for(endpoint_id ep) const noexcept {
-    // There is no need to check the DC here because if there is an in-flight hint for this end point then this means that
-    // its DC has already been checked and found to be ok.
-    return _stats.size_of_hints_in_progress > MAX_SIZE_OF_HINTS_IN_PROGRESS && !utils::fb_utilities::is_me(ep) && hints_in_progress_for(ep) > 0 && local_gossiper().get_endpoint_downtime(ep) <= _max_hint_window_us;
+    // There is no need to check the DC here because if there is an in-flight hint for this
+    // endpoint, then this means that its DC has already been checked and found to be ok.
+    return _stats.size_of_hints_in_progress > MAX_SIZE_OF_HINTS_IN_PROGRESS
+            && !utils::fb_utilities::is_me(ep)
+            && hints_in_progress_for(ep) > 0
+            && local_gossiper().get_endpoint_downtime(ep) <= _max_hint_window_us;
 }
 
 bool manager::can_hint_for(endpoint_id ep) const noexcept {

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -110,10 +110,6 @@ directory_initializer::directory_initializer(std::shared_ptr<directory_initializ
         : _impl(std::move(impl))
 { }
 
-directory_initializer directory_initializer::make_dummy() {
-    return directory_initializer{nullptr};
-}
-
 future<directory_initializer> directory_initializer::make(utils::directories& dirs, sstring hints_directory) {
     return smp::submit_to(0, [&dirs, hints_directory = std::move(hints_directory)] () mutable {
         auto impl = std::make_shared<directory_initializer::impl>(dirs, std::move(hints_directory));

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -240,7 +240,9 @@ void manager::allow_hints() {
 }
 
 void manager::forbid_hints() {
-    boost::for_each(_ep_managers, [] (auto& pair) { pair.second.forbid_hints(); });
+    for (auto& [_, ep_man] : _ep_managers) {
+        ep_man.forbid_hints();
+    }
 }
 
 void manager::forbid_hints_for_eps_with_pending_hints() {

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -257,8 +257,9 @@ void manager::forbid_hints_for_eps_with_pending_hints() {
     }
 }
 
-sync_point::shard_rps manager::calculate_current_sync_point(const std::vector<endpoint_id>& target_eps) const {
+sync_point::shard_rps manager::calculate_current_sync_point(std::span<const endpoint_id> target_eps) const {
     sync_point::shard_rps rps;
+
     for (auto addr : target_eps) {
         auto it = _ep_managers.find(addr);
         if (it != _ep_managers.end()) {
@@ -266,6 +267,7 @@ sync_point::shard_rps manager::calculate_current_sync_point(const std::vector<en
             rps[ep_man.end_point_key()] = ep_man.last_written_replay_position();
         }
     }
+
     return rps;
 }
 

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -82,9 +82,9 @@ public:
         utils::directories::set dir_set;
         dir_set.add_sharded(_hints_directory);
         
+        manager_logger.debug("Creating and validating hint directories: {}", _hints_directory);
         co_await _dirs.create_and_verify(std::move(dir_set));
         
-        manager_logger.debug("Creating and validating hint directories: {}", _hints_directory);
         _state = state::created_and_validated;
     }
 

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -318,7 +318,7 @@ hint_endpoint_manager& manager::get_ep_manager(endpoint_id ep) {
     return it->second;
 }
 
-inline bool manager::have_ep_manager(endpoint_id ep) const noexcept {
+bool manager::have_ep_manager(endpoint_id ep) const noexcept {
     return find_ep_manager(ep) != ep_managers_end();
 }
 

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -309,7 +309,7 @@ future<> manager::wait_for_sync_point(abort_source& as, const sync_point::shard_
 
 hint_endpoint_manager& manager::get_ep_manager(endpoint_id ep) {
     auto it = _ep_managers.find(ep);
-    if (it == ep_managers_end()) {
+    if (it == _ep_managers.end()) {
         manager_logger.trace("Creating an ep_manager for {}", ep);
         hint_endpoint_manager& ep_man = _ep_managers.emplace(ep, hint_endpoint_manager(ep, *this)).first->second;
         ep_man.start();
@@ -355,7 +355,7 @@ bool manager::can_hint_for(endpoint_id ep) const noexcept {
     }
 
     auto it = _ep_managers.find(ep);
-    if (it != ep_managers_end() && (it->second.stopping() || !it->second.can_hint())) {
+    if (it != _ep_managers.end() && (it->second.stopping() || !it->second.can_hint())) {
         return false;
     }
 
@@ -463,7 +463,7 @@ void manager::drain_for(endpoint_id endpoint) {
                     });
                 } else {
                     ep_managers_map_type::iterator ep_manager_it = _ep_managers.find(endpoint);
-                    if (ep_manager_it != ep_managers_end()) {
+                    if (ep_manager_it != _ep_managers.end()) {
                         return ep_manager_it->second.stop(drain::yes).finally([this, endpoint, &ep_man = ep_manager_it->second] {
                             return ep_man.with_file_update_mutex([&ep_man] {
                                 return remove_file(ep_man.hints_dir().c_str());

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -337,7 +337,9 @@ bool manager::have_ep_manager(endpoint_id ep) const noexcept {
     return _ep_managers.contains(ep);
 }
 
-bool manager::store_hint(endpoint_id ep, schema_ptr s, lw_shared_ptr<const frozen_mutation> fm, tracing::trace_state_ptr tr_state) noexcept {
+bool manager::store_hint(endpoint_id ep, schema_ptr s, lw_shared_ptr<const frozen_mutation> fm,
+        tracing::trace_state_ptr tr_state) noexcept
+{
     if (stopping() || draining_all() || !started() || !can_hint_for(ep)) {
         manager_logger.trace("Can't store a hint to {}", ep);
         ++_stats.dropped;

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -46,8 +46,7 @@
 
 using namespace std::literals::chrono_literals;
 
-namespace db {
-namespace hints {
+namespace db::hints {
 
 using namespace internal;
 
@@ -504,5 +503,4 @@ future<> directory_initializer::ensure_rebalanced() {
     });
 }
 
-}
-}
+} // namespace db::hints

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -135,11 +135,6 @@ future<> directory_initializer::ensure_rebalanced() {
     });
 }
 
-const std::string manager::FILENAME_PREFIX("HintsLog" + commitlog::descriptor::SEPARATOR);
-
-const std::chrono::seconds manager::hint_file_write_timeout = std::chrono::seconds(2);
-std::chrono::seconds manager::hints_flush_period = std::chrono::seconds(10);
-
 manager::manager(sstring hints_directory, host_filter filter, int64_t max_hint_window_ms, resource_manager& res_manager, distributed<replica::database>& db)
     : _hints_dir(fs::path(hints_directory) / format("{:d}", this_shard_id()))
     , _host_filter(std::move(filter))

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -51,12 +51,14 @@ namespace db::hints {
 using namespace internal;
 
 class directory_initializer::impl {
+private:
     enum class state {
         uninitialized,
         created_and_validated,
         rebalanced
     };
 
+private:
     utils::directories& _dirs;
     sstring _hints_directory;
     state _state = state::uninitialized;
@@ -64,10 +66,11 @@ class directory_initializer::impl {
 
 public:
     impl(utils::directories& dirs, sstring hints_directory)
-            : _dirs(dirs)
-            , _hints_directory(std::move(hints_directory))
+        : _dirs(dirs)
+        , _hints_directory(std::move(hints_directory))
     { }
 
+public:
     future<> ensure_created_and_verified() {
         if (_state != state::uninitialized) {
             return make_ready_future<>();

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -17,6 +17,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/smp.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 
 // Boost features.
@@ -135,8 +136,9 @@ future<> directory_initializer::ensure_rebalanced() {
     });
 }
 
-manager::manager(service::storage_proxy& proxy, sstring hints_directory, host_filter filter, int64_t max_hint_window_ms, resource_manager& res_manager, distributed<replica::database>& db)
-    : _hints_dir(fs::path(hints_directory) / format("{:d}", this_shard_id()))
+manager::manager(service::storage_proxy& proxy, sstring hints_directory, host_filter filter, int64_t max_hint_window_ms,
+        resource_manager& res_manager, distributed<replica::database>& db)
+    : _hints_dir(fs::path(hints_directory) / fmt::to_string(this_shard_id()))
     , _host_filter(std::move(filter))
     , _proxy(proxy)
     , _max_hint_window_us(max_hint_window_ms * 1000)

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -50,6 +50,93 @@ namespace db::hints {
 
 using namespace internal;
 
+class directory_initializer::impl {
+    enum class state {
+        uninitialized = 0,
+        created_and_validated = 1,
+        rebalanced = 2,
+    };
+
+    utils::directories& _dirs;
+    sstring _hints_directory;
+    state _state = state::uninitialized;
+    seastar::named_semaphore _lock = {1, named_semaphore_exception_factory{"hints directory initialization lock"}};
+
+public:
+    impl(utils::directories& dirs, sstring hints_directory)
+            : _dirs(dirs)
+            , _hints_directory(std::move(hints_directory))
+    { }
+
+    future<> ensure_created_and_verified() {
+        if (_state > state::uninitialized) {
+            return make_ready_future<>();
+        }
+
+        return with_semaphore(_lock, 1, [this] () {
+            utils::directories::set dir_set;
+            dir_set.add_sharded(_hints_directory);
+            return _dirs.create_and_verify(std::move(dir_set)).then([this] {
+                manager_logger.debug("Creating and validating hint directories: {}", _hints_directory);
+                _state = state::created_and_validated;
+            });
+        });
+    }
+
+    future<> ensure_rebalanced() {
+        if (_state < state::created_and_validated) {
+            return make_exception_future<>(std::logic_error("hints directory needs to be created and validated before rebalancing"));
+        }
+
+        if (_state > state::created_and_validated) {
+            return make_ready_future<>();
+        }
+
+        return with_semaphore(_lock, 1, [this] () {
+            manager_logger.debug("Rebalancing hints in {}", _hints_directory);
+            return rebalance_hints(fs::path{_hints_directory}).then([this] {
+                _state = state::rebalanced;
+            });
+        });
+    }
+};
+
+directory_initializer::directory_initializer(std::shared_ptr<directory_initializer::impl> impl)
+        : _impl(std::move(impl))
+{ }
+
+directory_initializer::~directory_initializer()
+{ }
+
+directory_initializer directory_initializer::make_dummy() {
+    return directory_initializer{nullptr};
+}
+
+future<directory_initializer> directory_initializer::make(utils::directories& dirs, sstring hints_directory) {
+    return smp::submit_to(0, [&dirs, hints_directory = std::move(hints_directory)] () mutable {
+        auto impl = std::make_shared<directory_initializer::impl>(dirs, std::move(hints_directory));
+        return make_ready_future<directory_initializer>(directory_initializer(std::move(impl)));
+    });
+}
+
+future<> directory_initializer::ensure_created_and_verified() {
+    if (!_impl) {
+        return make_ready_future<>();
+    }
+    return smp::submit_to(0, [impl = this->_impl] () mutable {
+        return impl->ensure_created_and_verified().then([impl] {});
+    });
+}
+
+future<> directory_initializer::ensure_rebalanced() {
+    if (!_impl) {
+        return make_ready_future<>();
+    }
+    return smp::submit_to(0, [impl = this->_impl] () mutable {
+        return impl->ensure_rebalanced().then([impl] {});
+    });
+}
+
 const std::string manager::FILENAME_PREFIX("HintsLog" + commitlog::descriptor::SEPARATOR);
 
 const std::chrono::seconds manager::hint_file_write_timeout = std::chrono::seconds(2);
@@ -414,93 +501,6 @@ void manager::update_backlog(size_t backlog, size_t max_backlog) {
     } else {
         forbid_hints_for_eps_with_pending_hints();
     }
-}
-
-class directory_initializer::impl {
-    enum class state {
-        uninitialized = 0,
-        created_and_validated = 1,
-        rebalanced = 2,
-    };
-
-    utils::directories& _dirs;
-    sstring _hints_directory;
-    state _state = state::uninitialized;
-    seastar::named_semaphore _lock = {1, named_semaphore_exception_factory{"hints directory initialization lock"}};
-
-public:
-    impl(utils::directories& dirs, sstring hints_directory)
-            : _dirs(dirs)
-            , _hints_directory(std::move(hints_directory))
-    { }
-
-    future<> ensure_created_and_verified() {
-        if (_state > state::uninitialized) {
-            return make_ready_future<>();
-        }
-
-        return with_semaphore(_lock, 1, [this] () {
-            utils::directories::set dir_set;
-            dir_set.add_sharded(_hints_directory);
-            return _dirs.create_and_verify(std::move(dir_set)).then([this] {
-                manager_logger.debug("Creating and validating hint directories: {}", _hints_directory);
-                _state = state::created_and_validated;
-            });
-        });
-    }
-
-    future<> ensure_rebalanced() {
-        if (_state < state::created_and_validated) {
-            return make_exception_future<>(std::logic_error("hints directory needs to be created and validated before rebalancing"));
-        }
-
-        if (_state > state::created_and_validated) {
-            return make_ready_future<>();
-        }
-
-        return with_semaphore(_lock, 1, [this] () {
-            manager_logger.debug("Rebalancing hints in {}", _hints_directory);
-            return rebalance_hints(fs::path{_hints_directory}).then([this] {
-                _state = state::rebalanced;
-            });
-        });
-    }
-};
-
-directory_initializer::directory_initializer(std::shared_ptr<directory_initializer::impl> impl)
-        : _impl(std::move(impl))
-{ }
-
-directory_initializer::~directory_initializer()
-{ }
-
-directory_initializer directory_initializer::make_dummy() {
-    return directory_initializer{nullptr};
-}
-
-future<directory_initializer> directory_initializer::make(utils::directories& dirs, sstring hints_directory) {
-    return smp::submit_to(0, [&dirs, hints_directory = std::move(hints_directory)] () mutable {
-        auto impl = std::make_shared<directory_initializer::impl>(dirs, std::move(hints_directory));
-        return make_ready_future<directory_initializer>(directory_initializer(std::move(impl)));
-    });
-}
-
-future<> directory_initializer::ensure_created_and_verified() {
-    if (!_impl) {
-        return make_ready_future<>();
-    }
-    return smp::submit_to(0, [impl = this->_impl] () mutable {
-        return impl->ensure_created_and_verified().then([impl] {});
-    });
-}
-
-future<> directory_initializer::ensure_rebalanced() {
-    if (!_impl) {
-        return make_ready_future<>();
-    }
-    return smp::submit_to(0, [impl = this->_impl] () mutable {
-        return impl->ensure_rebalanced().then([impl] {});
-    });
 }
 
 } // namespace db::hints

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -190,17 +190,21 @@ void manager::register_metrics(const sstring& group_name) {
 
 future<> manager::start(shared_ptr<gms::gossiper> gossiper_ptr) {
     _gossiper_anchor = std::move(gossiper_ptr);
-    return lister::scan_dir(_hints_dir, lister::dir_entry_types::of<directory_entry_type::directory>(), [this] (fs::path datadir, directory_entry de) {
-        endpoint_id ep = endpoint_id(de.name);
+
+
+    co_await lister::scan_dir(_hints_dir, lister::dir_entry_types::of<directory_entry_type::directory>(),
+            [this] (fs::path datadir, directory_entry de) {
+        endpoint_id ep = endpoint_id{de.name};
+
         if (!check_dc_for(ep)) {
             return make_ready_future<>();
         }
+
         return get_ep_manager(ep).populate_segments_to_replay();
-    }).then([this] {
-        return compute_hints_dir_device_id();
-    }).then([this] {
-        set_started();
     });
+    
+    co_await compute_hints_dir_device_id();
+    set_started();
 }
 
 future<> manager::stop() {

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -389,7 +389,7 @@ future<> manager::change_host_filter(host_filter filter) {
     }
 
     return with_gate(_draining_eps_gate, [this, filter = std::move(filter)] () mutable {
-        return with_semaphore(drain_lock(), 1, [this, filter = std::move(filter)] () mutable {
+        return with_semaphore(_drain_lock, 1, [this, filter = std::move(filter)] () mutable {
             if (draining_all()) {
                 return make_exception_future<>(std::logic_error("change_host_filter: cannot change the configuration because hints all hints were drained"));
             }
@@ -447,7 +447,7 @@ future<> manager::drain_for(endpoint_id endpoint) {
     manager_logger.trace("on_leave_cluster: {} is removed/decommissioned", endpoint);
 
     return with_gate(_draining_eps_gate, [this, endpoint] {
-        return with_semaphore(drain_lock(), 1, [this, endpoint] {
+        return with_semaphore(_drain_lock, 1, [this, endpoint] {
             return futurize_invoke([this, endpoint] () {
                 if (utils::fb_utilities::is_me(endpoint)) {
                     set_draining_all();

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -247,14 +247,14 @@ void manager::forbid_hints() {
 
 void manager::forbid_hints_for_eps_with_pending_hints() {
     manager_logger.trace("space_watchdog: Going to block hints to: {}", _eps_with_pending_hints);
-    boost::for_each(_ep_managers, [this] (auto& pair) {
-        hint_endpoint_manager& ep_man = pair.second;
+    
+    for (auto& [_, ep_man] : _ep_managers) {
         if (has_ep_with_pending_hints(ep_man.end_point_key())) {
             ep_man.forbid_hints();
         } else {
             ep_man.allow_hints();
         }
-    });
+    }
 }
 
 sync_point::shard_rps manager::calculate_current_sync_point(const std::vector<endpoint_id>& target_eps) const {

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -9,28 +9,30 @@
 
 #pragma once
 
-#include <unordered_map>
-#include <vector>
-#include <list>
-#include <chrono>
-#include <optional>
-#include <map>
-#include <seastar/core/gate.hh>
-#include <seastar/core/sharded.hh>
-#include <seastar/core/timer.hh>
-#include <seastar/core/lowres_clock.hh>
-#include <seastar/core/shared_mutex.hh>
+// Seastar features.
 #include <seastar/core/abort_source.hh>
-#include "inet_address_vectors.hh"
+#include <seastar/core/gate.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/shared_mutex.hh>
+#include <seastar/core/timer.hh>
+
+// Scylla includes.
 #include "db/commitlog/commitlog.hh"
-#include "utils/loading_shared_values.hh"
+#include "db/hints/internal/common.hh"
+#include "db/hints/internal/hint_storage.hh"
+#include "db/hints/internal/hint_endpoint_manager.hh"
 #include "db/hints/resource_manager.hh"
 #include "db/hints/host_filter.hh"
 #include "db/hints/sync_point.hh"
 #include "locator/abstract_replication_strategy.hh"
-#include "db/hints/internal/common.hh"
-#include "db/hints/internal/hint_storage.hh"
-#include "db/hints/internal/hint_endpoint_manager.hh"
+#include "utils/loading_shared_values.hh"
+#include "inet_address_vectors.hh"
+
+// STD.
+#include <chrono>
+#include <unordered_map>
+#include <vector>
 
 class fragmented_temporary_buffer;
 

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -237,10 +237,6 @@ public:
         return _hints_dir_device_id;
     }
 
-    seastar::named_semaphore& drain_lock() noexcept {
-        return _drain_lock;
-    }
-
     void allow_hints();
     void forbid_hints();
     void forbid_hints_for_eps_with_pending_hints();

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -32,8 +32,8 @@
 
 // STD.
 #include <chrono>
+#include <span>
 #include <unordered_map>
-#include <vector>
 
 class fragmented_temporary_buffer;
 
@@ -246,7 +246,7 @@ public:
     }
 
     /// \brief Returns a set of replay positions for hint queues towards endpoints from the `target_eps`.
-    sync_point::shard_rps calculate_current_sync_point(const std::vector<endpoint_id>& target_eps) const;
+    sync_point::shard_rps calculate_current_sync_point(std::span<const endpoint_id> target_eps) const;
 
     /// \brief Waits until hint replay reach replay positions described in `rps`.
     future<> wait_for_sync_point(abort_source& as, const sync_point::shard_rps& rps);

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -205,7 +205,7 @@ public:
     /// \param ep End point identificator
     /// \return Number of hints in-flight to \param ep.
     uint64_t hints_in_progress_for(endpoint_id ep) const noexcept {
-        auto it = find_ep_manager(ep);
+        auto it = _ep_managers.find(ep);
         if (it == ep_managers_end()) {
             return 0;
         }
@@ -323,14 +323,6 @@ private:
     }
 
 public:
-    ep_managers_map_type::iterator find_ep_manager(endpoint_id ep_key) noexcept {
-        return _ep_managers.find(ep_key);
-    }
-
-    ep_managers_map_type::const_iterator find_ep_manager(endpoint_id ep_key) const noexcept {
-        return _ep_managers.find(ep_key);
-    }
-
     ep_managers_map_type::iterator ep_managers_end() noexcept {
         return _ep_managers.end();
     }

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -94,8 +94,6 @@ private:
         state::draining_all,
         state::stopping>>;
 
-    using ep_managers_map_type = std::unordered_map<endpoint_id, hint_endpoint_manager>;
-
 public:
     static inline const std::string FILENAME_PREFIX{"HintsLog" + commitlog::descriptor::SEPARATOR};
     // Non-const - can be modified with an error injection.
@@ -120,7 +118,7 @@ private:
 
     resource_manager& _resource_manager;
 
-    ep_managers_map_type _ep_managers;
+    std::unordered_map<endpoint_id, hint_endpoint_manager> _ep_managers;
     hint_stats _stats;
     seastar::metrics::metric_groups _metrics;
     std::unordered_set<endpoint_id> _eps_with_pending_hints;

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -245,12 +245,6 @@ public:
     /// \brief Waits until hint replay reach replay positions described in `rps`.
     future<> wait_for_sync_point(abort_source& as, const sync_point::shard_rps& rps);
 
-    /// \brief Creates an object which aids in hints directory initialization.
-    /// This object can saafely be copied and used from any shard.
-    /// \arg dirs The utils::directories object, used to create and lock hints directories
-    /// \arg hints_directory The directory with hints which should be initialized
-    directory_initializer make_directory_initializer(utils::directories& dirs, fs::path hints_directory);
-
 private:
     future<> compute_hints_dir_device_id();
 

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -38,14 +38,13 @@ class fragmented_temporary_buffer;
 
 namespace utils {
 class directories;
-}
+} // namespace utils
 
 namespace gms {
 class gossiper;
-}
+} // namespace gms
 
-namespace db {
-namespace hints {
+namespace db::hints {
 
 /// A helper class which tracks hints directory creation
 /// and allows to perform hints directory initialization lazily.
@@ -325,5 +324,4 @@ public:
     }
 };
 
-}
-}
+} // namespace db::hints

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -126,14 +126,20 @@ private:
     seastar::named_semaphore _drain_lock = {1, named_semaphore_exception_factory{"drain lock"}};
 
 public:
-    manager(service::storage_proxy& proxy, sstring hints_directory, host_filter filter, int64_t max_hint_window_ms, resource_manager&res_manager, sharded<replica::database>& db);
+    manager(service::storage_proxy& proxy, sstring hints_directory, host_filter filter,
+            int64_t max_hint_window_ms, resource_manager& res_manager, sharded<replica::database>& db);
+    
     manager(const manager&) = delete;
     manager& operator=(const manager&) = delete;
+
+    manager(manager&&) = delete;
+    manager& operator=(manager&&) = delete;
+    
     ~manager() noexcept {
         assert(_ep_managers.empty());
     }
-    manager(manager&&) = delete;
-    manager& operator=(manager&&) = delete;
+
+public:
     void register_metrics(const sstring& group_name);
     future<> start(shared_ptr<gms::gossiper> gossiper_ptr);
     future<> stop();

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -289,7 +289,7 @@ public:
     /// corresponding hint_endpoint_manager objects.
     ///
     /// \param endpoint node that left the cluster
-    void drain_for(endpoint_id endpoint);
+    future<> drain_for(endpoint_id endpoint);
 
 private:
     void update_backlog(size_t backlog, size_t max_backlog);

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -128,6 +128,8 @@ private:
 public:
     manager(sstring hints_directory, host_filter filter, int64_t max_hint_window_ms, resource_manager&res_manager, sharded<replica::database>& db);
     virtual ~manager();
+    manager(const manager&) = delete;
+    manager& operator=(const manager&) = delete;
     manager(manager&&) = delete;
     manager& operator=(manager&&) = delete;
     void register_metrics(const sstring& group_name);

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -206,7 +206,7 @@ public:
     /// \return Number of hints in-flight to \param ep.
     uint64_t hints_in_progress_for(endpoint_id ep) const noexcept {
         auto it = _ep_managers.find(ep);
-        if (it == ep_managers_end()) {
+        if (it == _ep_managers.end()) {
             return 0;
         }
         return it->second.hints_in_progress();
@@ -320,15 +320,6 @@ private:
 
     bool draining_all() noexcept {
         return _state.contains(state::draining_all);
-    }
-
-public:
-    ep_managers_map_type::iterator ep_managers_end() noexcept {
-        return _ep_managers.end();
-    }
-
-    ep_managers_map_type::const_iterator ep_managers_end() const noexcept {
-        return _ep_managers.end();
     }
 };
 

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -127,9 +127,11 @@ private:
 
 public:
     manager(service::storage_proxy& proxy, sstring hints_directory, host_filter filter, int64_t max_hint_window_ms, resource_manager&res_manager, sharded<replica::database>& db);
-    virtual ~manager();
     manager(const manager&) = delete;
     manager& operator=(const manager&) = delete;
+    ~manager() noexcept {
+        assert(_ep_managers.empty());
+    }
     manager(manager&&) = delete;
     manager& operator=(manager&&) = delete;
     void register_metrics(const sstring& group_name);

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -80,7 +80,6 @@ private:
     using hint_endpoint_manager = internal::hint_endpoint_manager;
     using node_to_hint_store_factory_type = internal::node_to_hint_store_factory_type;
 
-public:
     enum class state {
         started,                // hinting is currently allowed (start() call is complete)
         replay_allowed,         // replaying (hints sending) is allowed
@@ -94,7 +93,6 @@ public:
         state::draining_all,
         state::stopping>>;
 
-private:
     using ep_managers_map_type = std::unordered_map<endpoint_id, hint_endpoint_manager>;
 
 public:
@@ -102,9 +100,10 @@ public:
     // Non-const - can be modified with an error injection.
     static inline std::chrono::seconds hints_flush_period = std::chrono::seconds(10);
     static constexpr std::chrono::seconds hint_file_write_timeout = std::chrono::seconds(2);
-
 private:
     static constexpr uint64_t max_size_of_hints_in_progress = 10 * 1024 * 1024; // 10MB
+
+private:
     state_set _state;
     const fs::path _hints_dir;
     dev_t _hints_dir_device_id = 0;

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -99,9 +99,9 @@ public:
     static inline const std::string FILENAME_PREFIX{"HintsLog" + commitlog::descriptor::SEPARATOR};
     // Non-const - can be modified with an error injection.
     static inline std::chrono::seconds hints_flush_period = std::chrono::seconds(10);
-    static constexpr std::chrono::seconds hint_file_write_timeout = std::chrono::seconds(2);
+    static constexpr std::chrono::seconds HINT_FILE_WRITE_TIMEOUT = std::chrono::seconds(2);
 private:
-    static constexpr uint64_t max_size_of_hints_in_progress = 10 * 1024 * 1024; // 10MB
+    static constexpr uint64_t MAX_SIZE_OF_HINTS_IN_PROGRESS = 10 * 1024 * 1024; // 10MB
 
 private:
     state_set _state;

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -110,7 +110,7 @@ private:
 
     node_to_hint_store_factory_type _store_factory;
     host_filter _host_filter;
-    shared_ptr<service::storage_proxy> _proxy_anchor;
+    service::storage_proxy& _proxy;
     shared_ptr<gms::gossiper> _gossiper_anchor;
     int64_t _max_hint_window_us = 0;
     replica::database& _local_db;
@@ -126,14 +126,14 @@ private:
     seastar::named_semaphore _drain_lock = {1, named_semaphore_exception_factory{"drain lock"}};
 
 public:
-    manager(sstring hints_directory, host_filter filter, int64_t max_hint_window_ms, resource_manager&res_manager, sharded<replica::database>& db);
+    manager(service::storage_proxy& proxy, sstring hints_directory, host_filter filter, int64_t max_hint_window_ms, resource_manager&res_manager, sharded<replica::database>& db);
     virtual ~manager();
     manager(const manager&) = delete;
     manager& operator=(const manager&) = delete;
     manager(manager&&) = delete;
     manager& operator=(manager&&) = delete;
     void register_metrics(const sstring& group_name);
-    future<> start(shared_ptr<service::storage_proxy> proxy_ptr, shared_ptr<gms::gossiper> gossiper_ptr);
+    future<> start(shared_ptr<gms::gossiper> gossiper_ptr);
     future<> stop();
     bool store_hint(endpoint_id ep, schema_ptr s, lw_shared_ptr<const frozen_mutation> fm, tracing::trace_state_ptr tr_state) noexcept;
 
@@ -251,7 +251,7 @@ private:
     }
 
     service::storage_proxy& local_storage_proxy() const noexcept {
-        return *_proxy_anchor;
+        return _proxy;
     }
 
     gms::gossiper& local_gossiper() const noexcept {

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -60,7 +60,6 @@ public:
     static directory_initializer make_dummy();
     static future<directory_initializer> make(utils::directories& dirs, sstring hints_directory);
 
-    ~directory_initializer();
     future<> ensure_created_and_verified();
     future<> ensure_rebalanced();
 };

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -74,7 +74,6 @@ private:
     using hint_stats = internal::hint_stats;
     using drain = internal::drain;
 
-    friend class space_watchdog;
     friend class internal::hint_endpoint_manager;
     friend class internal::hint_sender;
 
@@ -285,9 +284,9 @@ public:
     /// \param endpoint node that left the cluster
     future<> drain_for(endpoint_id endpoint) noexcept;
 
-private:
     void update_backlog(size_t backlog, size_t max_backlog);
 
+private:
     bool stopping() const noexcept {
         return _state.contains(state::stopping);
     }

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -81,10 +81,12 @@ private:
     using node_to_hint_store_factory_type = internal::node_to_hint_store_factory_type;
 
     enum class state {
-        started,                // hinting is currently allowed (start() call is complete)
-        replay_allowed,         // replaying (hints sending) is allowed
-        draining_all,           // hinting is not allowed - all ep managers are being stopped because this node is leaving the cluster
-        stopping                // hinting is not allowed - stopping is in progress (stop() method has been called)
+        started,        // Hinting is currently allowed (start() has completed).
+        replay_allowed, // Replaying (sending) hints is allowed.
+        draining_all,   // Accepting new hints is not allowed. All endpoint managers
+                        // are being drained because the node is leaving the cluster.
+        stopping        // Accepting new hints is not allowed. Stopping this manager
+                        // is in progress (stop() has been called).
     };
 
     using state_set = enum_set<super_enum<state,

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -57,7 +57,9 @@ private:
 
 public:
     /// Creates an initializer that does nothing. Useful in tests.
-    static directory_initializer make_dummy();
+    static directory_initializer make_dummy() noexcept {
+        return {nullptr};
+    }
     static future<directory_initializer> make(utils::directories& dirs, sstring hints_directory);
 
     future<> ensure_created_and_verified();

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -285,7 +285,7 @@ public:
     /// corresponding hint_endpoint_manager objects.
     ///
     /// \param endpoint node that left the cluster
-    future<> drain_for(endpoint_id endpoint);
+    future<> drain_for(endpoint_id endpoint) noexcept;
 
 private:
     void update_backlog(size_t backlog, size_t max_backlog);

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -47,8 +47,6 @@ class gossiper;
 namespace db {
 namespace hints {
 
-using timer_clock_type = seastar::lowres_clock;
-
 /// A helper class which tracks hints directory creation
 /// and allows to perform hints directory initialization lazily.
 class directory_initializer {

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -98,10 +98,10 @@ private:
     using ep_managers_map_type = std::unordered_map<endpoint_id, hint_endpoint_manager>;
 
 public:
-    static const std::string FILENAME_PREFIX;
+    static inline const std::string FILENAME_PREFIX{"HintsLog" + commitlog::descriptor::SEPARATOR};
     // Non-const - can be modified with an error injection.
-    static std::chrono::seconds hints_flush_period;
-    static const std::chrono::seconds hint_file_write_timeout;
+    static inline std::chrono::seconds hints_flush_period = std::chrono::seconds(10);
+    static constexpr std::chrono::seconds hint_file_write_timeout = std::chrono::seconds(2);
 
 private:
     static constexpr uint64_t max_size_of_hints_in_progress = 10 * 1024 * 1024; // 10MB

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -146,9 +146,10 @@ void space_watchdog::on_timer() {
                 // not hintable).
                 // If exists - let's take a file update lock so that files are not changed under our feet. Otherwise, simply
                 // continue to enumeration - there is no one to change them.
-                auto it = shard_manager.find_ep_manager(de.name);
-                if (it != shard_manager.ep_managers_end()) {
-                    return with_file_update_mutex(it->second, [this, &shard_manager, dir = std::move(dir), ep_name = std::move(de.name)] () mutable {
+                const internal::endpoint_id ep{de.name};
+
+                if (shard_manager.have_ep_manager(ep)) {
+                    return shard_manager.with_file_update_mutex_for(ep, [this, &shard_manager, dir = std::move(dir), ep_name = std::move(de.name)] () mutable {
                         return scan_one_ep_dir(dir / ep_name, shard_manager, ep_key_type(ep_name));
                     });
                 } else {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6483,8 +6483,9 @@ future<> storage_proxy::wait_for_hint_sync_point(const db::hints::sync_point spo
 void storage_proxy::on_join_cluster(const gms::inet_address& endpoint) {};
 
 void storage_proxy::on_leave_cluster(const gms::inet_address& endpoint) {
-    _hints_manager.drain_for(endpoint);
-    _hints_for_views_manager.drain_for(endpoint);
+    // Discarding these futures is safe. They're awaited by db::hints::manager::stop().
+    (void) _hints_manager.drain_for(endpoint);
+    (void) _hints_for_views_manager.drain_for(endpoint);
 }
 
 void storage_proxy::on_up(const gms::inet_address& endpoint) {};


### PR DESCRIPTION
This PR is another step in refactoring the Hinted Handoff module. It aims at modernizing the code by moving to coroutines, using `std::ranges` instead of Boost's ones where possible, and uses other features coming with the new C++ standards.

It also tries to make the code clearer and get rid of confusing elements, e.g. using shared pointers where they shouldn't be used or marking methods as virtual even though nothing derives from the class. It also prevents `manager.hh` from giving direct access to internal structures (`hint_endpoint_manager` in this case).

Refs #15358 