### PR TITLE
migration_manager: don't attach empty system.scylla_local mutation in migration request handler

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2392,7 +2392,7 @@ future<mutation> system_keyspace::get_group0_history(distributed<replica::databa
     co_return mutation(s, partition_key::from_singular(*s, GROUP0_HISTORY_KEY));
 }
 
-future<mutation> system_keyspace::get_group0_schema_version() {
+future<std::optional<mutation>> system_keyspace::get_group0_schema_version() {
     auto s = _db.find_schema(db::system_keyspace::NAME, db::system_keyspace::SCYLLA_LOCAL);
 
     partition_key pk = partition_key::from_singular(*s, "group0_schema_version");
@@ -2406,7 +2406,7 @@ future<mutation> system_keyspace::get_group0_schema_version() {
         co_return std::move(mut);
     }
 
-    co_return mutation(s, pk);
+    co_return std::nullopt;
 }
 
 static constexpr auto GROUP0_UPGRADE_STATE_KEY = "group0_upgrade_state";

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -496,8 +496,8 @@ public:
     static future<mutation> get_group0_history(distributed<replica::database>&);
 
     // If the `group0_schema_version` key in `system.scylla_local` is present (either live or tombstone),
-    // returns the corresponding mutation. Otherwise returns an empty mutation for that key.
-    future<mutation> get_group0_schema_version();
+    // returns the corresponding mutation. Otherwise returns nullopt.
+    future<std::optional<mutation>> get_group0_schema_version();
 
     future<> sstables_registry_create_entry(sstring location, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc);
     future<> sstables_registry_update_entry_status(sstring location, sstables::generation_type gen, sstring status);

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -171,7 +171,10 @@ void migration_manager::init_messaging_service()
         // If it was modified in RECOVERY mode, we still need to return the mutation as it may contain a tombstone
         // that will force the pulling node to revert to digest calculation instead of using a version that it
         // could've persisted earlier.
-        cm.emplace_back(co_await self._sys_ks.local().get_group0_schema_version());
+        auto group0_schema_version = co_await self._sys_ks.local().get_group0_schema_version();
+        if (group0_schema_version) {
+            cm.emplace_back(std::move(*group0_schema_version));
+        }
 
         co_return rpc::tuple(std::vector<frozen_mutation>{}, std::move(cm));
     }, std::ref(*this)));


### PR DESCRIPTION

In effb9fb3cbeb3ea62b9e49f3c68a72b47221ce22 migration request handler (called when a node requests schema pull) was extended with a `system.scylla_local` mutation:
```
        cm.emplace_back(co_await self._sys_ks.local().get_group0_schema_version());
```

This mutation is empty if the GROUP0_SCHEMA_VERSIONING feature is disabled.

Nevertheless, it turned out to cause problems during upgrades. The following scenario shows the problem:

We upgrade from 5.2 to enterprise version with the aforementioned patch. In 5.2, `system.scylla_local` does not use schema commitlog. After the first node upgrades to the enterprise version, it immediately on boot creates a new enterprise-only table
(`system_replicated_keys.encrypted_keys`) -- the specific table is not important, only the fact that a schema change is performed. This happens before the restarting node notices other nodes being UP, so the schema change is not immediately pushed to the other nodes. Instead, soon after boot, the other non-upgraded nodes pull the schema from the upgraded node.
The upgraded node attaches a `system.scylla_local` mutation to the vector of returned mutations.
The non-upgraded nodes try to apply this vector of mutations. Because some of these mutations are for tables that already use schema commitlog, while the `system.scylla_local` table does not use schema commitlog, this triggers the following error (even though the mutation is empty):
```
    Cannot apply atomically across commitlog domains: system.scylla_local, system_schema.keyspaces
```

Fortunately, the fix is simple -- instead of attaching an empty mutation, do not attach a mutation at all if the handler of migration request notices that group0_schema_version is not present.

Note that group0_schema_version is only present if the GROUP0_SCHEMA_VERSIONING feature is enabled, which happens only after the whole upgrade finishes.

Refs: scylladb/scylladb#16414

Not using "Fixes" because the issue will only be fixed once this PR is merged to `master` and the commit is cherry-picked onto next-enterprise.