### PR TITLE
keyspace_metadata: Pack constructors with default arguments

### DIFF
--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -202,32 +202,6 @@ keyspace_metadata::keyspace_metadata(std::string_view name,
              std::string_view strategy_name,
              locator::replication_strategy_config_options strategy_options,
              bool durable_writes,
-             std::vector<schema_ptr> cf_defs)
-    : keyspace_metadata(name,
-                        strategy_name,
-                        std::move(strategy_options),
-                        durable_writes,
-                        std::move(cf_defs),
-                        user_types_metadata{}) { }
-
-keyspace_metadata::keyspace_metadata(std::string_view name,
-             std::string_view strategy_name,
-             locator::replication_strategy_config_options strategy_options,
-             bool durable_writes,
-             std::vector<schema_ptr> cf_defs,
-             user_types_metadata user_types)
-    : keyspace_metadata(name,
-                        strategy_name,
-                        std::move(strategy_options),
-                        durable_writes,
-                        std::move(cf_defs),
-                        std::move(user_types),
-                        storage_options{}) { }
-
-keyspace_metadata::keyspace_metadata(std::string_view name,
-             std::string_view strategy_name,
-             locator::replication_strategy_config_options strategy_options,
-             bool durable_writes,
              std::vector<schema_ptr> cf_defs,
              user_types_metadata user_types,
              storage_options storage_opts)

--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -35,20 +35,9 @@ public:
                  std::string_view strategy_name,
                  locator::replication_strategy_config_options strategy_options,
                  bool durable_writes,
-                 std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{});
-    keyspace_metadata(std::string_view name,
-                 std::string_view strategy_name,
-                 locator::replication_strategy_config_options strategy_options,
-                 bool durable_writes,
-                 std::vector<schema_ptr> cf_defs,
-                 user_types_metadata user_types);
-    keyspace_metadata(std::string_view name,
-                 std::string_view strategy_name,
-                 locator::replication_strategy_config_options strategy_options,
-                 bool durable_writes,
-                 std::vector<schema_ptr> cf_defs,
-                 user_types_metadata user_types,
-                 storage_options storage_opts);
+                 std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{},
+                 user_types_metadata user_types = {},
+                 storage_options storage_opts = {});
     static lw_shared_ptr<keyspace_metadata>
     new_keyspace(std::string_view name,
                  std::string_view strategy_name,


### PR DESCRIPTION
There's a cascade of keyspace_metadata constructors each adding one default argument to the prevuous one. All this can be expressed shorter with the help of native default argument