### PR TITLE
Invalidate MV prepared statements when base table is altered

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -234,7 +234,7 @@ future<> select_statement::check_access(query_processor& qp, const service::clie
 }
 
 bool select_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const {
-    return keyspace() == ks_name && (!cf_name || column_family() == *cf_name);
+    return keyspace() == ks_name && (!cf_name || column_family() == *cf_name || (_schema->is_view() && _schema->view_info()->base_name() == *cf_name));
 }
 
 const sstring& select_statement::keyspace() const {

--- a/test/cql-pytest/test_materialized_view.py
+++ b/test/cql-pytest/test_materialized_view.py
@@ -808,3 +808,14 @@ def test_mv_with_only_primary_key_rows(scylla_only, cql, test_keyspace):
             nodetool.flush(cql, view)
             assert(set([row.id for row in cql.execute(f'SELECT id FROM {view}')]) == set([1, 2, 3]))
             # We now believe that empty value serialization/deserialization is correct
+
+def test_mv_prepared_statement_with_altered_base(scylla_only, cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, 'id int PRIMARY KEY, v1 int') as base:
+        with new_materialized_view(cql, table=base, select='*', pk='id', where='id IS NOT NULL') as view:
+            base_query = cql.prepare(f"SELECT * FROM {base} WHERE id=?")
+            view_query = cql.prepare(f"SELECT * FROM {view} WHERE id=?")
+            cql.execute(f"INSERT INTO {base} (id,v1) VALUES (0,0)")
+            assert cql.execute(base_query,[0]) == cql.execute(view_query,[0])
+            cql.execute(f"ALTER TABLE {base} ADD (v2 int)")
+            cql.execute(f"INSERT INTO {base} (id,v1,v2) VALUES (1,1,1)")
+            assert list(cql.execute(base_query,[1])) == list(cql.execute(view_query,[1]))


### PR DESCRIPTION
This bug was discovered as part of another bug investigation,
if the base table changes, for example a row is added or removed,
the prepared statements of the materialized views doesn't change,
this will result in returning incomplete information until the prepared
statements cache is invalidated for some other reason or until the node
is rebooted.
This patch fixes it by accounting for the fact that a materialized view
select query also depends on it's base table.

Fixes https://github.com/scylladb/scylladb/issues/16392

Here we also add a test to catch regression, and this test fails without the fix and passes with it.
When the fix is not applied the test reliably fails with:
```
>               assert list(cql.execute(base_query,[1])) == list(cql.execute(view_query,[1]))
E               assert [Row(id=1, v1=1, v2=1)] == [Row(id=1, v1=1)]
E                 At index 0 diff: Row(id=1, v1=1, v2=1) != Row(id=1, v1=1)
```