### PR TITLE
view: revert cleanup filter that doesn't work with tablets

### DIFF
--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -169,8 +169,7 @@ future<> view_update_generator::start() {
                     auto close_sr = deferred_close(staging_sstable_reader);
 
                     inject_failure("view_update_generator_consume_staging_sstable");
-                    auto result = staging_sstable_reader.consume_in_thread(view_updating_consumer(*this, s, std::move(permit), *t, sstables, _as, staging_sstable_reader_handle),
-                        dht::incremental_owned_ranges_checker::make_partition_filter(_db.get_keyspace_local_ranges(s->ks_name())));
+                    auto result = staging_sstable_reader.consume_in_thread(view_updating_consumer(*this, s, std::move(permit), *t, sstables, _as, staging_sstable_reader_handle));
                     if (result == stop_iteration::yes) {
                         break;
                     }

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -179,6 +179,8 @@ future<> view_update_generator::start() {
                     // Need to add sstables back to the set so we can retry later. By now it may
                     // have had other updates.
                     std::move(sstables.begin(), sstables.end(), std::back_inserter(_sstables_with_tables[t]));
+                    // Sleep a bit, to avoid a tight loop repeatedly spamming the log with the same message.
+                    seastar::sleep(std::chrono::seconds(1)).get();
                     break;
                 }
                 try {

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -11,7 +11,6 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include "dht/token-sharding.hh"
-#include "dht/partition_filter.hh"
 #include "utils/class_registrator.hh"
 #include "types/types.hh"
 #include "utils/murmur_hash.hh"
@@ -390,12 +389,6 @@ split_range_to_shards(dht::partition_range pr, const schema& s, const sharder& r
         rprs = sharder.next(s);
     }
     return ret;
-}
-
-flat_mutation_reader_v2::filter incremental_owned_ranges_checker::make_partition_filter(const dht::token_range_vector& sorted_owned_ranges) {
-    return [checker = incremental_owned_ranges_checker(sorted_owned_ranges)] (const dht::decorated_key& dk) mutable {
-        return checker.belongs_to_current_node(dk.token());
-    };
 }
 
 future<dht::partition_range_vector> subtract_ranges(const schema& schema, const dht::partition_range_vector& source_ranges, dht::partition_range_vector ranges_to_subtract) {

--- a/dht/partition_filter.hh
+++ b/dht/partition_filter.hh
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "dht/i_partitioner_fwd.hh"
-#include "readers/flat_mutation_reader_v2.hh"
+#include "dht/token.hh"
 
 namespace dht {
 
@@ -46,7 +46,6 @@ public:
         return &*_it++;
     }
 
-    static flat_mutation_reader_v2::filter make_partition_filter(const dht::token_range_vector& sorted_owned_ranges);
 };
 
 } // dht


### PR DESCRIPTION
The goal of this PR is fix Scylla so that the dtest test_mvs_populating_from_existing_data, which starts to fail when enabling tablets, will pass.

The main fix (the second patch) is reverting code which doesn't work with tablets, and I explain why I think this code was not necessary in the first place.

Fixes #16598