### PR TITLE
test: topology: update run_first lists

### DIFF
--- a/test/topology/suite.yaml
+++ b/test/topology/suite.yaml
@@ -6,10 +6,9 @@ extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer
 run_first:
-    - test_topology_ip
+    - test_cluster_features
     - test_topology_remove_decom
     - test_mutation_schema_change
-    - test_tablets
 skip_in_release:
     - test_cluster_features
     - test_replace_alive_node

--- a/test/topology_custom/suite.yaml
+++ b/test/topology_custom/suite.yaml
@@ -5,6 +5,9 @@ cluster:
 extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer
+run_first:
+  - test_read_repair
+  - test_replace
 skip_in_release:
   - test_shutdown_hang
   - test_replace_ignore_nodes

--- a/test/topology_experimental_raft/suite.yaml
+++ b/test/topology_experimental_raft/suite.yaml
@@ -7,6 +7,10 @@ extra_scylla_config_options:
     authorizer: AllowAllAuthorizer
     enable_user_defined_functions: False
     experimental_features: ['consistent-topology-changes', 'tablets']
+run_first:
+  - test_raft_cluster_features
+  - test_raft_ignore_nodes
+  - test_tablets
 skip_in_release:
   - test_blocked_bootstrap
   - test_cdc_generation_clearing


### PR DESCRIPTION
`run_first` lists in `suite.yaml` files provide a simple way to
shorten the tests' average running time by running the slowest
tests at first.

We update these lists, since they got outdated over time:
- `test_topology_ip` was renamed to `test_replace`
   and changed suite,
- `test_tablets` changed suite,
- new slow tests were added:
  - `test_cluster_features`,
  - `test_raft_cluster_features`,
  - `test_raft_ignore_nodes`,
  - `test_read_repair`.