### PR TITLE
compaction_manager: flush tables before cleanup

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -802,7 +802,7 @@
          "operations":[
             {
                "method":"POST",
-               "summary":"Trigger a global cluster cleanup through the topology coordinator",
+               "summary":"Trigger a global cleanup",
                "type":"long",
                "nickname":"cleanup_all",
                "produces":[

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -1068,9 +1068,9 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         }};
 
         auto& compaction_module = ctx.db.local().get_compaction_manager().get_task_manager_module();
-        std::optional<major_compaction_task_impl::flush_mode> fmopt;
+        std::optional<flush_mode> fmopt;
         if (!flush) {
-            fmopt = major_compaction_task_impl::flush_mode::skip;
+            fmopt = flush_mode::skip;
         }
         auto task = co_await compaction_module.make_and_start_task<major_keyspace_compaction_task_impl>({}, std::move(keyspace), tasks::task_id::create_null_id(), ctx.db, std::move(table_infos), fmopt);
         co_await task->done();

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -39,6 +39,7 @@
 #include "log.hh"
 #include "release.hh"
 #include "compaction/compaction_manager.hh"
+#include "compaction/task_manager_module.hh"
 #include "sstables/sstables.hh"
 #include "replica/database.hh"
 #include "db/extensions.hh"
@@ -785,7 +786,8 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         }
 
         auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
-        auto task = co_await compaction_module.make_and_start_task<cleanup_keyspace_compaction_task_impl>({}, std::move(keyspace), db, table_infos);
+        auto task = co_await compaction_module.make_and_start_task<cleanup_keyspace_compaction_task_impl>(
+            {}, std::move(keyspace), db, table_infos, flush_mode::all_tables);
         try {
             co_await task->done();
         } catch (...) {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -723,9 +723,9 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         apilog.info("force_compaction: flush={}", flush);
 
         auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
-        std::optional<major_compaction_task_impl::flush_mode> fmopt;
+        std::optional<flush_mode> fmopt;
         if (!flush) {
-            fmopt = major_compaction_task_impl::flush_mode::skip;
+            fmopt = flush_mode::skip;
         }
         auto task = co_await compaction_module.make_and_start_task<global_major_compaction_task_impl>({}, db, fmopt);
         try {
@@ -752,9 +752,9 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         apilog.debug("force_keyspace_compaction: keyspace={} tables={}, flush={}", keyspace, table_infos, flush);
 
         auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
-        std::optional<major_compaction_task_impl::flush_mode> fmopt;
+        std::optional<flush_mode> fmopt;
         if (!flush) {
-            fmopt = major_compaction_task_impl::flush_mode::skip;
+            fmopt = flush_mode::skip;
         }
         auto task = co_await compaction_module.make_and_start_task<major_keyspace_compaction_task_impl>({}, std::move(keyspace), tasks::task_id::create_null_id(), db, table_infos, fmopt);
         try {

--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -50,9 +50,9 @@ void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<service::
         apilog.debug("force_keyspace_compaction_async: keyspace={} tables={}, flush={}", keyspace, table_infos, flush);
 
         auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
-        std::optional<major_compaction_task_impl::flush_mode> fmopt;
+        std::optional<flush_mode> fmopt;
         if (!flush) {
-            fmopt = major_compaction_task_impl::flush_mode::skip;
+            fmopt = flush_mode::skip;
         }
         auto task = co_await compaction_module.make_and_start_task<major_keyspace_compaction_task_impl>({}, std::move(keyspace), tasks::task_id::create_null_id(), db, table_infos, fmopt);
 

--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -71,7 +71,7 @@ void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<service::
         }
 
         auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
-        auto task = co_await compaction_module.make_and_start_task<cleanup_keyspace_compaction_task_impl>({}, std::move(keyspace), db, table_infos);
+        auto task = co_await compaction_module.make_and_start_task<cleanup_keyspace_compaction_task_impl>({}, std::move(keyspace), db, table_infos, flush_mode::all_tables);
 
         co_return json::json_return_type(task->get_status().id.to_sstring());
     });

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -329,15 +329,6 @@ tasks::is_abortable compaction_task_impl::is_abortable() const noexcept {
     return tasks::is_abortable{!_parent_id};
 }
 
