### PR TITLE
locator: do not include unused headers

### DIFF
--- a/locator/azure_snitch.cc
+++ b/locator/azure_snitch.cc
@@ -21,6 +21,8 @@
 #include <boost/algorithm/string/split.hpp>
 #include <fmt/format.h>
 
+#include "utils/class_registrator.hh"
+
 namespace locator {
 
 const std::string azure_snitch::REGION_NAME_QUERY_PATH = fmt::format(AZURE_QUERY_PATH_TEMPLATE, "location");

--- a/locator/ec2_multi_region_snitch.cc
+++ b/locator/ec2_multi_region_snitch.cc
@@ -11,6 +11,7 @@
 #include "locator/ec2_multi_region_snitch.hh"
 #include "exceptions/exceptions.hh"
 #include "gms/gossiper.hh"
+#include "utils/class_registrator.hh"
 
 static constexpr const char* PUBLIC_IP_QUERY_REQ  = "/latest/meta-data/public-ipv4";
 static constexpr const char* PRIVATE_IP_QUERY_REQ = "/latest/meta-data/local-ipv4";

--- a/locator/ec2_snitch.cc
+++ b/locator/ec2_snitch.cc
@@ -1,11 +1,14 @@
 #include "locator/ec2_snitch.hh"
 #include <seastar/core/seastar.hh>
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/http/reply.hh>
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
+
+#include "utils/class_registrator.hh"
 
 namespace locator {
 

--- a/locator/gce_snitch.cc
+++ b/locator/gce_snitch.cc
@@ -17,6 +17,8 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 
+#include "utils/class_registrator.hh"
+
 namespace locator {
 
 gce_snitch::gce_snitch(const snitch_config& cfg) : production_snitch_base(cfg) {

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -9,10 +9,11 @@
  */
 
 #include "locator/gossiping_property_file_snitch.hh"
+
+#include <seastar/core/seastar.hh>
 #include "gms/versioned_value.hh"
-#include "message/msg_addr.hh"
-#include "message/messaging_service.hh"
 #include "gms/gossiper.hh"
+#include "utils/class_registrator.hh"
 
 namespace locator {
 future<bool> gossiping_property_file_snitch::property_file_was_modified() {

--- a/locator/gossiping_property_file_snitch.hh
+++ b/locator/gossiping_property_file_snitch.hh
@@ -11,13 +11,10 @@
 #pragma once
 
 #include <sstream>
-#include <string>
 #include <chrono>
 #include <optional>
 #include "production_snitch_base.hh"
-#include "exceptions/exceptions.hh"
 #include <seastar/core/file.hh>
-#include "log.hh"
 
 namespace locator {
 

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -11,7 +11,6 @@
 #include "abstract_replication_strategy.hh"
 
 #include <optional>
-#include <set>
 
 // forward declaration since replica/database.hh includes this file
 class keyspace;

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -16,6 +16,8 @@
 #include "locator/network_topology_strategy.hh"
 #include "locator/load_sketch.hh"
 #include <boost/algorithm/string.hpp>
+#include "exceptions/exceptions.hh"
+#include "utils/class_registrator.hh"
 #include "utils/hash.hh"
 
 namespace std {

--- a/locator/production_snitch_base.hh
+++ b/locator/production_snitch_base.hh
@@ -11,12 +11,8 @@
 #pragma once
 
 #include <unordered_map>
-#include <utility>
-#include <optional>
 #include <unordered_set>
 
-#include "gms/endpoint_state.hh"
-#include "locator/token_metadata.hh"
 #include <seastar/core/sstring.hh>
 #include "snitch_base.hh"
 

--- a/locator/rack_inferring_snitch.cc
+++ b/locator/rack_inferring_snitch.cc
@@ -8,6 +8,7 @@
  */
 
 #include "locator/rack_inferring_snitch.hh"
+#include "utils/class_registrator.hh"
 
 namespace locator {
 using registry = class_registrator<i_endpoint_snitch, rack_inferring_snitch, const snitch_config&>;

--- a/locator/simple_snitch.hh
+++ b/locator/simple_snitch.hh
@@ -10,7 +10,6 @@
 
 #pragma once
 #include "snitch_base.hh"
-#include <memory>
 
 namespace locator {
 

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -6,8 +6,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <algorithm>
-
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
@@ -15,7 +13,6 @@
 #include "exceptions/exceptions.hh"
 #include "utils/class_registrator.hh"
 #include <boost/algorithm/string.hpp>
-#include "utils/sequenced_set.hh"
 
 namespace locator {
 

--- a/locator/simple_strategy.hh
+++ b/locator/simple_strategy.hh
@@ -11,7 +11,6 @@
 #include "abstract_replication_strategy.hh"
 
 #include <optional>
-#include <set>
 
 namespace locator {
 

--- a/locator/snitch_base.cc
+++ b/locator/snitch_base.cc
@@ -10,6 +10,7 @@
 
 #include "locator/snitch_base.hh"
 #include "gms/application_state.hh"
+#include "utils/class_registrator.hh"
 
 namespace locator {
 

--- a/locator/snitch_base.hh
+++ b/locator/snitch_base.hh
@@ -10,20 +10,15 @@
 
 #pragma once
 
-#include <unordered_set>
-#include <vector>
 #include <boost/signals2.hpp>
 #include <boost/signals2/dummy_mutex.hpp>
 
 #include "gms/endpoint_state.hh"
 #include "locator/types.hh"
 #include "gms/inet_address.hh"
-#include "inet_address_vectors.hh"
-#include "gms/versioned_value.hh"
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/distributed.hh>
-#include "utils/class_registrator.hh"
 #include "log.hh"
 
 namespace gms {

--- a/locator/tablet_replication_strategy.hh
+++ b/locator/tablet_replication_strategy.hh
@@ -9,15 +9,10 @@
 #pragma once
 
 #include "locator/abstract_replication_strategy.hh"
-#include "exceptions/exceptions.hh"
 #include "locator/token_metadata.hh"
 #include "locator/tablets.hh"
 
 #include <seastar/core/sstring.hh>
-
-#include <optional>
-#include <set>
-#include <string_view>
 
 namespace locator {
 

--- a/locator/tablet_sharder.hh
+++ b/locator/tablet_sharder.hh
@@ -8,8 +8,8 @@
 
 #pragma once
 
+#include "dht/token-sharding.hh"
 #include "locator/tablets.hh"
-#include "dht/sharder.hh"
 #include "locator/token_metadata.hh"
 
 namespace locator {

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -10,12 +10,10 @@
 
 #pragma once
 
-#include <map>
 #include <unordered_set>
 #include <unordered_map>
 #include "gms/inet_address.hh"
 #include "dht/ring_position.hh"
-#include "inet_address_vectors.hh"
 #include <optional>
 #include <memory>
 #include <boost/range/iterator_range.hpp>

--- a/main.cc
+++ b/main.cc
@@ -44,6 +44,7 @@
 #include "db/hints/manager.hh"
 #include "db/commitlog/commitlog_replayer.hh"
 #include "db/view/view_builder.hh"
+#include "utils/class_registrator.hh"
 #include "utils/error_injection.hh"
 #include "utils/runtime.hh"
 #include "log.hh"

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -60,6 +60,7 @@
 #include "db/system_distributed_keyspace.hh"
 #include "db/sstables-format-selector.hh"
 #include "repair/row_level.hh"
+#include "utils/class_registrator.hh"
 #include "utils/cross-shard-barrier.hh"
 #include "streaming/stream_manager.hh"
 #include "debug.hh"


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.