### PR TITLE
gms/inet_address: pass sstring param by std::move()

### DIFF
--- a/gms/inet_address.cc
+++ b/gms/inet_address.cc
@@ -24,7 +24,7 @@ static_assert(std::is_nothrow_copy_constructible_v<gms::inet_address>);
 static_assert(std::is_nothrow_move_constructible_v<gms::inet_address>);
 
 future<gms::inet_address> gms::inet_address::lookup(sstring name, opt_family family, opt_family preferred) {
-    return seastar::net::dns::get_host_by_name(name, family).then([preferred](seastar::net::hostent&& h) {
+    return seastar::net::dns::get_host_by_name(std::move(name), family).then([preferred](seastar::net::hostent&& h) {
         for (auto& addr : h.addr_list) {
             if (!preferred || addr.in_family() == preferred) {
                 return gms::inet_address(addr);


### PR DESCRIPTION
less overhead this way. the caller of lookup() always passes
a rvalue reference. and seastar::dns::get_host_by_name() actually
moves away from the parameter, so let's pass by std::move() for
slightly better performance, and to match the expectation of
the underlying seastar API.
