### PR TITLE
scylla-sstable: print "validate-checksum" result in JSON

### DIFF
--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1517,10 +1517,14 @@ void validate_checksums_operation(schema_ptr schema, reader_permit permit, const
         throw std::invalid_argument("no sstables specified on the command line");
     }
 
+    json_writer writer;
+    writer.StartStream();
     for (auto& sst : sstables) {
         const auto valid = sstables::validate_checksums(sst, permit).get();
-        sst_log.info("validated the checksums of {}: {}", sst->get_filename(), valid ? "valid" : "invalid");
+        writer.Key(sst->get_filename());
+        writer.Bool(valid);
     }
+    writer.EndStream();
 }
 
 void decompress_operation(schema_ptr schema, reader_permit permit, const std::vector<sstables::shared_sstable>& sstables,


### PR DESCRIPTION
instead of printing the result of the "validate-checksum" subcommand with the logging message, let's print it using JSON. for three reasons:

1. it is simpler to consume the output with other tools and tests.
2. more consistent with other commands.
3. the logging system is used for audit the behavior and for debugging purposes, not for building a user-facing command line interface.
4. the behavior should match with the corresponding document. and
    in docs/operating-scylla/admin-tools/scylla-sstable.sst, we claim
    that `validate-checksums` subcommand prints a dict of
    
    ```
    $ROOT := { "$sstable_path": Bool, ... }
    ```
