### PR TITLE
commitlog: Add optional max lifetime parameter to cl instance

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -113,6 +113,9 @@ db::commitlog::config db::commitlog::config::from_db_config(const db::config& cf
     if (cfg.commitlog_flush_threshold_in_mb() >= 0) {
         c.commitlog_flush_threshold_in_mb = cfg.commitlog_flush_threshold_in_mb();
     }
+    if (cfg.commitlog_max_data_lifetime_in_seconds() > 0) {
+        c.commitlog_data_max_lifetime_in_seconds = cfg.commitlog_max_data_lifetime_in_seconds();
+    }
 
     return c;
 }

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -490,6 +490,7 @@ public:
     }
 
     void flush_segments(uint64_t size_to_remove);
+    void check_no_data_older_than_allowed();
 
 private:
     class shutdown_marker{};
@@ -1793,6 +1794,76 @@ void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
     totals.bytes_flush_requested += flushing;
 }
 
+void db::commitlog::segment_manager::check_no_data_older_than_allowed() {
+    if (!cfg.commitlog_data_max_lifetime_in_seconds) {
+        return;
+    }
+
+    auto now = gc_clock::now();
+
+    std::unordered_set<cf_id_type> ids;
+    std::optional<replay_position> high;
+
+    for (auto& s : _segments) {
+        auto rp = replay_position(s->_desc.id, db::position_type(s->size_on_disk()));
+        if (rp <= _flush_position) {
+            // already requested.
+            continue;
+        }
+
+        bool any_found = false;
+
+        for (auto [id, low_ts] : s->_cf_min_time) {
+            // Ignore CF:s already released.
+            if (!s->_cf_dirty.count(id)) {
+                continue;
+            }
+
+            uint64_t time_since_first_added = std::chrono::duration_cast<std::chrono::seconds>(now - low_ts).count();
+            if (time_since_first_added >= *cfg.commitlog_data_max_lifetime_in_seconds) {
+                // There is data in this segment that has lived longer than allowed (might be flushed actually
+                // but can still affect compaction/resurrect stuff on replay). Collect all dirty 
+                // id:s (stuff keeping this segment alive), and ask for them to be memtable flushed
+                for (auto& id : s->_cf_dirty | boost::adaptors::map_keys) {
+                    ids.insert(id);
+                }
+
+                // highest position (so far) is end of segment.
+                high = rp;
+
+                // If this segment is actually the active one, we must close it. Otherwise flushing 
+                // won't help.
+                if (s->is_still_allocating()) {
+                    // fixme. discarded future.
+                    (void)s->close();
+                }
+                any_found = true;
+                break;
+            }
+        }
+
+        // segments are sequential. Can't start becoming older.
+        if (!any_found) {
+            break;
+        }
+    }
+
+    if (!ids.empty()) {
+        auto callbacks = boost::copy_range<std::vector<flush_handler>>(_flush_handlers | boost::adaptors::map_values);
+        // For each CF id: for each callback c: call c(id, high)
+        for (auto& f : callbacks) {
+            for (auto& id : ids) {
+                try {
+                    f(id, *high);
+                } catch (...) {
+                    clogger.error("Exception during flush request {}/{}: {}", id, *high, std::current_exception());
+                }
+            }
+        }
+        _flush_position = *high;
+    }
+}
+
 future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager::allocate_segment_ex(descriptor d, named_file f, open_flags flags) {
     file_open_options opt;
     opt.extent_allocation_size_hint = max_size;
@@ -2468,6 +2539,9 @@ void db::commitlog::segment_manager::on_timer() {
                 flush_segments(cur + extra - max);
             }
         }
+
+        check_no_data_older_than_allowed();
+
         return do_pending_deletes();
     });
     arm();

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -375,6 +375,9 @@ public:
     // be replayed on the next reboot.
     replay_position min_position() const;
 
+    // (Re-)set data mix lifetime.
+    void update_max_data_lifetime(std::optional<uint64_t> commitlog_data_max_lifetime_in_seconds);
+
     typedef std::function<future<>(buffer_and_replay_position)> commit_load_reader_func;
 
     class segment_error : public std::exception {};

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -95,6 +95,7 @@ public:
         sstring metrics_category_name;
         uint64_t commitlog_total_space_in_mb = 0;
         std::optional<uint64_t> commitlog_flush_threshold_in_mb = {};
