### PR TITLE
cql: tell driver schema was created even if IF NOT EXISTS

### DIFF
--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -92,22 +92,20 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector
     using namespace cql_transport;
     const auto& tm = *qp.proxy().get_token_metadata_ptr();
     const auto& feat = qp.proxy().features();
-    ::shared_ptr<event::schema_change> ret;
     std::vector<mutation> m;
 
     try {
         m = service::prepare_new_keyspace_announcement(qp.db().real_database(), _attrs->as_ks_metadata(_name, tm, feat), ts);
-
-        ret = ::make_shared<event::schema_change>(
-                event::schema_change::change_type::CREATED,
-                event::schema_change::target_type::KEYSPACE,
-                keyspace());
     } catch (const exceptions::already_exists_exception& e) {
         if (!_if_not_exists) {
           co_return coroutine::exception(std::current_exception());
         }
     }
 
+    auto ret = ::make_shared<event::schema_change>(
+        event::schema_change::change_type::CREATED,
+        event::schema_change::target_type::KEYSPACE,
+        keyspace());
     co_return std::make_tuple(std::move(ret), std::move(m), std::vector<sstring>());
 }
 


### PR DESCRIPTION
A schema-creation operations like CREATE KEYSPACE returns to the driver a special change "event" to tell the driver to wait until the whole cluster comes to an agreement on the new schema. The reason why this behavior is needed is that the driver may decide to send the next request to a *different* node, and we want this other node to surely know about the newly-created schema.

If one uses CREATE KEYSPACE IF NOT EXIST, the keyspace may already exist and the operation does nothing. When this happens, the existing code did NOT return the special change event. The thinking was that if the keyspace already exists, surely the entire cluster already knows about it? But this is not true if an application does multiple CREATE KEYSPACE IF NOT EXISTS in parallel: It is possible that:
 1. The first invocation created the keyspace and its caller is now waiting for schema agreement
 2. Now a second invocation of CREATE KEYSPACE IF NOT EXISTS notices the keyspace already exists. But it should also wait for the schema agreement - because there may still be other nodes that don't know about the new schema.

The fix in this patch is for CREATE KEYSPACE IF NOT EXIST to always return the change event - regardless of the question whether it really created the keyspace or it already existed.

The only downside to this change is that repeated, do-nothing, calls to CREATE KEYSPACE IF NOT EXIST are slowed down. We believe that this is not a problem, because in a reasonable application there wouldn't be a huge number of those attempts.

This patch changes not only CREATE KEYSPACE IF NOT EXISTS but also CREATE TABLE IF NOT EXISTS and CREATE MATERIALIZED VIEW IF NOT EXISTS.

Fixes #16909