### PR TITLE
Drop CentOS7 specific codes

### DIFF
--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -15,7 +15,6 @@ import shutil
 import io
 import stat
 import distro
-import platform
 from scylla_util import *
 from subprocess import run, DEVNULL
 
@@ -170,9 +169,6 @@ def warn_offline(setup):
 
 def warn_offline_missing_pkg(setup, pkg):
     colorprint('{red}{setup} disabled by default, since {pkg} not available.{nocolor}', setup=setup, pkg=pkg)
-
-def is_rhel7_old_kernel():
-    return is_redhat_variant() and distro.major_version() == '7' and platform.release().startswith('3.10')
 
 if __name__ == '__main__':
     if not is_nonroot() and os.getuid() > 0:
@@ -332,14 +328,6 @@ if __name__ == '__main__':
         return when_interactive_ask_service(interactive, msg1, msg2, default)
 
     if not is_nonroot():
-        if is_rhel7_old_kernel():
-            colorprint('{red}RHEL/CentOS7 default kernel detected.{nocolor}')
-            colorprint('{red}To get optimal performance, please install kernel-ml kernel.{nocolor}')
-            continue_setup = interactive_ask_service('Do you want to continue the setup with current kernel?', 'Yes - continue the setup, No - abort the setup.', True)
-            if not continue_setup:
-                colorprint('{red}Setup aborted.{nocolor}')
-                sys.exit(1)
-
         kernel_check = interactive_ask_service('Do you want to run check your kernel version?', 'Yes - runs a  script to verify that the kernel for this instance qualifies to run Scylla. No - skips the kernel check.', kernel_check)
         args.no_kernel_check = not kernel_check
         if kernel_check:

--- a/dist/common/systemd/scylla-helper.slice
+++ b/dist/common/systemd/scylla-helper.slice
@@ -15,10 +15,3 @@ MemoryHigh=4%
 # MemoryMax is the OOM point. As Scylla reserves 7% by default, the other two percent goes to
 # the kernel and other non contained processes
 MemoryMax=5%
-# Systemd deprecated settings BlockIOWeight, MemoryLimit and CPUShares. But they are still the ones used in RHEL7
-# Newer SystemD wants MemoryHigh/MemoryMax, IOWeight and CPUWeight instead. Luckily both newer and older SystemD seem to
-# ignore the unwanted option so safest to get both. Using just the old versions would work too but
-# seems less future proof. Using just the new versions does not work at all for RHEL7/
-MemoryLimit=5%
-CPUShares=10
-BlockIOWeight=10

--- a/dist/common/systemd/scylla-server.service
+++ b/dist/common/systemd/scylla-server.service
@@ -7,7 +7,6 @@ Wants=scylla-housekeeping-daily.timer
 Conflicts=abrt-ccpp.service
 
 [Service]
-PermissionsStartOnly=true
 Type=notify
 LimitCORE=infinity
 LimitMEMLOCK=infinity
