### PR TITLE
gms,service: add a feature to protect the usage of allow_mutation_read_page_without_live_row

### DIFF
--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -115,6 +115,7 @@ public:
     gms::feature separate_page_size_and_safety_limit { *this, "SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT"sv };
     // Replica is allowed to send back empty pages to coordinator on queries.
     gms::feature empty_replica_pages { *this, "EMPTY_REPLICA_PAGES"sv };
+    gms::feature empty_replica_mutation_pages { *this, "EMPTY_REPLICA_MUTATION_PAGES"sv };
     gms::feature supports_raft_cluster_mgmt { *this, "SUPPORTS_RAFT_CLUSTER_MANAGEMENT"sv };
     gms::feature tombstone_gc_options { *this, "TOMBSTONE_GC_OPTIONS"sv };
     gms::feature parallelized_aggregation { *this, "PARALLELIZED_AGGREGATION"sv };

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4981,7 +4981,9 @@ protected:
         data_resolver_ptr data_resolver = ::make_shared<data_read_resolver>(_schema, cl, _targets.size(), timeout);
         auto exec = shared_from_this();
 
-        cmd->slice.options.set<query::partition_slice::option::allow_mutation_read_page_without_live_row>();
+        if (_proxy->features().empty_replica_mutation_pages) {
+            cmd->slice.options.set<query::partition_slice::option::allow_mutation_read_page_without_live_row>();
+        }
 
         // Waited on indirectly.
         make_mutation_data_requests(cmd, data_resolver, _targets.begin(), _targets.end(), timeout);


### PR DESCRIPTION
allow_mutation_read_page_without_live_row is a new option in the partition_slice::option option set. In a mixed clusters, old nodes possibly don't know this new option, so its usage must be protected by a cluster feature. This patch does just that.

Fixes: #15795