### PR TITLE
compaction: do not include unused headers

### DIFF
--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -16,7 +16,6 @@
 #include <seastar/core/file.hh>
 #include "sstables/types_fwd.hh"
 #include "sstables/sstable_set.hh"
-#include "utils/UUID.hh"
 #include "compaction_fwd.hh"
 #include "mutation_writer/token_group_based_splitting_writer.hh"
 

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -21,7 +21,6 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include "sstables/exceptions.hh"
 #include "sstables/sstable_directory.hh"
-#include "locator/abstract_replication_strategy.hh"
 #include "utils/error_injection.hh"
 #include "utils/UUID_gen.hh"
 #include "db/system_keyspace.hh"

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -21,7 +21,6 @@
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/condition-variable.hh>
-#include "log.hh"
 #include "sstables/shared_sstable.hh"
 #include "utils/exponential_backoff_retry.hh"
 #include "utils/updateable_value.hh"
@@ -29,7 +28,6 @@
 #include <vector>
 #include <list>
 #include <functional>
-#include <algorithm>
 #include "compaction.hh"
 #include "compaction_backlog_manager.hh"
 #include "compaction/compaction_descriptor.hh"

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -15,12 +15,11 @@
 #include "seastar/core/on_internal_error.hh"
 #include "sstables/shared_sstable.hh"
 #include "sstables/sstables.hh"
-#include "compaction.hh"
 #include "compaction_strategy.hh"
 #include "compaction_strategy_impl.hh"
 #include "compaction_strategy_state.hh"
+#include "cql3/statements/property_definitions.hh"
 #include "schema/schema.hh"
-#include "sstables/sstable_set.hh"
 #include <boost/range/algorithm/find.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/adaptors.hpp>

--- a/compaction/compaction_strategy_impl.hh
+++ b/compaction/compaction_strategy_impl.hh
@@ -8,12 +8,10 @@
 
 #pragma once
 
-#include "cql3/statements/property_definitions.hh"
 #include "compaction_backlog_manager.hh"
 #include "compaction_strategy.hh"
 #include "db_clock.hh"
 #include "compaction_descriptor.hh"
-#include "tombstone_gc.hh"
 
 namespace sstables {
 

--- a/compaction/compaction_strategy_state.hh
+++ b/compaction/compaction_strategy_state.hh
@@ -11,7 +11,6 @@
 #include "time_window_compaction_strategy.hh"
 #include "leveled_compaction_strategy.hh"
 #include <utility>
-#include <type_traits>
 #include <variant>
 
 namespace compaction {

--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -8,6 +8,7 @@
 
 #include "sstables/sstables.hh"
 #include "size_tiered_compaction_strategy.hh"
+#include "cql3/statements/property_definitions.hh"
 
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/adaptors.hpp>

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -7,9 +7,10 @@
  */
 
 #include "time_window_compaction_strategy.hh"
-#include "leveled_manifest.hh"
 #include "mutation_writer/timestamp_based_splitting_writer.hh"
 #include "mutation/mutation_source_metadata.hh"
+#include "cql3/statements/property_definitions.hh"
+#include "sstables/sstables.hh"
 #include "compaction_strategy_state.hh"
 
 #include <boost/range/algorithm/find.hpp>


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.