### PR TITLE
storage_service: Reject nodetool removenode force

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6746,55 +6746,7 @@ future<sstring> storage_service::get_removal_status() {
 }
 
 future<> storage_service::force_remove_completion() {
-    return run_with_no_api_lock([] (storage_service& ss) -> future<> {
-        while (!ss._operation_in_progress.empty()) {
-            if (ss._operation_in_progress != sstring("removenode")) {
-                throw std::runtime_error(::format("Operation {} is in progress, try again", ss._operation_in_progress));
-            }
-
-            // This flag will make removenode stop waiting for the confirmation,
-            // wait it to complete
-            slogger.info("Operation removenode is in progress, wait for it to complete");
-            co_await sleep_abortable(std::chrono::seconds(1), ss._abort_source);
-        }
-        ss._operation_in_progress = sstring("removenode_force");
-
-        try {
-            const auto& tm = ss.get_token_metadata();
-            if (!tm.get_leaving_endpoints().empty()) {
-                auto leaving = tm.get_leaving_endpoints();
-                slogger.warn("Removal not confirmed, Leaving={}", leaving);
-                for (auto endpoint : leaving) {
-                    locator::host_id host_id;
-                    auto tokens = tm.get_tokens(endpoint);
-                    try {
-                        host_id = tm.get_host_id(endpoint);
-                    } catch (...) {
-                        slogger.warn("No host_id is found for endpoint {}", endpoint);
-                        continue;
-                    }
-                    auto permit = co_await ss._gossiper.lock_endpoint(endpoint, gms::null_permit_id);
-                    const auto& pid = permit.id();
-                    co_await ss._gossiper.advertise_token_removed(endpoint, host_id, pid);
-                    std::unordered_set<token> tokens_set(tokens.begin(), tokens.end());
-                    co_await ss.excise(tokens_set, endpoint, pid);
-
-                    slogger.info("force_remove_completion: removing endpoint {} from group 0", endpoint);
-                    assert(ss._group0);
-                    bool raft_available = co_await ss._group0->wait_for_raft();
-                    if (raft_available) {
-                        co_await ss._group0->remove_from_group0(raft::server_id{host_id.uuid()});
-                    }
-                }
-            } else {
-                slogger.warn("No tokens to force removal on, call 'removenode' first");
-            }
-            ss._operation_in_progress = {};
-        } catch (...) {
-            ss._operation_in_progress = {};
-            throw;
-        }
-    });
+    return make_exception_future<>(std::runtime_error("The unsafe nodetool removenode force is not supported anymore"));
 }
 
 /**


### PR DESCRIPTION
It is almost always a bad idea to run removenode force. This means a node is removed without the remaining nodes to stream data that they should own after the removal. This will make the cluster into a worse state than a node being down.

One can use one of the following procedure instead:

1) Fix the dead node and move it back to the cluster

2) Run replace ops to replace the dead node

3) Run removenode ops again

We have seen misuse of nodetool removenode force by users again and again. This patch rejects it so it can not be misused anymore.

Fixes #15833