### PR TITLE
doc: remove support for DateTieredCompactionStrategy

### DIFF
--- a/docs/architecture/compaction/compaction-strategies.rst
+++ b/docs/architecture/compaction/compaction-strategies.rst
@@ -8,8 +8,7 @@ Scylla implements the following compaction strategies in order to reduce :term:`
 * `Size-tiered compaction strategy (STCS)`_ - triggered when the system has enough (four by default) similarly sized SSTables.
 * `Leveled compaction strategy (LCS)`_ - the system uses small, fixed-size (by default 160 MB) SSTables distributed across different levels.
 * `Incremental Compaction Strategy (ICS)`_ - shares the same read and write amplification factors as STCS, but it fixes its 2x temporary space amplification issue by breaking huge sstables into SSTable runs, which are comprised of a sorted set of smaller (1 GB by default), non-overlapping SSTables. 
-* `Time-window compaction strategy (TWCS)`_ - designed for time series data; replaced Date-tiered compaction. 
-* `Date-tiered compaction strategy (DTCS)`_ - designed for time series data.
+* `Time-window compaction strategy (TWCS)`_ - designed for time series data.
 
 This document covers how to choose a compaction strategy and presents the benefits and disadvantages of each one. If you want more information on compaction in general or on any of these strategies, refer to the :doc:`Compaction Overview </kb/compaction>`. If you want an explanation of the CQL commands used to create a compaction strategy, refer to :doc:`Compaction CQL Reference </cql/compaction>` .
 
@@ -78,7 +77,6 @@ ICS is only available in ScyllaDB Enterprise. See the `ScyllaDB Enetrpise docume
 Time-window Compaction Strategy (TWCS)
 ======================================
 
-Time-window compaction strategy was introduced in Cassandra 3.0.8 for time-series data as a replacement for `Date-tiered Compaction Strategy (DTCS)`_.
 Time-Window Compaction Strategy compacts SSTables within each time window using `Size-tiered Compaction Strategy (STCS)`_.
 SSTables from different time windows are never compacted together. You set the :ref:`TimeWindowCompactionStrategy <time-window-compactionstrategy-twcs>` parameters when you create a table using a CQL command.
 
@@ -87,9 +85,8 @@ SSTables from different time windows are never compacted together. You set the :
 Time-window Compaction benefits
 -------------------------------
 
-* Keeps entries according to a time range, making searches for data within a given range easy to do, resulting in better read performance
-* Improves over DTCS in that it reduces the number to huge compactions
-* Allows you to expire an entire SSTable at once (using a TTL) as the data is already organized within a time frame
+* Keeps entries according to a time range, making searches for data within a given range easy to do, resulting in better read performance.
+* Allows you to expire an entire SSTable at once (using a TTL) as the data is already organized within a time frame.
 
 Time-window Compaction deficits
 -------------------------------
@@ -101,14 +98,6 @@ Time-window Compaction deficits
 Set the parameters for :ref:`Time-window Compaction <time-window-compactionstrategy-twcs>`.
 
 Use the table in `Which strategy is best`_ to determine if this is the right strategy for your needs. 
-
-.. _DTCS1:
-
-Date-tiered Compaction Strategy (DTCS)
-======================================
-
-Date-Tiered Compaction is designed for time series data. This strategy was introduced with Cassandra 2.1.
-It is only suitable for time-series data. This strategy is not recommended and has been replaced by :ref:`Time-window Compaction Strategy <TWCS1>`.
 
 .. _which-strategy-is-best:
 

--- a/docs/cql/compaction.rst
+++ b/docs/cql/compaction.rst
@@ -19,8 +19,6 @@ The following compaction strategies are supported by Scylla:
 
 * Time-window Compaction Strategy (`TWCS`_)
 
-* Date-tiered Compaction Strategy (DTCS) - use `TWCS`_ instead
-
 This page concentrates on the parameters to use when creating a table with a compaction strategy. If you are unsure which strategy to use or want general information on the compaction strategies which are available to Scylla, refer to :doc:`Compaction Strategies </architecture/compaction/compaction-strategies>`.
 
 Common options

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -682,19 +682,12 @@ Compaction options
 
 The ``compaction`` options must at least define the ``'class'`` sub-option, which defines the compaction strategy class
 to use. The default supported class are ``'SizeTieredCompactionStrategy'``,
