### PR TITLE
schema_tables: use smaller timestamp for base mutations included with view update

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -3440,9 +3440,15 @@ schema_mutations make_schema_mutations(schema_ptr s, api::timestamp_type timesta
 std::vector<mutation> make_create_view_mutations(lw_shared_ptr<keyspace_metadata> keyspace, view_ptr view, api::timestamp_type timestamp)
 {
     std::vector<mutation> mutations;
-    // And also the serialized base table.
+    // Include the serialized base table mutations in case the target node is missing them.
     auto base = keyspace->cf_meta_data().at(view->view_info()->base_name());
-    add_table_or_view_to_schema_mutation(base, timestamp, true, mutations);
+    // Use a smaller timestamp for the included base mutations.
+    // If the constructed schema change command also contains an update for the base table,
+    // these mutations would conflict with the base mutations we're returning here; using a smaller
+    // timestamp makes sure that the update mutations take precedence. Although there is no known
+    // scenario involving creation of new view where this might happen, there is one with updating
+    // a view (see `make_update_view_mutations`); we use similarly modified timestamp here for consistency.
+    add_table_or_view_to_schema_mutation(base, timestamp - 1, true, mutations);
     add_table_or_view_to_schema_mutation(view, timestamp, true, mutations);
     make_table_deleting_mutations(view->ks_name(), view->cf_name(), view->is_view(), timestamp)
         .copy_to(mutations);
@@ -3464,7 +3470,13 @@ std::vector<mutation> make_update_view_mutations(lw_shared_ptr<keyspace_metadata
     if (include_base) {
         // Include the serialized base table mutations in case the target node is missing them.
         auto base = keyspace->cf_meta_data().at(new_view->view_info()->base_name());
-        add_table_or_view_to_schema_mutation(base, timestamp, true, mutations);
+        // Use a smaller timestamp for the included base mutations.
+        // If the constructed schema change command also contains an update for the base table,
+        // these mutations would conflict with the base mutations we're returning here; using a smaller
+        // timestamp makes sure that the update mutations take precedence. Such conflicting mutations
+        // may appear, for example, when we modify a user defined type that is referenced by both base table
+        // and its attached view. See #15530.
+        add_table_or_view_to_schema_mutation(base, timestamp - 1, true, mutations);
     }
     add_table_or_view_to_schema_mutation(new_view, timestamp, false, mutations);
     make_update_columns_mutations(old_view, new_view, timestamp, false, mutations);


### PR DESCRIPTION
When a view schema is changed, the schema change command also includes mutations for the corresponding base table; these mutations don't modify the base schema but are included in case if the receiver of view mutations somehow didn't receive base mutations yet (this may in theory happen outside Raft mode).

There are situations where the schema change command contains both mutations that describe the current state of the base table -- included by a view update, as explained above -- and mutations that want to modify the base table. Such situation arises, for example, when we update a user-defined type which is referenced by both a view and its corresponding base table. This triggers a schema change of the view, which generates mutations to modify the view and includes mutations of the current base schema, and at the same time it triggers a schema change of the base, which generates mutations to modify the base.

These two sets of mutations are conflicting with each other. One set wants to preserve the current state of the base table while the other wants to modify it. And the two sets of mutations are generated using the same timestamp, which means that conflict resolution between them is made on a per-mutation-cell basis, comparing the values in each cell and taking the "larger" one (meaning of "larger" depends on the type of each cell).

Fortunately, this conflict is currently benign -- or at least there is no known situation where it causes problems.

Unfortunately, it started causing problems when I attempted to implement group 0 schema versioning (PR scylladb/scylladb#15331), where instead of calculating table versions as hashes of schema mutations, we would send versions as part of schema change command. These versions would be stored inside the `system_schema.scylla_tables` table, `version` column, and sent as part of schema change mutations.

And then the conflict showed. One set of mutations wanted to preserve the old value of `version` column while the other wanted to update it. It turned out that sometimes the old `version` prevailed, because the `version` column in `system_schema.scylla_tables` uses UUID-based comparison (not timeuuid-based comparison). This manifested as issue scylladb/scylladb#15530.

To prevent this, the idea in this commit is simple: when generating mutations for the base table as part of corresponding view update, do not use the provided timestamp directly -- instead, decrement it by one. This way, if the schema change command contains mutations that want to modify the base table, these modifying mutations will win all conflicts based on the timestamp alone (they are using the same provided timestamp, but not decremented).

One could argue that the choice of this timestamp is anyway arbitrary. The original purpose of including base mutations during view update was to ensure that a node which somehow missed the base mutations, gets them when applying the view. But in that case, the "most correct" solution should have been to use the *original* base mutations -- i.e. the ones that we have on disk -- instead of generating new mutations for the base with a refreshed timestamp. The base mutations that we have on disk have smaller timestamps already (since these mutations are from the past, when the base was last modified or created), so the conflict would also not happen in this case.

But that solution would require doing a disk read, and we can avoid the read while still fixing the conflict by using an intermediate solution: regenerating the mutations but with `timestamp - 1`.

Ref: scylladb/scylladb#15530