### PR TITLE
test: handle fast execution of test_user_function_filtering

### DIFF
--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -1097,7 +1097,7 @@ SEASTAR_TEST_CASE(test_user_function_filtering) {
         auto reset_on_internal_abort = defer([] {
             set_abort_on_internal_error(true);
         });
-        BOOST_REQUIRE_EXCEPTION(e.execute_cql("SELECT val FROM my_table WHERE key = 'foo' AND t < toTimestamp(now()) AND t >= minutesAgo(1, toTimestamp(now())) ALLOW FILTERING;").get(),
+        BOOST_REQUIRE_EXCEPTION(e.execute_cql("SELECT val FROM my_table WHERE key = 'foo' AND t <= toTimestamp(now()) AND t >= minutesAgo(1, toTimestamp(now())) ALLOW FILTERING;").get(),
                                 std::runtime_error, message_contains("User function cannot be executed in this context"));
     });
 }


### PR DESCRIPTION
Currently, when the test is executed too quickly, the timestamp insterted into the 'my_table' table might be the same as the timestamp used in the SELECT statement for comparison. However, the statement only selects rows where the inserted timestamp is strictly lower than current timestamp. As a result, when this comparison fails, we may skip executing the following comparison, which uses a user-defined function, due to which the statement is supposed to fail with an error. Instead, the select statement simply returns no rows and the test case fails.
To fix this, simply use the less or equal operator instead of using the strictly less operator for comparing timestamps.

Fixes #15616