### PR TITLE
DROP TYPE IF EXISTS should work on non-existent keyspace

### DIFF
--- a/cql3/statements/drop_type_statement.hh
+++ b/cql3/statements/drop_type_statement.hh
@@ -34,7 +34,7 @@ public:
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 private:
-    void validate_while_executing(query_processor&) const;
+    bool validate_while_executing(query_processor&) const;
 };
 
 }

--- a/test/cql-pytest/cassandra_tests/validation/entities/type_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/type_test.py
@@ -7,7 +7,6 @@
 
 from cassandra_tests.porting import *
 
-@pytest.mark.xfail(reason="Issue #9082")
 def testNonExistingOnes(cql, test_keyspace):
     # The Scylla and Cassandra error messages are slightly different, but both
     # include the type's full name and the word "exist":


### PR DESCRIPTION
DROP TYPE IF EXISTS should pass and do nothing  on non-existent keyspace