### PR TITLE
build: set an older version for cxxbridge that works in the frozen to…

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -314,7 +314,7 @@ elif [ "$ID" = "fedora" ]; then
     pip3 install traceback-with-variables
     pip3 install scylla-api-client
 
-    cargo install cxxbridge-cmd --root /usr/local
+    cargo install cxxbridge-cmd --root /usr/local --version 1.0.61
     if [ -f "$(node_exporter_fullpath)" ] && node_exporter_checksum; then
         echo "$(node_exporter_filename) already exists, skipping download"
     else


### PR DESCRIPTION
…olchain

In this branch(5.1) the most recent available rustc version is 1.60, despite that, the 'cargo install' command tries to install the most recent version of a package by default, which may rely on newer rustc versions. This patch specifies the version of the cxxbridge-cmd package to one that works with rustc 1.60.