### PR TITLE
topology_coordinator: fix misspellings in log

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1131,7 +1131,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     try {
                         co_await wait_for_ip(id, _address_map, _as);
                     } catch (...) {
-                        rtlogger.warn("wait_for_ip failed during cancelation: {}", std::current_exception());
+                        rtlogger.warn("wait_for_ip failed during cancellation: {}", std::current_exception());
                     }
                 }
                 break;
@@ -1771,7 +1771,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
 
                 rtbuilder.done();
 
-                co_await update_topology_state(take_guard(std::move(node)), {rtbuilder.build()}, "report request completion in left_token_ring sate");
+                co_await update_topology_state(take_guard(std::move(node)), {rtbuilder.build()}, "report request completion in left_token_ring state");
 
                 // Tell the node to shut down.
                 // This is done to improve user experience when there are no failures.


### PR DESCRIPTION
these misspellings are identified by codespell.