### PR TITLE
service/migration_manager: only reload schema when enabling disabled features

### DIFF
--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -108,13 +108,15 @@ void migration_manager::init_messaging_service()
     };
 
     if (this_shard_id() == 0) {
-        _feature_listeners.push_back(_feat.view_virtual_columns.when_enabled(reload_schema_in_bg));
-        _feature_listeners.push_back(_feat.digest_insensitive_to_expiry.when_enabled(reload_schema_in_bg));
-        _feature_listeners.push_back(_feat.cdc.when_enabled(reload_schema_in_bg));
-        _feature_listeners.push_back(_feat.per_table_partitioners.when_enabled(reload_schema_in_bg));
-
-        if (!_feat.table_digest_insensitive_to_expiry) {
-            _feature_listeners.push_back(_feat.table_digest_insensitive_to_expiry.when_enabled(reload_schema_in_bg));
+        for (const gms::feature& feature : {
+                std::cref(_feat.view_virtual_columns),
+                std::cref(_feat.digest_insensitive_to_expiry),
+                std::cref(_feat.cdc),
+                std::cref(_feat.per_table_partitioners),
+                std::cref(_feat.table_digest_insensitive_to_expiry)}) {
+            if (!feature) {
+                _feature_listeners.push_back(feature.when_enabled(reload_schema_in_bg));
+            }
         }
     }
 


### PR DESCRIPTION
Instead of unconditionally reloading schema when enabling any schema feature, only create a listener, if the feature was disabled in the first place. So that we don't trigger reloading of the schema on each schema feature, on node restarts. In this case, the node will start with all these features enabled already.
This prevents unnecessary work on restarts.

Fixes: #16112