### PR TITLE
replica: Make the storage snapshot survive concurrent compactions

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -103,6 +103,7 @@ class sstables_manager;
 class compaction_data;
 class sstable_set;
 class directory_semaphore;
+struct sstable_files_snapshot;
 
 }
 
@@ -1210,7 +1211,7 @@ public:
     // Takes snapshot of current storage state (includes memtable and sstables) from
     // all compaction groups that overlap with a given token range. The output is
     // a list of SSTables that represent the snapshot.
-    future<sstables::sstable_list> take_storage_snapshot(dht::token_range tr);
+    future<utils::chunked_vector<sstables::sstable_files_snapshot>> take_storage_snapshot(dht::token_range tr);
 
     friend class compaction_group;
 };

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -783,8 +783,8 @@ future<> table::parallel_foreach_compaction_group(std::function<future<>(compact
     });
 }
 
-future<sstables::sstable_list> table::take_storage_snapshot(dht::token_range tr) {
-    sstables::sstable_list ret;
+future<utils::chunked_vector<sstables::sstable_files_snapshot>> table::take_storage_snapshot(dht::token_range tr) {
+    utils::chunked_vector<sstables::sstable_files_snapshot> ret;
 
     for (auto& cg : compaction_groups_for_token_range(tr)) {
         // We don't care about sstables in snapshot being unlinked, as the file
@@ -795,14 +795,17 @@ future<sstables::sstable_list> table::take_storage_snapshot(dht::token_range tr)
 
         co_await cg->flush();
 
-        auto all_sstables = cg->make_compound_sstable_set();
+        auto set = cg->make_compound_sstable_set();
 
-        all_sstables->for_each_sstable([&ret] (const sstables::shared_sstable& sst) mutable {
-           ret.insert(sst);
-        });
+        for (auto all_sstables = set->all(); auto& sst : *all_sstables) {
+           ret.push_back({
+               .sst = sst,
+               .files = co_await sst->readable_file_for_all_components(),
+           });
+        }
     }
 
-    co_return ret;
+    co_return std::move(ret);
 }
 
 void table::update_stats_for_new_sstable(const sstables::shared_sstable& sst) noexcept {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -607,7 +607,7 @@ public:
     static future<std::vector<sstring>> read_and_parse_toc(file f);
 private:
     void unused(); // Called when reference count drops to zero
-    future<file> open_file(component_type, open_flags, file_open_options = {}) noexcept;
+    future<file> open_file(component_type, open_flags, file_open_options = {}) const noexcept;
 
     template <component_type Type, typename T>
     future<> read_simple(T& comp);
@@ -628,7 +628,7 @@ private:
     void write_crc(const checksum& c);
     void write_digest(uint32_t full_checksum);
 
-    future<file> new_sstable_component_file(const io_error_handler& error_handler, component_type f, open_flags flags, file_open_options options = {}) noexcept;
+    future<file> new_sstable_component_file(const io_error_handler& error_handler, component_type f, open_flags flags, file_open_options options = {}) const noexcept;
 
     future<file_writer> make_component_file_writer(component_type c, file_output_stream_options options,
             open_flags oflags = open_flags::wo | open_flags::create | open_flags::exclusive) noexcept;
@@ -936,6 +936,9 @@ public:
     // Drops all evictable in-memory caches of on-disk content.
     future<> drop_caches();
 
+    // Returns a read-only file for all existing components of the sstable
+    future<std::unordered_map<component_type, file>> readable_file_for_all_components() const;
+
     // Allow the test cases from sstable_test.cc to test private methods. We use
     // a placeholder to avoid cluttering this class too much. The sstable_test class
     // will then re-export as public every method it needs.
@@ -1022,5 +1025,11 @@ future<> remove_table_directory_if_has_no_snapshots(fs::path table_dir);
 // resolves into temporary-TOC file name or empty string if neither TOC nor temp.
 // TOC is there
 future<sstring> make_toc_temporary(sstring sstable_toc_name, storage::sync_dir sync = storage::sync_dir::yes);
+
+// This snapshot allows the sstable files to be read even if they were removed from the directory
+struct sstable_files_snapshot {
+    shared_sstable sst;
+    std::unordered_map<component_type, file> files;
+};
 
 } // namespace sstables


### PR DESCRIPTION
Consider this:
1) file streaming takes storage snapshot = list of sstables
2) concurrent compaction unlink some of those sstables from file system
3) file streaming tries to send unlinked sstables, but files other than data and index cannot be read as only data and index have file descriptors opened 

To fix it, the snapshot now returns a set of files, one per sstable component, for each sstable.