### PR TITLE
scylla-gdb.py: introduce scylla large-objects

### DIFF
--- a/test/scylla_gdb/test_misc.py
+++ b/test/scylla_gdb/test_misc.py
@@ -81,6 +81,12 @@ def test_small_object_1(gdb):
 def test_small_object_2(gdb):
     scylla(gdb, 'small-object -o 64 --summarize')
 
+def test_large_objects_1(gdb):
+    scylla(gdb, 'large-objects -o 131072 --random-page')
+
+def test_large_objects_2(gdb):
+    scylla(gdb, 'large-objects -o 32768 --summarize')
+
 def test_lsa(gdb):
     scylla(gdb, 'lsa')
 


### PR DESCRIPTION
The equivalent of small-objects, but for large objects (spans). Allows listing object of a large-class, and therefore investigating a run-away class, by attempting to identify the owners of the objects in it.

Written to investigate #16493

New functionality, no backport needed.