### PR TITLE
Add support for tablets in Alternator

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1737,7 +1737,6 @@ future<> view_update_generator::mutate_MV(
             remote_endpoints.pop_back();
         }
 
-        future<> remote_view_update = make_ready_future<>();
         // If target_endpoint is engaged by this point, then either the update
         // is not local, or the local update was already applied but we still
         // have pending endpoints to send to.
@@ -1749,40 +1748,38 @@ future<> view_update_generator::mutate_MV(
             // The "delay_before_remote_view_update" injection point can be
             // used to add a short delay (currently 0.5 seconds) before a base
             // replica sends its update to the remove view replica.
-            future<> view_update = utils::get_local_injector().inject("delay_before_remote_view_update", 500ms).then(
-                [this, s = std::move(s), &stats, &cf_stats, tr_state, base_token, view_token, target_endpoint,
-                 updates_pushed_remote, units = sem_units.split(sem_units.count()), apply_update_synchronously,
-                 view_ermp = std::move(view_ermp), remote_endpoints = std::move(remote_endpoints), mut = std::move(mut), allow_hints] () mutable {
-                return apply_to_remote_endpoints(_proxy.local(), std::move(view_ermp), *target_endpoint, std::move(remote_endpoints), std::move(mut), base_token, view_token, allow_hints, tr_state).then_wrapped(
-                    [s = std::move(s), &stats, &cf_stats, tr_state, base_token, view_token, target_endpoint, updates_pushed_remote, units = std::move(units), apply_update_synchronously] (future<>&& f) mutable {
-                    if (f.failed()) {
-                        stats.view_updates_failed_remote += updates_pushed_remote;
-                        cf_stats.total_view_updates_failed_remote += updates_pushed_remote;
-                        auto ep = f.get_exception();
-                        tracing::trace(tr_state, "Failed to apply view update for {} and {} remote endpoints",
-                            *target_endpoint, updates_pushed_remote);
-
-                        // Printing an error on every failed view mutation would cause log spam, so a rate limit is needed.
-                        static thread_local logger::rate_limit view_update_error_rate_limit(std::chrono::seconds(4));
-                        vlogger.log(log_level::warn, view_update_error_rate_limit,
-                                "Error applying view update to {} (view: {}.{}, base token: {}, view token: {}): {}",
-                                *target_endpoint, s->ks_name(), s->cf_name(), base_token, view_token, ep);
-                        return apply_update_synchronously ? make_exception_future<>(std::move(ep)) : make_ready_future<>();
-                    }
-                    tracing::trace(tr_state, "Successfully applied view update for {} and {} remote endpoints",
+            co_await utils::get_local_injector().inject("delay_before_remote_view_update", 500ms);
+            future<> remote_view_update = apply_to_remote_endpoints(_proxy.local(), std::move(view_ermp), *target_endpoint, std::move(remote_endpoints), std::move(mut), base_token, view_token, allow_hints, tr_state).then_wrapped(
+                [s = std::move(s), &stats, &cf_stats, tr_state, base_token, view_token, target_endpoint, updates_pushed_remote,
+                 units = sem_units.split(sem_units.count()), apply_update_synchronously] (future<>&& f) mutable {
+                if (f.failed()) {
+                    stats.view_updates_failed_remote += updates_pushed_remote;
+                    cf_stats.total_view_updates_failed_remote += updates_pushed_remote;
+                    auto ep = f.get_exception();
+                    tracing::trace(tr_state, "Failed to apply view update for {} and {} remote endpoints",
                         *target_endpoint, updates_pushed_remote);
-                    return make_ready_future<>();
-                });
+
+                    // Printing an error on every failed view mutation would cause log spam, so a rate limit is needed.
+                    static thread_local logger::rate_limit view_update_error_rate_limit(std::chrono::seconds(4));
+                    vlogger.log(log_level::warn, view_update_error_rate_limit,
+                        "Error applying view update to {} (view: {}.{}, base token: {}, view token: {}): {}",
+                        *target_endpoint, s->ks_name(), s->cf_name(), base_token, view_token, ep);
+                    return apply_update_synchronously ? make_exception_future<>(std::move(ep)) : make_ready_future<>();
+                }
+                tracing::trace(tr_state, "Successfully applied view update for {} and {} remote endpoints",
+                    *target_endpoint, updates_pushed_remote);
+                return make_ready_future<>();
             });
             if (apply_update_synchronously) {
-                remote_view_update = std::move(view_update);
+                co_return co_await when_all_succeed(
+                    std::move(local_view_update), std::move(remote_view_update)).discard_result();
             } else {
                 // The update is sent to background in order to preserve availability,
                 // its parallelism is limited by view_update_concurrency_semaphore
-                (void)view_update;
+                (void)remote_view_update;
             }
         }
-        return when_all_succeed(std::move(local_view_update), std::move(remote_view_update)).discard_result();
+        co_return co_await std::move(local_view_update);
     });
 }
 

