### PR TITLE
replica/tablets: drop keyspace_name from system.tablets partition-key

### DIFF
--- a/replica/tablet_mutation_builder.hh
+++ b/replica/tablet_mutation_builder.hh
@@ -24,13 +24,12 @@ private:
         return clustering_key::from_single_value(*_s, data_value(dht::token::to_int64(last_token)).serialize_nonnull());
     }
 public:
-    tablet_mutation_builder(api::timestamp_type ts, const sstring& keyspace_name, table_id table)
+    tablet_mutation_builder(api::timestamp_type ts, table_id table)
             : _ts(ts)
             , _s(db::system_keyspace::tablets())
-            , _m(_s, partition_key::from_exploded(*_s, {
-                    data_value(keyspace_name).serialize_nonnull(),
+            , _m(_s, partition_key::from_single_value(*_s,
                     data_value(table.uuid()).serialize_nonnull()
-            }))
+            ))
     { }
 
     tablet_mutation_builder& set_new_replicas(dht::token last_token, locator::tablet_replica_set replicas);

--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -50,7 +50,7 @@ future<mutation> tablet_map_to_mutation(const locator::tablet_map&,
                                         const sstring& table_name,
                                         api::timestamp_type);
 
-mutation make_drop_tablet_map_mutation(const sstring& keyspace_name, table_id, api::timestamp_type);
+mutation make_drop_tablet_map_mutation(table_id, api::timestamp_type);
 
 /// Stores a given tablet_metadata in system.tablets.
 ///

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -839,7 +839,7 @@ public:
         std::vector<mutation> result;
         if (rs.uses_tablets()) {
             auto tm = _db.get_shared_token_metadata().get();
-            muts.emplace_back(make_drop_tablet_map_mutation(s.keypace_name(), s.id(), ts));
+            muts.emplace_back(make_drop_tablet_map_mutation(s.id(), ts));
         }
     }
 
@@ -849,7 +849,7 @@ public:
         if (rs.uses_tablets()) {
             auto tm = _db.get_shared_token_metadata().get();
             for (auto&& [name, s] : ks.metadata()->cf_meta_data()) {
-                muts.emplace_back(make_drop_tablet_map_mutation(keyspace_name, s->id(), ts));
+                muts.emplace_back(make_drop_tablet_map_mutation(s->id(), ts));
             }
         }
     }

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -319,7 +319,7 @@ SEASTAR_TEST_CASE(test_mutation_builder) {
         save_tablet_metadata(e.local_db(), tm, ts++).get();
 
         {
-            tablet_mutation_builder b(ts++, "ks", table1);
+            tablet_mutation_builder b(ts++, table1);
             auto last_token = tm.get_tablet_map(table1).get_last_token(tid1);
             b.set_new_replicas(last_token, tablet_replica_set {
                     tablet_replica {h1, 2},
@@ -359,7 +359,7 @@ SEASTAR_TEST_CASE(test_mutation_builder) {
         }
 
         {
-            tablet_mutation_builder b(ts++, "ks", table1);
+            tablet_mutation_builder b(ts++, table1);
             auto last_token = tm.get_tablet_map(table1).get_last_token(tid1);
             b.set_stage(last_token, tablet_transition_stage::use_new);
             e.local_db().apply({freeze(b.build())}, db::no_timeout).get();
@@ -395,7 +395,7 @@ SEASTAR_TEST_CASE(test_mutation_builder) {
         }
 
         {
-            tablet_mutation_builder b(ts++, "ks", table1);
+            tablet_mutation_builder b(ts++, table1);
             auto last_token = tm.get_tablet_map(table1).get_last_token(tid1);
             b.set_replicas(last_token, tablet_replica_set {
                 tablet_replica {h1, 2},

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -50,7 +50,6 @@ async def get_tablet_replicas(manager: ManagerClient, server: ServerInfo, keyspa
 
     table_id = await manager.get_table_id(keyspace_name, table_name)
     rows = await manager.cql.run_async(f"SELECT last_token, replicas FROM system.tablets where "
-                                       f"keyspace_name = '{keyspace_name}' and "
                                        f"table_id = {table_id}", host=host)
     for row in rows:
         if row.last_token >= token:


### PR DESCRIPTION
The name of the keyspace being part of the partition key is not useful, the table_id already uniquely identifies the table. The keyspace name being part of the key, means that code wanting to interact with this table, often has to resolve the table id, just to be able to provide the keyspace name. This is counter productive, so make the keyspace_name just a static column instead, just like table_name already is.

Fixes: #16377