### PR TITLE
test/alternator: fix flaky test in test_filter_expression.py

### DIFF
--- a/test/alternator/test_filter_expression.py
+++ b/test/alternator/test_filter_expression.py
@@ -40,7 +40,7 @@ def random_sets():
 def random_bool():
     return bool(random.randint(0,1))
 def random_item(p, i):
-    item = {'p': p, 'c': i, 's': random_s(), 'b': random_b(), 'i': random_i(),
+    item = {'p': p, 'c': i, 's': random_s(), 'b': random_b(), 'i': i,
             'l': random_l(), 'm': random_m(), 'ns': random_set(), 'ss': random_sets(), 'bool': random_bool() }
     # The "r" attribute doesn't appears on all items, and when it does it has a random type
     if i == 0:


### PR DESCRIPTION
The test test_filter_expression.py::test_filter_expression_precedence is flaky - and can fail very rarely (so far we've only actually seen it fail once). The problem is that the test generates items with random clustering keys, chosen as an integer between 1 and 1 million, and there is a chance (roughly 2/10,000) that two of the 20 items happen to have the same key, so one of the items is "lost" and the comparison we do to the expected truth fails.

The solution is to just use sequential keys, not random keys. There is nothing to gain in this test by using random keys.

To make this test bug easy to reproduce, I temporarily changed random_i()'s range from 1,000,000 to 3, and saw the test failing every single run before this patch. After this patch - no longer using random_i() for the keys - the test doesn't fail any more.

Fixes #16647