### PR TITLE
cql3/restrictions/statement_restrictions: s/allow filtering/ALLOW FIL…

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -668,7 +668,7 @@ void statement_restrictions::add_single_column_parition_key_restriction(const ex
     if (restr.op != expr::oper_t::EQ && restr.op != expr::oper_t::IN && !allow_filtering && !for_view) {
         throw exceptions::invalid_request_exception(
                 "Only EQ and IN relation are supported on the partition key "
-                "(unless you use the token() function or allow filtering)");
+                "(unless you use the token() function or ALLOW FILTERING)");
     }
     if (has_token_restrictions()) {
         throw exceptions::invalid_request_exception(
@@ -1048,7 +1048,7 @@ dht::partition_range_vector partition_ranges_from_singles(
                 } else {
                     throw exceptions::invalid_request_exception(
                             "Only EQ and IN relation are supported on the partition key "
-                            "(unless you use the token() function or allow filtering)");
+                            "(unless you use the token() function or ALLOW FILTERING)");
                 }
             }
         }

--- a/test/cql-pytest/cassandra_tests/validation/operations/compact_storage_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/compact_storage_test.py
@@ -3271,7 +3271,7 @@ def testFilteringOnCompactTablesWithoutIndicesAndWithMaps(cql, test_keyspace):
                        row(1, 3, {6: 2}),
                        row(2, 3, {7: 1}))
 
