### PR TITLE
Support state change for S3-backed sstables

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2739,7 +2739,7 @@ future<> system_keyspace::sstables_registry_create_entry(sstring location, sstri
 
 future<> system_keyspace::sstables_registry_update_entry_status(sstring location, sstables::generation_type gen, sstring status) {
     static const auto req = format("UPDATE system.{} SET status = ? WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
-    slogger.trace("Updating {}.{} -> {} in {}", location, gen, status, SSTABLES_REGISTRY);
+    slogger.trace("Updating {}.{} -> status={} in {}", location, gen, status, SSTABLES_REGISTRY);
     co_await execute_cql(req, status, location, gen).discard_result();
 }
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2744,6 +2744,13 @@ future<> system_keyspace::sstables_registry_update_entry_status(sstring location
     co_await execute_cql(req, status, location, gen).discard_result();
 }
 
+future<> system_keyspace::sstables_registry_update_entry_state(sstring location, sstables::generation_type gen, sstables::sstable_state state) {
+    static const auto req = format("UPDATE system.{} SET state = ? WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
+    auto new_state = sstables::state_to_dir(state);
+    slogger.trace("Updating {}.{} -> state={} in {}", location, gen, new_state, SSTABLES_REGISTRY);
+    co_await execute_cql(req, new_state, location, gen).discard_result();
+}
+
 future<> system_keyspace::sstables_registry_delete_entry(sstring location, sstables::generation_type gen) {
     static const auto req = format("DELETE FROM system.{} WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
     slogger.trace("Removing {}.{} from {}", location, gen, SSTABLES_REGISTRY);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -501,6 +501,7 @@ public:
 
     future<> sstables_registry_create_entry(sstring location, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc);
     future<> sstables_registry_update_entry_status(sstring location, sstables::generation_type gen, sstring status);
+    future<> sstables_registry_update_entry_state(sstring location, sstables::generation_type gen, sstables::sstable_state state);
     future<> sstables_registry_delete_entry(sstring location, sstables::generation_type gen);
     using sstable_registry_entry_consumer = noncopyable_function<future<>(sstring status, sstables::sstable_state state, sstables::entry_descriptor desc)>;
     future<> sstables_registry_list(sstring location, sstable_registry_entry_consumer consumer);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -28,6 +28,7 @@
 namespace sstables {
     struct entry_descriptor;
     class generation_type;
+    enum class sstable_state;
 }
 
 namespace service {
@@ -498,10 +499,10 @@ public:
     // Assumes that the history table exists, i.e. Raft experimental feature is enabled.
     static future<mutation> get_group0_history(distributed<replica::database>&);
 
-    future<> sstables_registry_create_entry(sstring location, sstring status, sstables::entry_descriptor desc);
+    future<> sstables_registry_create_entry(sstring location, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc);
     future<> sstables_registry_update_entry_status(sstring location, sstables::generation_type gen, sstring status);
     future<> sstables_registry_delete_entry(sstring location, sstables::generation_type gen);
-    using sstable_registry_entry_consumer = noncopyable_function<future<>(sstring state, sstables::entry_descriptor desc)>;
+    using sstable_registry_entry_consumer = noncopyable_function<future<>(sstring status, sstables::sstable_state state, sstables::entry_descriptor desc)>;
     future<> sstables_registry_list(sstring location, sstable_registry_entry_consumer consumer);
 
     future<std::optional<sstring>> load_group0_upgrade_state();

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -351,7 +351,7 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
 }
 
 future<> sstable_directory::system_keyspace_components_lister::process(sstable_directory& directory, process_flags flags) {
-    return _sys_ks.sstables_registry_list(_location, [this, flags, &directory] (sstring status, entry_descriptor desc) {
+    return _sys_ks.sstables_registry_list(_location, [this, flags, &directory] (sstring status, sstable_state state, entry_descriptor desc) {
         if (status != "sealed") {
             dirlog.warn("Skip processing {} {} entry from {} (must have been picked up by garbage collector)", status, desc.generation, _location);
             return make_ready_future<>();
@@ -383,7 +383,7 @@ future<> sstable_directory::system_keyspace_components_lister::commit() {
 
 future<> sstable_directory::system_keyspace_components_lister::garbage_collect(storage& st) {
     return do_with(std::set<generation_type>(), [this, &st] (auto& gens_to_remove) {
-        return _sys_ks.sstables_registry_list(_location, [&st, &gens_to_remove] (sstring status, entry_descriptor desc) {
+        return _sys_ks.sstables_registry_list(_location, [&st, &gens_to_remove] (sstring status, sstable_state state, entry_descriptor desc) {
             if (status == "sealed") {
                 return make_ready_future<>();
             }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -353,7 +353,7 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
 future<> sstable_directory::system_keyspace_components_lister::process(sstable_directory& directory, process_flags flags) {
     return _sys_ks.sstables_registry_list(_location, [this, flags, &directory] (sstring status, entry_descriptor desc) {
         if (status != "sealed") {
-            // FIXME -- handle
+            dirlog.warn("Skip processing {} {} entry from {} (must have been picked up by garbage collector)", status, desc.generation, _location);
             return make_ready_future<>();
         }
         if (!sstable_generation_generator::maybe_owned_by_this_shard(desc.generation)) {

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -352,6 +352,9 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
 
 future<> sstable_directory::system_keyspace_components_lister::process(sstable_directory& directory, process_flags flags) {
     return _sys_ks.sstables_registry_list(_location, [this, flags, &directory] (sstring status, sstable_state state, entry_descriptor desc) {
+        if (state != directory._state) {
+            return make_ready_future<>();
+        }
         if (status != "sealed") {
             dirlog.warn("Skip processing {} {} entry from {} (must have been picked up by garbage collector)", status, desc.generation, _location);
             return make_ready_future<>();

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -154,6 +154,23 @@ inline sstring state_to_dir(sstable_state state) {
     }
 }
 
+inline sstable_state state_from_dir(std::string_view dir) {
+    if (dir == "") {
+        return sstable_state::normal;
+    }
+    if (dir == staging_dir) {
+        return sstable_state::staging;
+    }
+    if (dir == quarantine_dir) {
+        return sstable_state::quarantine;
+    }
+    if (dir == upload_dir) {
+        return sstable_state::upload;
+    }
+
+    throw std::runtime_error(format("Unknown sstable state dir {}", dir));
+}
+
 inline std::ostream& operator<<(std::ostream& o, sstable_state s) {
     return o << state_to_dir(s);
 }

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -516,10 +516,13 @@ future<> s3_storage::seal(const sstable& sst) {
 }
 
 future<> s3_storage::change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) {
-    // FIXME -- this "move" means changing sstable state, e.g. move from staging
-    // or upload to base. To make this work the "status" part of the entry location
-    // must be detached from the entry location itself, see PR#12707
-    co_await coroutine::return_exception(std::runtime_error("Moving S3 objects not implemented"));
+    if (generation != sst._generation) {
+        // The 'generation' field is clustering key in system.sstables and cannot be
+        // changed. However, that's fine, state AND generation change means the sstable
+        // is moved from upload directory and this is another issue for S3 (#13018)
+        co_await coroutine::return_exception(std::runtime_error("Cannot change state and generation of an S3 object"));
+    }
+    co_await sst.manager().system_keyspace().sstables_registry_update_entry_state(_location, sst.generation(), state);
 }
 
 future<> s3_storage::wipe(const sstable& sst, sync_dir) noexcept {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -482,7 +482,7 @@ sstring s3_storage::make_s3_object_name(const sstable& sst, component_type type)
 
 void s3_storage::open(sstable& sst) {
     entry_descriptor desc(sst._generation, sst._version, sst._format, component_type::TOC);
-    sst.manager().system_keyspace().sstables_registry_create_entry(_location, status_creating, std::move(desc)).get();
+    sst.manager().system_keyspace().sstables_registry_create_entry(_location, status_creating, sst._state, std::move(desc)).get();
 
     memory_data_sink_buffers bufs;
     sst.write_toc(

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -5209,7 +5209,7 @@ SEASTAR_TEST_CASE(cleanup_during_offstrategy_incremental_compaction_test) {
     });
 }
 
-SEASTAR_TEST_CASE(test_sstables_excluding_staging_correctness) {
+future<> test_sstables_excluding_staging_correctness(test_env_config cfg) {
     return test_env::do_with_async([] (test_env& env) {
         simple_schema ss;
         auto s = ss.schema();
@@ -5254,7 +5254,15 @@ SEASTAR_TEST_CASE(test_sstables_excluding_staging_correctness) {
                     .produces(*sorted_muts.rbegin())
                     .produces_end_of_stream();
         }
-    });
+    }, std::move(cfg));
+}
+
+SEASTAR_TEST_CASE(test_sstables_excluding_staging_correctness_local) {
+    return test_sstables_excluding_staging_correctness({});
+}
+
+SEASTAR_TEST_CASE(test_sstables_excluding_staging_correctness_s3) {
+    return test_sstables_excluding_staging_correctness({ .storage = make_test_object_storage_options() });
 }
 
 // Reproducer for https://github.com/scylladb/scylladb/issues/15726.


### PR DESCRIPTION
The sstable currently can move between normal, staging and quarantine state runtime. For S3-backed sstables the state change means maintaining the state itself in the ownership table and updating it accordingly.

There's also the upload facility that's implemented as state change too, but this PR doesn't support this part.

fixes: #13017 