### PR TITLE
tools/scylla-sstable: always read scylla.yaml

### DIFF
--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -52,8 +52,10 @@ By default (no schema-related options are provided), the tool will try the follo
 
 * Try to load schema from ``schema.cql``.
 * Try to deduce the ScyllaDB data directory path and table names from the SStable path.
-* Try to load the schema from the ScyllaDB directory located at the standard location (``/var/lib/scylla``). For this to succeed, the table name has to be provided via ``--keyspace`` and ``--table``.
-* Try to load the schema from the ScyllaDB directory path obtained from config at the standard location (``./conf/scylla.yaml``). ``SCYLLA_CONF`` and ``SCYLLA_HOME`` environment variables are also checked. For this to succeed, the table name has to be provided via ``--keyspace`` and ``--table``.
+* Try to load the schema from the ScyllaDB data directory path, obtained from the configuration file, at the standard location (``./conf/scylla.yaml``).
+  ``SCYLLA_CONF`` and ``SCYLLA_HOME`` environment variables are also checked.
+  If the configuration file cannot be located, the default ScyllaDB data directory path (``/var/lib/scylla``) is used.
+  For this to succeed, the table name has to be provided via ``--keyspace`` and ``--table``.
 
 The tool stops after the first successful attempt. If none of the above succeed, an error message will be printed.
 A user provided schema in ``schema.cql`` (if present) always takes precedence over other methods. This is deliberate, to allow to manually override the schema to be used.

--- a/test/cql-pytest/test_tools.py
+++ b/test/cql-pytest/test_tools.py
@@ -600,6 +600,13 @@ class TestScyllaSsstableSchemaLoading:
                 system_scylla_local_sstable_prepared,
                 system_scylla_local_reference_dump)
 
+    def test_table_dir_system_schema_deduced_keyspace_table(self, scylla_path, system_scylla_local_sstable_prepared, system_scylla_local_reference_dump):
+        self.check(
+                scylla_path,
+                ["--system-schema"],
+                system_scylla_local_sstable_prepared,
+                system_scylla_local_reference_dump)
+
     def test_table_dir_schema_file(self, scylla_path, system_scylla_local_sstable_prepared, system_scylla_local_reference_dump, system_scylla_local_schema_file):
         self.check(
                 scylla_path,
@@ -614,11 +621,26 @@ class TestScyllaSsstableSchemaLoading:
                 system_scylla_local_sstable_prepared,
                 system_scylla_local_reference_dump)
 
+    def test_table_dir_data_dir_deduced_keyspace_table(self, scylla_path, system_scylla_local_sstable_prepared, system_scylla_local_reference_dump, scylla_data_dir):
+        self.check(
+                scylla_path,
+                ["--scylla-data-dir", scylla_data_dir],
+                system_scylla_local_sstable_prepared,
+                system_scylla_local_reference_dump)
+
     def test_table_dir_scylla_yaml(self, scylla_path, system_scylla_local_sstable_prepared, system_scylla_local_reference_dump, scylla_home_dir):
         scylla_yaml_file = os.path.join(scylla_home_dir, "conf", "scylla.yaml")
         self.check(
                 scylla_path,
                 ["--scylla-yaml-file", scylla_yaml_file, "--keyspace", self.keyspace, "--table", self.table],
+                system_scylla_local_sstable_prepared,
+                system_scylla_local_reference_dump)
+
+    def test_table_dir_scylla_yaml_deduced_keyspace_table(self, scylla_path, system_scylla_local_sstable_prepared, system_scylla_local_reference_dump, scylla_home_dir):
+        scylla_yaml_file = os.path.join(scylla_home_dir, "conf", "scylla.yaml")
+        self.check(
+                scylla_path,
+                ["--scylla-yaml-file", scylla_yaml_file],
                 system_scylla_local_sstable_prepared,
                 system_scylla_local_reference_dump)
 


### PR DESCRIPTION
Currently, scylla.yaml is read conditionally, if either the user provided `--scylla-yaml-file` command line parameter, or if deducing the data dir location from the sstable path failed.
We want the scylla.yaml file to be always read, so that when working with encrypted file (enterprise), scylla-sstable can pick up the configuration for the encryption.
This patch makes scylla-sstable always attempt to read the scylla-yaml file, whether the user provided a location for it or not. When not, the default location is used (also considering the `SCYLLA_CONF` and `SCYLLA_HOME` environment variables.
Failing to find the scylla.yaml file is not considered an error. The rational is that the user will discover this if they attempt to do an operation that requires this anyway.
There is a debug-level log about whether it was successfully read or not.

Fixes: #16132