### PR TITLE
view_update_generator: Unplug from database later

### DIFF
--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -234,12 +234,12 @@ void view_update_generator::do_abort() noexcept {
     }
 
     vug_logger.info("Terminating background fiber");
-    _db.unplug_view_update_generator();
     _as.request_abort();
     _pending_sstables.signal();
 }
 
 future<> view_update_generator::stop() {
+    _db.unplug_view_update_generator();
     do_abort();
     return std::move(_started).then([this] {
         _registration_sem.broken();


### PR DESCRIPTION
Patch 967ebacaa4 (view_update_generator: Move abort kicking to do_abort()) moved unplugging v.u.g from database from .stop() to .do_abort(). The latter call happens very early on stop -- once scylla receives SIGINT. However, database may still need v.u.g. plugged to flush views.

This patch moves unplug to later, namely to .stop() method of v.u.g. which happens after database is drained and should no longer continue view updates.

fixes: #16001