### PR TITLE
build: extract code fragments into functions

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1500,26 +1500,29 @@ wasm_deps['wasm/test_UDA_final.wat'] = 'test/resource/wasm/c/test_UDA_final.c'
 wasm_deps['wasm/test_UDA_scalar.wat'] = 'test/resource/wasm/c/test_UDA_scalar.c'
 wasm_deps['wasm/test_word_double.wat'] = 'test/resource/wasm/c/test_word_double.c'
 
-warnings = [
-    '-Wall',
-    '-Werror',
-    '-Wimplicit-fallthrough',
-    '-Wno-mismatched-tags',  # clang-only
-    '-Wno-c++11-narrowing',
-    '-Wno-overloaded-virtual',
-    '-Wno-unused-command-line-argument',
-    '-Wno-unsupported-friend',
-    '-Wno-implicit-int-float-conversion',
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77728
-    '-Wno-psabi',
-    '-Wno-narrowing',
-]
 
-warnings = [w
-            for w in warnings
-            if flag_supported(flag=w, compiler=args.cxx)]
+def get_warning_options(cxx):
+    warnings = [
+        '-Wall',
+        '-Werror',
+        '-Wimplicit-fallthrough',
+        '-Wno-mismatched-tags',  # clang-only
+        '-Wno-c++11-narrowing',
+        '-Wno-overloaded-virtual',
+        '-Wno-unused-command-line-argument',
+        '-Wno-unsupported-friend',
+        '-Wno-implicit-int-float-conversion',
+        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77728
+        '-Wno-psabi',
+        '-Wno-narrowing',
+    ]
 
-warnings = ' '.join(warnings + ['-Wno-error=deprecated-declarations'])
+    warnings = [w
+                for w in warnings
+                if flag_supported(flag=w, compiler=cxx)]
+
+    return ' '.join(warnings + ['-Wno-error=deprecated-declarations'])
+
 
 def get_clang_inline_threshold():
     if args.clang_inline_threshold != -1:
@@ -1808,6 +1811,7 @@ def write_build_file(f,
                      scylla_version,
                      scylla_release,
                      args):
+    warnings = get_warning_options(args.cxx)
     f.write(textwrap.dedent('''\
         configure_args = {configure_args}
         builddir = {outdir}

--- a/configure.py
+++ b/configure.py
@@ -1580,6 +1580,7 @@ pkgs = []
 pkgs.append('lua53' if have_pkg('lua53') else 'lua')
 
 pkgs.append('libsystemd')
+pkgs.append('jsoncpp')
 
 has_sanitize_address_use_after_scope = try_compile(compiler=args.cxx, flags=['-fsanitize-address-use-after-scope'], source='int f() {}')
 
@@ -1773,8 +1774,7 @@ abseil_pkgs = [
 
 pkgs += abseil_pkgs
 
-user_cflags += " " + pkg_config('jsoncpp', '--cflags')
-libs = ' '.join([maybe_static(args.staticyamlcpp, '-lyaml-cpp'), '-latomic', '-llz4', '-lz', '-lsnappy', pkg_config('jsoncpp', '--libs'),
+libs = ' '.join([maybe_static(args.staticyamlcpp, '-lyaml-cpp'), '-latomic', '-llz4', '-lz', '-lsnappy',
                  ' -lstdc++fs', ' -lcrypt', ' -lcryptopp', ' -lpthread',
                  # Must link with static version of libzstd, since
                  # experimental APIs that we use are only present there.

--- a/configure.py
+++ b/configure.py
@@ -1968,7 +1968,7 @@ def write_build_file(f,
               command = CARGO_BUILD_DEP_INFO_BASEDIR='.' cargo build --locked --manifest-path=rust/Cargo.toml --target-dir=$builddir/{mode} --profile=rust-{mode} $
                         && touch $out
               description = RUST_LIB $out
-            ''').format(mode=mode, antlr3_exec=args.antlr3_exec, fmt_lib=fmt_lib, test_repeat=test_repeat, test_timeout=test_timeout, **modeval))
+            ''').format(mode=mode, antlr3_exec=args.antlr3_exec, fmt_lib=fmt_lib, test_repeat=args.test_repeat, test_timeout=args.test_timeout, **modeval))
         f.write(
             'build {mode}-build: phony {artifacts} {wasms}\n'.format(
                 mode=mode,


### PR DESCRIPTION
this series is one of the steps to remove global statements in `configure.py`. 

not only the script is more structured this way, this also allows us to quickly identify the part which should/can be reused when migrating to CMake based building system.

Refs #15379