-            assertInvalidMessage(cql, table, 'filtering',
+            assertInvalidMessage(cql, table, 'FILTERING',
                                  "SELECT * FROM %s WHERE b <= 3 AND c < {6 : 2}")
 
             assert_rows(execute(cql, table, "SELECT * FROM %s WHERE b <= 3 AND c < {6 : 2} ALLOW FILTERING"),

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_single_column_relation_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_single_column_relation_test.py
@@ -522,7 +522,7 @@ def testInvalidSliceRestrictionOnPartitionKey(cql, test_keyspace):
         # ALLOW FILTERING, while Scylla *also* tells you that this
         # query would have worked with EQ or IN relations or with token().
         # The word "filtering" is common to both messages.
-        assert_invalid_message(cql, table, 'filtering',
+        assert_invalid_message(cql, table, 'FILTERING',
                              "SELECT * FROM %s WHERE a >= 1 and a < 4")
         # Again, different error messages. Cassandra says "Multi-column
         # relations can only be applied to clustering columns but was

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
@@ -1322,10 +1322,10 @@ def testAllowFilteringOnPartitionKeyWithDistinct(cql, test_keyspace):
             execute(cql, table, "INSERT INTO %s (pk0, pk1, ck0, val) VALUES (?, ?, 1, 1)", i, i)
 
         for _ in before_and_after_flush(cql, table):
-            assert_invalid_message(cql, table, 'filtering',
+            assert_invalid_message(cql, table, 'FILTERING',
                     "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk1 = 1 LIMIT 3")
 
-            assert_invalid_message(cql, table, 'filtering',
+            assert_invalid_message(cql, table, 'FILTERING',
                     "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk0 > 0 AND pk1 = 1 LIMIT 3")
 
             assert_rows(execute(cql, table, "SELECT DISTINCT pk0, pk1 FROM %s WHERE pk0 = 1 LIMIT 1 ALLOW FILTERING"),
@@ -1527,7 +1527,7 @@ def testAllowFilteringOnPartitionAndClusteringKey(cql, test_keyspace):
             # "Clustering column \"d\" cannot be restricted (preceding column
             # \"c\" is restricted by a non-EQ relation)", while Scylla says:
             # "Only EQ and IN relation are supported on the partition key
-            # (unless you use the token() function or allow filtering)
+            # (unless you use the token() function or ALLOW FILTERING)
             assert_invalid(cql, table,
                     "SELECT * FROM %s WHERE a <= 11 AND c > 15 AND d >= 16")
 
@@ -1856,7 +1856,7 @@ def dotestContainsOnPartitionKey(cql, test_keyspace, schema):
         execute(cql, table, "INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", {5: 6}, 5, 5)
         execute(cql, table, "INSERT INTO %s (pk, ck, v) VALUES (?, ?, ?)", {7: 8}, 6, 6)
 
-        assert_invalid_message_re(cql, table, 'allow filtering|ALLOW FILTERING',
+        assert_invalid_message(cql, table, 'ALLOW FILTERING',
                              "SELECT * FROM %s WHERE pk CONTAINS KEY 1")
 
         for _ in before_and_after_flush(cql, table):

--- a/test/cql/cassandra_cql_test.result
+++ b/test/cql/cassandra_cql_test.result
@@ -417,11 +417,11 @@ OK
 > SELECT * FROM test_filter WHERE k1 = 0;
 Error from server: code=2200 [Invalid query] message="Cannot execute this query as it might involve data filtering and thus may have unpredictable performance. If you want to execute this query despite the performance unpredictability, use ALLOW FILTERING"
 > SELECT * FROM test_filter WHERE k1 = 0 AND k2 > 0;
-Error from server: code=2200 [Invalid query] message="Only EQ and IN relation are supported on the partition key (unless you use the token() function or allow filtering)"
+Error from server: code=2200 [Invalid query] message="Only EQ and IN relation are supported on the partition key (unless you use the token() function or ALLOW FILTERING)"
 > SELECT * FROM test_filter WHERE k1 >= 0 AND k2 in (0,1,2);
-Error from server: code=2200 [Invalid query] message="Only EQ and IN relation are supported on the partition key (unless you use the token() function or allow filtering)"
+Error from server: code=2200 [Invalid query] message="Only EQ and IN relation are supported on the partition key (unless you use the token() function or ALLOW FILTERING)"
 > SELECT * FROM test_filter WHERE k2 > 0;
-Error from server: code=2200 [Invalid query] message="Only EQ and IN relation are supported on the partition key (unless you use the token() function or allow filtering)"
+Error from server: code=2200 [Invalid query] message="Only EQ and IN relation are supported on the partition key (unless you use the token() function or ALLOW FILTERING)"
 > DROP TABLE test_filter;
 OK
 > 

--- a/test/cql/lwt_test.result
+++ b/test/cql/lwt_test.result
@@ -2823,12 +2823,12 @@ OK
 Error from server: code=2200 [Invalid query] message="Columns "ColumnDefinition{name=a, type=org.apache.cassandra.db.marshal.Int32Type, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}" cannot be restricted by both a normal relation and a token relation"
 > -- error: can't use eq and non-eq restriction
 > update lwt set c = 1 where a = 1 and b = 1 and a < 0 if c = 1;
-Error from server: code=2200 [Invalid query] message="Only EQ and IN relation are supported on the partition key (unless you use the token() function or allow filtering)"
+Error from server: code=2200 [Invalid query] message="Only EQ and IN relation are supported on the partition key (unless you use the token() function or ALLOW FILTERING)"
 > update lwt set c = 1 where a = 1 and b = 1 and a < 0 if c = 1;
-Error from server: code=2200 [Invalid query] message="Only EQ and IN relation are supported on the partition key (unless you use the token() function or allow filtering)"
+Error from server: code=2200 [Invalid query] message="Only EQ and IN relation are supported on the partition key (unless you use the token() function or ALLOW FILTERING)"
 > -- error: partition key must be fully restricted
 > update lwt set c = 1 where a > 0 and a < 0 and b = 1 if c = 1;
-Error from server: code=2200 [Invalid query] message="Only EQ and IN relation are supported on the partition key (unless you use the token() function or allow filtering)"
+Error from server: code=2200 [Invalid query] message="Only EQ and IN relation are supported on the partition key (unless you use the token() function or ALLOW FILTERING)"
 > -- error: partition key and IN is not supported
 > update lwt set c = 1 where a in () and b = 1 if c = 1;
 Error from server: code=2200 [Invalid query] message="IN on the partition key is not supported with conditional updates"


### PR DESCRIPTION
…TERING/

use the captalized "ALLOW FILTERING" in the error message, because the error message is a part of the user interface, it would be better to keep it aligned with our document, where "ALLOW FILTERING" is used.

so, in this change, the lower-cased "allow filtering" error message is changed to "ALLOW FILTERING", and the tests are updated accordingly.

see also a0ffbf3291b74a238e89fd18d3eb3aecc8d00858

Refs #14321
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>