### PR TITLE
test: increase timeout for lua UDF execution

### DIFF
--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -304,6 +304,7 @@ def run_scylla_cmd(pid, dir):
         '--truncate-request-timeout-in-ms', '300000',
         '--write-request-timeout-in-ms', '300000',
         '--request-timeout-in-ms', '300000',
+        '--user-defined-function-time-limit-ms', '1000',
         # Allow testing experimental features. Following issue #9467, we need
         # to add here specific experimental features as they are introduced.
         # Note that Alternator-specific experimental features are listed in

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -99,6 +99,7 @@ def make_scylla_conf(workdir: pathlib.Path, host_addr: str, seed_addrs: List[str
         'truncate_request_timeout_in_ms': 300000,
         'write_request_timeout_in_ms': 300000,
         'request_timeout_in_ms': 300000,
+        'user_defined_function_time_limit_ms': 1000,
 
         'strict_allow_filtering': True,
         'strict_is_not_null_in_views': True,


### PR DESCRIPTION
When running on a particularly slow setup, for example on an ARM machine in debug mode, the execution time of even a small Lua UDF that we're using in tests may exceed our default limits.
To avoid timeout errors, the limit in tests is now increased to a value that won't be exceeded in any reasonable scenario (for the current set of tested UDFs), while not making the test take an excessive amount of time in case of an error in the UDF execution.

Fixes #15977