### PR TITLE
tools/scylla-sstable: use canonical path for sst_path

### DIFF
--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -282,7 +282,7 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
 
     parallel_for_each(sstable_names, [schema, &sst_man, &sstable_names, &sstables] (const sstring& sst_name) -> future<> {
         const auto i = std::distance(sstable_names.begin(), std::find(sstable_names.begin(), sstable_names.end(), sst_name));
-        const auto sst_path = std::filesystem::path(sst_name);
+        const auto sst_path = std::filesystem::canonical(std::filesystem::path(sst_name));
 
         if (const auto ftype_opt = co_await file_type(sst_path.c_str(), follow_symlink::yes)) {
             if (!ftype_opt) {


### PR DESCRIPTION
we deduce the paths to other SSTable components from the one specified from the command line, for instance, if
/a/b/c/me-really-big-Data.db is fed to `scylla sstable`, the tool would try to read /a/b/c/me-really-big-TOC.txt for the list of other components. this works fine if the full path is specified in the command line.

but if a relative path is specified, like, "me-really-big-Data.db", this does not work anymore. before this change, the tool would be reading "/me-really-big-TOC.txt", which does not exist under most circumstances. while $PWD/me-really-big-TOC.txt should exist if the SSTable is sane.

after this change, we always convert the specified path to its canonical representation, no matter it is relative or absolutate. this enables us to get the correct parent path path when trying to read, for instance, the TOC component.

Fixes #16955
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>