### PR TITLE
utils: add formatter for rjson::value

### DIFF
--- a/utils/rjson.cc
+++ b/utils/rjson.cc
@@ -565,7 +565,3 @@ sstring quote_json_string(const sstring& value) {
 }
 
 } // end namespace rjson
-
-std::ostream& std::operator<<(std::ostream& os, const rjson::value& v) {
-    return os << rjson::print(v);
-}

--- a/utils/rjson.hh
+++ b/utils/rjson.hh
@@ -397,6 +397,9 @@ public:
 
 } // end namespace rjson
 
-namespace std {
-std::ostream& operator<<(std::ostream& os, const rjson::value& v);
-}
+template <> struct fmt::formatter<rjson::value> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const rjson::value& v, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", rjson::print(v));
+    }
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for rjson::value, and drop its operator<<().

Refs #13245