### PR TITLE
raft: send group0 RPCs only if the destination group0 server is seen as alive

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1323,7 +1323,7 @@ scylla_tests_dependencies = scylla_core + alternator + idls + scylla_tests_gener
     'test/lib/key_utils.cc',
 ]
 
-scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc', 'utils/error_injection.cc']
+scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc', 'utils/error_injection.cc', 'utils/exceptions.cc']
 
 scylla_tools = ['tools/scylla-types.cc', 'tools/scylla-sstable.cc', 'tools/scylla-nodetool.cc', 'tools/schema_loader.cc', 'tools/utils.cc', 'tools/lua_sstable_consumer.cc']
 scylla_perfs = ['test/perf/perf_fast_forward.cc',

--- a/idl/raft.idl.hh
+++ b/idl/raft.idl.hh
@@ -121,8 +121,12 @@ struct wrong_destination {
     raft::server_id reached_id;
 };
 
+struct group_liveness_info {
+    bool group0_alive;
+};
+
 struct direct_fd_ping_reply {
-    std::variant<std::monostate, service::wrong_destination> result;
+    std::variant<std::monostate, service::wrong_destination, service::group_liveness_info> result;
 };
 
 verb [[with_client_info, cancellable]] direct_fd_ping (raft::server_id dst_id) -> service::direct_fd_ping_reply;

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -300,6 +300,15 @@ struct transport_error: public error {
     using error::error;
 };
 
+// Can be thrown by two-way RPCs when the destination is not seen as alive by the failure detector.
+// If thrown, the request was not sent at all.
+struct destination_not_alive_error: public transport_error {
+    server_id destination;
+
+    destination_not_alive_error(server_id destination, seastar::compat::source_location l = seastar::compat::source_location::current())
+            : transport_error(fmt::format("Failed to send {} to {}: node is not seen as alive by the failure detector", l.function_name(), destination)) {}
+};
+
 struct command_is_too_big_error: public error {
     size_t command_size;
     size_t limit;

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -190,6 +190,11 @@ public:
     // replication.
     virtual future<> abort(sstring reason = "") = 0;
 
+    // Returns whether the server is running.
+    // A server becomes alive after start() and becomes dead after abort()
+    // is called or an error happens in one of the internal fibers.
+    virtual bool is_alive() const = 0;
+
     // Return Raft protocol current term.
     virtual term_t get_current_term() const = 0;
 

--- a/service/raft/group0_fwd.hh
+++ b/service/raft/group0_fwd.hh
@@ -75,8 +75,12 @@ struct wrong_destination {
     raft::server_id reached_id;
 };
 
+struct group_liveness_info {
+    bool group0_alive;
+};
+
 struct direct_fd_ping_reply {
-    std::variant<std::monostate, wrong_destination> result;
+    std::variant<std::monostate, wrong_destination, group_liveness_info> result;
 };
 
 } // namespace service

--- a/service/raft/raft_rpc.cc
+++ b/service/raft/raft_rpc.cc
@@ -68,8 +68,7 @@ raft_rpc::two_way_rpc(sloc loc, raft::server_id id,
     using Fut = decltype(verb(&_messaging, netw::msg_addr(gms::inet_address()), db::no_timeout, _group_id, _my_id, id, std::forward<Args>(args)...));
     using Ret = typename Fut::value_type;
     if (!_failure_detector->is_alive(id)) {
-        const auto msg = format("Failed to send {} to {}: node is not seen as alive by the failure detector", loc.function_name(), id);
-        return make_exception_future<Ret>(raft::transport_error(msg));
+        return make_exception_future<Ret>(raft::destination_not_alive_error(id, loc));
     }
     auto ip_addr = _address_map.find(id);
     if (!ip_addr) {

--- a/service/raft/raft_rpc.cc
+++ b/service/raft/raft_rpc.cc
@@ -27,9 +27,9 @@ raft_ticker_type::time_point timeout() {
 }
 
 raft_rpc::raft_rpc(raft_state_machine& sm, netw::messaging_service& ms,
-        raft_address_map& address_map, raft::group_id gid, raft::server_id my_id)
+        raft_address_map& address_map, shared_ptr<raft::failure_detector> failure_detector, raft::group_id gid, raft::server_id my_id)
     : _sm(sm), _group_id(std::move(gid)), _my_id(my_id), _messaging(ms)
-    , _address_map(address_map)
+    , _address_map(address_map), _failure_detector(std::move(failure_detector))
 {}
 
 

--- a/service/raft/raft_rpc.hh
+++ b/service/raft/raft_rpc.hh
@@ -28,10 +28,11 @@ protected:
     raft::server_id _my_id;                     // Raft server id of this node.
     netw::messaging_service& _messaging;
     raft_address_map& _address_map;
+    shared_ptr<raft::failure_detector> _failure_detector;
     seastar::gate _shutdown_gate;
 
     explicit raft_rpc(raft_state_machine& sm, netw::messaging_service& ms,
-            raft_address_map& address_map, raft::group_id gid, raft::server_id my_id);
+            raft_address_map& address_map, shared_ptr<raft::failure_detector> failure_detector, raft::group_id gid, raft::server_id my_id);
 
 private:
     template <typename Verb, typename Msg> void

--- a/service/raft/raft_rpc.hh
+++ b/service/raft/raft_rpc.hh
@@ -35,7 +35,9 @@ protected:
             raft_address_map& address_map, shared_ptr<raft::failure_detector> failure_detector, raft::group_id gid, raft::server_id my_id);
 
 private:
-    template <typename Verb, typename Msg> void
+    enum class one_way_kind { request, reply };
+
+    template <one_way_kind rpc_kind, typename Verb, typename Msg> void
     one_way_rpc(std::source_location loc, raft::server_id id, Verb&& verb, Msg&& msg);
 
     template <typename Verb, typename... Args> auto


### PR DESCRIPTION
In topology on raft mode, the events "new node starts its group0 server" and "new node is added to group0 configuration" are not synchronized with each other. Therefore it might happen that the cluster starts sending commands to the new node before the node starts its server. This might lead to harmless, but ugly messages like:

    INFO  2023-09-27 15:42:42,611 [shard 0:stat] rpc - client 127.0.0.1:56352 msg_id 2:  exception "Raft group b8542540-5d3b-11ee-99b8-1052801f2975 not found" in no_wait handler ignored

In order to solve this, the failure detector verb is extended to report information about whether group0 is alive. The raft rpc layer will drop messages to nodes whose group0 is not seen as alive.

Tested by adding a delay before group0 is started on the joining node, running all topology tests and grepping for the aforementioned log messages.

Fixes: scylladb/scylladb#15853
Fixes: scylladb/scylladb#15167