### PR TITLE
doc: add experimental support for object storage

### DIFF
--- a/docs/cql/cql-extensions.md
+++ b/docs/cql/cql-extensions.md
@@ -79,27 +79,66 @@ and to the TRUNCATE data definition query.
 
 In addition, the timeout parameter can be applied to SELECT queries as well.
 
+```eval_rst 
+.. _keyspace-storage-options:
+ ```
+ 
 ## Keyspace storage options
 
-Storage options allows specifying the storage format assigned to a keyspace.
-The default storage format is `LOCAL`, which simply means storing all the sstables
-in a local directory.
-Experimental support for `S3` storage format is also added. This option is not fully
-implemented yet, but it will allow storing sstables in a shared, S3-compatible object store.
+<!---
+This section must be moved to Data Definition> CREATE KEYSPACE
+when support for object storage is GA.
+ --->
 
-Storage options can be specified via `CREATE KEYSPACE` or `ALTER KEYSPACE` statement
-and it's formatted as a map of options - similarly to how replication strategy is handled.
+By default, SStables of a keyspace are stored in a local directory.
+As an alternative, you can configure your keyspace to be stored
+on Amazon S3 or another S3-compatible object store.
 
-Examples:
+Support for object storage is experimental and must be explicitly
+enabled in the ``scylla.yaml`` configuration file by specifying 
+the ``keyspace-storage-options`` option:
+
+```
+ experimental_features:
+     - keyspace-storage-options
+```
+
+With support for object storage enabled, add your endpoint configuration
+to ``scylla.yaml``:
+
+1. Create an ``object-storage-config-file.yaml`` file with a description of 
+   allowed endpoints, for example:
+
+    ```
+      endpoints:
+        - name: $endpoint_address_or_domain_name
+          port: $port_number
+          https: optional True or False
+          aws_region: optional region name, e.g. us-east-1
+          aws_access_key_id: optional AWS access key ID
+          aws_secret_access_key: optional AWS secret access key
+          aws_session_token: optional AWS session token
+    ```
+1. Specify the ``object-storage-config-file`` option in your ``scylla.yaml``,
+   providing ``object-storage-config-file.yaml`` as the value:
+
+   ```
+   object-storage-config-file: object-storage-config-file.yaml
+   ```
+
+
+Now you can configure your object storage when creating a keyspace:
+
+```cql
+CREATE KEYSPACE with STORAGE = { 'type': 'S3', 'endpoint': '$endpoint_name', 'bucket': '$bucket' } 
+```
+
+**Example**
+
 ```cql
 CREATE KEYSPACE ks
     WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 }
     AND STORAGE = { 'type' : 'S3', 'bucket' : '/tmp/b1', 'endpoint' : 'localhost' } ;
-```
-
-```cql
-ALTER KEYSPACE ks WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 }
-    AND STORAGE = { 'type' : 'S3', 'bucket': '/tmp/b2', 'endpoint' : 'localhost' } ;
 ```
 
 Storage options can be inspected by checking the new system schema table: `system_schema.scylla_keyspaces`:

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -198,6 +198,18 @@ An example that excludes a datacenter while using ``replication_factor``::
     DESCRIBE KEYSPACE excalibur
         CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3'} AND durable_writes = true;
 
+
+
+.. only:: opensource
+  
+  Keyspace storage options :label-caution:`Experimental`
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  By default, SStables of a keyspace are stored locally.
+  As an alternative, you can configure your keyspace to be stored
+  on Amazon S3 or another S3-compatible object store.
+  See :ref:`Keyspace storage options <keyspace-storage-options>` for details.
+
 .. _use-statement:        
         
 USE


### PR DESCRIPTION
This PR adds information on how to enable object storage for a keyspace.

The "Keyspace storage options" section already existed in the doc, but it was not valid as the support was only added in version 5.4

The scope of this commit:
- Update the "Keyspace storage options" section.
- Add the information about object storage support to the Data Definition> CREATE KEYSPACE section
  * Marked as "Experimental".
  * Excluded from the Enterprise docs with the _.. only:: opensource_ directive (as Enterprise doesn't support experimental features).

This PR must be backported to branch-5.4, as support for object storage was added in version 5.4.

(backport)