### PR TITLE
cql3: test_assignment: define formatter for assignment_testable

### DIFF
--- a/cql3/assignment_testable.hh
+++ b/cql3/assignment_testable.hh
@@ -67,3 +67,11 @@ operator<<(std::ostream& os, const assignment_testable& at) {
 }
 
 }
+
+template <>
+struct fmt::formatter<cql3::assignment_testable> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const cql3::assignment_testable& at, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", at.assignment_testable_source_context());
+    }
+};


### PR DESCRIPTION
add fmt formatter for `assignment_testable`.

 this is a part of a series to migrating from `operator<<(ostream&, ..)`
 based formatting to fmtlib based formatting. the goal here is to enable
 fmtlib to print `assignment_testabe` without the help of `operator<<`.

since all of the callers of 'operator<<' of these types now use formatters, the operator<< are removed in this change.

Refs #13245
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>