### PR TITLE
gossiper: Elevate logging level for node restart events

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1683,7 +1683,7 @@ future<> gossiper::handle_major_state_change(inet_address ep, endpoint_state eps
 
     if (!is_dead_state(eps) && !is_in_shadow_round()) {
         if (_endpoint_state_map.contains(ep))  {
-            logger.debug("Node {} has restarted, now UP, status = {}", ep, get_gossip_status(eps));
+            logger.info("Node {} has restarted, now UP, status = {}", ep, get_gossip_status(eps));
         } else {
             logger.debug("Node {} is now part of the cluster, status = {}", ep, get_gossip_status(eps));
         }


### PR DESCRIPTION
They cause connection drops, which is a significant disruptive event. We should log it so that we can know that this is the cause of the problems it may cause, like requests timing out. Connection drop will cause coordinator-side requests to time out in the absence of speculation.

Refs #14746