### PR TITLE
Drop compaction_manager_test

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -444,7 +444,6 @@ public:
 
     friend class compacting_sstable_registration;
     friend class compaction_weight_registration;
-    friend class compaction_manager_test;
     friend class sstables::test_env_compaction_manager;
 
     friend class compaction::compaction_task_executor;

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -603,6 +603,7 @@ public:
     friend future<compaction_manager::compaction_stats_opt> compaction_manager::perform_task(shared_ptr<compaction_task_executor> task, throw_if_stopping do_throw_if_stopping);
     friend fmt::formatter<compaction_task_executor>;
     friend future<> compaction_manager::stop_tasks(std::vector<shared_ptr<compaction_task_executor>> tasks, sstring reason);
+    friend sstables::test_env_compaction_manager;
 };
 
 }

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -46,6 +46,8 @@ class system_keyspace;
 class compaction_history_entry;
 }
 
+namespace sstables { class test_env_compaction_manager; }
+
 class repair_history_map {
 public:
     boost::icl::interval_map<dht::token, gc_clock::time_point, boost::icl::partial_absorber, std::less, boost::icl::inplace_max> map;
@@ -443,6 +445,7 @@ public:
     friend class compacting_sstable_registration;
     friend class compaction_weight_registration;
     friend class compaction_manager_test;
+    friend class sstables::test_env_compaction_manager;
 
     friend class compaction::compaction_task_executor;
     friend class compaction::sstables_task_executor;

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3033,8 +3033,7 @@ SEASTAR_TEST_CASE(partial_sstable_run_filtered_out_test) {
         BOOST_REQUIRE(generation_exists(partial_sstable_run_sst->generation()));
 
         // register partial sstable run
-        auto cm_test = compaction_manager_test(cf->get_compaction_manager());
-        cm_test.run(env, partial_sstable_run_identifier, cf.as_table_state(), [&cf] (sstables::compaction_data&) {
+        run_compaction_task(env, partial_sstable_run_identifier, cf.as_table_state(), [&cf] (sstables::compaction_data&) {
             return cf->compact_all_sstables();
         }).get();
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2808,7 +2808,7 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
         cf->start();
         cf->set_compaction_strategy(sstables::compaction_strategy_type::size_tiered);
         auto compact = [&, s] (std::vector<shared_sstable> all, auto replacer) -> std::vector<shared_sstable> {
-            return compact_sstables(cf->get_compaction_manager(), sstables::compaction_descriptor(std::move(all), 1, 0), cf.as_table_state(), sst_gen, replacer).get0().new_sstables;
+            return compact_sstables(sstables::compaction_descriptor(std::move(all), 1, 0), cf, sst_gen, replacer).get0().new_sstables;
         };
         auto make_insert = [&] (const dht::decorated_key& key) {
             mutation m(s, key);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2831,7 +2831,7 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
                 sstables.insert(new_sst);
             }
             column_family_test(cf).rebuild_sstable_list(cf.as_table_state(), new_sstables, old_sstables).get();
-            compaction_manager_test(cf->get_compaction_manager()).propagate_replacement(cf.as_table_state(), old_sstables, new_sstables);
+            env.test_compaction_manager().propagate_replacement(cf.as_table_state(), old_sstables, new_sstables);
         };
 
         auto do_incremental_replace = [&] (auto old_sstables, auto new_sstables, auto& expected_sst, auto& closed_sstables_tracker) {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -110,13 +110,6 @@ static flat_mutation_reader_v2 sstable_reader(shared_sstable sst, schema_ptr s, 
     return sst->as_mutation_source().make_reader_v2(s, std::move(permit), query::full_partition_range, s->full_slice());
 }
 
-static future<compaction_result>
-compact_sstables(sstables::compaction_descriptor descriptor, table_for_tests t,
-                 std::function<shared_sstable()> creator, sstables::compaction_sstable_replacer_fn replacer = sstables::replacer_fn_no_op(),
-                 can_purge_tombstones can_purge = can_purge_tombstones::yes) {
-    return compact_sstables(t->get_compaction_manager(), std::move(descriptor), t.as_table_state(), std::move(creator), std::move(replacer), can_purge);
-}
-
 class strategy_control_for_test : public strategy_control {
     bool _has_ongoing_compaction;
     std::optional<std::vector<shared_sstable>> _candidates_opt;

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3034,7 +3034,7 @@ SEASTAR_TEST_CASE(partial_sstable_run_filtered_out_test) {
 
         // register partial sstable run
         auto cm_test = compaction_manager_test(cf->get_compaction_manager());
-        cm_test.run(partial_sstable_run_identifier, cf.as_table_state(), [&cf] (sstables::compaction_data&) {
+        cm_test.run(env, partial_sstable_run_identifier, cf.as_table_state(), [&cf] (sstables::compaction_data&) {
             return cf->compact_all_sstables();
         }).get();
 

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -26,6 +26,10 @@
 #include "test/lib/test_services.hh"
 #include "test/lib/log.hh"
 
+namespace compaction {
+class table_state;
+}
+
 namespace sstables {
 
 class test_env_sstables_manager : public sstables_manager {
@@ -55,6 +59,8 @@ public:
     {}
 
     compaction_manager& get_compaction_manager() { return _cm; }
+
+    void propagate_replacement(compaction::table_state& table_s, const std::vector<shared_sstable>& removed, const std::vector<shared_sstable>& added);
 };
 
 struct test_env_config {

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -28,6 +28,7 @@
 
 namespace compaction {
 class table_state;
+class compaction_task_executor;
 }
 
 namespace sstables {
@@ -61,6 +62,8 @@ public:
     compaction_manager& get_compaction_manager() { return _cm; }
 
     void propagate_replacement(compaction::table_state& table_s, const std::vector<shared_sstable>& removed, const std::vector<shared_sstable>& added);
+
+    future<> perform_compaction(shared_ptr<compaction::compaction_task_executor> task);
 };
 
 struct test_env_config {

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -162,7 +162,7 @@ protected:
 
 future<> compaction_manager_test::run(test_env& env, sstables::run_id output_run_id, table_state& table_s, noncopyable_function<future<> (sstables::compaction_data&)> job) {
     auto& tcm = env.test_compaction_manager();
-    auto task = make_shared<compaction_manager_test_task>(_cm, table_s, output_run_id, std::move(job));
+    auto task = make_shared<compaction_manager_test_task>(tcm.get_compaction_manager(), table_s, output_run_id, std::move(job));
     co_await tcm.perform_compaction(std::move(task));
 }
 

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -99,7 +99,7 @@ shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::memtable>
     return make_sstable_easy(env, mt->make_flat_reader(mt->schema(), env.make_reader_permit()), std::move(cfg), gen, v, estimated_partitions, query_time);
 }
 
-future<compaction_result> compact_sstables(sstables::compaction_descriptor descriptor, table_for_tests t,
+future<compaction_result> compact_sstables(test_env& env, sstables::compaction_descriptor descriptor, table_for_tests t,
                  std::function<shared_sstable()> creator, sstables::compaction_sstable_replacer_fn replacer, can_purge_tombstones can_purge) {
     auto& cm = t->get_compaction_manager();
     auto& table_s = t.as_table_state();

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -112,7 +112,7 @@ future<compaction_result> compact_sstables(test_env& env, sstables::compaction_d
     }
     auto cmt = compaction_manager_test(cm);
     sstables::compaction_result ret;
-    co_await cmt.run(descriptor.run_identifier, table_s, [&] (sstables::compaction_data& cdata) {
+    co_await cmt.run(env, descriptor.run_identifier, table_s, [&] (sstables::compaction_data& cdata) {
         return do_with(compaction_progress_monitor{}, [&] (compaction_progress_monitor& progress_monitor) {
             return sstables::compact_sstables(std::move(descriptor), cdata, table_s, progress_monitor).then([&] (sstables::compaction_result res) {
                 ret = std::move(res);
@@ -160,7 +160,7 @@ protected:
     friend class compaction_manager_test;
 };
 
-future<> compaction_manager_test::run(sstables::run_id output_run_id, table_state& table_s, noncopyable_function<future<> (sstables::compaction_data&)> job) {
+future<> compaction_manager_test::run(test_env& env, sstables::run_id output_run_id, table_state& table_s, noncopyable_function<future<> (sstables::compaction_data&)> job) {
     auto task = make_shared<compaction_manager_test_task>(_cm, table_s, output_run_id, std::move(job));
     _cm._tasks.push_back(task);
     auto unregister_task = defer([this, task] {

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -99,8 +99,10 @@ shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::memtable>
     return make_sstable_easy(env, mt->make_flat_reader(mt->schema(), env.make_reader_permit()), std::move(cfg), gen, v, estimated_partitions, query_time);
 }
 
-future<compaction_result> compact_sstables(compaction_manager& cm, sstables::compaction_descriptor descriptor, table_state& table_s, std::function<shared_sstable()> creator, compaction_sstable_replacer_fn replacer,
-                                           can_purge_tombstones can_purge) {
+future<compaction_result> compact_sstables(sstables::compaction_descriptor descriptor, table_for_tests t,
+                 std::function<shared_sstable()> creator, sstables::compaction_sstable_replacer_fn replacer, can_purge_tombstones can_purge) {
+    auto& cm = t->get_compaction_manager();
+    auto& table_s = t.as_table_state();
     descriptor.creator = [creator = std::move(creator)] (shard_id dummy) mutable {
         return creator();
     };

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -235,7 +235,7 @@ class compaction_manager_test {
 public:
     explicit compaction_manager_test(compaction_manager& cm) noexcept : _cm(cm) {}
 
-    future<> run(sstables::run_id output_run_id, table_state& table_s, noncopyable_function<future<> (sstables::compaction_data&)> job);
+    future<> run(test_env&, sstables::run_id output_run_id, table_state& table_s, noncopyable_function<future<> (sstables::compaction_data&)> job);
 };
 
 using can_purge_tombstones = compaction_manager::can_purge_tombstones;

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -239,7 +239,7 @@ public:
 };
 
 using can_purge_tombstones = compaction_manager::can_purge_tombstones;
-future<compaction_result> compact_sstables(sstables::compaction_descriptor descriptor, table_for_tests t,
+future<compaction_result> compact_sstables(test_env& env, sstables::compaction_descriptor descriptor, table_for_tests t,
                  std::function<shared_sstable()> creator, sstables::compaction_sstable_replacer_fn replacer = sstables::replacer_fn_no_op(),
                  can_purge_tombstones can_purge = can_purge_tombstones::yes);
 

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -236,11 +236,6 @@ public:
     explicit compaction_manager_test(compaction_manager& cm) noexcept : _cm(cm) {}
 
     future<> run(sstables::run_id output_run_id, table_state& table_s, noncopyable_function<future<> (sstables::compaction_data&)> job);
-
-private:
-    sstables::compaction_data& register_compaction(shared_ptr<compaction::compaction_task_executor> task);
-
-    void deregister_compaction(const sstables::compaction_data& c);
 };
 
 using can_purge_tombstones = compaction_manager::can_purge_tombstones;

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -244,9 +244,9 @@ private:
 };
 
 using can_purge_tombstones = compaction_manager::can_purge_tombstones;
-future<compaction_result> compact_sstables(compaction_manager& cm, sstables::compaction_descriptor descriptor, table_state& table_s,
-        std::function<shared_sstable()> creator, sstables::compaction_sstable_replacer_fn replacer = sstables::replacer_fn_no_op(),
-        can_purge_tombstones can_purge = can_purge_tombstones::yes);
+future<compaction_result> compact_sstables(sstables::compaction_descriptor descriptor, table_for_tests t,
+                 std::function<shared_sstable()> creator, sstables::compaction_sstable_replacer_fn replacer = sstables::replacer_fn_no_op(),
+                 can_purge_tombstones can_purge = can_purge_tombstones::yes);
 
 shared_sstable make_sstable_easy(test_env& env, flat_mutation_reader_v2 rd, sstable_writer_config cfg,
         sstables::generation_type gen, const sstables::sstable::version_types version = sstables::get_highest_sstable_version(), int expected_partition = 1, gc_clock::time_point = gc_clock::now());

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -237,9 +237,6 @@ public:
 
     future<> run(sstables::run_id output_run_id, table_state& table_s, noncopyable_function<future<> (sstables::compaction_data&)> job);
 
-    void propagate_replacement(table_state& table_s, const std::vector<sstables::shared_sstable>& removed, const std::vector<sstables::shared_sstable>& added) {
-        _cm.propagate_replacement(table_s, removed, added);
-    }
 private:
     sstables::compaction_data& register_compaction(shared_ptr<compaction::compaction_task_executor> task);
 

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -230,15 +230,8 @@ future<> for_each_sstable_version(AsyncAction action) {
 
 } // namespace sstables
 
-class compaction_manager_test {
-    compaction_manager& _cm;
-public:
-    explicit compaction_manager_test(compaction_manager& cm) noexcept : _cm(cm) {}
-
-    future<> run(test_env&, sstables::run_id output_run_id, table_state& table_s, noncopyable_function<future<> (sstables::compaction_data&)> job);
-};
-
 using can_purge_tombstones = compaction_manager::can_purge_tombstones;
+future<> run_compaction_task(test_env&, sstables::run_id output_run_id, table_state& table_s, noncopyable_function<future<> (sstables::compaction_data&)> job);
 future<compaction_result> compact_sstables(test_env& env, sstables::compaction_descriptor descriptor, table_for_tests t,
                  std::function<shared_sstable()> creator, sstables::compaction_sstable_replacer_fn replacer = sstables::replacer_fn_no_op(),
                  can_purge_tombstones can_purge = can_purge_tombstones::yes);

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -255,6 +255,10 @@ data_dictionary::storage_options make_test_object_storage_options() {
     return ret;
 }
 
+void test_env_compaction_manager::propagate_replacement(compaction::table_state& table_s, const std::vector<shared_sstable>& removed, const std::vector<shared_sstable>& added) {
+    _cm.propagate_replacement(table_s, removed, added);
+}
+
 }
 
 static std::pair<int, char**> rebuild_arg_list_without(int argc, char** argv, const char* filter_out, bool exclude_positional_arg = false) {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -259,6 +259,18 @@ void test_env_compaction_manager::propagate_replacement(compaction::table_state&
     _cm.propagate_replacement(table_s, removed, added);
 }
 
+// Test version of compaction_manager::perform_compaction<>()
+future<> test_env_compaction_manager::perform_compaction(shared_ptr<compaction::compaction_task_executor> task) {
+    _cm._tasks.push_back(task);
+    auto unregister_task = defer([this, task] {
+        if (_cm._tasks.remove(task) == 0) {
+            testlog.error("compaction_manager_test: deregister_compaction uuid={}: task not found", task->compaction_data().compaction_uuid);
+        }
+        task->switch_state(compaction_task_executor::state::none);
+    });
+    co_await task->run_compaction();
+}
+
 }
 
 static std::pair<int, char**> rebuild_arg_list_without(int argc, char** argv, const char* filter_out, bool exclude_positional_arg = false) {


### PR DESCRIPTION
This is continuation of a34c8dc4 (Drop compaction_manager_for_testing).

There's one more wrapper over compaction_manager to access its private fields. All such access was recently moved to sstables::test_env's compaction manager, now it's time to drop the remaining legacy wrapper class.