### PR TITLE
Typo: passs instead of pass in test_gsi.py

### DIFF
--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -938,7 +938,7 @@ def test_gsi_projection_error_duplicate(dynamodb):
                                     'NonKeyAttributes': ['a', 'a'] }
                 }
             ]) as table:
-            passs
+            pass
 
 # NonKeyAttributes must be a list of strings. Non-strings in this list
 # result, for some reason, in SerializationException instead of the more


### PR DESCRIPTION
Fix a typo.
Refs: https://github.com/scylladb/scylladb/issues/16255
Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>