### PR TITLE
api: storage_service: correct the descriptions of two APIs

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -739,7 +739,7 @@
                "parameters":[
                   {
                      "name":"keyspace",
-                     "description":"The keyspace to query about",
+                     "description":"The keyspace to compact",
                      "required":true,
                      "allowMultiple":false,
                      "type":"string",
@@ -779,7 +779,7 @@
                "parameters":[
                   {
                      "name":"keyspace",
-                     "description":"The keyspace to query about",
+                     "description":"The keyspace to cleanup",
                      "required":true,
                      "allowMultiple":false,
                      "type":"string",


### PR DESCRIPTION
this change is more about documentation of the RESTful API of storage_service. as we define the API using Swagger 2.0 format, and generate the API document from the definitions. so would be great if the document matches with the API.

in this change, since the keyspace is not queried but mutated. so changed to a more accurate description.

from the code perspective, it is but cosmetic. as we don't read the description fields or verify them in our tests.