### PR TITLE
Remove anonymous namespaces from headers

### DIFF
--- a/mutation/mutation.hh
+++ b/mutation/mutation.hh
@@ -189,8 +189,6 @@ private:
     friend std::ostream& operator<<(std::ostream& os, const mutation& m);
 };
 
-namespace {
-
 template<consume_in_reverse reverse, FlattenedConsumerV2 Consumer>
 std::optional<stop_iteration> consume_clustering_fragments(schema_ptr s, mutation_partition& partition, Consumer& consumer, mutation_consume_cookie& cookie, is_preemptible preempt = is_preemptible::no) {
     constexpr bool crs_in_reverse = reverse == consume_in_reverse::yes;
@@ -307,8 +305,6 @@ std::optional<stop_iteration> consume_clustering_fragments(schema_ptr s, mutatio
 
     return stop;
 }
-
-} // anonymous namespace
 
 template<FlattenedConsumerV2 Consumer>
 auto mutation::consume(Consumer& consumer, consume_in_reverse reverse, mutation_consume_cookie cookie) &&

--- a/utils/config_file_impl.hh
+++ b/utils/config_file_impl.hh
@@ -135,8 +135,6 @@ void validate(boost::any& out, const std::vector<std::string>& in, std::unordere
 
 namespace utils {
 
-namespace {
-
 /*
  * Our own bpo::typed_valye.
  * Only difference is that we _don't_ apply defaults (they are already applied)
@@ -170,8 +168,6 @@ inline typed_value_ex<T>* value_ex() {
     typed_value_ex<T>* r = new typed_value_ex<T>();
     maybe_multitoken(r);
     return r;
-}
-
 }
 
 sstring hyphenate(const std::string_view&);


### PR DESCRIPTION
Anonymous namespace implies internal linkage for its members.
When it is defined in a header, then each translation unit,
which includes such header defines its own unique instance
of members of the unnamed namespace that are ODR-used within
that translation unit.

This can lead to unexpected results including code bloat
or undefined behavior due to ODR violations.

This PR removes unnamed namespaces from header files.

References:

- [CppCoreGuidelines: "SF.21: Don’t use an unnamed (anonymous) namespace in a header"](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf21-dont-use-an-unnamed-anonymous-namespace-in-a-header)

- [SEI CERT C++: "DCL59-CPP. Do not define an unnamed namespace in a header file"](https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL59-CPP.+Do+not+define+an+unnamed+namespace+in+a+header+file)