### PR TITLE
docs: add myst extension

### DIFF
--- a/docs/alternator/alternator.md
+++ b/docs/alternator/alternator.md
@@ -201,7 +201,7 @@ want modify a non-top-level attribute directly (e.g., a.b[3].c) need RMW:
 Alternator implements such requests by reading the entire top-level
 attribute a, modifying only a.b[3].c, and then writing back a.
 
-```eval_rst
+```{eval-rst}
 .. toctree::
     :maxdepth: 2
 

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -178,7 +178,7 @@ feature's implementation is still subject to change and upgrades may not be
 possible if such a feature is used. For these reasons, experimental features
 are not recommended for mission-critical uses, and they need to be
 individually enabled with the "--experimental-features" configuration option.
-See [Enabling Experimental Features](/operating-scylla/admin#enabling-experimental-features) for details.
+See [Enabling Experimental Features](../operating-scylla/admin.rst#enabling-experimental-features) for details.
 
 In this release, the following DynamoDB API features are considered
 experimental:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,15 +35,15 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx_sitemap",
     "sphinx_scylladb_theme",
-    "sphinx_multiversion",  # optional
-    "recommonmark",  # optional
+    "sphinx_multiversion",
+    "sphinx_scylladb_markdown",
     "sphinxcontrib.datatemplates",
     "scylladb_cc_properties",
     "scylladb_aws_images"
 ]
 
 # The suffix(es) of source filenames.
-source_suffix = [".rst", ".md"]
+source_suffix = ['.rst']
 
 # The master toctree document.
 master_doc = "index"
@@ -73,6 +73,11 @@ notfound_template = "404.html"
 
 # Prefix added to all the URLs generated in the 404 page.
 notfound_urls_prefix = ""
+
+# -- Options for markdown extension
+scylladb_markdown_enable = True
+scylladb_markdown_recommonmark_versions = ['branch-5.1', 'branch-5.2', 'branch-5.4']
+suppress_warnings = ["myst.xref_missing"]
 
 # -- Options for sitemap extension
 
@@ -149,15 +154,3 @@ html_baseurl = BASE_URL
 
 # Dictionary of values to pass into the template engine’s context for all pages
 html_context = {"html_baseurl": html_baseurl}
-
-# -- Initialize Sphinx
-def setup(sphinx):
-    warnings.filterwarnings(
-        action="ignore",
-        category=UserWarning,
-        message=r".*Container node skipped.*",
-    )
-    sphinx.add_config_value('recommonmark_config', {
-        'enable_eval_rst': True,
-    }, True)
-    sphinx.add_transform(AutoStructify)

--- a/docs/cql/cql-extensions.md
+++ b/docs/cql/cql-extensions.md
@@ -79,7 +79,7 @@ and to the TRUNCATE data definition query.
 
 In addition, the timeout parameter can be applied to SELECT queries as well.
 
-```eval_rst 
+```{eval-rst}
 .. _keyspace-storage-options:
  ```
  

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -8,15 +8,14 @@ authors = ["ScyllaDB Contributors"]
 python = "^3.9"
 pyyaml = "6.0.1"
 pygments = "2.15.1"
-recommonmark = "0.7.1"
+redirects_cli ="~0.1.2"
 sphinx-scylladb-theme = "~1.6.1"
 sphinx-sitemap = "2.5.1"
 sphinx-autobuild = "2021.3.14"
 Sphinx = "7.2.6"
 sphinx-multiversion-scylla = "~0.3.1"
-sphinx-markdown-tables = "0.0.15"
-redirects_cli ="~0.1.2"
 sphinxcontrib-datatemplates = "^0.9.2"
+sphinx-scylladb-markdown = "^0.1.2"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/168

Replaces [recommonmark](https://recommonmark.readthedocs.io/en/latest/) (deprecated) for [Myst Parser](https://myst-parser.readthedocs.io/en/latest/).

## How to test

1. Build the docs.
2. Alternator docs (.md) should render without errors.