### PR TITLE
tablets: Release group0 guard when waiting for streaming to finish

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1729,6 +1729,7 @@ class topology_coordinator {
             // to check atomically with event.wait()
             if (!_tablets_ready) {
                 slogger.trace("raft topology: Going to sleep with active tablet transitions");
+                release_guard(std::move(guard));
                 co_await await_event();
             }
             co_return;


### PR DESCRIPTION
This bug manifested as delays in DDL statement execution, which had to wait until streaming is finished so that the topology change coordinator releases the guard.

The reason is that topology change coordinator didn't release the group0 guard if there is no work to do with active migrations, and awaits the condition variable without leaving the scope.

Fixes #16182