### PR TITLE
dist/redhat: drop unnecessary variables and tags

### DIFF
--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -69,8 +69,6 @@ This package contains ScyllaDB server.
 
 %build
 
-defines=()
-
 %install
 %if 0%{housekeeping}
 install_arg="--housekeeping"

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -60,8 +60,6 @@ This package installs all required packages for ScyllaDB,  including
 %package        server
 Group:          Applications/Databases
 Summary:        The Scylla database server
-License:        AGPLv3
-URL:            http://www.scylladb.com/
 Requires:       %{product}-conf = %{version}-%{release}
 Requires:       %{product}-python3 = %{version}-%{release}
 AutoReqProv:    no
@@ -156,8 +154,6 @@ rm -rf $RPM_BUILD_ROOT
 %package conf
 Group:          Applications/Databases
 Summary:        Scylla configuration package
-License:        AGPLv3
-URL:            http://www.scylladb.com/
 Obsoletes:	scylla-server < 1.1
 
 %description conf
@@ -203,8 +199,6 @@ fi
 %package kernel-conf
 Group:          Applications/Databases
 Summary:        Scylla configuration package for the Linux kernel
-License:        AGPLv3
-URL:            http://www.scylladb.com/
 Requires:       kmod
 # tuned overwrites our sysctl settings
 Obsoletes:      tuned >= 2.11.0

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -57,6 +57,17 @@ This package installs all required packages for ScyllaDB,  including
 %prep
 %setup -q -n scylla
 
+%build
+
+%install
+%if 0%{housekeeping}
+install_arg="--housekeeping"
+%endif
+./install.sh --packaging --root "$RPM_BUILD_ROOT" $install_arg
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
 %package        server
 Group:          Applications/Databases
 Summary:        The Scylla database server
@@ -66,14 +77,6 @@ AutoReqProv:    no
 
 %description server
 This package contains ScyllaDB server.
-
-%build
-
-%install
-%if 0%{housekeeping}
-install_arg="--housekeeping"
-%endif
-./install.sh --packaging --root "$RPM_BUILD_ROOT" $install_arg
 
 %pre server
 getent group scylla || /usr/sbin/groupadd scylla 2> /dev/null || :
@@ -101,9 +104,6 @@ if  [ -d /tmp/%{name}-%{version}-%{release} ]; then
     rm -rf /tmp/%{name}-%{version}-%{release}/
 fi
 ln -sfT /etc/scylla /var/lib/scylla/conf
-
-%clean
-rm -rf $RPM_BUILD_ROOT
 
 %files server
 %defattr(-,root,root)


### PR DESCRIPTION
this is a cleanup in `scylla.spec`.