### PR TITLE
api/api.hh: improve usage of standard containers

### DIFF
--- a/api/api.hh
+++ b/api/api.hh
@@ -26,6 +26,8 @@ namespace api {
 template<class T>
 std::vector<sstring> container_to_vec(const T& container) {
     std::vector<sstring> res;
+    res.reserve(std::size(container));
+
     for (auto i : container) {
         res.push_back(fmt::to_string(i));
     }
@@ -35,6 +37,8 @@ std::vector<sstring> container_to_vec(const T& container) {
 template<class T>
 std::vector<T> map_to_key_value(const std::map<sstring, sstring>& map) {
     std::vector<T> res;
+    res.reserve(map.size());
+
     for (auto i : map) {
         res.push_back(T());
         res.back().key = i.first;
@@ -45,6 +49,8 @@ std::vector<T> map_to_key_value(const std::map<sstring, sstring>& map) {
 
 template<class T, class MAP>
 std::vector<T>& map_to_key_value(const MAP& map, std::vector<T>& res) {
+    res.reserve(res.size() + std::size(map));
+
     for (auto i : map) {
         T val;
         val.key = fmt::to_string(i.first);
@@ -64,6 +70,8 @@ T map_sum(T&& dest, const S& src) {
 template <typename MAP>
 std::vector<sstring> map_keys(const MAP& map) {
     std::vector<sstring> res;
+    res.reserve(std::size(map));
+
     for (const auto& i : map) {
         res.push_back(fmt::to_string(i.first));
     }

--- a/api/api.hh
+++ b/api/api.hh
@@ -28,7 +28,7 @@ std::vector<sstring> container_to_vec(const T& container) {
     std::vector<sstring> res;
     res.reserve(std::size(container));
 
-    for (auto i : container) {
+    for (const auto& i : container) {
         res.push_back(fmt::to_string(i));
     }
     return res;
@@ -39,10 +39,10 @@ std::vector<T> map_to_key_value(const std::map<sstring, sstring>& map) {
     std::vector<T> res;
     res.reserve(map.size());
 
-    for (auto i : map) {
+    for (const auto& [key, value] : map) {
         res.push_back(T());
-        res.back().key = i.first;
-        res.back().value = i.second;
+        res.back().key = key;
+        res.back().value = value;
     }
     return res;
 }
@@ -51,17 +51,17 @@ template<class T, class MAP>
 std::vector<T>& map_to_key_value(const MAP& map, std::vector<T>& res) {
     res.reserve(res.size() + std::size(map));
 
-    for (auto i : map) {
+    for (const auto& [key, value] : map) {
         T val;
-        val.key = fmt::to_string(i.first);
-        val.value = fmt::to_string(i.second);
+        val.key = fmt::to_string(key);
+        val.value = fmt::to_string(value);
         res.push_back(val);
     }
     return res;
 }
 template <typename T, typename S = T>
 T map_sum(T&& dest, const S& src) {
-    for (auto i : src) {
+    for (const auto& i : src) {
         dest[i.first] += i.second;
     }
     return std::move(dest);


### PR DESCRIPTION
This PR contains improvements related to usage of std::vector and looping over containers in the range-for loop.

It is advised to use `std::vector::reserve()` to avoid unneeded memory allocations when the total size is known beforehand.

When looping over a container that stores non-trivial types usage of const reference is advised to avoid redundant copies.