### PR TITLE
raft: gossiper_state_change_subscriber_proxy: on_alive: wait in background

### DIFF
--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -400,7 +400,8 @@ seastar::future<> raft_group_registry::stop() {
 }
 
 seastar::future<> raft_group_registry::drain_on_shutdown() noexcept {
-    return stop_servers();
+    co_await stop_servers();
+    co_await async_gate().close();
 }
 
 raft_server_for_group& raft_group_registry::server_for_group(raft::group_id gid) {

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -86,7 +86,10 @@ private:
 
     void init_rpc_verbs();
     seastar::future<> uninit_rpc_verbs();
-    seastar::future<> stop_servers() noexcept;
+
+    // Stops all servers in the background,
+    // under the async_gate()
+    void stop_servers() noexcept;
 
     raft_server_for_group& server_for_group(raft::group_id id);
 

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -96,6 +96,8 @@ private:
     // My Raft ID. Shared between different Raft groups.
     raft::server_id _my_id;
 
+    mutable gate _gate;
+
 public:
     raft_group_registry(raft::server_id my_id, raft_address_map&, netw::messaging_service& ms,
             gms::gossiper& gs, direct_failure_detector::failure_detector& fd);
@@ -143,6 +145,10 @@ public:
     shared_ptr<raft::failure_detector> failure_detector();
     raft_address_map& address_map() { return _address_map; }
     direct_failure_detector::failure_detector& direct_fd() { return _direct_fd; }
+
+    gate& async_gate() const noexcept {
+        return _gate;
+    }
 };
 
 // Implementation of `direct_failure_detector::pinger` which uses DIRECT_FD_PING verb for pinging.


### PR DESCRIPTION
Wait in the error injection case in the background
so that the endpoint_lock that the gossiper holds around
this callback is freed while waiting.

Holding the gate may cause long delays in debug/dev testing
and may cause the error injection in on_alive to timeout in the
rare event that the endpoint state is not present yet in `topology_state_load`
and it ends up calling `add_saved_endpoint` which may deadlock on the
endpoint_lock held around the call to on_alive.

Fixes #16506
