### PR TITLE
test/cql-pytest: re-enable disabled tests

### DIFF
--- a/test/cql-pytest/conftest.py
+++ b/test/cql-pytest/conftest.py
@@ -257,11 +257,6 @@ def has_tablets(cql):
         return keyspace_has_tablets(cql, keyspace)
 
 @pytest.fixture(scope="function")
-def xfail_tablets(request, has_tablets):
-    if has_tablets:
-        request.node.add_marker(pytest.mark.xfail(reason='Test expected to fail with tablets experimental feature on'))
-
-@pytest.fixture(scope="function")
 def skip_with_tablets(has_tablets):
     if has_tablets:
         pytest.skip("Test may crash with tablets experimental feature on")

--- a/test/cql-pytest/conftest.py
+++ b/test/cql-pytest/conftest.py
@@ -88,16 +88,46 @@ def cql_test_connection(cql, request):
 def this_dc(cql):
     yield cql.execute("SELECT data_center FROM system.local").one()[0]
 
+@pytest.fixture(scope="session")
+def test_keyspace_tablets(cql, this_dc, has_tablets):
+    if not is_scylla(cql) or not has_tablets:
+        pytest.skip("tablet-specific test skipped")
+        return
+
+    name = unique_name()
+    cql.execute("CREATE KEYSPACE " + name + " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 } AND TABLETS = {'enabled': true}")
+    yield name
+    cql.execute("DROP KEYSPACE " + name)
+
+@pytest.fixture(scope="session")
+def test_keyspace_vnodes(cql, this_dc, has_tablets):
+    name = unique_name()
+    if has_tablets:
+        cql.execute("CREATE KEYSPACE " + name + " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 } AND TABLETS = {'enabled': false}")
+    else:
+        # If tablets are not available or not enabled, we just create a regular keyspace
+        cql.execute("CREATE KEYSPACE " + name + " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }")
+    yield name
+    cql.execute("DROP KEYSPACE " + name)
+
 # "test_keyspace" fixture: Creates and returns a temporary keyspace to be
 # used in tests that need a keyspace. The keyspace is created with RF=1,
 # and automatically deleted at the end. We use scope="session" so that all
 # tests will reuse the same keyspace.
 @pytest.fixture(scope="session")
-def test_keyspace(cql, this_dc):
-    name = unique_name()
-    cql.execute("CREATE KEYSPACE " + name + " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }")
-    yield name
-    cql.execute("DROP KEYSPACE " + name)
+def test_keyspace(request, test_keyspace_vnodes, test_keyspace_tablets, cql, this_dc):
+    if hasattr(request, "param"):
+        if request.param == "vnodes":
+            yield test_keyspace_vnodes
+        elif request.param == "tablets":
+            yield test_keyspace_tablets
+        else:
+            pytest.fail(f"test_keyspace(): invalid request parameter: {request.param}")
+    else:
+        name = unique_name()
+        cql.execute("CREATE KEYSPACE " + name + " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }")
+        yield name
+        cql.execute("DROP KEYSPACE " + name)
 
 # The "scylla_only" fixture can be used by tests for Scylla-only features,
 # which do not exist on Apache Cassandra. A test using this fixture will be

--- a/test/cql-pytest/test_tombstone_limit.py
+++ b/test/cql-pytest/test_tombstone_limit.py
@@ -247,8 +247,11 @@ def check_pages_many_partitions(results, expected):
         assert p == expected_pages.get(i, [])
 
 
-# xfail_tablets due to https://github.com/scylladb/scylladb/issues/16486
-def test_partition_tombstone_prefix(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1, xfail_tablets):
+# xfail with tablets due to https://github.com/scylladb/scylladb/issues/16486
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16486")]), "vnodes"],
+                         indirect=True)
+def test_partition_tombstone_prefix(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1):
     with new_test_table(cql, test_keyspace, 'pk int, ck int, v int, PRIMARY KEY (pk, ck)') as table:
         insert_row_id = cql.prepare(f"INSERT INTO {table} (pk, ck, v) VALUES (?, ?, ?)")
         delete_partition_id = cql.prepare(f"DELETE FROM {table} WHERE pk = ?")
@@ -268,8 +271,10 @@ def test_partition_tombstone_prefix(cql, test_keyspace, lowered_tombstone_limit,
         check_pages_many_partitions(cql.execute(statement), {-1: all_pks[-1]})
 
 
-# xfail_tablets due to https://github.com/scylladb/scylladb/issues/16486
-def test_partition_tombstone_span(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1, xfail_tablets):
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16486")]), "vnodes"],
+                         indirect=True)
+def test_partition_tombstone_span(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1):
     with new_test_table(cql, test_keyspace, 'pk int, ck int, v int, PRIMARY KEY (pk, ck)') as table:
         insert_row_id = cql.prepare(f"INSERT INTO {table} (pk, ck, v) VALUES (?, ?, ?)")
         delete_partition_id = cql.prepare(f"DELETE FROM {table} WHERE pk = ?")
@@ -289,8 +294,10 @@ def test_partition_tombstone_span(cql, test_keyspace, lowered_tombstone_limit, d
         check_pages_many_partitions(cql.execute(statement), {0: all_pks[0], -1: all_pks[-1]})
 
 
-# xfail_tablets due to https://github.com/scylladb/scylladb/issues/16486
-def test_static_row_tombstone_prefix(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1, xfail_tablets):
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16486")]), "vnodes"],
+                         indirect=True)
+def test_static_row_tombstone_prefix(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1):
     with new_test_table(cql, test_keyspace, 'pk int, ck int, v int, s int static, PRIMARY KEY (pk, ck)') as table:
         upsert_row_id = cql.prepare(f"UPDATE {table} SET s = ? WHERE pk = ?")
         delete_partition_id = cql.prepare(f"DELETE FROM {table} WHERE pk = ?")
@@ -310,8 +317,10 @@ def test_static_row_tombstone_prefix(cql, test_keyspace, lowered_tombstone_limit
         check_pages_many_partitions(cql.execute(statement), {-1: all_pks[-1]})
 
 
-# xfail_tablets due to https://github.com/scylladb/scylladb/issues/16486
-def test_static_row_tombstone_span(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1, xfail_tablets):
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16486")]), "vnodes"],
+                         indirect=True)
+def test_static_row_tombstone_span(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1):
     with new_test_table(cql, test_keyspace, 'pk int, ck int, v int, s int static, PRIMARY KEY (pk, ck)') as table:
         upsert_row_id = cql.prepare(f"UPDATE {table} SET s = ? WHERE pk = ?")
         delete_partition_id = cql.prepare(f"DELETE FROM {table} WHERE pk = ?")


### PR DESCRIPTION
In a previous PR (https://github.com/scylladb/scylladb/pull/16840), we enabled tablets by default when running the cql-pytest suite. To handle tests which are failing with tablets enabled, we used a new fixture, `xfail_tablets` to mark these as xfail. This means that we effectively lost test coverage, as these tests can now freely fail and no-one will notice if this is due to a new regression. To restore test coverage, this PR re-enables all the previously disabled tests, by parametrizing each one of them to run with both vnodes and tablets, and targetedly mark as xfail, only the tablet variant. After these tests are fixed with tablets (or the underlying functionality they test is fixed to work with tablets), we will run them with both vnodes and tablets, because these tests apparently *do* care which replication method is used.

Together with https://github.com/scylladb/scylladb/pull/16802, this means all previously disabled test is re-enabled and no coverage is lost.