### PR TITLE
sstables: Harden estimate_droppable_tombstone_ratio() interface

### DIFF
--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -66,8 +66,8 @@ bool compaction_strategy_impl::worth_dropping_tombstones(const shared_sstable& s
     if (db_clock::now()-_tombstone_compaction_interval < sst->data_file_write_time()) {
         return false;
     }
-    auto gc_before = sst->get_gc_before_for_drop_estimation(compaction_time, t.get_tombstone_gc_state(), t.schema());
-    return sst->estimate_droppable_tombstone_ratio(gc_before) >= _tombstone_threshold;
+    auto droppable_ratio = sst->estimate_droppable_tombstone_ratio(compaction_time, t.get_tombstone_gc_state(), t.schema());
+    return droppable_ratio >= _tombstone_threshold;
 }
 
 uint64_t compaction_strategy_impl::adjust_partition_estimate(const mutation_source_metadata& ms_meta, uint64_t partition_estimate, schema_ptr schema) const {

--- a/compaction/leveled_compaction_strategy.cc
+++ b/compaction/leveled_compaction_strategy.cc
@@ -58,9 +58,9 @@ compaction_descriptor leveled_compaction_strategy::get_sstables_for_compaction(t
             continue;
         }
         auto& sst = *std::max_element(sstables.begin(), sstables.end(), [&] (auto& i, auto& j) {
-            auto gc_before1 = i->get_gc_before_for_drop_estimation(compaction_time, table_s.get_tombstone_gc_state(), table_s.schema());
-            auto gc_before2 = j->get_gc_before_for_drop_estimation(compaction_time, table_s.get_tombstone_gc_state(), table_s.schema());
-            return i->estimate_droppable_tombstone_ratio(gc_before1) < j->estimate_droppable_tombstone_ratio(gc_before2);
+            auto ratio_i = i->estimate_droppable_tombstone_ratio(compaction_time, table_s.get_tombstone_gc_state(), table_s.schema());
+            auto ratio_j = j->estimate_droppable_tombstone_ratio(compaction_time, table_s.get_tombstone_gc_state(), table_s.schema());
+            return ratio_i < ratio_j;
         });
         return sstables::compaction_descriptor({ sst }, sst->get_sstable_level());
     }

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -92,8 +92,8 @@ uint64_t sstable_run::data_size() const {
     return boost::accumulate(_all | boost::adaptors::transformed(std::mem_fn(&sstable::data_size)), uint64_t(0));
 }
 
-double sstable_run::estimate_droppable_tombstone_ratio(gc_clock::time_point gc_before) const {
-    auto estimate_sum = boost::accumulate(_all | boost::adaptors::transformed(std::bind(&sstable::estimate_droppable_tombstone_ratio, std::placeholders::_1, gc_before)), double(0));
+double sstable_run::estimate_droppable_tombstone_ratio(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state, const schema_ptr& s) const {
+    auto estimate_sum = boost::accumulate(_all | boost::adaptors::transformed(std::bind(&sstable::estimate_droppable_tombstone_ratio, std::placeholders::_1, compaction_time, gc_state, s)), double(0));
     return _all.size() ? estimate_sum / _all.size() : double(0);
 }
 

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -51,7 +51,7 @@ public:
     // Data size of the whole run, meaning it's a sum of the data size of all its fragments.
     uint64_t data_size() const;
     const sstable_set& all() const { return _all; }
-    double estimate_droppable_tombstone_ratio(gc_clock::time_point gc_before) const;
+    double estimate_droppable_tombstone_ratio(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state, const schema_ptr& s) const;
     run_id run_identifier() const;
 };
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1233,7 +1233,9 @@ future<> sstable::load_first_and_last_position_in_partition() {
     _last_partition_last_position = std::move(*last_pos_opt);
 }
 
-double sstable::estimate_droppable_tombstone_ratio(gc_clock::time_point gc_before) const {
+double sstable::estimate_droppable_tombstone_ratio(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state, const schema_ptr& s) const {
+    auto gc_before = get_gc_before_for_drop_estimation(compaction_time, gc_state, s);
+
     auto& st = get_stats_metadata();
     auto estimated_count = st.estimated_cells_count.mean() * st.estimated_cells_count.count();
     if (estimated_count > 0) {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -899,8 +899,9 @@ public:
     }
 
     // Gets ratio of droppable tombstone. A tombstone is considered droppable here
-    // for cells expired before gc_before and regular tombstones older than gc_before.
-    double estimate_droppable_tombstone_ratio(gc_clock::time_point gc_before) const;
+    // for cells and tombstones expired before the time point "GC before", which
+    // is the point before which expiring data can be purged.
+    double estimate_droppable_tombstone_ratio(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state, const schema_ptr& s) const;
 
     // get sstable open info from a loaded sstable, which can be used to quickly open a sstable
     // at another shard.


### PR DESCRIPTION
The interface is fragile because the user may incorrectly use the wrong "gc before". Given that sstable knows how to properly calculate "gc before", let's do it in estimate__d__t__r(), leaving no room for mistakes.

sstable_run's variant was also changed to conform to new interface, allowing ICS to properly estimate droppable ratio, using GC before that is calculated using each sstable's range. That's important for upcoming tablets, as we want to query only the range that belongs to a particular tablet in the repair history table.