### PR TITLE
main: add a call to LLVM profile dump before exit for code coverage

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -552,6 +552,16 @@ static locator::host_id initialize_local_info_thread(sharded<db::system_keyspace
     return linfo.host_id;
 }
 
+extern "C" void __attribute__((weak)) __llvm_profile_dump();
+
+[[gnu::noinline]]
+void dump_performance_profiles() {
+    if (__llvm_profile_dump) {
+        startlog.info("Calling __llvm_profile_dump()");
+        __llvm_profile_dump();
+    }
+}
+
 static int scylla_main(int ac, char** av) {
     // Allow core dumps. The would be disabled by default if
     // CAP_SYS_NICE was added to the binary, as is suggested by the
@@ -1938,6 +1948,12 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             return 1;
           }
           startlog.info("Scylla version {} shutdown complete.", scylla_version());
+
+          // With -fprofile-generate, LLVM inserts an exit hook which saves the profile counters to disk.
+          // So does BOLT's instrumentation.
+          // But since we exit abruptly and skip those hooks, we have to trigger the dump manually.
+          dump_performance_profiles();
+
           // We should be returning 0 here, but the system is not yet prepared for orderly rollback of main() objects
           // and thread_local variables.
           _exit(0);


### PR DESCRIPTION
As part of code coverage support we need the ScyllaDB binaries to dump the profile data that contains the code
coverage counts, as explained in this commit by @michoecho since we bypass the hooks, it will not be called as intended
in the instrumented code and we need to trigger it before exiting.
After this commit when ScyllaDB is shut down gracefully (using the SIGTERM signal), it will dump the profile data.

NOTE: It is important to notice that using SIGKILL will still not dump the profiles so maybe in the future, another signal 
hook (i.e USR1/USR2) will be required in order to dump the profile if we would like to obtain coverage data also from 
ScyllaDB instances that are stopped in a non graceful manner or if we would like to obtain the coverage data while 
ScyllaDB is still running.

Refs #16323 

#### commit message

Scylla skips exit hooks so we have to manually trigger the data dump to disk
from the LLVM profiling instrumentation runtime which we need in order
to support code coverage.
We use a weak symbol to get the address of the profile dump function. This
is legal: the function is a public interface of the instrumentation runtime.