### PR TITLE
Guard tables in compaction tasks

### DIFF
--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -198,6 +198,8 @@ future<> run_on_table(sstring op, replica::database& db, std::string keyspace, t
         co_await func(t);
     } catch (const replica::no_such_column_family& e) {
         tasks::tmlogger.warn("Skipping {} of {}.{}: {}", op, keyspace, ti.name, e.what());
+    } catch (const gate_closed_exception& e) {
+        tasks::tmlogger.warn("Skipping {} of {}.{}: {}", op, keyspace, ti.name, e.what());
     } catch (...) {
         ex = std::current_exception();
         tasks::tmlogger.error("Failed {} of {}.{}: {}", op, keyspace, ti.name, ex);

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -193,7 +193,9 @@ future<> run_on_table(sstring op, replica::database& db, std::string keyspace, t
     std::exception_ptr ex;
     tasks::tmlogger.debug("Starting {} on {}.{}", op, keyspace, ti.name);
     try {
-        co_await func(db.find_column_family(ti.id));
+        auto& t = db.find_column_family(ti.id);
+        auto holder = t.hold();
+        co_await func(t);
     } catch (const replica::no_such_column_family& e) {
         tasks::tmlogger.warn("Skipping {} of {}.{}: {}", op, keyspace, ti.name, e.what());
     } catch (...) {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -67,6 +67,11 @@ static seastar::metrics::label keyspace_label("ks");
 
 using namespace std::chrono_literals;
 
+table_holder::table_holder(table& t)
+    : _holder(t.async_gate())
+    , _table_ptr(t.shared_from_this())
+{ }
+
 void table::update_sstables_known_generation(sstables::generation_type generation) {
     auto gen = generation ? generation.as_int() : 0;
     if (_sstable_generation_generator) {


### PR DESCRIPTION
Currently, if a compaction function enters the table
or compaction_group async_gate, we can't stop it
on the table/compaction_group stop path as they co_await
their respective async_gate.close().

This series introduces a table_ptr smart pointer to guards
the table object by entering its async_gate, and
it also defers awaiting the gate.close future
till after stopping ongoing compaction so that
closing the gate will prevent starting new compactions
while ongoing compaction can be stopped and finally
awaiting the close() future will wait for them to
unwind and exit the gate after being stopped.

Fixes #16305