### PR TITLE
docs/operating-scylla: scylla-sstable.rst: fix checksum list

### DIFF
--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -573,6 +573,7 @@ validate-checksums
 ^^^^^^^^^^^^^^^^^^
 
 There are two kinds of checksums for SStable data files:
+
 * The digest (full checksum), stored in the ``Digest.crc32`` file. It is calculated over the entire content of ``Data.db``.
 * The per-chunk checksum. For uncompressed SStables, it is stored in ``CRC.db``; for compressed SStables, it is stored inline after each compressed chunk in ``Data.db``.
 


### PR DESCRIPTION
Add empty line before list of different checksums in validate-checksums's description. Otherwise the list is not rendered.