### PR TITLE
doc: enable publishing docs for branch-5.4

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,11 +16,11 @@ sys.path.insert(0, os.path.abspath(".."))
 BASE_URL = 'https://opensource.docs.scylladb.com'
 # Build documentation for the following tags and branches.
 TAGS = []
-BRANCHES = ["master", "branch-5.1", "branch-5.2", "branch-5.3"]
+BRANCHES = ["master", "branch-5.1", "branch-5.2", "branch-5.4"]
 # Set the latest version.
 LATEST_VERSION = "branch-5.2"
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = ["master", "branch-5.3"]
+UNSTABLE_VERSIONS = ["master", "branch-5.4"]
 # Set which versions are deprecated.
 DEPRECATED_VERSIONS = [""]
 


### PR DESCRIPTION
This PR enables publishing documentation from branch-5.4. The docs will be published as UNSTABLE (the warning about version 5.4 being unstable will be displayed).

Version 5.4 replaces version 5.3, which was never released.

Fixes https://github.com/scylladb/scylladb/issues/15760