### PR TITLE
[Backport 5.4] tasks: compaction: drop regular compaction tasks after they are finished

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -22,6 +22,7 @@
 #include "sstables/exceptions.hh"
 #include "sstables/sstable_directory.hh"
 #include "locator/abstract_replication_strategy.hh"
+#include "utils/error_injection.hh"
 #include "utils/fb_utilities.hh"
 #include "utils/UUID_gen.hh"
 #include "db/system_keyspace.hh"
@@ -1147,6 +1148,11 @@ protected:
     }
 
     virtual future<compaction_manager::compaction_stats_opt> do_run() override {
+        if (!is_system_keyspace(_status.keyspace)) {
+            co_await utils::get_local_injector().inject_with_handler("compaction_regular_compaction_task_executor_do_run",
+                [] (auto& handler) { return handler.wait_for_message(db::timeout_clock::now() + 10s); });
+        }
+
         co_await coroutine::switch_to(_cm.compaction_sg());
 
         for (;;) {

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -660,6 +660,10 @@ public:
     virtual std::string type() const override {
         return "regular compaction";
     }
+
+    virtual tasks::is_internal is_internal() const noexcept override {
+        return tasks::is_internal::yes;
+    }
 protected:
     virtual future<> run() override = 0;
 };

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -186,7 +186,11 @@ void task_manager::task::start() {
         // Background fiber does not capture task ptr, so the task can be unregistered and destroyed independently in the foreground.
         // After the ttl expires, the task id will be used to unregister the task if that didn't happen in any other way.
         auto module = _impl->_module;
-        (void)done().finally([module] {
+        bool drop_after_complete = is_internal() && !get_parent_id();
+        (void)done().finally([module, drop_after_complete] {
+            if (drop_after_complete) {
+                return make_ready_future<>();
+            }
             return sleep_abortable(module->get_task_manager().get_task_ttl(), module->abort_source());
         }).then_wrapped([module, id = id()] (auto f) {
             f.ignore_ready_future();


### PR DESCRIPTION
Make compaction tasks internal. Drop all internal tasks without parents
immediately after they are done.

Fixes: https://github.com/scylladb/scylladb/issues/16735
Refs: https://github.com/scylladb/scylladb/issues/16694.