### PR TITLE
build: ignore the --date-stamp option

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -1,12 +1,11 @@
 #!/bin/sh
 
 USAGE=$(cat <<-END
-Usage: $(basename "$0") [-h|--help] [-o|--output-dir PATH] [--date-stamp DATE] -- generate Scylla version and build information files.
+Usage: $(basename "$0") [-h|--help] [-o|--output-dir PATH] -- generate Scylla version and build information files.
 
 Options:
   -h|--help show this help message.
   -o|--output-dir PATH specify destination path at which the version files are to be created.
-  -d|--date-stamp DATE manually set date for release parameter
   -v|--verbose also print out the version number
 
 By default, the script will attempt to parse 'version' file
@@ -33,7 +32,6 @@ using '-o PATH' option.
 END
 )
 
-DATE=""
 PRINT_VERSION=false
 
 while [ $# -gt 0 ]; do
@@ -45,11 +43,6 @@ while [ $# -gt 0 ]; do
 			;;
 		-o|--output-dir)
 			OUTPUT_DIR="$2"
-			shift
-			shift
-			;;
-		--date-stamp)
-			DATE="$2"
 			shift
 			shift
 			;;
@@ -70,10 +63,6 @@ SCRIPT_DIR="$(dirname "$0")"
 
 if [ -z "$OUTPUT_DIR" ]; then
 	OUTPUT_DIR="$SCRIPT_DIR/build"
-fi
-
-if [ -z "$DATE" ]; then
-  DATE=$(date --utc +%Y%m%d)
 fi
 
 # Default scylla product/version tags

--- a/configure.py
+++ b/configure.py
@@ -772,7 +772,7 @@ arg_parser.add_argument('--clang-inline-threshold', action='store', type=int, de
 arg_parser.add_argument('--list-artifacts', dest='list_artifacts', action='store_true', default=False,
                         help='List all available build artifacts, that can be passed to --with')
 arg_parser.add_argument('--date-stamp', dest='date_stamp', type=str,
-                        help='Set datestamp for SCYLLA-VERSION-GEN')
+                        help='This option is kept only for backward compatibility')
 args = arg_parser.parse_args()
 
 if args.list_artifacts:
@@ -1575,11 +1575,8 @@ else:
     build_artifacts = all_artifacts
 
 
-def generate_version(date_stamp):
-    date_stamp_opt = ''
-    if date_stamp:
-        date_stamp_opt = f'--date-stamp {date_stamp}'
-    status = subprocess.call(f"./SCYLLA-VERSION-GEN {date_stamp_opt}", shell=True)
+def generate_version():
+    status = subprocess.call("./SCYLLA-VERSION-GEN", shell=True)
     if status != 0:
         print('Version file generation failed')
         sys.exit(1)
@@ -2389,7 +2386,7 @@ def create_building_system(args):
 
     ninja = find_ninja()
     with open(args.buildfile, 'w') as f:
-        scylla_product, scylla_version, scylla_release = generate_version(args.date_stamp)
+        scylla_product, scylla_version, scylla_release = generate_version()
         arch = platform.machine()
         write_build_file(f,
                          arch,


### PR DESCRIPTION
we don't reference the date-stamp specified with this option at all. instead, we always overwrite it with the the output of `date --utc +%Y%m%d`, if we are going to reference this value.

so, in this series, instead of pretending that we support this option, let's just ignore it. we will completely remove this option once the CI workflow is updated. for those who are interested, this option stopped working since 839d8f40, which practically traded --date-stamp option for the env variable of `SCYLLA_RELEASE`.