### PR TITLE
alternator: do not include unused headers

### DIFF
--- a/alternator/auth.hh
+++ b/alternator/auth.hh
@@ -9,9 +9,6 @@
 #pragma once
 
 #include <string>
-#include <string_view>
-#include <array>
-#include "gc_clock.hh"
 #include "utils/loading_cache.hh"
 
 namespace service {

--- a/alternator/conditions.cc
+++ b/alternator/conditions.cc
@@ -6,12 +6,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <list>
-#include <map>
 #include <string_view>
 #include "alternator/conditions.hh"
 #include "alternator/error.hh"
-#include "cql3/constants.hh"
 #include <unordered_map>
 #include "utils/rjson.hh"
 #include "serialization.hh"

--- a/alternator/conditions.hh
+++ b/alternator/conditions.hh
@@ -18,8 +18,6 @@
 
 #pragma once
 
-#include "cql3/restrictions/statement_restrictions.hh"
-#include "serialization.hh"
 #include "expressions_types.hh"
 
 namespace alternator {

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -6,13 +6,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include "utils/base64.hh"
-
 #include <seastar/core/sleep.hh>
 #include "alternator/executor.hh"
 #include "log.hh"
 #include "schema/schema_builder.hh"
-#include "data_dictionary/keyspace_metadata.hh"
 #include "exceptions/exceptions.hh"
 #include "timestamp.hh"
 #include "types/map.hh"
@@ -21,17 +18,13 @@
 #include "query-result-reader.hh"
 #include "cql3/selection/selection.hh"
 #include "cql3/result_set.hh"
-#include "cql3/type_json.hh"
 #include "bytes.hh"
-#include "cql3/update_parameters.hh"
-#include "server.hh"
 #include "service/pager/query_pagers.hh"
 #include <functional>
 #include "error.hh"
 #include "serialization.hh"
 #include "expressions.hh"
 #include "conditions.hh"
-#include "cql3/constants.hh"
 #include "cql3/util.hh"
 #include <optional>
 #include "utils/overloaded_functor.hh"
@@ -41,6 +34,7 @@
 #include "schema/schema.hh"
 #include "db/tags/extension.hh"
 #include "db/tags/utils.hh"
+#include "replica/database.hh"
 #include "alternator/rmw_operation.hh"
 #include <seastar/core/coroutine.hh>
 #include <boost/range/adaptors.hpp>
@@ -48,7 +42,6 @@
 #include <unordered_set>
 #include "service/storage_proxy.hh"
 #include "gms/gossiper.hh"
-#include "schema/schema_registry.hh"
 #include "utils/error_injection.hh"
 #include "db/schema_tables.hh"
 #include "utils/rjson.hh"

--- a/alternator/serialization.cc
+++ b/alternator/serialization.cc
@@ -11,7 +11,6 @@
 #include "log.hh"
 #include "serialization.hh"
 #include "error.hh"
-#include "rapidjson/writer.h"
 #include "concrete_types.hh"
 #include "cql3/type_json.hh"
 #include "mutation/position_in_partition.hh"

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -11,7 +11,6 @@
 #include <cstdint>
 
 #include <seastar/core/metrics_registration.hh>
-#include "seastarx.hh"
 #include "utils/estimated_histogram.hh"
 #include "cql3/stats.hh"
 

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -13,8 +13,6 @@
 
 #include <seastar/json/formatter.hh>
 
-#include "utils/base64.hh"
-#include "log.hh"
 #include "db/config.hh"
 
 #include "cdc/log.hh"
@@ -25,7 +23,6 @@
 #include "utils/UUID_gen.hh"
 #include "cql3/selection/selection.hh"
 #include "cql3/result_set.hh"
-#include "cql3/type_json.hh"
 #include "cql3/column_identifier.hh"
 #include "schema/schema_builder.hh"
 #include "service/storage_proxy.hh"
@@ -33,7 +30,6 @@
 #include "gms/feature_service.hh"
 
 #include "executor.hh"
-#include "rmw_operation.hh"
 #include "data_dictionary/data_dictionary.hh"
 
 /**

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -32,7 +32,6 @@
 #include "service/pager/paging_state.hh"
 #include "service/pager/query_pagers.hh"
 #include "gms/feature_service.hh"
-#include "sstables/types.hh"
 #include "mutation/mutation.hh"
 #include "types/types.hh"
 #include "types/map.hh"


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.