### PR TITLE
raft topology: send barrier_and_drain to a decommissioning node

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -385,9 +385,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             const std::unordered_set<raft::server_id>& exclude_nodes,
             drop_guard_and_retake drop_and_retake = drop_guard_and_retake::yes) {
         rtlogger.info("executing global topology command {}, excluded nodes: {}", cmd.cmd, exclude_nodes);
-        auto nodes = _topo_sm._topology.normal_nodes
-            | boost::adaptors::filtered([&exclude_nodes] (const std::pair<const raft::server_id, replica_state>& n) {
-                return !exclude_nodes.contains(n.first);
+        auto nodes = boost::range::join(_topo_sm._topology.normal_nodes, _topo_sm._topology.transition_nodes)
+            | boost::adaptors::filtered([&cmd, &exclude_nodes] (const std::pair<const raft::server_id, replica_state>& n) {
+                // We must send barrier_and_drain to the decommissioning node as it might be coordinating requests.
+                bool drain_decommissioning_node = cmd.cmd == raft_topology_cmd::command::barrier_and_drain
+                        && (n.second.state == node_state::decommissioning || n.second.state == node_state::left_token_ring);
+                return !exclude_nodes.contains(n.first) && (n.second.state == node_state::normal || drain_decommissioning_node);
             })
             | boost::adaptors::map_keys;
         if (drop_and_retake) {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -132,7 +132,8 @@ struct topology {
     // Nodes that are waiting to be joined by the topology coordinator
     std::unordered_map<raft::server_id, replica_state> new_nodes;
     // Nodes that are in the process to be added to the ring
-    // Currently only at most one node at a time will be here
+    // Currently at most one node at a time will be here, but the code shouldn't assume it
+    // because we might support parallel operations in the future.
     std::unordered_map<raft::server_id, replica_state> transition_nodes;
 
     // Pending topology requests

--- a/test/topology_experimental_raft/test_topology_ops.py
+++ b/test/topology_experimental_raft/test_topology_ops.py
@@ -75,8 +75,7 @@ async def test_topology_ops(request, manager: ManagerClient):
 async def check_node_log_for_failed_mutations(manager: ManagerClient, server: ServerInfo):
     logger.info(f"Checking that node {server} had no failed mutations")
     log = await manager.server_open_log(server.server_id)
-    occurrences = await log.grep(expr="Failed to apply mutation from", \
-                                 filter_expr="replica::stale_topology_exception") # Disabled due to #15804
+    occurrences = await log.grep(expr="Failed to apply mutation from")
     assert len(occurrences) == 0
 
 


### PR DESCRIPTION
We didn't send the `barrier_and_drain` command to a
decommissioning node that could still be coordinating requests. It
could happen that a decommissioning node sent a request with an
old topology version after normal nodes received the new fence
version. Then, the request would fail on replicas with the stale
topology exception.

This PR fixes this problem by modifying `exec_global_command`.
From now on, it sends `barrier_and_drain` to a decommissioning
node.

We also stop filtering stale topology exceptions in
`test_topology_ops`. We added this filter after detecting the bug
fixed by this PR.

Fixes scylladb/scylladb#15804
Fixes scylladb/scylladb#16579
Fixes scylladb/scylladb#16642