### PR TITLE
test: randomized failure injection for Raft-based topology

### DIFF
--- a/test/pylib/internal_types.py
+++ b/test/pylib/internal_types.py
@@ -6,6 +6,7 @@
 """Internal types for handling Scylla test servers.
 """
 
+from enum import Enum, auto
 from typing import NewType, NamedTuple
 
 
@@ -22,3 +23,10 @@ class ServerInfo(NamedTuple):
 
     def __str__(self):
         return f"Server({self.server_id}, {self.ip_addr}, {self.rpc_address})"
+
+
+class ServerUpState(Enum):
+    PROCESS_STARTED = auto()
+    HOST_ID_QUERIED = auto()
+    CQL_CONNECTED = auto()
+    CQL_QUERIED = auto()

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -492,6 +492,18 @@ class ManagerClient():
 
         return await wait_for(host_is_known, deadline or (time() + 30))
 
+    async def wait_for_scylla_process_status(self,
+                                             server_id: ServerNum,
+                                             expected_statuses: list[str],
+                                             deadline: Optional[float] = None) -> str:
+        """Wait for Scylla's process status for server_id will be as expected, with timeout."""
+        async def process_status_is_as_expected() -> str | None:
+            current_status = await self.client.get_json(f"/cluster/server/{server_id}/process_status")
+            if current_status in expected_statuses:
+                return current_status
+
+        return await wait_for(process_status_is_as_expected, deadline or (time() + 30))
+
     async def get_host_ip(self, server_id: ServerNum) -> IPAddress:
         """Get host IP Address"""
         try:

--- a/test/pylib/random_tables.py
+++ b/test/pylib/random_tables.py
@@ -297,6 +297,12 @@ class RandomTables():
         self.tables.append(table)
         return table
 
+    async def add_udt(self, name: str, cmd: str) -> None:
+        await self.manager.cql.run_async(f"CREATE TYPE {self.keyspace}.{name} {cmd}")
+
+    async def drop_udt(self, name) -> None:
+        await self.manager.cql.run_async(f"DROP TYPE {self.keyspace}.{name}")
+
     def __getitem__(self, pos: int) -> RandomTable:
         return self.tables[pos]
 

--- a/test/pylib/random_tables.py
+++ b/test/pylib/random_tables.py
@@ -250,6 +250,14 @@ class RandomTable():
         await self.manager.cql.run_async(f"DROP INDEX {self.keyspace}.{name}")
         self.removed_indexes.add(name)
 
+    async def enable_cdc(self) -> None:
+        assert self.manager.cql is not None
+        await self.manager.cql.run_async(f"ALTER TABLE {self.full_name} WITH cdc = {{ 'enabled' : true }}")
+
+    async def disable_cdc(self) -> None:
+        assert self.manager.cql is not None
+        await self.manager.cql.run_async(f"ALTER TABLE {self.full_name} WITH cdc = {{ 'enabled' : false }}")
+
     def __str__(self):
         return self.full_name
 

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -20,15 +20,14 @@ import shutil
 import tempfile
 import time
 import traceback
-from typing import Any, Optional, Dict, List, Set, Tuple, Callable, AsyncIterator, NamedTuple, Union
+from typing import Any, Optional, Dict, List, Set, Tuple, Callable, AsyncIterator, NamedTuple, Union, NoReturn
 import uuid
-from enum import Enum
 from io import BufferedWriter
 from test.pylib.host_registry import Host, HostRegistry
 from test.pylib.pool import Pool
 from test.pylib.rest_client import ScyllaRESTAPIClient, HTTPError
 from test.pylib.util import LogPrefixAdapter, read_last_line
-from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo
+from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
 from functools import partial
 import aiohttp
 import aiohttp.web
@@ -218,10 +217,6 @@ def merge_cmdline_options(
 
     return run()
 
-class CqlUpState(Enum):
-    NOT_CONNECTED = 1,
-    CONNECTED = 2,
-    QUERIED = 3
 
 
 def start_stop_lock(func):
@@ -379,14 +374,18 @@ class ScyllaServer:
 
         return size
 
-    async def install_and_start(self, api: ScyllaRESTAPIClient, expected_error: Optional[str] = None) -> None:
-        """Setup and start this server"""
+    async def install_and_start(self,
+                                api: ScyllaRESTAPIClient,
+                                expected_error: Optional[str] = None,
+                                expected_server_up_state: ServerUpState = ServerUpState.CQL_QUERIED) -> None:
+        """Setup and start this server."""
+
         await self.install()
 
         self.logger.info("starting server at host %s in %s...", self.ip_addr, self.workdir.name)
 
         try:
-            await self.start(api, expected_error)
+            await self.start(api, expected_error, expected_server_up_state)
         except:
             await self.stop()
             raise
@@ -486,8 +485,11 @@ class ScyllaServer:
             return None
         return maintenance_socket_option
 
-    async def cql_is_up(self) -> CqlUpState:
-        """Test that CQL is serving (a check we use at start up)."""
+    async def get_cql_up_state(self) -> ServerUpState | None:
+        """Get the CQL up state (a check we use at start up).
+
+        Return None if it fails to connect.
+        """
         caslog = logging.getLogger('cassandra')
         oldlevel = caslog.getEffectiveLevel()
         # Be quiet about connection failures.
@@ -535,10 +537,10 @@ class ScyllaServer:
                                                    control_connection_timeout=self.TOPOLOGY_TIMEOUT,
                                                    auth_provider=auth)
                     self.control_connection = self.control_cluster.connect()
