### PR TITLE
cql-pytest: add the ability to run all cql-pytests with tablets

### DIFF
--- a/test/cql-pytest/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/alter_test.py
@@ -204,7 +204,9 @@ def testCreateAlterKeyspaces(cql, test_keyspace, this_dc):
 # Test {@link ConfigurationException} thrown on alter keyspace to no DC
 # option in replication configuration.
 # Reproduces CASSANDRA-12681 and Scylla #10036
-def testAlterKeyspaceWithNoOptionThrowsConfigurationException(cql, test_keyspace, this_dc):
+# fails_with_tablets because Scylla doesn't allow switching from NTS
+# with tablets to SimpleStrategy (without tablets)
+def testAlterKeyspaceWithNoOptionThrowsConfigurationException(cql, test_keyspace, this_dc, fails_with_tablets):
     # Create keyspaces
     with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 3 }") as abc:
         with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 }") as xyz:

--- a/test/cql-pytest/run
+++ b/test/cql-pytest/run
@@ -14,6 +14,23 @@ else:
     cmd = run.run_scylla_cmd
     check_cql = run.check_cql
 
+# If the "--tablets" option is given, switch to the experimental Tablets-
+# based replication instead of vnodes. Some tests are expected to fail
+# when using tablets because of unimplemented features, so they use the
+# fails_with_tablets fixture that will cause them to xfail when tablets
+# are used.
+# TODO: In the near future, we should reverse this option: tests should run
+# with the tablets experimental feature by default, and a "--vnodes"
+# option will ask to run them without the tablets experimental feature.
+if '--tablets' in sys.argv:
+    sys.argv.remove('--tablets')
+    def run_with_tablets(pid, dir):
+        (c, e) = run_with_tablets.orig_cmd(pid, dir)
+        return (c + ['--experimental-features=consistent-topology-changes',
+                     '--experimental-features=tablets'], e)
+    run_with_tablets.orig_cmd = cmd
+    cmd = run_with_tablets
+
 if "-h" in sys.argv or "--help" in sys.argv:
     run.run_pytest(sys.path[0], sys.argv)
     exit(0)

--- a/test/cql-pytest/test_cdc.py
+++ b/test/cql-pytest/test_cdc.py
@@ -20,7 +20,8 @@ def wait_for_first_cdc_generation(cql, timeout):
         assert time.time() < deadline, "Timed out waiting for the first CDC generation"
         time.sleep(1)
 
-def test_cdc_log_entries_use_cdc_streams(scylla_only, cql, test_keyspace):
+# fails_with_tablets due to issue #16317
+def test_cdc_log_entries_use_cdc_streams(scylla_only, cql, test_keyspace, fails_with_tablets):
     '''Test that the stream IDs chosen for CDC log entries come from the CDC generation
     whose streams are listed in the streams description table. Since this test is executed
     on a single-node cluster, there is only one generation.'''
@@ -49,7 +50,8 @@ def test_cdc_log_entries_use_cdc_streams(scylla_only, cql, test_keyspace):
 
 # Test for #10473 - reading logs (from sstable) after dropping
 # column in base.
-def test_cdc_alter_table_drop_column(scylla_only, cql, test_keyspace):
+# fails_with_tablets due to issue #16317
+def test_cdc_alter_table_drop_column(scylla_only, cql, test_keyspace, fails_with_tablets):
     schema = "pk int primary key, v int"
     extra = " with cdc = {'enabled': true}"
     with new_test_table(cql, test_keyspace, schema, extra) as table:
@@ -62,7 +64,8 @@ def test_cdc_alter_table_drop_column(scylla_only, cql, test_keyspace):
 
 # Regression test for #12098 - check that LWT inserts don't observe
 # themselves inside preimages
-def test_cdc_with_lwt_preimage(scylla_only, cql, test_keyspace):
+# fails_with_tablets due to issue #16317
+def test_cdc_with_lwt_preimage(scylla_only, cql, test_keyspace, fails_with_tablets):
     schema = "pk int primary key"
     extra = " with cdc = {'enabled': true, 'preimage':true}"
     with new_test_table(cql, test_keyspace, schema, extra) as table:

--- a/test/cql-pytest/test_describe.py
+++ b/test/cql-pytest/test_describe.py
@@ -389,7 +389,8 @@ def test_desc_schema(cql, test_keyspace, random_seed):
 
 # Test that `DESC CLUSTER` contains token ranges to endpoints map
 # The test is `scylla_only` because there is no `system.token_ring` table in Cassandra
-def test_desc_cluster(scylla_only, cql, test_keyspace):
+# fails_with_tablets due to issue #16789
+def test_desc_cluster(scylla_only, cql, test_keyspace, fails_with_tablets):
     cql.execute(f"USE {test_keyspace}")
     desc = cql.execute("DESC CLUSTER").one()
     desc_endpoints = []
