### PR TITLE
build: add crypto++ to dependencies

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -48,6 +48,7 @@ debian_base_packages=(
     libdeflate-dev
     libabsl-dev
     librapidxml-dev
+    libcrypto++-dev
 )
 
 fedora_packages=(
@@ -67,6 +68,7 @@ fedora_packages=(
     libdeflate-devel
     systemd-devel
     abseil-cpp-devel
+    cryptopp-devel
     git
     python
     sudo


### PR DESCRIPTION
We depend on the crypto++ library (see utils/hashers.hh) but don't list it in install-dependencies.sh. Currently this works because Seastar's install-dependencies.sh installs it, but that's going away in [1]. List crypto++ directly to keep install-dependencies.sh working.

Regenerating the frozen toolchain is unnecessary since we're re-adding an existing dependency.

[1] https://github.com/scylladb/seastar/commit/6bdef1e4319fcc3af078844c2c2ed57f7a6debf3