### PR TITLE
test.py: pass self.suite.scylla_env to pytest process

### DIFF
--- a/test.py
+++ b/test.py
@@ -914,7 +914,7 @@ class PythonTest(Test):
             self.args.insert(0, "--host={}".format(cluster.endpoint()))
             self.is_before_test_ok = True
             cluster.take_log_savepoint()
-            status = await run_test(self, options)
+            status = await run_test(self, options, env=self.suite.scylla_env)
             if self.shortname in self.suite.dirties_cluster:
                 cluster.is_dirty = True
             cluster.after_test(self.uname, status)


### PR DESCRIPTION
before this change, pytest does not populate its suites's `scylla_env` down to the forked pytest child process. this works if the test does not care about the env variables in `scylla_env`. but object_store is an exception, as it launches scylla instances by itself. so, without the help of `scylla_env`, `run.find_scylla()` always find the newest file globbed by `build/*/scylla`. this is not always what we expect. on the contrary, if we launch object_store's pytest using `test.py`, there are good chances that object_store ends up with testing a wrong scylla executable if we have multiple builds under `build/*/scylla`.

so, in this change, we populate `self.suite.scylla_env` down to the child process created by `PythonTest`, so that all pytest based tests can have access to its suites's env variables. in addition to 'SCYLLA' env variable, they also include the the env variables required by LLVM code coverage instrumentation. this is also nice to have.

Fixes #15679
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>