### PR TITLE
test: Verify server exit code during graceful process shutdown.

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -516,6 +516,8 @@ class ScyllaServer:
             wait_task = self.cmd.wait()
             try:
                 await asyncio.wait_for(wait_task, timeout=STOP_TIMEOUT_SECONDS)
+                if self.cmd.returncode != 0:
+                    raise RuntimeError(f"Server {self} exited with non-zero exit code: {self.cmd.returncode}")
             except asyncio.TimeoutError:
                 self.cmd.kill()
                 await self.cmd.wait()


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylladb/issues/15365

# How to test:
Modify [main.cc](https://github.com/scylladb/scylladb/blob/master/main.cc#L123)
```C++
class stop_signal {
   void signaled() {
      // Causes abnormal program termination
      abort();
      // ...
   }
};
```
Run a test `./test.py --mode dev topology_custom/test_replace_ignore_nodes` or any other that relies on `manager.server_stop_gracefully(server_id)`

## Clean run (without changes to `scylla_cluster.py`):
> topology_custom   dev   [ **PASS** ] topology_custom.test_replace_ignore_nodes.1

The log file `test.py.dev.log` shows no issues.

## Modify `test/pylib/scylla_cluster.py` (apply the PR):
> topology_custom   dev   [ **FAIL** ] topology_custom.test_replace_ignore_nodes.1
...
The following test(s) have failed: topology_custom/test_replace_ignore_nodes
...
Server ScyllaServer(3, 127.68.82.3, e3ccf1b5-a8eb-4cfe-a322-0384babd1f02) exited with non-zero exit code: -6

The log file `test.py.dev.log` shows:
>22:43:44.078 INFO> [dev/topology_custom.test_replace_ignore_nodes.1] gracefully stopped ScyllaServer(3, 127.68.82.3, e3ccf1b5-a8eb-4cfe-a322-0384babd1f02)
22:43:44.079 ERROR> [dev/topology_custom.test_replace_ignore_nodes.1] Exception when executing _cluster_server_stop_gracefully: Server ScyllaServer(3, 127.68.82.3, e3ccf1b5-a8eb-4cfe-a322-0384babd1f02) exited with non-zero exit code: -6
Traceback (most recent call last):
...