### PR TITLE
mutation: do not include unused headers

### DIFF
--- a/mutation/atomic_cell.hh
+++ b/mutation/atomic_cell.hh
@@ -17,7 +17,6 @@
 #include <seastar/util/bool_class.hh>
 #include <cstdint>
 #include <iosfwd>
-#include <concepts>
 #include "utils/fragmented_temporary_buffer.hh"
 
 #include "serializer.hh"

--- a/mutation/atomic_cell_hash.hh
+++ b/mutation/atomic_cell_hash.hh
@@ -11,7 +11,6 @@
 // Not part of atomic_cell.hh to avoid cyclic dependency between types.hh and atomic_cell.hh
 
 #include "types/types.hh"
-#include "types/collection.hh"
 #include "atomic_cell.hh"
 #include "atomic_cell_or_collection.hh"
 #include "utils/hashing.hh"

--- a/mutation/canonical_mutation.cc
+++ b/mutation/canonical_mutation.cc
@@ -13,8 +13,6 @@
 #include "mutation_partition_serializer.hh"
 #include "counters.hh"
 #include "converting_mutation_partition_applier.hh"
-#include "hashing_partition_visitor.hh"
-#include "idl/mutation.dist.hh"
 #include "idl/mutation.dist.impl.hh"
 #include <iostream>
 

--- a/mutation/canonical_mutation.hh
+++ b/mutation/canonical_mutation.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "bytes.hh"
 #include "schema/schema_fwd.hh"
 #include "replica/database_fwd.hh"
 #include "bytes_ostream.hh"

--- a/mutation/frozen_mutation.cc
+++ b/mutation/frozen_mutation.cc
@@ -14,7 +14,6 @@
 #include "counters.hh"
 #include "partition_builder.hh"
 #include "mutation_partition_serializer.hh"
-#include "utils/data_input.hh"
 #include "query-result-set.hh"
 #include "idl/mutation.dist.hh"
 #include "idl/mutation.dist.impl.hh"

--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -10,6 +10,7 @@
 #include "query-result-writer.hh"
 #include "mutation_rebuilder.hh"
 #include "mutation/json.hh"
+#include "types/collection.hh"
 #include "types/tuple.hh"
 #include "dht/i_partitioner.hh"
 

--- a/mutation/mutation.hh
+++ b/mutation/mutation.hh
@@ -17,6 +17,7 @@
 #include "mutation_fragment_v2.hh"
 #include "mutation_consumer.hh"
 #include "range_tombstone_change_generator.hh"
+#include "mutation/mutation_consumer_concepts.hh"
 #include "utils/preempt.hh"
 
 #include <seastar/util/optimized_optional.hh>

--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -11,7 +11,6 @@
 #include "compaction/compaction_garbage_collector.hh"
 #include "mutation_fragment.hh"
 #include "mutation_fragment_stream_validator.hh"
-#include "range_tombstone_assembler.hh"
 #include "tombstone_gc.hh"
 #include "full_position.hh"
 

