### PR TITLE
build: cmake: disable sanitize-address-use-after-scope only when needed

### DIFF
--- a/cql3/CMakeLists.txt
+++ b/cql3/CMakeLists.txt
@@ -20,14 +20,17 @@ if(Seastar_OptimizationLevel_${build_mode} IN_LIST unoptimized_levels)
         "-O1")
 endif()
 
-include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag("-fsanitize-address-use-after-scope"
-    _sanitize_address_use_after_scope_supported)
-if(_sanitize_address_use_after_scope_supported)
-    # use-after-scope sanitizer also uses large amount of stack space
-    # and overflows the stack of CqlParser
-    list(APPEND cql_parser_compile_options
-        "-fno-sanitize-address-use-after-scope")
+set(SANITIZE_MODES "Debug" "Sanitize")
+if(CMAKE_BUILD_TYPE IN_LIST SANITIZE_MODES)
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag("-fsanitize-address-use-after-scope"
+        _sanitize_address_use_after_scope_supported)
+    if(_sanitize_address_use_after_scope_supported)
+        # use-after-scope sanitizer also uses large amount of stack space
+        # and overflows the stack of CqlParser
+        list(APPEND cql_parser_compile_options
+            "-fno-sanitize-address-use-after-scope")
+    endif()
 endif()
 
 if(DEFINED cql_parser_compile_options)


### PR DESCRIPTION
we enable sanitizer only in Debug and Sanitize build modes, if we pass `-fno-sanitize-address-use-after-scope` to compiler when the sanitizer is not enabled when compiling, Clang complains like:

```
clang-16: error: argument unused during compilation: '-fno-sanitize-address-use-after-scope' [-Werror,-Wunused-command-line-argument]
```

this breaks the build on the build modes where sanitizers are not enabled.

so, in this change, we only disable the sanitize-address-use-after-scope sanitizer if the sanitizers are enabled.