### PR TITLE
Docs: fix nodetool *autocompaction pages

### DIFF
--- a/docs/operating-scylla/nodetool-commands/disableautocompaction.rst
+++ b/docs/operating-scylla/nodetool-commands/disableautocompaction.rst
@@ -1,21 +1,21 @@
 Nodetool disableautocompaction
 ==============================
 
-**disableautocompaction** disables automatic compaction for the given keyspace and table according to its compaction strategy.
+**disableautocompaction** disables automatic compaction for the given keyspace and table(s).
 
 For example:
 
 ::
 
-    nodetool disableautocompaction keyspace.table
+    nodetool disableautocompaction keyspace1 standard1
 
 Syntax
 ------
 
 .. code-block:: none
   
-     nodetool disableautocompaction [<keyspace> <tables>...]
-                
+     nodetool disableautocompaction [<keyspace> [<tables>...]]
+
 nodetool disableautocompaction takes the following parameters:
 
 .. list-table::
@@ -24,10 +24,11 @@ nodetool disableautocompaction takes the following parameters:
 
    * - Parameter Name
      - Description
-   * - ``[<keyspace> <tables>...]``
-     - The keyspace followed by one or many tables      
-            
+   * - ``<keyspace>``
+     - The keyspace to operate on.  If omitted, auto-compaction will be disabled in all keyspaces.
+   * - ``<tables>...``
+     - A comma-separated list of one or more tables to operate on.  Tables may be specified only if a keyspace is given.  If omitted, auto-compaction will be disabled in all tables in the specified keyspace.
+
 .. include:: nodetool-index.rst  
 
 .. include:: /rst_include/apache-copyrights.rst
-          

--- a/docs/operating-scylla/nodetool-commands/enbleautocompaction.rst
+++ b/docs/operating-scylla/nodetool-commands/enbleautocompaction.rst
@@ -1,21 +1,21 @@
 Nodetool enableautocompaction
 =============================
 
-**enableautocompaction** enables automatic compaction for the given keyspace and table according to its compaction strategy.
+**enableautocompaction** enables automatic compaction for the given keyspace and table(s).
 
 For example:
 
 ::
 
-    nodetool enableautocompaction keyspace.table
+    nodetool enableautocompaction keyspace1 standard1
 
 Syntax
 ------
 
 .. code-block:: none
   
-     nodetool enableautocompaction [<keyspace> <tables>...]
-                
+     nodetool enableautocompaction [<keyspace> [<tables>...]]
+
 nodetool enableautocompaction takes the following parameters:
 
 .. list-table::
@@ -24,10 +24,11 @@ nodetool enableautocompaction takes the following parameters:
 
    * - Parameter Name
      - Description
-   * - ``[<keyspace> <tables>...]``
-     - The keyspace followed by one or many tables      
-            
-.. include:: nodetool-index.rst
+   * - ``<keyspace>``
+     - The keyspace to operate on.  If omitted, auto-compaction will be enabled in all keyspaces.
+   * - ``<tables>...``
+     - A comma-separated list of one or more tables to operate on.  Tables may be specified only if a keyspace is given.  If omitted, auto-compaction will be enabled in all tables in the specified keyspace.
+
+.. include:: nodetool-index.rst  
 
 .. include:: /rst_include/apache-copyrights.rst
-            


### PR DESCRIPTION
The nodetool enableautocompaction and disableautocompaction pages are inaccurate and have examples that are inconsistent with the documented syntax.

This change rephrases the description, makes the given example consistent with the commands syntax,
and improves the documentation for the optional parameters.

Fixes https://github.com/scylladb/scylladb/issues/15554