### PR TITLE
Generalize atomic sstables deletion

### DIFF
--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -276,7 +276,7 @@ public:
     // until all shards agree it can be deleted.
     //
     // This function only solves the second problem for now.
-    static future<> delete_with_pending_deletion_log(std::vector<shared_sstable> ssts);
+
     // Creates the deletion log for atomic deletion of sstables (helper for the
     // above function that's also used by tests)
     // Returns a pair of "logilfe name" and "directory with sstables"

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -75,6 +75,8 @@ public:
     virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const override {
         return sstable_directory::delete_with_pending_deletion_log;
     }
+    virtual future<atomic_delete_context> atomic_delete_prepare(const std::vector<shared_sstable>&) const override;
+    virtual future<> atomic_delete_complete(atomic_delete_context ctx) const override;
     virtual future<> remove_by_registry_entry(entry_descriptor desc) override;
 
     virtual sstring prefix() const override { return _dir; }
@@ -457,6 +459,14 @@ future<> filesystem_storage::wipe(const sstable& sst, sync_dir sync) noexcept {
     }
 }
 
+future<atomic_delete_context> filesystem_storage::atomic_delete_prepare(const std::vector<shared_sstable>& ssts) const {
+    co_return nullptr;
+}
+
+future<> filesystem_storage::atomic_delete_complete(atomic_delete_context ctx_) const {
+    co_return;
+}
+
 future<> filesystem_storage::remove_by_registry_entry(entry_descriptor desc) {
     on_internal_error(sstlog, "Filesystem storage doesn't keep its entries in registry");
 }
@@ -497,6 +507,8 @@ public:
     virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const override {
         return delete_with_system_keyspace;
     }
+    virtual future<atomic_delete_context> atomic_delete_prepare(const std::vector<shared_sstable>&) const override;
+    virtual future<> atomic_delete_complete(atomic_delete_context ctx) const override;
     virtual future<> remove_by_registry_entry(entry_descriptor desc) override;
 
     virtual sstring prefix() const override { return _location; }
@@ -564,6 +576,14 @@ future<> s3_storage::wipe(const sstable& sst, sync_dir) noexcept {
     });
 
     co_await sys_ks.sstables_registry_delete_entry(_location, sst.generation());
+}
+
+future<atomic_delete_context> s3_storage::atomic_delete_prepare(const std::vector<shared_sstable>&) const {
+    co_return nullptr;
+}
+
+future<> s3_storage::atomic_delete_complete(atomic_delete_context ctx) const {
+    co_return;
 }
 
 future<> s3_storage::remove_by_registry_entry(entry_descriptor desc) {

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -31,6 +31,11 @@ class delayed_commit_changes;
 class sstable;
 class sstables_manager;
 class entry_descriptor;
+class atomic_delete_context_impl {
+public:
+    virtual ~atomic_delete_context_impl() {}
+};
+using atomic_delete_context = std::unique_ptr<atomic_delete_context_impl>;
 
 class storage {
     friend class test;
@@ -63,6 +68,8 @@ public:
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) = 0;
     virtual future<> destroy(const sstable& sst) = 0;
     virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const = 0;
+    virtual future<atomic_delete_context> atomic_delete_prepare(const std::vector<shared_sstable>&) const = 0;
+    virtual future<> atomic_delete_complete(atomic_delete_context ctx) const = 0;
     virtual future<> remove_by_registry_entry(entry_descriptor desc) = 0;
 
     virtual sstring prefix() const  = 0;

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -67,7 +67,6 @@ public:
     virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) = 0;
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) = 0;
     virtual future<> destroy(const sstable& sst) = 0;
-    virtual noncopyable_function<future<>(std::vector<shared_sstable>)> atomic_deleter() const = 0;
     virtual future<atomic_delete_context> atomic_delete_prepare(const std::vector<shared_sstable>&) const = 0;
     virtual future<> atomic_delete_complete(atomic_delete_context ctx) const = 0;
     virtual future<> remove_by_registry_entry(entry_descriptor desc) = 0;


### PR DESCRIPTION
The current implementation starts in sstables_manager that gets the deletion function from storage which, in turn, should atomically do sst.unlink() over a list of sstables (s3 driver is still not atomic though #13567).

This PR generalizes the atomic deletion inside sstables_manager method and removes the atomic deletor function that nobody liked when it was introduced (#13562)