### PR TITLE
test/pylib: shutdown unix RESTful client

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -53,6 +53,7 @@ class ManagerClient():
     async def stop(self):
         """Close driver"""
         self.driver_close()
+        await self.client.shutdown()
 
     async def driver_connect(self, server: Optional[ServerInfo] = None) -> None:
         """Connect to cluster"""

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -122,6 +122,9 @@ class UnixRESTClient(RESTClient):
         self.default_host: str = f"{os.path.basename(sock_path)}"
         self.connector = UnixConnector(path=sock_path)
 
+    async def shutdown(self):
+        await self.connector.close()
+
 
 class TCPRESTClient(RESTClient):
     """An async helper for REST API operations"""


### PR DESCRIPTION
when stopping the ManagerClient, it would be better to close all connected connector, otherwise aiohttp complains like:

```
13:57:53.763 ERROR> Unclosed connector
connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x7f939d2ca5f0>, 96672.211256817)]']
connector: <aiohttp.connector.UnixConnector object at 0x7f939d2da890>
```

this warning message is printed to the console, and it is distracting when testing manually.

so, in this change, let's close the client connecting to unix domain socket.