### PR TITLE
cql3: Enforce Key-length limits during SELECT

### DIFF
--- a/test/cql-pytest/cassandra_tests/validation/operations/insert_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/insert_test.py
@@ -192,14 +192,12 @@ def testInsertWithDefaultTtl(cql, test_keyspace):
 TOO_BIG = 1024 * 65
 
 # Reproduces #12247:
-@pytest.mark.xfail(reason="Issue #12247")
 def testPKInsertWithValueOver64K(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(a text, b text, PRIMARY KEY (a, b))") as table:
         assertInvalidThrow(cql, table, InvalidRequest,
                            "INSERT INTO %s (a, b) VALUES (?, 'foo')", 'x'*TOO_BIG)
 
 # Reproduces #12247:
-@pytest.mark.xfail(reason="Issue #12247")
 def testCKInsertWithValueOver64K(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(a text, b text, PRIMARY KEY (a, b))") as table:
         assertInvalidThrow(cql, table, InvalidRequest,

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
@@ -1298,7 +1298,6 @@ def testIndexQueryWithValueOver64K(cql, test_keyspace):
         assert_empty(execute(cql, table, "SELECT * FROM %s WHERE c = ?  ALLOW FILTERING", too_big))
 
 # Reproduces #10366
-@pytest.mark.xfail(reason="#10366 - server error instead of InvalidRequest")
 def testPKQueryWithValueOver64K(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a text, b text, PRIMARY KEY (a, b))") as table:
         TOO_BIG = 1024 * 65
@@ -1307,7 +1306,7 @@ def testPKQueryWithValueOver64K(cql, test_keyspace):
                            "SELECT * FROM %s WHERE a = ?", too_big)
 
 # Reproduces #10366
-@pytest.mark.xfail(reason="#10366 - server error instead of silent return")
+@pytest.mark.xfail(reason="Cassandra silently ignores oversized clustering key, Scylla chose to generate an error as in the case of an oversized partition key - see discussion in #10366")
 def testCKQueryWithValueOver64K(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a text, b text, PRIMARY KEY (a, b))") as table:
         TOO_BIG = 1024 * 65


### PR DESCRIPTION
Validate if Partition keys length is less then 64k Return InvalidRequest error according to cassandra style in case of the key is too large.

fixes #10366