### PR TITLE
Don't allow ALTER KEYSPACE to change replication strategy vnode/per-table flavor

### DIFF
--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -49,7 +49,8 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
             throw exceptions::configuration_exception("Missing replication strategy class");
         }
         try {
-            data_dictionary::storage_options current_options = qp.db().find_keyspace(_name).metadata()->get_storage_options();
+            auto ks = qp.db().find_keyspace(_name);
+            data_dictionary::storage_options current_options = ks.metadata()->get_storage_options();
             data_dictionary::storage_options new_options = _attrs->get_storage_options();
             if (!current_options.can_update_to(new_options)) {
                 throw exceptions::invalid_request_exception(format("Cannot alter storage options: {} to {} is not supported",

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -56,6 +56,12 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
                 throw exceptions::invalid_request_exception(format("Cannot alter storage options: {} to {} is not supported",
                         current_options.type_string(), new_options.type_string()));
             }
+
+            auto new_ks = _attrs->as_ks_metadata_update(ks.metadata(), *qp.proxy().get_token_metadata_ptr());
+            auto new_rs = locator::abstract_replication_strategy::create_replication_strategy(new_ks->strategy_name(), new_ks->strategy_options());
+            if (new_rs->is_per_table() != ks.get_replication_strategy().is_per_table()) {
+                throw exceptions::invalid_request_exception(format("Cannot alter replication strategy vnode/tablets flavor"));
+            }
         } catch (const std::runtime_error& e) {
             throw exceptions::invalid_request_exception(e.what());
         }

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from cassandra.protocol import InvalidRequest
+from test.pylib.manager_client import ManagerClient
+import pytest
+import logging
+import asyncio
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_tablet_change_replication_vnode_to_tablets(manager: ManagerClient):
+    cfg = {'enable_user_defined_functions': False,
+           'experimental_features': ['tablets', 'consistent-topology-changes']}
+    server = await manager.server_add(config=cfg)
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};")
+    with pytest.raises(InvalidRequest):
+        await cql.run_async("ALTER KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 1};")
+


### PR DESCRIPTION
This switch is currently possible, but results in not supported keyspace state