### PR TITLE
When add duration field to UDT check whether this UDT is used in some…

### DIFF
--- a/cql3/statements/alter_type_statement.cc
+++ b/cql3/statements/alter_type_statement.cc
@@ -135,6 +135,18 @@ user_type alter_type_statement::add_or_alter::do_add(data_dictionary::database d
         throw exceptions::invalid_request_exception(format("Cannot add new field to type {}: maximum number of fields reached", _name));
     }
 
+    if (_field_type->is_duration()) {
+        auto&& ks = db.find_keyspace(keyspace());
+        for (auto&& schema : ks.metadata()->cf_meta_data() | boost::adaptors::map_values) {
+            for (auto&& column : schema->clustering_key_columns()) {
+                if (column.type->references_user_type(_name.get_keyspace(), _name.get_user_type_name())) {
+                    throw exceptions::invalid_request_exception(format("Cannot add new field to type {} because it is used in the clustering key column {} of table {}.{} where durations are not allowed",
+                        _name.to_cql_string(), column.name_as_text(), schema->ks_name(), schema->cf_name()));
+                }
+            }
+        }
+    }
+
     std::vector<bytes> new_names(to_update->field_names());
     new_names.push_back(_field_name->name());
     std::vector<data_type> new_types(to_update->field_types());

--- a/test/boost/user_types_test.cc
+++ b/test/boost/user_types_test.cc
@@ -199,6 +199,12 @@ SEASTAR_TEST_CASE(test_invalid_user_type_statements) {
                 "Cannot drop user type ks.ut6 as it is still used by user type ut7");
         e.execute_cql("drop type ut7").discard_result().get();
         e.execute_cql("drop type ut6").discard_result().get();
+
+        // cannot add duration field to UDT used in clustering keys (issue #12913)
+        e.execute_cql("create type ut8 (a int, b int)").discard_result().get();
+        e.execute_cql("create table cf4 (pk int, ck frozen<ut8>, primary key(pk, ck))").discard_result().get();
+        REQUIRE_INVALID(e, "alter type ut8 add d duration",
+                "Cannot add new field to type ks.ut8 because it is used in the clustering key column ck of table ks.cf4 where durations are not allowed");
     });
 }
 


### PR DESCRIPTION
… clustering key

Having values of the duration type is not allowed for clustering columns, because duration can't be ordered. This is correctly validated when creating a table but do not validated when we alter the type.

This issue is reproduced in cassandra as well and that's why we have only unit test here

Fixes #12913