### PR TITLE
thrift: add formatter for cassandra::ConsistencyLevel::type

### DIFF
--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -48,6 +48,8 @@
 #include "db/config.hh"
 #include "locator/abstract_replication_strategy.hh"
 
+#include <fmt/ostream.h>
+
 #ifdef THRIFT_USES_BOOST
 namespace thrift_fn = tcxx;
 #else
@@ -62,6 +64,8 @@ using namespace ::apache::thrift::async;
 using namespace  ::cassandra;
 
 using namespace thrift;
+
+template <> struct fmt::formatter<cassandra::ConsistencyLevel::type> : fmt::ostream_formatter {};
 
 class unimplemented_exception : public std::exception {
 public:


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for
cassandra::ConsistencyLevel::type.
please note, the operator<< for `cassandra::ConsistencyLevel::type` is generated using `thrift` command line tool, which does not emit specialization for fmt::formatter yet, so we need to use `fmt::ostream_formatter` to implement the formatter for this type.

Refs #13245