### PR TITLE
SCYLLA-VERSION-GEN: respect --date-stamp

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -87,7 +87,6 @@ then
 else
 	SCYLLA_VERSION=$VERSION
 	if [ -z "$SCYLLA_RELEASE" ]; then
-		DATE=$(date --utc +%Y%m%d)
 		GIT_COMMIT=$(git -C "$SCRIPT_DIR" log --pretty=format:'%h' -n 1 --abbrev=12)
 		# For custom package builds, replace "0" with "counter.your_name",
 		# where counter starts at 1 and increments for successive versions.


### PR DESCRIPTION
before this change the argument passed to --date-stamp option is ignored, as we don't reference the date-stamp specified with this option at all. instead, we always overwrite it with the the output of `date --utc +%Y%m%d`, if we are going to reference this value.

so, in this change instead of unconditionally overwriting it, we keep its value intact if it is already set.

Fixes #15894
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>