### PR TITLE
dht: do not include unused headers

### DIFF
--- a/dht/auto_refreshing_sharder.hh
+++ b/dht/auto_refreshing_sharder.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "dht/sharder.hh"
 #include "replica/database.hh"
 
 namespace dht {

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -12,10 +12,6 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include "dht/token-sharding.hh"
 #include "utils/class_registrator.hh"
-#include "types/types.hh"
-#include "utils/murmur_hash.hh"
-#include "utils/div_ceil.hh"
-#include <deque>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/irange.hpp>
 #include <boost/range/adaptor/transformed.hpp>

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -12,15 +12,9 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/util/optimized_optional.hh>
-#include "types/types.hh"
 #include "keys.hh"
-#include "utils/managed_bytes.hh"
 #include <memory>
-#include <random>
 #include <utility>
-#include <vector>
-#include <compare>
-#include "range.hh"
 #include <byteswap.h>
 #include "dht/token.hh"
 #include "dht/token-sharding.hh"

--- a/dht/murmur3_partitioner.hh
+++ b/dht/murmur3_partitioner.hh
@@ -10,7 +10,6 @@
 
 #include "i_partitioner.hh"
 #include "bytes.hh"
-#include <vector>
 
 namespace dht {
 

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -14,7 +14,6 @@
 #include "gms/gossiper.hh"
 #include "log.hh"
 #include "streaming/stream_plan.hh"
-#include "streaming/stream_state.hh"
 #include "db/config.hh"
 #include <seastar/core/semaphore.hh>
 #include <boost/range/adaptors.hpp>

--- a/dht/range_streamer.hh
+++ b/dht/range_streamer.hh
@@ -16,7 +16,6 @@
 #include "streaming/stream_reason.hh"
 #include "service/topology_guard.hh"
 #include "gms/inet_address.hh"
-#include "range.hh"
 #include <seastar/core/distributed.hh>
 #include <seastar/core/abort_source.hh>
 #include <unordered_map>

--- a/dht/token.cc
+++ b/dht/token.cc
@@ -9,11 +9,10 @@
 #include <algorithm>
 #include <limits>
 #include <ostream>
-#include <utility>
+#include <boost/lexical_cast.hpp>
 
 #include "dht/token.hh"
 #include "dht/token-sharding.hh"
-#include "dht/i_partitioner.hh"
 
 namespace dht {
 

--- a/dht/token.hh
+++ b/dht/token.hh
@@ -9,12 +9,10 @@
 #pragma once
 
 #include "bytes.hh"
-#include "utils/managed_bytes.hh"
 #include "types/types.hh"
 
 #include <seastar/net/byteorder.hh>
 #include <fmt/format.h>
-#include <array>
 #include <functional>
 #include <utility>
 #include <compare>


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.