### PR TITLE
raft: delay handling received group0 RPCs until the server is started

### DIFF
--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -462,6 +462,7 @@ future<> raft_group0::join_group0(std::vector<gms::inet_address> seeds, shared_p
                 // See #14066.
                 nontrivial_snapshot = true;
             } else {
+                _raft_gr.declare_group0_id(group0_id);
                 co_await handshaker->pre_server_start(g0_info);
             }
             // Bootstrap the initial configuration

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -195,22 +195,22 @@ void raft_group_registry::init_rpc_verbs() {
                     : make_ready_future<>();
 
             return f_wait_for_server.then([addr, from, gid, handler, &self] () mutable {
-            // Update the address mappings for the rpc module
-            // in case the sender is encountered for the first time
-            auto& rpc = self.get_rpc(gid);
-            // The address learnt from a probably unknown server should
-            // eventually expire. Do not use it to update
-            // a previously learned gossiper address: otherwise an RPC from
-            // a node outside of the config could permanently
-            // change the address map of a healthy cluster.
-            self._address_map.opt_add_entry(from, std::move(addr));
-            // Execute the actual message handling code
-            if constexpr (is_one_way) {
-                handler(rpc);
-                return netw::messaging_service::no_wait();
-            } else {
-                return handler(rpc);
-            }
+                // Update the address mappings for the rpc module
+                // in case the sender is encountered for the first time
+                auto& rpc = self.get_rpc(gid);
+                // The address learnt from a probably unknown server should
+                // eventually expire. Do not use it to update
+                // a previously learned gossiper address: otherwise an RPC from
+                // a node outside of the config could permanently
+                // change the address map of a healthy cluster.
+                self._address_map.opt_add_entry(from, std::move(addr));
+                // Execute the actual message handling code
+                if constexpr (is_one_way) {
+                    handler(rpc);
+                    return netw::messaging_service::no_wait();
+                } else {
+                    return handler(rpc);
+                }
             });
         });
     };

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -136,6 +136,13 @@ public:
     // Returns the list of all Raft groups on this shard by their IDs.
     std::vector<raft::group_id> all_groups() const;
 
+    // Declares that given group ID will be the group0's ID.
+    // It can only be called before the first server is started and added
+    // to the registry via `start_server_for_group`.
+    // After being called, the first server in the registry must have this
+    // exact group id.
+    void declare_group0_id(raft::group_id);
+
     // Return an instance of group 0. Valid only on shard 0,
     // after boot/upgrade is complete
     raft::server& group0();

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <seastar/core/future.hh>
+#include <seastar/core/shared_future.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/gate.hh>
 
@@ -96,6 +97,9 @@ private:
     // Group 0 id, valid only on shard 0 after boot/upgrade is over
     std::optional<raft::group_id> _group0_id;
 
+    // Used to wait until the group0 server is started
+    seastar::shared_promise<> _group0_started;
+
     // My Raft ID. Shared between different Raft groups.
     raft::server_id _my_id;
 
@@ -146,6 +150,9 @@ public:
     // Return an instance of group 0. Valid only on shard 0,
     // after boot/upgrade is complete
     raft::server& group0();
+
+    // Waits until group0 server is started.
+    seastar::future<> wait_for_group0();
 
     // Start raft server instance, store in the map of raft servers and
     // arm the associated timer to tick the server.


### PR DESCRIPTION
In topology on raft mode, the events "new node starts its group0 server" and "new node is added to group0 configuration" are not synchronized with each other. Therefore it might happen that the cluster starts sending commands to the new node before the node starts its server. This might lead to harmless, but ugly messages like:

    INFO  2023-09-27 15:42:42,611 [shard 0:stat] rpc - client 127.0.0.1:56352 msg_id 2:  exception "Raft group b8542540-5d3b-11ee-99b8-1052801f2975 not found" in no_wait handler ignored

To get rid of those errors, the group0 is made known to raft group registry before the node starts joining the cluster. Then, if any group0 RPCs arrive before group0 server is started, their handling is delayed until the server is started.

Tested by inserting a delay after `discover_group0` in `join_group0`, observing that the aforementioned errors appear without the changes from the PR, then applying the changes and seeing that the messages disappear.

Fixes: scylladb/scylladb#15853

