### PR TITLE
Sanitize API -> task_manager dependency

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -280,6 +280,10 @@ future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>
     });
 }
 
+future<> unset_server_task_manager(http_context& ctx) {
+    return ctx.http_server.set_routes([&ctx] (routes& r) { unset_task_manager(ctx, r); });
+}
+
 #ifndef SCYLLA_BUILD_MODE_RELEASE
 
 future<> set_server_task_manager_test(http_context& ctx, sharded<tasks::task_manager>& tm) {

--- a/api/api.cc
+++ b/api/api.cc
@@ -282,13 +282,13 @@ future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>
 
 #ifndef SCYLLA_BUILD_MODE_RELEASE
 
-future<> set_server_task_manager_test(http_context& ctx) {
+future<> set_server_task_manager_test(http_context& ctx, sharded<tasks::task_manager>& tm) {
     auto rb = std::make_shared < api_registry_builder > (ctx.api_doc);
 
-    return ctx.http_server.set_routes([rb, &ctx](routes& r) mutable {
+    return ctx.http_server.set_routes([rb, &ctx, &tm](routes& r) mutable {
         rb->register_function(r, "task_manager_test",
                 "The task manager test API");
-        set_task_manager_test(ctx, r);
+        set_task_manager_test(ctx, r, tm);
     });
 }
 

--- a/api/api.cc
+++ b/api/api.cc
@@ -270,13 +270,13 @@ future<> set_server_done(http_context& ctx) {
     });
 }
 
-future<> set_server_task_manager(http_context& ctx, lw_shared_ptr<db::config> cfg) {
+future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>& tm, lw_shared_ptr<db::config> cfg) {
     auto rb = std::make_shared < api_registry_builder > (ctx.api_doc);
 
-    return ctx.http_server.set_routes([rb, &ctx, &cfg = *cfg](routes& r) {
+    return ctx.http_server.set_routes([rb, &ctx, &tm, &cfg = *cfg](routes& r) {
         rb->register_function(r, "task_manager",
                 "The task manager API");
-        set_task_manager(ctx, r, cfg);
+        set_task_manager(ctx, r, tm, cfg);
     });
 }
 

--- a/api/api.cc
+++ b/api/api.cc
@@ -296,6 +296,10 @@ future<> set_server_task_manager_test(http_context& ctx, sharded<tasks::task_man
     });
 }
 
+future<> unset_server_task_manager_test(http_context& ctx) {
+    return ctx.http_server.set_routes([&ctx] (routes& r) { unset_task_manager_test(ctx, r); });
+}
+
 #endif
 
 void req_params::process(const request& req) {

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -121,5 +121,6 @@ future<> set_server_done(http_context& ctx);
 future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>& tm, lw_shared_ptr<db::config> cfg);
 future<> unset_server_task_manager(http_context& ctx);
 future<> set_server_task_manager_test(http_context& ctx, sharded<tasks::task_manager>& tm);
+future<> unset_server_task_manager_test(http_context& ctx);
 
 }

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -74,11 +74,10 @@ struct http_context {
     distributed<replica::database>& db;
     service::load_meter& lmeter;
     const sharded<locator::shared_token_metadata>& shared_token_metadata;
-    sharded<tasks::task_manager>& tm;
 
     http_context(distributed<replica::database>& _db,
-            service::load_meter& _lm, const sharded<locator::shared_token_metadata>& _stm, sharded<tasks::task_manager>& _tm)
-            : db(_db), lmeter(_lm), shared_token_metadata(_stm), tm(_tm) {
+            service::load_meter& _lm, const sharded<locator::shared_token_metadata>& _stm)
+            : db(_db), lmeter(_lm), shared_token_metadata(_stm) {
     }
 
     const locator::token_metadata& get_token_metadata();

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -119,6 +119,7 @@ future<> set_server_cache(http_context& ctx);
 future<> set_server_compaction_manager(http_context& ctx);
 future<> set_server_done(http_context& ctx);
 future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>& tm, lw_shared_ptr<db::config> cfg);
+future<> unset_server_task_manager(http_context& ctx);
 future<> set_server_task_manager_test(http_context& ctx, sharded<tasks::task_manager>& tm);
 
 }

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -120,6 +120,6 @@ future<> set_server_cache(http_context& ctx);
 future<> set_server_compaction_manager(http_context& ctx);
 future<> set_server_done(http_context& ctx);
 future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>& tm, lw_shared_ptr<db::config> cfg);
