### PR TITLE
build: regenerate frozen toolchain for tablets-aware Python driver

### DIFF
--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-38-20231210
+docker.io/scylladb/scylla-toolchain:fedora-38-20240117


### PR DESCRIPTION
Pull in scylla-driver 3.26.5, which supports tablets.