### PR TITLE
Sanitize keyspace_metadata creation

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -4534,7 +4534,7 @@ static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_vie
         initial_tablets = std::stol(tags_map.at(INITIAL_TABLETS_TAG_KEY));
     }
 
-    return keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.NetworkTopologyStrategy", std::move(opts), initial_tablets, true);
+    return keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.NetworkTopologyStrategy", std::move(opts), initial_tablets);
 }
 
 future<> executor::start() {

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -180,8 +180,7 @@ future<> service::create_keyspace_if_missing(::service::migration_manager& mm) c
                     meta::AUTH_KS,
                     "org.apache.cassandra.locator.SimpleStrategy",
                     opts,
-                    std::nullopt,
-                    true);
+                    std::nullopt);
 
             try {
                 co_return co_await mm.announce(::service::prepare_new_keyspace_announcement(db.real_database(), ksm, ts),

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -123,7 +123,7 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata(s
     std::optional<unsigned> initial_tablets;
     auto options = prepare_options(sc, tm, get_replication_options(), initial_tablets);
     return data_dictionary::keyspace_metadata::new_keyspace(ks_name, sc,
-            std::move(options), initial_tablets, get_boolean(KW_DURABLE_WRITES, true), std::vector<schema_ptr>{}, get_storage_options());
+            std::move(options), initial_tablets, get_boolean(KW_DURABLE_WRITES, true), get_storage_options());
 }
 
 lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata& tm) {
@@ -139,7 +139,7 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_u
         initial_tablets = old->initial_tablets();
     }
 
-    return data_dictionary::keyspace_metadata::new_keyspace(old->name(), *sc, options, initial_tablets, get_boolean(KW_DURABLE_WRITES, true), std::vector<schema_ptr>{}, get_storage_options());
+    return data_dictionary::keyspace_metadata::new_keyspace(old->name(), *sc, options, initial_tablets, get_boolean(KW_DURABLE_WRITES, true), get_storage_options());
 }
 
 

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -203,36 +203,6 @@ keyspace_metadata::keyspace_metadata(std::string_view name,
              locator::replication_strategy_config_options strategy_options,
              std::optional<unsigned> initial_tablets,
              bool durable_writes,
-             std::vector<schema_ptr> cf_defs)
-    : keyspace_metadata(name,
-                        strategy_name,
-                        std::move(strategy_options),
-                        initial_tablets,
-                        durable_writes,
-                        std::move(cf_defs),
-                        user_types_metadata{}) { }
-
-keyspace_metadata::keyspace_metadata(std::string_view name,
-             std::string_view strategy_name,
-             locator::replication_strategy_config_options strategy_options,
-             std::optional<unsigned> initial_tablets,
-             bool durable_writes,
-             std::vector<schema_ptr> cf_defs,
-             user_types_metadata user_types)
-    : keyspace_metadata(name,
-                        strategy_name,
-                        std::move(strategy_options),
-                        initial_tablets,
-                        durable_writes,
-                        std::move(cf_defs),
-                        std::move(user_types),
-                        storage_options{}) { }
-
-keyspace_metadata::keyspace_metadata(std::string_view name,
-             std::string_view strategy_name,
-             locator::replication_strategy_config_options strategy_options,
-             std::optional<unsigned> initial_tablets,
-             bool durable_writes,
              std::vector<schema_ptr> cf_defs,
              user_types_metadata user_types,
              storage_options storage_opts)

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -231,15 +231,14 @@ keyspace_metadata::new_keyspace(std::string_view name,
                                 locator::replication_strategy_config_options options,
                                 std::optional<unsigned> initial_tablets,
                                 bool durables_writes,
-                                std::vector<schema_ptr> cf_defs,
                                 storage_options storage_opts)
 {
-    return ::make_lw_shared<keyspace_metadata>(name, strategy_name, options, initial_tablets, durables_writes, cf_defs, user_types_metadata{}, storage_opts);
+    return ::make_lw_shared<keyspace_metadata>(name, strategy_name, options, initial_tablets, durables_writes, std::vector<schema_ptr>{}, user_types_metadata{}, storage_opts);
 }
 
 lw_shared_ptr<keyspace_metadata>
 keyspace_metadata::new_keyspace(const keyspace_metadata& ksm) {
-    return new_keyspace(ksm.name(), ksm.strategy_name(), ksm.strategy_options(), ksm.initial_tablets(), ksm.durable_writes(), std::vector<schema_ptr>{}, ksm.get_storage_options());
+    return new_keyspace(ksm.name(), ksm.strategy_name(), ksm.strategy_options(), ksm.initial_tablets(), ksm.durable_writes(), ksm.get_storage_options());
 }
 
 void keyspace_metadata::add_user_type(const user_type ut) {

--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -45,7 +45,7 @@ public:
                  std::string_view strategy_name,
                  locator::replication_strategy_config_options options,
                  std::optional<unsigned> initial_tablets,
-                 bool durables_writes,
+                 bool durables_writes = true,
                  std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{},
                  storage_options storage_opts = {});
     static lw_shared_ptr<keyspace_metadata>

