### PR TITLE
Nodetools docs improvements 1/N

### DIFF
--- a/docs/operating-scylla/nodetool-commands/compact.rst
+++ b/docs/operating-scylla/nodetool-commands/compact.rst
@@ -20,20 +20,6 @@ Syntax
 Options
 --------
 
-* ``-h <host>`` or  ``--host <host>`` - Node hostname or IP address.
-
-* ``-p <port>`` or ``--port <port>`` - Remote JMX agent port number.
-
-* ``-pp`` or ``--print-port`` - Operate in 4.0 mode with hosts disambiguated by port number.
-
-* ``-pw <password>`` or ``--password <password>`` - Remote JMX agent password.
-
-* ``-pwf <passwordFilePath>`` or ``--password-file <passwordFilePath>`` - Path to the JMX password file.
-
-* ``-u <username>`` or ``--username <username>`` - Remote JMX agent username.
-
-* ``--`` - Separates command-line options from the list of argument(useful when an argument might be mistaken for a command-line option).
-
 The following options are available in Cassandra's nodetool, but are NOT implemented in ScyllaDB's nodetool:
 
 * ``-st`` or ``--start-token``

--- a/docs/operating-scylla/nodetool-commands/compact.rst
+++ b/docs/operating-scylla/nodetool-commands/compact.rst
@@ -15,7 +15,7 @@ Syntax
 -------
 .. code-block:: console
 
-   nodetool [options] compact [--partition <partition_key>] [<keyspace> [<cfnames>]...]
+   nodetool [options] compact [<keyspace> [<cfnames>]...]
 
 Options
 --------
@@ -23,8 +23,6 @@ Options
 * ``-h <host>`` or  ``--host <host>`` - Node hostname or IP address.
 
 * ``-p <port>`` or ``--port <port>`` - Remote JMX agent port number.
-
-* ``--partition <partition_key>`` - String representation of the partition key.
 
 * ``-pp`` or ``--print-port`` - Operate in 4.0 mode with hosts disambiguated by port number.
 
@@ -36,7 +34,7 @@ Options
 
 * ``--`` - Separates command-line options from the list of argument(useful when an argument might be mistaken for a command-line option).
 
-The following options are NOT supported:
+The following options are available in Cassandra's nodetool, but are NOT implemented in ScyllaDB's nodetool:
 
 * ``-st`` or ``--start-token``
 * ``-et`` or ``--end-token``

--- a/docs/operating-scylla/nodetool-commands/stop.rst
+++ b/docs/operating-scylla/nodetool-commands/stop.rst
@@ -8,16 +8,17 @@ Usage
 .. code:: sh
 
           nodetool <options> stop -- <compaction_type>
-   
-   Supported compaction types: COMPACTION, CLEANUP, VALIDATION, SCRUB, RESHARD, RESHAPE
 
+Supported compaction types: COMPACTION, CLEANUP, SCRUB, RESHAPE
+
+Stopping a compaction by id (``--id <id>``) is not implemented.
 
 For example:
 
 .. code:: sh
 
-    nodetool stop compaction
+    nodetool stop COMPACTION
 
-    nodetool stop compaction RESHAPE
+    nodetool stop RESHAPE
 
 .. include:: nodetool-index.rst

--- a/docs/operating-scylla/nodetool.rst
+++ b/docs/operating-scylla/nodetool.rst
@@ -119,7 +119,7 @@ Operations that are not listed below are currently not available.
 * :doc:`statusbinary </operating-scylla/nodetool-commands/statusbinary/>` - Status of native transport (binary protocol).
 * :doc:`statusgossip </operating-scylla/nodetool-commands/statusgossip/>` - Status of gossip.
 * :doc:`status </operating-scylla/nodetool-commands/status/>` - Print cluster information.
-* :doc:`stop compaction </operating-scylla/nodetool-commands/stop/>` - Stop compaction operation.
+* :doc:`stop </operating-scylla/nodetool-commands/stop/>` - Stop compaction operation.
 * **tablehistograms** see :doc:`cfhistograms <nodetool-commands/cfhistograms/>`
 * :doc:`tablestats </operating-scylla/nodetool-commands/tablestats/>` - Provides in-depth diagnostics regard table. 
 * :doc:`toppartitions </operating-scylla/nodetool-commands/toppartitions/>` - Samples cluster writes and reads and reports the most active partitions in a specified table and time frame.

--- a/docs/operating-scylla/nodetool.rst
+++ b/docs/operating-scylla/nodetool.rst
@@ -63,13 +63,19 @@ Nodetool generic options
 ========================
 All options are supported:
 
-.. code-block:: shell
 
-   ( -h | --host ) <host name> | <ip address>
-   ( -p | --port ) <port number>
-   ( -pw | --password ) <password >
-   ( -u | --username ) <user name>
-   ( -pwf <passwordFilePath | --password-file <passwordFilePath> )
+
+* ``-p <port>`` or ``--port <port>`` - Remote JMX agent port number.
+
+* ``-pp`` or ``--print-port`` - Operate in 4.0 mode with hosts disambiguated by port number.
+
+* ``-pw <password>`` or ``--password <password>`` - Remote JMX agent password.
+
+* ``-pwf <passwordFilePath>`` or ``--password-file <passwordFilePath>`` - Path to the JMX password file.
+
+* ``-u <username>`` or ``--username <username>`` - Remote JMX agent username.
+
+* ``--`` - Separates command-line options from the list of argument(useful when an argument might be mistaken for a command-line option).
 
 Supported Nodetool operations
 =============================


### PR DESCRIPTION
While working on https://github.com/scylladb/scylladb/issues/15588, I noticed problems with the existing documentation, when comparing it with the actual code.
This PR contains fixes for nodetool compact, stop and scrub.