### PR TITLE
select statement: verify EXECUTE permissions only for non native functions

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -226,7 +226,8 @@ future<> select_statement::check_access(query_processor& qp, const service::clie
     }
     if (!_selection->is_trivial()) {
         std::vector<::shared_ptr<functions::function>> used_functions = _selection->used_functions();
-        for (const auto& used_function : used_functions) {
+        auto not_native = [] (::shared_ptr<functions::function> func) { return !func->is_native(); };
+        for (const auto& used_function : used_functions | std::ranges::views::filter(not_native)) {
             sstring encoded_signature = auth::encode_signature(used_function->name().name, used_function->arg_types());
             co_await state.has_function_access(used_function->name().keyspace, encoded_signature, auth::permission::EXECUTE);
         }


### PR DESCRIPTION
Commit 62458b8e4f9c387d5ff5ad294c3383c5e8d54ce1 introduced the enforcement of EXECUTE permissions of functions in cql select. However, according to the reference in #12869, the permissions should be enforced only on UDFs and UDAs.
The code does not distinguish between the two so the permissions are also unintenionally enforced also on native function. This commit introduce the distinction and only enforces the permissions on non native functions.

Fixes #16526

Manually verified (before and after change) with the reproducer supplied in #16526 and also with some the `min` and `max` native functions.
Also added test that checks for regression on native functions execution and verified that it fails on authorization before 
the fix and passes after the fix.