### PR TITLE
db/view: change log level of failed view updates to WARN

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1738,7 +1738,7 @@ future<> view_update_generator::mutate_MV(
 
                     // Printing an error on every failed view mutation would cause log spam, so a rate limit is needed.
                     static thread_local logger::rate_limit view_update_error_rate_limit(std::chrono::seconds(4));
-                    vlogger.log(log_level::error, view_update_error_rate_limit,
+                    vlogger.log(log_level::warn, view_update_error_rate_limit,
                                 "Error applying view update to {} (view: {}.{}, base token: {}, view token: {}): {}",
                                 *target_endpoint, s->ks_name(), s->cf_name(), base_token, view_token, ep);
                     return apply_update_synchronously ? make_exception_future<>(std::move(ep)) : make_ready_future<>();


### PR DESCRIPTION
When a remote view update doesn't succeed there's a log message saying "Error applying view update...".
This message had log level ERROR, but it's not really a hard error. View updates can fail for a multitude of reasons, even during normal operation. A failing view update isn't fatal, it will be saved as a view hint and retried later.

Let's change the log level to WARN. It's something that shouldn't happen too much, but it's not a disaster either.
ERROR log level causes trouble in tests which assume that an ERROR level message means that the test has failed.

Refs: https://github.com/scylladb/scylladb/issues/15046#issuecomment-1712748784

For local view updates the log level stays at "ERROR", local view updates shouldn't fail.