### PR TITLE
coverage libraries: bug fixes

### DIFF
--- a/test/pylib/coverage_utils.py
+++ b/test/pylib/coverage_utils.py
@@ -758,7 +758,7 @@ async def html_fixup(*, html_dir: Path):
     files names that contain url illegal characters
     """
     html_files = [f for f in html_dir.rglob("*.html") if f.is_file()]
-    href_re = re.compile(r'href=".*\.html">')
+    href_re = re.compile(r'href=".*?\.html">')
     for html_file in html_files:
         with open(html_file, "r") as f:
             content = f.read()

--- a/test/pylib/lcov_utils.py
+++ b/test/pylib/lcov_utils.py
@@ -555,7 +555,9 @@ class LcovRecord(metaclass = MakeLcovRouter):
         parts = line.split(":", maxsplit = 1)
         if len(parts) == 1:
             parts.append("")
-        return parts[0].strip(), [field.strip() for field in parts[1].split(",")]
+        type_str = parts[0].strip()
+        fields = [parts[1].strip()] if type_str == "SF" else [field.strip() for field in parts[1].split(",")]
+        return type_str, fields
 
     def add_line(self, line: str) -> bool:
         type_str, fields = self.get_type_and_fields(line)


### PR DESCRIPTION
This mini-series contains two bug fixes that were found as part of testing coverage reporting in CI:
ref: https://github.com/scylladb/scylladb/pull/16895

1. The html-fixup which is triggered when using:`test/pylib/coverage_utils.py lcov-tools genhtml...` rendered incorrect links for multiple links in the same line.
2. For files that contined `,` in their name the output was simply wrong and resulted in lcov not being able to find such files for the purpose of filtering or generating reports.

The aforementioned draft PR served as a testing bed for finding and fixing those bugs.