### PR TITLE
Sanitize hints API handlers and remove proxy from http context

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -220,10 +220,10 @@ future<> set_server_cache(http_context& ctx) {
             "The cache service API", set_cache_service);
 }
 
-future<> set_hinted_handoff(http_context& ctx, sharded<gms::gossiper>& g) {
+future<> set_hinted_handoff(http_context& ctx, sharded<service::storage_proxy>& proxy) {
     return register_api(ctx, "hinted_handoff",
-                "The hinted handoff API", [&g] (http_context& ctx, routes& r) {
-                    set_hinted_handoff(ctx, r, g.local());
+                "The hinted handoff API", [&proxy] (http_context& ctx, routes& r) {
+                    set_hinted_handoff(ctx, r, proxy);
                 });
 }
 

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -68,15 +68,13 @@ struct http_context {
     sstring api_doc;
     httpd::http_server_control http_server;
     distributed<replica::database>& db;
-    distributed<service::storage_proxy>& sp;
     service::load_meter& lmeter;
     const sharded<locator::shared_token_metadata>& shared_token_metadata;
     sharded<tasks::task_manager>& tm;
 
     http_context(distributed<replica::database>& _db,
-            distributed<service::storage_proxy>& _sp,
             service::load_meter& _lm, const sharded<locator::shared_token_metadata>& _stm, sharded<tasks::task_manager>& _tm)
-            : db(_db), sp(_sp), lmeter(_lm), shared_token_metadata(_stm), tm(_tm) {
+            : db(_db), lmeter(_lm), shared_token_metadata(_stm), tm(_tm) {
     }
 
     const locator::token_metadata& get_token_metadata();

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -111,7 +111,7 @@ future<> set_server_storage_proxy(http_context& ctx, sharded<service::storage_pr
 future<> unset_server_storage_proxy(http_context& ctx);
 future<> set_server_stream_manager(http_context& ctx, sharded<streaming::stream_manager>& sm);
 future<> unset_server_stream_manager(http_context& ctx);
-future<> set_hinted_handoff(http_context& ctx, sharded<gms::gossiper>& g);
+future<> set_hinted_handoff(http_context& ctx, sharded<service::storage_proxy>& p);
 future<> unset_hinted_handoff(http_context& ctx);
 future<> set_server_gossip_settle(http_context& ctx, sharded<gms::gossiper>& g);
 future<> set_server_cache(http_context& ctx);

--- a/api/hinted_handoff.cc
+++ b/api/hinted_handoff.cc
@@ -21,7 +21,7 @@ using namespace json;
 using namespace seastar::httpd;
 namespace hh = httpd::hinted_handoff_json;
 
-void set_hinted_handoff(http_context& ctx, routes& r, gms::gossiper& g) {
+void set_hinted_handoff(http_context& ctx, routes& r, sharded<service::storage_proxy>& proxy) {
     hh::create_hints_sync_point.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto parse_hosts_list = [] (sstring arg) {
             std::vector<sstring> hosts_str = split(arg, ",");

--- a/api/hinted_handoff.cc
+++ b/api/hinted_handoff.cc
@@ -28,15 +28,15 @@ void set_hinted_handoff(http_context& ctx, routes& r, gms::gossiper& g) {
             std::vector<gms::inet_address> hosts;
             hosts.reserve(hosts_str.size());
 
-                for (const auto& host_str : hosts_str) {
-                    try {
-                        gms::inet_address host;
-                        host = gms::inet_address(host_str);
-                        hosts.push_back(host);
-                    } catch (std::exception& e) {
-                        throw httpd::bad_param_exception(format("Failed to parse host address {}: {}", host_str, e.what()));
-                    }
+            for (const auto& host_str : hosts_str) {
+                try {
+                    gms::inet_address host;
+                    host = gms::inet_address(host_str);
+                    hosts.push_back(host);
+                } catch (std::exception& e) {
+                    throw httpd::bad_param_exception(format("Failed to parse host address {}: {}", host_str, e.what()));
                 }
+            }
 
             return hosts;
         };

--- a/api/hinted_handoff.hh
+++ b/api/hinted_handoff.hh
@@ -8,17 +8,14 @@
 
 #pragma once
 
+#include <seastar/core/sharded.hh>
 #include "api.hh"
 
-namespace gms {
-
-class gossiper;
-
-}
+namespace service { class storage_proxy; }
 
 namespace api {
 
-void set_hinted_handoff(http_context& ctx, httpd::routes& r, gms::gossiper& g);
+void set_hinted_handoff(http_context& ctx, httpd::routes& r, sharded<service::storage_proxy>& p);
 void unset_hinted_handoff(http_context& ctx, httpd::routes& r);
 
 }

--- a/main.cc
+++ b/main.cc
@@ -634,7 +634,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
     sharded<service::storage_service> ss;
     sharded<service::migration_manager> mm;
     sharded<tasks::task_manager> task_manager;
-    api::http_context ctx(db, proxy, load_meter, token_metadata, task_manager);
+    api::http_context ctx(db, load_meter, token_metadata, task_manager);
     httpd::http_server_control prometheus_server;
     std::optional<utils::directories> dirs = {};
     sharded<gms::feature_service> feature_service;

--- a/main.cc
+++ b/main.cc
@@ -1761,7 +1761,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             supervisor::notify("allow replaying hints");
             proxy.invoke_on_all(&service::storage_proxy::allow_replaying_hints).get();
 
-            api::set_hinted_handoff(ctx, gossiper).get();
+            api::set_hinted_handoff(ctx, proxy).get();
             auto stop_hinted_handoff_api = defer_verbose_shutdown("hinted handoff API", [&ctx] {
                 api::unset_hinted_handoff(ctx).get();
             });

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -664,7 +664,7 @@ public:
     future<> change_hints_host_filter(db::hints::host_filter new_filter);
     const db::hints::host_filter& get_hints_host_filter() const;
 
-    future<db::hints::sync_point> create_hint_sync_point(const std::vector<gms::inet_address> target_hosts) const;
+    future<db::hints::sync_point> create_hint_sync_point(std::vector<gms::inet_address> target_hosts) const;
     future<> wait_for_hint_sync_point(const db::hints::sync_point spoint, clock_type::time_point deadline);
 
     const stats& get_stats() const {


### PR DESCRIPTION
This is the continuation of 3e74432dbf.

Registering API handlers for services need to
 - happen next to the corresponding service's start
 - use only the provided service, not any other ones (if needed, the handler's service can use its internal dependencies to do its job)
 - get the service to handle requests via argument, not from http context (http context, in turn, is going _not_ to depend on anything)
    
Hints API handlers want to use proxy, but also reference gossiper and capture proxy via http context. This PR fixes both and removes http_contex -> proxy dependency as no longer needed