### PR TITLE
test.py: print out paths to all servers log files for TopologyTest

### DIFF
--- a/test.py
+++ b/test.py
@@ -787,8 +787,8 @@ Check test log at {}.""".format(self.log_filename))
                 # 1) failed pre-check, e.g. start failure
                 # 2) failed test execution.
                 if self.is_executed_ok is False:
-                    self.server_log = cluster.read_server_log()
-                    self.server_log_filename = cluster.server_log_filename()
+                    self.server_log = next(cluster.read_server_log())
+                    self.server_log_filename = next(cluster.server_log_filename())
                     if self.is_before_test_ok is False:
                         set_summary("pre-check failed: {}".format(e))
                         print("Test {} {}".format(self.name, self.summary))
@@ -921,8 +921,8 @@ class PythonTest(Test):
             self.is_after_test_ok = True
             self.success = status
         except Exception as e:
-            self.server_log = cluster.read_server_log()
-            self.server_log_filename = cluster.server_log_filename()
+            self.server_log = next(cluster.read_server_log())
+            self.server_log_filename = next(cluster.server_log_filename())
             if self.is_before_test_ok is False:
                 print("Test {} pre-check failed: {}".format(self.name, str(e)))
                 print("Server log of the first server:\n{}".format(self.server_log))
@@ -963,8 +963,8 @@ class TopologyTest(PythonTest):
                 await manager.start()
                 self.success = await run_test(self, options)
             except Exception as e:
-                self.server_log = manager.cluster.read_server_log()
-                self.server_log_filename = manager.cluster.server_log_filename()
+                self.server_log = next(manager.cluster.read_server_log())
+                self.server_log_filename = next(manager.cluster.server_log_filename())
                 if manager.is_before_test_ok is False:
                     print("Test {} pre-check failed: {}".format(self.name, str(e)))
                     print("Server log of the first server:\n{}".format(self.server_log))

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -18,7 +18,7 @@ import shutil
 import tempfile
 import time
 import traceback
-from typing import Any, Optional, Dict, List, Set, Tuple, Callable, AsyncIterator, NamedTuple, Union
+from typing import Any, Optional, Dict, List, Set, Tuple, Callable, AsyncIterator, Iterator, NamedTuple, Union
 import uuid
 from enum import Enum
 from io import BufferedWriter
@@ -809,21 +809,15 @@ class ScyllaCluster:
         for server in self.running.values():
             server.take_log_savepoint()
 
-    def read_server_log(self) -> str:
+    def read_server_log(self) -> Iterator[str]:
         """Read log data of failed server"""
-        # FIXME: pick failed server
-        if self.running:
-            return next(iter(self.running.values())).read_log()
-        else:
-            return ""
+        for server in self.running.values():
+            yield server.read_log()
 
-    def server_log_filename(self) -> Optional[pathlib.Path]:
+    def server_log_filename(self) -> Iterator[pathlib.Path]:
         """The log file name of the failed server"""
-        # FIXME: pick failed server
-        if self.running:
-            return next(server for server in self.running.values()).log_filename
-        else:
-            return None
+        for server in self.running.values():
+            yield server.log_filename
 
     def __str__(self):
         running = ", ".join(str(server) for server in self.running.values())


### PR DESCRIPTION
TopologyTest is likely to involve multiple servers. so it would be
ideal if we can print out all servers' logging messages when the
test fails.

before this change,

- `TopologyTest` does not collect the server's logging message
  if a test fails. it does so only when an exception is thrown.
  but if a test fails without throwing an exception, the server
  logging messages are not collected.
- `TopologyTest` just inherits the behavior of
  `PythonTest.print_summary()`, where only a single server's log
  messagess are printed when an exception is thrown.

after this change,

- the paths to the servers' logging files are collected when
  the test fails or throws.
- `TopologyTest` overrides `print_summary()` and print out
  paths to all servers' logging messages if the test fails.

`self.server_log_filename` is used when printing the
summary of JUnit tests in `write_junit_report()`, which is used
when printing the test summary in the JUnit test report XML.
and this XML is in turn consumed by Jenkins for rendering on
a per-test basis. since we already have the paths printed already
stdout, there is no need to include the path of the first
server in the XML file, so the corresponding
`TopologyTest.write_junit_failure_report()` is not defined.

Refs https://github.com/scylladb/scylladb/issues/16656