### PR TITLE
[Backport 5.4]: docs: render options with role

### DIFF
--- a/docs/_ext/scylladb_cc_properties.py
+++ b/docs/_ext/scylladb_cc_properties.py
@@ -1,13 +1,21 @@
 import os
 import re
 import yaml
-from sphinx.application import Sphinx
-from sphinxcontrib.datatemplates.directive import DataTemplateYAML
-from docutils.parsers.rst import directives
+from typing import Any, Dict, List
 
-CONFIG_FILE_PATH = "../db/config.cc"
-CONFIG_HEADER_FILE_PATH = "../db/config.hh"
-DESTINATION_PATH = "_data/db_config.yaml"
+import jinja2
+
+from sphinx import addnodes
+from sphinx.application import Sphinx
+from sphinx.directives import ObjectDescription
+from sphinx.util import logging, status_iterator, ws_re
+from sphinx.util.docfields import Field
+from sphinx.util.docutils import switch_source_input, SphinxDirective
+from sphinx.util.nodes import nested_parse_with_titles
+from sphinx.jinja2glue import BuiltinTemplateLoader
+from docutils import nodes
+from docutils.parsers.rst import directives
+from docutils.statemachine import StringList
 
 
 class DBConfigParser:
@@ -47,24 +55,11 @@ class DBConfigParser:
     """
     COMMENT_PATTERN = r"/\*.*?\*/|//.*?$"
 
-    def __init__(self, config_file_path, config_header_file_path, destination_path):
+    all_properties = {}
+
+    def __init__(self, config_file_path, config_header_file_path):
         self.config_file_path = config_file_path
         self.config_header_file_path = config_header_file_path
-        self.destination_path = destination_path
-
-    def _create_yaml_file(self, destination, data):
-        current_data = None
-
-        try:
-            with open(destination, "r") as file:
-                current_data = yaml.safe_load(file)
-        except FileNotFoundError:
-            pass
-
-        if current_data != data:
-            os.makedirs(os.path.dirname(destination), exist_ok=True)
-            with open(destination, "w") as file:
-                yaml.dump(data, file)
 
     @staticmethod
     def _clean_description(description):
@@ -111,14 +106,16 @@ class DBConfigParser:
         config_matches = re.findall(self.CONFIG_CC_REGEX_PATTERN, content, re.DOTALL)
 
         for match in config_matches:
+            name = match[1].strip()
             property_data = {
-                "name": match[1].strip(),
+                "name": name,
                 "value_status": match[4].strip(),
                 "default": match[5].strip(),
                 "liveness": "True" if match[3] else "False",
                 "description": self._clean_description(match[6].strip()),
             }
             properties.append(property_data)
+            DBConfigParser.all_properties[name] = property_data
 
         return properties
 
@@ -135,7 +132,7 @@ class DBConfigParser:
                     if property_data["name"] == property_key:
                         property_data["type"] = match[0].strip()
 
-    def _parse_db_properties(self):
+    def parse(self):
         groups = []
 
         with open(self.config_file_path, "r", encoding='utf-8') as file:
@@ -158,26 +155,56 @@ class DBConfigParser:
 
         return groups
 
-    def run(self, app: Sphinx):
-        dest_path = os.path.join(app.builder.srcdir, self.destination_path)
-        parsed_properties = self._parse_db_properties()
-        self._create_yaml_file(dest_path, parsed_properties)
+
+class ConfigOptionList(SphinxDirective):
+    has_content = False
+    required_arguments = 2
+    optional_arguments = 0
+    final_argument_whitespace = True
+    option_spec = {
+        'template': directives.path,
+        'value_status': directives.unchanged_required,
+    }
+
+    @property
+    def env(self):
+        document = self.state.document
+        return document.settings.env
+
+    def _resolve_src_path(self, path: str) -> str:
+        rel_filename, filename = self.env.relfn2path(path)
+        self.env.note_dependency(filename)
+        return filename
+
+    def _render(self, context: Dict[str, Any]) -> str:
+        builder = self.env.app.builder
+        template = self.options.get('template')
+        if template is None:
+            self.error(f'Option "template" not specified!')
+        return builder.templates.render(template, context)
+
+    def _make_context(self) -> Dict[str, Any]:
+        header = self._resolve_src_path(self.arguments[0])
+        source = self._resolve_src_path(self.arguments[1])
+        db_parser = DBConfigParser(source, header)
+        value_status = self.options.get("value_status")
+        return dict(data=db_parser.parse(),
+                    value_status=value_status)
+
+    def run(self) -> List[nodes.Node]:
+        rendered = self._render(self._make_context())
+        contents = StringList(rendered.splitlines())
+        node = nodes.section()
+        node.document = self.state.document
+        nested_parse_with_titles(self.state, contents, node)
+        return node.children
 
 
-class DBConfigTemplateDirective(DataTemplateYAML):
+def setup(app: Sphinx) -> Dict[str, Any]:
+    app.add_directive('scylladb_config_list', ConfigOptionList)
 
-    option_spec = DataTemplateYAML.option_spec.copy()
-    option_spec["value_status"] = directives.unchanged_required
-
-    def _make_context(self, data, config, env):
-        context = super()._make_context(data, config, env)
-        context["value_status"] = self.options.get("value_status")
-        return context
-
-
-def setup(app: Sphinx):
-    db_parser = DBConfigParser(
-        CONFIG_FILE_PATH, CONFIG_HEADER_FILE_PATH, DESTINATION_PATH
-    )
-    app.connect("builder-inited", db_parser.run)
-    app.add_directive("scylladb_config_template", DBConfigTemplateDirective)
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -28,3 +28,7 @@ h3 .pre {
 hr {
     max-width: 100%;
 }
+
+dl dt:hover > a.headerlink {
+    visibility: visible;
+}

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -17,10 +17,14 @@
 }
 
 .content blockquote li p {
-    margin-bottom: 10px;
+    margin-bottom: 5px;
 }
 
 h3 .pre {
     font-size: 16px;
     font-weight: bold;
+}
+
+hr {
+    max-width: 100%;
 }

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -32,3 +32,7 @@ hr {
 dl dt:hover > a.headerlink {
     visibility: visible;
 }
+
+dl.confval {
+    border-bottom: 1px solid #cacaca;
+}

--- a/docs/_templates/db_config.tmpl
+++ b/docs/_templates/db_config.tmpl
@@ -13,8 +13,8 @@
 
 {% for item in group.properties %}
 {% if item.value_status == value_status %}
-``{{ item.name }}``
-{{ '=' * (item.name|length + 4) }}
+{{ item.name }}
+{{ '=' * (item.name|length) }}
 
    .. raw:: html
 
@@ -24,6 +24,9 @@
    {% if item.default %}* **Default value:** ``{{ item.default }}``{% endif %}
    {% if item.liveness %}* **Liveness** :term:`* <Liveness>` **:** ``{{ item.liveness }}``{% endif %}
 
+.. raw:: html
+
+   <hr/>
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/docs/_templates/db_config.tmpl
+++ b/docs/_templates/db_config.tmpl
@@ -13,20 +13,7 @@
 
 {% for item in group.properties %}
 {% if item.value_status == value_status %}
-{{ item.name }}
-{{ '=' * (item.name|length) }}
-
-   .. raw:: html
-
-      <p>{{ item.description }}</p>
-
-   {% if item.type %}* **Type:** ``{{ item.type }}``{% endif %}
-   {% if item.default %}* **Default value:** ``{{ item.default }}``{% endif %}
-   {% if item.liveness %}* **Liveness** :term:`* <Liveness>` **:** ``{{ item.liveness }}``{% endif %}
-
-.. raw:: html
-
-   <hr/>
+.. confval:: {{ item.name }}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/docs/_templates/db_config.tmpl
+++ b/docs/_templates/db_config.tmpl
@@ -8,7 +8,7 @@
 {% if group.description %}
 .. raw:: html
 
-   <p>{{ group.description }}</p>
+   <p>{{ group.description | readable_desc }}</p>
 {% endif %}
 
 {% for item in group.properties %}

--- a/docs/_templates/db_option.tmpl
+++ b/docs/_templates/db_option.tmpl
@@ -5,7 +5,3 @@
    {% if type %}* **Type:** ``{{ type }}``{% endif %}
    {% if default %}* **Default value:** ``{{ default }}``{% endif %}
    {% if liveness %}* **Liveness** :term:`* <Liveness>` **:** ``{{ liveness }}``{% endif %}
-
-.. raw:: html
-
-   <hr/>

--- a/docs/_templates/db_option.tmpl
+++ b/docs/_templates/db_option.tmpl
@@ -1,6 +1,6 @@
    .. raw:: html
 
-      <p>{{ description }}</p>
+      <p>{{ description | readable_desc }}</p>
 
    {% if type %}* **Type:** ``{{ type }}``{% endif %}
    {% if default %}* **Default value:** ``{{ default }}``{% endif %}

--- a/docs/_templates/db_option.tmpl
+++ b/docs/_templates/db_option.tmpl
@@ -1,0 +1,11 @@
+   .. raw:: html
+
+      <p>{{ description }}</p>
+
+   {% if type %}* **Type:** ``{{ type }}``{% endif %}
+   {% if default %}* **Default value:** ``{{ default }}``{% endif %}
+   {% if liveness %}* **Liveness** :term:`* <Liveness>` **:** ``{{ liveness }}``{% endif %}
+
+.. raw:: html
+
+   <hr/>

--- a/docs/reference/configuration-parameters.rst
+++ b/docs/reference/configuration-parameters.rst
@@ -5,6 +5,6 @@ Configuration Parameters
 This section contains a list of properties that can be configured in ``scylla.yaml`` - the main configuration file for ScyllaDB.
 In addition, properties that support live updates (liveness) can be updated via the ``system.config`` virtual table or the REST API.
 
-.. scylladb_config_template:: ../_data/db_config.yaml
+.. scylladb_config_list:: ../../db/config.hh ../../db/config.cc
   :template: db_config.tmpl
   :value_status: Used


### PR DESCRIPTION
since we use `sphinx_multiversion` for building multiple versions of document. and in #15860, we changed the way how options are rendered, so the same change should be applied to the branch which includes the option list.

to address the conflicts, in addition to #15860, the depended PRs are also backported. so, in this pull request, following PRs are backported:

- #15827
- #15782
- #15860