### PR TITLE
test/pylib: increase control connection timeout in cql_is_up

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -362,6 +362,7 @@ class ScyllaServer:
                          contact_points=[self.ip_addr],
                          # This is the latest version Scylla supports
                          protocol_version=4,
+                         control_connection_timeout=self.TOPOLOGY_TIMEOUT,
                          auth_provider=auth) as cluster:
                 with cluster.connect() as session:
                     connected = True
@@ -371,6 +372,7 @@ class ScyllaServer:
                     self.control_cluster = Cluster(execution_profiles=
                                                         {EXEC_PROFILE_DEFAULT: profile},
                                                    contact_points=[self.ip_addr],
+                                                   control_connection_timeout=self.TOPOLOGY_TIMEOUT,
                                                    auth_provider=auth)
                     self.control_connection = self.control_cluster.connect()
                     return CqlUpState.QUERIED


### PR DESCRIPTION
After starting the associated node, ScyllaServer waits until the node starts serving CQL requests. It does that by periodically trying to establish a python driver session to the node.

During session establishment, the driver tries to fetch some metadata from the system tables, and uses a pretty short timeout to do so (by default it's 2 seconds). When running tests in debug mode, this timeout can prove to be too short and may prevent the testing framework from noticing that the node came up.

Fix the problem by increasing the timeout. Currently, after the session is established, a query is sent in order to further verify that the session works and it uses a very generous timeout of 1000 seconds to do so - use the same timeout for internal queries in the python driver.

Fixes: scylladb/scylladb#15898