### PR TITLE
repair: do_rebuild_replace_with_repair: use source_dc only when safe

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -1891,6 +1891,14 @@
                      "allowMultiple":false,
                      "type":"string",
                      "paramType":"query"
+                  },
+                  {
+                     "name":"force",
+                     "description":"Enforce the source_dc option, even if it unsafe to use for rebuild",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"boolean",
+                     "paramType":"query"
                   }
                ]
             }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1093,6 +1093,12 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         if (auto source_dc_str = req->get_query_param("source_dc"); !source_dc_str.empty()) {
             source_dc.emplace(std::move(source_dc_str)).set_user_provided();
         }
+        if (auto force_str = req->get_query_param("force"); !force_str.empty() && service::loosen_constraints(validate_bool(force_str))) {
+            if (!source_dc) {
+                throw bad_param_exception("The `source_dc` option must be provided for using the `force` option");
+            }
+            source_dc.set_force();
+        }
         apilog.info("rebuild: source_dc={}", source_dc);
         return ss.local().rebuild(std::move(source_dc)).then([] {
             return make_ready_future<json::json_return_type>(json_void());

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -54,6 +54,7 @@
 #include "locator/abstract_replication_strategy.hh"
 #include "sstables_loader.hh"
 #include "db/view/view_builder.hh"
+#include "utils/user_provided_param.hh"
 
 using namespace seastar::httpd;
 using namespace std::chrono_literals;
@@ -1088,7 +1089,10 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     });
 
     ss::rebuild.set(r, [&ss](std::unique_ptr<http::request> req) {
-        auto source_dc = req->get_query_param("source_dc");
+        utils::optional_param source_dc;
+        if (auto source_dc_str = req->get_query_param("source_dc"); !source_dc_str.empty()) {
+            source_dc.emplace(std::move(source_dc_str)).set_user_provided();
+        }
         apilog.info("rebuild: source_dc={}", source_dc);
         return ss.local().rebuild(std::move(source_dc)).then([] {
             return make_ready_future<json::json_return_type>(json_void());

--- a/docs/operating-scylla/nodetool-commands/rebuild.rst
+++ b/docs/operating-scylla/nodetool-commands/rebuild.rst
@@ -1,8 +1,17 @@
 Nodetool rebuild
 ================
 
-**rebuild** ``[<src-dc-name>]`` - This command rebuilds a node's data by streaming data from other nodes in the cluster (similarly to bootstrap).
-Rebuild operates on multiple nodes in a ScyllaDB cluster. It streams data from a single source replica when rebuilding a token range. When executing the command, ScyllaDB first figures out which ranges the local node (the one we want to rebuild) is responsible for. Then which node in the cluster contains the same ranges. Finally, ScyllaDB streams the data to the local node.
+**rebuild** ``[[--force] <source-dc-name>]`` - This command rebuilds a node's data by streaming data from other nodes in the cluster (similarly to bootstrap).
+
+When executing the command, ScyllaDB first figures out which ranges the local node (the one we want to rebuild) is responsible for.
+Then which node in the cluster contains the same ranges.
+If ``source-dc-name`` is provided, ScyllaDB will stream data only from nodes in that datacenter, when safe to do so.
+Otherwise, an alternative datacenter that lost no nodes will be considered, and if none exist, all datacenters will be considered.
+Use the ``--force`` option to enforce rebuild using the source datacenter, even if it is unsafe to do so.
+
+When ``rebuild`` is enabled in :doc:`Repair Based Node Operations (RBNO) </operating-scylla/procedures/cluster-management/repair-based-node-operation>`,
+data is rebuilt using repair-based-rebuild by reading all source replicas in each token range and repairing any discrepancies between them.
+Otherwise, data is streamed from a single source replica when rebuilding each token range.
  
 When :doc:`adding a new data-center into an existing ScyllaDB cluster </operating-scylla/procedures/cluster-management/add-dc-to-existing-dc/>` use the rebuild command.
 
@@ -14,6 +23,6 @@ For Example:
 
 .. code-block:: shell
 
-   nodetool rebuild <src-dc-name>
+   nodetool rebuild <source-dc-name>
 
 .. include:: nodetool-index.rst

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1952,9 +1952,9 @@ future<> repair_service::removenode_with_repair(locator::token_metadata_ptr tmpt
     });
 }
 
-future<> repair_service::do_rebuild_replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, sstring op, utils::optional_param source_dc, streaming::stream_reason reason, std::unordered_set<locator::host_id> ignore_nodes) {
+future<> repair_service::do_rebuild_replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, sstring op, utils::optional_param source_dc, streaming::stream_reason reason, std::unordered_set<locator::host_id> ignore_nodes, locator::host_id replaced_node) {
     SCYLLA_ASSERT(this_shard_id() == 0);
-    return seastar::async([this, ks_erms = std::move(ks_erms), tmptr = std::move(tmptr), source_dc = std::move(source_dc), op = std::move(op), reason, ignore_nodes = std::move(ignore_nodes)] () mutable {
+    return seastar::async([this, ks_erms = std::move(ks_erms), tmptr = std::move(tmptr), source_dc = std::move(source_dc), op = std::move(op), reason, ignore_nodes = std::move(ignore_nodes), replaced_node] () mutable {
         auto& db = get_db().local();
         auto myid = tmptr->get_my_id();
         size_t nr_ranges_total = 0;
@@ -1980,7 +1980,7 @@ future<> repair_service::do_rebuild_replace_with_repair(std::unordered_map<sstri
                 rs.get_metrics().replace_total_ranges = nr_ranges_total;
             }).get();
         }
-        rlogger.info("{}: started with keyspaces={}, source_dc={}, nr_ranges_total={}, ignore_nodes={}", op, ks_erms | boost::adaptors::map_keys, source_dc, nr_ranges_total, ignore_nodes);
+        rlogger.info("{}: started with keyspaces={}, source_dc={}, nr_ranges_total={}, ignore_nodes={} replaced_node={}", op, ks_erms | boost::adaptors::map_keys, source_dc, nr_ranges_total, ignore_nodes, replaced_node);
         for (const auto& [keyspace_name, erm] : ks_erms) {
             size_t nr_ranges_skipped = 0;
             if (!db.has_keyspace(keyspace_name)) {
@@ -1992,7 +1992,7 @@ future<> repair_service::do_rebuild_replace_with_repair(std::unordered_map<sstri
             auto& topology = erm->get_token_metadata().get_topology();
             std::unordered_map<dht::token_range, repair_neighbors> range_sources;
             auto nr_tables = get_nr_tables(db, keyspace_name);
-            rlogger.info("{}: started with keyspace={}, source_dc={}, nr_ranges={}, ignore_nodes={}", op, keyspace_name, source_dc, ranges.size() * nr_tables, ignore_nodes);
+            rlogger.info("{}: started with keyspace={}, source_dc={}, nr_ranges={}, ignore_nodes={} replaced_node={}", op, keyspace_name, source_dc, ranges.size() * nr_tables, ignore_nodes, replaced_node);
             for (auto it = ranges.begin(); it != ranges.end();) {
                 auto& r = *it;
                 seastar::thread::maybe_yield();
@@ -2046,7 +2046,7 @@ future<> repair_service::rebuild_with_repair(std::unordered_map<sstring, locator
     }
     auto reason = streaming::stream_reason::rebuild;
     rlogger.info("{}: this-node={} source_dc={}", op, *topology.this_node(), source_dc);
-    co_await do_rebuild_replace_with_repair(std::move(ks_erms), std::move(tmptr), std::move(op), std::move(source_dc), reason, {});
+    co_await do_rebuild_replace_with_repair(std::move(ks_erms), std::move(tmptr), std::move(op), std::move(source_dc), reason);
     co_await get_db().invoke_on_all([](replica::database& db) {
         for (auto& t : db.get_non_system_column_families()) {
             t->trigger_offstrategy_compaction();
@@ -2054,7 +2054,7 @@ future<> repair_service::rebuild_with_repair(std::unordered_map<sstring, locator
     });
 }
 
-future<> repair_service::replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::unordered_set<locator::host_id> ignore_nodes) {
+future<> repair_service::replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::unordered_set<locator::host_id> ignore_nodes, locator::host_id replaced_node) {
     SCYLLA_ASSERT(this_shard_id() == 0);
     auto cloned_tm = co_await tmptr->clone_async();
     auto op = sstring("replace_with_repair");
@@ -2068,7 +2068,7 @@ future<> repair_service::replace_with_repair(std::unordered_map<sstring, locator
     co_await cloned_tmptr->update_normal_tokens(replacing_tokens, tmptr->get_my_id());
     auto source_dc = utils::optional_param(myloc.dc);
     rlogger.info("{}: this-node={} ignore_nodes={} source_dc={}", op, *topology.this_node(), ignore_nodes, source_dc);
-    co_return co_await do_rebuild_replace_with_repair(std::move(ks_erms), std::move(cloned_tmptr), std::move(op), std::move(source_dc), reason, std::move(ignore_nodes));
+    co_return co_await do_rebuild_replace_with_repair(std::move(ks_erms), std::move(cloned_tmptr), std::move(op), std::move(source_dc), reason, std::move(ignore_nodes), replaced_node);
 }
 
 static std::unordered_set<gms::inet_address> get_nodes_in_dcs(std::vector<sstring> data_centers, locator::effective_replication_map_ptr erm) {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1952,11 +1952,10 @@ future<> repair_service::removenode_with_repair(locator::token_metadata_ptr tmpt
     });
 }
 
-future<> repair_service::do_rebuild_replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, sstring op, utils::optional_param source_dc, streaming::stream_reason reason, std::unordered_set<gms::inet_address> ignore_nodes) {
+future<> repair_service::do_rebuild_replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, sstring op, utils::optional_param source_dc, streaming::stream_reason reason, std::unordered_set<locator::host_id> ignore_nodes) {
     SCYLLA_ASSERT(this_shard_id() == 0);
     return seastar::async([this, ks_erms = std::move(ks_erms), tmptr = std::move(tmptr), source_dc = std::move(source_dc), op = std::move(op), reason, ignore_nodes = std::move(ignore_nodes)] () mutable {
         auto& db = get_db().local();
-        auto myip = tmptr->get_topology().my_address();
         auto myid = tmptr->get_my_id();
         size_t nr_ranges_total = 0;
         for (const auto& [keyspace_name, erm] : ks_erms) {
@@ -1998,15 +1997,17 @@ future<> repair_service::do_rebuild_replace_with_repair(std::unordered_map<sstri
                 auto& r = *it;
                 seastar::thread::maybe_yield();
                 auto end_token = r.end() ? r.end()->value() : dht::maximum_token();
-                auto neighbors = boost::copy_range<std::vector<gms::inet_address>>(strat.calculate_natural_ips(end_token, *tmptr).get() |
-                    boost::adaptors::filtered([myip, &source_dc, &topology, &ignore_nodes] (const gms::inet_address& node) {
-                        if (node == myip) {
+                auto neighbors = boost::copy_range<std::vector<gms::inet_address>>(strat.calculate_natural_endpoints(end_token, *tmptr).get() |
+                    boost::adaptors::filtered([&source_dc, &topology, &ignore_nodes] (const auto& node) {
+                        if (topology.is_me(node)) {
                             return false;
                         }
                         if (ignore_nodes.contains(node)) {
                             return false;
                         }
                         return !source_dc || topology.get_datacenter(node) == *source_dc;
+                    }) | boost::adaptors::transformed([&topology] (const auto& node) {
+                        return topology.get_node(node).endpoint();
                     })
                 );
                 rlogger.debug("{}: keyspace={}, range={}, neighbors={}", op, keyspace_name, r, neighbors);
@@ -2053,7 +2054,7 @@ future<> repair_service::rebuild_with_repair(std::unordered_map<sstring, locator
     });
 }
 
-future<> repair_service::replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::unordered_set<gms::inet_address> ignore_nodes) {
+future<> repair_service::replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::unordered_set<locator::host_id> ignore_nodes) {
     SCYLLA_ASSERT(this_shard_id() == 0);
     auto cloned_tm = co_await tmptr->clone_async();
     auto op = sstring("replace_with_repair");

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -48,6 +48,7 @@
 #include <atomic>
 
 #include "idl/partition_checksum.dist.hh"
+#include "utils/user_provided_param.hh"
 
 using namespace std::chrono_literals;
 
@@ -1951,7 +1952,7 @@ future<> repair_service::removenode_with_repair(locator::token_metadata_ptr tmpt
     });
 }
 
-future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, sstring source_dc, streaming::stream_reason reason, std::unordered_set<gms::inet_address> ignore_nodes) {
+future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, utils::optional_param source_dc, streaming::stream_reason reason, std::unordered_set<gms::inet_address> ignore_nodes) {
     SCYLLA_ASSERT(this_shard_id() == 0);
     return seastar::async([this, tmptr = std::move(tmptr), source_dc = std::move(source_dc), op = std::move(op), reason, ignore_nodes = std::move(ignore_nodes)] () mutable {
         auto& db = get_db().local();
@@ -2006,7 +2007,7 @@ future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_
                         if (ignore_nodes.contains(node)) {
                             return false;
                         }
-                        return source_dc.empty() ? true : topology.get_datacenter(node) == source_dc;
+                        return !source_dc || topology.get_datacenter(node) == *source_dc;
                     })
                 );
                 rlogger.debug("{}: keyspace={}, range={}, neighbors={}", op, keyspace_name, r, neighbors);
@@ -2036,14 +2037,15 @@ future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_
     });
 }
 
-future<> repair_service::rebuild_with_repair(locator::token_metadata_ptr tmptr, sstring source_dc) {
+future<> repair_service::rebuild_with_repair(locator::token_metadata_ptr tmptr, utils::optional_param source_dc) {
     SCYLLA_ASSERT(this_shard_id() == 0);
     auto op = sstring("rebuild_with_repair");
-    if (source_dc.empty()) {
-        auto& topology = tmptr->get_topology();
-        source_dc = topology.get_datacenter();
+    const auto& topology = tmptr->get_topology();
+    if (!source_dc) {
+        source_dc = utils::optional_param(topology.get_datacenter());
     }
     auto reason = streaming::stream_reason::rebuild;
+    rlogger.info("{}: this-node={} source_dc={}", op, *topology.this_node(), source_dc);
     co_await do_rebuild_replace_with_repair(std::move(tmptr), std::move(op), std::move(source_dc), reason, {});
     co_await get_db().invoke_on_all([](replica::database& db) {
         for (auto& t : db.get_non_system_column_families()) {
@@ -2064,7 +2066,9 @@ future<> repair_service::replace_with_repair(locator::token_metadata_ptr tmptr, 
     auto cloned_tmptr = make_token_metadata_ptr(std::move(cloned_tm));
     cloned_tmptr->update_topology(tmptr->get_my_id(), myloc, locator::node::state::replacing);
     co_await cloned_tmptr->update_normal_tokens(replacing_tokens, tmptr->get_my_id());
-    co_return co_await do_rebuild_replace_with_repair(std::move(cloned_tmptr), std::move(op), myloc.dc, reason, std::move(ignore_nodes));
+    auto source_dc = utils::optional_param(myloc.dc);
+    rlogger.info("{}: this-node={} ignore_nodes={} source_dc={}", op, *topology.this_node(), ignore_nodes, source_dc);
+    co_return co_await do_rebuild_replace_with_repair(std::move(cloned_tmptr), std::move(op), std::move(source_dc), reason, std::move(ignore_nodes));
 }
 
 static std::unordered_set<gms::inet_address> get_nodes_in_dcs(std::vector<sstring> data_centers, locator::effective_replication_map_ptr erm) {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1952,11 +1952,10 @@ future<> repair_service::removenode_with_repair(locator::token_metadata_ptr tmpt
     });
 }
 
-future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, utils::optional_param source_dc, streaming::stream_reason reason, std::unordered_set<gms::inet_address> ignore_nodes) {
+future<> repair_service::do_rebuild_replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, sstring op, utils::optional_param source_dc, streaming::stream_reason reason, std::unordered_set<gms::inet_address> ignore_nodes) {
     SCYLLA_ASSERT(this_shard_id() == 0);
-    return seastar::async([this, tmptr = std::move(tmptr), source_dc = std::move(source_dc), op = std::move(op), reason, ignore_nodes = std::move(ignore_nodes)] () mutable {
+    return seastar::async([this, ks_erms = std::move(ks_erms), tmptr = std::move(tmptr), source_dc = std::move(source_dc), op = std::move(op), reason, ignore_nodes = std::move(ignore_nodes)] () mutable {
         auto& db = get_db().local();
-        auto ks_erms = db.get_non_local_strategy_keyspaces_erms();
         auto myip = tmptr->get_topology().my_address();
         auto myid = tmptr->get_my_id();
         size_t nr_ranges_total = 0;
@@ -2037,7 +2036,7 @@ future<> repair_service::do_rebuild_replace_with_repair(locator::token_metadata_
     });
 }
 
-future<> repair_service::rebuild_with_repair(locator::token_metadata_ptr tmptr, utils::optional_param source_dc) {
+future<> repair_service::rebuild_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, utils::optional_param source_dc) {
     SCYLLA_ASSERT(this_shard_id() == 0);
     auto op = sstring("rebuild_with_repair");
     const auto& topology = tmptr->get_topology();
@@ -2046,7 +2045,7 @@ future<> repair_service::rebuild_with_repair(locator::token_metadata_ptr tmptr, 
     }
     auto reason = streaming::stream_reason::rebuild;
     rlogger.info("{}: this-node={} source_dc={}", op, *topology.this_node(), source_dc);
-    co_await do_rebuild_replace_with_repair(std::move(tmptr), std::move(op), std::move(source_dc), reason, {});
+    co_await do_rebuild_replace_with_repair(std::move(ks_erms), std::move(tmptr), std::move(op), std::move(source_dc), reason, {});
     co_await get_db().invoke_on_all([](replica::database& db) {
         for (auto& t : db.get_non_system_column_families()) {
             t->trigger_offstrategy_compaction();
@@ -2054,7 +2053,7 @@ future<> repair_service::rebuild_with_repair(locator::token_metadata_ptr tmptr, 
     });
 }
 
-future<> repair_service::replace_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::unordered_set<gms::inet_address> ignore_nodes) {
+future<> repair_service::replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::unordered_set<gms::inet_address> ignore_nodes) {
     SCYLLA_ASSERT(this_shard_id() == 0);
     auto cloned_tm = co_await tmptr->clone_async();
     auto op = sstring("replace_with_repair");
@@ -2068,7 +2067,7 @@ future<> repair_service::replace_with_repair(locator::token_metadata_ptr tmptr, 
     co_await cloned_tmptr->update_normal_tokens(replacing_tokens, tmptr->get_my_id());
     auto source_dc = utils::optional_param(myloc.dc);
     rlogger.info("{}: this-node={} ignore_nodes={} source_dc={}", op, *topology.this_node(), ignore_nodes, source_dc);
-    co_return co_await do_rebuild_replace_with_repair(std::move(cloned_tmptr), std::move(op), std::move(source_dc), reason, std::move(ignore_nodes));
+    co_return co_await do_rebuild_replace_with_repair(std::move(ks_erms), std::move(cloned_tmptr), std::move(op), std::move(source_dc), reason, std::move(ignore_nodes));
 }
 
 static std::unordered_set<gms::inet_address> get_nodes_in_dcs(std::vector<sstring> data_centers, locator::effective_replication_map_ptr erm) {

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -12,6 +12,7 @@
 #include <exception>
 #include <absl/container/btree_set.h>
 #include <fmt/core.h>
+#include <boost/range/adaptors.hpp>
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/sstring.hh>
@@ -144,6 +145,9 @@ public:
     repair_neighbors() = default;
     explicit repair_neighbors(std::vector<gms::inet_address> a)
         : all(std::move(a)) {
+    }
+    explicit repair_neighbors(const std::unordered_map<locator::host_id, gms::inet_address>& a)
+        : all(boost::copy_range<std::vector<gms::inet_address>>(a | boost::adaptors::map_values)) {
     }
     repair_neighbors(std::vector<gms::inet_address> a, std::vector<gms::inet_address> m)
         : all(std::move(a))

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -153,11 +153,11 @@ public:
     future<> decommission_with_repair(locator::token_metadata_ptr tmptr);
     future<> removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
     future<> rebuild_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, utils::optional_param source_dc);
-    future<> replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::unordered_set<locator::host_id> ignore_nodes);
+    future<> replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::unordered_set<locator::host_id> ignore_nodes, locator::host_id replaced_node);
 private:
     future<> do_decommission_removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
 
-    future<> do_rebuild_replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, sstring op, utils::optional_param source_dc, streaming::stream_reason reason, std::unordered_set<locator::host_id> ignore_nodes);
+    future<> do_rebuild_replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, sstring op, utils::optional_param source_dc, streaming::stream_reason reason, std::unordered_set<locator::host_id> ignore_nodes = {}, locator::host_id replaced_node = {});
 
     // Must be called on shard 0
     future<> sync_data_using_repair(sstring keyspace,

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include <vector>
 #include "gms/inet_address.hh"
 #include "repair/repair.hh"
@@ -17,6 +19,7 @@
 #include <seastar/core/distributed.hh>
 #include <seastar/util/bool_class.hh>
 #include "service/raft/raft_address_map.hh"
+#include "utils/user_provided_param.hh"
 
 using namespace seastar;
 
@@ -149,11 +152,12 @@ public:
     future<> bootstrap_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> bootstrap_tokens);
     future<> decommission_with_repair(locator::token_metadata_ptr tmptr);
     future<> removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
-    future<> rebuild_with_repair(locator::token_metadata_ptr tmptr, sstring source_dc);
+    future<> rebuild_with_repair(locator::token_metadata_ptr tmptr, utils::optional_param source_dc);
     future<> replace_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::unordered_set<gms::inet_address> ignore_nodes);
 private:
     future<> do_decommission_removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
-    future<> do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, sstring source_dc, streaming::stream_reason reason, std::unordered_set<gms::inet_address> ignore_nodes);
+
+    future<> do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, utils::optional_param source_dc, streaming::stream_reason reason, std::unordered_set<gms::inet_address> ignore_nodes);
 
     // Must be called on shard 0
     future<> sync_data_using_repair(sstring keyspace,

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -115,6 +115,8 @@ class repair_service : public seastar::peering_sharded_service<repair_service> {
 
     future<> _load_history_done = make_ready_future<>();
 
+    mutable std::default_random_engine _random_engine{std::random_device{}()};
+
     future<> init_ms_handlers();
     future<> uninit_ms_handlers();
 

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -152,12 +152,12 @@ public:
     future<> bootstrap_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> bootstrap_tokens);
     future<> decommission_with_repair(locator::token_metadata_ptr tmptr);
     future<> removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
-    future<> rebuild_with_repair(locator::token_metadata_ptr tmptr, utils::optional_param source_dc);
-    future<> replace_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::unordered_set<gms::inet_address> ignore_nodes);
+    future<> rebuild_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, utils::optional_param source_dc);
+    future<> replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::unordered_set<gms::inet_address> ignore_nodes);
 private:
     future<> do_decommission_removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
 
-    future<> do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, utils::optional_param source_dc, streaming::stream_reason reason, std::unordered_set<gms::inet_address> ignore_nodes);
+    future<> do_rebuild_replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, sstring op, utils::optional_param source_dc, streaming::stream_reason reason, std::unordered_set<gms::inet_address> ignore_nodes);
 
     // Must be called on shard 0
     future<> sync_data_using_repair(sstring keyspace,

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -153,11 +153,11 @@ public:
     future<> decommission_with_repair(locator::token_metadata_ptr tmptr);
     future<> removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
     future<> rebuild_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, utils::optional_param source_dc);
-    future<> replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::unordered_set<gms::inet_address> ignore_nodes);
+    future<> replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::unordered_set<locator::host_id> ignore_nodes);
 private:
     future<> do_decommission_removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
 
-    future<> do_rebuild_replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, sstring op, utils::optional_param source_dc, streaming::stream_reason reason, std::unordered_set<gms::inet_address> ignore_nodes);
+    future<> do_rebuild_replace_with_repair(std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr> ks_erms, locator::token_metadata_ptr tmptr, sstring op, utils::optional_param source_dc, streaming::stream_reason reason, std::unordered_set<locator::host_id> ignore_nodes);
 
     // Must be called on shard 0
     future<> sync_data_using_repair(sstring keyspace,

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3904,7 +3904,9 @@ void storage_service::run_replace_ops(std::unordered_set<token>& bootstrap_token
         // Step 7: Sync data for replace
         if (is_repair_based_node_ops_enabled(streaming::stream_reason::replace)) {
             slogger.info("replace[{}]: Using repair based node ops to sync data", uuid);
-            _repair.local().replace_with_repair(get_token_metadata_ptr(), bootstrap_tokens, ctl.ignore_nodes).get();
+            auto ks_erms = _db.local().get_non_local_strategy_keyspaces_erms();
+            auto tmptr = get_token_metadata_ptr();
+            _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), bootstrap_tokens, ctl.ignore_nodes).get();
         } else {
             slogger.info("replace[{}]: Using streaming based node ops to sync data", uuid);
             dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(), _snitch.local()->get_location(), bootstrap_tokens, get_token_metadata_ptr());
@@ -4740,8 +4742,9 @@ future<> storage_service::rebuild(utils::optional_param source_dc) {
         } else {
             slogger.info("rebuild from dc: {}", source_dc);
             auto tmptr = ss.get_token_metadata_ptr();
+            auto ks_erms = ss._db.local().get_non_local_strategy_keyspaces_erms();
             if (ss.is_repair_based_node_ops_enabled(streaming::stream_reason::rebuild)) {
-                co_await ss._repair.local().rebuild_with_repair(tmptr, std::move(source_dc));
+                co_await ss._repair.local().rebuild_with_repair(std::move(ks_erms), tmptr, std::move(source_dc));
             } else {
                 auto streamer = make_lw_shared<dht::range_streamer>(ss._db, ss._stream_manager, tmptr, ss._abort_source,
                         tmptr->get_my_id(), ss._snitch.local()->get_location(), "Rebuild", streaming::stream_reason::rebuild, null_topology_guard);
@@ -4749,7 +4752,6 @@ future<> storage_service::rebuild(utils::optional_param source_dc) {
                 if (source_dc) {
                     streamer->add_source_filter(std::make_unique<dht::range_streamer::single_datacenter_filter>(*source_dc));
                 }
-                auto ks_erms = ss._db.local().get_non_local_strategy_keyspaces_erms();
                 for (const auto& [keyspace_name, erm] : ks_erms) {
                     co_await streamer->add_ranges(keyspace_name, erm, ss.get_ranges_for_endpoint(erm, ss.get_broadcast_address()), ss._gossiper, false);
                 }
@@ -5546,7 +5548,9 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                         }
                                         ignored_ips.insert(*ip);
                                     }
-                                    co_await _repair.local().replace_with_repair(get_token_metadata_ptr(), rs.ring.value().tokens, std::move(ignored_ips));
+                                    auto ks_erms = _db.local().get_non_local_strategy_keyspaces_erms();
+                                    auto tmptr = get_token_metadata_ptr();
+                                    co_await _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), rs.ring.value().tokens, std::move(ignored_ips));
                                 } else {
                                     dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(),
                                                           locator::endpoint_dc_rack{rs.datacenter, rs.rack}, rs.ring.value().tokens, get_token_metadata_ptr());
@@ -5628,12 +5632,13 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                         auto task = co_await get_task_manager_module().make_and_start_task<node_ops::streaming_task_impl>(parent_info,
                                 parent_info.id, streaming::stream_reason::rebuild, _rebuild_result, [this, &source_dc] () -> future<> {
                             auto tmptr = get_token_metadata_ptr();
+                            auto ks_erms = _db.local().get_non_local_strategy_keyspaces_erms();
                             if (is_repair_based_node_ops_enabled(streaming::stream_reason::rebuild)) {
                                 utils::optional_param sdc_param;
                                 if (!source_dc.empty()) {
                                     sdc_param.emplace(source_dc).set_user_provided();
                                 }
-                                co_await _repair.local().rebuild_with_repair(tmptr, std::move(sdc_param));
+                                co_await _repair.local().rebuild_with_repair(std::move(ks_erms), tmptr, std::move(sdc_param));
                             } else {
                                 auto streamer = make_lw_shared<dht::range_streamer>(_db, _stream_manager, tmptr, _abort_source,
                                         tmptr->get_my_id(), _snitch.local()->get_location(), "Rebuild", streaming::stream_reason::rebuild, _topology_state_machine._topology.session);
@@ -5641,7 +5646,6 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                 if (source_dc != "") {
                                     streamer->add_source_filter(std::make_unique<dht::range_streamer::single_datacenter_filter>(source_dc));
                                 }
-                                auto ks_erms = _db.local().get_non_local_strategy_keyspaces_erms();
                                 for (const auto& [keyspace_name, erm] : ks_erms) {
                                     co_await streamer->add_ranges(keyspace_name, erm, get_ranges_for_endpoint(erm, get_broadcast_address()), _gossiper, false);
                                 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3909,7 +3909,7 @@ void storage_service::run_replace_ops(std::unordered_set<token>& bootstrap_token
             auto ignore_nodes = boost::copy_range<std::unordered_set<locator::host_id>>(replace_info.ignore_nodes | boost::adaptors::transformed([] (const auto& x) {
                 return x.first;
             }));
-            _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), bootstrap_tokens, std::move(ignore_nodes)).get();
+            _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), bootstrap_tokens, std::move(ignore_nodes), replace_info.host_id).get();
         } else {
             slogger.info("replace[{}]: Using streaming based node ops to sync data", uuid);
             dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(), _snitch.local()->get_location(), bootstrap_tokens, get_token_metadata_ptr());
@@ -5536,8 +5536,9 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                             }
                             // Bootstrap did not complete yet, but streaming did
                         } else {
+                            auto replaced_id = std::get<replace_param>(_topology_state_machine._topology.req_param[raft_server.id()]).replaced_id;
                             auto task = co_await get_task_manager_module().make_and_start_task<node_ops::streaming_task_impl>(parent_info,
-                                    parent_info.id, streaming::stream_reason::replace, _bootstrap_result, coroutine::lambda([this, &rs, &raft_server] () -> future<> {
+                                    parent_info.id, streaming::stream_reason::replace, _bootstrap_result, coroutine::lambda([this, &rs, &raft_server, replaced_id] () -> future<> {
                                 if (!_topology_state_machine._topology.req_param.contains(raft_server.id())) {
                                     on_internal_error(rtlogger, ::format("Cannot find request_param for node id {}", raft_server.id()));
                                 }
@@ -5547,11 +5548,11 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                     }));
                                     auto ks_erms = _db.local().get_non_local_strategy_keyspaces_erms();
                                     auto tmptr = get_token_metadata_ptr();
-                                    co_await _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), rs.ring.value().tokens, std::move(ignored_nodes));
+                                    auto replaced_node = locator::host_id(replaced_id.uuid());
+                                    co_await _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), rs.ring.value().tokens, std::move(ignored_nodes), replaced_node);
                                 } else {
                                     dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(),
                                                           locator::endpoint_dc_rack{rs.datacenter, rs.rack}, rs.ring.value().tokens, get_token_metadata_ptr());
