### PR TITLE
util: do not use variable length array

### DIFF
--- a/utils/managed_vector.hh
+++ b/utils/managed_vector.hh
@@ -34,7 +34,7 @@ private:
             _backref->_data = _data;
         }
         size_t storage_size() const noexcept {
-            return sizeof(*this) + sizeof(T[_backref->_capacity]);
+            return sizeof(*this) + sizeof(T) * _backref->_capacity;
         }
     };
     union maybe_constructed {


### PR DESCRIPTION
vla (variable length array) is an extension in GCC and Clang. and it is not part of the C++ standard.

so let's avoid using it if possible, for better standard compliant. it's also more consistent with other places where we calculate the size of an array of T in the same source file.