### PR TITLE
raft topology: reject replace if the node being replaced is not dead

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2287,7 +2287,7 @@ class topology_coordinator {
 
     std::variant<join_node_response_params::accepted, join_node_response_params::rejected>
     validate_joining_node(const node_to_work_on& node) {
-        if (node.rs->state == node_state::replacing) {
+        if (*node.request == topology_request::replace) {
             auto replaced_id = std::get<replace_param>(node.req_param.value()).replaced_id;
             if (!_topo_sm._topology.normal_nodes.contains(replaced_id)) {
                 return join_node_response_params::rejected {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2295,6 +2295,13 @@ class topology_coordinator {
                     .reason = ::format("Cannot replace node {} because it is not in the 'normal' state", replaced_id),
                 };
             }
+
+            auto replaced_ip = id2ip(locator::host_id(replaced_id.uuid()));
+            if (_gossiper.is_alive(replaced_ip)) {
+                return join_node_response_params::rejected {
+                    .reason = ::format("Cannot replace node {} because it is considered alive", replaced_id),
+                };
+            }
         }
 
         std::vector<sstring> unsupported_features;

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -21,6 +21,7 @@ from test.pylib.scylla_cluster import ReplaceConfig, ScyllaServer
 from cassandra.cluster import Session as CassandraSession  # type: ignore # pylint: disable=no-name-in-module
 from cassandra.cluster import Cluster as CassandraCluster  # type: ignore # pylint: disable=no-name-in-module
 import aiohttp
+import asyncio
 
 
 logger = logging.getLogger(__name__)
@@ -192,6 +193,16 @@ class ManagerClient():
                 data['property_file'] = property_file
             if expected_error:
                 data['expected_error'] = expected_error
+
+            # If we replace, we should wait until other nodes see the node being
+            # replaced as dead because the replace operation can be rejected if
+            # the node being replaced is considered alive. However, we sometimes
+            # do not want to wait, for example, when we test that replace fails
+            # as expected. Therefore, we make waiting optional and default.
+            if replace_cfg and replace_cfg.wait_replaced_dead:
+                replaced_ip = await self.get_host_ip(replace_cfg.replaced_id)
+                await self.others_not_see_server(replaced_ip)
+
             server_info = await self.client.put_json("/cluster/addserver", data, response_type="json",
                                                      timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
         except Exception as exc:
@@ -310,6 +321,12 @@ class ManagerClient():
             if not other_ip in alive_nodes:
                 return True
         await wait_for(_not_sees_another_server, time() + interval, period=.5)
+
+    async def others_not_see_server(self, server_ip: IPAddress, interval: float = 45.):
+        """Wait till a server is seen as dead by all other running servers in the cluster"""
+        others_ips = [srv.ip_addr for srv in await self.running_servers() if srv.ip_addr != server_ip]
+        await asyncio.gather(*(self.server_not_sees_other_server(ip, server_ip, interval)
+                               for ip in others_ips))
 
     async def server_open_log(self, server_id: ServerNum) -> ScyllaLogFile:
         logger.debug("ManagerClient getting log filename for %s", server_id)

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -177,7 +177,8 @@ class ManagerClient():
                          cmdline: Optional[List[str]] = None,
                          config: Optional[dict[str, Any]] = None,
                          property_file: Optional[dict[str, Any]] = None,
-                         start: bool = True) -> ServerInfo:
+                         start: bool = True,
+                         expected_error: Optional[str] = None) -> ServerInfo:
         """Add a new server"""
         try:
             data: dict[str, Any] = {'start': start}
@@ -189,6 +190,8 @@ class ManagerClient():
                 data['config'] = config
             if property_file:
                 data['property_file'] = property_file
+            if expected_error:
+                data['expected_error'] = expected_error
             server_info = await self.client.put_json("/cluster/addserver", data, response_type="json",
                                                      timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
         except Exception as exc:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -48,6 +48,7 @@ class ReplaceConfig(NamedTuple):
     reuse_ip_addr: bool
     use_host_id: bool
     ignore_dead_nodes: list[IPAddress | HostID] = []
+    wait_replaced_dead: bool = True
 
 
 def make_scylla_conf(workdir: pathlib.Path, host_addr: str, seed_addrs: List[str], cluster_name: str) -> dict[str, object]:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -253,14 +253,14 @@ class ScyllaServer:
         self._write_config_file()
 
 
-    async def install_and_start(self, api: ScyllaRESTAPIClient) -> None:
+    async def install_and_start(self, api: ScyllaRESTAPIClient, expected_error: Optional[str] = None) -> None:
         """Setup and start this server"""
         await self.install()
 
         self.logger.info("starting server at host %s in %s...", self.ip_addr, self.workdir.name)
 
         try:
-            await self.start(api)
+            await self.start(api, expected_error)
         except:
             await self.stop()
             raise
@@ -268,6 +268,9 @@ class ScyllaServer:
         if self.cmd:
             self.logger.info("started server at host %s in %s, pid %d", self.ip_addr,
                          self.workdir.name, self.cmd.pid)
+        elif expected_error:
+            self.logger.info("starting server at host %s in %s failed with an expected error",
+                             self.ip_addr, self.workdir.name)
 
     @property
     def is_running(self) -> bool:
@@ -684,7 +687,8 @@ class ScyllaCluster:
                          cmdline: Optional[List[str]] = None,
                          config: Optional[dict[str, Any]] = None,
                          property_file: Optional[dict[str, Any]] = None,
-                         start: bool = True) -> ServerInfo:
+                         start: bool = True,
+                         expected_error: Optional[str] = None) -> ServerInfo:
         """Add a new server to the cluster"""
         self.is_dirty = True
 
@@ -693,10 +697,13 @@ class ScyllaCluster:
         if self.servers and not self.running:
             raise RuntimeError("Can't add the server: all servers in the cluster are stopped")
 
+        assert start or not expected_error, \
+            f"add_server: cannot add a stopped server and expect an error"
+
         extra_config: dict[str, Any] = config.copy() if config else {}
         if replace_cfg:
             replaced_id = replace_cfg.replaced_id
-            assert replaced_id in self.servers, \
+            assert expected_error or replaced_id in self.servers, \
                 f"add_server: replaced id {replaced_id} not found in existing servers"
 
             replaced_srv = self.servers[replaced_id]
@@ -708,9 +715,9 @@ class ScyllaCluster:
             if replace_cfg.ignore_dead_nodes:
                 extra_config['ignore_dead_nodes_for_replace'] = ','.join(replace_cfg.ignore_dead_nodes)
 
-            assert replaced_id not in self.removed, \
+            assert expected_error or replaced_id not in self.removed, \
                 f"add_server: cannot replace removed server {replaced_srv}"
-            assert replaced_id in self.stopped, \
+            assert expected_error or replaced_id in self.stopped, \
                 f"add_server: cannot replace running server {replaced_srv}"
 
         if replace_cfg and replace_cfg.reuse_ip_addr:
@@ -739,7 +746,7 @@ class ScyllaCluster:
             server = self.create_server(params)
             self.logger.info("Cluster %s adding server...", self)
             if start:
-                await server.install_and_start(self.api)
+                await server.install_and_start(self.api, expected_error)
             else:
                 await server.install()
         except Exception as exc:
@@ -749,7 +756,7 @@ class ScyllaCluster:
                 self.leased_ips.remove(ip_addr)
                 await self.host_registry.release_host(Host(ip_addr))
             raise
-        if start:
+        if start and not expected_error:
             self.running[server.server_id] = server
         else:
             self.stopped[server.server_id] = server
@@ -1167,7 +1174,8 @@ class ScyllaClusterManager:
         data = await request.json()
         replace_cfg = ReplaceConfig(**data["replace_cfg"]) if "replace_cfg" in data else None
         s_info = await self.cluster.add_server(replace_cfg, data.get('cmdline'), data.get('config'),
-                                               data.get('property_file'), data.get('start', True))
+                                               data.get('property_file'), data.get('start', True),
+                                               data.get('expected_error', None))
         return {"server_id" : s_info.server_id, "ip_addr": s_info.ip_addr}
 
     async def _cluster_remove_node(self, request: aiohttp.web.Request) -> None:

--- a/test/topology/suite.yaml
+++ b/test/topology/suite.yaml
@@ -12,6 +12,9 @@ run_first:
     - test_tablets
 skip_in_release:
     - test_cluster_features
+    - test_replace_alive_node
     - test_topology_failure_recovery
+skip_in_debug:
+    - test_replace_alive_node
 run_in_release:
     - test_gossiper

--- a/test/topology/test_cluster_features.py
+++ b/test/topology/test_cluster_features.py
@@ -145,7 +145,7 @@ async def test_joining_old_node_fails(manager: ManagerClient) -> None:
     await manager.server_start(new_server_info.server_id, expected_error="Feature check failed")
 
     # Try to replace with a node that doesn't support the feature - should fail
-    await manager.server_stop(servers[0].server_id)
+    await manager.server_stop_gracefully(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id=servers[0].server_id, reuse_ip_addr=False, use_host_id=False)
     new_server_info = await manager.server_add(start=False, replace_cfg=replace_cfg)
     await manager.server_start(new_server_info.server_id, expected_error="Feature check failed")

--- a/test/topology/test_replace_alive_node.py
+++ b/test/topology/test_replace_alive_node.py
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from test.pylib.scylla_cluster import ReplaceConfig
+from test.pylib.manager_client import ManagerClient
+import asyncio
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_replacing_alive_node_fails(manager: ManagerClient) -> None:
+    """Try replacing an alive node and check that it fails"""
+    servers = await manager.running_servers()
+    await asyncio.gather(*(manager.server_sees_others(srv.server_id, len(servers) - 1) for srv in servers))
+
+    # We test for every server because we expect a different error depending on
+    # whether we try to replace the topology coordinator. We want to test both cases.
+    # Both errors contain the expected string below.
+    for srv in servers:
+        replace_cfg = ReplaceConfig(replaced_id = srv.server_id, reuse_ip_addr = False,
+                                    use_host_id = False, wait_replaced_dead = False)
+        await manager.server_add(replace_cfg=replace_cfg,
+                                 expected_error="the topology coordinator rejected request to join the cluster")

--- a/test/topology_custom/suite.yaml
+++ b/test/topology_custom/suite.yaml
@@ -12,6 +12,7 @@ skip_in_release:
   - test_different_group0_ids
 skip_in_debug:
   - test_shutdown_hang
+  - test_replace
   - test_replace_ignore_nodes
   - test_old_ip_notification_repro
   - test_different_group0_ids

--- a/test/topology_custom/test_replace.py
+++ b/test/topology_custom/test_replace.py
@@ -16,7 +16,7 @@ import pytest
 @pytest.mark.asyncio
 async def test_replace_different_ip(manager: ManagerClient) -> None:
     """Replace an existing node with new node using a different IP address"""
-    servers = [await manager.server_add() for _ in range(3)]
+    servers = [await manager.server_add(config={'failure_detector_timeout_in_ms': 2000}) for _ in range(3)]
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = False)
     await manager.server_add(replace_cfg)
