### PR TITLE
test.py: test_maintenance_socket: remove pytest.xfail

### DIFF
--- a/test/auth_cluster/test_maintenance_socket.py
+++ b/test/auth_cluster/test_maintenance_socket.py
@@ -12,7 +12,6 @@ from test.pylib.manager_client import ManagerClient
 
 import pytest
 
-@pytest.mark.xfail(reason="regression in python driver (https://github.com/scylladb/python-driver/issues/278)")
 @pytest.mark.asyncio
 async def test_maintenance_socket(manager: ManagerClient):
     """


### PR DESCRIPTION
Issue https://github.com/scylladb/python-driver/issues/278 was fixed in https://github.com/scylladb/python-driver/pull/279.