### PR TITLE
tests: Synchronize boost logger for multithreaded tests in sstable_directory_test

### DIFF
--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -312,8 +312,8 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_generation_sanity) {
             sstdir.invoke_on_all([&] (sstables::sstable_directory& sstdir) {
                 return seastar::async([&] {
                     sstdir.do_for_each_sstable([&] (const shared_sstable& sst) {
-                        BOOST_REQUIRE(sst->generation() == sst1->generation());
-                        BOOST_REQUIRE(!gen1_seen[this_shard_id()]);
+                        THREADSAFE_BOOST_REQUIRE(sst->generation() == sst1->generation());
+                        THREADSAFE_BOOST_REQUIRE(!gen1_seen[this_shard_id()]);
                         gen1_seen[this_shard_id()] = true;
                         return make_ready_future<>();
                     }).get();
@@ -330,12 +330,12 @@ future<> verify_that_all_sstables_are_local(sharded<sstable_directory>& sstdir, 
             return d.do_for_each_sstable([count] (sstables::shared_sstable sst) {
                 count->fetch_add(1, std::memory_order_relaxed);
                 auto shards = sst->get_shards_for_this_sstable();
-                BOOST_REQUIRE_EQUAL(shards.size(), 1);
-                BOOST_REQUIRE_EQUAL(shards[0], this_shard_id());
+                THREADSAFE_BOOST_REQUIRE_EQUAL(shards.size(), 1);
+                THREADSAFE_BOOST_REQUIRE_EQUAL(shards[0], this_shard_id());
                 return make_ready_future<>();
             });
          }).then([count = count.get(), expected_sstables] {
-            BOOST_REQUIRE_EQUAL(count->load(std::memory_order_relaxed), expected_sstables);
+            THREADSAFE_BOOST_REQUIRE_EQUAL(count->load(std::memory_order_relaxed), expected_sstables);
             return make_ready_future<>();
         });
     });

--- a/test/lib/test_utils.cc
+++ b/test/lib/test_utils.cc
@@ -98,4 +98,6 @@ future<> touch_file(std::string name) {
     co_await f.close();
 }
 
+std::mutex boost_logger_mutex;
+
 }


### PR DESCRIPTION
The logger is not thread safe, so a multithreaded test can concurrently write into the log, yielding unreadable XMLs.

Example:
`boost/sstable_directory_test: failed to parse XML output '/scylladir/testlog/x86_64/release/xml/boost.sstable_directory_test.sstable_directory_shared_sstables_reshard_correctly.3.xunit.xml': not well-formed (invalid token): line 1, column 1351`

The critical (today's unprotected) section is in boost/test/utils/xml_printer.hpp:
```
inline std::ostream&
operator<<( custom_printer<cdata> const& p, const_string value )
{
    *p << BOOST_TEST_L( "<![CDATA[" );
    print_escaped_cdata( *p, value );
    return  *p << BOOST_TEST_L( "]]>" );
}
```

The problem is not restricted to xml, but the unreadable xml file caused the test to fail when trying to parse it, to present a summary.

New thread-safe variants of BOOST_REQUIRE and BOOST_REQUIRE_EQUAL are introduced to help multithreaded tests. We'll start patching tests of sstable_directory_test that will call BOOST_REQUIRE* from multiple threads. Later, we can expand its usage to other tests.

Fixes #15654.