### PR TITLE
Move initial_tablets to system_schema.scylla_keyspaces

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -4520,7 +4520,7 @@ static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_vie
                 keyspace_name, rf, endpoint_count);
     }
     auto opts = get_network_topology_options(sp, gossiper, rf);
-    std::optional<unsigned> initial_tablets; // FIXME -- initialize
+    std::optional<unsigned> initial_tablets;
 
     // Tablets are not yet enabled by default on Alternator tables, because of
     // missing support for CDC (see issue #16313). Until then, allow
@@ -4531,7 +4531,7 @@ static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_vie
     // until then we give it the "experimental:" prefix to not commit to it.
     static constexpr auto INITIAL_TABLETS_TAG_KEY = "experimental:initial_tablets";
     if (tags_map.contains(INITIAL_TABLETS_TAG_KEY)) {
-        opts.emplace("initial_tablets", tags_map.at(INITIAL_TABLETS_TAG_KEY));
+        initial_tablets = std::stol(tags_map.at(INITIAL_TABLETS_TAG_KEY));
     }
 
     return keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.NetworkTopologyStrategy", std::move(opts), initial_tablets, true);

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -4520,6 +4520,7 @@ static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_vie
                 keyspace_name, rf, endpoint_count);
     }
     auto opts = get_network_topology_options(sp, gossiper, rf);
+    std::optional<unsigned> initial_tablets; // FIXME -- initialize
 
     // Tablets are not yet enabled by default on Alternator tables, because of
     // missing support for CDC (see issue #16313). Until then, allow
@@ -4533,7 +4534,7 @@ static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_vie
         opts.emplace("initial_tablets", tags_map.at(INITIAL_TABLETS_TAG_KEY));
     }
 
-    return keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.NetworkTopologyStrategy", std::move(opts), true);
+    return keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.NetworkTopologyStrategy", std::move(opts), initial_tablets, true);
 }
 
 future<> executor::start() {

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -180,6 +180,7 @@ future<> service::create_keyspace_if_missing(::service::migration_manager& mm) c
                     meta::AUTH_KS,
                     "org.apache.cassandra.locator.SimpleStrategy",
                     opts,
+                    std::nullopt,
                     true);
 
             try {

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -272,7 +272,7 @@ private:
     // to be attempted - in particular the log table we try to create will not
     // have tablets, and will cause a failure.
     static void ensure_that_table_uses_vnodes(const keyspace_metadata& ksm, const schema& schema) {
-        locator::replication_strategy_params params(ksm.strategy_options());
+        locator::replication_strategy_params params(ksm.strategy_options(), ksm.initial_tablets());
         auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), params);
         if (rs->uses_tablets()) {
             throw exceptions::invalid_request_exception(format("Cannot create CDC log for a table {}.{}, because keyspace uses tablets. See issue #16317.",

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -272,7 +272,8 @@ private:
     // to be attempted - in particular the log table we try to create will not
     // have tablets, and will cause a failure.
     static void ensure_that_table_uses_vnodes(const keyspace_metadata& ksm, const schema& schema) {
-        auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), ksm.strategy_options());
+        locator::replication_strategy_params params(ksm.strategy_options());
+        auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), params);
         if (rs->uses_tablets()) {
             throw exceptions::invalid_request_exception(format("Cannot create CDC log for a table {}.{}, because keyspace uses tablets. See issue #16317.",
                 schema.ks_name(), schema.cf_name()));

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -58,7 +58,8 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
             }
 
             auto new_ks = _attrs->as_ks_metadata_update(ks.metadata(), *qp.proxy().get_token_metadata_ptr());
