### PR TITLE
doc: fix rollback for RHEL (install command) in 5.4

### DIFF
--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.2-to-5.4/upgrade-guide-from-5.2-to-5.4-generic.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.2-to-5.4/upgrade-guide-from-5.2-to-5.4-generic.rst
@@ -335,9 +335,10 @@ Restore and install the old release
 
                sudo yum clean all
                sudo rm -rf /var/cache/yum
-               sudo yum remove scylla\\*tools-core
-               sudo yum downgrade scylla\\* -y
-               sudo yum install scylla
+               sudo yum downgrade scylla-\*cqlsh -y
+               sudo yum remove scylla-\*cqlsh -y
+               sudo yum downgrade scylla\* -y
+               sudo yum install scylla -y
 
 Restore the configuration file
 ------------------------------


### PR DESCRIPTION
This PR fixes the installation command in the Rollback section for RHEL/Centos in the 5.2-5.4 upgrade guide.

It's a follow-up to https://github.com/scylladb/scylladb/pull/16114 where the command was not updated.

Refs https://github.com/scylladb/scylladb/issues/11907

This commit must be backported to branch-5.4.