### PR TITLE
treewide: do not mark return value const if this has no effect 

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -16,6 +16,7 @@ add_compile_options(
   "-Werror"
   "-Wno-error=deprecated-declarations"
   "-Wimplicit-fallthrough"
+  "-Wignore-qualifiers"
   ${_supported_warnings})
 
 function(default_target_arch arch)

--- a/configure.py
+++ b/configure.py
@@ -1506,6 +1506,7 @@ def get_warning_options(cxx):
         '-Wall',
         '-Werror',
         '-Wimplicit-fallthrough',
+        '-Wignore-qualifiers',
         '-Wno-mismatched-tags',  # clang-only
         '-Wno-c++11-narrowing',
         '-Wno-overloaded-virtual',

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -219,7 +219,7 @@ public:
     const bool& get_value() const {
         return *value;
     }
-    const bool is_true() const {
+    bool is_true() const {
         return has_value() && get_value();
     }
 };

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -77,7 +77,7 @@ public:
         return _extensions;
     }
 
-    const unsigned murmur3_partitioner_ignore_msb_bits() const {
+    unsigned murmur3_partitioner_ignore_msb_bits() const {
         return _murmur3_partitioner_ignore_msb_bits;
     }
 

--- a/query-request.hh
+++ b/query-request.hh
@@ -243,13 +243,13 @@ public:
     const cql_serialization_format cql_format() const {
         return cql_serialization_format(4); // For IDL compatibility
     }
-    const uint32_t partition_row_limit_low_bits() const {
+    uint32_t partition_row_limit_low_bits() const {
         return _partition_row_limit_low_bits;
     }
-    const uint32_t partition_row_limit_high_bits() const {
+    uint32_t partition_row_limit_high_bits() const {
         return _partition_row_limit_high_bits;
     }
-    const uint64_t partition_row_limit() const {
+    uint64_t partition_row_limit() const {
         return (static_cast<uint64_t>(_partition_row_limit_high_bits) << 32) | _partition_row_limit_low_bits;
     }
     void set_partition_row_limit(uint64_t limit) {

--- a/query-result.hh
+++ b/query-result.hh
@@ -412,7 +412,7 @@ public:
         }
     }
 
-    const api::timestamp_type last_modified() const {
+    api::timestamp_type last_modified() const {
         return _last_modified;
     }
 

--- a/redis/options.hh
+++ b/redis/options.hh
@@ -61,8 +61,8 @@ public:
     {
     }
 
-    const db::consistency_level get_read_consistency_level() const { return _read_consistency; }
-    const db::consistency_level get_write_consistency_level() const { return _write_consistency; }
+    db::consistency_level get_read_consistency_level() const { return _read_consistency; }
+    db::consistency_level get_write_consistency_level() const { return _write_consistency; }
 
     const db::timeout_clock::duration get_read_timeout() const { return std::chrono::milliseconds(_timeout_config.read_timeout_in_ms); }
     const db::timeout_clock::duration get_write_timeout() const { return std::chrono::milliseconds(_timeout_config.write_timeout_in_ms); }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -901,7 +901,7 @@ public:
      */
     future<> write_schema_as_cql(database& db, sstring dir) const;
 
-    const bool incremental_backups_enabled() const {
+    bool incremental_backups_enabled() const {
         return _config.enable_incremental_backups;
     }
 
@@ -1251,7 +1251,7 @@ public:
     void add_user_type(const user_type ut);
     void remove_user_type(const user_type ut);
 
-    const bool incremental_backups_enabled() const {
+    bool incremental_backups_enabled() const {
         return _config.enable_incremental_backups;
     }
 
@@ -1336,7 +1336,7 @@ public:
         future<> parallel_for_each_table(std::function<future<>(table_id, lw_shared_ptr<table>)> f);
         const std::unordered_map<table_id, lw_shared_ptr<table>> get_column_families_copy() const;
 
-        const auto filter(std::function<bool(std::pair<table_id, lw_shared_ptr<table>>)> f) const {
+        auto filter(std::function<bool(std::pair<table_id, lw_shared_ptr<table>>)> f) const {
             return _column_families | boost::adaptors::filtered(std::move(f));
         }
     };

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -586,7 +586,7 @@ const sstring& index_metadata::name() const {
     return _name;
 }
 
-const index_metadata_kind index_metadata::kind() const {
+index_metadata_kind index_metadata::kind() const {
     return _kind;
 }
 

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -242,7 +242,7 @@ public:
     bool equals_noname(const index_metadata& other) const;
     const table_id& id() const;
     const sstring& name() const;
-    const index_metadata_kind kind() const;
+    index_metadata_kind kind() const;
     const index_options_map& options() const;
     bool local() const;
     static sstring get_default_index_name(const sstring& cf_name, std::optional<sstring> root);
@@ -734,7 +734,7 @@ public:
         return _raw._is_counter;
     }
 
-    const cf_type type() const {
+    cf_type type() const {
         return _raw._type;
     }
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1557,7 +1557,7 @@ public:
     const schema_ptr& get_schema() const {
         return _mutation_holder->schema();
     }
-    const size_t get_mutation_size() const {
+    size_t get_mutation_size() const {
         return _mutation_holder->size();
     }
     storage_proxy::response_id_type id() const {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1929,7 +1929,7 @@ uint64_t sstable::filter_size() const {
     return _components->filter->memory_size();
 }
 
-const bool sstable::has_component(component_type f) const {
+bool sstable::has_component(component_type f) const {
     return _recognized_components.contains(f);
 }
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -600,7 +600,7 @@ private:
     std::optional<scylla_metadata::large_data_stats> _large_data_stats;
     sstring _origin;
 public:
-    const bool has_component(component_type f) const;
+    bool has_component(component_type f) const;
     sstables_manager& manager() { return _manager; }
     const sstables_manager& manager() const { return _manager; }
 private:

--- a/transport/messages/result_message.hh
+++ b/transport/messages/result_message.hh
@@ -196,7 +196,7 @@ public:
         , _id{id}
     { }
 
-    const int32_t get_id() const {
+    int32_t get_id() const {
         return _id;
     }
 


### PR DESCRIPTION
this change is a cleanup to add `-Wignore-qualifiers` when building the tree.

to mark a return value without value semantics has no effect. these
`const` specifier useless. so let's drop them.

and, if we compile the tree with `-Wignore-qualifiers`, the compiler
would warn like:

```
/home/kefu/dev/scylladb/schema/schema.hh:245:5: error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]
  245 |     const index_metadata_kind kind() const;
      |     ^~~~~
```
so this change also silences the above warnings.
