### PR TITLE
raft topology: join: do not time out waiting for the node to be joined

### DIFF
--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -484,7 +484,6 @@ future<> raft_group0::join_group0(std::vector<gms::inet_address> seeds, shared_p
             break;
         }
 
-        // TODO: aborts?
         if (co_await handshaker->post_server_start(g0_info, _abort_source)) {
             break;
         }

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -485,7 +485,7 @@ future<> raft_group0::join_group0(std::vector<gms::inet_address> seeds, shared_p
         }
 
         // TODO: aborts?
-        if (co_await handshaker->post_server_start(g0_info)) {
+        if (co_await handshaker->post_server_start(g0_info, _abort_source)) {
             break;
         }
 
@@ -522,7 +522,7 @@ shared_ptr<service::group0_handshaker> raft_group0::make_legacy_handshaker(bool 
             co_return;
         }
 
-        future<bool> post_server_start(const group0_info& g0_info) override {
+        future<bool> post_server_start(const group0_info& g0_info, abort_source& as) override {
             netw::msg_addr peer(g0_info.ip_addr);
             auto timeout = db::timeout_clock::now() + std::chrono::milliseconds{1000};
             auto my_id = _group0.load_my_id();

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -84,7 +84,10 @@ public:
     //   retried.
     // - An exception is interpreted as an irrecoverable error and causes
     //   setup_group0 to fail.
-    virtual future<bool> post_server_start(const group0_info& info) = 0;
+    //
+    // The implementation can use the abort_source parameter to abort the
+    // function if needed.
+    virtual future<bool> post_server_start(const group0_info& info, abort_source& as) = 0;
 };
 
 class raft_group0 {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2647,7 +2647,7 @@ public:
         co_return;
     }
 
-    future<bool> post_server_start(const group0_info& g0_info) override {
+    future<bool> post_server_start(const group0_info& g0_info, abort_source& as) override {
         // Group 0 has been started. Allow the join_node_response to be handled.
         _ss._join_node_group0_started.set_value();
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2124,15 +2124,15 @@ class topology_coordinator {
 
                         slogger.info("raft topology: rejected node moved to left state {}", node.id);
 
-                            try {
-                                co_await respond_to_joining_node(node.id, join_node_response_params{
-                                    .response = std::move(validation_result),
-                                });
-                            } catch (const std::runtime_error& e) {
-                                slogger.warn("raft topology: attempt to send rejection response to {} failed: {}. "
-                                             "The node may hang. It's safe to shut it down manually now.",
-                                             node.id, e.what());
-                            }
+                        try {
+                            co_await respond_to_joining_node(node.id, join_node_response_params{
+                                .response = std::move(validation_result),
+                            });
+                        } catch (const std::runtime_error& e) {
+                            slogger.warn("raft topology: attempt to send rejection response to {} failed: {}. "
+                                         "The node may hang. It's safe to shut it down manually now.",
+                                         node.id, e.what());
+                        }
 
                         break;
                     }
@@ -2332,9 +2332,9 @@ class topology_coordinator {
 
         auto responded = false;
         try {
-        co_await respond_to_joining_node(id, join_node_response_params{
-            .response = join_node_response_params::accepted{},
-        });
+            co_await respond_to_joining_node(id, join_node_response_params{
+                .response = join_node_response_params::accepted{},
+            });
             responded = true;
         } catch (const std::runtime_error& e) {
             slogger.warn("raft topology: attempt to send acceptance response to {} failed: {}. "

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2652,8 +2652,10 @@ public:
         _ss._join_node_group0_started.set_value();
 
         // Processing of the response is done in `join_node_response_handler`.
-        // Wait for it to complete.
-        co_await _ss._join_node_response_done.get_shared_future(lowres_clock::now() + std::chrono::minutes(3));
+        // Wait for it to complete. If the topology coordinator fails to
+        // deliver the rejection, it won't complete. In such a case, the
+        // operator is responsible for shutting down the joining node.
+        co_await _ss._join_node_response_done.get_shared_future(as);
         slogger.info("raft topology: join: success");
         co_return true;
     }


### PR DESCRIPTION
When a node tries to join the cluster, it asks the topology
coordinator to add them and then waits for the response. The
response is not guaranteed to come back. If the topology
coordinator cannot contact the joining node, it moves the node to
the left state and moves on.

Currently, to handle the case when the response does not come back,
the joining node gives up waiting for it after 3 minutes. However,
it might take more time for the topology coordinator to start
handling the request to join, as it might be working on other tasks
like adding other nodes, performing tablet migrations, etc. In
general, any timeout duration would be unreliable.

Therefore, we get rid of the timeout. From now on, the operator
will be responsible for shutting down the node if the topology
coordinator fails to deliver the rejection.

Additionally, after removing the timeout, we adjust the topology
coordinator. We make it try sending the response (both acceptance
and rejection) only once since we do not care if it fails anymore. We
only need to ensure that the joining node is moved to the left state
if sending fails.

Fixes #15865