### PR TITLE
mv: throttle view update generation for large queries

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2763,5 +2763,23 @@ void delete_ghost_rows_visitor::accept_new_row(const clustering_key& ck, const q
     }
 }
 
+std::chrono::microseconds calculate_view_update_throttling_delay(db::view::update_backlog backlog,
+                                                                 db::timeout_clock::time_point timeout) {
+    constexpr auto delay_limit_us = 1000000;
+    auto adjust = [] (float x) { return x * x * x; };
+    auto budget = std::max(service::storage_proxy::clock_type::duration(0),
+        timeout - service::storage_proxy::clock_type::now());
+    std::chrono::microseconds ret(uint32_t(adjust(backlog.relative_size()) * delay_limit_us));
+    // "budget" has millisecond resolution and can potentially be long
+    // in the future so converting it to microseconds may overflow.
+    // So to compare buget and ret we need to convert both to the lower
+    // resolution.
+    if (std::chrono::duration_cast<service::storage_proxy::clock_type::duration>(ret) < budget) {
+        return ret;
+    } else {
+        // budget is small (< ret) so can be converted to microseconds
+        return std::chrono::duration_cast<std::chrono::microseconds>(budget);
+    }
+}
 } // namespace view
 } // namespace db

--- a/db/view/view_update_backlog.hh
+++ b/db/view/view_update_backlog.hh
@@ -11,6 +11,8 @@
 #include <compare>
 #include <cstddef>
 #include <limits>
+#include <chrono>
+#include "db/timeout_clock.hh"
 
 namespace db::view {
 
@@ -41,4 +43,17 @@ struct update_backlog {
     }
 };
 
+// View updates are asynchronous, and because of this limiting their concurrency requires
+// a special approach. The current algorithm places all of the pending view updates in the backlog
+// and artificially slows down new responses to coordinator requests based on how full the backlog is.
+// This function calculates how much a request should be slowed down based on the backlog's fullness.
+// The equation is basically: delay(in seconds) = view_fullness_ratio^3
+// The more full the backlog gets the more aggressively the requests are slowed down.
+// The delay is limited to the amount of time left until timeout.
+// After the timeout the request fails, so there's no point in waiting longer than that.
+// The second argument defines this timeout point - we can't delay the request more than this time point.
+// See: https://www.scylladb.com/2018/12/04/worry-free-ingestion-flow-control/
+std::chrono::microseconds calculate_view_update_throttling_delay(
+    update_backlog backlog,
+    db::timeout_clock::time_point timeout);
 }

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -6,6 +6,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "db/view/view_update_backlog.hh"
+#include "exceptions/exceptions.hh"
+#include "gms/inet_address.hh"
 #include <seastar/util/defer.hh>
 #include <boost/range/adaptor/map.hpp>
 #include "replica/database.hh"
