### PR TITLE
s3: use rapixml/rapidxml.hpp as a fallback

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -9,7 +9,11 @@
 #include <initializer_list>
 #include <memory>
 #include <stdexcept>
+#if __has_include(<rapidxml.h>)
 #include <rapidxml.h>
+#else
+#include <rapidxml/rapidxml.hpp>
+#endif
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/range/adaptor/map.hpp>


### PR DESCRIPTION
on debian derivatives librapidxml-dev installs rapidxml.h as rapixml/rapidxml.hpp, so let's use it as a fallback.