### PR TITLE
build: add an option to create building system with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,15 @@ option(Scylla_CHECK_HEADERS
   "Add check-headers target for checking the self-containness of headers")
 if(Scylla_CHECK_HEADERS)
     add_custom_target(check-headers)
+    # compatibility target used by CI, which builds "dev-headers" for building
+    # "headers" of the "dev" mode. but we don't have such an alias. what we
+    # have is check-headers:Dev, and we don't want to build check-headers
+    # for all "CMAKE_DEFAULT_CONFIGS". so, before we , let's add an target
+    # which only build build check-headers for Dev, and skip it otherwise.
+    add_custom_target(dev-headers
+        COMMAND ${CMAKE_COMMAND}
+          "$<IF:$<CONFIG:Dev>,--build;${CMAKE_BINARY_DIR};--config;$<CONFIG>;--target;check-headers,-E;echo;skipping;dev-headers;in;$<CONFIG>>"
+        COMMAND_EXPAND_LISTS)
 endif()
 
 include(check_headers)

--- a/configure.py
+++ b/configure.py
@@ -2426,6 +2426,7 @@ def configure_using_cmake(args):
         'CMAKE_CXX_FLAGS': args.user_cflags,
         'CMAKE_EXE_LINKER_FLAGS': semicolon_separated(args.user_ldflags),
         'CMAKE_EXPORT_COMPILE_COMMANDS': 'ON',
+        'Scylla_CHECK_HEADERS': 'ON',
     }
     if args.date_stamp:
         settings['Scylla_DATE_STAMP'] = args.date_stamp

--- a/configure.py
+++ b/configure.py
@@ -774,6 +774,7 @@ arg_parser.add_argument('--list-artifacts', dest='list_artifacts', action='store
                         help='List all available build artifacts, that can be passed to --with')
 arg_parser.add_argument('--date-stamp', dest='date_stamp', type=str,
                         help='Set datestamp for SCYLLA-VERSION-GEN')
+arg_parser.add_argument('--use-cmake', action='store_true', help='Use CMake as the build system')
 args = arg_parser.parse_args()
 
 if args.list_artifacts:
@@ -2404,5 +2405,54 @@ def create_build_system(args):
     generate_compdb('compile_commands.json', ninja, args.buildfile, selected_modes)
 
 
+def configure_using_cmake(args):
+    # all supported build modes, and if they are built by default if selected
+    build_by_default = {'debug': True,
+                        'release': True,
+                        'dev': True,
+                        'sanitize': False,
+                        'coverage': False}
+    selected_modes = args.selected_modes or build_by_default.keys()
+    selected_configs = ';'.join(mode.capitalize() for mode in selected_modes)
+    default_configs = ';'.join(mode.capitalize() for mode in selected_modes
+                               if build_by_default[mode])
+
+    settings = {
+        'CMAKE_CONFIGURATION_TYPES': selected_configs,
+        'CMAKE_CROSS_CONFIGS': default_configs,
+        'CMAKE_DEFAULT_CONFIGS': default_configs,
+        'CMAKE_C_COMPILER': args.cc,
+        'CMAKE_CXX_COMPILER': args.cxx,
+        'CMAKE_CXX_FLAGS': args.user_cflags,
+        'CMAKE_EXE_LINKER_FLAGS': semicolon_separated(args.user_ldflags),
+        'CMAKE_EXPORT_COMPILE_COMMANDS': 'ON',
+    }
+    if args.date_stamp:
+        settings['Scylla_DATE_STAMP'] = args.date_stamp
+
+    source_dir = os.path.realpath(os.path.dirname(__file__))
+    build_dir = os.path.join(source_dir, 'build')
+
+    cmake_command = ['cmake']
+    cmake_command += [f'-D{var}={value}' for var, value in settings.items()]
+    cmake_command += ['-G', 'Ninja Multi-Config',
+                      '-B', build_dir,
+                      '-S', source_dir]
+    subprocess.check_call(cmake_command, shell=False, cwd=source_dir)
+
+    compdb_source = os.path.join(source_dir, 'compile_commands.json')
+    compdb_target = os.path.join(build_dir, 'compile_commands.json')
+    
+    try:
+        os.symlink(compdb_target, compdb_source)
+    except FileExistsError:
+        # if there is already a valid compile_commands.json link in the
+        # source root, we are done.
+        pass
+
+
 if __name__ == '__main__':
-    create_build_system(args)
+    if args.use_cmake:
+        configure_using_cmake(args)
+    else:
+        create_build_system(args)


### PR DESCRIPTION
as part of the efforts to migrate to the CMake-based building system,
this change enables us to `configure.py` to optionally create
`build.ninja` with CMake.

in this change, we add a new option named `--use-cmake` to
`configure.py` so we can create `build.ninja`. please note,
instead of using the "Ninja" generator used by Seastar's
`configure.py` script, we use "Ninja Multi-Config" generator
along with `CMAKE_CROSS_CONFIGS` setting in this project.
so that we can generate a `build.ninja` which is capable of
building the same artifacts with multiple configuration.

Refs #15379
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>