### PR TITLE
gms/inet_address: remove unused '#include'

### DIFF
--- a/gms/inet_address.cc
+++ b/gms/inet_address.cc
@@ -8,14 +8,12 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
-#include <iomanip>
 #include <boost/io/ios_state.hpp>
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/dns.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/future.hh>
 #include "inet_address.hh"
-#include "utils/to_string.hh"
 
 using namespace seastar;
 


### PR DESCRIPTION
neither <iomanip> nor "utils/to_string.hh" is used in `gms/inet_address.cc`, so let's remove their "#include"s.