### PR TITLE
storage_proxy: do not fence reads and writes to local tables

### DIFF
--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -524,6 +524,8 @@ private:
     // Do the same when the future is resolved without exception.
     template <typename T>
     future<T> apply_fence(future<T> future, fencing_token fence, gms::inet_address caller_address) const;
+    // Returns fencing_token based on effective_replication_map.
+    static fencing_token get_fence(const locator::effective_replication_map& erm);
 
     mutation do_get_batchlog_mutation_for(schema_ptr schema, const std::vector<mutation>& mutations, const utils::UUID& id, int32_t version, db_clock::time_point now);
 public:


### PR DESCRIPTION
Fencing is necessary only for reads and writes to non-local tables.
Moreover, fencing a read or write to a local table can cause an
error on the bootstrapping node. It is explained in the comment
in storage_proxy::get_fence.

A scenario described in the comment has been reported in
scylladb/scylladb#16423. A write to the local RAFT table failed
because of fencing, and it killed server_impl::io_fiber.

Fixes scylladb/scylladb#16423