### PR TITLE
doc: fix the Reference page layout

### DIFF
--- a/docs/reference/aws-images.rst
+++ b/docs/reference/aws-images.rst
@@ -1,5 +1,5 @@
 ==========
-AWS images
+AWS Images
 ==========
 
 .. scylladb_aws_images_template::

--- a/docs/reference/configuration-parameters.rst
+++ b/docs/reference/configuration-parameters.rst
@@ -1,5 +1,5 @@
 ========================
-Configuration parameters
+Configuration Parameters
 ========================
 
 This section contains a list of properties that can be configured in ``scylla.yaml`` - the main configuration file for ScyllaDB.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -3,7 +3,7 @@ Reference
 ===============
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :glob:
 
    /reference/*


### PR DESCRIPTION
This PR fixes the layout of the Reference page. Previously, the toctree level was "2", which made the page hard to navigate.
![image](https://github.com/scylladb/scylladb/assets/37244380/0255144d-5e0d-44eb-b462-8e00ee27ac5b)

This PR changes the level to "1".

In addition, the capitalization of page titles is fixed.

This is a follow-up PR to the ones that created and updated the Reference section. It must be backported to branch-5.4.