### PR TITLE
Do not update endpoint state via gossiper::add_saved_endpoint once it was updated via gossip

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2093,13 +2093,13 @@ void gossiper::build_seeds_list() {
     }
 }
 
-future<> gossiper::add_saved_endpoint(inet_address ep) {
+future<> gossiper::add_saved_endpoint(inet_address ep, permit_id pid) {
     if (ep == get_broadcast_address()) {
         logger.debug("Attempt to add self as saved endpoint");
         co_return;
     }
 
-    auto permit = co_await lock_endpoint(ep, null_permit_id);
+    auto permit = co_await lock_endpoint(ep, pid);
 
     //preserve any previously known, in-memory data about the endpoint (such as DC, RACK, and so on)
     auto ep_state = endpoint_state();

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -607,7 +607,7 @@ public:
     /**
      * Add an endpoint we knew about previously, but whose state is unknown
      */
-    future<> add_saved_endpoint(inet_address ep);
+    future<> add_saved_endpoint(inet_address ep, permit_id);
 
     future<> add_local_application_state(application_state state, versioned_value value);
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -557,9 +557,16 @@ future<> storage_service::topology_state_load() {
     // will be up to date and reachable at the time of restart.
     const auto tmptr = get_token_metadata_ptr();
     for (const auto& e: tmptr->get_all_endpoints()) {
+        if (is_me(e)) {
+            continue;
+        }
         const auto ep = tmptr->get_endpoint_for_host_id(e);
-        if (!is_me(e) && !_gossiper.get_endpoint_state_ptr(ep)) {
-            co_await _gossiper.add_saved_endpoint(ep);
+        auto permit = co_await _gossiper.lock_endpoint(ep, gms::null_permit_id);
+        // Add the endpoint if it doesn't exist yet in gossip
+        // since it is not loaded in join_cluster in the
+        // _raft_topology_change_enabled case.
+        if (!_gossiper.get_endpoint_state_ptr(ep)) {
+            co_await _gossiper.add_saved_endpoint(ep, permit.id());
         }
     }
 
@@ -3075,7 +3082,9 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
         }
         co_await _gossiper.reset_endpoint_state_map();
         for (auto ep : loaded_endpoints) {
-            co_await _gossiper.add_saved_endpoint(ep);
+            // gossiping hasn't started yet
+            // so no need to lock the endpoint
+            co_await _gossiper.add_saved_endpoint(ep, gms::null_permit_id);
         }
     }
     auto features = _feature_service.supported_feature_set();
@@ -4271,7 +4280,9 @@ future<> storage_service::join_cluster(sharded<db::system_distributed_keyspace>&
                 co_await tmptr->update_normal_tokens(tokens, hostIdIt->second);
                 tmptr->update_host_id(hostIdIt->second, ep);
                 loaded_endpoints.insert(ep);
-                co_await _gossiper.add_saved_endpoint(ep);
+                // gossiping hasn't started yet
+                // so no need to lock the endpoint
+                co_await _gossiper.add_saved_endpoint(ep, gms::null_permit_id);
             }
         }
         co_await replicate_to_all_cores(std::move(tmptr));

--- a/test/topology_custom/test_old_ip_notification_repro.py
+++ b/test/topology_custom/test_old_ip_notification_repro.py
@@ -20,8 +20,8 @@ logger = logging.getLogger(__name__)
 async def test_old_ip_notification_repro(manager: ManagerClient) -> None:
     """
     Regression test for #14257.
-    It starts two nodes. It introduces a sleep in raft_group_registry::on_alive
-    (in raft_group_registry.cc) when receiving a gossip notification about
+    It starts two nodes. It introduces a sleep in gossiper::real_mark_alive
+    when receiving a gossip notification about
     HOST_ID update from the second node. Then it restarts the second node with
     a different IP. Due to the sleep, the old notification from the old IP arrives
     after the second node has restarted. If the bug is present, this notification
@@ -30,7 +30,7 @@ async def test_old_ip_notification_repro(manager: ManagerClient) -> None:
     """
     s1 = await manager.server_add()
     s2 = await manager.server_add(start=False)
-    async with inject_error(manager.api, s1.ip_addr, 'raft_group_registry::on_alive',
+    async with inject_error(manager.api, s1.ip_addr, 'gossiper::real_mark_alive',
                             parameters={ "second_node_ip": s2.ip_addr }) as handler:
         # This injection delays the gossip notification from the initial IP of s2.
         logger.info(f"Starting {s2}")


### PR DESCRIPTION
Currently, `add_saved_endpoint` is called from two paths:  One, is when loading states from system.peers in the join path (join_cluster, join_token_ring), when `_raft_topology_change_enabled` is false, and the other is from `storage_service::topology_state_load` when raft topology changes are enabled.

In the later path, from `topology_state_load`, `add_saved_endpoint` is called only if the endpoint_state does not exist yet.  However, this is checked without acquiring the endpoint_lock and so it races with the gossiper, and once `add_saved_endpoint` acquires the lock, the endpoint state may already be populated.

Since `add_saved_endpoint` applies local information about the endpoint state (e.g. tokens, dc, rack), it uses the local heart_beat_version, with generation=0 to update the endpoint states, and that is incompatible with changes applies via gossip that will carry the endpoint's generation and version, determining the state's update order.

This change makes sure that the endpoint state is never update in `add_saved_endpoint` if it has non-zero generation.
An internal error exception is thrown if non-zero generation is found, and in the only call site that might reach that state, in `storage_service::topology_state_load`, the caller acquires the endpoint_lock for checking for the existence of the endpoint_state, calling `add_saved_endpoint` under the lock only if the endpoint_state does not exist.

Fixes #16429