### PR TITLE
load_meter: get_load_map(): don't unconditionally dereference _lb

### DIFF
--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -44,11 +44,11 @@ future<std::map<sstring, double>> load_meter::get_load_map() {
                 load_map.emplace(format("{}", x.first), x.second);
                 llogger.debug("get_load_map endpoint={}, load={}", x.first, x.second);
             }
+            load_map.emplace(format("{}",
+                    _lb->gossiper().get_broadcast_address()), get_load());
         } else {
             llogger.debug("load_broadcaster is not set yet!");
         }
-        load_map.emplace(format("{}",
-                _lb->gossiper().get_broadcast_address()), get_load());
         return load_map;
     });
 }


### PR DESCRIPTION
Said method has a check on `_lb` not being null, before accessing it. However, since 0e5754a, there was an unconditional access, adding an entry for the local node. Move this inside the if, so it is covered by the null-check. The only caller is the api (probably nodetool), the worst that can happend is that they get completely empty load-map if they call too early during startup.

Fixes: #16617