### PR TITLE
Add more logging for `gossiper::lock_endpoint` and `storage_service::handle_state_normal`

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -775,14 +775,14 @@ future<> gossiper::do_status_check() {
     }
 }
 
-gossiper::endpoint_permit::endpoint_permit(endpoint_locks_map::entry_ptr&& ptr, inet_address addr, std::string caller) noexcept
+gossiper::endpoint_permit::endpoint_permit(endpoint_locks_map::entry_ptr&& ptr, inet_address addr, seastar::compat::source_location caller) noexcept
     : _ptr(std::move(ptr))
     , _permit_id(_ptr->pid)
     , _addr(std::move(addr))
     , _caller(std::move(caller))
 {
     ++_ptr->holders;
-    logger.debug("{}: lock_endpoint {}: acquired: permit_id={} holders={}", _caller, _addr, _permit_id, _ptr->holders);
+    logger.debug("{}: lock_endpoint {}: acquired: permit_id={} holders={}", _caller.function_name(), _addr, _permit_id, _ptr->holders);
 }
 
 gossiper::endpoint_permit::endpoint_permit(endpoint_permit&& o) noexcept
@@ -799,9 +799,9 @@ gossiper::endpoint_permit::~endpoint_permit() {
 bool gossiper::endpoint_permit::release() noexcept {
     if (auto ptr = std::exchange(_ptr, nullptr)) {
         assert(ptr->pid == _permit_id);
-        logger.debug("{}: lock_endpoint {}: released: permit_id={} holders={}", _caller, _addr, _permit_id, ptr->holders);
+        logger.debug("{}: lock_endpoint {}: released: permit_id={} holders={}", _caller.function_name(), _addr, _permit_id, ptr->holders);
         if (!--ptr->holders) {
-            logger.debug("{}: lock_endpoint {}: released: permit_id={}", _caller, _addr, _permit_id);
+            logger.debug("{}: lock_endpoint {}: released: permit_id={}", _caller.function_name(), _addr, _permit_id);
             ptr->units.return_all();
             ptr->pid = null_permit_id;
             _permit_id = null_permit_id;
@@ -820,27 +820,26 @@ future<gossiper::endpoint_permit> gossiper::lock_endpoint(inet_address ep, permi
     if (this_shard_id() != 0) {
         on_internal_error(logger, "lock_endpoint must be called on shard 0");
     }
-    std::string caller = l.function_name();
     auto eptr = co_await _endpoint_locks.get_or_load(ep, [] (const inet_address& ep) { return endpoint_lock_entry(); });
     if (pid) {
         if (eptr->pid == pid) {
             // Already locked with the same permit
-            co_return endpoint_permit(std::move(eptr), std::move(ep), std::move(caller));
+            co_return endpoint_permit(std::move(eptr), std::move(ep), std::move(l));
         } else {
             // permit_id mismatch means either that the endpoint lock was released,
             // or maybe we're passed a permit_id that was acquired for a different endpoint.
-            on_internal_error_noexcept(logger, fmt::format("{}: lock_endpoint {}: permit_id={}: endpoint_lock_entry has mismatching permit_id={}", caller, ep, pid, eptr->pid));
+            on_internal_error_noexcept(logger, fmt::format("{}: lock_endpoint {}: permit_id={}: endpoint_lock_entry has mismatching permit_id={}", l.function_name(), ep, pid, eptr->pid));
         }
     }
     pid = permit_id::create_random_id();
-    logger.debug("{}: lock_endpoint {}: waiting: permit_id={}", caller, ep, pid);
+    logger.debug("{}: lock_endpoint {}: waiting: permit_id={}", l.function_name(), ep, pid);
     eptr->units = co_await get_units(eptr->sem, 1, _abort_source);
     eptr->pid = pid;
     if (eptr->holders) {
-        on_internal_error_noexcept(logger, fmt::format("{}: lock_endpoint {}: newly held endpoint_lock_entry has {} holders", caller, ep, eptr->holders));
+        on_internal_error_noexcept(logger, fmt::format("{}: lock_endpoint {}: newly held endpoint_lock_entry has {} holders", l.function_name(), ep, eptr->holders));
     }
     _abort_source.check();
-    co_return endpoint_permit(std::move(eptr), std::move(ep), std::move(caller));
+    co_return endpoint_permit(std::move(eptr), std::move(ep), std::move(l));
 }
 
 void gossiper::permit_internal_error(const inet_address& addr, permit_id pid) {

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -160,9 +160,9 @@ public:
         endpoint_locks_map::entry_ptr _ptr;
         permit_id _permit_id;
         inet_address _addr;
-        std::string _caller;
+        seastar::compat::source_location _caller;
     public:
-        endpoint_permit(endpoint_locks_map::entry_ptr&& ptr, inet_address addr, std::string caller) noexcept;
+        endpoint_permit(endpoint_locks_map::entry_ptr&& ptr, inet_address addr, seastar::compat::source_location caller) noexcept;
         endpoint_permit(endpoint_permit&&) noexcept;
         ~endpoint_permit();
         bool release() noexcept;

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -152,6 +152,10 @@ public:
         permit_id pid;
         semaphore_units<> units;
         size_t holders = 0;
+        std::optional<seastar::compat::source_location> first_holder;
+        // last_holder is the caller of endpoint_permit who last took this entry,
+        // it might not be a current holder (the permit might've been destroyed)
+        std::optional<seastar::compat::source_location> last_holder;
 
         endpoint_lock_entry() noexcept;
     };


### PR DESCRIPTION
In a longevity test reported in scylladb/scylladb#16668 we observed that
NORMAL state is not being properly handled for a node that replaced
another node. Either handle_state_normal is not being called, or it is
but getting stuck in the middle. Which is the case couldn't be
determined from the logs, and attempts at creating a local reproducer
failed.

Thus the plan is to continue debugging using the longevity test, but we need
more logs. To check whether `handle_state_normal` was called and which branches
were taken, include some INFO level logs there. Also, detect deadlocks inside
`gossiper::lock_endpoint` by reporting an error message if `lock_endpoint`
waits for the lock for too long.

Ref: scylladb/scylladb#16668