### PR TITLE
Implement tablet splitting

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -29,6 +29,7 @@
 #include "config.hh"
 #include "extensions.hh"
 #include "log.hh"
+#include "service/tablet_allocator_fwd.hh"
 #include "utils/config_file_impl.hh"
 #include <seastar/core/metrics_api.hh>
 #include <seastar/core/relabel_config.hh>
@@ -1131,6 +1132,10 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , maximum_replication_factor_warn_threshold(this, "maximum_replication_factor_warn_threshold", liveness::LiveUpdate, value_status::Used, -1, "")
     , maximum_replication_factor_fail_threshold(this, "maximum_replication_factor_fail_threshold", liveness::LiveUpdate, value_status::Used, -1, "")
     , tablets_initial_scale_factor(this, "tablets_initial_scale_factor", value_status::Used, 1, "Calculated initial tablets are multiplied by this number")
+    , target_tablet_size_in_bytes(this, "target_tablet_size_in_bytes", liveness::LiveUpdate, value_status::Used, service::default_target_tablet_size,
+         "Allows target tablet size to be configured. Defaults to 5G (in bytes). Maintaining tablets at reasonable sizes is important to be able to " \
+         "redistribute load. A higher value means tablet migration throughput can be reduced. A lower value may cause number of tablets to increase significantly, " \
+         "potentially resulting in performance drawbacks.")
     , replication_strategy_warn_list(this, "replication_strategy_warn_list", liveness::LiveUpdate, value_status::Used, {locator::replication_strategy_type::simple}, "Controls which replication strategies to warn about when creating/altering a keyspace. Doesn't affect the pre-existing keyspaces.")
     , replication_strategy_fail_list(this, "replication_strategy_fail_list", liveness::LiveUpdate, value_status::Used, {}, "Controls which replication strategies are disallowed to be used when creating/altering a keyspace. Doesn't affect the pre-existing keyspaces.")
     , service_levels_interval(this, "service_levels_interval_ms", liveness::LiveUpdate, value_status::Used, 10000, "Controls how often service levels module polls configuration table")

--- a/db/config.hh
+++ b/db/config.hh
@@ -466,7 +466,10 @@ public:
     named_value<int> minimum_replication_factor_warn_threshold;
     named_value<int> maximum_replication_factor_warn_threshold;
     named_value<int> maximum_replication_factor_fail_threshold;
+
     named_value<int> tablets_initial_scale_factor;
+    named_value<uint64_t> target_tablet_size_in_bytes;
+
     named_value<std::vector<enum_option<replication_strategy_restriction_t>>> replication_strategy_warn_list;
     named_value<std::vector<enum_option<replication_strategy_restriction_t>>> replication_strategy_fail_list;
 

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -179,6 +179,47 @@ When tablet is not in transition, the following invariants hold:
 1. The storage layer (database) on any node contains writes for keys which belong to the tablet only if
     that shard is one of the current tablet replicas.
 
+# Tablet splitting
+
+Each table has its resize metadata stored in group0.
+
+Resize metadata is composed of:
+  - resize_type: it's the resize decision type, and can be either of 'split', 'merge' or 'none'
+  - resize_seq_number: a sequence number that globally identifies the resize; it's monotonically increasing
+and increased by one on every new decision.
+
+In order to determine if a table needs resize, the load balancer will calculate the average tablet size
+for a given table, which can be done by dividing average table size[1] by the tablet count.
+
+[1]: The average size of a table is the total size across all DCs divided by the number of replicas across
+all DCs.
+
+A table will need split if its average size surpasses the split threshold, which is 100% of the target
+tablet size, which defaults to 5G. The reasoning is that after split we want average size to return
+to the target size. By the same reason, merge threshold is 50% of target size.
+
+The load balancer might also decide to cancel an ongoing split if it realizes that after split, a merge
+will be needed. It does that, to avoid some back-and-forth, which is wasteful. Revoking an ongoing
+decision is done by setting resize metadata with type 'none'.
+
+When the load balancer decides to split a table, it sets resize_type field in metadata with 'split' and
+sets resize_seq_number with the next sequence number, which is the current seq number -- loaded from
+tablet metadata -- increased by 1.
+
+All table replicas will listen for the need to split with a replica component named split monitor, that
+wakes up on replication map updates, checks the need for split, and if so, it will start segregating the
+storage of every tablet replica into left and right sides of the token range spanned by an individual
+tablet. When a tablet replica has completed this work, it will then communicate its ready completion
+status with the coordinator by loading (mirroring) the resize_seq_number from tablet metadata into its
+local state,  which is pulled periodically by the coordinator.
+
+When the coordinator realizes all tablet replicas have completed the splitting work, the load balancer
+emits a decision to finalize the split request. The finalization is serialized with migration, as
+doubling tablet count would interfere with the migration process. When the state machine leaves the
+migration track, then finalize can proceed and split each preexisting tablet into two in the topology
+metadata. The replicas  will react to that by remapping its compaction groups into a new set which size
+is equal to the new tablet count.
+
 # Topology guards
 
 In addition to synchronizing with data access operations (e.g. CQL requests), we need to synchronize with

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -17,6 +17,15 @@ struct global_tablet_id final {
     locator::tablet_id tablet;
 };
 
