### PR TITLE
tracing: do not include unused headers

### DIFF
--- a/tracing/trace_keyspace_helper.hh
+++ b/tracing/trace_keyspace_helper.hh
@@ -9,7 +9,6 @@
  */
 #pragma once
 
-#include <tuple>
 #include <seastar/core/gate.hh>
 #include <seastar/core/metrics_registration.hh>
 #include "tracing/tracing.hh"

--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -10,14 +10,10 @@
 #include <chrono>
 #include "cql3/statements/prepared_statement.hh"
 #include "tracing/trace_state.hh"
-#include "tracing/trace_keyspace_helper.hh"
-#include "service/storage_proxy.hh"
-#include "utils/to_string.hh"
 #include "timestamp.hh"
 
 #include "cql3/values.hh"
 #include "cql3/query_options.hh"
-#include "utils/UUID_gen.hh"
 
 namespace tracing {
 

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -10,7 +10,6 @@
 #pragma once
 
 #include <deque>
-#include <unordered_set>
 #include <seastar/util/lazy.hh>
 #include <seastar/core/weak_ptr.hh>
 #include <seastar/core/checked_ptr.hh>

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -10,7 +10,6 @@
 #pragma once
 
 #include <vector>
-#include <atomic>
 #include <random>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/sstring.hh>


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.