### PR TITLE
Typos: fix typos in documentation

### DIFF
--- a/docs/_utils/remove-redirection-loops.py
+++ b/docs/_utils/remove-redirection-loops.py
@@ -15,7 +15,7 @@ d = yaml.load(open(f), Loader=yaml.FullLoader)
 replace_dict = {}
 for key, value in d.items():
      if value in d.keys():
-#        print ("duble redirection:", key, "->", value, "->",  d[value])
+#        print ("double redirection:", key, "->", value, "->",  d[value])
          replace_dict[value] = d[value]
 
 with open(f, "r") as source:

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -102,7 +102,7 @@ one or more of the following:
 Another guarantee that that `always_use_lwt` can make and other write
 isolation modes do not is that writes to the same item are _serialized_:
 Even if the two write are sent at exactly the same time to two different
-nodes, the result will appear as if one write happended first, and then
+nodes, the result will appear as if one write happened first, and then
 the other. But in other modes (with non-LWT writes), two writes can get
 exactly the same microsecond-resolution timestamp, the the result may be
 a mixture of both writes - some attributes from one and some from the

--- a/docs/architecture/architecture-fault-tolerance.rst
+++ b/docs/architecture/architecture-fault-tolerance.rst
@@ -75,4 +75,4 @@ Additional Resources
 
 * :doc:`Consistency Level Console Demo </architecture/console-CL-full-demo>`
 * :doc:`Consistency Levels </cql/consistency/>`
-* From ScyllaDB Univeristy: take the `Consistency Level lesson <https://university.scylladb.com/courses/scylla-essentials-overview/lessons/architecture/topic/consistency-level-cl/>`_
+* From ScyllaDB University: take the `Consistency Level lesson <https://university.scylladb.com/courses/scylla-essentials-overview/lessons/architecture/topic/consistency-level-cl/>`_

--- a/docs/architecture/ringarchitecture/index.rst
+++ b/docs/architecture/ringarchitecture/index.rst
@@ -5,7 +5,7 @@ Scylla is a database that scales out and up. Scylla adopted much of its distribu
 
 In the world of big data, a single node cannot hold the entire dataset and thus, a cluster of nodes is needed.
 
-A Scylla :term:`cluster<Cluster>` is a collection of :term:`nodes<Node>`, or Scylla instances, visualized as a ring. All of the nodes should be homogenous using a shared-nothing approach. This article describes the design that determines how data is distributed among the cluster members.
+A Scylla :term:`cluster<Cluster>` is a collection of :term:`nodes<Node>`, or Scylla instances, visualized as a ring. All of the nodes should be homogeneous using a shared-nothing approach. This article describes the design that determines how data is distributed among the cluster members.
 
 A Scylla :term:`keyspace<Keyspace>` is a collection of tables with attributes that define how data is replicated on nodes.   A keyspace is analogous to a database in SQL. When a new keyspace is created, the user sets a numerical attribute, the :term:`replication factor<Replication Factor (RF)>`, that defines how data is replicated on nodes. For example, an :abbr:`RF (Replication Factor)` of 2 means a given token or token range will be stored on 2 nodes (or replicated on one additional node).   We will use an RF value of 2 in our examples.
 

--- a/docs/cql/service-levels.rst
+++ b/docs/cql/service-levels.rst
@@ -8,7 +8,7 @@ Service Levels CQL commands
 ``LIST EFFECTIVE SERVICE LEVEL OF <role>``
 -----------------------------------------------------------
 
-Actual values of service level's options may come from different service levels, not only from the one user is assigned with. This can be achived by assigning one role to another.
+Actual values of service level's options may come from different service levels, not only from the one user is assigned with. This can be achieved by assigning one role to another.
 
 For instance:
 There are 2 roles: role1 and role2. Role1 is assigned with sl1 (timeout = 2s, workload_type = interactive) and role2 is assigned with sl2 (timeout = 10s, workload_type = batch).

--- a/docs/cql/types.rst
+++ b/docs/cql/types.rst
@@ -499,7 +499,7 @@ For example::
 
    - Attempting to create an already existing type will result in an error unless the ``IF NOT EXISTS`` option is used. If it is used, the statement will be a no-op if the type already exists.
    - A type is intrinsically bound to the keyspace in which it is created and can only be used in that keyspace. At creation, if the type name is prefixed by a keyspace name, it is created in that keyspace. Otherwise, it is created in the current keyspace.
-   - As of Scylla Open Source 3.2, UDTs not inside collections do not have to be frozen, but in all versions prior to Scylla Open Souce 3.2, and in all Scylla Enterprise versions, UDTs **must** be frozen. 
+   - As of Scylla Open Source 3.2, UDTs not inside collections do not have to be frozen, but in all versions prior to Scylla Open Source 3.2, and in all Scylla Enterprise versions, UDTs **must** be frozen. 
 
 
 A non-frozen UDT example with Scylla Open Source 3.2 and higher::

