### PR TITLE
build: cmake: use # for line comment

### DIFF
--- a/cmake/Findcryptopp.cmake
+++ b/cmake/Findcryptopp.cmake
@@ -1,10 +1,8 @@
-/*
- * Copyright (C) 2018-present ScyllaDB
- */
-
-/*
- * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
- */
+#
+# Copyright (C) 2018-present ScyllaDB
+#
+# SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+#
 
 find_library (cryptopp_LIBRARY
   NAMES cryptopp)


### PR DESCRIPTION
it was a copy-pasta error introduced by 2508d3394631e78f488415732f14bed096f7d2c9. the copyright blob was copied from a C++ source code, but the CMake language define the block comment is different from the C++ language.

let's use the line comment of CMake.