### PR TITLE
doc: mark the link to upgrade guide as OSS-only

### DIFF
--- a/docs/architecture/raft.rst
+++ b/docs/architecture/raft.rst
@@ -37,8 +37,12 @@ Enabling Raft
 
 .. note::
   In ScyllaDB 5.2 and ScyllaDB Enterprise 2023.1 Raft is Generally Available and can be safely used for consistent schema management.
-  It will get enabled by default when you upgrade your cluster to ScyllaDB 5.4. You can explicitly prevent it from getting enabled; see :doc:`5.2 -> 5.4 upgrade procedure </upgrade/upgrade-opensource/upgrade-guide-from-5.2-to-5.4/upgrade-guide-from-5.2-to-5.4-generic>` for details.
-  In further versions, it will be mandatory.
+  It will get enabled by default when you upgrade your cluster to ScyllaDB 5.4 or 2024.1.
+  If needed, you can explicitly prevent it from getting enabled upon upgrade.
+
+  .. only:: opensource
+
+    See :doc:`the upgrade guide from 5.2 to 5.4 </upgrade/upgrade-opensource/upgrade-guide-from-5.2-to-5.4/upgrade-guide-from-5.2-to-5.4-generic>` for details.
 
 ScyllaDB Open Source 5.2 and later, and ScyllaDB Enterprise 2023.1 and later come equipped with a procedure that can setup Raft-based consistent cluster management in an existing cluster. We refer to this as the **Raft upgrade procedure** (do not confuse with the :doc:`ScyllaDB version upgrade procedure </upgrade/index/>`).
 


### PR DESCRIPTION
This PR  adds the `.. only:: opensource` directive to the Raft page to exclude the link to the 5.2-to-5.4 upgrade guide from the Enterprise documentation.

The Raft page belongs to both OSS and Enterprise documentation sets, while the upgrade guide is OSS-only. This causes documentation build issues in the Enterprise repository, for example, https://github.com/scylladb/scylla-enterprise/pull/3242.
As a rule, all OSS-only links should be provided by using the `.. only:: opensource` directive.

In addition, this PR removes the information about "future releases" to avoid making promises that would have to be removed from the already released version via backporting.

This commit must be backported to branch-5.4 to prevent errors in the documentation for ScyllaDB Enterprise 2024.1

(backport)