### PR TITLE
Some cleanups in tests for tablets + MV 

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1611,7 +1611,7 @@ static future<> apply_to_remote_endpoints(service::storage_proxy& proxy, locator
         service::allow_hints allow_hints, tracing::trace_state_ptr tr_state) {
     // The "delay_before_remote_view_update" injection point can be
     // used to add a short delay (currently 0.5 seconds) before a base
-    // replica sends its update to the remove view replica.
+    // replica sends its update to the remote view replica.
     co_await utils::get_local_injector().inject("delay_before_remote_view_update", 500ms);
     tracing::trace(tr_state, "Sending view update for {}.{} to {}, with pending endpoints = {}; base token = {}; view token = {}",
             mut.s->ks_name(), mut.s->cf_name(), target, pending_endpoints, base_token, view_token);


### PR DESCRIPTION
This small series improves two things in the multi-node tests for tablet supports in materialized views:

1. The test for Alternator LSI, which "sometimes" could reproduce the bug by creating 10-node cluster with a random tablet distribution, is replaced by a reliable 2-node cluster which controls the tablet distribution. The new test also confirms that tablets are actually enabled in Alternator (reviewers of the original test noted it would be easy to pass the test if tablets were accidentally not enabled... :-)).
2. Simplify the tablet lookup code in the test to not go through a "table id", and lookup the table's (or view's) name directly (requires a full-table of the tablets table, but that's entirely reasonable in a test).

The third patch in this series also fixes a comment typo discovered in a previous review.