### PR TITLE
Drain view_builder in generic drain

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2587,12 +2587,17 @@ void view_builder::execute(build_step& step, exponential_backoff_retry r) {
     }).get();
 }
 
+future<> view_builder::mark_as_built(view_ptr view) {
+    return seastar::when_all_succeed(
+            _sys_ks.mark_view_as_built(view->ks_name(), view->cf_name()),
+            _sys_dist_ks.finish_view_build(view->ks_name(), view->cf_name())).discard_result();
+}
+
 future<> view_builder::mark_existing_views_as_built() {
     assert(this_shard_id() == 0);
     auto views = _db.get_views();
-    co_await coroutine::parallel_for_each(views, [this] (view_ptr& view) -> future<> {
-        co_await _sys_ks.mark_view_as_built(view->ks_name(), view->cf_name());
-        co_await _sys_dist_ks.finish_view_build(view->ks_name(), view->cf_name());
+    co_await coroutine::parallel_for_each(views, [this] (view_ptr& view) {
+        return mark_as_built(view);
     });
 }
 
@@ -2615,9 +2620,7 @@ future<> view_builder::maybe_mark_view_as_built(view_ptr view, dht::token next_t
                 }
                 auto view = builder._db.find_schema(view_id);
                 vlogger.info("Finished building view {}.{}", view->ks_name(), view->cf_name());
-                return seastar::when_all_succeed(
-                        builder._sys_ks.mark_view_as_built(view->ks_name(), view->cf_name()),
-                        builder._sys_dist_ks.finish_view_build(view->ks_name(), view->cf_name())).then_unpack([&builder, view] {
+                return builder.mark_as_built(view_ptr(view)).then([&builder, view] {
                     // The view is built, so shard 0 can remove the entry in the build progress system table on
                     // behalf of all shards. It is guaranteed to have a higher timestamp than the per-shard entries.
                     return builder._sys_ks.remove_view_build_progress_across_all_shards(view->ks_name(), view->cf_name());

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -233,6 +233,7 @@ private:
     future<> do_build_step();
     void execute(build_step&, exponential_backoff_retry);
     future<> maybe_mark_view_as_built(view_ptr, dht::token);
+    future<> mark_as_built(view_ptr);
     void setup_metrics();
 
     struct consumer;

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -219,6 +219,9 @@ public:
 
     future<std::unordered_map<sstring, sstring>> view_build_statuses(sstring keyspace, sstring view_name) const;
 
+    // Can only be called on shard-0
+    future<> mark_existing_views_as_built();
+
 private:
     build_step& get_or_create_build_step(table_id);
     future<> initialize_reader_at_current_token(build_step&);

--- a/main.cc
+++ b/main.cc
@@ -2037,12 +2037,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 ss.local().drain_on_shutdown().get();
             });
 
-            auto drain_view_builder = defer_verbose_shutdown("view builder ops", [cfg] {
-                if (cfg->view_building()) {
-                    view_builder.invoke_on_all(&db::view::view_builder::drain).get();
-                }
-            });
-
             startlog.info("Scylla version {} initialization completed.", scylla_version());
             stop_signal.wait().get();
             startlog.info("Signal received; shutting down");

--- a/main.cc
+++ b/main.cc
@@ -1438,7 +1438,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 std::ref(feature_service), std::ref(mm), std::ref(token_metadata), std::ref(erm_factory),
                 std::ref(messaging), std::ref(repair),
                 std::ref(stream_manager), std::ref(lifecycle_notifier), std::ref(bm), std::ref(snitch),
-                std::ref(tablet_allocator), std::ref(cdc_generation_service), std::ref(qp), std::ref(sl_controller)).get();
+                std::ref(tablet_allocator), std::ref(cdc_generation_service), std::ref(view_builder), std::ref(qp), std::ref(sl_controller)).get();
 
             auto stop_storage_service = defer_verbose_shutdown("storage_service", [&] {
                 ss.stop().get();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4343,6 +4343,7 @@ future<> storage_service::do_drain() {
     co_await _db.invoke_on_all(&replica::database::drain);
     co_await _sys_ks.invoke_on_all(&db::system_keyspace::shutdown);
     co_await _repair.invoke_on_all(&repair_service::shutdown);
+    co_await _view_builder.invoke_on_all(&db::view::view_builder::drain);
 }
 
 future<> storage_service::do_cluster_cleanup() {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -132,6 +132,7 @@ storage_service::storage_service(abort_source& abort_source,
     sharded<locator::snitch_ptr>& snitch,
     sharded<service::tablet_allocator>& tablet_allocator,
     sharded<cdc::generation_service>& cdc_gens,
+    sharded<db::view::view_builder>& view_builder,
     cql3::query_processor& qp,
     sharded<qos::service_level_controller>& sl_controller)
         : _abort_source(abort_source)
@@ -160,6 +161,7 @@ storage_service::storage_service(abort_source& abort_source,
         })
         , _tablet_allocator(tablet_allocator)
         , _cdc_gens(cdc_gens)
+        , _view_builder(view_builder)
 {
     register_metrics();
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -70,6 +70,9 @@ namespace db {
 class system_distributed_keyspace;
 class system_keyspace;
 class batchlog_manager;
+namespace view {
+class view_builder;
+}
 }
 
 namespace netw {
@@ -202,6 +205,7 @@ public:
         sharded<locator::snitch_ptr>& snitch,
         sharded<service::tablet_allocator>& tablet_allocator,
         sharded<cdc::generation_service>& cdc_gs,
+        sharded<db::view::view_builder>& view_builder,
         cql3::query_processor& qp,
         sharded<qos::service_level_controller>& sl_controller);
 
@@ -511,6 +515,7 @@ private:
     locator::snitch_signal_slot_t _snitch_reconfigure;
     sharded<service::tablet_allocator>& _tablet_allocator;
     sharded<cdc::generation_service>& _cdc_gens;
+    sharded<db::view::view_builder>& _view_builder;
 private:
     /**
      * Handle node bootstrap

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -393,8 +393,6 @@ public:
 
 private:
     void set_mode(mode m);
-    // Can only be called on shard-0
-    future<> mark_existing_views_as_built();
 
     // Stream data for which we become a new replica.
     // Before that, if we're not replacing another node, inform other nodes about our chosen tokens

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -842,6 +842,11 @@ private:
 
             _sys_dist_ks.start(std::ref(_qp), std::ref(_mm), std::ref(_proxy)).get();
 
+            _view_builder.start(std::ref(_db), std::ref(_sys_ks), std::ref(_sys_dist_ks), std::ref(_mnotifier), std::ref(_view_update_generator)).get();
+            auto stop_view_builder = defer([this] {
+                _view_builder.stop().get();
+            });
+
             if (cfg_in.need_remote_proxy) {
                 _proxy.invoke_on_all(&service::storage_proxy::start_remote, std::ref(_ms), std::ref(_gossiper), std::ref(_mm), std::ref(_sys_ks)).get();
             }
@@ -942,13 +947,9 @@ private:
                 _batchlog_manager.stop().get();
             });
 
-            _view_builder.start(std::ref(_db), std::ref(_sys_ks), std::ref(_sys_dist_ks), std::ref(_mnotifier), std::ref(_view_update_generator)).get();
             _view_builder.invoke_on_all([this] (db::view::view_builder& vb) {
                 return vb.start(_mm.local());
             }).get();
-            auto stop_view_builder = defer([this] {
-                _view_builder.stop().get();
-            });
 
             // Create the testing user.
             try {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -770,6 +770,7 @@ private:
                 std::ref(_snitch),
                 std::ref(_tablet_allocator),
                 std::ref(_cdc_generation_service),
+                std::ref(_view_builder),
                 std::ref(_qp),
                 std::ref(_sl_controller)).get();
             auto stop_storage_service = defer([this] { _ss.stop().get(); });


### PR DESCRIPTION
For view builder draining there's dedicated deferred action in main while all other services that need to be drained do it via storage_service. The latter is to unify shutdown for services and to make `nodetool drain` drain everything, not just some part of those. This PR makes view builder drain look the same. As a side effect it also moves `mark_existing_views_as_built` from storage service to view builder and generalizes this marking code inside view builder itself.

refs: #2737
refs: #2795