### PR TITLE
Multishard mutation query test fix misses expectations

### DIFF
--- a/test/lib/test_utils.hh
+++ b/test/lib/test_utils.hh
@@ -41,10 +41,45 @@ inline void require(bool condition, seastar::compat::source_location sl = seasta
     do_require(condition, sl, {});
 }
 
+template <typename LHS, typename RHS, typename Compare>
+void do_require_relation(
+        const LHS& lhs,
+        const RHS& rhs,
+        const Compare& relation,
+        const char* relation_operator,
+        seastar::compat::source_location sl) {
+    const auto condition = relation(lhs, rhs);
+    do_require(condition, sl, fmt::format("assertion {} {} {} failed", lhs, relation_operator, rhs));
+}
+
+template <typename LHS, typename RHS>
+void require_less(const LHS& lhs, const RHS& rhs, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+    do_require_relation(lhs, rhs, std::less<LHS>{}, "<", sl);
+}
+
+template <typename LHS, typename RHS>
+void require_less_equal(const LHS& lhs, const RHS& rhs, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+    do_require_relation(lhs, rhs, std::less_equal<LHS>{}, "<=", sl);
+}
+
 template <typename LHS, typename RHS>
 void require_equal(const LHS& lhs, const RHS& rhs, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
-    const auto condition = (lhs == rhs);
-    do_require(condition, sl, fmt::format("{} {}= {}", lhs, condition ? "=" : "!", rhs));
+    do_require_relation(lhs, rhs, std::equal_to<LHS>{}, "==", sl);
+}
+
+template <typename LHS, typename RHS>
+void require_not_equal(const LHS& lhs, const RHS& rhs, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+    do_require_relation(lhs, rhs, std::not_equal_to<LHS>{}, "!=", sl);
+}
+
+template <typename LHS, typename RHS>
+void require_greater_equal(const LHS& lhs, const RHS& rhs, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+    do_require_relation(lhs, rhs, std::greater_equal<LHS>{}, ">=", sl);
+}
+
+template <typename LHS, typename RHS>
+void require_greater(const LHS& lhs, const RHS& rhs, seastar::compat::source_location sl = seastar::compat::source_location::current()) {
+    do_require_relation(lhs, rhs, std::greater<LHS>{}, ">", sl);
 }
 
 void fail(std::string_view msg, seastar::compat::source_location sl = seastar::compat::source_location::current());


### PR DESCRIPTION
There are two tests, test_read_all and test_read_with_partition_row_limits, which asserts on every page as well
as at the end that there are no misses whatsoever. This is incorrect, because it is possible that on a given page, not all shards participate and thus there won't be a saved reader on every shard. On the subsequent page, a shard without a reader may produce a miss. This is fine. Refine the asserts, to check that we have only as much misses, as many
shards we have without readers on them.

Fixes: https://github.com/scylladb/scylladb/issues/14087