-sstring major_compaction_task_impl::to_string(flush_mode fm) {
-    switch (fm) {
-    case flush_mode::skip: return "skip";
-    case flush_mode::compacted_tables: return "compacted_tables";
-    case flush_mode::all_tables: return "all_tables";
-    }
-    __builtin_unreachable();
-}
-
 static future<bool> maybe_flush_all_tables(sharded<replica::database>& db) {
     auto interval = db.local().get_config().compaction_flush_all_tables_before_major_seconds();
     if (interval) {
@@ -663,4 +654,21 @@ future<> shard_resharding_compaction_task_impl::run() {
     co_await _dir.local().move_foreign_sstables(_dir);
 }
 
+}
+
+auto fmt::formatter<compaction::flush_mode>::format(compaction::flush_mode fm, fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    std::string_view name;
+    switch (fm) {
+    using enum compaction::flush_mode;
+    case skip:
+        name = "skip";
+        break;
+    case compacted_tables:
+        name = "compacted_tables";
+        break;
+    case all_tables:
+        name = "all_tables";
+        break;
+    }
+    return fmt::format_to(ctx.out(), "{}", name);
 }

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -48,14 +48,14 @@ protected:
     future<tasks::task_manager::task::progress> get_progress(const sstables::compaction_data& cdata, const sstables::compaction_progress_monitor& progress_monitor) const;
 };
 
+enum class flush_mode {
+    skip,               // Skip flushing.  Useful when application explicitly flushes all tables prior to compaction
+    compacted_tables,   // Flush only the compacted keyspace/tables
+    all_tables          // Flush all tables in the database prior to compaction
+};
+
 class major_compaction_task_impl : public compaction_task_impl {
 public:
-    enum class flush_mode {
-        skip,               // Skip flushing.  Useful when application explicitly flushes all tables prior to compaction
-        compacted_tables,   // Flush only the compacted keyspace/tables
-        all_tables          // Flush all tables in the database prior to compaction
-    };
-
     major_compaction_task_impl(tasks::task_manager::module_ptr module,
             tasks::task_id id,
             unsigned sequence_number,
@@ -718,10 +718,10 @@ protected:
 } // namespace compaction
 
 template <>
-struct fmt::formatter<major_compaction_task_impl::flush_mode> {
+struct fmt::formatter<compaction::flush_mode> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     template <typename FormatContext>
-    auto format(const major_compaction_task_impl::flush_mode& fm, FormatContext& ctx) const {
+    auto format(const compaction::flush_mode& fm, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", major_compaction_task_impl::to_string(fm));
     }
 };

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -75,7 +75,6 @@ public:
         return "major compaction";
     }
 
-    static sstring to_string(flush_mode);
 protected:
     flush_mode _flush_mode;
 
@@ -723,8 +722,5 @@ protected:
 template <>
 struct fmt::formatter<compaction::flush_mode> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-    template <typename FormatContext>
-    auto format(const compaction::flush_mode& fm, FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "{}", major_compaction_task_impl::to_string(fm));
-    }
+    auto format(compaction::flush_mode, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -214,6 +214,22 @@ protected:
     virtual future<> run() override;
 };
 
+class global_cleanup_compaction_task_impl : public compaction_task_impl {
+private:
+    sharded<replica::database>& _db;
+public:
+    global_cleanup_compaction_task_impl(tasks::task_manager::module_ptr module,
+            sharded<replica::database>& db) noexcept
+        : compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "global", "", "", "", tasks::task_id::create_null_id())
+        , _db(db)
+    {}
+    std::string type() const final {
+        return "global cleanup compaction";
+    }
+private:
+    future<> run() final;
+};
+
 class shard_cleanup_keyspace_compaction_task_impl : public cleanup_compaction_task_impl {
 private:
     replica::database& _db;

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -199,14 +199,17 @@ class cleanup_keyspace_compaction_task_impl : public cleanup_compaction_task_imp
 private:
     sharded<replica::database>& _db;
     std::vector<table_info> _table_infos;
+    const flush_mode _flush_mode;
 public:
     cleanup_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
             sharded<replica::database>& db,
-            std::vector<table_info> table_infos) noexcept
+            std::vector<table_info> table_infos,
+            flush_mode mode) noexcept
         : cleanup_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "keyspace", std::move(keyspace), "", "", tasks::task_id::create_null_id())
         , _db(db)
         , _table_infos(std::move(table_infos))
+        , _flush_mode(mode)
     {}
 protected:
     virtual future<> run() override;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -996,7 +996,9 @@ public:
     // a future<bool> that is resolved when offstrategy_compaction completes.
     // The future value is true iff offstrategy compaction was required.
     future<bool> perform_offstrategy_compaction(std::optional<tasks::task_info> info = std::nullopt);
