### PR TITLE
Improve task-tracking memory leak

### DIFF
--- a/test/cql-pytest/test_tablets.py
+++ b/test/cql-pytest/test_tablets.py
@@ -1,0 +1,47 @@
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+#############################################################################
+# Some tests for the new "tablets"-based replication, replicating the old
+# "vnodes". Eventually, ScyllaDB will use tablets by default and all tests
+# will run using tablets, but these tests are for specific issues discovered
+# while developing tablets that didn't exist for vnodes. Note that most tests
+# for tablets require multiple nodes, and are in the test/topology*
+# directory, so here we'll probably only ever have a handful of single-node
+# tests.
+#############################################################################
+
+import pytest
+from util import unique_name
+from cassandra.protocol import ConfigurationException
+
+# A fixture similar to "test_keyspace", just creates a keyspace that enables
+# tablets with initial_tablets=128
+# The "initial_tablets" feature doesn't work if the "tablets" experimental
+# feature is not turned on; In such a case, the tests using this fixture
+# will be skipped.
+@pytest.fixture(scope="module")
+def test_keyspace_128_tablets(cql, this_dc):
+    name = unique_name()
+    try:
+        cql.execute("CREATE KEYSPACE " + name + " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "': 1, 'initial_tablets': 128 }")
+    except ConfigurationException:
+        pytest.skip('Scylla does not support initial_tablets, or the tablets feature is not enabled')
+    yield name
+    cql.execute("DROP KEYSPACE " + name)
+
+# In the past (issue #16493), repeatedly creating and deleting a table
+# would leak memory. Creating a table with 128 tablets would make this
+# leak 128 times more serious and cause a failure faster. This is a
+# reproducer for this problem. We basically expect this test not to
+# OOM Scylla - the test doesn't "check" anything, the way it failed was
+# for Scylla to run out of memory and then fail one of the CREATE TABLE
+# or DROP TABLE operations in the loop.
+# Note that this test doesn't even involve any data inside the table.
+# Reproduces #16493.
+def test_create_loop_with_tablets(cql, test_keyspace_128_tablets):
+    table = test_keyspace_128_tablets + "." + unique_name()
+    for i in range(100):
+        cql.execute(f"CREATE TABLE {table} (p int PRIMARY KEY, v int)")
+        cql.execute("DROP TABLE " + table)


### PR DESCRIPTION
This PR improves a rather serious memory leak we had - creating and deleting a table just 100 times in a keyspace with 128 tablets would run out of memory (for 1GB memory). The first patch is a Seastar update which a wastage of memory in abortable_fifo, and the second patch is a test reproducing Scylla running out of memory in 100 iterations of create and drop of the same table.

Note that this patch probably does not get rid of the memory leak entirely. Most of the memory leakage is gone, and now 10,000 iterations of create and delete work just fine - but it is assumed that the task structures that contained the wasteful abortable_fifo are still leaked - they are just much smaller. This will need to be fixed separately. I want to get this interim fix quickly because it interferes with testing Scylla with tablets (every time a test ends up creating and deleting many tables, it runs out of memory).

Fixes #16493.