### PR TITLE
api: storage_service: correct a typo

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -802,7 +802,7 @@
          "operations":[
             {
                "method":"POST",
-               "summary":"Trigger a global cluster cleanup trough the topology coordinator",
+               "summary":"Trigger a global cluster cleanup through the topology coordinator",
                "type":"long",
                "nickname":"cleanup_all",
                "produces":[


### PR DESCRIPTION
s/trough/through/