### PR TITLE
schema_tables: turn view schema fixing code into a sanity check

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -829,13 +829,6 @@ future<std::vector<canonical_mutation>> convert_schema_to_mutations(distributed<
 
 std::vector<mutation>
 adjust_schema_for_schema_features(std::vector<mutation> schema, schema_features features) {
-    //Don't send the `computed_columns` table mutations to nodes that doesn't know it.
-    if (!features.contains(schema_feature::COMPUTED_COLUMNS)) {
-        schema.erase(std::remove_if(schema.begin(), schema.end(), [] (const mutation& m) {
-            return m.schema()->cf_name() == COMPUTED_COLUMNS;
-        }) , schema.end());
-    }
-
     for (auto& m : schema) {
         m = redact_columns_for_missing_features(m, features);
     }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -3680,8 +3680,8 @@ view_ptr maybe_fix_legacy_secondary_index_mv_schema(replica::database& db, const
     }
 
     // If the first clustering key part of a view is a column with name not found in base schema,
-    // it implies it might be backing an index created before computed columns were introduced,
-    // and as such it must be recreated properly.
+    // and the column is not computed (which we checked above), then it must be backing an index
+    // created before computed columns were introduced, and as such it must be recreated properly.
     if (!base_schema->columns_by_name().contains(first_view_ck.name())) {
         schema_builder builder{schema_ptr(v)};
         builder.mark_column_computed(first_view_ck.name(), std::make_unique<legacy_token_column_computation>());

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -264,9 +264,7 @@ std::vector<mutation> make_update_view_mutations(lw_shared_ptr<keyspace_metadata
 
 std::vector<mutation> make_drop_view_mutations(lw_shared_ptr<keyspace_metadata> keyspace, view_ptr view, api::timestamp_type timestamp);
 
-class preserve_version_tag {};
-using preserve_version = bool_class<preserve_version_tag>;
-view_ptr maybe_fix_legacy_secondary_index_mv_schema(replica::database& db, const view_ptr& v, schema_ptr base_schema, preserve_version preserve_version);
+void check_no_legacy_secondary_index_mv_schema(replica::database& db, const view_ptr& v, schema_ptr base_schema);
 
 sstring serialize_kind(column_kind kind);
 column_kind deserialize_kind(sstring kind);

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -577,7 +577,7 @@ private:
     const std::optional<clustering_or_static_row>& _existing;
 
 public:
-    value_getter(const schema& base, const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing, bool backing_secondary_index)
+    value_getter(const schema& base, const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing)
         : _base(base)
         , _base_key(base_key)
         , _update(update)
@@ -647,7 +647,7 @@ private:
 
 std::vector<view_updates::view_row_entry>
 view_updates::get_view_rows(const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing) {
-    value_getter getter(*_base, base_key, update, existing, _backing_secondary_index);
+    value_getter getter(*_base, base_key, update, existing);
     auto get_value = boost::adaptors::transformed(std::ref(getter));
 
 
@@ -1452,8 +1452,7 @@ view_update_builder make_view_update_builder(
                                               " base schema version of the view ({}) for view {}.{} of {}.{}",
                 base->version(), v.base->base_schema()->version(), v.view->ks_name(), v.view->cf_name(), base->ks_name(), base->cf_name()));
         }
-        bool is_index = base_table.get_index_manager().is_index(v.view);
-        return view_updates(std::move(v), is_index);
+        return view_updates(std::move(v));
     }));
     return view_update_builder(std::move(db), base_table, base, std::move(vs), std::move(updates), std::move(existings), now);
 }

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -210,15 +210,13 @@ class view_updates final {
     base_info_ptr _base_info;
     std::unordered_map<partition_key, mutation_partition, partition_key::hashing, partition_key::equality> _updates;
     mutable size_t _op_count = 0;
-    const bool _backing_secondary_index;
 public:
-    explicit view_updates(view_and_base vab, bool backing_secondary_index)
+    explicit view_updates(view_and_base vab)
             : _view(std::move(vab.view))
             , _view_info(*_view->view_info())
             , _base(vab.base->base_schema())
             , _base_info(vab.base)
             , _updates(8, partition_key::hashing(*_view), partition_key::equality(*_view))
-            , _backing_secondary_index(backing_secondary_index)
     {
     }
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -138,6 +138,7 @@ std::set<std::string_view> feature_service::supported_feature_set() const {
         "CORRECT_STATIC_COMPACT_IN_MC"sv,
         "UNBOUNDED_RANGE_TOMBSTONES"sv,
         "MC_SSTABLE_FORMAT"sv,
+        "COMPUTED_COLUMNS"sv,
     };
 
     if (is_test_only_feature_deprecated()) {
@@ -195,7 +196,7 @@ db::schema_features feature_service::cluster_schema_features() const {
     db::schema_features f;
     f.set_if<db::schema_feature::VIEW_VIRTUAL_COLUMNS>(view_virtual_columns);
     f.set_if<db::schema_feature::DIGEST_INSENSITIVE_TO_EXPIRY>(digest_insensitive_to_expiry);
-    f.set_if<db::schema_feature::COMPUTED_COLUMNS>(computed_columns);
+    f.set<db::schema_feature::COMPUTED_COLUMNS>();
     f.set_if<db::schema_feature::CDC_OPTIONS>(cdc);
     f.set_if<db::schema_feature::PER_TABLE_PARTITIONERS>(per_table_partitioners);
     f.set_if<db::schema_feature::SCYLLA_KEYSPACES>(keyspace_storage_options);

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -87,7 +87,6 @@ public:
     gms::feature me_sstable { *this, "ME_SSTABLE_FORMAT"sv };
     gms::feature view_virtual_columns { *this, "VIEW_VIRTUAL_COLUMNS"sv };
     gms::feature digest_insensitive_to_expiry { *this, "DIGEST_INSENSITIVE_TO_EXPIRY"sv };
-    gms::feature computed_columns { *this, "COMPUTED_COLUMNS"sv };
     gms::feature cdc { *this, "CDC"sv };
     gms::feature nonfrozen_udts { *this, "NONFROZEN_UDTS"sv };
     gms::feature hinted_handoff_separate_connection { *this, "HINTED_HANDOFF_SEPARATE_CONNECTION"sv };

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -109,7 +109,6 @@ void migration_manager::init_messaging_service()
         _feature_listeners.push_back(_feat.digest_insensitive_to_expiry.when_enabled(update_schema));
         _feature_listeners.push_back(_feat.cdc.when_enabled(update_schema));
         _feature_listeners.push_back(_feat.per_table_partitioners.when_enabled(update_schema));
-        _feature_listeners.push_back(_feat.computed_columns.when_enabled(update_schema));
 
         if (!_feat.table_digest_insensitive_to_expiry) {
             _feature_listeners.push_back(_feat.table_digest_insensitive_to_expiry.when_enabled([this] {


### PR DESCRIPTION
The purpose of `maybe_fix_legacy_secondary_index_mv_schema` was to deal
with legacy materialized view schemas used for secondary indexes,
schemas which were created before the notion of "computed columns" was
introduced. Back then, secondary index schemas would use a regular
"token" column. Later it became a computed column and old schemas would
be migrated during rolling upgrade.

The migration code was introduced in 2019
(db8d4a0cc649c74e30198dd83b082b0ad50b1314) and then fixed in 2020
(d473bc9b0669e9d3879ff0f329a9ed16378dd569).

The fix was present in Enterprise 2022.1 and in OSS 4.5. So, assuming
that users don't try crazy things like upgrading from 2021.X to 2023.X
(which we do not support), all clusters will have already executed the
migration code once they upgrade to 2023.X, meaning we can get rid of
it.

The main motivation of this PR is to get rid of the
`db::schema_tables::merge_schema` call in `parse_schema_tables`. In Raft
mode this was the only call to `merge_schema` outside "group 0 code" and
in fact it is unsafe -- it uses locally generated mutations with locally
generated timestamp (`api::new_timestamp()`), so if we actually did it,
we would permanently diverge the group 0 state machine across nodes
(the schema pulling code is disabled in Raft mode). Fortunately, this
should be dead code by now, as explained in the previous paragraph.

The migration code is now turned into a sanity check, if the users
try something crazy, they will get an error instead of silent data
corruption.

