### PR TITLE
tools/scylla-sstable: pass error handler to utils::config_file::read_from_file()

### DIFF
--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2992,7 +2992,9 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
         }
 
         if (file_exists(scylla_yaml_path).get()) {
-            dbcfg.read_from_file(scylla_yaml_path).get();
+            dbcfg.read_from_file(scylla_yaml_path, [] (const sstring& opt, const sstring& msg, std::optional<::utils::config_file::value_status> status) {
+                sst_log.debug("error processing configuration item: {} : {}", msg, opt);
+            }).get();
             dbcfg.setup_directories();
             sst_log.debug("Successfully read scylla.yaml from {} location of {}", scylla_yaml_path_source, scylla_yaml_path);
         } else {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -3013,7 +3013,9 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
             if (!schema_sources) {
                 sst_log.debug("No user-provided schema source, attempting to auto-detect it");
                 schema_with_source = try_load_schema_autodetect(app_config, dbcfg);
-            } else if (schema_sources == 1) {
+            } else if (schema_sources == 1 || (schema_sources == 2 && app_config.contains("scylla-yaml-file"))) {
+                // We make an exception for the case where 2 schema sources are provided, but one of them is scylla-yaml file.
+                // We want to always accept the --scylla-yaml-file option.
                 sst_log.debug("Single schema source provided");
                 schema_with_source = try_load_schema_from_user_provided_source(app_config, dbcfg);
             } else {


### PR DESCRIPTION
The default error handler throws an exception, which means scylla-sstable will exit with exception if there is any problem in the configuration. Not even ScyllaDB itself is this harsh -- it will just log a warning for most errors. A tool should be much more lenient. So this patch passes an error handler which just logs all errors with debug level.
If reading an sstable fails, the user is expected to investigate turning debug-level logging on. When they do so, they will see any problems while reading the configuration (if it is relevant, e.g. when using EAR).

Fixes: #16538