### PR TITLE
config: define formatter for db::seed_provider_type

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1166,6 +1166,14 @@ void db::config::maybe_in_workdir(named_value<string_list>& tos, const char* sub
 
 const sstring db::config::default_tls_priority("SECURE128:-VERS-TLS1.0");
 
+template <>
+struct fmt::formatter<db::seed_provider_type> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const db::seed_provider_type& s, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "seed_provider_type{{class={}, params={}}}",
+                              s.class_name, s.parameters);
+    }
+};
 
 namespace db {
 


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define a formatter for db::seed_provider_type.

please note, we are still formatting vector<db::seed_provider_type>
with the helper provided by `seastar/core/sstring.hh`, which uses
`operator<<()` to print the elements in the vector being printed.
so we have to keep the operator<< formatter before disabling
the generic formatter for `vector<T>`.

Refs #13245
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>