### PR TITLE
build: cmake: use $<CONFIG:cfgs> when appropriate

### DIFF
--- a/cql3/CMakeLists.txt
+++ b/cql3/CMakeLists.txt
@@ -12,18 +12,18 @@ set_source_files_properties(${cql_grammar_srcs}
 set(cql_parser_srcs ${cql_grammar_srcs})
 list(FILTER cql_parser_srcs INCLUDE REGEX "Parser.cpp$")
 
-set(unoptimized_modes "Coverage" "Debug" "Sanitize")
-set(sanitized_modes "Debug" "Sanitize")
+set(unoptimized_modes "Coverage,Debug,Sanitize")
+set(sanitized_modes "Debug,Sanitize")
 set_property(
     SOURCE ${cql_parser_srcs}
     APPEND
     PROPERTY COMPILE_OPTIONS
       # Unoptimized parsers end up using huge amounts of stack space and
       # overflowing their stack
-      $<$<IN_LIST:$<CONFIG>,${unoptimized_modes}>:-O1>
+      $<$<CONFIG:${unoptimized_modes}>:-O1>
       # use-after-scope sanitizer also uses large amount of stack space
       # and overflows the stack of CqlParser
-      $<$<IN_LIST:$<CONFIG>,${sanitized_modes}>:-fsanitize-address-use-after-scope>)
+      $<$<CONFIG:${sanitized_modes}>:-fsanitize-address-use-after-scope>)
 
 add_library(cql3 STATIC)
 target_sources(cql3


### PR DESCRIPTION
since CMake 3.19, we are able to use $<CONFIG:cfgs> instead of the more cubersume $<IN_LIST:$<CONFIG>,foo;bar> expression for checking if a config is in a list of configurations. and since the minimal required CMake of scylla is 3.27, so let's use $<CONFIG:cfgs> when possible.

see also https://cmake.org/cmake/help/git-stage/manual/cmake-generator-expressions.7.html#configuration-expressions