### PR TITLE
gossiper: do not use {:d} fmt specifier when formating generation_number

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1794,7 +1794,7 @@ future<> gossiper::apply_new_states(inet_address addr, endpoint_state local_stat
             auto remote_gen = remote_state.get_heart_beat_state().get_generation();
             auto local_gen = local_state.get_heart_beat_state().get_generation();
             if(remote_gen != local_gen) {
-                auto err = format("Remote generation {:d} != local generation {:d}", remote_gen, local_gen);
+                auto err = format("Remote generation {} != local generation {}", remote_gen, local_gen);
                 logger.warn("{}", err);
                 throw std::runtime_error(err);
             }


### PR DESCRIPTION
generation_number's type is `generation_type`, which in turn is a `utils::tagged_integer<struct generation_type_tag, int32_t>`, which formats using either fmtlib which uses ostream_formatter backed by operator<< . but `ostream_formatter` does not provide the specifier support. so {:d} does apply to this type, when compiling with fmtlib v10, it rejects the format specifier (the error is attached at the end of the commit message).

so in this change, we just drop the format specifier. as fmtlib prints `int32_t` as a decimal integer, so even if {:d} applied, it does not change the behavior.

```
/home/kefu/dev/scylladb/gms/gossiper.cc:1798:35: error: call to consteval function 'fmt::basic_format_string<char, utils::tagged_tagged_integer<utils::final, gms::generation_type_tag, int> &, utils::tagged_tagged_integer<utils::final, gms::generation_type_tag, int> &>::basic_format_string<char[48], 0>' is not a constant expression
 1798 |                 auto err = format("Remote generation {:d} != local generation {:d}", remote_gen, local_gen);
      |                                   ^
/usr/include/fmt/core.h:2322:31: note: non-constexpr function 'throw_format_error' cannot be used in a constant expression
 2322 |       if (!in(arg_type, set)) throw_format_error("invalid format specifier");
      |                               ^
/usr/include/fmt/core.h:2395:14: note: in call to 'parse_presentation_type.operator()(1, 510)'
 2395 |       return parse_presentation_type(pres::dec, integral_set);
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/core.h:2706:9: note: in call to 'parse_format_specs<char>(&"Remote generation {:d} != local generation {:d}"[20], &"Remote generation {:d} != local generation {:d}"[47], formatter<mapped_type, char_type>().formatter::specs_, checker(s).context_, 13)'
 2706 |         detail::parse_format_specs(ctx.begin(), ctx.end(), specs_, ctx, type);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/core.h:2561:10: note: in call to 'formatter<mapped_type, char_type>().parse<fmt::detail::compile_parse_context<char>>(checker(s).context_)'
 2561 |   return formatter<mapped_type, char_type>().parse(ctx);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/core.h:2647:39: note: in call to 'parse_format_specs<utils::tagged_tagged_integer<utils::final, gms::generation_type_tag, int>, fmt::detail::compile_parse_context<char>>(checker(s).context_)'
 2647 |     return id >= 0 && id < num_args ? parse_funcs_[id](context_) : begin;
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/core.h:2485:15: note: in call to 'handler.on_format_specs(0, &"Remote generation {:d} != local generation {:d}"[20], &"Remote generation {:d} != local generation {:d}"[47])'
 2485 |       begin = handler.on_format_specs(adapter.arg_id, begin + 1, end);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/core.h:2541:13: note: in call to 'parse_replacement_field<char, fmt::detail::format_string_checker<char, utils::tagged_tagged_integer<utils::final, gms::generation_type_tag, int>, utils::tagged_tagged_integer<utils::final, gms::generation_type_tag, int>> &>(&"Remote generation {:d} != local generation {:d}"[19], &"Remote generation {:d} != local generation {:d}"[47], checker(s))'
 2541 |     begin = parse_replacement_field(p, end, handler);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/core.h:2769:7: note: in call to 'parse_format_string<true, char, fmt::detail::format_string_checker<char, utils::tagged_tagged_integer<utils::final, gms::generation_type_tag, int>, utils::tagged_tagged_integer<utils::final, gms::generation_type_tag, int>>>({&"Remote generation {:d} != local generation {:d}"[0], 47}, checker(s))'
 2769 |       detail::parse_format_string<true>(str_, checker(s));
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kefu/dev/scylladb/gms/gossiper.cc:1798:35: note: in call to 'basic_format_string<char[48], 0>("Remote generation {:d} != local generation {:d}")'
 1798 |                 auto err = format("Remote generation {:d} != local generation {:d}", remote_gen, local_gen);
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```