### PR TITLE
sstable: drop unused parse() overload for deletion_time

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -557,10 +557,6 @@ future<summary_entry&> sstable::read_summary_entry(size_t i) {
     return make_ready_future<summary_entry&>(_components->summary.entries[i]);
 }
 
-future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, deletion_time& d) {
-    return parse(s, v, in, d.local_deletion_time, d.marked_for_delete_at);
-}
-
 template <typename Child>
 future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, std::unique_ptr<metadata>& p) {
     p.reset(new Child);


### PR DESCRIPTION
`deletion_time` is a part of the `partition_header`, which is in turn a part of `partition`. and `data_file` is a sequence of `partition`. `data_file` represents *-Data.db component of an SSTable. see docs/architecture/sstable3/sstables-3-data-file-format.rst. we always parse the data component via `flat_mutation_reader_v2`, which is in turn implemented with mx/reader.cc or kl/reader.cc depending on the version of SSTable to be read.

in other words, we decode `deletion_time` in mx/reader.cc or kl/reader.cc, not in sstable.cc. so let's drop the overload parse() for deletion_time. it's not necessary and more importantly, confusing.

Refs #15116
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>