-                                    auto replaced_id = std::get<replace_param>(_topology_state_machine._topology.req_param[raft_server.id()]).replaced_id;
                                     auto existing_ip = _group0->address_map().find(replaced_id);
                                     SCYLLA_ASSERT(existing_ip);
                                     co_await bs.bootstrap(streaming::stream_reason::replace, _gossiper, _topology_state_machine._topology.session, *existing_ip);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -58,6 +58,7 @@
 #include <seastar/core/thread.hh>
 #include <algorithm>
 #include "locator/local_strategy.hh"
+#include "utils/user_provided_param.hh"
 #include "version.hh"
 #include "dht/range_streamer.hh"
 #include <boost/range/adaptors.hpp>
@@ -4628,7 +4629,7 @@ future<> storage_service::wait_for_topology_not_busy() {
     }
 }
 
-future<> storage_service::raft_rebuild(sstring source_dc) {
+future<> storage_service::raft_rebuild(utils::optional_param sdc_param) {
     auto& raft_server = _group0->group0_server();
     utils::UUID request_id;
 
@@ -4650,9 +4651,10 @@ future<> storage_service::raft_rebuild(sstring source_dc) {
             throw std::runtime_error("Cannot rebuild a single node");
         }
 
-        rtlogger.info("request rebuild for: {}", raft_server.id());
+        rtlogger.info("request rebuild for: {} source_dc={}", raft_server.id(), sdc_param);
         topology_mutation_builder builder(guard.write_timestamp());
         builder.set_session(session_id(guard.new_group0_state_id()));
+        auto source_dc = sdc_param.value_or("");
         builder.with_node(raft_server.id())
                .set("topology_request", topology_request::rebuild)
                .set("rebuild_option", source_dc)
@@ -4730,13 +4732,13 @@ future<> storage_service::raft_check_and_repair_cdc_streams() {
     });
 }
 