@@ -16,9 +15,9 @@ LimitAS=infinity
 LimitNPROC=8096
 EnvironmentFile=/etc/sysconfig/scylla-server
 EnvironmentFile=/etc/scylla.d/*.conf
-ExecStartPre=/opt/scylladb/scripts/scylla_prepare
+ExecStartPre=+/opt/scylladb/scripts/scylla_prepare
 ExecStart=/usr/bin/scylla $SCYLLA_ARGS $SEASTAR_IO $DEV_MODE $CPUSET $MEM_CONF
-ExecStopPost=/opt/scylladb/scripts/scylla_stop
+ExecStopPost=+/opt/scylladb/scripts/scylla_stop
 TimeoutStartSec=1y
 TimeoutStopSec=900
 KillMode=process

--- a/dist/common/systemd/scylla-server.service
+++ b/dist/common/systemd/scylla-server.service
@@ -26,6 +26,7 @@ Restart=on-abnormal
 User=scylla
 OOMScoreAdjust=-950
 SyslogLevelPrefix=false
+AmbientCapabilities=CAP_SYS_NICE CAP_IPC_LOCK
 Slice=scylla-server.slice
 
 [Install]

--- a/dist/common/systemd/scylla-server.slice
+++ b/dist/common/systemd/scylla-server.slice
@@ -12,8 +12,7 @@ CPUAccounting=true
 # seems less future proof. Using just the new versions does not work at all for RHEL7/
 BlockIOWeight=1000
 IOWeight=1000
-# Should be zero, but work around https://github.com/systemd/systemd/issues/8363 for older systemd
-MemorySwapMax=1
+MemorySwapMax=0
 CPUShares=1000
 CPUWeight=1000
 

--- a/scylla_post_install.sh
+++ b/scylla_post_install.sh
@@ -18,34 +18,16 @@ version_ge() {
 # Install capabilities.conf when AmbientCapabilities supported
 . /etc/os-release
 
-# the command below will still work in systems without systemctl (like docker) and across all
-# versions of systemd. We will set the version to 0 if systemctl is not found and then be able
-# to use that in tests.
-SYSTEMD_VER=$(( systemctl --version 2>/dev/null || echo 0 0) | head -n1 | awk '{print $2}')
-RHEL=$(echo $ID $ID_LIKE | grep -oi rhel)
-SYSTEMD_REL=0
-if [ "$RHEL" ]; then
-    SYSTEMD_REL=`rpm -q systemd --qf %{release}|sed -n "s/\([0-9]*\).*/\1/p"`
-fi
-
-AMB_SUPPORT=`grep -c ^CapAmb: /proc/self/status`
-
 KERNEL_VER=$(uname -r)
 
-# AmbientCapabilities supported from v229 but it backported to v219-33 on RHEL7
-if [ $SYSTEMD_VER -ge 229 ] || [[ $SYSTEMD_VER -eq 219 && $SYSTEMD_REL -ge 33 ]]; then
-    if [ $AMB_SUPPORT -eq 1 ]; then
-        AMB_CAPABILITIES="CAP_SYS_NICE CAP_IPC_LOCK"
-        # CAP_PERFMON is only available on linux-5.8+
-        if version_ge $KERNEL_VER 5.8; then
-            AMB_CAPABILITIES="$AMB_CAPABILITIES CAP_PERFMON"
-        fi
-        mkdir -p /etc/systemd/system/scylla-server.service.d/
-        cat << EOS > /etc/systemd/system/scylla-server.service.d/capabilities.conf
+# CAP_PERFMON is only available on linux-5.8+
+if version_ge $KERNEL_VER 5.8; then
+    AMB_CAPABILITIES="$AMB_CAPABILITIES CAP_PERFMON"
+    mkdir -p /etc/systemd/system/scylla-server.service.d/
+    cat << EOS > /etc/systemd/system/scylla-server.service.d/capabilities.conf
 [Service]
-AmbientCapabilities=$AMB_CAPABILITIES
+AmbientCapabilities=CAP_PERFMON
 EOS
-    fi
 fi
 
 # For systems with not a lot of memory, override default reservations for the slices

--- a/scylla_post_install.sh
+++ b/scylla_post_install.sh
@@ -41,18 +41,6 @@ if [ $MEMTOTAL_BYTES -lt 23008753371 ]; then
 [Slice]
 MemoryHigh=1200M
 MemoryMax=1400M
-MemoryLimit=1400M
-EOS
-
-# On CentOS7, systemd does not support percentage-based parameter.
-# To apply memory parameter on CentOS7, we need to override the parameter
-# in bytes, instead of percentage.
-elif [ "$RHEL" -a "$VERSION_ID" = "7" ]; then
-    MEMORY_LIMIT=$((MEMTOTAL_BYTES / 100 * 5))
-    mkdir -p /etc/systemd/system/scylla-helper.slice.d/
-    cat << EOS > /etc/systemd/system/scylla-helper.slice.d/memory.conf
-[Slice]
-MemoryLimit=$MEMORY_LIMIT
 EOS
 fi
 


### PR DESCRIPTION
Since we decided to drop CentOS7 support from latest version of Scylla, now we can drop CentOS7 specific codes from packaging scripts and setup scripts.

Related scylladb/scylla-enterprise#3502