### PR TITLE
github action: add auto assign to PR

### DIFF
--- a/.github/workflows/auto_assign.yaml
+++ b/.github/workflows/auto_assign.yaml
@@ -1,0 +1,11 @@
+name: 'Auto Assign'
+on:
+  pull_request_target:
+    types: [opened]
+jobs:
+  assignAuthor:
+    name: Assign author to PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign author to PR
+        uses: technote-space/assign-author@v1


### PR DESCRIPTION
Adding github action to auto assign a PR to the user who opened it. This is a preparation for backport automation project we started to work on. Once we have assignee for each PR, we can easly reflect it to the release PR for backports

Fixes: https://github.com/scylladb/scylladb/issues/16988