### PR TITLE
commitlog.hh: Fix numeric constant for file format version 3 to be actual '3'

### DIFF
--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -134,7 +134,7 @@ public:
 
         static inline constexpr uint32_t segment_version_1 = 1u;
         static inline constexpr uint32_t segment_version_2 = 2u;
-        static inline constexpr uint32_t segment_version_3 = 4u;
+        static inline constexpr uint32_t segment_version_3 = 3u;
         static inline constexpr uint32_t current_version = segment_version_3;
 
         descriptor(descriptor&&) noexcept = default;


### PR DESCRIPTION
Fixes #16277

When the PR for 'tagged pages' was submitted for RFC, it was assumed that PR #12849 (compression) would be committed first. The latter introduced v3 format, and the format in #12849 (tagged pages) was assumed to have to be bumped to 4.

This ended up not the case, and I missed that the code went in with file format tag numeric value being '4' (and constant named v3).

While not detrimental, it is confusing, and should be changed asap (before anything depends on files with the tag applied).