### PR TITLE
cql-pytest: add reproducer for GROUP BY regression

### DIFF
--- a/test/cql-pytest/test_group_by.py
+++ b/test/cql-pytest/test_group_by.py
@@ -36,6 +36,22 @@ def table1(cql, test_keyspace):
 def test_group_by_partition(cql, table1):
     assert {(0,0,0,1), (1,0,0,5)} == set(cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY p'))
 
+# Try the same restricting the scan to a single partition instead of a
+# whole-table scan. We should get just one row (the first row in the
+# clustering order).
+# Reproduces #16531.
+@pytest.mark.xfail(reason="issue #16531")
+def test_group_by_partition_one_partition(cql, table1):
+    assert {(0,0,0,1)} == set(cql.execute(f'SELECT p,c1,c2,v FROM {table1} WHERE p=0 GROUP BY p'))
+    # Try the same with "SELECT *" instead of "SELECT p,c1,c2,v". Shouldn't
+    # make any difference, but bug #16531 was that it did!
+    assert {(0,0,0,1)} == set(cql.execute(f'SELECT * FROM {table1} WHERE p=0 GROUP BY p'))
+
+# And if filtering excludes some rows, the GROUP BY should return the first
+# row that matches the filter.
+def test_group_by_partition_with_filtering(cql, table1):
+    assert {(0,0,1,2), (1,0,1,6)} == set(cql.execute(f'SELECT p,c1,c2,v FROM {table1} WHERE c2>0 GROUP BY p ALLOW FILTERING'))
+
 # Similarly, GROUP BY a partition key plus just a prefix of the clustering
 # key retrieves the first row in each of the clustering ranges
 def test_group_by_clustering_prefix(cql, table1):


### PR DESCRIPTION
test/cql-pytest/test_group_by.py has tests that verifies that requests like

```
   SELECT p,c1,c2,v FROM tbl WHERE p=0 GROUP BY p
```

work as expected - the "GROUP BY p" means in this case that we should only return the first row in the p=0 partition.

As a user discover, it turns out that the almost identical request:

```
   SELECT * FROM tbl WHERE p=0 GROUP BY p
```

Doesn't work the same - it erroneously returns all rows in p=0, not just the first one. The test in this patch demonstrates this - it fails on Scylla 5.4 (in what seems to be a regression) and passes on Cassandra. So the new test is marked "xfail".

This patch includes another tiny test, to check the interaction of GROUP BY with filtering. This second test passes on Scylla - but I want it in anyway because it is yet another interaction that might break (the user that reported #16531 also had filtering, and I was worried it might have been related).

Refs #16531