### PR TITLE
build_docker: Add `description` and `summary` labels

### DIFF
--- a/dist/docker/debian/build_docker.sh
+++ b/dist/docker/debian/build_docker.sh
@@ -102,6 +102,10 @@ bconfig --entrypoint  '["/docker-entrypoint.py"]'
 bconfig --cmd  ''
 bconfig --port 10000 --port 9042 --port 9160 --port 9180 --port 7000 --port 7001 --port 22
 bconfig --volume "/var/lib/scylla"
+bconfig --label org.opencontainers.image.ref.name="ScyllaDB"
+bconfig --label org.opencontainers.image.version="$version-$release"
+bconfig --label description="ScyllaDB Open Source"
+bconfig --label summary="NoSQL data store using the seastar framework, compatible with Apache Cassandra"
 
 mkdir -p build/$mode/dist/docker/
 image="oci-archive:build/$mode/dist/docker/$product-$version-$release"


### PR DESCRIPTION
Adding description and summary labels to our docker images per @tzach and @mykaul request,

Related to https://github.com/scylladb/scylla-enterprise/issues/863