### PR TITLE
hints: move formatter of db::hints::sync_point to test

### DIFF
--- a/db/hints/sync_point.cc
+++ b/db/hints/sync_point.cc
@@ -180,12 +180,6 @@ sstring sync_point::encode() const {
     return base64_encode(serialized);
 }
 
-std::ostream& operator<<(std::ostream& out, const sync_point& sp) {
-    out << "{regular_per_shard_rps: " << sp.regular_per_shard_rps
-        << ", mv_per_shard_rps: " << sp.mv_per_shard_rps
-        << "}";
-    return out;
+}
 }
 
-}
-}

--- a/db/hints/sync_point.hh
+++ b/db/hints/sync_point.hh
@@ -38,8 +38,6 @@ struct sync_point {
     bool operator==(const sync_point& other) const = default;
 };
 
-std::ostream& operator<<(std::ostream& out, const sync_point& sp);
-
 // IDL type
 // Contains per-endpoint and per-shard information about replay positions
 // for a particular type of hint queues (regular mutation hints or MV update hints)

--- a/test/boost/hint_test.cc
+++ b/test/boost/hint_test.cc
@@ -12,6 +12,15 @@
 
 #include "db/hints/sync_point.hh"
 
+namespace db::hints {
+std::ostream& operator<<(std::ostream& out, const sync_point& sp) {
+    out << "{regular_per_shard_rps: " << sp.regular_per_shard_rps
+        << ", mv_per_shard_rps: " << sp.mv_per_shard_rps
+        << "}";
+    return out;
+}
+}
+
 SEASTAR_TEST_CASE(test_hint_sync_point_faithful_reserialization) {
     const unsigned encoded_shard_count = 2;
 


### PR DESCRIPTION
the operator<<() based formatter is only used in its test, so
let's move it to where it is used.
we can always bring it back later if it is required in other places.
but better off implementing it as a fmt::formatter<> then.

Refs #13245
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>