### PR TITLE
storage_service: pass local host's host id when formatting it

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6846,7 +6846,7 @@ future<> storage_service::move_tablet(table_id table, dht::token token, locator:
             throw std::runtime_error(format("Unknown host: {}", dst.host));
         }
         if (dst.shard >= node->get_shard_count()) {
-            throw std::runtime_error(format("Host {} does not have shard {}", dst.shard));
+            throw std::runtime_error(format("Host {} does not have shard {}", *node, dst.shard));
         }
         if (src.host == dst.host) {
             throw std::runtime_error("Migrating within the same node is not supported");


### PR DESCRIPTION
before this change, we use the format string of
"Host {} does not have shard {}", but fail to include the host id as `seastar::format()`'s arguments. this fails the compile-time check of fmt, which is yet merged. so, if we really run into this problem, {fmt} would throw before the intended `runtime_error` is raised -- currently, seastar::log formats the logging messages at runtime, this is not intended.

in this change, we pass local host's host id, so it can be formatted, and the intended exception can be raised.

Refs 1f57d1ea