### PR TITLE
types: use more readable error message when serializing non-ASCII string

### DIFF
--- a/test/cql-pytest/test_validation.py
+++ b/test/cql-pytest/test_validation.py
@@ -321,6 +321,7 @@ def test_validation_ascii_bound_column(cql, table1):
 #    itself. The request itself is valid (it just needs to be UTF-8), but
 #    the non-ASCII insertion should be refused.
 # Reproduces issue #5421.
+# Reproduces issue #14320.
 def test_validation_ascii_query(cql, table1):
     for s in good_ascii:
         print(s)
@@ -330,11 +331,7 @@ def test_validation_ascii_query(cql, table1):
         assert results[0].k == 1 and results[0].a == s
     for s in bad_ascii:
         print(s)
-        # Scylla prints "marshaling error: Value not compatible with type
-        # org.apache.cassandra.db.marshal.AsciiType: '...'". Cassandra prints
-        # "Invalid ASCII character in string literal". The only thing in common
-        # is the word "ascii"...
-        with pytest.raises(InvalidRequest, match=re.compile('ascii', re.IGNORECASE)):
+        with pytest.raises(InvalidRequest, match='Invalid ASCII character'):
             cql.execute(f"INSERT INTO {table1} (k, a) VALUES (1, '{s}')")
 
 # 4. The invalid ASCII can be the result of a user-defined function in Lua,

--- a/types/types.cc
+++ b/types/types.cc
@@ -2691,7 +2691,7 @@ struct from_string_visitor {
         if (utils::ascii::validate(bv)) {
             return to_bytes(bv);
         } else {
-            throw marshal_exception(format("Value not compatible with type {}: '{}'", ascii_type_name, s));
+            throw marshal_exception(format("Invalid ASCII character in string literal: '{}'", s));
         }
     }
     bytes operator()(const string_type_impl&) {


### PR DESCRIPTION
before this change, we print

marshaling error: Value not compatible with type org.apache.cassandra.db.marshal.AsciiType: '...'

but the wording is not quite user friendly, it is a mapping of the underlying implementation, user would have difficulty understanding "marshaling" and/or "org.apache.cassandra.db.marshal.AsciiType" when reading this error message.

so, in this change

1. change the error message to: Invalid ASCII character in string literal: '...' which should be more straightforward, and easier to digest.
2. update the test accordingly

please note, the quoted non-ASCII string is preserved instead of being printed in hex, as otherwise user would not be able to map it with his/her input.

Refs #14320