### PR TITLE
scylla-sstable: print "validate" result in JSON

### DIFF
--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -536,6 +536,18 @@ The following things are validated:
 
 Any errors found will be logged with error level to ``stderr``.
 
+The validation result is dumped in JSON, using the following schema:
+
+.. code-block:: none
+    :class: hide-copy-button
+
+    $ROOT := { "$sstable_path": $RESULT }
+
+    $RESULT := {
+        "errors": Uint64,
+        "valid": Bool,
+    }
+
 scrub
 ^^^^^
 

--- a/test/cql-pytest/test_sstable_validation.py
+++ b/test/cql-pytest/test_sstable_validation.py
@@ -112,7 +112,8 @@ def validate_mixed_sstable_pair(ssta, sstb, scylla_path, sst_cache, sst_work_dir
                          stderr=subprocess.PIPE)
     out = res.stdout.decode('utf-8')
     err = res.stderr.decode('utf-8')
-    valid = out.split(":")[1].strip() == "valid"
+    sstables = json.loads(out)['sstables']
+    valid = next(iter(sstables.values()))['valid']
     if error_message:
         assert not valid
         assert error_message in err


### PR DESCRIPTION
instead of printing the result of the "validate" subcommand in a free-style plain text, let's print it using JSON. for two reasons:

1. it is simpler to consume the output with other tools and tests.
2. more consistent with other commands.