### PR TITLE
keyspace_metadata: Add default value for new_keyspace's durable_writes

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -4505,7 +4505,7 @@ static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_vie
     }
     auto opts = get_network_topology_options(sp, gossiper, rf);
 
-    return keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.NetworkTopologyStrategy", std::move(opts), true);
+    return keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.NetworkTopologyStrategy", std::move(opts));
 }
 
 future<> executor::start() {

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -175,8 +175,7 @@ future<> service::create_keyspace_if_missing(::service::migration_manager& mm) c
             auto ksm = data_dictionary::keyspace_metadata::new_keyspace(
                     meta::AUTH_KS,
                     "org.apache.cassandra.locator.SimpleStrategy",
-                    opts,
-                    true);
+                    opts);
 
             try {
                 co_return co_await mm.announce(::service::prepare_new_keyspace_announcement(db.real_database(), ksm, ts),

--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -53,7 +53,7 @@ public:
     new_keyspace(std::string_view name,
                  std::string_view strategy_name,
                  locator::replication_strategy_config_options options,
-                 bool durables_writes,
+                 bool durables_writes = true,
                  std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{},
                  storage_options storage_opts = {});
     static lw_shared_ptr<keyspace_metadata>

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -264,8 +264,7 @@ future<> system_distributed_keyspace::start() {
         auto sd_ksm = keyspace_metadata::new_keyspace(
                 NAME,
                 "org.apache.cassandra.locator.SimpleStrategy",
-                {{"replication_factor", "3"}},
-                true /* durable_writes */);
+                {{"replication_factor", "3"}});
         if (!db.has_keyspace(NAME)) {
             mutations = service::prepare_new_keyspace_announcement(db.real_database(), sd_ksm, ts);
             description += format(" create {} keyspace;", NAME);
@@ -276,8 +275,7 @@ future<> system_distributed_keyspace::start() {
         auto sde_ksm = keyspace_metadata::new_keyspace(
                 NAME_EVERYWHERE,
                 "org.apache.cassandra.locator.EverywhereStrategy",
-                {},
-                true /* durable_writes */);
+                {});
         if (!db.has_keyspace(NAME_EVERYWHERE)) {
             auto sde_mutations = service::prepare_new_keyspace_announcement(db.real_database(), sde_ksm, ts);
             std::move(sde_mutations.begin(), sde_mutations.end(), std::back_inserter(mutations));

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -145,7 +145,7 @@ future<> table_helper::setup_keyspace(cql3::query_processor& qp, service::migrat
 
     std::map<sstring, sstring> opts;
     opts["replication_factor"] = replication_factor;
-    auto ksm = keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.SimpleStrategy", std::move(opts), true);
+    auto ksm = keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.SimpleStrategy", std::move(opts));
 
     while (!db.has_keyspace(keyspace_name)) {
         auto group0_guard = co_await mm.start_group0_operation();


### PR DESCRIPTION
Almost all callers call new_keyspace with durable writes ON, so it's worth having default value for it