### PR TITLE
build: cmake: move message/* into message/CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,6 @@ target_sources(scylla-main
     debug.cc
     init.cc
     keys.cc
-    message/messaging_service.cc
     multishard_mutation_query.cc
     mutation_query.cc
     partition_slice_builder.cc
@@ -124,6 +123,7 @@ add_subdirectory(index)
 add_subdirectory(interface)
 add_subdirectory(lang)
 add_subdirectory(locator)
+add_subdirectory(message)
 add_subdirectory(mutation)
 add_subdirectory(mutation_writer)
 add_subdirectory(node_ops)
@@ -165,6 +165,7 @@ target_link_libraries(scylla PRIVATE
     index
     lang
     locator
+    message
     mutation
     mutation_writer
     raft

--- a/message/CMakeLists.txt
+++ b/message/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(message STATIC)
+target_sources(message
+  PRIVATE
+    messaging_service.cc
+    messaging_service.hh)
+target_include_directories(message
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(message
+  PUBLIC
+    gms
+    Seastar::seastar
+  PRIVATE
+    idl)

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(test-lib
     idl
     index # used by cql3
     locator
+    message
     schema
     scylla_version
     service

--- a/test/manual/CMakeLists.txt
+++ b/test/manual/CMakeLists.txt
@@ -9,7 +9,8 @@ add_scylla_test(gossip
 add_scylla_test(manual_hint_test
   SOURCES hint_test.cc
   KIND SEASTAR)
-add_scylla_test(message
+add_scylla_test(message_test
+  SOURCES message.cc
   KIND SEASTAR)
 add_scylla_test(partition_data_test
   KIND SEASTAR)


### PR DESCRIPTION
messaging_service.cc depends on idl, but many source files in scylla-main do no depend on idl, so let's

* move "message/*" into its own directory and add an inter-library dependency between it and the "idl" library.
* rename the target of "message" under test/manual to "message_test" to avoid the name collision

this should address the compilation failure of
```
FAILED: CMakeFiles/scylla-main.dir/message/messaging_service.cc.o
/usr/bin/clang++ -DBOOST_NO_CXX98_FUNCTION_BASE -DDEBUG -DDEBUG_LSA_SANITIZER -DFMT_DEPRECATED_OSTREAM -DFMT_SHARED -DSANITIZE -DSCYLLA_BUILD_MODE=debug -DSCYLLA_ENABLE_ERROR_INJECTION -DSEASTAR_API_LEVEL=7 -DSEASTAR_BROKEN_SOURCE_LOCATION -DSEASTAR_DEBUG -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_SSTRING -DSEASTAR_TYPE_ERASE_MORE -DXXH_PRIVATE_API -I/home/kefu/dev/scylladb -I/home/kefu/dev/scylladb/build/cmake/gen -I/home/kefu/dev/scylladb/seastar/include -I/home/kefu/dev/scylladb/build/cmake/seastar/gen/include -Wall -Werror -Wextra -Wno-error=deprecated-declarations -Wimplicit-fallthrough -Wno-c++11-narrowing -Wno-mismatched-tags -Wno-overloaded-virtual -Wno-unsupported-friend -Wno-unused-parameter -Wno-missing-field-initializers -Wno-deprecated-copy -Wno-ignored-qualifiers -march=westmere  -Og -g -gz -std=gnu++20 -fvisibility=hidden -U_FORTIFY_SOURCE -Wno-error=unused-result "-Wno-error=#warnings" -fstack-clash-protection -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr -MD -MT CMakeFiles/scylla-main.dir/message/messaging_service.cc.o -MF CMakeFiles/scylla-main.dir/message/messaging_service.cc.o.d -o CMakeFiles/scylla-main.dir/message/messaging_service.cc.o -c /home/kefu/dev/scylladb/message/messaging_service.cc
/home/kefu/dev/scylladb/message/messaging_service.cc:81:10: fatal error: 'idl/join_node.dist.hh' file not found
         ^~~~~~~~~~~~~~~~~~~~~~~
```
where the compiler failed to find the included `idl/join_node.dist.hh`, which is exposed by the idl library as part of its public interface.