### PR TITLE
tools/scylla-nodetool: implement additional commands, part 5/N 

### DIFF
--- a/test/nodetool/test_logging.py
+++ b/test/nodetool/test_logging.py
@@ -1,0 +1,20 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from rest_api_mock import expected_request
+
+
+def test_getlogginglevels(nodetool):
+    res = nodetool("getlogginglevels", expected_requests=[
+        expected_request("GET", "/storage_service/logging_level",
+                         response=[{"key": "sstable", "value": "info"}, {"key": "cache", "value": "trace"}])])
+
+    assert res == \
+"""
+Logger Name                                        Log Level
+sstable                                                 info
+cache                                                  trace
+"""

--- a/test/nodetool/test_logging.py
+++ b/test/nodetool/test_logging.py
@@ -5,6 +5,7 @@
 #
 
 from rest_api_mock import expected_request
+import utils
 
 
 def test_getlogginglevels(nodetool):
@@ -18,3 +19,24 @@ Logger Name                                        Log Level
 sstable                                                 info
 cache                                                  trace
 """
+
+
+def test_setlogginglevel(nodetool):
+    nodetool("setlogginglevel", "wasm", "trace", expected_requests=[
+        expected_request("POST", "/system/logger/wasm", params={"level": "trace"})])
+
+
+def test_setlogginglevel_reset_logger(nodetool, scylla_only):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("setlogginglevel", "wasm"),
+            {"expected_requests": []},
+            ["error processing arguments: resetting logger(s) is not supported yet, the logger and level parameters are required"])
+
+
+def test_setlogginglevel_reset_all_loggers(nodetool, scylla_only):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("setlogginglevel",),
+            {"expected_requests": []},
+            ["error processing arguments: resetting logger(s) is not supported yet, the logger and level parameters are required"])

--- a/test/nodetool/test_nodeops.py
+++ b/test/nodetool/test_nodeops.py
@@ -10,3 +10,13 @@ from rest_api_mock import expected_request
 def test_decommission(nodetool):
     nodetool("decommission", expected_requests=[
         expected_request("POST", "/storage_service/decommission")])
+
+
+def test_rebuild(nodetool):
+    nodetool("rebuild", expected_requests=[
+        expected_request("POST", "/storage_service/rebuild")])
+
+
+def test_rebuild_with_dc(nodetool):
+    nodetool("rebuild", "DC1", expected_requests=[
+        expected_request("POST", "/storage_service/rebuild", params={"source_dc": "DC1"})])

--- a/test/nodetool/test_nodeops.py
+++ b/test/nodetool/test_nodeops.py
@@ -1,0 +1,12 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from rest_api_mock import expected_request
+
+
+def test_decommission(nodetool):
+    nodetool("decommission", expected_requests=[
+        expected_request("POST", "/storage_service/decommission")])

--- a/test/nodetool/test_refresh.py
+++ b/test/nodetool/test_refresh.py
@@ -1,0 +1,54 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import pytest
+from rest_api_mock import expected_request
+import utils
+
+
+def test_refresh(nodetool):
+    nodetool("refresh", "ks", "tbl", expected_requests=[
+        expected_request("POST", "/storage_service/sstables/ks", params={"cf": "tbl"})])
+
+
+@pytest.mark.parametrize("load_and_stream_opt", ["--load-and-stream", "-las"])
+def test_refresh_load_and_stream(nodetool, load_and_stream_opt):
+    nodetool("refresh", "ks", "tbl", load_and_stream_opt, expected_requests=[
+        expected_request("POST", "/storage_service/sstables/ks", params={"cf": "tbl", "load_and_stream": "true"})])
+
+
+@pytest.mark.parametrize("load_and_stream_opt", ["--load-and-stream", "-las"])
+@pytest.mark.parametrize("primary_replica_only_opt", ["--primary-replica-only", "-pro"])
+def test_refresh_load_and_stream_and_primary_replica_only(nodetool, load_and_stream_opt, primary_replica_only_opt):
+    nodetool("refresh", "ks", "tbl", load_and_stream_opt, primary_replica_only_opt, expected_requests=[
+        expected_request("POST", "/storage_service/sstables/ks",
+                         params={"cf": "tbl", "load_and_stream": "true", "primary_replica_only": "true"})])
+
+
+def test_refresh_no_table(nodetool):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("refresh", "ks"),
+            {"expected_requests": []},
+            ["nodetool: refresh requires ks and cf args",
+             "error processing arguments: required parameters are missing: keyspace and/or table"])
+
+
+def test_refresh_no_table_no_keyspace(nodetool):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("refresh",),
+            {"expected_requests": []},
+            ["nodetool: refresh requires ks and cf args",
+             "error processing arguments: required parameters are missing: keyspace and/or table"])
+
+
+def test_refresh_primary_replica_only(nodetool, scylla_only):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("refresh", "ks", "tbl", "--primary-replica-only"),
+            {"expected_requests": []},
+            ["error processing arguments: --primary-replica-only|-pro takes no effect without --load-and-stream|-las"])

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -491,6 +491,10 @@ void listsnapshots_operation(scylla_rest_client& client, const bpo::variables_ma
     fmt::print(std::cout, "\nTotal TrueDiskSpaceUsed: {}\n\n", format_hr_size(utils::to_hr_size(true_size)));
 }
 
+void move_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    throw std::invalid_argument("This operation is not supported");
+}
+
 void help_operation(const tool_app_template::config& cfg, const bpo::variables_map& vm) {
     if (vm.count("command")) {
         const auto command = vm["command"].as<sstring>();
@@ -1017,6 +1021,20 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
                 { },
             },
             listsnapshots_operation
+        },
+        {
+            {
+                "move",
+                "Move the token to this node",
+R"(
+This operation is not supported.
+)",
+                { },
+                {
+                    typed_option<sstring>("new-token", "The new token to move to this node", 1),
+                },
+            },
+            move_operation
         },
         {
             {

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -585,6 +585,13 @@ void removenode_operation(scylla_rest_client& client, const bpo::variables_map& 
     }
 }
 
+void setlogginglevel_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    if (!vm.count("logger") || !vm.count("level")) {
+        throw std::invalid_argument("resetting logger(s) is not supported yet, the logger and level parameters are required");
+    }
+    client.post(format("/system/logger/{}", vm["logger"].as<sstring>()), {{"level", vm["level"].as<sstring>()}});
+}
+
 void settraceprobability_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     if (!vm.count("trace_probability")) {
         throw std::invalid_argument("required parameters are missing: trace_probability");
@@ -1051,6 +1058,23 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
                 },
             },
             removenode_operation
+        },
+        {
+            {
+                "setlogginglevel",
+                "Sets the level log threshold for a given logger during runtime",
+R"(
+Resetting the log level of one or all loggers is not supported yet.
+
+Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/setlogginglevel.html
+)",
+                { },
+                {
+                    typed_option<sstring>("logger", "The logger to set the log level for, if unspecified, all loggers are reset to the default level", 1),
+                    typed_option<sstring>("level", "The log level to set, one of (trace, debug, info, warn and error), if unspecified, default level is reset to default log level", 1),
+                },
+            },
+            setlogginglevel_operation
         },
         {
             {

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -540,6 +540,14 @@ void help_operation(const tool_app_template::config& cfg, const bpo::variables_m
     }
 }
 
+void rebuild_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    std::unordered_map<sstring, sstring> params;
+    if (vm.count("source-dc")) {
+        params["source_dc"] = vm["source-dc"].as<sstring>();
+    }
+    client.post("/storage_service/rebuild", std::move(params));
+}
+
 void settraceprobability_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     if (!vm.count("trace_probability")) {
         throw std::invalid_argument("required parameters are missing: trace_probability");
@@ -955,6 +963,26 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
                 { },
             },
             listsnapshots_operation
+        },
+        {
+            {
+                "rebuild",
+                "Rebuilds a node’s data by streaming data from other nodes in the cluster (similarly to bootstrap)",
+R"(
+Rebuild operates on multiple nodes in a Scylla cluster. It streams data from a
+single source replica when rebuilding a token range. When executing the command,
+Scylla first figures out which ranges the local node (the one we want to rebuild)
+is responsible for. Then which node in the cluster contains the same ranges.
+Finally, Scylla streams the data to the local node.
+
+Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/rebuild.html
+)",
+                { },
+                {
+                    typed_option<sstring>("source-dc", "DC from which to stream data (default: any DC)", 1),
+                },
+            },
+            rebuild_operation
         },
         {
             {

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -347,6 +347,11 @@ void compactionhistory_operation(scylla_rest_client& client, const bpo::variable
     }
 }
 
+
+void decommission_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    client.post("/storage_service/decommission");
+}
+
 void disableautocompaction_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     if (!vm.count("keyspace")) {
         for (const auto& keyspace :  get_keyspaces(client)) {
@@ -772,6 +777,16 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
                 },
             },
             compactionhistory_operation
+        },
+        {
+            {
+                "decommission",
+                "Deactivate a selected node by streaming its data to the next node in the ring",
+R"(
+Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/decommission.html
+)",
+            },
+            decommission_operation
         },
         {
             {

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -423,6 +423,21 @@ void flush_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     client.post(format("/storage_service/keyspace_flush/{}", keyspace), std::move(params));
 }
 
+void getlogginglevels_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    auto res = client.get("/storage_service/logging_level");
+    const auto row_format = "{:<50}{:>10}\n";
+    fmt::print(std::cout, "\n");
+    fmt::print(std::cout, fmt::runtime(row_format), "Logger Name", "Log Level");
+    for (const auto& element : res.GetArray()) {
+        const auto& logger_obj = element.GetObject();
+        fmt::print(
+                std::cout,
+                fmt::runtime(row_format),
+                rjson::to_string_view(logger_obj["key"]),
+                rjson::to_string_view(logger_obj["value"]));
+    }
+}
+
 void gettraceprobability_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     auto res = client.get("/storage_service/trace_probability");
     fmt::print(std::cout, "Current trace probability: {}\n", res.GetDouble());
@@ -947,6 +962,16 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
                 }
             },
             flush_operation
+        },
+        {
+            {
+                "getlogginglevels",
+                "Get the runtime logging levels",
+R"(
+Prints a table with the name and current logging level for each logger in ScyllaDB.
+)",
+            },
+            getlogginglevels_operation
         },
         {
             {


### PR DESCRIPTION
This PR implements the following new nodetool commands:
* decomission
* rebuild
* removenode
* getlogginglevels
* setlogginglevel
* move
* refresh

All commands come with tests and all tests pass with both the new and the current nodetool implementations.

Refs: https://github.com/scylladb/scylladb/issues/15588