### PR TITLE
tools/nodetool: implement additional commands, part 2/N

### DIFF
--- a/mutation/json.hh
+++ b/mutation/json.hh
@@ -10,9 +10,6 @@
 #include "schema/schema_fwd.hh"
 #include "utils/rjson.hh"
 
-// has to be below the utils/rjson.hh include
-#include <rapidjson/ostreamwrapper.h>
-
 /*
  * Utilities for converting mutations, mutation-fragments and their parts into json.
  */
@@ -27,34 +24,9 @@ struct collection_mutation_view_description;
 
 namespace mutation_json {
 
-class json_writer {
-    using stream = rapidjson::BasicOStreamWrapper<std::ostream>;
-    using writer = rapidjson::Writer<stream, rjson::encoding, rjson::encoding, rjson::allocator>;
-
-    stream _stream;
-    writer _writer;
-
+class json_writer : public rjson::streaming_writer {
 public:
-    json_writer(std::ostream& os = std::cout) : _stream(os), _writer(_stream)
-    { }
-
-    writer& rjson_writer() { return _writer; }
-
-    // following the rapidjson method names here
-    bool Null() { return _writer.Null(); }
-    bool Bool(bool b) { return _writer.Bool(b); }
-    bool Int(int i) { return _writer.Int(i); }
-    bool Uint(unsigned i) { return _writer.Uint(i); }
-    bool Int64(int64_t i) { return _writer.Int64(i); }
-    bool Uint64(uint64_t i) { return _writer.Uint64(i); }
-    bool Double(double d) { return _writer.Double(d); }
-    bool RawNumber(std::string_view str) { return _writer.RawNumber(str.data(), str.size(), false); }
-    bool String(std::string_view str) { return _writer.String(str.data(), str.size(), false); }
-    bool StartObject() { return _writer.StartObject(); }
-    bool Key(std::string_view str) { return _writer.Key(str.data(), str.size(), false); }
-    bool EndObject(rapidjson::SizeType memberCount = 0) { return _writer.EndObject(memberCount); }
-    bool StartArray() { return _writer.StartArray(); }
-    bool EndArray(rapidjson::SizeType elementCount = 0) { return _writer.EndArray(elementCount); }
+    using rjson::streaming_writer::streaming_writer;
 
     // scylla-specific extensions (still following rapidjson naming scheme for consistency)
     template <typename T>

--- a/test/nodetool/rest_api_mock.py
+++ b/test/nodetool/rest_api_mock.py
@@ -21,12 +21,13 @@ logger = logging.getLogger(__name__)
 
 class expected_request:
     def __init__(self, method: str, path: str, params: dict = {}, multiple: bool = False,
-                 response: Dict[str, Any] = None):
+                 response: Dict[str, Any] = None, response_status: int = 200):
         self.method = method
         self.path = path
         self.params = params
         self.multiple = multiple
         self.response = response
+        self.response_status = response_status
 
         self.hit = 0
 
@@ -36,7 +37,8 @@ class expected_request:
                 "path": self.path,
                 "multiple": self.multiple,
                 "params": self.params,
-                "response": self.response}
+                "response": self.response,
+                "response_status": self.response_status}
 
     def __eq__(self, o):
         return self.method == o.method and self.path == o.path and self.params == o.params
@@ -51,7 +53,8 @@ def _make_expected_request(req_json):
             req_json["path"],
             params=req_json.get("params", dict()),
             multiple=req_json.get("multiple", False),
-            response=req_json.get("response"))
+            response=req_json.get("response"),
+            response_status=req_json.get("response_status", 200))
 
 
 class handler_match_info(aiohttp.abc.AbstractMatchInfo):
@@ -146,7 +149,7 @@ class rest_server(aiohttp.abc.AbstractRouter):
             return aiohttp.web.json_response({})
         else:
             logger.info(f"expected_request: {expected_req}, response: {expected_req.response}")
-            return aiohttp.web.json_response(expected_req.response)
+            return aiohttp.web.json_response(expected_req.response, status=expected_req.response_status)
 
 
 async def run_server(ip, port):

