### PR TITLE
scylla-sstable: add support for loading schema of views and indexes

### DIFF
--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -73,8 +73,7 @@ create_index_statement::validate(query_processor& qp, const service::client_stat
     _properties->validate();
 }
 
-std::vector<::shared_ptr<index_target>> create_index_statement::validate_while_executing(query_processor& qp) const {
-    auto db = qp.db();
+std::vector<::shared_ptr<index_target>> create_index_statement::validate_while_executing(data_dictionary::database db) const {
     auto schema = validation::validate_column_family(db, keyspace(), column_family());
 
     if (schema->is_counter()) {
@@ -327,10 +326,9 @@ void create_index_statement::validate_targets_for_multi_column_index(std::vector
     }
 }
 
-schema_ptr create_index_statement::build_index_schema(query_processor& qp) const {
-    auto targets = validate_while_executing(qp);
+schema_ptr create_index_statement::build_index_schema(data_dictionary::database db) const {
+    auto targets = validate_while_executing(db);
 
-    data_dictionary::database db = qp.db();
     auto schema = db.find_schema(keyspace(), column_family());
 
     sstring accepted_name = _index_name;
@@ -378,7 +376,7 @@ schema_ptr create_index_statement::build_index_schema(query_processor& qp) const
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
 create_index_statement::prepare_schema_mutations(query_processor& qp, api::timestamp_type ts) const {
     using namespace cql_transport;
-    auto schema = build_index_schema(qp);
+    auto schema = build_index_schema(qp.db());
 
     ::shared_ptr<event::schema_change> ret;
     std::vector<mutation> m;

--- a/cql3/statements/create_index_statement.hh
+++ b/cql3/statements/create_index_statement.hh
@@ -52,7 +52,11 @@ public:
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 
-    schema_ptr build_index_schema(data_dictionary::database db) const;
+    struct base_schema_with_new_index {
+        schema_ptr schema;
+        index_metadata index;
+    };
+    std::optional<base_schema_with_new_index> build_index_schema(data_dictionary::database db) const;
 private:
     void validate_for_local_index(const schema& schema) const;
     void validate_for_frozen_collection(const index_target& target) const;

--- a/cql3/statements/create_index_statement.hh
+++ b/cql3/statements/create_index_statement.hh
@@ -51,6 +51,8 @@ public:
 
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
+
+    schema_ptr build_index_schema(data_dictionary::database db) const;
 private:
     void validate_for_local_index(const schema& schema) const;
     void validate_for_frozen_collection(const index_target& target) const;
@@ -66,7 +68,6 @@ private:
                                               index_metadata_kind kind,
                                               const index_options_map& options);
     std::vector<::shared_ptr<index_target>> validate_while_executing(data_dictionary::database db) const;
-    schema_ptr build_index_schema(data_dictionary::database db) const;
 };
 
 }

--- a/cql3/statements/create_index_statement.hh
+++ b/cql3/statements/create_index_statement.hh
@@ -65,8 +65,8 @@ private:
                                               const sstring& name,
                                               index_metadata_kind kind,
                                               const index_options_map& options);
-    std::vector<::shared_ptr<index_target>> validate_while_executing(query_processor& qp) const;
-    schema_ptr build_index_schema(query_processor& qp) const;
+    std::vector<::shared_ptr<index_target>> validate_while_executing(data_dictionary::database db) const;
+    schema_ptr build_index_schema(data_dictionary::database db) const;
 };
 
 }

--- a/cql3/statements/create_view_statement.hh
+++ b/cql3/statements/create_view_statement.hh
@@ -39,8 +39,6 @@ private:
     cf_properties _properties;
     bool _if_not_exists;
 
-    std::pair<view_ptr, cql3::cql_warnings_vec> prepare_view(data_dictionary::database db) const;
-
 public:
     create_view_statement(
             cf_name view_name,
@@ -50,6 +48,8 @@ public:
             std::vector<::shared_ptr<cql3::column_identifier::raw>> partition_keys,
             std::vector<::shared_ptr<cql3::column_identifier::raw>> clustering_keys,
             bool if_not_exists);
+
+    std::pair<view_ptr, cql3::cql_warnings_vec> prepare_view(data_dictionary::database db) const;
 
     auto& properties() {
         return _properties;

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -35,6 +35,21 @@ sstring index_table_name(const sstring& index_name);
  */
 sstring index_name_from_table_name(const sstring& table_name);
 
+/// Given a list of base-table schemas, return all their secondary indexes, except that specified in cf_to_exclude.
+std::set<sstring>
+existing_index_names(const std::vector<schema_ptr>& tables, std::string_view cf_to_exclude);
+
+/// Given a base-table keyspace and table name, return the first available index
+/// name (containing index_name_root if specified).
+/// If needed, a running counder is appended to the index name, if it is already
+/// taken (existing_names contains it).
+sstring get_available_index_name(
+        std::string_view ks_name,
+        std::string_view cf_name,
+        std::optional<sstring> index_name_root,
+        const std::set<sstring>& existing_names,
+        std::function<bool(std::string_view, std::string_view)> has_schema);
+
 class index {
     index_metadata _im;
     cql3::statements::index_target::target_type _target_type;

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -56,6 +56,7 @@ struct database {
 
     database(const db::config& cfg, gms::feature_service& features) : cfg(cfg), features(features)
     { }
+    database(database&&) = delete;
 };
 
 struct keyspace {
@@ -63,6 +64,7 @@ struct keyspace {
 
     explicit keyspace(lw_shared_ptr<keyspace_metadata> metadata) : metadata(std::move(metadata))
     { }
+    keyspace(keyspace&&) = delete;
 };
 
 struct table {
@@ -71,6 +73,7 @@ struct table {
     secondary_index::secondary_index_manager secondary_idx_man;
 
     table(data_dictionary_impl& impl, keyspace& ks, schema_ptr schema);
+    table(table&&) = delete;
 };
 
 class data_dictionary_impl : public data_dictionary::impl {

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -68,11 +68,11 @@ struct keyspace {
 };
 
 struct table {
-    keyspace& ks;
+    const keyspace& ks;
     schema_ptr schema;
     secondary_index::secondary_index_manager secondary_idx_man;
 
-    table(data_dictionary_impl& impl, keyspace& ks, schema_ptr schema);
+    table(data_dictionary_impl& impl, const keyspace& ks, schema_ptr schema);
     table(table&&) = delete;
 };
 
@@ -202,7 +202,7 @@ public:
     }
 };
 
-table::table(data_dictionary_impl& impl, keyspace& ks, schema_ptr schema) :
+table::table(data_dictionary_impl& impl, const keyspace& ks, schema_ptr schema) :
     ks(ks), schema(std::move(schema)), secondary_idx_man(impl.wrap(*this))
 { }
 


### PR DESCRIPTION
Loading schemas of views and indexes was not supported, with either `--schema-file`, or when loading schema from schema sstables.
This PR addresses both:
* When loading schema from CQL (file), `CREATE MATERIALIZED VIEW` and `CREATE INDEX` statements are now also processed correctly.
* When loading schema from schema tables, `system_schema.views` is also processed, when the table has no corresponding entry in `system_schema.tables`.

Tests are also added.

Fixes: #16492
