### PR TITLE
When creating S3-backed keyspace, check the endpoint instantly

### DIFF
--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -77,10 +77,6 @@ void create_keyspace_statement::validate(query_processor& qp, const service::cli
     } catch (const std::runtime_error& e) {
         throw exceptions::invalid_request_exception(e.what());
     }
-    if (!qp.proxy().features().keyspace_storage_options
-            && _attrs->get_storage_options().type_string() != "LOCAL") {
-        throw exceptions::invalid_request_exception("Keyspace storage options not supported in the cluster");
-    }
 #if 0
     // The strategy is validated through KSMetaData.validate() in announceNewKeyspace below.
     // However, for backward compatibility with thrift, this doesn't validate unexpected options yet,

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1422,6 +1422,7 @@ void database::validate_new_keyspace(keyspace_metadata& ksm) {
     if (has_keyspace(ksm.name())) {
         throw exceptions::already_exists_exception{ksm.name()};
     }
+    _user_sstables_manager->validate_new_keyspace_storage_options(ksm.get_storage_options());
 }
 
 schema_ptr database::find_schema(const sstring& ks_name, const sstring& cf_name) const {

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -91,6 +91,10 @@ shared_ptr<s3::client> storage_manager::get_endpoint_client(sstring endpoint) {
     return ep.client;
 }
 
+bool storage_manager::is_known_endpoint(sstring endpoint) const {
+    return _s3_endpoints.contains(endpoint);
+}
+
 storage_manager::config_updater::config_updater(const db::config& cfg, storage_manager& sstm)
     : action([&sstm, &cfg] () mutable {
         return sstm.container().invoke_on_all([&cfg] (auto& sstm) {

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -212,4 +212,16 @@ future<> sstables_manager::destroy_table_storage(const data_dictionary::storage_
     return sstables::destroy_table_storage(so, dir);
 }
 
+void sstables_manager::validate_new_keyspace_storage_options(const data_dictionary::storage_options& so) {
+    std::visit(overloaded_functor {
+        [] (const data_dictionary::storage_options::local&) {
+        },
+        [this] (const data_dictionary::storage_options::s3& so) {
+            if (!_features.keyspace_storage_options) {
+                throw exceptions::invalid_request_exception("Keyspace storage options not supported in the cluster");
+            }
+        }
+    }, so.value);
+}
+
 }   // namespace sstables

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -220,6 +220,10 @@ void sstables_manager::validate_new_keyspace_storage_options(const data_dictiona
             if (!_features.keyspace_storage_options) {
                 throw exceptions::invalid_request_exception("Keyspace storage options not supported in the cluster");
             }
+            // It's non-system keyspace
+            if (!is_known_endpoint(so.endpoint)) {
+                throw exceptions::configuration_exception(format("Endpoint {} not configured", so.endpoint));
+            }
         }
     }, so.value);
 }

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -71,6 +71,7 @@ public:
 
     storage_manager(const db::config&, config cfg);
     shared_ptr<s3::client> get_endpoint_client(sstring endpoint);
+    bool is_known_endpoint(sstring endpoint) const;
     future<> stop();
 };
 
@@ -126,6 +127,11 @@ public:
     shared_ptr<s3::client> get_endpoint_client(sstring endpoint) const {
         assert(_storage != nullptr);
         return _storage->get_endpoint_client(std::move(endpoint));
+    }
+
+    bool is_known_endpoint(sstring endpoint) const {
+        assert(_storage != nullptr);
+        return _storage->is_known_endpoint(std::move(endpoint));
     }
 
     virtual sstable_writer_config configure_writer(sstring origin) const;

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -171,6 +171,8 @@ public:
     future<> destroy_table_storage(const data_dictionary::storage_options& so, sstring dir);
     future<> init_keyspace_storage(const data_dictionary::storage_options& so, sstring dir);
 
+    void validate_new_keyspace_storage_options(const data_dictionary::storage_options&);
+
 private:
     void add(sstable* sst);
     // Transition the sstable to the "inactive" state. It has no