-                    return CqlUpState.QUERIED
+                    return ServerUpState.CQL_QUERIED
         except (NoHostAvailable, InvalidRequest, OperationTimedOut) as exc:
             self.logger.debug("Exception when checking if CQL is up: %s", exc)
-            return CqlUpState.CONNECTED if connected else CqlUpState.NOT_CONNECTED
+            return ServerUpState.CQL_CONNECTED if connected else None
         finally:
             caslog.setLevel(oldlevel)
         # Any other exception may indicate a problem, and is passed to the caller.
@@ -555,7 +557,10 @@ class ScyllaServer:
         # Any other exception may indicate a problem, and is passed to the caller.
 
     @start_stop_lock
-    async def start(self, api: ScyllaRESTAPIClient, expected_error: Optional[str] = None) -> None:
+    async def start(self,
+                    api: ScyllaRESTAPIClient,
+                    expected_error: Optional[str] = None,
+                    expected_server_up_state: ServerUpState = ServerUpState.CQL_QUERIED) -> None:
         """Start an installed server. May be used for restarts."""
 
         env = os.environ.copy()
@@ -575,14 +580,17 @@ class ScyllaServer:
             preexec_fn=os.setsid,
         )
 
+        if expected_server_up_state == ServerUpState.PROCESS_STARTED:
+            return
+
+        server_up_state = ServerUpState.PROCESS_STARTED
+
         self.start_time = time.time()
         sleep_interval = 0.1
-        cql_up_state = CqlUpState.NOT_CONNECTED
 
-        def report_error(message: str):
+        def report_error(message: str) -> NoReturn:
             message += f", server_id {self.server_id}, IP {self.ip_addr}, workdir {self.workdir.name}"
-            message += f", host_id {self.host_id if hasattr(self, 'host_id') else '<missing>'}"
-            message += f", cql [{'connected' if cql_up_state == CqlUpState.CONNECTED else 'not connected'}]"
+            message += f", host_id {getattr(self, 'host_id', '<missing>')}"
             if expected_error is not None:
                 message += f", the node log was expected to contain the string [{expected_error}]"
             self.logger.error(message)
@@ -601,7 +609,7 @@ class ScyllaServer:
             if self.cmd.returncode:
                 self.cmd = None
                 if expected_error is not None:
-                    with self.log_filename.open('r') as log_file:
+                    with self.log_filename.open("r", encoding="utf-8") as log_file:
                         for line in log_file:
                             if expected_error in line:
                                 return
@@ -609,10 +617,15 @@ class ScyllaServer:
                 report_error("failed to start the node")
 
             if hasattr(self, "host_id") or await self.get_host_id(api):
-                cql_up_state = await self.cql_is_up()
-                if cql_up_state == CqlUpState.QUERIED:
+                if server_up_state == ServerUpState.PROCESS_STARTED:
+                    server_up_state = ServerUpState.HOST_ID_QUERIED
+                server_up_state = await self.get_cql_up_state() or server_up_state
+                if server_up_state == expected_server_up_state:
                     if expected_error is not None:
-                        report_error("the node started, but was expected to fail with the expected error")
+                        report_error(
+                            f"the node has reached {server_up_state} state,"
+                            f" but was expected to fail with the expected error"
+                        )
                     return
 
             # Sleep and retry
@@ -621,7 +634,10 @@ class ScyllaServer:
         if self.stop_event.is_set():
             report_error('failed to start the node as it was requested to be stopped in the meantime')
         else:
