### PR TITLE
migration_manager: also reload schema on enabling digest_insensitive_to_expiry

### DIFF
--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -96,26 +96,25 @@ future<> migration_manager::drain()
 
 void migration_manager::init_messaging_service()
 {
-    auto update_schema = [this] {
-        //FIXME: future discarded.
-        (void)with_gate(_background_tasks, [this] {
-            mlogger.debug("features changed, recalculating schema version");
-            return db::schema_tables::recalculate_schema_version(_sys_ks, _storage_proxy.container(), _feat);
+    auto reload_schema_in_bg = [this] {
+        (void) with_gate(_background_tasks, [this] {
+            return reload_schema().handle_exception([] (std::exception_ptr ep) {
+                // Due to features being unordered, reload might fail because
+                // some tables still have the wrong version and looking up e.g.
+                // the base-table of a view will fail.
+                mlogger.debug("Failed to reload schema: {}", ep);
+            });
         });
     };
 
     if (this_shard_id() == 0) {
-        _feature_listeners.push_back(_feat.view_virtual_columns.when_enabled(update_schema));
-        _feature_listeners.push_back(_feat.digest_insensitive_to_expiry.when_enabled(update_schema));
-        _feature_listeners.push_back(_feat.cdc.when_enabled(update_schema));
-        _feature_listeners.push_back(_feat.per_table_partitioners.when_enabled(update_schema));
+        _feature_listeners.push_back(_feat.view_virtual_columns.when_enabled(reload_schema_in_bg));
+        _feature_listeners.push_back(_feat.digest_insensitive_to_expiry.when_enabled(reload_schema_in_bg));
+        _feature_listeners.push_back(_feat.cdc.when_enabled(reload_schema_in_bg));
+        _feature_listeners.push_back(_feat.per_table_partitioners.when_enabled(reload_schema_in_bg));
 
         if (!_feat.table_digest_insensitive_to_expiry) {
-            _feature_listeners.push_back(_feat.table_digest_insensitive_to_expiry.when_enabled([this] {
-                (void) with_gate(_background_tasks, [this] {
-                    return reload_schema();
-                });
-            }));
+            _feature_listeners.push_back(_feat.table_digest_insensitive_to_expiry.when_enabled(reload_schema_in_bg));
         }
     }
 


### PR DESCRIPTION
Currently, when said feature is enables, we recalcuate the schema digest. But this feature also influences how table versions are calculated, so it has to trigger a recalculation of all table versions, so that we can guarantee correct versions.
Before, this used to happen by happy accident. Another feature -- table_digest_insensitive_to_expiry -- used to take care of this, by triggering a table version recalulation. However this feature only takes effect if digest_insensitive_to_expiry is also enabled. This used to be the case incidently, by the time the reload triggered by table_digest_insensitive_to_expiry ran, digest_insensitive_to_expiry was already enabled. But this was not guaranteed whatsoever and as we've recently seen, any change to the feature list, which changes the order in which features are enabled, can cause this intricate balance to break.
This patch makes digest_insensitive_to_expiry also kick off a schema reload, to eliminate our dependence on(unguaranteed) feature order, and to guarantee that table schemas have a correct version after all features are enabled.

Fixes: #16004