### PR TITLE
build: cmake: define per-mode compile definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ string(TOUPPER "${CMAKE_BUILD_TYPE}" build_mode)
 include(mode.${build_mode})
 include(mode.common)
 add_compile_definitions(
-    ${Seastar_DEFINITIONS_${build_mode}}
     FMT_DEPRECATED_OSTREAM)
 include(limit_jobs)
 # Configure Seastar compile options to align with Scylla

--- a/cmake/mode.COVERAGE.cmake
+++ b/cmake/mode.COVERAGE.cmake
@@ -8,11 +8,15 @@ string(APPEND CMAKE_CXX_FLAGS_COVERAGE
   " -O${Seastar_OptimizationLevel_SANITIZE}")
 
 set(Seastar_DEFINITIONS_COVERAGE
-  SCYLLA_BUILD_MODE=debug
+  SCYLLA_BUILD_MODE=coverage
   DEBUG
   SANITIZE
   DEBUG_LSA_SANITIZER
   SCYLLA_ENABLE_ERROR_INJECTION)
+foreach(definition ${Seastar_DEFINITIONS_COVERAGE})
+  add_compile_definitions(
+    $<$<CONFIG:Coverage>:${definition}>)
+endforeach()
 
 set(CMAKE_CXX_FLAGS_COVERAGE
   " -O${Seastar_OptimizationLevel_COVERAGE} -fprofile-instr-generate -fcoverage-mapping -g -gz")

--- a/cmake/mode.DEBUG.cmake
+++ b/cmake/mode.DEBUG.cmake
@@ -16,6 +16,10 @@ set(Seastar_DEFINITIONS_DEBUG
   SANITIZE
   DEBUG_LSA_SANITIZER
   SCYLLA_ENABLE_ERROR_INJECTION)
+foreach(definition ${Seastar_DEFINITIONS_DEBUG})
+  add_compile_definitions(
+    $<$<CONFIG:Debug>:${definition}>)
+endforeach()
 
 set(CMAKE_CXX_FLAGS_DEBUG
   " -O${Seastar_OptimizationLevel_DEBUG} -g -gz")

--- a/cmake/mode.DEV.cmake
+++ b/cmake/mode.DEV.cmake
@@ -12,5 +12,9 @@ set(Seastar_DEFINITIONS_DEV
   DEVEL
   SEASTAR_ENABLE_ALLOC_FAILURE_INJECTION
   SCYLLA_ENABLE_ERROR_INJECTION)
+foreach(definition ${Seastar_DEFINITIONS_DEV})
+  add_compile_definitions(
+    $<$<CONFIG:Dev>:${definition}>)
+endforeach()
 
 set(stack_usage_threshold_in_KB 21)

--- a/cmake/mode.RELEASE.cmake
+++ b/cmake/mode.RELEASE.cmake
@@ -13,14 +13,16 @@ else()
   set(clang_inline_threshold 2500)
 endif()
 add_compile_options(
-  "$<$<CXX_COMPILER_ID:GNU>:--param;inline-unit-growth=300>"
-  "$<$<CXX_COMPILER_ID:Clang>:-mllvm;-inline-threshold=${clang_inline_threshold}>"
-  # clang generates 16-byte loads that break store-to-load forwarding
-  # gcc also has some trouble: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103554
-  "-fno-slp-vectorize")
-set(Seastar_DEFINITIONS_RELEASE
-  SCYLLA_BUILD_MODE=release)
+  "$<$<AND:$<CONFIG:Release>,$<CXX_COMPILER_ID:GNU>>:--param;inline-unit-growth=300>"
+  "$<$<AND:$<CONFIG:Release>,$<CXX_COMPILER_ID:Clang>>:-mllvm;-inline-threshold=${clang_inline_threshold}>")
+# clang generates 16-byte loads that break store-to-load forwarding
+# gcc also has some trouble: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103554
+check_cxx_compiler_flag("-fno-slp-vectorize" _slp_vectorize_supported)
+if(_slp_vectorize_supported)
+  add_compile_options(
+    $<$<CONFIG:Release>:-fno-slp-vectorize>)
+endif()
 
-add_link_options("LINKER:--gc-sections")
+add_link_options($<$<CONFIG:Release>:LINKER:--gc-sections>)
 
 set(stack_usage_threshold_in_KB 13)

--- a/cmake/mode.SANITIZE.cmake
+++ b/cmake/mode.SANITIZE.cmake
@@ -13,5 +13,9 @@ set(Seastar_DEFINITIONS_SANITIZE
   SANITIZE
   DEBUG_LSA_SANITIZER
   SCYLLA_ENABLE_ERROR_INJECTION)
+foreach(definition ${Seastar_DEFINITIONS_SANITIZE})
+  add_compile_definitions(
+    $<$<CONFIG:Sanitize>:${definition}>)
+endforeach()
 
 set(stack_usage_threshold_in_KB 50)


### PR DESCRIPTION
instead of setting for a single CMAKE_BUILD_TYPE, set the compilation definitions for each build configuration.

this prepares for the multi-config generator.