### PR TITLE
tablets: alter keyspace

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -55,6 +55,10 @@ struct query_processor::remote {
     seastar::gate gate;
 };
 
+bool query_processor::topology_global_queue_empty() {
+    return remote().first.get().ss.topology_global_queue_empty();
+}
+
 static service::query_state query_state_for_internal_call() {
     return {service::client_state::for_internal_calls(), empty_service_permit()};
 }

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -1039,6 +1039,7 @@ query_processor::execute_schema_statement(const statements::schema_altering_stat
             co_await remote_.get().mm.announce<service::topology_change>(std::move(m), std::move(*guard), description);
             // TODO: eliminate timeout from alter ks statement on the cqlsh/driver side
             auto error = co_await remote_.get().ss.wait_for_topology_request_completion(request_id);
+            co_await remote_.get().ss.wait_for_topology_not_busy();
             if (!error.empty()) {
                 log.error("CQL statement \"{}\" with topology request_id \"{}\" failed with error: \"{}\"", stmt.raw_cql_statement, request_id, error);
                 throw exceptions::request_execution_exception(exceptions::exception_code::INVALID, error);

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -461,6 +461,8 @@ public:
 
     void reset_cache();
 
+    bool topology_global_queue_empty();
+
 private:
     // Keep the holder until you stop using the `remote` services.
     std::pair<std::reference_wrapper<remote>, gate::holder> remote();

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -150,7 +150,8 @@ public:
 
     ~query_processor();
 
-    void start_remote(service::migration_manager&, service::forward_service&, service::raft_group0_client&);
+    void start_remote(service::migration_manager&, service::forward_service&,
+                      service::storage_service& ss, service::raft_group0_client&);
     future<> stop_remote();
 
     data_dictionary::database db() {

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -49,11 +49,16 @@ public:
 private:
     std::optional<sstring> _strategy_class;
 public:
+    ks_prop_defs() = default;
+    explicit ks_prop_defs(std::map<sstring, sstring> options);
+
     void validate();
     std::map<sstring, sstring> get_replication_options() const;
     std::optional<sstring> get_replication_strategy_class() const;
     std::optional<unsigned> get_initial_tablets(const sstring& strategy_class, bool enabled_by_default) const;
     data_dictionary::storage_options get_storage_options() const;
+    bool get_durable_writes() const;
+    std::map<sstring, sstring> get_all_options_flattened(const gms::feature_service& feat) const;
     lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata(sstring ks_name, const locator::token_metadata&, const gms::feature_service&);
     lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata&, const gms::feature_service&);
 };

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -63,6 +63,7 @@ protected:
 
 public:
     virtual future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const = 0;
+    mutable utils::UUID global_req_id;
 };
 
 }

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -289,6 +289,17 @@ For instance::
 
 The supported options are the same as :ref:`creating a keyspace <create-keyspace-statement>`.
 
