### PR TITLE
db: add formatter for db::operation_type

### DIFF
--- a/db/operation_type.hh
+++ b/db/operation_type.hh
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <cstdint>
-#include <iosfwd>
+#include <fmt/core.h>
 
 namespace db {
 
@@ -18,6 +18,9 @@ enum class operation_type : uint8_t {
     write = 1
 };
 
-std::ostream& operator<<(std::ostream& os, operation_type op_type);
-
 }
+
+template <> struct fmt::formatter<db::operation_type> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(db::operation_type, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2155,15 +2155,16 @@ std::ostream& operator<<(std::ostream& os, const write_type& t) {
     abort();
 }
 
-std::ostream& operator<<(std::ostream& os, operation_type op_type) {
+}
+
+auto fmt::formatter<db::operation_type>::format(db::operation_type op_type, fmt::format_context& ctx) const -> decltype(ctx.out()) {
     switch (op_type) {
-    case operation_type::read: return os << "read";
-    case operation_type::write: return os << "write";
+    case operation_type::read: return fmt::format_to(ctx.out(), "read");
+    case operation_type::write: return fmt::format_to(ctx.out(), "write");
     }
     abort();
 }
 
-}
 
 std::string_view fmt::formatter<db::consistency_level>::to_string(db::consistency_level cl) {
     switch (cl) {


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define a formatter for db::operation_type, and remove their operator<<().

Refs #13245