### PR TITLE
db: add formatter for dht::decorated_key and repair_sync_boundary

### DIFF
--- a/dht/decorated_key.hh
+++ b/dht/decorated_key.hh
@@ -99,3 +99,11 @@ struct hash<dht::decorated_key> {
 };
 
 } // namespace std
+
+template <> struct fmt::formatter<dht::decorated_key> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const dht::decorated_key& dk, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{{key: {}, token: {}}}", dk._key, dk._token);
+    }
+};

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -54,7 +54,7 @@ sharder::next_shard(const token& t) const {
 }
 
 std::ostream& operator<<(std::ostream& out, const decorated_key& dk) {
-    fmt::print(out, "{{key: {}, token: {}}}", dk._key, dk._token);
+    fmt::print(out, "{}", dk);
     return out;
 }
 

--- a/repair/sync_boundary.hh
+++ b/repair/sync_boundary.hh
@@ -29,9 +29,16 @@ struct repair_sync_boundary {
             return ret;
         }
     };
-    friend std::ostream& operator<<(std::ostream& os, const repair_sync_boundary& x) {
-        return os << "{ " << x.pk << "," <<  x.position << " }";
+};
+
+template <> struct fmt::formatter<repair_sync_boundary> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const repair_sync_boundary& boundary, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{{ {}, {} }}", boundary.pk, boundary.position);
     }
 };
 
-
+inline std::ostream& operator<<(std::ostream& os, const repair_sync_boundary& x) {
+    fmt::print(os, "{}", x);
+    return os;
+}


### PR DESCRIPTION
db: add formatter for dht::decorated_key and repair_sync_boundary

before this change, we rely on the default-generated fmt::formatter
created from operator<<, but fmt v10 dropped the default-generated
formatter.

in this change, we define formatters for dht::decorated_key and
repair_sync_boundary.

please note, before this change, repair_sync_boundary was using
the operator<< based formatter of `dht::decorated_key`, so we are
updating both of them in a single commit.

because we still use the homebrew generic formatter of vector<>
in to format vector<repair_sync_boundary> and vector<dht::decorated_key>,
so their operator<< are preserved.

Refs #13245