### PR TITLE
alternator/auth: remove unused #include

### DIFF
--- a/alternator/auth.cc
+++ b/alternator/auth.cc
@@ -13,13 +13,10 @@
 #include "bytes.hh"
 #include "alternator/auth.hh"
 #include <fmt/format.h>
-#include "auth/common.hh"
 #include "auth/password_authenticator.hh"
-#include "auth/roles-metadata.hh"
 #include "service/storage_proxy.hh"
 #include "alternator/executor.hh"
 #include "cql3/selection/selection.hh"
-#include "query-result-set.hh"
 #include "cql3/result_set.hh"
 #include <seastar/core/coroutine.hh>
 


### PR DESCRIPTION
in `alternator/auth.cc`, none of the symbols in "query" namespace provided by the removed headers is used, so there is no need to include this header file.

the same applies to other removed header files.