### PR TITLE
memtable: add formatter for replica::{memtable,memtable_entry}

### DIFF
--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -858,14 +858,15 @@ size_t memtable_entry::object_memory_size(allocation_strategy& allocator) {
     return memtable::partitions_type::estimated_object_memory_size_in_allocator(allocator, this);
 }
 
-std::ostream& operator<<(std::ostream& out, memtable& mt) {
+}
+
+auto fmt::formatter<replica::memtable_entry>::format(const replica::memtable_entry& mt,
+                                                     fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{{{}: {}}}", mt.key(), partition_entry::printer(mt.partition()));
+}
+
+auto fmt::formatter<replica::memtable>::format(replica::memtable& mt,
+                                        fmt::format_context& ctx) const -> decltype(ctx.out()) {
     logalloc::reclaim_lock rl(mt);
-    fmt::print(out, "{{memtable: [{}]}}", fmt::join(mt.partitions, ",\n"));
-    return out;
-}
-
-std::ostream& operator<<(std::ostream& out, const memtable_entry& mt) {
-    return out << "{" << mt.key() << ": " << partition_entry::printer(mt.partition()) << "}";
-}
-
+    return fmt::format_to(ctx.out(), "{{memtable: [{}]}}", fmt::join(mt.partitions, ",\n"));
 }

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -10,7 +10,7 @@
 
 #include <map>
 #include <memory>
-#include <iosfwd>
+#include <fmt/core.h>
 #include "replica/database_fwd.hh"
 #include "dht/decorated_key.hh"
 #include "dht/ring_position.hh"
@@ -90,7 +90,6 @@ public:
     }
 
     friend dht::ring_position_view ring_position_view_to_compare(const memtable_entry& mt) { return mt._key; }
-    friend std::ostream& operator<<(std::ostream&, const memtable_entry&);
 };
 
 }
@@ -297,7 +296,17 @@ public:
         return _dirty_mgr;
     }
 
-    friend std::ostream& operator<<(std::ostream&, memtable&);
+    friend fmt::formatter<memtable>;
 };
 
 }
+
+template <> struct fmt::formatter<replica::memtable_entry> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const replica::memtable_entry&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <> struct fmt::formatter<replica::memtable> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(replica::memtable&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define a formatter for replica::memtable and replica::memtable_entry, and remove their operator<<().

Refs #13245