### PR TITLE
test.py: always override env when executing scylla subprocess

### DIFF
--- a/test.py
+++ b/test.py
@@ -1626,6 +1626,12 @@ async def workaround_python26789() -> int:
 
 if __name__ == "__main__":
     colorama.init()
+    # gh-16583: ignore the inherited client host's ScyllaDB environment,
+    # since it may break the tests
+    if "SCYLLA_CONF" in os.environ:
+        del os.environ["SCYLLA_CONF"]
+    if "SCYLLA_HOME" in os.environ:
+        del os.environ["SCYLLA_HOME"]
 
     if sys.version_info < (3, 7):
         print("Python 3.7 or newer is required to run this program")


### PR DESCRIPTION
test.py inherits its env from the user, which is the right thing: some python modules, e.g. logging, do accept env-based configuration.

However, test.py also starts subprocesses, i.e. tests, which start other subprocesses, e.g. scylladb instances. And when the instance is started without an explicit configuration file, SCYLLA_CONF from user environment can be used.

If this scylla.conf contains funny parameters, e.g. unsupported configuration options, the tests may break in an unexpected way.

Avoid that by overriding the env in all scylla subprocess invocations (test/pylib/scylla_cluster.py is already clean in that regard).

Fixes all the patched tests on my machine.