### PR TITLE
generic_server: use mutable reference in `for_each_genlty`

### DIFF
--- a/generic_server.cc
+++ b/generic_server.cc
@@ -40,7 +40,7 @@ connection::~connection()
     _server.maybe_stop();
 }
 
-future<> server::for_each_gently(noncopyable_function<void(const connection&)> fn) {
+future<> server::for_each_gently(noncopyable_function<void(connection&)> fn) {
     _gentle_iterators.emplace_front(*this);
     std::list<gentle_iterator>::iterator gi = _gentle_iterators.begin();
     return seastar::do_until([ gi ] { return gi->iter == gi->end; },

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -85,8 +85,8 @@ protected:
     using connections_list_t = boost::intrusive::list<connection>;
     connections_list_t _connections_list;
     struct gentle_iterator {
-        connections_list_t::const_iterator iter, end;
-        gentle_iterator(const server& s) : iter(s._connections_list.begin()), end(s._connections_list.end()) {}
+        connections_list_t::iterator iter, end;
+        gentle_iterator(server& s) : iter(s._connections_list.begin()), end(s._connections_list.end()) {}
         gentle_iterator(const gentle_iterator&) = delete;
         gentle_iterator(gentle_iterator&&) = delete;
     };
@@ -118,7 +118,7 @@ protected:
 
     virtual future<> unadvertise_connection(shared_ptr<connection> conn);
 
-    future<> for_each_gently(noncopyable_function<void(const connection&)>);
+    future<> for_each_gently(noncopyable_function<void(connection&)>);
 
     void maybe_stop();
 };


### PR DESCRIPTION
Make `generic_server::gentle_iterator` a mutable iterator to allow `for_each_gently` to make changes to the connections.

Fixes: #16035