### PR TITLE
test/pylib: always return a response from `put_json`

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -86,7 +86,8 @@ class ManagerClient():
         if dirty:
             self.driver_close()  # Close driver connection to old cluster
         try:
-            cluster_str = await self.client.put_json(f"/cluster/before-test/{test_case_name}", timeout=600)
+            cluster_str = await self.client.put_json(f"/cluster/before-test/{test_case_name}", timeout=600,
+                                                     response_type = "json")
             logger.info(f"Using cluster: {cluster_str} for test {test_case_name}")
         except aiohttp.ClientError as exc:
             raise RuntimeError(f"Failed before test check {exc}") from exc
@@ -99,7 +100,8 @@ class ManagerClient():
     async def after_test(self, test_case_name: str, success: bool) -> None:
         """Tell harness this test finished"""
         logger.debug("after_test for %s (success: %s)", test_case_name, success)
-        cluster_str = await self.client.put_json(f"/cluster/after-test/{success}")
+        cluster_str = await self.client.put_json(f"/cluster/after-test/{success}",
+                                                 response_type = "json")
         logger.info("Cluster after test %s: %s", test_case_name, cluster_str)
 
     async def is_manager_up(self) -> bool:


### PR DESCRIPTION
In 20ff2ae5e146de02c03564154e367bb3aeed3bab mutating endpoints were changed to use PUT. But some of them return a response, and I forgot to provide `response_type` parameter to `put_json` (which causes `RESTClient` to actually obtain the response). These endpoints now return `None`.

Fix this.