### PR TITLE
row_cache: when the constructor fails, clear `_partitions` in the right allocator

### DIFF
--- a/row_cache.cc
+++ b/row_cache.cc
@@ -859,7 +859,7 @@ flat_mutation_reader_v2 row_cache::make_nonpopulating_reader(schema_ptr schema, 
     });
 }
 
-row_cache::~row_cache() {
+void row_cache::clear_on_destruction() noexcept {
     with_allocator(_tracker.allocator(), [this] {
         _partitions.clear_and_dispose([this] (cache_entry* p) mutable noexcept {
             if (!p->is_dummy_entry()) {
@@ -868,6 +868,10 @@ row_cache::~row_cache() {
             p->evict(_tracker);
         });
     });
+}
+
+row_cache::~row_cache() {
+    clear_on_destruction();
 }
 
 void row_cache::clear_now() noexcept {
@@ -1271,12 +1275,20 @@ row_cache::row_cache(schema_ptr s, snapshot_source src, cache_tracker& tracker, 
     , _underlying(src())
     , _snapshot_source(std::move(src))
 {
+  try {
     with_allocator(_tracker.allocator(), [this, cont] {
         cache_entry entry(cache_entry::dummy_entry_tag{});
         entry.set_continuous(bool(cont));
         auto raw_token = entry.position().token().raw();
         _partitions.insert(raw_token, std::move(entry), dht::ring_position_comparator{*_schema});
     });
+  } catch (...) {
+    // The code above might have allocated something in _partitions.
+    // The destructor of _partitions will be called with the wrong allocator,
+    // so we have to clear _partitions manually here, before it is destroyed.
+    clear_on_destruction();
+    throw;
+  }
 }
 
 cache_entry::cache_entry(cache_entry&& o) noexcept

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -265,6 +265,7 @@ private:
     void upgrade_entry(cache_entry&);
     void invalidate_locked(const dht::decorated_key&);
     void clear_now() noexcept;
+    void clear_on_destruction() noexcept;
 
     struct previous_entry_pointer {
         std::optional<dht::decorated_key> _key;


### PR DESCRIPTION
If the constructor of row_cache throws, `_partitions` is cleared in the wrong allocator, possibly causing allocator corruption.

Fix that.

Fixes #15632