--- a/test/cql-pytest/test_keyspace.py
+++ b/test/cql-pytest/test_keyspace.py
@@ -252,16 +252,6 @@ def test_storage_options_alter_type(cql, scylla_only):
         with pytest.raises(InvalidRequest):
             res = cql.execute(f"ALTER KEYSPACE {keyspace} {ksdef_local}")
 
-# Test that server-side desc statement is able to describe storage options, when not local.
-def test_storage_options_describe(cql, scylla_only):
-    ksdef = "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : '1' } " \
-            "AND STORAGE = {'type': 'S3', 'bucket': '42', 'endpoint': 'localhost'}"
-
-    with new_test_keyspace(cql, ksdef) as keyspace:
-        desc_output = cql.execute(f"DESC KEYSPACE \"{keyspace}\"").one().create_statement
-
-        assert "{'type': 'S3', 'bucket': '42', 'endpoint': 'localhost'}" in desc_output
-
 # Reproducer for scylladb#14139
 def test_alter_keyspace_preserves_udt(cql):
     ks = unique_name()

--- a/test/object_store/test_basic.py
+++ b/test/object_store/test_basic.py
@@ -146,6 +146,11 @@ async def test_basic(test_tempdir, s3_server, ssl):
         # Sanity check that the path is constructed correctly
         assert os.path.exists(os.path.join(test_tempdir, 'data/system')), "Datadir is elsewhere"
 
+        desc = conn.execute(f"DESCRIBE KEYSPACE {ks}").one().create_statement
+        # The storage_opts wraps options with '{ <options> }' while the DESCRIBE
+        # does it like '{<options>}' so strip the corner brances and spaces for check
+        assert f"{{'type': 'S3', 'bucket': '{s3_server.bucket_name}', 'endpoint': '{s3_server.address}'}}" in desc, "DESCRIBE generates unexpected storage options"
+
         res = conn.execute(f"SELECT * FROM {ks}.{cf};")
         rows = {x.name: x.value for x in res}
         assert len(rows) > 0, 'Test table is empty'

--- a/test/object_store/test_basic.py
+++ b/test/object_store/test_basic.py
@@ -14,6 +14,7 @@ import xml.etree.ElementTree as ET
 
 from contextlib import contextmanager
 from test.pylib.rest_client import ScyllaRESTAPIClient
+from cassandra.protocol import ConfigurationException
 
 
 def get_scylla_with_s3_cmd(ssl, s3_server):
@@ -227,3 +228,20 @@ async def test_garbage_collect(test_tempdir, s3_server, ssl):
         for o in objects:
             for ent in sstable_entries:
                 assert not o.startswith(str(ent[1])), f'Sstable object not cleaned, found {o}'
+
+@pytest.mark.asyncio
+async def test_misconfigured_storage(test_tempdir, s3_server, ssl):
+    '''creating keyspace with unknown endpoint is not allowed'''
+    # scylladb/scylladb#15074
+    with managed_cluster(test_tempdir, ssl, s3_server) as cluster:
+        print(f'Create keyspace (minio listening at {s3_server.address})')
+        replication_opts = format_tuples({'class': 'NetworkTopologyStrategy',
+                                          'replication_factor': '1'})
+        storage_opts = format_tuples(type='S3',
+                                     endpoint='unknown_endpoint',
+                                     bucket=s3_server.bucket_name)
+
+        conn = cluster.cql.connect()
+        with pytest.raises(ConfigurationException):
+            conn.execute((f"CREATE KEYSPACE test_ks WITH"
+                          f" REPLICATION = {replication_opts} AND STORAGE = {storage_opts};"))


### PR DESCRIPTION
Currently CREATE KEYSPACE ... WITH STORAGE = { 'type' = 'S3' ... } will create keyspace even if the backend configuration is "invalid" in the sense that the requested endpoint is not known to scylla via object_storage.yaml config file. The first time after that when this misconfiguration will reveal itself is when flushing a memtable (see #15635), but it's good to know the endpoint is not configured earlier than that.

fixes: #15074 