### PR TITLE
scylla_swap_setup: fix AttributeError

### DIFF
--- a/dist/common/scripts/scylla_swap_setup
+++ b/dist/common/scripts/scylla_swap_setup
@@ -63,7 +63,7 @@ if __name__ == '__main__':
 
     swapunit_bn = out('systemd-escape -p --suffix=swap {}'.format(swapfile))
     swapunit = Path('/etc/systemd/system/{}'.format(swapunit_bn))
-    if not args.overwrite_unit_file and swapunit.exists():
+    if swapunit.exists():
         print('swap unit {} already exists'.format(swapunit))
         sys.exit(1)
 


### PR DESCRIPTION
On dffadabb945f5fa16a15ed46ea7576706ed4a083 we mistakenly added "if args.overwrite_unit_file", but the option is comming from unmerged patch.
So we need to drop this to fix script error.

Fixes #16331