### PR TITLE
install-dependencies.sh : Add packages for supporting code coverage

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -81,6 +81,9 @@ fedora_packages=(
     python3-pytest
     python3-pytest-asyncio
     python3-redis
+    python3-unidiff
+    python3-humanfriendly
+    python3-jinja2
     dnf-utils
     pigz
     net-tools
@@ -107,6 +110,7 @@ fedora_packages=(
     rust-std-static-wasm32-wasi
     wabt
     binaryen
+    lcov
 )
 
 # lld is not available on s390x, see
@@ -135,6 +139,7 @@ declare -A pip_packages=(
     [geomet]="<0.3,>=0.1"
     [traceback-with-variables]=
     [scylla-api-client]=
+    [treelib]=
 )
 
 pip_symlinks=(

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-38-20231117
+docker.io/scylladb/scylla-toolchain:fedora-38-20231210


### PR DESCRIPTION
As part of code coverage we need some additional packages in order to being able to process the code coverage data and being able to provide some meaningful information in logs.
Here we add the following packages:
fedora packages:
----------------
lcov - A package of utilities to manipulate lcov traces and generate
       coverage html reports

fedora python3 packages:
------------------------
The following packages are added into fedora_packages and not the python3_packages since we don't need them to be packaged into scylla-python3 package but we only require them for the build environment.

python3-unidiff - A python library for working with patch files, this is
                  required in order to generate "patch coverage" reports.
python3-humanfriendly - A python library to format some quantities into
                        a human readable strings (time spans, sizes, etc...)
                        we use it to print meaningful logs that tracks
                        the volume and time it takes to process coverage
                        data so we can better debug and optimize it in the
                        future.
python3-jinja3 - This is a template based generator that will eventually
                 will allow to consolidate and rearrange several reports into one so we
                 can publish a single report "site" for all of the coverage information.
                 For example, include both, coverage report as well as
                 patch report in a tab based site.

pip packages:
-------------
treelib - A tree data structure that supports also pretty printing of
          the tree data. We use it to log the coverage processing steps in
          order to have debugging capabilities in the future.

Signed-off-by: Eliran Sinvani <eliransin@scylladb.com>

Closes scylladb/scylladb#16330

[avi: regenerate toolchain]