### PR TITLE
types: add formatter for data_value

### DIFF
--- a/types/types.cc
+++ b/types/types.cc
@@ -3679,11 +3679,17 @@ make_user_value(data_type type, user_type_impl::native_type value) {
     return data_value::make_new(std::move(type), std::move(value));
 }
 
-std::ostream& operator<<(std::ostream& out, const data_value& v) {
+ auto fmt::formatter<data_value>::format(const data_value& v,
+                                         fmt::format_context& ctx) const -> decltype(ctx.out()) {
     if (v.is_null()) {
-        return out << "null";
+        return fmt::format_to(ctx.out(), "null");
     }
-    return out << v.type()->to_string_impl(v);
+    return fmt::format_to(ctx.out(), "{}", v.type()->to_string_impl(v));
+}
+
+std::ostream& operator<<(std::ostream& out, const data_value& v) {
+    fmt::print(out, "{}", v);
+    return out;
 }
 
 shared_ptr<const reversed_type_impl> reversed_type_impl::get_instance(data_type type) {

--- a/types/types.hh
+++ b/types/types.hh
@@ -269,7 +269,6 @@ public:
     friend class empty_type_impl;
     template <typename T> friend const T& value_cast(const data_value&);
     template <typename T> friend T&& value_cast(data_value&&);
-    friend std::ostream& operator<<(std::ostream&, const data_value&);
     friend data_value make_tuple_value(data_type, maybe_empty<std::vector<data_value>>);
     friend data_value make_set_value(data_type, maybe_empty<std::vector<data_value>>);
     friend data_value make_list_value(data_type, maybe_empty<std::vector<data_value>>);
@@ -1034,4 +1033,12 @@ struct fmt::formatter<data_value_or_unset> : fmt::formatter<std::string_view> {
     }
 };
 
+template <> struct fmt::formatter<data_value> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const data_value&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+std::ostream& operator<<(std::ostream& out, const data_value& v);
+
 using data_value_list = std::initializer_list<data_value_or_unset>;
+


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define a formatter for data_value, and remove its operator<<().

Refs #13245