### PR TITLE
database: wait until commitlog are reclaimed in flush_all_tables()

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2378,6 +2378,7 @@ future<> database::flush_all_tables() {
         return t->flush();
     });
     _all_tables_flushed_at = db_clock::now();
+    co_await _commitlog->wait_for_pending_deletes();
 }
 
 future<db_clock::time_point> database::get_all_tables_flushed_at(sharded<database>& sharded_db) {


### PR DESCRIPTION
this change addresses the possible data resurrection after "nodetool compact" and "nodetool flush" commands. and prepare for the fix of a similar data resurrection issue after "nodetool cleanup".

active commitlog segments are recycled in the background once they are discarded.

and there is a chance that we could have data resurrection even after "nodetool cleanup", because the mutations in commitlog's active segments could change the tables which are supposed to be removed by "nodetool cleanup", so as a solution to address this problem in the pre-tablets era, we force new active segments of commitlog, and flush the involved memtables. since the active segments are discarded in the background, the completion of the "nodetool cleanup" does not guarantee that these mutation won't be applied to memtable when server restarts, if it is killed right away.

the same applies to "force_flush", "force_compaction" and "force_keyspace_compaction" API calls which are used by nodetool as well. quote from Benny's comment

> If major comapction doesn't wait for the commitlog deletion it is
> also exposed to data resurrection since theoretically it could purge
> tombstones based on the assumption that commitlog would not resurrect
> data that they might shadow, BUT on a crash/restart scenario commitlog
> replay would happen since the commitlog segments weren't deleted -
> breaking the contract with compaction.

so to ensure that the active segments are reclaimed upon completion of "nodetool cleanup", "nodetool compact" and "nodetool flush" commands, let's wait for pending deletes in `database::flush_all_tables()`, so the caller wait until the reclamation of deleted active segments completes.

Refs #4734
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>