### PR TITLE
Typos: fix typos in code

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -28,7 +28,7 @@ The files created are:
 
 By default, these files are created in the 'build'
 subdirectory under the directory containing the script.
-The destination directory can be overriden by
+The destination directory can be overridden by
 using '-o PATH' option.
 END
 )

--- a/configure.py
+++ b/configure.py
@@ -1623,7 +1623,7 @@ def dynamic_linker_option():
 
     if employ_ld_trickery:
         # gdb has a SO_NAME_MAX_PATH_SIZE of 512, so limit the path size to
-        # that. The 512 includes the null at the end, hence the 511 bellow.
+        # that. The 512 includes the null at the end, hence the 511 below.
         dynamic_linker = '/' * (511 - len(original_dynamic_linker)) + original_dynamic_linker
     else:
         dynamic_linker = original_dynamic_linker

--- a/gen_segmented_compress_params.py
+++ b/gen_segmented_compress_params.py
@@ -148,7 +148,7 @@ struct segment_info {{
     uint8_t grouped_offsets;
 }};
 
-// Precomputed optimal segment informations for different data and chunk sizes.
+// Precomputed optimal segment information for different data and chunk sizes.
 const std::array<segment_info, {segment_infos_size}> segment_infos{{{{
 {segment_infos}}}}};
 

--- a/idl-compiler.py
+++ b/idl-compiler.py
@@ -1665,7 +1665,7 @@ def handle_types(tree):
 def setup_additional_metadata(tree, ns_context = [], parent_template_params=[]):
     '''Cache additional metadata for each type declaration directly in the AST node.
 
-    This currenty includes namespace info and template parameters for the
+    This currently includes namespace info and template parameters for the
     parent scope (applicable only to enums and classes).'''
     for obj in tree:
         if isinstance(obj, NamespaceDef):
@@ -1767,7 +1767,7 @@ if __name__ == "__main__":
     parser.add_argument('-f', help='input file', default='')
     parser.add_argument('--ns', help="""namespace, when set function will be created
     under the given namespace""", default='')
-    parser.add_argument('file', nargs='*', help="combine one or more file names for the genral include files")
+    parser.add_argument('file', nargs='*', help="combine one or more file names for the general include files")
 
     config = parser.parse_args()
     if config.file:

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ Options:
   --prefix /prefix         directory prefix (default /usr)
   --python3 /opt/python3   path of the python3 interpreter relative to install root (default /opt/scylladb/python3/bin/python3)
   --housekeeping           enable housekeeping service
-  --nonroot                install Scylla without required root priviledge
+  --nonroot                install Scylla without required root privilege
   --sysconfdir /etc/sysconfig   specify sysconfig directory name
   --packaging               use install.sh for packaging
   --upgrade                 upgrade existing scylla installation (don't overwrite config files)

--- a/scripts/base36-uuid.py
+++ b/scripts/base36-uuid.py
@@ -139,7 +139,7 @@ class TimeUuid:
     @property
     def timestamp(self) -> (datetime.datetime, int):
         # UUID v1 uses a timestamp epoch derived from Gregorian calendar, so we
-        # need to translate the timetamp to the UNIX time
+        # need to translate the timestamp to the UNIX time
         unix_time = self.uuid.time - self.UNIX_EPOCH_SINCE_GREGORIAN_DAY0
         seconds, decimicro_seconds = divmod(unix_time, DECIMICRO_RATIO)
         return datetime.datetime.fromtimestamp(seconds), decimicro_seconds

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -1528,7 +1528,7 @@ class scylla_tables(gdb.Command):
 
 
 class scylla_table(gdb.Command):
-    """Prints various info about individial table
+    """Prints various info about individual table
         Example:
           scylla table ks.cf
     """
@@ -1990,7 +1990,7 @@ class span(object):
 
         Due to https://github.com/scylladb/seastar/issues/625 there may be some
         pages at the end of the span which are not used by the small pool.
-        We try to detect this. It's not 100% accurrate but should work in most cases.
+        We try to detect this. It's not 100% accurate but should work in most cases.
 
         Returns 0 for free spans.
         """
@@ -4747,7 +4747,7 @@ class scylla_small_objects(gdb.Command):
     spans belonging to the pool linearly, until the desired range of object is
     found. This can take a long time for well populated pools. To speed this
     up, the span iterator is saved and reused when possible. This caching can
-    only be exploited withing the same pool and only with monotonically
+    only be exploited within the same pool and only with monotonically
     increasing pages.
 
     For usage see: scylla small-objects --help

--- a/test.py
+++ b/test.py
@@ -699,7 +699,7 @@ class BoostTest(UnitTest):
 
 
 class CQLApprovalTest(Test):
-    """Run a sequence of CQL commands against a standlone Scylla"""
+    """Run a sequence of CQL commands against a standalone Scylla"""
 
     def __init__(self, test_no: int, shortname: str, suite) -> None:
         super().__init__(test_no, shortname, suite)
@@ -959,7 +959,7 @@ class TopologyTest(PythonTest):
             self.args.insert(0, "--manager-api={}".format(manager.sock_path))
 
             try:
-                # Note: start manager here so cluster (and its logs) is availale in case of failure
+                # Note: start manager here so cluster (and its logs) is available in case of failure
                 await manager.start()
                 self.success = await run_test(self, options)
             except Exception as e:
@@ -1532,7 +1532,7 @@ def write_consolidated_boost_junit_xml(tmpdir: str, mode: str) -> None:
     for full_path, tests in itertools.groupby(
             test_cases,
             key=BoostTest.test_path_of_element):
-        # dedup the tests with the same name, so only the representive one is
+        # dedup the tests with the same name, so only the representative one is
         # preserved
         test_case = summarize_tests(tests)
         test_case.attrib.pop('path')

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -362,7 +362,7 @@ public:
             auto&& prange = make_partition_range(*schema, range);
             auto cmd = slice_pred_to_read_cmd(proxy, *schema, predicate);
             // KeyRange::count is the number of thrift rows to return, while
-            // SlicePredicte::slice_range::count limits the number of thrift colums.
+            // SlicePredicte::slice_range::count limits the number of thrift columns.
             if (schema->thrift().is_dynamic()) {
                 // For dynamic CFs we must limit the number of partitions returned.
                 cmd->partition_limit = range.count;


### PR DESCRIPTION
Last batch, hopefully, sing codespell, went over the docs and fixed some typos.

Refs: https://github.com/scylladb/scylladb/issues/16255