### PR TITLE
Minor fixes and refactors

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -966,7 +966,7 @@ future<> merge_schema(sharded<db::system_keyspace>& sys_ks, distributed<service:
     if (this_shard_id() != 0) {
         // mutations must be applied on the owning shard (0).
         co_await smp::submit_to(0, [&, fmuts = freeze(mutations)] () mutable -> future<> {
-            return merge_schema(sys_ks, proxy, feat, unfreeze(fmuts));
+            return merge_schema(sys_ks, proxy, feat, unfreeze(fmuts), reload);
         });
         co_return;
     }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -330,31 +330,35 @@ schema_ptr tables() {
 
 // Holds Scylla-specific table metadata.
 schema_ptr scylla_tables(schema_features features) {
-    static auto make = [] (bool has_cdc_options, bool has_per_table_partitioners) -> schema_ptr {
+    static thread_local schema_ptr schemas[2][2]{};
+
+    bool has_cdc_options = features.contains(schema_feature::CDC_OPTIONS);
+    bool has_per_table_partitioners = features.contains(schema_feature::PER_TABLE_PARTITIONERS);
+
+    schema_ptr& s = schemas[has_cdc_options][has_per_table_partitioners];
+    if (!s) {
         auto id = generate_legacy_id(NAME, SCYLLA_TABLES);
         auto sb = schema_builder(NAME, SCYLLA_TABLES, std::make_optional(id))
             .with_column("keyspace_name", utf8_type, column_kind::partition_key)
             .with_column("table_name", utf8_type, column_kind::clustering_key)
             .with_column("version", uuid_type)
             .set_gc_grace_seconds(schema_gc_grace);
-        // 0 - false, false
-        // 1 - true, false
-        // 2 - false, true
-        // 3 - true, true
-        int offset = 0;
+        // Each bit in `offset` denotes a different schema feature,
+        // so different values of `offset` are used for different combinations of features.
+        uint16_t offset = 0;
         if (has_cdc_options) {
             sb.with_column("cdc", map_type_impl::get_instance(utf8_type, utf8_type, false));
-            ++offset;
+            offset |= 0b1;
         }
         if (has_per_table_partitioners) {
             sb.with_column("partitioner", utf8_type);
-            offset += 2;
+            offset |= 0b10;
         }
         sb.with_version(system_keyspace::generate_schema_version(id, offset));
-        return sb.build();
-    };
-    static thread_local schema_ptr schemas[2][2] = { {make(false, false), make(false, true)}, {make(true, false), make(true, true)} };
-    return schemas[features.contains(schema_feature::CDC_OPTIONS)][features.contains(schema_feature::PER_TABLE_PARTITIONERS)];
+        s = sb.build();
+    }
+
+    return s;
 }
 
 // The "columns" table lists the definitions of all columns in all tables

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -496,7 +496,7 @@ public:
             utils::UUID state_id, std::optional<gc_clock::duration> gc_older_than, std::string_view description);
 
     // Obtain the contents of the group 0 history table in mutation form.
-    // Assumes that the history table exists, i.e. Raft experimental feature is enabled.
+    // Assumes that the history table exists, i.e. Raft feature is enabled.
     static future<mutation> get_group0_history(distributed<replica::database>&);
 
     future<> sstables_registry_create_entry(sstring location, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc);

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3166,7 +3166,7 @@ repair_service::insert_repair_meta(
         streaming::stream_reason reason,
         gc_clock::time_point compaction_time,
         abort_source& as) {
-    return get_migration_manager().get_schema_for_write(schema_version, {from, src_cpu_id}, get_messaging(), &as).then([this,
+    return get_migration_manager().get_schema_for_write(schema_version, {from, src_cpu_id}, get_messaging(), as).then([this,
             from,
             repair_meta_id,
             range,

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -1121,11 +1121,11 @@ static future<schema_ptr> get_schema_definition(table_schema_version v, netw::me
     });
 }
 
-future<schema_ptr> migration_manager::get_schema_for_read(table_schema_version v, netw::messaging_service::msg_addr dst, netw::messaging_service& ms, abort_source* as) {
+future<schema_ptr> migration_manager::get_schema_for_read(table_schema_version v, netw::messaging_service::msg_addr dst, netw::messaging_service& ms, abort_source& as) {
     return get_schema_for_write(v, dst, ms, as);
 }
 
-future<schema_ptr> migration_manager::get_schema_for_write(table_schema_version v, netw::messaging_service::msg_addr dst, netw::messaging_service& ms, abort_source* as) {
+future<schema_ptr> migration_manager::get_schema_for_write(table_schema_version v, netw::messaging_service::msg_addr dst, netw::messaging_service& ms, abort_source& as) {
     if (_as.abort_requested()) {
         co_return coroutine::exception(std::make_exception_ptr(abort_requested_exception()));
     }
@@ -1137,7 +1137,7 @@ future<schema_ptr> migration_manager::get_schema_for_write(table_schema_version 
         // Schema is synchronized through Raft, so perform a group 0 read barrier.
         // Batch the barriers so we don't invoke them redundantly.
         mlogger.trace("Performing raft read barrier because schema is not synced, version: {}", v);
-        co_await (as ? _group0_barrier.trigger(*as) : _group0_barrier.trigger());
+        co_await _group0_barrier.trigger(as);
     }
 
     if (!s) {

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -952,7 +952,7 @@ future<> migration_manager::push_schema_mutation(const gms::inet_address& endpoi
 future<> migration_manager::announce_with_raft(std::vector<mutation> schema, group0_guard guard, std::string_view description) {
     assert(this_shard_id() == 0);
     auto schema_features = _feat.cluster_schema_features();
-    auto adjusted_schema = db::schema_tables::adjust_schema_for_schema_features(schema, schema_features);
+    auto adjusted_schema = db::schema_tables::adjust_schema_for_schema_features(std::move(schema), schema_features);
 
     auto group0_cmd = _group0_client.prepare_command(
         schema_change{

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -118,20 +118,16 @@ void migration_manager::init_messaging_service()
         }
     }
 
-    _messaging.register_definitions_update([this] (const rpc::client_info& cinfo, std::vector<frozen_mutation> fm, rpc::optional<std::vector<canonical_mutation>> cm) {
+    _messaging.register_definitions_update([this] (const rpc::client_info& cinfo, std::vector<frozen_mutation>, rpc::optional<std::vector<canonical_mutation>> cm) {
         auto src = netw::messaging_service::get_source(cinfo);
-        auto f = make_ready_future<>();
-        if (cm) {
-            f = do_with(std::move(*cm), [this, src] (const std::vector<canonical_mutation>& mutations) {
-                return merge_schema_in_background(src, mutations);
-            });
-        } else {
-            f = do_with(std::move(fm), [this, src] (const std::vector<frozen_mutation>& mutations) {
-                return merge_schema_in_background(src, mutations);
-            });
+        if (!cm) {
+            on_internal_error(mlogger, ::format(
+                "definitions_update handler: canonical mutations not supported by {}", src));
         }
         // Start a new fiber.
-        (void)f.then_wrapped([src] (auto&& f) {
+        (void)do_with(std::move(*cm), [this, src] (const std::vector<canonical_mutation>& mutations) {
+            return merge_schema_in_background(src, mutations);
+        }).then_wrapped([src] (auto&& f) {
             if (f.failed()) {
                 mlogger.error("Failed to update definitions from {}: {}", src, f.get_exception());
             } else {
@@ -144,18 +140,19 @@ void migration_manager::init_messaging_service()
             [] (migration_manager& self, const rpc::client_info& cinfo, rpc::optional<netw::schema_pull_options> options)
                 -> future<rpc::tuple<std::vector<frozen_mutation>, std::vector<canonical_mutation>>> {
         const auto cm_retval_supported = options && options->remote_supports_canonical_mutation_retval;
+        if (!cm_retval_supported) {
+            // Canonical mutations support was added way back in scylla-3.2 and we don't support
+            // skipping versions during upgrades (certainly not a 3.2 -> 5.4 upgrade).
+            auto src = netw::messaging_service::get_source(cinfo);
+            on_internal_error(mlogger, ::format(
+                "canonical mutations not supported by {}", src));
+        }
 
         auto features = self._feat.cluster_schema_features();
         auto& proxy = self._storage_proxy.container();
         auto& db = proxy.local().get_db();
         auto cm = co_await db::schema_tables::convert_schema_to_mutations(proxy, features);
         if (options->group0_snapshot_transfer) {
-            // if `group0_snapshot_transfer` is `true`, the sender must also understand canonical mutations
-            // (`group0_snapshot_transfer` was added more recently).
-            if (!cm_retval_supported) {
-                on_internal_error(mlogger,
-                    "migration request handler: group0 snapshot transfer requested, but canonical mutations not supported");
-            }
             cm.emplace_back(co_await db::system_keyspace::get_group0_history(db));
             if (proxy.local().local_db().get_config().check_experimental(db::experimental_features_t::feature::TABLETS)) {
                 for (auto&& m: co_await replica::read_tablet_mutations(db)) {
@@ -163,13 +160,7 @@ void migration_manager::init_messaging_service()
                 }
             }
         }
-        if (cm_retval_supported) {
-            co_return rpc::tuple(std::vector<frozen_mutation>{}, std::move(cm));
-        }
-        auto fm = boost::copy_range<std::vector<frozen_mutation>>(cm | boost::adaptors::transformed([&db = db.local()] (const canonical_mutation& cm) {
-            return cm.to_mutation(db.find_column_family(cm.column_family_id()).schema());
-        }));
-        co_return rpc::tuple(std::move(fm), std::move(cm));
+        co_return rpc::tuple(std::vector<frozen_mutation>{}, std::move(cm));
     }, std::ref(*this)));
     _messaging.register_schema_check([this] {
         return make_ready_future<table_schema_version>(_storage_proxy.get_db().local().get_version());
@@ -342,12 +333,13 @@ future<> migration_manager::do_merge_schema_from(netw::messaging_service::msg_ad
 {
     mlogger.info("Pulling schema from {}", id);
     auto frozen_and_canonical_mutations = co_await _messaging.send_migration_request(id, netw::schema_pull_options{});
-    auto&& [mutations, canonical_mutations] = frozen_and_canonical_mutations;
-    if (canonical_mutations) {
-        co_await merge_schema_from(id, *canonical_mutations);
-    } else {
-        co_await merge_schema_from(id, mutations);
+    auto&& [_, canonical_mutations] = frozen_and_canonical_mutations;
+    if (!canonical_mutations) {
+        on_internal_error(mlogger, format(
+            "do_merge_schema_from: {} returned frozen_mutations instead of canonical_mutations", id));
     }
+
+    co_await merge_schema_from(id, *canonical_mutations);
     mlogger.info("Schema merge with {} completed", id);
 }
 
@@ -944,9 +936,8 @@ future<> migration_manager::push_schema_mutation(const gms::inet_address& endpoi
     netw::messaging_service::msg_addr id{endpoint, 0};
     auto schema_features = _feat.cluster_schema_features();
     auto adjusted_schema = db::schema_tables::adjust_schema_for_schema_features(schema, schema_features);
-    auto fm = std::vector<frozen_mutation>(adjusted_schema.begin(), adjusted_schema.end());
     auto cm = std::vector<canonical_mutation>(adjusted_schema.begin(), adjusted_schema.end());
-    return _messaging.send_definitions_update(id, std::move(fm), std::move(cm));
+    return _messaging.send_definitions_update(id, std::vector<frozen_mutation>{}, std::move(cm));
 }
 
 future<> migration_manager::announce_with_raft(std::vector<mutation> schema, group0_guard guard, std::string_view description) {

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -50,9 +50,6 @@ namespace service {
 
 class storage_proxy;
 
-template<typename M>
-concept MergeableMutation = std::is_same<M, canonical_mutation>::value || std::is_same<M, frozen_mutation>::value;
-
 class migration_manager : public seastar::async_sharded_service<migration_manager>,
                             public gms::i_endpoint_state_change_subscriber,
                             public seastar::peering_sharded_service<migration_manager> {
@@ -119,14 +116,6 @@ public:
     future<> merge_schema_from(netw::msg_addr src, const std::vector<canonical_mutation>& mutations);
     // Incremented each time the function above is called. Needed by tests.
     size_t canonical_mutation_merge_count = 0;
-
-    template<typename M>
-    requires MergeableMutation<M>
-    future<> merge_schema_in_background(netw::msg_addr src, const std::vector<M>& mutations) {
-        return with_gate(_background_tasks, [this, src, &mutations] {
-            return merge_schema_from(src, mutations);
-        });
-    }
 
     bool should_pull_schema_from(const gms::inet_address& endpoint);
     bool has_compatible_schema_tables_version(const gms::inet_address& endpoint);

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -119,8 +119,6 @@ public:
     future<> merge_schema_from(netw::msg_addr src, const std::vector<canonical_mutation>& mutations);
     // Incremented each time the function above is called. Needed by tests.
     size_t canonical_mutation_merge_count = 0;
-    // Deprecated. The canonical mutation should be used instead.
-    future<> merge_schema_from(netw::msg_addr src, const std::vector<frozen_mutation>& mutations);
 
     template<typename M>
     requires MergeableMutation<M>

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -169,12 +169,12 @@ public:
     // Returns schema of given version, either from cache or from remote node identified by 'from'.
     // The returned schema may not be synchronized. See schema::is_synced().
     // Intended to be used in the read path.
-    future<schema_ptr> get_schema_for_read(table_schema_version, netw::msg_addr from, netw::messaging_service& ms, abort_source* as = nullptr);
+    future<schema_ptr> get_schema_for_read(table_schema_version, netw::msg_addr from, netw::messaging_service& ms, abort_source& as);
 
     // Returns schema of given version, either from cache or from remote node identified by 'from'.
     // Ensures that this node is synchronized with the returned schema. See schema::is_synced().
     // Intended to be used in the write path, which relies on synchronized schema.
-    future<schema_ptr> get_schema_for_write(table_schema_version, netw::msg_addr from, netw::messaging_service& ms, abort_source* as = nullptr);
+    future<schema_ptr> get_schema_for_write(table_schema_version, netw::msg_addr from, netw::messaging_service& ms, abort_source& as);
 
 private:
     virtual future<> on_join(gms::inet_address endpoint, gms::endpoint_state_ptr ep_state, gms::permit_id) override;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -398,12 +398,12 @@ public:
 private:
     future<schema_ptr> get_schema_for_read(table_schema_version v, netw::msg_addr from, clock_type::time_point timeout) {
         abort_on_expiry aoe(timeout);
-        co_return co_await _mm.get_schema_for_read(std::move(v), std::move(from), _ms, &aoe.abort_source());
+        co_return co_await _mm.get_schema_for_read(std::move(v), std::move(from), _ms, aoe.abort_source());
     }
 
     future<schema_ptr> get_schema_for_write(table_schema_version v, netw::msg_addr from, clock_type::time_point timeout) {
         abort_on_expiry aoe(timeout);
-        co_return co_await _mm.get_schema_for_write(std::move(v), std::move(from), _ms, &aoe.abort_source());
+        co_return co_await _mm.get_schema_for_write(std::move(v), std::move(from), _ms, aoe.abort_source());
     }
 
     future<replica::exception_variant> handle_counter_mutation(

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -119,7 +119,7 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
             return make_exception_future<rpc::sink<int>>(std::runtime_error(format("Node {} is not fully initialized for streaming, try again later",
                     utils::fb_utilities::get_broadcast_address())));
         }
-        return _mm.local().get_schema_for_write(schema_id, from, _ms.local(), &as).then([this, from, estimated_partitions, plan_id, cf_id, source, reason] (schema_ptr s) mutable {
+        return _mm.local().get_schema_for_write(schema_id, from, _ms.local(), as).then([this, from, estimated_partitions, plan_id, cf_id, source, reason] (schema_ptr s) mutable {
           return _db.local().obtain_reader_permit(s, "stream-session", db::no_timeout, {}).then([this, from, estimated_partitions, plan_id, cf_id, source, reason, s] (reader_permit permit) mutable {
             auto sink = _ms.local().make_sink_for_stream_mutation_fragments(source);
             struct stream_mutation_fragments_cmd_status {

--- a/test/pylib/log_browsing.py
+++ b/test/pylib/log_browsing.py
@@ -75,7 +75,7 @@ class ScyllaLogFile():
                         await asyncio.sleep(0.01)
 
     async def grep(self, expr: str | re.Pattern, filter_expr: Optional[str | re.Pattern] = None,
-             from_mark: Optional[int] = None) -> list[(str, re.Match[str])]:
+             from_mark: Optional[int] = None) -> list[tuple[str, re.Match[str]]]:
         """
         Returns a list of lines matching the regular expression in the Scylla log.
         The list contains tuples of (line, match), where line is the full line


### PR DESCRIPTION
- remove some code that is obsolete in newer Scylla versions,
- fix some minor bugs. These bugs appear to be benign, there are no known issues caused by them, but fixing them is a good idea nevertheless,
- refactor some code for better maintainability.

Parts of this PR were extracted from https://github.com/scylladb/scylladb/pull/15331 (which was merged but later reverted), parts of it are new.