### PR TITLE
scylla-nodetool: implement the scrub command

### DIFF
--- a/api/scrub_status.hh
+++ b/api/scrub_status.hh
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace api {
+
+enum class scrub_status {
+    successful = 0,
+    aborted,
+    unable_to_cancel,   // Not used in Scylla, included to ensure compatibility with nodetool api.
+    validation_errors,
+};
+
+} // namespace api

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -9,6 +9,7 @@
 #include "storage_service.hh"
 #include "api/api-doc/storage_service.json.hh"
 #include "api/api-doc/storage_proxy.json.hh"
+#include "api/scrub_status.hh"
 #include "db/config.hh"
 #include "db/schema_tables.hh"
 #include "utils/hash.hh"
@@ -1479,13 +1480,6 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::tablet_balancing_enable.unset(r);
     sp::get_schema_versions.unset(r);
 }
-
-enum class scrub_status {
-    successful = 0,
-    aborted,
-    unable_to_cancel,   // Not used in Scylla, included to ensure compatibility with nodetool api.
-    validation_errors,
-};
 
 void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_ctl) {
     ss::get_snapshot_details.set(r, [&snap_ctl](std::unique_ptr<http::request> req) {

--- a/test/nodetool/rest_api_mock.py
+++ b/test/nodetool/rest_api_mock.py
@@ -178,7 +178,7 @@ class rest_server(aiohttp.abc.AbstractRouter):
                     continue
 
             logger.error(f"unexpected request\nexpected {expected_req}\ngot      {this_req}")
-            return aiohttp.web.Response(status=500, text="Expected {expected_req}, got {this_req}")
+            return aiohttp.web.Response(status=500, text=f"Expected {expected_req}, got {this_req}")
 
         if expected_req.multiple == expected_request.ONE:
             del self.expected_requests[0]

--- a/test/nodetool/test_scrub.py
+++ b/test/nodetool/test_scrub.py
@@ -1,0 +1,169 @@
+#
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import enum
+import pytest
+from rest_api_mock import expected_request
+import utils
+
+
+class scrub_status(enum.Enum):
+    successful = 0
+    aborted = 1
+    unable_to_cancel = 2  # not used by ScyllaDB
+    validation_errors = 3
+
+
+def test_scrub_keyspace(nodetool):
+    nodetool("scrub", "ks", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        expected_request("GET", "/storage_service/keyspace_scrub/ks", response=scrub_status.successful.value)])
+
+
+def test_scrub_one_table(nodetool):
+    nodetool("scrub", "ks", "tbl1", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        expected_request("GET", "/storage_service/keyspace_scrub/ks", params={"cf": "tbl1"},
+                         response=scrub_status.successful.value)])
+
+
+def test_scrub_two_tables(nodetool):
+    nodetool("scrub", "ks", "tbl1", "tbl2", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        expected_request("GET", "/storage_service/keyspace_scrub/ks", params={"cf": "tbl1,tbl2"},
+                         response=scrub_status.successful.value)])
+
+
+# Cassandra parser completely borks when positional args are missing
+def test_scrub_nokeyspace(nodetool, scylla_only):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("scrub",),
+            {},
+            ["error processing arguments: missing mandatory positional argument: keyspace"])
+
+
+def test_scrub_non_existent_keyspace(nodetool):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("scrub", "non_existent_ks"),
+            {"expected_requests": [expected_request("GET", "/storage_service/keyspaces", response=["ks"])]},
+            ["nodetool: Keyspace [non_existent_ks] does not exist.",
+             "error processing arguments: keyspace non_existent_ks does not exist"])
+
+
+# We don't test all values for --mode and --qurantine-mode, they are passed as-is
+# to the REST API, so their value make no difference when testing nodetool itself.
+@pytest.mark.parametrize("table", [[], ["tbl1"], ["tbl1", "tbl2"]])
+@pytest.mark.parametrize("mode", [None, ("-m", "ABORT"), ("--mode", "ABORT"), "ABORT"])
+@pytest.mark.parametrize("quarantine_mode", [None, ("--quarantine-mode", "INCLUDE"), ("-q", "ONLY")])
+@pytest.mark.parametrize("disable_snapshot", [None, "--no-snapshot", "-ns"])
+def test_scrub_options(request, nodetool, table, mode, quarantine_mode, disable_snapshot):
+    args = ["scrub", "ks"] + table
+    expected_params = {}
+
+    if table:
+        expected_params["cf"] = ",".join(table)
+
+    if mode is not None:
+        if type(mode) is tuple:
+            args += list(mode)
+            expected_params["scrub_mode"] = mode[1]
+        else:
+            args += ["--mode", mode]
+            expected_params["scrub_mode"] = mode
+
+    if quarantine_mode is not None:
+        if request.config.getoption("nodetool") == "scylla":
+            args += list(quarantine_mode)
+            expected_params["quarantine_mode"] = quarantine_mode[1]
+        else:
+            pytest.skip("--quarantine-mode only supported by scylla-nodetool")
+
+    if disable_snapshot:
+        args.append(disable_snapshot)
+        expected_params["disable_snapshot"] = "true"
+
+    nodetool(*args, expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        expected_request("GET", "/storage_service/keyspace_scrub/ks", params=expected_params,
+                         response=scrub_status.successful.value)])
+
+
+def test_scrub_skip_corrupted(nodetool):
+    nodetool("scrub", "ks", "tbl1", "tbl2", "--skip-corrupted", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        expected_request("GET", "/storage_service/keyspace_scrub/ks", params={"cf": "tbl1,tbl2", "scrub_mode": "SKIP"},
+                         response=scrub_status.successful.value)])
+
+    nodetool("scrub", "ks", "tbl1", "tbl2", "-s", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        expected_request("GET", "/storage_service/keyspace_scrub/ks", params={"cf": "tbl1,tbl2", "scrub_mode": "SKIP"},
+                         response=scrub_status.successful.value)])
+
+
+def test_scrub_skip_corrupted_with_mode(nodetool):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("scrub", "ks", "--skip-corrupted", "--mode", "ABORT"),
+            {"expected_requests": [expected_request("GET", "/storage_service/keyspaces", response=["ks"])]},
+            ["nodetool: skipCorrupted and scrubMode must not be specified together",
+             "error processing arguments: cannot use --skip-corrupted when --mode is used"])
+
+
+@pytest.mark.parametrize("ignored_opt", ["--reinsert-overflowed-ttl", "-r", ("--jobs", "2"), "-j2", "--no-validate",
+                                         "-n"])
+def test_scrub_ignored_options(nodetool, ignored_opt):
+    args = ["scrub", "ks"]
+    if type(ignored_opt) is tuple:
+        args += list(ignored_opt)
+    else:
+        args.append(ignored_opt)
+
+    nodetool(*args, expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        expected_request("GET", "/storage_service/keyspace_scrub/ks", response=scrub_status.successful.value)])
+
+
+# Cassandra nodetool ignores the returned status
+@pytest.mark.parametrize("status", [scrub_status.successful, scrub_status.aborted, scrub_status.validation_errors])
+def test_scrub_return_status(nodetool, status, cassandra_only):
+    nodetool("scrub", "ks", "--mode=VALIDATE", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        expected_request("GET", "/storage_service/keyspace_scrub/ks", params={"scrub_mode": "VALIDATE"},
+                         response=status.value)])
+
+
+def test_scrub_validation_errors_exit_code(nodetool, scylla_only):
+    nodetool("scrub", "ks", "--mode=VALIDATE", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        expected_request("GET", "/storage_service/keyspace_scrub/ks", params={"scrub_mode": "VALIDATE"},
+                         response=scrub_status.successful.value)])
+
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("scrub", "ks", "--mode=VALIDATE"),
+            {"expected_requests": [
+                    expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+                    expected_request("GET", "/storage_service/keyspace_scrub/ks", params={"scrub_mode": "VALIDATE"},
+                                     response=scrub_status.validation_errors.value)]},
+            ["scrub failed: there are invalid sstables"])
+
+
+def test_scrub_abort_exit_code(nodetool, scylla_only):
+    nodetool("scrub", "ks", "--mode=ABORT", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        expected_request("GET", "/storage_service/keyspace_scrub/ks", params={"scrub_mode": "ABORT"},
+                         response=scrub_status.successful.value)])
+
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("scrub", "ks", "--mode=ABORT"),
+            {"expected_requests": [
+                    expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+                    expected_request("GET", "/storage_service/keyspace_scrub/ks", params={"scrub_mode": "ABORT"},
+                                     response=scrub_status.aborted.value)]},
+            ["scrub failed: aborted"])


### PR DESCRIPTION
On top of the capabilities of the java-nodetool command, the following additional functionalit is implemented:
* Expose quarantine-mode option of the scrub_keyspace REST API
* Exit with error and print a message, when scrub finishes with abort or validation_errors return code

The command comes with tests and all tests pass with both the new and the current nodetool implementations.

Refs: #15588
Refs: #16208