### PR TITLE
Docs: Improve wording on repair-based-node-operation

### DIFF
--- a/docs/operating-scylla/procedures/cluster-management/repair-based-node-operation.rst
+++ b/docs/operating-scylla/procedures/cluster-management/repair-based-node-operation.rst
@@ -11,12 +11,9 @@ By default, the row-level repair mechanism used for the repair process is also
 used during node operations (instead of streaming). We refer to it as 
 Repair-Based Node Operations (RBNO).
 
-RBNO is more robust, reliable, and safer for data consistency than streaming.
-In particular, a failed node operation can resume from the point it stopped -
-without sending data that has already been synced, which is a significant 
-time-saver when adding or removing large nodes. In addition, with RBNO enabled,
-you don't need to run repair befor or after node operations, such as replace
-or removenode.
+RBNO provides a more robust, reliable, and safer data streaming for node operations like node-replace and node-add/remove. 
+In particular, a failed node operation can resume from the point it stopped - without sending data that has already been synced. 
+In addition, with RBNO enabled, you don’t need to repair before or after node operations, such as replace or removenode.
 
 RBNO is enabled for the following node operations:
 


### PR DESCRIPTION
Remove a minor typo ("befor") and rewrite the entire paragraph, making it shorter and clearer.