### PR TITLE
tools/schema_loader: add db::config parameter to all load methods

### DIFF
--- a/test/boost/schema_loader_test.cc
+++ b/test/boost/schema_loader_test.cc
@@ -8,39 +8,47 @@
 
 #include "test/lib/scylla_test_case.hh"
 
+#include "db/config.hh"
 #include "tools/schema_loader.hh"
 
 SEASTAR_THREAD_TEST_CASE(test_empty) {
-    BOOST_REQUIRE_THROW(tools::load_schemas("").get(), std::exception);
-    BOOST_REQUIRE_THROW(tools::load_schemas(";").get(), std::exception);
+    db::config dbcfg;
+    BOOST_REQUIRE_THROW(tools::load_schemas(dbcfg, "").get(), std::exception);
+    BOOST_REQUIRE_THROW(tools::load_schemas(dbcfg, ";").get(), std::exception);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_keyspace_only) {
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};").get().size(), 0);
+    db::config dbcfg;
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};").get().size(), 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_single_table) {
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE TABLE ks.cf (pk int PRIMARY KEY, v int)").get().size(), 1);
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE TABLE ks.cf (pk int PRIMARY KEY, v map<int, int>)").get().size(), 1);
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
+    db::config dbcfg;
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE TABLE ks.cf (pk int PRIMARY KEY, v int)").get().size(), 1);
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE TABLE ks.cf (pk int PRIMARY KEY, v map<int, int>)").get().size(), 1);
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_keyspace_replication_strategy) {
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'mydc1': 1, 'mydc2': 4}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
+    db::config dbcfg;
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'mydc1': 1, 'mydc2': 4}; CREATE TABLE ks.cf (pk int PRIMARY KEY, v int);").get().size(), 1);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_multiple_tables) {
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE TABLE ks.cf1 (pk int PRIMARY KEY, v int); CREATE TABLE ks.cf2 (pk int PRIMARY KEY, v int)").get().size(), 2);
-    BOOST_REQUIRE_EQUAL(tools::load_schemas("CREATE TABLE ks.cf1 (pk int PRIMARY KEY, v int); CREATE TABLE ks.cf2 (pk int PRIMARY KEY, v int);").get().size(), 2);
+    db::config dbcfg;
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE TABLE ks.cf1 (pk int PRIMARY KEY, v int); CREATE TABLE ks.cf2 (pk int PRIMARY KEY, v int)").get().size(), 2);
+    BOOST_REQUIRE_EQUAL(tools::load_schemas(dbcfg, "CREATE TABLE ks.cf1 (pk int PRIMARY KEY, v int); CREATE TABLE ks.cf2 (pk int PRIMARY KEY, v int);").get().size(), 2);
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; "
                 "CREATE TABLE ks.cf1 (pk int PRIMARY KEY, v int); "
                 "CREATE TABLE ks.cf2 (pk int PRIMARY KEY, v int); "
                 "CREATE TABLE ks.cf3 (pk int PRIMARY KEY, v int); "
     ).get().size(), 3);
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; "
                 "CREATE TABLE ks1.cf (pk int PRIMARY KEY, v int); "
                 "CREATE KEYSPACE ks2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; "
@@ -49,17 +57,21 @@ SEASTAR_THREAD_TEST_CASE(test_multiple_tables) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_udts) {
+    db::config dbcfg;
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; "
                 "CREATE TYPE ks.type1 (f1 int, f2 text); "
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v frozen<type1>); "
     ).get().size(), 1);
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; "
                 "CREATE TYPE ks.type1 (f1 int, f2 text); "
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v type1); "
     ).get().size(), 1);
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}; "
                 "CREATE TYPE ks1.type1 (f1 int, f2 text); "
                 "CREATE TABLE ks1.cf (pk int PRIMARY KEY, v frozen<type1>); "
@@ -68,10 +80,12 @@ SEASTAR_THREAD_TEST_CASE(test_udts) {
                 "CREATE TABLE ks2.cf (pk int PRIMARY KEY, v frozen<type1>); "
     ).get().size(), 2);
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE TYPE ks.type1 (f1 int, f2 text); "
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v frozen<type1>); "
     ).get().size(), 1);
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE TYPE ks1.type1 (f1 int, f2 text); "
                 "CREATE TABLE ks1.cf (pk int PRIMARY KEY, v frozen<type1>); "
                 "CREATE TYPE ks2.type1 (f1 int, f2 text); "
