### PR TITLE
build: cmake: correct the variable names in mode.Dev.cmake

### DIFF
--- a/cmake/mode.DEV.cmake
+++ b/cmake/mode.DEV.cmake
@@ -4,8 +4,8 @@ set(CMAKE_CXX_FLAGS_DEV
   CACHE
   INTERNAL
   "")
-string(APPEND CMAKE_CXX_FLAGS_RELEASE
-  " -O${Seastar_OptimizationLevel_RELEASE}")
+string(APPEND CMAKE_CXX_FLAGS_DEV
+  " -O${Seastar_OptimizationLevel_DEV}")
 
 set(Seastar_DEFINITIONS_DEV
   SCYLLA_BUILD_MODE=devel


### PR DESCRIPTION
it was a copy-pasta error.

- s/CMAKE_CXX_FLAGS_RELEASE/CMAKE_CXX_FLAGS_DEV/
- s/Seastar_OptimizationLevel_RELEASE/Seastar_OptimizationLevel_DEV/