-future<> storage_service::rebuild(sstring source_dc) {
+future<> storage_service::rebuild(utils::optional_param source_dc) {
     return run_with_api_lock(sstring("rebuild"), [source_dc] (storage_service& ss) -> future<> {
         ss.check_ability_to_perform_topology_operation("rebuild");
         if (ss.raft_topology_change_enabled()) {
             co_await ss.raft_rebuild(source_dc);
         } else {
-            slogger.info("rebuild from dc: {}", source_dc == "" ? "(any dc)" : source_dc);
+            slogger.info("rebuild from dc: {}", source_dc);
             auto tmptr = ss.get_token_metadata_ptr();
             if (ss.is_repair_based_node_ops_enabled(streaming::stream_reason::rebuild)) {
                 co_await ss._repair.local().rebuild_with_repair(tmptr, std::move(source_dc));
@@ -4744,8 +4746,8 @@ future<> storage_service::rebuild(sstring source_dc) {
                 auto streamer = make_lw_shared<dht::range_streamer>(ss._db, ss._stream_manager, tmptr, ss._abort_source,
                         tmptr->get_my_id(), ss._snitch.local()->get_location(), "Rebuild", streaming::stream_reason::rebuild, null_topology_guard);
                 streamer->add_source_filter(std::make_unique<dht::range_streamer::failure_detector_source_filter>(ss._gossiper.get_unreachable_members()));
-                if (source_dc != "") {
-                    streamer->add_source_filter(std::make_unique<dht::range_streamer::single_datacenter_filter>(source_dc));
+                if (source_dc) {
+                    streamer->add_source_filter(std::make_unique<dht::range_streamer::single_datacenter_filter>(*source_dc));
                 }
                 auto ks_erms = ss._db.local().get_non_local_strategy_keyspaces_erms();
                 for (const auto& [keyspace_name, erm] : ks_erms) {
@@ -5627,7 +5629,11 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                 parent_info.id, streaming::stream_reason::rebuild, _rebuild_result, [this, &source_dc] () -> future<> {
                             auto tmptr = get_token_metadata_ptr();
                             if (is_repair_based_node_ops_enabled(streaming::stream_reason::rebuild)) {
-                                co_await _repair.local().rebuild_with_repair(tmptr, std::move(source_dc));
+                                utils::optional_param sdc_param;
+                                if (!source_dc.empty()) {
+                                    sdc_param.emplace(source_dc).set_user_provided();
+                                }
+                                co_await _repair.local().rebuild_with_repair(tmptr, std::move(sdc_param));
                             } else {
                                 auto streamer = make_lw_shared<dht::range_streamer>(_db, _stream_manager, tmptr, _abort_source,
                                         tmptr->get_my_id(), _snitch.local()->get_location(), "Rebuild", streaming::stream_reason::rebuild, _topology_state_machine._topology.session);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3906,7 +3906,10 @@ void storage_service::run_replace_ops(std::unordered_set<token>& bootstrap_token
             slogger.info("replace[{}]: Using repair based node ops to sync data", uuid);
             auto ks_erms = _db.local().get_non_local_strategy_keyspaces_erms();
             auto tmptr = get_token_metadata_ptr();
-            _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), bootstrap_tokens, ctl.ignore_nodes).get();
+            auto ignore_nodes = boost::copy_range<std::unordered_set<locator::host_id>>(replace_info.ignore_nodes | boost::adaptors::transformed([] (const auto& x) {
+                return x.first;
+            }));
+            _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), bootstrap_tokens, std::move(ignore_nodes)).get();
         } else {
             slogger.info("replace[{}]: Using streaming based node ops to sync data", uuid);
             dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(), _snitch.local()->get_location(), bootstrap_tokens, get_token_metadata_ptr());
@@ -5539,18 +5542,12 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                     on_internal_error(rtlogger, ::format("Cannot find request_param for node id {}", raft_server.id()));
                                 }
                                 if (is_repair_based_node_ops_enabled(streaming::stream_reason::replace)) {
-                                    // FIXME: we should not need to translate ids to IPs here. See #6403.
-                                    std::unordered_set<gms::inet_address> ignored_ips;
-                                    for (const auto& id : _topology_state_machine._topology.ignored_nodes) {
-                                        auto ip = _group0->address_map().find(id);
-                                        if (!ip) {
-                                            on_fatal_internal_error(rtlogger, ::format("Cannot find a mapping from node id {} to its ip", id));
-                                        }
-                                        ignored_ips.insert(*ip);
-                                    }
+                                    auto ignored_nodes = boost::copy_range<std::unordered_set<locator::host_id>>(_topology_state_machine._topology.ignored_nodes | boost::adaptors::transformed([] (const auto& id) {
+                                        return locator::host_id(id.uuid());
+                                    }));
                                     auto ks_erms = _db.local().get_non_local_strategy_keyspaces_erms();
                                     auto tmptr = get_token_metadata_ptr();
-                                    co_await _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), rs.ring.value().tokens, std::move(ignored_ips));
+                                    co_await _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), rs.ring.value().tokens, std::move(ignored_nodes));
                                 } else {
                                     dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(),
                                                           locator::endpoint_dc_rack{rs.datacenter, rs.rack}, rs.ring.value().tokens, get_token_metadata_ptr());

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -45,6 +45,7 @@
 #include "service/raft/raft_address_map.hh"
 #include "service/topology_state_machine.hh"
 #include "service/tablet_allocator.hh"
+#include "utils/user_provided_param.hh"
 
 class node_ops_cmd_request;
 class node_ops_cmd_response;
@@ -405,7 +406,7 @@ private:
             gms::generation_type new_generation);
 public:
 
-    future<> rebuild(sstring source_dc);
+    future<> rebuild(utils::optional_param source_dc);
 
 private:
     void set_mode(mode m);
@@ -869,7 +870,7 @@ private:
     future<> raft_initialize_discovery_leader(const join_node_request_params& params);
     future<> raft_decommission();
     future<> raft_removenode(locator::host_id host_id, std::list<locator::host_id_or_endpoint> ignore_nodes_params);
-    future<> raft_rebuild(sstring source_dc);
+    future<> raft_rebuild(utils::optional_param source_dc);
     future<> raft_check_and_repair_cdc_streams();
     future<> update_topology_with_local_metadata(raft::server&);
     void set_topology_change_kind(topology_change_kind kind);

--- a/test/nodetool/test_rebuild.py
+++ b/test/nodetool/test_rebuild.py
@@ -1,0 +1,57 @@
+#
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import pytest
+
+from test.nodetool.rest_api_mock import expected_request
+
+
+def test_rebuild(nodetool):
+    nodetool("rebuild", expected_requests=[
+        expected_request(
+            "POST",
+            "/storage_service/rebuild",
+            params = {},
+            response = "SUCCESSFUL")
+    ])
+
+
+def test_rebuild_source_dc(nodetool):
+    source_dc = "UNKNOWN_DC"
+    nodetool("rebuild", source_dc, expected_requests=[
+        expected_request(
+            "POST",
+            "/storage_service/rebuild",
+            params = {"source_dc": source_dc},
+            response = "SUCCESSFUL")
+    ])
+
+
+def test_rebuild_force_source_dc(nodetool, scylla_only):
+    source_dc = "UNKNOWN_DC"
+    nodetool("rebuild", "--force", source_dc, expected_requests=[
+        expected_request(
+            "POST",
+            "/storage_service/rebuild",
+            params = {
+                "force": "true",
+                "source_dc": source_dc
+            },
+            response = "SUCCESSFUL")
+    ])
+
+
+def test_rebuild_force_no_source_dc(nodetool):
+    nodetool("rebuild", "--force", expected_requests=[
+        expected_request(
+            "POST",
+            "/storage_service/rebuild",
+            params = {
+                "force": "true"
+            },
+            response = None,
+            response_status = 500)
+    ])

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1250,6 +1250,9 @@ void rebuild_operation(scylla_rest_client& client, const bpo::variables_map& vm)
     if (vm.count("source-dc")) {
         params["source_dc"] = vm["source-dc"].as<sstring>();
     }
+    if (vm.contains("force")) {
+        params["force"] = "true";
+    }
     client.post("/storage_service/rebuild", std::move(params));
 }
 
