### PR TITLE
configure.py: s/--std=/-std/

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1839,7 +1839,7 @@ def write_build_file(f,
         configure_args = {configure_args}
         builddir = {outdir}
         cxx = {cxx}
-        cxxflags = --std=gnu++20 {user_cflags} {warnings} {defines}
+        cxxflags = -std=gnu++20 {user_cflags} {warnings} {defines}
         ldflags = {linker_flags} {user_ldflags}
         ldflags_build = {linker_flags}
         libs = {libs}


### PR DESCRIPTION
neither clang nor gcc supports the --std flag, they support -std= though. see https://clang.llvm.org/cxx_status.html and https://gcc.gnu.org/onlinedocs/gcc/C-Dialect-Options.html so, let's use the -std=gnu++20 for the C++20 standard with GNU extensions.

this change also helps to reduce the difference between the rules generated by `configure.py` and those generated by CMake.