### PR TITLE
commitlog: add max disk size api

### DIFF
--- a/api/api-doc/commitlog.json
+++ b/api/api-doc/commitlog.json
@@ -144,6 +144,21 @@
           "parameters": []
         }
       ]
+    },
+    {
+      "path": "/commitlog/metrics/max_disk_size",
+      "operations": [
+        {
+          "method": "GET",
+          "summary": "Get max disk size",
+          "type": "long",
+          "nickname": "get_max_disk_size",
+          "produces": [
+            "application/json"
+          ],
+          "parameters": []
+        }
+      ]
     }
    ]
 }

--- a/api/commitlog.cc
+++ b/api/commitlog.cc
@@ -62,6 +62,9 @@ void set_commitlog(http_context& ctx, routes& r) {
     httpd::commitlog_json::get_total_commit_log_size.set(r, [&ctx](std::unique_ptr<request> req) {
         return acquire_cl_metric<uint64_t>(ctx, std::bind(&db::commitlog::get_total_size, std::placeholders::_1));
     });
+    httpd::commitlog_json::get_max_disk_size.set(r, [&ctx](std::unique_ptr<request> req) {
+        return acquire_cl_metric<uint64_t>(ctx, std::bind(&db::commitlog::disk_limit, std::placeholders::_1));
+    });
 }
 
 }


### PR DESCRIPTION
Currently, the max size of commitlog is obtained either from the config parameter commitlog_total_space_in_mb or, when the parameter is -1, from the total memory allocated for Scylla. To facilitate testing of the behavior of commitlog hard limit, expose the value of commitlog max_disk_size in a dedicated API