### PR TITLE
install.sh: use a temporary file when packaging scylla.yaml

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -317,11 +317,15 @@ fi
 # scylla-conf
 install -d -m755 "$retc"/scylla
 install -d -m755 "$retc"/scylla.d
-grep -v api_ui_dir conf/scylla.yaml | grep -v api_doc_dir > /tmp/scylla.yaml
-echo "api_ui_dir: /opt/scylladb/swagger-ui/dist/" >> /tmp/scylla.yaml
-echo "api_doc_dir: /opt/scylladb/api/api-doc/" >> /tmp/scylla.yaml
-installconfig 644 /tmp/scylla.yaml "$retc"/scylla
-rm -f /tmp/scylla.yaml
+
+scylla_yaml_dir=$(mktemp -d)
+scylla_yaml=$scylla_yaml_dir/scylla.yaml
+grep -v api_ui_dir conf/scylla.yaml | grep -v api_doc_dir > $scylla_yaml
+echo "api_ui_dir: /opt/scylladb/swagger-ui/dist/" >> $scylla_yaml
+echo "api_doc_dir: /opt/scylladb/api/api-doc/" >> $scylla_yaml
+installconfig 644 $scylla_yaml "$retc"/scylla
+rm -rf $scylla_yaml_dir
+
 installconfig 644 conf/cassandra-rackdc.properties "$retc"/scylla
 if $housekeeping; then
     installconfig 644 conf/housekeeping.cfg "$retc"/scylla.d


### PR DESCRIPTION
we create a default `scylla.yaml` on the fly in `install.sh`. but
the path to the temporary file holding the default yaml file is
hardwired to `/tmp/scylla.yaml`. this works fine if we only have a
single `install.sh` at a certain time point. but if we have multiple
`install.sh` process running in parallel, these packaging jobs could
step on each other when they create and remove the `scylla.yaml`.

in this change, because the limit of `installconfig`, it always consider
the "dest" parameter as a directory, `mktemp` is used for creating a
parent directory of the temporary file.

Fixes #16591
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>