### PR TITLE
tablets: Add support for removenode and replace handling

### DIFF
--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -202,6 +202,7 @@ CREATE TABLE system.tablets (
     new_replicas frozen<list<frozen<tuple<uuid, int>>>>,
     replicas frozen<list<frozen<tuple<uuid, int>>>>,
     stage text,
+    transition text,
     table_name text static,
     tablet_count int static,
     PRIMARY KEY ((keyspace_name, table_id), last_token)
@@ -225,8 +226,12 @@ Only tables which use tablet-based replication strategy have an entry here.
 Each tablet is represented by a single row. `replicas` holds the set of shard-replicas of the tablet.
 It's a list of tuples where the first element is `host_id` of the replica and the second element is the `shard_id` of the replica.
 
-During tablet migration, the columns `new_replicas` and `stage` are set to represent the transition. The
+During tablet migration, the columns `new_replicas`, `stage` and `transition` are set to represent the transition. The
 `new_replicas` column holds what will be put in `replicas` after transition is done.
+
+The `transition` column can have the following values:
+  * `migration` - One tablet replica is moving from one shard to another.
+  * `rebuild` - New tablet replica is created from the remaining replicas.
 
 # Virtual tables in the system keyspace
 

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -79,6 +79,10 @@ tablet_transition_info::tablet_transition_info(tablet_transition_stage stage,
     , reads(get_selector_for_reads(stage))
 { }
 
+tablet_migration_streaming_info get_migration_streaming_info(const tablet_info& tinfo, const tablet_migration_info& trinfo) {
+    return get_migration_streaming_info(tinfo, migration_to_transition_info(tinfo, trinfo));
+}
+
 tablet_migration_streaming_info get_migration_streaming_info(const tablet_info& tinfo, const tablet_transition_info& trinfo) {
     tablet_migration_streaming_info result = {
         .read_from = std::unordered_set<tablet_replica>(tinfo.replicas.begin(), tinfo.replicas.end()),

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -111,6 +111,15 @@ tablet_replica_set get_new_replicas(const tablet_info& tinfo, const tablet_migra
     return replace_replica(tinfo.replicas, mig.src, mig.dst);
 }
 
+tablet_transition_info migration_to_transition_info(const tablet_info& ti, const tablet_migration_info& mig) {
+    return tablet_transition_info {
+            tablet_transition_stage::allow_write_both_read_old,
+            mig.kind,
+            get_new_replicas(ti, mig),
+            mig.dst
+    };
+}
+
 const tablet_map& tablet_metadata::get_tablet_map(table_id id) const {
     try {
         return _tablets.at(id);

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -107,6 +107,10 @@ tablet_replica get_leaving_replica(const tablet_info& tinfo, const tablet_transi
     return *leaving.begin();
 }
 
+tablet_replica_set get_new_replicas(const tablet_info& tinfo, const tablet_migration_info& mig) {
+    return replace_replica(tinfo.replicas, mig.src, mig.dst);
+}
+
 const tablet_map& tablet_metadata::get_tablet_map(table_id id) const {
     try {
         return _tablets.at(id);

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -66,10 +66,12 @@ read_replica_set_selector get_selector_for_reads(tablet_transition_stage stage) 
 }
 
 tablet_transition_info::tablet_transition_info(tablet_transition_stage stage,
+                                               tablet_transition_kind transition,
                                                tablet_replica_set next,
                                                tablet_replica pending_replica,
                                                service::session_id session_id)
     : stage(stage)
+    , transition(transition)
     , next(std::move(next))
     , pending_replica(std::move(pending_replica))
     , session_id(session_id)
@@ -260,6 +262,31 @@ sstring tablet_transition_stage_to_string(tablet_transition_stage stage) {
 
 tablet_transition_stage tablet_transition_stage_from_string(const sstring& name) {
     return tablet_transition_stage_from_name.at(name);
+}
+
+// The names are persisted in system tables so should not be changed.
+static const std::unordered_map<tablet_transition_kind, sstring> tablet_transition_kind_to_name = {
+        {tablet_transition_kind::migration, "migration"},
+};
+
+static const std::unordered_map<sstring, tablet_transition_kind> tablet_transition_kind_from_name = std::invoke([] {
+    std::unordered_map<sstring, tablet_transition_kind> result;
+    for (auto&& [v, s] : tablet_transition_kind_to_name) {
+        result.emplace(s, v);
+    }
+    return result;
+});
+
+sstring tablet_transition_kind_to_string(tablet_transition_kind kind) {
+    auto i = tablet_transition_kind_to_name.find(kind);
+    if (i == tablet_transition_kind_to_name.end()) {
+        on_internal_error(tablet_logger, format("Invalid tablet transition kind: {}", static_cast<int>(kind)));
+    }
+    return i->second;
+}
+
+tablet_transition_kind tablet_transition_kind_from_string(const sstring& name) {
+    return tablet_transition_kind_from_name.at(name);
 }
 
 std::ostream& operator<<(std::ostream& out, tablet_id id) {
@@ -581,4 +608,9 @@ auto fmt::formatter<locator::global_tablet_id>::format(const locator::global_tab
 auto fmt::formatter<locator::tablet_transition_stage>::format(const locator::tablet_transition_stage& stage, fmt::format_context& ctx) const
         -> decltype(ctx.out()) {
     return fmt::format_to(ctx.out(), "{}", locator::tablet_transition_stage_to_string(stage));
+}
+
+auto fmt::formatter<locator::tablet_transition_kind>::format(const locator::tablet_transition_kind& kind, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", locator::tablet_transition_kind_to_string(kind));
 }

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -220,6 +220,7 @@ struct tablet_migration_streaming_info {
 };
 
 tablet_migration_streaming_info get_migration_streaming_info(const tablet_info&, const tablet_transition_info&);
+tablet_migration_streaming_info get_migration_streaming_info(const tablet_info&, const tablet_migration_info&);
 
 // Describes if a given token is located at either left or right side of a tablet's range
 enum tablet_range_side {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -209,6 +209,9 @@ struct tablet_migration_info {
     locator::tablet_replica dst;
 };
 
+/// Returns the replica set which will become the replica set of the tablet after executing a given tablet transition.
+tablet_replica_set get_new_replicas(const tablet_info&, const tablet_migration_info&);
+
 /// Describes streaming required for a given tablet transition.
 struct tablet_migration_streaming_info {
     std::unordered_set<tablet_replica> read_from;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -201,6 +201,14 @@ struct tablet_transition_info {
 // Returns the leaving replica for a given transition.
 tablet_replica get_leaving_replica(const tablet_info&, const tablet_transition_info&);
 
+/// Represents intention to move a single tablet replica from src to dst.
+struct tablet_migration_info {
+    locator::tablet_transition_kind kind;
+    locator::global_tablet_id tablet;
+    locator::tablet_replica src;
+    locator::tablet_replica dst;
+};
+
 /// Describes streaming required for a given tablet transition.
 struct tablet_migration_streaming_info {
     std::unordered_set<tablet_replica> read_from;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -211,6 +211,7 @@ struct tablet_migration_info {
 
 /// Returns the replica set which will become the replica set of the tablet after executing a given tablet transition.
 tablet_replica_set get_new_replicas(const tablet_info&, const tablet_migration_info&);
+tablet_transition_info migration_to_transition_info(const tablet_info&, const tablet_migration_info&);
 
 /// Describes streaming required for a given tablet transition.
 struct tablet_migration_streaming_info {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -26,6 +26,8 @@
 
 namespace locator {
 
+class topology;
+
 extern seastar::logger tablet_logger;
 
 using token = dht::token;
@@ -163,6 +165,11 @@ enum class tablet_transition_kind {
     // The new replica is (tablet_transition_info::next - tablet_info::replicas).
     // The leaving replica is (tablet_info::replicas - tablet_transition_info::next).
     migration,
+
+    // New tablet replica is replacing a dead one.
+    // The new replica is (tablet_transition_info::next - tablet_info::replicas).
+    // The leaving replica is (tablet_info::replicas - tablet_transition_info::next).
+    rebuild,
 };
 
 sstring tablet_transition_stage_to_string(tablet_transition_stage);
@@ -219,8 +226,8 @@ struct tablet_migration_streaming_info {
     std::unordered_set<tablet_replica> written_to;
 };
 
-tablet_migration_streaming_info get_migration_streaming_info(const tablet_info&, const tablet_transition_info&);
-tablet_migration_streaming_info get_migration_streaming_info(const tablet_info&, const tablet_migration_info&);
+tablet_migration_streaming_info get_migration_streaming_info(const locator::topology&, const tablet_info&, const tablet_transition_info&);
+tablet_migration_streaming_info get_migration_streaming_info(const locator::topology&, const tablet_info&, const tablet_migration_info&);
 
 // Describes if a given token is located at either left or right side of a tablet's range
 enum tablet_range_side {

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -423,6 +423,12 @@ const node* topology::find_node(host_id id) const noexcept {
     return nullptr;
 }
 
+// Finds a node by its host_id
+// Returns nullptr if not found
+node* topology::find_node(host_id id) noexcept {
+    return make_mutable(const_cast<const topology*>(this)->find_node(id));
+}
+
 // Finds a node by its endpoint
 // Returns nullptr if not found
 const node* topology::find_node(const inet_address& ep) const noexcept {

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -63,6 +63,7 @@ private:
     endpoint_dc_rack _dc_rack;
     state _state;
     shard_id _shard_count = 0;
+    bool _excluded = false;
 
     // Is this node the `localhost` instance
     this_node _is_this_node;
@@ -117,6 +118,16 @@ public:
 
     bool is_normal() const noexcept {
         return _state == state::normal;
+    }
+
+    // Excluded nodes are still part of topology, possibly present in replica sets, but
+    // are not going to be up again and can be ignored in barriers.
+    bool is_excluded() const {
+        return _excluded;
+    }
+
+    void set_excluded(bool excluded) {
+        _excluded = excluded;
     }
 
     bool is_leaving() const noexcept {
@@ -208,6 +219,7 @@ public:
     // Looks up a node by its host_id.
     // Returns a pointer to the node if found, or nullptr otherwise.
     const node* find_node(host_id id) const noexcept;
+    node* find_node(host_id id) noexcept;
 
     const node& get_node(host_id id) const {
         auto n = find_node(id);

--- a/replica/tablet_mutation_builder.hh
+++ b/replica/tablet_mutation_builder.hh
@@ -35,6 +35,7 @@ public:
     tablet_mutation_builder& set_new_replicas(dht::token last_token, locator::tablet_replica_set replicas);
     tablet_mutation_builder& set_replicas(dht::token last_token, locator::tablet_replica_set replicas);
     tablet_mutation_builder& set_stage(dht::token last_token, locator::tablet_transition_stage stage);
+    tablet_mutation_builder& set_transition(dht::token last_token, locator::tablet_transition_kind);
     tablet_mutation_builder& set_session(dht::token last_token, service::session_id);
     tablet_mutation_builder& del_session(dht::token last_token);
     tablet_mutation_builder& del_transition(dht::token last_token);

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -48,6 +48,7 @@ schema_ptr make_tablets_schema() {
             .with_column("replicas", replica_set_type)
             .with_column("new_replicas", replica_set_type)
             .with_column("stage", utf8_type)
+            .with_column("transition", utf8_type)
             .with_column("session", uuid_type)
             .with_version(db::system_keyspace::generate_schema_version(id))
             .build();
@@ -87,6 +88,7 @@ tablet_map_to_mutation(const tablet_map& tablets, table_id id, const sstring& ke
         m.set_clustered_cell(ck, "replicas", make_list_value(replica_set_type, replicas_to_data_value(tablet.replicas)), ts);
         if (auto tr_info = tablets.get_tablet_transition_info(tid)) {
             m.set_clustered_cell(ck, "stage", tablet_transition_stage_to_string(tr_info->stage), ts);
+            m.set_clustered_cell(ck, "transition", tablet_transition_kind_to_string(tr_info->transition), ts);
             m.set_clustered_cell(ck, "new_replicas", make_list_value(replica_set_type, replicas_to_data_value(tr_info->next)), ts);
             if (tr_info->session_id) {
                 m.set_clustered_cell(ck, "session", data_value(tr_info->session_id.uuid()), ts);
@@ -117,6 +119,12 @@ tablet_mutation_builder::set_stage(dht::token last_token, locator::tablet_transi
 }
 
 tablet_mutation_builder&
+tablet_mutation_builder::set_transition(dht::token last_token, locator::tablet_transition_kind kind) {
+    _m.set_clustered_cell(get_ck(last_token), "transition", data_value(tablet_transition_kind_to_string(kind)), _ts);
+    return *this;
+}
+
+tablet_mutation_builder&
 tablet_mutation_builder::set_session(dht::token last_token, service::session_id session_id) {
     _m.set_clustered_cell(get_ck(last_token), "session", data_value(session_id.uuid()), _ts);
     return *this;
@@ -134,6 +142,8 @@ tablet_mutation_builder::del_transition(dht::token last_token) {
     auto ck = get_ck(last_token);
     auto stage_col = _s->get_column_definition("stage");
     _m.set_clustered_cell(ck, *stage_col, atomic_cell::make_dead(_ts, gc_clock::now()));
+    auto transition_col = _s->get_column_definition("transition");
+    _m.set_clustered_cell(ck, *transition_col, atomic_cell::make_dead(_ts, gc_clock::now()));
     auto new_replicas_col = _s->get_column_definition("new_replicas");
     _m.set_clustered_cell(ck, *new_replicas_col, atomic_cell::make_dead(_ts, gc_clock::now()));
     auto session_col = _s->get_column_definition("session");
@@ -212,6 +222,7 @@ future<tablet_metadata> read_tablet_metadata(cql3::query_processor& qp) {
 
         if (row.has("stage")) {
             auto stage = tablet_transition_stage_from_string(row.get_as<sstring>("stage"));
+            auto transition = tablet_transition_kind_from_string(row.get_as<sstring>("transition"));
 
             std::unordered_set<tablet_replica> pending(new_tablet_replicas.begin(), new_tablet_replicas.end());
             for (auto&& r : tablet_replicas) {
@@ -229,7 +240,7 @@ future<tablet_metadata> read_tablet_metadata(cql3::query_processor& qp) {
             if (row.has("session")) {
                 session_id = service::session_id(row.get_as<utils::UUID>("session"));
             }
-            current->map.set_tablet_transition_info(current->tid, tablet_transition_info{stage,
+            current->map.set_tablet_transition_info(current->tid, tablet_transition_info{stage, transition,
                     std::move(new_tablet_replicas), *pending.begin(), session_id});
         }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2046,6 +2046,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             replica::tablet_mutation_builder(guard.write_timestamp(), mig.tablet.table)
                 .set_new_replicas(last_token, replace_replica(tmap.get_tablet_info(mig.tablet.tablet).replicas, mig.src, mig.dst))
                 .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
+                .set_transition(last_token, mig.kind)
                 .build());
     }
 
@@ -7605,6 +7606,7 @@ future<> storage_service::move_tablet(table_id table, dht::token token, locator:
         updates.push_back(canonical_mutation(replica::tablet_mutation_builder(guard.write_timestamp(), table)
             .set_new_replicas(last_token, locator::replace_replica(tinfo.replicas, src, dst))
             .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
+            .set_transition(last_token, locator::tablet_transition_kind::migration)
             .build()));
         updates.push_back(canonical_mutation(topology_mutation_builder(guard.write_timestamp())
             .set_transition_state(topology::transition_state::tablet_migration)

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1982,6 +1982,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
     bool advance_in_background(locator::global_tablet_id gid, background_action_holder& holder, const char* name,
                                std::function<future<>()> action) {
         if (!holder || holder->failed()) {
+            if (holder && holder->failed()) {
+                // Prevent warnings about abandoned failed future. Logged below.
+                holder->ignore_ready_future();
+            }
             holder = futurize_invoke(action)
                         .finally([this, g = _async_gate.hold(), gid, name] () noexcept {
                 rtlogger.debug("{} for tablet {} resolved.", name, gid);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2044,7 +2044,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
         }
         out.emplace_back(
             replica::tablet_mutation_builder(guard.write_timestamp(), mig.tablet.table)
-                .set_new_replicas(last_token, replace_replica(tmap.get_tablet_info(mig.tablet.tablet).replicas, mig.src, mig.dst))
+                .set_new_replicas(last_token, locator::get_new_replicas(tmap.get_tablet_info(mig.tablet.tablet), mig))
                 .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
                 .set_transition(last_token, mig.kind)
                 .build());

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -721,7 +721,7 @@ public:
 
             auto& target_load_sketch = co_await target_info.get_load_sketch(_tm);
             auto dst = global_shard_id {target, target_load_sketch.next_shard(target)};
-            auto mig = tablet_migration_info {source_tablet, src, dst};
+            auto mig = tablet_migration_info {tablet_transition_kind::migration, source_tablet, src, dst};
 
             if (target_info.shards[dst.shard].streaming_write_load < max_write_streaming_load
                     && src_node_info.shards[src_shard].streaming_read_load < max_read_streaming_load) {

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -13,13 +13,7 @@
 
 namespace service {
 
-/// Represents intention to move a single tablet replica from src to dst.
-struct tablet_migration_info {
-    locator::tablet_transition_kind kind;
-    locator::global_tablet_id tablet;
-    locator::tablet_replica src;
-    locator::tablet_replica dst;
-};
+using tablet_migration_info = locator::tablet_migration_info;
 
 class migration_plan {
 public:

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -15,6 +15,7 @@ namespace service {
 
 /// Represents intention to move a single tablet replica from src to dst.
 struct tablet_migration_info {
+    locator::tablet_transition_kind kind;
     locator::global_tablet_id tablet;
     locator::tablet_replica src;
     locator::tablet_replica dst;

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -43,6 +43,51 @@ bool topology::is_busy() const {
     return tstate.has_value();
 }
 
+raft::server_id topology::parse_replaced_node(const std::optional<request_param>& req_param) {
+    if (req_param) {
+        auto *param = std::get_if<replace_param>(&*req_param);
+        if (param) {
+            return param->replaced_id;
+        }
+    }
+    return {};
+}
+
+std::unordered_set<raft::server_id> topology::parse_ignore_nodes(const std::optional<request_param>& req_param) {
+    if (req_param) {
+        auto* remove_param = std::get_if<removenode_param>(&*req_param);
+        if (remove_param) {
+            return remove_param->ignored_ids;
+        }
+        auto* rep_param = std::get_if<replace_param>(&*req_param);
+        if (rep_param) {
+            return rep_param->ignored_ids;
+        }
+    }
+    return {};
+}
+
+std::unordered_set<raft::server_id> topology::get_excluded_nodes(raft::server_id id,
+                                                                 const std::optional<topology_request>& req,
+                                                                 const std::optional<request_param>& req_param) {
+    auto exclude_nodes = parse_ignore_nodes(req_param);
+    if (auto replaced_node = parse_replaced_node(req_param)) {
+        exclude_nodes.insert(replaced_node);
+    }
+    if (req && *req == topology_request::remove) {
+        exclude_nodes.insert(id);
+    }
+    return exclude_nodes;
+}
+
+std::optional<request_param> topology::get_request_param(raft::server_id id) const {
+    auto rit = req_param.find(id);
+    if (rit != req_param.end()) {
+        return rit->second;
+    }
+    return std::nullopt;
+};
+
 std::set<sstring> calculate_not_yet_enabled_features(const std::set<sstring>& enabled_features, const auto& supported_features) {
     std::set<sstring> to_enable;
     bool first = true;

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -88,6 +88,25 @@ std::optional<request_param> topology::get_request_param(raft::server_id id) con
     return std::nullopt;
 };
 
+std::unordered_set<raft::server_id> topology::get_excluded_nodes() const {
+    std::unordered_set<raft::server_id> result;
+
+    for (auto& [id, rs] : transition_nodes) {
+        std::optional<topology_request> req;
+        auto req_i = requests.find(id);
+        if (req_i != requests.end()) {
+            req = req_i->second;
+        }
+        if (rs.state == node_state::removing) {
+            result.insert(id);
+        }
+        auto excluded = get_excluded_nodes(id, req, get_request_param(id));
+        result.insert(excluded.begin(), excluded.end());
+    }
+
+    return result;
+}
+
 std::set<sstring> calculate_not_yet_enabled_features(const std::set<sstring>& enabled_features, const auto& supported_features) {
     std::set<sstring> to_enable;
     bool first = true;

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -177,6 +177,11 @@ struct topology {
     // Returns false iff we can safely start a new topology change.
     bool is_busy() const;
 
+    std::optional<request_param> get_request_param(raft::server_id) const;
+    static raft::server_id parse_replaced_node(const std::optional<request_param>&);
+    static std::unordered_set<raft::server_id> parse_ignore_nodes(const std::optional<request_param>&);
+    static std::unordered_set<raft::server_id> get_excluded_nodes(raft::server_id id, const std::optional<topology_request>& req, const std::optional<request_param>& req_param);
+
     // Calculates a set of features that are supported by all normal nodes but not yet enabled.
     std::set<sstring> calculate_not_yet_enabled_features() const;
 };

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -177,6 +177,10 @@ struct topology {
     // Returns false iff we can safely start a new topology change.
     bool is_busy() const;
 
+    // Returns the set of nodes currently excluded from synchronization-with in the topology.
+    // Barrier should not wait for those nodes.
+    std::unordered_set<raft::server_id> get_excluded_nodes() const;
+
     std::optional<request_param> get_request_param(raft::server_id) const;
     static raft::server_id parse_replaced_node(const std::optional<request_param>&);
     static std::unordered_set<raft::server_id> parse_ignore_nodes(const std::optional<request_param>&);

--- a/streaming/stream_reason.hh
+++ b/streaming/stream_reason.hh
@@ -23,6 +23,7 @@ enum class stream_reason : uint8_t {
     repair,
     replace,
     tablet_migration,
+    tablet_rebuild,
 };
 
 }
@@ -49,6 +50,8 @@ struct fmt::formatter<streaming::stream_reason> : fmt::formatter<std::string_vie
             return formatter<std::string_view>::format("replace", ctx);
         case tablet_migration:
             return formatter<std::string_view>::format("tablet migration", ctx);
+        case tablet_rebuild:
+            return formatter<std::string_view>::format("tablet rebuild", ctx);
         }
         std::abort();
     }

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -612,23 +612,13 @@ void apply_plan(token_metadata& tm, const migration_plan& plan) {
     }
 }
 
-static
-tablet_transition_info migration_to_transition_info(const tablet_migration_info& mig, const tablet_info& ti) {
-    return tablet_transition_info {
-            tablet_transition_stage::allow_write_both_read_old,
-            mig.kind,
-            get_new_replicas(ti, mig),
-            mig.dst
-    };
-}
-
 // Reflects the plan in a given token metadata as if the migrations were started but not yet executed.
 static
 void apply_plan_as_in_progress(token_metadata& tm, const migration_plan& plan) {
     for (auto&& mig : plan.migrations()) {
         tablet_map& tmap = tm.tablets().get_tablet_map(mig.tablet.table);
         auto tinfo = tmap.get_tablet_info(mig.tablet.tablet);
-        tmap.set_tablet_transition_info(mig.tablet.tablet, migration_to_transition_info(mig, tinfo));
+        tmap.set_tablet_transition_info(mig.tablet.tablet, migration_to_transition_info(tinfo, mig));
     }
 }
 

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -617,7 +617,7 @@ tablet_transition_info migration_to_transition_info(const tablet_migration_info&
     return tablet_transition_info {
             tablet_transition_stage::allow_write_both_read_old,
             mig.kind,
-            replace_replica(ti.replicas, mig.src, mig.dst),
+            get_new_replicas(ti, mig),
             mig.dst
     };
 }

--- a/test/topology_experimental_raft/test_tablets_removenode.py
+++ b/test/topology_experimental_raft/test_tablets_removenode.py
@@ -1,0 +1,192 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from cassandra.query import SimpleStatement, ConsistencyLevel
+
+from test.pylib.manager_client import ManagerClient
+
+import pytest
+import asyncio
+import logging
+
+from test.pylib.scylla_cluster import ReplaceConfig
+
+logger = logging.getLogger(__name__)
+
+
+async def create_keyspace(cql, name, initial_tablets, rf):
+    await cql.run_async(f"CREATE KEYSPACE {name} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}}"
+                        f" AND tablets = {{'initial': {initial_tablets}}};")
+
+
+@pytest.mark.asyncio
+async def test_replace(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    cmdline = ['--logger-log-level', 'storage_service=trace']
+
+    # 4 nodes so that we can find new tablet replica for the RF=3 table on removenode
+    servers = await manager.servers_add(4, cmdline=cmdline)
+
+    cql = manager.get_cql()
+
+    await create_keyspace(cql, "test", 32, rf=1)
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+
+    await create_keyspace(cql, "test2", 32, rf=2)
+    await cql.run_async("CREATE TABLE test2.test (pk int PRIMARY KEY, c int);")
+
+    # RF=3
+    await create_keyspace(cql, "test3", 32, rf=3)
+    await cql.run_async("CREATE TABLE test3.test (pk int PRIMARY KEY, c int);")
+
+    logger.info("Populating table")
+
+    keys = range(256)
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test2.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test3.test (pk, c) VALUES ({k}, {k});") for k in keys])
+
+    async def check():
+        # RF=1 table "test" will experience data loss so don't check it.
+        # We include it to check that the system doesn't crash.
+
+        logger.info("Checking table test2")
+        query = SimpleStatement("SELECT * FROM test2.test;", consistency_level=ConsistencyLevel.ONE)
+        rows = await cql.run_async(query)
+        assert len(rows) == len(keys)
+        for r in rows:
+            assert r.c == r.pk
+
+        logger.info("Checking table test3")
+        query = SimpleStatement("SELECT * FROM test3.test;", consistency_level=ConsistencyLevel.ONE)
+        rows = await cql.run_async(query)
+        assert len(rows) == len(keys)
+        for r in rows:
+            assert r.c == r.pk
+
+    await check()
+
+    # Disable migrations concurrent with replace since we don't handle nodes going down during migration yet.
+    # See https://github.com/scylladb/scylladb/issues/16527
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    logger.info('Replacing a node')
+    await manager.server_stop(servers[0].server_id)
+    replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = True)
+    await manager.server_add(replace_cfg)
+    servers = servers[1:]
+
+    await check()
+
+
+@pytest.mark.asyncio
+async def test_removenode(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    cmdline = ['--logger-log-level', 'storage_service=trace']
+
+    # 4 nodes so that we can find new tablet replica for the RF=3 table on removenode
+    servers = await manager.servers_add(4, cmdline=cmdline)
+
+    cql = manager.get_cql()
+
+    # RF=1
+    await create_keyspace(cql, "test", 32, rf=1)
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+
+    # RF=2
+    await create_keyspace(cql, "test2", 32, rf=2)
+    await cql.run_async("CREATE TABLE test2.test (pk int PRIMARY KEY, c int);")
+
+    # RF=3
+    await create_keyspace(cql, "test3", 32, rf=3)
+    await cql.run_async("CREATE TABLE test3.test (pk int PRIMARY KEY, c int);")
+
+    logger.info("Populating table")
+
+    keys = range(256)
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test2.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test3.test (pk, c) VALUES ({k}, {k});") for k in keys])
+
+    async def check():
+        # RF=1 table "test" will experience data loss so don't check it.
+        # We include it to check that the system doesn't crash.
+
+        logger.info("Checking table test2")
+        query = SimpleStatement("SELECT * FROM test2.test;", consistency_level=ConsistencyLevel.ONE)
+        rows = await cql.run_async(query)
+        assert len(rows) == len(keys)
+        for r in rows:
+            assert r.c == r.pk
+
+        logger.info("Checking table test3")
+        query = SimpleStatement("SELECT * FROM test3.test;", consistency_level=ConsistencyLevel.ONE)
+        rows = await cql.run_async(query)
+        assert len(rows) == len(keys)
+        for r in rows:
+            assert r.c == r.pk
+
+    await check()
+
+    # Disable migrations concurrent with removenode since we don't handle nodes going down during migration yet.
+    # See https://github.com/scylladb/scylladb/issues/16527
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    logger.info('Removing a node')
+    await manager.server_stop(servers[0].server_id)
+    await manager.remove_node(servers[1].server_id, servers[0].server_id)
+    servers = servers[1:]
+
+    await check()
+
+
+@pytest.mark.asyncio
+async def test_removenode_with_ignored_node(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    cmdline = [
+        '--logger-log-level', 'storage_service=trace',
+    ]
+
+    # 5 nodes because we need a quorum with 2 nodes down.
+    # 4 nodes would be enough to not lose data with RF=3.
+    servers = await manager.servers_add(5, cmdline=cmdline)
+
+    cql = manager.get_cql()
+
+    await create_keyspace(cql, "test", 32, rf=3)
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+
+    logger.info("Populating table")
+
+    keys = range(512)
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+
+    async def check():
+        logger.info("Checking")
+        query = SimpleStatement("SELECT * FROM test.test;", consistency_level=ConsistencyLevel.ONE)
+        rows = await cql.run_async(query)
+        assert len(rows) == len(keys)
+        for r in rows:
+            assert r.c == r.pk
+
+    await check()
+
+    # Disable migrations concurrent with removenode since we don't handle nodes going down during migration yet.
+    # See https://github.com/scylladb/scylladb/issues/16527
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    logger.info('Removing a node with another node down')
+    await manager.server_stop(servers[0].server_id) # removed
+    await manager.server_stop(servers[1].server_id) # ignored
+    await manager.remove_node(servers[2].server_id, servers[0].server_id, [servers[1].ip_addr])
+    servers = servers[1:]
+
+    await check()
+
+    logger.info('Removing a node')
+    await manager.remove_node(servers[1].server_id, servers[0].server_id)
+
+    await check()


### PR DESCRIPTION
New tablet replicas are allocated and rebuilt synchronously with node
operations. They are safely rebuilt from all existing replicas.
The list of ignored nodes passed to node operations is respected.

Tablet scheduler is responsible for scheduling tablet rebuilding transition which
changes the replicas set. The infrastructure for handling decommission
in tablet scheduler is reused for this.

Scheduling is done incrementally, respecting per-shard load
limits. Rebuilding transitions are recognized by load calculation to
affect all tablet replicas.

New kind of tablet transition is introduced called "rebuild" which
adds new tablet replica and rebuilds it from existing replicas. Other
than that, the transition goes through the same stages as regular
migration to ensure safe synchronization with request coordinators.

In this PR we simply stream from all tablet replicas. Later we should
switch to calling repair to avoid sending excessive amounts of data.

Fixes https://github.com/scylladb/scylladb/issues/16690.