### PR TITLE
treewide: use consteval string as format string when formatting log m…

### DIFF
--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -215,10 +215,10 @@ void batch_statement::verify_batch_size(query_processor& qp, const std::vector<m
                     mutations.size(), fmt::join(ks_cf_pairs, ", "), size, type, threshold, size - threshold);
         };
         if (size > fail_threshold) {
-            _logger.error(error("FAIL", fail_threshold).c_str());
+            _logger.error("{}", error("FAIL", fail_threshold).c_str());
             throw exceptions::invalid_request_exception("Batch too large");
         } else {
-            _logger.warn(error("WARN", warn_threshold).c_str());
+            _logger.warn("{}", error("WARN", warn_threshold).c_str());
         }
     }
 }

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1568,7 +1568,7 @@ db::commitlog::segment_manager::list_descriptors(sstring dirname) const {
             try {
                 result.emplace_back(de.name, cfg.fname_prefix);
             } catch (std::domain_error& e) {
-                clogger.warn(e.what());
+                clogger.warn("{}", e.what());
             }
         }
     });

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -191,7 +191,7 @@ static void check_exists(std::string_view ks_name, std::string_view cf_name, con
         // on which this check does not pass. We don't want the node to crash in these dtests,
         // but throw an error instead. In production clusters we don't crash on `on_internal_error` anyway.
         auto err = format("expected {}.{} to exist but it doesn't", ks_name, cf_name);
-        dlogger.error(err.c_str());
+        dlogger.error("{}", err);
         throw std::runtime_error{std::move(err)};
     }
 }

--- a/main.cc
+++ b/main.cc
@@ -407,9 +407,9 @@ verify_seastar_io_scheduler(const boost::program_options::variables_map& opts, b
 
         sstring devmode_msg = msg + "To ignore this, see the developer-mode configuration option.";
         if (developer_mode) {
-            startlog.warn(msg.c_str());
+            startlog.warn("{}", msg.c_str());
         } else {
-            startlog.error(devmode_msg.c_str());
+            startlog.error("{}", devmode_msg.c_str());
             throw std::runtime_error("Bad I/O Scheduler configuration");
         }
     };

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -326,7 +326,7 @@ flat_mutation_reader_v2 read_context::create_reader(
         auto msg = format("Unexpected request to create reader for shard {}."
                 " The reader is expected to be in either `used`, `successful_lookup` or `inexistent` state,"
                 " but is in `{}` state instead.", shard, reader_state_to_string(rm.state));
-        mmq_log.warn(msg.c_str());
+        mmq_log.warn("{}", msg);
         throw std::logic_error(msg.c_str());
     }
 

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -37,7 +37,7 @@ public:
     }
 
     future<> mark_alive(direct_failure_detector::pinger::endpoint_id id) override {
-        static const auto msg = "marking Raft server {} as alive for raft groups";
+        static constexpr auto msg = "marking Raft server {} as alive for raft groups";
 
         auto raft_id = raft::server_id{id};
         _alive_set.insert(raft_id);
@@ -54,7 +54,7 @@ public:
     }
 
     future<> mark_dead(direct_failure_detector::pinger::endpoint_id id) override {
-        static const auto msg = "marking Raft server {} as dead for raft groups";
+        static constexpr auto msg = "marking Raft server {} as dead for raft groups";
 
         auto raft_id = raft::server_id{id};
         _alive_set.erase(raft_id);

--- a/service/raft/raft_rpc.cc
+++ b/service/raft/raft_rpc.cc
@@ -78,7 +78,7 @@ raft_rpc::two_way_rpc(sloc loc, raft::server_id id,
     return verb(&_messaging, netw::msg_addr(*ip_addr), db::no_timeout, _group_id, _my_id, id, std::forward<Args>(args)...)
         .handle_exception_type([loc= std::move(loc), id] (const seastar::rpc::closed_error& e) {;
             const auto msg = format("Failed to execute {} on leader {}: {}", loc.function_name(), id, e);
-            rlogger.trace(std::string_view(msg));
+            rlogger.trace("{}", msg);
             return make_exception_future<Ret>(raft::transport_error(msg));
     });
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5269,7 +5269,7 @@ future<> storage_service::removenode(locator::host_id host_id, std::list<locator
                     "removenode[{}]: Rejected removenode operation (node={}); "
                     "the node being removed is alive, maybe you should use decommission instead?",
                     uuid, *endpoint_opt);
-                slogger.warn(std::string_view(message));
+                slogger.warn("{}", message);
                 throw std::runtime_error(message);
             }
 

--- a/streaming/stream_result_future.cc
+++ b/streaming/stream_result_future.cc
@@ -42,7 +42,7 @@ shared_ptr<stream_result_future> stream_result_future::init_receiving_side(strea
     if (sr) {
         auto err = fmt::format("[Stream #{}] GOT PREPARE_MESSAGE from {}, description={},"
                           "stream_plan exists, duplicated message received?", plan_id, description, from);
-        sslog.warn(err.c_str());
+        sslog.warn("{}", err);
         throw std::runtime_error(err);
     }
     sslog.info("[Stream #{}] Executing streaming plan for {} with peers={}, slave", plan_id, description, from);

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1752,7 +1752,7 @@ class json_mutation_stream_parser {
 #else
             auto parse_error = fmt::format(msg, std::forward<decltype(args)>(args)...);
 #endif
-            sst_log.trace(parse_error.c_str());
+            sst_log.trace("{}", parse_error);
             _queue.abort(std::make_exception_ptr(std::runtime_error(parse_error)));
             return false;
         }

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -234,7 +234,7 @@ void trace_keyspace_helper::write_one_session_records(lw_shared_ptr<one_session_
                 tlogger.warn("Tracing is enabled but {}", e.what());
             }
         } catch (std::logic_error& e) {
-            tlogger.error(e.what());
+            tlogger.error("{}", e.what());
         } catch (...) {
             // TODO: Handle some more exceptions maybe?
         }


### PR DESCRIPTION
…essage

seastar::logger is using the compile-time format checking by default if compiled using {fmt} 8.0 and up. and it requires the format string to be consteval string, otherwise we have to use `fmt::runtime()` explicitly.

so adapt the change, let's use the consteval string when formatting logging messages.