### PR TITLE
.git: add codespell workflow

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -1,0 +1,20 @@
+name: codespell
+on:
+  pull_request:
+    branches:
+      - master
+      - enterprise
+permissions: {}
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: codespell-project/actions-codespell@master
+        with:
+          only_warn: 1
+          ignore_words_list: "ser"
+          skip: "./.git,build/*,tools/*,*.js,*.thrift,test/*"


### PR DESCRIPTION
to identify misspelling in the code.

The GitHub actions in this workflow run codespell when a new pull
request is created targetting master or enterprise branch. Errors
will be annotated in the pull request. A new entry along with the
existing tests like build, unit test and dtest will be added to the
"checks" shown in github PR web UI. one can follow the "Details" to
find the details of the errors.

unfortunately, this check checks all text files unless they
are explicitly skipped, not just the new ones added / changed in the
PR under test. in other words, if there are 42 misspelling
errors in master, and you are adding a new one in your PR,
this workflow shows all of the 43 errors -- both the old
and new ones.

the misspelling in the code hurts the user experience and some
time developer's experience, but the text files under test/cql
can be sensitive to the text, sometimes, a tiny editing could
break the test, so it is added to the skip list.

So far, we don't consider the errors are just represented for
information purpose, so even if the check fails, it is not considered
as blockers for merging the tested PR. we can change this in github's
Branch protectionn rule on a per-branch basis.


