### PR TITLE
cql: Reject empty options while altering a keyspace

### DIFF
--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -256,6 +256,9 @@ network_topology_strategy::calculate_natural_endpoints(
 }
 
 void network_topology_strategy::validate_options(const gms::feature_service& fs) const {
+    if(_config_options.empty()) {
+        throw exceptions::configuration_exception("Configuration for at least one datacenter must be present");
+    }
     validate_tablet_options(fs, _config_options);
     auto tablet_opts = recognized_tablet_options();
     for (auto& c : _config_options) {

--- a/test/cql-pytest/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/alter_test.py
@@ -204,7 +204,6 @@ def testCreateAlterKeyspaces(cql, test_keyspace, this_dc):
 # Test {@link ConfigurationException} thrown on alter keyspace to no DC
 # option in replication configuration.
 # Reproduces CASSANDRA-12681 and Scylla #10036
-@pytest.mark.xfail(reason="Issue #10036")
 def testAlterKeyspaceWithNoOptionThrowsConfigurationException(cql, test_keyspace, this_dc):
     # Create keyspaces
     with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 3 }") as abc:

--- a/test/cql-pytest/cassandra_tests/validation/operations/create_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/create_test.py
@@ -320,6 +320,7 @@ def testCreateKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, this_dc):
     execute(cql, n, "DROP KEYSPACE IF EXISTS %s")
 
 # Test {@link ConfigurationException} is not thrown on create NetworkTopologyStrategy keyspace without any options.
+@pytest.mark.xfail(reason="Issue #16028")
 def testCreateKeyspaceWithNetworkTopologyStrategyNoOptions(cql):
     n = unique_name()
     execute(cql, n, "CREATE KEYSPACE %s with replication = { 'class': 'NetworkTopologyStrategy' }")


### PR DESCRIPTION
Reject ALTER KEYSPACE request for NetworkTopologyStrategy when replication options are missed.

fixes #10036