### PR TITLE
Major compaction: flush commitlog by forcing new active segment and flushing all tables

### DIFF
--- a/api/api-doc/column_family.json
+++ b/api/api-doc/column_family.json
@@ -85,6 +85,14 @@
                      "paramType":"path"
                   },
                   {
+                     "name":"flush_memtables",
+                     "description":"Controls flushing of memtables before compaction (true by default). Set to \"false\" to skip automatic flushing of memtables before compaction, e.g. when the table is flushed explicitly before invoking the compaction api.",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"boolean",
+                     "paramType":"query"
+                  },
+                  {
                      "name":"split_output",
                      "description":"true if the output of the major compaction should be split in several sstables",
                      "required":false,

--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -728,6 +728,14 @@
                      "allowMultiple":false,
                      "type":"string",
                      "paramType":"query"
+                  },
+                  {
+                     "name":"flush_memtables",
+                     "description":"Controls flushing of memtables before compaction (true by default). Set to \"false\" to skip automatic flushing of memtables before compaction, e.g. when tables were flushed explicitly before invoking the compaction api.",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"boolean",
+                     "paramType":"query"
                   }
                ]
             }

--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -921,6 +921,21 @@
          ]
       },
       {
+         "path":"/storage_service/flush",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Flush all memtables in all keyspaces.",
+               "type":"void",
+               "nickname":"force_flush",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[]
+            }
+         ]
+      },
+      {
          "path":"/storage_service/keyspace_flush/{keyspace}",
          "operations":[
             {

--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -702,6 +702,30 @@
          ]
       },
       {
+         "path":"/storage_service/compact",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Forces major compaction in all keyspaces",
+               "type":"void",
+               "nickname":"force_compaction",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"flush_memtables",
+                     "description":"Controls flushing of memtables before compaction (true by default). Set to \"false\" to skip automatic flushing of memtables before compaction, e.g. when tables were flushed explicitly before invoking the compaction api.",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"boolean",
+                     "paramType":"query"
+                  }
+               ]
+            }
+         ]
+      },
+      {
          "path":"/storage_service/keyspace_compaction/{keyspace}",
          "operations":[
             {

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -1071,7 +1071,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         if (!flush) {
             fmopt = major_compaction_task_impl::flush_mode::skip;
         }
-        auto task = co_await compaction_module.make_and_start_task<major_keyspace_compaction_task_impl>({}, std::move(keyspace), ctx.db, std::move(table_infos), fmopt);
+        auto task = co_await compaction_module.make_and_start_task<major_keyspace_compaction_task_impl>({}, std::move(keyspace), tasks::task_id::create_null_id(), ctx.db, std::move(table_infos), fmopt);
         co_await task->done();
         co_return json_void();
     });

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -638,12 +638,23 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
 
     ss::force_keyspace_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto& db = ctx.db;
-        auto keyspace = validate_keyspace(ctx, req->param);
-        auto table_infos = parse_table_infos(keyspace, ctx, req->query_parameters, "cf");
-        apilog.debug("force_keyspace_compaction: keyspace={} tables={}", keyspace, table_infos);
+        auto params = req_params({
+            std::pair("keyspace", mandatory::yes),
+            std::pair("cf", mandatory::no),
+            std::pair("flush_memtables", mandatory::no),
+        });
+        params.process(*req);
+        auto keyspace = validate_keyspace(ctx, *params.get("keyspace"));
+        auto table_infos = parse_table_infos(keyspace, ctx, params.get("cf").value_or(""));
+        auto flush = params.get_as<bool>("flush_memtables").value_or(true);
+        apilog.debug("force_keyspace_compaction: keyspace={} tables={}, flush={}", keyspace, table_infos, flush);
 
         auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
-        auto task = co_await compaction_module.make_and_start_task<major_keyspace_compaction_task_impl>({}, std::move(keyspace), db, table_infos);
+        std::optional<major_compaction_task_impl::flush_mode> fmopt;
+        if (!flush) {
+            fmopt = major_compaction_task_impl::flush_mode::skip;
+        }
+        auto task = co_await compaction_module.make_and_start_task<major_keyspace_compaction_task_impl>({}, std::move(keyspace), db, table_infos, fmopt);
         try {
             co_await task->done();
         } catch (...) {

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -82,20 +82,46 @@ protected:
     virtual future<> run() override = 0;
 };
 
+class global_major_compaction_task_impl : public major_compaction_task_impl {
+private:
+    sharded<replica::database>& _db;
+public:
+    global_major_compaction_task_impl(tasks::task_manager::module_ptr module,
+            sharded<replica::database>& db,
+            std::optional<flush_mode> fm = std::nullopt) noexcept
+        : major_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "global", "", "", "", tasks::task_id::create_null_id(),
+                fm.value_or(flush_mode::all_tables))
+        , _db(db)
+    {}
+protected:
+    virtual future<> run() override;
+};
+
 class major_keyspace_compaction_task_impl : public major_compaction_task_impl {
 private:
     sharded<replica::database>& _db;
     std::vector<table_info> _table_infos;
+    // _cvp and _current_task are engaged when the task is invoked from
+    // global_major_compaction_task_impl
+    seastar::condition_variable* _cv;
+    tasks::task_manager::task_ptr* _current_task;
 public:
     major_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
+            tasks::task_id parent_id,
             sharded<replica::database>& db,
             std::vector<table_info> table_infos,
-            std::optional<flush_mode> fm = std::nullopt) noexcept
-        : major_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "keyspace", std::move(keyspace), "", "", tasks::task_id::create_null_id(),
+            std::optional<flush_mode> fm = std::nullopt,
+            seastar::condition_variable* cv = nullptr,
+            tasks::task_manager::task_ptr* current_task = nullptr) noexcept
+        : major_compaction_task_impl(module, tasks::task_id::create_random_id(),
+                parent_id ? 0 : module->new_sequence_number(),
+                "keyspace", std::move(keyspace), "", "", parent_id,
                 fm.value_or(flush_mode::all_tables))
         , _db(db)
         , _table_infos(std::move(table_infos))
