### PR TITLE
docs: add only_latest option to aws_images_template extension

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -91,7 +91,7 @@ redirects: setup
 # Preview commands
 .PHONY: preview
 preview: setup
-	$(POETRY) run sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml --host $(PREVIEW_HOST) --port 5500 --ignore '_data/*'
+	$(POETRY) run sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml --host $(PREVIEW_HOST) --port 5500 --ignore *.csv --ignore *.yaml
 
 .PHONY: multiversionpreview
 multiversionpreview: multiversion

--- a/docs/_ext/scylladb_aws_images.py
+++ b/docs/_ext/scylladb_aws_images.py
@@ -118,6 +118,7 @@ class AMIVersionsTemplateDirective(Directive):
     option_spec = {
         "version": directives.unchanged,
         "exclude": directives.unchanged,
+        "only_latest": directives.flag,
     }
 
     def _extract_version_from_filename(self, filename):
@@ -169,6 +170,8 @@ class AMIVersionsTemplateDirective(Directive):
             LOGGER.warning(
                 f"No files match in directory '{download_directory}' with version pattern '{version_pattern}'."
             )
+        elif "only_latest" in self.options:
+            files = [files[0]]
 
         output = []
         for file in files:


### PR DESCRIPTION
Continuation of https://github.com/scylladb/scylladb/pull/15276

This PR:

- Extends the functionality of the `scylladb_aws_images_template` extension to support a new `only_latest `option.
- Addresses a bug affecting local documentation preview (infinite loop).

In detail:

When the `only_latest` option is enabled, it restricts the rendered table to show only the latest AWS AMI Image version. This new feature was requested  to  display the latest AWS AMI image on [this page](https://opensource.docs.scylladb.com/master/getting-started/install-scylla/launch-on-aws.html), instead of linking to the ScyllaDB download center.

## How to test

1. Clone this pull request.
2. Include the following directive in a rst page:

  ```
  .. scylladb_aws_images_template::
     :version: 5.2
     :exclude: rc,dev
     :only_latest:
   ```
    
3. Preview the changes. You should be able to see only a table that renders the latest 5.2 version information.
