### PR TITLE
alternator:  improve create table error message in case of missing request attributes

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -930,6 +930,9 @@ static future<executor::request_return_type> create_table_on_shard0(tracing::tra
         co_return api_error::validation(format("Prefix {} is reserved for accessing internal tables", executor::INTERNAL_TABLE_PREFIX));
     }
     std::string keyspace_name = executor::KEYSPACE_NAME_PREFIX + table_name;
+    if (!request.HasMember("AttributeDefinitions")) {
+        co_return api_error::validation("No Attribute Schemas Defined");
+    }
     const rjson::value& attribute_definitions = request["AttributeDefinitions"];
     validate_attribute_definitions(attribute_definitions);
 

--- a/test/alternator/test_manual_requests.py
+++ b/test/alternator/test_manual_requests.py
@@ -174,6 +174,20 @@ def test_tags_return_empty_body(dynamodb, test_table):
     response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
     assert not response.text
 
+# Reproduces issue #16233
+def test_create_table_without_keyschema(dynamodb, test_table_s):
+    payload = '{"TableName": "alternator_Test1", "*ttributeDefinitions": [{"AttributeName": "lock_key", "AttributeType": "S"}, {"AttributeName": "sort_key", "AttributeType": "S"}], "BillingMode": "PAY_PER_REQUEST"}'
+    req = get_signed_request(dynamodb, 'CreateTable', payload)
+    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    assert "ValidationException" in response.text and "Missing KeySchema member" in response.text
+
+# Reproduces issue #16233
+def test_create_table_without_attribute_definition(dynamodb, test_table_s):
+    payload = '{"TableName": "alternator_Test2", "KeySchema": [{"AttributeName": "lock_key", "KeyType": "HASH"}, {"AttributeName": "sort_key", "KeyType": "RANGE"}], "BillingMode": "PAY_PER_REQUEST"}'
+    req = get_signed_request(dynamodb, 'CreateTable', payload)
+    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    assert "ValidationException" in response.text and "No Attribute Schemas Defined" in response.text
+
 # Test that incorrect number values are detected
 def test_incorrect_numbers(dynamodb, test_table):
     for incorrect in ["NaN", "Infinity", "-Infinity", "-NaN", "dog", "-dog"]:


### PR DESCRIPTION
In order to fix the problem of creating table response msg inaccurately when missing attribute definitions:
1. add error response if missing attribute definitions
2. add missing key schema or attribute definitions tests

Fixes #16233
Signed-off-by: qiulijuan2<qiulijuan2_yewu@cmss.chinamobile.com>