### PR TITLE
raft_rpc: use compat source location instead of std one

### DIFF
--- a/service/raft/raft_rpc.cc
+++ b/service/raft/raft_rpc.cc
@@ -20,7 +20,7 @@ namespace service {
 
 static seastar::logger rlogger("raft_rpc");
 
-using sloc = std::source_location;
+using sloc = seastar::compat::source_location;
 
 raft_ticker_type::time_point timeout() {
     return raft_ticker_type::clock::now() + raft_tick_interval * (raft::ELECTION_TIMEOUT.count() / 2);

--- a/service/raft/raft_rpc.hh
+++ b/service/raft/raft_rpc.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <seastar/core/gate.hh>
+#include "seastar/util/std-compat.hh"
 #include "raft/raft.hh"
 #include "message/messaging_service_fwd.hh"
 #include "utils/UUID.hh"
@@ -38,10 +39,10 @@ private:
     enum class one_way_kind { request, reply };
 
     template <one_way_kind rpc_kind, typename Verb, typename Msg> void
-    one_way_rpc(std::source_location loc, raft::server_id id, Verb&& verb, Msg&& msg);
+    one_way_rpc(seastar::compat::source_location loc, raft::server_id id, Verb&& verb, Msg&& msg);
 
     template <typename Verb, typename... Args> auto
-    two_way_rpc(std::source_location loc, raft::server_id id, Verb&& verb, Args&&... args);
+    two_way_rpc(seastar::compat::source_location loc, raft::server_id id, Verb&& verb, Args&&... args);
 
 public:
     future<raft::snapshot_reply> send_snapshot(raft::server_id server_id, const raft::install_snapshot& snap, seastar::abort_source& as) override;


### PR DESCRIPTION
The std::source_location is broken on some versions of clang. In order to be able to use its functionality in code, seastar defines seastar::compat::source_location, which is a typedef over std::source_location if the latter works, or s custom, dummy implementation if the std type doesn't work. Therefore, sometimes seastar::compat::source_location == std::source_location, but not always.

In service/raft/raft_rpc.cc, both std source location and compat source location are used and std source location sometimes passed as an argument to compat source location, breaking builds on older toolchains. Fix this by switching the code there to only use compat source location.

Fixes: scylladb/scylladb#16336