### PR TITLE
locator: include used headers

### DIFF
--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -12,10 +12,9 @@
 
 #include "locator/abstract_replication_strategy.hh"
 #include "locator/tablet_replication_strategy.hh"
-#include "exceptions/exceptions.hh"
 
 #include <optional>
-#include <set>
+#include <unordered_set>
 
 namespace locator {
 


### PR DESCRIPTION
* exceptions/exceptions.hh is not used
* std::set is not used, while std::unordered_set is used