### PR TITLE
test: add __repr__ for MinIoServer and S3_Server

### DIFF
--- a/test/object_store/conftest.py
+++ b/test/object_store/conftest.py
@@ -47,6 +47,9 @@ class S3_Server:
             MinioServer.create_conf_file(self.address, self.port, self.acc_key, self.secret_key, self.region, conffile)
         return conffile
 
+    def __repr__(self):
+        return f"[unknown] {self.address}:{self.port}/{self.bucket_name}@{self.config_file}"
+
     async def start(self):
         pass
 

--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -54,6 +54,9 @@ class MinioServer:
         self.secret_key = ''.join(random.choice(string.hexdigits) for i in range(32))
         self.log_filename = (self.tempdir / 'minio').with_suffix(".log")
 
+    def __repr__(self):
+        return f"[minio] {self.address}:{self.port}/{self.bucket_name}@{self.config_file}"
+
     def check_server(self, port):
         s = socket.socket()
         try:


### PR DESCRIPTION
it is printed when pytest passes it down as a fixture as part of the logging message. it would help with debugging an object_store test.