### PR TITLE
Generalize sstables TOC file reading

### DIFF
--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -603,6 +603,8 @@ public:
     bool has_component(component_type f) const;
     sstables_manager& manager() { return _manager; }
     const sstables_manager& manager() const { return _manager; }
+
+    static future<std::vector<sstring>> read_and_parse_toc(file f);
 private:
     void unused(); // Called when reference count drops to zero
     future<file> open_file(component_type, open_flags, file_open_options = {}) noexcept;


### PR DESCRIPTION
TOC file is read and parsed in several places in the code. All do it differently, and it's worth generalizing this place.
To make it happen also fix the S3 readable_file so that it could be used inside file_input_stream.