### PR TITLE
build: extract code fragments into functions

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1757,8 +1757,6 @@ user_ldflags += ' -fvisibility=hidden'
 if args.staticcxx:
     user_ldflags += " -static-libstdc++"
 
-os.makedirs(outdir, exist_ok=True)
-
 
 def get_extra_cxxflags(mode, mode_config, cxx, debuginfo):
     cxxflags = []
@@ -2378,6 +2376,8 @@ def write_build_file(f,
 check_for_minimal_compiler_version(args.cxx)
 check_for_boost(args.cxx)
 check_for_lz4(args.cxx, args.user_cflags)
+
+os.makedirs(outdir, exist_ok=True)
 
 if not args.dist_only:
     # args.buildfile builds seastar with the rules of

--- a/configure.py
+++ b/configure.py
@@ -1568,15 +1568,6 @@ perf_tests_link_rule = 'link' if args.perf_tests_debuginfo else 'link_stripped'
 # debug info from the libraries we static link with
 regular_link_rule = 'link' if args.debuginfo else 'link_stripped'
 
-pkgs = []
-
-# Lua can be provided by lua53 package on Debian-like
-# systems and by Lua on others.
-pkgs.append('lua53' if have_pkg('lua53') else 'lua')
-
-pkgs.append('libsystemd')
-pkgs.append('jsoncpp')
-
 has_sanitize_address_use_after_scope = try_compile(compiler=args.cxx, flags=['-fsanitize-address-use-after-scope'], source='int f() {}')
 
 defines = ' '.join(['-D' + d for d in defines])
@@ -1757,13 +1748,14 @@ def query_seastar_flags(pc_file, use_shared_libs, link_static_cxx=False):
             'seastar_libs': libs,
             'seastar_testing_libs': testing_libs}
 
+pkgs = ['libsystemd',
+        'jsoncpp',
+        'absl_raw_hash_set',
+        'absl_hash']
+# Lua can be provided by lua53 package on Debian-like
+# systems and by Lua on others.
+pkgs.append('lua53' if have_pkg('lua53') else 'lua')
 
