### PR TITLE
cql3: define format_as() for formatting cql3::cql3_type

### DIFF
--- a/cql3/cql3_type.hh
+++ b/cql3/cql3_type.hh
@@ -77,6 +77,9 @@ private:
     class raw_collection;
     class raw_ut;
     class raw_tuple;
+    friend std::string_view format_as(const cql3_type& t) {
+        return t.to_string();
+    }
     friend std::ostream& operator<<(std::ostream& os, const cql3_type& t) {
         return os << t.to_string();
     }


### PR DESCRIPTION
in the same spirit of 724a6e26f3b2dc2d3c32c855184ad2bd867f0715, format_as() is defined for cql3::cql3_type. despite that this is not used yet by fmt v9, where we still have FMT_DEPRECATED_OSTREAM, this prepares us for fmt v10.

Refs #13245
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>