+        std::optional<uint64_t> commitlog_data_max_lifetime_in_seconds = {};
         uint64_t commitlog_segment_size_in_mb = 32;
         uint64_t commitlog_sync_period_in_ms = 10 * 1000; //TODO: verify default!
         // Max number of segments to keep in pre-alloc reserve.

--- a/db/config.cc
+++ b/db/config.cc
@@ -544,6 +544,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     /* Note: does not exist on the listing page other than in above comment, wtf? */
     , commitlog_sync_batch_window_in_ms(this, "commitlog_sync_batch_window_in_ms", value_status::Used, 10000,
         "Controls how long the system waits for other writes before performing a sync in ``batch`` mode.")
+    , commitlog_max_data_lifetime_in_seconds(this, "commitlog_max_data_lifetime_in_seconds", value_status::Used, 24*60*60,
+        "Controls how long data remains in commit log before the system tries to evict it to sstable, regardless of usage pressure. (0 disables)")
     , commitlog_total_space_in_mb(this, "commitlog_total_space_in_mb", value_status::Used, -1,
         "Total space used for commitlogs. If the used space goes above this value, Scylla rounds up to the next nearest segment multiple and flushes memtables to disk for the oldest commitlog segments, removing those log segments. This reduces the amount of data to replay on startup, and prevents infrequently-updated tables from indefinitely keeping commitlog segments. A small total commitlog space tends to cause more flush activity on less-active tables.\n"
         "\n"

--- a/db/config.cc
+++ b/db/config.cc
@@ -544,7 +544,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     /* Note: does not exist on the listing page other than in above comment, wtf? */
     , commitlog_sync_batch_window_in_ms(this, "commitlog_sync_batch_window_in_ms", value_status::Used, 10000,
         "Controls how long the system waits for other writes before performing a sync in ``batch`` mode.")
-    , commitlog_max_data_lifetime_in_seconds(this, "commitlog_max_data_lifetime_in_seconds", value_status::Used, 24*60*60,
+    , commitlog_max_data_lifetime_in_seconds(this, "commitlog_max_data_lifetime_in_seconds", liveness::LiveUpdate, value_status::Used, 24*60*60,
         "Controls how long data remains in commit log before the system tries to evict it to sstable, regardless of usage pressure. (0 disables)")
     , commitlog_total_space_in_mb(this, "commitlog_total_space_in_mb", value_status::Used, -1,
         "Total space used for commitlogs. If the used space goes above this value, Scylla rounds up to the next nearest segment multiple and flushes memtables to disk for the oldest commitlog segments, removing those log segments. This reduces the amount of data to replay on startup, and prevents infrequently-updated tables from indefinitely keeping commitlog segments. A small total commitlog space tends to cause more flush activity on less-active tables.\n"

--- a/db/config.hh
+++ b/db/config.hh
@@ -212,6 +212,7 @@ public:
     named_value<uint32_t> schema_commitlog_segment_size_in_mb;
     named_value<uint32_t> commitlog_sync_period_in_ms;
     named_value<uint32_t> commitlog_sync_batch_window_in_ms;
+    named_value<uint32_t> commitlog_max_data_lifetime_in_seconds;
     named_value<int64_t> commitlog_total_space_in_mb;
     named_value<bool> commitlog_reuse_segments; // unused. retained for upgrade compat
     named_value<int64_t> commitlog_flush_threshold_in_mb;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -760,6 +760,10 @@ database::init_commitlog() {
             // Initiate a background flush. Waited upon in `stop()`.
             (void)_tables_metadata.get_table(id).flush(pos);
         }).release(); // we have longer life time than CL. Ignore reg anchor
+
+        _cfg.commitlog_max_data_lifetime_in_seconds.observe([this](uint32_t max_time) {
+            _commitlog->update_max_data_lifetime(max_time == 0 ? std::nullopt : std::make_optional(uint64_t(max_time)));
+        });
     });
 }
 

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -1759,3 +1759,65 @@ SEASTAR_TEST_CASE(test_commitlog_max_data_lifetime) {
     co_await log.shutdown();
     co_await log.clear();
 }
