### PR TITLE
Change all tests to shut down gracefully on shutdown

### DIFF
--- a/test.py
+++ b/test.py
@@ -365,7 +365,7 @@ class PythonTestSuite(TestSuite):
                which would delete the log file and directory - we might want to preserve
                these if it came from a failed test.
             """
-            await cluster.stop()
+            await cluster.stop_gracefully()
             await cluster.release_ips()
 
         self.clusters = Pool(pool_size, self.create_cluster, recycle_cluster)
@@ -406,7 +406,7 @@ class PythonTestSuite(TestSuite):
             cluster = ScyllaCluster(logger, self.hosts, cluster_size, create_server)
 
             async def stop() -> None:
-                await cluster.stop()
+                await cluster.stop_gracefully()
 
             # Suite artifacts are removed when
             # the entire suite ends successfully.
@@ -414,7 +414,7 @@ class PythonTestSuite(TestSuite):
             if not self.options.save_log_on_success:
                 # If a test fails, we might want to keep the data dirs.
                 async def uninstall() -> None:
-                    await cluster.uninstall()
+                    await cluster.uninstall_gracefully()
 
                 self.artifacts.add_suite_artifact(self, uninstall)
             self.artifacts.add_exit_artifact(self, stop)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -639,6 +639,15 @@ class ScyllaCluster:
         await asyncio.gather(*(self.host_registry.release_host(Host(ip))
                                for ip in self.leased_ips))
 
+    async def uninstall_gracefully(self) -> None:
+        """Stop running servers in a clean way and uninstall all servers"""
+        self.is_dirty = True
+        self.logger.info("Uninstalling cluster %s gracefully", self)
+        await self.stop_gracefully()
+        await asyncio.gather(*(srv.uninstall() for srv in self.stopped.values()))
+        await asyncio.gather(*(self.host_registry.release_host(Host(ip))
+                               for ip in self.leased_ips))
+
     async def release_ips(self) -> None:
         """Release all IPs leased from the host registry by this cluster.
         Call this function only if the cluster is stopped and will not be started again."""


### PR DESCRIPTION
This mini series purpose is to move all tests (that uses the infrastructure to create a Scylla cluster) to shut down gracefully
on shutdown.
One benefit is that the shutdown sequence for cluster will be tested better, however it is not the main purpose of this change. The main purpose of this change is to pave the way for coverage reporting on all tests and not only the ones that
has a standalone executables.

Full test runs are only slightly impacted by this change (~2.4% increase in runtime):

Without gracefull shutdown
```
time ./test.py --mode dev
Found 2966 tests.
================================================================================
[N/TOTAL]   SUITE    MODE   RESULT   TEST
------------------------------------------------------------------------------
[2966/2966] topology_experimental_raft   dev   [ PASS ] topology_experimental_raft.test_raft_cluster_features.1                                                                    
------------------------------------------------------------------------------
CPU utilization: 13.1%

real    4m50.587s
user    13m58.358s
sys     6m55.975s
```

With gracefull shutdown
```
time ./test.py --mode dev
Found 2966 tests.
================================================================================
[N/TOTAL]   SUITE    MODE   RESULT   TEST
------------------------------------------------------------------------------
[2966/2966] topology_experimental_raft   dev   [ PASS ] topology_experimental_raft.test_raft_cluster_features.1                                                                    
------------------------------------------------------------------------------
CPU utilization: 12.6%

real    4m57.637s
user    13m56.864s
sys     6m46.657s
```