### PR TITLE
tests: Skip unnecessary sleeps in cql_test_env teardown

### DIFF
--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -944,6 +944,10 @@ private:
             with_scheduling_group(dbcfg.statement_scheduling_group, [&func, this] {
                 return func(*this);
             }).get();
+
+            abort_sources.invoke_on_all([] (auto&& as) {
+                as.request_abort();
+            }).get();
     }
 
 public:

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -675,6 +675,7 @@ private:
             gcfg.cluster_name = "Test Cluster";
             gcfg.seeds = std::move(seeds);
             gcfg.skip_wait_for_gossip_to_settle = 0;
+            gcfg.shutdown_announce_ms = 0;
             _gossiper.start(std::ref(abort_sources), std::ref(_token_metadata), std::ref(_ms), std::ref(*cfg), std::move(gcfg)).get();
             auto stop_ms_fd_gossiper = defer([this] {
                 _gossiper.stop().get();


### PR DESCRIPTION
This PR contains two patches which get rid of unnecessary sleeps on cql_test_env teardown greatly reducing run time of tests.

Reduces run time of `build/dev/test/boost/schema_change_test` from 90s to 6s.