+struct table_load_stats final {
+    uint64_t size_in_bytes;
+    int64_t split_ready_seq_number;
+};
+
+struct load_stats final {
+    std::unordered_map<::table_id, locator::table_load_stats> tables;
+};
+
 }
 
 namespace service {
@@ -54,4 +63,5 @@ verb raft_topology_cmd (raft::server_id dst_id, raft::term_t term, uint64_t cmd_
 verb [[cancellable]] raft_pull_topology_snapshot (raft::server_id dst_id, service::raft_topology_pull_params) -> service::raft_topology_snapshot;
 verb [[cancellable]] tablet_stream_data (raft::server_id dst_id, locator::global_tablet_id);
 verb [[cancellable]] tablet_cleanup (raft::server_id dst_id, locator::global_tablet_id);
+verb [[cancellable]] table_load_stats (raft::server_id dst_id) -> locator::load_stats;
 }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -374,6 +374,34 @@ size_t tablet_map::external_memory_usage() const {
     return result;
 }
 
+bool resize_decision::operator==(const resize_decision& o) const {
+    return way.index() == o.way.index() && sequence_number == o.sequence_number;
+}
+
+static auto to_resize_type(sstring decision) {
+    static const std::unordered_map<sstring, decltype(resize_decision::way)> string_to_type = {
+        {"none", resize_decision::none{}},
+        {"split", resize_decision::split{}},
+        {"merge", resize_decision::merge{}},
+    };
+    return string_to_type.at(decision);
+}
+
+resize_decision::resize_decision(sstring decision, uint64_t seq_number)
+    : way(to_resize_type(decision))
+    , sequence_number(seq_number) {
+}
+
+sstring resize_decision::type_name() const {
+    static const std::array<sstring, 3> index_to_string = {
+        "none",
+        "split",
+        "merge",
+    };
+    static_assert(std::variant_size_v<decltype(way)> == index_to_string.size());
+    return index_to_string[way.index()];
+}
+
 // Estimates the external memory usage of std::unordered_map<>.
 // Does not include external memory usage of elements.
 template <typename K, typename V>

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -414,6 +414,19 @@ sstring resize_decision::type_name() const {
     return index_to_string[way.index()];
 }
 
+table_load_stats& table_load_stats::operator+=(const table_load_stats& s) noexcept {
+    size_in_bytes = size_in_bytes + s.size_in_bytes;
+    split_ready_seq_number = std::min(split_ready_seq_number, s.split_ready_seq_number);
+    return *this;
+}
+
+load_stats& load_stats::operator+=(const load_stats& s) {
+    for (auto& [id, stats] : s.tables) {
+        tables[id] += stats;
+    }
+    return *this;
+}
+
 // Estimates the external memory usage of std::unordered_map<>.
 // Does not include external memory usage of elements.
 template <typename K, typename V>

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -222,6 +222,10 @@ void tablet_map::set_tablet_transition_info(tablet_id id, tablet_transition_info
     _transitions.insert_or_assign(id, std::move(info));
 }
 
+void tablet_map::set_resize_decision(locator::resize_decision decision) {
+    _resize_decision = std::move(decision);
+}
+
 future<> tablet_map::for_each_tablet(seastar::noncopyable_function<void(tablet_id, const tablet_info&)> func) const {
     std::optional<tablet_id> tid = first_tablet();
     for (const tablet_info& ti : tablets()) {
@@ -376,6 +380,14 @@ size_t tablet_map::external_memory_usage() const {
 
 bool resize_decision::operator==(const resize_decision& o) const {
     return way.index() == o.way.index() && sequence_number == o.sequence_number;
+}
+
+bool tablet_map::needs_split() const {
+    return std::holds_alternative<resize_decision::split>(_resize_decision.way);
+}
+
+const locator::resize_decision& tablet_map::resize_decision() const {
+    return _resize_decision;
 }
 
 static auto to_resize_type(sstring decision) {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -414,6 +414,14 @@ sstring resize_decision::type_name() const {
     return index_to_string[way.index()];
 }
 
+resize_decision::seq_number_t resize_decision::next_sequence_number() const {
+    // Doubt we'll ever wrap around, but just in case.
+    // Even if sequence number is bumped every second, it would take 292471208677 years
+    // for it to happen, about 21x the age of the universe, or ~11x according to the new
+    // prediction after james webb.
+    return (sequence_number == std::numeric_limits<seq_number_t>::max()) ? 0 : sequence_number + 1;
+}
+
 table_load_stats& table_load_stats::operator+=(const table_load_stats& s) noexcept {
     size_in_bytes = size_in_bytes + s.size_in_bytes;
     split_ready_seq_number = std::min(split_ready_seq_number, s.split_ready_seq_number);

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -282,6 +282,8 @@ struct load_stats {
     }
 };
 
+using load_stats_ptr = lw_shared_ptr<const load_stats>;
+
 /// Stores information about tablets of a single table.
 ///
 /// The map contains a constant number of tablets, tablet_count().

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -287,6 +287,7 @@ private:
     tablet_container _tablets;
     size_t _log2_tablets; // log_2(_tablets.size())
     std::unordered_map<tablet_id, tablet_transition_info> _transitions;
+    resize_decision _resize_decision;
 public:
     /// Constructs a tablet map.
     ///
@@ -375,9 +376,14 @@ public:
     size_t external_memory_usage() const;
 
     bool operator==(const tablet_map&) const = default;
+
+    bool needs_split() const;
+
+    const locator::resize_decision& resize_decision() const;
 public:
     void set_tablet(tablet_id, tablet_info);
     void set_tablet_transition_info(tablet_id, tablet_transition_info);
+    void set_resize_decision(locator::resize_decision);
     void clear_transitions();
 
     // Destroys gently.

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -260,6 +260,27 @@ struct resize_decision {
     sstring type_name() const;
 };
 
+struct table_load_stats {
+    uint64_t size_in_bytes = 0;
+    // Stores the minimum seq number among all replicas, as coordinator wants to know if
+    // all replicas have completed splitting, which happens when they all store the
+    // seq number of the current split decision.
+    resize_decision::seq_number_t split_ready_seq_number = std::numeric_limits<resize_decision::seq_number_t>::max();
+
+    table_load_stats& operator+=(const table_load_stats& s) noexcept;
+    friend table_load_stats operator+(table_load_stats a, const table_load_stats& b) {
+        return a += b;
+    }
+};
+
+struct load_stats {
+    std::unordered_map<table_id, table_load_stats> tables;
+
+    load_stats& operator+=(const load_stats& s);
+    friend load_stats operator+(load_stats a, const load_stats& b) {
+        return a += b;
+    }
+};
 
 /// Stores information about tablets of a single table.
 ///

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -258,6 +258,7 @@ struct resize_decision {
     }
     bool operator==(const resize_decision&) const;
     sstring type_name() const;
+    seq_number_t next_sequence_number() const;
 };
 
 struct table_load_stats {

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -265,6 +265,12 @@ public:
     }
 
     const std::unordered_map<sstring,
+                            std::unordered_set<const node*>>&
+    get_datacenter_nodes() const {
+        return _dc_nodes;
+    }
+
+    const std::unordered_map<sstring,
                        std::unordered_map<sstring,
                                           std::unordered_set<inet_address>>>&
     get_datacenter_racks() const {

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -618,6 +618,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::TABLET_STREAM_FILES:
     case messaging_verb::TABLET_STREAM_DATA:
     case messaging_verb::TABLET_CLEANUP:
+    case messaging_verb::TABLE_LOAD_STATS:
         return 1;
     case messaging_verb::CLIENT_ID:
     case messaging_verb::MUTATION:

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -190,7 +190,8 @@ enum class messaging_verb : int32_t {
     JOIN_NODE_RESPONSE = 69,
     TABLET_STREAM_FILES = 70,
     STREAM_BLOB = 71,
-    LAST = 72,
+    TABLE_LOAD_STATS = 72,
+    LAST = 73,
 };
 
 } // namespace netw

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -36,7 +36,7 @@ class compaction_group {
     table& _t;
     class table_state;
     std::unique_ptr<table_state> _table_state;
-    const size_t _group_id;
+    size_t _group_id;
     // Tokens included in this compaction_groups
     dht::token_range _token_range;
     compaction::compaction_strategy_state _compaction_strategy_state;
@@ -79,6 +79,11 @@ public:
         boost::intrusive::constant_time_size<false>>;
 
     compaction_group(table& t, size_t gid, dht::token_range token_range);
+
+    void update_id_and_range(size_t id, dht::token_range token_range) {
+        _group_id = id;
+        _token_range = std::move(token_range);
+    }
 
     size_t group_id() const noexcept {
         return _group_id;
@@ -174,20 +179,21 @@ using compaction_group_list = compaction_group::list_t;
 // by the same storage group.
 class storage_group {
     compaction_group_ptr _main_cg;
-    compaction_group_ptr _left_cg;
-    compaction_group_ptr _right_cg;
+    std::vector<compaction_group_ptr> _split_ready_groups;
 private:
     bool splitting_mode() const {
-        return bool(_left_cg) && bool(_right_cg);
+        return !_split_ready_groups.empty();
     }
+    size_t to_idx(locator::tablet_range_side) const;
 public:
-    storage_group(compaction_group_ptr cg, compaction_group_list& list);
+    storage_group(compaction_group_ptr cg, compaction_group_list* list);
 
     const dht::token_range& token_range() const noexcept;
 
     size_t memtable_count() const noexcept;
 
     compaction_group_ptr& main_compaction_group() noexcept;
+    std::vector<compaction_group_ptr> split_ready_compaction_groups() &&;
     compaction_group_ptr& select_compaction_group(locator::tablet_range_side) noexcept;
 
     uint64_t live_disk_space_used() const noexcept;

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -190,6 +190,8 @@ public:
     compaction_group_ptr& main_compaction_group() noexcept;
     compaction_group_ptr& select_compaction_group(locator::tablet_range_side) noexcept;
 
+    uint64_t live_disk_space_used() const noexcept;
+
     utils::small_vector<compaction_group*, 3> compaction_groups() noexcept;
 
     // Puts the storage group in split mode, in which it internally segregates data

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -578,6 +578,8 @@ public:
                        const std::vector<sstables::shared_sstable>& old_sstables);
     };
 
+    // Precondition: table needs tablet splitting.
+    // Returns true if all storage of table is ready for splitting.
     bool all_storage_groups_split();
     future<> split_all_storage_groups();
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -589,6 +589,11 @@ public:
     // be split once it returns.
     future<> maybe_split_compaction_group_of(locator::tablet_id);
 private:
+    // Called when coordinator executes tablet splitting, i.e. commit the new tablet map with
+    // each tablet split into two, so this replica will remap all of its compaction groups
+    // that were previously split.
+    void handle_tablet_split_completion(size_t old_tablet_count, const locator::tablet_map& new_tmap);
+
     sstables::compaction_type_options::split split_compaction_options() const noexcept;
 
     // Select a compaction group from a given token.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -580,7 +580,15 @@ public:
 
     bool all_storage_groups_split();
     future<> split_all_storage_groups();
+
+    // Splits compaction group of a single tablet, if and only if the underlying table has
+    // split request emitted by coordinator (found in tablet metadata).
+    // If split is required, then the compaction group of the given tablet is guaranteed to
+    // be split once it returns.
+    future<> maybe_split_compaction_group_of(locator::tablet_id);
 private:
+    sstables::compaction_type_options::split split_compaction_options() const noexcept;
+
     // Select a compaction group from a given token.
     std::pair<size_t, locator::tablet_range_side> storage_group_of(dht::token token) const noexcept;
     size_t storage_group_id_for_token(dht::token token) const noexcept;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1291,6 +1291,11 @@ uint64_t compaction_group::live_disk_space_used() const noexcept {
     return _main_sstables->bytes_on_disk() + _maintenance_sstables->bytes_on_disk();
 }
 
+uint64_t storage_group::live_disk_space_used() const noexcept {
+    auto cgs = const_cast<storage_group&>(*this).compaction_groups();
+    return boost::accumulate(cgs | boost::adaptors::transformed(std::mem_fn(&compaction_group::live_disk_space_used)), uint64_t(0));
+}
+
 uint64_t compaction_group::total_disk_space_used() const noexcept {
     return live_disk_space_used() + boost::accumulate(_sstables_compacted_but_not_deleted | boost::adaptors::transformed(std::mem_fn(&sstables::sstable::bytes_on_disk)), uint64_t(0));
 }

--- a/replica/tablet_mutation_builder.hh
+++ b/replica/tablet_mutation_builder.hh
@@ -39,6 +39,7 @@ public:
     tablet_mutation_builder& set_session(dht::token last_token, service::session_id);
     tablet_mutation_builder& del_session(dht::token last_token);
     tablet_mutation_builder& del_transition(dht::token last_token);
+    tablet_mutation_builder& set_resize_decision(locator::resize_decision);
 
     mutation build() {
         return std::move(_m);

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -155,6 +155,13 @@ tablet_mutation_builder::del_transition(dht::token last_token) {
     return *this;
 }
 
+tablet_mutation_builder&
+tablet_mutation_builder::set_resize_decision(locator::resize_decision resize_decision) {
+    _m.set_static_cell("resize_type", data_value(resize_decision.type_name()), _ts);
+    _m.set_static_cell("resize_seq_number", data_value(int64_t(resize_decision.sequence_number)), _ts);
+    return *this;
+}
+
 mutation make_drop_tablet_map_mutation(table_id id, api::timestamp_type ts) {
     auto s = db::system_keyspace::tablets();
     mutation m(s, partition_key::from_single_value(*s,

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -170,6 +170,8 @@ private:
     future<> stream_tablet(locator::global_tablet_id);
     future<> cleanup_tablet(locator::global_tablet_id);
     inet_address host2ip(locator::host_id);
+    // Handler for table load stats RPC.
+    future<locator::load_stats> load_stats_for_tablet_based_tables();
 public:
     storage_service(abort_source& as, distributed<replica::database>& db,
         gms::gossiper& gossiper,

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1099,8 +1099,7 @@ public:
     }
 
     future<migration_plan> balance_tablets(token_metadata_ptr tm, locator::load_stats_ptr table_load_stats) {
-        // TODO: make target size a live-update-able config for tests.
-        load_balancer lb(tm, std::move(table_load_stats), _load_balancer_stats, default_target_tablet_size);
+        load_balancer lb(tm, std::move(table_load_stats), _load_balancer_stats, _db.get_config().target_tablet_size_in_bytes());
         co_return co_await lb.make_plan();
     }
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -226,6 +226,119 @@ class load_balancer {
         }
     };
 
+    // We have split and merge thresholds, which work respectively as (target) upper and lower
+    // bound for average size of tablets.
+    //
+    // The merge threshold is 50% of target tablet size (a midpoint between split and merge),
+    // such that after a merge, the average size is equally far from split and merge.
+    // The same applies to split. It's 100% of target size, so after split, the average is
+    // close to the target size (assuming small variations during the operation).
+    //
+    // It might happen that during a resize decision, average size changes drastically, and
+    // split or merge might get cancelled. E.g. after deleting a large partition or lots of
+    // data becoming suddenly expired.
+    // If we're splitting, we will only cancel it, if the average size dropped below the
+    // target size. That's because a merge would be required right after split completes,
+    // due to the average size dropping below the merge threshold, as tablet count doubles.
+    const uint64_t _target_tablet_size = default_target_tablet_size;
+
+    static constexpr uint64_t target_max_tablet_size(uint64_t target_tablet_size) {
+        return target_tablet_size * 2;
+    }
+    static constexpr uint64_t target_min_tablet_size(uint64_t max_tablet_size) {
+        return double(max_tablet_size / 2) * 0.5;
+    }
+
+    struct table_size_desc {
+        uint64_t target_max_tablet_size;
+        uint64_t avg_tablet_size;
+        locator::resize_decision resize_decision;
+        size_t tablet_count;
+        size_t shard_count;
+
+        uint64_t target_min_tablet_size() const noexcept {
+            return load_balancer::target_min_tablet_size(target_max_tablet_size);
+        }
+    };
+
+    struct cluster_resize_load {
+        using table_id_and_size_desc = std::pair<table_id, table_size_desc>;
+        std::vector<table_id_and_size_desc> tables_need_resize;
+        std::vector<table_id_and_size_desc> tables_being_resized;
+
+        static bool table_needs_merge(const table_size_desc& d) {
+            // FIXME: ignore merge request if tablet_count == initial_tablets.
+            return d.tablet_count > 1 && d.avg_tablet_size < d.target_min_tablet_size();
+        }
+        static bool table_needs_split(const table_size_desc& d) {
+            return d.avg_tablet_size > d.target_max_tablet_size;
+        }
+
+        bool table_needs_resize(const table_size_desc& d) const {
+            return table_needs_merge(d) || table_needs_split(d);
+        }
+
+        // Resize cancellation will account for possible oscillations caused by compaction, etc.
+        // We shouldn't rush into cancelling an ongoing resize. That will only happen if the
+        // average size is past the point it would be if either split or merge had completed.
+        // If we cancel a split, that's because average size dropped so much a merge would be
+        // required post completion, and vice-versa.
+        bool table_needs_resize_cancellation(const table_size_desc& d) const {
+            auto& way = d.resize_decision.way;
+            if (std::holds_alternative<locator::resize_decision::split>(way)) {
+                return d.avg_tablet_size < d.target_max_tablet_size / 2;
+            } else if (std::holds_alternative<locator::resize_decision::merge>(way)) {
+                return d.avg_tablet_size > d.target_min_tablet_size() * 2;
+            }
+            return false;
+        }
+
+        void update(table_id id, table_size_desc d) {
+            bool table_undergoing_resize = d.resize_decision.split_or_merge();
+
+            // Resizing tables that no longer need resize will have the resize decision revoked,
+            // therefore they must be listed as being resized.
+            if (!table_needs_resize(d) && !table_undergoing_resize) {
+                return;
+            }
+
+            auto entry = std::make_pair(id, std::move(d));
+            if (table_undergoing_resize) {
+                tables_being_resized.push_back(entry);
+            } else {
+                tables_need_resize.push_back(entry);
+            }
+        }
+
+        // Comparator that measures the weight of the need for resizing.
+        auto resize_urgency_cmp() const {
+            return [] (const table_id_and_size_desc& a, const table_id_and_size_desc& b) {
+                auto urgency = [] (const table_size_desc& d) -> double {
+                    // FIXME: only takes into account split today.
+                    return double(d.avg_tablet_size) / d.target_max_tablet_size;
+                };
+                return urgency(a.second) < urgency(b.second);
+            };
+        }
+
+        static locator::resize_decision to_resize_decision(const table_size_desc& d) {
+            locator::resize_decision decision;
+            if (table_needs_split(d)) {
+                decision.way = locator::resize_decision::split{};
+            } else if (table_needs_merge(d)) {
+                decision.way = locator::resize_decision::merge{};
+            }
+            return decision;
+        }
+
+        // Resize decisions can be revoked with an empty (none) decision, so replicas
+        // will know they're no longer required to prepare storage for the execution of
+        // topology changes.
+        static locator::resize_decision revoke_resize_decision() {
+            return locator::resize_decision{};
+        }
+    };
+
     // Per-shard limits for active tablet streaming sessions.
     //
     // There is no hard reason for these values being what they are other than
@@ -290,8 +403,9 @@ private:
     }
 
 public:
-    load_balancer(token_metadata_ptr tm, locator::load_stats_ptr table_load_stats, load_balancer_stats_manager& stats)
-        : _tm(std::move(tm))
+    load_balancer(token_metadata_ptr tm, locator::load_stats_ptr table_load_stats, load_balancer_stats_manager& stats, uint64_t target_tablet_size)
+        : _target_tablet_size(target_tablet_size)
+        , _tm(std::move(tm))
         , _table_load_stats(std::move(table_load_stats))
         , _stats(stats)
     { }
@@ -306,10 +420,127 @@ public:
             lblogger.info("Prepared {} migrations in DC {}", dc_plan.size(), dc);
             plan.merge(std::move(dc_plan));
         }
+        plan.set_resize_plan(co_await make_resize_plan());
 
         lblogger.info("Prepared {} migration plans, out of which there were {} tablet migration(s) and {} resize decision(s)",
                       plan.size(), plan.tablet_migration_count(), plan.resize_decision_count());
         co_return std::move(plan);
+    }
+
+    const locator::table_load_stats* load_stats_for_table(table_id id) const {
+        if (!_table_load_stats) {
+            return nullptr;
+        }
+        auto it = _table_load_stats->tables.find(id);
+        return (it != _table_load_stats->tables.end()) ? &it->second : nullptr;
+    }
+
+    future<table_resize_plan> make_resize_plan() {
+        table_resize_plan resize_plan;
+
+        if (!_tm->tablets().balancing_enabled()) {
+            co_return std::move(resize_plan);
+        }
+
+        cluster_resize_load resize_load;
+
+        for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
+            auto& tmap = tmap_;
+
+            const auto* table_stats = load_stats_for_table(table);
+            if (!table_stats) {
+                continue;
+            }
+
+            auto avg_tablet_size = table_stats->size_in_bytes / std::max(tmap.tablet_count(), size_t(1));
+            // shard presence of a table across the cluster
+            size_t shard_count = std::accumulate(tmap.tablets().begin(), tmap.tablets().end(), size_t(0),
+                [] (size_t shard_count, const locator::tablet_info& info) {
+                    return shard_count + info.replicas.size();
+                });
+
+            table_size_desc size_desc {
+                .target_max_tablet_size = target_max_tablet_size(_target_tablet_size),
+                .avg_tablet_size = avg_tablet_size,
+                .resize_decision = tmap.resize_decision(),
+                .tablet_count = tmap.tablet_count(),
+                .shard_count = shard_count
+            };
+
+            resize_load.update(table, std::move(size_desc));
+            lblogger.info("Table {} with tablet_count={} has an average tablet size of {}", table, tmap.tablet_count(), avg_tablet_size);
+            co_await coroutine::maybe_yield();
+        }
+
+        // Emit new resize decisions
+
+        // The limit of resize requests is determined by the shard presence (count) of tables involved.
+        // If tables still have a low tablet count, the concurrency must be high in order to saturate the cluster.
+        // If a table covers the entire cluster, and needs split, concurrency will be reduced to 1.
+
+        size_t total_shard_count = std::invoke([&topo = _tm->get_topology()] {
+            size_t shard_count = 0;
+            topo.for_each_node([&] (const locator::node* node_ptr) {
+                shard_count += node_ptr->get_shard_count();
+            });
+            return shard_count;
+        });
+        size_t resizing_shard_count = std::accumulate(resize_load.tables_being_resized.begin(), resize_load.tables_being_resized.end(), size_t(0),
+             [] (size_t shard_count, const auto& table_desc) {
+                 return shard_count + table_desc.second.shard_count;
+             });
+        // Limits the amount of new resize requests to be generated in a single round, as each one is a mutation to group0.
+        constexpr size_t max_new_resize_requests = 10;
+
+        auto available_shards = std::max(ssize_t(total_shard_count) - ssize_t(resizing_shard_count), ssize_t(0));
+
+        std::make_heap(resize_load.tables_need_resize.begin(), resize_load.tables_need_resize.end(), resize_load.resize_urgency_cmp());
+        while (resize_load.tables_need_resize.size() && resize_plan.size() < max_new_resize_requests) {
+            const auto& [table, size_desc] = resize_load.tables_need_resize.front();
+
+            if (resize_plan.size() > 0 && available_shards < size_desc.shard_count) {
+                break;
+            }
+
+            auto resize_decision = cluster_resize_load::to_resize_decision(size_desc);
+            lblogger.info("Emitting resize decision of type {} for table {} due to avg tablet size of {}",
+                          resize_decision.type_name(), table, size_desc.avg_tablet_size);
+            resize_plan.resize[table] = std::move(resize_decision);
+
+            std::pop_heap(resize_load.tables_need_resize.begin(), resize_load.tables_need_resize.end(), resize_load.resize_urgency_cmp());
+            resize_load.tables_need_resize.pop_back();
+
+            available_shards -= size_desc.shard_count;
+        }
+
+        // Revoke resize decision if any table no longer needs it
+        // Also communicate coordinator if any table is ready for finalizing resizing
+
+        for (const auto& [table, size_desc] : resize_load.tables_being_resized) {
+            if (resize_load.table_needs_resize_cancellation(size_desc)) {
+                resize_plan.resize[table] = cluster_resize_load::revoke_resize_decision();
+                lblogger.info("Revoking resize decision for table {} due to avg tablet size of {}", table, size_desc.avg_tablet_size);
+                continue;
+            }
+
+            auto& tmap = _tm->tablets().get_tablet_map(table);
+
+            const auto* table_stats = load_stats_for_table(table);
+            if (!table_stats) {
+                continue;
+            }
+
+            // If all replicas have completed split work for the current sequence number, it means that
+            // load balancer can emit finalize decision, for split to be completed.
+            if (table_stats->split_ready_seq_number == tmap.resize_decision().sequence_number) {
+                resize_plan.resize[table] = cluster_resize_load::revoke_resize_decision();
+                resize_plan.finalize_resize.insert(table);
+                lblogger.info("Finalizing resize decision for table {} as all replicas agree on sequence number {}",
+                              table, table_stats->split_ready_seq_number);
+            }
+        }
+
+        co_return std::move(resize_plan);
     }
 
     future<migration_plan> make_plan(dc_name dc) {
@@ -366,6 +597,7 @@ public:
 
         for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
             auto& tmap = tmap_;
+
             co_await tmap.for_each_tablet([&, table = table] (tablet_id tid, const tablet_info& ti) {
                 auto trinfo = tmap.get_tablet_transition_info(tid);
 
@@ -867,7 +1099,8 @@ public:
     }
 
     future<migration_plan> balance_tablets(token_metadata_ptr tm, locator::load_stats_ptr table_load_stats) {
-        load_balancer lb(tm, std::move(table_load_stats), _load_balancer_stats);
+        // TODO: make target size a live-update-able config for tests.
+        load_balancer lb(tm, std::move(table_load_stats), _load_balancer_stats, default_target_tablet_size);
         co_return co_await lb.make_plan();
     }
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -307,7 +307,8 @@ public:
             plan.merge(std::move(dc_plan));
         }
 
-        lblogger.info("Prepared {} migrations", plan.size());
+        lblogger.info("Prepared {} migration plans, out of which there were {} tablet migration(s) and {} resize decision(s)",
+                      plan.size(), plan.tablet_migration_count(), plan.resize_decision_count());
         co_return std::move(plan);
     }
 

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -86,7 +86,7 @@ public:
     ///
     /// The algorithm takes care of limiting the streaming load on the system, also by taking active migrations into account.
     ///
-    future<migration_plan> balance_tablets(locator::token_metadata_ptr);
+    future<migration_plan> balance_tablets(locator::token_metadata_ptr, locator::load_stats_ptr = {});
 
     /// Should be called when the node is no longer a leader.
     void on_leadership_lost();

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -118,6 +118,8 @@ public:
     ///
     future<migration_plan> balance_tablets(locator::token_metadata_ptr, locator::load_stats_ptr = {});
 
+    future<locator::tablet_map> split_tablets(locator::token_metadata_ptr, table_id);
+
     /// Should be called when the node is no longer a leader.
     void on_leadership_lost();
 };

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -8,9 +8,10 @@
 
 #pragma once
 
-#include "replica/database.hh"
+#include "replica/database_fwd.hh"
 #include "locator/tablets.hh"
 #include "tablet_allocator_fwd.hh"
+#include "locator/token_metadata_fwd.hh"
 
 namespace service {
 
@@ -71,6 +72,8 @@ public:
         _resize_plan = std::move(resize_plan);
     }
 };
+
+class migration_notifier;
 
 class tablet_allocator {
 public:

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -10,6 +10,7 @@
 
 #include "replica/database.hh"
 #include "locator/tablets.hh"
+#include "tablet_allocator_fwd.hh"
 
 namespace service {
 
@@ -70,8 +71,6 @@ public:
         _resize_plan = std::move(resize_plan);
     }
 };
-
-class tablet_allocator_impl;
 
 class tablet_allocator {
 public:

--- a/service/tablet_allocator_fwd.hh
+++ b/service/tablet_allocator_fwd.hh
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace service {
+
+// This the default target size of tablets.
+static constexpr uint64_t default_target_tablet_size = 5UL * 1024 * 1024 * 1024;
+
+class tablet_allocator_impl;
+
+class tablet_allocator;
+
+}

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1024,7 +1024,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             }
         }
         if (!preempt) {
-            auto plan = co_await _tablet_allocator.balance_tablets(get_token_metadata_ptr());
+            auto plan = co_await _tablet_allocator.balance_tablets(get_token_metadata_ptr(), _tablet_load_stats);
             if (!drain || plan.has_nodes_to_drain()) {
                 co_await generate_migration_updates(updates, guard, plan);
             }
@@ -2036,7 +2036,7 @@ future<bool> topology_coordinator::maybe_start_tablet_migration(group0_guard gua
     }
 
     auto tm = get_token_metadata_ptr();
-    auto plan = co_await _tablet_allocator.balance_tablets(tm);
+    auto plan = co_await _tablet_allocator.balance_tablets(tm, _tablet_load_stats);
     if (plan.empty()) {
         rtlogger.debug("Tablets are balanced");
         co_return false;

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -230,6 +230,18 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
             }
 
             verify_tablet_metadata_persistence(e, tm, ts);
+
+            // Change resize decision of table1
+            {
+                tablet_map tmap(1);
+                locator::resize_decision decision;
+                decision.way = locator::resize_decision::split{},
+                decision.sequence_number = 1;
+                tmap.set_resize_decision(decision);
+                tm.set_tablet_map(table1, std::move(tmap));
+            }
+
+            verify_tablet_metadata_persistence(e, tm, ts);
         }
     }, tablet_cql_test_config());
 }

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -649,6 +649,21 @@ SEASTAR_THREAD_TEST_CASE(test_token_ownership_splitting) {
     }
 }
 
