### PR TITLE
topology_state_machine: add formatter for service::cleanup_status

### DIFF
--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -225,11 +225,6 @@ static std::unordered_map<cleanup_status, sstring> cleanup_status_to_name_map = 
     {cleanup_status::running, "running"},
 };
 
-std::ostream& operator<<(std::ostream& os, cleanup_status status) {
-    os << cleanup_status_to_name_map[status];
-    return os;
-}
-
 cleanup_status cleanup_status_from_string(const sstring& s) {
     for (auto&& e : cleanup_status_to_name_map) {
         if (e.second == s) {
@@ -239,4 +234,9 @@ cleanup_status cleanup_status_from_string(const sstring& s) {
     throw std::runtime_error(fmt::format("cannot map name {} to cleanup_status", s));
 }
 
+}
+
+auto fmt::formatter<service::cleanup_status>::format(service::cleanup_status status,
+                                                     fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", service::cleanup_status_to_name_map[status]);
 }

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -245,6 +245,11 @@ topology_request topology_request_from_string(const sstring& s);
 std::ostream& operator<<(std::ostream&, const global_topology_request&);
 global_topology_request global_topology_request_from_string(const sstring&);
 std::ostream& operator<<(std::ostream& os, const raft_topology_cmd::command& cmd);
-std::ostream& operator<<(std::ostream& os, cleanup_status s);
 cleanup_status cleanup_status_from_string(const sstring& s);
 }
+
+template <> struct fmt::formatter<service::cleanup_status> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(service::cleanup_status status, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define a formatter for service::cleanup_status, and remove its operator<<().

Refs #13245