### PR TITLE
api: failure_detector: invoke on shard 0

### DIFF
--- a/api/failure_detector.cc
+++ b/api/failure_detector.cc
@@ -19,41 +19,41 @@ namespace fd = httpd::failure_detector_json;
 void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
     fd::get_all_endpoint_states.set(r, [&g](std::unique_ptr<request> req) {
         return g.container().invoke_on(0, [] (gms::gossiper& g) {
-        std::vector<fd::endpoint_state> res;
-        res.reserve(g.num_endpoints());
-        g.for_each_endpoint_state([&] (const gms::inet_address& addr, const gms::endpoint_state& eps) {
-            fd::endpoint_state val;
-            val.addrs = fmt::to_string(addr);
-            val.is_alive = g.is_alive(addr);
-            val.generation = eps.get_heart_beat_state().get_generation().value();
-            val.version = eps.get_heart_beat_state().get_heart_beat_version().value();
-            val.update_time = eps.get_update_timestamp().time_since_epoch().count();
-            for (const auto& [as_type, app_state] : eps.get_application_state_map()) {
-                fd::version_value version_val;
-                // We return the enum index and not it's name to stay compatible to origin
-                // method that the state index are static but the name can be changed.
-                version_val.application_state = static_cast<std::underlying_type<gms::application_state>::type>(as_type);
-                version_val.value = app_state.value();
-                version_val.version = app_state.version().value();
-                val.application_state.push(version_val);
-            }
-            res.emplace_back(std::move(val));
-        });
-        return make_ready_future<json::json_return_type>(res);
+            std::vector<fd::endpoint_state> res;
+            res.reserve(g.num_endpoints());
+            g.for_each_endpoint_state([&] (const gms::inet_address& addr, const gms::endpoint_state& eps) {
+                fd::endpoint_state val;
+                val.addrs = fmt::to_string(addr);
+                val.is_alive = g.is_alive(addr);
+                val.generation = eps.get_heart_beat_state().get_generation().value();
+                val.version = eps.get_heart_beat_state().get_heart_beat_version().value();
+                val.update_time = eps.get_update_timestamp().time_since_epoch().count();
+                for (const auto& [as_type, app_state] : eps.get_application_state_map()) {
+                    fd::version_value version_val;
+                    // We return the enum index and not it's name to stay compatible to origin
+                    // method that the state index are static but the name can be changed.
+                    version_val.application_state = static_cast<std::underlying_type<gms::application_state>::type>(as_type);
+                    version_val.value = app_state.value();
+                    version_val.version = app_state.version().value();
+                    val.application_state.push(version_val);
+                }
+                res.emplace_back(std::move(val));
+            });
+            return make_ready_future<json::json_return_type>(res);
         });
     });
 
     fd::get_up_endpoint_count.set(r, [&g](std::unique_ptr<request> req) {
         return g.container().invoke_on(0, [] (gms::gossiper& g) {
-        int res = g.get_up_endpoint_count();
-        return make_ready_future<json::json_return_type>(res);
+            int res = g.get_up_endpoint_count();
+            return make_ready_future<json::json_return_type>(res);
         });
     });
 
     fd::get_down_endpoint_count.set(r, [&g](std::unique_ptr<request> req) {
         return g.container().invoke_on(0, [] (gms::gossiper& g) {
-        int res = g.get_down_endpoint_count();
-        return make_ready_future<json::json_return_type>(res);
+            int res = g.get_down_endpoint_count();
+            return make_ready_future<json::json_return_type>(res);
         });
     });
 
@@ -63,11 +63,11 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
 
     fd::get_simple_states.set(r, [&g] (std::unique_ptr<request> req) {
         return g.container().invoke_on(0, [] (gms::gossiper& g) {
-        std::map<sstring, sstring> nodes_status;
-        g.for_each_endpoint_state([&] (const gms::inet_address& node, const gms::endpoint_state&) {
-            nodes_status.emplace(node.to_sstring(), g.is_alive(node) ? "UP" : "DOWN");
-        });
-        return make_ready_future<json::json_return_type>(map_to_key_value<fd::mapper>(nodes_status));
+            std::map<sstring, sstring> nodes_status;
+            g.for_each_endpoint_state([&] (const gms::inet_address& node, const gms::endpoint_state&) {
+                nodes_status.emplace(node.to_sstring(), g.is_alive(node) ? "UP" : "DOWN");
+            });
+            return make_ready_future<json::json_return_type>(map_to_key_value<fd::mapper>(nodes_status));
         });
     });
 
