### PR TITLE
build: s/-Wignore-qualifiers/-Wignored-qualifiers/

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -16,7 +16,7 @@ add_compile_options(
   "-Werror"
   "-Wno-error=deprecated-declarations"
   "-Wimplicit-fallthrough"
-  "-Wignore-qualifiers"
+  "-Wignored-qualifiers"
   ${_supported_warnings})
 
 function(default_target_arch arch)

--- a/configure.py
+++ b/configure.py
@@ -1506,7 +1506,7 @@ def get_warning_options(cxx):
         '-Wall',
         '-Werror',
         '-Wimplicit-fallthrough',
-        '-Wignore-qualifiers',
+        '-Wignored-qualifiers',
         '-Wno-mismatched-tags',  # clang-only
         '-Wno-c++11-narrowing',
         '-Wno-overloaded-virtual',


### PR DESCRIPTION
this was a typo introduced by 781b7de5. which intended to add -Wignored-qualifiers to the compiling options, but it ended up adding -Wignore-qualifiers.

in this change, the typo is corrected.