### PR TITLE
database: don't allow keyspace objects to be copied

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1258,6 +1258,9 @@ private:
 
 public:
     explicit keyspace(lw_shared_ptr<keyspace_metadata> metadata, config cfg, locator::effective_replication_map_factory& erm_factory);
+    keyspace(const keyspace&) = delete;
+    void operator=(const keyspace&) = delete;
+    keyspace(keyspace&&) = default;
 
     future<> shutdown() noexcept;
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1087,7 +1087,7 @@ future<> storage_service::sstable_cleanup_fiber(raft::server& server, sharded<se
                 tasks.reserve(keyspaces.size());
 
                 co_await coroutine::parallel_for_each(keyspaces.begin(), keyspaces.end(), [this, &tasks, &do_cleanup_ks] (const sstring& ks_name) -> future<> {
-                    auto ks = _db.local().find_keyspace(ks_name);
+                    auto& ks = _db.local().find_keyspace(ks_name);
                     if (ks.get_replication_strategy().is_per_table() || is_system_keyspace(ks_name)) {
                         // Skip tablets tables since they do their own cleanup and system tables
                         // since they are local and not affected by range movements.


### PR DESCRIPTION
keyspace objects are heavyweight and copies are immediately our-of-date, so copying them is bad.

Fix by deleting the copy constructor and copy assignment operator. One call site is fixed. This call site is safe since the it's only used for accessing a few attributes (introduced in f70c4127c6c).