### PR TITLE
raft_state_machine: Check system.topology presense before tying to fi…

### DIFF
--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -61,6 +61,10 @@ static mutation extract_history_mutation(std::vector<canonical_mutation>& muts, 
 }
 
 static bool should_flush_system_topology_after_applying(const mutation& mut, const data_dictionary::database db) {
+    if (!db.has_schema(db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY)) {
+        return false;
+    }
+
     auto s_topology = db.find_schema(db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY);
     if (mut.column_family_id() == s_topology->id()) {
         auto enabled_features_id = s_topology->columns_by_name().at("enabled_features")->id;


### PR DESCRIPTION
…nd it

The write_mutations_to_database() decides if it needs to flush the database by checking if the mutations came to system.topology table and performing some more checks if they did. Overall this looks like

    auto topo_schema = db.find_schema(system.topology)
    if (target_schema != topo_schema)
        return false;

    // extra checks go here

However, the system.topology table exists only if the feature named CONSISTENT_TOPOLOGY_CHANGES is enabled via commandline. If it's not, the call to db.find_schema(system.topology) throws and the whole attempt to write mutations throws too stopping raft state machine.

Since the intention is to check if the target schema is the topology table, the presense of this table should come first.