-            report_error('failed to start the node, timeout reached')
+            report_error(
+                f"the node failed to reach the expected state ({expected_server_up_state}) within the timeout,"
+                f" last seen state {server_up_state}"
+            )
 
     async def force_schema_migration(self) -> None:
         """This is a hack to change schema hash on an existing cluster node
@@ -875,7 +891,8 @@ class ScyllaCluster:
                          start: bool = True,
                          seeds: Optional[List[IPAddress]] = None,
                          server_encryption: str = "none",
-                         expected_error: Optional[str] = None) -> ServerInfo:
+                         expected_error: Optional[str] = None,
+                         expected_server_up_state: ServerUpState = ServerUpState.CQL_QUERIED) -> ServerInfo:
         """Add a new server to the cluster"""
         self.is_dirty = True
 
@@ -941,7 +958,7 @@ class ScyllaCluster:
             server = self.create_server(params)
             self.logger.info("Cluster %s adding server...", self)
             if start:
-                await server.install_and_start(self.api, expected_error)
+                await server.install_and_start(self.api, expected_error, expected_server_up_state)
             else:
                 await server.install()
         except Exception as exc:
@@ -1484,13 +1501,23 @@ class ScyllaClusterManager:
         self.cluster.server_unpause(server_id)
 
     async def _cluster_server_add(self, request) -> dict[str, object]:
-        """Add a new server"""
+        """Add a new server."""
+
         assert self.cluster
+
         data = await request.json()
         replace_cfg = ReplaceConfig(**data["replace_cfg"]) if "replace_cfg" in data else None
-        s_info = await self.cluster.add_server(replace_cfg, data.get('cmdline'), data.get('config'),
-                                               data.get('property_file'), data.get('start', True),
-                                               data.get('seeds', None), data.get('server_encryption'), data.get('expected_error', None))
+        s_info = await self.cluster.add_server(
+            replace_cfg=replace_cfg,
+            cmdline=data.get("cmdline"),
+            config=data.get("config"),
+            property_file=data.get("property_file"),
+            start=data.get("start", True),
+            seeds=data.get("seeds"),
+            server_encryption=data.get("server_encryption", "none"),
+            expected_error=data.get("expected_error"),
+            expected_server_up_state=getattr(ServerUpState, data.get("expected_server_up_state", "CQL_QUERIED")),
+        )
         return {"server_id": s_info.server_id, "ip_addr": s_info.ip_addr, "rpc_address": s_info.rpc_address}
 
     async def _cluster_servers_add(self, request) -> list[dict[str, object]]:

--- a/test/topology_random_failures/cluster_events.py
+++ b/test/topology_random_failures/cluster_events.py
@@ -1,0 +1,625 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from __future__ import annotations
+
+import os
+import asyncio
+import logging
+from shutil import rmtree
+from typing import TYPE_CHECKING
+
+from test.pylib.tablets import get_all_tablet_replicas
+from test.topology.util import get_coordinator_host, get_non_coordinator_host
+from test.topology_random_failures.error_injections import ERROR_INJECTIONS
+
+if TYPE_CHECKING:
+    from typing import ParamSpec, TypeAlias, TypeVar
+    from collections.abc import Callable, AsyncIterator
+
+    from test.pylib.random_tables import RandomTables
+    from test.pylib.manager_client import ManagerClient
+
+
+TOPOLOGY_TIMEOUT = 300  # default topology timeout is too big for these tests
+
+LOGGER = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    ClusterEventType: TypeAlias = Callable[
+        [ManagerClient, RandomTables, str],
+        AsyncIterator[None],
+    ]
+    P = ParamSpec("P")
+    T = TypeVar("T")
+
+
+def deselect_for(reason: str, error_injections: list[str] | None = None) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Add a metadata with disabled error injections to a cluster event function.
+
+    If `error_injection` is None then the cluster event disabled for all error injections available.
+    """
+    def add_deselected_metadata(fn: Callable[P, T]) -> Callable[P, T]:
+        if not hasattr(fn, "deselected_random_failures"):
+            fn.deselected_random_failures = {}
+        for inj in ERROR_INJECTIONS if error_injections is None else error_injections:
+            fn.deselected_random_failures[inj] = reason
+        return fn
+    return add_deselected_metadata
+
+
+# Each cluster event is an async generator which has 2 yields and should be used in the following way:
+#
+#   0. Start the generator:
+#       >>> cluster_event_steps = cluster_event(manager, random_tables, error_injection)
+#
+#   1. Run the prepare part (before the first yield)
+#       >>> await anext(cluster_event_steps)
+#
+#   2. Run the cluster event itself (between the yields)
+#       >>> await anext(cluster_event_steps)
+#
+#   3. Run the check part (after the second yield)
+#       >>> await anext(cluster_event, None)
+
+
+async def sleep_for_30_seconds(manager: ManagerClient,
+                               random_tables: RandomTables,
+                               error_injection: str) -> AsyncIterator[None]:
+    yield
+
+    LOGGER.info("Sleep for 30 seconds")
+    await asyncio.sleep(30)
+
+    yield
+
+
+async def add_new_table(manager: ManagerClient,
+                        random_tables: RandomTables,
+                        error_injection: str) -> AsyncIterator[None]:
+    yield
+
+    LOGGER.info("Add a new table to the schema")
+    table = await random_tables.add_table(ncolumns=5)
+
+    yield
+
+    LOGGER.info("Check if the table was created by dropping it")
+    await random_tables.drop_table(table=table)
+
+
+async def drop_table(manager: ManagerClient,
+                     random_tables: RandomTables,
+                     error_injection: str) -> AsyncIterator[None]:
+    table_name = "test_random_failures_table_to_drop"
+
+    LOGGER.info("Add a new table to drop")
+    table = await random_tables.add_table(ncolumns=5, name=table_name)
+
+    yield
+
+    LOGGER.info("Drop the table `%s' from the schema", table.name)
+    await random_tables.drop_table(table=table)
+
+    yield
+
+    LOGGER.info("Check if the table was dropped by re-creating it")
+    await random_tables.add_table(ncolumns=5, name=table_name)
+
+
+async def add_index(manager: ManagerClient,
+                    random_tables: RandomTables,
+                    error_injection: str) -> AsyncIterator[None]:
+    yield
+
+    LOGGER.info("Add an index to a table")
+    index_name = await random_tables[0].add_index(column=random_tables[0].columns[-1])
+
+    yield
+
+    LOGGER.info("Check if the index was created by dropping it")
+    await random_tables[0].drop_index(name=index_name)
+
+
+async def drop_index(manager: ManagerClient,
+                     random_tables: RandomTables,
+                     error_injection: str) -> AsyncIterator[None]:
+    index_name = "test_random_failures_index_to_drop"
+
+    LOGGER.info("Add an index to a table")
+    await random_tables[0].add_index(column=random_tables[0].columns[-2], name=index_name)
+
+    yield
+
+    LOGGER.info("Drop the index from the table")
+    await random_tables[0].drop_index(name=index_name)
+
+    yield
+
+    LOGGER.info("Check if the index was dropped by re-creating it")
+    await random_tables[0].add_index(column=random_tables[0].columns[-2], name=index_name)
+
+
+async def add_new_keyspace(manager: ManagerClient,
+                           random_tables: RandomTables,
+                           error_injection: str) -> AsyncIterator[None]:
+    ks_name = "test_random_failures_new_ks"
+
+    yield
+
+    LOGGER.info("Add a new keyspace to the schema")
+    await manager.cql.run_async(
+        f"CREATE KEYSPACE {ks_name}"
+        f" WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 }}"
+    )
+
+    yield
+
+    LOGGER.info("Check if the keyspace exists by dropping it")
+    await manager.cql.run_async(f"DROP KEYSPACE {ks_name}")
+
+
+async def drop_keyspace(manager: ManagerClient,
+                        random_tables: RandomTables,
+                        error_injection: str) -> AsyncIterator[None]:
+    ks_name = "test_random_failures_ks_to_drop"
+
+    LOGGER.info("Add a keyspace to drop")
+    await manager.cql.run_async(
+        f"CREATE KEYSPACE {ks_name}"
+        f" WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 }}"
+    )
+
+    yield
+
+    LOGGER.info("Drop the keyspace from the schema")
+    await manager.cql.run_async(f"DROP KEYSPACE {ks_name}")
+
+    yield
+
+    LOGGER.info("Check if the keyspace was dropped by re-creating it")
+    await manager.cql.run_async(
+        f"CREATE KEYSPACE {ks_name}"
+        f" WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 }}"
+    )
+
+
+@deselect_for(
+    # TODO: remove this skip when #16317 will be resolved.
+    reason="Cannot create CDC log for tables, because keyspace uses tablets. See issue #16317",
+)
+async def add_cdc(manager: ManagerClient,
+                  random_tables: RandomTables,
+                  error_injection: str) -> AsyncIterator[None]:
+    table_name = "test_random_failures_table_with_cdc"
+
+    yield
+
+    LOGGER.info("Add a table with CDC enabled and add some data")
+    table = await random_tables.add_table(ncolumns=5, name=table_name)
+    await table.enable_cdc()
+    await table.insert_seq()
+
+    yield
+
+
+@deselect_for(
+    # TODO: remove this skip when #16317 will be resolved.
+    reason="Cannot create CDC log for tables, because keyspace uses tablets. See issue #16317",
+)
+async def drop_cdc(manager: ManagerClient,
+                   random_tables: RandomTables,
+                   error_injection: str) -> AsyncIterator[None]:
+    table_name = "test_random_failures_table_with_cdc"
+
+    LOGGER.info("Add a table with CDC enabled and add some data")
+    table = await random_tables.add_table(ncolumns=5, name=table_name)
+    await table.enable_cdc()
+    await table.insert_seq()
+
+    yield
+
+    LOGGER.info("Disable CDC for the table and add some more data")
+    await table.disable_cdc()
+    await table.insert_seq()
+
+    yield
+
+
+async def add_new_udt(manager: ManagerClient,
+                      random_tables: RandomTables,
+                      error_injection: str) -> AsyncIterator[None]:
+    udt_name = "test_random_failures_new_udt"
+
+    yield
+
+    LOGGER.info("Add a new UDT to the schema")
+    await random_tables.add_udt(name=udt_name, cmd="(a text, b int)")
+
+    yield
+
+    LOGGER.info("Check if the UDT was created by dropping it")
+    await random_tables.drop_udt(name=udt_name)
+
+
+async def drop_udt(manager: ManagerClient,
+                   random_tables: RandomTables,
+                   error_injection: str) -> AsyncIterator[None]:
+    udt_name = "test_random_failures_udt_to_drop"
+
+    LOGGER.info("Add an UDT to drop")
+    await random_tables.add_udt(name=udt_name, cmd="(a text, b int)")
+
+    yield
+
+    LOGGER.info("Drop an UDT from the schema")
+    await random_tables.drop_udt(name=udt_name)
+
+    yield
+
+    LOGGER.info("Check if the UDT was dropped by re-creating it")
+    await random_tables.add_udt(name=udt_name, cmd="(a text, b int)")
+
+
+async def insert_records(manager: ManagerClient,
+                         random_tables: RandomTables,
+                         error_injection: str) -> AsyncIterator[None]:
+    yield
+
+    LOGGER.info("Add records to the table")
+    await random_tables[0].insert_seq()
+
+    yield
+
+
+async def update_record(manager: ManagerClient,
+                        random_tables: RandomTables,
+                        error_injection: str) -> AsyncIterator[None]:
+    LOGGER.info("Add a record to the table")
+    table = random_tables[0]
+    await table.insert_seq()
+
+    yield
+
+    pk_columns = table.columns[:table.pks]
+    set_column = table.columns[-1]
+    next_seq = table.next_seq()
+    set_value = set_column.val(seed=next_seq)
+
+    LOGGER.info("Update the record in the table")
+    await manager.cql.run_async(
+        f"UPDATE {table.full_name} SET {set_column} = %s WHERE {' AND '.join(f'{c.name} = %s' for c in pk_columns)}",
+        [set_value] + [c.val(next_seq-1) for c in pk_columns],
+    )
+
+    yield
+
+
+@deselect_for(
+    # TODO: remove this skip when #18068 will be resolved.
+    reason="LWT is not yet supported with tablets. See issue #18068"
+)
+async def execute_lwt_transaction(manager: ManagerClient,
+                                  random_tables: RandomTables,
+                                  error_injection: str) -> AsyncIterator[None]:
+    LOGGER.info("Add a record to the table")
+    table = random_tables[0]
+    await table.insert_seq()
+
+    yield
+
+    pk_columns = table.columns[:table.pks]
+    set_column = table.columns[-1]
+    next_seq = table.next_seq()
+    set_value = set_column.val(seed=next_seq)
+
+    LOGGER.info("Execute a lightweight transaction")
+    await manager.cql.run_async(
+        f"UPDATE {table.full_name}"
+        f" SET {set_column} = %s"
+        f" WHERE {' AND '.join(f'{c.name} = %s' for c in pk_columns)}"
+        f" IF EXISTS",
+        [set_value] + [c.val(next_seq-1) for c in pk_columns],
+    )
+
+    yield
+
+
+@deselect_for(
+    error_injections=[
+        "stop_after_starting_auth_service",
+        "stop_after_setting_mode_to_normal_raft_topology",
+        "stop_before_becoming_raft_voter",
+        "stop_after_updating_cdc_generation",
+        "stop_before_streaming",
+        "stop_after_streaming",
+    ],
+    reason="See issue #19151 (decommission process stuck while boostrapping node is paused)",
+)
+async def init_tablet_transfer(manager: ManagerClient,
+                               random_tables: RandomTables,
+                               error_injection: str) -> AsyncIterator[None]:
+    await manager.cql.run_async(
+        "CREATE KEYSPACE test"
+        " WITH replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 3 } AND"
+        "      tablets = { 'initial': 1 }"
+    )
+    await manager.cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int)")
+    await asyncio.gather(
+        *[manager.cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k})") for k in range(256)]
+    )
+
+    servers = await manager.running_servers()
+    host_ids = set()
+    for s in servers:
+        host_ids.add(await manager.get_host_id(s.server_id))
+        await manager.api.disable_tablet_balancing(node_ip=s.ip_addr)
+
+    replicas = await get_all_tablet_replicas(
+        manager=manager,
+        server=servers[0],
+        keyspace_name="test",
+        table_name="test",
+    )
+
+    LOGGER.info("Tablet is on [%s]", replicas)
+
+    assert len(replicas) == 1 and len(replicas[0].replicas) == 3
+
+    old_host, old_shard = replicas[0].replicas[0]
+    new_host = (host_ids - {r[0] for r in replicas[0].replicas}).pop()
+
+    yield
+
+    LOGGER.info("Move tablet %s -> %s", old_host, new_host)
+    await manager.api.move_tablet(
+        node_ip=servers[0].ip_addr,
+        ks="test",
+        table="test",
+        src_host=old_host,
+        src_shard=old_shard,
+        dst_host=new_host,
+        dst_shard=0,
+        token=0,
+    )
+
+    yield
+
+    replicas = await get_all_tablet_replicas(
+        manager=manager,
+        server=servers[0],
+        keyspace_name="test",
+        table_name="test",
+    )
+
+    assert len(replicas) == 1
+
+    hosts_with_replica = [r[0] for r in replicas[0].replicas]
+
+    assert len(hosts_with_replica) == 3
+    assert new_host in hosts_with_replica
+    assert old_host not in hosts_with_replica
+
+
+@deselect_for(
+    error_injections=[
+        "stop_after_starting_auth_service",
+        "stop_after_setting_mode_to_normal_raft_topology",
+        "stop_before_becoming_raft_voter",
+        "stop_after_updating_cdc_generation",
+        "stop_before_streaming",
+        "stop_after_streaming",
+    ],
+    reason="Can't add a node to a cluster with a banned node",
+)
+async def remove_data_dir_of_dead_node(manager: ManagerClient,
+                                       random_tables: RandomTables,
+                                       error_injection: str) -> AsyncIterator[None]:
+    running_servers = await manager.running_servers()
+    data_dir = os.path.join(await manager.server_get_workdir(running_servers[1].server_id), "data")
+
+    LOGGER.info("Kill a node")
+    await manager.server_stop(server_id=running_servers[1].server_id)
+    await manager.server_not_sees_other_server(
+        server_ip=running_servers[0].ip_addr,
+        other_ip=running_servers[1].ip_addr,
+    )
+
+    yield
+
+    LOGGER.info("Remove data dir of the dead node and start it")
+    rmtree(path=data_dir, ignore_errors=True)
+    await manager.server_start(server_id=running_servers[1].server_id)
+
+    yield
+
+
+@deselect_for(
+    error_injections=[
+        "stop_after_starting_auth_service",
+        "stop_after_setting_mode_to_normal_raft_topology",
+        "stop_before_becoming_raft_voter",
+        "stop_after_updating_cdc_generation",
+        "stop_before_streaming",
+        "stop_after_streaming",
+    ],
+    reason="See issue #18640 (failed to add a node to a cluster if another bootstrapping node is stuck)",
+)
+async def add_new_node(manager: ManagerClient,
+                       random_tables: RandomTables,
+                       error_injection: str) -> AsyncIterator[None]:
+    yield
+
+    LOGGER.info("Add a new node to the cluster")
+    await manager.server_add(timeout=TOPOLOGY_TIMEOUT)
+
+    yield
+
+
+@deselect_for(
+    error_injections=[
+        "stop_after_starting_auth_service",
+        "stop_after_setting_mode_to_normal_raft_topology",
+        "stop_before_becoming_raft_voter",
+        "stop_after_updating_cdc_generation",
+        "stop_before_streaming",
+        "stop_after_streaming",
+    ],
+    reason="See issue #19151 (decommission process stuck while bootstrapping node is paused)",
+)
+async def decommission_node(manager: ManagerClient,
+                            random_tables: RandomTables,
+                            error_injection: str) -> AsyncIterator[None]:
+    yield
+
+    LOGGER.info("Decommission a node")
+    await manager.decommission_node(
+        server_id=(await manager.running_servers())[1].server_id,
+        timeout=TOPOLOGY_TIMEOUT,
+    )
+
+    yield
+
+
+@deselect_for(
+    error_injections=[
+        "stop_after_starting_auth_service",
+        "stop_after_setting_mode_to_normal_raft_topology",
+        "stop_before_becoming_raft_voter",
+        "stop_after_updating_cdc_generation",
+        "stop_before_streaming",
+        "stop_after_streaming",
+    ],
+    reason="Can't add a node to a cluster with a banned node",
+)
+async def remove_node(manager: ManagerClient,
+                      random_tables: RandomTables,
+                      error_injection: str) -> AsyncIterator[None]:
+    running_servers = await manager.running_servers()
+
+    LOGGER.info("Kill a node")
+    await manager.server_stop(server_id=running_servers[1].server_id)
+    await manager.server_not_sees_other_server(
+        server_ip=running_servers[0].ip_addr,
+        other_ip=running_servers[1].ip_addr,
+    )
+
+    yield
+
+    LOGGER.info("Remove the dead node")
+    await manager.remove_node(
+        initiator_id=running_servers[0].server_id,
+        server_id=running_servers[1].server_id,
+        wait_removed_dead=False,
+        timeout=TOPOLOGY_TIMEOUT,
+    )
+
+    yield
+
+
+async def restart_non_coordinator_node(manager: ManagerClient,
+                                       random_tables: RandomTables,
+                                       error_injection: str) -> AsyncIterator[None]:
+    yield
+
+    LOGGER.info("Restart a non-coordinator node")
+    await manager.server_restart(server_id=(await get_non_coordinator_host(manager=manager)).server_id, wait_others=3)
+
+    yield
+
+
+async def restart_coordinator_node(manager: ManagerClient,
+                                   random_tables: RandomTables,
+                                   error_injection: str) -> AsyncIterator[None]:
+    yield
+
+    LOGGER.info("Restart the coordinator node")
+    await manager.server_restart(server_id=(await get_coordinator_host(manager=manager)).server_id, wait_others=3)
+
+    yield
+
+
+async def stop_non_coordinator_node_gracefully(manager: ManagerClient,
+                                               random_tables: RandomTables,
+                                               error_injection: str) -> AsyncIterator[None]:
+    yield
+
+    LOGGER.info("Stop a non-coordinator node gracefully")
+    await manager.server_stop_gracefully(server_id=(await get_non_coordinator_host(manager=manager)).server_id)
+
+    yield
+
+
+async def stop_coordinator_node_gracefully(manager: ManagerClient,
+                                           random_tables: RandomTables,
+                                           error_injection: str) -> AsyncIterator[None]:
+    yield
+
+    LOGGER.info("Stop the coordinator node gracefully")
+    await manager.server_stop_gracefully(server_id=(await get_coordinator_host(manager=manager)).server_id)
+
+    yield
+
+
+async def kill_non_coordinator_node(manager: ManagerClient,
+                                    random_tables: RandomTables,
+                                    error_injection: str) -> AsyncIterator[None]:
+    yield
+
+    LOGGER.info("Kill a non-coordinator node")
+    await manager.server_stop(server_id=(await get_non_coordinator_host(manager=manager)).server_id)
+
+    LOGGER.info("Sleep for 2 seconds")
+    await asyncio.sleep(2)
+
+    yield
+
+
+async def kill_coordinator_node(manager: ManagerClient,
+                                random_tables: RandomTables,
+                                error_injection: str) -> AsyncIterator[None]:
+    yield
+
+    LOGGER.info("Kill the coordinator node")
+    await manager.server_stop(server_id=(await get_coordinator_host(manager=manager)).server_id)
+
+    LOGGER.info("Sleep for 2 seconds")
+    await asyncio.sleep(2)
+
+    yield
+
+
+# - New items should be added to the end of the tuple
+# - Existing items should not be rearranged or deleted
+
+CLUSTER_EVENTS: tuple[ClusterEventType, ...] = (
+    sleep_for_30_seconds,
+    add_new_table,
+    drop_table,
+    add_index,
+    drop_index,
+    add_new_keyspace,
+    drop_keyspace,
+    add_cdc,
+    drop_cdc,
+    add_new_udt,
+    drop_udt,
+    insert_records,
+    update_record,
+    execute_lwt_transaction,
+    init_tablet_transfer,
+    remove_data_dir_of_dead_node,
+    add_new_node,
+    decommission_node,
+    remove_node,
+    restart_non_coordinator_node,
+    restart_coordinator_node,
+    stop_non_coordinator_node_gracefully,
+    stop_coordinator_node_gracefully,
+    kill_non_coordinator_node,
+    kill_coordinator_node,
+)

