### PR TITLE
compaction, api: drop unused functions

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -130,25 +130,6 @@ std::vector<table_info> parse_table_infos(const sstring& ks_name, http_context& 
     return parse_table_infos(ks_name, ctx, it != query_params.end() ? it->second : "");
 }
 
-// Run on all tables, skipping dropped tables
-future<> run_on_existing_tables(sstring op, replica::database& db, std::string_view keyspace, const std::vector<table_info> local_tables, std::function<future<> (replica::table&)> func) {
-    std::exception_ptr ex;
-    for (const auto& ti : local_tables) {
-        apilog.debug("Starting {} on {}.{}", op, keyspace, ti);
-        try {
-            co_await func(db.find_column_family(ti.id));
-        } catch (const replica::no_such_column_family& e) {
-            apilog.warn("Skipping {} of {}.{}: {}", op, keyspace, ti, e.what());
-        } catch (...) {
-            ex = std::current_exception();
-            apilog.error("Failed {} of {}.{}: {}", op, keyspace, ti, ex);
-        }
-        if (ex) {
-            co_await coroutine::return_exception_ptr(std::move(ex));
-        }
-    }
-}
-
 static ss::token_range token_range_endpoints_to_json(const dht::token_range_endpoints& d) {
     ss::token_range r;
     r.start_token = d._start_token;

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -205,13 +205,6 @@ future<> run_on_table(sstring op, replica::database& db, std::string keyspace, t
     }
 }
 
-// Run on all tables, skipping dropped tables
-future<> run_on_existing_tables(sstring op, replica::database& db, std::string keyspace, const std::vector<table_info> local_tables, std::function<future<> (replica::table&)> func) {
-    for (const auto& ti : local_tables) {
-        co_await run_on_table(op, db, keyspace, ti, func);
-    }
-}
-
 future<> wait_for_your_turn(seastar::condition_variable& cv, tasks::task_manager::task_ptr& current_task, tasks::task_id id) {
     co_await cv.wait([&] {
         return current_task && current_task->id() == id;


### PR DESCRIPTION
run_on_existing_tables() is not used at all. and we have two of them. in this change, let's drop them.