### PR TITLE
.git: do not apply codespell to licenses

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -15,4 +15,4 @@ jobs:
         with:
           only_warn: 1
           ignore_words_list: "ser,ue,crate"
-          skip: "./.git,./build,./tools,*.js,*.thrift,*.lock,./test"
+          skip: "./.git,./build,./tools,*.js,*.thrift,*.lock,./test,./licenses"


### PR DESCRIPTION
we should keep the licenses as they are, even with misspellings.