### PR TITLE
data_dictionary: use insert_or_assign() when appropriate

### DIFF
--- a/data_dictionary/user_types_metadata.hh
+++ b/data_dictionary/user_types_metadata.hh
@@ -28,7 +28,7 @@ public:
     void add_type(user_type type) {
         auto i = _user_types.find(type->_name);
         assert(i == _user_types.end() || type->is_compatible_with(*i->second));
-        _user_types[type->_name] = std::move(type);
+        _user_types.insert_or_assign(i, type->_name, type);
     }
     void remove_type(user_type type) {
         _user_types.erase(type->_name);


### PR DESCRIPTION
when compiling clang-18 in "release" mode, `assert()` is optimized out. so `i` is not used. and clang complains like:

```
/home/kefu/dev/scylladb/data_dictionary/user_types_metadata.hh:29:14: error: unused variable 'i' [-Werror,-Wunused-variable]
   29 |         auto i = _user_types.find(type->_name);
      |              ^
```

in this change, we use `i` as the hint for the insertion, for two reasons:

- silence the warning.
- avoid the looking up in the unordered_map twice with the same key.

`type` is not moved away when being passed to `insert_or_assign()`, because otherwise, `type->_name` could be referencing a moved-away shared_ptr, because the order of evaluating a function's parameters is not determined. since `type` is a shared_ptr, the overhead is negligible.