+        , _cv(cv)
+        , _current_task(current_task)
     {}
 protected:
     virtual future<> run() override;

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include "compaction/compaction.hh"
 #include "replica/database_fwd.hh"
 #include "schema/schema_fwd.hh"
@@ -48,6 +50,13 @@ protected:
 
 class major_compaction_task_impl : public compaction_task_impl {
 public:
+    enum class flush_mode {
+        skip,               // Skip flushing.  Useful when application explicitly flushes all tables prior to compaction
+        compacted_tables,   // Flush only the compacted keyspace/tables
+        // FIXME: flushing all_tables is not implemented yet
+        all_tables          // Flush all tables in the database prior to compaction
+    };
+
     major_compaction_task_impl(tasks::task_manager::module_ptr module,
             tasks::task_id id,
             unsigned sequence_number,
@@ -55,8 +64,10 @@ public:
             std::string keyspace,
             std::string table,
             std::string entity,
-            tasks::task_id parent_id) noexcept
+            tasks::task_id parent_id,
+            flush_mode fm = flush_mode::compacted_tables) noexcept
         : compaction_task_impl(module, id, sequence_number, std::move(scope), std::move(keyspace), std::move(table), std::move(entity), parent_id)
+        , _flush_mode(fm)
     {
         // FIXME: add progress units
     }
@@ -64,7 +75,11 @@ public:
     virtual std::string type() const override {
         return "major compaction";
     }
+
+    static sstring to_string(flush_mode);
 protected:
+    flush_mode _flush_mode;
+
     virtual future<> run() override = 0;
 };
 
@@ -76,8 +91,10 @@ public:
     major_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
             sharded<replica::database>& db,
-            std::vector<table_info> table_infos) noexcept
-        : major_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "keyspace", std::move(keyspace), "", "", tasks::task_id::create_null_id())
+            std::vector<table_info> table_infos,
+            std::optional<flush_mode> fm = std::nullopt) noexcept
+        : major_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "keyspace", std::move(keyspace), "", "", tasks::task_id::create_null_id(),
+                fm.value_or(flush_mode::all_tables))
         , _db(db)
         , _table_infos(std::move(table_infos))
     {}
@@ -94,8 +111,9 @@ public:
             std::string keyspace,
             tasks::task_id parent_id,
             replica::database& db,
