### PR TITLE
Initialize datadir for system and non-system keyspaces the same way

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1926,6 +1926,7 @@ future<> system_keyspace::make(
         replica::database& db) {
     for (auto&& table : system_keyspace::all_tables(db.get_config())) {
         co_await db.create_local_system_table(table, maybe_write_in_user_memory(table), erm_factory);
+        co_await db.find_column_family(table).init_storage();
     }
 }
 

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -214,16 +214,16 @@ future<> sstable_directory::filesystem_components_lister::prepare(sstable_direct
         }
     }
 
-        // verify owner and mode on the sstables directory
-        // and all its subdirectories, except for "snapshots"
-        // as there could be a race with scylla-manager that might
-        // delete snapshots concurrently
-        co_await utils::directories::verify_owner_and_mode(_directory, utils::directories::recursive::no);
-        co_await lister::scan_dir(_directory, lister::dir_entry_types::of<directory_entry_type::directory>(), [] (fs::path dir, directory_entry de) -> future<> {
-            if (de.name != sstables::snapshots_dir) {
-                co_await utils::directories::verify_owner_and_mode(dir / de.name, utils::directories::recursive::yes);
-            }
-        });
+    // verify owner and mode on the sstables directory
+    // and all its subdirectories, except for "snapshots"
+    // as there could be a race with scylla-manager that might
+    // delete snapshots concurrently
+    co_await utils::directories::verify_owner_and_mode(_directory, utils::directories::recursive::no);
+    co_await lister::scan_dir(_directory, lister::dir_entry_types::of<directory_entry_type::directory>(), [] (fs::path dir, directory_entry de) -> future<> {
+        if (de.name != sstables::snapshots_dir) {
+            co_await utils::directories::verify_owner_and_mode(dir / de.name, utils::directories::recursive::yes);
+        }
+    });
 
     if (flags.garbage_collect) {
         co_await garbage_collect(st);

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -208,12 +208,12 @@ future<> sstable_directory::prepare(process_flags flags) {
 }
 
 future<> sstable_directory::filesystem_components_lister::prepare(sstable_directory& dir, process_flags flags, storage& st) {
-    if (!co_await file_exists(_directory.native())) {
-        if (dir._state == sstable_state::quarantine) {
+    if (dir._state == sstable_state::quarantine) {
+        if (!co_await file_exists(_directory.native())) {
             co_return;
         }
-        co_await io_check([this] { return recursive_touch_directory(_directory.native()); });
-    } else {
+    }
+
         // verify owner and mode on the sstables directory
         // and all its subdirectories, except for "snapshots"
         // as there could be a race with scylla-manager that might
@@ -224,7 +224,6 @@ future<> sstable_directory::filesystem_components_lister::prepare(sstable_direct
                 co_await utils::directories::verify_owner_and_mode(dir / de.name, utils::directories::recursive::yes);
             }
         });
-    }
 
     if (flags.garbage_collect) {
         co_await garbage_collect(st);


### PR DESCRIPTION
When populating system keyspace the sstable_directory forgets to create upload/ subdir in the tables' datadir because of the way it's invoked from distributed loader. For non-system keyspaces directories are created in table::init_storage() which is self-contained and just creates the whole layout regardless of what.

This PR makes system keyspace's tables use table::init_storage() as well so that the datadir layout is the same for all on-disk tables.

Test included.

fixes: #15708 
closes: scylladb/scylla-manager#3603