### PR TITLE
chunked_vector: remove range constructor

### DIFF
--- a/test/boost/string_format_test.cc
+++ b/test/boost/string_format_test.cc
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(test_vector_format) {
     auto small_vector = utils::small_vector<int, 1>(ints);
     test_format_range("small_vector", small_vector, ordered_strings);
 
-    auto chunked_vector = utils::chunked_vector<int, 131072>(ints);
+    auto chunked_vector = boost::copy_range<utils::chunked_vector<int, 131072>>(ints);
     test_format_range("chunked_vector", chunked_vector, ordered_strings);
 
     test_format_range("initializer_list", std::initializer_list<std::string>{"1", "2", "3"}, ordered_strings);

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -106,8 +106,6 @@ public:
     chunked_vector(chunked_vector&& x) noexcept;
     template <typename Iterator>
     chunked_vector(Iterator begin, Iterator end);
-    template <std::ranges::range Range>
-    chunked_vector(const Range& r) : chunked_vector(r.begin(), r.end()) {}
     explicit chunked_vector(size_t n, const T& value = T());
     ~chunked_vector();
     chunked_vector& operator=(const chunked_vector& x);


### PR DESCRIPTION
Standard containers don't have constructors that take ranges; instead people use boost::copy_range or C++23 std::ranges::to.

Make the API more uniform by removing this special constructor.

The only caller, in a test, is adjusted.