### PR TITLE
utils/pretty_printers: stop using undocumented fmt api

### DIFF
--- a/utils/pretty_printers.hh
+++ b/utils/pretty_printers.hh
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <chrono>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace utils {
 
@@ -70,7 +70,7 @@ struct fmt::formatter<utils::pretty_printed_data_size> {
             }
         }
         if (it != end && *it != '}') {
-            ctx.on_error("invalid format");
+            throw fmt::format_error("invalid format specifier");
         }
         return it;
     }


### PR DESCRIPTION
format_parse_context::on_error() is an undocumented API in fmt v9 and in fmt v10, see

- https://fmt.dev/9.1.0/api.html#_CPPv4I0EN3fmt16basic_format_argE
- https://fmt.dev/10.0.0/api.html#_CPPv4I0EN3fmt26basic_format_parse_contextE

despite that this API was once used in its document for fmt v10.0.0, see https://fmt.dev/10.0.0/api.html#formatting-user-defined-types. it's still, well, undocumented.

so, to have better compatibility, let's use the documented API in place of undocumented one. please note, `throw_format_error()` was still not a public API before 10.1.0, so before that release we have to throw `fmt::format_error` explicitly. so we cannot use it yet during the transitional period.

because the class of `fmt::format_error` is defined in `fmt/format.h`, we need to include this header for using it.

Refs #13245