### PR TITLE
build: ignore FileExistsError when creating compile_commands.json

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -291,15 +291,16 @@ def generate_compdb(compdb, ninja, buildfile, modes):
                 subprocess.run(['./scripts/merge-compdb.py', 'build/' + mode,
                                 ninja_compdb.name] + submodule_compdbs, stdout=combined_mode_specific_compdb)
 
-    # make sure there is a valid compile_commands.json link in the source root
-    if os.path.exists(compdb):
-        return
-
     # sort modes by supposed indexing speed
     for mode in ['dev', 'debug', 'release', 'sanitize']:
         compdb_target = outdir + '/' + mode + '/' + compdb
         if os.path.exists(compdb_target):
-            os.symlink(compdb_target, compdb)
+            try:
+                os.symlink(compdb_target, compdb)
+            except FileExistsError:
+                # if there is already a valid compile_commands.json link in the
+                # source root, we are done.
+                pass
             return
 
 


### PR DESCRIPTION
before this change, we only check the existence of compile_commands.json before creating a symlink to build/*/compile_commands.json. but there are chances that multiple ninja tasks are calling into `configure.py` for updating `build.ninja`: this does not break the process, as the last one wins: we just unconditionally `mv build.ninja.new build.ninja` for updating the this file. but this could break the build of `'compile_commands.json`: we create a symlink with Python, and if it fails the Python script errors out.

in this change, we just ignore the `FileExistsError` when creating the symlink to `compile_commands.json`. because, if this symlink, we've achieved the goal, and should not consider it a failure.