--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -37,22 +37,9 @@ public:
                  locator::replication_strategy_config_options strategy_options,
                  std::optional<unsigned> initial_tablets,
                  bool durable_writes,
-                 std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{});
-    keyspace_metadata(std::string_view name,
-                 std::string_view strategy_name,
-                 locator::replication_strategy_config_options strategy_options,
-                 std::optional<unsigned> initial_tablets,
-                 bool durable_writes,
-                 std::vector<schema_ptr> cf_defs,
-                 user_types_metadata user_types);
-    keyspace_metadata(std::string_view name,
-                 std::string_view strategy_name,
-                 locator::replication_strategy_config_options strategy_options,
-                 std::optional<unsigned> initial_tablets,
-                 bool durable_writes,
-                 std::vector<schema_ptr> cf_defs,
-                 user_types_metadata user_types,
-                 storage_options storage_opts);
+                 std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{},
+                 user_types_metadata user_types = user_types_metadata{},
+                 storage_options storage_opts = storage_options{});
     static lw_shared_ptr<keyspace_metadata>
     new_keyspace(std::string_view name,
                  std::string_view strategy_name,

--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -46,7 +46,6 @@ public:
                  locator::replication_strategy_config_options options,
                  std::optional<unsigned> initial_tablets,
                  bool durables_writes = true,
-                 std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{},
                  storage_options storage_opts = {});
     static lw_shared_ptr<keyspace_metadata>
     new_keyspace(const keyspace_metadata& ksm);

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2213,8 +2213,7 @@ lw_shared_ptr<keyspace_metadata> create_keyspace_from_schema_partition(const sch
             initial_tablets = row.get<int>("initial_tablets");
         }
     }
-    return make_lw_shared<keyspace_metadata>(keyspace_name, strategy_name, strategy_options, initial_tablets, durable_writes,
-            std::vector<schema_ptr>{}, data_dictionary::user_types_metadata{}, storage_opts);
+    return keyspace_metadata::new_keyspace(keyspace_name, strategy_name, strategy_options, initial_tablets, durable_writes, storage_opts);
 }
 
 template<typename V>

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -265,8 +265,7 @@ future<> system_distributed_keyspace::start() {
                 NAME,
                 "org.apache.cassandra.locator.SimpleStrategy",
                 {{"replication_factor", "3"}},
-                std::nullopt,
-                true /* durable_writes */);
+                std::nullopt);
         if (!db.has_keyspace(NAME)) {
             mutations = service::prepare_new_keyspace_announcement(db.real_database(), sd_ksm, ts);
             description += format(" create {} keyspace;", NAME);
@@ -278,8 +277,7 @@ future<> system_distributed_keyspace::start() {
                 NAME_EVERYWHERE,
                 "org.apache.cassandra.locator.EverywhereStrategy",
                 {},
-                std::nullopt,
-                true /* durable_writes */);
+                std::nullopt);
         if (!db.has_keyspace(NAME_EVERYWHERE)) {
             auto sde_mutations = service::prepare_new_keyspace_announcement(db.real_database(), sde_ksm, ts);
             std::move(sde_mutations.begin(), sde_mutations.end(), std::back_inserter(mutations));

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -145,7 +145,7 @@ future<> table_helper::setup_keyspace(cql3::query_processor& qp, service::migrat
 
     std::map<sstring, sstring> opts;
     opts["replication_factor"] = replication_factor;
-    auto ksm = keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.SimpleStrategy", std::move(opts), std::nullopt, true);
+    auto ksm = keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.SimpleStrategy", std::move(opts), std::nullopt);
 
     while (!db.has_keyspace(keyspace_name)) {
         auto group0_guard = co_await mm.start_group0_operation();

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -497,12 +497,12 @@ class mock_database_impl : public data_dictionary::impl {
 public:
     explicit mock_database_impl(schema_ptr table_schema)
         : _table_schema(table_schema),
-          _keyspace_metadata(data_dictionary::keyspace_metadata::new_keyspace(_table_schema->ks_name(),
+          _keyspace_metadata(make_lw_shared<data_dictionary::keyspace_metadata>(_table_schema->ks_name(),
                                                                               "MockReplicationStrategy",
-                                                                              {},
-                                                                              {},
+                                                                              locator::replication_strategy_config_options{},
+                                                                              std::nullopt,
                                                                               false,
-                                                                              {_table_schema})) {}
+                                                                              std::vector<schema_ptr>({_table_schema}))) {}
 
     static std::pair<data_dictionary::database, std::unique_ptr<mock_database_impl>> make(schema_ptr table_schema) {
         std::unique_ptr<mock_database_impl> mock_db = std::make_unique<mock_database_impl>(table_schema);


### PR DESCRIPTION
The amount of arguments needed to create ks metadata object is pretty large and there are many different ways it can be and it is created over the code. This set simplifies it for the most typical patterns.

closes: #16447
closes: #16449 