### PR TITLE
raft topology: handle abort exceptions better in fence_previous_coordinator

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2410,6 +2410,10 @@ future<> topology_coordinator::fence_previous_coordinator() noexcept {
         } catch (group0_concurrent_modification&) {
             // If we failed to write because of concurrent modification lets retry
             continue;
+        } catch (raft::request_aborted&) {
+            // Abort was requested. Break the loop
+            slogger.debug("raft topology: request to fence previous coordinator was aborted");
+            break;
         } catch (...) {
             slogger.error("raft topology: failed to fence previous coordinator {}", std::current_exception());
         }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2340,7 +2340,7 @@ class topology_coordinator {
         co_await _topo_sm.event.when();
     }
 
-    future<> fence_previous_coordinator() noexcept;
+    future<> fence_previous_coordinator();
     future<> rollback_current_topology_op(group0_guard&& guard);
 
 public:
@@ -2360,7 +2360,7 @@ public:
         , _ring_delay(ring_delay)
     {}
 
-    future<> run() noexcept;
+    future<> run();
 };
 
 future<bool> topology_coordinator::maybe_start_tablet_migration(group0_guard guard) {
@@ -2387,7 +2387,7 @@ future<bool> topology_coordinator::maybe_start_tablet_migration(group0_guard gua
     co_return true;
 }
 
-future<> topology_coordinator::fence_previous_coordinator() noexcept {
+future<> topology_coordinator::fence_previous_coordinator() {
     // Write empty change to make sure that a guard taken by any previous coordinator cannot
     // be used to do a successful write any more. Otherwise the following can theoretically happen
     // while a coordinator tries to execute RPC R and move to state S.
@@ -2479,7 +2479,7 @@ future<> topology_coordinator::rollback_current_topology_op(group0_guard&& guard
     }
 }
 
-future<> topology_coordinator::run() noexcept {
+future<> topology_coordinator::run() {
     slogger.info("raft topology: start topology coordinator fiber");
 
     auto abort = _as.subscribe([this] () noexcept {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2563,7 +2563,27 @@ future<> storage_service::raft_state_monitor_fiber(raft::server& raft, sharded<d
                     std::bind_front(&storage_service::raft_topology_cmd_handler, this),
                     _tablet_allocator.local(),
                     get_ring_delay()),
-                [] (std::unique_ptr<topology_coordinator>& coordinator) { return coordinator->run(); });
+                    std::ref(raft),
+                [] (std::unique_ptr<topology_coordinator>& coordinator, raft::server& raft) -> future<> {
+                    std::exception_ptr ex;
+                    try {
+                        co_await coordinator->run();
+                    } catch (...) {
+                        ex = std::current_exception();
+                    }
+                    if (ex) {
+                        try {
+                            if (raft.is_leader()) {
+                                slogger.warn("raft topology: unhandled exception in topology_coordinator::run: {}; stepping down as a leader", ex);
+                                const auto stepdown_timeout_ticks = std::chrono::seconds(5) / raft_tick_interval;
+                                co_await raft.stepdown(raft::logical_clock::duration(stepdown_timeout_ticks));
+                            }
+                        } catch (...) {
+                            slogger.error("raft topology: failed to step down before aborting: {}", std::current_exception());
+                        }
+                        on_fatal_internal_error(slogger, format("raft topology: unhandled exception in topology_coordinator::run: {}", ex));
+                    }
+                });
         }
     } catch (...) {
         slogger.info("raft_state_monitor_fiber aborted with {}", std::current_exception());


### PR DESCRIPTION
When topology coordinator tries to fence the previous coordinator it performs a group0 operation. The current topology coordinator might be aborted in the meantime, which will result in a `raft::request_aborted` exception being thrown. After the fix to scylladb/scylladb#15728 was merged, the exception is caught, but then `sleep_abortable` is called which immediately throws `abort_requested_exception` as it uses the same abort source as the group0 operation. The `fence_previous_coordinator` function which does all those things is not supposed to throw exceptions, if it does - it causes `raft_state_monitor_fiber` to exit, completely disabling the topology coordinator functionality on that node.

Modify the code in the following way:

- Catch `abort_requested_exception` thrown from `sleep_abortable` and exit the function if it happens. In addition to the described issue, it will also handle the case when abort is requested while `sleep_abortable` happens,
- Catch `raft::request_aborted` thrown from group0 operation, log the exception with lower verbosity and exit the function explicitly.

Finally, wrap both `fence_previous_coordinator` and `run` functions in a `try` block with `on_fatal_internal_error` in the catch handler in order to implement the behavior that adding `noexcept` was originally supposed to introduce.

Fixes: scylladb/scylladb#15747