### PR TITLE
docs: add dynamic version on aws images extension

### DIFF
--- a/docs/_ext/scylladb_aws_images.py
+++ b/docs/_ext/scylladb_aws_images.py
@@ -145,10 +145,28 @@ class AMIVersionsTemplateDirective(Directive):
         version = self._extract_version_from_filename(filename)
         return tuple(map(int, version.split("."))) if version else (0,)
 
+    def _get_current_version(self, current_version, stable_version):
+        prefix = 'branch-'
+        version = current_version
+
+        if current_version.startswith(prefix):
+            version = current_version
+        elif not stable_version.startswith(prefix):
+            LOGGER.error("Invalid stable_version format in conf.py. It should start with 'branch-'")
+        else:
+            version = stable_version
+
+        return version.replace(prefix, '')
 
     def run(self):
         app = self.state.document.settings.env.app
-        version_pattern = self.options.get("version", "")
+        current_version = os.environ.get('SPHINX_MULTIVERSION_NAME', '')
+        stable_version = app.config.smv_latest_version
+
+        version_pattern = self._get_current_version(current_version, stable_version)
+        version_options = self.options.get("version", "")
+        if version_options:
+            version_pattern = version_options
         exclude_patterns = self.options.get("exclude", "").split(",")
 
         download_directory = os.path.join(

--- a/docs/getting-started/install-scylla/launch-on-aws.rst
+++ b/docs/getting-started/install-scylla/launch-on-aws.rst
@@ -13,7 +13,6 @@ Launching Instances from ScyllaDB AMI
    The following table shows the latest patch release. See :doc:`AWS Images </reference/aws-images/>` for earlier releases.
 
    .. scylladb_aws_images_template::
-      :version: 5.2
       :exclude: rc,dev
       :only_latest:
 

--- a/docs/reference/aws-images.rst
+++ b/docs/reference/aws-images.rst
@@ -3,5 +3,4 @@ AWS Images
 ==========
 
 .. scylladb_aws_images_template::
-   :version: 5.2
    :exclude: rc,dev


### PR DESCRIPTION
## Motivation

This update removes the need to specify the latest version of ScyllaDB for AWS images documentation manually.

Instead, the latest version is automatically pulled from the `SPHINX_MULTIVERSION_NAME` environment variable, which the multiversion extension sets for every version.

For branches like `master` that don't have a specific version, the configuration will default to using the `smv_latest_version` setting in `conf.py`.

## How to test

1. Build the docs with `make preview`.
2. Open the pages `getting-started/install-scylla/launch-on-aws` and `reference/aws-images` in the browser.
3. Check that information for the 5.2 version is correctly displayed.