### PR TITLE
[Backport 5.2] schema: add scylla specific options to schema description

### DIFF
--- a/test/cql-pytest/test_describe.py
+++ b/test/cql-pytest/test_describe.py
@@ -818,6 +818,9 @@ def new_random_table(cql, keyspace, udts=[]):
     extras["min_index_interval"] = min_idx_interval
     extras["max_index_interval"] = random.randrange(min_idx_interval, 10000)
     extras["memtable_flush_period_in_ms"] = random.randrange(0, 10000)
+    extras["paxos_grace_seconds"] = random.randrange(1000, 100000)
+
+    extras["tombstone_gc"] = f"{{'mode': 'timeout', 'propagation_delay_in_seconds': '{random.randrange(100, 100000)}'}}"
 
     extra_options = [f"{k} = {v}" for (k, v) in extras.items()]
     extra_str = " AND ".join(extra_options)


### PR DESCRIPTION
This is backport of https://github.com/scylladb/scylladb/pull/14275

Add `paxos_grace_seconds`, `tombstone_gc`, `cdc` and `synchronous_updates` options to schema description.

Fixes: #12389
Fixes: scylladb/scylla-enterprise#2979