--- a/test/nodetool/test_compactionhistory.py
+++ b/test/nodetool/test_compactionhistory.py
@@ -1,0 +1,139 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import datetime
+import json
+import yaml
+
+from rest_api_mock import expected_request
+import utils
+
+
+def format_compacted_at(compacted_at: int):
+    compacted_at_time = compacted_at / 1000
+    milliseconds = compacted_at % 1000
+    return "{:%FT%T}.{}".format(
+            datetime.datetime.fromtimestamp(compacted_at_time),
+            milliseconds)
+
+
+HISTORY_RESPONSE = [
+        {
+            "id": "edde9300-5e9c-11ee-a8f6-7d85dcfeb8f4",
+            "cf": "peers",
+            "ks": "system",
+            "compacted_at": 1695973859380,
+            "bytes_in": 11714,
+            "bytes_out": 11808,
+        },
+        {
+            "id": "edef82f0-5e9c-11ee-a8f6-7d85dcfeb8f4",
+            "cf": "functions",
+            "ks": "system_schema",
+            "compacted_at": 1695973859491,
+            "bytes_in": 5790,
+            "bytes_out": 5944,
+        }]
+
+EXPECTED_REQUEST = expected_request("GET", "/compaction_manager/compaction_history", response=HISTORY_RESPONSE)
+
+
+def test_text(request, nodetool):
+    expected_res_cassandra = \
+"""Compaction History: 
+id                                   keyspace_name columnfamily_name compacted_at            bytes_in bytes_out rows_merged
+edef82f0-5e9c-11ee-a8f6-7d85dcfeb8f4 system_schema functions         {} 5790     5944                 
+edde9300-5e9c-11ee-a8f6-7d85dcfeb8f4 system        peers             {} 11714    11808                
+""".format(format_compacted_at(1695973859491), format_compacted_at(1695973859380))
+
+    # Scylla aligns number columns to the right.
+    expected_res_scylla = \
+"""Compaction History:
+id                                   keyspace_name columnfamily_name compacted_at            bytes_in bytes_out rows_merged
+edef82f0-5e9c-11ee-a8f6-7d85dcfeb8f4 system_schema functions         {}     5790      5944            
+edde9300-5e9c-11ee-a8f6-7d85dcfeb8f4 system        peers             {}    11714     11808            
+""".format(format_compacted_at(1695973859491), format_compacted_at(1695973859380))
+
+    for cmd in [("compactionhistory",), ("compactionhistory", "--format", "text"), ("compactionhistory", "-F", "text")]:
+        if request.config.getoption("nodetool") != "scylla" and len(cmd) > 1:
+            # The -F text is a scylla-extension, cassandra-nodetool doesn't support it
+            continue
+
+        res = nodetool(*cmd, expected_requests=[EXPECTED_REQUEST])
+
+        if request.config.getoption("nodetool") == "scylla":
+            assert res == expected_res_scylla
+        else:
+            assert res == expected_res_cassandra
+
+
+def test_json(nodetool):
+    expected_res = {
+            "CompactionHistory": [
+                {
+                    "id": "edef82f0-5e9c-11ee-a8f6-7d85dcfeb8f4",
+                    "columnfamily_name": "functions",
+                    "keyspace_name": "system_schema",
+                    "compacted_at": format_compacted_at(1695973859491),
+                    "bytes_in": 5790,
+                    "bytes_out": 5944,
+                    "rows_merged": "",
+                },
+                {
+                    "id": "edde9300-5e9c-11ee-a8f6-7d85dcfeb8f4",
+                    "columnfamily_name": "peers",
+                    "keyspace_name": "system",
+                    "compacted_at": format_compacted_at(1695973859380),
+                    "bytes_in": 11714,
+                    "bytes_out": 11808,
+                    "rows_merged": "",
+                }
+            ]
+        }
+
+    for cmd in [("compactionhistory", "--format", "json"), ("compactionhistory", "-F", "json")]:
+        res = nodetool(*cmd, expected_requests=[EXPECTED_REQUEST])
+
+        assert json.loads(res) == expected_res
+
+
+def test_yaml(nodetool):
+    expected_res = {
+            "CompactionHistory": [
+                {
+                    "id": "edef82f0-5e9c-11ee-a8f6-7d85dcfeb8f4",
+                    "columnfamily_name": "functions",
+                    "keyspace_name": "system_schema",
+                    "compacted_at": format_compacted_at(1695973859491),
+                    "bytes_in": 5790,
+                    "bytes_out": 5944,
+                    "rows_merged": "",
+                },
+                {
+                    "id": "edde9300-5e9c-11ee-a8f6-7d85dcfeb8f4",
+                    "columnfamily_name": "peers",
+                    "keyspace_name": "system",
+                    "compacted_at": format_compacted_at(1695973859380),
+                    "bytes_in": 11714,
+                    "bytes_out": 11808,
+                    "rows_merged": "",
+                }
+            ]
+        }
+
+    for cmd in [("compactionhistory", "--format", "yaml"), ("compactionhistory", "-F", "yaml")]:
+        res = nodetool(*cmd, expected_requests=[EXPECTED_REQUEST])
+
+        assert yaml.load(res, Loader=yaml.Loader) == expected_res
+
+
+def test_invalid_format(nodetool):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("compactionhistory", "-F", "foo"),
+            {},
+            ["error processing arguments: invalid format foo, valid formats are: {text, json, yaml}",
+             "nodetool: arguments for -F are json,yaml only."])

