### PR TITLE
test/cql-pytest: test_select_from_mutation_fragments: bump timeout for test_many_partitions

### DIFF
--- a/test/cql-pytest/test_select_from_mutation_fragments.py
+++ b/test/cql-pytest/test_select_from_mutation_fragments.py
@@ -431,7 +431,11 @@ def test_many_partitions(cql, test_keyspace, scylla_only):
         for pk in range(num_partitions):
             cql.execute(delete_id, (pk,))
 
-        res = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table})"))
+        # since this scan is very slow, we create an extra patient cql connection,
+        # with an abundant 10 minutes timeout
+        ep = cql.hosts[0].endpoint
+        with util.cql_session(ep.address, ep.port, False, 'cassandra', 'cassandra', 600) as patient_cql:
+            res = list(patient_cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table})"))
         pks = set()
         partition_starts = 0
         partition_ends = 0


### PR DESCRIPTION
The test test_many_partitions is very slow, as it tests a slow scan over a lot of partitions. This was observed to time out on the slower ARM machines, making the test flaky. To prevent this, create an extra-patient cql connection with a 10 minutes timeout for the scan itself.
This is a follow-up to fb9379edf1b46015ced3e1d1977412c453bd42ef, which attempted to fix this, but didn't patch all the places doing slow scans. This patch fixes the other scan, the one actually observed to time-out in CI.

Fixes: #16145