@@ -25,7 +25,7 @@ async def test_replace_different_ip(manager: ManagerClient) -> None:
 @pytest.mark.asyncio
 async def test_replace_different_ip_using_host_id(manager: ManagerClient) -> None:
     """Replace an existing node with new node reusing the replaced node host id"""
-    servers = [await manager.server_add() for _ in range(3)]
+    servers = [await manager.server_add(config={'failure_detector_timeout_in_ms': 2000}) for _ in range(3)]
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = True)
     await manager.server_add(replace_cfg)
@@ -34,7 +34,7 @@ async def test_replace_different_ip_using_host_id(manager: ManagerClient) -> Non
 @pytest.mark.asyncio
 async def test_replace_reuse_ip(manager: ManagerClient) -> None:
     """Replace an existing node with new node using the same IP address"""
-    servers = [await manager.server_add() for _ in range(3)]
+    servers = [await manager.server_add(config={'failure_detector_timeout_in_ms': 2000}) for _ in range(3)]
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = True, use_host_id = False)
     await manager.server_add(replace_cfg)
@@ -43,7 +43,7 @@ async def test_replace_reuse_ip(manager: ManagerClient) -> None:
 @pytest.mark.asyncio
 async def test_replace_reuse_ip_using_host_id(manager: ManagerClient) -> None:
     """Replace an existing node with new node using the same IP address and same host id"""
