### PR TITLE
topology_state_load: stop waiting for IP-s

### DIFF
--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -29,7 +29,8 @@ struct raft_topology_cmd {
         barrier,
         barrier_and_drain,
         stream_ranges,
-        shutdown
+        shutdown,
+        wait_for_ip
     };
     service::raft_topology_cmd::command cmd;
 };

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -29,7 +29,7 @@ struct raft_topology_cmd {
         barrier,
         barrier_and_drain,
         stream_ranges,
-        fence
+        shutdown
     };
     service::raft_topology_cmd::command cmd;
 };

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -19,8 +19,9 @@
 
 namespace locator {
 
-static endpoint_set resolve_endpoints(const host_id_set& host_ids, const token_metadata& tm) {
-    endpoint_set result{};
+template <typename ResultSet, typename SourceSet>
+static ResultSet resolve_endpoints(const SourceSet& host_ids, const token_metadata& tm) {
+    ResultSet result{};
     result.reserve(host_ids.size());
     for (const auto& host_id: host_ids) {
         // Empty host_id is used as a marker for local address.
@@ -68,7 +69,7 @@ void abstract_replication_strategy::validate_replication_strategy(const sstring&
 
 future<endpoint_set> abstract_replication_strategy::calculate_natural_ips(const token& search_token, const token_metadata& tm) const {
     const auto host_ids = co_await calculate_natural_endpoints(search_token, tm);
-    co_return resolve_endpoints(host_ids, tm);
+    co_return resolve_endpoints<endpoint_set>(host_ids, tm);
 }
 
 using strategy_class_registry = class_registry<
@@ -109,7 +110,7 @@ void maybe_remove_node_being_replaced(const token_metadata& tm,
     }
 }
 
-static const std::unordered_set<inet_address>* find_token(const ring_mapping& ring_mapping, const token& token) {
+static const std::unordered_set<locator::host_id>* find_token(const ring_mapping& ring_mapping, const token& token) {
     if (ring_mapping.empty()) {
         return nullptr;
     }
@@ -123,7 +124,7 @@ inet_address_vector_topology_change vnode_effective_replication_map::get_pending
     const auto* pending_endpoints = find_token(_pending_endpoints, search_token);
     if (pending_endpoints) {
         // interval_map does not work with std::vector, convert to inet_address_vector_topology_change
-        endpoints = inet_address_vector_topology_change(pending_endpoints->begin(), pending_endpoints->end());
+        endpoints = resolve_endpoints<inet_address_vector_topology_change>(*pending_endpoints, *_tmptr);
     }
     return endpoints;
 }
@@ -133,7 +134,7 @@ inet_address_vector_replica_set vnode_effective_replication_map::get_endpoints_f
     if (endpoints == nullptr) {
         return get_natural_endpoints_without_node_being_replaced(token);
     }
-    return inet_address_vector_replica_set(endpoints->begin(), endpoints->end());
+    return resolve_endpoints<inet_address_vector_replica_set>(*endpoints, *_tmptr);
 }
 
 std::optional<tablet_routing_info> vnode_effective_replication_map::check_locality(const token& token) const {
@@ -141,13 +142,9 @@ std::optional<tablet_routing_info> vnode_effective_replication_map::check_locali
 }
 
 bool vnode_effective_replication_map::has_pending_ranges(locator::host_id endpoint) const {
-    const auto ep = _tmptr->get_endpoint_for_host_id_if_known(endpoint);
-    if (!ep) {
-        return false;
-    }
     for (const auto& item : _pending_endpoints) {
         const auto& nodes = item.second;
-        if (nodes.contains(*ep)) {
+        if (nodes.contains(endpoint)) {
             return true;
         }
     }
@@ -392,7 +389,7 @@ future<mutable_vnode_effective_replication_map_ptr> calculate_effective_replicat
             auto current_endpoints = co_await rs->calculate_natural_endpoints(token, *tmptr);
             auto target_endpoints = co_await rs->calculate_natural_endpoints(token, *topology_changes->target_token_metadata);
 
-            auto add_mapping = [&](ring_mapping& target, std::unordered_set<inet_address>&& endpoints) {
+            auto add_mapping = [&](ring_mapping& target, std::unordered_set<locator::host_id>&& endpoints) {
                 using interval = ring_mapping::interval_type;
                 if (!depend_on_token) {
                     target += std::make_pair(
@@ -420,30 +417,30 @@ future<mutable_vnode_effective_replication_map_ptr> calculate_effective_replicat
                     }
                 }
                 if (!endpoints_diff.empty()) {
-                    add_mapping(pending_endpoints, resolve_endpoints(endpoints_diff, *tmptr).extract_set());
+                    add_mapping(pending_endpoints, std::move(endpoints_diff).extract_set());
                 }
             }
 
             // in order not to waste memory, we update read_endpoints only if the
             // new endpoints differs from the old one
             if (topology_changes->read_new && target_endpoints.get_vector() != current_endpoints.get_vector()) {
-                add_mapping(read_endpoints, resolve_endpoints(target_endpoints, *tmptr).extract_set());
+                add_mapping(read_endpoints, std::move(target_endpoints).extract_set());
             }
 
             if (!depend_on_token) {
-                replication_map.emplace(default_replication_map_key, resolve_endpoints(current_endpoints, *tmptr).extract_vector());
+                replication_map.emplace(default_replication_map_key, std::move(current_endpoints).extract_vector());
                 break;
             } else if (current_tokens.contains(token)) {
-                replication_map.emplace(token, resolve_endpoints(current_endpoints, *tmptr).extract_vector());
+                replication_map.emplace(token, std::move(current_endpoints).extract_vector());
             }
         }
     } else if (depend_on_token) {
         for (const auto &t : sorted_tokens) {
-            auto eps = co_await rs->calculate_natural_ips(t, *tmptr);
+            auto eps = co_await rs->calculate_natural_endpoints(t, *tmptr);
             replication_map.emplace(t, std::move(eps).extract_vector());
         }
     } else {
-        auto eps = co_await rs->calculate_natural_ips(default_replication_map_key, *tmptr);
+        auto eps = co_await rs->calculate_natural_endpoints(default_replication_map_key, *tmptr);
         replication_map.emplace(default_replication_map_key, std::move(eps).extract_vector());
     }
 
@@ -472,14 +469,14 @@ auto vnode_effective_replication_map::clone_data_gently() const -> future<std::u
     co_return std::move(result);
 }
 
-const inet_address_vector_replica_set& vnode_effective_replication_map::do_get_natural_endpoints(const token& tok,
+inet_address_vector_replica_set vnode_effective_replication_map::do_get_natural_endpoints(const token& tok,
     bool is_vnode) const
 {
     const token& key_token = _rs->natural_endpoints_depend_on_token()
         ? (is_vnode ? tok : _tmptr->first_token(tok))
         : default_replication_map_key;
     const auto it = _replication_map.find(key_token);
-    return it->second;
+    return resolve_endpoints<inet_address_vector_replica_set>(it->second, *_tmptr);
 }
 
 inet_address_vector_replica_set vnode_effective_replication_map::get_natural_endpoints(const token& search_token) const {

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -140,10 +140,14 @@ std::optional<tablet_routing_info> vnode_effective_replication_map::check_locali
     return {};
 }
 
-bool vnode_effective_replication_map::has_pending_ranges(inet_address endpoint) const {
+bool vnode_effective_replication_map::has_pending_ranges(locator::host_id endpoint) const {
+    const auto ep = _tmptr->get_endpoint_for_host_id_if_known(endpoint);
+    if (!ep) {
+        return false;
+    }
     for (const auto& item : _pending_endpoints) {
         const auto& nodes = item.second;
-        if (nodes.contains(endpoint)) {
+        if (nodes.contains(*ep)) {
             return true;
         }
     }

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -483,8 +483,8 @@ inet_address_vector_replica_set vnode_effective_replication_map::get_natural_end
     return do_get_natural_endpoints(search_token, false);
 }
 
-stop_iteration vnode_effective_replication_map::for_each_natural_endpoint_until(const token& search_token, const noncopyable_function<stop_iteration(const inet_address&)>& func) const {
-    for (const auto& ep : do_get_natural_endpoints(search_token, false)) {
+stop_iteration vnode_effective_replication_map::for_each_natural_endpoint_until(const token& vnode_tok, const noncopyable_function<stop_iteration(const inet_address&)>& func) const {
+    for (const auto& ep : do_get_natural_endpoints(vnode_tok, true)) {
         if (func(ep) == stop_iteration::yes) {
             return stop_iteration::yes;
         }

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -230,7 +230,7 @@ public:
     /// Returns true if there are any pending ranges for this endpoint.
     /// This operation is expensive, for vnode_erm it iterates
     /// over all pending ranges which is O(number of tokens).
-    virtual bool has_pending_ranges(inet_address endpoint) const = 0;
+    virtual bool has_pending_ranges(locator::host_id endpoint) const = 0;
 
     /// Returns a token_range_splitter which is line with the replica assignment of this replication map.
     /// The splitter can live longer than this instance.
@@ -303,7 +303,7 @@ public: // effective_replication_map
     inet_address_vector_topology_change get_pending_endpoints(const token& search_token) const override;
     inet_address_vector_replica_set get_endpoints_for_reading(const token& search_token) const override;
     std::optional<tablet_routing_info> check_locality(const token& token) const override;
-    bool has_pending_ranges(inet_address endpoint) const override;
+    bool has_pending_ranges(locator::host_id endpoint) const override;
     std::unique_ptr<token_range_splitter> make_splitter() const override;
     const dht::sharder& get_sharder(const schema& s) const override;
 public:

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -327,8 +327,6 @@ public:
     // since future_state requires T to be no_throw_move_constructible.
     future<std::unique_ptr<cloned_data>> clone_data_gently() const;
 
-    stop_iteration for_each_natural_endpoint_until(const token& search_token, const noncopyable_function<stop_iteration(const inet_address&)>& func) const;
-
     // get_ranges() returns the list of ranges held by the given endpoint.
     // The list is sorted, and its elements are non overlapping and non wrap-around.
     // It the analogue of Origin's getAddressRanges().get(endpoint).
@@ -360,6 +358,7 @@ public:
 private:
     dht::token_range_vector do_get_ranges(noncopyable_function<stop_iteration(bool& add_range, const inet_address& natural_endpoint)> consider_range_for_endpoint) const;
     inet_address_vector_replica_set do_get_natural_endpoints(const token& tok, bool is_vnode) const;
+    stop_iteration for_each_natural_endpoint_until(const token& vnode_tok, const noncopyable_function<stop_iteration(const inet_address&)>& func) const;
 
 public:
     static factory_key make_factory_key(const replication_strategy_ptr& rs, const token_metadata_ptr& tmptr);

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -55,7 +55,7 @@ struct replication_strategy_params {
     explicit replication_strategy_params(const replication_strategy_config_options& o, std::optional<unsigned> it) noexcept : options(o), initial_tablets(it) {}
 };
 
-using replication_map = std::unordered_map<token, inet_address_vector_replica_set>;
+using replication_map = std::unordered_map<token, host_id_vector_replica_set>;
 
 using endpoint_set = utils::basic_sequenced_set<inet_address, inet_address_vector_replica_set>;
 using host_id_set = utils::basic_sequenced_set<locator::host_id, host_id_vector_replica_set>;
@@ -163,7 +163,7 @@ public:
     future<dht::token_range_vector> get_pending_address_ranges(const token_metadata_ptr tmptr, std::unordered_set<token> pending_tokens, locator::host_id pending_address, locator::endpoint_dc_rack dr) const;
 };
 
-using ring_mapping = boost::icl::interval_map<token, std::unordered_set<inet_address>>;
+using ring_mapping = boost::icl::interval_map<token, std::unordered_set<locator::host_id>>;
 using replication_strategy_ptr = seastar::shared_ptr<const abstract_replication_strategy>;
 using mutable_replication_strategy_ptr = seastar::shared_ptr<abstract_replication_strategy>;
 
@@ -359,7 +359,7 @@ public:
 
 private:
     dht::token_range_vector do_get_ranges(noncopyable_function<stop_iteration(bool& add_range, const inet_address& natural_endpoint)> consider_range_for_endpoint) const;
-    const inet_address_vector_replica_set& do_get_natural_endpoints(const token& tok, bool is_vnode) const;
+    inet_address_vector_replica_set do_get_natural_endpoints(const token& tok, bool is_vnode) const;
 
 public:
     static factory_key make_factory_key(const replication_strategy_ptr& rs, const token_metadata_ptr& tmptr);

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -465,13 +465,9 @@ public:
         return make_tablet_routing_info();
     }
 
-    virtual bool has_pending_ranges(inet_address endpoint) const override {
-        const auto host_id = _tmptr->get_host_id_if_known(endpoint);
-        if (!host_id.has_value()) {
-            return false;
-        }
+    virtual bool has_pending_ranges(locator::host_id host_id) const override {
         for (const auto& [id, transition_info]: get_tablet_map().transitions()) {
-            if (transition_info.pending_replica.host == *host_id) {
+            if (transition_info.pending_replica.host == host_id) {
                 return true;
             }
         }

--- a/service/raft/raft_address_map.hh
+++ b/service/raft/raft_address_map.hh
@@ -379,7 +379,4 @@ public:
 
 using raft_address_map = raft_address_map_t<seastar::lowres_clock>;
 
-// Populates the given raft_address_map from the mapping stored in the system.peers table.
-future<> load_address_map(db::system_keyspace&, raft_address_map&);
-
 } // end of namespace service

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -1721,12 +1721,6 @@ std::ostream& operator<<(std::ostream& os, group0_upgrade_state state) {
     return os;
 }
 
-future<> load_address_map(db::system_keyspace& sys_ks, raft_address_map& address_map) {
-    for (auto [ip, host] : co_await sys_ks.load_host_ids()) {
-        address_map.add_or_update_entry(raft::server_id(host.uuid()), ip);
-    }
-}
-
 
 } // end of namespace service
 

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -18,10 +18,6 @@
 #include "direct_failure_detector/failure_detector.hh"
 #include "service/raft/group0_fwd.hh"
 
-namespace gms {
-class gossiper;
-}
-
 namespace db {
 class system_keyspace;
 }
@@ -57,7 +53,6 @@ struct raft_server_for_group {
 
 class direct_fd_pinger;
 class direct_fd_proxy;
-class gossiper_state_change_subscriber_proxy;
 
 // This class is responsible for creating, storing and accessing raft servers.
 // It also manages the raft rpc verbs initialization.
@@ -67,10 +62,6 @@ class gossiper_state_change_subscriber_proxy;
 class raft_group_registry : public seastar::peering_sharded_service<raft_group_registry> {
 private:
     netw::messaging_service& _ms;
-    gms::gossiper& _gossiper;
-    // A proxy class representing subscription to on_change
-    // events, and updating the address map on this events.
-    shared_ptr<gossiper_state_change_subscriber_proxy> _gossiper_proxy;
     // Raft servers along with the corresponding timers to tick each instance.
     // Currently ticking every 100ms.
     std::unordered_map<raft::group_id, raft_server_for_group> _servers;
@@ -98,7 +89,7 @@ private:
 
 public:
     raft_group_registry(raft::server_id my_id, raft_address_map&, netw::messaging_service& ms,
-            gms::gossiper& gs, direct_failure_detector::failure_detector& fd);
+            direct_failure_detector::failure_detector& fd);
     ~raft_group_registry();
 
     // Called manually at start on every shard.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -392,7 +392,7 @@ future<> storage_service::sync_raft_topology_nodes(mutable_token_metadata_ptr tm
         tmptr->update_host_id(id, ip);
     };
 
-    for (const auto& id: _topology_state_machine._topology.left_nodes) {
+    auto process_left_node = [&] (raft::server_id id) -> future<> {
         auto ip = co_await id2ip(id);
         if (_gossiper.get_live_members().contains(ip) || _gossiper.get_unreachable_members().contains(ip)) {
             co_await remove_endpoint(ip, gms::null_permit_id);
@@ -404,6 +404,10 @@ future<> storage_service::sync_raft_topology_nodes(mutable_token_metadata_ptr tm
         //
         // However if we do that, we need to also implement unbanning a node and do it if `removenode` is aborted.
         co_await _messaging.local().ban_host(locator::host_id{id.uuid()});
+    };
+
+    for (const auto& id: _topology_state_machine._topology.left_nodes) {
+        co_await process_left_node(id);
     }
 
     auto process_normal_node = [&] (raft::server_id id, const replica_state& rs) -> future<> {
@@ -439,7 +443,7 @@ future<> storage_service::sync_raft_topology_nodes(mutable_token_metadata_ptr tm
         co_await process_normal_node(id, rs);
     }
 
-    for (const auto& [id, rs]: _topology_state_machine._topology.transition_nodes) {
+    auto process_transition_node = [&](raft::server_id id, const replica_state& rs) -> future<> {
         locator::host_id host_id{id.uuid()};
         auto ip = co_await id2ip(id);
 
@@ -509,6 +513,10 @@ future<> storage_service::sync_raft_topology_nodes(mutable_token_metadata_ptr tm
         default:
             on_fatal_internal_error(slogger, ::format("Unexpected state {} for node {}", rs.state, id));
         }
+    };
+
+    for (const auto& [id, rs]: _topology_state_machine._topology.transition_nodes) {
+        co_await process_transition_node(id, rs);
     }
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1175,11 +1175,11 @@ class topology_coordinator {
             group0_guard guard, const raft_topology_cmd& cmd,
             const std::unordered_set<raft::server_id>& exclude_nodes,
             drop_guard_and_retake drop_and_retake = drop_guard_and_retake::yes) {
-        auto nodes = _topo_sm._topology.normal_nodes | boost::adaptors::filtered(
-                [&exclude_nodes] (const std::pair<const raft::server_id, replica_state>& n) {
-                    return std::none_of(exclude_nodes.begin(), exclude_nodes.end(),
-                            [&n] (const raft::server_id& m) { return n.first == m; });
-                }) | boost::adaptors::map_keys;
+        auto nodes = _topo_sm._topology.normal_nodes
+            | boost::adaptors::filtered([&exclude_nodes] (const std::pair<const raft::server_id, replica_state>& n) {
+                return !exclude_nodes.contains(n.first);
+            })
+            | boost::adaptors::map_keys;
         if (drop_and_retake) {
             release_guard(std::move(guard));
         }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -40,6 +40,7 @@
 #include "raft/raft.hh"
 #include "node_ops/id.hh"
 #include "raft/server.hh"
+#include "service/raft/raft_address_map.hh"
 #include "service/topology_state_machine.hh"
 #include "service/tablet_allocator.hh"
 
@@ -334,6 +335,10 @@ public:
     future<> join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy);
 
     void set_group0(service::raft_group0&, bool raft_topology_change_enabled);
+
+    future<> init_address_map(raft_address_map& address_map);
+
+    future<> uninit_address_map();
 
     future<> drain_on_shutdown();
 
@@ -758,6 +763,10 @@ private:
         raft::term_t term{0};
         uint64_t last_index{0};
     } _raft_topology_cmd_handler_state;
+    class gossiper_state_change_subscriber_proxy;
+    // A proxy class representing subscription to on_change
+    // events, and updating the address map on this events.
+    shared_ptr<gossiper_state_change_subscriber_proxy> _gossiper_proxy;
 
     std::unordered_set<raft::server_id> find_raft_nodes_from_hoeps(const std::list<locator::host_id_or_endpoint>& hoeps);
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -791,6 +791,9 @@ public:
     future<> set_tablet_balancing_enabled(bool);
 
 private:
+    // Synchronizes the local node state (token_metadata, system.peers/system.local tables,
+    // gossiper) to align it with the other raft topology nodes.
+    future<> sync_raft_topology_nodes(mutable_token_metadata_ptr tmptr);
     // load topology state machine snapshot into memory
     // raft_group0_client::_read_apply_mutex must be held
     future<> topology_state_load();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -793,7 +793,8 @@ public:
 private:
     // Synchronizes the local node state (token_metadata, system.peers/system.local tables,
     // gossiper) to align it with the other raft topology nodes.
-    future<> sync_raft_topology_nodes(mutable_token_metadata_ptr tmptr);
+    // Optional target_node can be provided to restrict the synchronization to the specified node.
+    future<> sync_raft_topology_nodes(mutable_token_metadata_ptr tmptr, std::optional<locator::host_id> target_node);
     // load topology state machine snapshot into memory
     // raft_group0_client::_read_apply_mutex must be held
     future<> topology_state_load();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -763,10 +763,12 @@ private:
         raft::term_t term{0};
         uint64_t last_index{0};
     } _raft_topology_cmd_handler_state;
-    class gossiper_state_change_subscriber_proxy;
-    // A proxy class representing subscription to on_change
-    // events, and updating the address map on this events.
-    shared_ptr<gossiper_state_change_subscriber_proxy> _gossiper_proxy;
+    class raft_ip_address_updater;
+    // Represents a subscription to gossiper on_change events,
+    // updating the raft data structures that depend on
+    // IP addresses (raft_address_map, token_metadata.topology, erm-s),
+    // as well as the system.peers table.
+    shared_ptr<raft_ip_address_updater> _raft_ip_address_updater;
 
     std::unordered_set<raft::server_id> find_raft_nodes_from_hoeps(const std::list<locator::host_id_or_endpoint>& hoeps);
 

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -211,6 +211,9 @@ std::ostream& operator<<(std::ostream& os, const raft_topology_cmd::command& cmd
         case raft_topology_cmd::command::shutdown:
             os << "shutdown";
             break;
+        case raft_topology_cmd::command::wait_for_ip:
+            os << "wait_for_ip";
+            break;
     }
     return os;
 }

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -195,6 +195,7 @@ struct raft_topology_cmd {
           stream_ranges,        // request to stream data, return when streaming is
                                 // done
           shutdown,             // a decommissioning node should shut down
+          wait_for_ip           // wait for a joining node IP to appear in raft_address_map
       };
       command cmd;
 

--- a/test/topology/test_change_ip.py
+++ b/test/topology/test_change_ip.py
@@ -9,6 +9,9 @@ Test clusters can restart fine after an IP address change.
 
 import logging
 import pytest
+from test.pylib.util import wait_for_cql_and_get_hosts, wait_for
+from test.pylib.random_tables import Column, IntType, TextType
+import time
 logger = logging.getLogger(__name__)
 
 
@@ -17,7 +20,10 @@ async def test_change_two(manager, random_tables):
     """Stop two nodes, change their IPs and start, check the cluster is
     functional"""
     servers = await manager.running_servers()
-    table = await random_tables.add_table(ncolumns=5)
+    table = await random_tables.add_table(name='t1', pks=1, columns=[
+        Column("pk", IntType),
+        Column('int_c', IntType)
+    ])
     s_1 = servers[1].server_id
     s_2 = servers[2].server_id
     logger.info("Gracefully stopping servers %s and %s to change ips", s_1, s_2)
@@ -27,5 +33,33 @@ async def test_change_two(manager, random_tables):
     await manager.server_change_ip(s_2)
     await manager.server_start(s_1)
     await manager.server_start(s_2)
-    await table.add_column()
+
+    manager.driver_close()
+    await manager.driver_connect()
+    cql = manager.get_cql()
+    servers = await manager.running_servers()
+
+    await table.add_column(column=Column("str_c", TextType))
     await random_tables.verify_schema()
+
+    host0 = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 60))[0]
+    all_ips = set([s.rpc_address for s in servers])
+    logger.info(f"waiting for {servers[0]} to see its peers, all ips {all_ips}")
+    async def see_peers():
+        peers = set()
+        for r in await cql.run_async("select peer from system.peers", host=host0):
+            peers.add(r.peer)
+        remaining = all_ips - {servers[0].rpc_address} - peers
+        if not remaining:
+            return True
+        logger.info(f"waiting for {host0} to see its peers, all_ips {all_ips}, peers {peers}, remaining {remaining}")
+    await wait_for(see_peers, time.time() + 60)
+
+    await cql.run_async(f"USE {random_tables.keyspace}")
+    await cql.run_async("insert into t1(pk, int_c, str_c) values (1, 2, 'test-val')", host=host0)
+    rows = list(await cql.run_async("select * from t1", host=host0))
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.pk == 1
+    assert row.int_c == 2
+    assert row.str_c == 'test-val'


### PR DESCRIPTION
The loop in `id2ip` lambda makes problems if we are applying an old raft log that contains long-gone nodes. In this case, we may never receive the `IP` for a node and stuck in the loop forever. In this series we replace the loop with an if - we just don't update the `host_id <-> ip` mapping in the `token_metadata.topology` if we don't have an `IP` yet.

The PR moves `host_id -> IP` resolution to the data plane, now it happens each time the IP-based methods of `erm` are called. We need this because IPs may not be known at the time the erm is built. The overhead of `raft_address_map` lookup is added to each data plane request, but it should be negligible. In this PR `erm/resolve_endpoints` continues to treat missing IP for `host_id` as `internal_error`, but we plan to relax this in the follow-up (see this PR first comment).