### PR TITLE
abstract_replication_strategy: prepare options: warn about replication_factor corner cases

### DIFF
--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -13,12 +13,16 @@
 #include "data_dictionary/keyspace_metadata.hh"
 #include "locator/token_metadata.hh"
 #include "locator/abstract_replication_strategy.hh"
+#include "log.hh"
 
 namespace cql3 {
+
+logging::logger logger("keyspace_options");
 
 namespace statements {
 
 static std::map<sstring, sstring> prepare_options(
+        const sstring& ks_name,
         const sstring& strategy_class,
         const locator::token_metadata& tm,
         std::map<sstring, sstring> options,
@@ -35,17 +39,21 @@ static std::map<sstring, sstring> prepare_options(
     // See issue CASSANDRA-14303.
 
     std::optional<sstring> rf;
+    bool old_rf_option = false;
     auto it = options.find(ks_prop_defs::REPLICATION_FACTOR_KEY);
     if (it != options.end()) {
         // Expand: the user explicitly provided a 'replication_factor'.
         rf = it->second;
         options.erase(it);
+        logger.warn("Using the \"replication_factor\" option is not recommended, but was used for keyspace \"{}\". "
+                "Use per-datacenter replication factor options instead.", ks_name);
     } else if (options.empty()) {
         auto it = old_options.find(ks_prop_defs::REPLICATION_FACTOR_KEY);
         if (it != old_options.end()) {
             // Expand: the user switched from another strategy that specified a 'replication_factor'
             // and didn't provide any additional options.
             rf = it->second;
+            old_rf_option = true;
         }
     }
 
@@ -54,15 +62,47 @@ static std::map<sstring, sstring> prepare_options(
         // already have rf settings), so let's validate it once (#8880).
         locator::abstract_replication_strategy::validate_replication_factor(*rf);
 
+        const auto& dcs = tm.get_topology().get_datacenters();
+        size_t old_dc_rfs = 0;
+        size_t new_dc_rfs = 0;
+
         // We keep previously specified DC factors for safety.
         for (const auto& opt : old_options) {
             if (opt.first != ks_prop_defs::REPLICATION_FACTOR_KEY) {
                 options.insert(opt);
+                if (dcs.contains(opt.first)) {
+                    ++old_dc_rfs;
+                }
             }
         }
 
-        for (const auto& dc : tm.get_topology().get_datacenters()) {
-            options.emplace(dc, *rf);
+        for (const auto& dc : dcs) {
+            if (options.emplace(dc, *rf).second) {
+                ++new_dc_rfs;
+            }
+        }
+
+        // Warn about non-trivial cases
+        if (new_dc_rfs) {
+            if (old_dc_rfs) {
+                logger.warn("The \"replication_factor\": {} option was applied only to newly added datacenters. "
+                        "Consider using explicit per-datacenter options instead. Current replication options are {}", *rf, options);
+            } else if (old_rf_option) {
+                const auto& dc_racks = tm.get_topology().get_datacenter_racks();
+                // Warn if topology has multiple datacenters, or multiple racks in a single dc.
+                // In this case the SimpleStrategy replication factor was applied globally, while
+                // now it will apply per dc/rack and secondary replica ownerships change -
+                // requiring repair and cleanup.
+                if (dcs.size() > 1 || (!dc_racks.empty() && dc_racks.begin()->second.size() != 1)) {
+                    logger.warn("\"replication_factor\": {} was inherited from a previous replication strategy, where it may have been applied globally in the cluster. "
+                            "It now applies to the following topology: {}. Current replication options are: {}. "
+                            "Run repair to rebuild the new token replicas and then cleanup to remove the stale replicas",
+                            *rf, dc_racks, options);
+                }
+            }
+        } else if (!old_rf_option) {
+            logger.warn("The \"replication_factor\": {} option did not apply to any existing datacenters. "
+                    "Consider using explicit per-datacenter options instead. Current replication options are {}", *rf, options);
         }
     }
 
@@ -114,7 +154,7 @@ std::optional<sstring> ks_prop_defs::get_replication_strategy_class() const {
 lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata(sstring ks_name, const locator::token_metadata& tm) {
     auto sc = get_replication_strategy_class().value();
     return data_dictionary::keyspace_metadata::new_keyspace(ks_name, sc,
-            prepare_options(sc, tm, get_replication_options()), get_boolean(KW_DURABLE_WRITES, true), std::vector<schema_ptr>{}, get_storage_options());
+            prepare_options(ks_name, sc, tm, get_replication_options()), get_boolean(KW_DURABLE_WRITES, true), std::vector<schema_ptr>{}, get_storage_options());
 }
 
 lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata& tm) {
@@ -122,7 +162,7 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_u
     const auto& old_options = old->strategy_options();
     auto sc = get_replication_strategy_class();
     if (sc) {
-        options = prepare_options(*sc, tm, get_replication_options(), old_options);
+        options = prepare_options(old->name(), *sc, tm, get_replication_options(), old_options);
     } else {
         sc = old->strategy_name();
         options = old_options;


### PR DESCRIPTION
Using the replication_factor option with
NetworkTopologyStrategy can currently lead to surprising, counter-intuitive results.

When creating a keyspace, the option initially sets the replication factor on all DCs.

But when used in ALTER KEYSPACE queries, the legacy `replication_factor` option is applied only to
DCs added after the keyspace was created, while
existing DCs are unaffected, and if no DCs were
added, the option is silently ignored.

This change detects when the `replication_factor`
can be applied safely, and otherwise, it prints a warning.

Fixes scylladb/scylladb#8881