### PR TITLE
test/nodetool: log response from mock server when handling JSONDecode…

### DIFF
--- a/test/nodetool/rest_api_mock.py
+++ b/test/nodetool/rest_api_mock.py
@@ -233,7 +233,11 @@ def get_expected_requests(server):
     ip, port = server
     r = requests.get(f"http://{ip}:{port}/{rest_server.EXPECTED_REQUESTS_PATH}")
     r.raise_for_status()
-    return [_make_expected_request(r) for r in r.json()]
+    try:
+        return [_make_expected_request(r) for r in r.json()]
+    except json.decoder.JSONDecodeError:
+        logger.exception('unable to decode server response as JSON: %r', r)
+        raise
 
 
 def clear_expected_requests(server):


### PR DESCRIPTION
…Error

it's observed that the mock server could return something not decodable as JSON. so let's print out the response in the logging message in this case. this should help us to understand the test failure better if it surfaces again.

Refs #16542
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>