+ALTER KEYSPACE with Tablets :label-caution:`Experimental`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Modifying a keyspace with tablets enabled is possible and doesn't require any special CQL syntax. However, there are some limitations:
+
+- The replication factor (RF) can be increased or decreased by at most 1 at a time. To reach the desired RF value, modify the RF repeatedly.
+- The ``ALTER`` statement rejects the ``replication_factor`` tag. List the DCs explicitly when altering a keyspace. See :ref:`NetworkTopologyStrategy <replication-strategy>`.
+- If there's any other ongoing global topology operation, executing the ``ALTER`` statement will fail (with an explicit and specific error) and needs to be repeated.
+- The ``ALTER`` statement may take longer than the regular query timeout, and even if it times out, it will continue to execute in the background.
+- The replication strategy cannot be modified, as keyspaces with tablets only support ``NetworkTopologyStrategy``.
+
 .. _drop-keyspace-statement:
 
 DROP KEYSPACE

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -549,7 +549,10 @@ CREATE TABLE system.topology (
     committed_cdc_generations set<tuple<timestamp, timeuuid>> static,
     unpublished_cdc_generations set<tuple<timestamp, timeuuid>> static,
     global_topology_request text static,
+    global_topology_request_id timeuuid static,
     new_cdc_generation_data_uuid timeuuid static,
+    new_keyspace_rf_change_ks_name text static,
+    new_keyspace_rf_change_data frozen<map<text, text>> static,
     PRIMARY KEY (key, host_id)
 )
 ```
@@ -575,8 +578,11 @@ There are also a few static columns for cluster-global properties:
 - `committed_cdc_generations` - the IDs of the committed CDC generations
 - `unpublished_cdc_generations` - the IDs of the committed yet unpublished CDC generations
 - `global_topology_request` - if set, contains one of the supported global topology requests
+- `global_topology_request_id` - if set, contains global topology request's id, which is a new group0's state id
 - `new_cdc_generation_data_uuid` - used in `commit_cdc_generation` state, the time UUID of the generation to be committed
 - `upgrade_state` - describes the progress of the upgrade to raft-based topology.
+- 'new_keyspace_rf_change_ks_name' - the name of the KS that is being the target of the scheduled ALTER KS statement 
+- 'new_keyspace_rf_change_data' - the KS options to be used when executing the scheduled ALTER KS statement
 
 # Join procedure
 

--- a/docs/operating-scylla/procedures/cluster-management/add-dc-to-existing-dc.rst
+++ b/docs/operating-scylla/procedures/cluster-management/add-dc-to-existing-dc.rst
@@ -156,7 +156,9 @@ Add New DC
       UN   54.160.174.243  109.54 KB       256     ?               c7686ffd-7a5b-4124-858e-df2e61130aaa    RACK1
       UN   54.235.9.159    109.75 KB       256     ?               39798227-9f6f-4868-8193-08570856c09a    RACK1
       UN   54.146.228.25   128.33 KB       256     ?               7a4957a1-9590-4434-9746-9c8a6f796a0c    RACK1
-   
+
+.. TODO possibly provide additional information WRT how ALTER works with tablets
+
 #. When all nodes are up and running ``ALTER`` the following Keyspaces in the new nodes:
 
    * Keyspace created by the user (which needed to replicate to the new DC).

--- a/idl/group0_state_machine.idl.hh
+++ b/idl/group0_state_machine.idl.hh
@@ -27,12 +27,16 @@ struct topology_change {
     std::vector<canonical_mutation> mutations;
 };
 
+struct mixed_change {
+    std::vector<canonical_mutation> mutations;
+};
+
 struct write_mutations {
     std::vector<canonical_mutation> mutations;
 };
 
 struct group0_command {
-    std::variant<service::schema_change, service::broadcast_table_query, service::topology_change, service::write_mutations> change;
+    std::variant<service::schema_change, service::broadcast_table_query, service::topology_change, service::write_mutations, service::mixed_change> change;
     canonical_mutation history_append;
 
     std::optional<utils::UUID> prev_state_id;

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -53,7 +53,7 @@ using can_yield = utils::can_yield;
 
 using replication_strategy_config_options = std::map<sstring, sstring>;
 struct replication_strategy_params {
-    const replication_strategy_config_options& options;
+    const replication_strategy_config_options options;
     std::optional<unsigned> initial_tablets;
     explicit replication_strategy_params(const replication_strategy_config_options& o, std::optional<unsigned> it) noexcept : options(o), initial_tablets(it) {}
 };

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -136,6 +136,7 @@ public:
 
     // Apply a group 0 change.
     // The future resolves after the change is applied locally.
+    template<typename mutation_type = schema_change>
     future<> announce(std::vector<mutation> schema, group0_guard, std::string_view description);
 
     void passive_announce(table_schema_version version);
@@ -164,6 +165,7 @@ private:
 
     future<> maybe_schedule_schema_pull(const table_schema_version& their_version, const gms::inet_address& endpoint);
 
+    template<typename mutation_type = schema_change>
     future<> announce_with_raft(std::vector<mutation> schema, group0_guard, std::string_view description);
     future<> announce_without_raft(std::vector<mutation> schema, group0_guard);
 
@@ -192,6 +194,17 @@ public:
     // For tests only.
     void set_concurrent_ddl_retries(size_t);
 };
+
+extern template
+future<> migration_manager::announce_with_raft<schema_change>(std::vector<mutation> schema, group0_guard, std::string_view description);
+extern template
+future<> migration_manager::announce_with_raft<topology_change>(std::vector<mutation> schema, group0_guard, std::string_view description);
+
+extern template
+future<> migration_manager::announce<schema_change>(std::vector<mutation> schema, group0_guard, std::string_view description);
+extern template
+future<> migration_manager::announce<topology_change>(std::vector<mutation> schema, group0_guard, std::string_view description);
+
 
 future<column_mapping> get_column_mapping(db::system_keyspace& sys_ks, table_id, table_schema_version v);
 

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -168,6 +168,11 @@ future<> group0_state_machine::merge_and_apply(group0_state_machine_merger& merg
         co_await write_mutations_to_database(_sp, cmd.creator_addr, std::move(chng.mutations));
         co_await _ss.topology_transition();
     },
+    [&] (mixed_change& chng) -> future<> {
+        co_await _mm.merge_schema_from(netw::messaging_service::msg_addr(std::move(cmd.creator_addr)), std::move(chng.mutations));
+        co_await _ss.topology_transition();
+        co_return;
+    },
     [&] (write_mutations& muts) -> future<> {
         return write_mutations_to_database(_sp, cmd.creator_addr, std::move(muts.mutations));
     }

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -46,6 +46,12 @@ struct topology_change {
     std::vector<canonical_mutation> mutations;
 };
 
+// Allows executing combined topology & schema mutations under a single RAFT command.
+// The order of the mutations doesn't matter.
+struct mixed_change {
+    std::vector<canonical_mutation> mutations;
+};
+
 // This command is used to write data to tables other than topology or
 // schema tables and it doesn't update any in-memory data structures.
 struct write_mutations {
@@ -53,7 +59,7 @@ struct write_mutations {
 };
 
 struct group0_command {
-    std::variant<schema_change, broadcast_table_query, topology_change, write_mutations> change;
+    std::variant<schema_change, broadcast_table_query, topology_change, write_mutations, mixed_change> change;
 
     // Mutation of group0 history table, appending a new state ID and optionally a description.
     canonical_mutation history_append;

--- a/service/raft/group0_state_machine_merger.cc
+++ b/service/raft/group0_state_machine_merger.cc
@@ -78,6 +78,9 @@ std::vector<canonical_mutation>& group0_state_machine_merger::get_command_mutati
         [] (topology_change& chng) -> std::vector<canonical_mutation>& {
             return chng.mutations;
         },
+        [] (mixed_change& chng) -> std::vector<canonical_mutation>& {
+            return chng.mutations;
+        },
         [] (write_mutations& muts) -> std::vector<canonical_mutation>& {
             return muts.mutations;
         }

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -297,7 +297,7 @@ future<group0_guard> raft_group0_client::start_operation(seastar::abort_source* 
 }
 
 template<typename Command>
-requires std::same_as<Command, schema_change> || std::same_as<Command, topology_change> || std::same_as<Command, write_mutations>
+requires std::same_as<Command, schema_change> || std::same_as<Command, topology_change> || std::same_as<Command, write_mutations> || std::same_as<Command, mixed_change>
 group0_command raft_group0_client::prepare_command(Command change, group0_guard& guard, std::string_view description) {
     group0_command group0_cmd {
         .change{std::move(change)},
@@ -501,5 +501,6 @@ template group0_command raft_group0_client::prepare_command(topology_change chan
 template group0_command raft_group0_client::prepare_command(write_mutations change, group0_guard& guard, std::string_view description);
 template group0_command raft_group0_client::prepare_command(broadcast_table_query change, std::string_view description);
 template group0_command raft_group0_client::prepare_command(write_mutations change, std::string_view description);
+template group0_command raft_group0_client::prepare_command(mixed_change change, group0_guard& guard, std::string_view description);
 
 }

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -137,7 +137,7 @@ public:
     requires std::same_as<Command, broadcast_table_query> || std::same_as<Command, write_mutations>
     group0_command prepare_command(Command change, std::string_view description);
     template<typename Command>
-    requires std::same_as<Command, schema_change> || std::same_as<Command, topology_change> || std::same_as<Command, write_mutations>
+    requires std::same_as<Command, schema_change> || std::same_as<Command, topology_change> || std::same_as<Command, write_mutations> || std::same_as<Command, mixed_change>
     group0_command prepare_command(Command change, group0_guard& guard, std::string_view description);
     // Checks maximum allowed serialized command size, server rejects bigger commands with command_is_too_big_error exception
     size_t max_command_size() const;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -903,6 +903,7 @@ public:
     // Waits for a topology request with a given ID to complete and return non empty error string
     // if request completes with an error
     future<sstring> wait_for_topology_request_completion(utils::UUID id);
+    future<> wait_for_topology_not_busy();
 
 private:
     future<std::vector<canonical_mutation>> get_system_mutations(schema_ptr schema);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -818,6 +818,11 @@ private:
     // coordinator fiber
     future<> raft_state_monitor_fiber(raft::server&, sharded<db::system_distributed_keyspace>& sys_dist_ks);
 
+public:
+    bool topology_global_queue_empty() const {
+        return !_topology_state_machine._topology.global_request.has_value();
+    }
+private:
      // State machine that is responsible for topology change
     topology_state_machine _topology_state_machine;
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -900,6 +900,10 @@ public:
     // It is incompatible with the `join_cluster` method.
     future<> start_maintenance_mode();
 
+    // Waits for a topology request with a given ID to complete and return non empty error string
+    // if request completes with an error
+    future<sstring> wait_for_topology_request_completion(utils::UUID id);
+
 private:
     future<std::vector<canonical_mutation>> get_system_mutations(schema_ptr schema);
     future<std::vector<canonical_mutation>> get_system_mutations(const sstring& ks_name, const sstring& cf_name);
@@ -936,9 +940,6 @@ private:
 
     future<> _sstable_cleanup_fiber = make_ready_future<>();
     future<> sstable_cleanup_fiber(raft::server& raft, sharded<service::storage_proxy>& proxy) noexcept;
-    // Waits for a topology request with a given ID to complete and return non empty error string
-    // if request completes with an error
-    future<sstring> wait_for_topology_request_completion(utils::UUID id);
 
     // We need to be able to abort all group0 operation during shutdown, so we need special abort source for that
     abort_source _group0_as;

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -53,6 +53,7 @@ struct load_balancer_cluster_stats {
 using dc_name = sstring;
 
 class load_balancer_stats_manager {
+    sstring group_name;
     std::unordered_map<dc_name, std::unique_ptr<load_balancer_dc_stats>> _dc_stats;
     std::unordered_map<host_id, std::unique_ptr<load_balancer_node_stats>> _node_stats;
     load_balancer_cluster_stats _cluster_stats;
@@ -63,7 +64,7 @@ class load_balancer_stats_manager {
     void setup_metrics(const dc_name& dc, load_balancer_dc_stats& stats) {
         namespace sm = seastar::metrics;
         auto dc_lb = dc_label(dc);
-        _metrics.add_group("load_balancer", {
+        _metrics.add_group(group_name, {
             sm::make_counter("calls", sm::description("number of calls to the load balancer"),
                              stats.calls)(dc_lb),
             sm::make_counter("migrations_produced", sm::description("number of migrations produced by the load balancer"),
@@ -77,7 +78,7 @@ class load_balancer_stats_manager {
         namespace sm = seastar::metrics;
         auto dc_lb = dc_label(dc);
         auto node_lb = node_label(node);
-        _metrics.add_group("load_balancer", {
+        _metrics.add_group(group_name, {
             sm::make_gauge("load", sm::description("node load during last load balancing"),
                            stats.load)(dc_lb)(node_lb)
         });
@@ -86,7 +87,7 @@ class load_balancer_stats_manager {
     void setup_metrics(load_balancer_cluster_stats& stats) {
         namespace sm = seastar::metrics;
         // FIXME: we can probably improve it by making it per resize type (split, merge or none).
-        _metrics.add_group("load_balancer", {
+        _metrics.add_group(group_name, {
             sm::make_counter("resizes_emitted", sm::description("number of resizes produced by the load balancer"),
                 stats.resizes_emitted),
             sm::make_counter("resizes_revoked", sm::description("number of resizes revoked by the load balancer"),
@@ -96,7 +97,9 @@ class load_balancer_stats_manager {
         });
     }
 public:
-    load_balancer_stats_manager() {
+    load_balancer_stats_manager(sstring group_name):
+        group_name(std::move(group_name))
+    {
         setup_metrics(_cluster_stats);
     }
 
@@ -1323,7 +1326,8 @@ public:
     tablet_allocator_impl(tablet_allocator::config cfg, service::migration_notifier& mn, replica::database& db)
             : _config(std::move(cfg))
             , _migration_notifier(mn)
-            , _db(db) {
+            , _db(db)
+            , _load_balancer_stats("load_balancer") {
         if (_config.initial_tablets_scale == 0) {
             throw std::runtime_error("Initial tablets scale must be positive");
         }

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -19,6 +19,7 @@
 
 #include "auth/service.hh"
 #include "cdc/generation.hh"
+#include "cql3/statements/ks_prop_defs.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "db/system_keyspace.hh"
 #include "dht/boot_strapper.hh"
@@ -28,10 +29,12 @@
 #include "locator/token_metadata.hh"
 #include "locator/network_topology_strategy.hh"
 #include "message/messaging_service.hh"
+#include "mutation/async_utils.hh"
 #include "replica/database.hh"
 #include "replica/tablet_mutation_builder.hh"
 #include "replica/tablets.hh"
 #include "service/qos/service_level_controller.hh"
+#include "service/migration_manager.hh"
 #include "service/raft/join_node.hh"
 #include "service/raft/raft_address_map.hh"
 #include "service/raft/raft_group0.hh"
@@ -40,6 +43,7 @@
 #include "service/topology_state_machine.hh"
 #include "topology_mutation.hh"
 #include "utils/error_injection.hh"
+#include "utils/stall_free.hh"
 #include "utils/to_string.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
 
@@ -755,6 +759,84 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
         case global_topology_request::cleanup:
             co_await start_cleanup_on_dirty_nodes(std::move(guard), true);
             break;
+        case global_topology_request::keyspace_rf_change: {
+            rtlogger.info("keyspace_rf_change requested");
+            while (true) {
+                sstring ks_name = *_topo_sm._topology.new_keyspace_rf_change_ks_name;
+                auto& ks = _db.find_keyspace(ks_name);
+                auto tmptr = get_token_metadata_ptr();
+                std::unordered_map<sstring, sstring> saved_ks_props = *_topo_sm._topology.new_keyspace_rf_change_data;
+                cql3::statements::ks_prop_defs new_ks_props{std::map<sstring, sstring>{saved_ks_props.begin(), saved_ks_props.end()}};
+
+                auto repl_opts = new_ks_props.get_replication_options();
+                repl_opts.erase(cql3::statements::ks_prop_defs::REPLICATION_STRATEGY_CLASS_KEY);
+                utils::UUID req_uuid = *_topo_sm._topology.global_request_id;
+                std::vector<canonical_mutation> updates;
+                sstring error;
+                size_t unimportant_init_tablet_count = 2; // must be a power of 2
+                locator::tablet_map new_tablet_map{unimportant_init_tablet_count};
+
+                for (const auto& table : ks.metadata()->tables()) {
+                    try {
+                        locator::tablet_map old_tablets = tmptr->tablets().get_tablet_map(table->id());
+                        locator::replication_strategy_params params{repl_opts, old_tablets.tablet_count()};
+                        auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params);
+                        new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table, tmptr, old_tablets);
+                    } catch (const std::exception& e) {
+                        error = e.what();
+                        rtlogger.error("Couldn't process global_topology_request::keyspace_rf_change, error: {},"
+                                       "desired new ks opts: {}", error, new_ks_props.get_replication_options());
+                        updates.clear(); // remove all tablets mutations ...
+                        break;           // ... and only create mutations deleting the global req
+                    }
+
+                    replica::tablet_mutation_builder tablet_mutation_builder(guard.write_timestamp(), table->id());
+                    co_await new_tablet_map.for_each_tablet([&](locator::tablet_id tablet_id, const locator::tablet_info& tablet_info) -> future<> {
+                        auto last_token = new_tablet_map.get_last_token(tablet_id);
+                        updates.emplace_back(co_await make_canonical_mutation_gently(
+                                replica::tablet_mutation_builder(guard.write_timestamp(), table->id())
+                                        .set_new_replicas(last_token, tablet_info.replicas)
+                                        .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
+                                        .set_transition(last_token, locator::tablet_transition_kind::rebuild)
+                                        .build()
+                        ));
+                        co_await coroutine::maybe_yield();
+                    });
+                }
+
+                updates.push_back(canonical_mutation(topology_mutation_builder(guard.write_timestamp())
+                                                             .set_transition_state(topology::transition_state::tablet_migration)
+                                                             .set_version(_topo_sm._topology.version + 1)
+                                                             .del_global_topology_request()
+                                                             .del_global_topology_request_id()
+                                                             .build()));
+                updates.push_back(canonical_mutation(topology_request_tracking_mutation_builder(req_uuid)
+                                                             .done(error)
+                                                             .build()));
+                if (error.empty()) {
+                    const sstring strategy_name = "NetworkTopologyStrategy";
+                    auto ks_md = keyspace_metadata::new_keyspace(ks_name, strategy_name, repl_opts,
+                                                                 new_ks_props.get_initial_tablets(strategy_name, true),
+                                                                 new_ks_props.get_durable_writes(), new_ks_props.get_storage_options());
+                    auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
+                    for (auto& m: schema_muts) {
+                        updates.emplace_back(m);
+                    }
+                }
+
+                sstring reason = format("ALTER tablets KEYSPACE called with options: {}", saved_ks_props);
+                rtlogger.trace("do update {} reason {}", updates, reason);
+                mixed_change change{std::move(updates)};
+                group0_command g0_cmd = _group0.client().prepare_command(std::move(change), guard, reason);
+                try {
+                    co_await _group0.client().add_entry(std::move(g0_cmd), std::move(guard), &_as);
+                    break;
+                } catch (group0_concurrent_modification&) {
+                    rtlogger.info("handle_global_request(): concurrent modification, retrying");
+                }
+            }
+            break;
+        }
         }
     }
 
@@ -1378,7 +1460,19 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             topology_mutation_builder builder(ts);
             topology_request_tracking_mutation_builder rtbuilder(_topo_sm._topology.find(id)->second.request_id);
             auto node_builder = builder.with_node(id).del("topology_request");
-            rtbuilder.done(fmt::format("Canceled. Dead nodes: {}", dead_nodes));
+            auto done_msg = fmt::format("Canceled. Dead nodes: {}", dead_nodes);
+            rtbuilder.done(done_msg);
+            if (_topo_sm._topology.global_request_id) {
+                try {
+                    utils::UUID uuid = utils::UUID{*_topo_sm._topology.global_request_id};
+                    topology_request_tracking_mutation_builder rt_global_req_builder{uuid};
+                    rt_global_req_builder.done(done_msg)
+                                         .set("end_time", db_clock::now());
+                    muts.emplace_back(rt_global_req_builder.build());
+                } catch (...) {
+                    rtlogger.warn("failed to cancel topology global request: {}", std::current_exception());
+                }
+            }
             switch (req) {
                 case topology_request::replace:
                 [[fallthrough]];

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -265,6 +265,10 @@ topology_mutation_builder& topology_mutation_builder::del_global_topology_reques
     return del("global_topology_request");
 }
 
+topology_mutation_builder& topology_mutation_builder::del_global_topology_request_id() {
+    return del("global_topology_request_id");
+}
+
 topology_node_mutation_builder& topology_mutation_builder::with_node(raft::server_id n) {
     _node_builder.emplace(*this, n);
     return *_node_builder;

--- a/service/topology_mutation.hh
+++ b/service/topology_mutation.hh
@@ -114,8 +114,10 @@ public:
     topology_mutation_builder& set_tablet_balancing_enabled(bool);
     topology_mutation_builder& set_new_cdc_generation_data_uuid(const utils::UUID& value);
     topology_mutation_builder& set_committed_cdc_generations(const std::vector<cdc::generation_id_v2>& values);
+    topology_mutation_builder& set_new_keyspace_rf_change_data(const sstring &ks_name, const std::map<sstring, sstring> &rf_per_dc);
     topology_mutation_builder& set_unpublished_cdc_generations(const std::vector<cdc::generation_id_v2>& values);
     topology_mutation_builder& set_global_topology_request(global_topology_request);
+    topology_mutation_builder& set_global_topology_request_id(const utils::UUID&);
     topology_mutation_builder& set_upgrade_state(topology::upgrade_state_type);
     topology_mutation_builder& add_enabled_features(const std::set<sstring>& value);
     topology_mutation_builder& add_ignored_nodes(const std::unordered_set<raft::server_id>& value);

--- a/service/topology_mutation.hh
+++ b/service/topology_mutation.hh
@@ -126,6 +126,7 @@ public:
     topology_mutation_builder& del_transition_state();
     topology_mutation_builder& del_session();
     topology_mutation_builder& del_global_topology_request();
+    topology_mutation_builder& del_global_topology_request_id();
     topology_node_mutation_builder& with_node(raft::server_id);
     canonical_mutation build() { return canonical_mutation{std::move(_m)}; }
 };

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -192,6 +192,7 @@ topology_request topology_request_from_string(const sstring& s) {
 static std::unordered_map<global_topology_request, sstring> global_topology_request_to_name_map = {
     {global_topology_request::new_cdc_generation, "new_cdc_generation"},
     {global_topology_request::cleanup, "cleanup"},
+    {global_topology_request::keyspace_rf_change, "keyspace_rf_change"},
 };
 
 global_topology_request global_topology_request_from_string(const sstring& s) {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -72,6 +72,7 @@ using request_param = std::variant<join_param, rebuild_param, replace_param>;
 enum class global_topology_request: uint16_t {
     new_cdc_generation,
     cleanup,
+    keyspace_rf_change,
 };
 
 struct ring_slice {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -154,6 +154,9 @@ struct topology {
     // Pending global topology request (i.e. not related to any specific node).
     std::optional<global_topology_request> global_request;
 
+    // Pending global topology request's id, which is a new group0's state id
+    std::optional<utils::UUID> global_request_id;
+
     // The IDs of the committed CDC generations sorted by timestamps.
     // The obsolete generations may not be in this list as they are continually deleted.
     std::vector<cdc::generation_id_v2> committed_cdc_generations;
@@ -162,6 +165,11 @@ struct topology {
     // e.g. when a new node bootstraps, needed in `commit_cdc_generation` transition state.
     // It's used as the first column of the clustering key in CDC_GENERATIONS_V3 table.
     std::optional<utils::UUID> new_cdc_generation_data_uuid;
+
+    // The name of the KS that is being the target of the scheduled ALTER KS statement
+    std::optional<sstring> new_keyspace_rf_change_ks_name;
+    // The KS options to be used when executing the scheduled ALTER KS statement
+    std::optional<std::unordered_map<sstring, sstring>> new_keyspace_rf_change_data;
 
     // The IDs of the committed yet unpublished CDC generations sorted by timestamps.
     std::vector<cdc::generation_id_v2> unpublished_cdc_generations;

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -15,19 +15,23 @@
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/log.hh"
 #include "test/lib/simple_schema.hh"
+#include "test/lib/key_utils.hh"
 #include "test/lib/test_utils.hh"
 #include "db/config.hh"
+#include "db/schema_tables.hh"
 #include "schema/schema_builder.hh"
 
 #include "replica/tablets.hh"
 #include "replica/tablet_mutation_builder.hh"
 #include "locator/tablets.hh"
 #include "service/tablet_allocator.hh"
+#include "locator/tablet_replication_strategy.hh"
 #include "locator/tablet_sharder.hh"
 #include "locator/load_sketch.hh"
 #include "utils/UUID_gen.hh"
 #include "utils/error_injection.hh"
 #include "utils/to_string.hh"
+#include "service/topology_coordinator.hh"
 
 using namespace locator;
 using namespace replica;
@@ -2331,4 +2335,359 @@ SEASTAR_THREAD_TEST_CASE(test_tablet_range_splitter) {
             {bound{dks[0], true}, bound{dks[1], false}},
             {bound{dks[1], true}, bound{dks[2], false}},
             {bound{dks[2], true}, bound{dks[3], false}}});
+
+}
+
+static locator::endpoint_dc_rack make_endpoint_dc_rack(gms::inet_address endpoint) {
+    // This resembles rack_inferring_snitch dc/rack generation which is
+    // still in use by this test via token_metadata internals
+    auto dc = std::to_string(uint8_t(endpoint.bytes()[1]));
+    auto rack = std::to_string(uint8_t(endpoint.bytes()[2]));
+    return locator::endpoint_dc_rack{dc, rack};
+}
+
+struct calculate_tablet_replicas_for_new_rf_config
+{
+    struct ring_point {
+        double point;
+        inet_address host;
+        host_id id = host_id::create_random_id();
+    };
+    std::vector<ring_point> ring_points;
+    std::map<sstring, sstring> options;
+    std::map<sstring, sstring> new_dc_rep_factor;
+    std::map<sstring, size_t> expected_rep_factor;
+};
+
+static void execute_tablet_for_new_rf_test(calculate_tablet_replicas_for_new_rf_config const& test_config)
+{
+    auto my_address = gms::inet_address("localhost");
+    // Create the RackInferringSnitch
+    snitch_config cfg;
+    cfg.listen_address = my_address;
+    cfg.broadcast_address = my_address;
+    cfg.name = "RackInferringSnitch";
+    sharded<snitch_ptr> snitch;
+    snitch.start(cfg).get();
+    auto stop_snitch = defer([&snitch] { snitch.stop().get(); });
+    snitch.invoke_on_all(&snitch_ptr::start).get();
+
+    static constexpr size_t tablet_count = 8;
+
+    std::vector<unsigned> nodes_shard_count(test_config.ring_points.size(), 3);
+
+    locator::token_metadata::config tm_cfg;
+    tm_cfg.topo_cfg.this_endpoint = test_config.ring_points[0].host;
+    tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
+    tm_cfg.topo_cfg.this_host_id = test_config.ring_points[0].id;
+    locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg);
+
+    // Initialize the token_metadata
+    stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
+        auto& topo = tm.get_topology();
+        for (const auto& [ring_point, endpoint, id] : test_config.ring_points) {
+            std::unordered_set<token> tokens;
+            tokens.insert({dht::token::kind::key, tests::d2t(ring_point / test_config.ring_points.size())});
+            topo.add_node(id, endpoint, make_endpoint_dc_rack(endpoint), locator::node::state::normal, 1);
+            tm.update_host_id(id, endpoint);
+            co_await tm.update_normal_tokens(std::move(tokens), id);
+        }
+    }).get();
+
+    locator::replication_strategy_params params(test_config.options, tablet_count);
+
+    auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
+        "NetworkTopologyStrategy", params);
+
+    auto tablet_aware_ptr = ars_ptr->maybe_as_tablet_aware();
+    BOOST_REQUIRE(tablet_aware_ptr);
+
+    auto s = schema_builder("ks", "tb")
+        .with_column("pk", utf8_type, column_kind::partition_key)
+        .with_column("v", utf8_type)
+        .build();
+
+    stm.mutate_token_metadata([&] (token_metadata& tm) {
+        for (size_t i = 0; i < test_config.ring_points.size(); ++i) {
+            auto& [ring_point, endpoint, id] = test_config.ring_points[i];
+            tm.update_host_id(id, endpoint);
+            tm.update_topology(id, make_endpoint_dc_rack(endpoint), std::nullopt, nodes_shard_count[i]);
+        }
+        return make_ready_future<>();
+    }).get();
+
+    auto allocated_map = tablet_aware_ptr->allocate_tablets_for_new_table(s, stm.get(), 0).get();
+
+    BOOST_REQUIRE_EQUAL(allocated_map.tablet_count(), tablet_count);
+
+    auto host_id_to_dc = [&stm](const locator::host_id& ep) -> std::optional<sstring> {
+        auto node = stm.get()->get_topology().find_node(ep);
+        if (node == nullptr) {
+            return std::nullopt;
+        }
+        return node->dc_rack().dc;
+    };
+
+    stm.mutate_token_metadata([&] (token_metadata& tm) {
+        tablet_metadata tab_meta;
+        auto table = s->id();
+        tab_meta.set_tablet_map(table, allocated_map);
+        tm.set_tablets(std::move(tab_meta));
+        return make_ready_future<>();
+    }).get();
+
+    std::map<sstring, size_t> initial_rep_factor;
+    for (auto const& [dc, shard_count] : test_config.options) {
+        initial_rep_factor[dc] = std::stoul(shard_count);
+    }
+
+    auto tablets = stm.get()->tablets().get_tablet_map(s->id());
+    BOOST_REQUIRE_EQUAL(tablets.tablet_count(), tablet_count);
+    for (auto tb : tablets.tablet_ids()) {
+        const locator::tablet_info& ti = tablets.get_tablet_info(tb);
+
+        std::map<sstring, size_t> dc_replicas_count;
+        for (const auto& r : ti.replicas) {
+            auto dc = host_id_to_dc(r.host);
+            if (dc) {
+                dc_replicas_count[*dc]++;
+            }
+        }
+
+        BOOST_REQUIRE_EQUAL(dc_replicas_count, initial_rep_factor);
+    }
+
+    try {
+        tablet_map old_tablets = stm.get()->tablets().get_tablet_map(s->id());
+        locator::replication_strategy_params params{test_config.new_dc_rep_factor, old_tablets.tablet_count()};
+        auto new_strategy = abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params);
+        auto tmap = new_strategy->maybe_as_tablet_aware()->reallocate_tablets(s, stm.get(), old_tablets).get();
+
+        auto const& ts = tmap.tablets();
+        BOOST_REQUIRE_EQUAL(ts.size(), tablet_count);
+
+        for (auto tb : tmap.tablet_ids()) {
+            const locator::tablet_info& ti = tmap.get_tablet_info(tb);
+
+            std::map<sstring, size_t> dc_replicas_count;
+            for (const auto& r : ti.replicas) {
+                auto dc = host_id_to_dc(r.host);
+                if (dc) {
+                    dc_replicas_count[*dc]++;
+                }
+            }
+
+            BOOST_REQUIRE_EQUAL(dc_replicas_count, test_config.expected_rep_factor);
+        }
+
+    } catch (exceptions::configuration_exception const& e) {
+        thread_local boost::regex re("Datacenter [0-9]+ doesn't have enough nodes for replication_factor=[0-9]+");
+        boost::cmatch what;
+        if (!boost::regex_search(e.what(), what, re)) {
+            BOOST_FAIL("Unexpected exception: " + std::string(e.what()));
+        }
+    } catch (std::exception const& e) {
+        BOOST_FAIL("Unexpected exception: " + std::string(e.what()));
+    } catch (...) {
+        BOOST_FAIL("Unexpected exception");
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_calculate_tablet_replicas_for_new_rf_upsize_one_dc) {
+    calculate_tablet_replicas_for_new_rf_config config;
+    config.ring_points = {
+            { 1.0,  inet_address("192.100.10.1") },
+            { 4.0,  inet_address("192.100.20.1") },
+            { 7.0,  inet_address("192.100.30.1") },
+    };
+    config.options = {{"100", "2"}};
+    config.new_dc_rep_factor = {{"100", "3"}};
+    config.expected_rep_factor = {{"100", 3}};
+    execute_tablet_for_new_rf_test(config);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_calculate_tablet_replicas_for_new_rf_downsize_one_dc) {
+    calculate_tablet_replicas_for_new_rf_config config;
+    config.ring_points = {
+            { 1.0,  inet_address("192.100.10.1") },
+            { 4.0,  inet_address("192.100.20.1") },
+            { 7.0,  inet_address("192.100.30.1") },
+    };
+    config.options = {{"100", "3"}};
+    config.new_dc_rep_factor = {{"100", "2"}};
+    config.expected_rep_factor = {{"100", 2}};
+    execute_tablet_for_new_rf_test(config);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_calculate_tablet_replicas_for_new_rf_no_change_one_dc) {
+    calculate_tablet_replicas_for_new_rf_config config;
+    config.ring_points = {
+            { 1.0,  inet_address("192.100.10.1") },
+            { 4.0,  inet_address("192.100.20.1") },
+            { 7.0,  inet_address("192.100.30.1") },
+    };
+    config.options = {{"100", "3"}};
+    config.new_dc_rep_factor = {{"100", "3"}};
+    config.expected_rep_factor = {{"100", 3}};
+    execute_tablet_for_new_rf_test(config);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_calculate_tablet_replicas_for_new_rf) {
+    calculate_tablet_replicas_for_new_rf_config config;
+    config.ring_points = {
+            { 1.0,  inet_address("192.100.10.1") },
+            { 2.0,  inet_address("192.101.10.1") },
+            { 3.0,  inet_address("192.102.10.1") },
+            { 4.0,  inet_address("192.100.20.1") },
+            { 5.0,  inet_address("192.101.20.1") },
+            { 6.0,  inet_address("192.102.20.1") },
+            { 7.0,  inet_address("192.100.30.1") },
+            { 8.0,  inet_address("192.101.30.1") },
+            { 9.0,  inet_address("192.102.30.1") },
+            { 10.0, inet_address("192.101.40.1") },
+            { 11.0, inet_address("192.102.40.1") },
+            { 12.0, inet_address("192.102.40.2") }
+    };
+    config.options = {
+        {"100", "3"},
+        {"101", "2"},
+        {"102", "3"}
+    };
+    config.new_dc_rep_factor = {
+        {"100", "3"},
+        {"101", "4"},
+        {"102", "2"}
+    };
+    config.expected_rep_factor = {
+        {"100", 3},
+        {"101", 4},
+        {"102", 2}
+    };
+
+    execute_tablet_for_new_rf_test(config);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_calculate_tablet_replicas_for_new_rf_not_enough_nodes) {
+
+    calculate_tablet_replicas_for_new_rf_config config;
+    config.ring_points = {
+            { 1.0,  inet_address("192.100.10.1") },
+            { 4.0,  inet_address("192.100.20.1") },
+            { 7.0,  inet_address("192.100.30.1") },
+    };
+    config.options = {{"100", "3"}};
+    config.new_dc_rep_factor = {{"100", "5"}};
+    config.expected_rep_factor = {{"100", 3}};
+    execute_tablet_for_new_rf_test(config);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_calculate_tablet_replicas_for_new_rf_one_dc) {
+    calculate_tablet_replicas_for_new_rf_config config;
+    config.ring_points = {
+            { 1.0,  inet_address("192.100.10.1") },
+            { 4.0,  inet_address("192.100.20.1") },
+            { 7.0,  inet_address("192.100.30.1") },
+    };
+    config.options = {{"100", "2"}};
+    config.new_dc_rep_factor = {{"100", "3"}};
+    config.expected_rep_factor = {{"100", 3}};
+    execute_tablet_for_new_rf_test(config);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_calculate_tablet_replicas_for_new_rf_one_dc_1_to_2) {
+    calculate_tablet_replicas_for_new_rf_config config;
+    config.ring_points = {
+            { 1.0,  inet_address("192.100.10.1") },
+            { 4.0,  inet_address("192.100.20.1") },
+    };
+    config.options = {{"100", "1"}};
+    config.new_dc_rep_factor = {{"100", "2"}};
+    config.expected_rep_factor = {{"100", 2}};
+    execute_tablet_for_new_rf_test(config);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_calculate_tablet_replicas_for_new_rf_one_dc_not_enough_nodes) {
+
+    calculate_tablet_replicas_for_new_rf_config config;
+    config.ring_points = {
+            { 1.0,  inet_address("192.100.10.1") },
+            { 4.0,  inet_address("192.100.10.2") },
+            { 7.0,  inet_address("192.100.10.3") },
+    };
+    config.options = {{"100", "3"}};
+    config.new_dc_rep_factor = {{"100", "5"}};
+    config.expected_rep_factor = {{"100", 3}};
+    execute_tablet_for_new_rf_test(config);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_calculate_tablet_replicas_for_new_rf_default_rf) {
+    calculate_tablet_replicas_for_new_rf_config config;
+    config.ring_points = {
+            { 1.0,  inet_address("192.100.10.1") },
+            { 2.0,  inet_address("192.101.10.1") },
+            { 3.0,  inet_address("192.102.10.1") },
+            { 4.0,  inet_address("192.100.20.1") },
+            { 5.0,  inet_address("192.101.20.1") },
+            { 6.0,  inet_address("192.102.20.1") },
+            { 7.0,  inet_address("192.100.30.1") },
+            { 8.0,  inet_address("192.101.30.1") },
+            { 9.0,  inet_address("192.102.30.1") },
+            { 10.0, inet_address("192.100.40.1") },
+            { 11.0, inet_address("192.101.40.1") },
+            { 12.0, inet_address("192.102.40.1") },
+            { 13.0, inet_address("192.102.40.2") }
+    };
+    config.options = {
+        {"100", "3"},
+        {"101", "2"},
+        {"102", "2"}
+    };
+    config.new_dc_rep_factor = {
+        {"100", "4"},
+        {"101", "3"},
+        {"102", "3"},
+    };
+    config.expected_rep_factor = {
+        {"100", 4},
+        {"101", 3},
+        {"102", 3},
+    };
+
+    execute_tablet_for_new_rf_test(config);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_calculate_tablet_replicas_for_new_rf_default_rf_upsize_by_two) {
+    calculate_tablet_replicas_for_new_rf_config config;
+    config.ring_points = {
+            { 1.0,  inet_address("192.100.10.1") },
+            { 2.0,  inet_address("192.101.10.1") },
+            { 3.0,  inet_address("192.102.10.1") },
+            { 4.0,  inet_address("192.100.20.1") },
+            { 5.0,  inet_address("192.101.20.1") },
+            { 6.0,  inet_address("192.102.20.1") },
+            { 7.0,  inet_address("192.100.30.1") },
+            { 8.0,  inet_address("192.101.30.1") },
+            { 9.0,  inet_address("192.102.30.1") },
+            { 10.0, inet_address("192.100.40.1") },
+            { 11.0, inet_address("192.101.40.1") },
+            { 12.0, inet_address("192.102.40.1") },
+            { 13.0, inet_address("192.102.40.2") }
+    };
+    config.options = {
+        {"100", "3"},
+        {"101", "2"},
+        {"102", "1"}
+    };
+    config.new_dc_rep_factor = {
+        {"100", "4"},
+        {"101", "3"},
+        {"102", "3"},
+    };
+    config.expected_rep_factor = {
+        {"100", 4},
+        {"101", 3},
+        {"102", 3},
+    };
+
+    execute_tablet_for_new_rf_test(config);
 }

--- a/test/boost/transport_test.cc
+++ b/test/boost/transport_test.cc
@@ -90,6 +90,7 @@ SEASTAR_THREAD_TEST_CASE(test_response_request_reader) {
     res.serialize({sc::change_type::CREATED, sc::target_type::TYPE, "foo", "bar"}, version);
     res.serialize({sc::change_type::CREATED, sc::target_type::FUNCTION, "foo", "bar", "zed"}, version);
     res.serialize({sc::change_type::CREATED, sc::target_type::AGGREGATE, "foo", "bar", "zed"}, version);
+    res.serialize({sc::change_type::CREATED, sc::target_type::TABLET_KEYSPACE, "foo"}, version);
 
     auto msg = res.make_message(version, cql_transport::cql_compression::none).release();
     auto total_length = msg.len();

--- a/test/cql-pytest/test_keyspace.py
+++ b/test/cql-pytest/test_keyspace.py
@@ -99,7 +99,19 @@ def test_drop_keyspace_nonexistent(cql):
 # Test trying to ALTER a keyspace.
 def test_alter_keyspace(cql, this_dc):
     with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as keyspace:
-        cql.execute(f"ALTER KEYSPACE {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 3 }} AND DURABLE_WRITES = false")
+        cql.execute(f"ALTER KEYSPACE {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 2 }} AND DURABLE_WRITES = false")
+
+# Test trying to ALTER RF of tablets-enabled KS by more than 1 at a time
+def test_alter_keyspace_rf_by_more_than_1(cql, this_dc):
+    with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as keyspace:
+        with pytest.raises(InvalidRequest):
+            cql.execute(f"ALTER KEYSPACE {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 3 }} AND DURABLE_WRITES = false")
+
+# Test trying to ALTER a tablets-enabled KS by providing the 'replication_factor' tag
+def test_alter_keyspace_with_replication_factor_tag(cql):
+    with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }") as keyspace:
+        with pytest.raises(InvalidRequest):
+            cql.execute(f"ALTER KEYSPACE {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2 }}")
 
 # Test trying to ALTER a keyspace with invalid options.
 def test_alter_keyspace_invalid(cql, this_dc):

--- a/test/cql-pytest/test_tablets.py
+++ b/test/cql-pytest/test_tablets.py
@@ -92,10 +92,10 @@ def test_tablets_can_be_explicitly_disabled(cql, skip_without_tablets):
         assert len(list(res)) == 0, "tablets replication strategy turned on"
 
 
-def test_alter_changes_initial_tablets(cql, skip_without_tablets):
-    ksdef = "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};"
+def test_alter_changes_initial_tablets(cql, this_dc, skip_without_tablets):
+    ksdef = f"WITH replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': 1}} AND tablets = {{'initial': 1}};"
     with new_test_keyspace(cql, ksdef) as keyspace:
-        cql.execute(f"ALTER KEYSPACE {keyspace} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': 2}};")
+        cql.execute(f"ALTER KEYSPACE {keyspace} WITH replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': 1}} AND tablets = {{'initial': 2}};")
         res = cql.execute(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{keyspace}'").one()
         assert res.initial_tablets == 2
 

--- a/test/lib/key_utils.cc
+++ b/test/lib/key_utils.cc
@@ -106,4 +106,13 @@ clustering_key generate_clustering_key(schema_ptr s, bool allow_prefix, std::opt
     return std::move(keys.front());
 }
 
+__attribute__((no_sanitize("undefined")))
+int64_t d2t(double d) {
+    // Double to unsigned long conversion will overflow if the
+    // input is greater than numeric_limits<long>::max(), so divide by two and
+    // multiply again later.
+    auto scale = std::numeric_limits<unsigned long>::max();
+    return static_cast<unsigned long>(d * static_cast<double>(scale >> 1)) << 1;
+};
+
 } // namespace tests

--- a/test/lib/key_utils.hh
+++ b/test/lib/key_utils.hh
@@ -48,4 +48,7 @@ std::vector<clustering_key> generate_clustering_keys(size_t n, schema_ptr s, boo
 // Overload for a single key
 clustering_key generate_clustering_key(schema_ptr s, bool allow_prefix = false, std::optional<key_size> size = {});
 
+// Double to unsigned long conversion
+int64_t d2t(double d);
+
 } // namespace tests

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -105,7 +105,6 @@ async def test_reshape_with_tablets(manager: ManagerClient):
 
 
 @pytest.mark.parametrize("direction", ["up", "down", "none"])
-@pytest.mark.xfail(reason="Scaling not implemented yet")
 @pytest.mark.asyncio
 async def test_tablet_rf_change(manager: ManagerClient, direction):
     cfg = {'enable_user_defined_functions': False,

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -110,6 +110,8 @@ async def test_tablet_rf_change(manager: ManagerClient, direction):
     cfg = {'enable_user_defined_functions': False,
            'experimental_features': ['tablets']}
     servers = await manager.servers_add(3, config=cfg)
+    for s in servers:
+        await manager.api.disable_tablet_balancing(s.ip_addr)
 
     cql = manager.get_cql()
     res = await cql.run_async("SELECT data_center FROM system.local")
@@ -146,7 +148,7 @@ async def test_tablet_rf_change(manager: ManagerClient, direction):
     logger.info(f"Checking {rf_to} re-allocated replicas")
     await check_allocated_replica(rf_to)
 
-    fragments = { pk: [] for pk in random.sample(range(128), 17) }
+    fragments = { pk: set() for pk in random.sample(range(128), 17) }
     for s in servers:
         host_id = await manager.get_host_id(s.server_id)
         host = await wait_for_cql_and_get_hosts(cql, [s], time.time() + 30)
@@ -155,7 +157,7 @@ async def test_tablet_rf_change(manager: ManagerClient, direction):
             res = await cql.run_async(f"SELECT partition_region FROM MUTATION_FRAGMENTS(test.test) WHERE pk={k}", host=host[0])
             for fragment in res:
                 if fragment.partition_region == 0: # partition start
-                    fragments[k].append(host_id)
+                    fragments[k].add(host_id)
     logger.info("Checking fragments")
     for k in fragments:
         assert len(fragments[k]) == rf_to, f"Found mutations for {k} key on {fragments[k]} hosts, but expected only {rf_to} of them"

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -148,6 +148,11 @@ async def test_tablet_rf_change(manager: ManagerClient, direction):
     logger.info(f"Checking {rf_to} re-allocated replicas")
     await check_allocated_replica(rf_to)
 
+    if direction != 'up':
+        # Don't check fragments for up/none changes, scylla crashes when checking nodes
+        # that (validly) miss the replica, see scylladb/scylladb#18786
+        return
+
     fragments = { pk: set() for pk in random.sample(range(128), 17) }
     for s in servers:
         host_id = await manager.get_host_id(s.server_id)

--- a/transport/event.cc
+++ b/transport/event.cc
@@ -57,6 +57,7 @@ event::schema_change::schema_change(change_type change, target_type target, sstr
 {
     switch (target) {
     case event::schema_change::target_type::KEYSPACE:
+    case event::schema_change::target_type::TABLET_KEYSPACE:
         assert(this->arguments.empty());
         break;
     case event::schema_change::target_type::TYPE:

--- a/transport/event.hh
+++ b/transport/event.hh
@@ -61,7 +61,7 @@ public:
 class event::schema_change : public event {
 public:
     enum class change_type { CREATED, UPDATED, DROPPED };
-    enum class target_type { KEYSPACE, TABLE, TYPE, FUNCTION, AGGREGATE };
+    enum class target_type { KEYSPACE, TABLE, TYPE, FUNCTION, AGGREGATE, TABLET_KEYSPACE };
 
     const change_type change;
     const target_type target;

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -170,6 +170,7 @@ sstring to_string(const event::schema_change::target_type t) {
     case event::schema_change::target_type::TYPE:     return "TYPE";
     case event::schema_change::target_type::FUNCTION: return "FUNCTION";
     case event::schema_change::target_type::AGGREGATE:return "AGGREGATE";
+    case event::schema_change::target_type::TABLET_KEYSPACE: return "KEYSPACE";
     }
     assert(false && "unreachable");
 }
@@ -1667,6 +1668,7 @@ void cql_server::response::serialize(const event::schema_change& event, uint8_t 
     write_string(event.keyspace);
     switch (event.target) {
     case event::schema_change::target_type::KEYSPACE:
+    case event::schema_change::target_type::TABLET_KEYSPACE:
         break;
     case event::schema_change::target_type::TYPE:
     case event::schema_change::target_type::TABLE:


### PR DESCRIPTION
This change supports changing replication factor in tablets-enabled keyspaces.
This covers both increasing and decreasing the number of tablets replicas through
first building topology mutations (`alter_keyspace_statement.cc`) and then
tablets/topology/schema mutations (`topology_coordinator.cc`).
For the limitations of the current solution, please see the docs changes attached to this PR.

Fixes: #16129