### PR TITLE
[Backport 5.2] Shard of shard repair task impl

### DIFF
--- a/repair/repair_task.hh
+++ b/repair/repair_task.hh
@@ -104,7 +104,7 @@ public:
     dht::token_range_vector ranges;
     std::vector<sstring> cfs;
     std::vector<table_id> table_ids;
-    repair_uniq_id id;
+    repair_uniq_id global_repair_id;
     std::vector<sstring> data_centers;
     std::vector<sstring> hosts;
     std::unordered_set<gms::inet_address> ignore_nodes;


### PR DESCRIPTION
Shard id is logged twice in repair (once explicitly, once added by logger).
Redundant occurrence is deleted.

shard_repair_task_impl::id (which contains global repair shard)
is renamed to avoid further confusion.

Fixes: https://github.com/scylladb/scylladb/issues/12955