### PR TITLE
[Backport 5.2] repair: release resources of shard_repair_task_impl

### DIFF
--- a/repair/repair_task.hh
+++ b/repair/repair_task.hh
@@ -158,6 +158,8 @@ public:
     future<> repair_range(const dht::token_range& range, table_id);
 
     size_t ranges_size();
+
+    virtual void release_resources() noexcept override;
 protected:
     future<> do_repair_ranges();
     future<> run() override;

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -204,6 +204,10 @@ const task_manager::foreign_task_vector& task_manager::task::get_children() cons
     return _impl->_children;
 }
 
+void task_manager::task::release_resources() noexcept {
+    return _impl->release_resources();
+}
+
 task_manager::module::module(task_manager& tm, std::string name) noexcept : _tm(tm), _name(std::move(name)) {}
 
 uint64_t task_manager::module::new_sequence_number() noexcept {

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -109,6 +109,7 @@ public:
             virtual tasks::is_abortable is_abortable() const noexcept;
             virtual tasks::is_internal is_internal() const noexcept;
             virtual future<> abort() noexcept;
+            virtual void release_resources() noexcept {}
         protected:
             virtual future<> run() = 0;
             void run_to_completion();
@@ -143,6 +144,7 @@ public:
         void register_task();
         void unregister_task() noexcept;
         const foreign_task_vector& get_children() const noexcept;
+        void release_resources() noexcept;
 
         friend class test_task;
         friend class ::repair_module;


### PR DESCRIPTION
Before integration with task manager the state of one shard repair was kept in repair_info. repair_info object was destroyed immediately after shard repair was finished.

In an integration process repair_info's fields were moved to shard_repair_task_impl as the two served the similar purposes. Though, shard_repair_task_impl isn't immediately destoyed, but is kept in task manager for task_ttl seconds after it's complete. Thus, some of repair_info's fields have their lifetime prolonged, which makes the repair state change delayed.

Release shard_repair_task_impl resources immediately after shard repair is finished.

Fixes: #15505.
(cherry picked from commit 0474e150a930b87ce2683707b8342319b08f2322)