-    servers = [await manager.server_add() for _ in range(3)]
+    servers = [await manager.server_add(config={'failure_detector_timeout_in_ms': 2000}) for _ in range(3)]
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = True, use_host_id = True)
     await manager.server_add(replace_cfg)

--- a/test/topology_custom/test_replace.py
+++ b/test/topology_custom/test_replace.py
@@ -16,7 +16,7 @@ import pytest
 @pytest.mark.asyncio
 async def test_replace_different_ip(manager: ManagerClient) -> None:
     """Replace an existing node with new node using a different IP address"""
-    servers = await manager.running_servers()
+    servers = [await manager.server_add() for _ in range(3)]
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = False)
     await manager.server_add(replace_cfg)
@@ -25,7 +25,7 @@ async def test_replace_different_ip(manager: ManagerClient) -> None:
 @pytest.mark.asyncio
 async def test_replace_different_ip_using_host_id(manager: ManagerClient) -> None:
     """Replace an existing node with new node reusing the replaced node host id"""
-    servers = await manager.running_servers()
+    servers = [await manager.server_add() for _ in range(3)]
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = True)
     await manager.server_add(replace_cfg)
@@ -34,7 +34,7 @@ async def test_replace_different_ip_using_host_id(manager: ManagerClient) -> Non
 @pytest.mark.asyncio
 async def test_replace_reuse_ip(manager: ManagerClient) -> None:
     """Replace an existing node with new node using the same IP address"""