-abseil_pkgs = [
-    'absl_raw_hash_set',
-    'absl_hash',
-]
-
-pkgs += abseil_pkgs
 
 libs = ' '.join([maybe_static(args.staticyamlcpp, '-lyaml-cpp'), '-latomic', '-llz4', '-lz', '-lsnappy',
                  ' -lstdc++fs', ' -lcrypt', ' -lcryptopp', ' -lpthread',

--- a/configure.py
+++ b/configure.py
@@ -1780,10 +1780,6 @@ user_cflags += ' -fvisibility=hidden'
 user_ldflags += ' -fvisibility=hidden'
 if args.staticcxx:
     user_ldflags += " -static-libstdc++"
-if args.staticthrift:
-    thrift_libs = "-Wl,-Bstatic -lthrift -Wl,-Bdynamic"
-else:
-    thrift_libs = "-lthrift"
 
 os.makedirs(outdir, exist_ok=True)
 
@@ -2004,7 +2000,8 @@ def write_build_file(f,
                 objs.append('$builddir/' + mode +'/rust-' + mode + '/librust_combined.a')
             local_libs = '$seastar_libs_{} $libs'.format(mode)
             if has_thrift:
-                local_libs += ' ' + thrift_libs + ' ' + maybe_static(args.staticboost, '-lboost_system')
+                local_libs += ' ' + maybe_static(args.staticthrift, '-lthrift')
+                local_libs += ' ' + maybe_static(args.staticboost, '-lboost_system')
             if binary in tests:
                 if binary in pure_boost_tests:
                     local_libs += ' ' + maybe_static(args.staticboost, '-lboost_unit_test_framework')

--- a/configure.py
+++ b/configure.py
@@ -1705,9 +1705,6 @@ def configure_seastar(build_dir, mode, mode_config):
     os.makedirs(seastar_build_dir, exist_ok=True)
     subprocess.check_call(seastar_cmd, shell=False, cwd=cmake_dir)
 
-if not args.dist_only:
-    for mode, mode_config in build_modes.items():
-        configure_seastar(outdir, mode, mode_config)
 
 def query_seastar_flags(pc_file, use_shared_libs, link_static_cxx=False):
     if use_shared_libs:
@@ -2381,6 +2378,14 @@ def write_build_file(f,
 check_for_minimal_compiler_version(args.cxx)
 check_for_boost(args.cxx)
 check_for_lz4(args.cxx, args.user_cflags)
+
+if not args.dist_only:
+    # args.buildfile builds seastar with the rules of
+    # {outdir}/{mode}/seastar/build.ninja, and
+    # {outdir}/{mode}/seastar/seastar.pc is queried for building flags
+    for mode, mode_config in build_modes.items():
+        configure_seastar(outdir, mode, mode_config)
+
 ninja = find_ninja()
 with open(args.buildfile, 'w') as f:
     scylla_product, scylla_version, scylla_release = generate_version(args.date_stamp)

--- a/configure.py
+++ b/configure.py
@@ -2382,7 +2382,7 @@ check_for_minimal_compiler_version(args.cxx)
 check_for_boost(args.cxx)
 check_for_lz4(args.cxx, args.user_cflags)
 ninja = find_ninja()
-with open(buildfile, 'w') as f:
+with open(args.buildfile, 'w') as f:
     scylla_product, scylla_version, scylla_release = generate_version(args.date_stamp)
     arch = platform.machine()
     write_build_file(f,
@@ -2392,4 +2392,4 @@ with open(buildfile, 'w') as f:
                      scylla_version,
                      scylla_release,
                      args)
-generate_compdb('compile_commands.json', ninja, buildfile, selected_modes)
+generate_compdb('compile_commands.json', ninja, args.buildfile, selected_modes)

--- a/configure.py
+++ b/configure.py
@@ -19,8 +19,6 @@ import tempfile
 import textwrap
 from distutils.spawn import find_executable
 
-curdir = os.getcwd()
-
 outdir = 'build'
 
 tempfile.tempdir = f"{outdir}/tmp"
@@ -1670,6 +1668,7 @@ forced_ldflags += dynamic_linker_option()
 
 user_ldflags = forced_ldflags + ' ' + args.user_ldflags
 
+curdir = os.getcwd()
 user_cflags = args.user_cflags + f" -ffile-prefix-map={curdir}=."
 
 if args.target != '':

--- a/configure.py
+++ b/configure.py
@@ -2373,28 +2373,33 @@ def write_build_file(f,
         ''').format(**globals()))
 
 
-check_for_minimal_compiler_version(args.cxx)
-check_for_boost(args.cxx)
-check_for_lz4(args.cxx, args.user_cflags)
+def create_building_system(args):
+    check_for_minimal_compiler_version(args.cxx)
+    check_for_boost(args.cxx)
+    check_for_lz4(args.cxx, args.user_cflags)
 
-os.makedirs(outdir, exist_ok=True)
+    os.makedirs(outdir, exist_ok=True)
 
-if not args.dist_only:
-    # args.buildfile builds seastar with the rules of
-    # {outdir}/{mode}/seastar/build.ninja, and
-    # {outdir}/{mode}/seastar/seastar.pc is queried for building flags
-    for mode, mode_config in build_modes.items():
-        configure_seastar(outdir, mode, mode_config)
+    if not args.dist_only:
+        # args.buildfile builds seastar with the rules of
+        # {outdir}/{mode}/seastar/build.ninja, and
+        # {outdir}/{mode}/seastar/seastar.pc is queried for building flags
+        for mode, mode_config in build_modes.items():
+            configure_seastar(outdir, mode, mode_config)
 
-ninja = find_ninja()
-with open(args.buildfile, 'w') as f:
-    scylla_product, scylla_version, scylla_release = generate_version(args.date_stamp)
-    arch = platform.machine()
-    write_build_file(f,
-                     arch,
-                     ninja,
-                     scylla_product,
-                     scylla_version,
-                     scylla_release,
-                     args)
-generate_compdb('compile_commands.json', ninja, args.buildfile, selected_modes)
+    ninja = find_ninja()
+    with open(args.buildfile, 'w') as f:
+        scylla_product, scylla_version, scylla_release = generate_version(args.date_stamp)
+        arch = platform.machine()
+        write_build_file(f,
+                         arch,
+                         ninja,
+                         scylla_product,
+                         scylla_version,
+                         scylla_release,
+                         args)
+    generate_compdb('compile_commands.json', ninja, args.buildfile, selected_modes)
+
+
+if __name__ == '__main__':
+    create_building_system(args)

--- a/configure.py
+++ b/configure.py
@@ -1568,10 +1568,6 @@ perf_tests_link_rule = 'link' if args.perf_tests_debuginfo else 'link_stripped'
 # debug info from the libraries we static link with
 regular_link_rule = 'link' if args.debuginfo else 'link_stripped'
 
-# a list element means a list of alternative packages to consider
-# the first element becomes the HAVE_pkg define
-# a string element is a package name with no alternatives
-optional_packages = [[]]
 pkgs = []
 
 # Lua can be provided by lua53 package on Debian-like


### PR DESCRIPTION
this series is one of the steps to remove global statements in `configure.py`. 

not only the script is more structured this way, this also allows us to quickly identify the part which should/can be reused when migrating to CMake based building system.

Refs #15379