### PR TITLE
docs: Replace instances of SimpleStrategy with NetworkTopologyStrategy.

### DIFF
--- a/docs/cql/cql-extensions.md
+++ b/docs/cql/cql-extensions.md
@@ -93,12 +93,12 @@ and it's formatted as a map of options - similarly to how replication strategy i
 Examples:
 ```cql
 CREATE KEYSPACE ks
-    WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 3 }
+    WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 }
     AND STORAGE = { 'type' : 'S3', 'bucket' : '/tmp/b1', 'endpoint' : 'localhost' } ;
 ```
 
 ```cql
-ALTER KEYSPACE ks WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 3 }
+ALTER KEYSPACE ks WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 }
     AND STORAGE = { 'type' : 'S3', 'bucket': '/tmp/b2', 'endpoint' : 'localhost' } ;
 ```
 

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -107,12 +107,6 @@ For example:
    WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1' : 1, 'DC2' : 3}
    AND durable_writes = true;
 
-
-.. code-block:: cql
-
-   CREATE KEYSPACE Excelsior
-   WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};
-
 .. TODO Add a link to the description of minimum_keyspace_rf when the ScyllaDB options section is added to the docs.
 
 You can configure the minimum acceptable replication factor using the ``minimum_keyspace_rf`` option. 
@@ -232,11 +226,6 @@ For instance::
 
   ALTER KEYSPACE Excelsior 
    WITH replication = { 'class' : 'NetworkTopologyStrategy', 'dc1' : 3, 'dc2' : 0};
-
-
-  ALTER KEYSPACE Excelsior
-   WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 4};
-
 
 
 The supported options are the same as :ref:`creating a keyspace <create-keyspace-statement>`.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -311,7 +311,7 @@ This will create a suffix for the node location for example:
 
 The problem may also arise if you are using some :code:`DC-aware snitch`, e.g. :code:`Ec2MultiRegionSnitch`, and a :code:`SimpleStrategy` in a multi-DC cluster.
 
-Please, make sure that both a snitch and a replication strategy of a keyspace are either both of a :code:`Simple` kind or both are :code:`DC-aware`.
+Please make sure that both the snitch and the replication strategy of the keyspace are :code:`DC-aware`.
 
 After that, if you are using a :code:`DC-aware` configuration, make sure that the replication strategy uses the proper data centers' names. Verify the data centers names in your cluster using a :code:`nodetool status` command.
 

--- a/docs/using-scylla/integrations/scylla-cdc-source-connector-quickstart.rst
+++ b/docs/using-scylla/integrations/scylla-cdc-source-connector-quickstart.rst
@@ -44,7 +44,7 @@ issuing the following CQL query and insert some example data:
 
 .. code-block:: cql
 
-   CREATE KEYSPACE quickstart_keyspace WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1};
+   CREATE KEYSPACE quickstart_keyspace WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
 
    CREATE TABLE quickstart_keyspace.orders(
       customer_id int, 


### PR DESCRIPTION
The goal is to make the available defaults safe for future use, as they are often taken from existing config files or documentation verbatim.

Referenced issue: #14290.