### PR TITLE
transport: remove additional options from TABLETS_ROUTING_V1

### DIFF
--- a/transport/cql_protocol_extension.cc
+++ b/transport/cql_protocol_extension.cc
@@ -35,8 +35,6 @@ std::vector<seastar::sstring> additional_options_for_proto_ext(cql_protocol_exte
             return {format("LWT_OPTIMIZATION_META_BIT_MASK={:d}", cql3::prepared_metadata::LWT_FLAG_MASK)};
         case cql_protocol_extension::RATE_LIMIT_ERROR:
             return {format("ERROR_CODE={}", exceptions::exception_code::RATE_LIMIT_ERROR)};
-        case cql_protocol_extension::TABLETS_ROUTING_V1:
-            return {"TABLETS_ROUTING_V1"};
         default:
             return {};
     }


### PR DESCRIPTION
The TABLETS_ROUTING_V1 protocol extension does not have any additional options; it only carries information about support for sending tablet info to the drivers. Previously, in this case, the name of the extension was added as the additional option. However, this only generated duplication and did not provide any benefit.

Now, this has been removed, and there is no duplication anymore.