-            auto new_rs = locator::abstract_replication_strategy::create_replication_strategy(new_ks->strategy_name(), new_ks->strategy_options());
+            locator::replication_strategy_params params(new_ks->strategy_options(), new_ks->initial_tablets());
+            auto new_rs = locator::abstract_replication_strategy::create_replication_strategy(new_ks->strategy_name(), params);
             if (new_rs->is_per_table() != ks.get_replication_strategy().is_per_table()) {
                 throw exceptions::invalid_request_exception(format("Cannot alter replication strategy vnode/tablets flavor"));
             }

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -147,7 +147,7 @@ std::vector<sstring> check_against_restricted_replication_strategies(
 
     std::vector<sstring> warnings;
     locator::replication_strategy_config_options opts;
-    locator::replication_strategy_params params(opts);
+    locator::replication_strategy_params params(opts, std::nullopt);
     auto replication_strategy = locator::abstract_replication_strategy::create_replication_strategy(
             locator::abstract_replication_strategy::to_qualified_class_name(
                     *attrs.get_replication_strategy_class()), params)->get_type();

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -146,9 +146,11 @@ std::vector<sstring> check_against_restricted_replication_strategies(
     }
 
     std::vector<sstring> warnings;
+    locator::replication_strategy_config_options opts;
+    locator::replication_strategy_params params(opts);
     auto replication_strategy = locator::abstract_replication_strategy::create_replication_strategy(
             locator::abstract_replication_strategy::to_qualified_class_name(
-                    *attrs.get_replication_strategy_class()), {})->get_type();
+                    *attrs.get_replication_strategy_class()), params)->get_type();
     auto rs_warn_list = qp.db().get_config().replication_strategy_warn_list();
     auto rs_fail_list = qp.db().get_config().replication_strategy_fail_list();
 

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -113,14 +113,16 @@ std::optional<sstring> ks_prop_defs::get_replication_strategy_class() const {
 
 lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata(sstring ks_name, const locator::token_metadata& tm) {
     auto sc = get_replication_strategy_class().value();
+    std::optional<unsigned> initial_tablets; // FIXME -- initialize
     return data_dictionary::keyspace_metadata::new_keyspace(ks_name, sc,
-            prepare_options(sc, tm, get_replication_options()), get_boolean(KW_DURABLE_WRITES, true), std::vector<schema_ptr>{}, get_storage_options());
+            prepare_options(sc, tm, get_replication_options()), initial_tablets, get_boolean(KW_DURABLE_WRITES, true), std::vector<schema_ptr>{}, get_storage_options());
 }
 
 lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata& tm) {
     std::map<sstring, sstring> options;
     const auto& old_options = old->strategy_options();
     auto sc = get_replication_strategy_class();
+    std::optional<unsigned> initial_tablets; // FIXME -- initialize
     if (sc) {
         options = prepare_options(*sc, tm, get_replication_options(), old_options);
     } else {
@@ -128,7 +130,7 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_u
         options = old_options;
     }
 
-    return data_dictionary::keyspace_metadata::new_keyspace(old->name(), *sc, options, get_boolean(KW_DURABLE_WRITES, true), std::vector<schema_ptr>{}, get_storage_options());
+    return data_dictionary::keyspace_metadata::new_keyspace(old->name(), *sc, options, initial_tablets, get_boolean(KW_DURABLE_WRITES, true), std::vector<schema_ptr>{}, get_storage_options());
 }
 
 

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -245,7 +245,8 @@ keyspace_metadata::keyspace_metadata(std::string_view name,
 
 void keyspace_metadata::validate(const gms::feature_service& fs, const locator::topology& topology) const {
     using namespace locator;
-    abstract_replication_strategy::validate_replication_strategy(name(), strategy_name(), strategy_options(), fs, topology);
+    locator::replication_strategy_params params(strategy_options());
+    abstract_replication_strategy::validate_replication_strategy(name(), strategy_name(), params, fs, topology);
 }
 
 lw_shared_ptr<keyspace_metadata>

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -251,7 +251,7 @@ keyspace_metadata::keyspace_metadata(std::string_view name,
 
 void keyspace_metadata::validate(const gms::feature_service& fs, const locator::topology& topology) const {
     using namespace locator;
-    locator::replication_strategy_params params(strategy_options());
+    locator::replication_strategy_params params(strategy_options(), initial_tablets());
     abstract_replication_strategy::validate_replication_strategy(name(), strategy_name(), params, fs, topology);
 }
 

--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -26,6 +26,7 @@ class keyspace_metadata final : public keyspace_element {
     sstring _name;
     sstring _strategy_name;
     locator::replication_strategy_config_options _strategy_options;
+    std::optional<unsigned> _initial_tablets;
     std::unordered_map<sstring, schema_ptr> _cf_meta_data;
     bool _durable_writes;
     user_types_metadata _user_types;
@@ -34,17 +35,20 @@ public:
     keyspace_metadata(std::string_view name,
                  std::string_view strategy_name,
                  locator::replication_strategy_config_options strategy_options,
+                 std::optional<unsigned> initial_tablets,
                  bool durable_writes,
                  std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{});
     keyspace_metadata(std::string_view name,
                  std::string_view strategy_name,
                  locator::replication_strategy_config_options strategy_options,
+                 std::optional<unsigned> initial_tablets,
                  bool durable_writes,
                  std::vector<schema_ptr> cf_defs,
                  user_types_metadata user_types);
     keyspace_metadata(std::string_view name,
                  std::string_view strategy_name,
                  locator::replication_strategy_config_options strategy_options,
+                 std::optional<unsigned> initial_tablets,
                  bool durable_writes,
                  std::vector<schema_ptr> cf_defs,
                  user_types_metadata user_types,
@@ -53,6 +57,7 @@ public:
     new_keyspace(std::string_view name,
                  std::string_view strategy_name,
                  locator::replication_strategy_config_options options,
+                 std::optional<unsigned> initial_tablets,
                  bool durables_writes,
                  std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{},
                  storage_options storage_opts = {});
@@ -67,6 +72,9 @@ public:
     }
     const locator::replication_strategy_config_options& strategy_options() const {
         return _strategy_options;
+    }
+    std::optional<unsigned> initial_tablets() const {
+        return _initial_tablets;
     }
     const std::unordered_map<sstring, schema_ptr>& cf_meta_data() const {
         return _cf_meta_data;

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -549,6 +549,7 @@ public:
             auto ksm = ::make_lw_shared<keyspace_metadata>(ks.name
                             , ks.replication_params["class"] // TODO, make ksm like c3?
                             , ks.replication_params
+                            , std::nullopt
                             , ks.durable_writes);
 
             // we want separate time stamps for tables/types, so cannot bulk them into the ksm.

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2191,6 +2191,7 @@ lw_shared_ptr<keyspace_metadata> create_keyspace_from_schema_partition(const sch
     bool durable_writes = row.get_nonnull<bool>("durable_writes");
 
     data_dictionary::storage_options storage_opts;
+    std::optional<unsigned> initial_tablets; // FIXME -- initialize
     // Scylla-specific row will only be present if SCYLLA_KEYSPACES schema feature is available in the cluster
     if (scylla_specific_rs) {
         if (!scylla_specific_rs->empty()) {
@@ -2206,7 +2207,7 @@ lw_shared_ptr<keyspace_metadata> create_keyspace_from_schema_partition(const sch
             }
         }
     }
-    return make_lw_shared<keyspace_metadata>(keyspace_name, strategy_name, strategy_options, durable_writes,
+    return make_lw_shared<keyspace_metadata>(keyspace_name, strategy_name, strategy_options, initial_tablets, durable_writes,
             std::vector<schema_ptr>{}, data_dictionary::user_types_metadata{}, storage_opts);
 }
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1347,7 +1347,7 @@ static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, shar
 
 future<lw_shared_ptr<query::result_set>> extract_scylla_specific_keyspace_info(distributed<service::storage_proxy>& proxy, const schema_result_value_type& partition) {
     lw_shared_ptr<query::result_set> scylla_specific_rs;
-    if (proxy.local().features().cluster_schema_features().contains<schema_feature::SCYLLA_KEYSPACES>()) {
+    if (proxy.local().local_db().has_schema(NAME, SCYLLA_KEYSPACES)) {
         auto&& rs = partition.second;
         if (rs->empty()) {
             co_await coroutine::return_exception(std::runtime_error("query result has no rows"));

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -265,6 +265,7 @@ future<> system_distributed_keyspace::start() {
                 NAME,
                 "org.apache.cassandra.locator.SimpleStrategy",
                 {{"replication_factor", "3"}},
+                std::nullopt,
                 true /* durable_writes */);
         if (!db.has_keyspace(NAME)) {
             mutations = service::prepare_new_keyspace_announcement(db.real_database(), sd_ksm, ts);
@@ -277,6 +278,7 @@ future<> system_distributed_keyspace::start() {
                 NAME_EVERYWHERE,
                 "org.apache.cassandra.locator.EverywhereStrategy",
                 {},
+                std::nullopt,
                 true /* durable_writes */);
         if (!db.has_keyspace(NAME_EVERYWHERE)) {
             auto sde_mutations = service::prepare_new_keyspace_announcement(db.real_database(), sde_ksm, ts);

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -198,6 +198,7 @@ db::schema_features feature_service::cluster_schema_features() const {
     f.set_if<db::schema_feature::CDC_OPTIONS>(cdc);
     f.set_if<db::schema_feature::PER_TABLE_PARTITIONERS>(per_table_partitioners);
     f.set_if<db::schema_feature::SCYLLA_KEYSPACES>(keyspace_storage_options);
+    f.set_if<db::schema_feature::SCYLLA_KEYSPACES>(tablets);
     f.set_if<db::schema_feature::SCYLLA_AGGREGATES>(aggregate_storage_options);
     f.set_if<db::schema_feature::TABLE_DIGEST_INSENSITIVE_TO_EXPIRY>(table_digest_insensitive_to_expiry);
     f.set_if<db::schema_feature::GROUP0_SCHEMA_VERSIONING>(group0_schema_versioning);

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -34,16 +34,15 @@ static endpoint_set resolve_endpoints(const host_id_set& host_ids, const token_m
 logging::logger rslogger("replication_strategy");
 
 abstract_replication_strategy::abstract_replication_strategy(
-    const replication_strategy_config_options& config_options,
+    replication_strategy_params params,
     replication_strategy_type my_type)
-        : _config_options(config_options)
+        : _config_options(params.options)
         , _my_type(my_type) {}
 
 abstract_replication_strategy::ptr_type abstract_replication_strategy::create_replication_strategy(const sstring& strategy_name, const replication_strategy_config_options& config_options) {
     try {
-        return create_object<abstract_replication_strategy,
-                             const replication_strategy_config_options&>
-            (strategy_name, config_options);
+        replication_strategy_params params(config_options);
+        return create_object<abstract_replication_strategy, replication_strategy_params>(strategy_name, std::move(params));
     } catch (const no_such_class& e) {
         throw exceptions::configuration_exception(e.what());
     }
@@ -75,7 +74,7 @@ future<endpoint_set> abstract_replication_strategy::calculate_natural_ips(const 
 
 using strategy_class_registry = class_registry<
     locator::abstract_replication_strategy,
-    const locator::replication_strategy_config_options&>;
+    replication_strategy_params>;
 
 sstring abstract_replication_strategy::to_qualified_class_name(std::string_view strategy_class_name) {
     return strategy_class_registry::to_qualified_class_name(strategy_class_name);

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -39,9 +39,8 @@ abstract_replication_strategy::abstract_replication_strategy(
         : _config_options(params.options)
         , _my_type(my_type) {}
 
-abstract_replication_strategy::ptr_type abstract_replication_strategy::create_replication_strategy(const sstring& strategy_name, const replication_strategy_config_options& config_options) {
+abstract_replication_strategy::ptr_type abstract_replication_strategy::create_replication_strategy(const sstring& strategy_name, replication_strategy_params params) {
     try {
-        replication_strategy_params params(config_options);
         return create_object<abstract_replication_strategy, replication_strategy_params>(strategy_name, std::move(params));
     } catch (const no_such_class& e) {
         throw exceptions::configuration_exception(e.what());
@@ -50,15 +49,15 @@ abstract_replication_strategy::ptr_type abstract_replication_strategy::create_re
 
 void abstract_replication_strategy::validate_replication_strategy(const sstring& ks_name,
                                                                   const sstring& strategy_name,
-                                                                  const replication_strategy_config_options& config_options,
+                                                                  replication_strategy_params params,
                                                                   const gms::feature_service& fs,
                                                                   const topology& topology)
 {
-    auto strategy = create_replication_strategy(strategy_name, config_options);
+    auto strategy = create_replication_strategy(strategy_name, params);
     strategy->validate_options(fs);
     auto expected = strategy->recognized_options(topology);
     if (expected) {
-        for (auto&& item : config_options) {
+        for (auto&& item : params.options) {
             sstring key = item.first;
             if (!expected->contains(key)) {
                  throw exceptions::configuration_exception(format("Unrecognized strategy option {{{}}} passed to {} for keyspace {}", key, strategy_name, ks_name));

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -51,7 +51,8 @@ using can_yield = utils::can_yield;
 using replication_strategy_config_options = std::map<sstring, sstring>;
 struct replication_strategy_params {
     const replication_strategy_config_options& options;
-    explicit replication_strategy_params(const replication_strategy_config_options& o) noexcept : options(o) {}
+    std::optional<unsigned> initial_tablets;
+    explicit replication_strategy_params(const replication_strategy_config_options& o, std::optional<unsigned> it) noexcept : options(o), initial_tablets(it) {}
 };
 
 using replication_map = std::unordered_map<token, inet_address_vector_replica_set>;

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -49,6 +49,10 @@ enum class replication_strategy_type {
 using can_yield = utils::can_yield;
 
 using replication_strategy_config_options = std::map<sstring, sstring>;
+struct replication_strategy_params {
+    const replication_strategy_config_options& options;
+    explicit replication_strategy_params(const replication_strategy_config_options& o) noexcept : options(o) {}
+};
 
 using replication_map = std::unordered_map<token, inet_address_vector_replica_set>;
 
@@ -91,7 +95,7 @@ public:
     using ptr_type = seastar::shared_ptr<abstract_replication_strategy>;
 
     abstract_replication_strategy(
-        const replication_strategy_config_options& config_options,
+        replication_strategy_params params,
         replication_strategy_type my_type);
 
     // Evaluates to true iff calculate_natural_endpoints

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -111,10 +111,10 @@ public:
     future<endpoint_set> calculate_natural_ips(const token& search_token, const token_metadata& tm) const;
 
     virtual ~abstract_replication_strategy() {}
-    static ptr_type create_replication_strategy(const sstring& strategy_name, const replication_strategy_config_options& config_options);
+    static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params);
     static void validate_replication_strategy(const sstring& ks_name,
                                               const sstring& strategy_name,
-                                              const replication_strategy_config_options& config_options,
+                                              replication_strategy_params params,
                                               const gms::feature_service& fs,
                                               const topology& topology);
     static void validate_replication_factor(sstring rf);

--- a/locator/everywhere_replication_strategy.cc
+++ b/locator/everywhere_replication_strategy.cc
@@ -15,8 +15,8 @@
 
 namespace locator {
 
-everywhere_replication_strategy::everywhere_replication_strategy(const replication_strategy_config_options& config_options) :
-        abstract_replication_strategy(config_options, replication_strategy_type::everywhere_topology) {
+everywhere_replication_strategy::everywhere_replication_strategy(replication_strategy_params params) :
+        abstract_replication_strategy(params, replication_strategy_type::everywhere_topology) {
     _natural_endpoints_depend_on_token = false;
 }
 
@@ -33,7 +33,7 @@ size_t everywhere_replication_strategy::get_replication_factor(const token_metad
     return tm.sorted_tokens().empty() ? 1 : tm.count_normal_token_owners();
 }
 
-using registry = class_registrator<abstract_replication_strategy, everywhere_replication_strategy, const replication_strategy_config_options&>;
+using registry = class_registrator<abstract_replication_strategy, everywhere_replication_strategy, replication_strategy_params>;
 static registry registrator("org.apache.cassandra.locator.EverywhereStrategy");
 static registry registrator_short_name("EverywhereStrategy");
 }

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -16,7 +16,7 @@
 namespace locator {
 class everywhere_replication_strategy : public abstract_replication_strategy {
 public:
-    everywhere_replication_strategy(const replication_strategy_config_options& config_options);
+    everywhere_replication_strategy(replication_strategy_params params);
 
     virtual future<host_id_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
 

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -13,8 +13,8 @@
 
 namespace locator {
 
-local_strategy::local_strategy(const replication_strategy_config_options& config_options) :
-        abstract_replication_strategy(config_options, replication_strategy_type::local) {
+local_strategy::local_strategy(replication_strategy_params params) :
+        abstract_replication_strategy(params, replication_strategy_type::local) {
     _natural_endpoints_depend_on_token = false;
 }
 
@@ -34,7 +34,7 @@ size_t local_strategy::get_replication_factor(const token_metadata&) const {
     return 1;
 }
 
-using registry = class_registrator<abstract_replication_strategy, local_strategy, const replication_strategy_config_options&>;
+using registry = class_registrator<abstract_replication_strategy, local_strategy, replication_strategy_params>;
 static registry registrator("org.apache.cassandra.locator.LocalStrategy");
 static registry registrator_short_name("LocalStrategy");
 

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -23,7 +23,7 @@ using token = dht::token;
 
 class local_strategy : public abstract_replication_strategy {
 public:
-    local_strategy(const replication_strategy_config_options& config_options);
+    local_strategy(replication_strategy_params params);
     virtual ~local_strategy() {};
     virtual size_t get_replication_factor(const token_metadata&) const override;
 

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -29,9 +29,8 @@ struct hash<locator::endpoint_dc_rack> {
 
 namespace locator {
 
-network_topology_strategy::network_topology_strategy(
-    const replication_strategy_config_options& config_options) :
-        abstract_replication_strategy(config_options,
+network_topology_strategy::network_topology_strategy(replication_strategy_params params) :
+        abstract_replication_strategy(params,
                                       replication_strategy_type::network_topology) {
     auto opts = _config_options;
     process_tablet_options(*this, opts);
@@ -332,7 +331,7 @@ future<tablet_map> network_topology_strategy::allocate_tablets_for_new_table(sch
     co_return tablets;
 }
 
-using registry = class_registrator<abstract_replication_strategy, network_topology_strategy, const replication_strategy_config_options&>;
+using registry = class_registrator<abstract_replication_strategy, network_topology_strategy, replication_strategy_params>;
 static registry registrator("org.apache.cassandra.locator.NetworkTopologyStrategy");
 static registry registrator_short_name("NetworkTopologyStrategy");
 }

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -258,7 +258,7 @@ void network_topology_strategy::validate_options(const gms::feature_service& fs)
     if(_config_options.empty()) {
         throw exceptions::configuration_exception("Configuration for at least one datacenter must be present");
     }
-    validate_tablet_options(fs, _config_options);
+    validate_tablet_options(*this, fs, _config_options);
     auto tablet_opts = recognized_tablet_options();
     for (auto& c : _config_options) {
         if (tablet_opts.contains(c.first)) {

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -33,7 +33,7 @@ network_topology_strategy::network_topology_strategy(replication_strategy_params
         abstract_replication_strategy(params,
                                       replication_strategy_type::network_topology) {
     auto opts = _config_options;
-    process_tablet_options(*this, opts);
+    process_tablet_options(*this, opts, params);
 
     for (auto& config_pair : opts) {
         auto& key = config_pair.first;

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -33,7 +33,7 @@ network_topology_strategy::network_topology_strategy(
     const replication_strategy_config_options& config_options) :
         abstract_replication_strategy(config_options,
                                       replication_strategy_type::network_topology) {
-    auto opts = config_options;
+    auto opts = _config_options;
     process_tablet_options(*this, opts);
 
     for (auto& config_pair : opts) {

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -21,8 +21,7 @@ namespace locator {
 class network_topology_strategy : public abstract_replication_strategy
                                 , public tablet_aware_replication_strategy {
 public:
-    network_topology_strategy(
-        const replication_strategy_config_options& config_options);
+    network_topology_strategy(replication_strategy_params params);
 
     virtual size_t get_replication_factor(const token_metadata&) const override {
         return _rep_factor;

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -18,8 +18,8 @@
 
 namespace locator {
 
-simple_strategy::simple_strategy(const replication_strategy_config_options& config_options) :
-        abstract_replication_strategy(config_options, replication_strategy_type::simple) {
+simple_strategy::simple_strategy(replication_strategy_params params) :
+        abstract_replication_strategy(params, replication_strategy_type::simple) {
     for (auto& config_pair : _config_options) {
         auto& key = config_pair.first;
         auto& val = config_pair.second;
@@ -79,7 +79,7 @@ std::optional<std::unordered_set<sstring>>simple_strategy::recognized_options(co
     return {{ "replication_factor" }};
 }
 
-using registry = class_registrator<abstract_replication_strategy, simple_strategy, const replication_strategy_config_options&>;
+using registry = class_registrator<abstract_replication_strategy, simple_strategy, replication_strategy_params>;
 static registry registrator("org.apache.cassandra.locator.SimpleStrategy");
 static registry registrator_short_name("SimpleStrategy");
 

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -20,7 +20,7 @@ namespace locator {
 
 simple_strategy::simple_strategy(const replication_strategy_config_options& config_options) :
         abstract_replication_strategy(config_options, replication_strategy_type::simple) {
-    for (auto& config_pair : config_options) {
+    for (auto& config_pair : _config_options) {
         auto& key = config_pair.first;
         auto& val = config_pair.second;
 

--- a/locator/simple_strategy.hh
+++ b/locator/simple_strategy.hh
@@ -17,7 +17,7 @@ namespace locator {
 
 class simple_strategy : public abstract_replication_strategy {
 public:
-    simple_strategy(const replication_strategy_config_options& config_options);
+    simple_strategy(replication_strategy_params params);
     virtual ~simple_strategy() {};
     virtual size_t get_replication_factor(const token_metadata& tm) const override;
     virtual void validate_options(const gms::feature_service&) const override;

--- a/locator/tablet_replication_strategy.hh
+++ b/locator/tablet_replication_strategy.hh
@@ -33,7 +33,7 @@ private:
     size_t parse_initial_tablets(const sstring&) const;
 protected:
     void validate_tablet_options(const gms::feature_service&, const replication_strategy_config_options&) const;
-    void process_tablet_options(abstract_replication_strategy&, replication_strategy_config_options&);
+    void process_tablet_options(abstract_replication_strategy&, replication_strategy_config_options&, replication_strategy_params);
     std::unordered_set<sstring> recognized_tablet_options() const;
     size_t get_initial_tablets() const { return _initial_tablets; }
     effective_replication_map_ptr do_make_replication_map(table_id,

--- a/locator/tablet_replication_strategy.hh
+++ b/locator/tablet_replication_strategy.hh
@@ -32,7 +32,7 @@ private:
     size_t _initial_tablets = 1;
     size_t parse_initial_tablets(const sstring&) const;
 protected:
-    void validate_tablet_options(const gms::feature_service&, const replication_strategy_config_options&) const;
+    void validate_tablet_options(const abstract_replication_strategy&, const gms::feature_service&, const replication_strategy_config_options&) const;
     void process_tablet_options(abstract_replication_strategy&, replication_strategy_config_options&, replication_strategy_params);
     std::unordered_set<sstring> recognized_tablet_options() const;
     size_t get_initial_tablets() const { return _initial_tablets; }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -537,7 +537,8 @@ void tablet_aware_replication_strategy::validate_tablet_options(const gms::featu
 }
 
 void tablet_aware_replication_strategy::process_tablet_options(abstract_replication_strategy& ars,
-                                                               replication_strategy_config_options& opts) {
+                                                               replication_strategy_config_options& opts,
+                                                               replication_strategy_params params) {
     auto i = opts.find("initial_tablets");
     if (i != opts.end()) {
         _initial_tablets = parse_initial_tablets(i->second);

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -527,13 +527,8 @@ size_t tablet_aware_replication_strategy::parse_initial_tablets(const sstring& v
 void tablet_aware_replication_strategy::validate_tablet_options(const abstract_replication_strategy& ars,
                                                                 const gms::feature_service& fs,
                                                                 const replication_strategy_config_options& opts) const {
-    for (auto& c: opts) {
-        if (c.first == "initial_tablets") {
-            if (!fs.tablets) {
-                throw exceptions::configuration_exception("Tablet replication is not enabled");
-            }
-            parse_initial_tablets(c.second);
-        }
+    if (ars._uses_tablets && !fs.tablets) {
+        throw exceptions::configuration_exception("Tablet replication is not enabled");
     }
 }
 
@@ -542,16 +537,18 @@ void tablet_aware_replication_strategy::process_tablet_options(abstract_replicat
                                                                replication_strategy_params params) {
     auto i = opts.find("initial_tablets");
     if (i != opts.end()) {
-        _initial_tablets = parse_initial_tablets(i->second);
+        throw exceptions::configuration_exception("initial_tablets is reserved name for NetworkTopologyStrategy");
+    }
+
+    if (params.initial_tablets.has_value()) {
+        _initial_tablets = *params.initial_tablets;
         ars._uses_tablets = true;
         mark_as_per_table(ars);
-        opts.erase(i);
     }
 }
 
 std::unordered_set<sstring> tablet_aware_replication_strategy::recognized_tablet_options() const {
     std::unordered_set<sstring> opts;
-    opts.insert("initial_tablets");
     return opts;
 }
 

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -524,7 +524,8 @@ size_t tablet_aware_replication_strategy::parse_initial_tablets(const sstring& v
     }
 }
 
-void tablet_aware_replication_strategy::validate_tablet_options(const gms::feature_service& fs,
+void tablet_aware_replication_strategy::validate_tablet_options(const abstract_replication_strategy& ars,
+                                                                const gms::feature_service& fs,
                                                                 const replication_strategy_config_options& opts) const {
     for (auto& c: opts) {
         if (c.first == "initial_tablets") {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1182,9 +1182,9 @@ future<>
 keyspace::create_replication_strategy(const locator::shared_token_metadata& stm) {
     using namespace locator;
 
+    locator::replication_strategy_params params(_metadata->strategy_options());
     _replication_strategy =
-            abstract_replication_strategy::create_replication_strategy(
-                _metadata->strategy_name(), _metadata->strategy_options());
+            abstract_replication_strategy::create_replication_strategy(_metadata->strategy_name(), params);
     rslogger.debug("replication strategy for keyspace {} is {}, opts={}",
             _metadata->name(), _metadata->strategy_name(), _metadata->strategy_options());
     if (!_replication_strategy->is_per_table()) {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1183,7 +1183,7 @@ future<>
 keyspace::create_replication_strategy(const locator::shared_token_metadata& stm) {
     using namespace locator;
 
-    locator::replication_strategy_params params(_metadata->strategy_options());
+    locator::replication_strategy_params params(_metadata->strategy_options(), _metadata->initial_tablets());
     _replication_strategy =
             abstract_replication_strategy::create_replication_strategy(_metadata->strategy_name(), params);
     rslogger.debug("replication strategy for keyspace {} is {}, opts={}",

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -769,7 +769,7 @@ future<> database::modify_keyspace_on_all_shards(sharded<database>& sharded_db, 
 
 future<> database::update_keyspace(const keyspace_metadata& tmp_ksm) {
     auto& ks = find_keyspace(tmp_ksm.name());
-    auto new_ksm = ::make_lw_shared<keyspace_metadata>(tmp_ksm.name(), tmp_ksm.strategy_name(), tmp_ksm.strategy_options(), tmp_ksm.durable_writes(),
+    auto new_ksm = ::make_lw_shared<keyspace_metadata>(tmp_ksm.name(), tmp_ksm.strategy_name(), tmp_ksm.strategy_options(), tmp_ksm.initial_tablets(), tmp_ksm.durable_writes(),
                     boost::copy_range<std::vector<schema_ptr>>(ks.metadata()->cf_meta_data() | boost::adaptors::map_values), std::move(ks.metadata()->user_types()));
 
     bool old_durable_writes = ks.metadata()->durable_writes();
@@ -846,6 +846,7 @@ future<> database::create_local_system_table(
         auto ksm = make_lw_shared<keyspace_metadata>(ks_name,
                 "org.apache.cassandra.locator.LocalStrategy",
                 std::map<sstring, sstring>{},
+                std::nullopt,
                 durable
                 );
         co_await create_keyspace(ksm, erm_factory, replica::database::system_keyspace::yes);

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -825,7 +825,7 @@ public:
     }
 
     void on_before_create_column_family(const keyspace_metadata& ksm, const schema& s, std::vector<mutation>& muts, api::timestamp_type ts) override {
-        locator::replication_strategy_params params(ksm.strategy_options());
+        locator::replication_strategy_params params(ksm.strategy_options(), ksm.initial_tablets());
         auto rs = abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), params);
         if (auto&& tablet_rs = rs->maybe_as_tablet_aware()) {
             auto tm = _db.get_shared_token_metadata().get();

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -825,7 +825,8 @@ public:
     }
 
     void on_before_create_column_family(const keyspace_metadata& ksm, const schema& s, std::vector<mutation>& muts, api::timestamp_type ts) override {
-        auto rs = abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), ksm.strategy_options());
+        locator::replication_strategy_params params(ksm.strategy_options());
+        auto rs = abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), params);
         if (auto&& tablet_rs = rs->maybe_as_tablet_aware()) {
             auto tm = _db.get_shared_token_metadata().get();
             auto map = tablet_rs->allocate_tablets_for_new_table(s.shared_from_this(), tm).get0();

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -145,7 +145,7 @@ future<> table_helper::setup_keyspace(cql3::query_processor& qp, service::migrat
 
     std::map<sstring, sstring> opts;
     opts["replication_factor"] = replication_factor;
-    auto ksm = keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.SimpleStrategy", std::move(opts), true);
+    auto ksm = keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.SimpleStrategy", std::move(opts), std::nullopt, true);
 
     while (!db.has_keyspace(keyspace_name)) {
         auto group0_guard = co_await mm.start_group0_operation();

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -433,9 +433,8 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
             {"100", "3"},
             {"101", "2"},
             {"102", "3"},
-            {"initial_tablets", "100"}
     };
-    locator::replication_strategy_params params323(options323, std::nullopt);
+    locator::replication_strategy_params params323(options323, 100);
 
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
             "NetworkTopologyStrategy", params323);
@@ -457,9 +456,8 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
             {"100", "3"},
             {"101", "2"},
             {"102", "0"},
-            {"initial_tablets", "100"}
     };
-    locator::replication_strategy_params params320(options320, std::nullopt);
+    locator::replication_strategy_params params320(options320, 100);
 
     ars_ptr = abstract_replication_strategy::create_replication_strategy(
             "NetworkTopologyStrategy", params320);
@@ -474,9 +472,8 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
             {"100", "3"},
             {"101", "4"},
             {"102", "2"},
-            {"initial_tablets", "100"}
     };
-    locator::replication_strategy_params params324(options324, std::nullopt);
+    locator::replication_strategy_params params324(options324, 100);
 
     ars_ptr = abstract_replication_strategy::create_replication_strategy(
             "NetworkTopologyStrategy", params324);

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -642,13 +642,13 @@ static void test_equivalence(const shared_token_metadata& stm, const locator::to
         using network_topology_strategy::calculate_natural_endpoints;
     };
 
-    my_network_topology_strategy nts(
+    my_network_topology_strategy nts(replication_strategy_params(
                     boost::copy_range<std::map<sstring, sstring>>(
                                     datacenters
                                                     | boost::adaptors::transformed(
                                                                     [](const std::pair<sstring, size_t>& p) {
                                                                         return std::make_pair(p.first, to_sstring(p.second));
-                                                                    })));
+                                                                    }))));
 
     const token_metadata& tm = *stm.get();
     for (size_t i = 0; i < 1000; ++i) {

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -267,9 +267,10 @@ void simple_test() {
         {"101", "2"},
         {"102", "3"}
     };
+    locator::replication_strategy_params params323(options323);
 
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-        "NetworkTopologyStrategy", options323);
+        "NetworkTopologyStrategy", params323);
 
     full_ring_check(ring_points, options323, ars_ptr, stm.get());
 
@@ -280,9 +281,10 @@ void simple_test() {
         {"101", "2"},
         {"102", "0"}
     };
+    locator::replication_strategy_params params320(options320);
 
     ars_ptr = abstract_replication_strategy::create_replication_strategy(
-        "NetworkTopologyStrategy", options320);
+        "NetworkTopologyStrategy", params320);
 
     full_ring_check(ring_points, options320, ars_ptr, stm.get());
 
@@ -365,8 +367,9 @@ void heavy_origin_test() {
         }
     }).get();
 
+    locator::replication_strategy_params params(config_options);
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-        "NetworkTopologyStrategy", config_options);
+        "NetworkTopologyStrategy", params);
 
     full_ring_check(ring_points, config_options, ars_ptr, stm.get());
 }
@@ -432,9 +435,10 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
             {"102", "3"},
             {"initial_tablets", "100"}
     };
+    locator::replication_strategy_params params323(options323);
 
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-            "NetworkTopologyStrategy", options323);
+            "NetworkTopologyStrategy", params323);
 
     auto tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
     BOOST_REQUIRE(tab_awr_ptr);
@@ -455,9 +459,10 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
             {"102", "0"},
             {"initial_tablets", "100"}
     };
+    locator::replication_strategy_params params320(options320);
 
     ars_ptr = abstract_replication_strategy::create_replication_strategy(
-            "NetworkTopologyStrategy", options320);
+            "NetworkTopologyStrategy", params320);
     tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
     BOOST_REQUIRE(tab_awr_ptr);
 
@@ -471,9 +476,10 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
             {"102", "2"},
             {"initial_tablets", "100"}
     };
+    locator::replication_strategy_params params324(options324);
 
     ars_ptr = abstract_replication_strategy::create_replication_strategy(
-            "NetworkTopologyStrategy", options324);
+            "NetworkTopologyStrategy", params324);
     tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
     BOOST_REQUIRE(tab_awr_ptr);
 

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -267,7 +267,7 @@ void simple_test() {
         {"101", "2"},
         {"102", "3"}
     };
-    locator::replication_strategy_params params323(options323);
+    locator::replication_strategy_params params323(options323, std::nullopt);
 
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
         "NetworkTopologyStrategy", params323);
@@ -281,7 +281,7 @@ void simple_test() {
         {"101", "2"},
         {"102", "0"}
     };
-    locator::replication_strategy_params params320(options320);
+    locator::replication_strategy_params params320(options320, std::nullopt);
 
     ars_ptr = abstract_replication_strategy::create_replication_strategy(
         "NetworkTopologyStrategy", params320);
@@ -367,7 +367,7 @@ void heavy_origin_test() {
         }
     }).get();
 
-    locator::replication_strategy_params params(config_options);
+    locator::replication_strategy_params params(config_options, std::nullopt);
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
         "NetworkTopologyStrategy", params);
 
@@ -435,7 +435,7 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
             {"102", "3"},
             {"initial_tablets", "100"}
     };
-    locator::replication_strategy_params params323(options323);
+    locator::replication_strategy_params params323(options323, std::nullopt);
 
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
             "NetworkTopologyStrategy", params323);
@@ -459,7 +459,7 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
             {"102", "0"},
             {"initial_tablets", "100"}
     };
-    locator::replication_strategy_params params320(options320);
+    locator::replication_strategy_params params320(options320, std::nullopt);
 
     ars_ptr = abstract_replication_strategy::create_replication_strategy(
             "NetworkTopologyStrategy", params320);
@@ -476,7 +476,7 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
             {"102", "2"},
             {"initial_tablets", "100"}
     };
-    locator::replication_strategy_params params324(options324);
+    locator::replication_strategy_params params324(options324, std::nullopt);
 
     ars_ptr = abstract_replication_strategy::create_replication_strategy(
             "NetworkTopologyStrategy", params324);
@@ -654,7 +654,7 @@ static void test_equivalence(const shared_token_metadata& stm, const locator::to
                                                     | boost::adaptors::transformed(
                                                                     [](const std::pair<sstring, size_t>& p) {
                                                                         return std::make_pair(p.first, to_sstring(p.second));
-                                                                    }))));
+                                                                    })), std::nullopt));
 
     const token_metadata& tm = *stm.get();
     for (size_t i = 0; i < 1000; ++i) {

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -41,7 +41,7 @@ namespace {
     mutable_vnode_erm_ptr create_erm(mutable_token_metadata_ptr tmptr, replication_strategy_config_options opts = {}) {
         dc_rack_fn get_dc_rack_fn = get_dc_rack;
         tmptr->update_topology_change_info(get_dc_rack_fn).get();
-        auto strategy = seastar::make_shared<Strategy>(replication_strategy_params(opts));
+        auto strategy = seastar::make_shared<Strategy>(replication_strategy_params(opts, std::nullopt));
         return calculate_effective_replication_map(std::move(strategy), tmptr).get0();
     }
 }

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -41,7 +41,7 @@ namespace {
     mutable_vnode_erm_ptr create_erm(mutable_token_metadata_ptr tmptr, replication_strategy_config_options opts = {}) {
         dc_rack_fn get_dc_rack_fn = get_dc_rack;
         tmptr->update_topology_change_info(get_dc_rack_fn).get();
-        auto strategy = seastar::make_shared<Strategy>(std::move(opts));
+        auto strategy = seastar::make_shared<Strategy>(replication_strategy_params(opts));
         return calculate_effective_replication_map(std::move(strategy), tmptr).get0();
     }
 }

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -500,6 +500,7 @@ public:
           _keyspace_metadata(data_dictionary::keyspace_metadata::new_keyspace(_table_schema->ks_name(),
                                                                               "MockReplicationStrategy",
                                                                               {},
+                                                                              {},
                                                                               false,
                                                                               {_table_schema})) {}
 

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -23,3 +23,55 @@ async def test_tablet_change_replication_vnode_to_tablets(manager: ManagerClient
     with pytest.raises(InvalidRequest):
         await cql.run_async("ALTER KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 1};")
 
+
+@pytest.mark.asyncio
+async def test_tablet_change_replication_strategy(manager: ManagerClient):
+    cfg = {'enable_user_defined_functions': False,
+           'experimental_features': ['tablets', 'consistent-topology-changes']}
+    server = await manager.server_add(config=cfg)
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};")
+    await cql.run_async("ALTER KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy'};")
+
+    res = await cql.run_async("DESCRIBE KEYSPACE test")
+    assert "NetworkTopologyStrategy" in res[0].create_statement, "NetworkTopologyStrategy wasn't switched onto"
+
+    res = await cql.run_async("SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = 'test'")
+    assert len(res) == 0, "tablets replication strategy turned on"
+
+
+@pytest.mark.asyncio
+async def test_tablet_default_initialization(manager: ManagerClient):
+    cfg = {'enable_user_defined_functions': False,
+           'experimental_features': ['tablets', 'consistent-topology-changes']}
+    server = await manager.server_add(config=cfg)
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 1};")
+
+    res = await cql.run_async("SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = 'test'")
+    assert res[0].initial_tablets > 0, "initial_tablets not configured"
+
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+    res = await cql.run_async("SELECT * FROM system.tablets")
+    for row in res:
+        if row.keyspace_name == 'test' and row.table_name == 'test':
+            assert row.tablet_count > 0, "zero tablets allocated"
+            break
+    else:
+        assert False, "tablets not allocated"
+
+
+@pytest.mark.asyncio
+async def test_tablet_change_initial_tablets(manager: ManagerClient):
+    cfg = {'enable_user_defined_functions': False,
+           'experimental_features': ['tablets', 'consistent-topology-changes']}
+    server = await manager.server_add(config=cfg)
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 1};")
+
+    await cql.run_async("ALTER KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1, 'initial_tablets': 2};")
+    res = await cql.run_async("SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = 'test'")
+    assert res[0].initial_tablets == 2, "initial_tablets not altered"

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -1424,6 +1424,7 @@ private:
             ks_def.name,
             ks_def.strategy_class,
             std::map<sstring, sstring>{ks_def.strategy_options.begin(), ks_def.strategy_options.end()},
+            std::nullopt,
             ks_def.durable_writes,
             std::move(cf_defs));
     }

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -237,6 +237,7 @@ std::vector<schema_ptr> do_load_schemas(std::string_view schema_str) {
                 db::schema_tables::NAME,
                 "org.apache.cassandra.locator.LocalStrategy",
                 std::map<sstring, sstring>{},
+                std::nullopt,
                 false));
     real_db.tables.emplace_back(dd_impl, real_db.keyspaces.back(), db::schema_tables::dropped_columns());
 
@@ -562,7 +563,7 @@ schema_ptr do_load_schema_from_schema_tables(std::filesystem::path scylla_data_p
     if (types_mut) {
         query::result_set result(*types_mut);
 
-        auto ks = make_lw_shared<keyspace_metadata>(keyspace, "org.apache.cassandra.locator.LocalStrategy", std::map<sstring, sstring>{}, false);
+        auto ks = make_lw_shared<keyspace_metadata>(keyspace, "org.apache.cassandra.locator.LocalStrategy", std::map<sstring, sstring>{}, std::nullopt, false);
         db::cql_type_parser::raw_builder ut_builder(*ks);
 
         auto get_list = [] (const query::result_set_row& row, const char* name) {


### PR DESCRIPTION
Right now the initial_tablets is kept as replication strategy option in the legacy system_schema.keyspaces table. However, r.s. options are all considered to be replication factors, not anything else. Other than being confusing, this also makes it impossible to extend keyspace configuration with non-integer tablets-related values.

This PR moves the initial_tablets into scylla-specific part of the schema. This opens a way to more ~~ugly~~ flexible ways of configuring tablets for keyspace, in particular it should be possible to use boolean on/off switch in CREATE KEYSPACE or some other trick we find appropriate.

Mos of what this PR does is extends arguments passed around keyspace_metadata and abstract_replication_strategy. The essence of the change is in last patches
* schema_tables: Relax extract_scylla_specific_ks_info() check
* locator,schema: Move initial tablets from r.s. options to params

refs: #16319 
refs: #16364 