### PR TITLE
build: cmake: link against cryptopp::cryptopp

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -56,7 +56,7 @@ target_link_libraries(utils
     xxHash::xxhash
   PRIVATE
     Boost::regex
-    cryptopp
+    cryptopp::cryptopp
     rapidxml::rapidxml)
 
 check_headers(check-headers utils


### PR DESCRIPTION
instead of linking against cryptopp, we should link against crytopp::crytopp. the latter is the target exposed by Findcryptopp.cmake, while the former is but a library name which is not even exposed by any find_package() call.