### PR TITLE
test/cql-pytest: add reproducer for task-tracking memory leak

### DIFF
--- a/test/cql-pytest/test_tablets.py
+++ b/test/cql-pytest/test_tablets.py
@@ -1,0 +1,47 @@
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+#############################################################################
+# Some tests for the new "tablets"-based replication, replicating the old
+# "vnodes". Eventually, ScyllaDB will use tablets by default and all tests
+# will run using tablets, but these tests are for specific issues discovered
+# while developing tablets that didn't exist for vnodes. Note that most tests
+# for tablets require multiple nodes, and are in the test/topology*
+# directory, so here we'll probably only ever have a handful of single-node
+# tests.
+#############################################################################
+
+import pytest
+from util import unique_name
+from cassandra.protocol import ConfigurationException
+
+# A fixture similar to "test_keyspace", just creates a keyspace that enables
+# tablets with initial_tablets=128
+# The "initial_tablets" feature doesn't work if the "tablets" experimental
+# feature is not turned on; In such a case, the tests using this fixture
+# will be skipped.
+@pytest.fixture(scope="module")
+def test_keyspace_128_tablets(cql, this_dc):
+    name = unique_name()
+    try:
+        cql.execute("CREATE KEYSPACE " + name + " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "': 1, 'initial_tablets': 128 }")
+    except ConfigurationException:
+        pytest.skip('Scylla does not support initial_tablets, or the tablets feature is not enabled')
+    yield name
+    cql.execute("DROP KEYSPACE " + name)
+
+# In the past (issue #16493), repeatedly creating and deleting a table
+# would leak memory. Creating a table with 128 tablets would make this
+# leak 128 times more serious and cause a failure faster. This is a
+# reproducer for this problem. We basically expect this test not to
+# OOM Scylla - the test doesn't "check" anything, the way it failed was
+# for Scylla to run out of memory and then fail one of the CREATE TABLE
+# or DROP TABLE operations in the loop.
+# Note that this test doesn't even involve any data inside the table.
+# Reproduces #16493.
+def test_create_loop_with_tablets(cql, test_keyspace_128_tablets):
+    table = test_keyspace_128_tablets + "." + unique_name()
+    for i in range(100):
+        cql.execute(f"CREATE TABLE {table} (p int PRIMARY KEY, v int)")
+        cql.execute("DROP TABLE " + table)


### PR DESCRIPTION
This patch adds a reproducer test for the memory leak described in issue #16493: If a table is repeatedly created and dropped, memory is leaked by task tracking. Although this "leak" can be temporary if task_ttl_in_seconds is properly configured, it may still use too much memory if tables are too frequently created and dropped. The test here shows that (before #16493 was fixed) as little as 100 tables created and deleted can cause Scylla to run out of memory.

The problem is severely exacerbated when tablets are used which is why the test here uses tablets. Before the fix for #16493 (a Seastar patch, scylladb/seastar#2023), this test of 100 iterations always failed (with test/cql-pytest/run's default memory allowance). After the fix, the test doesn't fail in 100 iterations - and even if increased manually to 10,000 iterations it doesn't fail.

The new test uses the initial_tablets feature, so requires Scylla to be run with the "tablets" experimental option turned on. This is not currently the default of test.py or test/cql-pytest/run, so I turned it on manually to check this test. I also checked that the test is correctly skipped if tablets are not turned on.

Refs #16493