### PR TITLE
streaming: handle table drop gracefully

### DIFF
--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -192,6 +192,9 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
                     auto distribute = [this, cf_id, s] (flat_mutation_reader_v2 producer,
                             std::function<future<> (flat_mutation_reader_v2)> consumer) -> future<received_partitions_t> {
                         try {
+                            utils::get_local_injector().inject("stream_mutation_fragments_table_dropped", [this] () {
+                                _db.local().find_column_family(table_id::create_null_id());
+                            });
                             auto& table = _db.local().find_column_family(cf_id);
                             auto op = table.stream_in_progress();
                             auto sharder_ptr = std::make_unique<dht::auto_refreshing_sharder>(table.shared_from_this());

--- a/streaming/stream_transfer_task.cc
+++ b/streaming/stream_transfer_task.cc
@@ -177,9 +177,9 @@ future<> send_mutation_fragments(lw_shared_ptr<send_info> si) {
                 }).handle_exception([&sink, got_error_from_peer] (std::exception_ptr ep) mutable {
                     // Notify the receiver the sender has failed
                     if (*got_error_from_peer) {
-                    return sink(frozen_mutation_fragment(bytes_ostream()), stream_mutation_fragments_cmd::error).then([ep = std::move(ep)] () mutable {
-                        return make_exception_future<>(std::move(ep));
-                    });
+                        return sink(frozen_mutation_fragment(bytes_ostream()), stream_mutation_fragments_cmd::error).then([ep = std::move(ep)] () mutable {
+                            return make_exception_future<>(std::move(ep));
+                        });
                     }
                     return make_ready_future();
                 }).finally([&sink] () mutable {
@@ -189,11 +189,11 @@ future<> send_mutation_fragments(lw_shared_ptr<send_info> si) {
         }();
 
         return when_all_succeed(std::move(source_op), std::move(sink_op)).then_unpack([got_error_from_peer, table_is_dropped, si] {
-                if (*table_is_dropped) {
-                     sslog.info("[Stream #{}] Skipped streaming the dropped table {}.{}", si->plan_id, si->cf->schema()->ks_name(), si->cf->schema()->cf_name());
-                } else if (*got_error_from_peer) {
-                    throw std::runtime_error(format("Peer failed to process mutation_fragment peer={}, plan_id={}, cf_id={}", si->id.addr, si->plan_id, si->cf_id));
-                }
+            if (*table_is_dropped) {
+                sslog.info("[Stream #{}] Skipped streaming the dropped table {}.{}", si->plan_id, si->cf->schema()->ks_name(), si->cf->schema()->cf_name());
+            } else if (*got_error_from_peer) {
+                throw std::runtime_error(format("Peer failed to process mutation_fragment peer={}, plan_id={}, cf_id={}", si->id.addr, si->plan_id, si->cf_id));
+            }
         });
     });
   });

--- a/test/topology_custom/test_streaming.py
+++ b/test/topology_custom/test_streaming.py
@@ -1,0 +1,11 @@
+from test.pylib.manager_client import ManagerClient
+import pytest
+
+@pytest.mark.asyncio
+async def test_drop_table_during_streaming_receiver_side(manager: ManagerClient):
+    servers = [await manager.server_add(config={
+        'error_injections_at_startup': ['stream_mutation_fragments_table_dropped'],
+        'enable_repair_based_node_ops': False,
+        'enable_user_defined_functions': False,
+        'experimental_features': []
+    }) for _ in range(2)]

--- a/test/topology_custom/test_streaming.py
+++ b/test/topology_custom/test_streaming.py
@@ -9,3 +9,12 @@ async def test_drop_table_during_streaming_receiver_side(manager: ManagerClient)
         'enable_user_defined_functions': False,
         'experimental_features': []
     }) for _ in range(2)]
+
+@pytest.mark.asyncio
+async def test_drop_table_during_streaming_sender_side(manager: ManagerClient):
+    servers = [await manager.server_add(config={
+        'error_injections_at_startup': ['stream_transfer_task_execute_table_dropped'],
+        'enable_repair_based_node_ops': False,
+        'enable_user_defined_functions': False,
+        'experimental_features': []
+    }) for _ in range(2)]


### PR DESCRIPTION
Handle gracefully a situation when mutation fragments
of a table are streamed to a destination node which has already 
dropped the table.

Fixes: #15370