### PR TITLE
Nodetool additional commands 4/N

### DIFF
--- a/test/nodetool/README.md
+++ b/test/nodetool/README.md
@@ -1,0 +1,23 @@
+# Front-end tests for nodetool
+
+The tests in this directory excercise the nodetool client itself, mocking the API backend.
+This allows for testing all combinations of all supported options, and still keeping the tests quick.
+
+The tests can be run against both the scylla-native nodetool (default), or the inherited, C\*-based nodetool.
+
+Run all tests against the scylla-native nodetool:
+```
+pytest --nodetool=scylla .
+```
+
+You can specify the path to the scylla binary with the `--nodetool-path` option. By default the tests will pick up the ScyllaDB executable, that is appropriate for the `--mode` option (defaults to `dev`).
+
+Run all tests against the C* nodetool:
+```
+pytest --nodetool=cassandra .
+```
+
+Again, you can specify the path to the nodetool binary with `--nodetool-path` option. By default, `<scylladb.git>/tools/java/bin/nodetool` will be used.
+When running the test against the java-nodeotol, you can specify the path to JMX with `--jmx-path` option. By default, `<scylladb.git>/tools/jmx/scripts/scylla-jmx` will be used.
+
+If you add new tests, make sure to run all tess against both nodetool implementations, to avoid regressions. Note that CI/promotion will only run the tests against the scylla-native nodetool.

--- a/test/nodetool/test_autocompaction.py
+++ b/test/nodetool/test_autocompaction.py
@@ -45,3 +45,42 @@ def test_disableautocompaction_none_existent_keyspace(nodetool):
             {"expected_requests": [expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"])]},
             ["nodetool: Keyspace [non_existent_ks] does not exist.",
              "error processing arguments: keyspace non_existent_ks does not exist"])
+
+
+def test_enableautocompaction(nodetool):
+    nodetool("enableautocompaction", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"],
+                         multiple=expected_request.MULTIPLE),
+        expected_request("POST", "/storage_service/auto_compaction/ks1"),
+        expected_request("POST", "/storage_service/auto_compaction/ks2")
+    ])
+
+
+def test_enableautocompaction_one_keyspace(nodetool):
+    nodetool("enableautocompaction", "ks1", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
+        expected_request("POST", "/storage_service/auto_compaction/ks1")
+    ])
+
+
+def test_enableautocompaction_one_table(nodetool):
+    nodetool("enableautocompaction", "ks1", "tbl1", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
+        expected_request("POST", "/storage_service/auto_compaction/ks1", params={"cf": "tbl1"})
+    ])
+
+
+def test_enableautocompaction_two_tables(nodetool):
+    nodetool("enableautocompaction", "ks1", "tbl1", "tbl2", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
+        expected_request("POST", "/storage_service/auto_compaction/ks1", params={"cf": "tbl1,tbl2"})
+    ])
+
+
+def test_enableautocompaction_none_existent_keyspace(nodetool):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("enableautocompaction", "non_existent_ks"),
+            {"expected_requests": [expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"])]},
+            ["nodetool: Keyspace [non_existent_ks] does not exist.",
+             "error processing arguments: keyspace non_existent_ks does not exist"])

--- a/test/nodetool/test_autocompaction.py
+++ b/test/nodetool/test_autocompaction.py
@@ -1,0 +1,47 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from rest_api_mock import expected_request
+import utils
+
+
+def test_disableautocompaction(nodetool):
+    nodetool("disableautocompaction", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"],
+                         multiple=expected_request.MULTIPLE),
+        expected_request("DELETE", "/storage_service/auto_compaction/ks1"),
+        expected_request("DELETE", "/storage_service/auto_compaction/ks2")
+    ])
+
+
+def test_disableautocompaction_one_keyspace(nodetool):
+    nodetool("disableautocompaction", "ks1", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
+        expected_request("DELETE", "/storage_service/auto_compaction/ks1")
+    ])
+
+
+def test_disableautocompaction_one_table(nodetool):
+    nodetool("disableautocompaction", "ks1", "tbl1", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
+        expected_request("DELETE", "/storage_service/auto_compaction/ks1", params={"cf": "tbl1"})
+    ])
+
+
+def test_disableautocompaction_two_tables(nodetool):
+    nodetool("disableautocompaction", "ks1", "tbl1", "tbl2", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
+        expected_request("DELETE", "/storage_service/auto_compaction/ks1", params={"cf": "tbl1,tbl2"})
+    ])
+
+
+def test_disableautocompaction_none_existent_keyspace(nodetool):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("disableautocompaction", "non_existent_ks"),
+            {"expected_requests": [expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"])]},
+            ["nodetool: Keyspace [non_existent_ks] does not exist.",
+             "error processing arguments: keyspace non_existent_ks does not exist"])

--- a/test/nodetool/test_drain.py
+++ b/test/nodetool/test_drain.py
@@ -1,0 +1,13 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from rest_api_mock import expected_request
+
+
+def test_drain(nodetool):
+    nodetool("drain", expected_requests=[
+        expected_request("POST", "/storage_service/drain")
+    ])

--- a/test/nodetool/test_flush.py
+++ b/test/nodetool/test_flush.py
@@ -1,0 +1,38 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from rest_api_mock import expected_request
+import utils
+
+
+def test_flush(nodetool):
+    nodetool("flush", "ks1", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
+        expected_request("POST", "/storage_service/keyspace_flush/ks1")
+    ])
+
+
+def test_flush_one_table(nodetool):
+    nodetool("flush", "ks1", "tbl1", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
+        expected_request("POST", "/storage_service/keyspace_flush/ks1", params={"cf": "tbl1"})
+    ])
+
+
+def test_flush_two_tables(nodetool):
+    nodetool("flush", "ks1", "tbl1", "tbl2", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
+        expected_request("POST", "/storage_service/keyspace_flush/ks1", params={"cf": "tbl1,tbl2"})
+    ])
+
+
+def test_flush_none_existent_keyspace(nodetool):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("flush", "non_existent_ks"),
+            {"expected_requests": [expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"])]},
+            ["nodetool: Keyspace [non_existent_ks] does not exist.",
+             "error processing arguments: keyspace non_existent_ks does not exist"])

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -324,6 +324,10 @@ void disablegossip_operation(scylla_rest_client& client, const bpo::variables_ma
     client.del("/storage_service/gossiping");
 }
 
+void drain_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    client.post("/storage_service/drain");
+}
+
 void enablebackup_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     client.post("/storage_service/incremental_backups", {{"value", "true"}});
 }
