### PR TITLE
build: cmake: detect rapidxml

### DIFF
--- a/cmake/Findrapidxml.cmake
+++ b/cmake/Findrapidxml.cmake
@@ -1,0 +1,27 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+find_path(rapidxml_INCLUDE_DIR
+  NAMES rapidxml.h rapidxml/rapidxml.hpp)
+
+mark_as_advanced(
+  rapidxml_INCLUDE_DIR)
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(rapidxml
+  REQUIRED_VARS
+    rapidxml_INCLUDE_DIR)
+
+if(rapidxml_FOUND)
+  if(NOT TARGET rapidxml::rapidxml)
+    add_library(rapidxml::rapidxml INTERFACE IMPORTED)
+    set_target_properties(rapidxml::rapidxml
+      PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES ${rapidxml_INCLUDE_DIR})
+  endif()
+endif()

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(cryptopp REQUIRED)
+find_package(rapidxml REQUIRED)
 
 add_library(utils STATIC)
 target_sources(utils
@@ -55,4 +56,5 @@ target_link_libraries(utils
     xxHash::xxhash
   PRIVATE
     Boost::regex
-    cryptopp)
+    cryptopp
+    rapidxml::rapidxml)


### PR DESCRIPTION
we use rapidxml for parsing XML, so let's detect it before using it.