### PR TITLE
test: tablets: Restart cluster in a graceful manner to avoid connection drop in the middle of request serving

### DIFF
--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -110,8 +110,7 @@ async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(m
     conn_logger.setLevel(logging.DEBUG)
     try:
         # Check that after rolling restart the tablet metadata is still there
-        for s in servers:
-            await manager.server_restart(s.server_id, wait_others=2)
+        await manager.rolling_restart(servers)
 
         cql = await reconnect_driver(manager)
 


### PR DESCRIPTION
After restarting each node, we should wait for other nodes to notice the node is UP before restarting the next server. Otherwise, the next node we restart may not send the shutdown notification to the previously restarted node, if it still sees it as down when we initiate its shutdown. In this case, the node will learn about the restart from gossip later, possible when we already started CQL requests. When a node learns that some node restarted while it considers it as UP, it will close connections to that node. This will fail RPC sent to that node, which will cause CQL request to time-out.

Fixes #14746