### PR TITLE
install.sh: fix scylla-server.service failure on nonroot mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -485,6 +485,7 @@ ExecStart=
 ExecStart=$rprefix/bin/scylla \$SCYLLA_ARGS \$SEASTAR_IO \$DEV_MODE \$CPUSET
 ExecStopPost=
 User=
+AmbientCapabilities=
 EOS
     else
         cat << EOS > "$rsystemd"/scylla-server.service.d/nonroot.conf
@@ -498,6 +499,7 @@ ExecStart=
 ExecStart=$rprefix/bin/scylla \$SCYLLA_ARGS \$SEASTAR_IO \$DEV_MODE \$CPUSET
 ExecStopPost=
 User=
+AmbientCapabilities=
 StandardOutput=
 StandardOutput=file:$rprefix/scylla-server.log
 StandardError=


### PR DESCRIPTION
On 3da346a86d6deae21386ffd34aa314f7006ff4d9, we moved AmbientCapabilities to scylla-server.service, but it causes "Operation not permitted" on nonroot mode.
It is because nonroot user does not have enough privilege to set capabilities, we need to disable the parameter on nonroot mode.