@@ -3282,7 +3285,9 @@ Finally, Scylla streams the data to the local node.
 
 For more information, see: {}"
 )", doc_link("operating-scylla/nodetool-commands/rebuild.html")),
-                { },
+                {
+                    typed_option<>("force", "Enforce the source_dc option, even if it unsafe to use for rebuild"),
+                },
                 {
                     typed_option<sstring>("source-dc", "DC from which to stream data (default: any DC)", 1),
                 },

--- a/utils/to_string.cc
+++ b/utils/to_string.cc
@@ -47,5 +47,8 @@ auto fmt::formatter<std::partial_ordering>::format(std::partial_ordering order, 
 auto fmt::formatter<utils::optional_param_flags_set>::format(const utils::optional_param_flags_set& flags, fmt::format_context& ctx) const
         -> decltype(ctx.out()) {
     auto ret = fmt::format_to(ctx.out(), "{}", flags.contains(utils::optional_param_flag::user_provided) ? "user-provided" : "implicit");
+    if (flags.contains(utils::optional_param_flag::force)) {
+        ret = fmt::format_to(ctx.out(), ",force");
+    }
     return ret;
 }

--- a/utils/to_string.cc
+++ b/utils/to_string.cc
@@ -7,6 +7,7 @@
  */
 
 #include "utils/to_string.hh"
+#include "utils/user_provided_param.hh"
 
 auto fmt::formatter<std::strong_ordering>::format(std::strong_ordering order, fmt::format_context& ctx) const
         -> decltype(ctx.out()) {
@@ -41,4 +42,10 @@ auto fmt::formatter<std::partial_ordering>::format(std::partial_ordering order, 
     } else {
         return fmt::format_to(ctx.out(), "eq");
     }
+}
+
+auto fmt::formatter<utils::optional_param_flags_set>::format(const utils::optional_param_flags_set& flags, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    auto ret = fmt::format_to(ctx.out(), "{}", flags.contains(utils::optional_param_flag::user_provided) ? "user-provided" : "implicit");
+    return ret;
 }

--- a/utils/user_provided_param.hh
+++ b/utils/user_provided_param.hh
@@ -21,10 +21,12 @@ namespace utils {
 
 enum class optional_param_flag {
     user_provided,
+    force
 };
 
 using optional_param_flags_set = enum_set<super_enum<optional_param_flag,
-    optional_param_flag::user_provided
+    optional_param_flag::user_provided,
+    optional_param_flag::force
 >>;
 
 template <class T = sstring>
@@ -90,6 +92,19 @@ public:
             _flags.set(flag::user_provided);
         } else {
             _flags.remove(flag::user_provided);
+        }
+        return *this;
+    }
+
+    constexpr bool force() const noexcept {
+        return _flags.contains(flag::force);
+    }
+
+    optional_param_base& set_force(bool value = true) {
+        if (value) {
+            _flags.set(flag::force);
+        } else {
+            _flags.remove(flag::force);
         }
         return *this;
     }

