### PR TITLE
repair: do not include unused headers

### DIFF
--- a/repair/reader.hh
+++ b/repair/reader.hh
@@ -5,7 +5,6 @@
 #include "dht/sharder.hh"
 #include "reader_permit.hh"
 #include "utils/phased_barrier.hh"
-#include "mutation/mutation_fragment.hh"
 #include "readers/mutation_fragment_v1_stream.hh"
 
 class repair_reader {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -9,22 +9,17 @@
 #include "repair.hh"
 #include "repair/row_level.hh"
 
-#include "mutation/atomic_cell_hash.hh"
-#include "dht/sharder.hh"
+#include "locator/network_topology_strategy.hh"
 #include "streaming/stream_reason.hh"
 #include "gms/inet_address.hh"
 #include "gms/gossiper.hh"
 #include "message/messaging_service.hh"
-#include "sstables/sstables.hh"
 #include "replica/database.hh"
-#include "db/config.hh"
-#include "utils/error_injection.hh"
-#include "utils/hashers.hh"
-#include "locator/network_topology_strategy.hh"
 #include "service/migration_manager.hh"
 #include "service/storage_service.hh"
+#include "sstables/sstables.hh"
 #include "partition_range_compat.hh"
-#include "gms/feature_service.hh"
+#include "utils/error_injection.hh"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -42,10 +37,8 @@
 #include <seastar/core/sleep.hh>
 
 #include <cfloat>
-#include <algorithm>
 #include <atomic>
 
-#include "idl/position_in_partition.dist.hh"
 #include "idl/partition_checksum.dist.hh"
 
 using namespace std::chrono_literals;

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -26,6 +26,7 @@
 #include "repair/hash.hh"
 #include "repair/sync_boundary.hh"
 #include "tasks/types.hh"
+#include "schema/schema.hh"
 
 namespace tasks {
 namespace repair {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -19,10 +19,8 @@
 #include "mutation_writer/multishard_writer.hh"
 #include "dht/i_partitioner.hh"
 #include "dht/sharder.hh"
-#include "utils/to_string.hh"
 #include "utils/xx_hasher.hh"
 #include "utils/UUID.hh"
-#include "utils/hash.hh"
 #include "replica/database.hh"
 #include <seastar/util/bool_class.hh>
 #include <seastar/core/metrics_registration.hh>
@@ -39,7 +37,6 @@
 #include "gms/i_endpoint_state_change_subscriber.hh"
 #include "gms/gossiper.hh"
 #include "repair/row_level.hh"
-#include "mutation/mutation_source_metadata.hh"
 #include "utils/stall_free.hh"
 #include "service/migration_manager.hh"
 #include "streaming/consumer.hh"
@@ -49,7 +46,6 @@
 #include "service/storage_proxy.hh"
 #include "service/raft/raft_address_map.hh"
 #include "db/batchlog_manager.hh"
-#include "idl/position_in_partition.dist.hh"
 #include "idl/partition_checksum.dist.hh"
 #include "readers/empty_v2.hh"
 #include "readers/evictable.hh"

--- a/repair/writer.hh
+++ b/repair/writer.hh
@@ -3,12 +3,9 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
 #include "schema/schema_fwd.hh"
-#include <optional>
 #include "reader_permit.hh"
 #include "streaming/stream_reason.hh"
 #include "repair/decorated_key_with_hash.hh"
-#include "readers/queue.hh"
-#include "sstables/sstable_set.hh"
 #include "readers/upgrading_consumer.hh"
 #include <seastar/core/coroutine.hh>
 


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.