### PR TITLE
compaction: delete default_compaction_progress_monitor

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -405,11 +405,6 @@ private:
     friend class compaction_progress_monitor;
 };
 
-static compaction_progress_monitor default_noop_compaction_progress_monitor;
-compaction_progress_monitor& default_compaction_progress_monitor() {
-    return default_noop_compaction_progress_monitor;
-}
-
 void compaction_progress_monitor::set_generator(std::unique_ptr<read_monitor_generator> generator) {
     _generator = std::move(generator);
 }
@@ -1820,7 +1815,7 @@ static future<compaction_result> scrub_sstables_validate_mode(sstables::compacti
     };
 }
 
-future<compaction_result> scrub_sstables_validate_mode(sstables::compaction_descriptor descriptor, compaction_data& cdata, table_state& table_s, compaction_progress_monitor& progress_monitor = default_compaction_progress_monitor()) {
+future<compaction_result> scrub_sstables_validate_mode(sstables::compaction_descriptor descriptor, compaction_data& cdata, table_state& table_s, compaction_progress_monitor& progress_monitor) {
     progress_monitor.set_generator(std::make_unique<compaction_read_monitor_generator>(table_s, use_backlog_tracker::no));
     auto d = defer([&] { progress_monitor.reset_generator(); });
     auto res = co_await scrub_sstables_validate_mode(descriptor, cdata, table_s, *progress_monitor._generator);

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -116,14 +116,12 @@ public:
     friend future<compaction_result> scrub_sstables_validate_mode(sstables::compaction_descriptor, compaction_data&, table_state&, compaction_progress_monitor&);
 };
 
-compaction_progress_monitor& default_compaction_progress_monitor();
-
 // Compact a list of N sstables into M sstables.
 // Returns info about the finished compaction, which includes vector to new sstables.
 //
 // compaction_descriptor is responsible for specifying the type of compaction, and influencing
 // compaction behavior through its available member fields.
-future<compaction_result> compact_sstables(sstables::compaction_descriptor descriptor, compaction_data& cdata, table_state& table_s, compaction_progress_monitor& progress_monitor = default_compaction_progress_monitor());
+future<compaction_result> compact_sstables(sstables::compaction_descriptor descriptor, compaction_data& cdata, table_state& table_s, compaction_progress_monitor& progress_monitor);
 
 // Return list of expired sstables for column family cf.
 // A sstable is fully expired *iff* its max_local_deletion_time precedes gc_before and its

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3031,7 +3031,8 @@ static flat_mutation_reader_v2 compacted_sstable_reader(test_env& env, schema_pt
     };
     desc.replacer = replacer_fn_no_op();
     auto cdata = compaction_manager::create_compaction_data();
-    sstables::compact_sstables(std::move(desc), cdata, cf->as_table_state()).get();
+    compaction_progress_monitor progress_monitor;
+    sstables::compact_sstables(std::move(desc), cdata, cf->as_table_state(), progress_monitor).get();
 
     return compacted_sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), query::full_partition_range, s->full_slice());
 }

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -107,7 +107,8 @@ void run_sstable_resharding_test(sstables::test_env& env) {
         return env.make_sstable(cf->schema(), gen, version);
     };
     auto cdata = compaction_manager::create_compaction_data();
-    auto res = sstables::compact_sstables(std::move(descriptor), cdata, cf.as_table_state()).get0();
+    compaction_progress_monitor progress_monitor;
+    auto res = sstables::compact_sstables(std::move(descriptor), cdata, cf.as_table_state(), progress_monitor).get0();
     sst->destroy().get();
 
     auto new_sstables = std::move(res.new_sstables);

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -122,8 +122,10 @@ future<compaction_result> compact_sstables(compaction_manager& cm, sstables::com
     auto cmt = compaction_manager_test(cm);
     sstables::compaction_result ret;
     co_await cmt.run(descriptor.run_identifier, table_s, [&] (sstables::compaction_data& cdata) {
-        return sstables::compact_sstables(std::move(descriptor), cdata, table_s).then([&] (sstables::compaction_result res) {
-            ret = std::move(res);
+        return do_with(compaction_progress_monitor{}, [&] (compaction_progress_monitor& progress_monitor) {
+            return sstables::compact_sstables(std::move(descriptor), cdata, table_s, progress_monitor).then([&] (sstables::compaction_result res) {
+                ret = std::move(res);
+            });
         });
     });
     co_return ret;

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -239,7 +239,8 @@ public:
                 };
                 descriptor.replacer = sstables::replacer_fn_no_op();
                 auto cdata = compaction_manager::create_compaction_data();
-                auto ret = sstables::compact_sstables(std::move(descriptor), cdata, cf->as_table_state()).get0();
+                compaction_progress_monitor progress_monitor;
+                auto ret = sstables::compact_sstables(std::move(descriptor), cdata, cf->as_table_state(), progress_monitor).get0();
                 auto end = perf_sstable_test_env::now();
 
                 auto partitions_per_sstable = _cfg.partitions / _cfg.sstables;

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -966,7 +966,8 @@ void scrub_operation(schema_ptr schema, reader_permit permit, const std::vector<
 
     auto compaction_data = sstables::compaction_data{};
 
-    sstables::compact_sstables(std::move(compaction_descriptor), compaction_data, table_state).get();
+    compaction_progress_monitor progress_monitor;
+    sstables::compact_sstables(std::move(compaction_descriptor), compaction_data, table_state, progress_monitor).get();
 }
 
 void dump_index_operation(schema_ptr schema, reader_permit permit, const std::vector<sstables::shared_sstable>& sstables,


### PR DESCRIPTION
default_compaction_progress_monitor returns a reference to a static object. So, it should be read-only, but its users need to modify it.

Delete default_compaction_progress_monitor and use one's own compaction_progress_monitor instance where it's needed.