### PR TITLE
build: cmake: map 'release' to 'RelWithDebInfo'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,14 @@ list(APPEND CMAKE_MODULE_PATH
 
 # Set the possible values of build type for cmake-gui
 set(scylla_build_types
-    "Debug" "Release" "Dev" "Sanitize" "Coverage")
+    "Debug" "RelWithDebInfo" "Dev" "Sanitize" "Coverage")
 if(DEFINED CMAKE_BUILD_TYPE)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
      ${scylla_build_types})
     if(NOT CMAKE_BUILD_TYPE)
-        set(CMAKE_BUILD_TYPE "Release" CACHE
+        set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE
             STRING "Choose the type of build." FORCE)
-        message(WARNING "CMAKE_BUILD_TYPE not specified, Using 'Release'")
+        message(WARNING "CMAKE_BUILD_TYPE not specified, Using 'RelWithDebInfo'")
     elseif(NOT CMAKE_BUILD_TYPE IN_LIST scylla_build_types)
         message(FATAL_ERROR "Unknown CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}. "
             "Following types are supported: ${scylla_build_types}")

--- a/cmake/mode.RelWithDebInfo.cmake
+++ b/cmake/mode.RelWithDebInfo.cmake
@@ -1,14 +1,14 @@
-set(CMAKE_CXX_FLAGS_RELEASE
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
   "-ffunction-sections -fdata-sections"
   CACHE
   INTERNAL
   "")
-update_cxx_flags(CMAKE_CXX_FLAGS_RELEASE
+update_cxx_flags(CMAKE_CXX_FLAGS_RELWITHDEBINFO
   WITH_DEBUG_INFO
   OPTIMIZATION_LEVEL "3")
 
 add_compile_definitions(
-    $<$<CONFIG:Release>:SCYLLA_BUILD_MODE=release>)
+    $<$<CONFIG:RelWithDebInfo>:SCYLLA_BUILD_MODE=release>)
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
   set(clang_inline_threshold 300)
@@ -16,16 +16,16 @@ else()
   set(clang_inline_threshold 2500)
 endif()
 add_compile_options(
-  "$<$<AND:$<CONFIG:Release>,$<CXX_COMPILER_ID:GNU>>:--param;inline-unit-growth=300>"
-  "$<$<AND:$<CONFIG:Release>,$<CXX_COMPILER_ID:Clang>>:-mllvm;-inline-threshold=${clang_inline_threshold}>")
+  "$<$<AND:$<CONFIG:RelWithDebInfo>,$<CXX_COMPILER_ID:GNU>>:--param;inline-unit-growth=300>"
+  "$<$<AND:$<CONFIG:RelWithDebInfo>,$<CXX_COMPILER_ID:Clang>>:-mllvm;-inline-threshold=${clang_inline_threshold}>")
 # clang generates 16-byte loads that break store-to-load forwarding
 # gcc also has some trouble: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103554
 check_cxx_compiler_flag("-fno-slp-vectorize" _slp_vectorize_supported)
 if(_slp_vectorize_supported)
   add_compile_options(
-    $<$<CONFIG:Release>:-fno-slp-vectorize>)
+    $<$<CONFIG:RelWithDebInfo>:-fno-slp-vectorize>)
 endif()
 
-add_link_options($<$<CONFIG:Release>:LINKER:--gc-sections>)
+add_link_options($<$<CONFIG:RelWithDebInfo>:LINKER:--gc-sections>)
 
-maybe_limit_stack_usage_in_KB(13 Release)
+maybe_limit_stack_usage_in_KB(13 RelWithDebInfo)

--- a/configure.py
+++ b/configure.py
@@ -2415,19 +2415,21 @@ def create_build_system(args):
 
 class BuildType(NamedTuple):
     build_by_default: bool
+    cmake_build_type: str
 
 
 def configure_using_cmake(args):
     # all supported build modes, and if they are built by default if selected
-    build_modes = {'debug': BuildType(True),
-                   'release': BuildType(True),
-                   'dev': BuildType(True),
-                   'sanitize': BuildType(False),
-                   'coverage': BuildType(False)}
-    selected_modes = args.selected_modes or build_modes.keys()
-    selected_configs = ';'.join(mode.capitalize() for mode in selected_modes)
-    default_configs = ';'.join(mode.capitalize() for mode in selected_modes
-                               if build_modes[mode].build_by_default)
+    build_modes = {'debug': BuildType(True, 'Debug'),
+                   'release': BuildType(True, 'RelWithDebInfo'),
+                   'dev': BuildType(True, 'Dev'),
+                   'sanitize': BuildType(False, 'Sanitize'),
+                   'coverage': BuildType(False, 'Coverage')}
+    selected_modes = list(build_modes[mode] for mode in
+                          args.selected_modes or build_modes.keys())
+    selected_configs = ';'.join(mode.cmake_build_type for mode in selected_modes)
+    default_configs = ';'.join(mode.cmake_build_type for mode in selected_modes
+                               if mode.build_by_default)
 
     settings = {
         'CMAKE_CONFIGURATION_TYPES': selected_configs,

--- a/configure.py
+++ b/configure.py
@@ -18,6 +18,7 @@ import sys
 import tempfile
 import textwrap
 from distutils.spawn import find_executable
+from typing import NamedTuple
 
 outdir = 'build'
 
@@ -2412,17 +2413,21 @@ def create_build_system(args):
     generate_compdb('compile_commands.json', ninja, args.buildfile, selected_modes)
 
 
+class BuildType(NamedTuple):
+    build_by_default: bool
+
+
 def configure_using_cmake(args):
     # all supported build modes, and if they are built by default if selected
-    build_by_default = {'debug': True,
-                        'release': True,
-                        'dev': True,
-                        'sanitize': False,
-                        'coverage': False}
-    selected_modes = args.selected_modes or build_by_default.keys()
+    build_modes = {'debug': BuildType(True),
+                   'release': BuildType(True),
+                   'dev': BuildType(True),
+                   'sanitize': BuildType(False),
+                   'coverage': BuildType(False)}
+    selected_modes = args.selected_modes or build_modes.keys()
     selected_configs = ';'.join(mode.capitalize() for mode in selected_modes)
     default_configs = ';'.join(mode.capitalize() for mode in selected_modes
-                               if build_by_default[mode])
+                               if build_modes[mode].build_by_default)
 
     settings = {
         'CMAKE_CONFIGURATION_TYPES': selected_configs,


### PR DESCRIPTION
this preserves the existing behavior of `configure.py` in the CMake
generated `build.ninja`.

* configure.py: map 'release' to 'RelWithDebInfo'
* cmake: rename cmake/mode.Release.cmake to cmake/mode.RelWithDebInfo.cmake
* CMakeLists.txt: s/Release/RelWithDebInfo/
