### PR TITLE
cql3: define format_as() for formatting cql3::cql3_type::raw

### DIFF
--- a/cql3/cql3_type.hh
+++ b/cql3/cql3_type.hh
@@ -66,6 +66,9 @@ public:
         static shared_ptr<raw> tuple(std::vector<shared_ptr<raw>> ts);
         static shared_ptr<raw> frozen(shared_ptr<raw> t);
         friend std::ostream& operator<<(std::ostream& os, const raw& r);
+        friend sstring format_as(const raw& r) {
+            return r.to_string();
+        }
         friend class auth::resource;
     };
 


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter
created from operator<<, but fmt v10 dropped the default-generated
formatter.

to define a formatter which can be used by raw class and its derived
classes, we have to put the full template specialization before the
call sites. also, please note, the forward declaration is not enough,
as the compile-time formatter check of fmt requires the definition of
formatter. since fmt v10 also enables us to use `format_as()` to format
a certain type with the return value of `format_as()`.

this fulfills our needs.

Refs #13245
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>