### PR TITLE
raft: do not include unused headers

### DIFF
--- a/raft/internal.hh
+++ b/raft/internal.hh
@@ -7,8 +7,6 @@
  */
 #pragma once
 
-#include <ostream>
-#include <functional>
 #include "utils/UUID.hh"
 #include "utils/tagged_integer.hh"
 

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -10,7 +10,6 @@
 #include <vector>
 #include <unordered_set>
 #include <functional>
-#include <source_location>
 #include <boost/container/deque.hpp>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/future.hh>
@@ -18,7 +17,6 @@
 #include <seastar/util/source_location-compat.hh>
 #include <seastar/core/abort_source.hh>
 #include "bytes_ostream.hh"
-#include "utils/UUID.hh"
 #include "internal.hh"
 #include "logical_clock.hh"
 


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.