### PR TITLE
Reduce empty compaction tasks

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1892,7 +1892,7 @@ future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_range
 
         auto has_sstables_eligible_for_compaction = [&] {
             for (auto& sst : cs.sstables_requiring_cleanup) {
-                if (sstables::is_eligible_for_compaction(sst)) {
+                if (eligible_for_compaction(sst)) {
                     return true;
                 }
             }

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1627,6 +1627,9 @@ future<compaction_manager::compaction_stats_opt> compaction_manager::perform_tas
             return a->data_size() > b->data_size();
         });
     });
+    if (sstables.empty()) {
+        co_return std::nullopt;
+    }
     co_return co_await perform_compaction<TaskType>(throw_if_stopping::no, info, &t, info.value_or(tasks::task_info{}).id, std::move(options), std::move(owned_ranges_ptr), std::move(sstables), std::move(compacting), std::forward<Args>(args)...);
 }
 

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -306,7 +306,8 @@ public:
     future<> get_compaction_history(compaction_history_consumer&& f);
 
     // Submit a table to be compacted.
-    void submit(compaction::table_state& t);
+    // Caller can pass candidates for compaction if known in advance
+    void submit(compaction::table_state& t, std::optional<std::vector<sstables::shared_sstable>> candidates_opt = std::nullopt);
 
     // Can regular compaction be performed in the given table
     bool can_perform_regular_compaction(compaction::table_state& t);

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -551,7 +551,7 @@ struct null_backlog_tracker final : public compaction_backlog_tracker::impl {
 //
 class null_compaction_strategy : public compaction_strategy_impl {
 public:
-    virtual compaction_descriptor get_sstables_for_compaction(table_state& table_s, strategy_control& control) override {
+    virtual compaction_descriptor get_sstables_for_compaction(table_state& table_s, strategy_control& control, std::optional<std::vector<shared_sstable>> candidates_opt) override {
         return sstables::compaction_descriptor();
     }
 
@@ -670,8 +670,8 @@ compaction_strategy_type compaction_strategy::type() const {
     return _compaction_strategy_impl->type();
 }
 
-compaction_descriptor compaction_strategy::get_sstables_for_compaction(table_state& table_s, strategy_control& control) {
-    return _compaction_strategy_impl->get_sstables_for_compaction(table_s, control);
+compaction_descriptor compaction_strategy::get_sstables_for_compaction(table_state& table_s, strategy_control& control, std::optional<std::vector<shared_sstable>> candidates_opt) {
+    return _compaction_strategy_impl->get_sstables_for_compaction(table_s, control, std::move(candidates_opt));
 }
 
 compaction_descriptor compaction_strategy::get_major_compaction_job(table_state& table_s, std::vector<sstables::shared_sstable> candidates) {

--- a/compaction/compaction_strategy.hh
+++ b/compaction/compaction_strategy.hh
@@ -44,7 +44,7 @@ public:
     compaction_strategy& operator=(compaction_strategy&&);
 
     // Return a list of sstables to be compacted after applying the strategy.
-    compaction_descriptor get_sstables_for_compaction(table_state& table_s, strategy_control& control);
+    compaction_descriptor get_sstables_for_compaction(table_state& table_s, strategy_control& control, std::optional<std::vector<shared_sstable>> candidates_opt = std::nullopt);
 
     compaction_descriptor get_major_compaction_job(table_state& table_s, std::vector<shared_sstable> candidates);
 

--- a/compaction/compaction_strategy_impl.hh
+++ b/compaction/compaction_strategy_impl.hh
@@ -12,6 +12,7 @@
 #include "compaction_strategy.hh"
 #include "db_clock.hh"
 #include "compaction_descriptor.hh"
+#include "sstables/shared_sstable.hh"
 
 namespace sstables {
 
@@ -43,7 +44,7 @@ protected:
             uint64_t max_sstable_bytes = compaction_descriptor::default_max_sstable_bytes);
 public:
     virtual ~compaction_strategy_impl() {}
-    virtual compaction_descriptor get_sstables_for_compaction(table_state& table_s, strategy_control& control) = 0;
+    virtual compaction_descriptor get_sstables_for_compaction(table_state& table_s, strategy_control& control, std::optional<std::vector<shared_sstable>> candidates_opt) = 0;
     virtual compaction_descriptor get_major_compaction_job(table_state& table_s, std::vector<sstables::shared_sstable> candidates) {
         return make_major_compaction_job(std::move(candidates));
     }

--- a/compaction/leveled_compaction_strategy.cc
+++ b/compaction/leveled_compaction_strategy.cc
@@ -19,9 +19,9 @@ leveled_compaction_strategy_state& leveled_compaction_strategy::get_state(table_
     return table_s.get_compaction_strategy_state().get<leveled_compaction_strategy_state>();
 }
 
-compaction_descriptor leveled_compaction_strategy::get_sstables_for_compaction(table_state& table_s, strategy_control& control) {
+compaction_descriptor leveled_compaction_strategy::get_sstables_for_compaction(table_state& table_s, strategy_control& control, std::optional<std::vector<shared_sstable>> candidates_opt) {
     auto& state = get_state(table_s);
-    auto candidates = control.candidates(table_s);
+    auto candidates = candidates_opt ? std::move(*candidates_opt) : control.candidates(table_s);
     // NOTE: leveled_manifest creation may be slightly expensive, so later on,
     // we may want to store it in the strategy itself. However, the sstable
     // lists managed by the manifest may become outdated. For example, one

--- a/compaction/leveled_compaction_strategy.hh
+++ b/compaction/leveled_compaction_strategy.hh
@@ -49,7 +49,7 @@ public:
     static void validate_options(const std::map<sstring, sstring>& options, std::map<sstring, sstring>& unchecked_options);
 
     leveled_compaction_strategy(const std::map<sstring, sstring>& options);
-    virtual compaction_descriptor get_sstables_for_compaction(table_state& table_s, strategy_control& control) override;
+    virtual compaction_descriptor get_sstables_for_compaction(table_state& table_s, strategy_control& control, std::optional<std::vector<shared_sstable>> candidates_opt) override;
 
     virtual std::vector<compaction_descriptor> get_cleanup_compaction_jobs(table_state& table_s, std::vector<shared_sstable> candidates) const override;
 

--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -211,12 +211,12 @@ size_tiered_compaction_strategy::most_interesting_bucket(std::vector<std::vector
 }
 
 compaction_descriptor
-size_tiered_compaction_strategy::get_sstables_for_compaction(table_state& table_s, strategy_control& control) {
+size_tiered_compaction_strategy::get_sstables_for_compaction(table_state& table_s, strategy_control& control, std::optional<std::vector<shared_sstable>> candidates_opt) {
     // make local copies so they can't be changed out from under us mid-method
     int min_threshold = table_s.min_compaction_threshold();
     int max_threshold = table_s.schema()->max_compaction_threshold();
     auto compaction_time = gc_clock::now();
-    auto candidates = control.candidates(table_s);
+    auto candidates = candidates_opt ? std::move(*candidates_opt) : control.candidates(table_s);
 
     // TODO: Add support to filter cold sstables (for reference: SizeTieredCompactionStrategy::filterColdSSTables).
 

--- a/compaction/size_tiered_compaction_strategy.hh
+++ b/compaction/size_tiered_compaction_strategy.hh
@@ -77,7 +77,7 @@ public:
     explicit size_tiered_compaction_strategy(const size_tiered_compaction_strategy_options& options);
     static void validate_options(const std::map<sstring, sstring>& options, std::map<sstring, sstring>& unchecked_options);
 
-    virtual compaction_descriptor get_sstables_for_compaction(table_state& table_s, strategy_control& control) override;
+    virtual compaction_descriptor get_sstables_for_compaction(table_state& table_s, strategy_control& control, std::optional<std::vector<shared_sstable>> candidates_opt) override;
 
     virtual std::vector<compaction_descriptor> get_cleanup_compaction_jobs(table_state& table_s, std::vector<shared_sstable> candidates) const override;
 

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -315,10 +315,10 @@ time_window_compaction_strategy::get_reshaping_job(std::vector<shared_sstable> i
 }
 
 compaction_descriptor
-time_window_compaction_strategy::get_sstables_for_compaction(table_state& table_s, strategy_control& control) {
+time_window_compaction_strategy::get_sstables_for_compaction(table_state& table_s, strategy_control& control, std::optional<std::vector<shared_sstable>> candidates_opt) {
     auto& state = get_state(table_s);
     auto compaction_time = gc_clock::now();
-    auto candidates = control.candidates(table_s);
+    auto candidates = candidates_opt ? std::move(*candidates_opt) : control.candidates(table_s);
 
     if (candidates.empty()) {
         state.estimated_remaining_tasks = 0;

--- a/compaction/time_window_compaction_strategy.hh
+++ b/compaction/time_window_compaction_strategy.hh
@@ -81,7 +81,7 @@ public:
     enum class bucket_compaction_mode { none, size_tiered, major };
 public:
     time_window_compaction_strategy(const std::map<sstring, sstring>& options);
-    virtual compaction_descriptor get_sstables_for_compaction(table_state& table_s, strategy_control& control) override;
+    virtual compaction_descriptor get_sstables_for_compaction(table_state& table_s, strategy_control& control, std::optional<std::vector<shared_sstable>> candidates_opt) override;
 
     virtual std::vector<compaction_descriptor> get_cleanup_compaction_jobs(table_state& table_s, std::vector<shared_sstable> candidates) const override;
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -120,18 +120,17 @@ static flat_mutation_reader_v2 sstable_reader(shared_sstable sst, schema_ptr s, 
 
 class strategy_control_for_test : public strategy_control {
     bool _has_ongoing_compaction;
-    std::optional<std::vector<shared_sstable>> _candidates_opt;
 public:
-    explicit strategy_control_for_test(bool has_ongoing_compaction, std::optional<std::vector<shared_sstable>> candidates) noexcept
+    explicit strategy_control_for_test(bool has_ongoing_compaction) noexcept
         : _has_ongoing_compaction(has_ongoing_compaction)
-        , _candidates_opt(candidates) {}
+    {}
 
     bool has_ongoing_compaction(table_state& table_s) const noexcept override {
         return _has_ongoing_compaction;
     }
 
     std::vector<sstables::shared_sstable> candidates(table_state& t) const override {
-        return _candidates_opt.value_or(boost::copy_range<std::vector<sstables::shared_sstable>>(*t.main_sstable_set().all()));
+        return boost::copy_range<std::vector<sstables::shared_sstable>>(*t.main_sstable_set().all());
     }
 
     std::vector<sstables::frozen_sstable_run> candidates_as_runs(table_state& t) const override {
@@ -139,17 +138,17 @@ public:
     }
 };
 
-static std::unique_ptr<strategy_control> make_strategy_control_for_test(bool has_ongoing_compaction, std::optional<std::vector<shared_sstable>> candidates = std::nullopt) {
-    return std::make_unique<strategy_control_for_test>(has_ongoing_compaction, std::move(candidates));
+static std::unique_ptr<strategy_control> make_strategy_control_for_test(bool has_ongoing_compaction) {
+    return std::make_unique<strategy_control_for_test>(has_ongoing_compaction);
 }
 
 template <typename CompactionStrategy>
-requires requires(CompactionStrategy cs, table_state& t, strategy_control& c) {
-    { cs.get_sstables_for_compaction(t, c) } -> std::same_as<sstables::compaction_descriptor>;
+requires requires(CompactionStrategy cs, table_state& t, strategy_control& c, std::optional<std::vector<shared_sstable>> co) {
+    { cs.get_sstables_for_compaction(t, c, co) } -> std::same_as<sstables::compaction_descriptor>;
 }
 static compaction_descriptor get_sstables_for_compaction(CompactionStrategy& cs, table_state& t, std::vector<shared_sstable> candidates) {
-    auto control = make_strategy_control_for_test(false, std::move(candidates));
-    return cs.get_sstables_for_compaction(t, *control);
+    auto control = make_strategy_control_for_test(false);
+    return cs.get_sstables_for_compaction(t, *control, std::move(candidates));
 }
 
 static void assert_table_sstable_count(table_for_tests& t, size_t expected_count) {

--- a/test/lib/sstable_run_based_compaction_strategy_for_tests.hh
+++ b/test/lib/sstable_run_based_compaction_strategy_for_tests.hh
@@ -22,7 +22,7 @@ class sstable_run_based_compaction_strategy_for_tests : public compaction_strate
 public:
     sstable_run_based_compaction_strategy_for_tests();
 
-    virtual compaction_descriptor get_sstables_for_compaction(table_state& table_s, strategy_control& control) override;
+    virtual compaction_descriptor get_sstables_for_compaction(table_state& table_s, strategy_control& control, std::optional<std::vector<shared_sstable>> candidates_opt) override;
 
     virtual int64_t estimated_pending_compactions(table_state& table_s) const override;
 

--- a/test/rest_api/task_manager_utils.py
+++ b/test/rest_api/task_manager_utils.py
@@ -56,7 +56,7 @@ def assert_task_does_not_exist(rest_api, task_id):
     assert resp.status_code == requests.codes.bad_request, f"Task {task_id} is kept in memory"
 
 def check_child_parent_relationship(rest_api, parent, tree_depth, allow_no_children, depth=0):
-    assert allow_no_children or parent.get("children_ids", []), "Child tasks were not created"
+    assert allow_no_children or parent.get("children_ids", []), f"Child tasks were not created for {parent}"
 
     for child_id in parent.get("children_ids", []):
         child = wait_for_task(rest_api, child_id)

--- a/test/rest_api/test_compaction_task.py
+++ b/test/rest_api/test_compaction_task.py
@@ -91,7 +91,7 @@ def test_offstrategy_keyspace_compaction_task(cql, this_dc, rest_api):
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_offstrategy_compaction/{keyspace}"), "offstrategy compaction", task_tree_depth, True)
 
 def test_rewrite_sstables_keyspace_compaction_task(cql, this_dc, rest_api):
-    task_tree_depth = 3
+    task_tree_depth = 2
     # upgrade sstables compaction
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("GET", f"storage_service/keyspace_upgrade_sstables/{keyspace}"), "upgrade sstables compaction", task_tree_depth)
     # scrub sstables compaction


### PR DESCRIPTION
This short series prevents the creation of compaction tasks when we know in advance that they have nothing to do.
This is possible in the clean path by:
- improve the detection of candidates for cleanup by skipping sstables that require cleanup but are already being compacted
- checking that list of sstables selected for cleanup isn't empty before creating the cleanup task

For upgrade sstables, and generally when rewriting all sstable: launch the task only if the list off candidate sstables isn't empty.

For regular compaction, when triggered via `submit` that's called en-mass when the `compaction_reenabler` is destroyed upon exiting `run_with_compaction_disabled`, calculate the candidate sstables list in `compaction_reenabler` dtor, while compaction is disabled and pass it down to submit, so it can check if it's empty before launching (in the background) the regular compaction task executor.

Refs scylladb/scylladb#15673
Refs scylladb/scylladb#16694
Fixes scylladb/scylladb#16803
Fixes scylladb/scylladb#16804
