### PR TITLE
s3/client: add client::upload_file()

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -6,6 +6,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/format.h>
+#include <cstdlib>
+#include <exception>
 #include <initializer_list>
 #include <memory>
 #include <stdexcept>
@@ -18,8 +21,15 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/fstream.hh>
+#include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/on_internal_error.hh>
+#include <seastar/core/pipe.hh>
 #include <seastar/core/units.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/util/short_streams.hh>
 #include <seastar/util/lazy.hh>
@@ -852,6 +862,234 @@ data_sink client::make_upload_sink(sstring object_name) {
 
 data_sink client::make_upload_jumbo_sink(sstring object_name, std::optional<unsigned> max_parts_per_piece) {
     return data_sink(std::make_unique<upload_jumbo_sink>(shared_from_this(), std::move(object_name), max_parts_per_piece));
+}
+
+// unlike upload_sink and upload_jumbo_sink, do_upload_file reads from the
+// specified file, and sends the data read from disk right away to the wire,
+// without accumulating them first.
+class client::do_upload_file {
+    shared_ptr<client> _client;
+    const std::filesystem::path _path;
+    sstring _object_name;
+    sstring _upload_id;
+    utils::chunked_vector<sstring> _part_etags;
+    std::optional<tag> _tag;
+    size_t _part_size;
+    gate _bg_uploads;
+
+    // each time, we read up to transmit size from disk.
+    // this is also an option which limits the number of multipart upload tasks.
+    //
+    // connected_socket::output() uses 8 KiB for its buffer_size, and
+    // file_input_stream_options.buffer_size is also 8 KiB, taking the
+    // read-ahead into consideration, for maximizing the throughput,
+    // we use 64K buffer size.
+    static constexpr size_t _transmit_size = 64_KiB;
+
+    future<> create_multipart_upload() {
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html
+        auto req = http::request::make("POST", _client->_host, _object_name);
+        req.query_parameters["uploads"] = "";
+        if (_tag) {
+            req._headers["x-amz-tagging"] = seastar::format("{}={}", _tag->key, _tag->value);
+        }
+        co_await _client->make_request(std::move(req), [this] (const http::reply& rep, input_stream<char>&& in_) -> future<> {
+            auto in = std::move(in_);
+            auto body = co_await util::read_entire_stream_contiguous(in);
+            _upload_id = parse_multipart_upload_id(body);
+            if (_upload_id.empty()) {
+                co_await coroutine::return_exception(std::runtime_error("cannot initiate upload"));
+            }
+            s3l.trace("created multipart upload for {} -> id = {}", _object_name, _upload_id);
+        });
+    }
+
+    future<> complete_multipart_upload() {
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
+        unsigned parts_xml_len = prepare_multipart_upload_parts(_part_etags);
+        auto req = http::request::make("POST", _client->_host, _object_name);
+        req.query_parameters["uploadId"] = _upload_id;
+        req.write_body("xml", parts_xml_len, [this] (output_stream<char>&& out) -> future<> {
+            return dump_multipart_upload_parts(std::move(out), _part_etags);
+        });
+        // If this request fails, complete_multipart_upload() throws, the upload should then
+        // be aborted in .close() method
+        co_await _client->make_request(std::move(req));
+        _upload_id = ""; // now upload_started() returns false
+    }
+
+    future<> abort_multipart_upload() {
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
+        s3l.trace("abort multipart upload {}", _upload_id);
+        auto req = http::request::make("DELETE", _client->_host, _object_name);
+        req.query_parameters["uploadId"] = std::exchange(_upload_id, "");
+        co_await _client->make_request(std::move(req), ignore_reply, http::reply::status_type::no_content);
+    }
+
+    // transmit data from input to output in chunks sized up to unit_size
+    static future<> copy_to(input_stream<char> input,
+                            output_stream<char> output,
+                            size_t unit_size) {
+        std::exception_ptr ex;
+        try {
+            for (;;) {
+                auto buf = co_await input.read_up_to(unit_size);
+                if (buf.empty()) {
+                    break;
+                }
+                co_await output.write(buf.get(), buf.size());
+            }
+            co_await output.flush();
+        } catch (...) {
+            ex = std::current_exception();
+        }
+        co_await output.close();
+        co_await input.close();
+        if (ex) {
+            co_await coroutine::return_exception_ptr(std::move(ex));
+        }
+    }
+
+    future<> upload_part(file f, uint64_t offset, uint64_t part_size) {
+        // upload a part in a multipart upload, see
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html
+        auto mem_units = co_await _client->claim_memory(_transmit_size);
+
+        unsigned part_number = _part_etags.size();
+        _part_etags.emplace_back();
+        auto req = http::request::make("PUT", _client->_host, _object_name);
+        req._headers["Content-Length"] = to_sstring(part_size);
+        req.query_parameters.emplace("partNumber", to_sstring(part_number + 1));
+        req.query_parameters.emplace("uploadId", _upload_id);
+        s3l.trace("PUT part {}, {} bytes (upload id {})", part_number, part_size, _upload_id);
+        req.write_body("bin", part_size, [f=std::move(f), mem_units=std::move(mem_units), offset, part_size] (output_stream<char>&& out_) mutable {
+            auto input = make_file_input_stream(std::move(f), offset, part_size);
+            auto output = std::move(out_);
+            return copy_to(std::move(input), std::move(output), _transmit_size);
+        });
+        // upload the parts in the background for better throughput
+        auto gh = _bg_uploads.hold();
+        std::ignore = _client->make_request(std::move(req), [this, part_size, part_number, start = s3_clock::now()] (group_client& gc, const http::reply& reply, input_stream<char>&& in_) mutable -> future<> {
+            auto etag = reply.get_header("ETag");
+            s3l.trace("uploaded {} part data -> etag = {} (upload id {})", part_number, etag, _upload_id);
+            _part_etags[part_number] = std::move(etag);
+            gc.write_stats.update(part_size, s3_clock::now() - start);
+            return make_ready_future();
+        }).handle_exception([this, part_number] (auto ex) {
+            s3l.warn("couldn't upload part {}: {} (upload id {})", part_number, ex, _upload_id);
+        }).finally([gh = std::move(gh)] {});
+    }
+
+    static size_t div_ceil(size_t x, size_t y) {
+        assert(std::in_range<long long>(x));
+        assert(std::in_range<long long>(y));
+        auto [quot, rem] = std::lldiv(x, y);
+        return rem ? quot + 1 : quot;
+    }
+
+    // returns pair<num_of_parts, part_size>
+    static std::pair<unsigned, size_t> calc_part_size(size_t total_size, size_t part_size) {
+        if (part_size > 0) {
+            if (part_size < aws_minimum_part_size) {
+                on_internal_error(s3l, fmt::format("part_size too large: {} < {}", part_size, aws_minimum_part_size));
+            }
+            const size_t num_parts = div_ceil(total_size, part_size);
+            if (num_parts > aws_maximum_parts_in_piece) {
+                on_internal_error(s3l, fmt::format("too many parts: {} > {}", num_parts, aws_maximum_parts_in_piece));
+            }
+            return {num_parts, part_size};
+        }
+        // if part_size is 0, this means the caller leaves it to us to decide
+        // the part_size. to be more reliance, say, we don't have to re-upload
+        // a giant chunk of buffer if a certain part fails to upload, we prefer
+        // small parts, let's make it a multiple of MiB.
+        part_size = div_ceil(total_size / aws_maximum_parts_in_piece, 1_MiB);
+        part_size = std::max(part_size, aws_minimum_part_size);
+        return {div_ceil(total_size, part_size), part_size};
+    }
+
+    future<> multi_part_upload(file&& f, uint64_t total_size, size_t part_size) {
+        co_await create_multipart_upload();
+
+        for (size_t offset = 0; offset < total_size; offset += part_size) {
+            part_size = std::min(total_size - offset, part_size);
+            s3l.trace("upload_part: {}~{}/{}", offset, part_size, total_size);
+            co_await upload_part(file{f}, offset, part_size);
+        }
+
+        co_await _bg_uploads.close();
+        std::exception_ptr ex;
+        try {
+            co_await complete_multipart_upload();
+        } catch (...) {
+            ex = std::current_exception();
+        }
+        if (ex) {
+            co_await abort_multipart_upload();
+            std::rethrow_exception(ex);
+        }
+    }
+
+    future<> put_object(file&& f, uint64_t len) {
+        // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
+        s3l.trace("PUT {} ({})", _object_name, _path.native());
+        auto mem_units = co_await _client->claim_memory(_transmit_size);
+
+        auto req = http::request::make("PUT", _client->_host, _object_name);
+        if (_tag) {
+            req._headers["x-amz-tagging"] = seastar::format("{}={}", _tag->key, _tag->value);
+        }
+        req.write_body("bin", len, [f = std::move(f)] (output_stream<char>&& out_) mutable {
+            auto input = make_file_input_stream(std::move(f));
+            auto output = std::move(out_);
+            return copy_to(std::move(input), std::move(output), _transmit_size);
+        });
+        co_await _client->make_request(std::move(req), [len, start = s3_clock::now()] (group_client& gc, const auto& rep, auto&& in) {
+            gc.write_stats.update(len, s3_clock::now() - start);
+            return ignore_reply(rep, std::move(in));
+        });
+    }
+
+public:
+    do_upload_file(shared_ptr<client> cln,
+                   std::filesystem::path path,
+                   sstring object_name,
+                   std::optional<tag> tag,
+                   size_t part_size)
+        : _client{std::move(cln)}
+        , _path{std::move(path)}
+        , _object_name{std::move(object_name)}
+        , _tag{std::move(tag)}
+        , _part_size{part_size} {
+    }
+
+    future<> upload() {
+        auto f = co_await open_file_dma(_path.native(), open_flags::ro);
+        const auto stat = co_await f.stat();
+        const uint64_t file_size = stat.st_size;
+        // use multipart upload when possible in order to transmit parts in
+        // parallel to improve throughput
+        if (file_size > aws_minimum_part_size) {
+            auto [num_parts, part_size] = calc_part_size(file_size, _part_size);
+            _part_etags.reserve(num_parts);
+            co_await multi_part_upload(std::move(f), file_size, part_size);
+        } else {
+            // single part upload
+            co_await put_object(std::move(f), file_size);
+        }
+    }
+};
+
+future<> client::upload_file(std::filesystem::path path,
+                              sstring object_name,
+                              std::optional<tag> tag,
+                              std::optional<size_t> part_size) {
+    do_upload_file do_upload{shared_from_this(),
+                             std::move(path),
+                             std::move(object_name),
+                             std::move(tag),
+                             part_size.value_or(0)};
+    co_await do_upload.upload();
 }
 
 class client::readable_file : public file_impl {

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -13,6 +13,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/http/client.hh>
+#include <filesystem>
 #include "utils/s3/creds.hh"
 
 using namespace seastar;
@@ -45,6 +46,7 @@ class client : public enable_shared_from_this<client> {
     class upload_sink_base;
     class upload_sink;
     class upload_jumbo_sink;
+    class do_upload_file;
     class readable_file;
     std::string _host;
     endpoint_config_ptr _cfg;
@@ -100,6 +102,16 @@ public:
     file make_readable_file(sstring object_name);
     data_sink make_upload_sink(sstring object_name);
     data_sink make_upload_jumbo_sink(sstring object_name, std::optional<unsigned> max_parts_per_piece = {});
+    /// upload a file with specified path to s3
+    ///
+    /// @param path the path to the file
+    /// @param object_name object name for the created object in S3
+    /// @param tag an optional tag
+    /// @param part_size the size of each part of the multipart upload
+    future<> upload_file(std::filesystem::path path,
+                         sstring object_name,
+                         std::optional<tag> tag = {},
+                         std::optional<size_t> max_part_size = {});
 
     void update_config(endpoint_config_ptr);
 


### PR DESCRIPTION
this member function prepares for the backup feature, where the
object to be stored in the object storage is already persisted as a
file on local filesystem. this brings us two benefits:

- with the file, we don't need to accumulate the payloads in memory
  and send them in batch, as we do in upload_sink and in
  upload_jumbo_sink. this puts less pressure on the memory subsystem.
- with the file, we can read multiple parts in parallel if multpart
  upload applies to it, this helps to improve the throughput.

so, this new helper is introduced to help upload an sstable from local
filesystem to the object storage.

Fixes https://github.com/scylladb/scylladb/issues/16287