### PR TITLE
 compaction: abort compaction tasks

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -22,6 +22,7 @@
 #include "sstables/exceptions.hh"
 #include "sstables/sstable_directory.hh"
 #include "locator/abstract_replication_strategy.hh"
+#include "utils/error_injection.hh"
 #include "utils/fb_utilities.hh"
 #include "utils/UUID_gen.hh"
 #include "db/system_keyspace.hh"
@@ -1188,6 +1189,11 @@ protected:
     }
 
     virtual future<compaction_manager::compaction_stats_opt> do_run() override {
+        if (!is_system_keyspace(_status.keyspace)) {
+            co_await utils::get_local_injector().inject_with_handler("compaction_regular_compaction_task_executor_do_run",
+                [] (auto& handler) { return handler.wait_for_message(db::timeout_clock::now() + 10s); });
+        }
+
         co_await coroutine::switch_to(_cm.compaction_sg());
 
         for (;;) {

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -488,6 +488,10 @@ public:
     virtual future<tasks::task_manager::task::progress> get_progress() const override {
         return compaction_task_impl::get_progress(_compaction_data, _progress_monitor);
     }
+
+    virtual future<> abort() noexcept override {
+        return compaction_task_executor::abort(_as);
+    }
 protected:
     virtual future<> run() override {
         return perform();
@@ -508,6 +512,10 @@ public:
 
     virtual future<tasks::task_manager::task::progress> get_progress() const override {
         return compaction_task_impl::get_progress(_compaction_data, _progress_monitor);
+    }
+
+    virtual future<> abort() noexcept override {
+        return compaction_task_executor::abort(_as);
     }
 protected:
     virtual future<> run() override {
@@ -620,6 +628,10 @@ public:
 
     virtual future<tasks::task_manager::task::progress> get_progress() const override {
         return compaction_task_impl::get_progress(_compaction_data, _progress_monitor);
+    }
+
+    virtual future<> abort() noexcept override {
+        return compaction_task_executor::abort(_as);
     }
 protected:
     virtual future<> run() override {
@@ -842,6 +854,14 @@ void compaction_task_executor::finish_compaction(state finish_state) noexcept {
         _compaction_retry.reset();
     }
     _compaction_state.compaction_done.signal();
+}
+
+future<> compaction_task_executor::abort(abort_source& as) noexcept {
+    if (!as.abort_requested()) {
+        as.request_abort();
+        stop_compaction("user requested abort");
+    }
+    return make_ready_future();
 }
 
 void compaction_task_executor::stop_compaction(sstring reason) noexcept {
@@ -1158,6 +1178,10 @@ public:
         : compaction_task_executor(mgr, do_throw_if_stopping, &t, sstables::compaction_type::Compaction, "Compaction")
         , regular_compaction_task_impl(mgr._task_manager_module, tasks::task_id::create_random_id(), mgr._task_manager_module->new_sequence_number(), t.schema()->ks_name(), t.schema()->cf_name(), "", tasks::task_id::create_null_id())
     {}
+
+    virtual future<> abort() noexcept override {
+        return compaction_task_executor::abort(_as);
+    }
 protected:
     virtual future<> run() override {
         return perform();
@@ -1318,6 +1342,10 @@ public:
 
     virtual future<tasks::task_manager::task::progress> get_progress() const override {
         return compaction_task_impl::get_progress(_compaction_data, _progress_monitor);
+    }
+
+    virtual future<> abort() noexcept override {
+        return compaction_task_executor::abort(_as);
     }
 protected:
     virtual future<> run() override {
@@ -1666,6 +1694,10 @@ public:
 
     virtual future<tasks::task_manager::task::progress> get_progress() const override {
         return compaction_task_impl::get_progress(_compaction_data, _progress_monitor);
+    }
+
+    virtual future<> abort() noexcept override {
+        return compaction_task_executor::abort(_as);
     }
 protected:
     virtual future<> run() override {

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -588,6 +588,8 @@ public:
         return _compaction_data.abort.abort_requested();
     }
 
+    future<> abort(abort_source& as) noexcept;
+
     void stop_compaction(sstring reason) noexcept;
 
     sstables::compaction_stopped_exception make_compaction_stopped_exception() const;

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -13,7 +13,10 @@
 #include "replica/database.hh"
 #include "sstables/sstables.hh"
 #include "sstables/sstable_directory.hh"
+#include "utils/error_injection.hh"
 #include "utils/pretty_printers.hh"
+
+using namespace std::chrono_literals;
 
 namespace replica {
 
@@ -270,6 +273,9 @@ tasks::is_abortable compaction_task_impl::is_abortable() const noexcept {
 }
 
 future<> major_keyspace_compaction_task_impl::run() {
+    co_await utils::get_local_injector().inject_with_handler("compaction_major_keyspace_compaction_task_impl_run",
+            [] (auto& handler) { return handler.wait_for_message(db::timeout_clock::now() + 10s); });
+
     co_await _db.invoke_on_all([&] (replica::database& db) -> future<> {
         tasks::task_info parent_info{_status.id, _status.shard};
         auto& module = db.get_compaction_manager().get_task_manager_module();

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -265,6 +265,10 @@ future<tasks::task_manager::task::progress> compaction_task_impl::get_progress(c
     };
 }
 
+tasks::is_abortable compaction_task_impl::is_abortable() const noexcept {
+    return tasks::is_abortable{!_parent_id};
+}
+
 future<> major_keyspace_compaction_task_impl::run() {
     co_await _db.invoke_on_all([&] (replica::database& db) -> future<> {
         tasks::task_info parent_info{_status.id, _status.shard};

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -39,6 +39,7 @@ public:
     }
 
     virtual std::string type() const override = 0;
+    virtual tasks::is_abortable is_abortable() const noexcept override;
 protected:
     virtual future<> run() override = 0;
 

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -124,7 +124,12 @@ void task_manager::task::impl::run_to_completion() {
         if (f.failed()) {
             finish_failed(f.get_exception());
         } else {
-            finish();
+            try {
+                _as.check();
+                finish();
+            } catch (...) {
+                finish_failed(std::current_exception());
+            }
         }
     });
 }

--- a/test/rest_api/suite.yaml
+++ b/test/rest_api/suite.yaml
@@ -3,3 +3,4 @@ pool_size: 1
 
 skip_in_release:
     - test_task_manager
+    - test_compaction_task

--- a/test/rest_api/test_compaction_task.py
+++ b/test/rest_api/test_compaction_task.py
@@ -3,8 +3,8 @@ import sys
 # Use the util.py library from ../cql-pytest:
 sys.path.insert(1, sys.path[0] + '/../cql-pytest')
 from util import new_test_table, new_test_keyspace
-from rest_util import set_tmp_task_ttl
-from task_manager_utils import wait_for_task, list_tasks, check_child_parent_relationship, drain_module_tasks
+from rest_util import set_tmp_task_ttl, scylla_inject_error
+from task_manager_utils import wait_for_task, list_tasks, check_child_parent_relationship, drain_module_tasks, abort_task
 
 module_name = "compaction"
 long_time = 1000000000
@@ -87,4 +87,35 @@ def test_regular_compaction_task(cql, this_dc, rest_api):
 
                 failed = [status["task_id"] for status in statuses if status["state"] != "done"]
                 assert not failed, f"Regular compaction tasks with ids = {failed} failed"
+    drain_module_tasks(rest_api, module_name)
+
+def test_running_compaction_task_abort(cql, this_dc, rest_api):
+    drain_module_tasks(rest_api, module_name)
+    with set_tmp_task_ttl(rest_api, long_time):
+        with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
+            schema = 'p int, v text, primary key (p)'
+            with new_test_table(cql, keyspace, schema) as t0:
+                stmt = cql.prepare(f"INSERT INTO {t0} (p, v) VALUES (?, ?)")
+                cql.execute(stmt, [0, 'hello'])
+                cql.execute(stmt, [1, 'world'])
+
+                injection = "compaction_regular_compaction_task_executor_do_run"
+                with scylla_inject_error(rest_api, injection, True):
+                    [_, table] = t0.split(".")
+                    resp = rest_api.send("POST", f"column_family/autocompaction/{keyspace}:{table}")
+                    resp.raise_for_status()
+
+                    tasks = [task for task in list_tasks(rest_api, module_name, False, keyspace, table) if task["type"] == "regular compaction"]
+                    assert tasks, "Compaction task was not created"
+
+                    for task in tasks:
+                        abort_task(rest_api, task["task_id"])
+
+                    resp = rest_api.send("POST", f"v2/error_injection/injection/{injection}/message")
+                    resp.raise_for_status()
+
+                    statuses = [wait_for_task(rest_api, task["task_id"]) for task in tasks]
+                    aborted = [status for status in statuses if "abort requested" in status["error"]]
+                    assert aborted, "Task wasn't aborted by user"
+                    assert all([status["state"] == "failed" for status in aborted]), "Task finished successfully"
     drain_module_tasks(rest_api, module_name)


### PR DESCRIPTION
Compaction tasks which do not have a parent are abortable
through task manager. Their children are aborted recursively.

Compaction tasks of the lowest level are aborted using existing
compaction task executors stopping mechanism.
