### PR TITLE
docs: render options with role

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -28,3 +28,7 @@ h3 .pre {
 hr {
     max-width: 100%;
 }
+
+dl dt:hover > a.headerlink {
+    visibility: visible;
+}

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -32,3 +32,7 @@ hr {
 dl dt:hover > a.headerlink {
     visibility: visible;
 }
+
+dl.confval {
+    border-bottom: 1px solid #cacaca;
+}

--- a/docs/_templates/db_config.tmpl
+++ b/docs/_templates/db_config.tmpl
@@ -13,20 +13,7 @@
 
 {% for item in group.properties %}
 {% if item.value_status == value_status %}
-{{ item.name }}
-{{ '=' * (item.name|length) }}
-
-   .. raw:: html
-
-      <p>{{ item.description }}</p>
-
-   {% if item.type %}* **Type:** ``{{ item.type }}``{% endif %}
-   {% if item.default %}* **Default value:** ``{{ item.default }}``{% endif %}
-   {% if item.liveness %}* **Liveness** :term:`* <Liveness>` **:** ``{{ item.liveness }}``{% endif %}
-
-.. raw:: html
-
-   <hr/>
+.. confval:: {{ item.name }}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/docs/_templates/db_config.tmpl
+++ b/docs/_templates/db_config.tmpl
@@ -8,7 +8,7 @@
 {% if group.description %}
 .. raw:: html
 
-   <p>{{ group.description }}</p>
+   <p>{{ group.description | readable_desc }}</p>
 {% endif %}
 
 {% for item in group.properties %}

--- a/docs/_templates/db_option.tmpl
+++ b/docs/_templates/db_option.tmpl
@@ -5,7 +5,3 @@
    {% if type %}* **Type:** ``{{ type }}``{% endif %}
    {% if default %}* **Default value:** ``{{ default }}``{% endif %}
    {% if liveness %}* **Liveness** :term:`* <Liveness>` **:** ``{{ liveness }}``{% endif %}
-
-.. raw:: html
-
-   <hr/>

--- a/docs/_templates/db_option.tmpl
+++ b/docs/_templates/db_option.tmpl
@@ -1,6 +1,6 @@
    .. raw:: html
 
-      <p>{{ description }}</p>
+      <p>{{ description | readable_desc }}</p>
 
    {% if type %}* **Type:** ``{{ type }}``{% endif %}
    {% if default %}* **Default value:** ``{{ default }}``{% endif %}

--- a/docs/_templates/db_option.tmpl
+++ b/docs/_templates/db_option.tmpl
@@ -1,0 +1,11 @@
+   .. raw:: html
+
+      <p>{{ description }}</p>
+
+   {% if type %}* **Type:** ``{{ type }}``{% endif %}
+   {% if default %}* **Default value:** ``{{ default }}``{% endif %}
+   {% if liveness %}* **Liveness** :term:`* <Liveness>` **:** ``{{ liveness }}``{% endif %}
+
+.. raw:: html
+
+   <hr/>

--- a/docs/reference/configuration-parameters.rst
+++ b/docs/reference/configuration-parameters.rst
@@ -5,6 +5,6 @@ Configuration Parameters
 This section contains a list of properties that can be configured in ``scylla.yaml`` - the main configuration file for ScyllaDB.
 In addition, properties that support live updates (liveness) can be updated via the ``system.config`` virtual table or the REST API.
 
-.. scylladb_config_template:: ../_data/db_config.yaml
+.. scylladb_config_list:: ../../db/config.hh ../../db/config.cc
   :template: db_config.tmpl
   :value_status: Used


### PR DESCRIPTION
this series tries to 

1. render options with role. so the options can be cross referenced and defined.
2. move the formatting out of the content. so the representation can be defined in a more flexible way.