### PR TITLE
auth: do not include unused headers

### DIFF
--- a/auth/allow_all_authorizer.hh
+++ b/auth/allow_all_authorizer.hh
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "auth/authorizer.hh"
-#include "exceptions/exceptions.hh"
 
 namespace cql3 {
 class query_processor;

--- a/auth/authentication_options.hh
+++ b/auth/authentication_options.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <iosfwd>
 #include <optional>
 #include <stdexcept>
 #include <unordered_map>

--- a/auth/authenticator.cc
+++ b/auth/authenticator.cc
@@ -11,10 +11,6 @@
 #include "auth/authenticator.hh"
 
 #include "auth/authenticated_user.hh"
-#include "auth/common.hh"
-#include "auth/password_authenticator.hh"
-#include "cql3/query_processor.hh"
-#include "utils/class_registrator.hh"
 
 const sstring auth::authenticator::USERNAME_KEY("username");
 const sstring auth::authenticator::PASSWORD_KEY("password");

--- a/auth/authenticator.hh
+++ b/auth/authenticator.hh
@@ -12,8 +12,6 @@
 
 #include <string_view>
 #include <memory>
-#include <set>
-#include <stdexcept>
 #include <unordered_map>
 #include <optional>
 #include <functional>
@@ -26,9 +24,6 @@
 #include "auth/authentication_options.hh"
 #include "auth/resource.hh"
 #include "auth/sasl_challenge.hh"
-#include "bytes.hh"
-#include "enum_set.hh"
-#include "exceptions/exceptions.hh"
 
 namespace db {
     class config;

--- a/auth/authorizer.hh
+++ b/auth/authorizer.hh
@@ -11,8 +11,6 @@
 #pragma once
 
 #include <string_view>
-#include <functional>
-#include <optional>
 #include <stdexcept>
 #include <tuple>
 #include <vector>

--- a/auth/common.cc
+++ b/auth/common.cc
@@ -6,14 +6,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/core/coroutine.hh>
 #include "auth/common.hh"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/shared_ptr.hh>
 
+#include "utils/exponential_backoff_retry.hh"
 #include "cql3/query_processor.hh"
 #include "cql3/statements/create_table_statement.hh"
-#include "replica/database.hh"
 #include "schema/schema_builder.hh"
 #include "service/migration_manager.hh"
 #include "timeout_config.hh"

--- a/auth/common.hh
+++ b/auth/common.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <chrono>
 #include <string_view>
 
 #include <seastar/core/future.hh>
@@ -19,9 +18,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/smp.hh>
 
-#include "log.hh"
 #include "seastarx.hh"
-#include "utils/exponential_backoff_retry.hh"
 
 using namespace std::chrono_literals;
 

--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -15,14 +15,11 @@ extern "C" {
 #include <unistd.h>
 }
 
-#include <chrono>
-#include <random>
-
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range.hpp>
 #include <seastar/core/seastar.hh>
+#include <seastar/core/sleep.hh>
 
-#include "auth/authenticated_user.hh"
 #include "auth/common.hh"
 #include "auth/permission.hh"
 #include "auth/role_or_anonymous.hh"
@@ -30,7 +27,6 @@ extern "C" {
 #include "cql3/untyped_result_set.hh"
 #include "exceptions/exceptions.hh"
 #include "log.hh"
-#include "replica/database.hh"
 #include "utils/class_registrator.hh"
 
 namespace auth {

--- a/auth/default_authorizer.hh
+++ b/auth/default_authorizer.hh
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#include <functional>
-
 #include <seastar/core/abort_source.hh>
 
 #include "auth/authorizer.hh"

--- a/auth/maintenance_socket_role_manager.cc
+++ b/auth/maintenance_socket_role_manager.cc
@@ -11,7 +11,6 @@
 #include <seastar/core/future.hh>
 #include <stdexcept>
 #include <string_view>
-#include "log.hh"
 #include "utils/class_registrator.hh"
 
 namespace auth {

--- a/auth/maintenance_socket_role_manager.hh
+++ b/auth/maintenance_socket_role_manager.hh
@@ -10,9 +10,7 @@
 
 #include "auth/resource.hh"
 #include "auth/role_manager.hh"
-#include "authorizer.hh"
 #include "seastar/core/future.hh"
-#include <stdexcept>
 
 namespace cql3 {
 class query_processor;

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -10,14 +10,13 @@
 
 #include "auth/password_authenticator.hh"
 
-#include <algorithm>
-#include <chrono>
 #include <random>
 #include <string_view>
 #include <optional>
 
 #include <boost/algorithm/cxx11/all_of.hpp>
 #include <seastar/core/seastar.hh>
+#include <seastar/core/sleep.hh>
 
 #include "auth/authenticated_user.hh"
 #include "auth/common.hh"

--- a/auth/password_authenticator.hh
+++ b/auth/password_authenticator.hh
@@ -12,6 +12,7 @@
 
 #include <seastar/core/abort_source.hh>
 
+#include "db/consistency_level_type.hh"
 #include "auth/authenticator.hh"
 
 namespace db {

--- a/auth/passwords.cc
+++ b/auth/passwords.cc
@@ -9,7 +9,6 @@
 #include "auth/passwords.hh"
 
 #include <cerrno>
-#include <optional>
 
 extern "C" {
 #include <crypt.h>

--- a/auth/permissions_cache.cc
+++ b/auth/permissions_cache.cc
@@ -9,7 +9,6 @@
 #include "auth/permissions_cache.hh"
 
 #include "auth/authorizer.hh"
-#include "auth/common.hh"
 #include "auth/service.hh"
 
 namespace auth {

--- a/auth/permissions_cache.hh
+++ b/auth/permissions_cache.hh
@@ -8,11 +8,7 @@
 
 #pragma once
 
-#include <chrono>
-#include <string_view>
-#include <functional>
 #include <iostream>
-#include <optional>
 #include <utility>
 
 #include <fmt/core.h>
@@ -20,7 +16,6 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
 
-#include "auth/authenticated_user.hh"
 #include "auth/permission.hh"
 #include "auth/resource.hh"
 #include "auth/role_or_anonymous.hh"

--- a/auth/resource.cc
+++ b/auth/resource.cc
@@ -19,8 +19,6 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 
-#include "service/storage_proxy.hh"
-#include "data_dictionary/user_types_metadata.hh"
 #include "cql3/util.hh"
 #include "db/marshal/type_parser.hh"
 

--- a/auth/role_manager.hh
+++ b/auth/role_manager.hh
@@ -11,7 +11,6 @@
 #include <string_view>
 #include <memory>
 #include <optional>
-#include <stdexcept>
 #include <unordered_set>
 
 #include <seastar/core/future.hh>

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -11,7 +11,6 @@
 #include "auth/service.hh"
 
 #include <algorithm>
-#include <map>
 
 #include <seastar/core/future-util.hh>
 #include <seastar/core/sharded.hh>
@@ -21,20 +20,17 @@
 #include "auth/allow_all_authorizer.hh"
 #include "auth/common.hh"
 #include "auth/role_or_anonymous.hh"
-#include "cql3/functions/function_name.hh"
 #include "cql3/functions/functions.hh"
 #include "cql3/query_processor.hh"
 #include "cql3/untyped_result_set.hh"
 #include "db/config.hh"
 #include "db/consistency_level_type.hh"
 #include "db/functions/function_name.hh"
-#include "exceptions/exceptions.hh"
 #include "log.hh"
 #include "service/migration_manager.hh"
 #include "utils/class_registrator.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "data_dictionary/keyspace_metadata.hh"
-#include "mutation/mutation.hh"
 
 namespace auth {
 

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -27,7 +27,6 @@
 #include "exceptions/exceptions.hh"
 #include "log.hh"
 #include "utils/class_registrator.hh"
-#include "replica/database.hh"
 #include "service/migration_manager.hh"
 #include "password_authenticator.hh"
 

--- a/auth/standard_role_manager.hh
+++ b/auth/standard_role_manager.hh
@@ -11,7 +11,6 @@
 #include "auth/role_manager.hh"
 
 #include <string_view>
-#include <unordered_set>
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.