### PR TITLE
doc: replace the OSS-only link on the Raft page

### DIFF
--- a/docs/architecture/raft.rst
+++ b/docs/architecture/raft.rst
@@ -42,7 +42,7 @@ Enabling Raft
 
   .. only:: opensource
 
-    See :doc:`the upgrade guide from 5.2 to 5.4 </upgrade/upgrade-opensource/upgrade-guide-from-5.2-to-5.4/upgrade-guide-from-5.2-to-5.4-generic>` for details.
+    See :doc:`the upgrade guide from 5.2 to 5.4 </upgrade/index>` for details.
 
 ScyllaDB Open Source 5.2 and later, and ScyllaDB Enterprise 2023.1 and later come equipped with a procedure that can setup Raft-based consistent cluster management in an existing cluster. We refer to this as the **Raft upgrade procedure** (do not confuse with the :doc:`ScyllaDB version upgrade procedure </upgrade/index/>`).
 


### PR DESCRIPTION
This PR replaces the link to the OSS-only page (the 5.2-to-5.4 upgrade guide not present in the Enterprise docs) on the Raft page.

While providing the link to the specific upgrade guide is more user-friendly, it causes build failures of the Enterprise documentation. I've replaced it with the link to the general _Upgrade_ section.

The `.. only:: opensource` directive used to wrap the OSS-only content correctly excludes the content from the Enterprise docs - but it doesn't prevent build warnings.

This commit must be backported to branch-5.4 to prevent errors in all versions.

Related: https://github.com/scylladb/scylladb/pull/16064 