### PR TITLE
dist: let scylla-server.service Wants var-lib-systemd-coredump

### DIFF
--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -72,7 +72,7 @@ Type=none
 Options=bind
 
 [Install]
-WantedBy=local-fs.target
+WantedBy=local-fs.target scylla-server.service
 '''[1:-1]
             with open('/etc/systemd/system/var-lib-systemd-coredump.mount', 'w') as f:
                 f.write(dot_mount)


### PR DESCRIPTION
without adding `WantedBy=scylla-server.service` in var-lib-systemd-coredump, if we starts `scylla-server.service`, it does not necessarily starts `var-lib-systemd-coredump` even if the latter is installed.

with `WantedBy=scylla-server.service` in var-lib-systemd-coredump, if we starts `scylla-server.service`, var-lib-systemd-coredump will be started also. and `Before=scylla-server.service` ensures that, before `scylla-server.service` is started,
var-lib-systemd-coredump is already ready.