### PR TITLE
gms: heart_beat_state: add formatter for gms::heart_beat_state

### DIFF
--- a/gms/endpoint_state.cc
+++ b/gms/endpoint_state.cc
@@ -35,7 +35,7 @@ const versioned_value* endpoint_state::get_application_state_ptr(application_sta
 }
 
 std::ostream& operator<<(std::ostream& os, const endpoint_state& x) {
-    os << "HeartBeatState = " << x._heart_beat_state << ", AppStateMap =";
+    fmt::print(os, "HeartBeatState = {}, AppStateMap =", x._heart_beat_state);
     for (auto&entry : x._application_state) {
         const application_state& state = entry.first;
         const versioned_value& value = entry.second;

--- a/gms/heart_beat_state.hh
+++ b/gms/heart_beat_state.hh
@@ -12,7 +12,7 @@
 
 #include "gms/generation-number.hh"
 #include "gms/version_generator.hh"
-#include <ostream>
+#include <fmt/core.h>
 #include <limits>
 
 namespace gms {
@@ -61,9 +61,16 @@ public:
         _version = std::numeric_limits<version_type>::max();
     }
 
-    friend inline std::ostream& operator<<(std::ostream& os, const heart_beat_state& h) {
-        return os << "{ generation = " << h._generation << ", version = " << h._version << " }";
-    }
+    friend fmt::formatter<heart_beat_state>;
 };
 
 } // gms
+
+template<>
+struct fmt::formatter<gms::heart_beat_state> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const gms::heart_beat_state& h, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{{ generation = {}, version = {} }}",
+                              h._generation, h._version);
+    }
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define a formatter for gms::heart_beat_state, and remove its operator<<(). the only caller site of its operator<< is updated to use `fmt::print()`

Refs #13245
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>