### PR TITLE
tablets: Remove tablet_aware_replication_strategy::parse_initial_tablets

### DIFF
--- a/locator/tablet_replication_strategy.hh
+++ b/locator/tablet_replication_strategy.hh
@@ -25,7 +25,6 @@ namespace locator {
 class tablet_aware_replication_strategy : public per_table_replication_strategy {
 private:
     size_t _initial_tablets = 1;
-    size_t parse_initial_tablets(const sstring&) const;
 protected:
     void validate_tablet_options(const abstract_replication_strategy&, const gms::feature_service&, const replication_strategy_config_options&) const;
     void process_tablet_options(abstract_replication_strategy&, replication_strategy_config_options&, replication_strategy_params);

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -565,14 +565,6 @@ public:
     }
 };
 
-size_t tablet_aware_replication_strategy::parse_initial_tablets(const sstring& val) const {
-    try {
-        return std::stol(val);
-    } catch (...) {
-        throw exceptions::configuration_exception(format("\"initial_tablets\" must be numeric; found {}", val));
-    }
-}
-
 void tablet_aware_replication_strategy::validate_tablet_options(const abstract_replication_strategy& ars,
                                                                 const gms::feature_service& fs,
                                                                 const replication_strategy_config_options& opts) const {


### PR DESCRIPTION
It's now unused, string with initial tablets its parsed elsewhere