### PR TITLE
types/types.cc: move stringstream content instead of copying it

### DIFF
--- a/concrete_types.hh
+++ b/concrete_types.hh
@@ -131,7 +131,6 @@ struct varint_type_impl final : public concrete_type<utils::multiprecision_int> 
 
 struct inet_addr_type_impl final : public concrete_type<seastar::net::inet_address> {
     inet_addr_type_impl();
-    static sstring to_sstring(const seastar::net::inet_address& addr);
     static seastar::net::inet_address from_sstring(sstring_view s);
 };
 

--- a/lang/lua.cc
+++ b/lang/lua.cc
@@ -1030,7 +1030,7 @@ struct to_lua_visitor {
 
     void operator()(const inet_addr_type_impl& t, const emptyable<seastar::net::inet_address>* v) {
         // returns a string
-        sstring s = inet_addr_type_impl::to_sstring(v->get());
+        sstring s = fmt::to_string(v->get());
         push_sstring(l, s);
     }
 

--- a/types/types.cc
+++ b/types/types.cc
@@ -100,7 +100,7 @@ sstring simple_date_to_string(const uint32_t days_count) {
     date::year_month_day ymd{date::local_days{days}};
     std::ostringstream str;
     str << ymd;
-    return str.str();
+    return std::move(str).str();
 }
 
 sstring time_to_string(const int64_t nanoseconds_count) {
@@ -1178,14 +1178,14 @@ static sstring map_to_string(const std::vector<std::pair<data_value, data_value>
         const auto& v = p.second;
         out << "{" << k.type()->to_string_impl(k) << " : ";
         out << v.type()->to_string_impl(v) << "}";
-        return out.str();
+        return std::move(out).str();
     }), ", "));
 
     if (include_frozen_type) {
         out << ")";
     }
 
-    return out.str();
+    return std::move(out).str();
 }
 
 bytes
@@ -2839,7 +2839,7 @@ static sstring tuple_to_string(const tuple_type_impl &t, const tuple_type_impl::
         }
     }
 
-    return out.str();
+    return std::move(out).str();
 }
 
 template <typename N, typename A, typename F>
@@ -3234,7 +3234,7 @@ user_type_impl::make_name(sstring keyspace,
     if (!is_multi_cell) {
         os << ")";
     }
-    return os.str();
+    return std::move(os).str();
 }
 
 static std::optional<data_type> update_user_type_aux(
@@ -3564,7 +3564,7 @@ sstring data_value::to_parsable_string() const {
             result << (*the_list)[i].to_parsable_string();
         }
         result << "]";
-        return result.str();
+        return std::move(result).str();
         //return fmt::format("[{}]", fmt::join(*the_list | to_parsable_str_transform, ", "));
     }
 
@@ -3580,7 +3580,7 @@ sstring data_value::to_parsable_string() const {
             result << (*the_set)[i].to_parsable_string();
         }
         result << "}";
-        return result.str();
+        return std::move(result).str();
         //return fmt::format("{{{}}}", fmt::join(*the_set | to_parsable_str_transform, ", "));
     }
 
@@ -3596,7 +3596,7 @@ sstring data_value::to_parsable_string() const {
             result << (*the_map)[i].first.to_parsable_string() << ":" << (*the_map)[i].second.to_parsable_string();
         }
         result << "}";
-        return result.str();
+        return std::move(result).str();
         //auto to_map_elem_transform = boost::adaptors::transformed(
         //    [](const std::pair<data_value, data_value>& map_elem) -> sstring {
         //        return fmt::format("{{{}:{}}}", map_elem.first.to_parsable_string(), map_elem.second.to_parsable_string());
@@ -3619,7 +3619,7 @@ sstring data_value::to_parsable_string() const {
             result << user_typ->string_field_names().at(i) << ":" << (*field_values)[i].to_parsable_string();
         }
         result << "}";
-        return result.str();
+        return std::move(result).str();
     }
 
     if (_type->without_reversed().is_tuple()) {
@@ -3634,7 +3634,7 @@ sstring data_value::to_parsable_string() const {
             result << (*tuple_elements)[i].to_parsable_string();
         }
         result << ")";
-        return result.str();
+        return std::move(result).str();
     }
 
     abstract_type::kind type_kind = _type->without_reversed().get_kind();

--- a/types/types.cc
+++ b/types/types.cc
@@ -115,12 +115,6 @@ sstring boolean_to_string(const bool b) {
     return b ? "true" : "false";
 }
 
-sstring inet_addr_type_impl::to_sstring(const seastar::net::inet_address& addr) {
-    std::ostringstream out;
-    out << addr;
-    return out.str();
-}
-
 static const char* byte_type_name      = "org.apache.cassandra.db.marshal.ByteType";
 static const char* short_type_name     = "org.apache.cassandra.db.marshal.ShortType";
 static const char* int32_type_name     = "org.apache.cassandra.db.marshal.Int32Type";
@@ -2882,7 +2876,7 @@ struct to_string_impl_visitor {
     }
     sstring operator()(const empty_type_impl&, const void*) { return sstring(); }
     sstring operator()(const inet_addr_type_impl& a, const inet_addr_type_impl::native_type* v) {
-        return format_if_not_empty(a, v, inet_addr_type_impl::to_sstring);
+        return format_if_not_empty(a, v, [] (const seastar::net::inet_address& addr) { return fmt::to_string(addr); });
     }
     sstring operator()(const list_type_impl& l, const list_type_impl::native_type* v) {
         return format_if_not_empty(


### PR DESCRIPTION
C++20 introduced a new overload of std::ostringstream::str() that is selected when the mentioned member function is called on r-value.

The new overload returns a string, that is move-constructed from the underlying string instead of being copy-constructed.

This change applies std::move() on stringstream objects before calling str() member function to avoid copying of the underlying buffer.

It also removes a helper function `inet_addr_type_impl::to_sstring()` - it was used only in two places. It was replaced with `fmt::to_string()`.