### PR TITLE
build: cmake: drop Seastar_OptimizationLevel_*

### DIFF
--- a/cmake/mode.Coverage.cmake
+++ b/cmake/mode.Coverage.cmake
@@ -1,4 +1,3 @@
-set(Seastar_OptimizationLevel_COVERAGE "g")
 set(CMAKE_CXX_FLAGS_COVERAGE
   "-fprofile-instr-generate -fcoverage-mapping"
   CACHE
@@ -6,7 +5,7 @@ set(CMAKE_CXX_FLAGS_COVERAGE
   "")
 update_cxx_flags(CMAKE_CXX_FLAGS_COVERAGE
   WITH_DEBUG_INFO
-  OPTIMIZATION_LEVEL ${Seastar_OptimizationLevel_COVERAGE})
+  OPTIMIZATION_LEVEL "g")
 
 set(Seastar_DEFINITIONS_COVERAGE
   SCYLLA_BUILD_MODE=coverage

--- a/cmake/mode.Debug.cmake
+++ b/cmake/mode.Debug.cmake
@@ -1,14 +1,13 @@
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
   # -fasan -Og breaks some coroutines on aarch64, use -O0 instead
-  set(default_Seastar_OptimizationLevel_DEBUG "0")
+  set(OptimizationLevel "0")
 else()
-  set(default_Seastar_OptimizationLevel_DEBUG "g")
+  set(OptimizationLevel "g")
 endif()
-set(Seastar_OptimizationLevel_DEBUG
-  ${default_Seastar_OptimizationLevel_DEBUG}
-  CACHE
-  INTERNAL
-  "")
+
+update_cxx_flags(CMAKE_CXX_FLAGS_DEBUG
+  WITH_DEBUG_INFO
+  OPTIMIZATION_LEVEL ${OptimizationLevel})
 
 set(Seastar_DEFINITIONS_DEBUG
   SCYLLA_BUILD_MODE=debug
@@ -20,9 +19,5 @@ foreach(definition ${Seastar_DEFINITIONS_DEBUG})
   add_compile_definitions(
     $<$<CONFIG:Debug>:${definition}>)
 endforeach()
-
-update_cxx_flags(CMAKE_CXX_FLAGS_DEBUG
-  WITH_DEBUG_INFO
-  OPTIMIZATION_LEVEL ${Seastar_OptimizationLevel_DEBUG})
 
 maybe_limit_stack_usage_in_KB(40 Debug)

--- a/cmake/mode.Dev.cmake
+++ b/cmake/mode.Dev.cmake
@@ -1,11 +1,10 @@
-set(Seastar_OptimizationLevel_DEV "2")
 set(CMAKE_CXX_FLAGS_DEV
   ""
   CACHE
   INTERNAL
   "")
-update_cxx_flags(CMAKE_CXX_FLAGS_RELEASE
-  OPTIMIZATION_LEVEL ${Seastar_OptimizationLevel_Dev})
+update_cxx_flags(CMAKE_CXX_FLAGS_DEV
+  OPTIMIZATION_LEVEL "2")
 
 set(Seastar_DEFINITIONS_DEV
   SCYLLA_BUILD_MODE=devel

--- a/cmake/mode.Release.cmake
+++ b/cmake/mode.Release.cmake
@@ -1,4 +1,3 @@
-set(Seastar_OptimizationLevel_RELEASE "3")
 set(CMAKE_CXX_FLAGS_RELEASE
   "-ffunction-sections -fdata-sections"
   CACHE
@@ -6,7 +5,7 @@ set(CMAKE_CXX_FLAGS_RELEASE
   "")
 update_cxx_flags(CMAKE_CXX_FLAGS_RELEASE
   WITH_DEBUG_INFO
-  OPTIMIZATION_LEVEL ${Seastar_OptimizationLevel_RELEASE})
+  OPTIMIZATION_LEVEL "3")
 
 add_compile_definitions(
     $<$<CONFIG:Release>:SCYLLA_BUILD_MODE=release>)

--- a/cmake/mode.Sanitize.cmake
+++ b/cmake/mode.Sanitize.cmake
@@ -1,12 +1,11 @@
-set(Seastar_OptimizationLevel_SANITIZE "s")
 set(CMAKE_CXX_FLAGS_SANITIZE
   ""
   CACHE
   INTERNAL
   "")
-update_cxx_flags(CMAKE_CXX_FLAGS_COVERAGE
+update_cxx_flags(CMAKE_CXX_FLAGS_SANITIZE
   WITH_DEBUG_INFO
-  OPTIMIZATION_LEVEL ${Seastar_OptimizationLevel_SANITIZE})
+  OPTIMIZATION_LEVEL "s")
 
 set(Seastar_DEFINITIONS_SANITIZE
   SCYLLA_BUILD_MODE=sanitize


### PR DESCRIPTION
in this change,

* all `Seastar_OptimizationLevel_*` are dropped.
* mode.Sanitize.cmake: s/CMAKE_CXX_FLAGS_COVERAGE/CMAKE_CXX_FLAGS_SANITIZE/
* mode.Dev.cmake: s/CMAKE_CXX_FLAGS_RELEASE/CMAKE_CXX_FLAGS_DEV/

Seastar_OptimizationLevel_* variables have nothing to do with Seastar, and they introduce unnecessary indirection. the function of `update_cxx_flags()` already requires an option name for this parameter, so there is no need to have a name for it.

the cached entry of `Seastar_OptimizationLevel_DEBUG` is also dropped, if we really need to have knobs which can be configured by user, we should define them in a more formal way. at this moment, this is not necessary. so drop it along with this variable.