### PR TITLE
tablets, mv: fix base-view pairing to consider base replication map

### DIFF
--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -11,6 +11,7 @@
 #include "sstables/shared_sstable.hh"
 #include "db/timeout_clock.hh"
 #include "utils/chunked_vector.hh"
+#include "schema/schema_fwd.hh"
 
 #include <seastar/core/sharded.hh>
 #include <seastar/core/metrics_registration.hh>
@@ -77,6 +78,7 @@ public:
     replica::database& get_db() noexcept { return _db; }
 
     future<> mutate_MV(
+            schema_ptr base,
             dht::token base_token,
             utils::chunked_vector<frozen_mutation_and_schema> view_updates,
             db::view::stats& stats,

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2206,7 +2206,7 @@ future<> table::generate_and_propagate_view_updates(shared_ptr<db::view::view_up
         tracing::trace(tr_state, "Generated {} view update mutations", updates->size());
         auto units = seastar::consume_units(*_config.view_update_concurrency_semaphore, memory_usage_of(*updates));
         try {
-            co_await gen->mutate_MV(base_token, std::move(*updates), _view_stats, *_config.cf_stats, tr_state,
+            co_await gen->mutate_MV(base, base_token, std::move(*updates), _view_stats, *_config.cf_stats, tr_state,
                 std::move(units), service::allow_hints::yes, db::view::wait_for_all_updates::no);
         } catch (...) {
             // Ignore exceptions: any individual failure to propagate a view update will be reported
@@ -2340,7 +2340,7 @@ future<> table::populate_views(
             size_t units_to_wait_for = std::min(_config.view_update_concurrency_semaphore_limit, update_size);
             auto units = co_await seastar::get_units(*_config.view_update_concurrency_semaphore, units_to_wait_for);
             units.adopt(seastar::consume_units(*_config.view_update_concurrency_semaphore, update_size - units_to_wait_for));
-            co_await gen->mutate_MV(base_token, std::move(*updates), _view_stats, *_config.cf_stats,
+            co_await gen->mutate_MV(schema, base_token, std::move(*updates), _view_stats, *_config.cf_stats,
                     tracing::trace_state_ptr(), std::move(units), service::allow_hints::no, db::view::wait_for_all_updates::yes);
         } catch (...) {
             if (!err) {

--- a/test/topology_experimental_raft/test_mv_tablets.py
+++ b/test/topology_experimental_raft/test_mv_tablets.py
@@ -23,7 +23,7 @@ async def test_tablet_mv_create(manager: ManagerClient):
        delete it - that's it, we don't read or write the table.
        Reproduces issue #16194.
     """
-    servers = [await manager.server_add() for i in range(1)]
+    servers = await manager.servers_add(1)
     cql = manager.get_cql()
 
     await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 100}")
@@ -41,9 +41,31 @@ async def test_tablet_mv_simple(manager: ManagerClient):
        node anyway.
        Reproduces issue #16209.
     """
-    servers = [await manager.server_add() for i in range(1)]
+    servers = await manager.servers_add(1)
     cql = manager.get_cql()
 
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 100}")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int)")
+    await cql.run_async("CREATE MATERIALIZED VIEW test.tv AS SELECT * FROM test.test WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (c, pk) WITH SYNCHRONOUS_UPDATES = TRUE")
+    await cql.run_async("INSERT INTO test.test (pk, c) VALUES (2, 3)")
+    # We used SYNCHRONOUS_UPDATES=TRUE, so the view should be updated:
+    assert [(3,2)] == list(await cql.run_async("SELECT * FROM test.tv WHERE c=3"))
+    await cql.run_async("DROP KEYSPACE test")
+
+@pytest.mark.asyncio
+async def test_tablet_mv_simple_6node(manager: ManagerClient):
+    """A simple reproducer for a bug of forgetting that the view table has a
+       different tablet mapping from the base: Using the wrong tablet mapping
+       for the base table or view table can cause us to send a view update
+       to the wrong view replica - or not send a view update at all. A row
+       that we write on the base table will not be readable in the view.
+       We start a large-enough cluster (6 nodes) to increase the probability
+       that if the mapping is different for the one row we write, and the test
+       will fail if the bug exists.
+       Reproduces #16227.
+    """
+    servers = await manager.servers_add(6)
+    cql = manager.get_cql()
     await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 100}")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int)")
     await cql.run_async("CREATE MATERIALIZED VIEW test.tv AS SELECT * FROM test.test WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (c, pk) WITH SYNCHRONOUS_UPDATES = TRUE")


### PR DESCRIPTION
In the view update code, the function get_view_natural_endpoint() determines which view replica this base replica should send an update to. It currently gets the *view* table's replication map (i.e., the map from view tokens to lists of replicas holding the token), but assumes that this is also the *base* table's replication map.

This assumption was true with vnodes, but is no longer true with tablets - the base table's replication map can be completely different from the view table's. By looking at the wrong mapping, get_view_natural_endpoint() can believe that this node isn't really a base-replica and drop the view update. Alternatively, it can think it is a base replica - but use the wrong base-view pairing and create base-view inconsistencies.

This patch solves this bug - get_view_natural_endpoint() now gets two separate replication maps - the base's and the view's. The callers need to remember what the base table was (in some cases they didn't care at the point of the call), and pass it to the function call.

This patch also includes a simple test that reproduces the bug, and confirms it is fixed: The test has a 6-node cluster using tablets and a base table with RF=1, and writes one row to it. Before this patch, the code usually gets confused, thinking the base replica isn't a replica and loses the view update. With this patch, the view update works.

Fixes #16227.