### PR TITLE
Update scylla-jmx submodule (CI; don't merge)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 	ignore = dirty
 [submodule "scylla-jmx"]
 	path = tools/jmx
-	url = ../scylla-jmx
+	url = ../../avelanarius/scylla-jmx
 [submodule "scylla-tools"]
 	path = tools/java
 	url = ../scylla-tools-java


### PR DESCRIPTION
Don't merge this PR. Created for purposes of running CI.

Updates scylla-jmx submodule to avelanarius/update-dependencies