### PR TITLE
schema: add whitespaces to values of table options

### DIFF
--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -760,7 +760,7 @@ static std::ostream& map_as_cql_param(std::ostream& os, const std::map<sstring, 
         if (first) {
             first = false;
         } else {
-            os << ",";
+            os << ", ";
         }
         os << "'" << i.first << "': '" << i.second << "'";
     }
@@ -931,13 +931,14 @@ std::ostream& schema::describe(replica::database& db, std::ostream& os, bool wit
     os << "\n    AND read_repair_chance = " << read_repair_chance();
     os << "\n    AND speculative_retry = '" << speculative_retry().to_sstring() << "'";
     os << "\n    AND paxos_grace_seconds = " << paxos_grace_seconds().count();
-
-    auto tombstone_gc_str = tombstone_gc_options().to_sstring();
-    std::replace(tombstone_gc_str.begin(), tombstone_gc_str.end(), '"', '\'');
-    os << "\n    AND tombstone_gc = " << tombstone_gc_str;
+    os << "\n    AND tombstone_gc = {";
+    map_as_cql_param(os, tombstone_gc_options().to_map());
+    os << "}";
     
     if (cdc_options().enabled()) {
-        os << "\n    AND cdc = " << cdc_options().to_sstring();
+        os << "\n    AND cdc = {";
+        map_as_cql_param(os, cdc_options().to_map());
+        os << "}";
     }
     if (is_view() && !is_index(db, view_info()->base_id(), *this)) {
         auto is_sync_update = db::find_tag(*this, db::SYNCHRONOUS_VIEW_UPDATES_TAG_KEY);

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -4111,7 +4111,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    col1 blob,\n"
                 "    PRIMARY KEY (pk)\n"
                 ") WITH bloom_filter_fp_chance = 0.01\n"
-                "    AND caching = {'keys': 'ALL','rows_per_partition': 'ALL'}\n"
+                "    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}\n"
                 "    AND comment = ''\n"
                 "    AND compaction = {'class': 'SizeTieredCompactionStrategy'}\n"
                 "    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
@@ -4125,7 +4125,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    AND read_repair_chance = 0\n"
                 "    AND speculative_retry = '99.0PERCENTILE'\n"
                 "    AND paxos_grace_seconds = 43200\n"
-                "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'};\n"
+                "    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};\n"
             },
             {"cf1", "CREATE TABLE ks.cf1 (\n"
                 "    pk blob,\n"
@@ -4149,7 +4149,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    AND read_repair_chance = 0\n"
                 "    AND speculative_retry = '99.0PERCENTILE'\n"
                 "    AND paxos_grace_seconds = 43200\n"
-                "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'};\n"
+                "    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};\n"
             },
             {"CF2", "CREATE TABLE ks.\"CF2\" (\n"
                 "    pk blob,\n"
@@ -4159,7 +4159,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    PRIMARY KEY (pk, \"CK\")\n"
                 ") WITH CLUSTERING ORDER BY (\"CK\" DESC)\n"
                 "    AND bloom_filter_fp_chance = 0.02\n"
-                "    AND caching = {'keys': 'ALL','rows_per_partition': 'ALL'}\n"
+                "    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}\n"
                 "    AND comment = ''\n"
                 "    AND compaction = {'class': 'SizeTieredCompactionStrategy'}\n"
                 "    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
@@ -4173,7 +4173,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    AND read_repair_chance = 0\n"
                 "    AND speculative_retry = '99.0PERCENTILE'\n"
                 "    AND paxos_grace_seconds = 43200\n"
-                "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'};\n"
+                "    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};\n"
             },
             {"Cf3", "CREATE TABLE ks.\"Cf3\" (\n"
                 "    pk blob,\n"
@@ -4184,7 +4184,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    PRIMARY KEY ((pk, pk2), \"CK\")\n"
                 ") WITH CLUSTERING ORDER BY (\"CK\" DESC)\n"
                 "    AND bloom_filter_fp_chance = 0.02\n"
-                "    AND caching = {'keys': 'ALL','rows_per_partition': 'ALL'}\n"
+                "    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}\n"
                 "    AND comment = ''\n"
                 "    AND compaction = {'class': 'SizeTieredCompactionStrategy'}\n"
                 "    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
@@ -4198,7 +4198,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    AND read_repair_chance = 0\n"
                 "    AND speculative_retry = '99.0PERCENTILE'\n"
                 "    AND paxos_grace_seconds = 43200\n"
-                "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'};\n"
+                "    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};\n"
             },
             {"cf4", "CREATE TABLE ks.cf4 (\n"
                 "    pk blob,\n"
@@ -4208,7 +4208,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    PRIMARY KEY (pk)\n"
                 ") WITH "
                 "     bloom_filter_fp_chance = 0.02\n"
-                "    AND caching = {'keys': 'ALL','rows_per_partition': 'ALL'}\n"
+                "    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}\n"
                 "    AND comment = ''\n"
                 "    AND compaction = {'class': 'SizeTieredCompactionStrategy'}\n"
                 "    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
@@ -4222,7 +4222,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    AND read_repair_chance = 0\n"
                 "    AND speculative_retry = '99.0PERCENTILE'\n"
                 "    AND paxos_grace_seconds = 43200\n"
-                "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'};\n"
+                "    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};\n"
             }
 
         };
@@ -4253,7 +4253,7 @@ SEASTAR_TEST_CASE(test_describe_view_schema) {
                 "    PRIMARY KEY ((pk, pk1), ck, ck1)\n"
                 ") WITH CLUSTERING ORDER BY (ck ASC, ck1 ASC)\n"
                 "    AND bloom_filter_fp_chance = 0.01\n"
-                "    AND caching = {'keys': 'ALL','rows_per_partition': 'ALL'}\n"
+                "    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}\n"
                 "    AND comment = ''\n"
                 "    AND compaction = {'class': 'SizeTieredCompactionStrategy'}\n"
                 "    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
@@ -4267,7 +4267,7 @@ SEASTAR_TEST_CASE(test_describe_view_schema) {
                 "    AND read_repair_chance = 0\n"
                 "    AND speculative_retry = '99.0PERCENTILE'\n"
                 "    AND paxos_grace_seconds = 43200\n"
-                "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'};\n";
+                "    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};\n";
 
         std::unordered_map<std::string, std::string> cql_create_tables {
           {"cf_view", "CREATE MATERIALIZED VIEW \"KS\".cf_view AS\n"
@@ -4277,7 +4277,7 @@ SEASTAR_TEST_CASE(test_describe_view_schema) {
               "    PRIMARY KEY (\"COL1\", pk, pk1, ck1, ck)\n"
               "    WITH CLUSTERING ORDER BY (pk ASC, pk1 ASC, ck1 ASC, ck ASC)\n"
               "    AND bloom_filter_fp_chance = 0.01\n"
-              "    AND caching = {'keys': 'ALL','rows_per_partition': 'ALL'}\n"
+              "    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}\n"
               "    AND comment = ''\n"
               "    AND compaction = {'class': 'SizeTieredCompactionStrategy'}\n"
               "    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}\n"
@@ -4291,7 +4291,7 @@ SEASTAR_TEST_CASE(test_describe_view_schema) {
               "    AND read_repair_chance = 0\n"
               "    AND speculative_retry = '99.0PERCENTILE'\n"
               "    AND paxos_grace_seconds = 43200\n"
-              "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'};\n"},
+              "    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};\n"},
           {"cf_index_index", "CREATE INDEX cf_index ON \"KS\".\"cF\"(col2);"},
           {"cf_index1_index", "CREATE INDEX cf_index1 ON \"KS\".\"cF\"(pk);"},
           {"cf_index2_index", "CREATE INDEX cf_index2 ON \"KS\".\"cF\"(pk1);"},


### PR DESCRIPTION
Add a space after each colon and comma (if they don't have any after) in values of table option which are json objects (`caching`, `tombstone_gc` and `cdc`).
This improves readability and matches client-side describe format.

Fixes: #14895