@@ -718,6 +722,23 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
 )",
             },
             disablegossip_operation
+        },
+        {
+            {
+                "drain",
+                "Drain the node (stop accepting writes and flush all tables)",
+R"(
+Flushes all memtables from a node to the SSTables that are on the disk. Scylla
+stops listening for connections from the client and other nodes. You need to
+restart Scylla after running this command. This command is usually executed
+before upgrading a node to a new version or before any maintenance action is
+performed. When you want to simply flush memtables to disk, use the nodetool
+flush command.
+
+Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/drain.html
+)",
+            },
+            drain_operation
         },
         {
             {

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -108,23 +108,40 @@ std::vector<sstring> get_keyspaces(scylla_rest_client& client, std::optional<sst
     return keyspaces;
 }
 
+struct keyspace_and_tables {
+    sstring keyspace;
+    std::vector<sstring> tables;
+};
+
+keyspace_and_tables parse_keyspace_and_tables(scylla_rest_client& client, const bpo::variables_map& vm, const char* common_keyspace_table_arg_name) {
+    keyspace_and_tables ret;
+
+    const auto args = vm[common_keyspace_table_arg_name].as<std::vector<sstring>>();
+
+    ret.keyspace = args.at(0);
+
+    const auto all_keyspaces = get_keyspaces(client);
+    if (std::ranges::find(all_keyspaces, ret.keyspace) == all_keyspaces.end()) {
+        throw std::invalid_argument(fmt::format("keyspace {} does not exist", ret.keyspace));
+    }
+
+    if (args.size() > 1) {
+        ret.tables.insert(ret.tables.end(), args.begin() + 1, args.end());
+    }
+
+    return ret;
+}
+
 using operation_func = void(*)(scylla_rest_client&, const bpo::variables_map&);
 
 std::map<operation, operation_func> get_operations_with_func();
 
 void cleanup_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     if (vm.count("cleanup_arg")) {
-        const auto all_keyspaces = get_keyspaces(client);
-
-        auto args = vm["cleanup_arg"].as<std::vector<sstring>>();
+        const auto [keyspace, tables] = parse_keyspace_and_tables(client, vm, "cleanup_arg");
         std::unordered_map<sstring, sstring> params;
-        const auto keyspace = args[0];
-        if (std::ranges::find(all_keyspaces, keyspace) == all_keyspaces.end()) {
-            throw std::invalid_argument(fmt::format("keyspace {} does not exist", keyspace));
-        }
-
-        if (args.size() > 1) {
-            params["cf"] = fmt::to_string(fmt::join(args.begin() + 1, args.end(), ","));
+        if (!tables.empty()) {
+            params["cf"] = fmt::to_string(fmt::join(tables.begin(), tables.end(), ","));
         }
         client.post(format("/storage_service/keyspace_cleanup/{}", keyspace), std::move(params));
     } else {
@@ -164,22 +181,15 @@ void compact_operation(scylla_rest_client& client, const bpo::variables_map& vm)
         throw std::invalid_argument("--user-defined flag is unsupported");
     }
 
-    const auto all_keyspaces = get_keyspaces(client);
-
     if (vm.count("compaction_arg")) {
-        auto args = vm["compaction_arg"].as<std::vector<sstring>>();
+        const auto [keyspace, tables] = parse_keyspace_and_tables(client, vm, "compaction_arg");
         std::unordered_map<sstring, sstring> params;
-        const auto keyspace = args[0];
-        if (std::ranges::find(all_keyspaces, keyspace) == all_keyspaces.end()) {
-            throw std::invalid_argument(fmt::format("keyspace {} does not exist", keyspace));
-        }
-
-        if (args.size() > 1) {
-            params["cf"] = fmt::to_string(fmt::join(args.begin() + 1, args.end(), ","));
+        if (!tables.empty()) {
+            params["cf"] = fmt::to_string(fmt::join(tables.begin(), tables.end(), ","));
         }
         client.post(format("/storage_service/keyspace_compaction/{}", keyspace), std::move(params));
     } else {
-        for (const auto& keyspace : all_keyspaces) {
+        for (const auto& keyspace : get_keyspaces(client)) {
             client.post(format("/storage_service/keyspace_compaction/{}", keyspace));
         }
     }


### PR DESCRIPTION
This PR implements the following new nodetool commands:
* snapshot
* drain
* flush
* disableautocompaction
* enableautocompaction

All commands come with tests and all tests pass with both the new and the current nodetool implementations.

Refs: https://github.com/scylladb/scylladb/issues/15588