### PR TITLE
alternator: enable tablets by default if experimental feature is enabled

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -8,6 +8,7 @@
 
 #include <seastar/core/sleep.hh>
 #include "alternator/executor.hh"
+#include "db/config.hh"
 #include "log.hh"
 #include "schema/schema_builder.hh"
 #include "exceptions/exceptions.hh"
@@ -4513,20 +4514,34 @@ static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_vie
                 keyspace_name, rf, endpoint_count);
     }
     auto opts = get_network_topology_options(sp, gossiper, rf);
-    std::optional<unsigned> initial_tablets;
 
-    // Tablets are not yet enabled by default on Alternator tables, because of
-    // missing support for CDC (see issue #16313). Until then, allow
-    // requesting tablets at table-creation time by supplying following tag,
-    // with an integer value. This is useful for testing Tablet support in
-    // Alternator even before it is ready for prime time.
+    // If the "tablets" experimental feature is available, we enable tablets
+    // by default on all Alternator tables. However, some Alternator features
+    // are not yet available with tablets (Streams #16313 and TTL #16567) so
+    // we allow disabling tablets at table-creation by supplying the following
+    // tags with any non-numeric value (e.g., empty string or the word "none").
+    // Supplying it with an integer value allows overriding the default choice
+    // of initial_tablets (setting the value to 0 asks for the default choice).
     // If we make this tag a permanent feature, it will get a "system:" prefix -
     // until then we give it the "experimental:" prefix to not commit to it.
     static constexpr auto INITIAL_TABLETS_TAG_KEY = "experimental:initial_tablets";
-    if (tags_map.contains(INITIAL_TABLETS_TAG_KEY)) {
-        initial_tablets = std::stol(tags_map.at(INITIAL_TABLETS_TAG_KEY));
+    std::optional<unsigned> initial_tablets;
+    if (sp.get_db().local().get_config().check_experimental(db::experimental_features_t::feature::TABLETS)) {
+        auto it = tags_map.find(INITIAL_TABLETS_TAG_KEY);
+        if (it == tags_map.end()) {
+            // No tag - ask to choose a reasonable default number of tablets
+            initial_tablets = 0;
+        } else {
+            // Tag set. If it's a valid number, use it. If not - e.g., it's
+            // empty or a word like "none", disable tablets by setting
+            // initial_tablets to a disengaged optional.
+            try {
+                initial_tablets = std::stol(tags_map.at(INITIAL_TABLETS_TAG_KEY));
+            } catch(...) {
+                initial_tablets = std::nullopt;
+            }
+        }
     }
-
     return keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.NetworkTopologyStrategy", std::move(opts), initial_tablets);
 }
 

--- a/test/alternator/run
+++ b/test/alternator/run
@@ -24,6 +24,15 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 print('Scylla is: ' + run.find_scylla() + '.')
 
 extra_scylla_options = []
+remove_scylla_options = []
+
+# If the "--vnodes" option is given, drop the "tablets" experimental
+# feature (turned on in run.py) so that all tests will be run with the
+# old vnode-based replication instead of tablets. This option only has
+# temporary usefulness, and should eventually be removed.
+if '--vnodes' in sys.argv:
+    sys.argv.remove('--vnodes')
+    remove_scylla_options.append('--experimental-features=tablets')
 
 if "-h" in sys.argv or "--help" in sys.argv:
     run.run_pytest(sys.path[0], sys.argv)
@@ -59,6 +68,9 @@ def run_alternator_cmd(pid, dir):
     else:
         cmd += ['--alternator-port', '8000']
     cmd += extra_scylla_options
+
+    for i in remove_scylla_options:
+        cmd.remove(i)
 
     return (cmd, env)
 

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -262,10 +262,15 @@ def alternator_ttl_period_in_seconds(dynamodb, request):
 # up to the setting of alternator_ttl_period_in_seconds. test/alternator/run
 # sets this to 1 second, which becomes the maximum delay of this test, but
 # if it is set higher we skip this test unless --runveryslow is enabled.
+# This test fails with tablets due to #16567, so to temporarily ensure that
+# Alternator TTL is still being tested, we use the following TAGS to
+# coerce Alternator to create the test table without tablets.
+TAGS = [{'Key': 'experimental:initial_tablets', 'Value': 'none'}]
 def test_ttl_stats(dynamodb, metrics, alternator_ttl_period_in_seconds):
     print(alternator_ttl_period_in_seconds)
     with check_increases_metric(metrics, ['scylla_expiration_scan_passes', 'scylla_expiration_scan_table', 'scylla_expiration_items_deleted']):
         with new_test_table(dynamodb,
+            Tags = TAGS,
             KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, ],
             AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' } ]) as table:
             # Insert one already-expired item, and then enable TTL:


### PR DESCRIPTION
This series does a similar change to Alternator as was done recently to CQL:

1. If the "tablets" experimental feature in enabled, new Alternator tables will use tablets automatically, without requiring an option on each new table. A default choice of initial_tablets is used. These choices can still be overridden per-table if the user wants to.
3. In particular, all test/alternator tests will also automatically run with tablets enabled
4. However, some tests will fail on tablets because they use features that haven't yet been implemented with tablets - namely Alternator Streams (Refs #16317) and Alternator TTL (Refs #16567). These tests will - until those features are implemented with tablets - continue to be run without tablets.
5. An option is added to the test/alternator/run to allow developers to manually run tests without tablets enabled, if they wish to (this option will be useful in the short term, and can be removed later).

Fixes #16355