### PR TITLE
alternator: avoid using the deprecated API

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -566,14 +566,14 @@ future<> server::init(net::inet_address addr, std::optional<uint16_t> port, std:
             set_routes(_https_server._routes);
             _https_server.set_content_length_limit(server::content_length_limit);
             _https_server.set_content_streaming(true);
-            _https_server.set_tls_credentials(creds->build_reloadable_server_credentials([](const std::unordered_set<sstring>& files, std::exception_ptr ep) {
+            auto server_creds = creds->build_reloadable_server_credentials([](const std::unordered_set<sstring>& files, std::exception_ptr ep) {
                 if (ep) {
                     slogger.warn("Exception loading {}: {}", files, ep);
                 } else {
                     slogger.info("Reloaded {}", files);
                 }
-            }).get0());
-            _https_server.listen(socket_address{addr, *https_port}).get();
+            }).get0();
+            _https_server.listen(socket_address{addr, *https_port}, std::move(server_creds)).get();
             _enabled_servers.push_back(std::ref(_https_server));
         }
     });


### PR DESCRIPTION
this change silences following compiling warning due to using the deprecated API by using the recommended API in place of the deprecated one:

```
/home/kefu/dev/scylladb/alternator/server.cc:569:27: warning: 'set_tls_credentials' is deprecated: use listen(socket_address addr, server_credentials_ptr credentials) [-Wdeprecated-declarations]
            _https_server.set_tls_credentials(creds->build_reloadable_server_credentials([](const std::unordered_set<sstring>& files, std::exception_ptr ep) {
                          ^
/home/kefu/dev/scylladb/seastar/include/seastar/http/httpd.hh:186:7: note: 'set_tls_credentials' has been explicitly marked deprecated here
    [[deprecated("use listen(socket_address addr, server_credentials_ptr credentials)")]]
      ^
1 warning generated.
```