### PR TITLE
virtual_tables, schema_registry: fix use after free related to schema registry

### DIFF
--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -24,6 +24,7 @@
 #include "cdc/generation_id.hh"
 #include "locator/host_id.hh"
 #include "mutation/canonical_mutation.hh"
+#include "virtual_tables.hh"
 
 namespace sstables {
     struct entry_descriptor;
@@ -112,6 +113,7 @@ class system_keyspace : public seastar::peering_sharded_service<system_keyspace>
     cql3::query_processor& _qp;
     replica::database& _db;
     std::unique_ptr<local_cache> _cache;
+    virtual_tables_registry _virtual_tables_registry;
 
     static schema_ptr raft_snapshot_config();
     static schema_ptr local();
@@ -521,6 +523,7 @@ public:
     ~system_keyspace();
     future<> shutdown();
 
+    virtual_tables_registry& get_virtual_tables_registry() { return _virtual_tables_registry; }
 private:
     future<::shared_ptr<cql3::untyped_result_set>> execute_cql(const sstring& query_string, const std::initializer_list<data_value>& values);
     template <typename... Args>

--- a/db/virtual_tables.hh
+++ b/db/virtual_tables.hh
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <seastar/core/distributed.hh>
+#include <map>
 #include "schema/schema_fwd.hh"
 
 namespace replica {
@@ -37,5 +38,17 @@ future<> initialize_virtual_tables(
     sharded<service::raft_group_registry>&,
     sharded<db::system_keyspace>& sys_ks,
     db::config&);
+
+
+class virtual_table;
+
+using virtual_tables_registry_impl = std::map<table_id, std::unique_ptr<virtual_table>>;
+
+// Pimpl to hide virtual_table from the rest of the code
+class virtual_tables_registry : public std::unique_ptr<virtual_tables_registry_impl> {
+public:
+    virtual_tables_registry();
+    ~virtual_tables_registry();
+};
 
 } // namespace db

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -636,6 +636,7 @@ void database::set_format(sstables::sstable_version_types format) noexcept {
 
 database::~database() {
     _user_types->deactivate();
+    local_schema_registry().clear();
 }
 
 void database::update_version(const table_schema_version& version) {

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -164,6 +164,10 @@ schema_ptr schema_registry::get_or_load(table_schema_version v, const schema_loa
     return e.get_schema();
 }
 
+void schema_registry::clear() {
+    _entries.clear();
+}
+
 schema_ptr schema_registry_entry::load(frozen_schema fs) {
     _frozen_schema = std::move(fs);
     auto s = get_schema();

--- a/schema/schema_registry.hh
+++ b/schema/schema_registry.hh
@@ -150,6 +150,12 @@ public:
     // The schema instance pointed to by the argument will be attached to the registry
     // entry and will keep it alive.
     schema_ptr learn(const schema_ptr&);
+
+    // Removes all entries from the registry. This in turn removes all dependencies
+    // on the Seastar reactor.
+    //
+    // Prerequisite: all futures from get_or_load() are resolved.
+    void clear();
 };
 
 schema_registry& local_schema_registry();


### PR DESCRIPTION
Both virtual tables and schema registry contain thread_local caches that are destroyed
at thread exit. after a Seastar change[1], these destructions can happen after the reactor
is destroyed, triggering a use-after-free.

Fix by scoping the destruction so it takes place earlier.

[1] https://github.com/scylladb/seastar/commit/101b245ed709d7170f3addcb4ebdc87763d6f65b