### PR TITLE
tasks: include used headers

### DIFF
--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <list>
 #include <boost/range/algorithm/transform.hpp>
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/core/gate.hh>


### PR DESCRIPTION
when compiling with Clang-18 + libstdc++-13, the tree fails to build:
```
/home/kefu/dev/scylladb/tasks/task_manager.hh:45:36: error: no template named 'list' in namespace 'std'
   45 |     using foreign_task_list = std::list<foreign_task_ptr>;
      |                               ~~~~~^
```
so let's include the used header