### PR TITLE
test/boost/auth_resource_test.cc: do not rely on templated operator<<

### DIFF
--- a/test/boost/auth_resource_test.cc
+++ b/test/boost/auth_resource_test.cc
@@ -10,16 +10,18 @@
 
 #include "auth/resource.hh"
 
-#include <sstream>
-
 #include <boost/test/unit_test.hpp>
-
-#include "utils/to_string.hh"
+#include <fmt/ranges.h>
 
 namespace auth {
 
-std::ostream& operator<<(std::ostream& os, resource_kind kind) {
+std::ostream& boost_test_print_type(std::ostream& os, const resource_kind& kind) {
     fmt::print(os, "{}", kind);
+    return os;
+}
+
+std::ostream& boost_test_print_type(std::ostream& os, const resource_set& resources) {
+    fmt::print(os, "{}", resources);
     return os;
 }
 


### PR DESCRIPTION
This change is intended to remove the dependency to `operator<<(std::ostream&, const std::unordered_set<T>&)` from auth_resource_test.cc.

It prepares the test for removal of the templated helpers from utils/to_string.hh, which is one of goals of the referenced issue that is linked below.

Refs: #13245