### PR TITLE
docs: update cofig params design

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -17,10 +17,14 @@
 }
 
 .content blockquote li p {
-    margin-bottom: 10px;
+    margin-bottom: 5px;
 }
 
 h3 .pre {
     font-size: 16px;
     font-weight: bold;
+}
+
+hr {
+    max-width: 100%;
 }

--- a/docs/_templates/db_config.tmpl
+++ b/docs/_templates/db_config.tmpl
@@ -13,8 +13,8 @@
 
 {% for item in group.properties %}
 {% if item.value_status == value_status %}
-``{{ item.name }}``
-{{ '=' * (item.name|length + 4) }}
+{{ item.name }}
+{{ '=' * (item.name|length) }}
 
    .. raw:: html
 
@@ -24,6 +24,9 @@
    {% if item.default %}* **Default value:** ``{{ item.default }}``{% endif %}
    {% if item.liveness %}* **Liveness** :term:`* <Liveness>` **:** ``{{ item.liveness }}``{% endif %}
 
+.. raw:: html
+
+   <hr/>
 {% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
## Motivation

In the page https://opensource.docs.scylladb.com/master/reference/configuration-parameters.html:

- Separation between properties is not clear enough.
- Lists have still have too much vertical padding.

## Proposal

![image](https://github.com/scylladb/scylladb/assets/9107969/a6a13e8f-eb1f-46bb-962c-874a3ec137ff)

- Add horizontal separation
- Reduce vertical padding
- Change code-font titles to regular headings