### PR TITLE
tool: check for existence of keyspace before getting it

### DIFF
--- a/cql3/statements/cf_statement.cc
+++ b/cql3/statements/cf_statement.cc
@@ -39,6 +39,11 @@ void cf_statement::prepare_keyspace(std::string_view keyspace)
     }
 }
 
+bool cf_statement::has_keyspace() const {
+    assert(_cf_name.has_value());
+    return _cf_name->has_keyspace();
+}
+
 const sstring& cf_statement::keyspace() const
 {
     assert(_cf_name->has_keyspace()); // "The statement hasn't be prepared correctly";

--- a/cql3/statements/raw/cf_statement.hh
+++ b/cql3/statements/raw/cf_statement.hh
@@ -38,6 +38,8 @@ public:
     // Only for internal calls, use the version with ClientState for user queries
     void prepare_keyspace(std::string_view keyspace);
 
+    virtual bool has_keyspace() const;
+
     virtual const sstring& keyspace() const;
 
     virtual const sstring& column_family() const;

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -267,6 +267,9 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
         if (!cf_statement) {
             continue; // we don't support any non-cf statements here
         }
+        if (!cf_statement->has_keyspace()) {
+            throw std::runtime_error("tools::do_load_schemas(): CQL statement does not have keyspace specified");
+        }
         auto ks = find_or_create_keyspace(cf_statement->keyspace());
         auto prepared_statement = cf_statement->prepare(db, cql_stats);
         auto* statement = prepared_statement->statement.get();


### PR DESCRIPTION
in general, user should save output of `DESC foo.bar` to a file, and pass the path to the file as the argument of `--schema-file` option of `scylla sstable` commands. the CQL statement generated from `DESC` command always include the keyspace name of the table. but in case user create the CQL statement manually and misses the keyspace name. he/she would have following assertion failure
```
scylla: cql3/statements/cf_statement.cc:49: virtual const sstring &cql3::statements::raw::cf_statement::keyspace() const: Assertion `_cf_name->has_keyspace()' failed.
```
this is not a great user experience.

so, in this change, we check for the existence of keyspace before looking it up. and throw a runtime error with a better error mesage. so when the CQL statement does not have the keyspace name, the new error message would look like:
```
error processing arguments: could not load schema via schema-file: std::runtime_error (tools::do_load_schemas(): CQL statement does not have keyspace specified)
```