### PR TITLE
test/cql-pytest: use raw string when appropriate

### DIFF
--- a/test/cql-pytest/nodetool.py
+++ b/test/cql-pytest/nodetool.py
@@ -122,7 +122,7 @@ def disablebinary(cql):
         run_nodetool(cql, "disablebinary")
 
 def parse_keyspace_table(name, separator_chars = '.'):
-    pat = f"(?P<keyspace>\w+)(?:[{separator_chars}](?P<table>\w+))?"
+    pat = rf"(?P<keyspace>\w+)(?:[{separator_chars}](?P<table>\w+))?"
     m = re.match(pat, name)
     return m.group('keyspace'), m.group('table')
 


### PR DESCRIPTION
we use "\w" to represent a character class in Python. see https://docs.python.org/3/library/re.html. but "\" should be escaped as well, CPython accepts "\w" after trying to find an escaped character of "\w"  but failed, and leave "\w" as it is. but it complains.

in this change, we use raw string to avoid escaping "`\`" in the regular expression.