### PR TITLE
tools/scylla-sstable-scripts: add keys.lua and largest-key.lua

### DIFF
--- a/tools/scylla-sstable-scripts/keys.lua
+++ b/tools/scylla-sstable-scripts/keys.lua
@@ -1,0 +1,104 @@
+--
+-- Copyright (C) 2024-present ScyllaDB
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+-- Dumps all keys from an sstable
+--
+-- Only partition and cluster keys are dumped.
+-- Example output -- excerpt from a run on an sstable from system_schema.columns:
+--
+-- [
+--   {
+--     "key": {
+--       "token": "5501786289152180687",
+--       "raw": "000d73797374656d5f747261636573",
+--       "key_size": 15,
+--       "value": "system_traces"
+--     },
+--     "clustering_elements": [
+--       {
+--         "type": "range-tombstone-change",
+--         "key": {
+--           "raw": "00066576656e7473",
+--           "key_size": 8,
+--           "value": "events"
+--         }
+--       },
+--       {
+--         "type": "clustering-row",
+--         "key": {
+--           "raw": "00066576656e747300086163746976697479",
+--           "key_size": 18,
+--           "value": "events:activity"
+--         }
+--       }
+--     ]
+--   }
+-- ]
+
+writer = Scylla.new_json_writer()
+
+function write_key(obj)
+    writer:start_object()
+
+    if obj.token then
+        writer:key("token")
+        writer:string(tostring(obj.token))
+    end
+
+    raw_key = obj.key:to_hex()
+
+    writer:key("raw")
+    writer:string(raw_key)
+
+    writer:key("key_size")
+    writer:int(raw_key:len() / 2) -- to_hex() converts each byte to 2 characters
+
+    writer:key("value")
+    writer:string(tostring(obj.key))
+
+    writer:end_object()
+end
+
+function consume_stream_start()
+    writer:start_array()
+end
+
+function consume_partition_start(ps)
+    writer:start_object()
+    writer:key("key")
+    write_key(ps)
+    writer:key("clustering_elements")
+    writer:start_array()
+end
+
+function consume_clustering_row(cr)
+    writer:start_object()
+    writer:key("type")
+    writer:string("clustering-row")
+    writer:key("key")
+    write_key(cr)
+    writer:end_object()
+end
+
+function consume_range_tombstone_change(crt)
+    writer:start_object()
+    writer:key("type")
+    writer:string("range-tombstone-change")
+    if crt.key then
+        writer:key("key")
+        write_key(crt)
+    end
+    writer:end_object()
+end
+
+function consume_partition_end()
+    writer:end_array()
+    writer:end_object()
+end
+
+function consume_stream_end()
+    writer:end_array()
+end

--- a/tools/scylla-sstable-scripts/largest-key.lua
+++ b/tools/scylla-sstable-scripts/largest-key.lua
@@ -1,0 +1,75 @@
+--
+-- Copyright (C) 2024-present ScyllaDB
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+-- Find the largest key in an sstable
+--
+-- Only partition and cluster keys are considered.
+-- Example output -- a run on an sstable from system_schema.columns:
+--
+-- Largest key is of size 52, found in partition system
+--         token: 2008276574632865675
+--         raw partition key: 000673797374656d
+--         mutation fragment kind: clustering-row
+--         key: scylla_views_builds_in_progress:generation_number
+--         raw key: 001f7363796c6c615f76696577735f6275696c64735f696e5f70726f6772657373001167656e65726174696f6e5f6e756d626572
+
+current_partition = nil
+largest_key = {
+    size=0,
+    partition=nil,
+    fragment_kind=nil,
+    raw=nil,
+    value=nil,
+}
+
+function handle_key(obj, fragment_kind)
+    raw_key = obj.key:to_hex()
+    key_size = raw_key:len() / 2 -- to_hex() converts each byte to 2 characters
+
+    if key_size <= largest_key.size then
+        return
+    end
+
+    largest_key.size = key_size
+    largest_key.partition = current_partition
+    largest_key.fragment_kind = fragment_kind
+
+    if obj.token then
+        largest_key.raw = nil
+        largest_key.value = nil
+    else
+        largest_key.raw = raw_key
+        largest_key.value = tostring(obj.key)
+    end
+end
+
+function consume_partition_start(ps)
+    current_partition = {token = ps.token, raw = ps.key:to_hex(), value = tostring(ps.key)}
+    handle_key(ps, "partition-start")
+end
+
+function consume_clustering_row(cr)
+    handle_key(cr, "clustering-row")
+end
+
+function consume_range_tombstone_change(crt)
+    if crt.key then
+        handle_key(crt, "range-tombstone-change")
+    end
+end
+
+function consume_stream_end()
+    print(string.format("Largest key is of size %d, found in partition %s",
+        largest_key.size,
+        largest_key.partition.value))
+    print(string.format("\ttoken: %s", largest_key.partition.token))
+    print(string.format("\traw partition key: %s", largest_key.partition.raw))
+    print(string.format("\tmutation fragment kind: %s", largest_key.fragment_kind))
+    if largest_key.raw and largest_key.value then
+        print(string.format("\tkey: %s", largest_key.value))
+        print(string.format("\traw key: %s", largest_key.raw))
+    end
+end


### PR DESCRIPTION
I wrote these scripts to identify sstables with too large keys for a recent investigation. I think they could be useful in the future, certainly as further examples on how to write lua scripts for scylla-sstable script.