### PR TITLE
configure.py: reenable -Wnarrowing

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1536,7 +1536,6 @@ def get_warning_options(cxx):
         '-Wno-unsupported-friend',
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77728
         '-Wno-psabi',
-        '-Wno-narrowing',
         '-Wno-enum-constexpr-conversion',
     ]
 


### PR DESCRIPTION
it seems that the tree builds just fine with this warning enabled. and narrowing is a potentially unsafe numeric conversion. so let's enable this warning option.

this change also helps to reduce the difference between the rules generated by configure.py and those generated by CMake.