### PR TITLE
docker: put cqlsh configuration in correct place

### DIFF
--- a/dist/docker/scyllasetup.py
+++ b/dist/docker/scyllasetup.py
@@ -75,7 +75,8 @@ class ScyllaSetup:
             hostname = self._listenAddress
         else:
             hostname = subprocess.check_output(['hostname', '-i']).decode('ascii').strip()
-        with open("%s/.cqlshrc" % home, "w") as cqlshrc:
+        self._run(["mkdir", "-p",  "%s/.cassandra" % home])
+        with open("%s/.cassandra/cqlshrc" % home, "w") as cqlshrc:
             cqlshrc.write("[connection]\nhostname = %s\n" % hostname)
 
     def set_housekeeping(self):


### PR DESCRIPTION
since always we were putting cqlsh configuration into `~/.cqlshrc` acording to commit from 8 years ago [1], this path is deprecated.

until this commit [2], actully remove this path from cqlsh code

as part of moving to scylla-cqlsh, we got [2], and didn't notice until the first release with it.

this change write the configuration into `~/.casssndra/cqlshrc` as this is the default place cqlsh is looking.

[1]: https://github.com/scylladb/scylla-cqlsh/blame/13ea8a6669979b068ab04aac14f7826172c6d1cd/bin/cqlsh.py#L264
[2]: https://github.com/scylladb/scylla-cqlsh/commit/2024ea4796b928cb6dd8502783bb270bc67dcbcf
Fixes: scylladb/scylladb#16329