### PR TITLE
build: cmake: update 3rd party library deps where it is found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,10 @@ add_subdirectory(seastar)
 # System libraries dependencies
 find_package(Boost REQUIRED
     COMPONENTS filesystem program_options system thread regex unit_test_framework)
+target_link_libraries(Boost::regex
+  INTERFACE
+    ICU::i18n
+    ICU::uc)
 find_package(Lua REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(ICU COMPONENTS uc i18n REQUIRED)
@@ -185,10 +189,6 @@ target_link_libraries(scylla PRIVATE
     transport
     types
     utils)
-target_link_libraries(Boost::regex
-  INTERFACE
-    ICU::i18n
-    ICU::uc)
 
 target_link_libraries(scylla PRIVATE
     seastar


### PR DESCRIPTION
move the code which updates the third-party library closer to where the library is found. for better readability.