### PR TITLE
test/nodetool: only test "storage_service/cleanup_all" with scylla

### DIFF
--- a/test/nodetool/test_cleanup.py
+++ b/test/nodetool/test_cleanup.py
@@ -8,7 +8,7 @@ from rest_api_mock import expected_request
 import utils
 
 
-def test_cleanup(nodetool):
+def test_cleanup(nodetool, scylla_only):
     nodetool("cleanup", expected_requests=[
         expected_request("POST", "/storage_service/cleanup_all", response=0),
     ])


### PR DESCRIPTION
this RESTful API is a scylla specific extension and is only used by scylla-nodetool. currently, the java-based nodetool does not use it at all, so mark it with "scylla_only".

one can verify this change with:
```
pytest --mode=debug --nodetool=cassandra test_cleanup.py::test_cleanup
```