### PR TITLE
repair: do not compare unsigned with signed

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -219,7 +219,7 @@ repair_neighbors::repair_neighbors(std::vector<gms::inet_address> nodes, std::ve
     if (all.size() != shards.size()) {
         throw std::runtime_error("The number of shards and nodes do not match");
     }
-    for (int i = 0; i < all.size(); i++) {
+    for (unsigned i = 0; i < all.size(); i++) {
         shard_map[all[i]] = shards[i];
     }
 }

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -902,7 +902,7 @@ public:
             }
             assert(all_live_peer_shards.size() == all_live_peer_nodes.size());
             _all_node_states.push_back(repair_node_state(_myip, this_shard_id()));
-            for (int i = 0; i < all_live_peer_nodes.size(); i++) {
+            for (unsigned i = 0; i < all_live_peer_nodes.size(); i++) {
                 _all_node_states.push_back(repair_node_state(all_live_peer_nodes[i], all_live_peer_shards[i].value_or(repair_unspecified_shard)));
             }
     }


### PR DESCRIPTION
this change should silence the warning like

```
/home/kefu/dev/scylladb/repair/repair.cc:222:23: error: comparison of integers of different signs: 'int' and 'size_type' (aka 'unsigned long') [-Werror,-Wsign-compare]
  222 |     for (int i = 0; i < all.size(); i++) {
      |                     ~ ^ ~~~~~~~~~~
```