### PR TITLE
Sanitize storage service init/deinit sequences

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1591,12 +1591,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 cdc.stop().get();
             });
 
-            supervisor::notify("starting storage service", true);
-            ss.local().init_messaging_service_part(sys_dist_ks, raft_topology_change_enabled).get();
-            auto stop_ss_msg = defer_verbose_shutdown("storage service messaging", [&ss] {
-                ss.local().uninit_messaging_service_part().get();
-            });
-
             api::set_server_messaging_service(ctx, messaging).get();
             auto stop_messaging_api = defer_verbose_shutdown("messaging service API", [&ctx] {
                 api::unset_server_messaging_service(ctx).get();

--- a/main.cc
+++ b/main.cc
@@ -1380,7 +1380,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             supervisor::notify("initializing storage service");
             debug::the_storage_service = &ss;
             ss.start(std::ref(stop_signal.as_sharded_abort_source()),
-                std::ref(db), std::ref(gossiper), std::ref(sys_ks),
+                std::ref(db), std::ref(gossiper), std::ref(sys_ks), std::ref(sys_dist_ks),
                 std::ref(feature_service), std::ref(mm), std::ref(token_metadata), std::ref(erm_factory),
                 std::ref(messaging), std::ref(repair),
                 std::ref(stream_manager), std::ref(lifecycle_notifier), std::ref(bm), std::ref(snitch),

--- a/main.cc
+++ b/main.cc
@@ -1384,7 +1384,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 std::ref(feature_service), std::ref(mm), std::ref(token_metadata), std::ref(erm_factory),
                 std::ref(messaging), std::ref(repair),
                 std::ref(stream_manager), std::ref(lifecycle_notifier), std::ref(bm), std::ref(snitch),
-                std::ref(tablet_allocator), std::ref(cdc_generation_service)).get();
+                std::ref(tablet_allocator), std::ref(cdc_generation_service), std::ref(qp)).get();
 
             auto stop_storage_service = defer_verbose_shutdown("storage_service", [&] {
                 ss.stop().get();
@@ -1399,8 +1399,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             smp::invoke_on_all([&] {
                 return db::initialize_virtual_tables(db, ss, gossiper, raft_gr, sys_ks, *cfg);
             }).get();
-
-            ss.invoke_on_all(&service::storage_service::set_query_processor, std::ref(qp)).get();
 
             // #293 - do not stop anything
             // engine().at_exit([&qp] { return qp.stop(); });

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3983,14 +3983,6 @@ future<> storage_service::drain_on_shutdown() {
         _drain_finished.get_future() : do_drain();
 }
 
-future<> storage_service::init_messaging_service_part(sharded<db::system_distributed_keyspace>& sys_dist_ks, bool raft_topology_change_enabled) {
-    return make_ready_future<>();
-}
-
-future<> storage_service::uninit_messaging_service_part() {
-    return make_ready_future<>();
-}
-
 void storage_service::set_group0(raft_group0& group0, bool raft_topology_change_enabled) {
     _group0 = &group0;
     _raft_topology_change_enabled = raft_topology_change_enabled;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6749,8 +6749,8 @@ void storage_service::init_messaging_service(bool raft_topology_change_enabled) 
         });
     });
     if (raft_topology_change_enabled) {
-        auto handle_raft_rpc = [&cont = container()] (raft::server_id dst_id, auto handler) {
-            return cont.invoke_on(0, [dst_id, handler = std::move(handler)] (auto& ss) mutable {
+        auto handle_raft_rpc = [this] (raft::server_id dst_id, auto handler) {
+            return container().invoke_on(0, [dst_id, handler = std::move(handler)] (auto& ss) mutable {
                 if (!ss._group0 || !ss._group0->joined_group0()) {
                     throw std::runtime_error("The node did not join group 0 yet");
                 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -123,13 +123,15 @@ storage_service::storage_service(abort_source& abort_source,
     sharded<db::batchlog_manager>& bm,
     sharded<locator::snitch_ptr>& snitch,
     sharded<service::tablet_allocator>& tablet_allocator,
-    sharded<cdc::generation_service>& cdc_gens)
+    sharded<cdc::generation_service>& cdc_gens,
+    cql3::query_processor& qp)
         : _abort_source(abort_source)
         , _feature_service(feature_service)
         , _db(db)
         , _gossiper(gossiper)
         , _messaging(ms)
         , _migration_manager(mm)
+        , _qp(&qp)
         , _repair(repair)
         , _stream_manager(stream_manager)
         , _snitch(snitch)

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -112,6 +112,7 @@ static constexpr std::chrono::seconds wait_for_live_nodes_timeout{30};
 storage_service::storage_service(abort_source& abort_source,
     distributed<replica::database>& db, gms::gossiper& gossiper,
     sharded<db::system_keyspace>& sys_ks,
+    sharded<db::system_distributed_keyspace>& sys_dist_ks,
     gms::feature_service& feature_service,
     sharded<service::migration_manager>& mm,
     locator::shared_token_metadata& stm,
@@ -142,6 +143,7 @@ storage_service::storage_service(abort_source& abort_source,
         , _lifecycle_notifier(elc_notif)
         , _batchlog_manager(bm)
         , _sys_ks(sys_ks)
+        , _sys_dist_ks(sys_dist_ks)
         , _snitch_reconfigure([this] {
             return container().invoke_on(0, [] (auto& ss) {
                 return ss.snitch_reconfigured();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -134,7 +134,7 @@ private:
     gms::gossiper& _gossiper;
     sharded<netw::messaging_service>& _messaging;
     sharded<service::migration_manager>& _migration_manager;
-    cql3::query_processor* _qp = nullptr;
+    cql3::query_processor& _qp;
     sharded<repair_service>& _repair;
     sharded<streaming::stream_manager>& _stream_manager;
     sharded<locator::snitch_ptr>& _snitch;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -323,34 +323,6 @@ public:
     future<> check_for_endpoint_collision(std::unordered_set<gms::inet_address> initial_contact_nodes,
             const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features);
 
-    /*!
-     * \brief Init the messaging service part of the service.
-     *
-     * This is the first part of the initialization, call this method
-     * first.
-     *
-     * After this method is completed, it is ok to start the storage_service
-     * API.
-     * \see init_server_without_the_messaging_service_part
-     */
-    future<> init_messaging_service_part(sharded<db::system_distributed_keyspace>& sys_dist_ks, bool raft_topology_change_enabled);
-    /*!
-     * \brief Uninit the messaging service part of the service.
-     */
-    future<> uninit_messaging_service_part();
-
-    /*!
-     * \brief complete the server initialization
-     *
-     * The storage_service initialization is done in two parts.
-     *
-     * It is safe to start the API after init_messaging_service_part
-     * completed
-     *
-     * Must be called on shard 0.
-     *
-     * \see init_messaging_service_part
-     */
     future<> join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy);
 
     void set_group0(service::raft_group0&, bool raft_topology_change_enabled);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -188,7 +188,7 @@ public:
 
     // Needed by distributed<>
     future<> stop();
-    void init_messaging_service(sharded<db::system_distributed_keyspace>& sys_dist_ks, bool raft_topology_change_enabled);
+    void init_messaging_service(bool raft_topology_change_enabled);
     future<> uninit_messaging_service();
 
     future<> load_tablet_metadata();
@@ -377,7 +377,7 @@ public:
 private:
     void set_mode(mode m);
     // Can only be called on shard-0
-    future<> mark_existing_views_as_built(sharded<db::system_distributed_keyspace>&);
+    future<> mark_existing_views_as_built();
 
     // Stream data for which we become a new replica.
     // Before that, if we're not replacing another node, inform other nodes about our chosen tokens
@@ -786,7 +786,7 @@ private:
 
     std::unordered_set<raft::server_id> find_raft_nodes_from_hoeps(const std::list<locator::host_id_or_endpoint>& hoeps);
 
-    future<raft_topology_cmd_result> raft_topology_cmd_handler(sharded<db::system_distributed_keyspace>& sys_dist_ks, raft::term_t term, uint64_t cmd_index, const raft_topology_cmd& cmd);
+    future<raft_topology_cmd_result> raft_topology_cmd_handler(raft::term_t term, uint64_t cmd_index, const raft_topology_cmd& cmd);
 
     future<> raft_initialize_discovery_leader(raft::server&, const join_node_request_params& params);
     future<> raft_decommission();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -171,6 +171,7 @@ public:
     storage_service(abort_source& as, distributed<replica::database>& db,
         gms::gossiper& gossiper,
         sharded<db::system_keyspace>&,
+        sharded<db::system_distributed_keyspace>&,
         gms::feature_service& feature_service,
         sharded<service::migration_manager>& mm,
         locator::shared_token_metadata& stm,
@@ -497,6 +498,7 @@ private:
     // Should be serialized under token_metadata_lock.
     future<> replicate_to_all_cores(mutable_token_metadata_ptr tmptr) noexcept;
     sharded<db::system_keyspace>& _sys_ks;
+    sharded<db::system_distributed_keyspace>& _sys_dist_ks;
     locator::snitch_signal_slot_t _snitch_reconfigure;
     sharded<service::tablet_allocator>& _tablet_allocator;
     sharded<cdc::generation_service>& _cdc_gens;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -182,7 +182,8 @@ public:
         sharded<db::batchlog_manager>& bm,
         sharded<locator::snitch_ptr>& snitch,
         sharded<service::tablet_allocator>& tablet_allocator,
-        sharded<cdc::generation_service>& cdc_gs);
+        sharded<cdc::generation_service>& cdc_gs,
+        cql3::query_processor& qp);
 
     // Needed by distributed<>
     future<> stop();
@@ -291,10 +292,6 @@ public:
 
     void register_protocol_server(protocol_server& server) {
         _protocol_servers.push_back(&server);
-    }
-
-    void set_query_processor(cql3::query_processor& qp) {
-        _qp = &qp;
     }
 
     // All pointers are valid.

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -739,6 +739,7 @@ private:
             _ss.start(std::ref(abort_sources), std::ref(_db),
                 std::ref(_gossiper),
                 std::ref(_sys_ks),
+                std::ref(_sys_dist_ks),
                 std::ref(_feature_service), std::ref(_mm),
                 std::ref(_token_metadata), std::ref(_erm_factory), std::ref(_ms),
                 std::ref(_repair),

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -747,7 +747,8 @@ private:
                 std::ref(_batchlog_manager),
                 std::ref(_snitch),
                 std::ref(_tablet_allocator),
-                std::ref(_cdc_generation_service)).get();
+                std::ref(_cdc_generation_service),
+                std::ref(_qp)).get();
             auto stop_storage_service = defer([this] { _ss.stop().get(); });
 
             _mnotifier.local().register_listener(&_ss.local());
@@ -755,9 +756,6 @@ private:
                 _mnotifier.local().unregister_listener(&_ss.local()).get();
             });
 
-            _ss.invoke_on_all([this] (service::storage_service& ss) {
-                ss.set_query_processor(_qp.local());
-            }).get();
             smp::invoke_on_all([&] {
                 return db::initialize_virtual_tables(_db, _ss, _gossiper, _group0_registry, _sys_ks, *cfg);
             }).get();


### PR DESCRIPTION
Currently storage service starts too early and its initialization is split into several steps. This PR makes storage service start "late enough" and makes its initialization (minimally required before joining cluster) happen in on place.

refs: #2795
refs: #2737 