### PR TITLE
.git: add more skip words

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -14,5 +14,5 @@ jobs:
       - uses: codespell-project/actions-codespell@master
         with:
           only_warn: 1
-          ignore_words_list: "ser,ue,crate"
+          ignore_words_list: "ans,datas,fo,ser,ue,crate,nd,reenable,strat,stap,te"
           skip: "./.git,./build,./tools,*.js,*.thrift,*.lock,./test,./licenses"


### PR DESCRIPTION
these words are either

* shortened words: strategy => strat, read_from_primary => fro
* or acronyms: node_or_data => nd

before we rename them with better names, let's just add them to the ignore word list.