@@ -534,7 +535,8 @@ def test_desc_udf_uda(cql, test_keyspace, scylla_only):
 # Example: caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
 # Reproduces #14895
 # The test is marked scylla_only because it uses a Scylla-only property "cdc".
-def test_whitespaces_in_table_options(cql, test_keyspace, scylla_only):
+# fails_with_tablets due to issue #16317
+def test_whitespaces_in_table_options(cql, test_keyspace, scylla_only, fails_with_tablets):
     regex = "\\{[^}]*[:,][^\\s][^}]*\\}" # looks for any colon or comma without space after it inside a { }
     
     with new_test_table(cql, test_keyspace, "a int primary key", "WITH cdc = {'enabled': true}") as tbl:

--- a/test/cql-pytest/test_guardrail_replication_strategy.py
+++ b/test/cql-pytest/test_guardrail_replication_strategy.py
@@ -83,7 +83,7 @@ def test_given_already_existing_ks_when_altering_ks_should_validate_against_disc
             config_value_context(cql, 'replication_strategy_fail_list', 'EverywhereStrategy'))
 
         # create a ks with "allowed" strategy
-        with new_test_keyspace(cql, " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 3 }") as keyspace:
+        with new_test_keyspace(cql, " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 3 } AND TABLETS = {'enabled': false}") as keyspace:
             # alter this ks to use other strategy that is NOT present on any list
             response_future = cql.execute_async(
                 "ALTER KEYSPACE " + keyspace + " WITH REPLICATION = { 'class' : 'LocalStrategy', 'replication_factor' : 3 }")

