### PR TITLE
compaction_manager: pass std::string_view when appropriate

### DIFF
--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -189,7 +189,7 @@ struct table_tasks_info {
     {}
 };
 
-future<> run_on_table(sstring op, replica::database& db, std::string keyspace, table_info ti, std::function<future<> (replica::table&)> func) {
+future<> run_on_table(std::string_view op, replica::database& db, std::string keyspace, table_info ti, std::function<future<> (replica::table&)> func) {
     std::exception_ptr ex;
     tasks::tmlogger.debug("Starting {} on {}.{}", op, keyspace, ti.name);
     try {


### PR DESCRIPTION
most of the times, we just pass a string literal for the `op` argument, and we just print it in the logging message, so there is no need to create an instance of sstring for formatting it.

in this change, we use std::string_view for the type of this parameter for better readability.