### PR TITLE
build: cmake: define SCYLLA_BUILD_MODE for Release build

### DIFF
--- a/cmake/mode.Release.cmake
+++ b/cmake/mode.Release.cmake
@@ -7,6 +7,9 @@ set(CMAKE_CXX_FLAGS_RELEASE
 string(APPEND CMAKE_CXX_FLAGS_RELEASE
   " -O${Seastar_OptimizationLevel_RELEASE}")
 
+add_compile_definitions(
+    $<$<CONFIG:Release>:SCYLLA_BUILD_MODE=release>)
+
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
   set(clang_inline_threshold 300)
 else()


### PR DESCRIPTION
this macro definition was dropped in 2b961d8e3f by accident. in this change, let's bring it back. this macro is always necessary, as it is checked in scylla source.