### PR TITLE
sstable: drop repaired_at related code

### DIFF
--- a/sstables/metadata_collector.hh
+++ b/sstables/metadata_collector.hh
@@ -114,7 +114,6 @@ private:
     utils::estimated_histogram _estimated_cells_count{114};
     db::replay_position _replay_position;
     min_max_tracker<api::timestamp_type> _timestamp_tracker;
-    uint64_t _repaired_at = 0;
     min_max_tracker<int32_t> _local_deletion_time_tracker{std::numeric_limits<int32_t>::max(), std::numeric_limits<int32_t>::max()};
     min_max_tracker<int32_t> _ttl_tracker{0, 0};
     double _compression_ratio = NO_COMPRESSION_RATIO;
@@ -180,10 +179,6 @@ public:
         _replay_position = rp;
     }
 
-    void set_repaired_at(uint64_t repaired_at) {
-        _repaired_at = repaired_at;
-    }
-
     void set_sstable_level(int sstable_level) {
         _sstable_level = sstable_level;
     }
@@ -225,7 +220,6 @@ public:
         m.compression_ratio = _compression_ratio;
         m.estimated_tombstone_drop_time = std::move(_estimated_tombstone_drop_time);
         m.sstable_level = _sstable_level;
-        m.repaired_at = _repaired_at;
         convert(m.min_column_names, _min_clustering_pos);
         convert(m.max_column_names, _max_clustering_pos);
         m.has_legacy_counter_shards = _has_legacy_counter_shards;

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -311,7 +311,9 @@ struct stats_metadata : public metadata_base<stats_metadata> {
     double compression_ratio;
     utils::streaming_histogram estimated_tombstone_drop_time;
     uint32_t sstable_level;
-    uint64_t repaired_at;
+    // There is not meaningful value to put in this field, since we have no
+    // incremental repair. Before we have it, let's set it to 0.
+    uint64_t repaired_at = 0;
     disk_array<uint32_t, disk_string<uint16_t>> min_column_names;
     disk_array<uint32_t, disk_string<uint16_t>> max_column_names;
     bool has_legacy_counter_shards;


### PR DESCRIPTION
before we support incremental repair, these is no point have the code path setting / getting it. and even worse, it incurs confusion.

so, in this change, we

* just set the field to 0,
* drop the corresponding field in metadata_collector, as we never update it.
* add a comment to explain why this variable is initialized to 0

Fixes #16098
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>