### PR TITLE
repair: handle table drop durring repair

### DIFF
--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -218,6 +218,7 @@ enum class repair_stream_cmd : uint8_t {
     end_of_current_rows,
     get_full_row_hashes,
     put_rows_done,
+    table_dropped,
 };
 
 struct repair_hash_with_cmd {


### PR DESCRIPTION
If a table is dropped during repair, repair master may send row of a dropped table to a follower.

Currently, in this situation no_such_column_family is thrown on the follower node which responds with repair_stream_cmd::error and then handles the exception at its side.

When follower receives repair_stream_cmd::error, it assumes that the repair failed.

To avoid that add table_dropped option to repair_stream_cmd and send it in this case. Handle table_dropped as if the range repair succedd on repair master.

Fixes: #15598.