-future<> set_server_task_manager_test(http_context& ctx);
+future<> set_server_task_manager_test(http_context& ctx, sharded<tasks::task_manager>& tm);
 
 }

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -61,6 +61,10 @@ class gossiper;
 
 namespace auth { class service; }
 
+namespace tasks {
+class task_manager;
+}
+
 namespace api {
 
 struct http_context {
@@ -115,7 +119,7 @@ future<> set_server_gossip_settle(http_context& ctx, sharded<gms::gossiper>& g);
 future<> set_server_cache(http_context& ctx);
 future<> set_server_compaction_manager(http_context& ctx);
 future<> set_server_done(http_context& ctx);
-future<> set_server_task_manager(http_context& ctx, lw_shared_ptr<db::config> cfg);
+future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>& tm, lw_shared_ptr<db::config> cfg);
 future<> set_server_task_manager_test(http_context& ctx);
 
 }

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -111,7 +111,7 @@ future<full_task_status> retrieve_status(const tasks::task_manager::foreign_task
     co_return s;
 }
 
-void set_task_manager(http_context& ctx, routes& r, db::config& cfg) {
+void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>& tm, db::config& cfg) {
     tm::get_modules.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         std::vector<std::string> v = boost::copy_range<std::vector<std::string>>(ctx.tm.local().get_modules() | boost::adaptors::map_keys);
         co_return v;

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -264,4 +264,14 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
     });
 }
 
+void unset_task_manager(http_context& ctx, routes& r) {
+    tm::get_modules.unset(r);
+    tm::get_tasks.unset(r);
+    tm::get_task_status.unset(r);
+    tm::abort_task.unset(r);
+    tm::wait_task.unset(r);
+    tm::get_task_status_recursively.unset(r);
+    tm::get_and_update_ttl.unset(r);
+}
+
 }

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -112,15 +112,15 @@ future<full_task_status> retrieve_status(const tasks::task_manager::foreign_task
 }
 
 void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>& tm, db::config& cfg) {
-    tm::get_modules.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        std::vector<std::string> v = boost::copy_range<std::vector<std::string>>(ctx.tm.local().get_modules() | boost::adaptors::map_keys);
+    tm::get_modules.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        std::vector<std::string> v = boost::copy_range<std::vector<std::string>>(tm.local().get_modules() | boost::adaptors::map_keys);
         co_return v;
     });
 
-    tm::get_tasks.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+    tm::get_tasks.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         using chunked_stats = utils::chunked_vector<task_stats>;
         auto internal = tasks::is_internal{req_param<bool>(*req, "internal", false)};
