### PR TITLE
utils: specialize fmt::formatter for utils::tagged_integer

### DIFF
--- a/utils/tagged_integer.hh
+++ b/utils/tagged_integer.hh
@@ -13,6 +13,8 @@
 #include <iostream>
 #include <type_traits>
 
+#include <fmt/core.h>
+
 namespace utils {
 
 // Note: do not use directly, use utils::tagged_integer instead.
@@ -83,6 +85,15 @@ template <typename Tag, std::integral ValueType>
 using tagged_integer = tagged_tagged_integer<struct final, Tag, ValueType>;
 
 } // namespace utils
+
+template <typename Final, typename Tag, std::integral ValueType>
+struct fmt::formatter<utils::tagged_tagged_integer<Final, Tag, ValueType>> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const utils::tagged_tagged_integer<Final, Tag, ValueType>& x,
+		fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", x.value());
+    }
+};
 
 namespace std {
 


### PR DESCRIPTION
This change introduces a specialization of fmt::formatter for utils::tagged_integer. This enables the usage of this type with FMTv10, which dropped the default generated formatter.

Usage of utils::tagged_integer without the defined formatter resulted in compilation error when compiled with FMTv10.

Refs: #13245