### PR TITLE
Don't calculate hashes for schema versions in Raft mode

### DIFF
--- a/db/schema_features.hh
+++ b/db/schema_features.hh
@@ -28,6 +28,9 @@ enum class schema_feature {
     // When enabled, schema_mutations::digest() will skip empty mutations (with only tombstones),
     // so that the digest remains the same after schema tables are compacted.
     TABLE_DIGEST_INSENSITIVE_TO_EXPIRY,
+
+    // When enabled we'll add a new column to the `system_schema.scylla_tables` table.
+    GROUP0_SCHEMA_VERSIONING,
 };
 
 using schema_features = enum_set<super_enum<schema_feature,
@@ -38,7 +41,8 @@ using schema_features = enum_set<super_enum<schema_feature,
     schema_feature::PER_TABLE_PARTITIONERS,
     schema_feature::SCYLLA_KEYSPACES,
     schema_feature::SCYLLA_AGGREGATES,
-    schema_feature::TABLE_DIGEST_INSENSITIVE_TO_EXPIRY
+    schema_feature::TABLE_DIGEST_INSENSITIVE_TO_EXPIRY,
+    schema_feature::GROUP0_SCHEMA_VERSIONING
     >>;
 
 }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -712,6 +712,8 @@ schema_ptr system_keyspace::large_cells() {
     return large_cells;
 }
 
