### PR TITLE
gms/inet_address: format gms::inet_address via net::inet_address

### DIFF
--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -90,14 +90,6 @@ template <>
 struct fmt::formatter<gms::inet_address> : fmt::formatter<std::string_view> {
     template <typename FormatContext>
     auto format(const ::gms::inet_address& x, FormatContext& ctx) const {
-        if (x.addr().is_ipv4()) {
-            return fmt::format_to(ctx.out(), "{}", x.addr());
-        }
-        // print 2 bytes in a group, and use ':' as the delimiter
-        fmt::format_to(ctx.out(), "{:2:}", fmt_hex(x.bytes()));
-        if (x.addr().scope() != seastar::net::inet_address::invalid_scope) {
-            return fmt::format_to(ctx.out(), "%{}", x.addr().scope());
-        }
-        return ctx.out();
+        return fmt::format_to(ctx.out(), "{}", x.addr());
     }
 };


### PR DESCRIPTION
in 4ea6e06c, we specialized fmt::formatter<gms::inet_address> using the formatter of bytes if the underlying address is an IPv6 address. this breaks the tests with JMX which expected the shortened form of the text representation of the IPv6 address.

in this change, instead of reinventing the wheel, let's reuse the existing formatter of net::inet_address, which is able to handle both IPv4 and IPv6 addresses, also it follows
https://datatracker.ietf.org/doc/html/rfc5952 by compressing the consecutive zeros.

since this new formatter is a thin wrapper of seastar::net::inet_addresss, the corresponding unit test will be added to Seastar.

Refs #16039
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>