-            std::vector<table_info> local_tables) noexcept
-        : major_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "shard", std::move(keyspace), "", "", parent_id)
+            std::vector<table_info> local_tables,
+            flush_mode fm) noexcept
+        : major_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "shard", std::move(keyspace), "", "", parent_id, fm)
         , _db(db)
         , _local_tables(std::move(local_tables))
     {}
@@ -117,8 +135,9 @@ public:
             replica::database& db,
             table_info ti,
             seastar::condition_variable& cv,
-            tasks::task_manager::task_ptr& current_task) noexcept
-        : major_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "table", std::move(keyspace), std::move(table), "", parent_id)
+            tasks::task_manager::task_ptr& current_task,
+            flush_mode fm) noexcept
+        : major_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "table", std::move(keyspace), std::move(table), "", parent_id, fm)
         , _db(db)
         , _ti(std::move(ti))
         , _cv(cv)
@@ -667,4 +686,13 @@ protected:
     virtual future<> run() override = 0;
 };
 
-}
+} // namespace compaction
+
+template <>
+struct fmt::formatter<major_compaction_task_impl::flush_mode> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const major_compaction_task_impl::flush_mode& fm, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", major_compaction_task_impl::to_string(fm));
+    }
+};

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -53,7 +53,6 @@ public:
     enum class flush_mode {
         skip,               // Skip flushing.  Useful when application explicitly flushes all tables prior to compaction
         compacted_tables,   // Flush only the compacted keyspace/tables
-        // FIXME: flushing all_tables is not implemented yet
         all_tables          // Flush all tables in the database prior to compaction
     };
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -361,6 +361,10 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "If set to higher than 0, ignore the controller's output and set the compaction shares statically. Do not set this unless you know what you are doing and suspect a problem in the controller. This option will be retired when the controller reaches more maturity")
     , compaction_enforce_min_threshold(this, "compaction_enforce_min_threshold", liveness::LiveUpdate, value_status::Used, false,
         "If set to true, enforce the min_threshold option for compactions strictly. If false (default), Scylla may decide to compact even if below min_threshold")
