### PR TITLE
 db: Make the "me" sstable format mandatory

### DIFF
--- a/db/sstables-format-selector.cc
+++ b/db/sstables-format-selector.cc
@@ -66,7 +66,6 @@ sstables_format_listener::sstables_format_listener(gms::gossiper& g, sharded<gms
     : _gossiper(g)
     , _features(f)
     , _selector(selector)
-    , _md_feature_listener(*this, sstables::sstable_version_types::md)
     , _me_feature_listener(*this, sstables::sstable_version_types::me)
 { }
 
@@ -87,7 +86,6 @@ future<> sstables_format_listener::start() {
     // The listener may fire immediately, create a thread for that case.
     co_await seastar::async([this] {
         _features.local().me_sstable.when_enabled(_me_feature_listener);
-        _features.local().md_sstable.when_enabled(_md_feature_listener);
     });
 }
 

--- a/db/sstables-format-selector.hh
+++ b/db/sstables-format-selector.hh
@@ -68,7 +68,6 @@ class sstables_format_listener {
     seastar::named_semaphore _sem = {1, named_semaphore_exception_factory{"feature listeners"}};
     seastar::gate _sel;
 
-    feature_enabled_listener _md_feature_listener;
     feature_enabled_listener _me_feature_listener;
 public:
     sstables_format_listener(gms::gossiper& g, sharded<gms::feature_service>& f, sstables_format_selector& selector);

--- a/docs/architecture/sstable/index.rst
+++ b/docs/architecture/sstable/index.rst
@@ -9,6 +9,8 @@ ScyllaDB SSTable Format
 
 .. include:: _common/sstable_what_is.rst
 
+* In Scylla 5.5 and above, *me* format is enabled by default.
+
 * In Scylla Enterprise 2021.1, Scylla 4.3 and above, *md* format is enabled by default.
   
 * In Scylla 3.1 and above, *mc* format is enabled by default. 

--- a/docs/architecture/sstable/sstable3/index.rst
+++ b/docs/architecture/sstable/sstable3/index.rst
@@ -12,6 +12,7 @@ ScyllaDB SSTable - 3.x
 
 .. include:: ../_common/sstable_what_is.rst
 
+* In ScyllaDB 5.5 and above, the ``me`` format is mandatory, and ``md`` format is used only when upgrading from an existing cluster using ``md``. The ``sstable_format`` parameter is ignored if it is set to ``md``.
 * In ScyllaDB 5.1 and above, the ``me`` format is enabled by default.
 * In ScyllaDB 4.3 to 5.0, the ``md`` format is enabled by default.
 * In ScyllaDB 3.1 to 4.2, the ``mc`` format is enabled by default. 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -52,16 +52,13 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
     fcfg._disabled_features = std::move(disabled);
 
     switch (sstables::version_from_string(cfg.sstable_format())) {
-    case sstables::sstable_version_types::ka:
-    case sstables::sstable_version_types::la:
-    case sstables::sstable_version_types::mc:
-        fcfg._disabled_features.insert("MD_SSTABLE_FORMAT"s);
-        [[fallthrough]];
     case sstables::sstable_version_types::md:
         fcfg._disabled_features.insert("ME_SSTABLE_FORMAT"s);
         [[fallthrough]];
     case sstables::sstable_version_types::me:
         break;
+    default:
+        assert(false && "Invalid sstable_format");
     }
 
     if (!cfg.enable_user_defined_functions()) {

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -53,8 +53,8 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
 
     switch (sstables::version_from_string(cfg.sstable_format())) {
     case sstables::sstable_version_types::md:
-        fcfg._disabled_features.insert("ME_SSTABLE_FORMAT"s);
-        [[fallthrough]];
+        logger.warn("sstable_format must be 'me', '{}' is specified", cfg.sstable_format());
+        break;
     case sstables::sstable_version_types::me:
         break;
     default:

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -89,7 +89,7 @@ private:
     // that format. read_sstables_format() also overwrites _sstables_format
     // if an sstable format was chosen earlier (and this choice was persisted
     // in the system table).
-    sstable_version_types _format = sstable_version_types::mc;
+    sstable_version_types _format = sstable_version_types::md;
 
     // _active and _undergoing_close are used in scylla-gdb.py to fetch all sstables
     // on current shard using "scylla sstables" command. If those fields are renamed,


### PR DESCRIPTION
The `me` sstable format includes an important feature of storing the `host_id` of the local node when writing sstables.
The is crucial for validating the sstable's `replay_position` in stats metadata as it is valid only on the originating node and shard (#10080), therefor we would like to make the me format mandatory.

in this series, `sstable_format` option is deprecated, and the default sstable format is bumped up from `mc` to `md`, so that a cluster composed of nodes with this change should always use `me` as the sstable format.  if a node with this change joins a 5.x cluster which still using `md` because they are configured as such, this node will also be using `md`, unless the other node(s) changes its `sstable_format` setting to `me`.

Fixes #16551