-        std::vector<chunked_stats> res = co_await ctx.tm.map([&req, internal] (tasks::task_manager& tm) {
+        std::vector<chunked_stats> res = co_await tm.map([&req, internal] (tasks::task_manager& tm) {
             chunked_stats local_res;
             tasks::task_manager::module_ptr module;
             try {
@@ -156,11 +156,11 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         co_return std::move(f);
     });
 
-    tm::get_task_status.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+    tm::get_task_status.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto id = tasks::task_id{utils::UUID{req->param["task_id"]}};
         tasks::task_manager::foreign_task_ptr task;
         try {
-            task = co_await tasks::task_manager::invoke_on_task(ctx.tm, id, std::function([] (tasks::task_manager::task_ptr task) -> future<tasks::task_manager::foreign_task_ptr> {
+            task = co_await tasks::task_manager::invoke_on_task(tm, id, std::function([] (tasks::task_manager::task_ptr task) -> future<tasks::task_manager::foreign_task_ptr> {
                 if (task->is_complete()) {
                     task->unregister_task();
                 }
@@ -173,10 +173,10 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         co_return make_status(s);
     });
 
-    tm::abort_task.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+    tm::abort_task.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto id = tasks::task_id{utils::UUID{req->param["task_id"]}};
         try {
-            co_await tasks::task_manager::invoke_on_task(ctx.tm, id, [] (tasks::task_manager::task_ptr task) -> future<> {
+            co_await tasks::task_manager::invoke_on_task(tm, id, [] (tasks::task_manager::task_ptr task) -> future<> {
                 if (!task->is_abortable()) {
                     co_await coroutine::return_exception(std::runtime_error("Requested task cannot be aborted"));
                 }
@@ -188,11 +188,11 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         co_return json_void();
     });
 
-    tm::wait_task.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+    tm::wait_task.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto id = tasks::task_id{utils::UUID{req->param["task_id"]}};
         tasks::task_manager::foreign_task_ptr task;
         try {
-            task = co_await tasks::task_manager::invoke_on_task(ctx.tm, id, std::function([] (tasks::task_manager::task_ptr task) {
+            task = co_await tasks::task_manager::invoke_on_task(tm, id, std::function([] (tasks::task_manager::task_ptr task) {
                 return task->done().then_wrapped([task] (auto f) {
                     task->unregister_task();
                     // done() is called only because we want the task to be complete before getting its status.
@@ -208,8 +208,8 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         co_return make_status(s);
     });
 
-    tm::get_task_status_recursively.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        auto& _ctx = ctx;
+    tm::get_task_status_recursively.set(r, [&_tm = tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        auto& tm = _tm;
         auto id = tasks::task_id{utils::UUID{req->param["task_id"]}};
         std::queue<tasks::task_manager::foreign_task_ptr> q;
         utils::chunked_vector<full_task_status> res;
@@ -217,7 +217,7 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         tasks::task_manager::foreign_task_ptr task;
         try {
             // Get requested task.
-            task = co_await tasks::task_manager::invoke_on_task(_ctx.tm, id, std::function([] (tasks::task_manager::task_ptr task) -> future<tasks::task_manager::foreign_task_ptr> {
+            task = co_await tasks::task_manager::invoke_on_task(tm, id, std::function([] (tasks::task_manager::task_ptr task) -> future<tasks::task_manager::foreign_task_ptr> {
                 if (task->is_complete()) {
                     task->unregister_task();
                 }

--- a/api/task_manager.hh
+++ b/api/task_manager.hh
@@ -19,5 +19,6 @@ namespace tasks {
 namespace api {
 
 void set_task_manager(http_context& ctx, httpd::routes& r, sharded<tasks::task_manager>& tm, db::config& cfg);
+void unset_task_manager(http_context& ctx, httpd::routes& r);
 
 }

--- a/api/task_manager.hh
+++ b/api/task_manager.hh
@@ -8,11 +8,16 @@
 
 #pragma once
 
+#include <seastar/core/sharded.hh>
 #include "api.hh"
 #include "db/config.hh"
 
+namespace tasks {
+    class task_manager;
+}
+
 namespace api {
 
-void set_task_manager(http_context& ctx, httpd::routes& r, db::config& cfg);
+void set_task_manager(http_context& ctx, httpd::routes& r, sharded<tasks::task_manager>& tm, db::config& cfg);
 
 }

--- a/api/task_manager_test.cc
+++ b/api/task_manager_test.cc
@@ -20,7 +20,7 @@ namespace tmt = httpd::task_manager_test_json;
 using namespace json;
 using namespace seastar::httpd;
 
-void set_task_manager_test(http_context& ctx, routes& r) {
+void set_task_manager_test(http_context& ctx, routes& r, sharded<tasks::task_manager>& tm) {
     tmt::register_test_module.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         co_await ctx.tm.invoke_on_all([] (tasks::task_manager& tm) {
             auto m = make_shared<tasks::test_module>(tm);

--- a/api/task_manager_test.cc
+++ b/api/task_manager_test.cc
@@ -105,6 +105,14 @@ void set_task_manager_test(http_context& ctx, routes& r, sharded<tasks::task_man
     });
 }
 
+void unset_task_manager_test(http_context& ctx, routes& r) {
+    tmt::register_test_module.unset(r);
+    tmt::unregister_test_module.unset(r);
+    tmt::register_test_task.unset(r);
+    tmt::unregister_test_task.unset(r);
+    tmt::finish_test_task.unset(r);
+}
+
 }
 
 #endif

--- a/api/task_manager_test.cc
+++ b/api/task_manager_test.cc
@@ -21,16 +21,16 @@ using namespace json;
 using namespace seastar::httpd;
 
 void set_task_manager_test(http_context& ctx, routes& r, sharded<tasks::task_manager>& tm) {
-    tmt::register_test_module.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        co_await ctx.tm.invoke_on_all([] (tasks::task_manager& tm) {
+    tmt::register_test_module.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        co_await tm.invoke_on_all([] (tasks::task_manager& tm) {
             auto m = make_shared<tasks::test_module>(tm);
             tm.register_module("test", m);
         });
         co_return json_void();
     });
 
-    tmt::unregister_test_module.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        co_await ctx.tm.invoke_on_all([] (tasks::task_manager& tm) -> future<> {
+    tmt::unregister_test_module.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        co_await tm.invoke_on_all([] (tasks::task_manager& tm) -> future<> {
             auto module_name = "test";
             auto module = tm.find_module(module_name);
             co_await module->stop();
@@ -38,8 +38,8 @@ void set_task_manager_test(http_context& ctx, routes& r, sharded<tasks::task_man
         co_return json_void();
     });
 
-    tmt::register_test_task.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        sharded<tasks::task_manager>& tms = ctx.tm;
+    tmt::register_test_task.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        sharded<tasks::task_manager>& tms = tm;
         auto it = req->query_parameters.find("task_id");
         auto id = it != req->query_parameters.end() ? tasks::task_id{utils::UUID{it->second}} : tasks::task_id::create_null_id();
         it = req->query_parameters.find("shard");
@@ -54,7 +54,7 @@ void set_task_manager_test(http_context& ctx, routes& r, sharded<tasks::task_man
         tasks::task_info data;
         if (it != req->query_parameters.end()) {
             data.id = tasks::task_id{utils::UUID{it->second}};
-            auto parent_ptr = co_await tasks::task_manager::lookup_task_on_all_shards(ctx.tm, data.id);
+            auto parent_ptr = co_await tasks::task_manager::lookup_task_on_all_shards(tm, data.id);
             data.shard = parent_ptr->get_status().shard;
         }
 
@@ -69,10 +69,10 @@ void set_task_manager_test(http_context& ctx, routes& r, sharded<tasks::task_man
         co_return id.to_sstring();
     });
 
-    tmt::unregister_test_task.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+    tmt::unregister_test_task.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto id = tasks::task_id{utils::UUID{req->query_parameters["task_id"]}};
         try {
-            co_await tasks::task_manager::invoke_on_task(ctx.tm, id, [] (tasks::task_manager::task_ptr task) -> future<> {
+            co_await tasks::task_manager::invoke_on_task(tm, id, [] (tasks::task_manager::task_ptr task) -> future<> {
                 tasks::test_task test_task{task};
                 co_await test_task.unregister_task();
             });
@@ -82,14 +82,14 @@ void set_task_manager_test(http_context& ctx, routes& r, sharded<tasks::task_man
         co_return json_void();
     });
 
-    tmt::finish_test_task.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+    tmt::finish_test_task.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto id = tasks::task_id{utils::UUID{req->param["task_id"]}};
         auto it = req->query_parameters.find("error");
         bool fail = it != req->query_parameters.end();
         std::string error = fail ? it->second : "";
 
         try {
-            co_await tasks::task_manager::invoke_on_task(ctx.tm, id, [fail, error = std::move(error)] (tasks::task_manager::task_ptr task) {
+            co_await tasks::task_manager::invoke_on_task(tm, id, [fail, error = std::move(error)] (tasks::task_manager::task_ptr task) {
                 tasks::test_task test_task{task};
                 if (fail) {
                     test_task.finish_failed(std::make_exception_ptr(std::runtime_error(error)));

--- a/api/task_manager_test.hh
+++ b/api/task_manager_test.hh
@@ -10,11 +10,16 @@
 
 #pragma once
 
+#include <seastar/core/sharded.hh>
 #include "api.hh"
+
+namespace tasks {
+class task_manager;
+}
 
 namespace api {
 
-void set_task_manager_test(http_context& ctx, httpd::routes& r);
+void set_task_manager_test(http_context& ctx, httpd::routes& r, sharded<tasks::task_manager>& tm);
 
 }
 

--- a/api/task_manager_test.hh
+++ b/api/task_manager_test.hh
@@ -20,6 +20,7 @@ class task_manager;
 namespace api {
 
 void set_task_manager_test(http_context& ctx, httpd::routes& r, sharded<tasks::task_manager>& tm);
+void unset_task_manager_test(http_context& ctx, httpd::routes& r);
 
 }
 

--- a/main.cc
+++ b/main.cc
@@ -1592,6 +1592,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             api::set_server_task_manager(ctx, task_manager, cfg).get();
+            auto stop_tm_api = defer_verbose_shutdown("task manager API", [&ctx] {
+                api::unset_server_task_manager(ctx).get();
+            });
 #ifndef SCYLLA_BUILD_MODE_RELEASE
             api::set_server_task_manager_test(ctx, task_manager).get();
 #endif

--- a/main.cc
+++ b/main.cc
@@ -1593,7 +1593,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             api::set_server_task_manager(ctx, task_manager, cfg).get();
 #ifndef SCYLLA_BUILD_MODE_RELEASE
-            api::set_server_task_manager_test(ctx).get();
+            api::set_server_task_manager_test(ctx, task_manager).get();
 #endif
             supervisor::notify("starting sstables loader");
             sst_loader.start(std::ref(db), std::ref(sys_dist_ks), std::ref(view_update_generator), std::ref(messaging)).get();

--- a/main.cc
+++ b/main.cc
@@ -1591,7 +1591,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 api::unset_server_repair(ctx).get();
             });
 
-            api::set_server_task_manager(ctx, cfg).get();
+            api::set_server_task_manager(ctx, task_manager, cfg).get();
 #ifndef SCYLLA_BUILD_MODE_RELEASE
             api::set_server_task_manager_test(ctx).get();
 #endif

--- a/main.cc
+++ b/main.cc
@@ -1597,6 +1597,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 #ifndef SCYLLA_BUILD_MODE_RELEASE
             api::set_server_task_manager_test(ctx, task_manager).get();
+            auto stop_tm_test_api = defer_verbose_shutdown("task manager API", [&ctx] {
+                api::unset_server_task_manager_test(ctx).get();
+            });
 #endif
             supervisor::notify("starting sstables loader");
             sst_loader.start(std::ref(db), std::ref(sys_dist_ks), std::ref(view_update_generator), std::ref(messaging)).get();

--- a/main.cc
+++ b/main.cc
@@ -634,7 +634,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
     sharded<service::storage_service> ss;
     sharded<service::migration_manager> mm;
     sharded<tasks::task_manager> task_manager;
-    api::http_context ctx(db, load_meter, token_metadata, task_manager);
+    api::http_context ctx(db, load_meter, token_metadata);
     httpd::http_server_control prometheus_server;
     std::optional<utils::directories> dirs = {};
     sharded<gms::feature_service> feature_service;


### PR DESCRIPTION
This is the continuation of 8c03eeb85d6b49d5adc4558d41e5695b0c8a642b

Registering API handlers for services need to

* get the service to handle requests via argument, not from http context (http context, in turn, is going not to depend on anything)
* unset the handlers on stop so that the service is not used after it's stopped (and before API server is stopped)

This makes task manager handlers work this way