### PR TITLE
feature_service: disable `GROUP0_SCHEMA_VERSIONING`

### DIFF
--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -79,9 +79,10 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
     if (!cfg.check_experimental(db::experimental_features_t::feature::ALTERNATOR_STREAMS)) {
         fcfg._disabled_features.insert("ALTERNATOR_STREAMS"s);
     }
+    // FIXME: temporarily disabled -- user type definitions may be not updated properly (#15530)
+    fcfg._disabled_features.insert("GROUP0_SCHEMA_VERSIONING"s);
     if (!cfg.consistent_cluster_management()) {
         fcfg._disabled_features.insert("SUPPORTS_RAFT_CLUSTER_MANAGEMENT"s);
-        fcfg._disabled_features.insert("GROUP0_SCHEMA_VERSIONING"s);
     }
     if (!cfg.check_experimental(db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS)) {
         fcfg._disabled_features.insert("KEYSPACE_STORAGE_OPTIONS"s);


### PR DESCRIPTION
It turns out that 3d4398d1b2b9bc2139718e49a806214171ee081f introduced a regression. The dtest `test_add_udt_to_another_data_types` started failing in a flaky way.  The test is adding a field to the user-defined type `user_refs` and then inserting to a table that references this type. The insert fails with the following error: `Invalid tuple literal for entity_info: component 5 is not of type frozen<user_refs>`. But Scylla apparently keeps using the old version of this type, without the new field. And this doesn't seem a race in schema propagation across shards in Scylla -- once the first insert fails, sleeping and retrying the insert fails in the same way, so it seems that schema enters a broken state that is not transient.

The feature wasn't released in any version of Scylla yet, so we can safely disable it for now. When the feature is disabled, Scylla uses the old way of determining schema versions (calculating hashes). I verified using @Lorak-mmk's reproducer that disabling the feature solves the problem.

Fixes scylladb/scylladb#15530