### PR TITLE
Turn on tablets on keyspace by default when the feature is enabled

### DIFF
--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -57,7 +57,7 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
                         current_options.type_string(), new_options.type_string()));
             }
 
-            auto new_ks = _attrs->as_ks_metadata_update(ks.metadata(), *qp.proxy().get_token_metadata_ptr());
+            auto new_ks = _attrs->as_ks_metadata_update(ks.metadata(), *qp.proxy().get_token_metadata_ptr(), qp.proxy().features());
             locator::replication_strategy_params params(new_ks->strategy_options(), new_ks->initial_tablets());
             auto new_rs = locator::abstract_replication_strategy::create_replication_strategy(new_ks->strategy_name(), params);
             if (new_rs->is_per_table() != ks.get_replication_strategy().is_per_table()) {
@@ -87,8 +87,9 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
     try {
         auto old_ksm = qp.db().find_keyspace(_name).metadata();
         const auto& tm = *qp.proxy().get_token_metadata_ptr();
+        const auto& feat = qp.proxy().features();
 
-        auto m = service::prepare_keyspace_update_announcement(qp.db().real_database(), _attrs->as_ks_metadata_update(old_ksm, tm), ts);
+        auto m = service::prepare_keyspace_update_announcement(qp.db().real_database(), _attrs->as_ks_metadata_update(old_ksm, tm, feat), ts);
 
         using namespace cql_transport;
         auto ret = ::make_shared<event::schema_change>(

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -92,11 +92,12 @@ void create_keyspace_statement::validate(query_processor& qp, const service::cli
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> create_keyspace_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
     using namespace cql_transport;
     const auto& tm = *qp.proxy().get_token_metadata_ptr();
+    const auto& feat = qp.proxy().features();
     ::shared_ptr<event::schema_change> ret;
     std::vector<mutation> m;
 
     try {
-        m = service::prepare_new_keyspace_announcement(qp.db().real_database(), _attrs->as_ks_metadata(_name, tm), ts);
+        m = service::prepare_new_keyspace_announcement(qp.db().real_database(), _attrs->as_ks_metadata(_name, tm, feat), ts);
 
         ret = ::make_shared<event::schema_change>(
                 event::schema_change::change_type::CREATED,
@@ -257,7 +258,7 @@ create_keyspace_statement::execute(query_processor& qp, service::query_state& st
 
 lw_shared_ptr<data_dictionary::keyspace_metadata> create_keyspace_statement::get_keyspace_metadata(const locator::token_metadata& tm, const gms::feature_service& feat) {
     _attrs->validate();
-    return _attrs->as_ks_metadata(_name, tm);
+    return _attrs->as_ks_metadata(_name, tm, feat);
 }
 
 }

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -255,7 +255,7 @@ create_keyspace_statement::execute(query_processor& qp, service::query_state& st
     });
 }
 
-lw_shared_ptr<data_dictionary::keyspace_metadata> create_keyspace_statement::get_keyspace_metadata(const locator::token_metadata& tm) {
+lw_shared_ptr<data_dictionary::keyspace_metadata> create_keyspace_statement::get_keyspace_metadata(const locator::token_metadata& tm, const gms::feature_service& feat) {
     _attrs->validate();
     return _attrs->as_ks_metadata(_name, tm);
 }

--- a/cql3/statements/create_keyspace_statement.hh
+++ b/cql3/statements/create_keyspace_statement.hh
@@ -20,6 +20,8 @@ namespace locator {
 class token_metadata;
 };
 
+namespace gms { class feature_service; }
+
 namespace data_dictionary {
 class keyspace_metadata;
 }
@@ -72,7 +74,7 @@ public:
     virtual future<::shared_ptr<messages::result_message>>
     execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
 
-    lw_shared_ptr<data_dictionary::keyspace_metadata> get_keyspace_metadata(const locator::token_metadata& tm);
+    lw_shared_ptr<data_dictionary::keyspace_metadata> get_keyspace_metadata(const locator::token_metadata& tm, const gms::feature_service& feat);
 };
 
 std::vector<sstring> check_against_restricted_replication_strategies(

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -121,7 +121,22 @@ std::optional<unsigned> ks_prop_defs::get_initial_tablets(const sstring& strateg
 
     std::optional<unsigned> ret;
 
-    auto it = tablets_options->find("initial");
+    auto it = tablets_options->find("enabled");
+    if (it != tablets_options->end()) {
+        auto enabled = it->second;
+        tablets_options->erase(it);
+
+        if (enabled == "true") {
+            ret = 0; // even if 'initial' is not set, it'll start with auto-detection
+        } else if (enabled == "false") {
+            assert(!ret.has_value());
+            return ret;
+        } else {
+            throw exceptions::configuration_exception(sstring("Tablets enabled value must be true or false; found ") + it->second);
+        }
+    }
+
+    it = tablets_options->find("initial");
     if (it != tablets_options->end()) {
         try {
             ret = std::stol(it->second);

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -157,7 +157,7 @@ std::optional<sstring> ks_prop_defs::get_replication_strategy_class() const {
     return _strategy_class;
 }
 
-lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata(sstring ks_name, const locator::token_metadata& tm) {
+lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata(sstring ks_name, const locator::token_metadata& tm, const gms::feature_service& feat) {
     auto sc = get_replication_strategy_class().value();
     std::optional<unsigned> initial_tablets = get_initial_tablets(sc);
     auto options = prepare_options(sc, tm, get_replication_options(), initial_tablets);

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -165,7 +165,7 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata(s
             std::move(options), initial_tablets, get_boolean(KW_DURABLE_WRITES, true), get_storage_options());
 }
 
-lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata& tm) {
+lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata& tm, const gms::feature_service& feat) {
     std::map<sstring, sstring> options;
     const auto& old_options = old->strategy_options();
     auto sc = get_replication_strategy_class();

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -25,6 +25,8 @@ namespace gms {
     class inet_address;
 }
 
+namespace gms { class feature_service; }
+
 namespace locator {
     class token_metadata;
     class shared_token_metadata;
@@ -53,7 +55,7 @@ public:
     std::optional<sstring> get_replication_strategy_class() const;
     std::optional<unsigned> get_initial_tablets(const sstring& strategy_class) const;
     data_dictionary::storage_options get_storage_options() const;
-    lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata(sstring ks_name, const locator::token_metadata&);
+    lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata(sstring ks_name, const locator::token_metadata&, const gms::feature_service&);
     lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata&);
 
 #if 0

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -53,7 +53,7 @@ public:
     void validate();
     std::map<sstring, sstring> get_replication_options() const;
     std::optional<sstring> get_replication_strategy_class() const;
-    std::optional<unsigned> get_initial_tablets(const sstring& strategy_class) const;
+    std::optional<unsigned> get_initial_tablets(const sstring& strategy_class, bool enabled_by_default) const;
     data_dictionary::storage_options get_storage_options() const;
     lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata(sstring ks_name, const locator::token_metadata&, const gms::feature_service&);
     lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata&, const gms::feature_service&);

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -56,7 +56,7 @@ public:
     std::optional<unsigned> get_initial_tablets(const sstring& strategy_class) const;
     data_dictionary::storage_options get_storage_options() const;
     lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata(sstring ks_name, const locator::token_metadata&, const gms::feature_service&);
-    lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata&);
+    lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata&, const gms::feature_service&);
 
 #if 0
     public KSMetaData asKSMetadataUpdate(KSMetaData old) throws RequestValidationException

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -41,6 +41,7 @@ public:
     static constexpr auto KW_DURABLE_WRITES = "durable_writes";
     static constexpr auto KW_REPLICATION = "replication";
     static constexpr auto KW_STORAGE = "storage";
+    static constexpr auto KW_TABLETS = "tablets";
 
     static constexpr auto REPLICATION_STRATEGY_CLASS_KEY = "class";
     static constexpr auto REPLICATION_FACTOR_KEY = "replication_factor";
@@ -50,6 +51,7 @@ public:
     void validate();
     std::map<sstring, sstring> get_replication_options() const;
     std::optional<sstring> get_replication_strategy_class() const;
+    std::optional<unsigned> get_initial_tablets(const sstring& strategy_class) const;
     data_dictionary::storage_options get_storage_options() const;
     lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata(sstring ks_name, const locator::token_metadata&);
     lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata&);

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -225,8 +225,12 @@ Options:
 ===================================== ====== =============================================
 sub-option                             type  description
 ===================================== ====== =============================================
+``'enabled'``                          bool  Whether or not to enable tablets for keyspace
 ``'initial'``                          int   The number of tablets to start with
 ===================================== ====== =============================================
+
+By default if tablets cluster feature is enabled, any keyspace will be created with tablets
+enabled. The ``tablets`` option is used to opt-out a keyspace from tablets replication.
 
 A good rule of thumb to calculate initial tablets is to divide the expected total storage used
 by tables in this keyspace by (``replication_factor`` * 5GB). For example, if you expect a 30TB

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -122,6 +122,7 @@ name                 kind       mandatory   default   description
                                                       details below).
 ``durable_writes``   *simple*   no          true      Whether to use the commit log for updates on this keyspace
                                                       (disable this option at your own risk!).
+``tablets``          *map*      no                    Experimental - enables tablets for this keyspace (see :ref:`tablets<tablets>`)
 =================== ========== =========== ========= ===================================================================
 
 The ``replication`` property is mandatory and must at least contains the ``'class'`` sub-option, which defines the
@@ -142,7 +143,6 @@ query latency. For a production ready strategy, see *NetworkTopologyStrategy* . 
 sub-option                 type   since   description
 ========================= ====== ======= =============================================
 ``'replication_factor'``   int    all     The number of replicas to store per range
-``'initial_tablets'``      int    5.4     Experimental - enables tablets for this keyspace (see :ref:`initial_tablets<initial-tablets>`)
 ========================= ====== ======= =============================================
 
 .. note:: Using NetworkTopologyStrategy is recommended. Using SimpleStrategy will make it harder to add Data Center in the future.
@@ -166,7 +166,6 @@ sub-option                             type  description
                                              definitions or explicit datacenter settings.
                                              For example, to have three replicas per
                                              datacenter, supply this with a value of 3.
-``'initial_tablets'``                  int   (since 5.4) Experimental - enables tablets for this keyspace (see :ref:`initial_tablets<initial-tablets>`)
 ===================================== ====== =============================================
 
 Note that when ``ALTER`` ing keyspaces and supplying ``replication_factor``,
@@ -212,16 +211,24 @@ An example that excludes a datacenter while using ``replication_factor``::
   on Amazon S3 or another S3-compatible object store.
   See :ref:`Keyspace storage options <keyspace-storage-options>` for details.
 
-.. _initial-tablets:
+.. _tablets:
 
-The ``initial_tablets`` option :label-caution:`Experimental`
+The ``tablets`` property :label-caution:`Experimental`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``initial_tablets`` option is used to specify how many tablets the table is split into.
+The ``tablets`` property is used to make keyspace replication tablets-based.
 It is only valid when ``experimental_features: tablets`` is specified in ``scylla.yaml`` (which
 in turn requires ``consistent_cluster_management: true``); it must be a power of two.
 
-A good rule of thumb to calculate initial_tablets is to divide the expected total storage used
+Options:
+
+===================================== ====== =============================================
+sub-option                             type  description
+===================================== ====== =============================================
+``'initial'``                          int   The number of tablets to start with
+===================================== ====== =============================================
+
+A good rule of thumb to calculate initial tablets is to divide the expected total storage used
 by tables in this keyspace by (``replication_factor`` * 5GB). For example, if you expect a 30TB
 table and have a replication factor of 3, divide 30TB by (3*5GB) for a result of 2000. Since the
 value must be a power of two, round up to 2048.
@@ -232,7 +239,7 @@ value must be a power of two, round up to 2048.
    in the future.
 
 .. caution::
-   The ``initial_tablets`` option may change its definition or be completely removed as it is part
+   The ``initial`` option may change its definition or be completely removed as it is part
    of an experimental feature.
 
 
@@ -242,7 +249,8 @@ An example that creates a keyspace with 2048 tablets per table::
     WITH replication = {
         'class': 'NetworkTopologyStrategy',
         'replication_factor': 3,
-        'initial_tablets': 2048
+    } AND tablets = {
+        'initial': 2048
     };
 
 .. _use-statement:        

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -525,11 +525,6 @@ void tablet_aware_replication_strategy::validate_tablet_options(const abstract_r
 void tablet_aware_replication_strategy::process_tablet_options(abstract_replication_strategy& ars,
                                                                replication_strategy_config_options& opts,
                                                                replication_strategy_params params) {
-    auto i = opts.find("initial_tablets");
-    if (i != opts.end()) {
-        throw exceptions::configuration_exception("initial_tablets is reserved name for NetworkTopologyStrategy");
-    }
-
     if (params.initial_tablets.has_value()) {
         _initial_tablets = *params.initial_tablets;
         ars._uses_tablets = true;

--- a/redis/keyspace_utils.cc
+++ b/redis/keyspace_utils.cc
@@ -189,7 +189,7 @@ future<> create_keyspace_if_not_exists_impl(seastar::sharded<service::storage_pr
             attrs.add_property(cql3::statements::ks_prop_defs::KW_REPLICATION, replication_properties);
             attrs.validate();
 
-            ksms.push_back(attrs.as_ks_metadata(ks_name, *tm));
+            ksms.push_back(attrs.as_ks_metadata(ks_name, *tm, proxy.local().features()));
         }
 
         auto group0_guard = co_await mml.start_group0_operation();

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -5730,7 +5730,7 @@ bool has_tablet_routing(::shared_ptr<cql_transport::messages::result_message> re
 SEASTAR_TEST_CASE(test_sending_tablet_info_unprepared_insert) {
     BOOST_ASSERT(smp::count == 2);
     return do_with_cql_env_thread([](cql_test_env& e) {
-        e.execute_cql("create keyspace ks_tablet with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 8};").get();
+        e.execute_cql("create keyspace ks_tablet with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1 } and tablets = {'initial': 8};").get();
         e.execute_cql("create table ks_tablet.test_tablet (pk int, ck int, v int, PRIMARY KEY (pk, ck));").get();
 
         smp::submit_to(0, [&] {
@@ -5751,7 +5751,7 @@ SEASTAR_TEST_CASE(test_sending_tablet_info_unprepared_insert) {
 
 SEASTAR_TEST_CASE(test_sending_tablet_info_unprepared_select) {
     return do_with_cql_env_thread([](cql_test_env& e) {
-        e.execute_cql("create keyspace ks_tablet with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 8};").get();
+        e.execute_cql("create keyspace ks_tablet with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1 } and tablets = {'initial': 8};").get();
         e.execute_cql("create table ks_tablet.test_tablet (pk int, ck int, v int, PRIMARY KEY (pk, ck));").get();
         e.execute_cql("insert into ks_tablet.test_tablet (pk, ck, v) VALUES (1, 2, 3);").get();
 
@@ -5773,7 +5773,7 @@ SEASTAR_TEST_CASE(test_sending_tablet_info_unprepared_select) {
 
 SEASTAR_TEST_CASE(test_sending_tablet_info_insert) {
     return do_with_cql_env_thread([](cql_test_env& e) {
-        e.execute_cql("create keyspace ks_tablet with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 8};").get();
+        e.execute_cql("create keyspace ks_tablet with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1 } and tablets = {'initial': 8};").get();
         e.execute_cql("create table ks_tablet.test_tablet (pk int, ck int, v int, PRIMARY KEY (pk, ck));").get();
         auto insert = e.prepare("insert into ks_tablet.test_tablet (pk, ck, v) VALUES (?, ?, ?);").get0();
         
@@ -5816,7 +5816,7 @@ SEASTAR_TEST_CASE(test_sending_tablet_info_insert) {
 
 SEASTAR_TEST_CASE(test_sending_tablet_info_select) {
     return do_with_cql_env_thread([](cql_test_env& e) {
-        e.execute_cql("create keyspace ks_tablet with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 8};").get();
+        e.execute_cql("create keyspace ks_tablet with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} and tablets = {'initial': 8};").get();
         e.execute_cql("create table ks_tablet.test_tablet (pk int, ck int, v int, PRIMARY KEY (pk, ck));").get();
         e.execute_cql("insert into ks_tablet.test_tablet (pk, ck, v) VALUES (1, 2, 3);").get();
         

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -30,7 +30,9 @@ using namespace locator;
 using namespace replica;
 using namespace service;
 
-static api::timestamp_type next_timestamp = api::new_timestamp();
+static api::timestamp_type current_timestamp(cql_test_env& e) {
+    return api::new_timestamp();
+}
 
 static utils::UUID next_uuid() {
     static uint64_t counter = 1;
@@ -40,8 +42,8 @@ static utils::UUID next_uuid() {
 }
 
 static
-void verify_tablet_metadata_persistence(cql_test_env& env, const tablet_metadata& tm) {
-    save_tablet_metadata(env.local_db(), tm, next_timestamp++).get();
+void verify_tablet_metadata_persistence(cql_test_env& env, const tablet_metadata& tm, api::timestamp_type& ts) {
+    save_tablet_metadata(env.local_db(), tm, ts++).get();
     auto tm2 = read_tablet_metadata(env.local_qp()).get0();
     BOOST_REQUIRE_EQUAL(tm, tm2);
 }
@@ -75,12 +77,13 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
 
         auto table1 = add_table(e).get0();
         auto table2 = add_table(e).get0();
+        auto ts = current_timestamp(e);
 
         {
             tablet_metadata tm;
 
             // Empty
-            verify_tablet_metadata_persistence(e, tm);
+            verify_tablet_metadata_persistence(e, tm, ts);
 
             // Add table1
             {
@@ -95,7 +98,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                 tm.set_tablet_map(table1, std::move(tmap));
             }
 
-            verify_tablet_metadata_persistence(e, tm);
+            verify_tablet_metadata_persistence(e, tm, ts);
 
             // Add table2
             {
@@ -127,7 +130,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                 tm.set_tablet_map(table2, std::move(tmap));
             }
 
-            verify_tablet_metadata_persistence(e, tm);
+            verify_tablet_metadata_persistence(e, tm, ts);
 
             // Increase RF of table2
             {
@@ -156,7 +159,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                 });
             }
 
-            verify_tablet_metadata_persistence(e, tm);
+            verify_tablet_metadata_persistence(e, tm, ts);
 
             // Reduce tablet count in table2
             {
@@ -176,7 +179,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                 tm.set_tablet_map(table2, std::move(tmap));
             }
 
-            verify_tablet_metadata_persistence(e, tm);
+            verify_tablet_metadata_persistence(e, tm, ts);
 
             // Reduce RF for table1, increasing tablet count
             {
@@ -196,7 +199,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                 tm.set_tablet_map(table1, std::move(tmap));
             }
 
-            verify_tablet_metadata_persistence(e, tm);
+            verify_tablet_metadata_persistence(e, tm, ts);
 
             // Reduce tablet count for table1
             {
@@ -210,7 +213,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                 tm.set_tablet_map(table1, std::move(tmap));
             }
 
-            verify_tablet_metadata_persistence(e, tm);
+            verify_tablet_metadata_persistence(e, tm, ts);
 
             // Change replica of table1
             {
@@ -224,7 +227,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                 tm.set_tablet_map(table1, std::move(tmap));
             }
 
-            verify_tablet_metadata_persistence(e, tm);
+            verify_tablet_metadata_persistence(e, tm, ts);
         }
     }, tablet_cql_test_config());
 }
@@ -288,6 +291,7 @@ SEASTAR_TEST_CASE(test_mutation_builder) {
         auto h3 = host_id(utils::UUID_gen::get_time_UUID());
 
         auto table1 = add_table(e).get0();
+        auto ts = current_timestamp(e);
 
         tablet_metadata tm;
         tablet_id tid(0);
@@ -312,10 +316,10 @@ SEASTAR_TEST_CASE(test_mutation_builder) {
             tm.set_tablet_map(table1, std::move(tmap));
         }
 
-        save_tablet_metadata(e.local_db(), tm, next_timestamp++).get();
+        save_tablet_metadata(e.local_db(), tm, ts++).get();
 
         {
-            tablet_mutation_builder b(next_timestamp++, "ks", table1);
+            tablet_mutation_builder b(ts++, "ks", table1);
             auto last_token = tm.get_tablet_map(table1).get_last_token(tid1);
             b.set_new_replicas(last_token, tablet_replica_set {
                     tablet_replica {h1, 2},
@@ -355,7 +359,7 @@ SEASTAR_TEST_CASE(test_mutation_builder) {
         }
 
         {
-            tablet_mutation_builder b(next_timestamp++, "ks", table1);
+            tablet_mutation_builder b(ts++, "ks", table1);
             auto last_token = tm.get_tablet_map(table1).get_last_token(tid1);
             b.set_stage(last_token, tablet_transition_stage::use_new);
             e.local_db().apply({freeze(b.build())}, db::no_timeout).get();
@@ -391,7 +395,7 @@ SEASTAR_TEST_CASE(test_mutation_builder) {
         }
 
         {
-            tablet_mutation_builder b(next_timestamp++, "ks", table1);
+            tablet_mutation_builder b(ts++, "ks", table1);
             auto last_token = tm.get_tablet_map(table1).get_last_token(tid1);
             b.set_replicas(last_token, tablet_replica_set {
                 tablet_replica {h1, 2},
@@ -555,7 +559,8 @@ SEASTAR_TEST_CASE(test_large_tablet_metadata) {
             tm.set_tablet_map(id, std::move(tmap));
         }
 
-        verify_tablet_metadata_persistence(e, tm);
+        auto ts = current_timestamp(e);
+        verify_tablet_metadata_persistence(e, tm, ts);
     }, tablet_cql_test_config());
 }
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -396,8 +396,8 @@ public:
     }
 
     future<> create_keyspace(const cql_test_config& cfg, std::string_view name) {
-        auto query = format("create keyspace {} with replication = {{ 'class' : 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'replication_factor' : 1{}}};", name,
-                            cfg.initial_tablets ? format(", 'initial_tablets' : {}", *cfg.initial_tablets) : "");
+        auto query = format("create keyspace {} with replication = {{ 'class' : 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'replication_factor' : 1}}{};", name,
+                            cfg.initial_tablets ? format(" and tablets = {{'initial' : {}}}", *cfg.initial_tablets) : "");
         return execute_cql(query).discard_result();
     }
 

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -76,8 +76,7 @@ def make_scylla_conf(workdir: pathlib.Path, host_addr: str, seed_addrs: List[str
                                   'alternator-streams',
                                   'consistent-topology-changes',
                                   'broadcast-tables',
-                                  'keyspace-storage-options',
-                                  'tablets'],
+                                  'keyspace-storage-options'],
 
         'skip_wait_for_gossip_to_settle': 0,
         'ring_delay_ms': 0,

--- a/test/topology/test_topology_failure_recovery.py
+++ b/test/topology/test_topology_failure_recovery.py
@@ -83,8 +83,7 @@ async def test_tablet_drain_failure_during_decommission(manager: ManagerClient):
     marks = [await log.mark() for log in logs]
 
     cql = manager.get_cql()
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', "
-                  "'replication_factor': 1, 'initial_tablets': 32};")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 32};")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
 
     logger.info("Populating table")

--- a/test/topology/test_topology_failure_recovery.py
+++ b/test/topology/test_topology_failure_recovery.py
@@ -74,28 +74,3 @@ async def test_topology_streaming_failure(request, manager: ManagerClient):
     assert s not in servers
     matches = [await log.grep("storage_service - rollback.*after replacing failure to state left_token_ring", from_mark=mark) for log, mark in zip(logs, marks)]
     assert sum(len(x) for x in matches) == 1
-
-@pytest.mark.asyncio
-async def test_tablet_drain_failure_during_decommission(manager: ManagerClient):
-    servers = await manager.running_servers()
-
-    logs = [await manager.server_open_log(srv.server_id) for srv in servers]
-    marks = [await log.mark() for log in logs]
-
-    cql = manager.get_cql()
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 32};")
-    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
-
-    logger.info("Populating table")
-
-    keys = range(256)
-    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
-
-    await inject_error_on(manager, "stream_tablet_fail_on_drain", servers)
-
-    await manager.decommission_node(servers[2].server_id, expected_error="Decommission failed. See earlier errors")
-
-    matches = [await log.grep("storage_service - rollback.*after decommissioning failure to state rollback_to_normal", from_mark=mark) for log, mark in zip(logs, marks)]
-    assert sum(len(x) for x in matches) == 1
-
-    await cql.run_async("DROP KEYSPACE test;")

--- a/test/topology_custom/suite.yaml
+++ b/test/topology_custom/suite.yaml
@@ -17,6 +17,7 @@ skip_in_release:
   - test_old_ip_notification_repro
   - test_different_group0_ids
   - test_group0_schema_versioning
+  - test_topology_failure_recovery
 skip_in_debug:
   - test_shutdown_hang
   - test_replace

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -48,10 +48,10 @@ async def test_tablet_default_initialization(manager: ManagerClient):
     server = await manager.server_add(config=cfg)
 
     cql = manager.get_cql()
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': true};")
 
     res = await cql.run_async("SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = 'test'")
-    assert res[0].initial_tablets > 0, "initial_tablets not configured"
+    assert res[0].initial_tablets == 0, "initial_tablets not configured"
 
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
     res = await cql.run_async("SELECT * FROM system.tablets")

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -21,7 +21,7 @@ async def test_tablet_change_replication_vnode_to_tablets(manager: ManagerClient
     cql = manager.get_cql()
     await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};")
     with pytest.raises(InvalidRequest):
-        await cql.run_async("ALTER KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 1};")
+        await cql.run_async("ALTER KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
 
 
 @pytest.mark.asyncio
@@ -48,7 +48,7 @@ async def test_tablet_default_initialization(manager: ManagerClient):
     server = await manager.server_add(config=cfg)
 
     cql = manager.get_cql()
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 1};")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
 
     res = await cql.run_async("SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = 'test'")
     assert res[0].initial_tablets > 0, "initial_tablets not configured"
@@ -70,8 +70,8 @@ async def test_tablet_change_initial_tablets(manager: ManagerClient):
     server = await manager.server_add(config=cfg)
 
     cql = manager.get_cql()
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 1};")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
 
-    await cql.run_async("ALTER KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 2};")
+    await cql.run_async("ALTER KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2};")
     res = await cql.run_async("SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = 'test'")
     assert res[0].initial_tablets == 2, "initial_tablets not altered"

--- a/test/topology_custom/test_topology_failure_recovery.py
+++ b/test/topology_custom/test_topology_failure_recovery.py
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from test.pylib.manager_client import ManagerClient
+from test.pylib.internal_types import ServerInfo
+from test.pylib.scylla_cluster import ReplaceConfig
+import pytest
+import logging
+import asyncio
+
+logger = logging.getLogger(__name__)
+
+async def inject_error_on(manager, error_name, servers):
+    errs = [manager.api.enable_injection(s.ip_addr, error_name, True) for s in servers]
+    await asyncio.gather(*errs)
+
+@pytest.mark.asyncio
+async def test_tablet_drain_failure_during_decommission(manager: ManagerClient):
+    cfg = {'enable_user_defined_functions': False,
+           'experimental_features': ['tablets', 'consistent-topology-changes']}
+    servers = [await manager.server_add(config=cfg) for _ in range(3)]
+
+    logs = [await manager.server_open_log(srv.server_id) for srv in servers]
+    marks = [await log.mark() for log in logs]
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 32};")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+
+    logger.info("Populating table")
+
+    keys = range(256)
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+
+    await inject_error_on(manager, "stream_tablet_fail_on_drain", servers)
+
+    await manager.decommission_node(servers[2].server_id, expected_error="Decommission failed. See earlier errors")
+
+    matches = [await log.grep("storage_service - rollback.*after decommissioning failure to state rollback_to_normal", from_mark=mark) for log, mark in zip(logs, marks)]
+    assert sum(len(x) for x in matches) == 1
+
+    await cql.run_async("DROP KEYSPACE test;")
+

--- a/test/topology_experimental_raft/test_mv_tablets.py
+++ b/test/topology_experimental_raft/test_mv_tablets.py
@@ -86,7 +86,7 @@ async def test_tablet_mv_create(manager: ManagerClient):
     servers = await manager.servers_add(1)
     cql = manager.get_cql()
 
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 100}")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 100}")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int)")
     await cql.run_async("CREATE MATERIALIZED VIEW test.tv AS SELECT * FROM test.test WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (c, pk)")
     await cql.run_async("DROP KEYSPACE test")
@@ -104,7 +104,7 @@ async def test_tablet_mv_simple(manager: ManagerClient):
     servers = await manager.servers_add(1)
     cql = manager.get_cql()
 
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 100}")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 100}")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int)")
     await cql.run_async("CREATE MATERIALIZED VIEW test.tv AS SELECT * FROM test.test WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (c, pk) WITH SYNCHRONOUS_UPDATES = TRUE")
     await cql.run_async("INSERT INTO test.test (pk, c) VALUES (2, 3)")
@@ -126,7 +126,7 @@ async def test_tablet_mv_simple_6node(manager: ManagerClient):
     """
     servers = await manager.servers_add(6)
     cql = manager.get_cql()
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 100}")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 100}")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int)")
     await cql.run_async("CREATE MATERIALIZED VIEW test.tv AS SELECT * FROM test.test WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (c, pk) WITH SYNCHRONOUS_UPDATES = TRUE")
     await cql.run_async("INSERT INTO test.test (pk, c) VALUES (2, 3)")
@@ -262,7 +262,7 @@ async def test_tablet_si_create(manager: ManagerClient):
     servers = await manager.servers_add(1)
     cql = manager.get_cql()
 
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 100}")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 100}")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int)")
     await cql.run_async("CREATE INDEX my_idx ON test.test(c)")
     await cql.run_async("DROP INDEX test.my_idx")
@@ -277,7 +277,7 @@ async def test_tablet_lsi_create(manager: ManagerClient):
     servers = await manager.servers_add(1)
     cql = manager.get_cql()
 
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 100}")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 100}")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int)")
     await cql.run_async("CREATE INDEX my_idx ON test.test((pk),c)")
     await cql.run_async("DROP INDEX test.my_idx")
@@ -306,7 +306,7 @@ async def test_tablet_cql_lsi(manager: ManagerClient):
     # Create a table with an LSI, using tablets. Use just 1 tablets,
     # which is silly in any real-world use case, but makes this test simpler
     # and faster.
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 1}")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int)")
     await cql.run_async("CREATE INDEX my_idx ON test.test((pk),c)")
 

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -91,8 +91,7 @@ async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(m
     await manager.server_stop_gracefully(s0)
 
     cql = manager.get_cql()
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', "
-                        "'replication_factor': 3, 'initial_tablets': 100};")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 100};")
 
     # force s0 to catch up later from the snapshot and not the raft log
     await inject_error_one_shot_on(manager, 'raft_server_force_snapshot', not_s0)
@@ -113,8 +112,7 @@ async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(m
     await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 60)
 
     # Trigger a schema change to invoke schema agreement waiting to make sure that s0 has the latest schema
-    await cql.run_async("CREATE KEYSPACE test_dummy WITH replication = {'class': 'NetworkTopologyStrategy', "
-                        "'replication_factor': 1, 'initial_tablets': 1};")
+    await cql.run_async("CREATE KEYSPACE test_dummy WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
 
     await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, 2);", execution_profile='whitelist')
                            for k in keys])
@@ -154,8 +152,7 @@ async def test_scans(manager: ManagerClient):
     servers = await manager.servers_add(3)
 
     cql = manager.get_cql()
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', "
-                  "'replication_factor': 1, 'initial_tablets': 8};")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 8};")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
 
     keys = range(100)
@@ -185,7 +182,7 @@ async def test_table_drop_with_auto_snapshot(manager: ManagerClient):
 
     for i in range(3):
         await cql.run_async("DROP KEYSPACE IF EXISTS test;")
-        await cql.run_async("CREATE KEYSPACE IF NOT EXISTS test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 8 };")
+        await cql.run_async("CREATE KEYSPACE IF NOT EXISTS test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 8 };")
         await cql.run_async("CREATE TABLE IF NOT EXISTS test.tbl_sample_kv (id int, value text, PRIMARY KEY (id));")
         await cql.run_async("INSERT INTO test.tbl_sample_kv (id, value) VALUES (1, 'ala');")
 
@@ -198,8 +195,7 @@ async def test_topology_changes(manager: ManagerClient):
     servers = await manager.servers_add(3)
 
     cql = manager.get_cql()
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', "
-                  "'replication_factor': 1, 'initial_tablets': 32};")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 32};")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
 
     logger.info("Populating table")
@@ -247,8 +243,7 @@ async def test_streaming_is_guarded_by_topology_guard(manager: ManagerClient):
     await manager.api.disable_tablet_balancing(servers[0].ip_addr)
 
     cql = manager.get_cql()
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', "
-                        "'replication_factor': 1, 'initial_tablets': 1};")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
 
     servers.append(await manager.server_add(cmdline=cmdline))
@@ -323,8 +318,7 @@ async def test_table_dropped_during_streaming(manager: ManagerClient):
     await manager.api.disable_tablet_balancing(servers[0].ip_addr)
 
     cql = manager.get_cql()
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', "
-                        "'replication_factor': 1, 'initial_tablets': 1};")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
     await cql.run_async("CREATE TABLE test.test2 (pk int PRIMARY KEY, c int);")
 

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -251,7 +251,7 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
         auto* statement = prepared_statement->statement.get();
         auto p = dynamic_cast<cql3::statements::create_keyspace_statement*>(statement);
         assert(p);
-        real_db.keyspaces.emplace_back(p->get_keyspace_metadata(*token_metadata.local().get()));
+        real_db.keyspaces.emplace_back(p->get_keyspace_metadata(*token_metadata.local().get(), feature_service));
         return db.find_keyspace(name);
     };
 
@@ -272,7 +272,7 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
         auto* statement = prepared_statement->statement.get();
 
         if (auto p = dynamic_cast<cql3::statements::create_keyspace_statement*>(statement)) {
-            real_db.keyspaces.emplace_back(p->get_keyspace_metadata(*token_metadata.local().get()));
+            real_db.keyspaces.emplace_back(p->get_keyspace_metadata(*token_metadata.local().get(), feature_service));
         } else if (auto p = dynamic_cast<cql3::statements::create_type_statement*>(statement)) {
             dd_impl.unwrap(ks).metadata->add_user_type(p->create_type(db));
         } else if (auto p = dynamic_cast<cql3::statements::create_table_statement*>(statement)) {


### PR DESCRIPTION
To enable tablets replication one needs to turn on the (experimental) feature and specify the `initial_tablets: N` option when creating a keyspace. We want tablets to become default in the future and allow users to explicitly opt it out if they want to.

This PR solves this by changing the CREATE KEYSPACE syntax wrt tablets options. Now there's a new TABLETS options map and the usage is

* `CREATE KEYSPACE ...` will turn tablets on or off based on cluster feature being enabled/disabled
* `CREATE KEYSPACE ... WITH TABLETS = { 'enabled': false }` will turn tablets off regardless of what
* `CREATE KEYSPACE ... WITH TABLETS = { 'enabled': true }` will try to enable tablets with default configuration
* `CREATE KEYSPACE ... WITH TABLETS = { 'initial': <int> }` is now the replacement for `REPLICATION = { ... 'initial_tablets': <int> }` thing

fixes: #16319 