### PR TITLE
treewide: apply codespell to the comments in source code

### DIFF
--- a/backlog_controller.hh
+++ b/backlog_controller.hh
@@ -22,7 +22,7 @@
 // Goal is to consume the backlog as fast as we can, but not so fast that we steal all the CPU from
 // incoming requests, and at the same time minimize user-visible fluctuations in the quota.
 //
-// What that translates to is we'll try to keep the backlog's firt derivative at 0 (IOW, we keep
+// What that translates to is we'll try to keep the backlog's first derivative at 0 (IOW, we keep
 // backlog constant). As the backlog grows we increase CPU usage, decreasing CPU usage as the
 // backlog diminishes.
 //

--- a/multishard_mutation_query.hh
+++ b/multishard_mutation_query.hh
@@ -53,7 +53,7 @@ namespace tracing {
 /// their respective shard's `querier_cache`, instead of creating new shard
 /// readers.
 /// To enable stateful queries set the `query_uuid` field of the read command
-/// to an id unique to the query. This can be easily achived by generating a
+/// to an id unique to the query. This can be easily achieved by generating a
 /// random uuid with `utils::make_random_uuid()`.
 /// It is advisable that the `is_first_page` flag of the read command is set on
 /// the first page of the query so that a pointless lookup is avoided.

--- a/test/boost/exception_container_test.cc
+++ b/test/boost/exception_container_test.cc
@@ -56,7 +56,7 @@ SEASTAR_TEST_CASE(test_exception_container) {
     BOOST_REQUIRE_THROW(bar.throw_me(), bar_exception);
 
     // Construct the futures outside BOOST_REQUIRE_THROW
-    // otherwise the checks would pass if as_exception_future throwed
+    // otherwise the checks would pass if as_exception_future throws
     // and we don't want that
     auto f_empty = empty.as_exception_future();
     auto f_foo = foo.as_exception_future();

--- a/test/raft/replication_test.cc
+++ b/test/raft/replication_test.cc
@@ -301,7 +301,7 @@ RAFT_TEST_CASE(rpc_load_conf_from_log, (test_case{
 
 
 // 3 node cluster {A, B, C}.
-// Shrinked later to 2 nodes and then expanded back to 3 nodes.
+// Shrunk later to 2 nodes and then expanded back to 3 nodes.
 // Test that both configuration changes update RPC configuration correspondingly
 // on all nodes.
 RAFT_TEST_CASE(rpc_propose_conf_change, (test_case{

--- a/types/types.hh
+++ b/types/types.hh
@@ -466,7 +466,7 @@ protected:
     bool _contains_set_or_map = false;
     bool _contains_collection = false;
 
-    // native_value_* methods are virualized versions of native_type's
+    // native_value_* methods are virtualized versions of native_type's
     // sizeof/alignof/copy-ctor/move-ctor etc.
     void* native_value_clone(const void* from) const;
     const std::type_info& native_typeid() const;

--- a/utils/date.h
+++ b/utils/date.h
@@ -25,7 +25,7 @@
 // SOFTWARE.
 //
 // Our apologies.  When the previous paragraph was written, lowercase had not yet
-// been invented (that woud involve another several millennia of evolution).
+// been invented (that would involve another several millennia of evolution).
 // We did not mean to shout.
 
 #include <algorithm>


### PR DESCRIPTION
for less spelling errors in comment.