### PR TITLE
build: cmake: add "unit_test_list" target

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,6 +44,12 @@ function(add_scylla_test name)
   add_executable(${name} ${src})
   add_dependencies(tests ${name})
 
+  cmake_path(RELATIVE_PATH CMAKE_CURRENT_SOURCE_DIR
+    BASE_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    OUTPUT_VARIABLE dirname)
+  list(APPEND scylla_tests "${dirname}/${name}")
+  set(scylla_tests "${scylla_tests}" PARENT_SCOPE)
+
   target_include_directories(${name}
     PRIVATE
       ${CMAKE_SOURCE_DIR})
@@ -87,3 +93,12 @@ if(BUILD_TESTING)
     add_subdirectory(raft)
     add_subdirectory(resource/wasm)
 endif()
+
+if(CMAKE_CONFIGURATION_TYPES)
+  set(by_products_option BYPRODUCTS test-list.phony.stamp)
+endif()
+add_custom_target(unit_test_list
+  COMMAND echo -e "'$<LIST:JOIN,${scylla_tests},\\n>'"
+  COMMENT "List configured unit tests"
+  ${by_products_option}
+  COMMAND_EXPAND_LISTS)

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -360,3 +360,7 @@ add_scylla_test(wasm_test
   KIND SEASTAR)
 add_scylla_test(pretty_printers_test
   KIND BOOST)
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/suite.yaml")
+  set(scylla_tests "${scylla_tests}" PARENT_SCOPE)
+endif()

--- a/test/raft/CMakeLists.txt
+++ b/test/raft/CMakeLists.txt
@@ -35,3 +35,7 @@ add_scylla_test(randomized_nemesis_test
 add_scylla_test(replication_test
   KIND SEASTAR
   LIBRARIES test-raft)
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/suite.yaml")
+  set(scylla_tests "${scylla_tests}" PARENT_SCOPE)
+endif()

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -20,3 +20,7 @@ add_scylla_test(row_cache_alloc_stress_test
   KIND UNIT)
 add_scylla_test(row_cache_stress_test
   KIND UNIT)
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/suite.yaml")
+  set(scylla_tests "${scylla_tests}" PARENT_SCOPE)
+endif()


### PR DESCRIPTION
this target is used by test.py for enumerating unit tests

* test/CMakeLists.txt: append executable's full path to `scylla_tests`. add `unit_test_list` target printing `scylla_tests`, please note, `cmake -E echo` does not support the `-e` option of `echo`, and ninja does not support command line with newline in it, we have to use `echo` to print the list of tests.
* test/{boost,raft,unit}/CMakeLists.txt: set scylla_tests only if $PWD/suite.yaml exists. we could hardwire this logic in these files, as it is known that this file exists in these directory, but this is still put this way, so that it serves as a comment explaining that the reason why we update scylla_tests here but not somewhere else where we also use `add_scylla_test()` function is just suite.yaml exists here.