### PR TITLE
add formatter for auth::role_or_anonymous

### DIFF
--- a/auth/role_or_anonymous.cc
+++ b/auth/role_or_anonymous.cc
@@ -8,8 +8,6 @@
 
 #include "auth/role_or_anonymous.hh"
 
-#include <iostream>
-
 namespace auth {
 
 std::ostream& operator<<(std::ostream& os, const role_or_anonymous& mr) {
@@ -21,4 +19,9 @@ bool is_anonymous(const role_or_anonymous& mr) noexcept {
     return !mr.name.has_value();
 }
 
+}
+
+auto fmt::formatter<auth::role_or_anonymous>::format(const auth::role_or_anonymous& mr,
+                                                     fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", mr.name.value_or("<anonymous>"));
 }

--- a/auth/role_or_anonymous.hh
+++ b/auth/role_or_anonymous.hh
@@ -10,8 +10,8 @@
 
 #include <string_view>
 #include <functional>
-#include <iosfwd>
 #include <optional>
+#include <fmt/core.h>
 
 #include <seastar/core/sstring.hh>
 
@@ -29,8 +29,6 @@ public:
     friend bool operator==(const role_or_anonymous&, const role_or_anonymous&) noexcept = default;
 };
 
-std::ostream& operator<<(std::ostream&, const role_or_anonymous&);
-
 bool is_anonymous(const role_or_anonymous&) noexcept;
 
 }
@@ -45,3 +43,8 @@ struct hash<auth::role_or_anonymous> {
 };
 
 }
+
+template <> struct fmt::formatter<auth::role_or_anonymous> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const auth::role_or_anonymous&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define a formatter for auth::role_or_anonymous, and remove their operator<<().

Refs #13245