+static
+void apply_resize_plan(token_metadata& tm, const migration_plan& plan) {
+    for (auto [table_id, resize_decision] : plan.resize_plan().resize) {
+        tablet_map& tmap = tm.tablets().get_tablet_map(table_id);
+        resize_decision.sequence_number = tmap.resize_decision().sequence_number + 1;
+        tmap.set_resize_decision(resize_decision);
+    }
+    for (auto table_id : plan.resize_plan().finalize_resize) {
+        auto& old_tmap = tm.tablets().get_tablet_map(table_id);
+        testlog.info("Setting new tablet map of size {}", old_tmap.tablet_count() * 2);
+        tablet_map tmap(old_tmap.tablet_count() * 2);
+        tm.tablets().set_tablet_map(table_id, std::move(tmap));
+    }
+}
+
 // Reflects the plan in a given token metadata as if the migrations were fully executed.
 static
 void apply_plan(token_metadata& tm, const migration_plan& plan) {
@@ -658,6 +673,7 @@ void apply_plan(token_metadata& tm, const migration_plan& plan) {
         tinfo.replicas = replace_replica(tinfo.replicas, mig.src, mig.dst);
         tmap.set_tablet(mig.tablet.tablet, tinfo);
     }
+    apply_resize_plan(tm, plan);
 }
 
 // Reflects the plan in a given token metadata as if the migrations were started but not yet executed.
