### PR TITLE
storage_service: avoid using non-constexpr as format string

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2457,7 +2457,7 @@ future<> topology_coordinator::rollback_current_topology_op(group0_guard&& guard
     auto str = fmt::format("rollback {} after {} failure to state {}", node.id, node.rs->state, state);
 
     co_await update_topology_state(std::move(node.guard), {builder.build()}, str);
-    slogger.info(str.c_str());
+    slogger.info("{}", str);
     // Try to run metadata barrier to wait for all double writes to complete
     // but ignore failures
     try {
@@ -4551,7 +4551,7 @@ future<> storage_service::raft_decommission() {
         // Need to set it otherwise gossiper will try to send shutdown on exit
         co_await _gossiper.add_local_application_state({{ gms::application_state::STATUS, gms::versioned_value::left({}, _gossiper.now().time_since_epoch().count()) }});
     } else {
-        const auto err = "Decommission failed. See earlier errors";
+        constexpr auto err = "Decommission failed. See earlier errors";
         slogger.error(err);
         throw std::runtime_error(err);
     }
@@ -4911,7 +4911,7 @@ future<> storage_service::raft_removenode(locator::host_id host_id, std::list<lo
             slogger.info("raft topology removenode: already removed from the raft config by the topology coordinator");
         }
     } else {
-        const auto err = "Removenode failed. See earlier errors";
+        constexpr auto err = "Removenode failed. See earlier errors";
         slogger.error(err);
         throw std::runtime_error(err);
     }


### PR DESCRIPTION
in order to use compile-time format check, we would need to use compile-time constexpr for the format string. despite that we might be able to find a way to tell if an expression is compile-time constexpr in C++20, it'd be much simpler to always use a known-to-be-constexpr format string. this would help us to eventually migrate to the compile-time format check in seastar's logging subsystem.

so, in this change, instead of feeding `seastar::logger::info()` and friends with a non-constexpr format string, let's just use "{}" for printing it, or mark the format string with `constexpr` instead of `const`. as the former tells the compiler it is a variable that can be evaluated at compile-time, while the latter just inform the compiler that the variable is not mutable after it is initialized.

This change also helps to address the compiling failure with the yet-merged compile-time format check patch in Seastar:

```
/usr/bin/clang++ -DBOOST_NO_CXX98_FUNCTION_BASE -DDEBUG -DDEBUG_LSA_SANITIZER -DFMT_DEPRECATED_OSTREAM -DFMT_SHARED -DSANITIZE -DSCYLLA_BUILD_MODE=debug -DSCYLLA_ENABLE_ERROR_INJECTION -DSEASTAR_API_LEVEL=7 -DSEASTAR_DEBUG -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_SSTRING -DSEASTAR_TYPE_ERASE_MORE -DXXH_PRIVATE_API -I/home/kefu/dev/scylladb -I/home/kefu/dev/scylladb/build/cmake/gen -I/home/kefu/dev/scylladb/seastar/include -I/home/kefu/dev/scylladb/build/cmake/seastar/gen/include -Og -g -gz -std=gnu++20 -fvisibility=hidden -Wall -Werror -Wextra -Wno-error=deprecated-declarations -Wimplicit-fallthrough -Wno-c++11-narrowing -Wno-mismatched-tags -Wno-overloaded-virtual -Wno-unsupported-friend -Wno-unused-parameter -Wno-missing-field-initializers -Wno-deprecated-copy -Wno-ignored-qualifiers -ffile-prefix-map=/home/kefu/dev/scylladb=. -march=westmere -U_FORTIFY_SOURCE -Werror=unused-result "-Wno-error=#warnings" -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr -MD -MT service/CMakeFiles/service.dir/storage_service.cc.o -MF service/CMakeFiles/service.dir/storage_service.cc.o.d -o service/CMakeFiles/service.dir/storage_service.cc.o -c /home/kefu/dev/scylladb/service/storage_service.cc
/home/kefu/dev/scylladb/service/storage_service.cc:2460:18: error: call to consteval function 'seastar::logger::format_info<>::format_info<const char *, 0>' is not a constant expression
    slogger.info(str.c_str());
                 ^
```