### PR TITLE
.git: use ssh/key or token for auth

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
       - uses: codespell-project/actions-codespell@master
         with:
           only_warn: 1


### PR DESCRIPTION
enable checkout action to get authenticated if the action need to clone a non-public repo.