### PR TITLE
replica: do not include unused headers

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -29,7 +29,6 @@
 #include <boost/algorithm/string/erase.hpp>
 #include "sstables/sstables.hh"
 #include "sstables/sstables_manager.hh"
-#include "compaction/compaction.hh"
 #include <boost/range/adaptor/map.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/algorithm/find_if.hpp>
@@ -51,7 +50,6 @@
 #include "multishard_mutation_query.hh"
 
 #include "utils/human_readable.hh"
-#include "utils/stall_free.hh"
 #include "utils/fmt-compat.hh"
 #include "utils/error_injection.hh"
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -21,7 +21,6 @@
 #include <seastar/core/distributed.hh>
 #include <functional>
 #include <unordered_map>
-#include <map>
 #include <set>
 #include <boost/functional/hash.hpp>
 #include <boost/range/algorithm/find.hpp>
@@ -32,7 +31,6 @@
 #include <seastar/core/gate.hh>
 #include "db/commitlog/replay_position.hh"
 #include "db/commitlog/commitlog_types.hh"
-#include <limits>
 #include "schema/schema_fwd.hh"
 #include "db/view/view.hh"
 #include "db/snapshot-ctl.hh"

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <iterator>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/maybe_yield.hh>
@@ -20,8 +19,6 @@
 #include "db/system_keyspace.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "db/schema_tables.hh"
-#include "utils/lister.hh"
-#include "compaction/compaction.hh"
 #include "compaction/compaction_manager.hh"
 #include "compaction/task_manager_module.hh"
 #include "sstables/sstables.hh"
@@ -278,7 +275,7 @@ class table_populator {
     sstring _ks;
     sstring _cf;
     global_table_ptr& _global_table;
-    fs::path _base_path;
+    std::filesystem::path _base_path;
     std::unordered_map<sstables::sstable_state, lw_shared_ptr<sharded<sstables::sstable_directory>>> _sstable_directories;
     sstables::sstable_version_types _highest_version = sstables::oldest_writable_sstable_format;
     sstables::generation_type _highest_generation;

--- a/replica/exceptions.cc
+++ b/replica/exceptions.cc
@@ -6,13 +6,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <concepts>
-#include <sstream>
 #include <stdexcept>
 #include <type_traits>
 
 #include "replica/exceptions.hh"
-#include "utils/exceptions.hh"
 
 
 namespace replica {

--- a/replica/exceptions.hh
+++ b/replica/exceptions.hh
@@ -10,15 +10,12 @@
 
 #include <cstdint>
 #include <exception>
-#include <optional>
 #include <variant>
 
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/print.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/timed_out_error.hh>
-
-#include "utils/exception_container.hh"
-#include "utils/result.hh"
 
 namespace replica {
 

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -14,6 +14,7 @@
 #include "mutation/mutation_partition_view.hh"
 #include "readers/empty_v2.hh"
 #include "readers/forwardable_v2.hh"
+#include "sstables/types.hh"
 
 namespace replica {
 

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <map>
-#include <memory>
 #include <fmt/core.h>
 #include "replica/database_fwd.hh"
 #include "dht/decorated_key.hh"
@@ -21,7 +19,6 @@
 #include "db/commitlog/rp_set.hh"
 #include "utils/extremum_tracking.hh"
 #include "mutation/mutation_cleaner.hh"
-#include "sstables/types.hh"
 #include "utils/double-decker.hh"
 #include "readers/empty_v2.hh"
 #include "readers/mutation_source.hh"

--- a/replica/tablet_mutation_builder.hh
+++ b/replica/tablet_mutation_builder.hh
@@ -10,8 +10,8 @@
 
 #include "mutation/mutation.hh"
 #include "db/system_keyspace.hh"
-#include "replica/tablets.hh"
 #include "service/session.hh"
+#include "locator/tablets.hh"
 
 namespace replica {
 


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.