### PR TITLE
network_topology_strategy: Print map of dc:rf pairs in one go

### DIFF
--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -65,13 +65,7 @@ network_topology_strategy::network_topology_strategy(
         _rep_factor += one_dc_rep_factor.second;
     }
 
-    if (rslogger.is_enabled(log_level::debug)) {
-        sstring cfg;
-        for (auto& p : _dc_rep_factor) {
-            cfg += format(" {}:{}", p.first, p.second);
-        }
-        rslogger.debug("Configured datacenter replicas are: {}", cfg);
-    }
+    rslogger.debug("Configured datacenter replicas are: {}", _dc_rep_factor);
 }
 
 using endpoint_dc_rack_set = std::unordered_set<endpoint_dc_rack>;


### PR DESCRIPTION
The strategy constructor prints the dc:rf at the end making the sstring for it by hand. Modern fmt-based logger can format unordered_map-s on its own. The message would look slightly different though:

  Configured datacenter replicas are: foo:1 bar:2

into

  Configured datacenter replicas are: {"foo": 1, "bar": 2}