### PR TITLE
readers/flat_mutation_reader_v2: call set_close_required() from consume*()

### DIFF
--- a/readers/mutation_reader.hh
+++ b/readers/mutation_reader.hh
@@ -409,18 +409,21 @@ public:
     ~mutation_reader();
 
     future<mutation_fragment_v2_opt> operator()() {
+        _impl->set_close_required();
         return _impl->operator()();
     }
 
     template <typename Consumer>
     requires FlatMutationReaderConsumerV2<Consumer>
     auto consume_pausable(Consumer consumer) {
+        _impl->set_close_required();
         return _impl->consume_pausable(std::move(consumer));
     }
 
     template <typename Consumer>
     requires FlattenedConsumerV2<Consumer>
     auto consume(Consumer consumer) {
+        _impl->set_close_required();
         return _impl->consume(std::move(consumer));
     }
 
@@ -472,12 +475,14 @@ public:
     template<typename Consumer, typename Filter>
     requires FlattenedConsumerV2<Consumer> && FlattenedConsumerFilterV2<Filter>
     auto consume_in_thread(Consumer consumer, Filter filter) {
+        _impl->set_close_required();
         return _impl->consume_in_thread(std::move(consumer), std::move(filter));
     }
 
     template<typename Consumer>
     requires FlattenedConsumerV2<Consumer>
     auto consume_in_thread(Consumer consumer) {
+        _impl->set_close_required();
         return consume_in_thread(std::move(consumer), no_filter{});
     }
 

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -89,6 +89,7 @@ repair_rows_on_wire make_random_repair_rows_on_wire(random_mutation_generator& g
         auto m2 = make_memtable(s, {mut});
         m->apply(mut);
         auto reader = mutation_fragment_v1_stream(m2->make_flat_reader(s, permit));
+        auto close_reader = deferred_close(reader);
         std::list<frozen_mutation_fragment> mfs;
         reader.consume_pausable([s, &mfs](mutation_fragment mf) {
             if ((mf.is_partition_start() && !mf.as_partition_start().partition_tombstone()) || mf.is_end_of_partition()) {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -1980,6 +1980,7 @@ static std::deque<mutation_fragment_v2> explode(reader_permit permit, std::vecto
     std::deque<mutation_fragment_v2> frags;
 
     auto mr = make_mutation_reader_from_mutations_v2(schema, permit, std::move(muts));
+    auto close_mr = deferred_close(mr);
     mr.consume_pausable([&frags] (mutation_fragment_v2&& mf) {
         frags.emplace_back(std::move(mf));
         return stop_iteration::no;


### PR DESCRIPTION
The `consume*()` variants just forward the call to the `_impl` method with the same name. The latter, being a member of `::impl`, will bypass the top level `fill_buffer()`, etc. methods and thus will never call `set_close_required()`. Do this in the top-level `consume*()` methods instead, to ensure a reader, on which only `consume*()` is called, and then is destroyed, will complain as it should (and abort).
Only one place was found in core code, which didn't close the reader: `split_mutation() in `mutation/mutation.cc` and this reader is the "from-mutation" one which has no real close routine. All other places were in tests. All this is to say, there were no real bugs uncovered by this PR.

Fixes #16520

Improvement, no backport required.