### PR TITLE
test/nodetool: return a randomized address if not running with unshare

### DIFF
--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -48,8 +48,13 @@ def server_address(request):
         except FileNotFoundError:
             args = "/sbin/ifconfig lo up".split()
             subprocess.run(args, check=True)
-    # we use a fixed ip and port, because the network namespace is not shared
-    yield ServerAddress('127.0.0.1', 12345)
+        # we use a fixed ip and port, because the network namespace is not shared
+        ip = '127.0.0.1'
+        port = 12345
+    else:
+        ip = f"127.{random.randint(0, 255)}.{random.randint(0, 255)}.{random.randint(0, 255)}"
+        port = random.randint(10000, 65535)
+    yield ServerAddress(ip, port)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
we should allow user to run nodetool tests without `test.py`. but there
are good chance that the host could be reused by multiple tests or
multiple users who could be using port 12345. by randomizing the IP and
port, they would have better chance to complete the test without running
into used port problem.
