### PR TITLE
replica: keyspace::create_replication_strategy: remove a redundant parameter

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1229,7 +1229,7 @@ public:
      * boom, it is replaced.
      */
     lw_shared_ptr<keyspace_metadata> metadata() const;
-    future<> create_replication_strategy(const locator::shared_token_metadata& stm, const locator::replication_strategy_config_options& options);
+    future<> create_replication_strategy(const locator::shared_token_metadata& stm);
     void update_effective_replication_map(locator::vnode_effective_replication_map_ptr erm);
 
     /**


### PR DESCRIPTION
The options parameter is redundant. We always use
`_metadata->strategy_options()` and
`keyspace::create_replication_strategy` already assumes that
`_metadata` is set by using its other fields.