### PR TITLE
storage_service: Set session id for raft_rebuild

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2882,6 +2882,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 node = co_await exec_direct_command(
                         std::move(node), raft_topology_cmd::command::stream_ranges);
                 topology_mutation_builder builder(node.guard.write_timestamp());
+                builder.del_session();
                 topology_request_tracking_mutation_builder rtbuilder(node.rs->request_id);
                 builder.with_node(node.id)
                        .set("node_state", node_state::normal)
@@ -6501,6 +6502,7 @@ future<> storage_service::raft_rebuild(sstring source_dc) {
 
         slogger.info("raft topology: request rebuild for: {}", raft_server.id());
         topology_mutation_builder builder(guard.write_timestamp());
+        builder.set_session(session_id(guard.new_group0_state_id()));
         builder.with_node(raft_server.id())
                .set("topology_request", topology_request::rebuild)
                .set("rebuild_option", source_dc)


### PR DESCRIPTION
Raft rebuild is broken because the session id is not set.

The following was seen when run rebuild

stream_session - [Stream #8cfca940-afc9-11ee-b6f1-30b8f78c1451] stream_transfer_task: Fail to send to 127.0.70.1:0: seastar::rpc::remote_verb_error (Session not found: 00000000-0000-0000-0000-000000000000)

with raft topology, e.g.,

scylla --enable-repair-based-node-ops 0 --consistent-cluster-management true --experimental-features consistent-topology-changes

Fix by setting the session id.

Fixes #16741