@@ -668,12 +684,13 @@ void apply_plan_as_in_progress(token_metadata& tm, const migration_plan& plan) {
         auto tinfo = tmap.get_tablet_info(mig.tablet.tablet);
         tmap.set_tablet_transition_info(mig.tablet.tablet, migration_to_transition_info(tinfo, mig));
     }
+    apply_resize_plan(tm, plan);
 }
 
 static
-void rebalance_tablets(tablet_allocator& talloc, shared_token_metadata& stm) {
+void rebalance_tablets(tablet_allocator& talloc, shared_token_metadata& stm, locator::load_stats_ptr load_stats = {}) {
     while (true) {
-        auto plan = talloc.balance_tablets(stm.get()).get0();
+        auto plan = talloc.balance_tablets(stm.get(), load_stats).get0();
         if (plan.empty()) {
             break;
         }
@@ -1602,4 +1619,122 @@ SEASTAR_THREAD_TEST_CASE(basic_tablet_storage_splitting_test) {
             return make_ready_future<bool>(table.all_storage_groups_split());
         }, bool(false), std::logical_or<bool>()).get0(), true);
     }, std::move(cfg)).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
+    do_with_cql_env_thread([] (auto& e) {
+        inet_address ip1("192.168.0.1");
+        inet_address ip2("192.168.0.2");
+
+        auto host1 = host_id(next_uuid());
+        auto host2 = host_id(next_uuid());
+
+        auto table1 = table_id(next_uuid());
+
+        unsigned shard_count = 2;
+
+        semaphore sem(1);
+        shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
+                locator::topology::config{
+                        .this_endpoint = ip1,
+                        .local_dc_rack = locator::endpoint_dc_rack::default_location
+                }
+        });
+
+        stm.mutate_token_metadata([&] (token_metadata& tm) {
+            tm.update_host_id(host1, ip1);
+            tm.update_host_id(host2, ip2);
+            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+
+            tablet_map tmap(2);
+            for (auto tid : tmap.tablet_ids()) {
+                tmap.set_tablet(tid, tablet_info {
+                        tablet_replica_set {
+                                tablet_replica {host1, tests::random::get_int<shard_id>(0, shard_count - 1)},
+                                tablet_replica {host2, tests::random::get_int<shard_id>(0, shard_count - 1)},
+                        }
+                });
+            }
+            tablet_metadata tmeta;
+            tmeta.set_tablet_map(table1, std::move(tmap));
+            tm.set_tablets(std::move(tmeta));
+            return make_ready_future<>();
+        }).get();
+
+        auto tablet_count = [&] {
+            return stm.get()->tablets().get_tablet_map(table1).tablet_count();
+        };
+        auto resize_decision = [&] {
+            return stm.get()->tablets().get_tablet_map(table1).resize_decision();
+        };
+
+        auto do_rebalance_tablets = [&] (locator::load_stats load_stats) {
+            rebalance_tablets(e.get_tablet_allocator().local(), stm, make_lw_shared(std::move(load_stats)));
+        };
+
+        const size_t initial_tablets = tablet_count();
+        const uint64_t max_tablet_size = service::default_target_tablet_size * 2;
+        auto to_size_in_bytes = [&] (double max_tablet_size_pctg) -> uint64_t {
+            return (max_tablet_size * max_tablet_size_pctg) * tablet_count();
+        };
+
+
+        const auto initial_ready_seq_number = std::numeric_limits<locator::resize_decision::seq_number_t>::min();
+
+        // there are 2 tablets, each with avg size hitting merge threshold, so merge request is emitted
+        {
+            locator::load_stats load_stats = {
+                .tables = {
+                    { table1, table_load_stats{ .size_in_bytes = to_size_in_bytes(0.0), .split_ready_seq_number = initial_ready_seq_number }},
+                }
+            };
+
+            do_rebalance_tablets(std::move(load_stats));
+            BOOST_REQUIRE(tablet_count() == initial_tablets);
+            BOOST_REQUIRE(std::holds_alternative<locator::resize_decision::merge>(resize_decision().way));
+        }
+
+        // avg size moved above target size, so merge is cancelled
+        {
+            locator::load_stats load_stats = {
+                .tables = {
+                    { table1, table_load_stats{ .size_in_bytes = to_size_in_bytes(0.75), .split_ready_seq_number = initial_ready_seq_number }},
+                }
+            };
+
+            do_rebalance_tablets(std::move(load_stats));
+            BOOST_REQUIRE(tablet_count() == initial_tablets);
+            BOOST_REQUIRE(std::holds_alternative<locator::resize_decision::none>(resize_decision().way));
+        }
+
+        // avg size hits split threshold, and balancer emits split request
+        {
+            locator::load_stats load_stats = {
+                .tables = {
+                    { table1, table_load_stats{ .size_in_bytes = to_size_in_bytes(1.1), .split_ready_seq_number = initial_ready_seq_number }},
+                }
+            };
+
+            do_rebalance_tablets(std::move(load_stats));
+            BOOST_REQUIRE(tablet_count() == initial_tablets);
+            BOOST_REQUIRE(std::holds_alternative<locator::resize_decision::split>(resize_decision().way));
+            BOOST_REQUIRE(resize_decision().sequence_number > 0);
+        }
+
+        // replicas set their split status as ready, and load balancer finalizes split generating a new
+        // tablet map, twice as large as the previous one.
+        {
+            locator::load_stats load_stats = {
+                .tables = {
+                    { table1, table_load_stats{ .size_in_bytes = to_size_in_bytes(1.1), .split_ready_seq_number = resize_decision().sequence_number }},
+                }
+            };
+
+            do_rebalance_tablets(std::move(load_stats));
+
+            BOOST_REQUIRE(tablet_count() == initial_tablets * 2);
+            BOOST_REQUIRE(std::holds_alternative<locator::resize_decision::none>(resize_decision().way));
+        }
+    }).get();
 }

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -551,3 +551,73 @@ async def test_tablet_cleanup(manager: ManagerClient):
 
     # Bonus: check that commitlog_cleanups doesn't have any garbage after restart.
     assert 0 == (await cql.run_async("SELECT COUNT(*) FROM system.commitlog_cleanups", host=hosts[0]))[0].count
