### PR TITLE
Internal server error replace with invalid syntax error

### DIFF
--- a/compound.hh
+++ b/compound.hh
@@ -17,6 +17,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include "utils/serialization.hh"
 #include <seastar/util/backtrace.hh>
+#include "exceptions/exceptions.hh"
 
 enum class allow_prefixes { no, yes };
 
@@ -117,7 +118,7 @@ public:
     managed_bytes serialize_optionals(std::span<const bytes_opt> values) const {
         return serialize_value(boost::make_iterator_range(values.begin(), values.end()) | boost::adaptors::transformed([] (const bytes_opt& bo) -> bytes_view {
             if (!bo) {
-                throw std::logic_error("attempted to create key component from empty optional");
+                throw exceptions::invalid_request_exception("Invalid null value in condition for column {}");
             }
             return *bo;
         }));
@@ -125,7 +126,7 @@ public:
     managed_bytes serialize_optionals(std::span<const managed_bytes_opt> values) const {
         return serialize_value(boost::make_iterator_range(values.begin(), values.end()) | boost::adaptors::transformed([] (const managed_bytes_opt& bo) -> managed_bytes_view {
             if (!bo) {
-                throw std::logic_error("attempted to create key component from empty optional");
+                throw exceptions::invalid_request_exception("Invalid null value in condition for column {}");
             }
             return managed_bytes_view(*bo);
         }));


### PR DESCRIPTION
When null is used in multi-column relation we receive "Invalid null value in condition for column {}" now, instead of "Attempted to create key component from empty optional". This commit still needs to be improved to include a column with null value at the end of the message, or just remove the brackets if we don't want to specify the column.

Fixes scylladb#13217