### PR TITLE
scylla-gdb: raise if no tasks are found

### DIFF
--- a/test/scylla-gdb/test_misc.py
+++ b/test/scylla-gdb/test_misc.py
@@ -152,6 +152,7 @@ def task(gdb, scylla_gdb):
         name = scylla_gdb.resolve(vtable_addr, startswith='vtable for seastar::continuation')
         if name and 'do_accept_one' in name:
             return obj_addr.cast(gdb.lookup_type('uintptr_t'))
+    raise gdb.error("no tasks found with expected name")
 
 def test_fiber(gdb, task):
     scylla(gdb, f'fiber {task}')


### PR DESCRIPTION
the "task" fixture is supposed to return a task for test, if it fails to do so, it would be an issue not directly related to the test. so let's fail it early.

this change was inspired when debugging the test failures found in #16037 .