--- a/test/topology_random_failures/conftest.py
+++ b/test/topology_random_failures/conftest.py
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file configures pytest for all tests in this directory, and also
+# defines common test fixtures for all of them to use
+
+import pytest
+
+
+pytest_plugins = [
+    "test.topology.conftest",
+]

--- a/test/topology_random_failures/error_injections.py
+++ b/test/topology_random_failures/error_injections.py
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+# - New items should be added to the end of the list
+# - Items in the following list should not be rearranged or deleted
+ERROR_INJECTIONS = (
+    "stop_after_init_of_system_ks",
+    "stop_after_init_of_schema_commitlog",
+    "stop_after_starting_gossiper",
+    "stop_after_starting_raft_address_map",
+    "stop_after_starting_migration_manager",
+    "stop_after_starting_commitlog",
+    "stop_after_starting_repair",
+    "stop_after_starting_cdc_generation_service",
+    "stop_after_starting_group0_service",
+    "stop_after_starting_auth_service",
+    "stop_during_gossip_shadow_round",
+    "stop_after_saving_tokens",
+    "stop_after_starting_gossiping",
+    "stop_after_sending_join_node_request",
+    "stop_after_setting_mode_to_normal_raft_topology",
+    "stop_before_becoming_raft_voter",
+    "stop_after_updating_cdc_generation",
+    "stop_before_streaming",
+    "stop_after_streaming",
+    "stop_after_bootstrapping_initial_raft_configuration",
+)

