### PR TITLE
Improvements to gossiper shadow round

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2033,8 +2033,9 @@ future<> gossiper::do_shadow_round(std::unordered_set<gms::inet_address> nodes, 
                     auto err = format("Node {} does not support get_endpoint_states verb", node);
                     logger.error("{}", err);
                     throw std::runtime_error{err};
-                }).handle_exception_type([node] (seastar::rpc::timeout_error&) {
-                    logger.warn("The get_endpoint_states verb to node {} was timeout", node);
+                }).handle_exception_type([node, &nodes_down] (seastar::rpc::timeout_error&) {
+                    nodes_down++;
+                    logger.warn("The get_endpoint_states verb to node {} timed out", node);
                 }).handle_exception_type([node, &nodes_down] (seastar::rpc::closed_error&) {
                     nodes_down++;
                     logger.warn("Node {} is down for get_endpoint_states verb", node);

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2005,8 +2005,8 @@ future<> gossiper::advertise_to_nodes(generation_for_nodes advertise_to_nodes) {
     });
 }
 
-future<> gossiper::do_shadow_round(std::unordered_set<gms::inet_address> nodes) {
-    return seastar::async([this, g = this->shared_from_this(), nodes = std::move(nodes)] () mutable {
+future<> gossiper::do_shadow_round(std::unordered_set<gms::inet_address> nodes, mandatory is_mandatory) {
+    return seastar::async([this, g = this->shared_from_this(), nodes = std::move(nodes), is_mandatory] () mutable {
         nodes.erase(get_broadcast_address());
         gossip_get_endpoint_states_request request{{
             gms::application_state::STATUS,
@@ -2046,7 +2046,7 @@ future<> gossiper::do_shadow_round(std::unordered_set<gms::inet_address> nodes) 
             if (!nodes_talked.empty()) {
                 break;
             }
-            if (nodes_down == nodes.size()) {
+            if (nodes_down == nodes.size() && !is_mandatory) {
                 logger.warn("All nodes={} are down for get_endpoint_states verb. Skip ShadowRound.", nodes);
                 break;
             }

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2018,10 +2018,10 @@ future<> gossiper::do_shadow_round(std::unordered_set<gms::inet_address> nodes, 
             gms::application_state::SNITCH_NAME}};
         logger.info("Gossip shadow round started with nodes={}", nodes);
         std::unordered_set<gms::inet_address> nodes_talked;
-        size_t nodes_down = 0;
         auto start_time = clk::now();
         std::list<gms::gossip_get_endpoint_states_response> responses;
         for (;;) {
+            size_t nodes_down = 0;
             parallel_for_each(nodes.begin(), nodes.end(), [this, &request, &responses, &nodes_talked, &nodes_down] (gms::inet_address node) {
                 logger.debug("Sent get_endpoint_states request to {}, request={}", node, request.application_states);
                 return _messaging.send_gossip_get_endpoint_states(msg_addr(node), std::chrono::milliseconds(5000), request).then(

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -592,7 +592,7 @@ public:
     /**
      *  Do a single 'shadow' round of gossip, where we do not modify any state
      */
-    future<> do_shadow_round(std::unordered_set<gms::inet_address> nodes = {});
+    future<> do_shadow_round(std::unordered_set<gms::inet_address> nodes);
 
 private:
     void build_seeds_list();

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -589,10 +589,11 @@ public:
             gms::advertise_myself advertise = gms::advertise_myself::yes);
 
 public:
+    using mandatory = bool_class<class mandatory_tag>;
     /**
      *  Do a single 'shadow' round of gossip, where we do not modify any state
      */
-    future<> do_shadow_round(std::unordered_set<gms::inet_address> nodes);
+    future<> do_shadow_round(std::unordered_set<gms::inet_address> nodes, mandatory is_mandatory);
 
 private:
     void build_seeds_list();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2846,7 +2846,7 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
     } else {
         auto local_features = _feature_service.supported_feature_set();
         slogger.info("Performing gossip shadow round, initial_contact_nodes={}", initial_contact_nodes);
-        co_await _gossiper.do_shadow_round(initial_contact_nodes);
+        co_await _gossiper.do_shadow_round(initial_contact_nodes, gms::gossiper::mandatory::no);
         if (!_raft_topology_change_enabled) {
             _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
         }
@@ -4146,7 +4146,7 @@ future<> storage_service::check_for_endpoint_collision(std::unordered_set<gms::i
         auto local_features = _feature_service.supported_feature_set();
         do {
             slogger.info("Performing gossip shadow round");
-            _gossiper.do_shadow_round(initial_contact_nodes).get();
+            _gossiper.do_shadow_round(initial_contact_nodes, gms::gossiper::mandatory::yes).get();
             if (!_raft_topology_change_enabled) {
                 _gossiper.check_knows_remote_features(local_features, loaded_peer_features);
             }
@@ -4225,7 +4225,7 @@ storage_service::prepare_replacement_info(std::unordered_set<gms::inet_address> 
 
     // make magic happen
     slogger.info("Performing gossip shadow round");
-    co_await _gossiper.do_shadow_round(initial_contact_nodes);
+    co_await _gossiper.do_shadow_round(initial_contact_nodes, gms::gossiper::mandatory::yes);
     if (!_raft_topology_change_enabled) {
         auto local_features = _feature_service.supported_feature_set();
         _gossiper.check_knows_remote_features(local_features, loaded_peer_features);


### PR DESCRIPTION
Remove `fall_back_to_syn_msg` which is not necessary in newer Scylla versions.
Fix the calculation of `nodes_down` which could count a single node multiple times.
Make shadow round mandatory during bootstrap and replace -- these operations are unsafe to do without checking features first, which are obtained during the shadow round (outside raft-topology mode).
Finally, during node restart, allow the shadow round to be skipped when getting `timeout_error`s from contact points, not only when getting `closed_error`s (during restart it's best-effort anyway, and in general it's impossible to distinguish between a dead node and a partitioned node).
More details in commit messages.

Ref: https://github.com/scylladb/scylladb/issues/15675