### PR TITLE
tasks: keep task's children in list

### DIFF
--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -232,8 +232,8 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         while (!q.empty()) {
             auto& current = q.front();
             res.push_back(co_await retrieve_status(current));
-            for (size_t i = 0; i < current->get_children().size(); ++i) {
-                q.push(co_await current->get_children()[i].copy());
+            for (auto& child: current->get_children()) {
+                q.push(co_await child.copy());
             }
             q.pop();
         }

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -71,9 +71,7 @@ future<task_manager::task::progress> task_manager::task::impl::get_progress() co
     }
 
     tasks::task_manager::task::progress progress{};
-    // _children vector may be modified in the meantime. Do not use foreach loop as the iterators may get invalidated.
-    for (unsigned i = 0; i < _children.size(); ++i) {
-        auto& child = _children[i];
+    for (auto& child: _children) {
         progress += co_await smp::submit_to(child.get_owner_shard(), [&child] {
             return child->get_progress();
         });
@@ -251,7 +249,7 @@ void task_manager::task::unregister_task() noexcept {
     _impl->_module->unregister_task(id());
 }
 
-const task_manager::foreign_task_vector& task_manager::task::get_children() const noexcept {
+const task_manager::foreign_task_list& task_manager::task::get_children() const noexcept {
     return _impl->_children;
 }
 

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -42,7 +42,7 @@ public:
     using task_ptr = lw_shared_ptr<task_manager::task>;
     using task_map = std::unordered_map<task_id, task_ptr>;
     using foreign_task_ptr = foreign_ptr<task_ptr>;
-    using foreign_task_vector = std::vector<foreign_task_ptr>;
+    using foreign_task_list = std::list<foreign_task_ptr>;
     using module_ptr = shared_ptr<module>;
     using modules = std::unordered_map<std::string, module_ptr>;
 private:
@@ -109,7 +109,7 @@ public:
         protected:
             status _status;
             task_id _parent_id;
-            foreign_task_vector _children;
+            foreign_task_list _children;
             shared_promise<> _done;
             module_ptr _module;
             seastar::abort_source _as;
@@ -167,7 +167,7 @@ public:
         future<> done() const noexcept;
         void register_task();
         void unregister_task() noexcept;
-        const foreign_task_vector& get_children() const noexcept;
+        const foreign_task_list& get_children() const noexcept;
         bool is_complete() const noexcept;
         void release_resources() noexcept;
 


### PR DESCRIPTION
If std::vector is resized its iterators and references may get invalidated. While task_manager::task::impl::_children's iterators are avoided throughout the code, references to its elements are being used.

Since children vector does not need random access to its elements, change its type to std::list<foreign_task_ptr>, which iterators and references aren't invalidated on element insertion.

Fixes: #16380.