### PR TITLE
main: Postpone start-up of hint manager

### DIFF
--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -295,10 +295,12 @@ private:
         _state.set(state::stopping);
     }
 
+public:
     bool started() const noexcept {
         return _state.contains(state::started);
     }
 
+private:
     void set_started() noexcept {
         _state.set(state::started);
     }

--- a/main.cc
+++ b/main.cc
@@ -1553,9 +1553,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }
             view_hints_dir_initializer.ensure_rebalanced().get();
 
-            proxy.invoke_on_all([&lifecycle_notifier, &gossiper] (service::storage_proxy& local_proxy) {
+            proxy.invoke_on_all([&lifecycle_notifier] (service::storage_proxy& local_proxy) {
                 lifecycle_notifier.local().register_subscriber(&local_proxy);
-                return local_proxy.start_hints_manager(gossiper.local().shared_from_this());
             }).get();
 
             auto drain_proxy = defer_verbose_shutdown("drain storage proxy", [&proxy, &lifecycle_notifier] {
@@ -1746,7 +1745,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }).get();
 
             with_scheduling_group(maintenance_scheduling_group, [&] {
-                return ss.local().join_cluster(sys_dist_ks, proxy);
+                return ss.local().join_cluster(sys_dist_ks, proxy, gossiper, service::start_hint_manager::yes);
             }).get();
 
             sl_controller.invoke_on_all([&lifecycle_notifier] (qos::service_level_controller& controller) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3638,10 +3638,12 @@ future<> storage_service::update_topology_with_local_metadata(raft::server& raft
 
 future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspace>& sys_dist_ks,
         sharded<service::storage_proxy>& proxy,
+        sharded<gms::gossiper>& gossiper,
         std::unordered_set<gms::inet_address> initial_contact_nodes,
         std::unordered_set<gms::inet_address> loaded_endpoints,
         std::unordered_map<gms::inet_address, sstring> loaded_peer_features,
-        std::chrono::milliseconds delay) {
+        std::chrono::milliseconds delay,
+        start_hint_manager start_hm) {
     std::unordered_set<token> bootstrap_tokens;
     gms::application_state_map app_states;
     /* The timestamp of the CDC streams generation that this node has proposed when joining.
@@ -3909,6 +3911,16 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
     } ();
 
     co_await _gossiper.wait_for_gossip_to_settle();
+
+    // This is the moment when the locator::topology has gathered information about other nodes
+    // in the cluster -- either through gossiper, or by loading it from disk -- so it's safe
+    // to start the hint managers.
+    if (start_hm) {
+        co_await proxy.invoke_on_all([&gossiper] (storage_proxy& local_proxy) {
+            return local_proxy.start_hints_manager(gossiper.local().shared_from_this());
+        });
+    }
+    
     // TODO: Look at the group 0 upgrade state and use it to decide whether to attach or not
     if (!_raft_topology_change_enabled) {
         co_await _feature_service.enable_features_on_join(_gossiper, _sys_ks.local());
@@ -4902,7 +4914,8 @@ bool storage_service::is_topology_coordinator_enabled() const {
     return _raft_topology_change_enabled;
 }
 
-future<> storage_service::join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy) {
+future<> storage_service::join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy,
+        sharded<gms::gossiper>& gossiper, start_hint_manager start_hm) {
     assert(this_shard_id() == 0);
 
     set_mode(mode::STARTING);
@@ -4972,7 +4985,8 @@ future<> storage_service::join_cluster(sharded<db::system_distributed_keyspace>&
     for (auto& x : loaded_peer_features) {
         slogger.info("peer={}, supported_features={}", x.first, x.second);
     }
-    co_return co_await join_token_ring(sys_dist_ks, proxy, std::move(initial_contact_nodes), std::move(loaded_endpoints), std::move(loaded_peer_features), get_ring_delay());
+    co_return co_await join_token_ring(sys_dist_ks, proxy, gossiper, std::move(initial_contact_nodes),
+            std::move(loaded_endpoints), std::move(loaded_peer_features), get_ring_delay(), start_hm);
 }
 
 future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmptr) noexcept {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -102,6 +102,8 @@ enum class disk_error { regular, commit };
 
 class node_ops_meta_data;
 
+using start_hint_manager = seastar::bool_class<class start_hint_manager_tag>;
+
 /**
  * This abstraction contains the token/identifier of this node
  * on the identifier space. This token gets gossiped around.
@@ -333,7 +335,8 @@ public:
     future<> check_for_endpoint_collision(std::unordered_set<gms::inet_address> initial_contact_nodes,
             const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features);
 
-    future<> join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy);
+    future<> join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy,
+            sharded<gms::gossiper>& gossiper_ptr, start_hint_manager start_hm);
 
     void set_group0(service::raft_group0&, bool raft_topology_change_enabled);
 
@@ -354,10 +357,12 @@ private:
     bool is_first_node();
     future<> join_token_ring(sharded<db::system_distributed_keyspace>& sys_dist_ks,
             sharded<service::storage_proxy>& proxy,
+            sharded<gms::gossiper>& gossiper,
             std::unordered_set<gms::inet_address> initial_contact_nodes,
             std::unordered_set<gms::inet_address> loaded_endpoints,
             std::unordered_map<gms::inet_address, sstring> loaded_peer_features,
-            std::chrono::milliseconds);
+            std::chrono::milliseconds,
+            start_hint_manager start_hm);
     future<> start_sys_dist_ks();
 public:
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -902,7 +902,7 @@ private:
             });
 
             try {
-                _ss.local().join_cluster(_sys_dist_ks, _proxy).get();
+                _ss.local().join_cluster(_sys_dist_ks, _proxy, _gossiper, service::start_hint_manager::no).get();
             } catch (std::exception& e) {
                 // if any of the defers crashes too, we'll never see
                 // the error


### PR DESCRIPTION
### Context (#11870)
When we start the hint managers, one of the things that happen at that time is creating endpoint managers – data structures managed by `db::hints::manager`. Whether we create an instance of endpoint manager depends on the returned value by `host_filter::can_hint_for`. The logic looks like this:
```cpp
return _host_filter.is_enabled_for_all()
        || have_ep_manager(ep)
        || _host_filter.can_hint_for(_proxy.get_token_metadata_ptr()->get_topology(), ep);
```
If the first two predicates fail and the endpoint is not in the passed topology, the corresponding endpoint manager will not be created.

The situation like this can happen because we start the hint managers too early – when we still don't have all of the information about the cluster's state, the full list of nodes being part of it in particular. As a result, some endpoint managers might not be working even though they could and should. It only changes when we end up storing a hint towards that node.

### Solution
These changes solve the problem. We only start the hint managers when we've successfully constructed the `locator::topology` and thus have all relevant information about the cluster. The code still works correctly because up until we start the hint managers, all of the mutations the local node performs are directed towards itself – and we never store hints towards ourselves.

Fixes #11870 