### PR TITLE
test: randomized_nemesis_test: add formatter for append_entry

### DIFF
--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -3007,17 +3007,19 @@ struct inconsistency {
     std::string what;
 };
 
-struct append_reg_model {
+struct append_entry {
     using elem_t = typename append_seq::elem_t;
+    elem_t elem;
+    elem_t digest;
+};
 
-    struct entry {
-        elem_t elem;
-        elem_t digest;
-    };
+std::ostream& operator<<(std::ostream& os, const append_entry& e) {
+    return os << e.elem;
+}
 
-    friend std::ostream& operator<<(std::ostream& os, const entry& e) {
-        return os << e.elem;
-    }
+struct append_reg_model {
+    using elem_t = typename append_entry::elem_t;
+    using entry = append_entry;
 
     std::vector<entry> seq{{0, 0}};
     std::unordered_map<elem_t, size_t> index{{0, 0}};

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -3013,6 +3013,14 @@ struct append_entry {
     elem_t digest;
 };
 
+template <>
+struct fmt::formatter<append_entry> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const append_entry& e, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", e.elem);
+    }
+};
+
 std::ostream& operator<<(std::ostream& os, const append_entry& e) {
     return os << e.elem;
 }


### PR DESCRIPTION
we are using `seastar::format()` to format `append_entry` in
`append_reg_model`, so we have to provide a `fmt::formatter` for
these callers which format `append_entry`.

despite that, with FMT_DEPRECATED_OSTREAM, the formatter is defined
by fmt v9, we don't have it since fmt v10. so this change prepares us
for fmt v10.

Refs https://github.com/scylladb/scylladb/issues/13245