### PR TITLE
alternator: reply service unavariable when request timeout

### DIFF
--- a/alternator/error.hh
+++ b/alternator/error.hh
@@ -88,6 +88,9 @@ public:
     static api_error table_not_found(std::string msg) {
         return api_error("TableNotFoundException", std::move(msg));
     }
+    static api_error unavailable(std::string msg) {
+        return api_error("ServiceUnavailable", std::move(msg), http::reply::status_type::service_unavailable);
+    }
     static api_error internal(std::string msg) {
         return api_error("InternalServerError", std::move(msg), http::reply::status_type::internal_server_error);
     }

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -112,6 +112,9 @@ public:
                  } catch (rjson::error & re) {
                      generate_error_reply(*rep,
                              api_error::validation(re.what()));
+                 } catch (exceptions::request_timeout_exception& ex) {
+                     generate_error_reply(*rep,
+                             api_error::unavailable(format("Service unavailable: {}", std::current_exception())));
                  } catch (...) {
                      generate_error_reply(*rep,
                              api_error::internal(format("Internal server error: {}", std::current_exception())));


### PR DESCRIPTION
Request timeouts caused by overload should be distinguished from internal server error, so that users can make better decisions on how to adjust the load. Using http status 503 service unavariable to identify overload timeout scenarios is also compatible with Dynamodb.

Refs scylladb#16262