### PR TITLE
tools: do not include unused headers

### DIFF
--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -10,10 +10,10 @@
 #include <boost/algorithm/string/join.hpp>
 #include <filesystem>
 #include <set>
-#include <source_location>
 #include <fmt/chrono.h>
 #include <seastar/core/coroutine.hh>
 #include <seastar/util/closeable.hh>
+#include <seastar/core/queue.hh>
 
 #include "compaction/compaction.hh"
 #include "compaction/compaction_strategy.hh"
@@ -29,9 +29,6 @@
 #include "sstables/sstables_manager.hh"
 #include "sstables/sstable_directory.hh"
 #include "sstables/open_info.hh"
-#include "types/user.hh"
-#include "types/set.hh"
-#include "types/map.hh"
 #include "tools/json_writer.hh"
 #include "tools/lua_sstable_consumer.hh"
 #include "tools/schema_loader.hh"

--- a/tools/scylla-types.cc
+++ b/tools/scylla-types.cc
@@ -12,7 +12,6 @@
 
 #include "compound.hh"
 #include "db/marshal/type_parser.hh"
-#include "log.hh"
 #include "schema/schema_builder.hh"
 #include "tools/utils.hh"
 #include "dht/i_partitioner.hh"


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.