### PR TITLE
Skip auto snapshot for non-local storages

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2571,6 +2571,10 @@ future<> database::truncate_table_on_all_shards(sharded<database>& sharded_db, s
     if (!sharded_db.local().get_config().auto_snapshot()) {
         with_snapshot = false;
     }
+    if (with_snapshot && !table_shards->get_storage_options().is_local_type()) {
+        dblog.warn("Not snapshotting dropped/truncated table {}.{} despite auto_snapshot=true - table is not using local disk", s->ks_name(), s->cf_name());
+        with_snapshot = false;
+    }
 
     dblog.info("Truncating {}.{} {}snapshot", s->ks_name(), s->cf_name(), with_snapshot ? "with auto-" : "without ");
 


### PR DESCRIPTION
When a table is truncated or dropped it can be auto-snapshotted if the respective config option is set (by default it is). Non local storages don't implement snapshotting yet and emit on_internal_error() in that case aborting the whole process. It's better to skip snapshot with a warning instead.