### PR TITLE
Enlight sstable_directory construction

### DIFF
--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -346,12 +346,7 @@ private:
 future<> table_populator::start_subdir(sstables::sstable_state state) {
     auto dptr = make_lw_shared<sharded<sstables::sstable_directory>>();
     auto& directory = *dptr;
-    auto& global_table = _global_table;
-    auto& db = _db;
-    co_await directory.start(_global_table.as_sharded_parameter(),
-        state,
-        default_io_error_handler_gen()
-    );
+    co_await directory.start(_global_table.as_sharded_parameter(), state, default_io_error_handler_gen());
 
     // directory must be stopped using table_populator::stop below
     _sstable_directories[state] = dptr;
@@ -360,7 +355,7 @@ future<> table_populator::start_subdir(sstables::sstable_state state) {
 
     sstables::sstable_directory::process_flags flags {
         .throw_on_missing_toc = true,
-        .enable_dangerous_direct_import_of_cassandra_counters = db.local().get_config().enable_dangerous_direct_import_of_cassandra_counters(),
+        .enable_dangerous_direct_import_of_cassandra_counters = _db.local().get_config().enable_dangerous_direct_import_of_cassandra_counters(),
         .allow_loading_materialized_view = true,
         .garbage_collect = true,
     };
@@ -371,7 +366,7 @@ future<> table_populator::start_subdir(sstables::sstable_state state) {
     // in the system tables. In that case we'll rely on what we find on disk: we'll
     // at least not downgrade any files. If we already know that we support a higher
     // format than the one we see then we use that.
-    auto sys_format = global_table->get_sstables_manager().get_highest_supported_format();
+    auto sys_format = _global_table->get_sstables_manager().get_highest_supported_format();
     auto sst_version = co_await highest_version_seen(directory, sys_format);
     auto generation = co_await highest_generation_seen(directory);
 

--- a/replica/global_table_ptr.hh
+++ b/replica/global_table_ptr.hh
@@ -25,6 +25,9 @@ public:
     void assign(table& t);
     table* operator->() const noexcept;
     table& operator*() const noexcept;
+    auto as_sharded_parameter() {
+        return sharded_parameter([this] { return std::ref(**this); });
+    }
 };
 
 future<global_table_ptr> get_table_on_all_shards(sharded<database>& db, table_id uuid);

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -61,6 +61,20 @@ sstable_directory::make_components_lister() {
     }, _storage_opts->value);
 }
 
+sstable_directory::sstable_directory(replica::table& table,
+        sstable_state state,
+        io_error_handler_gen error_handler_gen)
+    : sstable_directory(
+        table.get_sstables_manager(),
+        table.schema(),
+        table.get_effective_replication_map()->get_sharder(*table.schema()),
+        table.get_storage_options_ptr(),
+        table.dir(),
+        std::move(state),
+        std::move(error_handler_gen)
+    )
+{}
+
 sstable_directory::sstable_directory(sstables_manager& manager,
         schema_ptr schema,
         const dht::sharder& sharder,

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -192,6 +192,9 @@ private:
     future<foreign_sstable_open_info> get_open_info_for_this_sstable(const sstables::entry_descriptor& desc) const;
 
 public:
+    sstable_directory(replica::table& table,
+            sstable_state state,
+            io_error_handler_gen error_handler_gen);
     sstable_directory(sstables_manager& manager,
             schema_ptr schema,
             const dht::sharder& sharder,


### PR DESCRIPTION
Currently distributed_loader starts sharded<sstable_directory> with four sharded parameters. That's quite bulky and can be made much shorter.