### PR TITLE
sstables_loader: load_new_sstables: auto-enable load-and-stream for tablets

### DIFF
--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -178,6 +178,11 @@ distributed_loader::process_upload_dir(distributed<replica::database>& db, distr
     seastar::thread_attributes attr;
     attr.sched_group = db.local().get_streaming_scheduling_group();
 
+    const auto& rs = db.local().find_keyspace(ks).get_replication_strategy();
+    if (rs.is_per_table()) {
+        on_internal_error(dblog, "process_upload_dir is not supported with tablets");
+    }
+
     return seastar::async(std::move(attr), [&db, &view_update_generator, &sys_dist_ks, ks = std::move(ks), cf = std::move(cf)] {
         auto global_table = get_table_on_all_shards(db, ks, cf).get0();
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -256,8 +256,16 @@ future<> sstables_loader::load_new_sstables(sstring ks_name, sstring cf_name,
     } else {
         _loading_new_sstables = true;
     }
+
+    sstring load_and_stream_desc = fmt::format("{}", load_and_stream);
+    const auto& rs = _db.local().find_keyspace(ks_name).get_replication_strategy();
+    if (rs.is_per_table() && !load_and_stream) {
+        load_and_stream = true;
+        load_and_stream_desc = "auto-enabled-for-tablets";
+    }
+
     llog.info("Loading new SSTables for keyspace={}, table={}, load_and_stream={}, primary_replica_only={}",
-            ks_name, cf_name, load_and_stream, primary_replica_only);
+            ks_name, cf_name, load_and_stream_desc, primary_replica_only);
     try {
         if (load_and_stream) {
             ::table_id table_id;


### PR DESCRIPTION
And call on_internal_error if process_upload_dir
is called for tablets-enabled keyspace as it isn't supported at the moment (maybe it could be in the future if we make sure that the sstables are confined to tablets boundaries).

Refs #12775
Fixes #16743