### PR TITLE
doc: Offer replication_factor=3 as the default in the examples

### DIFF
--- a/docs/cql/dml/delete.rst
+++ b/docs/cql/dml/delete.rst
@@ -67,7 +67,7 @@ For example, suppose your data set for events at Madison Square Garden includes:
 
 .. code-block:: none
 
-   CREATE KEYSPACE mykeyspace WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}  AND durable_writes = true;
+   CREATE KEYSPACE mykeyspace WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '3'}  AND durable_writes = true;
    use mykeyspace ;
    CREATE TABLE events ( id text, created_at date, content text, PRIMARY KEY (id, created_at) );
    

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -265,8 +265,6 @@ Which snitch or replication strategy should I use?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 If you are creating a production cluster or if your cluster is going to have more than one data center you need to use a **DC-aware** snitch, e.g. :code:`GossipingPropertyFileSnitch` or :code:`Ec2MultiRegionSnitch`. You will also need to use a **DC-aware** replication strategy, e.g. :code:`NetworkTopologyStrategy`.
 
-However, if you are going to create your first cluster or want to try something simple, if your cluster is going to have a single data center then you may use a :code:`SimpleSnitch` and then use a :code:`SimpleStrategy` for your keyspaces.
-
 Our general recommendation is to always use a :code:`NetworkTopologyStrategy` and use :code:`Ec2XXX` snitches on AWS based clusters and :code:`GossipingPropertyFileSnitch` in all other cases.
 
 A description of all snitch options we support may be found here: `Snitches <https://github.com/scylladb/scylla/wiki/Snitches>`_.

--- a/docs/kb/scylla-and-spark-integration.rst
+++ b/docs/kb/scylla-and-spark-integration.rst
@@ -28,7 +28,7 @@ create a new keyspace for our tests and make it the current one.
 
 ::
 
-    CREATE KEYSPACE spark_example WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+    CREATE KEYSPACE spark_example WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};
     USE spark_example;
 
 Then, tables both for input and output data need to be created:

--- a/docs/operating-scylla/security/rbac-usecase.rst
+++ b/docs/operating-scylla/security/rbac-usecase.rst
@@ -87,9 +87,9 @@ If you proceed with the following example without authorization, you will see th
 
 .. code-block:: cql
 
-   CREATE KEYSPACE IF NOT EXISTS customer WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 };
+   CREATE KEYSPACE IF NOT EXISTS customer WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 };
    CREATE TABLE IF NOT EXISTS customer.info (ssid UUID, name text, DOB text, telephone text, email text, memberid text, PRIMARY KEY (ssid,  name, memberid));
-   CREATE KEYSPACE IF NOT EXISTS schedule WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 };
+   CREATE KEYSPACE IF NOT EXISTS schedule WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 };
    CREATE TABLE IF NOT EXISTS schedule.cust (memberid UUID, ssid text, class text, meeting_day text, meeting_time text, PRIMARY KEY (memberid, ssid));
    CREATE TABLE IF NOT EXISTS schedule.train (trainerid UUID, class text, meeting_day text, meeting_time text, PRIMARY KEY (trainerid));
 

--- a/docs/troubleshooting/time-zone.rst
+++ b/docs/troubleshooting/time-zone.rst
@@ -25,7 +25,7 @@ This example creates a table, inserts data with a time zone timestamp, and then 
 .. code-block:: cql 
 
    CREATE KEYSPACE IF NOT EXISTS mykeyspace 
-      WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 };
+      WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 };
    USE mykeyspace;
    CREATE TABLE heartrate (
       pet_chip_id uuid,

--- a/docs/using-scylla/cdc/cdc-stream-generations.rst
+++ b/docs/using-scylla/cdc/cdc-stream-generations.rst
@@ -213,7 +213,7 @@ If you then immediately create a CDC-enabled table and attempt to make an insert
 
 .. code-block:: cql
 
-   CREATE KEYSPACE ks WITH replication = {'class':'SimpleStrategy', 'replication_factor': 1};
+   CREATE KEYSPACE ks WITH replication = {'class':'NetworkTopologyStrategy', 'replication_factor': 3};
    CREATE TABLE ks.t (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH cdc = {'enabled': true};
    INSERT INTO ks.t (pk, ck, v) values (0, 0, 0);
 

--- a/docs/using-scylla/integrations/scylla-cdc-source-connector-quickstart.rst
+++ b/docs/using-scylla/integrations/scylla-cdc-source-connector-quickstart.rst
@@ -27,14 +27,18 @@ environments, please refer to the :doc:`Install Scylla page </getting-started/in
    .. code-block:: bash
 
       docker run --name scylla-cdc-quickstart --hostname scylla-cdc-quickstart -d scylladb/scylla
+      docker run --name scylla-cdc-quickstart-2 --hostname scylla-cdc-quickstart-2 -d scylladb/scylla --seeds="$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' scylla-cdc-quickstart)"
+      docker run --name scylla-cdc-quickstart-3 --hostname scylla-cdc-quickstart-3 -d scylladb/scylla --seeds="$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' scylla-cdc-quickstart)"
 
 #. Run ``docker ps`` to show the exposed ports. The output should be similar to this example:
 
    .. code-block:: none
 
-      docker ps 
-      CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                                                            NAMES
-      4fca02217055        scylladb/scylla     "/docker-entrypoint.…"   8 seconds ago       Up 7 seconds        22/tcp, 7000-7001/tcp, 9042/tcp, 9160/tcp, 9180/tcp, 10000/tcp   scylla-cdc-quickstart
+      docker ps
+      CONTAINER ID   IMAGE                 COMMAND                  CREATED              STATUS              PORTS                                                            NAMES
+      b72f341f53c0   scylladb/scylla       "/docker-entrypoint.…"   12 seconds ago       Up 11 seconds       22/tcp, 7000-7001/tcp, 9042/tcp, 9160/tcp, 9180/tcp, 10000/tcp   scylla-cdc-quickstart-3
+      e1ac1ccb4d12   scylladb/scylla       "/docker-entrypoint.…"   16 seconds ago       Up 15 seconds       22/tcp, 7000-7001/tcp, 9042/tcp, 9160/tcp, 9180/tcp, 10000/tcp   scylla-cdc-quickstart-2
+      f1668fba1e7b   scylladb/scylla       "/docker-entrypoint.…"   About a minute ago   Up About a minute   22/tcp, 7000-7001/tcp, 9042/tcp, 9160/tcp, 9180/tcp, 10000/tcp   scylla-cdc-quickstart
 
 Creating a CDC-enabled table
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +48,7 @@ issuing the following CQL query and insert some example data:
 
 .. code-block:: cql
 
-   CREATE KEYSPACE quickstart_keyspace WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+   CREATE KEYSPACE quickstart_keyspace WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};
 
    CREATE TABLE quickstart_keyspace.orders(
       customer_id int, 


### PR DESCRIPTION
The goal is to make the available defaults safe for future use, as they are often taken from existing config files or documentation verbatim.

Referenced issue: #14290

@annastuchlik Please give it a look if there are other places that require changes to NetworkTopologyStrategy or RF=3. I think I caught them all.