### PR TITLE
Fix a typo in the metric description of cas_dropped_prune

### DIFF
--- a/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-4.0-to-2020.1/metric-update-4.0-to-2020.1.rst
+++ b/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-4.0-to-2020.1/metric-update-4.0-to-2020.1.rst
@@ -5,9 +5,9 @@ Scylla Metric Update - Scylla 4.0 to Scylla Enterprise 2019.1
 
 The following metrics are new in Scylla Enterprise 2020.1 compared to Scylla Open Source 4.0:
 
-* *scylla_storage_proxy_coordinator_cas_dropped_prune* : How many times a coordinator did not perfom prune after cas
+* *scylla_storage_proxy_coordinator_cas_dropped_prune* : How many times a coordinator did not perform prune after cas
 * *scylla_storage_proxy_coordinator_cas_prune* : How many times paxos prune was done after successful cas operation
-* *scylla_storage_proxy_replica_cas_dropped_prune* : How many times a coordinator did not perfom prune after cas
+* *scylla_storage_proxy_replica_cas_dropped_prune* : How many times a coordinator did not perform prune after cas
 
 The following metrics are not available in Scylla Enterprise 2020.1 compared to Scylla Open Source 4.0:
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2677,7 +2677,7 @@ void storage_proxy_stats::stats::register_stats() {
                        {storage_proxy_stats::current_scheduling_group_label()}),
 
         sm::make_total_operations("cas_dropped_prune", cas_coordinator_dropped_prune,
-                       sm::description("how many times a coordinator did not perfom prune after cas"),
+                       sm::description("how many times a coordinator did not perform prune after cas"),
                        {storage_proxy_stats::current_scheduling_group_label()}).set_skip_when_empty(),
 
         sm::make_total_operations("cas_total_operations", cas_total_operations,
@@ -2727,7 +2727,7 @@ void storage_proxy_stats::stats::register_stats() {
                        {storage_proxy_stats::current_scheduling_group_label()}).set_skip_when_empty(),
 
         sm::make_total_operations("cas_dropped_prune", cas_replica_dropped_prune,
-                       sm::description("how many times a coordinator did not perfom prune after cas"),
+                       sm::description("how many times a coordinator did not perform prune after cas"),
                        {storage_proxy_stats::current_scheduling_group_label()}).set_skip_when_empty(),
     });
     _metrics = std::exchange(new_metrics, {});


### PR DESCRIPTION
Fix "perfom" to "perform"