### PR TITLE
gossiping_property_file_snitch: drop unused using namespace

### DIFF
--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -120,8 +120,6 @@ gms::application_state_map gossiping_property_file_snitch::get_app_states() cons
 }
 
 future<> gossiping_property_file_snitch::read_property_file() {
-    using namespace exceptions;
-
     return load_property_file().then([this] {
         return reload_configuration();
     }).then_wrapped([this] (auto&& f) {


### PR DESCRIPTION
we don't use any symbol in this namespace, in this function, so drop it.