### PR TITLE
test/pylib: unset the env variables set by MinIoServer 

### DIFF
--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -198,6 +198,10 @@ class MinioServer:
                 self.ENV_ACCESS_KEY,
                 self.ENV_SECRET_KEY]
 
+    def _unset_environ(self):
+        for env in self._get_environs():
+            del os.environ[env]
+
     def print_environ(self):
         msgs = []
         for key in self._get_environs():
@@ -254,6 +258,9 @@ class MinioServer:
         if not self.cmd:
             return
 
+        # so the test's process environment is not polluted by a test case
+        # which launches the MinioServer by itself.
+        self._unset_environ()
         try:
             self.cmd.kill()
         except ProcessLookupError:


### PR DESCRIPTION
before this change, when running object_store tests with `pytest`
directly, an instance of MinIoServer is started as a function-scope
fixture, but the environmental variables set by it stay with the
process, even after the fixture is teared down. So, when the 2nd test
in the same process check these environmental variables, it would
under the impression that there is already a S3 server running, and
thinks it is drived by `test.py`, hence try to reuse the S3 server.
But the MinIoServer instance is teared down at that moment, when
the first test is completed.

So the test is likely to fail when the Scylla instance tries
to read the missing conf file previously created by the MinIoServer.

after this change, the environmental variables are reset, so they
won't be seen by the succeeding tests in the same pytest session.