--- a/docs/dev/backport.md
+++ b/docs/dev/backport.md
@@ -50,7 +50,7 @@ It's the easiest to show it by an example, so let's look at PR [#12031](https://
 First the original PR should get merged.
 In the example the author wanted to merge the branch `cvybhu:filter_multi_bug` into `scylladb:master`.
 Each PR is submitted on its own branch, which the PR author wants to merge into the `master` branch.
-Before the changes end up on `master`, they are first added to the `next` branch to run some additional tests. Later the `next` branch is merged into `master` and the PR is officialy merged.
+Before the changes end up on `master`, they are first added to the `next` branch to run some additional tests. Later the `next` branch is merged into `master` and the PR is officially merged.
 
 ### A backport PR
 Released versions of `Scylla` live on their own branches - `branch-5.0`, `branch-4.6` etc.

--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -290,7 +290,7 @@ binaries.
 
 The most convenient way to open a coredump is [scripts/open-coredump.sh](https://github.com/scylladb/scylladb/blob/master/scripts/open-coredump.sh).
 Just point it to a coredump and after some time you should get a shell inside the
-appropriate dbuild container, with a suggested gdb invokation line to open the
+appropriate dbuild container, with a suggested gdb invocation line to open the
 coredump.
 
 If you prefer to open the coredump manually or the script fails for you, continue
@@ -904,7 +904,7 @@ hundreds or more) can cause an otherwise non-problematic amount of reads to use
 excessive amount of memory, potentially leading to OOM.
 
 Reversed- and unpaged-reads (or both, combined) can also consume a huge amount
-of memory, to the point of a fiew of such reads causing OOM. The way to find
+of memory, to the point of a few of such reads causing OOM. The way to find
 these is to inspect readers in memory, trying to locate their partition slice
 and having a look at their respective options:
 * `partition_slice::option::reversed` is set for a reversed query

--- a/docs/dev/maintainer.md
+++ b/docs/dev/maintainer.md
@@ -249,7 +249,7 @@ Alternatively
  1. Check out the relevant branch (the `branch-3.2` from the example above) 
  2. Apply all the necessary patches (by cherry-picking them or doing any
     other relevant manipulations)
- 3. Push the udpated branch.
+ 3. Push the updated branch.
  * In the `scylla` repository
  1. Check out the relevant next branch (e.g. `next-3.2` one)
  2. Use the refreshing script specifying the `seastar:<branch>` as its
@@ -310,4 +310,4 @@ still has to rely on their judgemenet.
    before backported on older stable releases.
 
 5. Make sure the target branch is not under freeze, waiting
-   for an iminent release.
+   for an imminent release.

--- a/docs/dev/paged-queries.md
+++ b/docs/dev/paged-queries.md
@@ -322,7 +322,7 @@ mainly cold start and result merging.
 
 Implementing a stateful range scan using `multishard_combining_reader`,
 `querier` and `querier_cache` still has a lot of involved details to
-it. To make this as accessible and resuable as possible a function was
+it. To make this as accessible and reusable as possible a function was
 added that takes care of all this, offering a simple interface to
 clients. This is `query_mutations_on_all_shards()`, which takes care of
 all details related to replica local range scans. It supports both

--- a/docs/dev/per-partition-rate-limit.md
+++ b/docs/dev/per-partition-rate-limit.md
@@ -71,7 +71,7 @@ Only reads and writes explicitly issued by the user are counted to the limit.
 Read repair, hints, batch replay, CDC preimage query and internal system queries
 are _not_ counted to the limit.
 
-Paxos and counters are not covered in current implemenation.
+Paxos and counters are not covered in current implementation.
 
 ### Coordinator is not a replica
 

--- a/docs/dev/protocols.md
+++ b/docs/dev/protocols.md
@@ -79,7 +79,7 @@ as gossip were sent to a different port. So today we are still stuck with
 this outdated name of this configuration option.
 
 Configuring `storage_port` or `ssl_storage_port` to 0 disables listening
-on the respective unecrypted/encrypted inter-node communication port.
+on the respective unencrypted/encrypted inter-node communication port.
 
 There is also a `listen_address` configuration option to set the IP address
 (and therefore network interface) on which Scylla should listen for the

--- a/docs/dev/raft-in-scylla.md
+++ b/docs/dev/raft-in-scylla.md
@@ -145,7 +145,7 @@ schema changes out of the box, for two reasons:
       could store entire CQL statements in the log and read
       the state of the schema when the command is already committed
       to the Raft log and is being applied: but that would make
-      reporting erros back to the client difficult. Besides, that
+      reporting errors back to the client difficult. Besides, that
       would require that each participant of the cluster performs
       the same reads and checks, that would be an unwanted
       overhead.

--- a/docs/dev/reader-concurrency-semaphore.md
+++ b/docs/dev/reader-concurrency-semaphore.md
@@ -30,7 +30,7 @@ For more details on the reader concurrency semaphore's API, check [reader_concur
 
 Permits can be registered as "inactive". This means that the reader object associated with the permit will be kept around only as long as resource consumption is below the semaphore's limit. Otherwise, the reader object will be evicted (destroyed) to free up resources. Evicted permits have to be re-admitted to continue the read.
 
-This is used in multiple places, but in general it is used to cache readers between differnt pages of a query.
+This is used in multiple places, but in general it is used to cache readers between different pages of a query.
 Making reads inactive is also used to prevent deadlocks, where a single process has to obtain permits on multiple shards. To avoid deadlocks, the process marks all shards it is not currently using, as inactive, to allow a concurrent process to be able to obtain permits on those shards. Repair and multi-shard reads mark unused shard readers as inactive for this purpose.
 
 Inactive reads are only evicted when their eviction can potentially allow for permits currently waiting on admission to be admitted. So for example if admission is blocked by lack of memory, inactive reads will be evicted. If admission is blocked by some permit being marked as `need_cpu`, inactive readers will not be evicted.
@@ -43,7 +43,7 @@ The semaphore has anti-OOM protection measures. This is governed by two limits:
 
 Both limits are multipliers and the final limit is calculated by multiplying them with the semaphore's memory limit. So e.g. a `serialize_limit_multiplier` limit of `2` means that the protection menchanism is activated when the memory consumption of the current reads reaches the semaphore limit times two.
 
-After reaching the serialize limit, requests for more memory are queued for all reads except one, which is called the blessed read. The hope is that if only one read is allowed to progress at a time, the memory consumption will not baloon any more. When the memory consumption goes back below the serialize limit, reads are again allowed to progress in parallel.
+After reaching the serialize limit, requests for more memory are queued for all reads except one, which is called the blessed read. The hope is that if only one read is allowed to progress at a time, the memory consumption will not balloon any more. When the memory consumption goes back below the serialize limit, reads are again allowed to progress in parallel.
 Note that participation in this is opt-in for reads, in that there is a separate accounting method for registering memory consumption, which participates in this system. Currently only memory request on behalf of I/O use this API.
 
 When reaching the kill limit, the semaphore will start throwing `std::bad_alloc` from all memory consumption registering API calls. This is a drastic measure which will result in reads being killed. This is meant to provide a hard upper limit on the memory consumption of all reads.
@@ -110,7 +110,7 @@ There might be inactive reads if CPU is a bottleneck; otherwise, there shouldn't
 
 ### Operations
 
-Table of all permit operations possibly contained in disgnostic dumps, from the user or system semaphore:
+Table of all permit operations possibly contained in diagnostic dumps, from the user or system semaphore:
 
 | Operation name                                | Description                                                                                                                  |
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
@@ -123,13 +123,13 @@ Table of all permit operations possibly contained in disgnostic dumps, from the 
 | `shard-reader`                                | Part of a range-scan, which runs on replica-shards.                                                                          |
 
 
-Table of all permit operations possibly contained in disgnostic dumps, from the streaming semaphore:
+Table of all permit operations possibly contained in diagnostic dumps, from the streaming semaphore:
 
 | Operation name                                | Description                                                                                                                  |
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | `repair-meta`                                 | Repair reader.                                                                                                               |
 | `sstables_loader::load_and_stream()`          | Sstable reader, reading sstables on behalf of load-and-stream.                                                               |
-| `stream-session`                              | Permit created for streaming (reciever side).                                                                                |
+| `stream-session`                              | Permit created for streaming (receiver side).                                                                                |
 | `stream-transfer-task`                        | Permit created for streaming (sender side).                                                                                  |
 | `view_builder`                                | Permit created for the view-builder service.                                                                                 |
 | `view_update_generator`                       | Reader which reads the staging sstables, for which view updates have to be generated.                                        |

--- a/docs/dev/redis.md
+++ b/docs/dev/redis.md
@@ -23,7 +23,7 @@ features:
 * Low and consistent latency
 * Data persistence
 * High availability
-* High throughtput
+* High throughput
 * Highly scalable
 * Auto tuning
 
@@ -32,7 +32,7 @@ It's achieved great progress in cluster master management, data persistence,
 failover and replication.
 
 The benefits to the users are easy to use and develop in their production
-environment, and taking avantages of Scylla.
+environment, and taking advantages of Scylla.
 
 ## 3. The Protocol Server
 
@@ -46,7 +46,7 @@ command is received, it's processed and a reply is sent back to the client.
 Two kind of Redis clients are widely used, the smart Redis client and
 simple Redis client. When using smart Redis client to connect the Redis
 cluster, it will send the commands to the right Redis server. Because the
-client will get the hash slots and server nodes mapping data at the bootrap
+client will get the hash slots and server nodes mapping data at the bootstrap
 time. When using simple Redis client,  the server address is needed, and
 all the requests are sent to this address, and the requests only send to
 the single Redis server.
@@ -85,7 +85,7 @@ HASHes, and  ZSETs. (In fact, Now Redis has support other structure types,
 but the basic structure types are used widely).
 
 In this proposal, We use the column family of Scylla to simulate the
-database within Redis. At the bootrap phase, the column families with fixed
+database within Redis. At the bootstrap phase, the column families with fixed
 name should be created (if not exists) or loaded.
 
 We known that, Redis allows us to store keys that map to any one of the
@@ -112,7 +112,7 @@ will have more performance cost with bigger data structure.
 > element (as a string) is 512MB. It's very common that the size of data
 > structure is exceeded the server's memory size.
 
-So single table to store all the data strucutures is not good idea, instead
+So single table to store all the data structures is not good idea, instead
 of five independent tables are created to hold the the different Redis
 structure types within each column family related Redis database. In other
 words, all of the STRINGs of the Redis will be stored in a table within the
@@ -124,10 +124,10 @@ table within the column family, and so on.
 > will be created.
 
 The disadvantages of this proposal is that, we can not the TYPE command of
-Redis. The different type strutures are stored in the different Scylla
+Redis. The different type structures are stored in the different Scylla
 tables, and each Scylla table provide the independent keyspace. In Redis,
 keys are unique in the database. However,  the keys with column family of
-Scylla are not unique. Because the keys are splited into independent
+Scylla are not unique. Because the keys are split into independent
 Scylla tables, it's different to original Redis.
 
 **IMPORTANT NOTE**: The keys with database of Redis are not unique  in this
@@ -314,7 +314,7 @@ original Reids about the RMW commands.
 ### 5.2 Non-RMW Command
 
 The Non-RMW command only performs a single read or write operation. For
-instance, The SET, GET, EXISTS of STRINGs strucutures. The behaviour of
+instance, The SET, GET, EXISTS of STRINGs structures. The behaviour of
 these commands are not different with the original Redis.
 
 ### 5.3 Transaction

--- a/docs/dev/service_levels.md
+++ b/docs/dev/service_levels.md
@@ -138,7 +138,7 @@ the conflicts are resolved as follows:
 
 ### Effective service level
 
-Actual values of service level's options may come from different service levels, not only from the one user is assigned with. This can be achived by assigning one role to another.
+Actual values of service level's options may come from different service levels, not only from the one user is assigned with. This can be achieved by assigning one role to another.
 
 For instance:
 There are 2 roles: role1 and role2. Role1 is assigned with sl1 (timeout = 2s, workload_type = interactive) and role2 is assigned with sl2 (timeout = 10s, workload_type = batch).

--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -395,7 +395,7 @@ CREATE TABLE system.config (
 
 The source of the option is one of 'default', 'config', 'cli', 'cql' or 'internal'
 which means the value wasn't changed from its default, was configured via config
-file, was set by commanline option or via updating this table, or was deliberately
+file, was set by commandline option or via updating this table, or was deliberately
 configured by Scylla internals. Any way the option was updated overrides the
 previous one, so shown here is the latest one used.
 

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -4,7 +4,7 @@ The topology state machine tracks all the nodes in a cluster,
 their state, properties (topology, tokens, etc) and requested actions.
 
 Node state can be one of those:
-- `none`             - the new node joined group0 but did not bootstraped yet (has no tokens and data to serve)
+- `none`             - the new node joined group0 but did not bootstrapped yet (has no tokens and data to serve)
 - `bootstrapping`    - the node is currently in the process of streaming its part of the ring
 - `decommissioning`  - the node is being decommissioned and stream its data to nodes that took over
 - `removing`         - the node is being removed and its data is streamed to nodes that took over from still alive owners

--- a/docs/getting-started/cloud-instance-recommendations.rst
+++ b/docs/getting-started/cloud-instance-recommendations.rst
@@ -9,7 +9,7 @@ Cloud Instance Recommendations for AWS, GCP, and Azure
 
 You can run your ScyllaDB workloads on AWS, GCE, and Azure using a ScyllaDB image. This page includes the recommended instance types to be used with ScyllaDB.
 
-.. TO DO: Add a link to the installatation section for cloud deployments - when the page is added.
+.. TO DO: Add a link to the installation section for cloud deployments - when the page is added.
 
 .. note:: 
 

--- a/docs/getting-started/install-scylla/install-on-linux.rst
+++ b/docs/getting-started/install-scylla/install-on-linux.rst
@@ -1,7 +1,7 @@
 .. |UBUNTU_SCYLLADB_LIST| replace:: scylla-5.4.list
 .. |CENTOS_SCYLLADB_REPO| replace:: scylla-5.4.repo
 
-.. The |RHEL_EPEL| variable needs to be adjuster per release, depening on support for RHEL.
+.. The |RHEL_EPEL| variable needs to be adjuster per release, depending on support for RHEL.
 .. 5.2 supports Rocky/RHEL 8 only
 .. 5.4 supports Rocky/RHEL 8 and 9
 .. |RHEL_EPEL_8| replace:: https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm

--- a/docs/getting-started/install-scylla/launch-on-gcp.rst
+++ b/docs/getting-started/install-scylla/launch-on-gcp.rst
@@ -37,7 +37,7 @@ Launching ScyllaDB on GCP
    
         gcloud compute instances create scylla-node1 --image scylladb-5-2-1 --image-project scylla-images --local-ssd interface=nvme --machine-type=n1-highmem-8
    
-   To add more storage to the VM, add multipe ``--local-ssd interface=nvm`` options to the command. For example, the following 
+   To add more storage to the VM, add multiple ``--local-ssd interface=nvm`` options to the command. For example, the following 
    command will launch a VM with 4 SSD, and 1.5TB of data (4 * `375 GB <https://cloud.google.com/compute/docs/disks/local-ssd>`_):
 
    .. code-block:: console

--- a/docs/getting-started/installation-common/scylla-web-installer.rst
+++ b/docs/getting-started/installation-common/scylla-web-installer.rst
@@ -42,7 +42,7 @@ You can run the command with the ``-h`` or ``--help`` flag to print information 
 Examples
 ---------
 
-Installing ScyllaDB Open Souce 4.6.1:
+Installing ScyllaDB Open Source 4.6.1:
 
 .. code:: console
 

--- a/docs/kb/cdc-experimental-upgrade.rst
+++ b/docs/kb/cdc-experimental-upgrade.rst
@@ -16,7 +16,7 @@ First, if you enabled CDC on any table (using ``with cdc = { ... }``), you shoul
 
 This should work even if you already upgraded, but preferably disable CDC on all tables before the upgrade.
 
-After disabling CDC and finishing the upgrade you can safely reenable it.
+After disabling CDC and finishing the upgrade you can safely re-enable it.
 
 The next step is running ``nodetool checkAndRepairCdcStreams``. Up to this point, Scylla may have periodically reported the following errors in its logs:
 

--- a/docs/kb/consistency.rst
+++ b/docs/kb/consistency.rst
@@ -81,7 +81,7 @@ and if so, it conducts the transaction. If the condition is not met, the transac
 Additional References
 ----------------------
 
-* `Jepsen and ScyllaDB: Putting Consistency to the Test blog post <hhttps://www.scylladb.com/2020/12/23/jepsen-and-scylla-putting-consistency-to-the-test/>`_ 
+* `Jepsen and ScyllaDB: Putting Consistency to the Test blog post <https://www.scylladb.com/2020/12/23/jepsen-and-scylla-putting-consistency-to-the-test/>`_ 
 * `Nauto: Achieving Consistency in an Eventually Consistent Environment blog post <https://www.scylladb.com/2020/02/20/nauto-achieving-consistency-in-an-eventually-consistent-environment/>`_ 
 * `Consistency Levels documentation <https://docs.scylladb.com/stable/cql/consistency.html>`_ 
 * `High Availability lesson on ScyllaDB University <https://university.scylladb.com/courses/scylla-essentials-overview/lessons/high-availability/>`_ 

--- a/docs/kb/scylla-limits-systemd.rst
+++ b/docs/kb/scylla-limits-systemd.rst
@@ -22,7 +22,7 @@ When running under systemd, Scylla enforces the **LimitNOFILE** and **LimitNPROC
 
 **LimitNPROC** - Maximum number of processes allowed to run in parallel (defaults to 8096)
 
-Even though Scylla's provided defaults are suitable for most workloads, there may be situations on which these values may need to be overriden.
+Even though Scylla's provided defaults are suitable for most workloads, there may be situations on which these values may need to be overridden.
 
 Before you start
 ----------------

--- a/docs/kb/seed-nodes.rst
+++ b/docs/kb/seed-nodes.rst
@@ -22,7 +22,7 @@ It allows nodes to discover the cluster ring topology on startup (when joining t
 -  Which token ranges are available
 -  Which nodes will own which tokens when a new node joins the cluster
 
-**Once the nodes have joined the clutser, seed node has no function.**
+**Once the nodes have joined the cluster, seed node has no function.**
      
 The first node in a new cluster needs to be a seed node.
 

--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -767,7 +767,7 @@ In addition to the `ScyllaDB Consume API <scylla-consume-api_>`_, the Lua bindin
 The listing uses the following terminology:
 
 * Attribute - a simple attribute accessible via ``obj.attribute_name``;
-* Method - a method operating on an instance of said type, invokable as ``obj:method()``;
+* Method - a method operating on an instance of said type, invocable as ``obj:method()``;
 * Magic method - magic methods defined in the metatable which define behaviour of these objects w.r.t. `Lua operators and more <http://www.lua.org/manual/5.4/manual.html#2.4>`_;
 
 The format of an attribute description is the following:
@@ -998,7 +998,7 @@ Scylla.new_ring_position()
 
 Creates a `Scylla.ring_position <scylla-ring-position-type_>`_ instance.
 
-Has severeal overloads:
+Has several overloads:
 
 * ``Scylla.new_ring_position(weight, key)``.
 * ``Scylla.new_ring_position(weight, token)``.
@@ -1060,7 +1060,7 @@ Currently used only for clustering positions.
 Attributes:
 
 * key (`Scylla.clustering_key <scylla-clustering-key-type_>`_) - the clustering key, ``nil`` if the position in partition represents the min or max clustering positions.
-* weight (integer) - weight of the position, either -1 (before key), 0 (at key) or 1 (after key). If key atribute is ``nil``, the weight is never 0.
+* weight (integer) - weight of the position, either -1 (before key), 0 (at key) or 1 (after key). If key attribute is ``nil``, the weight is never 0.
 
 Methods:
 
@@ -1090,7 +1090,7 @@ Attributes:
 
 * token (integer) - the token, ``nil`` if the ring position represents the min or max ring positions.
 * key (`Scylla.partition_key <scylla-partition-key-type_>`_) - the partition key, ``nil`` if the ring position represents a position before/after a token.
-* weight (integer) - weight of the position, either -1 (before key/token), 0 (at key) or 1 (after key/token). If key atribute is ``nil``, the weight is never 0.
+* weight (integer) - weight of the position, either -1 (before key/token), 0 (at key) or 1 (after key/token). If key attribute is ``nil``, the weight is never 0.
 
 Methods:
 

--- a/docs/operating-scylla/admin-tools/select-from-mutation-fragments.rst
+++ b/docs/operating-scylla/admin-tools/select-from-mutation-fragments.rst
@@ -7,7 +7,7 @@ SELECT * FROM MUTATION_FRAGMENTS() Statement
 .. note:: The target audience of this statement and therefore that of this document is people who are familiar with the internals of ScyllaDB.
 
 The ``SELECT * FROM MUTATION_FRAGMENTS()`` statement allows for reading the raw underlying mutations (data) from a table.
-This is indended to be used as a diagnostics tool to debug performance or correctness issues, where inspecting the raw underlying data, as scylla stores it, is desired.
+This is intended to be used as a diagnostics tool to debug performance or correctness issues, where inspecting the raw underlying data, as scylla stores it, is desired.
 So far this was only possible with sstables, using a tool like :doc:`Scylla SStable</operating-scylla/admin-tools/scylla-sstable>`.
 This statement allows inspecting the content of the row-cache, as well as that of individual memtables, in addition to individual sstables.
 
@@ -136,7 +136,7 @@ The kind of the mutation fragment, the row represents. One of:
 * ``partition end``
 
 
-This is the text representation of the ``enum class mutation_fragment_v2_kind``. Since this is a regular column, the human readeable name is used.
+This is the text representation of the ``enum class mutation_fragment_v2_kind``. Since this is a regular column, the human readable name is used.
 
 metadata
 ~~~~~~~~
@@ -146,7 +146,7 @@ This is uses the same JSON schema as :ref:`scylla sstable dump-data<scylla-sstab
 Content of ``metadata`` column for various mutation fragment kinds:
 
 +------------------------+-------------------------------------------------------------+
-| mutation frament kind  | Content                                                     |
+| mutation fragment kind | Content                                                     |
 +========================+=============================================================+
 | partition start        | ``{"tombstone": $TOMBSTONE}``                               |
 +------------------------+-------------------------------------------------------------+
@@ -176,7 +176,7 @@ Limitations and Peculiarities
 
 Data is read locally, from the node which receives the query, so replica is always the same node as the coordinator.
 The query cannot be migrated between nodes. If a query is paged, all its pages have to be served by the same coordinator. This is enforced, and any attempt to migrate the query to another coordinator will result in the query being aborted.
-Note that by default, drivers use round robin load balancing policies, and consequently they will attemp to read each page from a different coordinator.
+Note that by default, drivers use round robin load balancing policies, and consequently they will attempt to read each page from a different coordinator.
 
 
 The statement can output rows with a non-full clustering prefix.

--- a/docs/operating-scylla/nodetool.rst
+++ b/docs/operating-scylla/nodetool.rst
@@ -106,7 +106,7 @@ Operations that are not listed below are currently not available.
 * **getlogginglevels** - Get the runtime logging levels.
 * :doc:`gettraceprobability </operating-scylla/nodetool-commands/gettraceprobability>` - Displays the current trace probability value. 0 is disabled 1 is enabled.
 * :doc:`gossipinfo </operating-scylla/nodetool-commands/gossipinfo/>` - Shows the gossip information for the cluster.
-* :doc:`help </operating-scylla/nodetool-commands/help/>` - Display list of avilable nodetool commands.
+* :doc:`help </operating-scylla/nodetool-commands/help/>` - Display list of available nodetool commands.
 * :doc:`info </operating-scylla/nodetool-commands/info/>` - Print node information
 * :doc:`listsnapshots </operating-scylla/nodetool-commands/listsnapshots/>` - Lists all the snapshots along with the size on disk and true size.
 * **move** :code:`<new token>`- Move node on the token ring to a new token

--- a/docs/operating-scylla/procedures/cassandra-to-scylla-migration-process.rst
+++ b/docs/operating-scylla/procedures/cassandra-to-scylla-migration-process.rst
@@ -120,7 +120,7 @@ Procedure
 
 See the full code example `here <https://github.com/scylladb/scylla-code-samples/tree/master/dual_writes>`_
 
-3. On each Apache Cassandra node, take a snapshot for every keyspace using the :doc:`nodetool snapshot </operating-scylla/nodetool-commands/snapshot>` comand. This will flush all SSTables to disk and generate a ``snapshots`` folder with an epoch timestamp for each underlying table in that keyspace. 
+3. On each Apache Cassandra node, take a snapshot for every keyspace using the :doc:`nodetool snapshot </operating-scylla/nodetool-commands/snapshot>` command. This will flush all SSTables to disk and generate a ``snapshots`` folder with an epoch timestamp for each underlying table in that keyspace. 
 
    Folder path post snapshot: ``/var/lib/cassandra/data/keyspace/table-[uuid]/snapshots/[epoch_timestamp]/``
 

--- a/docs/operating-scylla/procedures/cluster-management/repair-based-node-operation.rst
+++ b/docs/operating-scylla/procedures/cluster-management/repair-based-node-operation.rst
@@ -15,7 +15,7 @@ RBNO is more robust, reliable, and safer for data consistency than streaming.
 In particular, a failed node operation can resume from the point it stopped -
 without sending data that has already been synced, which is a significant 
 time-saver when adding or removing large nodes. In addition, with RBNO enabled,
-you don't need to run repair befor or after node operations, such as replace
+you don't need to run repair before or after node operations, such as replace
 or removenode.
 
 RBNO is enabled for the following node operations:

--- a/docs/operating-scylla/procedures/tips/benchmark-tips.rst
+++ b/docs/operating-scylla/procedures/tips/benchmark-tips.rst
@@ -28,7 +28,7 @@ Scylla does everything it can to control queues in userspace and not in the OS/d
 Thus, it assumes the bandwidth that was measured by ``scylla_setup``.
 
 It is not that difficult to get the best performance out of Scylla. Mostly, it is automatically tuned as long as you do not work against the system.
-The remainder of this document contains the best practices to follow to make sure that Scylla keeps tuning itself and tht your performance has maximum results.
+The remainder of this document contains the best practices to follow to make sure that Scylla keeps tuning itself and that your performance has maximum results.
 
 Install Scylla Monitoring Stack
 -------------------------------

--- a/docs/operating-scylla/scylla-yaml.inc
+++ b/docs/operating-scylla/scylla-yaml.inc
@@ -128,7 +128,7 @@ For example:
    - listen_address: 2a05:d018:223:f00:971d:14af:6418:fe2d
    - broadcast_rpc_address: 2a05:d018:223:f00:971d:14af:6418:fe2d
 
-To enable IPv6 addressing, set the following paramerter in scylla.yaml:
+To enable IPv6 addressing, set the following parameter in scylla.yaml:
 
 .. code-block:: yaml
 

--- a/docs/operating-scylla/security/create-superuser.rst
+++ b/docs/operating-scylla/security/create-superuser.rst
@@ -10,7 +10,7 @@ During login, the credentials for the default superuser ``cassandra`` are read w
 a consistency level of QUORUM, whereas those for all other roles are read at LOCAL_ONE. 
 QUORUM may significantly impact performance, especially in multi-datacenter deployments.
 
-To prevent performance degradation and ensure better secuirty, we highly recommend creating 
+To prevent performance degradation and ensure better security, we highly recommend creating 
 a custom superuser. You should:
 
 #. Use the default ``cassandra`` superuser to log in.

--- a/docs/operating-scylla/security/gen-cqlsh-file.rst
+++ b/docs/operating-scylla/security/gen-cqlsh-file.rst
@@ -69,7 +69,7 @@ Procedure
         - CQL version that the cluster you are connecting to is using
         - If you are not sure run ``nodetool version``
       * - certfile
-        - Root certificate that was used to sign file specified with the ``usercert`` patameter
+        - Root certificate that was used to sign file specified with the ``usercert`` parameter
         - Applies to CA signed certificates
       * - userkey
         - Key certificate used for ``cqlsh``

--- a/docs/troubleshooting/large-partition-table.rst
+++ b/docs/troubleshooting/large-partition-table.rst
@@ -82,7 +82,7 @@ Configure
 ^^^^^^^^^
 
 Configure the detection thresholds of large partitions with the ``compaction_large_partition_warning_threshold_mb`` parameter (default: 1000MB)
-and the ``compaction_rows_count_warning_threshold`` paramater (default 100000)
+and the ``compaction_rows_count_warning_threshold`` parameter (default 100000)
 in the scylla.yaml configuration file.
 Partitions that are bigger than the size threshold and/or hold more than the rows count threshold are reported in the ``system.large_partitions`` table and generate a warning in the Scylla log (refer to :doc:`log </getting-started/logging/>`).
 

--- a/docs/troubleshooting/report-scylla-problem.rst
+++ b/docs/troubleshooting/report-scylla-problem.rst
@@ -81,7 +81,7 @@ In the event the ``/var/lib/scylla/coredump`` directory is empty, the following 
 Operating System not set to generate core dump files
 ....................................................
 
-If Scylla restarts for some reason and there is no core dump file, the OS system deamon needs to be modified.
+If Scylla restarts for some reason and there is no core dump file, the OS system daemon needs to be modified.
 
 **Procedure**
 

--- a/docs/troubleshooting/support/index.rst
+++ b/docs/troubleshooting/support/index.rst
@@ -14,7 +14,7 @@ Errors and Support
    <div class="panel callout radius animated">
             <div class="row">
               <div class="medium-3 columns">
-                <h5 id="getting-started">Scylla Errors and Suppport</h5>
+                <h5 id="getting-started">Scylla Errors and Support</h5>
               </div>
               <div class="medium-9 columns">
 

--- a/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-4.0-to-2020.1/metric-update-4.0-to-2020.1.rst
+++ b/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-4.0-to-2020.1/metric-update-4.0-to-2020.1.rst
@@ -5,9 +5,9 @@ Scylla Metric Update - Scylla 4.0 to Scylla Enterprise 2019.1
 
 The following metrics are new in Scylla Enterprise 2020.1 compared to Scylla Open Source 4.0:
 
-* *scylla_storage_proxy_coordinator_cas_dropped_prune* : How many times a coordinator did not perfom prune after cas
+* *scylla_storage_proxy_coordinator_cas_dropped_prune* : How many times a coordinator did not perform prune after cas
 * *scylla_storage_proxy_coordinator_cas_prune* : How many times paxos prune was done after successful cas operation
-* *scylla_storage_proxy_replica_cas_dropped_prune* : How many times a coordinator did not perfom prune after cas
+* *scylla_storage_proxy_replica_cas_dropped_prune* : How many times a coordinator did not perform prune after cas
 
 The following metrics are not available in Scylla Enterprise 2020.1 compared to Scylla Open Source 4.0:
 

--- a/docs/using-scylla/cdc/cdc-consistency.rst
+++ b/docs/using-scylla/cdc/cdc-consistency.rst
@@ -26,7 +26,7 @@ CDC operations have to follow CL of the base table operations
 As a consequence of the previously described CDC synchronous nature, CDC Log writes are done with the same CL as Base Table writes that cause those CDC Log writes.
 This means that in order to achieve strong consistency, the CDC Log has to be read with an appropriate CL level matching the CL of the Base Table writes.
 For example, if the Base Table writes are done with CL = ONE then the CDC Log needs to be read with CL = ALL.
-If the Base Table is written with CL = QUORUM then the CDC Log reads have to be performed with CL = QUROUM at least.
+If the Base Table is written with CL = QUORUM then the CDC Log reads have to be performed with CL = QUORUM at least.
 
 -------------------------------------------------
 When do CDC updates become visible to the client?

--- a/docs/using-scylla/cdc/cdc-intro.rst
+++ b/docs/using-scylla/cdc/cdc-intro.rst
@@ -46,7 +46,7 @@ but with CDC, you can also learn the history of all changes:
 Use cases for CDC
 -----------------
 
-Some examples where CDC may be benificial:
+Some examples where CDC may be beneficial:
 
 * Heterogeneous database replication: applying captured changes to another database or table. The other database may use a different schema (or no schema at all), better suited for some specific workloads. An example is replication to ElasticSearch for efficient text searches.
 * Implementing a notification system.

--- a/docs/using-scylla/cdc/cdc-log-table.rst
+++ b/docs/using-scylla/cdc/cdc-log-table.rst
@@ -60,7 +60,7 @@ When performing a modification to the base table, such as inserting or deleting 
 
 * the CDC options you use (e.g. whether pre-image is enabled or not),
 * the write action you perform: insert, update, row deletion, range deletion, or partition deletion,
-* types of affected collumns (notably collections require complex handling).
+* types of affected columns (notably collections require complex handling).
 
 There are different types of entries appearing in the CDC log:
 

--- a/docs/using-scylla/cdc/cdc-preimages.rst
+++ b/docs/using-scylla/cdc/cdc-preimages.rst
@@ -304,7 +304,7 @@ A possible strategy may be to distribute the partition keys between your client 
 Postimage rows
 --------------
 
-Postimage rows use the CDC value columns to show the state of each row affected by the write as it appears after the write is applied. To enable postimages pass the ``'postimage': true`` paramer to the ``cdc`` table option.
+Postimage rows use the CDC value columns to show the state of each row affected by the write as it appears after the write is applied. To enable postimages pass the ``'postimage': true`` parameter to the ``cdc`` table option.
 
 Postimages only appear for rows that were modified using ``UPDATE`` or ``INSERT``. No postimages are generated for range deletes, partition deletes and, unlike preimages, for row deletes (there is no additional information that a postimage would give compared to the delta for row deletes).
 

--- a/docs/using-scylla/integrations/scylla-cdc-source-connector.rst
+++ b/docs/using-scylla/integrations/scylla-cdc-source-connector.rst
@@ -9,7 +9,7 @@ Scylla CDC Source Connector
 
 Scylla CDC Source Connector is a source connector capturing row-level changes in the tables of a Scylla cluster. It is a Debezium connector, compatible with Kafka Connect (with Kafka 2.6.0+) and built on top of scylla-cdc-java library. The source code of the connector is available at `GitHub <https://github.com/scylladb/scylla-cdc-source-connector>`_.
 
-The connector reads the CDC log for specified tables and produces Kafka messages for each row-level ``INSERT``, ``UPDATE`` or ``DELETE`` operation. The connector is able to split reading the CDC log accross multiple processes: the connector can start a separate Kafka Connect task for reading each :doc:`Vnode of Scylla cluster </architecture/ringarchitecture/index>` allowing for high throughput. You can limit the number of started tasks by using ``tasks.max`` property.
+The connector reads the CDC log for specified tables and produces Kafka messages for each row-level ``INSERT``, ``UPDATE`` or ``DELETE`` operation. The connector is able to split reading the CDC log across multiple processes: the connector can start a separate Kafka Connect task for reading each :doc:`Vnode of Scylla cluster </architecture/ringarchitecture/index>` allowing for high throughput. You can limit the number of started tasks by using ``tasks.max`` property.
 
 Scylla CDC Source Connector seamlessly handles schema changes and topology changes (adding, removing nodes from Scylla cluster). The connector is fault-tolerant, retrying reading data from Scylla in case of failure. It periodically saves the current position in Scylla CDC log using Kafka Connect offset tracking (configurable by ``offset.flush.interval.ms`` parameter). If the connector is stopped, it is able to resume reading from previously saved offset. Scylla CDC Source Connector has at-least-once semantics.
 
@@ -17,7 +17,7 @@ The connector has the following capabilities:
 
 * Kafka Connect connector using Debezium framework
 * Replication of row-level changes from Scylla using :doc:`Scylla CDC <../cdc/cdc-intro>`. The connector replicates the following operations: ``INSERT``, ``UPDATE``, ``DELETE`` (single row deletes)
-* High scalability - able to split work accross multiple Kafka Connect workers
+* High scalability - able to split work across multiple Kafka Connect workers
 * Fault tolerant - connector periodically saves its progress and can resume from previously saved offset (with at-least-once semantics)
 * Support for many standard Kafka Connect converters, such as JSON and Avro
 * Compatible with standard Kafka Connect transformations

--- a/docs/using-scylla/secondary-indexes.rst
+++ b/docs/using-scylla/secondary-indexes.rst
@@ -34,7 +34,7 @@ Scylla breaks indexed queries into two parts:
 
 .. image:: si_building_example.png
    :width: 800
-   :alt: Seconday Index Flow
+   :alt: Secondary Index Flow
 
 In the example above:
 
@@ -127,7 +127,7 @@ Note that you can use the ``DESCRIBE`` command to see the whole schema for the b
    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
    ...
 
-Note the Secondary Index is implemeted as MATERIALIZED VIEW.
+Note the Secondary Index is implemented as MATERIALIZED VIEW.
 
 
 More information 


### PR DESCRIPTION
Using codespell, went over the docs and fixed some typos.

Refs: https://github.com/scylladb/scylladb/issues/16255