### PR TITLE
raft: add formatter for raft::logical_clock::time_point

### DIFF
--- a/raft/logical_clock.hh
+++ b/raft/logical_clock.hh
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <chrono>
-#include <ostream>
+#include <fmt/chrono.h>
 
 namespace raft {
 
@@ -45,16 +45,12 @@ private:
     time_point _now = min();
 };
 
-inline std::ostream& operator<<(std::ostream& os, const logical_clock::time_point& p) {
-    return os << (p - logical_clock::min()).count();
-}
-
 } // end of namespace raft
 
-namespace std {
-
-inline std::ostream& operator<<(std::ostream& os, const raft::logical_clock::duration& d) {
-    return os << d.count();
-}
-
-} // end of namespace std
+template <>
+struct fmt::formatter<raft::logical_clock::time_point> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const raft::logical_clock::time_point& p, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", (p - raft::logical_clock::min()).count());
+    }
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we

* define a formatter for logical_clock::time_point, as fmt does not provide formatter for this time_point, as it is not a part of the standard library
* remove operator<<() for logical_clock::time_point, as its soly purpose is to generate the corresponding fmt::formatter when FMT_DEPRECATED_OSTREAM is defined.
* remove operator<<() for logical_clock::duration, as fmt provides a default implementation for formatting std::chrono::nanoseconds already, which uses `int64_t` as its rep template parameter as well.
* include "fmt/chrono.h" so that the source files including this header can have access the formatter without including it by themselves, this preserve the existing behavior which we have before removal of "operator<<()".

Refs #13245