@@ -80,13 +80,13 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
 
     fd::get_endpoint_state.set(r, [&g] (std::unique_ptr<request> req) {
         return g.container().invoke_on(0, [req = std::move(req)] (gms::gossiper& g) {
-        auto state = g.get_endpoint_state_ptr(gms::inet_address(req->param["addr"]));
-        if (!state) {
-            return make_ready_future<json::json_return_type>(format("unknown endpoint {}", req->param["addr"]));
-        }
-        std::stringstream ss;
-        g.append_endpoint_state(ss, *state);
-        return make_ready_future<json::json_return_type>(sstring(ss.str()));
+            auto state = g.get_endpoint_state_ptr(gms::inet_address(req->param["addr"]));
+            if (!state) {
+                return make_ready_future<json::json_return_type>(format("unknown endpoint {}", req->param["addr"]));
+            }
+            std::stringstream ss;
+            g.append_endpoint_state(ss, *state);
+            return make_ready_future<json::json_return_type>(sstring(ss.str()));
         });
     });
 

--- a/api/failure_detector.cc
+++ b/api/failure_detector.cc
@@ -18,6 +18,7 @@ namespace fd = httpd::failure_detector_json;
 
 void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
     fd::get_all_endpoint_states.set(r, [&g](std::unique_ptr<request> req) {
+        return g.container().invoke_on(0, [] (gms::gossiper& g) {
         std::vector<fd::endpoint_state> res;
         res.reserve(g.num_endpoints());
         g.for_each_endpoint_state([&] (const gms::inet_address& addr, const gms::endpoint_state& eps) {
@@ -39,16 +40,21 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
             res.emplace_back(std::move(val));
         });
         return make_ready_future<json::json_return_type>(res);
+        });
     });
 
     fd::get_up_endpoint_count.set(r, [&g](std::unique_ptr<request> req) {
+        return g.container().invoke_on(0, [] (gms::gossiper& g) {
         int res = g.get_up_endpoint_count();
         return make_ready_future<json::json_return_type>(res);
+        });
     });
 
     fd::get_down_endpoint_count.set(r, [&g](std::unique_ptr<request> req) {
+        return g.container().invoke_on(0, [] (gms::gossiper& g) {
         int res = g.get_down_endpoint_count();
         return make_ready_future<json::json_return_type>(res);
+        });
     });
 
     fd::get_phi_convict_threshold.set(r, [] (std::unique_ptr<request> req) {
@@ -56,11 +62,13 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
     });
 
     fd::get_simple_states.set(r, [&g] (std::unique_ptr<request> req) {
+        return g.container().invoke_on(0, [] (gms::gossiper& g) {
         std::map<sstring, sstring> nodes_status;
         g.for_each_endpoint_state([&] (const gms::inet_address& node, const gms::endpoint_state&) {
             nodes_status.emplace(node.to_sstring(), g.is_alive(node) ? "UP" : "DOWN");
         });
         return make_ready_future<json::json_return_type>(map_to_key_value<fd::mapper>(nodes_status));
+        });
     });
 
     fd::set_phi_convict_threshold.set(r, [](std::unique_ptr<request> req) {
@@ -71,6 +79,7 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
     });
 
     fd::get_endpoint_state.set(r, [&g] (std::unique_ptr<request> req) {
+        return g.container().invoke_on(0, [req = std::move(req)] (gms::gossiper& g) {
         auto state = g.get_endpoint_state_ptr(gms::inet_address(req->param["addr"]));
         if (!state) {
             return make_ready_future<json::json_return_type>(format("unknown endpoint {}", req->param["addr"]));
@@ -78,6 +87,7 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
         std::stringstream ss;
         g.append_endpoint_state(ss, *state);
         return make_ready_future<json::json_return_type>(sstring(ss.str()));
+        });
     });
 
     fd::get_endpoint_phi_values.set(r, [](std::unique_ptr<request> req) {

--- a/test/rest_api/test_failure_detector.py
+++ b/test/rest_api/test_failure_detector.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import re
+import time
 
 def test_failure_detector_endpoints(rest_api):
     resp = rest_api.send('GET', "failure_detector/endpoints")
@@ -16,3 +17,13 @@ def test_failure_detector_endpoint_phi_values(rest_api):
     # so just check it doesn't return an error or crash
     resp = rest_api.send('GET', "failure_detector/endpoint_phi_values")
     resp.raise_for_status()
+
+def test_nonzero_generation(rest_api):
+    # In older versions of Scylla, shards other than 0 would return generation=0.
+    # Call the endpoint multiple times to increase the chance of hitting nonzero shard.
+    for _ in range(100):
+        resp = rest_api.send('GET', "failure_detector/endpoints")
+        resp.raise_for_status()
+        assert len(resp.json()) == 1
+        gen = int(resp.json()[0]['generation'])
+        assert gen > 0


### PR DESCRIPTION
These APIs may return stale or simply incorrect data on shards
other than 0. Newer versions of Scylla are better at maintaining
cross-shard consistency, but we need a simple fix that can be easily and
without risk be backported to older versions; this is the fix.

Add a simple test to check that the `failure_detector/endpoints`
API returns nonzero generation.

Fixes: scylladb/scylladb#15816

