### PR TITLE
token_metadata: remove_endpoint: delete replacing endpoint by value

### DIFF
--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -579,6 +579,7 @@ void token_metadata_impl::remove_endpoint(host_id endpoint) {
     _topology.remove_endpoint(endpoint);
     _leaving_endpoints.erase(endpoint);
     del_replacing_endpoint(endpoint);
+    remove_by_value(_replacing_endpoints, endpoint);
     invalidate_cached_rings();
 }
 


### PR DESCRIPTION
Currently, we only attempt to remove a replacing endpoint from _replacing_endpoints by key, i.e. as an existing node, but it might exist there as a value, i.e. as a replacing node with consistent-topology-changes.

Regardless, remove_endpoint should leave no trace of the the removed endpoint in token_metadata and the respective topology hence the fix is implemented here and not in storage_service.
