### PR TITLE
[Backport 5.2] tasks: keep task's children in list

### DIFF
--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -204,8 +204,8 @@ void set_task_manager(http_context& ctx, routes& r) {
         while (!q.empty()) {
             auto& current = q.front();
             res.push_back(co_await retrieve_status(current));
-            for (auto i = 0; i < current->get_children().size(); ++i) {
-                q.push(co_await current->get_children()[i].copy());
+            for (auto& child: current->get_children()) {
+                q.push(co_await child.copy());
             }
             q.pop();
         }

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -201,7 +201,7 @@ void task_manager::task::unregister_task() noexcept {
     _impl->_module->unregister_task(id());
 }
 
-const task_manager::foreign_task_vector& task_manager::task::get_children() const noexcept {
+const task_manager::foreign_task_list& task_manager::task::get_children() const noexcept {
     return _impl->_children;
 }
 

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -40,7 +40,7 @@ public:
     using task_ptr = lw_shared_ptr<task_manager::task>;
     using task_map = std::unordered_map<task_id, task_ptr>;
     using foreign_task_ptr = foreign_ptr<task_ptr>;
-    using foreign_task_vector = std::vector<foreign_task_ptr>;
+    using foreign_task_list = std::list<foreign_task_ptr>;
     using module_ptr = shared_ptr<module>;
     using modules = std::unordered_map<std::string, module_ptr>;
 private:
@@ -95,7 +95,7 @@ public:
             status _status;
             progress _progress;             // Reliable only for tasks with no descendants.
             task_id _parent_id;
-            foreign_task_vector _children;
+            foreign_task_list _children;
             shared_promise<> _done;
             module_ptr _module;
             abort_source _as;
@@ -145,7 +145,7 @@ public:
         future<> done() const noexcept;
         void register_task();
         void unregister_task() noexcept;
-        const foreign_task_vector& get_children() const noexcept;
+        const foreign_task_list& get_children() const noexcept;
         void release_resources() noexcept;
 
         friend class test_task;


### PR DESCRIPTION
If std::vector is resized its iterators and references may get invalidated. While task_manager::task::impl::_children's iterators are avoided throughout the code, references to its elements are being used.

Since children vector does not need random access to its elements, change its type to std::list<foreign_task_ptr>, which iterators and references aren't invalidated on element insertion.

Fixes: #16380.

Closes scylladb/scylladb#16381

(cherry picked from commit 9b9ea1193c0c58c81fe428c38bccd27494b9c7fb)