### PR TITLE
Sanitize usage of make_sstable_easy+make_memtable in tests

### DIFF
--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -2557,10 +2557,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
 SEASTAR_THREAD_TEST_CASE(test_compacting_reader_as_mutation_source) {
     auto make_populate = [] (bool single_fragment_buffer) {
         return [single_fragment_buffer] (schema_ptr s, const std::vector<mutation>& mutations, gc_clock::time_point query_time) mutable {
-            auto mt = make_lw_shared<replica::memtable>(s);
-            for (auto& mut : mutations) {
-                mt->apply(mut);
-            }
+            auto mt = make_memtable(s, mutations);
             return mutation_source([=] (
                     schema_ptr s,
                     reader_permit permit,
@@ -2684,10 +2681,7 @@ SEASTAR_THREAD_TEST_CASE(test_compacting_reader_is_consistent_with_compaction) {
 
 SEASTAR_THREAD_TEST_CASE(test_auto_paused_evictable_reader_is_mutation_source) {
     auto make_populate = [] (schema_ptr s, const std::vector<mutation>& mutations, gc_clock::time_point query_time) {
-        auto mt = make_lw_shared<replica::memtable>(s);
-        for (auto& mut : mutations) {
-            mt->apply(mut);
-        }
+        auto mt = make_memtable(s, mutations);
         return mutation_source([=] (
                 schema_ptr s,
                 reader_permit permit,
@@ -2764,10 +2758,7 @@ SEASTAR_THREAD_TEST_CASE(test_manual_paused_evictable_reader_is_mutation_source)
     };
 
     auto make_populate = [] (schema_ptr s, const std::vector<mutation>& mutations, gc_clock::time_point query_time) {
-        auto mt = make_lw_shared<replica::memtable>(s);
-        for (auto& mut : mutations) {
-            mt->apply(mut);
-        }
+        auto mt = make_memtable(s, mutations);
         return mutation_source([=] (
                 schema_ptr s,
                 reader_permit permit,

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -20,6 +20,7 @@
 #include "service/storage_proxy.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
 #include "test/lib/scylla_test_case.hh"
+#include "test/lib/sstable_utils.hh"
 #include "readers/mutation_fragment_v1_stream.hh"
 
 // Helper mutation_fragment_queue that stores the received stream of
@@ -85,9 +86,8 @@ repair_rows_on_wire make_random_repair_rows_on_wire(random_mutation_generator& g
 
     for (mutation& mut : muts) {
         partition_key pk = mut.key();
-        auto m2 = make_lw_shared<replica::memtable>(s);
+        auto m2 = make_memtable(s, {mut});
         m->apply(mut);
-        m2->apply(mut);
         auto reader = mutation_fragment_v1_stream(m2->make_flat_reader(s, permit));
         std::list<frozen_mutation_fragment> mfs;
         reader.consume_pausable([s, &mfs](mutation_fragment mf) {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2181,10 +2181,7 @@ SEASTAR_TEST_CASE(sstable_validate_test) {
         auto rd = make_flat_mutation_reader_from_fragments(schema, permit, std::move(frags));
         auto config = env.manager().configure_writer();
         config.validation_level = mutation_fragment_stream_validation_level::partition_region; // this test violates key order on purpose
-        auto sst = env.make_sstable(schema);
-        sst->write_components(std::move(rd), local_keys.size(), schema, config, encoding_stats{}).get();
-        sst->load(sst->get_schema()->get_sharder()).get();
-        return sst;
+        return make_sstable_easy(env, std::move(rd), std::move(config), sstables::get_highest_sstable_version(), local_keys.size());
     };
 
     auto info = make_lw_shared<compaction_data>();

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -28,7 +28,7 @@ using namespace std::chrono_literals;
 static
 mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, sstring dir, std::vector<mutation> mutations,
         sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
-    return as_mutation_source(make_sstable(env, s, dir, std::move(mutations), cfg, version, query_time));
+    return make_sstable(env, s, dir, std::move(mutations), cfg, version, query_time)->as_mutation_source();
 }
 
 static void consume_all(flat_mutation_reader_v2& rd) {

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -28,7 +28,12 @@ using namespace std::chrono_literals;
 static
 mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, sstring dir, std::vector<mutation> mutations,
         sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
-    return make_sstable(env, s, dir, std::move(mutations), cfg, version, query_time)->as_mutation_source();
+    auto sst = env.make_sstable(s, dir, env.new_generation(), version, sstable_format_types::big, default_sstable_buffer_size, query_time);
+    auto mt = make_memtable(s, mutations);
+    auto mr = mt->make_flat_reader(s, env.make_reader_permit());
+    sst->write_components(std::move(mr), mutations.size(), s, cfg, mt->get_encoding_stats()).get();
+    sst->load(s->get_sharder()).get();
+    return sst->as_mutation_source();
 }
 
 static void consume_all(flat_mutation_reader_v2& rd) {

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -116,8 +116,6 @@ SEASTAR_TEST_CASE(datafile_generation_11) {
     return test_env::do_with_async([] (test_env& env) {
         auto s = complex_schema();
 
-        auto mt = make_lw_shared<replica::memtable>(s);
-
         const column_definition& set_col = *s->get_column_definition("reg_set");
         const column_definition& static_set_col = *s->get_column_definition("static_collection");
 
@@ -144,8 +142,7 @@ SEASTAR_TEST_CASE(datafile_generation_11) {
 
         m2.set_clustered_cell(c_key, set_col, set_mut_single.serialize(*set_col.type));
 
-        mt->apply(std::move(m));
-        mt->apply(std::move(m2));
+        auto mt = make_memtable(s, {std::move(m), std::move(m2)});
 
         auto verifier = [s, set_col, c_key] (auto& mutation) {
             auto& mp = mutation->partition();
@@ -198,8 +195,6 @@ SEASTAR_TEST_CASE(datafile_generation_12) {
     return test_env::do_with_async([] (test_env& env) {
         auto s = complex_schema();
 
-        auto mt = make_lw_shared<replica::memtable>(s);
-
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         auto cp = clustering_key_prefix::from_exploded(*s, {to_bytes("c1")});
 
@@ -207,7 +202,8 @@ SEASTAR_TEST_CASE(datafile_generation_12) {
 
         tombstone tomb(api::new_timestamp(), gc_clock::now());
         m.partition().apply_delete(*s, cp, tomb);
-        mt->apply(std::move(m));
+
+        auto mt = make_memtable(s, {std::move(m)});
 
         verify_mutation(env, env.make_sstable(s), mt, "key1", [&] (mutation_opt& mutation) {
             auto& mp = mutation->partition();
@@ -226,8 +222,6 @@ static future<> sstable_compression_test(compressor_ptr c) {
         builder.set_compressor_params(c);
         auto s = builder.build(schema_builder::compact_storage::no);
 
-        auto mtp = make_lw_shared<replica::memtable>(s);
-
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         auto cp = clustering_key_prefix::from_exploded(*s, {to_bytes("c1")});
 
@@ -235,7 +229,7 @@ static future<> sstable_compression_test(compressor_ptr c) {
 
         tombstone tomb(api::new_timestamp(), gc_clock::now());
         m.partition().apply_delete(*s, cp, tomb);
-        mtp->apply(std::move(m));
+        auto mtp = make_memtable(s, {std::move(m)});
 
         verify_mutation(env, env.make_sstable(s), mtp, "key1", [&] (mutation_opt& mutation) {
             auto& mp = mutation->partition();
@@ -304,8 +298,6 @@ SEASTAR_TEST_CASE(datafile_generation_37) {
     return test_env::do_with_async([] (test_env& env) {
         auto s = compact_simple_dense_schema();
 
-        auto mtp = make_lw_shared<replica::memtable>(s);
-
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         mutation m(s, key);
 
@@ -313,7 +305,7 @@ SEASTAR_TEST_CASE(datafile_generation_37) {
         const column_definition& cl2 = *s->get_column_definition("cl2");
 
         m.set_clustered_cell(c_key, cl2, make_atomic_cell(bytes_type, bytes_type->decompose(data_value(to_bytes("cl2")))));
-        mtp->apply(std::move(m));
+        auto mtp = make_memtable(s, {std::move(m)});
 
         verify_mutation(env, env.make_sstable(s), mtp, "key1", [&] (mutation_opt& mutation) {
             auto& mp = mutation->partition();
@@ -330,8 +322,6 @@ SEASTAR_TEST_CASE(datafile_generation_38) {
     return test_env::do_with_async([] (test_env& env) {
         auto s = compact_dense_schema();
 
-        auto mtp = make_lw_shared<replica::memtable>(s);
-
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         mutation m(s, key);
 
@@ -339,7 +329,7 @@ SEASTAR_TEST_CASE(datafile_generation_38) {
 
         const column_definition& cl3 = *s->get_column_definition("cl3");
         m.set_clustered_cell(c_key, cl3, make_atomic_cell(bytes_type, bytes_type->decompose(data_value(to_bytes("cl3")))));
-        mtp->apply(std::move(m));
+        auto mtp = make_memtable(s, {std::move(m)});
 
         verify_mutation(env, env.make_sstable(s), mtp, "key1", [&] (mutation_opt& mutation) {
             auto& mp = mutation->partition();
@@ -355,8 +345,6 @@ SEASTAR_TEST_CASE(datafile_generation_39) {
     return test_env::do_with_async([] (test_env& env) {
         auto s = compact_sparse_schema();
 
-        auto mtp = make_lw_shared<replica::memtable>(s);
-
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         mutation m(s, key);
 
@@ -366,7 +354,7 @@ SEASTAR_TEST_CASE(datafile_generation_39) {
         m.set_clustered_cell(c_key, cl1, make_atomic_cell(bytes_type, bytes_type->decompose(data_value(to_bytes("cl1")))));
         const column_definition& cl2 = *s->get_column_definition("cl2");
         m.set_clustered_cell(c_key, cl2, make_atomic_cell(bytes_type, bytes_type->decompose(data_value(to_bytes("cl2")))));
-        mtp->apply(std::move(m));
+        auto mtp = make_memtable(s, {std::move(m)});
 
         verify_mutation(env, env.make_sstable(s), mtp, "key1", [&] (mutation_opt& mutation) {
             auto& mp = mutation->partition();
@@ -382,15 +370,13 @@ SEASTAR_TEST_CASE(datafile_generation_41) {
         auto s = make_shared_schema({}, some_keyspace, some_column_family,
             {{"p1", utf8_type}}, {{"c1", utf8_type}}, {{"r1", int32_type}, {"r2", int32_type}}, {}, utf8_type);
 
-        auto mt = make_lw_shared<replica::memtable>(s);
-
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         auto c_key = clustering_key::from_exploded(*s, {to_bytes("c1")});
         mutation m(s, key);
 
         tombstone tomb(api::new_timestamp(), gc_clock::now());
         m.partition().apply_delete(*s, std::move(c_key), tomb);
-        mt->apply(std::move(m));
+        auto mt = make_memtable(s, {std::move(m)});
 
         verify_mutation(env, env.make_sstable(s), mt, "key1", [&] (mutation_opt& mutation) {
             auto& mp = mutation->partition();

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1687,8 +1687,7 @@ SEASTAR_TEST_CASE(test_repeated_tombstone_skipping) {
         for (auto&& mf : fragments) {
             mut.apply(mf);
         }
-        auto sst = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(table.schema(), std::move(permit), std::move(mut)), cfg, version);
-        auto ms = as_mutation_source(sst);
+        auto ms = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(table.schema(), std::move(permit), std::move(mut)), cfg, version)->as_mutation_source();
 
         for (uint32_t i = 3; i < seq; i++) {
             auto ck1 = table.make_ckey(1);
@@ -1736,9 +1735,7 @@ SEASTAR_TEST_CASE(test_skipping_using_index) {
         sstable_writer_config cfg = env.manager().configure_writer();
         cfg.promoted_index_block_size = 1; // So that every fragment is indexed
         cfg.promoted_index_auto_scale_threshold = 0; // disable auto-scaling
-        auto sst = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(table.schema(), env.make_reader_permit(), partitions), cfg, version);
-
-        auto ms = as_mutation_source(sst);
+        auto ms = make_sstable_easy(env, make_flat_mutation_reader_from_mutations_v2(table.schema(), env.make_reader_permit(), partitions), cfg, version)->as_mutation_source();
         auto rd = ms.make_reader_v2(table.schema(),
             env.make_reader_permit(),
             query::full_partition_range,

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -1611,10 +1611,7 @@ SEASTAR_TEST_CASE(writer_handles_subsequent_range_tombstone_changes_without_tomb
             deferred_close dc1{input_reader};
             sstable_writer_config cfg = env.manager().configure_writer();
             auto _ = env.tempdir().make_sweeper();
-            shared_sstable sstable = env.make_sstable(s);
-            encoding_stats es;
-            sstable->write_components(std::move(input_reader), 1, s, cfg, es).get();
-            sstable->load(sstable->get_schema()->get_sharder()).get();
+            auto sstable = make_sstable_easy(env, std::move(input_reader), cfg);
 
             mutation_fragment_stream_validating_filter f{"mutation_order_violation_test", *s, mutation_fragment_stream_validation_level::clustering_key};
             auto sstable_reader = sstable->make_reader(s, sem.make_permit(), query::full_partition_range, s->full_slice());

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -393,7 +393,7 @@ SEASTAR_TEST_CASE(read_partial_range_2) {
 static
 mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, std::vector<mutation> mutations,
         sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
-    return as_mutation_source(make_sstable(env, s, std::move(mutations), env.manager().configure_writer(), version, query_time));
+    return make_sstable(env, s, std::move(mutations), env.manager().configure_writer(), version, query_time)->as_mutation_source();
 }
 
 SEASTAR_TEST_CASE(test_sstable_can_write_and_read_range_tombstone) {

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -393,7 +393,7 @@ SEASTAR_TEST_CASE(read_partial_range_2) {
 static
 mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, std::vector<mutation> mutations,
         sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
-    return make_sstable(env, s, std::move(mutations), env.manager().configure_writer(), version, query_time)->as_mutation_source();
+    return make_sstable_easy(env, make_memtable(s, mutations), env.manager().configure_writer(), version, mutations.size(), query_time)->as_mutation_source();
 }
 
 SEASTAR_TEST_CASE(test_sstable_can_write_and_read_range_tombstone) {

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -438,12 +438,6 @@ inline void match_collection_element(const std::pair<bytes, atomic_cell>& elemen
 
 }
 
-inline
-::mutation_source as_mutation_source(sstables::shared_sstable sst) {
-    return sst->as_mutation_source();
-}
-
-
 inline dht::decorated_key make_dkey(schema_ptr s, bytes b)
 {
     auto sst_key = sstables::key::from_bytes(b);

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -837,11 +837,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
 
         auto permit = sem.obtain_permit(schema.get(), get_name(), replica::new_reader_base_cost, db::no_timeout, {}).get0();
 
-        auto mt = make_lw_shared<replica::memtable>(schema);
-        for (const auto& mut : muts) {
-            mt->apply(mut);
-        }
-
+        auto mt = make_memtable(schema, muts);
         auto p = make_manually_paused_evictable_reader_v2(
                 mt->as_data_source(),
                 schema,
@@ -939,8 +935,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering_with_random_mutati
     reader_concurrency_semaphore sem(reader_concurrency_semaphore::for_tests{}, get_name(), 1, replica::new_reader_base_cost);
     auto stop_sem = deferred_stop(sem);
     const abort_source as;
-    auto mt = make_lw_shared<replica::memtable>(schema);
-    mt->apply(mut);
+    auto mt = make_memtable(schema, {mut});
     auto permit = sem.obtain_permit(schema.get(), get_name(), replica::new_reader_base_cost, db::no_timeout, {}).get0();
     auto p = make_manually_paused_evictable_reader_v2(
             mt->as_data_source(),

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -85,17 +85,6 @@ sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, s
     return sst;
 }
 
-shared_sstable make_sstable(sstables::test_env& env, schema_ptr s, sstring dir, std::vector<mutation> mutations,
-        sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time) {
-    fs::path dir_path(dir);
-    auto mt = make_memtable(s, mutations);
-    auto sst = env.make_sstable(s, dir_path.string(), env.new_generation(), version, sstable_format_types::big, default_sstable_buffer_size, query_time);
-    auto mr = mt->make_flat_reader(s, env.make_reader_permit());
-    sst->write_components(std::move(mr), mutations.size(), s, cfg, mt->get_encoding_stats()).get();
-    sst->load(s->get_sharder()).get();
-    return sst;
-}
-
 shared_sstable make_sstable_easy(test_env& env, flat_mutation_reader_v2 rd, sstable_writer_config cfg,
         sstables::generation_type gen, const sstables::sstable::version_types version, int expected_partition, gc_clock::time_point query_time) {
     auto s = rd.schema();

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -41,11 +41,6 @@ inline future<> write_memtable_to_sstable_for_test(replica::memtable& mt, sstabl
 shared_sstable make_sstable(sstables::test_env& env, schema_ptr s, sstring dir, std::vector<mutation> mutations,
         sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now());
 
-inline shared_sstable make_sstable(sstables::test_env& env, schema_ptr s, std::vector<mutation> mutations,
-        sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
-    return make_sstable(env, std::move(s), env.tempdir().path().native(), std::move(mutations), std::move(cfg), version, query_time);
-}
-
 namespace sstables {
 
 using sstable_ptr = shared_sstable;

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -38,9 +38,6 @@ inline future<> write_memtable_to_sstable_for_test(replica::memtable& mt, sstabl
     return write_memtable_to_sstable(mt, sst, sst->manager().configure_writer("memtable"));
 }
 
-shared_sstable make_sstable(sstables::test_env& env, schema_ptr s, sstring dir, std::vector<mutation> mutations,
-        sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now());
-
 namespace sstables {
 
 using sstable_ptr = shared_sstable;

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -274,3 +274,5 @@ inline shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::me
         const sstable::version_types version = sstables::get_highest_sstable_version(), int estimated_partitions = 1, gc_clock::time_point query_time = gc_clock::now()) {
     return make_sstable_easy(env, std::move(mt), std::move(cfg), env.new_generation(), version, estimated_partitions, query_time);
 }
+
+lw_shared_ptr<replica::memtable> make_memtable(schema_ptr s, const std::vector<mutation>& muts);


### PR DESCRIPTION
The helper makes sstable, writes mutations into it and loads one. Internally it uses the make_memtable() helper that prepares a memtable out of a vector of mutations. There are many test cases that don't use these facilities generating some code duplication.

The make_sstable() wrapper around make_sstable_easy() is removed along the way.