### PR TITLE
test/nodetool: run nodetool tests using "unshare"

### DIFF
--- a/test.py
+++ b/test.py
@@ -1015,12 +1015,15 @@ class ToolTest(Test):
 
     def __init__(self, test_no: int, shortname: str, suite) -> None:
         super().__init__(test_no, shortname, suite)
-        self.path = "pytest"
+        launcher = self.suite.cfg.get("launcher", "pytest")
+        self.path = launcher.split(maxsplit=1)[0]
         self.xmlout = os.path.join(self.suite.options.tmpdir, self.mode, "xml", self.uname + ".xunit.xml")
         ToolTest._reset(self)
 
     def _prepare_pytest_params(self, options: argparse.Namespace):
-        self.args = [
+        launcher = self.suite.cfg.get("launcher", "pytest")
+        self.args = launcher.split()[1:]
+        self.args += [
             "-s",  # don't capture print() output inside pytest
             "--log-level=DEBUG",   # Capture logs
             "-o",

--- a/test/nodetool/suite.yaml
+++ b/test/nodetool/suite.yaml
@@ -1,2 +1,3 @@
 type: Tool
 coverage: false
+launcher: unshare -rn pytest --run-within-unshare


### PR DESCRIPTION
before this change, we use a random address when launching
rest_api_mock server, but there are chances that the randomly
picked address conflicts with an already-used address on the
host. and the subprocess fails right away with the returncode of
1 upon this failure, but we just continue on and check the readiness
of the already-dead server. actually, we've seen test failures
caused by the EADDRINUSE failure, and when we checked the readiness
of the rest_api_mock by sending HTTP request and reading the
response, what we had is not a JSON encoded response but a webpage,
which was likely the one returned by a minio server.

in this change, we

* specify the "launcher" option of nodetool
  test suite to "unshare", so that all its tests are launched
  in separated namespaces.
* do not use a random address for the mock server, as the network
  namespaces are separated.

Fixes #16542