### PR TITLE
doc: fix the rollback procedure in the 5.2-to-5.4 upgrade guide

### DIFF
--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.2-to-5.4/upgrade-guide-from-5.2-to-5.4-generic.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.2-to-5.4/upgrade-guide-from-5.2-to-5.4-generic.rst
@@ -102,7 +102,6 @@ For each of the nodes in the cluster, serially (i.e., one node at a time), you w
 * Backup the configuration file
 * Stop ScyllaDB
 * Download and install new ScyllaDB packages
-* (Optional) Enable consistent cluster management in the configuration file
 * Start ScyllaDB
 * Validate that the upgrade was successful
 
@@ -151,9 +150,26 @@ When the upgrade is completed on all nodes, remove the snapshot with the
 
 Backup the configuration file
 ------------------------------
-.. code:: sh
 
-   sudo cp -a /etc/scylla/scylla.yaml /etc/scylla/scylla.yaml.backup-src
+Back up the ``scylla.yaml`` configuration file and the ScyllaDB packages
+in case you need to rollback the upgrade.
+
+.. tabs::
+
+   .. group-tab:: Debian/Ubuntu
+
+      .. code:: sh
+         
+         sudo cp -a /etc/scylla/scylla.yaml /etc/scylla/scylla.yaml.backup
+         sudo cp /etc/apt/sources.list.d/scylla.list ~/scylla.list-backup
+
+   .. group-tab:: RHEL/CentOS
+
+      .. code:: sh
+         
+         sudo cp -a /etc/scylla/scylla.yaml /etc/scylla/scylla.yaml.backup
+         sudo cp /etc/yum.repos.d/scylla.repo ~/scylla.repo-backup
+
 
 Gracefully stop the node
 ------------------------
@@ -259,7 +275,6 @@ at a time), you will:
 * Drain the node and stop Scylla
 * Retrieve the old ScyllaDB packages
 * Restore the configuration file
-* Restore system tables
 * Reload systemd configuration
 * Restart ScyllaDB
 * Validate the rollback success
@@ -276,25 +291,24 @@ Drain and gracefully stop the node
 .. code:: sh
 
    nodetool drain
+   nodetool snapshot
    sudo service scylla-server stop
 
-Download and install the old release
+Restore and install the old release
 ------------------------------------
-
-..
-    TODO: downgrade for 3rd party packages in EC2/GCP/Azure - like in the upgrade section?
 
 .. tabs::
 
    .. group-tab:: Debian/Ubuntu
 
-        #. Remove the old repo file.
+        #. Restore the |SRC_VERSION| packages backed up during the upgrade.
 
             .. code:: sh
 
-               sudo rm -rf /etc/apt/sources.list.d/scylla.list
+               sudo cp ~/scylla.list-backup /etc/apt/sources.list.d/scylla.list
+               sudo chown root.root /etc/apt/sources.list.d/scylla.list
+               sudo chmod 644 /etc/apt/sources.list.d/scylla.list
 
-        #. Update the |SCYLLA_DEB_SRC_REPO| to |SRC_VERSION|.
         #. Install:
 
             .. code-block::
@@ -307,20 +321,21 @@ Download and install the old release
 
    .. group-tab:: RHEL/CentOS
 
-        #. Remove the old repo file.
+        #. Restore the |SRC_VERSION| packages backed up during the upgrade procedure.
 
             .. code:: sh
 
-               sudo rm -rf /etc/yum.repos.d/scylla.repo
+               sudo cp ~/scylla.repo-backup /etc/yum.repos.d/scylla.repo
+               sudo chown root.root /etc/yum.repos.d/scylla.repo
+               sudo chmod 644 /etc/yum.repos.d/scylla.repo
 
-        #. Update the |SCYLLA_RPM_SRC_REPO|_  to |SRC_VERSION|.
         #. Install:
 
             .. code:: console
 
                sudo yum clean all
                sudo rm -rf /var/cache/yum
-               sudo yum remove scylla\\*cqlsh
+               sudo yum remove scylla\\*tools-core
                sudo yum downgrade scylla\\* -y
                sudo yum install scylla
 
@@ -329,21 +344,7 @@ Restore the configuration file
 .. code:: sh
 
    sudo rm -rf /etc/scylla/scylla.yaml
-   sudo cp -a /etc/scylla/scylla.yaml.backup-src | /etc/scylla/scylla.yaml
-
-Restore system tables
----------------------
-
-Restore all tables of **system** and **system_schema** from the previous snapshot 
-because |NEW_VERSION| uses a different set of system tables. 
-See :doc:`Restore from a Backup and Incremental Backup </operating-scylla/procedures/backup-restore/restore/>` 
-for reference.
-
-.. code:: sh
-
-    cd /var/lib/scylla/data/keyspace_name/table_name-UUID/snapshots/<snapshot_name>/
-    sudo cp -r * /var/lib/scylla/data/keyspace_name/table_name-UUID/
-    sudo chown -R scylla:scylla /var/lib/scylla/data/keyspace_name/table_name-UUID/
+   sudo cp /etc/scylla/scylla.yaml-backup /etc/scylla/scylla.yaml
 
 Reload systemd configuration
 ----------------------------


### PR DESCRIPTION
This PR fixes the rollback procedure in the 5.2-to-5.4 upgrade guide:
- The "Restore system tables" step is removed.
- The "Restore the configuration file" command is fixed.
- The "Gracefully shutdown ScyllaDB" command is fixed.

In addition, there are the following updates to be in sync with the tests:
- The "Backup the configuration file" step is extended to include a command to backup the packages (for this reason, there are separate tabs for Ubuntu/Debian and RHEL/Centos. as the commands are different).
- The Rollback procedure is extended to restore the backup packages.
- The Reinstallation section is fixed for RHEL.

Also, I've removed the optional step to enable consistent schema management from the list of steps - the appropriate section has already been removed, but it remained in the procedure description, which was misleading.

Refs https://github.com/scylladb/scylladb/issues/11907

This PR must be backported to branch-5.4