### PR TITLE
repair: remove unused #include

### DIFF
--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <unordered_set>
 #include <unordered_map>
 #include <exception>
 #include <absl/container/btree_set.h>
@@ -23,12 +22,8 @@
 #include "locator/abstract_replication_strategy.hh"
 #include "replica/database_fwd.hh"
 #include "mutation/frozen_mutation.hh"
-#include "utils/UUID.hh"
 #include "utils/hash.hh"
-#include "streaming/stream_reason.hh"
-#include "locator/token_metadata.hh"
 #include "repair/hash.hh"
-#include "node_ops/id.hh"
 #include "repair/sync_boundary.hh"
 #include "tasks/types.hh"
 

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -10,6 +10,7 @@
 
 #include "node_ops/node_ops_ctl.hh"
 #include "repair/repair.hh"
+#include "streaming/stream_reason.hh"
 #include "tasks/task_manager.hh"
 
 namespace repair {


### PR DESCRIPTION
remove the unused #include headers from repair.hh, as they are not directly used. after this change, task_manager_module.hh fails to have access to stream_reason, so include it where it is used.