### PR TITLE
tasks: call release_resources when task is finished

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -573,7 +573,6 @@ future<compaction_manager::compaction_stats_opt> compaction_manager::perform_com
     auto unregister_task = defer([this, task_executor] {
         _tasks.remove(task_executor);
         task_executor->switch_state(compaction_task_executor::state::none);
-        task_executor->release_resources();
     });
 
     if (parent_info) {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1322,9 +1322,6 @@ future<> repair::user_requested_repair_task_impl::run() {
                 auto task = co_await local_repair._repair_module->make_and_start_task<repair::shard_repair_task_impl>(parent_data, tasks::task_id::create_random_id(), keyspace,
                         local_repair, germs->get().shared_from_this(), std::move(ranges), std::move(table_ids),
                         id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), streaming::stream_reason::repair, hints_batchlog_flushed, small_table_optimization, ranges_parallelism);
-                auto release_task_resources = defer([&] () noexcept {
-                    task->release_resources();
-                });
                 co_await task->done();
             });
             repair_results.push_back(std::move(f));
@@ -1447,9 +1444,6 @@ future<> repair::data_sync_repair_task_impl::run() {
                         id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), reason, hints_batchlog_flushed, small_table_optimization, ranges_parallelism);
                 task_impl_ptr->neighbors = std::move(neighbors);
                 auto task = co_await local_repair._repair_module->make_task(std::move(task_impl_ptr), parent_data);
-                auto release_task_resources = defer([&] () noexcept {
-                    task->release_resources();
-                });
                 task->start();
                 co_await task->done();
             });

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -137,6 +137,7 @@ void task_manager::task::impl::finish() noexcept {
         _status.end_time = db_clock::now();
         _status.state = task_manager::task_state::done;
         _done.set_value();
+        release_resources();
     }
 }
 
@@ -146,6 +147,7 @@ void task_manager::task::impl::finish_failed(std::exception_ptr ex, std::string 
         _status.state = task_manager::task_state::failed;
         _status.error = std::move(error);
         _done.set_exception(ex);
+        release_resources();
     }
 }
 
@@ -255,10 +257,6 @@ const task_manager::foreign_task_list& task_manager::task::get_children() const 
 
 bool task_manager::task::is_complete() const noexcept {
     return _impl->is_complete();
-}
-
-void task_manager::task::release_resources() noexcept {
-    return _impl->release_resources();
 }
 
 task_manager::module::module(task_manager& tm, std::string name) noexcept : _tm(tm), _name(std::move(name)) {

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -170,7 +170,6 @@ public:
         void unregister_task() noexcept;
         const foreign_task_list& get_children() const noexcept;
         bool is_complete() const noexcept;
-        void release_resources() noexcept;
 
         friend class test_task;
         friend class ::repair::task_manager_module;


### PR DESCRIPTION
Call task_manager::task::impl::release_resources when task is finished instead of putting the responsibility on user.