--- a/test/topology_random_failures/pytest.ini
+++ b/test/topology_random_failures/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+asyncio_mode = auto
+
+log_cli = true
+log_format = %(asctime)s.%(msecs)03d %(levelname)s> %(message)s
+log_date_format = %H:%M:%S

--- a/test/topology_random_failures/suite.yaml
+++ b/test/topology_random_failures/suite.yaml
@@ -1,0 +1,11 @@
+type: Topology
+pool_size: 1
+cluster:
+  initial_size: 0
+extra_scylla_config_options:
+    authenticator: AllowAllAuthenticator
+    authorizer: AllowAllAuthorizer
+    enable_user_defined_functions: False
+    enable_tablets: True
+run_in_debug:
+  - test_random_failures

--- a/test/topology_random_failures/test_random_failures.py
+++ b/test/topology_random_failures/test_random_failures.py
@@ -1,0 +1,216 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from __future__ import annotations
+
+import sys
+import time
+import random
+import logging
+import itertools
+from typing import TYPE_CHECKING
+from contextlib import suppress
+
+import psutil
+import pytest
+from cassandra.cluster import NoHostAvailable
+
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from test.topology.util import wait_for_token_ring_and_group0_consistency, get_coordinator_host
+from test.topology.conftest import skip_mode
+from test.pylib.internal_types import ServerUpState
+from test.topology_random_failures.cluster_events import CLUSTER_EVENTS, TOPOLOGY_TIMEOUT
+from test.topology_random_failures.error_injections import ERROR_INJECTIONS
+
+if TYPE_CHECKING:
+    from test.pylib.random_tables import RandomTables
+    from test.pylib.manager_client import ManagerClient
+    from test.topology_random_failures.cluster_events import ClusterEventType
+
+
+TESTS_COUNT = 1  # number of tests from the whole matrix to run, None to run the full matrix.
+
+# Following parameters can be adjusted to run same sequence of tests from a previous run.  Look at logs for the values.
+# Also see `pytest_generate_tests()` below for details.
+TESTS_SHUFFLE_SEED = None  # seed for the tests order randomization
+ERROR_INJECTIONS_COUNT = None  # limit number of error injections
+CLUSTER_EVENTS_COUNT = None  # limit number of cluster events
+
+WAIT_FOR_IP_TIMEOUT = 30  # seconds
+
+LOGGER = logging.getLogger(__name__)
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    error_injections = ERROR_INJECTIONS[:ERROR_INJECTIONS_COUNT]
+    cluster_events = CLUSTER_EVENTS[:CLUSTER_EVENTS_COUNT]
+    tests = list(itertools.product(error_injections, cluster_events))
+
+    seed = random.randrange(sys.maxsize) if TESTS_SHUFFLE_SEED is None else TESTS_SHUFFLE_SEED
+    random.Random(seed).shuffle(tests)
+
+    # Deselect unsupported combinations.  Do it after the shuffle to have the stable order.
+    tests = [
+        (inj, event) for inj, event in tests if inj not in getattr(event, "deselected_random_failures", {})
+    ]
+
+    metafunc.parametrize(["error_injection", "cluster_event"], tests[:TESTS_COUNT])
+
+    LOGGER.info(
+        "To repeat this run set TESTS_COUNT to %s, TESTS_SHUFFLE_SEED to %s, ERROR_INJECTIONS_COUNT to %s,"
+        " and CLUSTER_EVENTS_COUNT to %s",
+        TESTS_COUNT, seed, len(error_injections), len(cluster_events),
+    )
+
+
+@pytest.fixture
+async def four_nodes_cluster(manager: ManagerClient) -> None:
+    LOGGER.info("Booting initial 4-node cluster.")
+    for _ in range(4):
+        server = await manager.server_add()
+        await manager.api.enable_injection(
+            node_ip=server.ip_addr,
+            injection="raft_server_set_snapshot_thresholds",
+            one_shot=True,
+            parameters={
+                "snapshot_threshold": "3",
+                "snapshot_trailing": "1",
+            }
+        )
+    await wait_for_token_ring_and_group0_consistency(manager=manager, deadline=time.time() + 30)
+
+
+@pytest.mark.usefixtures("four_nodes_cluster")
+@pytest.mark.asyncio
+@skip_mode("release", "error injections are not supported in release mode")
+async def test_random_failures(manager: ManagerClient,
+                               random_tables: RandomTables,
+                               error_injection: str,
+                               cluster_event: ClusterEventType) -> None:
+    table = await random_tables.add_table(ncolumns=5)
+    await table.insert_seq()
+
+    cluster_event_steps = cluster_event(manager, random_tables, error_injection)
+
+    LOGGER.info("Run preparation step of the cluster event.")
+    await anext(cluster_event_steps)
+
+    if error_injection == "stop_after_updating_cdc_generation":
+        # This error injection is a special one and should be handled on a coordinator node:
+        #   1. Enable `topology_coordinator_pause_after_updating_cdc_generation` injection on a coordinator node
+        #   2. Bootstrap a new node
+        #   3. Wait till the injection handler will print the message to the log
+        #   4. Pause the bootstrapping node
+        #   5. Send the message to the injection handler to continue
+        coordinator = await get_coordinator_host(manager=manager)
+        await manager.api.enable_injection(
+            node_ip=coordinator.ip_addr,
+            injection="topology_coordinator_pause_after_updating_cdc_generation",
+            one_shot=True,
+        )
+        coordinator_log = await manager.server_open_log(server_id=coordinator.server_id)
+        coordinator_log_mark = await coordinator_log.mark()
+        s_info = await manager.server_add(expected_server_up_state=ServerUpState.PROCESS_STARTED)
+        await coordinator_log.wait_for(
+            pattern="topology_coordinator_pause_after_updating_cdc_generation: wait for message for 5 minutes",
+            from_mark=coordinator_log_mark,
+        )
+        await manager.server_pause(server_id=s_info.server_id)
+        await manager.api.message_injection(
+            node_ip=coordinator.ip_addr,
+            injection="topology_coordinator_pause_after_updating_cdc_generation",
+        )
+    else:
+        s_info = await manager.server_add(
+            config={"error_injections_at_startup": [{"name": error_injection, "one_shot": True}]},
+            expected_server_up_state=ServerUpState.PROCESS_STARTED,
+        )
+
+    LOGGER.info("Wait till the bootstrapping node will be paused.")
+    await manager.wait_for_scylla_process_status(
+        server_id=s_info.server_id,
+        expected_statuses=[
+            psutil.STATUS_STOPPED,
+        ],
+    )
+
+    LOGGER.info("Run the cluster event main step.")
+    try:
+        cluster_event_start = time.perf_counter()
+        await anext(cluster_event_steps)
+        cluster_event_duration = time.perf_counter() - cluster_event_start
+        LOGGER.info("Cluster event `%s' took %.1fs", cluster_event.__name__, cluster_event_duration)
+    finally:
+        LOGGER.info("Unpause the server and wait till it wake up and become connectable using CQL.")
+        await manager.server_unpause(server_id=s_info.server_id)
+
+    server_log = await manager.server_open_log(server_id=s_info.server_id)
+
+    if cluster_event_duration + 1 >= WAIT_FOR_IP_TIMEOUT and error_injection in (  # give one more second for a tolerance
+        "stop_after_sending_join_node_request",
+        "stop_after_bootstrapping_initial_raft_configuration",
+    ):
+        LOGGER.info("Expecting the added node can hang and we'll have a message in the coordinator's log.  See #18638.")
+        coordinator = await get_coordinator_host(manager=manager)
+        coordinator_log = await manager.server_open_log(server_id=coordinator.server_id)
+        if matches := await coordinator_log.grep(r"The node may hang\. It's safe to shut it down manually now\."):
+            LOGGER.info("Found following message in the coordinator's log:\n\t%s", matches[-1][0])
+            await manager.server_stop(server_id=s_info.server_id)
+
+    if s_info in await manager.running_servers():
+        LOGGER.info("Wait until the new node initialization completes or fails.")
+        await server_log.wait_for("init - (Startup failed:|Scylla version .* initialization completed)", timeout=120)
+
+        if await server_log.grep("init - Startup failed:"):
+            LOGGER.info("Check that the new node is dead.")
+            expected_statuses = [psutil.STATUS_DEAD]
+        else:
+            LOGGER.info("Check that the new node is running.")
+            expected_statuses = [psutil.STATUS_RUNNING, psutil.STATUS_SLEEPING]
+
+        scylla_process_status = await manager.wait_for_scylla_process_status(
+            server_id=s_info.server_id,
+            expected_statuses=expected_statuses,
+        )
+    else:
+        scylla_process_status = psutil.STATUS_DEAD
+
+    if scylla_process_status in (psutil.STATUS_RUNNING, psutil.STATUS_SLEEPING):
+        LOGGER.info("The new node is running.  Check if we can connect to it.")
+
+        async def driver_connect() -> bool | None:
+            try:
+                await manager.driver_connect(server=s_info)
+            except NoHostAvailable:
+                LOGGER.info("Driver not connected to %s yet", s_info.ip_addr)
+                return None
+            return True
+
+        LOGGER.info("Check for the new node's health.")
+        await wait_for(pred=driver_connect, deadline=time.time() + 90)
+        await wait_for_cql_and_get_hosts(cql=manager.cql, servers=[s_info], deadline=time.time() + 30)
+    else:
+        if s_info in await manager.running_servers():
+            LOGGER.info("The new node is dead.  Check if it failed to startup.")
+            assert await server_log.grep("init - Startup failed:")
+            await manager.server_stop(server_id=s_info.server_id)  # remove the node from the list of running servers
+
+        LOGGER.info("Try to remove the dead new node from the cluster.")
+        with suppress(Exception):
+            await manager.remove_node(
+                initiator_id=(await manager.running_servers())[0].server_id,
+                server_id=s_info.server_id,
+                wait_removed_dead=False,
+                timeout=TOPOLOGY_TIMEOUT,
+            )
+
+    LOGGER.info("Check for the cluster's health.")
+    await manager.driver_connect()
+    await wait_for_token_ring_and_group0_consistency(manager=manager, deadline=time.time() + 90)
+    await table.add_column()
+    await random_tables.verify_schema()
+    await anext(cluster_event_steps, None)  # use default value to suppress StopIteration
+    await random_tables.verify_schema()


### PR DESCRIPTION
The idea of the test is to have a cluster where one node is stressed with injections and failures and the rest of the cluster is used to make progress of the raft state machine.

To achieve this following two lists introduced in the PR:

  - ERROR_INJECTIONS in error_injections.py
  - CLUSTER_EVENTS in cluster_events.py

Each cluster event is an async generator which has 2 yields and should be used in the following way:

   0. Start the generator:
       ```python
       >>> cluster_event_steps = cluster_event(manager, random_tables, error_injection)
       ```

   1. Run the prepare part (before the first yield)
       ```python
       >>> await anext(cluster_event_steps)
       ```

   2.  Run the cluster event itself (between the yields)
       ```python
       >>> await anext(cluster_event_steps)
       ```

   3. Run the check part (after the second yield)
       ```python
       >>> await anext(cluster_event, None)
       ```
