### PR TITLE
cql: make options case insensitive

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -241,7 +241,7 @@ using uexpression = uninitialized<expression>;
                 add_recognition_error(msg);
                 break;
             }
-            if (!res.emplace(left->raw_text, right->raw_text).second) {
+            if (!res.emplace(to_lower(left->raw_text), right->raw_text).second) {
                 sstring msg = fmt::format("Multiple definition for property {}", left->raw_text);
                 add_recognition_error(msg);
                 break;

--- a/test/cql-pytest/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/alter_test.py
@@ -222,10 +222,10 @@ def testAlterKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, test_keysp
     # Create a keyspace with expected DC name.
     with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 }") as ks:
         # try modifying the keyspace
-        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy for keyspace " + ks, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', 'INVALID_DC' : 2 }")
+        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {invalid_dc} passed to .*NetworkTopologyStrategy for keyspace " + ks, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', 'invalid_dc' : 2 }")
         execute(cql, ks, "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 3 }")
         # Mix valid and invalid, should throw an exception
-        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy for keyspace " + ks, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 , 'INVALID_DC': 1}")
+        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {invalid_dc} passed to .*NetworkTopologyStrategy for keyspace " + ks, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 , 'invalid_dc': 1}")
 
 def testAlterKeyspaceWithMultipleInstancesOfSameDCThrowsSyntaxException(cql, test_keyspace, this_dc):
     # Create a keyspace


### PR DESCRIPTION
fix an issue when options typed in various cases treat as different

This is just a possible solution. Probably we should add some tests as well

Fixes #15336