### PR TITLE
.git: only allow codespell to run on master branch

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -3,7 +3,6 @@ on:
   pull_request:
     branches:
       - master
-      - enterprise
 permissions: {}
 jobs:
   codespell:


### PR DESCRIPTION
so that non-master branches are not read by 3rd-party tools unless they are audited.