### PR TITLE
test.py: adapt to cmake building system

### DIFF
--- a/test.py
+++ b/test.py
@@ -90,6 +90,11 @@ def path_to(mode, *components):
     return os.path.join(build_dir, mode, *components)
 
 
+def ninja(target):
+    """Build specified target using ninja"""
+    return subprocess.Popen(['ninja', target], stdout=subprocess.PIPE).communicate()[0].decode()
+
+
 class TestSuite(ABC):
     """A test suite is a folder with tests of the same type.
     E.g. it can be unit tests, boost tests, or CQL tests."""
@@ -1277,7 +1282,7 @@ def parse_cmd_line() -> argparse.Namespace:
 
     if not args.modes:
         try:
-            out = subprocess.Popen(['ninja', 'mode_list'], stdout=subprocess.PIPE).communicate()[0].decode()
+            out = ninja('mode_list')
             # [1/1] List configured modes
             # debug release dev
             args.modes = re.sub(r'.* List configured modes\n(.*)\n', r'\1',
@@ -1303,7 +1308,7 @@ def parse_cmd_line() -> argparse.Namespace:
 
     # Get the list of tests configured by configure.py
     try:
-        out = subprocess.Popen(['ninja', 'unit_test_list'], stdout=subprocess.PIPE).communicate()[0].decode()
+        out = ninja('unit_test_list')
         # [1/1] List configured unit tests
         args.tests = set(re.sub(r'.* List configured unit tests\n(.*)\n', r'\1', out, 1, re.DOTALL).split("\n"))
     except Exception:

--- a/test.py
+++ b/test.py
@@ -92,7 +92,11 @@ def path_to(mode, *components):
 
 def ninja(target):
     """Build specified target using ninja"""
-    return subprocess.Popen(['ninja', target], stdout=subprocess.PIPE).communicate()[0].decode()
+    build_dir = 'build'
+    args = ['ninja', target]
+    if os.path.exists(os.path.join(build_dir, 'build.ninja')):
+        args = ['ninja', '-C', build_dir, target]
+    return subprocess.Popen(args, stdout=subprocess.PIPE).communicate()[0].decode()
 
 
 class TestSuite(ABC):

--- a/test.py
+++ b/test.py
@@ -45,9 +45,12 @@ launch_time = time.monotonic()
 
 output_is_a_tty = sys.stdout.isatty()
 
-all_modes = set(['debug', 'release', 'dev', 'sanitize', 'coverage'])
+all_modes = {'debug': 'Debug',
+             'release': 'RelWithDebInfo',
+             'dev': 'Dev',
+             'sanitize': 'Sanitize',
+             'coverage': 'Coverage'}
 debug_modes = set(['debug', 'sanitize'])
-
 
 def create_formatter(*decorators) -> Callable[[Any], str]:
     """Return a function which decorates its argument with the given
@@ -1199,7 +1202,7 @@ def parse_cmd_line() -> argparse.Namespace:
         help="""Path to temporary test data and log files. The data is
         further segregated per build mode. Default: ./testlog.""",
     )
-    parser.add_argument('--mode', choices=all_modes, action="append", dest="modes",
+    parser.add_argument('--mode', choices=all_modes.keys(), action="append", dest="modes",
                         help="Run only tests for given build mode(s)")
     parser.add_argument('--repeat', action="store", default="1", type=int,
                         help="number of times to repeat test execution")


### PR DESCRIPTION
in this series, we adapt to cmake building system by mapping scylla build mode to `CMAKE_BUILD_TYPE` and by using `build/build.ninja` if it exists, as `configure.py` generates `build.ninja` in `build` when using CMake for creating `build.ninja`.