--- a/test/topology_experimental_raft/test_mv_tablets.py
+++ b/test/topology_experimental_raft/test_mv_tablets.py
@@ -7,10 +7,12 @@
 # Tests for interaction of materialized views with *tablets*
 
 from test.pylib.manager_client import ManagerClient
+from test.topology.conftest import skip_mode
 
 import pytest
 import asyncio
 import logging
+import random
 
 
 logger = logging.getLogger(__name__)
@@ -73,3 +75,115 @@ async def test_tablet_mv_simple_6node(manager: ManagerClient):
     # We used SYNCHRONOUS_UPDATES=TRUE, so the view should be updated:
     assert [(3,2)] == list(await cql.run_async("SELECT * FROM test.tv WHERE c=3"))
     await cql.run_async("DROP KEYSPACE test")
+
+# Convenience function to open a connection to Alternator usable by the
+# AWS SDK. When more than one test needs it, we can move this function to
+# a separate library file. Until then, let's just have it in front of the
+# only test that needs it.
+import boto3
+import botocore
+alternator_config = {
+    'alternator_port': 8000,
+    'alternator_write_isolation': 'only_rmw_uses_lwt',
+}
+def get_alternator(ip):
+    url = f"http://{ip}:{alternator_config['alternator_port']}"
+    return boto3.resource('dynamodb', endpoint_url=url,
+        region_name='us-east-1',
+        aws_access_key_id='alternator',
+        aws_secret_access_key='secret_pass',
+        config=botocore.client.Config(
+            retries={"max_attempts": 0},
+            read_timeout=300)
+    )
+
+# Alternator convenience function for fetching the entire result set of a
+# query into an array of items.
+def full_query(table, ConsistentRead=True, **kwargs):
+    response = table.query(ConsistentRead=ConsistentRead, **kwargs)
+    items = response['Items']
+    while 'LastEvaluatedKey' in response:
+        response = table.query(ExclusiveStartKey=response['LastEvaluatedKey'],
+            ConsistentRead=ConsistentRead, **kwargs)
+        items.extend(response['Items'])
+    return items
+
+async def inject_error_on(manager, error_name, servers):
+    errs = [manager.api.enable_injection(s.ip_addr, error_name, False) for s in servers]
+    await asyncio.gather(*errs)
+
+# FIXME: boto3 is NOT async. So this test is not async. We could use
+# the aioboto3 library to write a really asynchronous test, or implement
+# an async wrapper to the boto3 functions ourselves (e.g., run them in a
+# separate thread) ourselves.
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+@skip_mode('debug', '10-node test is too slow in debug mode')
+async def test_tablet_alternator_lsi_consistency(manager: ManagerClient):
+    """A reproducer for a bug where Alternator LSI was not using synchronous
+       view updates when tablets are enabled, which could cause strongly-
+       consistent read of the LSI to miss the data just written to the base.
+       We use a fairly large cluster to increase the chance that the tablet
+       randomization results in non-local pairing of base and view tablets.
+       We could make this test fail more reliably and only need 4 nodes if
+       we had an API to control the tablet placement.
+       We also use the "delay_before_remote_view_update" injection point
+       to add a delay to the view update - without it it's almost impossible
+       to reproduce this issue on a fast machine.
+       Reproduces #16313.
+    """
+    servers = await manager.servers_add(10, config=alternator_config)
+    cql = manager.get_cql()
+    alternator = get_alternator(servers[0].ip_addr)
+    # Currently, to create an Alternator table with tablets, a special
+    # tag must be given. See issue #16203. In the future this should be
+    # automatic - any Alternator table will use tablets.
+    tablets_tags = [{'Key': 'experimental:initial_tablets', 'Value': '100'}]
+    # Create a table with an LSI
+    table = alternator.create_table(TableName='alternator_table',
+        BillingMode='PAY_PER_REQUEST',
+        KeySchema=[
+            {'AttributeName': 'p', 'KeyType': 'HASH' },
+            {'AttributeName': 'c', 'KeyType': 'RANGE' }
+        ],
+        AttributeDefinitions=[
+            {'AttributeName': 'p', 'AttributeType': 'S' },
+            {'AttributeName': 'c', 'AttributeType': 'S' },
+            {'AttributeName': 'd', 'AttributeType': 'S' }
+        ],
+        LocalSecondaryIndexes=[
+            {   'IndexName': 'ind',
+                'KeySchema': [
+                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
+                    { 'AttributeName': 'd', 'KeyType': 'RANGE' },
+                ],
+                'Projection': { 'ProjectionType': 'ALL' }
+            }
+        ],
+        Tags=tablets_tags)
+    # Above we connected to a one node to perform Alternator requests.
+    # Now we want to be able to connect to the above-created table through
+    # each one of the nodes. Let's define tables[i] as the same table accessed
+    # through node i (all of them refer to the same table):
+    alternators = [get_alternator(server.ip_addr) for server in servers]
+    tables = [alternator.Table(table.name) for alternator in alternators]
+
+    await inject_error_on(manager, "delay_before_remote_view_update", servers);
+
+    # write to the table through one node (table1) and read from the view
+    # through another node (table2). In an LSI, it is allowed to use strong
+    # consistency for the read, and it must return the just-written value.
+    # Try 10 times, in different combinations of nodes, to increase the
+    # chance of reproducing the bug.
+    for i in range(10):
+        table1 = tables[random.randrange(0, len(tables))]
+        table2 = tables[random.randrange(0, len(tables))]
+        item = {'p': 'dog', 'c': 'c'+str(i), 'd': 'd'+str(i)}
+        table1.put_item(Item=item)
+        assert [item] == full_query(table2, IndexName='ind',
+            KeyConditions={
+                'p': {'AttributeValueList': ['dog'], 'ComparisonOperator': 'EQ'},
+                'd': {'AttributeValueList': ['d'+str(i)], 'ComparisonOperator': 'EQ'}
+            }
+        )
+    table.delete()


### PR DESCRIPTION
The pull requests adds support for tablets in Alternator, and particularly focuses in getting Alternator's GSI and LSI (i.e., materialized views)  to work.

After this series support for tablets in Alternator _mostly_ work, but not completely:
1. CDC doesn't yet work with tablets, and Alternator needs to provide CDC (known as "DynamoDB Streams").
2. Alternator's TTL feature was not tested with tablets, and probably doesn't work because it assumes the replication map belongs to a keyspace.

Because of these reasons, Alternator does not yet use tablets by default and it needs to be enabled explicitly be adding an experimental tag to the new table. This will allow us to test Alternator with tablets even before it is ready for the limelight.

Fixes #16203
Fixes #16313
