### PR TITLE
service: validate replication strategy constraints in tablet-moving API

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2547,6 +2547,14 @@
                      "allowMultiple":false,
                      "type":"integer",
                      "paramType":"query"
+                  },
+                  {
+                     "name":"force",
+                     "description":"When set to true, replication strategy constraints can be broken (false by default)",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"boolean",
+                     "paramType":"query"
                   }
                ]
             }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1478,10 +1478,13 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         auto ks = req->get_query_param("ks");
         auto table = req->get_query_param("table");
         auto table_id = ctx.db.local().find_column_family(ks, table).schema()->id();
+        auto force_str = req->get_query_param("force");
+        auto force = service::loosen_constraints(force_str == "" ? false : validate_bool(force_str));
 
         co_await ss.local().move_tablet(table_id, token,
             locator::tablet_replica{src_host_id, src_shard_id},
-            locator::tablet_replica{dst_host_id, dst_shard_id});
+            locator::tablet_replica{dst_host_id, dst_shard_id},
+            force);
 
         co_return json_void();
     });

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -103,6 +103,7 @@ enum class disk_error { regular, commit };
 class node_ops_meta_data;
 
 using start_hint_manager = seastar::bool_class<class start_hint_manager_tag>;
+using loosen_constraints = seastar::bool_class<class loosen_constraints_tag>;
 
 /**
  * This abstraction contains the token/identifier of this node
@@ -797,7 +798,7 @@ public:
 
     future<> do_cluster_cleanup();
 public:
-    future<> move_tablet(table_id, dht::token, locator::tablet_replica src, locator::tablet_replica dst);
+    future<> move_tablet(table_id, dht::token, locator::tablet_replica src, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> set_tablet_balancing_enabled(bool);
 
     // In the maintenance mode, other nodes won't be available thus we disabled joining


### PR DESCRIPTION
Validate replication strategy constraints in /storage_service/tablets/move API:
- replicas are not on the same node
- replicas don't move across DC (violates RF in each DC)
- availability is not reduced due to rack overloading

Add flag to force tablet move even though dc/rack constraints aren't fulfilled.

Test for the change: https://github.com/scylladb/scylla-dtest/pull/3911.

Fixes: #16379.