### PR TITLE
thrift: do not include unused headers

### DIFF
--- a/thrift/server.cc
+++ b/thrift/server.cc
@@ -23,13 +23,7 @@
 #include <thrift/TProcessor.h>
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/async/TAsyncProcessor.h>
-#include <iostream>
 #include <algorithm>
-#include <unordered_map>
-#include <queue>
-#include <bitset>
-#include <limits>
-#include <cctype>
 #include <vector>
 
 #ifdef THRIFT_USES_BOOST

--- a/thrift/thrift_validation.hh
+++ b/thrift/thrift_validation.hh
@@ -12,7 +12,7 @@
 
 #include "schema/schema.hh"
 #include "bytes.hh"
-#include "Cassandra.h"
+#include "cassandra_types.h"
 
 using namespace ::cassandra;
 


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.