### PR TITLE
raft: topology: outside topology-on-raft mode, make sure not to use its RPCs

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1674,7 +1674,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // Need to do it before allowing incomming messaging service connections since
             // storage proxy's and migration manager's verbs may access group0.
             // This will also disable migration manager schema pulls if needed.
-            group0_service.setup_group0_if_exist(sys_ks.local(), ss.local(), qp.local(), mm.local()).get();
+            group0_service.setup_group0_if_exist(sys_ks.local(), ss.local(), qp.local(), mm.local(), raft_topology_change_enabled).get();
 
             // It's essential to load fencing_version prior to starting the messaging service,
             // since incoming messages may require fencing.

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -90,11 +90,12 @@ class group0_state_machine : public raft_state_machine {
     raft_address_map& _address_map;
     seastar::gate _gate;
     abort_source _abort_source;
+    bool _topology_change_enabled;
 
     future<> merge_and_apply(group0_state_machine_merger& merger);
 public:
-    group0_state_machine(raft_group0_client& client, migration_manager& mm, storage_proxy& sp, storage_service& ss, raft_address_map& address_map)
-            : _client(client), _mm(mm), _sp(sp), _ss(ss), _address_map(address_map) {}
+    group0_state_machine(raft_group0_client& client, migration_manager& mm, storage_proxy& sp, storage_service& ss, raft_address_map& address_map, bool topology_change_enabled)
+            : _client(client), _mm(mm), _sp(sp), _ss(ss), _address_map(address_map), _topology_change_enabled(topology_change_enabled) {}
     future<> apply(std::vector<raft::command_cref> command) override;
     future<raft::snapshot_id> take_snapshot() override;
     void drop_snapshot(raft::snapshot_id id) override;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6588,77 +6588,77 @@ void storage_service::init_messaging_service(sharded<db::system_distributed_keys
         });
     });
     if (raft_topology_change_enabled) {
-    auto handle_raft_rpc = [&cont = container()] (raft::server_id dst_id, auto handler) {
-        return cont.invoke_on(0, [dst_id, handler = std::move(handler)] (auto& ss) mutable {
-            if (!ss._group0 || !ss._group0->joined_group0()) {
-                throw std::runtime_error("The node did not join group 0 yet");
-            }
-            if (ss._group0->load_my_id() != dst_id) {
-                throw raft_destination_id_not_correct(ss._group0->load_my_id(), dst_id);
-            }
-            return handler(ss);
+        auto handle_raft_rpc = [&cont = container()] (raft::server_id dst_id, auto handler) {
+            return cont.invoke_on(0, [dst_id, handler = std::move(handler)] (auto& ss) mutable {
+                if (!ss._group0 || !ss._group0->joined_group0()) {
+                    throw std::runtime_error("The node did not join group 0 yet");
+                }
+                if (ss._group0->load_my_id() != dst_id) {
+                    throw raft_destination_id_not_correct(ss._group0->load_my_id(), dst_id);
+                }
+                return handler(ss);
+            });
+        };
+        ser::storage_service_rpc_verbs::register_raft_topology_cmd(&_messaging.local(), [&sys_dist_ks, handle_raft_rpc] (raft::server_id dst_id, raft::term_t term, uint64_t cmd_index, raft_topology_cmd cmd) {
+            return handle_raft_rpc(dst_id, [&sys_dist_ks, cmd = std::move(cmd), term, cmd_index] (auto& ss) {
+                return ss.raft_topology_cmd_handler(sys_dist_ks, term, cmd_index, cmd);
+            });
         });
-    };
-    ser::storage_service_rpc_verbs::register_raft_topology_cmd(&_messaging.local(), [&sys_dist_ks, handle_raft_rpc] (raft::server_id dst_id, raft::term_t term, uint64_t cmd_index, raft_topology_cmd cmd) {
-        return handle_raft_rpc(dst_id, [&sys_dist_ks, cmd = std::move(cmd), term, cmd_index] (auto& ss) {
-            return ss.raft_topology_cmd_handler(sys_dist_ks, term, cmd_index, cmd);
-        });
-    });
-    ser::storage_service_rpc_verbs::register_raft_pull_topology_snapshot(&_messaging.local(), [handle_raft_rpc] (raft::server_id dst_id, raft_topology_pull_params params) {
-        return handle_raft_rpc(dst_id, [] (storage_service& ss) -> future<raft_topology_snapshot> {
-            std::vector<canonical_mutation> topology_mutations;
-            {
-                // FIXME: make it an rwlock, here we only need to lock for reads,
-                // might be useful if multiple nodes are trying to pull concurrently.
-                auto read_apply_mutex_holder = co_await ss._group0->client().hold_read_apply_mutex();
-                auto rs = co_await db::system_keyspace::query_mutations(
-                    ss._db, db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY);
-                auto s = ss._db.local().find_schema(db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY);
-                topology_mutations.reserve(rs->partitions().size());
-                boost::range::transform(
-                        rs->partitions(), std::back_inserter(topology_mutations), [s] (const partition& p) {
-                    return canonical_mutation{p.mut().unfreeze(s)};
-                });
-            }
+        ser::storage_service_rpc_verbs::register_raft_pull_topology_snapshot(&_messaging.local(), [handle_raft_rpc] (raft::server_id dst_id, raft_topology_pull_params params) {
+            return handle_raft_rpc(dst_id, [] (storage_service& ss) -> future<raft_topology_snapshot> {
+                std::vector<canonical_mutation> topology_mutations;
+                {
+                    // FIXME: make it an rwlock, here we only need to lock for reads,
+                    // might be useful if multiple nodes are trying to pull concurrently.
+                    auto read_apply_mutex_holder = co_await ss._group0->client().hold_read_apply_mutex();
+                    auto rs = co_await db::system_keyspace::query_mutations(
+                        ss._db, db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY);
+                    auto s = ss._db.local().find_schema(db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY);
+                    topology_mutations.reserve(rs->partitions().size());
+                    boost::range::transform(
+                            rs->partitions(), std::back_inserter(topology_mutations), [s] (const partition& p) {
+                        return canonical_mutation{p.mut().unfreeze(s)};
+                    });
+                }
 
-            std::vector<canonical_mutation> cdc_generation_mutations;
-            {
-                // FIXME: when we bootstrap nodes in quick succession, the timestamp of the newest CDC generation
-                // may be for some time larger than the clocks of our nodes. The last bootstrapped node will only
-                // read the newest CDC generation into memory and not earlier ones, so it will only be able
-                // to coordinate writes to CDC-enabled tables after its clock advances to reach the newest
-                // generation's timestamp. In other words, it may not be able to coordinate writes for some
-                // time after bootstrapping and drivers connecting to it will receive errors.
-                // To fix that, we could store in topology a small history of recent CDC generation IDs
-                // (garbage-collected with time) instead of just the last one, and load all of them.
-                // Alternatively, a node would wait for some time before switching to normal state.
-                auto read_apply_mutex_holder = co_await ss._group0->client().hold_read_apply_mutex();
-                auto rs = co_await db::system_keyspace::query_mutations(
-                    ss._db, db::system_keyspace::NAME, db::system_keyspace::CDC_GENERATIONS_V3);
-                auto s = ss._db.local().find_schema(db::system_keyspace::NAME, db::system_keyspace::CDC_GENERATIONS_V3);
-                cdc_generation_mutations.reserve(rs->partitions().size());
-                boost::range::transform(
-                        rs->partitions(), std::back_inserter(cdc_generation_mutations), [s] (const partition& p) {
-                    return canonical_mutation{p.mut().unfreeze(s)};
-                });
-            }
+                std::vector<canonical_mutation> cdc_generation_mutations;
+                {
+                    // FIXME: when we bootstrap nodes in quick succession, the timestamp of the newest CDC generation
+                    // may be for some time larger than the clocks of our nodes. The last bootstrapped node will only
+                    // read the newest CDC generation into memory and not earlier ones, so it will only be able
+                    // to coordinate writes to CDC-enabled tables after its clock advances to reach the newest
+                    // generation's timestamp. In other words, it may not be able to coordinate writes for some
+                    // time after bootstrapping and drivers connecting to it will receive errors.
+                    // To fix that, we could store in topology a small history of recent CDC generation IDs
+                    // (garbage-collected with time) instead of just the last one, and load all of them.
+                    // Alternatively, a node would wait for some time before switching to normal state.
+                    auto read_apply_mutex_holder = co_await ss._group0->client().hold_read_apply_mutex();
+                    auto rs = co_await db::system_keyspace::query_mutations(
+                        ss._db, db::system_keyspace::NAME, db::system_keyspace::CDC_GENERATIONS_V3);
+                    auto s = ss._db.local().find_schema(db::system_keyspace::NAME, db::system_keyspace::CDC_GENERATIONS_V3);
+                    cdc_generation_mutations.reserve(rs->partitions().size());
+                    boost::range::transform(
+                            rs->partitions(), std::back_inserter(cdc_generation_mutations), [s] (const partition& p) {
+                        return canonical_mutation{p.mut().unfreeze(s)};
+                    });
+                }
 
-            co_return raft_topology_snapshot{
-                .topology_mutations = std::move(topology_mutations),
-                .cdc_generation_mutations = std::move(cdc_generation_mutations),
-            };
+                co_return raft_topology_snapshot{
+                    .topology_mutations = std::move(topology_mutations),
+                    .cdc_generation_mutations = std::move(cdc_generation_mutations),
+                };
+            });
         });
-    });
-    ser::storage_service_rpc_verbs::register_tablet_stream_data(&_messaging.local(), [handle_raft_rpc] (raft::server_id dst_id, locator::global_tablet_id tablet) {
-        return handle_raft_rpc(dst_id, [tablet] (auto& ss) {
-            return ss.stream_tablet(tablet);
+        ser::storage_service_rpc_verbs::register_tablet_stream_data(&_messaging.local(), [handle_raft_rpc] (raft::server_id dst_id, locator::global_tablet_id tablet) {
+            return handle_raft_rpc(dst_id, [tablet] (auto& ss) {
+                return ss.stream_tablet(tablet);
+            });
         });
-    });
-    ser::storage_service_rpc_verbs::register_tablet_cleanup(&_messaging.local(), [handle_raft_rpc] (raft::server_id dst_id, locator::global_tablet_id tablet) {
-        return handle_raft_rpc(dst_id, [tablet] (auto& ss) {
-            return ss.cleanup_tablet(tablet);
+        ser::storage_service_rpc_verbs::register_tablet_cleanup(&_messaging.local(), [handle_raft_rpc] (raft::server_id dst_id, locator::global_tablet_id tablet) {
+            return handle_raft_rpc(dst_id, [tablet] (auto& ss) {
+                return ss.cleanup_tablet(tablet);
+            });
         });
-    });
         ser::join_node_rpc_verbs::register_join_node_request(&_messaging.local(), [handle_raft_rpc] (raft::server_id dst_id, service::join_node_request_params params) {
             return handle_raft_rpc(dst_id, [params = std::move(params)] (auto& ss) mutable {
                 return ss.join_node_request_handler(std::move(params));

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6587,6 +6587,7 @@ void storage_service::init_messaging_service(sharded<db::system_distributed_keys
             return ss.node_ops_cmd_handler(coordinator, std::move(req));
         });
     });
+    if (raft_topology_change_enabled) {
     auto handle_raft_rpc = [&cont = container()] (raft::server_id dst_id, auto handler) {
         return cont.invoke_on(0, [dst_id, handler = std::move(handler)] (auto& ss) mutable {
             if (!ss._group0 || !ss._group0->joined_group0()) {
@@ -6658,7 +6659,6 @@ void storage_service::init_messaging_service(sharded<db::system_distributed_keys
             return ss.cleanup_tablet(tablet);
         });
     });
-    if (raft_topology_change_enabled) {
         ser::join_node_rpc_verbs::register_join_node_request(&_messaging.local(), [handle_raft_rpc] (raft::server_id dst_id, service::join_node_request_params params) {
             return handle_raft_rpc(dst_id, [params = std::move(params)] (auto& ss) mutable {
                 return ss.join_node_request_handler(std::move(params));


### PR DESCRIPTION
Topology on raft is still an experimental feature. The RPC verbs introduced in that mode shouldn't be used when it's disabled, otherwise we lose the right to make breaking changes to those verbs.

First, make sure that the aforementioned verbs are not sent outside the mode. It turns out that `raft_pull_topology_snapshot` could be sent outside topology-on-raft mode - after the PR, it no longer can.

Second, topology-on-raft mode verbs are now not registered at all on the receiving side when the mode is disabled.

Additionally tested by running `topology/` tests with `consistent_cluster_management: True` but with experimental features disabled.

Fixes: scylladb/scylladb#15862