### PR TITLE
repair: add formatter for row_level_diff_detect_algorithm

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -120,13 +120,18 @@ static std::ostream& operator<<(std::ostream& os, const std::unordered_map<T1, T
 }
 
 std::ostream& operator<<(std::ostream& out, row_level_diff_detect_algorithm algo) {
+    return out << format_as(algo);
+}
+
+std::string_view format_as(row_level_diff_detect_algorithm algo) {
+    using enum row_level_diff_detect_algorithm;
     switch (algo) {
-    case row_level_diff_detect_algorithm::send_full_set:
-        return out << "send_full_set";
-    case row_level_diff_detect_algorithm::send_full_set_rpc_stream:
-        return out << "send_full_set_rpc_stream";
+    case send_full_set:
+        return "send_full_set";
+    case send_full_set_rpc_stream:
+        return "send_full_set_rpc_stream";
     };
-    return out << "unknown";
+    return "unknown";
 }
 
 static size_t get_nr_tables(const replica::database& db, const sstring& keyspace) {

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -234,6 +234,7 @@ enum class row_level_diff_detect_algorithm : uint8_t {
 };
 
 std::ostream& operator<<(std::ostream& out, row_level_diff_detect_algorithm algo);
+std::string_view format_as(row_level_diff_detect_algorithm);
 
 struct repair_update_system_table_request {
     tasks::task_id repair_uuid;


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define a formatter for
row_level_diff_detect_algorithm, and remove its operator<<().

Refs #13245