### PR TITLE
database: log when done with truncating

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2672,6 +2672,7 @@ future<> database::truncate_table_on_all_shards(sharded<database>& sharded_db, s
 
         return db.truncate(sys_ks.local(), cf, st, truncated_at);
     });
+    dblog.info("Truncated {}.{}", s->ks_name(), s->cf_name());
 }
 
 future<> database::truncate(db::system_keyspace& sys_ks, column_family& cf, const table_truncate_state& st, db_clock::time_point truncated_at) {


### PR DESCRIPTION
truncating is an unusual operation, and we write a logging message when the truncate op starts with INFO level, it would be great if we can have a matching logging messge indicating the end of truncate on the server side. this would help with investigation the TRUNCATE timeout spotted on the client. at least we can rule out the problem happening we server is performing truncate.

Refs #15610
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>