### PR TITLE
Make memtable flush tolerate misconfigured S3 storage

### DIFF
--- a/db/config.hh
+++ b/db/config.hh
@@ -467,7 +467,7 @@ public:
 
     const db::extensions& extensions() const;
 
-    utils::updateable_value<std::unordered_map<sstring, s3::endpoint_config>> object_storage_config;
+    utils::updateable_value_source<std::unordered_map<sstring, s3::endpoint_config>> object_storage_config;
 
     named_value<std::vector<error_injection_at_startup>> error_injections_at_startup;
 

--- a/main.cc
+++ b/main.cc
@@ -217,7 +217,7 @@ static future<> read_object_storage_config(db::config& db_cfg) {
         }
     }
 
-    db_cfg.object_storage_config = std::move(cfg);
+    db_cfg.object_storage_config.set(std::move(cfg));
 }
 
 static future<>

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -872,7 +872,7 @@ table::seal_active_memtable(compaction_group& cg, flush_permit&& flush_permit) n
 
                 auto should_retry = [](auto* ep) {
                     int ec = ep->code().value();
-                    return ec == ENOSPC || ec == EDQUOT;
+                    return ec == ENOSPC || ec == EDQUOT || ec == EPERM || ec == EACCES;
                 };
                 if (try_catch<std::bad_alloc>(ex)) {
                     // There is a chance something else will free the memory, so we can try again

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -22,6 +22,7 @@
 #include "test/lib/test_utils.hh"
 #include "utils/s3/client.hh"
 #include "utils/s3/creds.hh"
+#include "utils/exceptions.hh"
 #include "gc_clock.hh"
 
 // The test can be run on real AWS-S3 bucket. For that, create a bucket with
@@ -90,8 +91,8 @@ SEASTAR_THREAD_TEST_CASE(test_client_put_get_object) {
     cln->delete_object(name).get();
 
     testlog.info("Verify it's gone\n");
-    BOOST_REQUIRE_EXCEPTION(cln->get_object_size(name).get(), seastar::httpd::unexpected_status_error, [] (const seastar::httpd::unexpected_status_error& ex) {
-        return ex.status() == http::reply::status_type::not_found;
+    BOOST_REQUIRE_EXCEPTION(cln->get_object_size(name).get(), storage_io_error, [] (const storage_io_error& ex) {
+        return ex.code().value() == ENOENT;
     });
 }
 

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -743,7 +743,7 @@ future<> test_schema_digest_does_not_change_with_disabled_features(sstring data_
     db_cfg.experimental_features({experimental_features_t::feature::UDF, experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS}, db::config::config_source::CommandLine);
     std::unordered_map<sstring, s3::endpoint_config> so_config;
     so_config["localhost"] = s3::endpoint_config{};
-    db_cfg.object_storage_config = std::move(so_config);
+    db_cfg.object_storage_config.set(std::move(so_config));
     if (regenerate) {
         db_cfg.data_file_directories({data_dir}, db::config::config_source::CommandLine);
     } else {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -177,7 +177,7 @@ std::unordered_map<sstring, s3::endpoint_config> make_storage_options_config(con
 std::unique_ptr<db::config> make_db_config(sstring temp_dir, const data_dictionary::storage_options so) {
     auto cfg = std::make_unique<db::config>();
     cfg->data_file_directories.set({ temp_dir });
-    cfg->object_storage_config = make_storage_options_config(so);
+    cfg->object_storage_config.set(make_storage_options_config(so));
     return cfg;
 }
 
@@ -229,7 +229,7 @@ future<> test_env::do_with_async(noncopyable_function<void (test_env&)> func, te
         auto wrap = std::make_shared<test_env_with_cql>(std::move(func), std::move(cfg));
         auto db_cfg = make_shared<db::config>();
         db_cfg->experimental_features({db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS});
-        db_cfg->object_storage_config = make_storage_options_config(wrap->cfg.storage);
+        db_cfg->object_storage_config.set(make_storage_options_config(wrap->cfg.storage));
         return do_with_cql_env_thread([wrap = std::move(wrap)] (auto& cql_env) mutable {
             test_env env(std::move(wrap->cfg), &cql_env.get_sstorage_manager().local());
             auto close_env = defer([&] { env.stop().get(); });

--- a/test/object_store/conftest.py
+++ b/test/object_store/conftest.py
@@ -6,6 +6,7 @@ import logging
 import pytest
 import shutil
 import tempfile
+import pathlib
 
 # use minio_server
 sys.path.insert(1, sys.path[0] + '/../..')
@@ -47,7 +48,7 @@ class S3_Server:
         if conffile is None:
             conffile = os.path.join(self.tempdir, 'object-storage.yaml')
             MinioServer.create_conf_file(self.address, self.port, self.acc_key, self.secret_key, self.region, conffile)
-        return conffile
+        return pathlib.Path(conffile)
 
     def __repr__(self):
         return f"[unknown] {self.address}:{self.port}/{self.bucket_name}@{self.config_file}"

--- a/test/object_store/test_basic.py
+++ b/test/object_store/test_basic.py
@@ -87,10 +87,14 @@ def kill_with_dir(old_pid, run_dir):
 
 
 class Cluster:
-    def __init__(self, cql, ip: str):
+    def __init__(self, cql, ip: str, pid):
         self.cql = cql
         self.ip = ip
         self.api = ScyllaRESTAPIClient()
+        self.pid = pid
+
+    def reload_config(self):
+        os.kill(self.pid, signal.SIGHUP)
 
 
 @contextmanager
@@ -104,7 +108,7 @@ def managed_cluster(run_dir, ssl, s3_server):
     run.wait_for_services(pid, [check_with_cql(ip, ssl)])
     cluster = run.get_cql_cluster(ip)
     try:
-        yield Cluster(cluster, ip)
+        yield Cluster(cluster, ip, pid)
     finally:
         cluster.shutdown()
         kill_with_dir(pid, run_dir)

--- a/test/object_store/test_basic.py
+++ b/test/object_store/test_basic.py
@@ -5,13 +5,17 @@ sys.path.insert(1, sys.path[0] + '/../cql-pytest')
 import run
 from util import format_tuples
 
+import asyncio
 import os
 import requests
 import signal
 import yaml
 import pytest
 import xml.etree.ElementTree as ET
+import shutil
+import pathlib
 
+from test.pylib.minio_server import MinioServer
 from contextlib import contextmanager
 from test.pylib.rest_client import ScyllaRESTAPIClient
 from cassandra.protocol import ConfigurationException
@@ -249,3 +253,44 @@ async def test_misconfigured_storage(test_tempdir, s3_server, ssl):
         with pytest.raises(ConfigurationException):
             conn.execute((f"CREATE KEYSPACE test_ks WITH"
                           f" REPLICATION = {replication_opts} AND STORAGE = {storage_opts};"))
+
+
+@pytest.mark.asyncio
+async def test_memtable_flush_retries(test_tempdir, s3_server, ssl):
+    '''verify that memtable flush doesn't crash in case storage access keys are incorrect'''
+
+    print('Spoof the object-store config')
+    local_config = pathlib.Path(test_tempdir) / 'object_storage.yaml'
+    MinioServer.create_conf_file(s3_server.address, s3_server.port, 'bad_key', 'bad_secret', 'bad_region', local_config)
+
+    orig_config = s3_server.config_file
+    s3_server.config_file = local_config
+
+    with managed_cluster(test_tempdir, ssl, s3_server) as cluster:
+        print(f'Create keyspace (minio listening at {s3_server.address})')
+
+        conn = cluster.cql.connect()
+        ks, cf = create_ks_and_cf(conn, s3_server)
+        res = conn.execute(f"SELECT * FROM {ks}.{cf};")
+        rows = {x.name: x.value for x in res}
+
+        print(f'Flush keyspace')
+        flush = asyncio.create_task(cluster.api.flush_keyspace(cluster.ip, ks))
+        print(f'Wait few seconds')
+        await asyncio.sleep(8)
+        print(f'Restore and reload config')
+        shutil.copyfile(orig_config, s3_server.config_file)
+        cluster.reload_config()
+        print(f'Wait for flush to finish')
+        await flush
+        print(f'Check the sstables table')
+        res = conn.execute("SELECT * FROM system.sstables;")
+        ssts = "\n".join(f"{row.location} {row.generation} {row.status}" for row in res)
+        print(f'sstables:\n{ssts}')
+
+    print('Restart scylla')
+    with managed_cluster(test_tempdir, ssl, s3_server) as cluster:
+        conn = cluster.cql.connect()
+        res = conn.execute(f"SELECT * FROM {ks}.{cf};")
+        have_res = { x.name: x.value for x in res }
+        assert have_res == dict(rows), f'Unexpected table content: {have_res}'

--- a/utils/exceptions.hh
+++ b/utils/exceptions.hh
@@ -43,9 +43,17 @@ private:
     std::error_code _code;
     std::string _what;
 public:
+    storage_io_error(std::error_code c, std::string s) noexcept
+        : _code(std::move(c))
+        , _what(std::move(s))
+    { }
+
+    storage_io_error(int err, std::string s) noexcept
+        : storage_io_error(std::error_code(err, std::system_category()), std::move(s))
+    { }
+
     storage_io_error(std::system_error& e) noexcept
-        : _code{e.code()}
-        , _what{std::string("Storage I/O error: ") + std::to_string(e.code().value()) + ": " + e.what()}
+        : storage_io_error(e.code(), std::string("Storage I/O error: ") + std::to_string(e.code().value()) + ": " + e.what())
     { }
 
     virtual const char* what() const noexcept override {

--- a/utils/s3/creds.hh
+++ b/utils/s3/creds.hh
@@ -25,9 +25,13 @@ struct endpoint_config {
         // the security token, only for session credentials
         std::string session_token;
         std::string region;
+
+        std::strong_ordering operator<=> (const aws_config& o) const = default;
     };
 
     std::optional<aws_config> aws;
+
+    std::strong_ordering operator<=> (const endpoint_config& o) const = default;
 };
 
 using endpoint_config_ptr = seastar::lw_shared_ptr<endpoint_config>;


### PR DESCRIPTION
Nowadays if memtable gets flushed into misconfigured S3 storage, the flush fails and aborts the whole scylla process. That's not very elegant. First, because upon restart garbage collecting non-sealed sstables would fail again. Second, because re-configuring an endpoint can be done runtime, scylla re-reads this config upon HUP signal.

Flushing memtable restarts when seeing ENOSPC/EDQUOT errors from on-disk sstables. This PR extends this to handle misconfigured S3 endpoints as well.

fixes: #13745