### PR TITLE
dht: specialize fmt::formatter<decorated_key>

### DIFF
--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -58,11 +58,6 @@ sharder::next_shard(const token& t) const {
     return shard_and_token{next_shard, next_token};
 }
 
-std::ostream& operator<<(std::ostream& out, const decorated_key& dk) {
-    fmt::print(out, "{{key: {}, token: {}}}", dk._key, dk._token);
-    return out;
-}
-
 std::ostream& operator<<(std::ostream& out, partition_ranges_view v) {
     out << "{";
 

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -599,8 +599,6 @@ struct token_comparator {
     std::strong_ordering operator()(const token& t1, const token& t2) const;
 };
 
-std::ostream& operator<<(std::ostream& out, const decorated_key& t);
-
 std::ostream& operator<<(std::ostream& out, const i_partitioner& p);
 
 class partition_ranges_view {
@@ -687,3 +685,11 @@ struct hash<dht::decorated_key> {
 
 
 }
+
+template <>
+struct fmt::formatter<dht::decorated_key> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const dht::decorated_key& dk, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{{key: {}, token: {}}}", dk._key, dk._token);
+    }
+};

--- a/repair/sync_boundary.hh
+++ b/repair/sync_boundary.hh
@@ -30,7 +30,8 @@ struct repair_sync_boundary {
         }
     };
     friend std::ostream& operator<<(std::ostream& os, const repair_sync_boundary& x) {
-        return os << "{ " << x.pk << "," <<  x.position << " }";
+        fmt::print(os, "{{ {}, {}}}", x.pk, x.position);
+        return os;
     }
 };
 

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -868,7 +868,8 @@ std::ostream& operator<<(std::ostream& out, memtable& mt) {
 }
 
 std::ostream& operator<<(std::ostream& out, const memtable_entry& mt) {
-    return out << "{" << mt.key() << ": " << partition_entry::printer(mt.partition()) << "}";
+    fmt::print(out, "{{{}: {}}}", mt.key(), partition_entry::printer(mt.partition()));
+    return out;
 }
 
 }


### PR DESCRIPTION
this change specializes `fmt::formatter<decorated_key>` for two reasons.

1. to ensure that `dk._key` is formatted with the "pk" prefix. as in
   https://github.com/tchaikov/scylladb/commit/3738fcbe054ef1540f262079d89e44c9b873769e, the `operator<<` for
   partition_key was removed. so the compiler has to find an alternative
   when trying to fulfill the needs when this operator<< is called.
   fortunately, from the compiler's perspective, `partition_key` has
   an `operator managed_bytes_view`, and this operator does not have
   the explicit specifier, and, `managed_bytes_view` does support
   `operator<<`. so this ends up with a change in the format of
   `decorated_key` when it is printed using `operator<<`.
   the code compiles. but unfortunately, the behavior is changed,
   and it breaks scylla-dtest/cdc_tracing_info_test.py where
   the partition_key is supposed to be printed like "pk{010203}"
   instead of "010203". the latter is how `managed_bytes_view`
   is formatted.
2. to migrating from `operator<<(ostream&, ..)` based formatting to
   fmtlib based formatting.

Refs https://github.com/scylladb/scylladb/issues/13245