### PR TITLE
treewide: fix misspellings in code comments

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -2001,7 +2001,7 @@ username returns [sstring str]
     | QUOTED_NAME { add_recognition_error("Quoted strings are not supported for user names"); }
     ;
 
-// Basically the same as cident, but we need to exlude existing CQL3 types
+// Basically the same as cident, but we need to exclude existing CQL3 types
 // (which for some reason are not reserved otherwise)
 non_type_ident returns [shared_ptr<cql3::column_identifier> id]
     : t=IDENT                    { if (_reserved_type_names().contains($t.text)) { add_recognition_error("Invalid (reserved) user type name " + $t.text); } $id = ::make_shared<cql3::column_identifier>($t.text, false); }

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1361,7 +1361,7 @@ public:
         auto size = align_up(buf_pos, _alignment);
         auto fill_size = size - buf_pos;
         if (fill_size > 0) {
-            // we want to fill to a sector boundry, must leave room for metadata
+            // we want to fill to a sector boundary, must leave room for metadata
             assert((fill_size - detail::sector_overhead_size) <= _buffer_ostream.size());
             _buffer_ostream.fill('\0', fill_size - detail::sector_overhead_size);
             _segment_manager->totals.bytes_slack += fill_size;
@@ -1587,7 +1587,7 @@ db::commitlog::segment_manager::list_descriptors(sstring dirname) const {
 }
 
 // #11237 - make get_segments_to_replay on-demand. Since we base the time-part of
-// descriptor ids on hightest of wall-clock and segments found on disk on init,
+// descriptor ids on highest of wall-clock and segments found on disk on init,
 // we can just scan files now and include only those representing generations before
 // the creation of this commitlog instance.
 // This _could_ give weird results iff we had a truly sharded commitlog folder

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -2106,7 +2106,7 @@ uint64_t mutation_querier::consume_end_of_stream() {
     // If we got no rows, but have live static columns, we should only
     // give them back IFF we did not have any CK restrictions.
     // #589
-    // If ck:s exist, and we do a restriction on them, we either have maching
+    // If ck:s exist, and we do a restriction on them, we either have matching
     // rows, or return nothing, since cql does not allow "is null".
     bool return_static_content_on_partition_with_no_rows =
         _pw.slice().options.contains(query::partition_slice::option::always_return_static_content) ||

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -2058,7 +2058,7 @@ future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_nam
             throw std::runtime_error(format("repair[{}] Table {}.{} is not a tablet table", rid.uuid(), keyspace_name, table_name));
         }
         table_id tid = t->schema()->id();
-        // FIXME: we need to wait for current tablet movement and disable future tablet movment
+        // FIXME: we need to wait for current tablet movement and disable future tablet movement
         auto erm = t->get_effective_replication_map();
         auto& tmap = erm->get_token_metadata_ptr()->tablets().get_tablet_map(tid);
         struct repair_tablet_meta {

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -125,10 +125,10 @@ public:
     future<> stop();
 
     /**
-     * Chack the distributed data for changes in a constant interval and updates
+     * Check the distributed data for changes in a constant interval and updates
      * the service_levels configuration in accordance (adds, removes, or updates
      * service levels as necessairy).
-     * @param interval_f - lambda function which returns a interval in miliseconds.
+     * @param interval_f - lambda function which returns a interval in milliseconds.
                            The interval is time to check the distributed data.
      * @return a future that is resolved when the update loop stops.
      */

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -284,7 +284,7 @@ private:
     std::unique_ptr<cancellable_write_handlers_list> _cancellable_write_handlers_list;
 
     /* This is a pointer to the shard-local part of the sharded cdc_service:
-     * storage_proxy needs access to cdc_service to augument mutations.
+     * storage_proxy needs access to cdc_service to augment mutations.
      *
      * It is a pointer and not a reference since cdc_service must be initialized after storage_proxy,
      * because it uses storage_proxy to perform pre-image queries, for one thing.

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -260,7 +260,7 @@ future<> parse(const schema&, sstable_version_types, random_access_reader& in, u
 
 template <typename Tag>
 future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, utils::tagged_uuid<Tag>& id) {
-    // Read directly into tha tagged_uuid `id` member
+    // Read directly into the tagged_uuid `id` member
     // This is ugly, but save an allocation or reimplementation
     // of parse(..., utils::UUID&)
     utils::UUID& uuid = *const_cast<utils::UUID*>(&id.uuid());
@@ -1957,7 +1957,7 @@ std::optional<bool> sstable::originated_on_this_node() const {
         // we don't know the local host id before it is loaded from
         // (or generated and written to) system.local, but some system
         // sstable reads must happen before the bootstrap process gets
-        // there (like in ther resharding case)
+        // there (like in the resharding case)
         return std::nullopt;
     }
 

--- a/utils/pretty_printers.hh
+++ b/utils/pretty_printers.hh
@@ -43,7 +43,7 @@ public:
 //   fmt::print("{:ib}", 10'024); // prints "10Ki", IEC unit is used, without
 //                                // the " bytes" or "B" unit
 //   fmt::print("{:I}", 1024); // prints "1K", IEC unit is used, but without
-//                             // the "iB" postifx.
+//                             // the "iB" postfix.
 //   fmt::print("{:s}", 10); // prints "10 bytes", SI unit is used
 //   fmt::print("{:sb}", 10'000); // prints "10k", SI unit is used, without
 //                                // the unit postfix


### PR DESCRIPTION
these misspellings are identified by codespell.