### PR TITLE
bytes.hh: correct spelling of delimiter and delimited

### DIFF
--- a/bytes.hh
+++ b/bytes.hh
@@ -57,11 +57,11 @@ struct fmt::formatter<fmt_hex> {
     size_t _group_size_in_bytes = 0;
     char _delimiter = ' ';
 public:
-    // format_spec := [group_size[delimeter]]
+    // format_spec := [group_size[delimiter]]
     // group_size := a char from '0' to '9'
-    // delimeter := a char other than '{'  or '}'
+    // delimiter := a char other than '{'  or '}'
     //
-    // by default, the given bytes are printed without delimeter, just
+    // by default, the given bytes are printed without delimiter, just
     // like a string. so a string view of {0x20, 0x01, 0x0d, 0xb8} is
     // printed like:
     // "20010db8".
@@ -70,14 +70,14 @@ public:
     // are printed. for instance, to print an bytes_view like IPv6. so
     // the format specfier would be "{:2:}", where
     // - "2": bytes are printed in groups of 2 bytes
-    // - ":": each group is delimeted by ":"
+    // - ":": each group is delimited by ":"
     // and the formatted output will look like:
     // "2001:0db8:0000"
     //
     // or we can mimic how the default format of used by hexdump using
     // "{:2 }", where
     // - "2": bytes are printed in group of 2 bytes
-    // - " ": each group is delimeted by " "
+    // - " ": each group is delimited by " "
     // and the formatted output will look like:
     // "2001 0db8 0000"
     //
@@ -86,7 +86,7 @@ public:
     // and the formatted output will look like:
     // "20-01-0b-b8-00-00"
     constexpr auto parse(fmt::format_parse_context& ctx) {
-        // get the delimeter if any
+        // get the delimiter if any
         auto it = ctx.begin();
         auto end = ctx.end();
         if (it != end) {


### PR DESCRIPTION
Pointed out by the new spellcheck workflow.