### PR TITLE
Send all tablet info to the drivers under one key in `custom_payload`

### DIFF
--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -24,9 +24,14 @@ using namespace locator;
 
 static thread_local auto replica_type = tuple_type_impl::get_instance({uuid_type, int32_type});
 static thread_local auto replica_set_type = list_type_impl::get_instance(replica_type, false);
+static thread_local auto tablet_info_type = tuple_type_impl::get_instance({long_type, long_type, replica_set_type});
 
 data_type get_replica_set_type() {
     return replica_set_type;
+}
+
+data_type get_tablet_info_type() {
+    return tablet_info_type;
 }
 
 schema_ptr make_tablets_schema() {

--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -33,6 +33,8 @@ namespace replica {
 
 data_type get_replica_set_type();
 
+data_type get_tablet_info_type();
+
 schema_ptr make_tablets_schema();
 
 std::vector<data_value> replicas_to_data_value(const locator::tablet_replica_set& replicas);

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -5721,7 +5721,7 @@ cql_test_config tablet_cql_test_config() {
 static
 bool has_tablet_routing(::shared_ptr<cql_transport::messages::result_message> result) {
     auto custom_payload = result->custom_payload();
-    if (!custom_payload.has_value() || custom_payload->find("tablet_replicas") == custom_payload->end() || custom_payload->find("token_range") == custom_payload->end()) {
+    if (!custom_payload.has_value() || custom_payload->find("tablets-routing-v1") == custom_payload->end()) {
         return false;
     }
     return true;

--- a/transport/messages/result_message_base.hh
+++ b/transport/messages/result_message_base.hh
@@ -49,14 +49,11 @@ public:
     void add_tablet_info(locator::tablet_replica_set tablet_replicas, std::pair<dht::token, dht::token> token_range) {
         if (!tablet_replicas.empty()) {
             auto replicas_values = make_list_value(replica::get_replica_set_type(), replica::replicas_to_data_value(tablet_replicas));
-            this->add_custom_payload("tablet_replicas", replicas_values.serialize_nonnull());
             auto v1 = data_value(dht::token::to_int64(token_range.first));
             auto v2 = data_value(dht::token::to_int64(token_range.second));
-            bytes token_bytes(bytes::initialized_later(), v1.serialized_size() + v2.serialized_size());
-            auto i = token_bytes.begin();
-            v1.serialize(i);
-            v2.serialize(i);
-            this->add_custom_payload("token_range", token_bytes);
+
+            auto tablets_routing = make_tuple_value(replica::get_tablet_info_type(), {v1, v2, replicas_values});
+            this->add_custom_payload("tablets-routing-v1", tablets_routing.serialize_nonnull());
         }
     }
 


### PR DESCRIPTION
Previously, the tablet information was sent to the drivers in two pieces within the `custom_payload`. We had information about the replicas under the `tablet_replicas` key and token range information under `token_range`. These names were quite generic and might have caused problems for other `custom_payload` users. Additionally, dividing the information into two pieces raised the question of what to do if one key is present while the other is missing.

This PR changes the serialization mechanism to pack all information under one specific name, `tablets-routing-v1`, leaving room for future extensions.

The documentation has been updated.