### PR TITLE
test: randomized_nemesis_test: move std::variant formatter up

### DIFF
--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -34,6 +34,20 @@
 
 #include "utils/to_string.hh"
 
+namespace std {
+
+std::ostream& operator<<(std::ostream& os, const std::monostate&) {
+    return os << "";
+}
+
+template <typename T, typename... Ts>
+std::ostream& operator<<(std::ostream& os, const std::variant<T, Ts...>& v) {
+    std::visit([&os] (auto& arg) { os << arg; }, v);
+    return os;
+}
+
+} // namespace std
+
 using namespace seastar;
 using namespace std::chrono_literals;
 
@@ -2857,20 +2871,6 @@ struct stop_crash {
         return os << "";
     }
 };
-
-namespace std {
-
-std::ostream& operator<<(std::ostream& os, const std::monostate&) {
-    return os << "";
-}
-
-template <typename T, typename... Ts>
-std::ostream& operator<<(std::ostream& os, const std::variant<T, Ts...>& v) {
-    std::visit([&os] (auto& arg) { os << arg; }, v);
-    return os;
-}
-
-} // namespace std
 
 namespace operation {
 


### PR DESCRIPTION
we format `std::variant<std::monostate, seastar::timed_out_error, raft::not_a_leader, raft::dropped_entry, raft::commit_status_unknown, raft::conf_change_in_progress, raft::stopped_error, raft::not_a_member>` in this source file. and currently, we format `std::variant<..>` using the default-generated `fmt::formatter` from `operator<<`, so in order to format it using {fmt}'s compile-time check enabled, we have to make the `operator<<` overload for `std::variant<...>` visible from the caller sites which format `std::variant<...>` using {fmt}.

in this change, the `operator<<` for `std::variant<...>` is moved to from the middle of the source file to the top of it, so that it can be found when the compiler looks up for a matched `fmt::formatter` for `std::variant<...>`.

please note, we cannot use the `fmt::formatter` provided by `fmt/std.h`, as its specialization for `std::variant` requires that all the types of the variant is `is_formattable`. but the default generated formatter for type `T` is not considered as the proof that `T` is formattable.

this should address the FTBFS with the latest seastar like:

```
 /usr/include/fmt/core.h:2743:12: error: call to deleted constructor of 'conditional_t<has_formatter<mapped_type, context>::value, formatter<mapped_type, char_type>, fallback_formatter<stripped_type, char_type>>' (aka 'fmt::detail::fallback_formatter<std::variant<std::monostate, seastar::timed_out_error, raft::not_a_leader, raft::dropped_entry, raft::commit_status_unknown, raft::conf_change_in_progress, raft::stopped_error, raft::not_a_member>>')
```