### PR TITLE
docs: add updated php driver into 5.2

### DIFF
--- a/docs/using-scylla/drivers/cql-drivers/index.rst
+++ b/docs/using-scylla/drivers/cql-drivers/index.rst
@@ -48,7 +48,8 @@ Scylla supports the CQL binary protocol version 3, so any Apache Cassandra/CQL d
   * `DataStax Ruby Driver <https://github.com/datastax/ruby-driver/>`_
   * `DataStax Node.js Driver <https://github.com/datastax/nodejs-driver/>`_
   * `DataStax C++ Driver <https://github.com/datastax/cpp-driver/>`_
-  * `DataStax PHP Driver  <https://github.com/datastax/php-driver/>`_
+  * `DataStax PHP Driver (Supported versions: 7.1) <https://github.com/datastax/php-driver/>`_
+  * `He4rt PHP Driver (Supported versions: 8.1 and 8.2)  <https://github.com/he4rt/scylladb-php-driver/>`_
   * `Rust <https://github.com/AlexPikalov/cdrs>`_
   * `Scala Phantom Project <https://github.com/outworkers/phantom>`_
 


### PR DESCRIPTION
I just realized that the updated driver is missing at branch 5.2 and I just published at master since it's pointing on the docs directly to there and not to the right branch.

