### PR TITLE
sstables: writer: don't block topology changes while writing sstables

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1121,7 +1121,6 @@ table::try_flush_memtable_to_sstable(compaction_group& cg, lw_shared_ptr<memtabl
           try {
             sstables::sstable_writer_config cfg = get_sstables_manager().configure_writer("memtable");
             cfg.backup = incremental_backups_enabled();
-            cfg.erm = _erm;
 
             auto newtab = make_sstable();
             newtabs.push_back(newtab);
@@ -3078,7 +3077,6 @@ public:
     }
     sstables::sstable_writer_config configure_writer(sstring origin) const override {
         auto cfg = _t.get_sstables_manager().configure_writer(std::move(origin));
-        cfg.erm = _t.get_effective_replication_map();
         return cfg;
     }
     api::timestamp_type min_memtable_timestamp() const override {

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -821,6 +821,10 @@ public:
     // To obtain a sharder which is valid for all kinds of tables, use table::get_effective_replication_map()->get_sharder()
     const dht::sharder& get_sharder() const;
 
+    // Returns a sharder for this table, but only if it is a static sharder (token->shard mappings
+    // don't change while the node is up)
+    const dht::sharder* try_get_static_sharder() const;
+
     // Returns a pointer to the table if the local database has a table which this object references by id().
     // The table pointer is not guaranteed to be stable, schema_ptr doesn't keep the table alive.
     replica::table* maybe_table() const;

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1472,9 +1472,7 @@ void writer::consume_end_of_stream() {
             { large_data_type::elements_in_collection, std::move(_elements_in_collection_entry) },
         }
     });
-    const dht::sharder& sharder = _cfg.erm ? _cfg.erm->get_sharder(_schema)
-                                           : _schema.get_sharder(); // Used in tests
-    _sst.write_scylla_metadata(_shard, sharder, std::move(features), std::move(identifier), std::move(ld_stats), _cfg.origin);
+    _sst.write_scylla_metadata(_shard, std::move(features), std::move(identifier), std::move(ld_stats), _cfg.origin);
     _sst.seal_sstable(_cfg.backup).get();
 }
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -39,7 +39,7 @@
 #include "readers/flat_mutation_reader_fwd.hh"
 #include "tracing/trace_state.hh"
 #include "utils/updateable_value.hh"
-#include "locator/abstract_replication_strategy.hh"
+#include "dht/decorated_key.hh"
 
 #include <seastar/util/optimized_optional.hh>
 
@@ -111,7 +111,6 @@ struct sstable_writer_config {
     run_id run_identifier = run_id::create_random_id();
     size_t summary_byte_cost;
     sstring origin;
-    locator::effective_replication_map_ptr erm;
 
 private:
     explicit sstable_writer_config() {}
@@ -642,7 +641,6 @@ private:
     future<> read_scylla_metadata() noexcept;
 
     void write_scylla_metadata(shard_id shard,
-                               const dht::sharder& sharder,
                                sstable_enabled_features features,
                                run_identifier identifier,
                                std::optional<scylla_metadata::large_data_stats> ld_stats,

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -58,7 +58,6 @@ std::function<future<> (flat_mutation_reader_v2)> make_streaming_consumer(sstrin
                 schema_ptr s = reader.schema();
 
                 auto cfg = cf->get_sstables_manager().configure_writer(origin);
-                cfg.erm = cf->get_effective_replication_map();
                 return sst->write_components(std::move(reader), adjusted_estimated_partitions, s,
                                              cfg, encoding_stats{}).then([sst] {
                     return sst->open_data();


### PR DESCRIPTION
The sstable writer held the effective_replication_map_ptr while writing
sstables, which is both a layering violation and slows down tablet load
balancing. It was needed in order to ensure the sharder was stable. But
it turns out that sharding metadata is unnecessary for tablets, so just
skip the whole thing when writing an sstable for tablets.