### PR TITLE
db/system_keyspace: explicitly instantiate used template

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1698,6 +1698,10 @@ future<std::optional<T>> system_keyspace::get_scylla_local_param_as(const sstrin
     });
 }
 
+template
+future<std::optional<utils::UUID>>
+system_keyspace::get_scylla_local_param_as<utils::UUID>(const sstring& key);
+
 future<> system_keyspace::set_scylla_local_param(const sstring& key, const sstring& value, bool visible_before_cl_replay) {
     return set_scylla_local_param_as<sstring>(key, value, visible_before_cl_replay);
 }


### PR DESCRIPTION
`future<std::optional<utils::UUID>>
system_keyspace::get_scylla_local_param_as<utils::UUID>(const sstring&)` is used by db/schema_tables.cc. so let's instantiate this template explicitly.
otherwise we'd have following link failure:

```
: && /home/kefu/.local/bin/clang++ -ffunction-sections -fdata-sections -O3 -g -gz -Xlinker --build-id=sha1 -fuse-ld=lld -dynamic-linker=/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////lib64/ld-linux-x86-64.so.2 -Xlinker --gc-sections CMakeFiles/scylla_version.dir/Release/release.cc.o CMakeFiles/scylla.dir/Release/main.cc.o -o Release/scylla  Release/libscylla-main.a  api/Release/libapi.a  alternator/Release/libalternator.a  db/Release/libdb.a  cdc/Release/libcdc.a  compaction/Release/libcompaction.a  cql3/Release/libcql3.a  data_dictionary/Release/libdata_dictionary.a  gms/Release/libgms.a  index/Release/libindex.a  lang/Release/liblang.a  message/Release/libmessage.a  mutation/Release/libmutation.a  mutation_writer/Release/libmutation_writer.a  raft/Release/libraft.a  readers/Release/libreaders.a  redis/Release/libredis.a  repair/Release/librepair.a  replica/Release/libreplica.a  schema/Release/libschema.a  service/Release/libservice.a  sstables/Release/libsstables.a  streaming/Release/libstreaming.a  test/perf/Release/libtest-perf.a  thrift/Release/libthrift.a  tools/Release/libtools.a  transport/Release/libtransport.a  types/Release/libtypes.a  utils/Release/libutils.a  seastar/Release/libseastar.a  /usr/lib64/libboost_program_options.so.1.81.0  test/lib/Release/libtest-lib.a  Release/libscylla-main.a  -Xlinker --push-state -Xlinker --whole-archive  auth/Release/libscylla_auth.a  -Xlinker --pop-state  /usr/lib64/libcrypt.so  cdc/Release/libcdc.a  compaction/Release/libcompaction.a  mutation_writer/Release/libmutation_writer.a  -Xlinker --push-state -Xlinker --whole-archive  dht/Release/libscylla_dht.a  -Xlinker --pop-state  index/Release/libindex.a  -Xlinker --push-state -Xlinker --whole-archive  locator/Release/libscylla_locator.a  -Xlinker --pop-state  message/Release/libmessage.a  gms/Release/libgms.a  sstables/Release/libsstables.a  readers/Release/libreaders.a  schema/Release/libschema.a  -Xlinker --push-state -Xlinker --whole-archive  tracing/Release/libscylla_tracing.a  -Xlinker --pop-state  service/Release/libservice.a  node_ops/Release/libnode_ops.a  service/Release/libservice.a  node_ops/Release/libnode_ops.a  raft/Release/libraft.a  repair/Release/librepair.a  streaming/Release/libstreaming.a  replica/Release/libreplica.a  /usr/lib64/libabsl_raw_hash_set.so.2308.0.0  /usr/lib64/libabsl_hash.so.2308.0.0  /usr/lib64/libabsl_city.so.2308.0.0  /usr/lib64/libabsl_bad_variant_access.so.2308.0.0  /usr/lib64/libabsl_low_level_hash.so.2308.0.0  /usr/lib64/libabsl_bad_optional_access.so.2308.0.0  /usr/lib64/libabsl_hashtablez_sampler.so.2308.0.0  /usr/lib64/libabsl_exponential_biased.so.2308.0.0  /usr/lib64/libabsl_synchronization.so.2308.0.0  /usr/lib64/libabsl_graphcycles_internal.so.2308.0.0  /usr/lib64/libabsl_kernel_timeout_internal.so.2308.0.0  /usr/lib64/libabsl_stacktrace.so.2308.0.0  /usr/lib64/libabsl_symbolize.so.2308.0.0  /usr/lib64/libabsl_malloc_internal.so.2308.0.0  /usr/lib64/libabsl_debugging_internal.so.2308.0.0  /usr/lib64/libabsl_demangle_internal.so.2308.0.0  /usr/lib64/libabsl_time.so.2308.0.0  /usr/lib64/libabsl_strings.so.2308.0.0  /usr/lib64/libabsl_int128.so.2308.0.0  /usr/lib64/libabsl_strings_internal.so.2308.0.0  /usr/lib64/libabsl_string_view.so.2308.0.0  /usr/lib64/libabsl_throw_delegate.so.2308.0.0  /usr/lib64/libabsl_base.so.2308.0.0  /usr/lib64/libabsl_spinlock_wait.so.2308.0.0  /usr/lib64/libabsl_civil_time.so.2308.0.0  /usr/lib64/libabsl_time_zone.so.2308.0.0  /usr/lib64/libabsl_raw_logging_internal.so.2308.0.0  /usr/lib64/libabsl_log_severity.so.2308.0.0  -lsystemd  /usr/lib64/libz.so  /usr/lib64/libdeflate.so  types/Release/libtypes.a  utils/Release/libutils.a  /usr/lib64/libcryptopp.so  /usr/lib64/libboost_regex.so.1.81.0  /usr/lib64/libicui18n.so  /usr/lib64/libicuuc.so  /usr/lib64/libboost_unit_test_framework.so.1.81.0  seastar/Release/libseastar_perf_testing.a  /usr/lib64/libjsoncpp.so.1.9.5  interface/Release/libinterface.a  /usr/lib64/libthrift.so  db/Release/libdb.a  data_dictionary/Release/libdata_dictionary.a  cql3/Release/libcql3.a  transport/Release/libtransport.a  cql3/Release/libcql3.a  transport/Release/libtransport.a  lang/Release/liblang.a  /usr/lib64/liblua-5.4.so  -lm  rust/Release/libwasmtime_bindings.a  rust/librust_combined.a  /usr/lib64/libsnappy.so.1.1.10  mutation/Release/libmutation.a  seastar/Release/libseastar.a  /usr/lib64/libboost_program_options.so  /usr/lib64/libboost_thread.so  /usr/lib64/libboost_chrono.so  /usr/lib64/libboost_atomic.so  /usr/lib64/libcares.so  /usr/lib64/libcryptopp.so  /usr/lib64/libfmt.so.10.0.0  /usr/lib64/liblz4.so  -ldl  /usr/lib64/libgnutls.so  -latomic  /usr/lib64/libsctp.so  /usr/lib64/libyaml-cpp.so  /usr/lib64/libhwloc.so  //usr/lib64/liburing.so  /usr/lib64/libnuma.so  /usr/lib64/libxxhash.so && :
ld.lld: error: undefined symbol: seastar::future<std::optional<utils::UUID>> db::system_keyspace::get_scylla_local_param_as<utils::UUID>(seastar::basic_sstring<char, unsigned int, 15u, true> const&)
>>> referenced by schema_tables.cc:981 (./build/./db/schema_tables.cc:981)
>>>               schema_tables.cc.o:(db::schema_tables::merge_schema(seastar::sharded<db::system_keyspace>&, seastar::sharded<service::storage_proxy>&, gms::feature_service&, std::vector<mutation, std::allocator<mutation>>, bool)::$_1::operator()()) in archive db/Release/libdb.a
>>> referenced by schema_tables.cc:981 (./build/./db/schema_tables.cc:981)
>>>               schema_tables.cc.o:(db::schema_tables::recalculate_schema_version(seastar::sharded<db::system_keyspace>&, seastar::sharded<service::storage_proxy>&, gms::feature_service&)::$_0::operator()() const) in archive db/Release/libdb.a
>>> referenced by schema_tables.cc:981 (./build/./db/schema_tables.cc:981)
>>>               schema_tables.cc.o:(db::schema_tables::merge_schema(seastar::sharded<db::system_keyspace>&, seastar::sharded<service::storage_proxy>&, gms::feature_service&, std::vector<mutation, std::allocator<mutation>>, bool)::$_1::operator()() (.resume)) in archive db/Release/libdb.a
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

it seems that, without the explicit instantiation, clang-18 just inlines the body of the instantiated template function at the caller site.