### PR TITLE
cql3: add formatter for cql3::ut_name

### DIFF
--- a/cql3/ut_name.hh
+++ b/cql3/ut_name.hh
@@ -12,6 +12,7 @@
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
+#include <fmt/core.h>
 #include "seastarx.hh"
 #include "bytes.hh"
 
@@ -38,10 +39,13 @@ public:
     sstring get_string_type_name() const;
 
     sstring to_cql_string() const;
-
-    friend std::ostream& operator<<(std::ostream& os, const ut_name& n) {
-        return os << n.to_cql_string();
-    }
 };
 
 }
+
+template <> struct fmt::formatter<cql3::ut_name> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const cql3::ut_name& n, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", n.to_cql_string());
+    }
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define a formatter for cql3::ut_name, and remove their operator<<().

Refs #13245