### PR TITLE
streaming: Optionally disable off-strategy for TWCS tables

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -362,6 +362,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "If set to higher than 0, ignore the controller's output and set the compaction shares statically. Do not set this unless you know what you are doing and suspect a problem in the controller. This option will be retired when the controller reaches more maturity")
     , compaction_enforce_min_threshold(this, "compaction_enforce_min_threshold", liveness::LiveUpdate, value_status::Used, false,
         "If set to true, enforce the min_threshold option for compactions strictly. If false (default), Scylla may decide to compact even if below min_threshold")
+    , compaction_twcs_offstrategy_enabled(this, "compaction_twcs_offstrategy_enabled", liveness::LiveUpdate, value_status::Used, true,
+        "If set to true, off-strategy compaction is enabled for tables using time window strategy. Setting it to false helps to limit space overhead after streaming to 1 / N, where N is the number of windows configured.")
     , compaction_flush_all_tables_before_major_seconds(this, "compaction_flush_all_tables_before_major_seconds", value_status::Used, 86400,
         "Set the minimum interval in seconds between flushing all tables before each major compaction (default is 86400). "
         "This option is useful for maximizing tombstone garbage collection by releasing all active commitlog segments. "

--- a/db/config.hh
+++ b/db/config.hh
@@ -171,6 +171,7 @@ public:
     named_value<float> memtable_flush_static_shares;
     named_value<float> compaction_static_shares;
     named_value<bool> compaction_enforce_min_threshold;
+    named_value<bool> compaction_twcs_offstrategy_enabled;
     named_value<uint32_t> compaction_flush_all_tables_before_major_seconds;
     named_value<sstring> cluster_name;
     named_value<sstring> listen_address;

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -11,12 +11,41 @@
 #include "consumer.hh"
 #include "replica/database.hh"
 #include "mutation/mutation_source_metadata.hh"
+#include "db/config.hh"
 #include "db/view/view_update_generator.hh"
 #include "db/view/view_update_checks.hh"
 #include "sstables/sstables.hh"
 #include "sstables/sstables_manager.hh"
 
 namespace streaming {
+
+sstables::offstrategy maybe_disable_offstrategy(const replica::database& db, const sstables::compaction_strategy& cs, const schema_ptr& s, sstables::offstrategy offstrategy) {
+    // Optionally disable off-strategy compaction for TWCS tables.
+    // The benefit is that space overhead for such a table is limited to 1 / N, where N is
+    // the configured number of time windows. The disadvantage is increased write ampl,
+    // but the option is there to help critical scenarios where the space overhead will
+    // make node run out of space.
+    //
+    // We cannot enable segregation on TWCS tables and still allow off-strategy, due to:
+    //  1) streaming would produce 1 sstable per range per RF per window.
+    //  2) hundreds of sstables per window will make reads inefficient
+    // Streaming is token range oriented, so any range potentially have data for any window,
+    // meaning each window will receive at least 1 new sstable for each range processed,
+    // until operation completes.
+    //
+    // Even with off-strategy disabled, the old optimization of temporarily increasing the
+    // min threshold still applies -- for replace and bootstrap --, in order to reduce the
+    // write amp. For ops like decommission, we'll rely on compaction manager temporarily
+    // increasing the minimum threshold when the write rate is high.
+
+    // The long term fix is about enabling incremental compaction in TWCS.
+    //
+    if (cs.type() == sstables::compaction_strategy_type::time_window && !db.get_config().compaction_twcs_offstrategy_enabled()) {
+        dblog.info0("Disabled off-strategy for table {}.{} using time window compaction strategy.", s->ks_name(), s->cf_name());
+        return sstables::offstrategy::no;
+    }
+    return offstrategy;
+}
 
 std::function<future<> (flat_mutation_reader_v2)> make_streaming_consumer(sstring origin,
         sharded<replica::database>& db,
@@ -26,7 +55,7 @@ std::function<future<> (flat_mutation_reader_v2)> make_streaming_consumer(sstrin
         stream_reason reason,
         sstables::offstrategy offstrategy,
         service::frozen_topology_guard frozen_guard) {
-    return [&db, &sys_dist_ks, &vug, estimated_partitions, reason, offstrategy, origin = std::move(origin), frozen_guard] (flat_mutation_reader_v2 reader) -> future<> {
+    return [&db, &sys_dist_ks, &vug, estimated_partitions, reason, offstrategy, origin = std::move(origin), frozen_guard] (flat_mutation_reader_v2 reader) mutable -> future<> {
         std::exception_ptr ex;
         try {
             auto cf = db.local().find_column_family(reader.schema()).shared_from_this();
@@ -35,6 +64,9 @@ std::function<future<> (flat_mutation_reader_v2)> make_streaming_consumer(sstrin
             //FIXME: for better estimations this should be transmitted from remote
             auto metadata = mutation_source_metadata{};
             auto& cs = cf->get_compaction_strategy();
+
+            offstrategy = maybe_disable_offstrategy(db.local(), cs, cf->schema(), offstrategy);
+
             // Data segregation is postponed to happen during off-strategy if latter is enabled, which
             // means partition estimation shouldn't be adjusted.
             const auto adjusted_estimated_partitions = (offstrategy) ? estimated_partitions : cs.adjust_partition_estimate(metadata, estimated_partitions, cf->schema());


### PR DESCRIPTION
off-strategy on TWCS tables has 100% space overhead.

The overhead might prevent scale out if disk usage of a single TWCS table is above the 50%.

Disabling offstrategy limits the space overhead to 1 / N, where N is the number of configured windows. The disadvantage is increased write ampl, but the option is there to help critical scenarios where the space overhead will cause nodes to run out of space during node op. Optimizations that temporarily increase the min threshold (during node op or high write rate) help mitigating the write ampl problem.

The long term plan is to bring incremental compaction to TWCS, and after that, the usage of this option can be deprecated.