+
+async def get_tablet_count(manager: ManagerClient, server: ServerInfo, keyspace_name: str, table_name: str):
+    host = manager.cql.cluster.metadata.get_host(server.ip_addr)
+
+    # read_barrier is needed to ensure that local tablet metadata on the queried node
+    # reflects the finalized tablet movement.
+    await read_barrier(manager.cql, host)
+
+    table_id = await manager.get_table_id(keyspace_name, table_name)
+    rows = await manager.cql.run_async(f"SELECT tablet_count FROM system.tablets where "
+                                       f"table_id = {table_id}", host=host)
+    return rows[0].tablet_count
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_tablet_split(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    cmdline = [
+        '--logger-log-level', 'storage_service=debug',
+        '--target-tablet-size-in-bytes', '1024',
+    ]
+    servers = [await manager.server_add(cmdline=cmdline)]
+
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+
+    # enough to trigger multiple splits with max size of 1024 bytes.
+    keys = range(256)
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+
+    async def check():
+        logger.info("Checking table")
+        cql = manager.get_cql()
+        rows = await cql.run_async("SELECT * FROM test.test;")
+        assert len(rows) == len(keys)
+        for r in rows:
+            assert r.c == r.pk
+
+    await check()
+
+    await manager.api.flush_keyspace(servers[0].ip_addr, "test")
+
+    tablet_count = await get_tablet_count(manager, servers[0], 'test', 'test')
+    assert tablet_count == 1
+
+    logger.info("Adding new server")
+    servers.append(await manager.server_add(cmdline=cmdline))
+
+    # Increases the chance of tablet migration concurrent with split
+    await inject_error_one_shot_on(manager, "tablet_allocator_shuffle", servers)
+    await inject_error_on(manager, "tablet_load_stats_refresh_before_rebalancing", servers)
+
+    s1_log = await manager.server_open_log(servers[0].server_id)
+    s1_mark = await s1_log.mark()
+
+    # Now there's a split and migration need, so they'll potentially run concurrently.
+    await manager.api.enable_tablet_balancing(servers[0].ip_addr)
+
+    await check()
+    time.sleep(5) # Give load balancer some time to do work
+
+    await s1_log.wait_for('Detected tablet split for table', from_mark=s1_mark)
+
+    await check()
+
+    tablet_count = await get_tablet_count(manager, servers[0], 'test', 'test')
+    assert tablet_count > 1


### PR DESCRIPTION
The motivation for tablet resizing is that we want to keep the average tablet size reasonable, such that load rebalancing can remain efficient. Too large tablet makes migration inefficient, therefore slowing down the balancer.

If the avg size grows beyond the upper bound (split threshold), then balancer decides to split. Split spans all tablets of a table, due to power-of-two constraint.

Likewise, if the avg size decreases below the lower bound (merge threshold), then merge takes place in order to grow the avg size. Merge is not implemented yet, although this series lays foundation for it to be impĺemented later on.

A resize decision can be revoked if the avg size changes and the decision is no longer needed. For example, let's say table is being split and avg size drops below the target size (which is 50% of split threshold and 100% of merge one). That means after split, the avg size would drop below the merge threshold, causing a merge after split, which is wasteful, so it's better to just cancel the split.

Tablet metadata gains 2 new fields for managing this:
resize_type: resize decision type, can be either of "merge", "split", or "none".
resize_seq_number: a sequence number that works as the global identifier of the decision (monotonically increasing, increased by 1 on every new decision emitted by the coordinator).

A new RPC was implemented to pull stats from each table replica, such that load balancer can calculate the avg tablet size and know the "split status", for a given table. Avg size is aggregated carefully while taking RF of each DC into account (which might differ).
When a table is done splitting its storage, it loads (mirror) the resize_seq_number from tablet metadata into its local state (in another words, my split status is ready). If a table is split ready, coordinator will see that table's seq number is the same as the one in tablet metadata. Helps to distinguish stale decisions from the latest one (in case decisions are revoked and re-emited later on). Also, it's aggregated carefully, by taking the minimum among all replicas, so coordinator will only update topology when all replicas are ready.

When load balancer emits split decision, replicas will listen to need to split with a "split monitor" that is awakened once a table has replication metadata updated and detects the need for split (i.e. resize_type field is "split").
The split monitor will start splitting of compaction groups (using mechanism introduced here: https://github.com/scylladb/scylladb/commit/081f30d1492f8250ecd7a871d170f77feb847cd7) for the table. And once splitting work is completed, the table updates its local state as having completed split.

When coordinator pulls the split status of all replicas for a table via RPC, the balancer can see whether that table is ready for "finalizing" the decision, which is about updating tablet metadata to split each tablet into two. Once table replicas have their replication metadata updated with the new tablet count, they can update appropriately their set of compaction groups (that were previously split in the preparation step).

Fixes #16536.