### PR TITLE
build: extract code fragments into functions

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -27,16 +27,6 @@ tempfile.tempdir = f"{outdir}/tmp"
 
 configure_args = str.join(' ', [shlex.quote(x) for x in sys.argv[1:] if not x.startswith('--out=')])
 
-employ_ld_trickery = True
-
-# distro-specific setup
-def distro_setup_nix():
-    global employ_ld_trickery
-    employ_ld_trickery = False
-
-if os.environ.get('NIX_CC'):
-        distro_setup_nix()
-
 # distribution "internationalization", converting package names.
 # Fedora name is key, values is distro -> package name dict.
 i18n_xlat = {
@@ -1650,6 +1640,12 @@ for m, mode_config in modes.items():
 def dynamic_linker_option():
     gcc_linker_output = subprocess.check_output(['gcc', '-###', '/dev/null', '-o', 't'], stderr=subprocess.STDOUT).decode('utf-8')
     original_dynamic_linker = re.search('-dynamic-linker ([^ ]*)', gcc_linker_output).groups()[0]
+
+    employ_ld_trickery = True
+    # distro-specific setup
+    if os.environ.get('NIX_CC'):
+        employ_ld_trickery = False
+
     if employ_ld_trickery:
         # gdb has a SO_NAME_MAX_PATH_SIZE of 512, so limit the path size to
         # that. The 512 includes the null at the end, hence the 511 bellow.

--- a/configure.py
+++ b/configure.py
@@ -1314,8 +1314,6 @@ idls = ['idl/gossip_digest.idl.hh',
         'idl/utils.idl.hh',
         ]
 
-headers = find_headers('.', excluded_dirs=['idl', 'build', 'seastar', '.git'])
-
 scylla_tests_generic_dependencies = [
     'test/lib/cql_test_env.cc',
     'test/lib/test_services.cc',
@@ -2071,6 +2069,8 @@ def write_build_file(f,
                 objs=' '.join(compiles)
             )
         )
+
+        headers = find_headers('.', excluded_dirs=['idl', 'build', 'seastar', '.git'])
         f.write(
             'build {mode}-headers: phony {header_objs}\n'.format(
                 mode=mode,


### PR DESCRIPTION
this series is one of the steps to remove global statements in `configure.py`. 

not only the script is more structured this way, this also allows us to quickly identify the part which should/can be reused when migrating to CMake based building system.

Refs #15379