### PR TITLE
auth: fix error message when consistency level is not met

### DIFF
--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -245,6 +245,8 @@ future<authenticated_user> password_authenticator::authenticate(
             std::throw_with_nested(exceptions::authentication_exception(e.what()));
         } catch (exceptions::authentication_exception& e) {
             std::throw_with_nested(e);
+        } catch (exceptions::unavailable_exception& e) {
+            std::throw_with_nested(exceptions::authentication_exception(e.get_message()));
         } catch (...) {
             std::throw_with_nested(exceptions::authentication_exception("authentication failed"));
         }

--- a/test/auth_cluster/conftest.py
+++ b/test/auth_cluster/conftest.py
@@ -1,0 +1,9 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file configures pytest for all tests in this directory, and also
+# defines common test fixtures for all of them to use
+
+from test.topology.conftest import *

--- a/test/auth_cluster/pytest.ini
+++ b/test/auth_cluster/pytest.ini
@@ -1,0 +1,12 @@
+[pytest]
+addopts = --auth_username=cassandra --auth_password=cassandra
+
+asyncio_mode = auto
+
+log_cli = true
+log_format = %(asctime)s.%(msecs)03d %(levelname)s> %(message)s
+log_date_format = %H:%M:%S
+
+markers =
+    slow: tests that take more than 30 seconds to run
+    replication_factor: replication factor for RandomTables

--- a/test/auth_cluster/suite.yaml
+++ b/test/auth_cluster/suite.yaml
@@ -1,0 +1,4 @@
+type: Topology
+pool_size: 2
+cluster:
+  initial_size: 0

--- a/test/auth_cluster/test_password_login_message.py
+++ b/test/auth_cluster/test_password_login_message.py
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from test.pylib.manager_client import ManagerClient
+import pytest
+import logging
+from cassandra.cluster import NoHostAvailable
+
+logger = logging.getLogger(__name__)
+
+"""
+Tests the error message after half of the cluster goes down.
+
+This test reproduces ScyllaDB OSS issue #2339. We create a
+new cluster with 2 nodes and then stop one of them. We then
+try to connect to the cluster and expect to get the error
+message:
+"Cannot achieve consistency level for cl QUORUM. Requires 1, alive 0"
+"""
+@pytest.mark.asyncio
+async def test_login_message_after_half_of_the_cluster_is_down(manager: ManagerClient) -> None:
+    """Tests the error message after half of the cluster goes down"""
+    config = {
+        'failure_detector_timeout_in_ms': 2000,
+        'authenticator': 'PasswordAuthenticator',
+        'authorizer': 'CassandraAuthorizer',
+        'permissions_validity_in_ms': 0,
+        'permissions_update_interval_in_ms': 0,
+    }
+
+    servers = [await manager.server_add(config=config) for _ in range(2)]
+    cql = manager.get_cql()
+    # system_auth is ALTERed to make the test stable, because by default
+    # system_auth has SimpleStrategy with RF=1, but if RF=1, we cannot make sure
+    # which node has the replica, and we have to kill one node
+    cql.execute(f"ALTER KEYSPACE system_auth WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}}")
+    await manager.server_stop_gracefully(servers[1].server_id)
+    try:
+        """This is expected to fail"""
+        await manager.driver_connect(server=servers[0])
+    except NoHostAvailable as e:
+        message = str([v for k, v in e.args[1].items()][0])
+        expected_msg = "Cannot achieve consistency level for cl QUORUM. Requires 2, alive 1"
+        assert expected_msg in message, f"Expected message: '{expected_msg}', got: '{message}'"
+    else:
+        pytest.fail("Expected NoHostAvailable exception")

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -34,11 +34,12 @@ class ManagerClient():
     """
     # pylint: disable=too-many-public-methods
 
-    def __init__(self, sock_path: str, port: int, use_ssl: bool,
-                 con_gen: Callable[[List[IPAddress], int, bool], CassandraSession]) \
+    def __init__(self, sock_path: str, port: int, use_ssl: bool, auth_provider: Any|None,
+                 con_gen: Callable[[List[IPAddress], int, bool, Any], CassandraSession]) \
                          -> None:
         self.port = port
         self.use_ssl = use_ssl
+        self.auth_provider = auth_provider
         self.con_gen = con_gen
         self.ccluster: Optional[CassandraCluster] = None
         self.cql: Optional[CassandraSession] = None
@@ -57,7 +58,7 @@ class ManagerClient():
         targets = [server] if server else await self.running_servers()
         servers = [s_info.ip_addr for s_info in targets]
         logger.debug("driver connecting to %s", servers)
-        self.ccluster = self.con_gen(servers, self.port, self.use_ssl)
+        self.ccluster = self.con_gen(servers, self.port, self.use_ssl, self.auth_provider)
         self.cql = self.ccluster.connect()
 
     def driver_close(self) -> None:


### PR DESCRIPTION
Propagate `exceptions::unavailable_exception` error message to the client such as cqlsh.

Fixes #2339