### PR TITLE
mutation: do not include unused header

### DIFF
--- a/mutation/canonical_mutation.cc
+++ b/mutation/canonical_mutation.cc
@@ -14,7 +14,6 @@
 #include "counters.hh"
 #include "converting_mutation_partition_applier.hh"
 #include "hashing_partition_visitor.hh"
-#include "utils/UUID.hh"
 #include "idl/mutation.dist.hh"
 #include "idl/mutation.dist.impl.hh"
 #include <iostream>


### PR DESCRIPTION
the `utils::UUID` class is not used by the implementation of `canonical_mutation`, so let's remove the include from this source file.

the `#include` was originally added in
5a353486c69e49697f2d162083fd8f090b71ea0a, but that commit did not add any code using UUID to this file.