### PR TITLE
feature_service: abort if sstable_format < md

### DIFF
--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -52,16 +52,13 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
     fcfg._disabled_features = std::move(disabled);
 
     switch (sstables::version_from_string(cfg.sstable_format())) {
-    case sstables::sstable_version_types::ka:
-    case sstables::sstable_version_types::la:
-    case sstables::sstable_version_types::mc:
-        fcfg._disabled_features.insert("MD_SSTABLE_FORMAT"s);
-        [[fallthrough]];
     case sstables::sstable_version_types::md:
         fcfg._disabled_features.insert("ME_SSTABLE_FORMAT"s);
-        [[fallthrough]];
+        break;
     case sstables::sstable_version_types::me:
         break;
+    default:
+        assert(false && "Invalid sstable_format");
     }
 
     if (!cfg.enable_user_defined_functions()) {


### PR DESCRIPTION
sstable_format comes from scylla.yaml or from the command line arguments, and we gate scylla from unallowed sstable formats lower than `md` when parsing the configuration, and scylla bails out at seeing the unallowed sstable format like:

```
terminate called after throwing an instance of 'std::invalid_argument'
  what():  Invalid value for sstable_format: got ka which is not inside the set of allowed values md, me
Aborted (core dumped)
```

scylla errors out way before `feature_config_from_db_config()` gets called -- it throws in `bpo::notify(configuration)`,  before `func` is evaluated in `app_template::run_deprecated()`.

so, in this change, we do not handle these values anymore, and consider it a bug if we run into any of them.

Refs #16551
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>