### PR TITLE
./: not include unused headers

### DIFF
--- a/compress.cc
+++ b/compress.cc
@@ -11,6 +11,7 @@
 #include <snappy-c.h>
 
 #include "compress.hh"
+#include "exceptions/exceptions.hh"
 #include "utils/class_registrator.hh"
 
 const sstring compressor::namespace_prefix = "org.apache.cassandra.io.compress.";

--- a/compress.hh
+++ b/compress.hh
@@ -14,9 +14,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
-
-#include "exceptions/exceptions.hh"
-
+#include "seastarx.hh"
 
 class compressor {
     sstring _name;

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -13,6 +13,7 @@
 #include "data_dictionary/keyspace_metadata.hh"
 #include "locator/token_metadata.hh"
 #include "locator/abstract_replication_strategy.hh"
+#include "exceptions/exceptions.hh"
 
 namespace cql3 {
 

--- a/db/per_partition_rate_limit_options.cc
+++ b/db/per_partition_rate_limit_options.cc
@@ -8,7 +8,7 @@
 
 #include <optional>
 #include <boost/range/adaptor/map.hpp>
-
+#include "exceptions/exceptions.hh"
 #include "serializer.hh"
 #include "schema/schema.hh"
 #include "log.hh"

--- a/hashing_partition_visitor.hh
+++ b/hashing_partition_visitor.hh
@@ -12,8 +12,6 @@
 #include "utils/hashing.hh"
 #include "schema/schema.hh"
 #include "mutation/atomic_cell_hash.hh"
-#include "keys.hh"
-#include "counters.hh"
 #include "mutation/position_in_partition.hh"
 
 // Calculates a hash of a mutation_partition which is consistent with

--- a/index/secondary_index.cc
+++ b/index/secondary_index.cc
@@ -17,6 +17,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptors.hpp>
 
+#include "exceptions/exceptions.hh"
 #include "utils/rjson.hh"
 #include "log.hh"
 

--- a/init.cc
+++ b/init.cc
@@ -7,7 +7,6 @@
  */
 
 #include "init.hh"
-#include "utils/to_string.hh"
 #include "gms/inet_address.hh"
 #include "seastarx.hh"
 #include "db/config.hh"

--- a/locator/ec2_multi_region_snitch.cc
+++ b/locator/ec2_multi_region_snitch.cc
@@ -9,6 +9,7 @@
  */
 
 #include "locator/ec2_multi_region_snitch.hh"
+#include "exceptions/exceptions.hh"
 #include "gms/gossiper.hh"
 
 static constexpr const char* PUBLIC_IP_QUERY_REQ  = "/latest/meta-data/public-ipv4";

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -12,6 +12,7 @@
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include "simple_strategy.hh"
+#include "exceptions/exceptions.hh"
 #include "utils/class_registrator.hh"
 #include <boost/algorithm/string.hpp>
 #include "utils/sequenced_set.hh"

--- a/map_difference.hh
+++ b/map_difference.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <map>
 #include <set>
 
 template<typename Key>

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -18,8 +18,6 @@
 #include "gms/gossip_digest_syn.hh"
 #include "gms/gossip_digest_ack.hh"
 #include "gms/gossip_digest_ack2.hh"
-#include "locator/tablets.hh"
-#include "query-request.hh"
 #include "query-result.hh"
 #include <seastar/rpc/rpc.hh>
 #include "mutation/canonical_mutation.hh"

--- a/mutation_query.cc
+++ b/mutation_query.cc
@@ -7,9 +7,6 @@
  */
 
 #include "mutation_query.hh"
-#include "gc_clock.hh"
-#include "mutation/mutation_partition_serializer.hh"
-#include "query-result-writer.hh"
 
 reconcilable_result::~reconcilable_result() {}
 

--- a/partition_range_compat.hh
+++ b/partition_range_compat.hh
@@ -12,7 +12,6 @@
 #include <vector>
 #include "range.hh"
 #include "dht/ring_position.hh"
-#include "query-request.hh"
 
 namespace compat {
 

--- a/partition_snapshot_row_cursor.hh
+++ b/partition_snapshot_row_cursor.hh
@@ -12,6 +12,7 @@
 #include "row_cache.hh"
 #include "utils/small_vector.hh"
 #include <boost/algorithm/cxx11/any_of.hpp>
+#include <boost/range/algorithm/find_if.hpp>
 #include <boost/range/algorithm/heap_algorithm.hpp>
 
 class partition_snapshot_row_cursor;

--- a/query-request.hh
+++ b/query-request.hh
@@ -15,6 +15,7 @@
 #include "db/functions/function_name.hh"
 #include "db/functions/function.hh"
 #include "db/functions/aggregate_function.hh"
+#include "db/consistency_level_type.hh"
 #include "keys.hh"
 #include "dht/ring_position.hh"
 #include "enum_set.hh"
@@ -23,7 +24,6 @@
 #include "utils/small_vector.hh"
 #include "db/per_partition_rate_limit_info.hh"
 #include "query_id.hh"
-#include "utils/UUID.hh"
 #include "bytes.hh"
 #include "cql_serialization_format.hh"
 

--- a/query-result-reader.hh
+++ b/query-result-reader.hh
@@ -12,7 +12,6 @@
 #include <boost/range/numeric.hpp>
 
 #include "query-result.hh"
-#include "utils/digest_algorithm.hh"
 #include "full_position.hh"
 
 #include "idl/query.dist.hh"

--- a/query-result-set.cc
+++ b/query-result-set.cc
@@ -11,7 +11,6 @@
 #include "partition_slice_builder.hh"
 #include "mutation/mutation.hh"
 #include "types/map.hh"
-#include "utils/exceptions.hh"
 #include "mutation_query.hh"
 
 #include <fmt/format.h>

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -18,7 +18,6 @@
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include "db/marshal/type_parser.hh"
-#include "version.hh"
 #include "schema_registry.hh"
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm.hpp>

--- a/serializer.hh
+++ b/serializer.hh
@@ -7,22 +7,14 @@
  */
 #pragma once
 
-#include <vector>
-#include <unordered_set>
-#include <list>
-#include <array>
 #include <seastar/core/sstring.hh>
-#include <unordered_map>
 #include <optional>
-#include "enum_set.hh"
 #include "utils/managed_bytes.hh"
 #include "bytes_ostream.hh"
 #include <seastar/core/simple-stream.hh>
 #include "boost/variant/variant.hpp"
 #include "bytes_ostream.hh"
-#include "utils/input_stream.hh"
 #include "utils/fragment_range.hh"
-#include "utils/chunked_vector.hh"
 #include <variant>
 
 #include <boost/range/algorithm/for_each.hpp>

--- a/serializer_impl.hh
+++ b/serializer_impl.hh
@@ -9,6 +9,9 @@
 #pragma once
 
 #include "serializer.hh"
+#include "enum_set.hh"
+#include "utils/chunked_vector.hh"
+#include "utils/input_stream.hh"
 #include <seastar/util/bool_class.hh>
 #include "utils/small_vector.hh"
 #include <absl/container/btree_set.h>

--- a/service/pager/paging_state.cc
+++ b/service/pager/paging_state.cc
@@ -14,6 +14,7 @@
 #include <seastar/core/simple-stream.hh>
 #include "idl/paging_state.dist.hh"
 #include "idl/paging_state.dist.impl.hh"
+#include "exceptions/exceptions.hh"
 #include "message/messaging_service.hh"
 #include "utils/bit_cast.hh"
 

--- a/timeout_config.cc
+++ b/timeout_config.cc
@@ -9,7 +9,6 @@
 
 #include "timeout_config.hh"
 #include "db/config.hh"
-#include "db/timeout_clock.hh"
 #include <chrono>
 #include <seastar/core/future.hh>
 

--- a/timeout_config.hh
+++ b/timeout_config.hh
@@ -11,7 +11,6 @@
 
 #include "db/timeout_clock.hh"
 #include "utils/updateable_value.hh"
-#include <chrono>
 
 namespace db { class config; }
 

--- a/tombstone_gc.cc
+++ b/tombstone_gc.cc
@@ -10,7 +10,6 @@
 #include <boost/icl/interval.hpp>
 #include <boost/icl/interval_map.hpp>
 #include "schema/schema.hh"
-#include "dht/i_partitioner.hh"
 #include "gc_clock.hh"
 #include "tombstone_gc.hh"
 #include "locator/token_metadata.hh"

--- a/tombstone_gc.hh
+++ b/tombstone_gc.hh
@@ -12,7 +12,6 @@
 #include "gc_clock.hh"
 #include "dht/token.hh"
 #include "schema/schema_fwd.hh"
-#include "range.hh"
 #include "interval.hh"
 
 namespace dht {

--- a/unimplemented.hh
+++ b/unimplemented.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <iosfwd>
 #include <seastar/core/print.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/enum.hh>

--- a/vint-serialization.cc
+++ b/vint-serialization.cc
@@ -15,7 +15,6 @@
 #include <algorithm>
 #include <array>
 #include <limits>
-#include <type_traits>
 
 static_assert(-1 == ~0, "Not a twos-complement architecture");
 

--- a/zstd.cc
+++ b/zstd.cc
@@ -14,6 +14,7 @@
 #include "zstd.h"
 
 #include "compress.hh"
+#include "exceptions/exceptions.hh"
 #include "utils/class_registrator.hh"
 #include "utils/reusable_buffer.hh"
 #include <concepts>


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.