+    , compaction_flush_all_tables_before_major_seconds(this, "compaction_flush_all_tables_before_major_seconds", value_status::Used, 86400,
+        "Set the minimum interval in seconds between flushing all tables before each major compaction (default is 86400). "
+        "This option is useful for maximizing tombstone garbage collection by releasing all active commitlog segments. "
+        "Set to 0 to disable automatic flushing all tables before major compaction")
     /**
     * @Group Initialization properties
     * @GroupDescription The minimal properties needed for configuring a cluster.

--- a/db/config.hh
+++ b/db/config.hh
@@ -168,6 +168,7 @@ public:
     named_value<float> memtable_flush_static_shares;
     named_value<float> compaction_static_shares;
     named_value<bool> compaction_enforce_min_threshold;
+    named_value<uint32_t> compaction_flush_all_tables_before_major_seconds;
     named_value<sstring> cluster_name;
     named_value<sstring> listen_address;
     named_value<sstring> listen_interface;

--- a/docs/operating-scylla/nodetool-commands/compact.rst
+++ b/docs/operating-scylla/nodetool-commands/compact.rst
@@ -34,7 +34,7 @@ Examples
 
    nodetool compact
    nodetool compact keyspace1
-   nodetool compact standard1
+   nodetool compact keyspace1 standard1
 
 See Also
 --------

--- a/docs/operating-scylla/nodetool-commands/flush.rst
+++ b/docs/operating-scylla/nodetool-commands/flush.rst
@@ -1,12 +1,32 @@
 Nodetool flush
 ==============
-**flush** ``[<keyspace> <cfnames>...]``- Specify a keyspace and one or more tables that you want to flush from the memtable to on disk SSTables.
+**flush** - Flush memtables to on-disk SSTables in the specified keyspace and table(s).
 
 For example:
 
 .. code-block:: shell
 
    nodetool flush keyspaces1 standard1
+
+Syntax
+------
+
+.. code-block:: none
+
+   nodetool flush [<keyspace> [<table> ...]]
+
+nodetool flush takes the following parameters:
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+
+   * - Parameter Name
+     - Description
+   * - ``<keyspace>``
+     - The keyspace to operate on.  If omitted, all keyspaces are flushed.
+   * - ``<table> ...``
+     - One or more tables to operate on.  Tables may be specified only if a keyspace is given.  If omitted, all tables in the specified keyspace are flushed.
 
 See also
 

--- a/docs/operating-scylla/nodetool-commands/flush.rst
+++ b/docs/operating-scylla/nodetool-commands/flush.rst
@@ -6,7 +6,9 @@ For example:
 
 .. code-block:: shell
 
-   nodetool flush keyspaces1 standard1
+   nodetool flush
+   nodetool flush keyspace1
+   nodetool flush keyspace1 standard1
 
 Syntax
 ------

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2514,6 +2514,17 @@ future<> database::flush_all_tables() {
     co_await get_tables_metadata().parallel_for_each_table([] (table_id, lw_shared_ptr<table> t) {
         return t->flush();
     });
+    _all_tables_flushed_at = db_clock::now();
+}
+
+future<db_clock::time_point> database::get_all_tables_flushed_at(sharded<database>& sharded_db) {
+    db_clock::time_point min_all_tables_flushed_at;
+    co_await sharded_db.map_reduce0([&] (const database& db) {
+        return db._all_tables_flushed_at;
+    }, db_clock::now(), [] (db_clock::time_point l, db_clock::time_point r) {
+        return std::min(l, r);
+    });
+    co_return min_all_tables_flushed_at;
 }
 
 future<> database::drop_cache_for_keyspace_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name) {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1448,6 +1448,8 @@ private:
     serialized_action _update_memtable_flush_static_shares_action;
     utils::observer<float> _memtable_flush_static_shares_observer;
 
+    db_clock::time_point _all_tables_flushed_at;
+
 public:
     data_dictionary::database as_data_dictionary() const;
     db::commitlog* commitlog_for(const schema_ptr& schema);
@@ -1743,6 +1745,8 @@ public:
     // Note: force_new_active_segment in the commitlog, so that
     // flushing all tables will allow reclaiming of all commitlog segments
     future<> flush_all_tables();
+
+    static future<db_clock::time_point> get_all_tables_flushed_at(sharded<database>& sharded_db);
 
     static future<> drop_cache_for_table_on_all_shards(sharded<database>& sharded_db, table_id id);
     static future<> drop_cache_for_keyspace_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1739,6 +1739,10 @@ public:
     static future<> flush_tables_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name, std::vector<sstring> table_names);
     // flush all tables in a keyspace on all shards.
     static future<> flush_keyspace_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name);
+    // flush all tables on this shard.
+    // Note: force_new_active_segment in the commitlog, so that
+    // flushing all tables will allow reclaiming of all commitlog segments
+    future<> flush_all_tables();
 
     static future<> drop_cache_for_table_on_all_shards(sharded<database>& sharded_db, table_id id);
     static future<> drop_cache_for_keyspace_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -861,10 +861,12 @@ public:
 
     bool can_flush() const;
 
+    using do_flush = bool_class<struct do_flush_tag>;
+
     // Start a compaction of all sstables in a process known as major compaction
     // Active memtable is flushed first to guarantee that data like tombstone,
     // sitting in the memtable, will be compacted with shadowed data.
-    future<> compact_all_sstables(std::optional<tasks::task_info> info = std::nullopt);
+    future<> compact_all_sstables(std::optional<tasks::task_info> info = std::nullopt, do_flush = do_flush::yes);
 
     future<bool> snapshot_exists(sstring name);
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1373,8 +1373,10 @@ compaction_group::update_main_sstable_list_on_compaction_completion(sstables::co
 }
 
 future<>
-table::compact_all_sstables(std::optional<tasks::task_info> info) {
-    co_await flush();
+table::compact_all_sstables(std::optional<tasks::task_info> info, do_flush do_flush) {
+    if (do_flush) {
+        co_await flush();
+    }
     // Forces off-strategy before major, so sstables previously sitting on maintenance set will be included
     // in the compaction's input set, to provide same semantics as before maintenance set came into existence.
     co_await perform_offstrategy_compaction(info);

--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -68,7 +68,7 @@ def jmx(request, rest_api_mock_server):
 
     jmx_path = request.config.getoption("jmx_path")
     if jmx_path is None:
-        jmx_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "scylla-jmx", "scripts",
+        jmx_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "tools", "jmx", "scripts",
                                                 "scylla-jmx"))
     else:
         jmx_path = os.path.abspath(jmx_path)

--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -141,6 +141,12 @@ def scylla_only(request):
         pytest.skip('Scylla-only test skipped')
 
 
+@pytest.fixture(scope="function")
+def cassandra_only(request):
+    if request.config.getoption("nodetool") != "cassandra":
+        pytest.skip('Cassandra-only test skipped')
+
+
 @pytest.fixture(scope="module")
 def nodetool(request, jmx, nodetool_path, rest_api_mock_server):
     def invoker(method, *args, expected_requests=None):

--- a/test/nodetool/test_compact.py
+++ b/test/nodetool/test_compact.py
@@ -9,7 +9,14 @@ import utils
 import pytest
 
 
-def test_all_keyspaces(nodetool):
+# `scylla nodetool compact` invokes the newly added global compact api
+def test_all_keyspaces(nodetool, scylla_only):
+    nodetool("compact", expected_requests=[
+        expected_request("POST", "/storage_service/compact")])
+
+
+# The java-based `nodetool compact` lists all keyspaces and invoke the keyspace_compaction api on each of them
+def test_all_keyspaces_jmx(nodetool, cassandra_only):
     nodetool("compact", expected_requests=[
         expected_request("GET", "/storage_service/keyspaces", multiple=expected_request.MULTIPLE,
                          response=["system", "system_schema"]),
@@ -94,7 +101,4 @@ def test_keyspace_flush_memtables_option(nodetool, scylla_only, flush):
 def test_all_keyspaces_flush_memtables_option(nodetool, scylla_only, flush):
     params = {"flush_memtables": flush}
     nodetool("compact", "--flush-memtables", flush, expected_requests=[
-            expected_request("GET", "/storage_service/keyspaces", multiple=expected_request.MULTIPLE,
-                            response=["system", "system_schema"]),
-            expected_request("POST", "/storage_service/keyspace_compaction/system", params=params),
-            expected_request("POST", "/storage_service/keyspace_compaction/system_schema", params=params)])
+            expected_request("POST", "/storage_service/compact", params=params)])

--- a/test/nodetool/test_compact.py
+++ b/test/nodetool/test_compact.py
@@ -6,6 +6,7 @@
 
 from rest_api_mock import expected_request
 import utils
+import pytest
 
 
 def test_all_keyspaces(nodetool):
@@ -76,3 +77,24 @@ def test_user_defined(nodetool, scylla_only):
              "me-3g8w_11cg_4317k2ppfb6d5vgp0w-big-Data.db"),
             {},
             ["error processing arguments: --user-defined flag is unsupported"])
+
+
+@pytest.mark.parametrize("flush", ("true", "false"))
+# The `--flush-memtables` option to `nodetool compact` is available only with `scylla_nodetool`
+def test_keyspace_flush_memtables_option(nodetool, scylla_only, flush):
+    params = {"flush_memtables": flush}
+    nodetool("compact", "system_schema", "--flush-memtables", flush, expected_requests=[
+            expected_request("GET", "/storage_service/keyspaces", multiple=expected_request.MULTIPLE,
+                             response=["system", "system_schema"]),
+            expected_request("POST", "/storage_service/keyspace_compaction/system_schema", params=params)])
+
+
+@pytest.mark.parametrize("flush", ("true", "false"))
+# The `--flush-memtables` option to `nodetool compact` is available only with `scylla_nodetool`
+def test_all_keyspaces_flush_memtables_option(nodetool, scylla_only, flush):
+    params = {"flush_memtables": flush}
+    nodetool("compact", "--flush-memtables", flush, expected_requests=[
+            expected_request("GET", "/storage_service/keyspaces", multiple=expected_request.MULTIPLE,
+                            response=["system", "system_schema"]),
+            expected_request("POST", "/storage_service/keyspace_compaction/system", params=params),
+            expected_request("POST", "/storage_service/keyspace_compaction/system_schema", params=params)])

--- a/test/nodetool/test_flush.py
+++ b/test/nodetool/test_flush.py
@@ -8,7 +8,24 @@ from rest_api_mock import expected_request
 import utils
 
 
-def test_flush(nodetool):
+# `scylla nodetool flush` invokes the newly added global flush api
+def test_flush_all_tables(nodetool, scylla_only):
+    nodetool("flush", expected_requests=[
+        expected_request("POST", "/storage_service/flush")
+    ])
+
+
+# The java-based `nodetool flush` lists all keyspaces and invoke the per-keyspace flush api on each of them
+def test_flush_all_tables_jmx(nodetool, cassandra_only):
+    nodetool("flush", expected_requests=[
+            expected_request("GET", "/storage_service/keyspaces", multiple=expected_request.MULTIPLE,
+                            response=["ks1", "ks2"]),
+            expected_request("POST", "/storage_service/keyspace_flush/ks1"),
+            expected_request("POST", "/storage_service/keyspace_flush/ks2")
+    ])
+
+
+def test_flush_one_keyspace(nodetool):
     nodetool("flush", "ks1", expected_requests=[
         expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
         expected_request("POST", "/storage_service/keyspace_flush/ks1")

--- a/test/rest_api/test_compaction_task.py
+++ b/test/rest_api/test_compaction_task.py
@@ -46,6 +46,13 @@ def test_major_keyspace_compaction_task(cql, this_dc, rest_api):
     # column family major compaction
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, table: rest_api.send("POST", f"column_family/major_compaction/{keyspace}:{table}"), "major compaction", task_tree_depth)
 
+    # keyspace major compaction, flush option
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_compaction/{keyspace}?flush_memtables=true"), "major compaction", task_tree_depth)
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_compaction/{keyspace}?flush_memtables=false"), "major compaction", task_tree_depth)
+    # column family major compaction, flush option
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, table: rest_api.send("POST", f"column_family/major_compaction/{keyspace}:{table}?flush_memtables=true"), "major compaction", task_tree_depth)
+    check_compaction_task(cql, this_dc, rest_api, lambda keyspace, table: rest_api.send("POST", f"column_family/major_compaction/{keyspace}:{table}?flush_memtables=false"), "major compaction", task_tree_depth)
+
 def test_cleanup_keyspace_compaction_task(cql, this_dc, rest_api):
     task_tree_depth = 3
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_cleanup/{keyspace}"), "cleanup compaction", task_tree_depth, True)

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -276,6 +276,10 @@ def test_storage_service_flush(cql, this_dc, rest_api):
                 stmt = cql.prepare(f"INSERT INTO {table1} (p) VALUES (?)")
                 cql.execute(stmt, ["pk1"])
 
+                # test global flush
+                resp = rest_api.send("POST", f"storage_service/flush")
+                resp.raise_for_status()
+
                 # test the keyspace_flush doesn't produce any errors when called on existing keyspace and table(s)
                 resp = rest_api.send("POST", f"storage_service/keyspace_flush/{ks}")
                 resp.raise_for_status()

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -216,9 +216,7 @@ void compact_operation(scylla_rest_client& client, const bpo::variables_map& vm)
         }
         client.post(format("/storage_service/keyspace_compaction/{}", keyspace), std::move(params));
     } else {
-        for (const auto& keyspace : get_keyspaces(client)) {
-            client.post(format("/storage_service/keyspace_compaction/{}", keyspace), params);
-        }
+        client.post("/storage_service/compact", std::move(params));
     }
 }
 

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -875,8 +875,9 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
                 "flush",
                 "Flush one or more tables",
 R"(
-Specify a keyspace and one or more tables that you want to flush from the
-memtable to on disk SSTables.
+Flush memtables to on-disk SSTables in the specified keyspace and table(s).
+If no keyspace is specified, all keyspaces are flushed.
+If no table(s) are specified, all tables in the specified keyspace are flushed.
 
 Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/flush.html
 )",

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -132,10 +132,16 @@ keyspace_and_tables parse_keyspace_and_tables(scylla_rest_client& client, const 
     return ret;
 }
 
-keyspace_and_tables parse_keyspace_and_tables(scylla_rest_client& client, const bpo::variables_map& vm) {
+keyspace_and_tables parse_keyspace_and_tables(scylla_rest_client& client, const bpo::variables_map& vm, bool keyspace_required = true) {
     keyspace_and_tables ret;
 
-    ret.keyspace = vm["keyspace"].as<sstring>();
+    if (vm.contains("keyspace")) {
+        ret.keyspace = vm["keyspace"].as<sstring>();
+    } else if (keyspace_required) {
+        throw std::invalid_argument(fmt::format("keyspace must be specified"));
+    } else {
+        return ret;
+    }
 
     const auto all_keyspaces = get_keyspaces(client);
     if (std::ranges::find(all_keyspaces, ret.keyspace) == all_keyspaces.end()) {
@@ -402,7 +408,11 @@ void enablegossip_operation(scylla_rest_client& client, const bpo::variables_map
 }
 
 void flush_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
-    const auto [keyspace, tables] = parse_keyspace_and_tables(client, vm);
+    const auto [keyspace, tables] = parse_keyspace_and_tables(client, vm, false);
+    if (keyspace.empty()) {
+        client.post("/storage_service/flush");
+        return;
+    }
     std::unordered_map<sstring, sstring> params;
     if (!tables.empty()) {
         params["cf"] = fmt::to_string(fmt::join(tables.begin(), tables.end(), ","));

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -198,16 +198,20 @@ void compact_operation(scylla_rest_client& client, const bpo::variables_map& vm)
         throw std::invalid_argument("--user-defined flag is unsupported");
     }
 
+    std::unordered_map<sstring, sstring> params;
+    if (vm.count("flush-memtables")) {
+        params["flush_memtables"] = vm["flush-memtables"].as<bool>() ? "true" : "false";
+    }
+
     if (vm.count("compaction_arg")) {
         const auto [keyspace, tables] = parse_keyspace_and_tables(client, vm, "compaction_arg");
-        std::unordered_map<sstring, sstring> params;
         if (!tables.empty()) {
             params["cf"] = fmt::to_string(fmt::join(tables.begin(), tables.end(), ","));
         }
         client.post(format("/storage_service/keyspace_compaction/{}", keyspace), std::move(params));
     } else {
         for (const auto& keyspace : get_keyspaces(client)) {
-            client.post(format("/storage_service/keyspace_compaction/{}", keyspace));
+            client.post(format("/storage_service/keyspace_compaction/{}", keyspace), params);
         }
     }
 }
@@ -735,6 +739,8 @@ command-line arguments, the compaction will run on these tables.
 Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/compact.html
 )",
                 {
+                    typed_option<bool>("flush-memtables", "Control flushing of tables before major compaction (true by default)"),
+
                     typed_option<>("split-output,s", "Don't create a single big file (unused)"),
                     typed_option<>("user-defined", "Submit listed SStable files for user-defined compaction (unused)"),
                     typed_option<int64_t>("start-token", "Specify a token at which the compaction range starts (unused)"),


### PR DESCRIPTION
Major compaction already flushes each table to make
sure it considers any mutations that are present in the
memtable for the purpose of tombstone purging.
See 64ec1c6ec64291064678e3818e3ffdee4294dbfe

However, tombstone purging may be inhibited by data
in commitlog segments based on `gc_time_min` in the
`tombstone_gc_state` (See f42eb4d1ce321e93b934ce23e128af29d23d66f8).

Flushing all sstables in the database release
all references to commitlog segments and there
it maximizes the potential for tombstone purging,
which is typically the reason for running major compaction.

However, flushing all tables too frequently might
result in tiny sstables.  Since when flushing all
keyspaces using `nodetool flush` the `force_keyspace_compaction`
api is invoked for keyspace successively, we need a mechanism
to prevent too frequent flushes by major compaction.

Hence a `compaction_flush_all_tables_before_major_seconds` interval
configuration option is added (defaults to 24 hours).

In the case that not all tables are flushed prior
to major compaction, we revert to the old behavior of
flushing each table in the keyspace before major-compacting it.

Fixes scylladb/scylladb#15777