### PR TITLE
token_metadata: pass node id when formatting it

### DIFF
--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -801,7 +801,7 @@ void token_metadata_impl::del_leaving_endpoint(host_id endpoint) {
 
 void token_metadata_impl::add_replacing_endpoint(host_id existing_node, host_id replacing_node) {
     if (existing_node == replacing_node) {
-        on_internal_error(tlogger, format("Can't replace node {} with itself"));
+        on_internal_error(tlogger, format("Can't replace node {} with itself", existing_node));
     }
     tlogger.info("Added node {} as pending replacing endpoint which replaces existing node {}",
             replacing_node, existing_node);


### PR DESCRIPTION
before this change, we use the format string of
"Can't replace node {} with itself", but fail to include the host id as seastar::format()'s arguments. this fails the compile-time check of fmt, which is yet merged. so, if we really run into this problem, {fmt} would throw before the intended runtime_error is raised -- currently, seastar::log formats the logging messages at runtime, this is not intended.

in this change, we pass `existing_node`, so it can be formatted, and the intended error message can be printed in log.

Refs 11a4908683d17338a8b30ce119b06be7b2f835b9
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>