### PR TITLE
main: notify systemd that the service is ready

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1591,6 +1591,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 cdc.stop().get();
             });
 
+            supervisor::notify("starting storage service", true);
+
             api::set_server_messaging_service(ctx, messaging).get();
             auto stop_messaging_api = defer_verbose_shutdown("messaging service API", [&ctx] {
                 api::unset_server_messaging_service(ctx).get();


### PR DESCRIPTION
this change addresses a regression introduced by
f4626f6b8e54a11d80e6412d8022a0f8aca830c3, which stopped notifying systemd with the status that scylla is READY. without the notification, systemd would wait in vain for the readiness of scylla.

Refs f4626f6b8e54a11d80e6412d8022a0f8aca830c3

Fixes #16159
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>