### PR TITLE
table, memtable: share log structured allocator statistics across all tablets in a table

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1795,7 +1795,7 @@ future<> memtable_list::flush() {
 
 lw_shared_ptr<memtable> memtable_list::new_memtable() {
     return make_lw_shared<memtable>(_current_schema(), *_dirty_memory_manager,
-            _read_section, _allocating_section,
+            _table_shared_data,
             _table_stats, this, _compaction_scheduling_group);
 }
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -183,21 +183,24 @@ public:
             seal_immediate_fn_type seal_immediate_fn,
             std::function<schema_ptr()> cs,
             dirty_memory_manager* dirty_memory_manager,
+            memtable_table_shared_data& table_shared_data,
             replica::table_stats& table_stats,
             seastar::scheduling_group compaction_scheduling_group = seastar::current_scheduling_group())
         : _memtables({})
         , _seal_immediate_fn(seal_immediate_fn)
         , _current_schema(cs)
         , _dirty_memory_manager(dirty_memory_manager)
+        , _table_shared_data(table_shared_data)
         , _compaction_scheduling_group(compaction_scheduling_group)
         , _table_stats(table_stats) {
         add_memtable();
     }
 
     memtable_list(std::function<schema_ptr()> cs, dirty_memory_manager* dirty_memory_manager,
+            memtable_table_shared_data& table_shared_data,
             replica::table_stats& table_stats,
             seastar::scheduling_group compaction_scheduling_group = seastar::current_scheduling_group())
-        : memtable_list({}, std::move(cs), dirty_memory_manager, table_stats, compaction_scheduling_group) {
+        : memtable_list({}, std::move(cs), dirty_memory_manager, table_shared_data, table_stats, compaction_scheduling_group) {
     }
 
     bool may_flush() const noexcept {
@@ -432,6 +435,7 @@ private:
     config _config;
     locator::effective_replication_map_ptr _erm;
     lw_shared_ptr<const storage_options> _storage_opts;
+    memtable_table_shared_data _memtable_shared_data;
     mutable table_stats _stats;
     mutable db::view::stats _view_stats;
     mutable row_locker::stats _row_locker_stats;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -171,8 +171,7 @@ private:
     seal_immediate_fn_type _seal_immediate_fn;
     std::function<schema_ptr()> _current_schema;
     replica::dirty_memory_manager* _dirty_memory_manager;
-    logalloc::allocating_section _read_section;
-    logalloc::allocating_section _allocating_section;
+    memtable_table_shared_data _table_shared_data;
     std::optional<shared_future<>> _flush_coalescing;
     seastar::scheduling_group _compaction_scheduling_group;
     replica::table_stats& _table_stats;

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -97,6 +97,12 @@ public:
 
 namespace replica {
 
+// Statistics that need to be shared across all memtables for a single table
+struct memtable_table_shared_data {
+    logalloc::allocating_section read_section;
+    logalloc::allocating_section allocating_section;
+};
+
 class dirty_memory_manager;
 
 struct table_stats;
@@ -112,8 +118,7 @@ private:
     mutation_cleaner _cleaner;
     memtable_list *_memtable_list;
     schema_ptr _schema;
-    logalloc::allocating_section& _read_section;
-    logalloc::allocating_section& _allocating_section;
+    memtable_table_shared_data& _table_shared_data;
     partitions_type partitions;
     size_t nr_partitions = 0;
     db::replay_position _replay_position;
@@ -173,8 +178,7 @@ private:
     uint64_t dirty_size() const;
 public:
     explicit memtable(schema_ptr schema, dirty_memory_manager&,
-            logalloc::allocating_section& read_section,
-            logalloc::allocating_section& allocating_section,
+            memtable_table_shared_data& shared_data,
             replica::table_stats& table_stats, memtable_list *memtable_list = nullptr,
             seastar::scheduling_group compaction_scheduling_group = seastar::current_scheduling_group());
     // Used for testing that want to control the flush process.

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1750,7 +1750,7 @@ const std::vector<sstables::shared_sstable>& compaction_group::compacted_undelet
 lw_shared_ptr<memtable_list>
 table::make_memory_only_memtable_list() {
     auto get_schema = [this] { return schema(); };
-    return make_lw_shared<memtable_list>(std::move(get_schema), _config.dirty_memory_manager, _stats, _config.memory_compaction_scheduling_group);
+    return make_lw_shared<memtable_list>(std::move(get_schema), _config.dirty_memory_manager, _memtable_shared_data, _stats, _config.memory_compaction_scheduling_group);
 }
 
 lw_shared_ptr<memtable_list>
@@ -1759,7 +1759,7 @@ table::make_memtable_list(compaction_group& cg) {
         return seal_active_memtable(cg, std::move(permit));
     };
     auto get_schema = [this] { return schema(); };
-    return make_lw_shared<memtable_list>(std::move(seal), std::move(get_schema), _config.dirty_memory_manager, _stats, _config.memory_compaction_scheduling_group);
+    return make_lw_shared<memtable_list>(std::move(seal), std::move(get_schema), _config.dirty_memory_manager, _memtable_shared_data, _stats, _config.memory_compaction_scheduling_group);
 }
 
 compaction_group::compaction_group(table& t, size_t group_id, dht::token_range token_range)


### PR DESCRIPTION
In 7d5e22b43b6 ("replica: memtable: don't forget memtable
memory allocation statistics") we taught memtable_list to remember
learned memory allocation reserves so a new memtable inherits these
statistics from an older memtable. Share it now further across tablets
that belong to the same table as well. This helps the statistics be more
accurate for tablets that are migrated in, as they can share existing
tablet's memory allocation history.