+static constexpr auto schema_gc_grace = std::chrono::duration_cast<std::chrono::seconds>(days(7)).count();
+
 /*static*/ schema_ptr system_keyspace::scylla_local() {
     static thread_local auto scylla_local = [] {
         schema_builder builder(generate_legacy_id(NAME, SCYLLA_LOCAL), NAME, SCYLLA_LOCAL,
@@ -730,7 +732,9 @@ schema_ptr system_keyspace::large_cells() {
         // comment
         "Scylla specific information about the local node"
        );
-       builder.set_gc_grace_seconds(0);
+       // scylla_local may store a replicated tombstone related to schema
+       // (see `make_group0_schema_version_mutation`), so we use nonzero gc grace.
+       builder.set_gc_grace_seconds(schema_gc_grace);
        builder.with_version(generate_schema_version(builder.uuid()));
        return builder.build(schema_builder::compact_storage::no);
     }();
@@ -1121,8 +1125,6 @@ schema_ptr system_keyspace::legacy::batchlog() {
     }();
     return schema;
 }
-
-static constexpr auto schema_gc_grace = std::chrono::duration_cast<std::chrono::seconds>(days(7)).count();
 
 schema_ptr system_keyspace::legacy::keyspaces() {
     static thread_local auto schema = [] {
@@ -2387,6 +2389,23 @@ future<mutation> system_keyspace::get_group0_history(distributed<replica::databa
 
     slogger.warn("get_group0_history: '{}' partition not found", GROUP0_HISTORY_KEY);
     co_return mutation(s, partition_key::from_singular(*s, GROUP0_HISTORY_KEY));
+}
+
+future<mutation> system_keyspace::get_group0_schema_version() {
+    auto s = _db.find_schema(db::system_keyspace::NAME, db::system_keyspace::SCYLLA_LOCAL);
+
+    partition_key pk = partition_key::from_singular(*s, "group0_schema_version");
+    dht::partition_range pr = dht::partition_range::make_singular(dht::decorate_key(*s, pk));
+
+    auto rs = co_await replica::query_mutations(_db.container(), s, pr, s->full_slice(), db::no_timeout);
+    assert(rs);
+    auto& ps = rs->partitions();
+    for (auto& p: ps) {
+        auto mut = p.mut().unfreeze(s);
+        co_return std::move(mut);
+    }
+
+    co_return mutation(s, pk);
 }
 
 static constexpr auto GROUP0_UPGRADE_STATE_KEY = "group0_upgrade_state";

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -495,6 +495,10 @@ public:
     // Assumes that the history table exists, i.e. Raft feature is enabled.
     static future<mutation> get_group0_history(distributed<replica::database>&);
 
+    // If the `group0_schema_version` key in `system.scylla_local` is present (either live or tombstone),
+    // returns the corresponding mutation. Otherwise returns an empty mutation for that key.
+    future<mutation> get_group0_schema_version();
+
     future<> sstables_registry_create_entry(sstring location, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc);
     future<> sstables_registry_update_entry_status(sstring location, sstables::generation_type gen, sstring status);
     future<> sstables_registry_update_entry_state(sstring location, sstables::generation_type gen, sstables::sstable_state state);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -275,7 +275,6 @@ public:
     future<> set_scylla_local_param(const sstring& key, const sstring& value, bool visible_before_cl_replay);
     future<std::optional<sstring>> get_scylla_local_param(const sstring& key);
 
-private:
     // Saves the key-value pair into system.scylla_local table.
     // Pass visible_before_cl_replay = true iff the data should be available before
     // schema commitlog replay. We do table.flush in this case, so it's rather slow and heavyweight.
@@ -284,7 +283,6 @@ private:
     template <typename T>
     future<std::optional<T>> get_scylla_local_param_as(const sstring& key);
 
-public:
     static std::vector<schema_ptr> all_tables(const db::config& cfg);
     future<> make(
             locator::effective_replication_map_factory&,

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -76,13 +76,12 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
         }
     }
 
-    fcfg._disabled_features.insert("GROUP0_SCHEMA_VERSIONING"s);
-
     if (!cfg.check_experimental(db::experimental_features_t::feature::ALTERNATOR_STREAMS)) {
         fcfg._disabled_features.insert("ALTERNATOR_STREAMS"s);
     }
     if (!cfg.consistent_cluster_management()) {
         fcfg._disabled_features.insert("SUPPORTS_RAFT_CLUSTER_MANAGEMENT"s);
+        fcfg._disabled_features.insert("GROUP0_SCHEMA_VERSIONING"s);
     }
     if (!cfg.check_experimental(db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS)) {
         fcfg._disabled_features.insert("KEYSPACE_STORAGE_OPTIONS"s);

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -76,6 +76,8 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
         }
     }
 
+    fcfg._disabled_features.insert("GROUP0_SCHEMA_VERSIONING"s);
+
     if (!cfg.check_experimental(db::experimental_features_t::feature::ALTERNATOR_STREAMS)) {
         fcfg._disabled_features.insert("ALTERNATOR_STREAMS"s);
     }
@@ -203,6 +205,7 @@ db::schema_features feature_service::cluster_schema_features() const {
     f.set_if<db::schema_feature::SCYLLA_KEYSPACES>(keyspace_storage_options);
     f.set_if<db::schema_feature::SCYLLA_AGGREGATES>(aggregate_storage_options);
     f.set_if<db::schema_feature::TABLE_DIGEST_INSENSITIVE_TO_EXPIRY>(table_digest_insensitive_to_expiry);
+    f.set_if<db::schema_feature::GROUP0_SCHEMA_VERSIONING>(group0_schema_versioning);
     return f;
 }
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -129,6 +129,14 @@ public:
     gms::feature tablets { *this, "TABLETS"sv };
     gms::feature uuid_sstable_identifiers { *this, "UUID_SSTABLE_IDENTIFIERS"sv };
     gms::feature table_digest_insensitive_to_expiry { *this, "TABLE_DIGEST_INSENSITIVE_TO_EXPIRY"sv };
+    // If this feature is enabled, schema versions are persisted by the group 0 command
+    // that modifies schema instead of being calculated as a digest (hash) by each node separately.
+    // The feature controls both the 'global' schema version (the one gossiped as application_state::SCHEMA)
+    // and the per-table schema versions (schema::version()).
+    // The feature affects non-Raft mode as well (e.g. during RECOVERY), where we send additional
+    // tombstones and flags to schema tables when performing schema changes, allowing us to
+    // revert to the digest method when necessary (if we must perform a schema change during RECOVERY).
+    gms::feature group0_schema_versioning { *this, "GROUP0_SCHEMA_VERSIONING"sv };
 
     // A feature just for use in tests. It must not be advertised unless
     // the "features_enable_test_feature" injection is enabled.

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -164,6 +164,15 @@ void migration_manager::init_messaging_service()
                 }
             }
         }
