### PR TITLE
doc: add 2024.1 to the OSS vs. Enterprise matrix

### DIFF
--- a/docs/reference/versions-matrix-enterprise-oss.rst
+++ b/docs/reference/versions-matrix-enterprise-oss.rst
@@ -14,6 +14,8 @@ The following table shows ScyllaDB Enterprise versions and their corresponding S
 
    * - ScyllaDB Enterprise
      - ScyllaDB Open Source
+   * - 2024.1
+     - 5.4
    * - 2023.1
      - 5.2
    * - 2022.2


### PR DESCRIPTION
This commit adds the information that ScyllaDB Enterprise 2024.1 is based on ScyllaDB Open Source 5.4 to the OSS vs. Enterprise matrix.

(backport to 5.4)