### PR TITLE
Update scylla-tools-java submodule (CI; don't merge)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,7 +11,7 @@
 	url = ../scylla-jmx
 [submodule "scylla-tools"]
 	path = tools/java
-	url = ../scylla-tools-java
+	url = ../../avelanarius/scylla-tools-java
 [submodule "scylla-python3"]
 	path = tools/python3
 	url = ../scylla-python3


### PR DESCRIPTION
Don't merge this PR. Created for purposes of running CI.

Updates scylla-tools-java submodule to avelanarius/pr-351-and-353 (changes from https://github.com/scylladb/scylla-tools-java/pull/351 and https://github.com/scylladb/scylla-tools-java/pull/353)