### PR TITLE
api: do not include unused headers

### DIFF
--- a/api/api.hh
+++ b/api/api.hh
@@ -14,11 +14,11 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/units/detail/utility.hpp>
+#include "api/api_init.hh"
 #include "api/api-doc/utils.json.hh"
 #include "utils/histogram.hh"
 #include "utils/estimated_histogram.hh"
 #include <seastar/http/exception.hh>
-#include "api_init.hh"
 #include "seastarx.hh"
 
 namespace api {

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -10,7 +10,6 @@
 #include <seastar/http/httpd.hh>
 #include <seastar/core/future.hh>
 
-#include "locator/host_id.hh"
 #include "replica/database_fwd.hh"
 #include "tasks/task_manager.hh"
 #include "seastarx.hh"

--- a/api/authorization_cache.cc
+++ b/api/authorization_cache.cc
@@ -9,8 +9,6 @@
 #include "api/api-doc/authorization_cache.json.hh"
 
 #include "api/authorization_cache.hh"
-#include "api/api.hh"
-#include "auth/common.hh"
 #include "auth/service.hh"
 
 namespace api {

--- a/api/collectd.cc
+++ b/api/collectd.cc
@@ -10,9 +10,9 @@
 #include "api/api-doc/collectd.json.hh"
 #include <seastar/core/scollectd.hh>
 #include <seastar/core/scollectd_api.hh>
-#include "endian.h"
 #include <boost/range/irange.hpp>
 #include <regex>
+#include "api/api_init.hh"
 
 namespace api {
 

--- a/api/collectd.hh
+++ b/api/collectd.hh
@@ -8,10 +8,13 @@
 
 #pragma once
 
-#include "api.hh"
+namespace seastar::httpd {
+class routes;
+}
 
 namespace api {
 
-void set_collectd(http_context& ctx, httpd::routes& r);
+struct http_context;
+void set_collectd(http_context& ctx, seastar::httpd::routes& r);
 
 }

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -7,6 +7,7 @@
  */
 
 #include "column_family.hh"
+#include "api/api.hh"
 #include "api/api-doc/column_family.json.hh"
 #include <vector>
 #include <seastar/http/exception.hh>

--- a/api/column_family.hh
+++ b/api/column_family.hh
@@ -8,11 +8,11 @@
 
 #pragma once
 
-#include "api.hh"
-#include "api/api-doc/column_family.json.hh"
 #include "replica/database.hh"
 #include <seastar/core/future-util.hh>
+#include <seastar/json/json_elements.hh>
 #include <any>
+#include "api/api_init.hh"
 
 namespace db {
 class system_keyspace;

--- a/api/commitlog.cc
+++ b/api/commitlog.cc
@@ -9,6 +9,7 @@
 #include "commitlog.hh"
 #include "db/commitlog/commitlog.hh"
 #include "api/api-doc/commitlog.json.hh"
+#include "api/api_init.hh"
 #include "replica/database.hh"
 #include <vector>
 

--- a/api/commitlog.hh
+++ b/api/commitlog.hh
@@ -8,10 +8,12 @@
 
 #pragma once
 
-#include "api.hh"
+namespace seastar::httpd {
+class routes;
+}
 
 namespace api {
-
-void set_commitlog(http_context& ctx, httpd::routes& r);
+struct http_context;
+void set_commitlog(http_context& ctx, seastar::httpd::routes& r);
 
 }

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -10,6 +10,7 @@
 
 #include "compaction_manager.hh"
 #include "compaction/compaction_manager.hh"
+#include "api/api.hh"
 #include "api/api-doc/compaction_manager.json.hh"
 #include "db/system_keyspace.hh"
 #include "column_family.hh"

--- a/api/compaction_manager.hh
+++ b/api/compaction_manager.hh
@@ -8,10 +8,12 @@
 
 #pragma once
 
-#include "api.hh"
+namespace seastar::httpd {
+class routes;
+}
 
 namespace api {
-
-void set_compaction_manager(http_context& ctx, httpd::routes& r);
+struct http_context;
+void set_compaction_manager(http_context& ctx, seastar::httpd::routes& r);
 
 }

--- a/api/config.cc
+++ b/api/config.cc
@@ -11,6 +11,7 @@
 #include "db/config.hh"
 #include <sstream>
 #include <boost/algorithm/string/replace.hpp>
+#include <seastar/http/exception.hh>
 
 namespace api {
 using namespace seastar::httpd;

--- a/api/config.hh
+++ b/api/config.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "api.hh"
+#include "api/api_init.hh"
 #include <seastar/http/api_docs.hh>
 
 namespace api {

--- a/api/endpoint_snitch.cc
+++ b/api/endpoint_snitch.cc
@@ -7,7 +7,6 @@
  */
 
 #include "locator/snitch_base.hh"
-#include "locator/production_snitch_base.hh"
 #include "endpoint_snitch.hh"
 #include "api/api-doc/endpoint_snitch_info.json.hh"
 #include "api/api-doc/storage_service.json.hh"

--- a/api/endpoint_snitch.hh
+++ b/api/endpoint_snitch.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "api.hh"
+#include "api/api_init.hh"
 
 namespace locator {
 class snitch_ptr;

--- a/api/error_injection.hh
+++ b/api/error_injection.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "api.hh"
+#include "api/api_init.hh"
 
 namespace api {
 

--- a/api/failure_detector.cc
+++ b/api/failure_detector.cc
@@ -7,6 +7,7 @@
  */
 
 #include "failure_detector.hh"
+#include "api/api.hh"
 #include "api/api-doc/failure_detector.json.hh"
 #include "gms/application_state.hh"
 #include "gms/gossiper.hh"

--- a/api/failure_detector.hh
+++ b/api/failure_detector.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "api.hh"
+#include "api_init.hh"
 
 namespace gms {
 

--- a/api/gossiper.cc
+++ b/api/gossiper.cc
@@ -12,6 +12,7 @@
 #include "api/api-doc/gossiper.json.hh"
 #include "gms/endpoint_state.hh"
 #include "gms/gossiper.hh"
+#include "api/api.hh"
 
 namespace api {
 using namespace seastar::httpd;

--- a/api/gossiper.hh
+++ b/api/gossiper.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "api.hh"
+#include "api/api_init.hh"
 
 namespace gms {
 

--- a/api/hinted_handoff.cc
+++ b/api/hinted_handoff.cc
@@ -6,10 +6,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <algorithm>
 #include <vector>
 
 #include "hinted_handoff.hh"
+#include "api/api.hh"
 #include "api/api-doc/hinted_handoff.json.hh"
 
 #include "gms/inet_address.hh"

--- a/api/hinted_handoff.hh
+++ b/api/hinted_handoff.hh
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <seastar/core/sharded.hh>
-#include "api.hh"
+#include "api/api_init.hh"
 
 namespace service { class storage_proxy; }
 

--- a/api/lsa.cc
+++ b/api/lsa.cc
@@ -8,7 +8,6 @@
 
 #include "api/api-doc/lsa.json.hh"
 #include "api/lsa.hh"
-#include "api/api.hh"
 
 #include <seastar/http/exception.hh>
 #include "utils/logalloc.hh"

--- a/api/lsa.hh
+++ b/api/lsa.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "api.hh"
+#include "api/api_init.hh"
 
 namespace api {
 

--- a/api/messaging_service.cc
+++ b/api/messaging_service.cc
@@ -11,8 +11,7 @@
 #include <seastar/rpc/rpc_types.hh>
 #include "api/api-doc/messaging_service.json.hh"
 #include "api/api-doc/error_injection.json.hh"
-#include <iostream>
-#include <sstream>
+#include "api/api.hh"
 
 using namespace seastar::httpd;
 using namespace httpd::messaging_service_json;

--- a/api/messaging_service.hh
+++ b/api/messaging_service.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "api.hh"
+#include "api/api_init.hh"
 
 namespace netw { class messaging_service; }
 

--- a/api/storage_proxy.cc
+++ b/api/storage_proxy.cc
@@ -8,6 +8,7 @@
 
 #include "storage_proxy.hh"
 #include "service/storage_proxy.hh"
+#include "api/api.hh"
 #include "api/api-doc/storage_proxy.json.hh"
 #include "api/api-doc/utils.json.hh"
 #include "db/config.hh"

--- a/api/storage_proxy.hh
+++ b/api/storage_proxy.hh
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <seastar/core/sharded.hh>
-#include "api.hh"
+#include "api/api_init.hh"
 
 namespace service { class storage_proxy; }
 

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -7,6 +7,8 @@
  */
 
 #include "storage_service.hh"
+#include "api/api.hh"
+#include "api/api-doc/column_family.json.hh"
 #include "api/api-doc/storage_service.json.hh"
 #include "api/api-doc/storage_proxy.json.hh"
 #include "api/scrub_status.hh"

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -8,10 +8,9 @@
 
 #pragma once
 
-#include <iostream>
-
 #include <seastar/core/sharded.hh>
-#include "api.hh"
+#include <seastar/json/json_elements.hh>
+#include "api/api_init.hh"
 #include "db/data_listeners.hh"
 
 namespace cql_transport { class controller; }

--- a/api/stream_manager.cc
+++ b/api/stream_manager.cc
@@ -9,8 +9,10 @@
 #include "stream_manager.hh"
 #include "streaming/stream_manager.hh"
 #include "streaming/stream_result_future.hh"
+#include "api/api.hh"
 #include "api/api-doc/stream_manager.json.hh"
 #include <vector>
+#include <rapidjson/document.h>
 #include "gms/gossiper.hh"
 
 namespace api {

--- a/api/stream_manager.hh
+++ b/api/stream_manager.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "api.hh"
+#include "api/api_init.hh"
 
 namespace api {
 

--- a/api/system.cc
+++ b/api/system.cc
@@ -6,21 +6,20 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "api/api_init.hh"
 #include "api/api-doc/system.json.hh"
 #include "api/api-doc/metrics.json.hh"
+#include "replica/database.hh"
 
-#include "api/api.hh"
-
+#include <rapidjson/document.h>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/metrics_api.hh>
 #include <seastar/core/relabel_config.hh>
 #include <seastar/http/exception.hh>
 #include <seastar/util/short_streams.hh>
 #include <seastar/http/short_streams.hh>
-#include "utils/rjson.hh"
 
 #include "log.hh"
-#include "replica/database.hh"
 
 extern logging::logger apilog;
 

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -7,13 +7,12 @@
  */
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/http/exception.hh>
 
 #include "task_manager.hh"
+#include "api/api.hh"
 #include "api/api-doc/task_manager.json.hh"
 #include "db/system_keyspace.hh"
-#include "column_family.hh"
-#include "unimplemented.hh"
-#include "storage_service.hh"
 
 #include <utility>
 #include <boost/range/adaptors.hpp>

--- a/api/task_manager.hh
+++ b/api/task_manager.hh
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <seastar/core/sharded.hh>
-#include "api.hh"
+#include "api/api_init.hh"
 #include "db/config.hh"
 
 namespace tasks {

--- a/api/token_metadata.cc
+++ b/api/token_metadata.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include "storage_service.hh"
+#include "api/api.hh"
 #include "api/api-doc/storage_service.json.hh"
 #include "api/api-doc/endpoint_snitch_info.json.hh"
 #include "locator/token_metadata.hh"

--- a/api/token_metadata.hh
+++ b/api/token_metadata.hh
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <seastar/core/sharded.hh>
-#include "api.hh"
+#include "api/api_init.hh"
 
 namespace locator { class shared_token_metadata; }
 


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.