### PR TITLE
utils/pretty_printers: add "I" specifier support

### DIFF
--- a/test/boost/pretty_printers_test.cc
+++ b/test/boost/pretty_printers_test.cc
@@ -12,7 +12,7 @@
 #include <boost/test/unit_test.hpp>
 #include "utils/pretty_printers.hh"
 
-BOOST_AUTO_TEST_CASE(test_print_data_size) {
+BOOST_AUTO_TEST_CASE(test_print_data_size_SI) {
     struct {
         size_t n;
         std::string_view formatted;
@@ -20,7 +20,9 @@ BOOST_AUTO_TEST_CASE(test_print_data_size) {
         {0ULL, "0 bytes"},
         {1ULL, "1 byte"},
         {42ULL, "42 bytes"},
+        {9'000ULL, "9000 bytes"},
         {10'000ULL, "10kB"},
+        {10'001ULL, "10kB"},
         {10'000'000ULL, "10MB"},
         {10'000'000'000ULL, "10GB"},
         {10'000'000'000'000ULL, "10TB"},
@@ -30,6 +32,26 @@ BOOST_AUTO_TEST_CASE(test_print_data_size) {
     for (auto [n, expected] : sizes) {
         std::string actual;
         fmt::format_to(std::back_inserter(actual), "{}", utils::pretty_printed_data_size{n});
+        BOOST_CHECK_EQUAL(actual, expected);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_print_data_size_IEC) {
+    struct {
+        size_t n;
+        std::string_view formatted;
+    } sizes[] = {
+        {0ULL, "0 bytes"},
+        {1ULL, "1 byte"},
+        {42ULL, "42 bytes"},
+        {8'191LL, "8191 bytes"},
+        {8'192LL, "8KiB"},
+        {8'193LL, "8KiB"},
+        {10'000ULL, "9KiB"},
+    };
+    for (auto [n, expected] : sizes) {
+        std::string actual;
+        fmt::format_to(std::back_inserter(actual), "{:i}", utils::pretty_printed_data_size{n});
         BOOST_CHECK_EQUAL(actual, expected);
     }
 }

--- a/test/boost/pretty_printers_test.cc
+++ b/test/boost/pretty_printers_test.cc
@@ -56,6 +56,23 @@ BOOST_AUTO_TEST_CASE(test_print_data_size_IEC) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(test_print_data_size_IEC_SANS_I) {
+    struct {
+        size_t n;
+        std::string_view formatted;
+    } sizes[] = {
+        {0ULL, "0B"},
+        {1ULL, "1B"},
+        {42ULL, "42B"},
+        {8'192LL, "8K"},
+    };
+    for (auto [n, expected] : sizes) {
+        std::string actual;
+        fmt::format_to(std::back_inserter(actual), "{:I}", utils::pretty_printed_data_size{n});
+        BOOST_CHECK_EQUAL(actual, expected);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(test_print_throughput) {
     struct {
         size_t n;

--- a/utils/pretty_printers.cc
+++ b/utils/pretty_printers.cc
@@ -8,18 +8,26 @@
 
 #include "pretty_printers.hh"
 #include <tuple>
+#include <cassert>
 
 template <typename Suffixes>
 static constexpr std::tuple<size_t, std::string_view, std::string_view>
-do_format(size_t n, Suffixes suffixes, unsigned scale, bool bytes) {
+do_format(size_t n, Suffixes suffixes, unsigned scale, unsigned precision, bool bytes) {
+    assert(scale < precision);
     size_t factor = n;
     const char* suffix = "";
+    size_t remainder = 0;
     for (auto next_suffix : suffixes) {
-        size_t next_factor = factor / scale;
-        if (next_factor == 0) {
+        if (factor < precision && remainder == 0) {
+            // If there is no remainder we go below precision because we don't
+            // loose any.
             break;
         }
-        factor = next_factor;
+        if (factor < scale) {
+            break;
+        }
+        remainder = factor % scale;
+        factor /= scale;
         suffix = next_suffix;
     }
     if (!bytes) {
@@ -42,12 +50,12 @@ auto fmt::formatter<utils::pretty_printed_data_size>::format(utils::pretty_print
     if (_prefix == prefix_type::IEC) {
         // ISO/IEC units
         static constexpr auto suffixes = {"Ki", "Mi", "Gi", "Ti", "Pi"};
-        auto [n, suffix, bytes] = do_format(data_size._size, suffixes, 1024, _bytes);
+        auto [n, suffix, bytes] = do_format(data_size._size, suffixes, 1024, 8192, _bytes);
         return fmt::format_to(ctx.out(), "{}{}{}", n, suffix, bytes);
     } else {
         // SI units
         static constexpr auto suffixes = {"k", "M", "G", "T", "P"};
-        auto [n, suffix, bytes] = do_format(data_size._size, suffixes, 1000, _bytes);
+        auto [n, suffix, bytes] = do_format(data_size._size, suffixes, 1000, 10000, _bytes);
         return fmt::format_to(ctx.out(), "{}{}{}", n, suffix, bytes);
     }
 }

--- a/utils/pretty_printers.cc
+++ b/utils/pretty_printers.cc
@@ -52,6 +52,13 @@ auto fmt::formatter<utils::pretty_printed_data_size>::format(utils::pretty_print
         static constexpr auto suffixes = {"Ki", "Mi", "Gi", "Ti", "Pi"};
         auto [n, suffix, bytes] = do_format(data_size._size, suffixes, 1024, 8192, _bytes);
         return fmt::format_to(ctx.out(), "{}{}{}", n, suffix, bytes);
+    } else if (_prefix == prefix_type::IEC_SANS_I) {
+        static constexpr auto suffixes = {"K", "M", "G", "T", "P"};
+        auto [n, suffix, bytes] = do_format(data_size._size, suffixes, 1024, 8192, false);
+        if (suffix.empty()) {
+            bytes = "B";
+        }
+        return fmt::format_to(ctx.out(), "{}{}{}", n, suffix, bytes);
     } else {
         // SI units
         static constexpr auto suffixes = {"k", "M", "G", "T", "P"};

--- a/utils/pretty_printers.hh
+++ b/utils/pretty_printers.hh
@@ -42,6 +42,8 @@ public:
 //   fmt::print("{:i}", 42);   // prints "42 bytes"
 //   fmt::print("{:ib}", 10'024); // prints "10Ki", IEC unit is used, without
 //                                // the " bytes" or "B" unit
+//   fmt::print("{:I}", 1024); // prints "1K", IEC unit is used, but without
+//                             // the "iB" postifx.
 //   fmt::print("{:s}", 10); // prints "10 bytes", SI unit is used
 //   fmt::print("{:sb}", 10'000); // prints "10k", SI unit is used, without
 //                                // the unit postfix
@@ -50,6 +52,7 @@ struct fmt::formatter<utils::pretty_printed_data_size> {
     enum class prefix_type {
         SI,
         IEC,
+        IEC_SANS_I,
     };
     prefix_type _prefix = prefix_type::SI;
     bool _bytes = true;
@@ -62,6 +65,9 @@ struct fmt::formatter<utils::pretty_printed_data_size> {
                 ++it;
             } else if (*it == 'i') {
                 _prefix = prefix_type::IEC;
+                ++it;
+            } else if (*it == 'I') {
+                _prefix = prefix_type::IEC_SANS_I;
                 ++it;
             }
             if (*it == 'b') {


### PR DESCRIPTION
this is to mimic the formatting of `human_readable_value`, and to prepare for consolidating these two formatters, so we don't have two pretty printers in the tree.