### PR TITLE
build: enable -Wimplicit-int-float-conversion

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1522,7 +1522,6 @@ def get_warning_options(cxx):
         '-Wno-overloaded-virtual',
         '-Wno-unused-command-line-argument',
         '-Wno-unsupported-friend',
-        '-Wno-implicit-int-float-conversion',
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77728
         '-Wno-psabi',
         '-Wno-narrowing',


### PR DESCRIPTION
a209ae15 addresses the last -Wimplicit-int-float-conversion warning in the tree, so we now have the luxury of enabling this warning.