### PR TITLE
RFC - move the metrics descriptions to a dedicated file

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -45,7 +45,7 @@
 
 #include "idl/position_in_partition.dist.hh"
 #include "idl/partition_checksum.dist.hh"
-
+#include "repair_description.hh"
 using namespace std::chrono_literals;
 
 logging::logger rlogger("repair");
@@ -71,17 +71,17 @@ node_ops_metrics::node_ops_metrics(shared_ptr<repair::task_manager_module> modul
     auto ops_label_type = sm::label("ops");
     _metrics.add_group("node_ops", {
         sm::make_gauge("finished_percentage", [this] { return bootstrap_finished_percentage(); },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("bootstrap")}),
+                node_ops_finished_percentage , {ops_label_type("bootstrap")}),
         sm::make_gauge("finished_percentage", [this] { return replace_finished_percentage(); },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("replace")}),
+                node_ops_finished_percentage, {ops_label_type("replace")}),
         sm::make_gauge("finished_percentage", [this] { return rebuild_finished_percentage(); },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("rebuild")}),
+                node_ops_finished_percentage, {ops_label_type("rebuild")}),
         sm::make_gauge("finished_percentage", [this] { return decommission_finished_percentage(); },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("decommission")}),
+                node_ops_finished_percentage, {ops_label_type("decommission")}),
         sm::make_gauge("finished_percentage", [this] { return removenode_finished_percentage(); },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("removenode")}),
+                node_ops_finished_percentage, {ops_label_type("removenode")}),
         sm::make_gauge("finished_percentage", [this] { return repair_finished_percentage(); },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("repair")}),
+                node_ops_finished_percentage, {ops_label_type("repair")}),
     });
 }
 

--- a/repair/repair_description.hh
+++ b/repair/repair_description.hh
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+
+#include <seastar/core/metrics.hh>
+
+/*
+ * The following macro will be part of metrics.hh
+ * It's here just for the RFC
+ * Using a macro will allow future changes, such as centralizing
+ * registration.
+ */
+#define METRICS_DESCRIPTION(m, d) static sm::description m(d)
+
+
+
+namespace sm = seastar::metrics;
+
+METRICS_DESCRIPTION(node_ops_finished_percentage, "Finished percentage of node operation on this shard");


### PR DESCRIPTION
This series acts as an RFC for a greater change. The problem it solves is the complexity of following what metrics we have and their documentation (descriptions).

The suggested solution adds an additional header file for each file that contains descriptions, in this PR there is just one file (repair.cc), which just happens to have one description, making it easier to follow.

What I would like to achieve with this RFC:
1. Agree on the way to split code - I suggest placing it as static variables ~~inline in a class~~, with the plus side that it's a regular C++ code and would be recognized by IDE; there are alternatives.
2. Scope naming: each such header file is included by only one file, I didn't use a namespace to make it easier to use inside the code.
3. file naming, we can add a suffix before or instead of .hh; for example, for repair.cc, the description file could be reapir.descriptions.hh,  reapair_descriptions.hh, or reapair.hd

Relates to #16136 

Once there is an agreement on all those topics, I'll send a PR that moves all metrics descriptions to external files.

General note: please see the above 3 bullets that need to be addressed.
Implementation notes:
a. We don't want to add an extra dependency (a single file), which would hurt the compilation
b. It's easier to add header files than source files (no need to update the compilation config)
c. A solution should be easy for an IDE
d. We cannot rely on run-time. Some of the metrics may not be registered in run time, for example, Alternator metrics when not using Alternator.
e. Think of two personas: a developer who needs to find a metric inside the code and the doc team who needs to change the descriptions.

