### PR TITLE
build: cmake: add check-header target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,17 @@ target_link_libraries(scylla-main
     Snappy::snappy
     systemd
     ZLIB::ZLIB)
+
+option(Scylla_CHECK_HEADERS
+  "Add check-headers target for checking the self-containness of headers")
+if(Scylla_CHECK_HEADERS)
+    add_custom_target(check-headers)
+endif()
+
+include(check_headers)
+check_headers(check-headers scylla-main
+  GLOB ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)
+
 add_subdirectory(api)
 add_subdirectory(alternator)
 add_subdirectory(db)

--- a/alternator/CMakeLists.txt
+++ b/alternator/CMakeLists.txt
@@ -28,3 +28,6 @@ target_link_libraries(alternator
   idl
   Seastar::seastar
   xxHash::xxhash)
+
+check_headers(check-headers alternator
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -67,6 +67,8 @@ target_include_directories(api
 target_link_libraries(api
   idl
   wasmtime_bindings
-
   Seastar::seastar
   xxHash::xxhash)
+
+check_headers(check-headers api
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/auth/CMakeLists.txt
+++ b/auth/CMakeLists.txt
@@ -35,3 +35,6 @@ target_link_libraries(scylla_auth
     libxcrypt::libxcrypt)
 
 add_whole_archive(auth scylla_auth)
+
+check_headers(check-headers scylla_auth
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/cdc/CMakeLists.txt
+++ b/cdc/CMakeLists.txt
@@ -15,3 +15,6 @@ target_link_libraries(cdc
     xxHash::xxhash
   PRIVATE
     replica)
+
+check_headers(check-headers cdc
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/cmake/check_headers.cmake
+++ b/cmake/check_headers.cmake
@@ -1,0 +1,104 @@
+function (check_headers check_headers_target target)
+  if(NOT TARGET ${check_headers_target})
+    return()
+  endif()
+
+  # "target" is required, so we can get the compiling options for compiling
+  # the headers.
+  cmake_parse_arguments (
+    parsed_args
+    ""
+    "GLOB;GLOB_RECURSE;EXCLUDE;INCLUDE"
+    ""
+    ${ARGN})
+
+  set(sources "")
+  if(DEFINED parsed_args_GLOB)
+    file(GLOB sources
+      LIST_DIRECTORIES false
+      RELATIVE ${CMAKE_SOURCE_DIR}
+      "${parsed_args_GLOB}")
+  elseif(DEFINED parsed_args_GLOB_RECURSE)
+    file(GLOB_RECURSE sources
+      LIST_DIRECTORIES false
+      RELATIVE ${CMAKE_SOURCE_DIR}
+      "${parsed_args_RECURSIVE}")
+  else()
+    message(FATAL_ERROR "Please specify GLOB or GLOB_RECURSE.")
+  endif()
+  if(DEFINED parsed_args_INCLUDE)
+    list(FILTER sources INCLUDE REGEX "${parsed_args_INCLUDE}")
+  endif()
+  if(DEFINED parsed_args_EXCLUDE)
+    list(FILTER sources EXCLUDE REGEX "${parsed_args_EXCLUDE}")
+  endif()
+
+  foreach(fn ${sources})
+    get_filename_component(file_dir ${fn} DIRECTORY)
+    list(APPEND includes "${CMAKE_SOURCE_DIR}/${file_dir}")
+    set(src_dir "${CMAKE_BINARY_DIR}/check-headers/${file_dir}")
+    file(MAKE_DIRECTORY "${src_dir}")
+    get_filename_component(file_name ${fn} NAME)
+    set(src "${src_dir}/${file_name}.cc")
+    # CMake refuses to compile .hh files, so we need to rename them first.
+    add_custom_command(
+      OUTPUT ${src}
+      DEPENDS ${CMAKE_SOURCE_DIR}/${fn}
+      # silence "-Wpragma-once-outside-header"
+      COMMAND sed
+            -e "s/^#pragma once//"
+            "${fn}" > "${src}"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+      VERBATIM)
+    list(APPEND srcs "${src}")
+  endforeach()
+
+  if(NOT srcs)
+    # not headers to checks
+    return()
+  endif()
+
+  set(check_lib "${check_headers_target}-${target}")
+  add_library(${check_lib} EXCLUDE_FROM_ALL)
+  target_sources(${check_lib}
+    PRIVATE ${srcs})
+  # use ${target} as an interface library by consuming all of its
+  # compile time options
+  get_target_property(libraries ${target} LINK_LIBRARIES)
+  if (libraries)
+    target_link_libraries(${check_lib}
+      PRIVATE ${libraries})
+  endif()
+
+  # if header includes other header files with relative path,
+  # we should satisfy it.
+  list(REMOVE_DUPLICATES includes)
+  target_include_directories(${check_lib}
+    PRIVATE ${includes})
+  get_target_property(includes ${target} INCLUDE_DIRECTORIES)
+  if(includes)
+    target_include_directories(${check_lib}
+      PRIVATE ${includes})
+  endif()
+
+  get_target_property(compile_options ${target} COMPILE_OPTIONS)
+  if(compile_options)
+    target_compile_options(${check_lib}
+      PRIVATE ${compile_options})
+  endif ()
+  # symbols in header file should always be referenced, but these
+  # are just pure headers, so unused variables should be tolerated.
+  target_compile_options(${check_lib}
+    PRIVATE
+      -Wno-unused-const-variable
+      -Wno-unused-function
+      -Wno-unused-variable)
+
+  get_target_property(compile_definitions ${target} COMPILE_DEFINITIONS)
+  if(compile_definitions)
+    target_compile_definitions(${check_lib}
+      PRIVATE ${compile_definitions})
+  endif()
+
+  add_dependencies(${check_headers_target} ${check_lib})
+endfunction ()

--- a/compaction/CMakeLists.txt
+++ b/compaction/CMakeLists.txt
@@ -18,3 +18,6 @@ target_link_libraries(compaction
   PRIVATE
     mutation_writer
     replica)
+
+check_headers(check-headers compaction
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/cql3/CMakeLists.txt
+++ b/cql3/CMakeLists.txt
@@ -150,3 +150,6 @@ target_link_libraries(cql3
   PRIVATE
     lang
     transport)
+
+check_headers(check-headers cql3
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/data_dictionary/CMakeLists.txt
+++ b/data_dictionary/CMakeLists.txt
@@ -11,3 +11,6 @@ target_link_libraries(data_dictionary
   PUBLIC
     Seastar::seastar
     xxHash::xxhash)
+
+check_headers(check-headers data_dictionary
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -47,3 +47,6 @@ target_link_libraries(db
   PRIVATE
     data_dictionary
     cql3)
+
+check_headers(check-headers db
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/dht/CMakeLists.txt
+++ b/dht/CMakeLists.txt
@@ -19,3 +19,6 @@ target_link_libraries(scylla_dht
     replica)
 
 add_whole_archive(dht scylla_dht)
+
+check_headers(check-headers scylla_dht
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/gms/CMakeLists.txt
+++ b/gms/CMakeLists.txt
@@ -21,3 +21,6 @@ target_link_libraries(gms
     xxHash::xxhash
   PRIVATE
     db)
+
+check_headers(check-headers gms
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/idl/CMakeLists.txt
+++ b/idl/CMakeLists.txt
@@ -77,3 +77,7 @@ add_dependencies(idl idl-sources)
 target_include_directories(idl
   INTERFACE
     ${scylla_gen_build_dir})
+
+# *.idl.hh headers are not C++ headers but the ones
+# to be processed by the idl compiler, so we don't
+# check their self-containness.

--- a/index/CMakeLists.txt
+++ b/index/CMakeLists.txt
@@ -14,3 +14,6 @@ target_link_libraries(index
     xxHash::xxhash
   PRIVATE
     cql3)
+
+check_headers(check-headers index
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -17,3 +17,6 @@ target_link_libraries(lang
     xxHash::xxhash
   PRIVATE
     ${LUA_LIBRARIES})
+
+check_headers(check-headers lang
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/locator/CMakeLists.txt
+++ b/locator/CMakeLists.txt
@@ -32,3 +32,6 @@ target_link_libraries(scylla_locator
     db)
 
 add_whole_archive(locator scylla_locator)
+
+check_headers(check-headers scylla_locator
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/message/CMakeLists.txt
+++ b/message/CMakeLists.txt
@@ -12,3 +12,6 @@ target_link_libraries(message
     Seastar::seastar
   PRIVATE
     idl)
+
+check_headers(check-headers message
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/mutation/CMakeLists.txt
+++ b/mutation/CMakeLists.txt
@@ -22,3 +22,6 @@ target_link_libraries(mutation
     idl
     Seastar::seastar
     xxHash::xxhash)
+
+check_headers(check-headers mutation
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/mutation_writer/CMakeLists.txt
+++ b/mutation_writer/CMakeLists.txt
@@ -15,3 +15,6 @@ target_link_libraries(mutation_writer
     xxHash::xxhash
   PRIVATE
     schema)
+
+check_headers(check-headers mutation_writer
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/node_ops/CMakeLists.txt
+++ b/node_ops/CMakeLists.txt
@@ -11,3 +11,6 @@ target_link_libraries(node_ops
     Seastar::seastar
   PRIVATE
     service)
+
+check_headers(check-headers api
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/raft/CMakeLists.txt
+++ b/raft/CMakeLists.txt
@@ -13,3 +13,6 @@ target_link_libraries(raft
   PUBLIC
     Seastar::seastar
     xxHash::xxhash)
+
+check_headers(check-headers raft
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/readers/CMakeLists.txt
+++ b/readers/CMakeLists.txt
@@ -14,3 +14,6 @@ target_link_libraries(readers
     xxHash::xxhash
   PRIVATE
     schema)
+
+check_headers(check-headers readers
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/redis/CMakeLists.txt
+++ b/redis/CMakeLists.txt
@@ -33,3 +33,6 @@ target_link_libraries(redis
     xxHash::xxhash
   PRIVATE
     db)
+
+check_headers(check-headers redis
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/repair/CMakeLists.txt
+++ b/repair/CMakeLists.txt
@@ -11,3 +11,6 @@ target_link_libraries(repair
     idl
     Seastar::seastar
     xxHash::xxhash)
+
+check_headers(check-headers repair
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/replica/CMakeLists.txt
+++ b/replica/CMakeLists.txt
@@ -21,3 +21,6 @@ target_link_libraries(replica
     xxHash::xxhash
   PRIVATE
     absl::raw_hash_set)
+
+check_headers(check-headers replica
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/schema/CMakeLists.txt
+++ b/schema/CMakeLists.txt
@@ -13,3 +13,6 @@ target_link_libraries(schema
     idl
     Seastar::seastar
     xxHash::xxhash)
+
+check_headers(check-headers schema
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -42,3 +42,6 @@ target_link_libraries(service
     repair
     streaming
     systemd)
+
+check_headers(check-headers service
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/sstables/CMakeLists.txt
+++ b/sstables/CMakeLists.txt
@@ -33,3 +33,6 @@ target_link_libraries(sstables
     tracing
     libdeflate::libdeflate
     ZLIB::ZLIB)
+
+check_headers(check-headers streaming
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -510,6 +510,7 @@ private:
     friend class sstable_directory;
     friend class filesystem_storage;
     friend class s3_storage;
+    friend class tiered_storage;
 
     size_t sstable_buffer_size;
 

--- a/streaming/CMakeLists.txt
+++ b/streaming/CMakeLists.txt
@@ -24,3 +24,6 @@ target_link_libraries(streaming
     xxHash::xxhash
   PRIVATE
     replica)
+
+check_headers(check-headers streaming
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/thrift/CMakeLists.txt
+++ b/thrift/CMakeLists.txt
@@ -15,3 +15,6 @@ target_link_libraries(thrift
   PRIVATE
     interface
     Thrift::thrift)
+
+check_headers(check-headers thrift
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -47,3 +47,6 @@ build_submodule(python3 python3
   "${pip_dependencies}"
   --pip-symlinks
   "${pip_symlinks}")
+
+check_headers(check-headers tools
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/tracing/CMakeLists.txt
+++ b/tracing/CMakeLists.txt
@@ -18,3 +18,6 @@ target_link_libraries(scylla_tracing
     service)
 
 add_whole_archive(tracing scylla_tracing)
+
+check_headers(check-headers scylla_tracing
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/transport/CMakeLists.txt
+++ b/transport/CMakeLists.txt
@@ -17,3 +17,6 @@ target_link_libraries(transport
   PRIVATE
     cql3
     Snappy::snappy)
+
+check_headers(check-headers transport
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/types/CMakeLists.txt
+++ b/types/CMakeLists.txt
@@ -10,3 +10,6 @@ target_link_libraries(types
     idl
     Seastar::seastar
     xxHash::xxhash)
+
+check_headers(check-headers types
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -58,3 +58,6 @@ target_link_libraries(utils
     Boost::regex
     cryptopp
     rapidxml::rapidxml)
+
+check_headers(check-headers utils
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)


### PR DESCRIPTION
to have feature parity with `configure.py`. we won't need this once we migrate to C++20 modules. but before that day comes, we need to stick with C++ headers.

we generate a rule for each .hh files to create a corresponding .cc and then compile it, in order to verify the self-containness of that header. so the number of rule is quite large, to avoid the unnecessary overhead. the check-header target is enabled only if `Scylla_CHECK_HEADERS` option is enabled.