### PR TITLE
build: cmake: do not link against Boost::dynamic_linking

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,8 +62,7 @@ function(add_scylla_test name)
   elseif(kind STREQUAL "BOOST")
     target_link_libraries(${name}
       PRIVATE
-        Boost::unit_test_framework
-        Boost::dynamic_linking)
+        Boost::unit_test_framework)
   elseif(kind STREQUAL "UNIT")
     target_link_libraries(${name}
       PRIVATE


### PR DESCRIPTION
Boost::dynamic_linking was introduced as a compatibility target which adds "BOOST_ALL_DYN_LINK" macro on Win32 platform. but since Scylla only runs on Linux, there is no need to link against this library.