### PR TITLE
directories: prevent inode cache fragmentation by orderly verifying data directory contents

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -969,11 +969,15 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             supervisor::notify("creating and verifying directories");
             utils::directories::set dir_set;
-            dir_set.add(cfg->data_file_directories());
             dir_set.add(cfg->commitlog_directory());
             dir_set.add(cfg->schema_commitlog_directory());
             dirs.emplace(cfg->developer_mode());
             dirs->create_and_verify(std::move(dir_set)).get();
+
+            // do not recursively check data dir;
+            utils::directories::set data_dir_set;
+            data_dir_set.add(cfg->data_file_directories());
+            dirs->create_and_verify(std::move(data_dir_set), utils::directories::recursive::no).get();
 
             auto hints_dir_initializer = db::hints::directory_initializer::make(*dirs, cfg->hints_directory()).get();
             auto view_hints_dir_initializer = db::hints::directory_initializer::make(*dirs, cfg->view_hints_directory()).get();

--- a/utils/directories.hh
+++ b/utils/directories.hh
@@ -44,11 +44,12 @@ public:
     directories(bool developer_mode);
     future<> create_and_verify(set dir_set, recursive recursive = recursive::yes);
     static future<> verify_owner_and_mode(std::filesystem::path path, recursive recursive = recursive::yes);
+    static future<> verify_owner_and_mode_of_data_dir(set dir_set);
 private:
     bool _developer_mode;
     std::vector<file_lock> _locks;
 
-    static future<> do_verify_owner_and_mode(std::filesystem::path path, recursive, int level);
+    static future<> do_verify_owner_and_mode(std::filesystem::path path, recursive, int level, std::function<bool(const fs::path&)> do_verify_subpath = {});
 };
 
 } // namespace utils

--- a/utils/directories.hh
+++ b/utils/directories.hh
@@ -42,8 +42,8 @@ public:
     using recursive = bool_class<struct recursive_tag>;
 
     directories(bool developer_mode);
-    future<> create_and_verify(set dir_set);
-    static future<> verify_owner_and_mode(std::filesystem::path path, recursive r = recursive::yes);
+    future<> create_and_verify(set dir_set, recursive recursive = recursive::yes);
+    static future<> verify_owner_and_mode(std::filesystem::path path, recursive recursive = recursive::yes);
 private:
     bool _developer_mode;
     std::vector<file_lock> _locks;


### PR DESCRIPTION
During startup, the contents of the data directory are verified to ensure that they have the right owner and permissions. Verifying all the contents, which includes files that will be read and closed immediately, and files that will be held open for longer durations, together, can lead to memory fragementation in the dentry/inode cache.

Mitigate this by updating the verification in a such way that these two set of files will be verified separately ensuring their separation in the dentry/inode cache.

Fixes https://github.com/scylladb/scylladb/issues/14506