### PR TITLE
Do not create directories in datadir for S3-backed sstables

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1021,7 +1021,7 @@ future<> database::add_column_family(keyspace& ks, schema_ptr schema, column_fam
         erm = ks.get_effective_replication_map();
     }
     // avoid self-reporting
-    auto& sst_manager = is_system_table(*schema) ? get_system_sstables_manager() : get_user_sstables_manager();
+    auto& sst_manager = get_sstables_manager(system_keyspace(is_system_table(*schema)));
     auto cf = make_lw_shared<column_family>(schema, std::move(cfg), ks.metadata()->get_storage_options_ptr(), _compaction_manager, sst_manager, *_cl_stats, _row_cache_tracker, erm);
     cf->set_durable_writes(ks.metadata()->durable_writes());
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1716,6 +1716,10 @@ public:
         return *_system_sstables_manager;
     }
 
+    sstables::sstables_manager& get_sstables_manager(system_keyspace is_sys_ks) const noexcept {
+        return is_sys_ks ? get_system_sstables_manager() : get_user_sstables_manager();
+    }
+
     // Returns the list of ranges held by this endpoint
     // The returned list is sorted, and its elements are non overlapping and non wrap-around.
     dht::token_range_vector get_keyspace_local_ranges(sstring ks);

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -196,4 +196,16 @@ void sstables_manager::unplug_system_keyspace() noexcept {
     _sys_ks = nullptr;
 }
 
+future<> sstables_manager::init_table_storage(const data_dictionary::storage_options& so, sstring dir) {
+    return sstables::init_table_storage(so, dir);
+}
+
+future<> sstables_manager::init_keyspace_storage(const data_dictionary::storage_options& so, sstring dir) {
+    return sstables::init_keyspace_storage(so, dir);
+}
+
+future<> sstables_manager::destroy_table_storage(const data_dictionary::storage_options& so, sstring dir) {
+    return sstables::destroy_table_storage(so, dir);
+}
+
 }   // namespace sstables

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -161,6 +161,9 @@ public:
     }
 
     future<> delete_atomically(std::vector<shared_sstable> ssts);
+    future<> init_table_storage(const data_dictionary::storage_options& so, sstring dir);
+    future<> destroy_table_storage(const data_dictionary::storage_options& so, sstring dir);
+    future<> init_keyspace_storage(const data_dictionary::storage_options& so, sstring dir);
 
 private:
     void add(sstable* sst);

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -589,4 +589,18 @@ std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const
     }, s_opts.value);
 }
 
+future<> init_table_storage(const data_dictionary::storage_options& so, sstring dir) {
+            co_await io_check([&dir] { return recursive_touch_directory(dir); });
+            co_await io_check([&dir] { return touch_directory(dir + "/upload"); });
+            co_await io_check([&dir] { return touch_directory(dir + "/staging"); });
+}
+
+future<> init_keyspace_storage(const data_dictionary::storage_options& so, sstring dir) {
+            co_await io_check([&dir] { return touch_directory(dir); });
+}
+
+future<> destroy_table_storage(const data_dictionary::storage_options& so, sstring dir) {
+            co_await sstables::remove_table_directory_if_has_no_snapshots(fs::path(dir));
+}
+
 } // namespace sstables

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -590,17 +590,38 @@ std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const
 }
 
 future<> init_table_storage(const data_dictionary::storage_options& so, sstring dir) {
+    co_await std::visit(overloaded_functor {
+        [&dir] (const data_dictionary::storage_options::local&) -> future<> {
             co_await io_check([&dir] { return recursive_touch_directory(dir); });
             co_await io_check([&dir] { return touch_directory(dir + "/upload"); });
             co_await io_check([&dir] { return touch_directory(dir + "/staging"); });
+        },
+        [] (const data_dictionary::storage_options::s3&) -> future<> {
+            co_return;
+        }
+    }, so.value);
 }
 
 future<> init_keyspace_storage(const data_dictionary::storage_options& so, sstring dir) {
+    co_await std::visit(overloaded_functor {
+        [&dir] (const data_dictionary::storage_options::local&) -> future<> {
             co_await io_check([&dir] { return touch_directory(dir); });
+        },
+        [] (const data_dictionary::storage_options::s3&) -> future<> {
+            co_return;
+        }
+    }, so.value);
 }
 
 future<> destroy_table_storage(const data_dictionary::storage_options& so, sstring dir) {
+    co_await std::visit(overloaded_functor {
+        [&dir] (const data_dictionary::storage_options::local&) -> future<> {
             co_await sstables::remove_table_directory_if_has_no_snapshots(fs::path(dir));
+        },
+        [] (const data_dictionary::storage_options::s3&) -> future<> {
+            co_return;
+        }
+    }, so.value);
 }
 
 } // namespace sstables

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -69,5 +69,8 @@ public:
 };
 
 std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstring table_dir, sstable_state state);
+future<> init_table_storage(const data_dictionary::storage_options& so, sstring dir);
+future<> destroy_table_storage(const data_dictionary::storage_options& so, sstring dir);
+future<> init_keyspace_storage(const data_dictionary::storage_options& so, sstring dir);
 
 } // namespace sstables


### PR DESCRIPTION
After 146e49d0dd (Rewrap keyspace population loop) the datadir layout is no longer needed by sstables boot-time loader and finally directories can be omitted for S3-backed keyspaces. Tables of that keyspace don't touch/remove their datadirs either (snapshots still don't work for S3)

fixes: #13020