### PR TITLE
Fix test_tablet_missing_data_repair

### DIFF
--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -292,7 +292,8 @@ class ScyllaRESTAPIClient():
         """Repair the given table and wait for it to complete"""
         sequence_number = await self.client.post_json(f"/storage_service/repair_async/{keyspace}", host=node_ip, params={"columnFamilies": table})
         status = await self.client.get_json(f"/storage_service/repair_status", host=node_ip, params={"id": str(sequence_number)})
-        return status
+        if status != 'SUCCESSFUL':
+            raise Exception(f"Repair id {sequence_number} on node {node_ip} for table {keyspace}.{table} failed: status={status}")
 
 class ScyllaMetrics:
     def __init__(self, lines: list[str]):

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -419,7 +419,6 @@ async def test_tablet_repair(manager: ManagerClient):
 
     await cql.run_async("DROP KEYSPACE test;")
 
-@pytest.mark.skip(reason="failing a lot, see https://github.com/scylladb/scylladb/issues/16859")
 @pytest.mark.repair
 @pytest.mark.asyncio
 async def test_tablet_missing_data_repair(manager: ManagerClient):


### PR DESCRIPTION
This PR fixes test_tablet_missing_data_repair and enable the test again. 

If a node is not UP yet, repair in the test will be a partial repair. The partial repair will not repair all the data which cause the check of rows after repair to fail.  Check nodes see each other as UP before repair.
