### PR TITLE
compaction_manager: perform_cleanup: ignore condition_variable_timed_out

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1789,7 +1789,11 @@ future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_range
         };
 
         cmlog.debug("perform_cleanup: waiting for sstables to become eligible for cleanup");
-        co_await t.get_staging_done_condition().when(sleep_duration, [&] { return has_sstables_eligible_for_compaction(); });
+        try {
+            co_await t.get_staging_done_condition().when(sleep_duration, [&] { return has_sstables_eligible_for_compaction(); });
+        } catch (const seastar::condition_variable_timed_out&) {
+            // Ignored.  Keep retrying for max_idle_duration
+        }
 
         if (!has_sstables_eligible_for_compaction()) {
             continue;


### PR DESCRIPTION
The polling loop was intended to ignore
`condition_variable_timed_out` and check for progress using a longer `max_idle_duration` timeout in the loop.

Fixes #15669