### PR TITLE
cql-pytest: add "--vnodes" option to "run" script

### DIFF
--- a/test/cql-pytest/run
+++ b/test/cql-pytest/run
@@ -14,6 +14,19 @@ else:
     cmd = run.run_scylla_cmd
     check_cql = run.check_cql
 
+# If the "--vnodes" option is given, drop the "tablets" experimental
+# feature (turned on in run.py) so that all tests will be run with the
+# old vnode-based replication instead of tablets. This option only has
+# temporary usefulness, and should eventually be removed.
+if '--vnodes' in sys.argv:
+    sys.argv.remove('--vnodes')
+    def run_without_tablets(pid, dir):
+        (c, e) = run_without_tablets.orig_cmd(pid, dir)
+        c.remove('--experimental-features=tablets')
+        return (c, e)
+    run_without_tablets.orig_cmd = cmd
+    cmd = run_without_tablets
+
 if "-h" in sys.argv or "--help" in sys.argv:
     run.run_pytest(sys.path[0], sys.argv)
     exit(0)


### PR DESCRIPTION
Running test/cql-pytest/run now defaults to enabling the "tablets" experimental feature when running Scylla - and tests detect this and use this feature as appropriate. This is the correct default going forward, but in the short term it would be nice to also have an option to easily do a manual test run *without* tablets.

So this patch adds a "--vnodes" option to the test/cql-pytest/run script. This option causes "run" to run Scylla without enabling the "tablets" experimental feature.