### PR TITLE
utils: config_file: throw bpo::invalid_option_value() when seeing inv…

### DIFF
--- a/utils/config_file_impl.hh
+++ b/utils/config_file_impl.hh
@@ -184,7 +184,13 @@ void utils::config_file::named_value<T>::add_command_line_option(boost::program_
     // NOTE. We are not adding default values. We could, but must in that case manually (in some way) generate the textual
     // version, since the available ostream operators for things like pairs and collections don't match what we can deal with parser-wise.
     // See removed ostream operators above.
-    init(hyphenated_name.data(), value_ex<T>()->notifier([this](T new_val) { set(std::move(new_val), config_source::CommandLine); }), desc().data());
+    init(hyphenated_name.data(), value_ex<T>()->notifier([this](T new_val) {
+        try {
+            set(std::move(new_val), config_source::CommandLine);
+        } catch (const std::invalid_argument& e) {
+            throw bpo::invalid_option_value(e.what());
+        }
+    }), desc().data());
 
     if (!alias().empty()) {
         const auto alias_desc = fmt::format("Alias for {}", hyphenated_name);


### PR DESCRIPTION
…alid option

before this change, `std::invalid_argument` is thrown by `bpo::notify(configuration)` in `app_template::run_deprecated()` when invalid option is passed in via command line. `utils::named_value` throws `std::invalid_argument` if the given value is not listed in `_allowed_values`. but we don't handle `std::invalid_argument` in `app_template::run_deprecated()`. so the application aborts with unhandled exception if the specified argument is not allowed.

in this change, we convert the `std::invalid_argument` to a derived class of `bpo::error` in the customized notify handler, so that it can be handled in `app_template::run_deprecated()`.

because `name_value::operator()` is also used otherwhere, we should not throw a bpo::error there. so its exception type is preserved.

Fixes #16687
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>