### PR TITLE
database: setup_scylla_memory_diagnostics_producer: replace infinity sign with `unlimited` string

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -229,7 +229,7 @@ void database::setup_scylla_memory_diagnostics_producer() {
             const auto initial_res = sem.initial_resources();
             const auto available_res = sem.available_resources();
             if (sem.is_unlimited()) {
-                writeln("    {}: {}/∞, {}/∞\n",
+                writeln("    {}: {}/unlimited, {}/unlimited\n",
                         name,
                         initial_res.count - available_res.count,
                         utils::to_hr_size(initial_res.memory - available_res.memory),


### PR DESCRIPTION
The infinity unicode sign used for dumping read concurrency semaphore state, `∞` may be misrendered.
For example: https://jenkins.scylladb.com/job/scylla-master/job/dtest-release/451/artifact/logs-full.release.011/1703288463175_materialized_views_test.py%3A%3ATestMaterializedViews%3A%3Atest_add_dc_during_mv_insert/node1.log
```
  Read Concurrency Semaphores:
    user: 0/100, 1K/9M, queued: 0
    streaming: 0/10, 0B/9M, queued: 0
    system: 0/10, 0B/9M, queued: 0
    compaction: 0/âˆž, 0B/âˆž
```

Instead, just print the word `unlimited`.

This was introduced in 34c213f9bbf