--- a/mutation/mutation_consumer.hh
+++ b/mutation/mutation_consumer.hh
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include "mutation_consumer_concepts.hh"
-
 enum class consume_in_reverse {
     no = 0,
     yes,

--- a/mutation/mutation_fragment.cc
+++ b/mutation/mutation_fragment.cc
@@ -6,10 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <stack>
 #include <boost/range/algorithm/heap_algorithm.hpp>
 
-#include "mutation.hh"
 #include "mutation_fragment.hh"
 #include "mutation_fragment_v2.hh"
 #include "clustering_interval_set.hh"

--- a/mutation/mutation_fragment.hh
+++ b/mutation/mutation_fragment.hh
@@ -16,7 +16,6 @@
 
 #include <seastar/core/future-util.hh>
 
-#include "db/timeout_clock.hh"
 #include "reader_permit.hh"
 #include "mutation_fragment_fwd.hh"
 

--- a/mutation/mutation_fragment_v2.hh
+++ b/mutation/mutation_fragment_v2.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "mutation_partition.hh"
 #include "mutation_fragment.hh"
 #include "position_in_partition.hh"
 
@@ -18,7 +17,6 @@
 
 #include <seastar/core/future-util.hh>
 
-#include "db/timeout_clock.hh"
 #include "reader_permit.hh"
 
 // Mutation fragment which represents a range tombstone boundary.

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -15,8 +15,6 @@
 #include "converting_mutation_partition_applier.hh"
 #include "partition_builder.hh"
 #include "query-result-writer.hh"
-#include "atomic_cell_hash.hh"
-#include "reversibly_mergeable.hh"
 #include "mutation_fragment.hh"
 #include "mutation_query.hh"
 #include "mutation_compactor.hh"
@@ -27,7 +25,6 @@
 #include <seastar/core/execution_stage.hh>
 #include "types/map.hh"
 #include "compaction/compaction_garbage_collector.hh"
-#include "utils/exceptions.hh"
 #include "clustering_key_filter.hh"
 #include "mutation_partition_view.hh"
 #include "tombstone_gc.hh"

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <iosfwd>
-#include <map>
 #include <boost/intrusive/set.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/range/adaptor/filtered.hpp>

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -15,22 +15,11 @@
 #include "converting_mutation_partition_applier.hh"
 #include "partition_builder.hh"
 #include "query-result-writer.hh"
-#include "atomic_cell_hash.hh"
-#include "reversibly_mergeable.hh"
-#include "mutation_fragment.hh"
-#include "mutation_query.hh"
-#include "mutation_compactor.hh"
 #include "counters.hh"
 #include "row_cache.hh"
-#include "view_info.hh"
-#include "mutation_cleaner.hh"
 #include <seastar/core/execution_stage.hh>
-#include "types/map.hh"
 #include "compaction/compaction_garbage_collector.hh"
-#include "utils/exceptions.hh"
-#include "clustering_key_filter.hh"
 #include "mutation_partition_view.hh"
-#include "tombstone_gc.hh"
 #include "utils/unconst.hh"
 
 extern logging::logger mplog;

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <iosfwd>
-#include <map>
 #include <boost/intrusive/set.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/range/adaptor/filtered.hpp>

--- a/mutation/mutation_partition_view.cc
+++ b/mutation/mutation_partition_view.cc
@@ -13,8 +13,6 @@
 #include "mutation_partition_view.hh"
 #include "schema/schema.hh"
 #include "atomic_cell.hh"
-#include "utils/data_input.hh"
-#include "mutation_partition_serializer.hh"
 #include "mutation_partition.hh"
 #include "counters.hh"
 #include "frozen_mutation.hh"

--- a/mutation/range_tombstone.cc
+++ b/mutation/range_tombstone.cc
@@ -7,10 +7,9 @@
  */
 
 #include "range_tombstone.hh"
-#include "mutation/mutation_fragment.hh"
-#include "mutation/mutation_fragment_v2.hh"
 
 #include <boost/range/algorithm/upper_bound.hpp>
+#include <boost/range/numeric.hpp>
 
 std::optional<range_tombstone> range_tombstone::apply(const schema& s, range_tombstone&& src)
 {

--- a/mutation/range_tombstone_list.cc
+++ b/mutation/range_tombstone_list.cc
@@ -9,7 +9,6 @@
 #include <boost/range/adaptor/reversed.hpp>
 #include "range_tombstone_list.hh"
 #include "utils/allocation_strategy.hh"
-#include "utils/amortized_reserve.hh"
 #include <seastar/util/variant_utils.hh>
 
 range_tombstone_list::range_tombstone_list(const range_tombstone_list& x)

--- a/mutation/range_tombstone_list.hh
+++ b/mutation/range_tombstone_list.hh
@@ -13,7 +13,6 @@
 #include "query-request.hh"
 #include "utils/preempt.hh"
 #include "utils/chunked_vector.hh"
-#include <iosfwd>
 #include <variant>
 
 class position_in_partition_view;

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -16,6 +16,7 @@
 #include "gms/feature_service.hh"
 #include "db/system_keyspace.hh"
 #include "utils/s3/client.hh"
+#include "exceptions/exceptions.hh"
 
 namespace sstables {
 


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.