--- a/test/nodetool/test_stop.py
+++ b/test/nodetool/test_stop.py
@@ -1,0 +1,75 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from rest_api_mock import expected_request
+import utils
+
+
+def check_compaction_type(nodetool, compaction_type):
+    nodetool(f"stop", compaction_type, expected_requests=[
+        expected_request("POST", "/compaction_manager/stop_compaction", params={"type": compaction_type})])
+
+
+# Test compaction-types supported by both C* and Scylla
+def test_stop_common(nodetool):
+    for compaction_type in ("COMPACTION", "CLEANUP", "SCRUB", "RESHAPE"):
+        check_compaction_type(nodetool, compaction_type)
+
+
+# Even though our docs says it is supported, cassandra-nodetool doesn't know about RESHARD
+def test_stop_reshard(nodetool, scylla_only):
+    check_compaction_type(nodetool, "RESHARD")
+
+
+# Cassandra calls UPGRADE, UPGRADE_SSTABLES, which the scylla-code doesn't recognize
+def test_stop_upgrade(nodetool, scylla_only):
+    check_compaction_type(nodetool, "UPGRADE")
+
+
+# Recognized by scylla, but not supported
+def test_stop_unsupported(nodetool):
+    for compaction_type in ("VALIDATION", "INDEX_BUILD"):
+        req = expected_request(
+                "POST",
+                "/compaction_manager/stop_compaction",
+                params={"type": compaction_type},
+                response={"code": 500,
+                          "message": f"std::runtime_error (Compaction type {compaction_type} is unsupported)"},
+                response_status=500)
+        utils.check_nodetool_fails_with(
+                nodetool,
+                ("stop", compaction_type),
+                {"expected_requests": [req]},
+                ["nodetool: Scylla API server HTTP POST to URL 'compaction_manager/stop_compaction' failed:"
+                 f" std::runtime_error (Compaction type {compaction_type} is unsupported)",
+                 f"error processing arguments: invalid compaction type: {compaction_type}"])
+
+
+def test_stop_unknown(nodetool):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("stop", "FOO"),
+            {},
+            ["nodetool: compaction_type: can not convert \"FOO\" to a OperationType",
+             "error processing arguments: invalid compaction type: FOO"])
+
+
+def test_stop_no_type(nodetool, scylla_only):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("stop",),
+            {},
+            ["error processing arguments: missing required parameter: compaction_type"])
+
+
+# This is not implemented, nodetool logs a message and exits
+def test_stop_by_id(nodetool, scylla_only):
+    expected_error = "error processing arguments: stopping compactions by id is not implemented"
+
+    utils.check_nodetool_fails_with(nodetool, ("stop", "-id", "123"), {}, [expected_error])
+    utils.check_nodetool_fails_with(nodetool, ("stop", "-id=123"), {}, [expected_error])
+    utils.check_nodetool_fails_with(nodetool, ("stop", "--id", "123"), {}, [expected_error])
+    utils.check_nodetool_fails_with(nodetool, ("stop", "--id=123"), {}, [expected_error])


### PR DESCRIPTION
The following new commands are implemented:
* stop
* compactionhistory

All are associated with tests. All tests (both old and new) pass with both the scylla-native and the cassandra nodetool implementation.

Refs: https://github.com/scylladb/scylladb/issues/15588