### PR TITLE
utils: do not include unused headers

### DIFF
--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -16,6 +16,7 @@
 #include "gms/inet_address.hh"
 #include <seastar/rpc/rpc_types.hh>
 #include <unordered_map>
+#include "gc_clock.hh"
 #include "range.hh"
 #include "schema/schema_fwd.hh"
 #include "streaming/stream_fwd.hh"

--- a/test/boost/UUID_test.cc
+++ b/test/boost/UUID_test.cc
@@ -12,6 +12,7 @@
 #include <utility>
 #include "utils/UUID_gen.hh"
 #include "utils/lexicographical_compare.hh"
+#include "marshal_exception.hh"
 
 BOOST_AUTO_TEST_CASE(test_generation_of_name_based_UUID) {
     auto uuid = utils::UUID_gen::get_name_UUID("systembatchlog");

--- a/test/boost/double_decker_test.cc
+++ b/test/boost/double_decker_test.cc
@@ -15,6 +15,7 @@
 #include <string>
 
 #include "utils/double-decker.hh"
+#include "utils/logalloc.hh"
 #include "test/lib/random_utils.hh"
 
 class compound_key {

--- a/types/types.hh
+++ b/types/types.hh
@@ -13,6 +13,7 @@
 #include <iosfwd>
 #include <sstream>
 #include <initializer_list>
+#include <unordered_set>
 
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>

--- a/utils/UUID_gen.hh
+++ b/utils/UUID_gen.hh
@@ -12,13 +12,11 @@
 #include <stdint.h>
 #include <assert.h>
 
-#include <memory>
 #include <chrono>
 #include <random>
 #include <limits>
 
 #include "UUID.hh"
-#include "db_clock.hh"
 
 namespace utils {
 

--- a/utils/amortized_reserve.hh
+++ b/utils/amortized_reserve.hh
@@ -10,7 +10,6 @@
 
 #include <concepts>
 #include <vector>
-#include <memory>
 
 /// Represents a container which can preallocate space for future insertions
 /// which can be used to reduce the number of overall memory re-allocation and item movement.

--- a/utils/base64.cc
+++ b/utils/base64.cc
@@ -8,7 +8,6 @@
 
 #include "base64.hh"
 
-#include <ctype.h>
 #include <seastar/core/print.hh>
 
 // Arrays for quickly converting to and from an integer between 0 and 63,

--- a/utils/big_decimal.hh
+++ b/utils/big_decimal.hh
@@ -10,7 +10,6 @@
 
 #include "multiprecision_int.hh"
 #include <boost/multiprecision/cpp_int.hpp>
-#include <ostream>
 #include <compare>
 #include <concepts>
 

--- a/utils/bloom_filter.cc
+++ b/utils/bloom_filter.cc
@@ -10,13 +10,13 @@
 
 #include "i_filter.hh"
 #include "bytes.hh"
-#include "utils/murmur_hash.hh"
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/align.hh>
 #include <seastar/core/loop.hh>
 #include "utils/large_bitset.hh"
 #include <array>
 #include <cstdlib>
+#include "utils/bloom_calculations.hh"
 #include "bloom_filter.hh"
 
 namespace utils {

--- a/utils/bloom_filter.hh
+++ b/utils/bloom_filter.hh
@@ -12,10 +12,7 @@
  */
 #pragma once
 #include "i_filter.hh"
-#include "utils/murmur_hash.hh"
 #include "utils/large_bitset.hh"
-
-#include <vector>
 
 namespace utils {
 namespace filter {

--- a/utils/bptree.hh
+++ b/utils/bptree.hh
@@ -11,7 +11,8 @@
 #include <boost/intrusive/parent_from_member.hpp>
 #include <seastar/util/defer.hh>
 #include <cassert>
-#include "utils/logalloc.hh"
+#include <vector>
+#include "utils/allocation_strategy.hh"
 #include "utils/collection-concepts.hh"
 #include "utils/neat-object-id.hh"
 #include "utils/array-search.hh"

--- a/utils/cached_file.hh
+++ b/utils/cached_file.hh
@@ -11,6 +11,7 @@
 #include "reader_permit.hh"
 #include "utils/div_ceil.hh"
 #include "utils/bptree.hh"
+#include "utils/logalloc.hh"
 #include "utils/lru.hh"
 #include "utils/error_injection.hh"
 #include "tracing/trace_state.hh"
@@ -19,8 +20,6 @@
 #include <seastar/core/file.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
-
-#include <map>
 
 using namespace seastar;
 

--- a/utils/coroutine.hh
+++ b/utils/coroutine.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <functional>
 #include <seastar/core/future-util.hh>
 #include <seastar/util/noncopyable_function.hh>
 

--- a/utils/crc.hh
+++ b/utils/crc.hh
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <cstdint>
-#include <type_traits>
 #include <seastar/net/byteorder.hh>
 #include <seastar/core/byteorder.hh>
 

--- a/utils/directories.cc
+++ b/utils/directories.cc
@@ -13,7 +13,6 @@
 #include "directories.hh"
 #include "utils/disk-error-handler.hh"
 #include "utils/fmt-compat.hh"
-#include "db/config.hh"
 #include "utils/lister.hh"
 
 namespace utils {

--- a/utils/disk-error-handler.cc
+++ b/utils/disk-error-handler.cc
@@ -6,6 +6,7 @@
  */
 
 #include "utils/disk-error-handler.hh"
+#include "utils/exceptions.hh"
 
 thread_local disk_error_signal_type commit_error;
 thread_local disk_error_signal_type general_disk_error;

--- a/utils/disk-error-handler.hh
+++ b/utils/disk-error-handler.hh
@@ -12,7 +12,6 @@
 #include <type_traits>
 #include <concepts>
 
-#include "utils/exceptions.hh"
 #include <seastar/core/future.hh>
 
 #include "seastarx.hh"

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -20,9 +20,7 @@
 
 #include <algorithm>
 #include <chrono>
-#include <set>
 #include <type_traits>
-#include <concepts>
 #include <optional>
 #include <unordered_map>
 

--- a/utils/exceptions.cc
+++ b/utils/exceptions.cc
@@ -13,11 +13,8 @@
 
 #include <exception>
 #include <system_error>
-#include <atomic>
 #include "exceptions.hh"
 #include "utils/abi/eh_ia64.hh"
-
-#include <iostream>
 
 bool check_exception(system_error_lambda_t f)
 {

--- a/utils/hashing.hh
+++ b/utils/hashing.hh
@@ -8,10 +8,8 @@
 
 #pragma once
 
-#include <chrono>
-#include <map>
-#include <optional>
 #include <concepts>
+#include <map>
 #include <seastar/core/byteorder.hh>
 #include <seastar/core/sstring.hh>
 #include "seastarx.hh"

--- a/utils/i_filter.cc
+++ b/utils/i_filter.cc
@@ -10,6 +10,7 @@
 #include "log.hh"
 #include "bloom_filter.hh"
 #include "bloom_calculations.hh"
+#include "utils/murmur_hash.hh"
 #include <seastar/core/thread.hh>
 
 namespace utils {

--- a/utils/i_filter.hh
+++ b/utils/i_filter.hh
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "bytes.hh"
-#include "bloom_calculations.hh"
 
 namespace utils {
 

--- a/utils/lister.cc
+++ b/utils/lister.cc
@@ -1,6 +1,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/seastar.hh>
+#include <seastar/core/on_internal_error.hh>
 #include <seastar/util/log.hh>
 #include "utils/lister.hh"
 #include "checked-file-impl.hh"

--- a/utils/lsa/chunked_managed_vector.hh
+++ b/utils/lsa/chunked_managed_vector.hh
@@ -19,7 +19,6 @@
 #include <boost/range/algorithm/equal.hpp>
 #include <boost/algorithm/clamp.hpp>
 #include <boost/version.hpp>
-#include <memory>
 #include <type_traits>
 #include <iterator>
 #include <utility>

--- a/utils/reusable_buffer.hh
+++ b/utils/reusable_buffer.hh
@@ -11,7 +11,6 @@
 #include "utils/fragmented_temporary_buffer.hh"
 #include <seastar/core/timer.hh>
 #include <seastar/core/memory.hh>
-#include <chrono>
 #include <bit>
 
 namespace utils {

--- a/utils/rjson.hh
+++ b/utils/rjson.hh
@@ -27,7 +27,7 @@
  */
 
 #include <string>
-#include <stdexcept>
+#include <string_view>
 #include "utils/base64.hh"
 
 #include <seastar/core/future.hh>

--- a/utils/serialization.hh
+++ b/utils/serialization.hh
@@ -29,11 +29,7 @@
 
 #include <seastar/core/sstring.hh>
 #include <seastar/net/byteorder.hh>
-#include "bytes.hh"
-#include "fragment_range.hh"
-#include <iosfwd>
-#include <iterator>
-
+#include "seastarx.hh"
 
 class UTFDataFormatException { };
 class EOFException { };

--- a/utils/tagged_integer.hh
+++ b/utils/tagged_integer.hh
@@ -8,10 +8,7 @@
 
 #pragma once
 
-#include <cstdint>
-#include <compare>
 #include <iostream>
-#include <type_traits>
 
 #include <fmt/core.h>
 

--- a/utils/top_k.hh
+++ b/utils/top_k.hh
@@ -46,7 +46,6 @@
 #include <cstdio>
 #include <list>
 #include <unordered_map>
-#include <memory>
 #include <tuple>
 #include <assert.h>
 

--- a/utils/uuid.cc
+++ b/utils/uuid.cc
@@ -14,7 +14,6 @@
 #include <boost/algorithm/string.hpp>
 #include <string>
 #include <seastar/core/sstring.hh>
-#include "utils/serialization.hh"
 #include "marshal_exception.hh"
 
 namespace utils {


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.