### PR TITLE
result_message: add formatter for result_message::rows

### DIFF
--- a/transport/messages/result_message.hh
+++ b/transport/messages/result_message.hh
@@ -245,8 +245,6 @@ public:
     }
 };
 
-std::ostream& operator<<(std::ostream& os, const result_message::rows& msg);
-
 
 template<typename ResultMessagePtr>
 requires requires (ResultMessagePtr ptr) {
@@ -264,3 +262,9 @@ inline future<ResultMessagePtr> propagate_exception_as_future(ResultMessagePtr&&
 }
 
 }
+
+template <>
+struct fmt::formatter<cql_transport::messages::result_message::rows> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const cql_transport::messages::result_message::rows&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define a formatter for
`cql_transport::messages::result_message::rows`

Refs #13245