### PR TITLE
test/nodetool: use build/$CMAKE_BUILD_TYPE when appropriate

### DIFF
--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -122,11 +122,25 @@ def jmx(request, rest_api_mock_server):
     jmx_process.wait()
 
 
+all_modes = {'debug': 'Debug',
+             'release': 'RelWithDebInfo',
+             'dev': 'Dev',
+             'sanitize': 'Sanitize',
+             'coverage': 'Coverage'}
+
+
+def _path_to_scylla(mode):
+    build_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "build"))
+    if os.path.exists(os.path.join(build_dir, 'build.ninja')):
+        return os.path.join(build_dir, all_modes[mode], "scylla")
+    return os.path.join(build_dir, mode, "scylla")
+
+
 @pytest.fixture(scope="session")
 def nodetool_path(request):
     if request.config.getoption("nodetool") == "scylla":
         mode = request.config.getoption("mode")
-        return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "build", mode, "scylla"))
+        return _path_to_scylla(mode)
 
     path = request.config.getoption("nodetool_path")
     if path is not None:


### PR DESCRIPTION
because the CMake-generated build.ninja is located under build/, and it puts the `scylla` executable at build/$CMAKE_BUILD_TYPE/scylla, instead of at build/$scylla_build_mode/scylla, so let's adapt to this change accordingly.

we will promote this change to a shared place if we have similar needs in other tests as well.