### PR TITLE
tablets: remove unused #includes

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -11,13 +11,7 @@
 #include "locator/tablet_metadata_guard.hh"
 #include "locator/tablet_sharder.hh"
 #include "locator/token_range_splitter.hh"
-#include "types/types.hh"
-#include "types/tuple.hh"
-#include "types/set.hh"
-#include "utils/hash.hh"
 #include "db/system_keyspace.hh"
-#include "cql3/query_processor.hh"
-#include "cql3/untyped_result_set.hh"
 #include "replica/database.hh"
 #include "utils/stall_free.hh"
 

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -24,8 +24,6 @@
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
-#include <vector>
-
 namespace locator {
 
 extern seastar::logger tablet_logger;


### PR DESCRIPTION
the removed #include headers are not used, so let's drop their `#include`s.