### PR TITLE
docs: add Deprecated to value_status_count 

### DIFF
--- a/docs/_ext/scylladb_cc_properties.py
+++ b/docs/_ext/scylladb_cc_properties.py
@@ -76,7 +76,8 @@ class DBConfigParser:
             "value_status_count": {
                 'Used': 0,
                 'Unused': 0,
-                'Invalid': 0
+                'Invalid': 0,
+                'Deprecated': 0,
             },
         }
 


### PR DESCRIPTION
despite that the "value_status_count" is not rendered/used yet, it'd be better to keep it in sync with the code.

since 5fd30578d74ba94ca4a132924c170cd41ae590dc changed "Unused" to "Deprecated", let's update the sphinx extension accordingly.