+
+SEASTAR_TEST_CASE(test_commitlog_update_max_data_lifetime) {
+    commitlog::config cfg;
+
+    constexpr auto max_size_mb = 1;
+
+    cfg.commitlog_segment_size_in_mb = max_size_mb;
+    cfg.commitlog_total_space_in_mb = 2 * max_size_mb * smp::count;
+    cfg.commitlog_sync_period_in_ms = 10;
+    cfg.commitlog_data_max_lifetime_in_seconds = std::nullopt;
+    cfg.allow_going_over_size_limit = false;
+    cfg.use_o_dsync = true; // make sure we pre-allocate.
+
+    tmpdir tmp;
+    cfg.commit_log_location = tmp.path().string();
+    auto log = co_await commitlog::create_commitlog(cfg);
+
+    rp_set rps;
+    // uncomment for verbosity
+    // logging::logger_registry().set_logger_level("commitlog", logging::log_level::debug);
+
+    auto uuid = make_table_id();
+    auto size = log.max_record_size();
+
+    std::unordered_set<cf_id_type> ids;
+
+    condition_variable cond;
+
+    auto r = log.add_flush_handler([&](cf_id_type id, replay_position pos) {
+        log.discard_completed_segments(id, rps);
+        ids.insert(id);
+        cond.signal();
+    });
+
+    rp_handle h = co_await log.add_mutation(uuid, size, db::commitlog::force_sync::no, [&](db::commitlog::output& dst) {
+        dst.fill('1', size);
+    });
+    h.release();
+
+    try {
+        co_await cond.wait(10s);
+        BOOST_FAIL("should not reach");
+    } catch (condition_variable_timed_out&) {
+    }
+
+    // should not be signaled yet. 
+    BOOST_REQUIRE(!ids.contains(uuid));
+
+    log.update_max_data_lifetime(2);
+
+    int n = 0; 
+    while (!ids.contains(uuid) && n++ < 3) {
+        // way long, but lets give it some leeway on slow test cluster.
+        co_await cond.wait(10s);
+    }
+
+    // but now it must
+    BOOST_REQUIRE(ids.contains(uuid));
+
+    co_await log.shutdown();
+    co_await log.clear();
+}

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -1705,3 +1705,57 @@ SEASTAR_TEST_CASE(test_wait_for_delete) {
     co_await log.shutdown();
     co_await log.clear();
 }
+
+SEASTAR_TEST_CASE(test_commitlog_max_data_lifetime) {
+    commitlog::config cfg;
+
+    constexpr auto max_size_mb = 1;
+
+    cfg.commitlog_segment_size_in_mb = max_size_mb;
+    cfg.commitlog_total_space_in_mb = 2 * max_size_mb * smp::count;
+    cfg.commitlog_sync_period_in_ms = 10;
+    cfg.commitlog_data_max_lifetime_in_seconds = 2;
+    cfg.allow_going_over_size_limit = false;
+    cfg.use_o_dsync = true; // make sure we pre-allocate.
+
+    tmpdir tmp;
+    cfg.commit_log_location = tmp.path().string();
+    auto log = co_await commitlog::create_commitlog(cfg);
+
+    rp_set rps;
+    // uncomment for verbosity
+    // logging::logger_registry().set_logger_level("commitlog", logging::log_level::debug);
+
+    auto uuid = make_table_id();
+    auto size = log.max_record_size();
+
+    std::unordered_set<cf_id_type> ids;
+
+    condition_variable cond;
+
+    auto r = log.add_flush_handler([&](cf_id_type id, replay_position pos) {
+        log.discard_completed_segments(id, rps);
+        ids.insert(id);
+        cond.signal();
+    });
+
+    rp_handle h = co_await log.add_mutation(uuid, size, db::commitlog::force_sync::no, [&](db::commitlog::output& dst) {
+        dst.fill('1', size);
+    });
+    h.release();
+
+    // should not be signaled yet. 
+    BOOST_REQUIRE(!ids.contains(uuid));
+
+    int n = 0; 
+    while (!ids.contains(uuid) && n++ < 3) {
+        // way long, but lets give it some leeway on slow test cluster.
+        co_await cond.wait(20s);
+    }
+
+    // but now it must
+    BOOST_REQUIRE(ids.contains(uuid));
+
+    co_await log.shutdown();
+    co_await log.clear();
+}


### PR DESCRIPTION
If set, any remaining segment that has data older than this threshold will request flushing, regardless of data pressure. I.e. even a system where nothing happends will after X seconds flush data to free up the commit log.

Related to  #15820

The functionality here is to prevent pathological/test cases where a silent system cannot fully process stuff like compaction, GC etc due to things like CL forcing smaller GC windows etc. 