### PR TITLE
tasks: compaction: drop regular compaction tasks after they are finished

### DIFF
--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -707,6 +707,10 @@ public:
     virtual std::string type() const override {
         return "regular compaction";
     }
+
+    virtual tasks::is_internal is_internal() const noexcept override {
+        return tasks::is_internal::yes;
+    }
 protected:
     virtual future<> run() override = 0;
 };

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -197,7 +197,11 @@ void task_manager::task::start() {
         // Background fiber does not capture task ptr, so the task can be unregistered and destroyed independently in the foreground.
         // After the ttl expires, the task id will be used to unregister the task if that didn't happen in any other way.
         auto module = _impl->_module;
-        (void)done().finally([module] {
+        bool drop_after_complete = is_internal() && !get_parent_id();
+        (void)done().finally([module, drop_after_complete] {
+            if (drop_after_complete) {
+                return make_ready_future<>();
+            }
             return sleep_abortable(module->get_task_manager().get_task_ttl(), module->abort_source());
         }).then_wrapped([module, id = id()] (auto f) {
             f.ignore_ready_future();


### PR DESCRIPTION
Make compaction tasks internal. Drop all internal tasks without parents
immediately after they are done.

Fixes: #16735
Refs: #16694.