### PR TITLE
init: get_seeds_from_db_config: auto-seed node only in developer mode

### DIFF
--- a/docs/dev/docker-hub.md
+++ b/docs/dev/docker-hub.md
@@ -157,13 +157,15 @@ The ScyllaDB image supports many command line options that are passed to the `do
 
 #### `--seeds SEEDS`
 
-The `-seeds` command line option configures ScyllaDB's seed nodes.
-If no `--seeds` option is specified, ScyllaDB uses its own IP address as the seed.
+The `--seeds` command line option configures ScyllaDB's seed node.
+To start a single-node ScyllaDB cluster, pass the localhost address (127.0.0.1) as the `--seeds` argument.
+If no `--seeds` option is specified and both the listen address and broadcast address are equal to the localhost address
+or the `--developer-mode=1` option is used, ScyllaDB automatically uses the localhost address as the seed.
 
-For example, to configure ScyllaDB to run with two seed nodes `192.168.0.100` and `192.168.0.200`:
+For example, to configure ScyllaDB to run with seed node `192.168.0.100`:
 
 ```console
-$ docker run --name some-scylla -d scylladb/scylla --seeds 192.168.0.100,192.168.0.200
+$ docker run --name some-scylla -d scylladb/scylla --seeds 192.168.0.100
 ```
 
 #### `--listen-address ADDR`

--- a/docs/operating-scylla/admin.rst
+++ b/docs/operating-scylla/admin.rst
@@ -73,7 +73,7 @@ The following addresses can be configured in scylla.yaml:
    * - broadcast_rpc_address
      - Address that is broadcasted to tell the clients to connect to. Related to rpc_address.
    * - seeds
-     - The broadcast_addresses of the existing nodes. You must specify the address of at least one existing node.
+     - The broadcast_address of an existing node. Typically, the first node in the cluster.
    * - endpoint_snitch
      - Node's address resolution helper.
    * - api_address

--- a/docs/operating-scylla/procedures/tips/best-practices-scylla-on-docker.rst
+++ b/docs/operating-scylla/procedures/tips/best-practices-scylla-on-docker.rst
@@ -182,15 +182,17 @@ Network and Command-Line Settings
 +++++++++++++++++++++++++++++++++
 The ScyllaDB image supports many command line options that are passed to the Docker run command.  Keep in mind that these command-line settings override the corresponding settings in your ``scylla.yaml``.
 
---seeds SEEDS
--------------
-The ``--seeds`` command line option configures ScyllaDB's seed nodes. If no ``--seeds`` option is specified, ScyllaDB uses its own IP address as the seed.
+--seeds SEED
+------------
+The ``--seeds`` command line option configures ScyllaDB's seed node.
+If no `--seeds` option is specified and both the listen address and broadcast address (see below) are equal to the localhost address
+or the `--developer-mode=1` option is used, ScyllaDB automatically uses the localhost address as the seed.
 
-For example, to configure ScyllaDB to run with two seed nodes ``192.168.0.100`` and ``192.168.0.200``.
+For example, to configure ScyllaDB to run with seed node ``192.168.0.100``.
 
 .. code-block:: console
 
- docker run --name some-scylla -d scylladb/scylla --seeds 192.168.0.100,192.168.0.200
+ docker run --name some-scylla -d scylladb/scylla --seeds 192.168.0.100
 
 --listen-address ADDR
 ---------------------

--- a/init.cc
+++ b/init.cc
@@ -39,7 +39,14 @@ std::set<gms::inet_address> get_seeds_from_db_config(const db::config& cfg, gms:
         }
     }
     if (seeds.empty()) {
-        seeds.emplace(gms::inet_address("127.0.0.1"));
+        auto localhost = gms::inet_address("127.0.0.1");
+        // Single node cluster?
+        if (cfg.developer_mode() || (listen == localhost && broadcast_address == localhost)) {
+            seeds.emplace(localhost);
+        } else {
+            startlog.error("Bad configuration: no 'seeds' provided");
+            throw bad_configuration_error();
+        }
     }
     startlog.info("seeds={{{}}}, listen_address={}, broadcast_address={}",
             fmt::join(seeds, ", "), listen, broadcast_address);


### PR DESCRIPTION
Using the localhost as seed when no `seeds` are provided makes no sense in production.
Allow it only in developer mode or if both the listen and broadcast addresses are localhost
(indicating single node cluster).

Fixes scylladb/scylladb#15836