### PR TITLE
cql_auth_query_test.cc: do not rely on templated operator<<

### DIFF
--- a/test/boost/cql_auth_query_test.cc
+++ b/test/boost/cql_auth_query_test.cc
@@ -32,6 +32,15 @@
 static const auto alice = std::string_view("alice");
 static const auto bob = std::string_view("bob");
 
+namespace seastar {
+
+std::ostream& boost_test_print_type(std::ostream& os, const std::unordered_set<seastar::sstring>& strings) {
+    fmt::print(os, "{}", strings);
+    return os;
+}
+
+} // namespace seastar
+
 static shared_ptr<db::config> db_config_with_auth() {
     shared_ptr<db::config> config_ptr = make_shared<db::config>();
     auto& config = *config_ptr;


### PR DESCRIPTION
This change is intended to remove the dependency to `operator<<(std::ostream&, const std::unordered_set<seastar::sstring>&)` from test/boost/cql_auth_query_test.cc.

It prepares the test for removal of the templated helpers. Such removal is one of goals of the referenced issue that is linked below.

Refs: #13245