### PR TITLE
raft topology: assign tokens after join node response rpc

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2554,7 +2554,12 @@ future<service::topology> system_keyspace::load_topology_state() {
             map = &ret.new_nodes;
         } else {
             map = &ret.transition_nodes;
-            if (nstate != service::node_state::left_token_ring && !ring_slice) {
+            // Bootstrapping and replacing nodes don't have tokens at first,
+            // they are inserted only at some point during bootstrap/replace
+            if (!ring_slice
+                    && nstate != service::node_state::left_token_ring
+                    && nstate != service::node_state::bootstrapping
+                    && nstate != service::node_state::replacing) {
                 on_fatal_internal_error(slogger, format(
                     "load_topology_state: node {} in transitioning state but missing ring slice", host_id));
             }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2508,15 +2508,17 @@ future<service::topology> system_keyspace::load_topology_state() {
                 }
                 ret.req_param.emplace(host_id, service::rebuild_param{*rebuild_option});
                 break;
-            case service::topology_request::join:
-                ret.req_param.emplace(host_id, service::join_param{num_tokens});
-                break;
             default:
                 // no parameters for other requests
                 break;
             }
         } else {
             switch (nstate) {
+            case service::node_state::bootstrapping:
+                // The tokens aren't generated right away when we enter the `bootstrapping` node state.
+                // Therefore we need to know the number of tokens when we generate them during the bootstrap process.
+                ret.req_param.emplace(host_id, service::join_param{num_tokens});
+                break;
             case service::node_state::removing:
                 // If a node is removing we need to know which nodes are ignored
                 ret.req_param.emplace(host_id, service::removenode_param{std::move(ignored_ids)});

--- a/test/topology_experimental_raft/test_topology_ops.py
+++ b/test/topology_experimental_raft/test_topology_ops.py
@@ -5,8 +5,15 @@
 #
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.manager_client import ManagerClient
-from test.topology.util import check_token_ring_and_group0_consistency
+from test.pylib.internal_types import ServerInfo
+from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
+from test.topology.util import check_token_ring_and_group0_consistency, reconnect_driver
 
+from cassandra.cluster import Session, ConsistencyLevel
+from cassandra.query import SimpleStatement
+
+import asyncio
+import time
 import pytest
 import logging
 
@@ -23,6 +30,10 @@ async def test_topology_ops(request, manager: ManagerClient):
     await manager.server_stop_gracefully(servers[0].server_id)
     await manager.server_start(servers[0].server_id)
 
+    await wait_for_cql_and_get_hosts(manager.cql, await manager.running_servers(), time.time() + 60)
+    cql = await reconnect_driver(manager)
+    finish_writes = await start_writes(cql)
+
     logger.info("Bootstrapping other nodes")
     servers += [await manager.server_add(), await manager.server_add()]
 
@@ -32,6 +43,7 @@ async def test_topology_ops(request, manager: ManagerClient):
 
     logger.info(f"Stopping node {servers[0]}")
     await manager.server_stop_gracefully(servers[0].server_id)
+    await check_node_log_for_failed_mutations(manager, servers[0])
 
     logger.info(f"Replacing node {servers[0]}")
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = False)
@@ -40,6 +52,7 @@ async def test_topology_ops(request, manager: ManagerClient):
 
     logger.info(f"Stopping node {servers[0]}")
     await manager.server_stop_gracefully(servers[0].server_id)
+    await check_node_log_for_failed_mutations(manager, servers[0])
 
     logger.info(f"Removing node {servers[0]} using {servers[1]}")
     await manager.remove_node(servers[1].server_id, servers[0].server_id)
@@ -49,3 +62,57 @@ async def test_topology_ops(request, manager: ManagerClient):
     logger.info(f"Decommissioning node {servers[0]}")
     await manager.decommission_node(servers[0].server_id)
     await check_token_ring_and_group0_consistency(manager)
+
+    logger.info("Checking results of the background writes")
+    await finish_writes()
+
+    for server in servers:
+        await check_node_log_for_failed_mutations(manager, server)
+
+
+async def check_node_log_for_failed_mutations(manager: ManagerClient, server: ServerInfo):
+    logger.info(f"Checking that node {server} had no failed mutations")
+    log = await manager.server_open_log(server.server_id)
+    occurrences = await log.grep(expr="Failed to apply mutation from", \
+                                 filter_expr="replica::stale_topology_exception") # Disabled due to #15804
+    assert len(occurrences) == 0
+
+
+async def start_writes(cql: Session, concurrency: int = 3):
+    logger.info(f"Starting to asynchronously write, concurrency = {concurrency}")
+
+    stop_event = asyncio.Event()
+
+    ks_name = unique_name()
+    await cql.run_async(f"CREATE KEYSPACE {ks_name} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}}")
+    await cql.run_async(f"USE {ks_name}")
+    await cql.run_async(f"CREATE TABLE tbl (pk int PRIMARY KEY, v int)")
+
+    # In the test we only care about whether operations report success or not
+    # and whether they trigger errors in the nodes' logs. Inserting the same
+    # value repeatedly is enough for our purposes.
+    stmt = SimpleStatement("INSERT INTO tbl (pk, v) VALUES (0, 0)", consistency_level=ConsistencyLevel.ONE)
+
+    async def do_writes(worker_id: int):
+        write_count = 0
+        last_error = None
+        while not stop_event.is_set():
+            start_time = time.time()
+            try:
+                await cql.run_async(stmt)
+                write_count += 1
+            except Exception as e:
+                logger.error(f"Write started {time.time() - start_time}s ago failed: {e}")
+                last_error = e
+        logger.info(f"Worker #{worker_id} did {write_count} successful writes")
+        if last_error is not None:
+            raise last_error
+
+    tasks = [asyncio.create_task(do_writes(worker_id)) for worker_id in range(concurrency)]
+
+    async def finish():
+        logger.info("Stopping write workers")
+        stop_event.set()
+        await asyncio.gather(*tasks)
+
+    return finish


### PR DESCRIPTION
Currently, when the topology coordinator accepts a node, it moves it to bootstrap state and assigns tokens to it (either new ones during bootstrap, or the replaced node's tokens). Only then it contacts the joining node to tell it about the decision and let it perform a read barrier.

However, this means that the tokens are inserted too early. After inserting the tokens the cluster is free to route write requests to it, but it might not have learned about all of the schema yet.

Fix the issue by inserting the tokens later, after completing the join node response RPC which forces the receiving node to perform a read barrier.

Refs: #15686
Fixes: #15738