### PR TITLE
mutation_query: add formatter for reconcilable_result::printer

### DIFF
--- a/mutation_query.cc
+++ b/mutation_query.cc
@@ -45,21 +45,26 @@ reconcilable_result::operator==(const reconcilable_result& other) const {
     return boost::equal(_partitions, other._partitions);
 }
 
-std::ostream& operator<<(std::ostream& out, const reconcilable_result::printer& pr) {
-    out << "{rows=" << pr.self.row_count() << ", short_read="
-        << pr.self.is_short_read() << ", [";
+auto fmt::formatter<reconcilable_result::printer>::format(
+    const reconcilable_result::printer& pr,
+    fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    auto out = ctx.out();
+    out = fmt::format_to(out,
+                         "{{rows={}, short_read={}, ",
+                         pr.self.row_count(),
+                         pr.self.is_short_read());
     bool first = true;
     for (const partition& p : pr.self.partitions()) {
         if (!first) {
-            out << ", ";
+            out = fmt::format_to(out, ", ");
         }
         first = false;
-        out << "{rows=" << p.row_count() << ", ";
-        out << p._m.pretty_printer(pr.schema);
-        out << "}";
+        out = fmt::format_to(out,
+                             "{{rows={}, {}}}",
+                             p.row_count(),
+                             p._m.pretty_printer(pr.schema));
     }
-    out << "]}";
-    return out;
+    return fmt::format_to(out, "]}}");
 }
 
 reconcilable_result::printer reconcilable_result::pretty_printer(schema_ptr s) const {

--- a/mutation_query.hh
+++ b/mutation_query.hh
@@ -117,6 +117,14 @@ public:
     printer pretty_printer(schema_ptr) const;
 };
 
+template <>
+struct fmt::formatter<reconcilable_result::printer> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const reconcilable_result::printer&, fmt::format_context& ctx) const
+        -> decltype(ctx.out());
+};
+
+
 class reconcilable_result_builder {
     const schema& _schema;
     const query::partition_slice& _slice;


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define a formatter for
reconcilable_result::printer. and remove its operator<<().

Refs #13245