### PR TITLE
doc: document nodetool resetlocalschema

### DIFF
--- a/docs/operating-scylla/nodetool-commands/resetlocalschema.rst
+++ b/docs/operating-scylla/nodetool-commands/resetlocalschema.rst
@@ -1,0 +1,33 @@
+============================
+Nodetool resetlocalschema
+============================
+
+This command reloads in-memory schema objects from disk. It recalculates 
+the per-node and per-table schema versions. This can help you solve some 
+cases of schema version disagreement that would otherwise require a node restart.
+
+.. note::
+    
+    This command cannot be used to hot-update the node's schema from manually 
+    placed schema SStables. If the schema on disk doesn't match the schema in 
+    memory, such reload will likely fail.
+
+Syntax
+-------
+
+.. code-block:: console
+
+    nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
+                [(-pp | --print-port)] [(-pw <password> | --password <password>)]
+                [(-pwf <passwordFilePath> | --password-file <passwordFilePath>)]
+                [(-u <username> | --username <username>)] resetlocalschema
+
+
+Options
+--------
+
+* ``-h <host>`` or ``--host <host>`` - Node hostname or IP address.
+* For other options, see :ref:`Nodetool generic options <nodetool-generic-options>`.
+
+
+

--- a/docs/operating-scylla/nodetool.rst
+++ b/docs/operating-scylla/nodetool.rst
@@ -39,6 +39,7 @@ Nodetool
    nodetool-commands/refresh
    nodetool-commands/removenode
    nodetool-commands/repair
+   nodetool-commands/resetlocalschema
    nodetool-commands/ring
    nodetool-commands/scrub
    nodetool-commands/settraceprobability
@@ -116,6 +117,7 @@ Operations that are not listed below are currently not available.
 * :doc:`refresh </operating-scylla/nodetool-commands/refresh/>`- Load newly placed SSTables to the system without restart
 * :doc:`removenode </operating-scylla/nodetool-commands/removenode/>`- Remove node with the provided ID
 * :doc:`repair <nodetool-commands/repair/>`  :code:`<keyspace>` :code:`<table>` - Repair one or more tables
+* :doc:`resetlocalschema </operating-scylla/nodetool-commands/resetlocalschema/>` - Reset the node's local schema.
 * :doc:`ring <nodetool-commands/ring/>` - The nodetool ring command display the token ring information.
 * :doc:`scrub </operating-scylla/nodetool-commands/scrub>` :code:`[-m mode] [--no-snapshot] <keyspace> [<table>...]` - Scrub the SSTable files in the specified keyspace or table(s)
 * :doc:`setlogginglevel</operating-scylla/nodetool-commands/setlogginglevel>` - sets the logging level threshold for Scylla classes


### PR DESCRIPTION
This PR adds the documentation for the `nodetool resetlocalschema` command.
The syntax description is based on the description for Cassandra and the ScyllaDB help for nodetool.

Fixes https://github.com/scylladb/scylladb/issues/16286