--- a/utils/user_provided_param.hh
+++ b/utils/user_provided_param.hh
@@ -1,0 +1,121 @@
+#pragma once
+
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <fmt/format.h>
+
+#include <seastar/util/bool_class.hh>
+#include <seastar/core/sstring.hh>
+
+#include "enum_set.hh"
+
+using namespace seastar;
+
+namespace utils {
+
+enum class optional_param_flag {
+    user_provided,
+};
+
+using optional_param_flags_set = enum_set<super_enum<optional_param_flag,
+    optional_param_flag::user_provided
+>>;
+
+template <class T = sstring>
+class optional_param_base {
+public:
+    using value_type = T;
+
+    using flag = optional_param_flag;
+    using flags_set = optional_param_flags_set;
+
+    std::optional<T> _value;
+    // or implicitly provided as default by scylla
+    flags_set _flags;
+
+public:
+    optional_param_base() = default;
+
+    explicit optional_param_base(sstring value, flags_set opts = {}) noexcept
+        : _value(std::move(value))
+        , _flags(opts)
+    {}
+
+    template <typename... Args>
+    optional_param_base& emplace(Args... args) {
+        _value.emplace(std::forward<Args>(args)...);
+        return *this;
+    }
+
+    constexpr explicit operator bool() const noexcept {
+        return has_value();
+    }
+
+    constexpr const T* operator->() const noexcept {
+        return &_value;
+    }
+
+    constexpr const T& operator*() const noexcept {
+        return *_value;
+    }
+
+    constexpr bool has_value() const noexcept {
+        return _value.has_value();
+    }
+
+    constexpr const T& value() const noexcept {
+        return _value.value();
+    }
+
+    constexpr T value_or(T&& default_value) const noexcept {
+        return _value.value_or(std::forward<T>(default_value));
+    }
+
+    flags_set flags() const noexcept {
+        return _flags;
+    }
+
+    constexpr bool user_provided() const noexcept {
+        return _flags.contains(flag::user_provided);
+    }
+
+    optional_param_base& set_user_provided(bool value = true) noexcept {
+        if (value) {
+            _flags.set(flag::user_provided);
+        } else {
+            _flags.remove(flag::user_provided);
+        }
+        return *this;
+    }
+
+    void reset() noexcept {
+        _value.reset();
+        _flags = {};
+    }
+};
+
+using optional_param = optional_param_base<sstring>;
+
+} //namespace utils
+
+template<>
+struct fmt::formatter<utils::optional_param_flags_set> : fmt::formatter<string_view> {
+    auto format(const utils::optional_param_flags_set& flags, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template<class T>
+struct fmt::formatter<utils::optional_param_base<T>> : fmt::formatter<string_view> {
+    auto format(const utils::optional_param_base<T>& p, fmt::format_context& ctx) const -> decltype(ctx.out()) {
+        if (p) {
+            return fmt::format_to(ctx.out(), "{} ({})", p.value(), p.flags());
+        } else {
+            return fmt::format_to(ctx.out(), "(none)");
+        }
+    }
+};


### PR DESCRIPTION
It is unsafe to restrict the sync nodes for repair to the source data center if it has too low replication factor in network_topology_replication_strategy, or if other nodes in that DC are ignored.

Also, this change restricts the usage of source_dc to `network_topology` and `everywhere_topology`
strategies, as with simple replication strategy
there is no guarantee that there would be any
more replicas in that data center.

Fixes #16826

Reproducer submitted as https://github.com/scylladb/scylla-dtest/pull/3865
It fails without this fix and passes with it.

* Requires backport to live versions.  Issue hit in the filed with 2022.2.14