### PR TITLE
cdc: not include unused headers

### DIFF
--- a/cdc/cdc_extension.hh
+++ b/cdc/cdc_extension.hh
@@ -13,7 +13,6 @@
 
 #include "bytes.hh"
 #include "serializer.hh"
-#include "db/extensions.hh"
 #include "cdc/cdc_options.hh"
 #include "schema/schema.hh"
 #include "serializer_impl.hh"

--- a/cdc/cdc_partitioner.hh
+++ b/cdc/cdc_partitioner.hh
@@ -10,7 +10,6 @@
 
 #include <seastar/core/sstring.hh>
 
-#include "bytes.hh"
 #include "dht/i_partitioner.hh"
 
 class schema;

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -16,7 +16,6 @@
 #include "gms/endpoint_state.hh"
 #include "gms/versioned_value.hh"
 #include "keys.hh"
-#include "schema/schema_builder.hh"
 #include "replica/database.hh"
 #include "db/system_keyspace.hh"
 #include "db/system_distributed_keyspace.hh"
@@ -33,6 +32,7 @@
 #include "cdc/generation.hh"
 #include "cdc/cdc_options.hh"
 #include "cdc/generation_service.hh"
+#include "cdc/log.hh"
 
 extern logging::logger cdc_log;
 

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -24,7 +24,6 @@
 #include "bytes.hh"
 #include "replica/database.hh"
 #include "db/schema_tables.hh"
-#include "partition_slice_builder.hh"
 #include "schema/schema.hh"
 #include "schema/schema_builder.hh"
 #include "service/migration_listener.hh"
@@ -36,13 +35,11 @@
 #include "utils/rjson.hh"
 #include "utils/UUID_gen.hh"
 #include "utils/managed_bytes.hh"
-#include "utils/fragment_range.hh"
 #include "types/types.hh"
 #include "concrete_types.hh"
 #include "types/listlike_partial_deserializing_iterator.hh"
 #include "tracing/trace_state.hh"
 #include "stats.hh"
-#include "compaction/compaction_strategy.hh"
 
 namespace std {
 

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -14,10 +14,6 @@
 
 #pragma once
 
-#include <functional>
-#include <optional>
-#include <map>
-#include <string>
 #include <vector>
 
 #include <seastar/core/future.hh>
@@ -25,11 +21,9 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
 
-#include "exceptions/exceptions.hh"
 #include "timestamp.hh"
 #include "tracing/trace_state.hh"
 #include "utils/UUID.hh"
-#include "locator/host_id.hh"
 
 class schema;
 using schema_ptr = seastar::lw_shared_ptr<const schema>;

--- a/cdc/split.cc
+++ b/cdc/split.cc
@@ -16,8 +16,6 @@
 #include "log.hh"
 #include "change_visitor.hh"
 
-#include <type_traits>
-
 struct atomic_column_update {
     column_id id;
     atomic_cell cell;

--- a/cdc/split.hh
+++ b/cdc/split.hh
@@ -8,12 +8,9 @@
 
 #pragma once
 
-#include <vector>
 #include <boost/dynamic_bitset.hpp>
-#include "schema/schema_fwd.hh"
 #include "replica/database_fwd.hh"
 #include "timestamp.hh"
-#include "bytes.hh"
 #include <seastar/util/noncopyable_function.hh>
 
 class mutation;

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -20,6 +20,7 @@
 #include "service/storage_proxy.hh"
 #include "schema/schema_builder.hh"
 #include "schema/schema_registry.hh"
+#include "db/extensions.hh"
 #include "db/schema_tables.hh"
 #include "types/list.hh"
 #include "types/user.hh"


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.