@@ -370,6 +373,8 @@ future<> view_update_generator::populate_views(const replica::table& table,
  * @param views the affected views which need to be updated.
  * @param updates the base table updates being applied.
  * @param existings the existing values for the rows affected by updates. This is used to decide if a view is
+ * @param now the current time, used to calculate the deletion time for tombstones
+ * @param timeout client request timeout
  * obsoleted by the update and should be removed, gather the values for columns that may not be part of the update if
  * a new view entry needs to be created, and compute the minimal updates to be applied if the view entry isn't changed
  * but has simply some updated values.
@@ -382,7 +387,8 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
         mutation&& m,
         flat_mutation_reader_v2_opt existings,
         tracing::trace_state_ptr tr_state,
-        gc_clock::time_point now) {
+        gc_clock::time_point now,
+        db::timeout_clock::time_point timeout) {
     auto base_token = m.token();
     auto m_schema = m.schema();
     view_update_builder builder = make_view_update_builder(
@@ -395,7 +401,7 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
             now);
 
     std::exception_ptr err = nullptr;
-    while (true) {
+    for (size_t batch_num = 0; ; batch_num++) {
         std::optional<utils::chunked_vector<frozen_mutation_and_schema>> updates;
         try {
             updates = co_await builder.build_some();
@@ -408,7 +414,7 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
         }
         tracing::trace(tr_state, "Generated {} view update mutations", updates->size());
         auto units = seastar::consume_units(_db.view_update_sem(), memory_usage_of(*updates));
-        if (_db.view_update_sem().current() == 0) {
+        if (batch_num == 0 && _db.view_update_sem().current() == 0) {
             // We don't have resources to propagate view updates for this write. If we reached this point, we failed to
             // throttle the client. The memory queue is already full, waiting on the semaphore would block view updates
             // that we've already started applying, and generating hints would ultimately result in the disk queue being
@@ -417,6 +423,24 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
             err = std::make_exception_ptr(exceptions::overloaded_exception("Too many view updates started concurrently"));
             break;
         }
+        // To prevent overload we sleep for a moment before sending another batch of view updates.
+        // The amount of time to sleep for is chosen based on how full the view update backlog is,
+        // the more full the queue of pending view updates is the more aggressively we should delay
+        // new ones.
+        // The first batch of updates doesn't have any delays because it's slowed down by the other throttling mechanism,
+        // the one which limits the number of incoming client requests by delaying the response to the client.
+        if (batch_num > 0) {
+            update_backlog local_backlog = _db.get_view_update_backlog();
+            std::chrono::microseconds throttle_delay =  calculate_view_update_throttling_delay(local_backlog, timeout);
+
+            co_await seastar::sleep(throttle_delay);
+
+            if (db::timeout_clock::now() > timeout) {
+                err = std::make_exception_ptr(exceptions::view_update_generation_timeout_exception());
+                break;
+            }
+        }
+
         try {
             co_await mutate_MV(base, base_token, std::move(*updates), table.view_stats(), *table.cf_stats(), tr_state,
                 std::move(units), service::allow_hints::yes, wait_for_all_updates::no);

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -83,6 +83,8 @@ public:
 
     replica::database& get_db() noexcept { return _db; }
 
+    const sharded<service::storage_proxy>& get_storage_proxy() const noexcept { return _proxy; };
+
 private:
     future<> mutate_MV(
             schema_ptr base,

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -115,7 +115,8 @@ public:
             mutation&& m,
             flat_mutation_reader_v2_opt existings,
             tracing::trace_state_ptr tr_state,
-            gc_clock::time_point now);
+            gc_clock::time_point now,
+            db::timeout_clock::time_point timeout);
 
 private:
     bool should_throttle() const;

--- a/exceptions/exceptions.cc
+++ b/exceptions/exceptions.cc
@@ -58,8 +58,8 @@ unavailable_exception::unavailable_exception(db::consistency_level cl, int32_t r
         cl, required, alive)
     {}
 
-request_timeout_exception::request_timeout_exception(exception_code code, const sstring& ks, const sstring& cf, db::consistency_level consistency, int32_t received, int32_t block_for) noexcept
-    : cassandra_exception{code, prepare_message("Operation timed out for {}.{} - received only {} responses from {} CL={}.", ks, cf, received, block_for, consistency)}
+read_write_timeout_exception::read_write_timeout_exception(exception_code code, const sstring& ks, const sstring& cf, db::consistency_level consistency, int32_t received, int32_t block_for) noexcept
+    : request_timeout_exception{code, prepare_message("Operation timed out for {}.{} - received only {} responses from {} CL={}.", ks, cf, received, block_for, consistency)}
     , consistency{consistency}
     , received{received}
     , block_for{block_for}

--- a/exceptions/exceptions.cc
+++ b/exceptions/exceptions.cc
@@ -65,6 +65,10 @@ read_write_timeout_exception::read_write_timeout_exception(exception_code code, 
     , block_for{block_for}
     { }
 
+view_update_generation_timeout_exception::view_update_generation_timeout_exception()
+    : request_timeout_exception{
+          exception_code::WRITE_TIMEOUT, "Request timed out - couldn't prepare materialized view updates in time"} {}
+
 request_failure_exception::request_failure_exception(exception_code code, const sstring& ks, const sstring& cf, db::consistency_level consistency_, int32_t received_, int32_t failures_, int32_t block_for_) noexcept
     : cassandra_exception{code, prepare_message("Operation failed for {}.{} - received {} responses and {} failures from {} CL={}.", ks, cf, received_, failures_, block_for_, consistency_)}
     , consistency{consistency_}

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -120,29 +120,36 @@ public:
     truncate_exception(std::exception_ptr ep);
 };
 
+// Base class for various request timeout exceptions
 class request_timeout_exception : public cassandra_exception {
+public:
+    request_timeout_exception(exception_code code, sstring msg) : cassandra_exception(code, std::move(msg)) {}
+};
+
+// Timeout during read/write - didn't receive enough responses from remote nodes to fulfill the consistency requirement.
+class read_write_timeout_exception : public request_timeout_exception {
 public:
     db::consistency_level consistency;
     int32_t received;
     int32_t block_for;
 
-    request_timeout_exception(exception_code code, const sstring& ks, const sstring& cf, db::consistency_level consistency, int32_t received, int32_t block_for) noexcept;
+    read_write_timeout_exception(exception_code code, const sstring& ks, const sstring& cf, db::consistency_level consistency, int32_t received, int32_t block_for) noexcept;
 };
 
-class read_timeout_exception : public request_timeout_exception {
+class read_timeout_exception : public read_write_timeout_exception {
 public:
     bool data_present;
 
     read_timeout_exception(const sstring& ks, const sstring& cf, db::consistency_level consistency, int32_t received, int32_t block_for, bool data_present) noexcept
-        : request_timeout_exception{exception_code::READ_TIMEOUT, ks, cf, consistency, received, block_for}
+        : read_write_timeout_exception{exception_code::READ_TIMEOUT, ks, cf, consistency, received, block_for}
         , data_present{data_present}
     { }
 };
 
-struct mutation_write_timeout_exception : public request_timeout_exception {
+struct mutation_write_timeout_exception : public read_write_timeout_exception {
     db::write_type type;
     mutation_write_timeout_exception(const sstring& ks, const sstring& cf, db::consistency_level consistency, int32_t received, int32_t block_for, db::write_type type) noexcept :
-        request_timeout_exception(exception_code::WRITE_TIMEOUT, ks, cf, consistency, received, block_for)
+        read_write_timeout_exception(exception_code::WRITE_TIMEOUT, ks, cf, consistency, received, block_for)
         , type{std::move(type)}
     { }
 };

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -154,6 +154,14 @@ struct mutation_write_timeout_exception : public read_write_timeout_exception {
     { }
 };
 
+// Generating view updates for a single client request can take a long time and might not finish before the timeout is
+// reached. In such case this exception is thrown.
+// "Generating a view update" means creating a view update and scheduling it to be sent later.
+// This exception isn't thrown if the sending timeouts, it's only concrened with generating.
+struct view_update_generation_timeout_exception : public request_timeout_exception {
+    view_update_generation_timeout_exception();
+};
+
 class request_failure_exception : public cassandra_exception {
 public:
     db::consistency_level consistency;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3139,7 +3139,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
     const bool need_static = db::view::needs_static_row(m.partition(), views);
     if (!need_regular && !need_static) {
         tracing::trace(tr_state, "View updates do not require read-before-write");
-        co_await gen->generate_and_propagate_view_updates(*this, base, sem.make_tracking_only_permit(s, "push-view-updates-1", timeout, tr_state), std::move(views), std::move(m), { }, tr_state, now);
+        co_await gen->generate_and_propagate_view_updates(*this, base, sem.make_tracking_only_permit(s, "push-view-updates-1", timeout, tr_state), std::move(views), std::move(m), { }, tr_state, now, timeout);
         // In this case we are not doing a read-before-write, just a
         // write, so no lock is needed.
         co_return row_locker::lock_holder();
@@ -3174,7 +3174,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
     auto pk = dht::partition_range::make_singular(m.decorated_key());
     auto permit = sem.make_tracking_only_permit(base, "push-view-updates-2", timeout, tr_state);
     auto reader = source.make_reader_v2(base, permit, pk, slice, tr_state, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
-    co_await gen->generate_and_propagate_view_updates(*this, base, std::move(permit), std::move(views), std::move(m), std::move(reader), tr_state, now);
+    co_await gen->generate_and_propagate_view_updates(*this, base, std::move(permit), std::move(views), std::move(m), std::move(reader), tr_state, now, timeout);
     tracing::trace(tr_state, "View updates for {}.{} were generated and propagated", base->ks_name(), base->cf_name());
     // return the local partition/row lock we have taken so it
     // remains locked until the caller is done modifying this

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1528,28 +1528,11 @@ public:
                     return std::max(lhs, rhs);
                 });
     }
-    std::chrono::microseconds calculate_delay(db::view::update_backlog backlog) {
-        constexpr auto delay_limit_us = 1000000;
-        auto adjust = [] (float x) { return x * x * x; };
-        auto budget = std::max(storage_proxy::clock_type::duration(0),
-            _expire_timer.get_timeout() - storage_proxy::clock_type::now());
-        std::chrono::microseconds ret(uint32_t(adjust(backlog.relative_size()) * delay_limit_us));
-        // "budget" has millisecond resolution and can potentially be long
-        // in the future so converting it to microseconds may overflow.
-        // So to compare buget and ret we need to convert both to the lower
-        // resolution.
-        if (std::chrono::duration_cast<storage_proxy::clock_type::duration>(ret) < budget) {
-            return ret;
-        } else {
-            // budget is small (< ret) so can be converted to microseconds
-            return std::chrono::duration_cast<std::chrono::microseconds>(budget);
-        }
-    }
     // Calculates how much to delay completing the request. The delay adds to the request's inherent latency.
     template<typename Func>
     void delay(tracing::trace_state_ptr trace, Func&& on_resume) {
         auto backlog = max_backlog();
-        auto delay = calculate_delay(backlog);
+        auto delay = db::view::calculate_view_update_throttling_delay(backlog, _expire_timer.get_timeout());
         stats().last_mv_flow_control_delay = delay;
         if (delay.count() == 0) {
             tracing::trace(trace, "Delay decision due to throttling: do not delay, resuming now");

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -230,6 +230,13 @@ public:
     query::tombstone_limit get_tombstone_limit() const;
     inet_address_vector_replica_set get_live_endpoints(const locator::effective_replication_map& erm, const dht::token& token) const;
 
+    // Get information about this node's view update backlog. It combines information from all local shards.
+    db::view::update_backlog get_view_update_backlog() const;
+
+    // Get information about a remote node's view update backlog. Information about remote backlogs is constantly updated
+    // using gossip and by passing the information in each MUTATION_DONE rpc call response.
+    db::view::update_backlog get_backlog_of(gms::inet_address) const;
+
     future<std::vector<dht::token_range_endpoints>> describe_ring(const sstring& keyspace, bool include_only_local_dc = false) const;
 
 private:
@@ -437,11 +444,7 @@ private:
             allow_hints,
             is_cancellable);
 
-    db::view::update_backlog get_view_update_backlog() const;
-
     void maybe_update_view_backlog_of(gms::inet_address, std::optional<db::view::update_backlog>);
-
-    db::view::update_backlog get_backlog_of(gms::inet_address) const;
 
     template<typename Range>
     future<> mutate_counters(Range&& mutations, db::consistency_level cl, tracing::trace_state_ptr tr_state, service_permit permit, clock_type::time_point timeout);

--- a/test/topology_custom/test_mv_delete_partitions.py
+++ b/test/topology_custom/test_mv_delete_partitions.py
@@ -1,0 +1,86 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from test.pylib.manager_client import ManagerClient
+
+import asyncio
+import pytest
+import time
+import logging
+from test.topology.conftest import skip_mode
+from cassandra.cqltypes import Int32Type
+
+logger = logging.getLogger(__name__)
+
+async def insert_with_concurrency(cql, value_count, concurrency):
+    def serialize_int(i):
+        return Int32Type.serialize(i, cql.cluster.protocol_version)
+    def get_replicas(key):
+        return cql.cluster.metadata.get_replicas("ks", serialize_int(key))
+    local_node = get_replicas(0)[0]
+    logger.info(f"Starting writes with concurrency {concurrency}")
+    async def do_inserts(m: int):
+        m_count = value_count // concurrency
+        if value_count % concurrency >= m:
+            m_count += 1
+        update_key = m
+        # For each row in [0, value_count) with key % concurrency == m, insert a row with the same remainder m
+        insert_stmt = cql.prepare(f"INSERT INTO ks.tab (key, c) VALUES (?, ?)")
+        inserted_count = 0
+        while inserted_count < m_count:
+            # Only remote updates hold on to memory, so try another key until the update is remote
+            while local_node == get_replicas(update_key)[0]:
+                update_key = update_key + concurrency
+            await cql.run_async(insert_stmt, [0, update_key])
+            inserted_count += 1
+            update_key = update_key + concurrency
+    tasks = [asyncio.create_task(do_inserts(i)) for i in range(concurrency)]
+
+    await asyncio.gather(*tasks)
+    logger.info(f"Finished writes with concurrency {concurrency}")
+
+async def wait_for_views(cql, mvs_count, node_count):
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        done = await cql.run_async(f"SELECT COUNT(*) FROM system_distributed.view_build_status WHERE status = 'SUCCESS' ALLOW FILTERING")
+        logger.info(f"Views built: {done[0][0]}")
+        if done[0][0] == node_count * mvs_count:
+            return
+        else:
+            time.sleep(0.2)
+    raise Exception("Timeout waiting for views to build")
+
+# This test reproduces issue #12379
+# To quickly exceed the view update backlog limit, the test uses a minimal, 2 node
+# cluster and lowers the limit using the "view_update_limit" error injection.
+# Also, the "delay_before_remote_view_update" error injection is used to ensure that
+# we're hitting a scenario where the remote view update finishes after the base write
+# returns.
+# The test steps are:
+# 1. Create a table and with one partition and 200 rows
+# 2. Create a materialized view and wait until it's built
+# 3. Delete the entire partition in the base table, causing a large number of view updates
+# The "view_update_limit" error injections will cause the test to fail due to a failed
+# replica write if the view update limit is exceeded. If, thanks to throttling, we never
+# exceed the limit, the test will pass
+@pytest.mark.asyncio
+@skip_mode('release', "error injections aren't enabled in release mode")
+async def test_delete_partition_rows_from_table_with_mv(manager: ManagerClient) -> None:
+    node_count = 2
+    await manager.servers_add(node_count, config={'error_injections_at_startup': ['view_update_limit', 'delay_before_remote_view_update']})
+    cql = manager.get_cql()
+    await cql.run_async(f"CREATE KEYSPACE ks WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 1}}")
+    await cql.run_async(f"CREATE TABLE ks.tab (key int, c int, PRIMARY KEY (key, c))")
+    await insert_with_concurrency(cql, 200, 100)
+
+    await cql.run_async(f"CREATE MATERIALIZED VIEW ks.mv_cf_view AS SELECT * FROM ks.tab "
+                    "WHERE c IS NOT NULL and key IS NOT NULL PRIMARY KEY (c, key) ")
+
+    await wait_for_views(cql, 1, node_count)
+
+    logger.info(f"Deleting all rows from partition with key 0")
+    await cql.run_async(f"DELETE FROM ks.tab WHERE key = 0", timeout=300)
+
+    await cql.run_async(f"DROP KEYSPACE ks")


### PR DESCRIPTION
This series is a reupload of #13792 with a few modifications, namely a test is added and the conflicts with recent tablet related changes are fixed.

See https://github.com/scylladb/scylladb/issues/12379 and https://github.com/scylladb/scylladb/pull/13583 for a detailed description of the problem and discussions.

This PR aims to extend the existing throttling mechanism to work with requests that internally generate a large amount of view updates, as suggested by @nyh.

The existing mechanism works in the following way:

* Client sends a request, we generate the view updates corresponding to the request and spawn background tasks which will send these updates to remote nodes
* Each background task consumes some units from the `view_update_concurrency_semaphore`, but doesn't wait for these units, it's just for tracking
* We keep track of the percent of consumed units on each node, this is called `view update backlog`.
* Before sending a response to the client we sleep for a short amount of time. The amount of time to sleep for is based on the fullness of this `view update backlog`. For a well behaved client with limited concurrency this will limit the amount of incoming requests to a manageable level.

This mechanism doesn't handle large DELETE queries. Deleting a partition is fast for the base table, but it requires us to generate a view update for every single deleted row. The number of deleted rows per single client request can be in the millions. Delaying response to the request doesn't help when a single request can generate millions of updates.

To deal with this we could treat the view update generator just like any other client and force it to wait a bit of time before sending the next batch of updates. The amount of time to wait for is calculated just like in the existing throttling code, it's based on the fullness of `view update backlogs`.

The new algorithm of view update generation looks something like this:
```c++
for(;;) {
    auto updates = generate_updates_batch_with_max_100_rows();
    co_await seastar::sleep(calculate_sleep_time_from_backlogs());
    spawn_background_tasks_for_updates(updates);
}
```
Fixes: https://github.com/scylladb/scylladb/issues/12379