### PR TITLE
streaming: Ignore dropped table on both sides

### DIFF
--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -365,7 +365,7 @@ public:
     future<> unregister_prepare_done_message();
 
     // Wrapper for STREAM_MUTATION_FRAGMENTS
-    // The receiver of STREAM_MUTATION_FRAGMENTS sends status code to the sender to notify any error on the receiver side. The status code is of type int32_t. 0 means successful, -1 means error, other status code value are reserved for future use.
+    // The receiver of STREAM_MUTATION_FRAGMENTS sends status code to the sender to notify any error on the receiver side. The status code is of type int32_t. 0 means successful, -1 means error, -2 means error and table is dropped, other status code value are reserved for future use.
     void register_stream_mutation_fragments(std::function<future<rpc::sink<int32_t>> (const rpc::client_info& cinfo, streaming::plan_id plan_id, table_schema_version schema_id, table_id cf_id, uint64_t estimated_partitions, rpc::optional<streaming::stream_reason> reason_opt, rpc::source<frozen_mutation_fragment, rpc::optional<streaming::stream_mutation_fragments_cmd>> source)>&& func);
     future<> unregister_stream_mutation_fragments();
     rpc::sink<int32_t> make_sink_for_stream_mutation_fragments(rpc::source<frozen_mutation_fragment, rpc::optional<streaming::stream_mutation_fragments_cmd>>& source);

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -183,9 +183,14 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
                     if (try_catch<seastar::rpc::stream_closed>(ex)) {
                         level = seastar::log_level::debug;
                     }
+                    status = -1;
+                    // The status code -2 means error and the table is dropped
+                    if (try_catch<data_dictionary::no_such_column_family>(ex)) {
+                        level = seastar::log_level::debug;
+                        status = -2;
+                    }
                     sslog.log(level, "[Stream #{}] Failed to handle STREAM_MUTATION_FRAGMENTS (receive and distribute phase) for ks={}, cf={}, peer={}: {}",
                             plan_id, s->ks_name(), s->cf_name(), from.addr, ex);
-                    status = -1;
                 } else {
                     received_partitions = f.get0();
                 }


### PR DESCRIPTION
It is possible the sender and receiver of streaming nodes have different views on if a table is dropped or not.

For example:
- n1, n2 and n3 in the cluster

- n4 started to join the cluster and stream data from n1, n2, n3

- a table was dropped

- n4 failed to write data from n2 to sstable because a table was dropped

- n4 ended the streaming

- n2 checked if the table was present and would ignore the error if the table was dropped

- however n2 found the table was still present and was not dropped

- n2 marked the streaming as failed

This will fail the streaming when a table is dropped. We want streaming to ignore such dropped tables.

In this patch, a status code is sent back to the sender to notify the table is dropped so the sender could ignore the dropped table.

Fixes #15370