### PR TITLE
[Backport to 5.2] Merge 'Optimize topology::compare_endpoints' from Benny Halevy

### DIFF
--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -12,6 +12,7 @@
 
 #include <unordered_set>
 #include <unordered_map>
+#include <compare>
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
@@ -100,8 +101,13 @@ private:
     /**
      * compares two endpoints in relation to the target endpoint, returning as
      * Comparator.compare would
+     *
+     * The closest nodes to a given node are:
+     * 1. The node itself
+     * 2. Nodes in the same RACK as the reference node
+     * 3. Nodes in the same DC as the reference node
      */
-    int compare_endpoints(const inet_address& address, const inet_address& a1, const inet_address& a2) const;
+    std::weak_ordering compare_endpoints(const inet_address& address, const inet_address& a1, const inet_address& a2) const;
 
     /** multi-map: DC -> endpoints in that DC */
     std::unordered_map<sstring,
@@ -123,6 +129,9 @@ private:
     std::unordered_set<sstring> _datacenters;
 
     void calculate_datacenters();
+
+public:
+    void test_compare_endpoints(const inet_address& address, const inet_address& a1, const inet_address& a2) const;
 };
 
 } // namespace locator


### PR DESCRIPTION
The code for compare_endpoints originates at the dawn of time (locator: Convert AbstractNetworkTopologySnitch.java to C++) and is called on the fast path from storage_proxy via `sort_by_proximity`.

This series considerably reduces the function's footprint by:
1. carefully coding the many comparisons in the function so to reduce the number of conditional banches (apparently the compiler isn't doing a good enough job at optimizing it in this case)
2. avoid sstring copy in topology::get_{datacenter,rack}

\Closes #12761
Refs #14008

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>
(cherry picked from commit 6aa91c13c5af70fe0a3e3ba737f671615287eaef)