### PR TITLE
compaction/compaction_manager: perform_cleanup(): hold the compaction gate

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1878,6 +1878,11 @@ const std::unordered_set<sstables::shared_sstable>& compaction_manager::sstables
 }
 
 future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_ranges, table_state& t, std::optional<tasks::task_info> info) {
+    auto gh = start_compaction(t);
+    if (!gh) {
+        co_return;
+    }
+
     constexpr auto sleep_duration = std::chrono::seconds(10);
     constexpr auto max_idle_duration = std::chrono::seconds(300);
     auto& cs = get_compaction_state(&t);


### PR DESCRIPTION
While the cleanup is ongoing. Otherwise, a concurrent table drop might trigger a use-after-free, as we have seen in dtests recently.

Fixes: #16770