### PR TITLE
dist/redhat: drop rpm conflict with ABRT, add systemd conflict instead

### DIFF
--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -28,6 +28,14 @@ if __name__ == '__main__':
                         help='enable compress on systemd-coredump')
     args = parser.parse_args()
 
+    # abrt-ccpp.service needs to stop before enabling systemd-coredump,
+    # since both will try to install kernel coredump handler
+    # (This will only requires for abrt < 2.14)
+    if systemd_unit.available('abrt-ccpp.service'):
+        abrt_ccpp = systemd_unit('abrt-ccpp.service')
+        abrt_ccpp.disable()
+        abrt_ccpp.stop()
+
 # Gentoo may uses OpenRC
     if is_gentoo():
         run('sysctl -p /etc/sysctl.d/99-scylla-coredump.conf', shell=True, check=True)
@@ -85,7 +93,7 @@ WantedBy=multi-user.target
             run('sysctl -p /usr/lib/sysctl.d/50-coredump.conf', shell=True, check=True)
         else:
             with open('/etc/sysctl.d/99-scylla-coredump.conf', 'w') as f:
-                f.write('kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e"')
+                f.write('kernel.core_pattern=|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e')
             run('sysctl -p /etc/sysctl.d/99-scylla-coredump.conf', shell=True, check=True)
 
         fp = tempfile.NamedTemporaryFile()

--- a/dist/common/systemd/scylla-server.service
+++ b/dist/common/systemd/scylla-server.service
@@ -3,6 +3,8 @@ Description=Scylla Server
 Wants=scylla-jmx.service
 Wants=scylla-housekeeping-restart.timer
 Wants=scylla-housekeeping-daily.timer
+# This will only requires for abrt < 2.14
+Conflicts=abrt-ccpp.service
 
 [Service]
 PermissionsStartOnly=true

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -64,7 +64,6 @@ License:        AGPLv3
 URL:            http://www.scylladb.com/
 Requires:       %{product}-conf = %{version}-%{release}
 Requires:       %{product}-python3 = %{version}-%{release}
-Conflicts:      abrt
 AutoReqProv:    no
 
 %description server


### PR DESCRIPTION
Currently, "yum install scylla" causes conflict when ABRT is installed.

To avoid this behavior and keep using systemd-coredump for scylla coredump, let's drop "Conflicts: abrt" from rpm and add "Conflicts=abrt-ccpp.service" to systemd unit.

Fixes #892