### PR TITLE
test: Fix segfault when running offstrategy test

### DIFF
--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -5074,8 +5074,8 @@ static future<> run_incremental_compaction_test(sstables::offstrategy offstrateg
         }
 
         size_t last_input_sstable_count = sstables_nr;
+        auto t = env.make_table_for_tests(s);
         {
-            auto t = env.make_table_for_tests(s);
             auto& cm = t->get_compaction_manager();
             auto stop = deferred_stop(t);
             t->disable_auto_compaction().get();


### PR DESCRIPTION
Observer, that references table_for_test, must of course, not outlive table_for_test. Observer can be called later after the last input sstable is removed from sstable manager.