### PR TITLE
sync_raft_topology_nodes:  force_remove_endpoint for left nodes only if an IP is not used by other nodes

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4646,27 +4646,27 @@ future<> storage_service::on_change(gms::inet_address endpoint, const gms::appli
     if (_raft_topology_change_enabled) {
         slogger.debug("ignore status changes since topology changes are using raft");
     } else {
-    co_await on_application_state_change(endpoint, states, application_state::STATUS, pid, [this] (inet_address endpoint, const gms::versioned_value& value, gms::permit_id pid) -> future<> {
-        std::vector<sstring> pieces;
-        boost::split(pieces, value.value(), boost::is_any_of(sstring(versioned_value::DELIMITER_STR)));
-        if (pieces.empty()) {
-            slogger.warn("Fail to split status in on_change: endpoint={}, app_state={}, value={}", endpoint, application_state::STATUS, value);
-            co_return;
-        }
-        const sstring& move_name = pieces[0];
-        if (move_name == sstring(versioned_value::STATUS_BOOTSTRAPPING)) {
-            co_await handle_state_bootstrap(endpoint, pid);
-        } else if (move_name == sstring(versioned_value::STATUS_NORMAL) ||
-                   move_name == sstring(versioned_value::SHUTDOWN)) {
-            co_await handle_state_normal(endpoint, pid);
-        } else if (move_name == sstring(versioned_value::REMOVED_TOKEN)) {
-            co_await handle_state_removed(endpoint, std::move(pieces), pid);
-        } else if (move_name == sstring(versioned_value::STATUS_LEFT)) {
-            co_await handle_state_left(endpoint, std::move(pieces), pid);
-        } else {
-            co_return; // did nothing.
-        }
-    });
+        co_await on_application_state_change(endpoint, states, application_state::STATUS, pid, [this] (inet_address endpoint, const gms::versioned_value& value, gms::permit_id pid) -> future<> {
+            std::vector<sstring> pieces;
+            boost::split(pieces, value.value(), boost::is_any_of(sstring(versioned_value::DELIMITER_STR)));
+            if (pieces.empty()) {
+                slogger.warn("Fail to split status in on_change: endpoint={}, app_state={}, value={}", endpoint, application_state::STATUS, value);
+                co_return;
+            }
+            const sstring& move_name = pieces[0];
+            if (move_name == sstring(versioned_value::STATUS_BOOTSTRAPPING)) {
+                co_await handle_state_bootstrap(endpoint, pid);
+            } else if (move_name == sstring(versioned_value::STATUS_NORMAL) ||
+                       move_name == sstring(versioned_value::SHUTDOWN)) {
+                co_await handle_state_normal(endpoint, pid);
+            } else if (move_name == sstring(versioned_value::REMOVED_TOKEN)) {
+                co_await handle_state_removed(endpoint, std::move(pieces), pid);
+            } else if (move_name == sstring(versioned_value::STATUS_LEFT)) {
+                co_await handle_state_left(endpoint, std::move(pieces), pid);
+            } else {
+                co_return; // did nothing.
+            }
+        });
     }
     auto ep_state = _gossiper.get_endpoint_state_ptr(endpoint);
     if (!ep_state || _gossiper.is_dead_state(*ep_state)) {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -475,7 +475,7 @@ public:
     virtual void on_drop_view(const sstring& ks_name, const sstring& view_name) override {}
 private:
     db::system_keyspace::peer_info get_peer_info_for_update(inet_address endpoint);
-    static db::system_keyspace::peer_info get_peer_info_for_update(inet_address endpoint, const gms::application_state_map& app_state_map);
+    db::system_keyspace::peer_info get_peer_info_for_update(inet_address endpoint, const gms::application_state_map& app_state_map);
 
     std::unordered_set<token> get_tokens_for(inet_address endpoint);
     std::optional<locator::endpoint_dc_rack> get_dc_rack_for(const gms::endpoint_state& ep_state);

--- a/test/topology_custom/test_replace.py
+++ b/test/topology_custom/test_replace.py
@@ -9,18 +9,59 @@ Test replacing node in different scenarios
 import time
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.manager_client import ManagerClient
-from test.topology.util import wait_for_token_ring_and_group0_consistency
+from test.topology.util import wait_for_token_ring_and_group0_consistency, wait_for_cql_and_get_hosts, wait_for
 import pytest
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
 async def test_replace_different_ip(manager: ManagerClient) -> None:
     """Replace an existing node with new node using a different IP address"""
     servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': 2000})
+    logger.info(f"cluster started, servers {servers}")
+
+    logger.info(f"replacing server {servers[0]}")
     await manager.server_stop(servers[0].server_id)
-    replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = False)
-    await manager.server_add(replace_cfg)
+    replaced_server = servers[0]
+    replace_cfg = ReplaceConfig(replaced_id = replaced_server.server_id, reuse_ip_addr = False, use_host_id = False)
+    new_server = await manager.server_add(replace_cfg)
+    cql = manager.get_cql()
+    servers = await manager.running_servers()
+    all_ips = set([s.rpc_address for s in servers])
+    logger.info(f"new server {new_server} started, all ips {all_ips}, "
+                "waiting for token ring and group0 consistency")
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+
+    for s in servers:
+        peers_to_see = all_ips - {s.rpc_address}
+
+        logger.info(f'waiting for cql and get hosts for {s}')
+        h = (await wait_for_cql_and_get_hosts(cql, [s], time.time() + 60))[0]
+
+        logger.info(f"waiting for {s} to see its peers {peers_to_see}")
+        async def check_peers_and_gossiper():
+            peers = set([r.peer for r in await cql.run_async("select peer from system.peers", host=h)])
+            remaining = peers_to_see - peers
+            if remaining:
+                logger.info(f"server {h} doesn't see its peers, all_ips {all_ips}, peers_to_see {peers_to_see}, remaining {remaining}, continue waiting")
+                return None
+
+            alive_eps = await manager.api.get_alive_endpoints(s.ip_addr)
+            if replaced_server.ip_addr in alive_eps:
+                logger.info(f"server {h}, replaced ip {replaced_server.ip_addr} is contained in alive eps {alive_eps}, continue waiting")
+                return None
+
+            down_eps = await manager.api.get_down_endpoints(s.ip_addr)
+            if replaced_server.ip_addr in down_eps:
+                logger.info(f"server {h}, replaced ip {replaced_server.ip_addr} is contained in down eps {down_eps}, continue waiting")
+                return None
+
+            return True
+        await wait_for(check_peers_and_gossiper, time.time() + 60)
+        logger.info(f"server {s} system.peers and gossiper state is valid")
 
 @pytest.mark.asyncio
 async def test_replace_different_ip_using_host_id(manager: ManagerClient) -> None:

--- a/test/topology_custom/test_replace_with_same_ip_twice.py
+++ b/test/topology_custom/test_replace_with_same_ip_twice.py
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import time
+from test.pylib.scylla_cluster import ReplaceConfig
+from test.pylib.manager_client import ManagerClient
+from test.topology.util import wait_for_token_ring_and_group0_consistency
+from test.pylib.internal_types import ServerInfo
+import pytest
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_replace_with_same_ip_twice(manager: ManagerClient) -> None:
+    logger.info("starting a cluster with two nodes")
+    servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': 2000})
+    logger.info(f"cluster started {servers}")
+
+    async def replace_with_same_ip(s: ServerInfo) -> ServerInfo:
+        logger.info(f"stopping server {s.server_id}")
+        await manager.server_stop_gracefully(s.server_id)
+
+        logger.info(f"replacing server {s.server_id} with same ip")
+        replace_cfg = ReplaceConfig(replaced_id = s.server_id, reuse_ip_addr = True, use_host_id = False)
+        return await manager.server_add(replace_cfg)
+
+    test_server = servers[1]
+    test_server = await replace_with_same_ip(test_server)
+    await replace_with_same_ip(test_server)


### PR DESCRIPTION
Before the patch we called `gossiper.remove_endpoint` for IP-s of the left nodes. The problem is that in replace-with-same-ip scenario we called `gossiper.remove_endpoint` for IP which is used by the new, replacing node. The `gossiper.remove_endpoint` method puts the IP into quarantine, which means gossiper will ignore all events about this IP for `quarantine_delay` (one minute by default). If we immediately replace just replaced node with the same IP again, the bootstrap will fail since the gossiper events are blocked for this IP, and we won't be able to resolve an IP for the new host_id.

Another problem was that we called gossiper.remove_endpoint method, which doesn't remove an endpoint from `_endpoint_state_map`, only from live and unreachable lists. This means the IP will keep circulating in the gossiper message exchange between cluster nodes until full cluster restart.

This patch fixes both of these problems. First, we rely on the fact that when topology coordinator moves the `being_replaced` node to the left state, the IP of the `replacing` node is known to all nodes. This means before removing an IP from the gossiper we can check if this IP is currently used by another node in the current raft topology. This is done by constructing the `used_ips` map based on normal and transition nodes. This map is cached to avoid quadratic behaviour.

Second, we call `gossiper.force_remove_endpoint`, not `gossiper.remove_endpoint`. This function removes and IP from `_endpoint_state_map`, as well as from live and unreachable lists.