### PR TITLE
test/sstable_compaction_test: check every sstable replaced sstable 

### DIFF
--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2844,12 +2844,7 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
             BOOST_REQUIRE_EQUAL(*expected_sst, old_sstable->generation());
             expected_sst++;
             // check that previously released sstables were already closed
-            if (auto v = old_sstables.front()->generation().as_int(); v % 4 == 0) {
-                // Due to performance reasons, sstables are not released immediately, but in batches.
-                // At the time of writing, mutation_reader_merger releases it's sstable references
-                // in batches of 4. That's why we only perform this check every 4th sstable. 
-                BOOST_REQUIRE_EQUAL(*closed_sstables_tracker, old_sstable->generation());
-            }
+            BOOST_REQUIRE_EQUAL(*closed_sstables_tracker, old_sstable->generation());
 
             do_replace(old_sstables, new_sstables);
 
@@ -2917,7 +2912,7 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
                 .produces(make_insert(keys[i]))
                 .produces_end_of_stream();
         }
-    }, test_env_config{ .use_uuid = false });
+    });
 }
 
 SEASTAR_TEST_CASE(compaction_strategy_aware_major_compaction_test) {


### PR DESCRIPTION
before this change, in sstable_run_based_compaction_test, we check
every 4 sstables, to verify that we close the sstable to be replaced
in a batch of 4.

since the integer-based generation identifier is monotonically
incremental, we can assume that the identifiers of sstables are like
0, 1, 2, 3, .... so if the compaction consumes sstable in a
batch of 4, the identifier of the first one in the batch should
always be the multiple of 4. unfortunately, this test does not work
if we use uuid-based identifier.

but if we take a closer look at how we create the dataset, we can
have following facts:

1. the `compaction_descriptor` returned by
   `sstable_run_based_compaction_strategy_for_tests` never
   set `owned_ranges` in the returned descriptor
2. in `compaction::setup_sstable_reader`, `mutation_reader::forward::no`
   is used, if `_owned_ranges_checker` is empty
3. `mutation_reader_merger` respects the `fwd_mr` passed to its
   ctor, so it closes current sstable immediately when the underlying
   mutation reader reaches the end of stream.

in other words, we close every sstable once it is fully consumed in
sstable_ompaction_test. and the reason why the existing test passes
is that we just sample the sstables whose generation id is a multiple
of 4. what happens when we perform compaction in this test is:

1. replace 5 with 33, closing 5
2. replace 6 with 34, closing 6
3. replace 7 with 35, closing 7
4. replace 8 with 36, closing 8   << let's check here.. good, go on!
5. replace 13 with 37, closing 13
...
8. replace 16 with 40, closing 16 << let's check here.. also, good, go on!

so, in this change, we just check all old sstables, to verify that
we close each of them once it is fully consumed.

Fixes https://github.com/scylladb/scylladb/issues/16073