-``'LeveledCompactionStrategy'``, ``'IncrementalCompactionStrategy'``, and ``'DateTieredCompactionStrategy'``  
+``'LeveledCompactionStrategy'``, and ``'IncrementalCompactionStrategy'``.
 Custom strategy can be provided by specifying the full class name as a :ref:`string constant
 <constants>`.
 
 All default strategies support a number of common options, as well as options specific to
-the strategy chosen (see the section corresponding to your strategy for details: :ref:`STCS <stcs-options>`, :ref:`LCS <lcs-options>`, and :ref:`TWCS <twcs-options>`). DTCS is not recommended, and TWCS should be used instead.
-
-
-.. ``'Date Tiered Compaction Strategy is not recommended and has been replaced by Time Window Compaction Stragegy.'`` (:ref:`TWCS <TWCS>`) (the
-.. is also supported but is deprecated and ``'TimeWindowCompactionStrategy'`` should be
-.. preferred instead). 
-
-
+the strategy chosen (see the section corresponding to your strategy for details: :ref:`STCS <stcs-options>`, :ref:`LCS <lcs-options>`, and :ref:`TWCS <twcs-options>`).
 
 .. _cql-compression-options:
 

--- a/docs/operating-scylla/nodetool-commands/setlogginglevel.rst
+++ b/docs/operating-scylla/nodetool-commands/setlogginglevel.rst
@@ -70,7 +70,6 @@ To display the log classes (output changes with each version so your display may
    cql_server
    storage_proxy
    cache
-   DateTieredCompactionStrategy
    schema_tables
    rpc
    compaction_manager

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -37,9 +37,6 @@ Glossary
     Quorum
       Quorum is a *global* consistency level setting across the entire cluster including all data centers. See :doc:`Consistency Levels </cql/consistency>`.
 
-    Date-tiered compaction strategy (DTCS)
-      :abbr:`DTCS (Date-tiered compaction strategy)` is designed for time series data, but should not be used. Use :term:`Time-Window Compaction Strategy`. See :doc:`Compaction Strategies</architecture/compaction/compaction-strategies/>`.
-
     Entropy
       A state where data is not consistent. This is the result when replicas are not synced and data is random. Scylla has measures in place to be antientropic. See :doc:`Scylla Anti-Entropy </architecture/anti-entropy/index>`.
 
@@ -151,7 +148,7 @@ Glossary
       A collection of columns fetched by row. Columns are ordered by Clustering Key. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
 
     Time-window compaction strategy
-      TWCS is designed for time series data and replaced Date-tiered compaction. See :doc:`Compaction Strategies</architecture/compaction/compaction-strategies/>`.
+      TWCS is designed for time series data. See :doc:`Compaction Strategies</architecture/compaction/compaction-strategies/>`.
 
     Token
       A value in a range, used to identify both nodes and partitions. Each node in a Scylla cluster is given an (initial) token, which defines the end of the range a node handles. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.

--- a/docs/using-scylla/cassandra-compatibility.rst
+++ b/docs/using-scylla/cassandra-compatibility.rst
@@ -358,12 +358,12 @@ Create Table Compaction
 +----------------------------------------------------+-------------------------------------+
 |:ref:`LeveledCompactionStrategy <LCS>` (LCS)        | |v|                                 |
 +----------------------------------------------------+-------------------------------------+
-|DateTieredCompactionStrategy (DTCS)                 | |v|  :sup:`*`                       |
+|DateTieredCompactionStrategy (DTCS)                 | |x|     :sup:`*`                    |
 +----------------------------------------------------+-------------------------------------+
 |:ref:`TimeWindowCompactionStrategy <TWCS>` (TWCS)   | |v|                                 |
 +----------------------------------------------------+-------------------------------------+
 
-:sup:`*`  Deprecated; use TWCS instead.
+:sup:`*` No longer supported. Use TimeWindowCompactionStrategy (TWCS) instead.
 
 Create Table Compression
 ........................


### PR DESCRIPTION
This PR removes support for `DateTieredCompactionStrategy` from the documentation.
Refs https://github.com/scylladb/scylladb/issues/15869#issuecomment-1784181274

Support for DTCS was removed in 5.4, so this PR must be backported to branch-5.4.
The information is already added to the 5.2-to-5.4 upgrade guide: https://github.com/scylladb/scylladb/pull/15988

(backport)