### PR TITLE
utils:: add formatter for cql3::authorized_prepared_statements_cache_key

### DIFF
--- a/cql3/authorized_prepared_statements_cache.hh
+++ b/cql3/authorized_prepared_statements_cache.hh
@@ -179,8 +179,12 @@ struct hash<cql3::authorized_prepared_statements_cache_key> final {
     }
 };
 
-inline std::ostream& operator<<(std::ostream& out, const cql3::authorized_prepared_statements_cache_key& k) {
-    fmt::print(out, "{{{}, {}}}", k.key().first, k.key().second);
-    return out;
 }
-}
+
+template <>
+struct fmt::formatter<cql3::authorized_prepared_statements_cache_key> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const cql3::authorized_prepared_statements_cache_key& k, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{{{}, {}}}", k.key().first, k.key().second);
+    }
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for
cql3::authorized_prepared_statements_cache_key, and remove its operator<<().

Refs #13245