### PR TITLE
docs: dynamic include based on flag

### DIFF
--- a/docs/_ext/scylladb_include_flag.py
+++ b/docs/_ext/scylladb_include_flag.py
@@ -1,0 +1,25 @@
+from sphinx.directives.other import Include
+from docutils.parsers.rst import directives
+
+class IncludeFlagDirective(Include):
+    option_spec = Include.option_spec.copy()
+    option_spec['base_path'] = directives.unchanged
+
+    def run(self):
+        env = self.state.document.settings.env
+        base_path = self.options.get('base_path', '_common')
+
+        if env.app.tags.has('enterprise'):
+            self.arguments[0] = base_path + "_enterprise/" + self.arguments[0]
+        else:
+            self.arguments[0] = base_path + "/" + self.arguments[0]
+        return super().run()
+
+def setup(app):
+    app.add_directive('scylladb_include_flag', IncludeFlagDirective, override=True)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,8 @@ extensions = [
     "sphinx_scylladb_markdown",
     "sphinxcontrib.datatemplates",
     "scylladb_cc_properties",
-    "scylladb_aws_images"
+    "scylladb_aws_images",
+    "scylladb_include_flag"
 ]
 
 # The suffix(es) of source filenames.


### PR DESCRIPTION
## Motivation

The current system lacks an efficient way to include dynamic content on an RST page based on the opensource / enterprise flag. While we can leverage Sphinx's `only` directive to achieve so, it is preferable to keep the content maintained on each repo.

## Proposal

I propose a custom Sphinx extension that enhances the existing `include` directive, named `scylladb_include_flag`. This extension allows for dynamic loading of content based on 'opensource' or 'enterprise' tags.

When building documentation, this directive decides whether to pull content from either the `_common` (for open-source) or `_common_enterprise` (for enterprise) directories.

For instance, including `.. scylladb_include_flag:: path_to_file.rst` in an RST page will load either `_common/path_to_file.rst` for open-source or `_common_enterprise/path_to_file.rst` for the enterprise documentation.


## How to test

To test the opensource behaviour:

1. Add the directive into a RST page:

```
.. scylladb_include_flag:: path_to_file.rst
```

2. Create a `_common` directory at the same level as the RST page, if it doesn't exist.

3. In `_common`, add `path_to_file.rst` with your content.

4. Build the docs to see the content load.

To test the enterprise behavior:

1. In Makefile, change the `opensource` flag to `enterprise`:

```
FLAG          := enterprise
```

2. In the same file, remove the following lines:

```
# Internal variables
ifeq ($(FLAG), enterprise)
    CONF_PATH = ./_enterprise
endif
```

3. Next to the `_common` folder, create a `_common_enterprise` folder.

4. Within `_common_enterprise`, create a file `path_to_file.rst` with different content.

4. Build the docs to see the enterprise content load.

## Next steps

After merging this pull request into this repository, I'll activate it in the enterprise repository as well. This will allow us to use the directive in both repositories, ensuring the enterprise build does not break.