--- a/test/cql-pytest/test_keyspace.py
+++ b/test/cql-pytest/test_keyspace.py
@@ -206,7 +206,8 @@ def test_concurrent_create_and_drop_keyspace(cql, this_dc, fails_without_consist
 # and is not explicitly stored - since it's equal to the original storage
 def test_storage_options_local(cql, scylla_only):
     ksdef = "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : '1' } " \
-            "AND STORAGE = { 'type' : 'LOCAL' }"
+            "AND STORAGE = { 'type' : 'LOCAL' } " \
+            "AND TABLETS = { 'enabled': false }" # because tablets use scylla_keyspaces too
     with new_test_keyspace(cql, ksdef) as keyspace:
         res = cql.execute(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{keyspace}'")
         assert not res.all()

--- a/test/cql-pytest/test_keyspace.py
+++ b/test/cql-pytest/test_keyspace.py
@@ -113,7 +113,7 @@ def test_alter_keyspace_invalid(cql, this_dc):
 # Cassandra 4.1 and above, a missing replication_factor *is* allowed,
 # because there is a default_keyspace_rf configuration. See issue #16028.
 def test_alter_keyspace_missing_rf(cql, this_dc, scylla_only):
-    with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as keyspace:
+    with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 } AND TABLETS = { 'enabled': false }") as keyspace:
         # SimpleStrategy, if not outright forbidden, requires a
         # replication_factor option.
         with pytest.raises(ConfigurationException):

--- a/test/cql-pytest/test_select_from_mutation_fragments.py
+++ b/test/cql-pytest/test_select_from_mutation_fragments.py
@@ -27,7 +27,8 @@ def test_table(cql, test_keyspace):
         yield table
 
 
-def test_smoke(cql, test_table, scylla_only):
+# fails_with_tablets due to #16484
+def test_smoke(cql, test_table, scylla_only, fails_with_tablets):
     """ Simple smoke tests, this should fail first if something is very wrong. """
     partitions = {}
     for i in range(0, 1):
@@ -157,7 +158,8 @@ def test_count(cql, test_table, scylla_only):
     check_count('partition end', 1)
 
 
-def test_many_partition_scan(cql, test_keyspace, scylla_only):
+# fails_with_tablets due to #16484
+def test_many_partition_scan(cql, test_keyspace, scylla_only, fails_with_tablets):
     """
     Full scans work like secondary-index based scans. First, a query is
     issued to obtain partition-keys, then each partition is read individually.
@@ -199,7 +201,8 @@ def test_many_partition_scan(cql, test_keyspace, scylla_only):
         assert actual_partitions == partitions
 
 
-def test_metadata_and_value(cql, test_keyspace, scylla_path, scylla_data_dir, scylla_only):
+# fails_with_tablets due to #16484
+def test_metadata_and_value(cql, test_keyspace, scylla_path, scylla_data_dir, scylla_only, fails_with_tablets):
     """
     Test that metadata + value columns allow reconstructing a full sstable dump.
     Meaning that their json representation of metadata and value is the same.
@@ -424,7 +427,8 @@ def test_ck_in_query(cql, test_table):
             assert getattr(row, col_name) == expected_value
 
 
-def test_many_partitions(cql, test_keyspace, scylla_only):
+# fails_with_tablets due to #16484
+def test_many_partitions(cql, test_keyspace, scylla_only, fails_with_tablets):
     num_partitions = 5000
     with util.new_test_table(cql, test_keyspace, 'pk int PRIMARY KEY, v int') as table:
         delete_id = cql.prepare(f"DELETE FROM {table} WHERE pk = ?")

--- a/test/cql-pytest/test_tablets.py
+++ b/test/cql-pytest/test_tablets.py
@@ -25,7 +25,7 @@ from cassandra.protocol import ConfigurationException
 def test_keyspace_128_tablets(cql, this_dc):
     name = unique_name()
     try:
-        cql.execute("CREATE KEYSPACE " + name + " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "': 1, 'initial_tablets': 128 }")
+        cql.execute("CREATE KEYSPACE " + name + " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "': 1 } AND TABLETS = { 'enabled': true, 'initial': 128 }")
     except ConfigurationException:
         pytest.skip('Scylla does not support initial_tablets, or the tablets feature is not enabled')
     yield name

--- a/test/cql-pytest/test_tombstone_limit.py
+++ b/test/cql-pytest/test_tombstone_limit.py
@@ -49,7 +49,8 @@ def check_pages_single_partition(results, expected_pages):
     assert actual_pages == expected_pages
 
 
-def test_row_tombstone_prefix(cql, table, lowered_tombstone_limit):
+# fails_with_tablets due to #16486
+def test_row_tombstone_prefix(cql, table, lowered_tombstone_limit, fails_with_tablets):
     delete_row_id = cql.prepare(f"DELETE FROM {table} WHERE pk = ? AND ck = ?")
     insert_row_id = cql.prepare(f"INSERT INTO {table} (pk, ck, v) VALUES (?, ?, ?)")
 
@@ -77,7 +78,8 @@ def test_row_tombstone_prefix(cql, table, lowered_tombstone_limit):
     ])
 
 
-def test_row_tombstone_span(cql, table, lowered_tombstone_limit, driver_bug_1):
+# fails_with_tablets due to #16486
+def test_row_tombstone_span(cql, table, lowered_tombstone_limit, driver_bug_1, fails_with_tablets):
     delete_row_id = cql.prepare(f"DELETE FROM {table} WHERE pk = ? AND ck = ?")
     insert_row_id = cql.prepare(f"INSERT INTO {table} (pk, ck, v) VALUES (?, ?, ?)")
 
@@ -288,7 +290,8 @@ def test_partition_tombstone_span(cql, test_keyspace, lowered_tombstone_limit, d
         check_pages_many_partitions(cql.execute(statement), {0: all_pks[0], -1: all_pks[-1]})
 
 
-def test_static_row_tombstone_prefix(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1):
+# fails_with_tablets due to #16486
+def test_static_row_tombstone_prefix(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1, fails_with_tablets):
     with new_test_table(cql, test_keyspace, 'pk int, ck int, v int, s int static, PRIMARY KEY (pk, ck)') as table:
         upsert_row_id = cql.prepare(f"UPDATE {table} SET s = ? WHERE pk = ?")
         delete_partition_id = cql.prepare(f"DELETE FROM {table} WHERE pk = ?")
@@ -308,7 +311,8 @@ def test_static_row_tombstone_prefix(cql, test_keyspace, lowered_tombstone_limit
         check_pages_many_partitions(cql.execute(statement), {-1: all_pks[-1]})
 
 
-def test_static_row_tombstone_span(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1):
+# fails_with_tablets due to #16486
+def test_static_row_tombstone_span(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1, fails_with_tablets):
     with new_test_table(cql, test_keyspace, 'pk int, ck int, v int, s int static, PRIMARY KEY (pk, ck)') as table:
         upsert_row_id = cql.prepare(f"UPDATE {table} SET s = ? WHERE pk = ?")
         delete_partition_id = cql.prepare(f"DELETE FROM {table} WHERE pk = ?")


### PR DESCRIPTION
This pull requests add the option "--tablets" to test/cql-pytest/run, which simply adds the "tablets" experimental option to the Scylla it runs. The pull request then fixes all the existing tests to either work with tablets, or be marked "xfail" (expected failure) when running on tablets, when there is an open issue saying why this feature (e.g. CDC) doesn't yet work with tablets.

Some notes on the (very simple) design of this PR:
1. Tests that need to know check if they run on tablets or not, no matter how Scylla is run. This does not require any cooperation from whatever script was used to run Scylla (test/cql-pytest/run, test.py, or even some manual run) or special command line options. So this PR is not **only** about test/cql-pytest/run and will automatically apply to test.py if test.py is also modified to use the tablets experimental feature when running Scylla.
2. The simple command line option added to test/cql-pytest/run just changes which experimental features Scylla is run with - and nothing else.
3.  After this PR, "test/cql-pytest/run --tablets" will work, but a bunch of tests with known issues (e.g., missing CDC support) will be automatically skipped. These same tests will run normally when run against Scylla without the tablets experimental feature enabled.