### PR TITLE
Allow running perf-simple-query with tablets

### DIFF
--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -631,7 +631,13 @@ private:
                 _sys_ks.local().save_local_info(std::move(linfo), _snitch.local()->get_location()).get();
             }
             locator::shared_token_metadata::mutate_on_all_shards(_token_metadata, [hostid = host_id] (locator::token_metadata& tm) {
-                tm.get_topology().set_host_id_cfg(hostid);
+                auto& topo = tm.get_topology();
+                topo.set_host_id_cfg(hostid);
+                topo.add_or_update_endpoint(utils::fb_utilities::get_broadcast_address(),
+                                            hostid,
+                                            std::nullopt,
+                                            locator::node::state::normal,
+                                            smp::count);
                 return make_ready_future<>();
             }).get();
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -749,6 +749,11 @@ private:
                 std::ref(_cdc_generation_service)).get();
             auto stop_storage_service = defer([this] { _ss.stop().get(); });
 
+            _mnotifier.local().register_listener(&_ss.local());
+            auto stop_mm_listener = defer([this] {
+                _mnotifier.local().unregister_listener(&_ss.local()).get();
+            });
+
             _ss.invoke_on_all([this] (service::storage_service& ss) {
                 ss.set_query_processor(_qp.local());
             }).get();

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -92,6 +92,7 @@ public:
     std::set<sstring> disabled_features;
     std::optional<cql3::query_processor::memory_config> qp_mcfg;
     bool need_remote_proxy = false;
+    std::optional<uint64_t> initial_tablets; // When engaged, the default keyspace will use tablets.
     locator::host_id host_id;
 
     cql_test_config();


### PR DESCRIPTION
Usage:

```
build/dev/scylla perf-simple-query --tablets
```