@@ -80,27 +94,34 @@ SEASTAR_THREAD_TEST_CASE(test_udts) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_dropped_columns) {
+    db::config dbcfg;
     BOOST_REQUIRE_EQUAL(tools::load_schemas(
+                dbcfg,
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v1 int); "
                 "INSERT INTO system_schema.dropped_columns (keyspace_name, table_name, column_name, dropped_time, type) VALUES ('ks', 'cf', 'v2', 1631011979170675, 'int'); "
     ).get().size(), 1);
     BOOST_REQUIRE_THROW(tools::load_schemas(
+                dbcfg,
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v1 int); "
                 "INSERT INTO ks.cf (pk, v1) VALUES (0, 0); "
     ).get(), std::exception);
     BOOST_REQUIRE_THROW(tools::load_schemas(
+                dbcfg,
                 "INSERT INTO system_schema.dropped_columns (keyspace_name, table_name, column_name, dropped_time, type) VALUES ('ks', 'cf', 'v2', 1631011979170675, 'int'); "
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v1 int); "
     ).get(), std::exception);
     BOOST_REQUIRE_THROW(tools::load_schemas(
+                dbcfg,
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v1 int); "
                 "INSERT INTO system_schema.dropped_columns (keyspace_name, table_name, column_name, dropped_time, type) VALUES ('unknown_ks', 'unknown_cf', 'v2', 1631011979170675, 'int'); "
     ).get(), std::exception);
     BOOST_REQUIRE_THROW(tools::load_schemas(
+                dbcfg,
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v1 int); "
                 "INSERT INTO system_schema.dropped_columns (keyspace_name, table_name, column_name, dropped_time, type) VALUES ('unknown_ks', 'cf', 'v2', 1631011979170675, 'int'); "
     ).get(), std::exception);
     BOOST_REQUIRE_THROW(tools::load_schemas(
+                dbcfg,
                 "CREATE TABLE ks.cf (pk int PRIMARY KEY, v1 int); "
                 "INSERT INTO system_schema.dropped_columns (keyspace_name, table_name, column_name, dropped_time, type) VALUES ('ks', 'unknown_cf', 'v2', 1631011979170675, 'int'); "
     ).get(), std::exception);

--- a/tools/schema_loader.hh
+++ b/tools/schema_loader.hh
@@ -12,6 +12,10 @@
 #include "seastarx.hh"
 #include "schema/schema.hh"
 
+namespace db {
+class config;
+}
+
 namespace tools {
 
 /// Load the schema(s) from the specified string
@@ -28,13 +32,13 @@ namespace tools {
 ///
 /// [1] Currently some global services has to be instantiated (snitch) to
 /// be able to load the schema(s), these survive the call.
-future<std::vector<schema_ptr>> load_schemas(std::string_view schema_str);
+future<std::vector<schema_ptr>> load_schemas(const db::config& dbcfg, std::string_view schema_str);
 
 /// Load exactly one schema from the specified path
 ///
 /// If the file at the specified path contains more or less then one schema,
 /// an exception will be thrown. See \ref load_schemas().
-future<schema_ptr> load_one_schema_from_file(std::filesystem::path path);
+future<schema_ptr> load_one_schema_from_file(const db::config& dbcfg, std::filesystem::path path);
 
 /// Load the system schema, with the given keyspace and table
 ///
@@ -47,7 +51,7 @@ future<schema_ptr> load_one_schema_from_file(std::filesystem::path path);
 ///
 /// Any table from said keyspaces can be loaded. The keyspaces are created with
 /// all schema and experimental features enabled.
-schema_ptr load_system_schema(std::string_view keyspace, std::string_view table);
+schema_ptr load_system_schema(const db::config& dbcfg, std::string_view keyspace, std::string_view table);
 
 /// Load the schema of the table with the designated keyspace and table name,
 /// from the system schema table sstables.
@@ -56,6 +60,6 @@ schema_ptr load_system_schema(std::string_view keyspace, std::string_view table)
 /// tries very hard to have no side-effects.
 /// The \p scylla_data_path parameter is expected to point to the scylla data
 /// directory, which is usually /var/lib/scylla/data.
-future<schema_ptr> load_schema_from_schema_tables(std::filesystem::path scylla_data_path, std::string_view keyspace, std::string_view table);
+future<schema_ptr> load_schema_from_schema_tables(const db::config& dbcfg, std::filesystem::path scylla_data_path, std::string_view keyspace, std::string_view table);
 
 } // namespace tools


### PR DESCRIPTION
So that a single centrally managed db::config instance can be shared by all code requiring it, instead of creating local instances where needed. This is required to load schema from encrypted schema-tables, and it also helps memory consumption a bit (db::config consumes a lot of memory).

Fixes: #16480