### PR TITLE
clocks-impl: format time_point using fmt

### DIFF
--- a/clocks-impl.cc
+++ b/clocks-impl.cc
@@ -6,9 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/core/print.hh>
+#include <fmt/chrono.h>
 
-#include "db_clock.hh"
 #include "timestamp.hh"
 
 #include "clocks-impl.hh"
@@ -16,7 +15,6 @@
 std::atomic<int64_t> clocks_offset;
 
 std::string format_timestamp(api::timestamp_type ts) {
-    auto t = std::time_t(std::chrono::duration_cast<std::chrono::seconds>(api::timestamp_clock::duration(ts)).count());
-    ::tm t_buf;
-    return format("{}", std::put_time(::gmtime_r(&t, &t_buf), "%Y/%m/%d %T"));
+    std::chrono::system_clock::time_point when{api::timestamp_clock::duration(ts)};
+    return fmt::format("{:%Y/%m/%d %T}", when);
 }


### PR DESCRIPTION
instead of relying on the operator<<() of an opaque type, use fmtlib to print a timepoint for better support of new fmtlib which dropped the default-generated formatter for types with operator<<().

Refs #13245
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>