### PR TITLE
doc: document full support for RBNO

### DIFF
--- a/docs/operating-scylla/procedures/cluster-management/repair-based-node-operation.rst
+++ b/docs/operating-scylla/procedures/cluster-management/repair-based-node-operation.rst
@@ -1,25 +1,36 @@
-Repair Based Node Operations
-****************************
+====================================
+Repair-Based Node Operations (RBNO)
+====================================
 
-Scylla has two use cases for transferring data between nodes: 
+In ScyllaDB, data is transferred between nodes during:
 
-- Topology changes, like adding and removing nodes.
-- Repair, a background process to compare and sync data between nodes.
+* Topology changes via node operations, such as adding or removing nodes.
+* Repair - a row-level background process to compare and sync data between nodes.
 
-Up to Scylla 4.6, the two used different underline logic. In later releases, the same data transferring logic used for repair is also used for topology changes, making it more robust, reliable, and safer for data consistency. In particular, node operations can restart from the same point it stopped without sending data that has been synced, a significant time-saver when adding or removing large nodes.
-In 4.6, Repair Based Node Operations (RBNO) is enabled by default only for replace node operation. 
-Example from scylla.yaml:
+By default, the row-level repair mechanism used for the repair process is also 
+used during node operations (instead of streaming). We refer to it as 
+Repair-Based Node Operations (RBNO).
 
-.. code:: yaml
-   
-   enable_repair_based_node_ops: true
-   allowed_repair_based_node_ops: replace
+RBNO is more robust, reliable, and safer for data consistency than streaming.
+In particular, a failed node operation can resume from the point it stopped -
+without sending data that has already been synced, which is a significant 
+time-saver when adding or removing large nodes. In addition, with RBNO enabled,
+you don't need to run repair befor or after node operations, such as replace
+or removenode.
 
-To enable other operations (experimental), add them as a comma-separated list to allowed_repair_based_node_ops. Available operations are:
+RBNO is enabled for the following node operations:
 
 * bootstrap
-* replace
-* removenode
 * decommission
 * rebuild
+* removenode
+* replace
+
+The following configuration options can be used to enable or disable RBNO:
+
+* ``enable_repair_based_node_ops= true|false`` - Enables or disables RBNO.
+* ``allowed_repair_based_node_ops= "replace,removenode,rebuild,bootstrap,decommission"`` - 
+  Specifies the node operations for which the RBNO mechanism is enabled.
+
+See :doc:`Configuration Parameters </reference/configuration-parameters/>` for details.
 


### PR DESCRIPTION
This PR updates the Repair-Based NodeOperations page. In particular:
- Information about RBNO enabled for all node operations is added (before 5.4, RBNO was enabled for the replace operation, while it was experimental for others).
- The content is rewritten to remove redundant information about previous versions.

The improvement is part of the 5.4 release.

This PR must be backported to branch-5.4

(backport)