+
+        // If the schema we're returning was last modified in group 0 mode, we also need to return
+        // the persisted schema version so the pulling node uses it instead of calculating a schema digest.
+        //
+        // If it was modified in RECOVERY mode, we still need to return the mutation as it may contain a tombstone
+        // that will force the pulling node to revert to digest calculation instead of using a version that it
+        // could've persisted earlier.
+        cm.emplace_back(co_await self._sys_ks.local().get_group0_schema_version());
+
         co_return rpc::tuple(std::vector<frozen_mutation>{}, std::move(cm));
     }, std::ref(*this)));
     _messaging.register_schema_check([this] {
@@ -965,8 +974,26 @@ future<> migration_manager::announce_without_raft(std::vector<mutation> schema, 
     co_return co_await std::move(f);
 }
 
+static mutation make_group0_schema_version_mutation(const data_dictionary::database db, const group0_guard& guard) {
+    auto s = db.find_schema(db::system_keyspace::NAME, db::system_keyspace::SCYLLA_LOCAL);
+    auto* cdef = s->get_column_definition("value");
+    assert(cdef);
+
+    mutation m(s, partition_key::from_singular(*s, "group0_schema_version"));
+    auto cell = guard.with_raft()
+        ? atomic_cell::make_live(*cdef->type, guard.write_timestamp(),
+                                 cdef->type->decompose(guard.new_group0_state_id().to_sstring()))
+        : atomic_cell::make_dead(guard.write_timestamp(), gc_clock::now());
+    m.set_clustered_cell(clustering_key::make_empty(), *cdef, std::move(cell));
+    return m;
+}
+
 // Returns a future on the local application of the schema
 future<> migration_manager::announce(std::vector<mutation> schema, group0_guard guard, std::string_view description) {
+    if (_feat.group0_schema_versioning) {
+        schema.push_back(make_group0_schema_version_mutation(_storage_proxy.data_dictionary(), guard));
+    }
+
     if (guard.with_raft()) {
         return announce_with_raft(std::move(schema), std::move(guard), std::move(description));
     } else {

--- a/test/topology_custom/suite.yaml
+++ b/test/topology_custom/suite.yaml
@@ -16,9 +16,11 @@ skip_in_release:
   - test_replace_ignore_nodes
   - test_old_ip_notification_repro
   - test_different_group0_ids
+  - test_group0_schema_versioning
 skip_in_debug:
   - test_shutdown_hang
   - test_replace
   - test_replace_ignore_nodes
   - test_old_ip_notification_repro
   - test_different_group0_ids
+  - test_group0_schema_versioning

--- a/test/topology_custom/test_group0_schema_versioning.py
+++ b/test/topology_custom/test_group0_schema_versioning.py
@@ -1,0 +1,350 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import asyncio
+import time
+import pytest
+import logging
+import re
+from uuid import UUID
+
+from cassandra.cluster import Session, ConsistencyLevel # type: ignore
+from cassandra.query import SimpleStatement # type: ignore
+from cassandra.pool import Host # type: ignore
+
+from test.pylib.manager_client import ManagerClient, ServerInfo
+from test.pylib.util import wait_for_cql_and_get_hosts
+from test.pylib.log_browsing import ScyllaLogFile
+from test.topology.util import reconnect_driver, restart, wait_until_upgrade_finishes, \
+        enter_recovery_state, delete_raft_data_and_upgrade_state
+
+
+logger = logging.getLogger(__name__)
+
+
+async def get_local_schema_version(cql: Session, h: Host) -> UUID:
+    rs = await cql.run_async("select schema_version from system.local where key = 'local'", host=h)
+    assert(rs)
+    return rs[0].schema_version
+
+
+async def get_group0_schema_version(cql: Session, h: Host) -> UUID | None:
+    rs = await cql.run_async("select value from system.scylla_local where key = 'group0_schema_version'", host=h)
+    if rs:
+        return UUID(rs[0].value)
+    return None
+
+
+async def get_scylla_tables_versions(cql: Session, h: Host) -> list[tuple[str, str, UUID | None]]:
+    rs = await cql.run_async("select keyspace_name, table_name, version from system_schema.scylla_tables", host=h)
+    return [(r.keyspace_name, r.table_name, r.version) for r in rs]
+
+
+async def get_scylla_tables_version(cql: Session, h: Host, keyspace_name: str, table_name: str) -> UUID | None:
+    rs = await cql.run_async(
+            f"select version from system_schema.scylla_tables"
+            f" where keyspace_name = '{keyspace_name}' and table_name = '{table_name}'",
+            host=h)
+    if not rs:
+        pytest.fail(f"No scylla_tables row found for {keyspace_name}.{table_name}")
+    return rs[0].version
+
+
+async def verify_local_schema_versions_synced(cql: Session, hs: list[Host]) -> None:
+    versions = {h: await get_local_schema_version(cql, h) for h in hs}
+    logger.info(f"system.local schema_versions: {versions}")
+    h1, v1 = next(iter(versions.items()))
+    for h, v in versions.items():
+        if v != v1:
+            pytest.fail(f"{h1}'s system.local schema_version {v1} is different than {h}'s version {v}")
+
+
+async def verify_group0_schema_versions_synced(cql: Session, hs: list[Host]) -> None:
+    versions = {h: await get_group0_schema_version(cql, h) for h in hs}
+    logger.info(f"system.scylla_local group0_schema_versions: {versions}")
+    h1, v1 = next(iter(versions.items()))
+    for h, v in versions.items():
+        if v != v1:
+            pytest.fail(f"{h1}'s system.scylla_local group0_schema_version {v1} is different than {h}'s version {v}")
+
+
+async def verify_scylla_tables_versions_synced(cql: Session, hs: list[Host], ignore_system_tables: bool) -> None:
+    versions = {h: set(await get_scylla_tables_versions(cql, h)) for h in hs}
+    logger.info(f"system_schema.scylla_tables: {versions}")
+    h1, v1 = next(iter(versions.items()))
+    for h, v in versions.items():
+        diff = v.symmetric_difference(v1)
+        if ignore_system_tables:
+            diff = {(k, t, v) for k, t, v in diff if k != "system"}
+        if diff:
+            pytest.fail(f"{h1}'s system_schema.scylla_tables contents is different than {h}'s, symmetric diff: {diff}")
+
+
+async def verify_table_versions_synced(cql: Session, hs: list[Host], ignore_system_tables: bool = False) -> None:
+    logger.info("Verifying that versions stored in tables are in sync")
+    await verify_group0_schema_versions_synced(cql, hs)
+    await verify_local_schema_versions_synced(cql, hs)
+    await verify_scylla_tables_versions_synced(cql, hs, ignore_system_tables)
+
+
+async def verify_in_memory_table_versions(srvs: list[ServerInfo], logs: list[ScyllaLogFile], marks: list[int]):
+    """
+    Assumes that `logs` are log files of servers `srvs`, correspondingly in order.
+    Assumes that `marks` are log markers (obtained by `ScyllaLogFile.mark()`) corresponding to `logs` in order.
+    Assumes that an 'alter table ks.t ...' statement was performed after obtaining `marks`.
+    Checks that every server printed the same version in `Altering ks.t...' log message.
+    """
+    logger.info("Verifying that in-memory table schema versions are in sync")
+    matches = [await log.grep("Altering ks.t.*version=(.*)", from_mark=mark) for log, mark in zip(logs, marks)]
+
+    def get_version(srv: ServerInfo, matches: list[tuple[str, re.Match[str]]]):
+        if not matches:
+            pytest.fail(f"Server {srv} didn't log 'Altering' message")
+        _, match = matches[0]
+        return UUID(match.group(1))
+
+    versions = {srv: get_version(srv, m) for srv, m in zip(srvs, matches)}
+    logger.info(f"In-memory table versions: {versions}")
+
+    s1, v1 = next(iter(versions.items()))
+    for s, v in versions.items():
+        if v != v1:
+            pytest.fail(f"{s1}'s in-memory table version {v1} is different than {s}'s version {v}")
+
+
+@pytest.mark.asyncio
+async def test_schema_versioning_with_recovery(manager: ManagerClient):
+    """
+    Perform schema changes while mixing nodes in RECOVERY mode with nodes in group 0 mode.
+    Schema changes originating from RECOVERY node use digest-based schema versioning.
+    Schema changes originating from group 0 nodes use persisted versions committed through group 0.
+
+    Verify that schema versions are in sync after each schema change.
+    """
+    cfg = {'enable_user_defined_functions': False,
+           'experimental_features': list[str]()}
+    logger.info("Booting cluster")
+    servers = [await manager.server_add(config=cfg) for _ in range(3)]
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logger.info("Creating keyspace and table")
+    await cql.run_async("create keyspace ks with replication = "
+                        "{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}")
+    await verify_table_versions_synced(cql, hosts)
+    await cql.run_async("create table ks.t (pk int primary key)")
+
+    logger.info("Waiting for driver")
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    await verify_table_versions_synced(cql, hosts)
+    ks_t_version = await get_scylla_tables_version(cql, hosts[0], 'ks', 't')
+    assert ks_t_version
+
+    logs = [await manager.server_open_log(srv.server_id) for srv in servers]
+    marks = [await log.mark() for log in logs]
+
+    logger.info("Altering table")
+    await cql.run_async("alter table ks.t with comment = ''")
+
+    await verify_table_versions_synced(cql, hosts)
+    await verify_in_memory_table_versions(servers, logs, marks)
+
+    new_ks_t_version = await get_scylla_tables_version(cql, hosts[0], 'ks', 't')
+    assert new_ks_t_version
+    assert new_ks_t_version != ks_t_version
+    ks_t_version = new_ks_t_version
+
+    # We still have a group 0 majority, don't do this at home.
+    srv1 = servers[0]
+    logger.info(f"Rebooting {srv1} in RECOVERY mode")
+    h1 = next(h for h in hosts if h.address == srv1.ip_addr)
+    await cql.run_async("update system.scylla_local set value = 'recovery' where key = 'group0_upgrade_state'", host=h1)
+    await manager.server_restart(srv1.server_id)
+
+    cql = await reconnect_driver(manager)
+    logger.info(f"Waiting for driver")
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    await verify_table_versions_synced(cql, hosts)
+
+    # We're doing a schema change on RECOVERY node while we have two nodes running in group 0 mode.
+    # Don't do this at home.
+    #
+    # Now, the two nodes are not doing any schema changes right now, so this doesn't actually break anything:
+    # the RECOVERY node is operating using the old schema change procedure, which means
+    # that it pushes the schema mutations to other nodes directly with RPC, modifying
+    # the group 0 state machine on other two nodes.
+    #
+    # There is one problem with this however. If the RECOVERY node considers some other node
+    # as DOWN, it will silently *not* push the schema change, completing the operation
+    # "successfully" nevertheless (it will return to the driver without error).
+    # Usually in this case we rely on eventual convergence of schema through gossip,
+    # which will not happen here, because the group 0 nodes are not doing schema pulls!
+    # So we need to make sure that the RECOVERY node sees the other nodes as UP before
+    # we perform the schema change, so it pushes the mutations to them.
+    logger.info(f"Waiting until RECOVERY node ({srv1}) sees other servers as UP")
+    await manager.server_sees_others(srv1.server_id, 2)
+
+    marks = [await log.mark() for log in logs]
+    logger.info(f"Altering table on RECOVERY node ({srv1})")
+    await cql.run_async("alter table ks.t with comment = ''", host=h1)
+
+    await verify_table_versions_synced(cql, hosts)
+    await verify_in_memory_table_versions(servers, logs, marks)
+
+    new_ks_t_version = await get_scylla_tables_version(cql, hosts[0], 'ks', 't')
+    assert not new_ks_t_version
+    ks_t_version = new_ks_t_version
+
+    logger.info(f"Stopping {srv1} gracefully")
+    await manager.server_stop_gracefully(srv1.server_id)
+
+    srv2 = servers[1]
+    logger.info(f"Waiting until {srv2} sees {srv1} as dead")
+    await manager.server_not_sees_other_server(srv2.ip_addr, srv1.ip_addr)
+
+    # Now we modify schema through group 0 while the RECOVERY node is dead.
+    # Don't do this at home.
+    marks = [await log.mark() for log in logs]
+    h2 = next(h for h in hosts if h.address == srv2.ip_addr)
+    logger.info(f"Altering table on group 0 node {srv2}")
+    await cql.run_async("alter table ks.t with comment = ''", host=h2)
+
+    await manager.server_start(srv1.server_id)
+    cql = await reconnect_driver(manager)
+    logger.info(f"Waiting for driver")
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logger.info(f"Waiting until {srv2} sees {srv1} as UP")
+    await manager.server_sees_other_server(srv2.ip_addr, srv1.ip_addr)
+
+    # The RECOVERY node will pull schema when it gets a write.
+    # The other group 0 node will do a barrier so it will also sync schema before the write returns.
+    logger.info("Forcing schema sync through CL=ALL INSERT")
+    await cql.run_async(SimpleStatement("insert into ks.t (pk) values (0)", consistency_level=ConsistencyLevel.ALL),
+                        host=h2)
+
+    await verify_table_versions_synced(cql, hosts)
+    await verify_in_memory_table_versions(servers, logs, marks)
+
+    new_ks_t_version = await get_scylla_tables_version(cql, hosts[0], 'ks', 't')
+    assert new_ks_t_version
+    ks_t_version = new_ks_t_version
+
+    srv3 = servers[2]
+    h3 = next(h for h in hosts if h.address == srv3.ip_addr)
+    logger.info("Finishing recovery")
+    for h in [h2, h3]:
+        await cql.run_async(
+                "update system.scylla_local set value = 'recovery' where key = 'group0_upgrade_state'", host=h)
+    await asyncio.gather(*(manager.server_restart(srv.server_id) for srv in [srv2, srv3]))
+
+    cql = await reconnect_driver(manager)
+    logger.info("Waiting for driver")
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    for h in [h1, h2, h3]:
+        await delete_raft_data_and_upgrade_state(cql, h)
+
+    logger.info("Restarting servers")
+    await asyncio.gather(*(manager.server_restart(srv.server_id) for srv in servers))
+
+    cql = await reconnect_driver(manager)
+    logger.info("Waiting for driver")
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logging.info(f"Waiting until upgrade finishes")
+    for h in [h1, h2, h3]:
+        await wait_until_upgrade_finishes(cql, h, time.time() + 60)
+
+    await verify_table_versions_synced(cql, hosts)
+
+    for change in [
+            "alter table ks.t with comment = ''",
+            "alter table ks.t add v int",
+            "alter table ks.t alter v type blob"]:
+
+        marks = [await log.mark() for log in logs]
+        logger.info(f"Altering table with \"{change}\"")
+        await cql.run_async(change)
+
+        new_ks_t_version = await get_scylla_tables_version(cql, hosts[0], 'ks', 't')
+        assert new_ks_t_version
+        assert new_ks_t_version != ks_t_version
+        ks_t_version = new_ks_t_version
+
+        await verify_table_versions_synced(cql, hosts)
+        await verify_in_memory_table_versions(servers, logs, marks)
+
+    await cql.run_async("drop keyspace ks")
+
+@pytest.mark.asyncio
+async def test_upgrade(manager: ManagerClient):
+    """
+    While Raft is disabled, we use digest-based schema versioning.
+    Once Raft upgrade is complete, we use persisted versions committed through group 0.
+    """
+    # Raft upgrade tests had to be replaced with recovery tests (scylladb/scylladb#16192)
+    # as prerequisite for getting rid of `consistent_cluster_management` flag.
+    # So we do the same here: start a cluster in Raft mode, then enter recovery
+    # to simulate a non-Raft cluster.
+    cfg = {'enable_user_defined_functions': False,
+           'experimental_features': list[str]()}
+    logger.info("Booting cluster")
+    servers = [await manager.server_add(config=cfg) for _ in range(2)]
+    cql = manager.get_cql()
+
+    logging.info("Waiting until driver connects to every server")
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logging.info(f"Setting recovery state on {hosts} and restarting")
+    await asyncio.gather(*(enter_recovery_state(cql, h) for h in hosts))
+    await asyncio.gather(*(restart(manager, srv) for srv in servers))
+    cql = await reconnect_driver(manager)
+
+    logging.info("Waiting until driver connects to every server")
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logger.info("Creating keyspace and table")
+    await cql.run_async("create keyspace ks with replication = "
+                        "{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}")
+    await verify_table_versions_synced(cql, hosts)
+    await cql.run_async("create table ks.t (pk int primary key)")
+
+    logging.info(f"Deleting Raft data and upgrade state on {hosts}")
+    await asyncio.gather(*(delete_raft_data_and_upgrade_state(cql, h) for h in hosts))
+
+    logging.info(f"Restarting {servers}")
+    await asyncio.gather(*(restart(manager, srv) for srv in servers))
+    cql = await reconnect_driver(manager)
+
+    logger.info("Waiting for driver")
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logging.info(f"Waiting until Raft upgrade procedure finishes")
+    await asyncio.gather(*(wait_until_upgrade_finishes(cql, h, time.time() + 60) for h in hosts))
+
+    logs = [await manager.server_open_log(srv.server_id) for srv in servers]
+
+    marks = [await log.mark() for log in logs]
+    logger.info("Altering table")
+    await cql.run_async("alter table ks.t with comment = ''")
+
+    await verify_table_versions_synced(cql, hosts)
+    await verify_in_memory_table_versions(servers, logs, marks)
+
+    # `group0_schema_version` should be present
+    # and the version column for `ks.t` should be non-null.
+    for h in hosts:
+        logger.info(f"Checking that `group0_schema_version` is set on {h}")
+        assert (await get_group0_schema_version(cql, h)) is not None
+
+    for h in hosts:
+        logger.info(f"Checking that `version` column for `ks.t` is set on {h}")
+        versions = await get_scylla_tables_versions(cql, h)
+        for ks, _, v in versions:
+            if ks == "ks":
+                assert v is not None


### PR DESCRIPTION
When performing a schema change through group 0, extend the schema mutations with a version that's persisted and then used by the nodes in the cluster in place of the old schema digest, which becomes horribly slow as we perform more and more schema changes (#7620).

If the change is a table create or alter, also extend the mutations with a version for this table to be used for `schema::version()`s instead of having each node calculate a hash which is susceptible to bugs (#13957).

When performing a schema change in Raft RECOVERY mode we also extend schema mutations which forces nodes to revert to the old way of calculating schema versions when necessary.

We can only introduce these extensions if all of the cluster understands them, so protect this code by a new cluster/schema feature, `GROUP0_SCHEMA_VERSIONING`.

Fixes: #7620
Fixes: #13957

---

This is a reincarnation of PR scylladb/scylladb#15331. The previous PR was reverted due to a bug it unmasked; the bug has now been fixed (scylladb/scylladb#16139). Some refactors from the previous PR were already merged separately, so this one is a bit smaller.

I have checked with @Lorak-mmk's reproducer (https://github.com/Lorak-mmk/udt_schema_change_reproducer -- many thanks for it!) that the originally exposed bug is no longer reproducing on this PR, and that it can still be reproduced if I revert the aforementioned fix on top of this PR.