### PR TITLE
.git: skip more words and directories in codespell action

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -14,5 +14,5 @@ jobs:
       - uses: codespell-project/actions-codespell@master
         with:
           only_warn: 1
-          ignore_words_list: "ser"
-          skip: "./.git,build/*,tools/*,*.js,*.thrift,test/*"
+          ignore_words_list: "ser,ue,crate"
+          skip: "./.git,./build,./tools,*.js,*.thrift,*.lock,./test"


### PR DESCRIPTION
we use "ue" for the short of "update_expressions", before we change our minds and use a more readable name, let's add "ue" to the "ignore_word_list" option of the codespell.

also, use the abslolute path in "skip" option. as the absolute paths are also used by codespell's own github workflow. and we are still observing codespell github workflow is showing the misspelling errors in our "test/" directory even we have it listed in "skip". so this change should silence them as well.