### PR TITLE
repair: accelerate repair load_history time

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3230,7 +3230,7 @@ future<> repair_service::cleanup_history(tasks::task_id repair_id) {
 
 future<> repair_service::load_history() {
     co_await get_db().local().get_tables_metadata().parallel_for_each_table(coroutine::lambda([&] (table_id table_uuid, lw_shared_ptr<replica::table> table) -> future<> {
-        auto shard = unsigned(table_uuid.uuid().get_most_significant_bits()) % smp::count;
+        auto shard = utils::uuid_xor_to_uint32(table_uuid.uuid()) % smp::count;
         if (shard != this_shard_id()) {
             co_return;
         }

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3229,11 +3229,13 @@ future<> repair_service::cleanup_history(tasks::task_id repair_id) {
 }
 
 future<> repair_service::load_history() {
-    co_await get_db().local().get_tables_metadata().for_each_table_gently(coroutine::lambda([&] (table_id table_uuid, lw_shared_ptr<replica::table> table) -> future<> {
+    co_await get_db().local().get_tables_metadata().parallel_for_each_table(coroutine::lambda([&] (table_id table_uuid, lw_shared_ptr<replica::table> table) -> future<> {
         auto shard = unsigned(table_uuid.uuid().get_most_significant_bits()) % smp::count;
         if (shard != this_shard_id()) {
             co_return;
         }
+        auto permit = co_await seastar::get_units(_load_parallelism_semaphore, 1);
+
         rlogger.info("Loading repair history for keyspace={}, table={}, table_uuid={}",
                 table->schema()->ks_name(), table->schema()->cf_name(), table_uuid);
         co_await _sys_ks.local().get_repair_history(table_uuid, [this] (const auto& entry) -> future<> {

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -108,6 +108,7 @@ class repair_service : public seastar::peering_sharded_service<repair_service> {
 
     size_t _max_repair_memory;
     seastar::semaphore _memory_sem;
+    seastar::named_semaphore _load_parallelism_semaphore = {16, named_semaphore_exception_factory{"Load repair history parallelism"}};
 
     future<> init_ms_handlers();
     future<> uninit_ms_handlers();


### PR DESCRIPTION
Using `parallel_for_each_table` instance of `for_each_table_gently` on 
`repair_service::load_history`, to reduced bootstrap time.  
Using uuid_xor_to_uint32 on repair load_history dispatch to shard.


Ref: https://github.com/scylladb/scylladb/issues/16774  