### PR TITLE
install-dependencies.sh : Fix pip packages install logic and add packages for code coverage

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -107,6 +107,7 @@ fedora_packages=(
     rust-std-static-wasm32-wasi
     wabt
     binaryen
+    lcov
 )
 
 # lld is not available on s390x, see
@@ -127,6 +128,9 @@ fedora_python3_packages=(
     python3-click
     python3-six
     python3-pyudev
+    python3-unidiff
+    python3-humanfriendly
+    python3-jinja2
 )
 
 # an associative array from packages to constrains
@@ -135,6 +139,7 @@ declare -A pip_packages=(
     [geomet]="<0.3,>=0.1"
     [traceback-with-variables]=
     [scylla-api-client]=
+    [treelib]=
 )
 
 pip_symlinks=(


### PR DESCRIPTION
The series handles two things:
1. It fixes the pip packages installation logic to use the `pip_packages` array instead of using hardcoded instruction.
2. It add some fedora and python packages to be later used by coverage reporting code in unit testing and in processing
of the coverage results.

Fixes #16269 

NOTE: Do not merge yet.
A new dbuild image must be created and the `tools/toolchain/image` needs to be updated and added to this series
before merge.

Tests:
The changes were tested by building a local new image and:
1. Making sure that scylla packages are built without failing
2. Making sure that the coverage processing code runs correctly on this image