### PR TITLE
build: cmake: add token_metadata.cc to api

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(api
     system.cc
     task_manager.cc
     task_manager_test.cc
+    token_metadata.cc
     ${swagger_gen_files})
 target_include_directories(api
   PUBLIC


### PR DESCRIPTION
`token_metadata.cc` was moved into api in e4c0a4d34d, let's update CMake accordingly.