### PR TITLE
topology_coordinator: reject removenode if the removed node is alive

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2286,8 +2286,20 @@ class topology_coordinator {
                         co_await update_topology_state(take_guard(std::move(node)), {builder.build()},
                                                        "start decommission");
                         break;
-                    case topology_request::remove:
+                    case topology_request::remove: {
                         assert(node.rs->ring);
+
+                        auto ip = id2ip(locator::host_id(node.id.uuid()));
+                        if (_gossiper.is_alive(ip)) {
+                            builder.with_node(node.id)
+                                   .del("topology_request");
+                            co_await update_topology_state(take_guard(std::move(node)), {builder.build()},
+                                                           "reject removenode");
+                            slogger.warn("raft topology: rejected removenode operation for node {} "
+                                         "because it is alive", node.id);
+                            break;
+                        }
+
                         builder.set_transition_state(topology::transition_state::tablet_draining)
                                .set_version(_topo_sm._topology.version + 1)
                                .with_node(node.id)
@@ -2296,6 +2308,7 @@ class topology_coordinator {
                         co_await update_topology_state(take_guard(std::move(node)), {builder.build()},
                                                        "start removenode");
                         break;
+                        }
                     case topology_request::replace: {
                         assert(!node.rs->ring);
                         builder.set_transition_state(topology::transition_state::join_group0)

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -289,9 +289,20 @@ class ManagerClient():
 
     async def remove_node(self, initiator_id: ServerNum, server_id: ServerNum,
                           ignore_dead: List[IPAddress] | List[HostID] = list[IPAddress](),
-                          expected_error: str | None = None) -> None:
+                          expected_error: str | None = None,
+                          wait_removed_dead: bool = True) -> None:
         """Invoke remove node Scylla REST API for a specified server"""
         logger.debug("ManagerClient remove node %s on initiator %s", server_id, initiator_id)
+
+        # If we remove a node, we should wait until other nodes see it as dead
+        # because the removenode operation can be rejected if the node being
+        # removed is considered alive. However, we sometimes do not want to
+        # wait, for example, when we test that removenode fails as expected.
+        # Therefore, we make waiting optional and default.
+        if wait_removed_dead:
+            removed_ip = await self.get_host_ip(server_id)
+            await self.others_not_see_server(removed_ip)
+
         data = {"server_id": server_id, "ignore_dead": ignore_dead, "expected_error": expected_error}
         await self.client.put_json(f"/cluster/remove-node/{initiator_id}", data,
                                    timeout=ScyllaServer.TOPOLOGY_TIMEOUT)

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -363,14 +363,6 @@ class ManagerClient():
 
         return await wait_for(host_is_known, deadline or (time() + 30))
 
-    async def wait_for_host_down(self, dst_server_ip: IPAddress, server_ip: IPAddress, deadline: Optional[float] = None) -> None:
-        """Waits for dst_server_id to consider server_id as down, with timeout"""
-        async def host_is_down():
-            down_endpoints = await self.api.get_down_endpoints(dst_server_ip)
-            return True if server_ip in down_endpoints else None
-
-        return await wait_for(host_is_down, deadline or (time() + 30))
-
     async def get_host_ip(self, server_id: ServerNum) -> IPAddress:
         """Get host IP Address"""
         try:

--- a/test/topology/test_cluster_features.py
+++ b/test/topology/test_cluster_features.py
@@ -199,7 +199,6 @@ async def test_partial_upgrade_can_be_finished_with_removenode(manager: ManagerC
 
     # Remove the last node
     await manager.server_stop(servers[-1].server_id)
-    await manager.server_not_sees_other_server(servers[0].ip_addr, servers[-1].ip_addr)
     await manager.remove_node(servers[0].server_id, servers[-1].server_id)
 
     # The feature should eventually become enabled

--- a/test/topology/test_topology_remove_decom.py
+++ b/test/topology/test_topology_remove_decom.py
@@ -112,9 +112,6 @@ async def test_remove_node_with_concurrent_ddl(manager: ManagerClient, random_ta
             await manager.wait_for_host_known(initiator_info.ip_addr, target_host_id)
             logger.info(f'do_remove_node [{i}], stopping target server [{target_info.ip_addr}], host_id [{target_host_id}]')
             await manager.server_stop_gracefully(target_info.server_id)
-            logger.info(f'do_remove_node [{i}], target server [{target_info.ip_addr}] stopped, '
-                        f'waiting for it to be down on [{initiator_info.ip_addr}]')
-            await manager.wait_for_host_down(initiator_info.ip_addr, target_info.ip_addr)
             logger.info(f'do_remove_node [{i}], invoking remove_node')
             await manager.remove_node(initiator_info.server_id, target_info.server_id, [target_info.ip_addr])
             # TODO: check that group 0 no longer contains the removed node (#12153)

--- a/test/topology_custom/test_remove_alive_node.py
+++ b/test/topology_custom/test_remove_alive_node.py
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from test.pylib.scylla_cluster import ReplaceConfig
+from test.pylib.manager_client import ManagerClient
+import asyncio
+import logging
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_removing_alive_node_fails(manager: ManagerClient) -> None:
+    """
+    Test verifying that an attempt to remove an alive node fails as expected.
+    It uses a 3-node cluster:
+    srv1 - the topology coordinator,
+    srv2 - the removenode initiator,
+    srv3 - the node being removed.
+    srv1 has a much bigger failure detector timeout than srv2 to create a scenario
+    where srv2 considers srv3 dead, but srv1 still considers srv3 alive.
+    """
+    logging.info("Bootstrapping nodes")
+    srv1 = await manager.server_add(config={'failure_detector_timeout_in_ms': 300000})
+    srv2 = await manager.server_add(config={'failure_detector_timeout_in_ms': 2000})
+    srv3 = await manager.server_add()
+    await manager.server_sees_other_server(srv2.ip_addr, srv3.ip_addr)
+
+    # srv2 considers srv3 alive. The removenode operation should fail on the initiator
+    # side (in storage_service::raft_removenode).
+    logging.info(f"Removing {srv3} initiated by {srv2}")
+    await manager.remove_node(srv2.server_id, srv3.server_id, [],
+                              "the node being removed is alive, maybe you should use decommission instead?", False)
+
+    logging.info(f"Stopping {srv3}")
+    await manager.server_stop(srv3.server_id)
+    await manager.server_not_sees_other_server(srv2.ip_addr, srv3.ip_addr)
+
+    log_file1 = await manager.server_open_log(srv1.server_id)
+
+    # srv2 considers srv3 dead, but srv1 still considers srv3 alive. The removenode
+    # operation should fail on the topology coordinator side (in
+    # topology_coordinator::handle_node_transition).
+    logging.info(f"Removing {srv3} initiated by {srv2}")
+    await manager.remove_node(srv2.server_id, srv3.server_id, [], "Removenode failed. See earlier errors", False)
+    await log_file1.wait_for("raft topology: rejected removenode operation for node", timeout=60)

--- a/test/topology_custom/test_topology_remove_garbage_group0.py
+++ b/test/topology_custom/test_topology_remove_garbage_group0.py
@@ -82,8 +82,6 @@ async def test_remove_garbage_group0_members(manager: ManagerClient):
     logging.info(f'stop {servers[1]}')
     await manager.server_stop_gracefully(servers[1].server_id)
 
-    logging.debug(f'waiting for {servers[2]} to see {servers[1]} is down')
-    await manager.server_not_sees_other_server(servers[2].ip_addr, servers[1].ip_addr)
     logging.info(f'removenode {servers[1]} using {servers[2]}')
     await manager.remove_node(servers[2].server_id, servers[1].server_id)
 

--- a/test/topology_experimental_raft/test_node_isolation.py
+++ b/test/topology_experimental_raft/test_node_isolation.py
@@ -44,8 +44,6 @@ async def test_banned_node_cannot_communicate(manager: ManagerClient) -> None:
     # that we solved the harder problem of safely removing nodes which didn't shut down.
     logger.info(f"Pausing server {srvs[2]}")
     await manager.server_pause(srvs[2].server_id)
-    logger.info(f"Waiting until server {srvs[0]} marks {srvs[2]} as dead")
-    await manager.server_not_sees_other_server(srvs[0].ip_addr, srvs[2].ip_addr)
     logger.info(f"Removing {srvs[2]} using {srvs[0]}")
     await manager.remove_node(srvs[0].server_id, srvs[2].server_id)
     # Perform a read barrier on srvs[1] so it learns about the ban.


### PR DESCRIPTION
The removenode operation is defined to succeed only if the node
being removed is dead. Currently, we reject this operation on the
initiator side (in `storage_service::raft_removenode`) when the
failure detector considers the node being removed alive. However,
it is possible that even if the initiator considers the node dead,
the topology coordinator will consider it alive when handling the
topology request. For example, the topology coordinator can use
a bigger failure detector timeout, or the node being removed can
suddenly resurrect.

This PR makes the topology coordinator reject removenode if the
node being removed is considered alive. It also adds
`test_remove_alive_node` that verifies this change.

Fixes scylladb/scylladb#16109