### PR TITLE
System.peers: enforce host_id

### DIFF
--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -104,7 +104,6 @@ public:
         return _cdc_metadata;
     }
 
-    virtual future<> before_change(gms::inet_address, gms::endpoint_state_ptr, gms::application_state, const gms::versioned_value&) override { return make_ready_future(); }
     virtual future<> on_alive(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
     virtual future<> on_dead(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
     virtual future<> on_remove(gms::inet_address, gms::permit_id) override { return make_ready_future(); }

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -110,7 +110,7 @@ public:
     virtual future<> on_restart(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
 
     virtual future<> on_join(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override;
-    virtual future<> on_change(gms::inet_address, gms::application_state, const gms::versioned_value&, gms::permit_id) override;
+    virtual future<> on_change(gms::inet_address, const gms::application_state_map&, gms::permit_id) override;
 
     future<> check_and_repair_cdc_streams();
 

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -763,7 +763,7 @@ std::pair<std::reference_wrapper<struct query_processor::remote>, gate::holder> 
 
 query_options query_processor::make_internal_options(
         const statements::prepared_statement::checked_weak_ptr& p,
-        const std::initializer_list<data_value>& values,
+        const data_value_list& values,
         db::consistency_level cl,
         int32_t page_size) const {
     if (p->bound_names.size() != values.size()) {
@@ -814,7 +814,7 @@ struct internal_query_state {
 internal_query_state query_processor::create_paged_state(
         const sstring& query_string,
         db::consistency_level cl,
-        const std::initializer_list<data_value>& values,
+        const data_value_list& values,
         int32_t page_size) {
     auto p = prepare_internal(query_string);
     auto opts = make_internal_options(p, values, cl, page_size);
@@ -882,7 +882,7 @@ future<::shared_ptr<untyped_result_set>>
 query_processor::execute_internal(
         const sstring& query_string,
         db::consistency_level cl,
-        const std::initializer_list<data_value>& values,
+        const data_value_list& values,
         cache_internal cache) {
     auto qs = query_state_for_internal_call();
     co_return co_await execute_internal(query_string, cl, qs, values, cache);
@@ -893,7 +893,7 @@ query_processor::execute_internal(
         const sstring& query_string,
         db::consistency_level cl,
         service::query_state& query_state,
-        const std::initializer_list<data_value>& values,
+        const data_value_list& values,
         cache_internal cache) {
 
     if (log.is_enabled(logging::log_level::trace)) {
@@ -915,7 +915,7 @@ query_processor::execute_with_params(
         statements::prepared_statement::checked_weak_ptr p,
         db::consistency_level cl,
         service::query_state& query_state,
-        const std::initializer_list<data_value>& values) {
+        const data_value_list& values) {
     auto opts = make_internal_options(p, values, cl);
     auto statement = p->statement;
 
@@ -1123,7 +1123,7 @@ bool query_processor::migration_subscriber::should_invalidate(
 future<> query_processor::query_internal(
         const sstring& query_string,
         db::consistency_level cl,
-        const std::initializer_list<data_value>& values,
+        const data_value_list& values,
         int32_t page_size,
         noncopyable_function<future<stop_iteration>(const cql3::untyped_result_set_row&)>&& f) {
     auto query_state = create_paged_state(query_string, cl, values, page_size);

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -30,6 +30,7 @@
 #include "utils/observable.hh"
 #include "lang/wasm.hh"
 #include "service/raft/raft_group0_client.hh"
+#include "types/types.hh"
 
 
 namespace service {
@@ -309,7 +310,7 @@ public:
     future<> query_internal(
             const sstring& query_string,
             db::consistency_level cl,
-            const std::initializer_list<data_value>& values,
+            const data_value_list& values,
             int32_t page_size,
             noncopyable_function<future<stop_iteration>(const cql3::untyped_result_set_row&)>&& f);
 
@@ -342,13 +343,13 @@ public:
     future<::shared_ptr<untyped_result_set>> execute_internal(
             const sstring& query_string,
             db::consistency_level,
-            const std::initializer_list<data_value>&,
+            const data_value_list&,
             cache_internal cache);
     future<::shared_ptr<untyped_result_set>> execute_internal(
             const sstring& query_string,
             db::consistency_level,
             service::query_state& query_state,
-            const std::initializer_list<data_value>&,
+            const data_value_list& values,
             cache_internal cache);
     future<::shared_ptr<untyped_result_set>> execute_internal(
             const sstring& query_string,
@@ -364,7 +365,7 @@ public:
         return execute_internal(query_string, cl, query_state, {}, cache);
     }
     future<::shared_ptr<untyped_result_set>>
-    execute_internal(const sstring& query_string, const std::initializer_list<data_value>& values, cache_internal cache) {
+    execute_internal(const sstring& query_string, const data_value_list& values, cache_internal cache) {
         return execute_internal(query_string, db::consistency_level::ONE, values, cache);
     }
     future<::shared_ptr<untyped_result_set>>
@@ -375,7 +376,7 @@ public:
             statements::prepared_statement::checked_weak_ptr p,
             db::consistency_level,
             service::query_state& query_state,
-            const std::initializer_list<data_value>& = { });
+            const data_value_list& values = { });
 
     future<::shared_ptr<cql_transport::messages::result_message>> do_execute_with_params(
             service::query_state& query_state,
@@ -451,7 +452,7 @@ private:
 
     query_options make_internal_options(
             const statements::prepared_statement::checked_weak_ptr& p,
-            const std::initializer_list<data_value>&,
+            const data_value_list& values,
             db::consistency_level,
             int32_t page_size = -1) const;
 
@@ -466,7 +467,7 @@ private:
     internal_query_state create_paged_state(
             const sstring& query_string,
             db::consistency_level,
-            const std::initializer_list<data_value>&,
+            const data_value_list& values,
             int32_t page_size);
 
     /*!

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1565,17 +1565,6 @@ static std::vector<cdc::generation_id_v2> decode_cdc_generations_ids(const set_t
     return gen_ids_list;
 }
 
-future<> system_keyspace::update_tokens(gms::inet_address ep, const std::unordered_set<dht::token>& tokens)
-{
-    if (_db.get_token_metadata().get_topology().is_me(ep)) {
-        on_internal_error(slogger, format("update_tokens called for this node: {}", ep));
-    }
-
-    auto info = peer_info{ .tokens = tokens };
-    co_await update_peer_info(ep, info);
-}
-
-
 future<std::unordered_map<gms::inet_address, std::unordered_set<dht::token>>> system_keyspace::load_tokens() {
     sstring req = format("SELECT peer, tokens FROM system.{}", PEERS);
     return execute_cql(req).then([] (::shared_ptr<cql3::untyped_result_set> cql_result) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2824,7 +2824,7 @@ future<> system_keyspace::shutdown() {
     co_return;
 }
 
-future<::shared_ptr<cql3::untyped_result_set>> system_keyspace::execute_cql(const sstring& query_string, const std::initializer_list<data_value>& values) {
+future<::shared_ptr<cql3::untyped_result_set>> system_keyspace::execute_cql(const sstring& query_string, const data_value_list& values) {
     return _qp.execute_internal(query_string, values, cql3::query_processor::cache_internal::yes);
 }
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1659,58 +1659,6 @@ future<std::unordered_map<gms::inet_address, gms::inet_address>> system_keyspace
     });
 }
 
-// FIXME: implement update_peer_info specializations temporarily,
-// until all callers are converted to use peer_info
-template<> future<> system_keyspace::update_peer_info<sstring>(gms::inet_address ep, sstring column_name, sstring value) {
-    peer_info info;
-    if (column_name == "data_center") {
-        info.data_center.emplace(value);
-    } else if (column_name == "rack") {
-        info.rack.emplace(value);
-    } else if (column_name == "release_version") {
-        info.release_version.emplace(value);
-    } else if (column_name == "supported_features") {
-        info.supported_features.emplace(value);
-    } else {
-        on_fatal_internal_error(slogger, fmt::format("unsupported sstring peer info column_name \"{}\"", column_name));
-    }
-    co_await update_peer_info(ep, info);
-}
-
-template<> future<> system_keyspace::update_peer_info<utils::UUID>(gms::inet_address ep, sstring column_name, utils::UUID value) {
-    peer_info info;
-    if (column_name == "host_id") {
-        info.host_id.emplace(value);
-    } else if (column_name == "schema_version") {
-        info.schema_version.emplace(value);
-    } else {
-        on_fatal_internal_error(slogger, fmt::format("unsupported utils::UUID peer info column_name \"{}\"", column_name));
-    }
-    co_await update_peer_info(ep, info);
-}
-
-template<> future<> system_keyspace::update_peer_info<net::inet_address>(gms::inet_address ep, sstring column_name, net::inet_address value) {
-    peer_info info;
-    if (column_name == "preferred_ip") {
-        info.preferred_ip.emplace(value);
-    } else if (column_name == "rpc_address") {
-        info.rpc_address.emplace(value);
-    } else {
-        on_fatal_internal_error(slogger, fmt::format("unsupported net::inet_address peer info column_name \"{}\"", column_name));
-    }
-    co_await update_peer_info(ep, info);
-}
-
-template<> future<> system_keyspace::update_peer_info<std::unordered_set<dht::token>>(gms::inet_address ep, sstring column_name, std::unordered_set<dht::token> value) {
-    peer_info info;
-    if (column_name == "tokens") {
-        info.tokens.emplace(std::move(value));
-    } else {
-        on_fatal_internal_error(slogger, fmt::format("unsupported std::unordered_set<dht::token>> peer info column_name \"{}\"", column_name));
-    }
-    co_await update_peer_info(ep, info);
-}
-
 namespace {
 template <typename T>
 static data_value_or_unset make_data_value_or_unset(const std::optional<T>& opt, bool& any_set) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1567,7 +1567,7 @@ static std::vector<cdc::generation_id_v2> decode_cdc_generations_ids(const set_t
 future<> system_keyspace::update_tokens(gms::inet_address ep, const std::unordered_set<dht::token>& tokens)
 {
     if (_db.get_token_metadata().get_topology().is_me(ep)) {
-        co_return co_await remove_endpoint(ep);
+        on_internal_error(slogger, format("update_tokens called for this node: {}", ep));
     }
 
     sstring req = format("INSERT INTO system.{} (peer, tokens) VALUES (?, ?)", PEERS);
@@ -1661,7 +1661,7 @@ future<> system_keyspace::update_cached_values(gms::inet_address ep, sstring col
 template <typename Value>
 future<> system_keyspace::update_peer_info(gms::inet_address ep, sstring column_name, Value value) {
     if (_db.get_token_metadata().get_topology().is_me(ep)) {
-        co_return;
+        on_internal_error(slogger, format("update_peer_info called for this node: {}", ep));
     }
 
     co_await update_cached_values(ep, column_name, value);

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1654,17 +1654,11 @@ future<std::unordered_map<gms::inet_address, gms::inet_address>> system_keyspace
 }
 
 template <typename Value>
-future<> system_keyspace::update_cached_values(gms::inet_address ep, sstring column_name, Value value) {
-    return make_ready_future<>();
-}
-
-template <typename Value>
 future<> system_keyspace::update_peer_info(gms::inet_address ep, sstring column_name, Value value) {
     if (_db.get_token_metadata().get_topology().is_me(ep)) {
         on_internal_error(slogger, format("update_peer_info called for this node: {}", ep));
     }
 
-    co_await update_cached_values(ep, column_name, value);
     sstring req = format("INSERT INTO system.{} (peer, {}) VALUES (?, ?)", PEERS, column_name);
     slogger.debug("INSERT INTO system.{} (peer, {}) VALUES ({}, {})", PEERS, column_name, ep, value);
     co_await execute_cql(req, ep.addr(), value).discard_result();

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -44,6 +44,7 @@
 #include "cdc/generation.hh"
 #include "replica/tablets.hh"
 #include "replica/query.hh"
+#include "types/types.hh"
 
 using days = std::chrono::duration<int, std::ratio<24 * 3600>>;
 
@@ -1570,10 +1571,8 @@ future<> system_keyspace::update_tokens(gms::inet_address ep, const std::unorder
         on_internal_error(slogger, format("update_tokens called for this node: {}", ep));
     }
 
-    sstring req = format("INSERT INTO system.{} (peer, tokens) VALUES (?, ?)", PEERS);
-    slogger.debug("INSERT INTO system.{} (peer, tokens) VALUES ({}, {})", PEERS, ep, tokens);
-    auto set_type = set_type_impl::get_instance(utf8_type, true);
-    co_await execute_cql(req, ep.addr(), make_set_value(set_type, prepare_tokens(tokens))).discard_result();
+    auto info = peer_info{ .tokens = tokens };
+    co_await update_peer_info(ep, info);
 }
 
 
@@ -1653,20 +1652,111 @@ future<std::unordered_map<gms::inet_address, gms::inet_address>> system_keyspace
     });
 }
 
-template <typename Value>
-future<> system_keyspace::update_peer_info(gms::inet_address ep, sstring column_name, Value value) {
+// FIXME: implement update_peer_info specializations temporarily,
+// until all callers are converted to use peer_info
+template<> future<> system_keyspace::update_peer_info<sstring>(gms::inet_address ep, sstring column_name, sstring value) {
+    peer_info info;
+    if (column_name == "data_center") {
+        info.data_center.emplace(value);
+    } else if (column_name == "rack") {
+        info.rack.emplace(value);
+    } else if (column_name == "release_version") {
+        info.release_version.emplace(value);
+    } else if (column_name == "supported_features") {
+        info.supported_features.emplace(value);
+    } else {
+        on_fatal_internal_error(slogger, fmt::format("unsupported sstring peer info column_name \"{}\"", column_name));
+    }
+    co_await update_peer_info(ep, info);
+}
+
+template<> future<> system_keyspace::update_peer_info<utils::UUID>(gms::inet_address ep, sstring column_name, utils::UUID value) {
+    peer_info info;
+    if (column_name == "host_id") {
+        info.host_id.emplace(value);
+    } else if (column_name == "schema_version") {
+        info.schema_version.emplace(value);
+    } else {
+        on_fatal_internal_error(slogger, fmt::format("unsupported utils::UUID peer info column_name \"{}\"", column_name));
+    }
+    co_await update_peer_info(ep, info);
+}
+
+template<> future<> system_keyspace::update_peer_info<net::inet_address>(gms::inet_address ep, sstring column_name, net::inet_address value) {
+    peer_info info;
+    if (column_name == "preferred_ip") {
+        info.preferred_ip.emplace(value);
+    } else if (column_name == "rpc_address") {
+        info.rpc_address.emplace(value);
+    } else {
+        on_fatal_internal_error(slogger, fmt::format("unsupported net::inet_address peer info column_name \"{}\"", column_name));
+    }
+    co_await update_peer_info(ep, info);
+}
+
+template<> future<> system_keyspace::update_peer_info<std::unordered_set<dht::token>>(gms::inet_address ep, sstring column_name, std::unordered_set<dht::token> value) {
+    peer_info info;
+    if (column_name == "tokens") {
+        info.tokens.emplace(std::move(value));
+    } else {
+        on_fatal_internal_error(slogger, fmt::format("unsupported std::unordered_set<dht::token>> peer info column_name \"{}\"", column_name));
+    }
+    co_await update_peer_info(ep, info);
+}
+
+namespace {
+template <typename T>
+static data_value_or_unset make_data_value_or_unset(const std::optional<T>& opt, bool& any_set) {
+    if (opt) {
+        any_set = true;
+        return data_value(*opt);
+    } else {
+        return unset_value{};
+    }
+};
+
+static data_value_or_unset make_data_value_or_unset(const std::optional<std::unordered_set<dht::token>>& opt, bool& any_set) {
+    if (opt) {
+        any_set = true;
+        auto set_type = set_type_impl::get_instance(utf8_type, true);
+        return make_set_value(set_type, prepare_tokens(*opt));
+    } else {
+        return unset_value{};
+    }
+};
+}
+
+future<> system_keyspace::update_peer_info(gms::inet_address ep, const peer_info& info) {
     if (_db.get_token_metadata().get_topology().is_me(ep)) {
         on_internal_error(slogger, format("update_peer_info called for this node: {}", ep));
     }
 
-    sstring req = format("INSERT INTO system.{} (peer, {}) VALUES (?, ?)", PEERS, column_name);
-    slogger.debug("INSERT INTO system.{} (peer, {}) VALUES ({}, {})", PEERS, column_name, ep, value);
-    co_await execute_cql(req, ep.addr(), value).discard_result();
+    bool any_set = false;
+    data_value_list values = {
+        data_value_or_unset(data_value(ep.addr())),
+        make_data_value_or_unset(info.data_center, any_set),
+        make_data_value_or_unset(info.host_id, any_set),
+        make_data_value_or_unset(info.preferred_ip, any_set),
+        make_data_value_or_unset(info.rack, any_set),
+        make_data_value_or_unset(info.release_version, any_set),
+        make_data_value_or_unset(info.rpc_address, any_set),
+        make_data_value_or_unset(info.schema_version, any_set),
+        make_data_value_or_unset(info.tokens, any_set),
+        make_data_value_or_unset(info.supported_features, any_set),
+    };
+
+    if (!any_set) {
+        co_return;
+    }
+
+    auto query = fmt::format("INSERT INTO system.{} "
+            "(peer,data_center,host_id,preferred_ip,rack,release_version,rpc_address,schema_version,tokens,supported_features) VALUES"
+            "(?,?,?,?,?,?,?,?,?,?)", PEERS);
+
+    slogger.debug("{}: values={}", query, values);
+
+    co_await _qp.execute_internal(query, db::consistency_level::ONE, values, cql3::query_processor::cache_internal::yes);
 }
-// sets are not needed, since tokens are updated by another method
-template future<> system_keyspace::update_peer_info<sstring>(gms::inet_address ep, sstring column_name, sstring);
-template future<> system_keyspace::update_peer_info<utils::UUID>(gms::inet_address ep, sstring column_name, utils::UUID);
-template future<> system_keyspace::update_peer_info<net::inet_address>(gms::inet_address ep, sstring column_name, net::inet_address);
 
 template <typename T>
 future<> system_keyspace::set_scylla_local_param_as(const sstring& key, const T& value, bool visible_before_cl_replay) {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -265,6 +265,22 @@ public:
     future<std::unordered_map<gms::inet_address, gms::inet_address>> get_preferred_ips();
 
 public:
+    struct peer_info {
+        std::optional<sstring> data_center;
+        std::optional<utils::UUID> host_id;
+        std::optional<net::inet_address> preferred_ip;
+        std::optional<sstring> rack;
+        std::optional<sstring> release_version;
+        std::optional<net::inet_address> rpc_address;
+        std::optional<utils::UUID> schema_version;
+        std::optional<std::unordered_set<dht::token>> tokens;
+        std::optional<sstring> supported_features;
+    };
+
+    future<> update_peer_info(gms::inet_address ep, const peer_info& info);
+
+    // FIXME: implement update_peer_info specializations temporarily,
+    // until all callers are converted to use peer_info
     template <typename Value>
     future<> update_peer_info(gms::inet_address ep, sstring column_name, Value value);
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -257,11 +257,6 @@ public:
     */
     future<> update_tokens(const std::unordered_set<dht::token>& tokens);
 
-    /**
-     * Record tokens being used by another node in the PEERS table.
-     */
-    future<> update_tokens(gms::inet_address ep, const std::unordered_set<dht::token>& tokens);
-
     future<std::unordered_map<gms::inet_address, gms::inet_address>> get_preferred_ips();
 
 public:

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -25,6 +25,7 @@
 #include "locator/host_id.hh"
 #include "mutation/canonical_mutation.hh"
 #include "virtual_tables.hh"
+#include "types/types.hh"
 
 namespace sstables {
     struct entry_descriptor;
@@ -523,7 +524,7 @@ public:
 
     virtual_tables_registry& get_virtual_tables_registry() { return _virtual_tables_registry; }
 private:
-    future<::shared_ptr<cql3::untyped_result_set>> execute_cql(const sstring& query_string, const std::initializer_list<data_value>& values);
+    future<::shared_ptr<cql3::untyped_result_set>> execute_cql(const sstring& query_string, const data_value_list& values);
     template <typename... Args>
     future<::shared_ptr<cql3::untyped_result_set>> execute_cql_with_timeout(sstring req, db::timeout_clock::time_point timeout, Args&&... args);
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -128,8 +128,6 @@ class system_keyspace : public seastar::peering_sharded_service<system_keyspace>
     static schema_ptr large_cells();
     static schema_ptr scylla_local();
     future<> force_blocking_flush(sstring cfname);
-    template <typename Value>
-    future<> update_cached_values(gms::inet_address ep, sstring column_name, Value value);
 public:
     static schema_ptr size_estimates();
 public:

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -274,11 +274,6 @@ public:
 
     future<> update_peer_info(gms::inet_address ep, const peer_info& info);
 
-    // FIXME: implement update_peer_info specializations temporarily,
-    // until all callers are converted to use peer_info
-    template <typename Value>
-    future<> update_peer_info(gms::inet_address ep, sstring column_name, Value value);
-
     future<> remove_endpoint(gms::inet_address ep);
 
     // Saves the key-value pair into system.scylla_local table.

--- a/gms/endpoint_state.cc
+++ b/gms/endpoint_state.cc
@@ -9,6 +9,7 @@
  */
 
 #include "gms/endpoint_state.hh"
+#include "gms/i_endpoint_state_change_subscriber.hh"
 #include <optional>
 #include <ostream>
 #include <boost/lexical_cast.hpp>
@@ -53,6 +54,16 @@ bool endpoint_state::is_cql_ready() const noexcept {
     } catch (...) {
         return false;
     }
+}
+
+future<> i_endpoint_state_change_subscriber::on_application_state_change(inet_address endpoint,
+        const gms::application_state_map& states, application_state app_state, permit_id pid,
+        std::function<future<>(inet_address, const gms::versioned_value&, permit_id)> func) {
+    auto it = states.find(app_state);
+    if (it != states.end()) {
+        return func(endpoint, it->second, pid);
+    }
+    return make_ready_future<>();
 }
 
 }

--- a/gms/endpoint_state.cc
+++ b/gms/endpoint_state.cc
@@ -19,7 +19,7 @@ static_assert(std::is_default_constructible_v<heart_beat_state>);
 static_assert(std::is_nothrow_copy_constructible_v<heart_beat_state>);
 static_assert(std::is_nothrow_move_constructible_v<heart_beat_state>);
 
-static_assert(std::is_nothrow_default_constructible_v<std::map<application_state, versioned_value>>);
+static_assert(std::is_nothrow_default_constructible_v<application_state_map>);
 
 // Note: although std::map::find is not guaranteed to be noexcept
 // it depends on the comperator used and in this case comparing application_state

--- a/gms/endpoint_state.hh
+++ b/gms/endpoint_state.hh
@@ -19,7 +19,7 @@
 
 namespace gms {
 
-using application_state_map = std::map<application_state, versioned_value>;
+using application_state_map = std::unordered_map<application_state, versioned_value>;
 
 /**
  * This abstraction represents both the HeartBeatState and the ApplicationState in an EndpointState

--- a/gms/endpoint_state.hh
+++ b/gms/endpoint_state.hh
@@ -19,6 +19,8 @@
 
 namespace gms {
 
+using application_state_map = std::map<application_state, versioned_value>;
+
 /**
  * This abstraction represents both the HeartBeatState and the ApplicationState in an EndpointState
  * instance. Any state for a given endpoint can be retrieved from this instance.
@@ -28,7 +30,7 @@ public:
     using clk = seastar::lowres_system_clock;
 private:
     heart_beat_state _heart_beat_state;
-    std::map<application_state, versioned_value> _application_state;
+    application_state_map _application_state;
     /* fields below do not get serialized */
     clk::time_point _update_timestamp;
     bool _is_normal = false;
@@ -55,7 +57,7 @@ public:
     }
 
     endpoint_state(heart_beat_state&& initial_hb_state,
-            const std::map<application_state, versioned_value>& application_state)
+            const application_state_map& application_state)
         : _heart_beat_state(std::move(initial_hb_state))
         , _application_state(application_state)
         , _update_timestamp(clk::now())
@@ -84,11 +86,11 @@ public:
      * TODO replace this with operations that don't expose private state
      */
     // @Deprecated
-    std::map<application_state, versioned_value>& get_application_state_map() noexcept {
+    application_state_map& get_application_state_map() noexcept {
         return _application_state;
     }
 
-    const std::map<application_state, versioned_value>& get_application_state_map() const noexcept {
+    const application_state_map& get_application_state_map() const noexcept {
         return _application_state;
     }
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -227,8 +227,8 @@ public:
     future<> on_join(inet_address ep, endpoint_state_ptr state, gms::permit_id) override {
         return enable_features();
     }
-    future<> on_change(inet_address ep, application_state state, const versioned_value&, gms::permit_id) override {
-        if (state == application_state::SUPPORTED_FEATURES) {
+    future<> on_change(inet_address ep, const gms::application_state_map& states, gms::permit_id pid) override {
+        if (states.contains(application_state::SUPPORTED_FEATURES)) {
             return enable_features();
         }
         return make_ready_future();

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -233,7 +233,6 @@ public:
         }
         return make_ready_future();
     }
-    future<> before_change(inet_address, endpoint_state_ptr, application_state, const versioned_value&) override { return make_ready_future(); }
     future<> on_alive(inet_address, endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
     future<> on_dead(inet_address, endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
     future<> on_remove(inet_address, gms::permit_id) override { return make_ready_future(); }

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -474,7 +474,7 @@ gossiper::handle_get_endpoint_states_msg(gossip_get_endpoint_states_request requ
     for (const auto& [node, state] : _endpoint_state_map) {
         const heart_beat_state& hbs = state->get_heart_beat_state();
         auto state_wanted = endpoint_state(hbs);
-        const std::map<application_state, versioned_value>& apps = state->get_application_state_map();
+        auto& apps = state->get_application_state_map();
         for (const auto& app : apps) {
             if (application_states_wanted.count(app.first) > 0) {
                 state_wanted.get_application_state_map().emplace(app);
@@ -1945,7 +1945,7 @@ void gossiper::examine_gossiper(utils::chunked_vector<gossip_digest>& g_digest_l
     }
 }
 
-future<> gossiper::start_gossiping(gms::generation_type generation_nbr, std::map<application_state, versioned_value> preload_local_states, gms::advertise_myself advertise) {
+future<> gossiper::start_gossiping(gms::generation_type generation_nbr, application_state_map preload_local_states, gms::advertise_myself advertise) {
     auto permit = co_await lock_endpoint(get_broadcast_address(), null_permit_id);
     co_await container().invoke_on_all([advertise] (gossiper& g) {
         if (!advertise) {

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -522,10 +522,6 @@ private:
     // Must be called under lock_endpoint.
     future<> apply_new_states(inet_address addr, endpoint_state local_state, const endpoint_state& remote_state, permit_id);
 
-    // notify that a local application state is going to change (doesn't get triggered for remote changes)
-    // Must be called under lock_endpoint.
-    future<> do_before_change_notifications(inet_address addr, endpoint_state_ptr ep_state, const application_state& ap_state, const versioned_value& new_value) const;
-
     // notify that an application state has changed
     // Must be called under lock_endpoint.
     future<> do_on_change_notifications(inet_address addr, const application_state& state, const versioned_value& value, permit_id) const;

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -524,7 +524,7 @@ private:
 
     // notify that an application state has changed
     // Must be called under lock_endpoint.
-    future<> do_on_change_notifications(inet_address addr, const application_state& state, const versioned_value& value, permit_id) const;
+    future<> do_on_change_notifications(inet_address addr, const application_state_map& states, permit_id) const;
 
     // notify that a node is DOWN (dead)
     // Must be called under lock_endpoint.
@@ -611,7 +611,7 @@ public:
      * Applies all states in set "atomically", as in guaranteed monotonic versions and
      * inserted into endpoint state together (and assuming same grouping, overwritten together).
      */
-    future<> add_local_application_state(std::list<std::pair<application_state, versioned_value>>);
+    future<> add_local_application_state(application_state_map states);
 
     /**
      * Intentionally overenginered to avoid very rare string copies.

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -588,7 +588,7 @@ public:
      * existing nodes can talk to the replacing node. So the probability of
      * replacing node being talked to is pretty high.
      */
-    future<> start_gossiping(gms::generation_type generation_nbr, std::map<application_state, versioned_value> preload_local_states = {},
+    future<> start_gossiping(gms::generation_type generation_nbr, application_state_map preload_local_states = {},
             gms::advertise_myself advertise = gms::advertise_myself::yes);
 
 public:

--- a/gms/i_endpoint_state_change_subscriber.hh
+++ b/gms/i_endpoint_state_change_subscriber.hh
@@ -33,6 +33,10 @@ namespace gms {
  * null_permit_id to indicate that no endpoint lock is held for them.
  */
 class i_endpoint_state_change_subscriber {
+protected:
+    future<> on_application_state_change(inet_address endpoint, const application_state_map& states, application_state app_state, permit_id,
+        std::function<future<>(inet_address, const gms::versioned_value&, gms::permit_id)> func);
+
 public:
     virtual ~i_endpoint_state_change_subscriber() {}
     /**
@@ -44,7 +48,7 @@ public:
      */
     virtual future<> on_join(inet_address endpoint, endpoint_state_ptr ep_state, permit_id) = 0;
 
-    virtual future<> on_change(inet_address endpoint, application_state state, const versioned_value& value, permit_id) = 0;
+    virtual future<> on_change(inet_address endpoint, const application_state_map& states, permit_id) = 0;
 
     virtual future<> on_alive(inet_address endpoint, endpoint_state_ptr state, permit_id) = 0;
 

--- a/gms/i_endpoint_state_change_subscriber.hh
+++ b/gms/i_endpoint_state_change_subscriber.hh
@@ -44,8 +44,6 @@ public:
      */
     virtual future<> on_join(inet_address endpoint, endpoint_state_ptr ep_state, permit_id) = 0;
 
-    virtual future<> before_change(inet_address endpoint, endpoint_state_ptr current_state, application_state new_statekey, const versioned_value& newvalue) = 0;
-
     virtual future<> on_change(inet_address endpoint, application_state state, const versioned_value& value, permit_id) = 0;
 
     virtual future<> on_alive(inet_address endpoint, endpoint_state_ptr state, permit_id) = 0;

--- a/idl/gossip_digest.idl.hh
+++ b/idl/gossip_digest.idl.hh
@@ -43,7 +43,7 @@ class heart_beat_state {
 
 class endpoint_state {
     gms::heart_beat_state get_heart_beat_state();
-    std::map<gms::application_state, gms::versioned_value> get_application_state_map();
+    std::unordered_map<gms::application_state, gms::versioned_value> get_application_state_map();
 };
 
 class gossip_digest {

--- a/locator/ec2_multi_region_snitch.cc
+++ b/locator/ec2_multi_region_snitch.cc
@@ -78,7 +78,7 @@ void ec2_multi_region_snitch::set_local_private_addr(const sstring& addr_str) {
     _local_private_address = addr_str;
 }
 
-std::list<std::pair<gms::application_state, gms::versioned_value>> ec2_multi_region_snitch::get_app_states() const {
+gms::application_state_map ec2_multi_region_snitch::get_app_states() const {
     return {
         {gms::application_state::DC, gms::versioned_value::datacenter(_my_dc)},
         {gms::application_state::RACK, gms::versioned_value::rack(_my_rack)},

--- a/locator/ec2_multi_region_snitch.hh
+++ b/locator/ec2_multi_region_snitch.hh
@@ -16,7 +16,7 @@ namespace locator {
 class ec2_multi_region_snitch : public ec2_snitch {
 public:
     ec2_multi_region_snitch(const snitch_config&);
-    virtual std::list<std::pair<gms::application_state, gms::versioned_value>> get_app_states() const override;
+    virtual gms::application_state_map get_app_states() const override;
     virtual future<> start() override;
     virtual void set_local_private_addr(const sstring& addr_str) override;
     virtual sstring get_name() const override {

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -107,14 +107,14 @@ void gossiping_property_file_snitch::periodic_reader_callback() {
     });
 }
 
-std::list<std::pair<gms::application_state, gms::versioned_value>> gossiping_property_file_snitch::get_app_states() const {
-    std::list<std::pair<gms::application_state, gms::versioned_value>> ret = {
+gms::application_state_map gossiping_property_file_snitch::get_app_states() const {
+    gms::application_state_map ret = {
         {gms::application_state::DC, gms::versioned_value::datacenter(_my_dc)},
         {gms::application_state::RACK, gms::versioned_value::rack(_my_rack)},
     };
     if (_listen_address.has_value()) {
         sstring ip = format("{}", *_listen_address);
-        ret.emplace_back(gms::application_state::INTERNAL_IP, gms::versioned_value::internal_ip(std::move(ip)));
+        ret.emplace(gms::application_state::INTERNAL_IP, gms::versioned_value::internal_ip(std::move(ip)));
     }
     return ret;
 }

--- a/locator/gossiping_property_file_snitch.hh
+++ b/locator/gossiping_property_file_snitch.hh
@@ -35,7 +35,7 @@ public:
         return std::chrono::seconds(60);
     }
 
-    virtual std::list<std::pair<gms::application_state, gms::versioned_value>> get_app_states() const override;
+    virtual gms::application_state_map get_app_states() const override;
     virtual future<> stop() override;
     virtual future<> start() override;
     virtual future<> pause_io() override;

--- a/locator/snitch_base.cc
+++ b/locator/snitch_base.cc
@@ -13,7 +13,7 @@
 
 namespace locator {
 
-std::list<std::pair<gms::application_state, gms::versioned_value>> snitch_base::get_app_states() const {
+gms::application_state_map snitch_base::get_app_states() const {
     return {
         {gms::application_state::DC, gms::versioned_value::datacenter(_my_dc)},
         {gms::application_state::RACK, gms::versioned_value::rack(_my_rack)},

--- a/locator/snitch_base.hh
+++ b/locator/snitch_base.hh
@@ -15,6 +15,7 @@
 #include <boost/signals2.hpp>
 #include <boost/signals2/dummy_mutex.hpp>
 
+#include "gms/endpoint_state.hh"
 #include "locator/types.hh"
 #include "gms/inet_address.hh"
 #include "inet_address_vectors.hh"
@@ -83,7 +84,7 @@ public:
     /**
      * returns whatever info snitch wants to gossip
      */
-    virtual std::list<std::pair<gms::application_state, gms::versioned_value>> get_app_states() const = 0;
+    virtual gms::application_state_map get_app_states() const = 0;
 
     virtual ~i_endpoint_snitch() { assert(_state == snitch_state::stopped); };
 
@@ -295,7 +296,7 @@ public:
     // virtual sstring get_datacenter()  = 0;
     //
 
-    virtual std::list<std::pair<gms::application_state, gms::versioned_value>> get_app_states() const override;
+    virtual gms::application_state_map get_app_states() const override;
 
 protected:
     sstring _my_dc;

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3031,13 +3031,6 @@ public:
             gms::permit_id) override {
         return make_ready_future();
     }
-    virtual future<> before_change(
-            gms::inet_address endpoint,
-            gms::endpoint_state_ptr current_state,
-            gms::application_state new_state_key,
-            const gms::versioned_value& new_value) override {
-        return make_ready_future();
-    }
     virtual future<> on_change(
             gms::inet_address endpoint,
             gms::application_state state,

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -8,6 +8,7 @@
 
 #include <exception>
 #include <seastar/util/defer.hh>
+#include "gms/endpoint_state.hh"
 #include "repair/repair.hh"
 #include "message/messaging_service.hh"
 #include "repair/task_manager_module.hh"
@@ -3033,8 +3034,7 @@ public:
     }
     virtual future<> on_change(
             gms::inet_address endpoint,
-            gms::application_state state,
-            const gms::versioned_value& value,
+            const gms::application_state_map& states,
             gms::permit_id) override {
         return make_ready_future();
     }

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -4223,7 +4223,11 @@ class scylla_gms(gdb.Command):
                 pass
             ip = ip_to_str(int(get_ip(endpoint)), byteorder=sys.byteorder)
             gdb.write('%s: (gms::endpoint_state*) %s (%s)\n' % (ip, state.address, state['_heart_beat_state']))
-            for app_state, vv in std_map(state['_application_state']):
+            try:
+                app_states_map = std_unordered_map(state['_application_state'])
+            except:
+                app_states_map = std_map(state['_application_state'])
+            for app_state, vv in app_states_map:
                 value = get_gms_versioned_value(vv)
                 gdb.write('  %s: {version=%d, value=%s}\n' % (app_state, value['version'], value['value']))
 

--- a/service/load_broadcaster.hh
+++ b/service/load_broadcaster.hh
@@ -50,8 +50,6 @@ public:
         return make_ready_future();
     }
     
-    virtual future<> before_change(gms::inet_address endpoint, gms::endpoint_state_ptr current_state, gms::application_state new_state_key, const gms::versioned_value& newValue) override { return make_ready_future(); }
-
     future<> on_alive(gms::inet_address endpoint, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
 
     future<> on_dead(gms::inet_address endpoint, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }

--- a/service/load_broadcaster.hh
+++ b/service/load_broadcaster.hh
@@ -35,17 +35,17 @@ public:
         assert(_stopped);
     }
 
-    virtual future<> on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value, gms::permit_id) override {
-        if (state == gms::application_state::LOAD) {
+    virtual future<> on_change(gms::inet_address endpoint, const gms::application_state_map& states, gms::permit_id pid) override {
+        return on_application_state_change(endpoint, states, gms::application_state::LOAD, pid, [this] (gms::inet_address endpoint, const gms::versioned_value& value, gms::permit_id) {
             _load_info[endpoint] = std::stod(value.value());
-        }
-        return make_ready_future();
+            return make_ready_future<>();
+        });
     }
 
     virtual future<> on_join(gms::inet_address endpoint, gms::endpoint_state_ptr ep_state, gms::permit_id pid) override {
         auto* local_value = ep_state->get_application_state_ptr(gms::application_state::LOAD);
         if (local_value) {
-            return on_change(endpoint, gms::application_state::LOAD, *local_value, pid);
+            _load_info[endpoint] = std::stod(local_value->value());
         }
         return make_ready_future();
     }

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -178,7 +178,7 @@ public:
 
 private:
     virtual future<> on_join(gms::inet_address endpoint, gms::endpoint_state_ptr ep_state, gms::permit_id) override;
-    virtual future<> on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value, gms::permit_id) override;
+    virtual future<> on_change(gms::inet_address endpoint, const gms::application_state_map& states, gms::permit_id) override;
     virtual future<> on_alive(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) override;
     virtual future<> on_dead(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) override { return make_ready_future(); }
     virtual future<> on_remove(gms::inet_address endpoint, gms::permit_id) override { return make_ready_future(); }

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -183,7 +183,6 @@ private:
     virtual future<> on_dead(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) override { return make_ready_future(); }
     virtual future<> on_remove(gms::inet_address endpoint, gms::permit_id) override { return make_ready_future(); }
     virtual future<> on_restart(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> before_change(gms::inet_address endpoint, gms::endpoint_state_ptr current_state, gms::application_state new_statekey, const gms::versioned_value& newvalue) override { return make_ready_future(); }
 
 public:
     // For tests only.

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -266,8 +266,8 @@ future<> view_update_backlog_broker::stop() {
     });
 }
 
-future<> view_update_backlog_broker::on_change(gms::inet_address endpoint, gms::application_state state, const gms::versioned_value& value, gms::permit_id) {
-    if (state == gms::application_state::VIEW_BACKLOG) {
+future<> view_update_backlog_broker::on_change(gms::inet_address endpoint, const gms::application_state_map& states, gms::permit_id pid) {
+    return on_application_state_change(endpoint, states, gms::application_state::VIEW_BACKLOG, pid, [this] (gms::inet_address endpoint, const gms::versioned_value& value, gms::permit_id) {
         size_t current;
         size_t max;
         api::timestamp_type ticks;
@@ -292,8 +292,8 @@ future<> view_update_backlog_broker::on_change(gms::inet_address endpoint, gms::
         if (!inserted && it->second.ts < backlog.ts) {
             it->second = std::move(backlog);
         }
-    }
-    return make_ready_future();
+        return make_ready_future();
+    });
 }
 
 future<> view_update_backlog_broker::on_remove(gms::inet_address endpoint, gms::permit_id) {

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -102,14 +102,6 @@ public:
     }
 
     virtual future<>
-    before_change(gms::inet_address endpoint,
-        gms::endpoint_state_ptr current_state, gms::application_state new_statekey,
-        const gms::versioned_value& newvalue) override {
-        // Raft server ID never changes - do nothing
-        return make_ready_future<>();
-    }
-
-    virtual future<>
     on_change(gms::inet_address endpoint,
         gms::application_state state, const gms::versioned_value& value, gms::permit_id) override {
         // Raft server ID never changes - do nothing

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -102,8 +102,7 @@ public:
     }
 
     virtual future<>
-    on_change(gms::inet_address endpoint,
-        gms::application_state state, const gms::versioned_value& value, gms::permit_id) override {
+    on_change(gms::inet_address endpoint, const gms::application_state_map& states, gms::permit_id) override {
         // Raft server ID never changes - do nothing
         return make_ready_future<>();
     }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3988,11 +3988,6 @@ future<> storage_service::on_alive(gms::inet_address endpoint, gms::endpoint_sta
     }
 }
 
-future<> storage_service::before_change(gms::inet_address endpoint, gms::endpoint_state_ptr current_state, gms::application_state new_state_key, const gms::versioned_value& new_value) {
-    slogger.debug("endpoint={} before_change: new app_state={}, new versioned_value={}", endpoint, new_state_key, new_value);
-    return make_ready_future();
-}
-
 future<> storage_service::on_change(inet_address endpoint, application_state state, const versioned_value& value, gms::permit_id pid) {
     slogger.debug("endpoint={} on_change:     app_state={}, versioned_value={}, permit_id={}", endpoint, state, value, pid);
     if (state == application_state::STATUS) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3000,7 +3000,7 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
         std::unordered_map<gms::inet_address, sstring> loaded_peer_features,
         std::chrono::milliseconds delay) {
     std::unordered_set<token> bootstrap_tokens;
-    std::map<gms::application_state, gms::versioned_value> app_states;
+    gms::application_state_map app_states;
     /* The timestamp of the CDC streams generation that this node has proposed when joining.
      * This value is nullopt only when:
      * 1. this node is being upgraded from a non-CDC version,

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -472,7 +472,6 @@ private:
 
     template <typename T>
     future<> update_table(gms::inet_address endpoint, sstring col, T value);
-    future<> update_peer_info(inet_address endpoint);
     future<> do_update_system_peers_table(gms::inet_address endpoint, const application_state& state, const versioned_value& value);
 
     std::unordered_set<token> get_tokens_for(inet_address endpoint);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -467,6 +467,9 @@ public:
     virtual void on_drop_aggregate(const sstring& ks_name, const sstring& aggregate_name) override {}
     virtual void on_drop_view(const sstring& ks_name, const sstring& view_name) override {}
 private:
+    db::system_keyspace::peer_info get_peer_info_for_update(inet_address endpoint);
+    static db::system_keyspace::peer_info get_peer_info_for_update(inet_address endpoint, const gms::application_state_map& app_state_map);
+
     template <typename T>
     future<> update_table(gms::inet_address endpoint, sstring col, T value);
     future<> update_peer_info(inet_address endpoint);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -408,7 +408,6 @@ public:
             const dht::token_range_vector& ranges) const;
 public:
     virtual future<> on_join(gms::inet_address endpoint, gms::endpoint_state_ptr ep_state, gms::permit_id) override;
-    virtual future<> before_change(gms::inet_address endpoint, gms::endpoint_state_ptr current_state, gms::application_state new_state_key, const gms::versioned_value& new_value) override;
     /*
      * Handle the reception of a new particular ApplicationState for a particular endpoint. Note that the value of the
      * ApplicationState has not necessarily "changed" since the last known value, if we already received the same update

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <seastar/core/shared_future.hh>
+#include "gms/endpoint_state.hh"
 #include "gms/i_endpoint_state_change_subscriber.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "service/topology_guard.hh"
@@ -436,7 +437,7 @@ public:
      * Note: Any time a node state changes from STATUS_NORMAL, it will not be visible to new nodes. So it follows that
      * you should never bootstrap a new node during a removenode, decommission or move.
      */
-    virtual future<> on_change(inet_address endpoint, application_state state, const versioned_value& value, gms::permit_id) override;
+    virtual future<> on_change(gms::inet_address endpoint, const gms::application_state_map& states, gms::permit_id) override;
     virtual future<> on_alive(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) override;
     virtual future<> on_dead(gms::inet_address endpoint, gms::endpoint_state_ptr state, gms::permit_id) override;
     virtual future<> on_remove(gms::inet_address endpoint, gms::permit_id) override;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -470,10 +470,6 @@ private:
     db::system_keyspace::peer_info get_peer_info_for_update(inet_address endpoint);
     static db::system_keyspace::peer_info get_peer_info_for_update(inet_address endpoint, const gms::application_state_map& app_state_map);
 
-    template <typename T>
-    future<> update_table(gms::inet_address endpoint, sstring col, T value);
-    future<> do_update_system_peers_table(gms::inet_address endpoint, const application_state& state, const versioned_value& value);
-
     std::unordered_set<token> get_tokens_for(inet_address endpoint);
     std::optional<locator::endpoint_dc_rack> get_dc_rack_for(const gms::endpoint_state& ep_state);
     std::optional<locator::endpoint_dc_rack> get_dc_rack_for(inet_address endpoint);

--- a/service/view_update_backlog_broker.hh
+++ b/service/view_update_backlog_broker.hh
@@ -39,7 +39,7 @@ public:
 
     seastar::future<> stop();
 
-    virtual future<> on_change(gms::inet_address, gms::application_state, const gms::versioned_value&, gms::permit_id) override;
+    virtual future<> on_change(gms::inet_address, const gms::application_state_map& states, gms::permit_id) override;
 
     virtual future<> on_remove(gms::inet_address, gms::permit_id) override;
 

--- a/service/view_update_backlog_broker.hh
+++ b/service/view_update_backlog_broker.hh
@@ -44,7 +44,6 @@ public:
     virtual future<> on_remove(gms::inet_address, gms::permit_id) override;
 
     virtual future<> on_join(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> before_change(gms::inet_address, gms::endpoint_state_ptr, gms::application_state, const gms::versioned_value&) override { return make_ready_future(); }
     virtual future<> on_alive(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
     virtual future<> on_dead(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }
     virtual future<> on_restart(gms::inet_address, gms::endpoint_state_ptr, gms::permit_id) override { return make_ready_future(); }

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -171,7 +171,7 @@ public:
 
 public:
     virtual future<> on_join(inet_address endpoint, endpoint_state_ptr ep_state, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> on_change(inet_address endpoint, application_state state, const versioned_value& value, gms::permit_id) override { return make_ready_future(); }
+    virtual future<> on_change(gms::inet_address, const gms::application_state_map& states, gms::permit_id) override  { return make_ready_future(); }
     virtual future<> on_alive(inet_address endpoint, endpoint_state_ptr state, gms::permit_id) override { return make_ready_future(); }
     virtual future<> on_dead(inet_address endpoint, endpoint_state_ptr state, gms::permit_id) override;
     virtual future<> on_remove(inet_address endpoint, gms::permit_id) override;

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -171,7 +171,6 @@ public:
 
 public:
     virtual future<> on_join(inet_address endpoint, endpoint_state_ptr ep_state, gms::permit_id) override { return make_ready_future(); }
-    virtual future<> before_change(inet_address endpoint, endpoint_state_ptr current_state, application_state new_state_key, const versioned_value& new_value) override { return make_ready_future(); }
     virtual future<> on_change(inet_address endpoint, application_state state, const versioned_value& value, gms::permit_id) override { return make_ready_future(); }
     virtual future<> on_alive(inet_address endpoint, endpoint_state_ptr state, gms::permit_id) override { return make_ready_future(); }
     virtual future<> on_dead(inet_address endpoint, endpoint_state_ptr state, gms::permit_id) override;

--- a/test/manual/gossip.cc
+++ b/test/manual/gossip.cc
@@ -88,7 +88,7 @@ int main(int ac, char ** av) {
 
             std::cout << "Start gossiper service ...\n";
 
-            std::map<gms::application_state, gms::versioned_value> app_states = {
+            gms::application_state_map app_states = {
                 { gms::application_state::LOAD, gms::versioned_value::load(0.5) },
             };
 

--- a/types/types.hh
+++ b/types/types.hh
@@ -12,6 +12,7 @@
 #include <boost/functional/hash.hpp>
 #include <iosfwd>
 #include <sstream>
+#include <initializer_list>
 
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -1002,3 +1003,5 @@ struct appending_hash<data_type> {
         feed_hash(h, v->name());
     }
 };
+
+using data_value_list = std::initializer_list<data_value>;


### PR DESCRIPTION
The HOST_ID is already written to system.peers since inception pretty much (See https://github.com/scylladb/scylladb/pull/16376#discussion_r1429248185 for details).

However, it is written to the table using an individual CQL query and so it is not set atomically with other columns.
If scylla crashes or even hits an exception before updating the host_id, then system.peers might be left in an inconsistent state, and in particular without no HOST_ID value.

This series makes sure that HOST_ID is written to system.peers and use it to "seal" the record by upserting it in a single CQL BATCH query when adding the state for new nodes.

On the read side, skip rows that have no HOST_ID state in system.peers, assuming they are incomplete, i.e. scylla got an exception or crashed while writing them, so they can't be trusted.

With that change we can assume that endpoint state loaded from system.peers will always have a valid host_id.

Refs https://github.com/scylladb/scylladb/pull/15903