-    servers = await manager.running_servers()
+    servers = [await manager.server_add() for _ in range(3)]
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = True, use_host_id = False)
     await manager.server_add(replace_cfg)
@@ -43,7 +43,7 @@ async def test_replace_reuse_ip(manager: ManagerClient) -> None:
 @pytest.mark.asyncio
 async def test_replace_reuse_ip_using_host_id(manager: ManagerClient) -> None:
     """Replace an existing node with new node using the same IP address and same host id"""
-    servers = await manager.running_servers()
+    servers = [await manager.server_add() for _ in range(3)]
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = True, use_host_id = True)
     await manager.server_add(replace_cfg)

--- a/test/topology_experimental_raft/test_raft_ignore_nodes.py
+++ b/test/topology_experimental_raft/test_raft_ignore_nodes.py
@@ -24,7 +24,7 @@ async def test_raft_replace_ignore_nodes(manager: ManagerClient) -> None:
        we want to run it only in dev mode.
     """
     logger.info(f"Booting initial cluster")
-    servers = [await manager.server_add() for _ in range(7)]
+    servers = [await manager.server_add(config={'failure_detector_timeout_in_ms': 2000}) for _ in range(7)]
     s1_id = await manager.get_host_id(servers[1].server_id)
     s2_id = await manager.get_host_id(servers[2].server_id)
     logger.info(f"Stopping servers {servers[:3]}")


### PR DESCRIPTION
The replace operation is defined to succeed only if the node being
replaced is dead. We should reject this operation when the failure
detector considers the node being replaced alive.

Apart from adding this change, this PR adds a test case -
`test_replacing_alive_node_fails` - that verifies it. A few testing
framework adjustments were necessary to implement this test and
to avoid flakiness in other tests that use the replace operation after
the change. From now, we need to ensure that all nodes see the
node being replaced as dead before starting the replace. Otherwise,
the check added in this PR could reject the replace.

Additionally, this PR changes the replace procedure in a way that
if the replacing node reuses the IP of the node being replaced, other
nodes can see it as alive only after the topology coordinator accepts
its join request. The replacing node may become alive before the
topology coordinator checks if the node being replaced is dead. If
that happens and the replacing node reuses the IP of the node being
replaced, the topology coordinator cannot know which of these two
nodes is alive and whether it should reject the join request.

Fixes #15863