-    future<> perform_cleanup_compaction(owned_ranges_ptr sorted_owned_ranges, std::optional<tasks::task_info> info = std::nullopt);
+    future<> perform_cleanup_compaction(owned_ranges_ptr sorted_owned_ranges,
+                                        std::optional<tasks::task_info> info = std::nullopt,
+                                        do_flush = do_flush::yes);
     unsigned estimate_pending_compactions() const;
 
     void set_compaction_strategy(sstables::compaction_strategy_type strategy);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1626,9 +1626,12 @@ future<bool> table::perform_offstrategy_compaction(std::optional<tasks::task_inf
     co_return performed;
 }
 
-future<> table::perform_cleanup_compaction(compaction::owned_ranges_ptr sorted_owned_ranges, std::optional<tasks::task_info> info) {
-    co_await flush();
-
+future<> table::perform_cleanup_compaction(compaction::owned_ranges_ptr sorted_owned_ranges,
+                                           std::optional<tasks::task_info> info,
+                                           do_flush do_flush) {
+    if (do_flush) {
+        co_await flush();
+    }
     if (_compaction_groups.size() == 1) {
         auto& cg = *get_compaction_group(0);
         co_return co_await get_compaction_manager().perform_cleanup(std::move(sorted_owned_ranges), cg.as_table_state(), info);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -10,6 +10,7 @@
  */
 
 #include "storage_service.hh"
+#include "compaction/task_manager_module.hh"
 #include "gc_clock.hh"
 #include "service/topology_guard.hh"
 #include "service/session.hh"
@@ -767,7 +768,9 @@ future<> storage_service::sstable_cleanup_fiber(raft::server& server, sharded<se
                     co_return co_await sp.await_pending_writes();
                 });
                 auto& compaction_module = _db.local().get_compaction_manager().get_task_manager_module();
-                auto task = co_await compaction_module.make_and_start_task<cleanup_keyspace_compaction_task_impl>({}, ks_name, _db, table_infos);
+                // we flush all tables before cleanup the keyspaces individually, so skip the flush-tables step here
+                auto task = co_await compaction_module.make_and_start_task<cleanup_keyspace_compaction_task_impl>(
+                    {}, ks_name, _db, table_infos, flush_mode::skip);
                 try {
                     co_return co_await task->done();
                 } catch (...) {
@@ -792,6 +795,9 @@ future<> storage_service::sstable_cleanup_fiber(raft::server& server, sharded<se
 
                 tasks.reserve(keyspaces.size());
 
+                co_await _db.invoke_on_all([&] (replica::database& db) {
+                    return db.flush_all_tables();
+                });
                 co_await coroutine::parallel_for_each(keyspaces.begin(), keyspaces.end(), [this, &tasks, &do_cleanup_ks] (const sstring& ks_name) -> future<> {
                     auto& ks = _db.local().find_keyspace(ks_name);
                     if (ks.get_replication_strategy().is_per_table() || is_system_keyspace(ks_name)) {

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -173,15 +173,7 @@ void cleanup_operation(scylla_rest_client& client, const bpo::variables_map& vm)
         }
         client.post(format("/storage_service/keyspace_cleanup/{}", keyspace), std::move(params));
     } else {
-        auto res = client.post(format("/storage_service/cleanup_all"));
-        if (res.IsObject()) {
-            // If previous post returns an object instead of a simple value it means the request
-            // failed either because server does not support it yet or topology coordinator is disabled.
-            // Fall back to the old cleanup API.
-            for (const auto& keyspace : get_keyspaces(client, "non_local_strategy")) {
-                client.post(format("/storage_service/keyspace_cleanup/{}", keyspace));
-            }
-        }
+        client.post("/storage_service/cleanup_all");
     }
 }
 


### PR DESCRIPTION
according to the document "nodetool cleanup"

> Triggers removal of data that the node no longer owns

currently, scylla performs cleanup by rewriting the sstables. but
commitlog segments may still contain the mutations to the tables
which are dropped during sstable rewriting. when scylla server
restarts, the dirty mutations are replayed to the memtable. if
any of these dirty mutations changes the tables cleaned up. the
stale data are reapplied. this would lead to data resurrection.

so, in this change we following the same model of major compaction
where we

1. forcing new active segment,
2. flushing tables being cleaned up
3. perform cleanup using compaction

Fixes #4734