### PR TITLE
build: cmake: link against boost static when --static-boost is specified

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2445,6 +2445,9 @@ def configure_using_cmake(args):
     }
     if args.date_stamp:
         settings['Scylla_DATE_STAMP'] = args.date_stamp
+    if args.staticboost:
+        settings['Boost_USE_STATIC_LIBS'] = 'ON'
+
 
     source_dir = os.path.realpath(os.path.dirname(__file__))
     build_dir = os.path.join(source_dir, 'build')


### PR DESCRIPTION
`--static-boost` is an option provided by `configure.py`. this option is not used by our CI or building scripts. but in order to be compatible with the existing behavior of `configure.py`, let's support this option when building with CMake.

`Boost_USE_STATIC_LIBS` is a cmake variable supported by CMake's FindBoost and Boost's own `BoostConfig.cmake`. see https://cmake.org/cmake/help/latest/module/FindBoost.html#other-variables

by default boost is linked via its shared libraries. by setting this variable, we link boost's static libraries.