### PR TITLE
service/client_state.cc: remove redundant copying

### DIFF
--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -151,7 +151,7 @@ future<> service::client_state::has_access(const sstring& ks, auth::command_desc
         for (auto cf : { db::system_keyspace::LOCAL, db::system_keyspace::PEERS }) {
             tmp.insert(auth::make_data_resource(db::system_keyspace::NAME, cf));
         }
-        for (auto cf : db::schema_tables::all_table_names(db::schema_features::full())) {
+        for (const auto& cf : db::schema_tables::all_table_names(db::schema_features::full())) {
             tmp.insert(auth::make_data_resource(db::schema_tables::NAME, cf));
         }
         return tmp;


### PR DESCRIPTION
db::schema_tables::all_table_names() returns std::vector<sstring>. Usage of range-for loop without reference results in copying each of the elements of the traversed container. Such copying is redundant.

This change introduces usage of const reference to avoid copying.