### PR TITLE
test/unit/bptree_validation: use "{}" for formatting test_data

### DIFF
--- a/test/unit/bptree_validation.hh
+++ b/test/unit/bptree_validation.hh
@@ -291,11 +291,11 @@ private:
         }
         _fwd--;
         if (val != *_fwd) {
-            fmt::print(std::cout, "Iterator broken, {:d} != {:d}\n", val, *_fwd);
+            fmt::print(std::cout, "Iterator broken, {} != {}\n", val, *_fwd);
             throw "iterator";
         }
         if (val < _fprev) {
-            fmt::print(std::cout, "Iterator broken, {:d} < {:d}\n", val, _fprev);
+            fmt::print(std::cout, "Iterator broken, {} < {}\n", val, _fprev);
             throw "iterator";
         }
         _fprev = val;


### PR DESCRIPTION
before this change, "{:d}" is used for formatting `test_data` y bptree_stress_test.cc. but the "d" specifier is only used for formatting integers, not for formatting `test_data` or generic data types, so this fails when the test is compiled with {fmt} v10, like:

```
In file included from /home/kefu/dev/scylladb/test/unit/bptree_stress_test.cc:20:
/home/kefu/dev/scylladb/test/unit/bptree_validation.hh:294:35: error: call to consteval function 'fmt::basic_format_string<char, test_data &, test_data &>::basic_format_string<char[31], 0>' is not a constant expression
  294 |             fmt::print(std::cout, "Iterator broken, {:d} != {:d}\n", val, *_fwd);
      |                                   ^
/home/kefu/dev/scylladb/test/unit/bptree_validation.hh:267:20: note: in instantiation of member function 'bplus::iterator_checker<tree_test_key_base, test_data, test_key_compare, 16>::forward_check' requested here
  267 |             return forward_check();
      |                    ^
/home/kefu/dev/scylladb/test/unit/bptree_stress_test.cc:92:35: note: in instantiation of member function 'bplus::iterator_checker<tree_test_key_base, test_data, test_key_compare, 16>::step' requested here
   92 |                         if (!itc->step()) {
      |                                   ^
/usr/include/fmt/core.h:2322:31: note: non-constexpr function 'throw_format_error' cannot be used in a constant expression
 2322 |       if (!in(arg_type, set)) throw_format_error("invalid format specifier");
      |                               ^
```

in this change, instead of specifying "{:d}", let's just use "{}", which works for both integer and `test_data`.