### PR TITLE
build: cmake: consolidate the setting of cxx_flags

### DIFF
--- a/cmake/mode.Coverage.cmake
+++ b/cmake/mode.Coverage.cmake
@@ -1,11 +1,12 @@
 set(Seastar_OptimizationLevel_COVERAGE "g")
 set(CMAKE_CXX_FLAGS_COVERAGE
-  ""
+  "-fprofile-instr-generate -fcoverage-mapping"
   CACHE
   INTERNAL
   "")
-string(APPEND CMAKE_CXX_FLAGS_COVERAGE
-  " -O${Seastar_OptimizationLevel_SANITIZE}")
+update_cxx_flags(CMAKE_CXX_FLAGS_COVERAGE
+  WITH_DEBUG_INFO
+  OPTIMIZATION_LEVEL ${Seastar_OptimizationLevel_COVERAGE})
 
 set(Seastar_DEFINITIONS_COVERAGE
   SCYLLA_BUILD_MODE=coverage
@@ -17,9 +18,6 @@ foreach(definition ${Seastar_DEFINITIONS_COVERAGE})
   add_compile_definitions(
     $<$<CONFIG:Coverage>:${definition}>)
 endforeach()
-
-set(CMAKE_CXX_FLAGS_COVERAGE
-  " -O${Seastar_OptimizationLevel_COVERAGE} -fprofile-instr-generate -fcoverage-mapping -g -gz")
 
 set(CMAKE_STATIC_LINKER_FLAGS_COVERAGE
   "-fprofile-instr-generate -fcoverage-mapping")

--- a/cmake/mode.Debug.cmake
+++ b/cmake/mode.Debug.cmake
@@ -21,7 +21,8 @@ foreach(definition ${Seastar_DEFINITIONS_DEBUG})
     $<$<CONFIG:Debug>:${definition}>)
 endforeach()
 
-set(CMAKE_CXX_FLAGS_DEBUG
-  " -O${Seastar_OptimizationLevel_DEBUG} -g -gz")
+update_cxx_flags(CMAKE_CXX_FLAGS_DEBUG
+  WITH_DEBUG_INFO
+  OPTIMIZATION_LEVEL ${Seastar_OptimizationLevel_DEBUG})
 
 maybe_limit_stack_usage_in_KB(40 Debug)

--- a/cmake/mode.Dev.cmake
+++ b/cmake/mode.Dev.cmake
@@ -4,8 +4,8 @@ set(CMAKE_CXX_FLAGS_DEV
   CACHE
   INTERNAL
   "")
-string(APPEND CMAKE_CXX_FLAGS_DEV
-  " -O${Seastar_OptimizationLevel_DEV}")
+update_cxx_flags(CMAKE_CXX_FLAGS_RELEASE
+  OPTIMIZATION_LEVEL ${Seastar_OptimizationLevel_Dev})
 
 set(Seastar_DEFINITIONS_DEV
   SCYLLA_BUILD_MODE=devel

--- a/cmake/mode.Release.cmake
+++ b/cmake/mode.Release.cmake
@@ -4,8 +4,9 @@ set(CMAKE_CXX_FLAGS_RELEASE
   CACHE
   INTERNAL
   "")
-string(APPEND CMAKE_CXX_FLAGS_RELEASE
-  " -O${Seastar_OptimizationLevel_RELEASE}")
+update_cxx_flags(CMAKE_CXX_FLAGS_RELEASE
+  WITH_DEBUG_INFO
+  OPTIMIZATION_LEVEL ${Seastar_OptimizationLevel_RELEASE})
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
   set(clang_inline_threshold 300)

--- a/cmake/mode.Sanitize.cmake
+++ b/cmake/mode.Sanitize.cmake
@@ -4,8 +4,9 @@ set(CMAKE_CXX_FLAGS_SANITIZE
   CACHE
   INTERNAL
   "")
-string(APPEND CMAKE_CXX_FLAGS_SANITIZE
-  " -O${Seastar_OptimizationLevel_SANITIZE}")
+update_cxx_flags(CMAKE_CXX_FLAGS_COVERAGE
+  WITH_DEBUG_INFO
+  OPTIMIZATION_LEVEL ${Seastar_OptimizationLevel_SANITIZE})
 
 set(Seastar_DEFINITIONS_SANITIZE
   SCYLLA_BUILD_MODE=sanitize

--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -94,6 +94,23 @@ function(maybe_limit_stack_usage_in_KB stack_usage_threshold_in_KB config)
   endif()
 endfunction()
 
+macro(update_cxx_flags flags)
+  cmake_parse_arguments (
+    parsed_args
+    "WITH_DEBUG_INFO"
+    "OPTIMIZATION_LEVEL"
+    ""
+    ${ARGN})
+  if(NOT DEFINED parsed_args_OPTIMIZATION_LEVEL)
+    message(FATAL_ERROR "OPTIMIZATION_LEVEL is missing")
+  endif()
+  string(APPEND ${flags}
+    " -O${parsed_args_OPTIMIZATION_LEVEL}")
+  if(parsed_args_WITH_DEBUG_INFO)
+    string(APPEND ${flags} " -g -gz")
+  endif()
+endmacro()
+
 # Force SHA1 build-id generation
 add_link_options("LINKER:--build-id=sha1")
 include(CheckLinkerFlag)


### PR DESCRIPTION
before this change, we define the CMAKE_CXX_FLAGS_${CONFIG} directly. and some of the configurations are supposed to generate debugging info with "-g -gz" options, but they failed to include these options in the cxx flags.

in this change:

* a macro named `update_cxx_flags` is introduced to set this option.
* this macro also sets -O option

instead of using function, this facility is implemented as a macro so that we can update the CMAKE_CXX_FLAGS_${CONFIG} without setting this variable with awkward syntax like set

```cmake
set(${flags} "${${flags}}" PARENT_SCOPE)
```

this mirrors the behavior in configure.py in sense that the latter sets the option on a per-mode basis, and interprets the option to compiling option.