### PR TITLE
treewide: replace seastar::future::get0() with seastar::future::get()

### DIFF
--- a/alternator/controller.cc
+++ b/alternator/controller.cc
@@ -73,11 +73,11 @@ future<> controller::start_server() {
         // shards - if necessary for LWT.
         smp_service_group_config c;
         c.max_nonlocal_requests = 5000;
-        _ssg = create_smp_service_group(c).get0();
+        _ssg = create_smp_service_group(c).get();
 
         rmw_operation::set_default_write_isolation(_config.alternator_write_isolation());
 
-        net::inet_address addr = utils::resolve(_config.alternator_address, family).get0();
+        net::inet_address addr = utils::resolve(_config.alternator_address, family).get();
 
         auto get_cdc_metadata = [] (cdc::generation_service& svc) { return std::ref(svc.get_cdc_metadata()); };
         auto get_timeout_in_ms = [] (const db::config& cfg) -> utils::updateable_value<uint32_t> {

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -117,7 +117,7 @@ public:
                  }
                  return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
              }
-             auto res = resf.get0();
+             auto res = resf.get();
              std::visit(overloaded_functor {
                  [&] (const json::json_return_type& json_return_value) {
                      slogger.trace("api_handler success case");
@@ -574,7 +574,7 @@ future<> server::init(net::inet_address addr, std::optional<uint16_t> port, std:
                 } else {
                     slogger.info("Reloaded {}", files);
                 }
-            }).get0();
+            }).get();
             _https_server.listen(socket_address{addr, *https_port}, std::move(server_creds)).get();
             _enabled_servers.push_back(std::ref(_https_server));
         }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -432,7 +432,7 @@ void set_repair(http_context& ctx, routes& r, sharded<repair_service>& repair) {
                 .then_wrapped([] (future<repair_status>&& fut) {
             ss::ns_repair_async_status::return_type_wrapper res;
             try {
-                res = fut.get0();
+                res = fut.get();
             } catch(std::runtime_error& e) {
                 throw httpd::bad_param_exception(e.what());
             }
@@ -465,7 +465,7 @@ void set_repair(http_context& ctx, routes& r, sharded<repair_service>& repair) {
                 .then_wrapped([] (future<repair_status>&& fut) {
             ss::ns_repair_async_status::return_type_wrapper res;
             try {
-                res = fut.get0();
+                res = fut.get();
             } catch (std::exception& e) {
                 return make_exception_future<json::json_return_type>(httpd::bad_param_exception(e.what()));
             }

--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -125,11 +125,11 @@ future<> default_authorizer::start() {
                 _migration_manager).then([this] {
             _finished = do_after_system_ready(_as, [this] {
                 return async([this] {
-                    _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as).get0();
+                    _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as).get();
 
                     if (legacy_metadata_exists()) {
-                        if (!any_granted().get0()) {
-                            migrate_legacy_metadata().get0();
+                        if (!any_granted().get()) {
+                            migrate_legacy_metadata().get();
                             return;
                         }
 
@@ -268,7 +268,7 @@ future<> default_authorizer::revoke_all(const resource& resource) const {
             {resource.name()},
             cql3::query_processor::cache_internal::no).then_wrapped([this, resource](future<::shared_ptr<cql3::untyped_result_set>> f) {
         try {
-            auto res = f.get0();
+            auto res = f.get();
             return parallel_for_each(
                     res->begin(),
                     res->end(),

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -145,9 +145,9 @@ future<> password_authenticator::start() {
 
          _stopped = do_after_system_ready(_as, [this] {
              return async([this] {
-                 _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as).get0();
+                 _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as).get();
 
-                 if (any_nondefault_role_row_satisfies(_qp, &has_salted_hash, _superuser).get0()) {
+                 if (any_nondefault_role_row_satisfies(_qp, &has_salted_hash, _superuser).get()) {
                      if (legacy_metadata_exists()) {
                          plogger.warn("Ignoring legacy authentication metadata since nondefault data already exist.");
                      }
@@ -156,11 +156,11 @@ future<> password_authenticator::start() {
                  }
 
                  if (legacy_metadata_exists()) {
-                     migrate_legacy_metadata().get0();
+                     migrate_legacy_metadata().get();
                      return;
                  }
 
-                 create_default_if_missing().get0();
+                 create_default_if_missing().get();
              });
          });
 
@@ -229,7 +229,7 @@ future<authenticated_user> password_authenticator::authenticate(
                 cql3::query_processor::cache_internal::yes);
     }).then_wrapped([=](future<::shared_ptr<cql3::untyped_result_set>> f) {
         try {
-            auto res = f.get0();
+            auto res = f.get();
             auto salted_hash = std::optional<sstring>();
             if (!res->empty()) {
                 salted_hash = res->one().get_opt<sstring>(SALTED_HASH);

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -240,9 +240,9 @@ future<> standard_role_manager::start() {
         return this->create_metadata_tables_if_missing().then([this] {
             _stopped = auth::do_after_system_ready(_as, [this] {
                 return seastar::async([this] {
-                    _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as).get0();
+                    _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as).get();
 
-                    if (any_nondefault_role_row_satisfies(_qp, &has_can_login).get0()) {
+                    if (any_nondefault_role_row_satisfies(_qp, &has_can_login).get()) {
                         if (this->legacy_metadata_exists()) {
                             log.warn("Ignoring legacy user metadata since nondefault roles already exist.");
                         }
@@ -251,11 +251,11 @@ future<> standard_role_manager::start() {
                     }
 
                     if (this->legacy_metadata_exists()) {
-                        this->migrate_legacy_metadata().get0();
+                        this->migrate_legacy_metadata().get();
                         return;
                     }
 
-                    create_default_role_if_missing().get0();
+                    create_default_role_if_missing().get();
                 });
             });
         });

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -563,7 +563,7 @@ protected:
 
     void finish_new_sstable(compaction_writer* writer) {
         writer->writer.consume_end_of_stream();
-        writer->sst->open_data().get0();
+        writer->sst->open_data().get();
         _end_size += writer->sst->bytes_on_disk();
         _new_unused_sstables.push_back(writer->sst);
         _new_partial_sstables.erase(writer->sst);
@@ -619,7 +619,7 @@ protected:
     void stop_gc_compaction_writer(compaction_writer* c_writer) {
         c_writer->writer.consume_end_of_stream();
         auto sst = c_writer->sst;
-        sst->open_data().get0();
+        sst->open_data().get();
         _unused_garbage_collected_sstables.push_back(std::move(sst));
     }
 
@@ -1147,7 +1147,7 @@ private:
         if (!enable_garbage_collected_sstable_writer()) {
             return;
         }
-        auto permit = seastar::get_units(_replacer_lock, 1).get0();
+        auto permit = seastar::get_units(_replacer_lock, 1).get();
         // Replace exhausted sstable(s), if any, by new one(s) in the column family.
         auto not_exhausted = [s = _schema, &dk = sst->get_last_decorated_key()] (shared_sstable& sst) {
             return sst->get_last_decorated_key().tri_compare(*s, dk) > 0;

--- a/cql3/functions/error_injection_fcts.cc
+++ b/cql3/functions/error_injection_fcts.cc
@@ -66,7 +66,7 @@ shared_ptr<function> make_enable_injection_function() {
         const bool one_shot = ascii_type->get_string(parameters[1].value()) == "true";
         smp::invoke_on_all([injection_name, one_shot] () mutable {
             utils::get_local_injector().enable(injection_name, one_shot);
-        }).get0();
+        }).get();
         return std::nullopt;
     });
 }
@@ -77,7 +77,7 @@ shared_ptr<function> make_disable_injection_function() {
         sstring injection_name = ascii_type->get_string(parameters[0].value());
         smp::invoke_on_all([injection_name] () mutable {
             utils::get_local_injector().disable(injection_name);
-        }).get0();
+        }).get();
         return std::nullopt;
     });
 }
@@ -99,7 +99,7 @@ shared_ptr<function> make_enabled_injections_function() {
             }).then([list_type_inst](std::vector<data_value> const& active_injections) {
                 auto list_val = make_list_value(list_type_inst, active_injections);
                 return list_type_inst->decompose(list_val);
-            }).get0();
+            }).get();
         });
 }
 

--- a/cql3/functions/user_function.cc
+++ b/cql3/functions/user_function.cc
@@ -55,11 +55,11 @@ bytes_opt user_function::execute(std::span<const bytes_opt> parameters) {
                 const bytes_opt& bytes = parameters[i];
                 values.push_back(bytes ? type->deserialize(*bytes) : data_value::make_null(type));
             }
-            return lua::run_script(lua::bitcode_view{ctx.bitcode}, values, return_type(), ctx.cfg).get0();
+            return lua::run_script(lua::bitcode_view{ctx.bitcode}, values, return_type(), ctx.cfg).get();
         },
         [&] (wasm::context& ctx) -> bytes_opt {
             try {
-                return wasm::run_script(name(), ctx, arg_types(), parameters, return_type(), _called_on_null_input).get0();
+                return wasm::run_script(name(), ctx, arg_types(), parameters, return_type(), _called_on_null_input).get();
             } catch (const wasm::exception& e) {
                 throw exceptions::invalid_request_exception(format("UDF error: {}", e.what()));
             }

--- a/db/hints/internal/hint_sender.cc
+++ b/db/hints/internal/hint_sender.cc
@@ -442,7 +442,7 @@ void hint_sender::rewind_sent_replay_position_to(db::replay_position rp) {
 
 // runs in a seastar::async context
 bool hint_sender::send_one_file(const sstring& fname) {
-    timespec last_mod = get_last_file_modification(fname).get0();
+    timespec last_mod = get_last_file_modification(fname).get();
     gc_clock::duration secs_since_file_mod = std::chrono::seconds(last_mod.tv_sec);
     lw_shared_ptr<send_one_file_ctx> ctx_ptr = make_lw_shared<send_one_file_ctx>(_last_schema_ver_to_column_mapping);
 
@@ -514,7 +514,7 @@ bool hint_sender::send_one_file(const sstring& fname) {
 
     // If we got here we are done with the current segment and we can remove it.
     with_shared(_file_update_mutex, [&fname, this] {
-        auto p = _ep_manager.get_or_load().get0();
+        auto p = _ep_manager.get_or_load().get();
         return p->delete_segments({ fname });
     }).get();
 

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -35,7 +35,7 @@ future<bool> is_mountpoint(const fs::path& path) {
         return make_ready_future<bool>(true);
     }
     return when_all(get_device_id(path), get_device_id(path.parent_path())).then([](std::tuple<future<dev_t>, future<dev_t>> ids) {
-        return std::get<0>(ids).get0() != std::get<1>(ids).get0();
+        return std::get<0>(ids).get() != std::get<1>(ids).get();
     });
 }
 

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -138,10 +138,10 @@ public:
                         db::schema_tables::legacy::read_table_mutations(_sp, dst.name, cf_name, db::system_keyspace::legacy::column_families()))
                     .then([&dst, cf_name, timestamp](result_tuple&& t) {
 
-            result_set_type tables = std::get<0>(t).get0();
-            result_set_type columns = std::get<1>(t).get0();
-            result_set_type triggers = std::get<2>(t).get0();
-            db::schema_tables::legacy::schema_mutations sm = std::get<3>(t).get0();
+            result_set_type tables = std::get<0>(t).get();
+            result_set_type columns = std::get<1>(t).get();
+            result_set_type triggers = std::get<2>(t).get();
+            db::schema_tables::legacy::schema_mutations sm = std::get<3>(t).get();
 
             row_type& td = tables->one();
 

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -147,7 +147,7 @@ future<> view_update_generator::start() {
                     vug_logger.info("Processing {}.{}: {} in {} sstables",
                                     s->ks_name(), s->cf_name(), utils::pretty_printed_data_size(input_size), sstables.size());
 
-                    auto permit = _db.obtain_reader_permit(*t, "view_update_generator", db::no_timeout, {}).get0();
+                    auto permit = _db.obtain_reader_permit(*t, "view_update_generator", db::no_timeout, {}).get();
                     auto ms = mutation_source([this, ssts] (
                                 schema_ptr s,
                                 reader_permit permit,

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -82,7 +82,7 @@ std::unordered_map<dht::token_range, std::vector<inet_address>>
 range_streamer::get_all_ranges_with_sources_for(const sstring& keyspace_name, locator::vnode_effective_replication_map_ptr erm, dht::token_range_vector desired_ranges) {
     logger.debug("{} ks={}", __func__, keyspace_name);
 
-    auto range_addresses = erm->get_range_addresses().get0();
+    auto range_addresses = erm->get_range_addresses().get();
 
     logger.debug("keyspace={}, desired_ranges.size={}, range_addresses.size={}", keyspace_name, desired_ranges.size(), range_addresses.size());
 
@@ -122,13 +122,13 @@ range_streamer::get_all_ranges_with_strict_sources_for(const sstring& keyspace_n
     auto& strat = erm->get_replication_strategy();
 
     //Active ranges
-    auto metadata_clone = get_token_metadata().clone_only_token_map().get0();
-    auto range_addresses = strat.get_range_addresses(metadata_clone).get0();
+    auto metadata_clone = get_token_metadata().clone_only_token_map().get();
+    auto range_addresses = strat.get_range_addresses(metadata_clone).get();
 
     //Pending ranges
     metadata_clone.update_topology(_address, _dr);
     metadata_clone.update_normal_tokens(_tokens, _address).get();
-    auto pending_range_addresses  = strat.get_range_addresses(metadata_clone).get0();
+    auto pending_range_addresses  = strat.get_range_addresses(metadata_clone).get();
     metadata_clone.clear_gently().get();
 
     //Collects the source that will have its range moved to the new node

--- a/generic_server.cc
+++ b/generic_server.cc
@@ -185,7 +185,7 @@ future<> server::do_accepts(int which, bool keepalive, socket_address server_add
                 maybe_stop();
                 return stop_iteration::yes;
             }
-            auto cs_sa = f_cs_sa.get0();
+            auto cs_sa = f_cs_sa.get();
             auto fd = std::move(cs_sa.connection);
             auto addr = std::move(cs_sa.remote_address);
             fd.set_nodelay(true);

--- a/init.cc
+++ b/init.cc
@@ -19,7 +19,7 @@ logging::logger startlog("init");
 std::set<gms::inet_address> get_seeds_from_db_config(const db::config& cfg, gms::inet_address broadcast_address) {
     auto preferred = cfg.listen_interface_prefer_ipv6() ? std::make_optional(net::inet_address::family::INET6) : std::nullopt;
     auto family = cfg.enable_ipv6_dns_lookup() || preferred ? std::nullopt : std::make_optional(net::inet_address::family::INET);
-    const auto listen = gms::inet_address::lookup(cfg.listen_address(), family).get0();
+    const auto listen = gms::inet_address::lookup(cfg.listen_address(), family).get();
     auto seed_provider = cfg.seed_provider();
 
     std::set<gms::inet_address> seeds;
@@ -30,7 +30,7 @@ std::set<gms::inet_address> get_seeds_from_db_config(const db::config& cfg, gms:
         while (begin < seeds_str.length() && begin != (next=seeds_str.find(",",begin))) {
             auto seed = boost::trim_copy(seeds_str.substr(begin,next-begin));
             try {
-                seeds.emplace(gms::inet_address::lookup(seed, family, preferred).get0());
+                seeds.emplace(gms::inet_address::lookup(seed, family, preferred).get());
             } catch (...) {
                 startlog.error("Bad configuration: invalid value in 'seeds': '{}': {}", seed, std::current_exception());
                 throw bad_configuration_error();

--- a/lang/wasm.cc
+++ b/lang/wasm.cc
@@ -333,8 +333,8 @@ seastar::future<bytes_opt> run_script(const db::functions::function_name& name, 
     std::exception_ptr ex;
     bytes_opt ret;
     try {
-        func_inst = ctx.cache.get(name, arg_types, ctx).get0();
-        ret = wasm::run_script(ctx, *func_inst->instance->store, *func_inst->instance->instance, *func_inst->instance->func, arg_types, params, return_type, allow_null_input).get0();
+        func_inst = ctx.cache.get(name, arg_types, ctx).get();
+        ret = wasm::run_script(ctx, *func_inst->instance->store, *func_inst->instance->instance, *func_inst->instance->func, arg_types, params, return_type, allow_null_input).get();
     } catch (const wasm::instance_corrupting_exception& e) {
         func_inst->instance = std::nullopt;
         ex = std::current_exception();

--- a/locator/azure_snitch.cc
+++ b/locator/azure_snitch.cc
@@ -69,8 +69,8 @@ future<sstring> azure_snitch::azure_api_call(sstring path) {
     return seastar::async([path = std::move(path)] () -> sstring {
         using namespace boost::algorithm;
 
-        net::inet_address a = seastar::net::dns::resolve_name(AZURE_SERVER_ADDR, net::inet_address::family::INET).get0();
-        connected_socket sd(connect(socket_address(a, 80)).get0());
+        net::inet_address a = seastar::net::dns::resolve_name(AZURE_SERVER_ADDR, net::inet_address::family::INET).get();
+        connected_socket sd(connect(socket_address(a, 80)).get());
         input_stream<char> in(sd.input());
         output_stream<char> out(sd.output());
         auto close_in = deferred_close(in);
@@ -102,7 +102,7 @@ future<sstring> azure_snitch::azure_api_call(sstring path) {
         auto content_len = std::stoi(it->second);
 
         // Read HTTP response body
-        temporary_buffer<char> buf = in.read_exactly(content_len).get0();
+        temporary_buffer<char> buf = in.read_exactly(content_len).get();
 
         return sstring(buf.get(), buf.size());
     });

--- a/locator/gce_snitch.cc
+++ b/locator/gce_snitch.cc
@@ -83,8 +83,8 @@ future<sstring> gce_snitch::gce_api_call(sstring addr, sstring cmd) {
     return seastar::async([addr = std::move(addr), cmd = std::move(cmd)] () -> sstring {
         using namespace boost::algorithm;
 
-        net::inet_address a = seastar::net::dns::resolve_name(addr, net::inet_address::family::INET).get0();
-        connected_socket sd(connect(socket_address(a, 80)).get0());
+        net::inet_address a = seastar::net::dns::resolve_name(addr, net::inet_address::family::INET).get();
+        connected_socket sd(connect(socket_address(a, 80)).get());
         input_stream<char> in(sd.input());
         output_stream<char> out(sd.output());
         auto close_in = deferred_close(in);
@@ -116,7 +116,7 @@ future<sstring> gce_snitch::gce_api_call(sstring addr, sstring cmd) {
         auto content_len = std::stoi(it->second);
 
         // Read HTTP response body
-        temporary_buffer<char> buf = in.read_exactly(content_len).get0();
+        temporary_buffer<char> buf = in.read_exactly(content_len).get();
 
         sstring res(buf.get(), buf.size());
         std::vector<std::string> splits;

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -24,7 +24,7 @@ future<bool> gossiping_property_file_snitch::property_file_was_modified() {
         });
     }).then_wrapped([this] (auto&& f) {
         try {
-            auto st = f.get0();
+            auto st = f.get();
 
             if (!_last_file_mod ||
                 _last_file_mod->tv_sec != st.st_mtim.tv_sec) {

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -1000,7 +1000,7 @@ messaging_service::make_sink_and_source_for_stream_mutation_fragments(table_sche
         auto rpc_handler = rpc()->make_client<rpc::source<int32_t> (streaming::plan_id, table_schema_version, table_id, uint64_t, streaming::stream_reason, service::session_id, rpc::sink<frozen_mutation_fragment, streaming::stream_mutation_fragments_cmd>)>(messaging_verb::STREAM_MUTATION_FRAGMENTS);
         return rpc_handler(*rpc_client , plan_id, schema_id, cf_id, estimated_partitions, reason, session, sink).then_wrapped([sink, rpc_client] (future<rpc::source<int32_t>> source) mutable {
             return (source.failed() ? sink.close() : make_ready_future<>()).then([sink = std::move(sink), source = std::move(source)] () mutable {
-                return make_ready_future<value_type>(value_type(std::move(sink), source.get0()));
+                return make_ready_future<value_type>(value_type(std::move(sink), source.get()));
             });
         });
     });
@@ -1030,7 +1030,7 @@ do_make_sink_source(messaging_verb verb, uint32_t repair_meta_id, shard_id dst_s
         }
         co_return coroutine::exception(std::move(ex));
     }
-    co_return value_type(std::move(sink), std::move(source_fut.get0()));
+    co_return value_type(std::move(sink), std::move(source_fut.get()));
 }
 
 // Wrapper for REPAIR_GET_ROW_DIFF_WITH_RPC_STREAM

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -726,7 +726,7 @@ future<page_consume_result<ResultBuilder>> read_page(
                 cmd.partition_limit, cmd.timestamp));
     if (!f.failed()) {
         // no exceptions are thrown in this block
-        auto result = std::move(f).get0();
+        auto result = std::move(f).get();
         const auto& cstats = compaction_state->stats();
         tracing::trace(trace_state, "Page stats: {} partition(s), {} static row(s) ({} live, {} dead), {} clustering row(s) ({} live, {} dead) and {} range tombstone(s)",
                 cstats.partitions,
@@ -775,7 +775,7 @@ future<typename ResultBuilder::result_type> do_query(
     if (f.failed()) {
         co_return coroutine::exception(f.get_exception());
     }
-    co_return f.get0();
+    co_return f.get();
 }
 
 template <typename ResultBuilder>

--- a/noexcept_traits.hh
+++ b/noexcept_traits.hh
@@ -23,7 +23,7 @@
 //   T val{};
 //   using traits = noexcept_movable<T>;
 //   auto f = make_ready_future<typename traits::type>(traits::wrap(std::move(val)));
-//   T val2 = traits::unwrap(f.get0());
+//   T val2 = traits::unwrap(f.get());
 //
 
 template<typename T>

--- a/readers/flat_mutation_reader_v2.hh
+++ b/readers/flat_mutation_reader_v2.hh
@@ -248,7 +248,7 @@ public:
                 auto do_stop = futurize_invoke([&consumer, mf = std::move(mf)] () mutable {
                     return consumer(std::move(mf));
                 });
-                if (do_stop.get0()) {
+                if (do_stop.get()) {
                     return;
                 }
             }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2030,7 +2030,7 @@ future<bool> table::snapshot_exists(sstring tag) {
     sstring jsondir = _config.datadir + "/snapshots/" + tag;
     return open_checked_directory(general_disk_error_handler, std::move(jsondir)).then_wrapped([] (future<file> f) {
         try {
-            f.get0();
+            f.get();
             return make_ready_future<bool>(true);
         } catch (std::system_error& e) {
             if (e.code() != std::error_code(ENOENT, std::system_category())) {
@@ -2046,7 +2046,7 @@ future<std::unordered_map<sstring, table::snapshot_details>> table::get_snapshot
         std::unordered_map<sstring, snapshot_details> all_snapshots;
         for (auto& datadir : _config.all_datadirs) {
             fs::path snapshots_dir = fs::path(datadir) / sstables::snapshots_dir;
-            auto file_exists = io_check([&snapshots_dir] { return seastar::file_exists(snapshots_dir.native()); }).get0();
+            auto file_exists = io_check([&snapshots_dir] { return seastar::file_exists(snapshots_dir.native()); }).get();
             if (!file_exists) {
                 continue;
             }
@@ -2072,7 +2072,7 @@ future<std::unordered_map<sstring, table::snapshot_details>> table::get_snapshot
                         return io_check(file_size, (fs::path(datadir) / name).native()).then_wrapped([&all_snapshots, snapshot_name, size] (auto fut) {
                             try {
                                 // File exists in the main SSTable directory. Snapshots are not contributing to size
-                                fut.get0();
+                                fut.get();
                             } catch (std::system_error& e) {
                                 if (e.code() != std::error_code(ENOENT, std::system_category())) {
                                     throw;

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -209,7 +209,7 @@ future<schema_ptr> schema_registry_entry::start_loading(async_schema_loader load
         }
         try {
             try {
-                load(f.get0());
+                load(f.get());
                 _registry.attach_table(*this);
             } catch (...) {
                 std::throw_with_nested(schema_version_loading_failed(_version));

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -116,7 +116,7 @@ void cache_hitrate_calculator::recalculate_timer() {
         if (f.failed()) {
             d = std::chrono::milliseconds(2000);
         } else {
-            d = f.get0();
+            d = f.get();
         }
         p->run_on((this_shard_id() + 1) % smp::count, d);
     });

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -92,7 +92,7 @@ future<prepare_response> paxos_state::prepare(storage_proxy& sp, db::system_keys
                         }
                         std::optional<std::variant<foreign_ptr<lw_shared_ptr<query::result>>, query::result_digest>> data_or_digest;
                         if (!f2.failed()) {
-                            auto&& [result, hit_rate] = f2.get0();
+                            auto&& [result, hit_rate] = f2.get();
                             if (only_digest) {
                                 data_or_digest = *result->digest();
                             } else {

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -119,7 +119,7 @@ future<> service_level_controller::update_service_levels_from_distributed_data()
             // to be able to agreggate those failures and only report when it is critical or noteworthy.
             // one common reason for failure is because one of the nodes comes down and before this node
             // detects it the scan query done inside this call is failing.
-            service_levels = _sl_data_accessor->get_service_levels().get0();
+            service_levels = _sl_data_accessor->get_service_levels().get();
 
             service_levels_info service_levels_for_add_or_update;
             service_levels_info service_levels_for_delete;
@@ -191,7 +191,7 @@ future<std::optional<service_level_options>> service_level_controller::find_serv
     return ::map_reduce(roles.begin(), roles.end(), [&role_manager, include_names, this] (const sstring& role) {
         return role_manager.get_attribute(role, "service_level").then_wrapped([include_names, this, role] (future<std::optional<sstring>> sl_name_fut) -> std::optional<service_level_options> {
             try {
-                std::optional<sstring> sl_name = sl_name_fut.get0();
+                std::optional<sstring> sl_name = sl_name_fut.get();
                 if (!sl_name) {
                     return std::nullopt;
                 }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4925,7 +4925,7 @@ protected:
                 std::exception_ptr ex;
                 try {
                   if (!f.failed()) {
-                    auto v = f.get0();
+                    auto v = f.get();
                     _cf->set_hit_rate(ep, std::get<1>(v));
                     resolver->add_mutate_data(ep, std::get<0>(std::move(v)));
                     ++_proxy->get_stats().mutation_data_read_completed.get_ep_stat(get_topology(), ep);
@@ -4951,7 +4951,7 @@ protected:
                 std::exception_ptr ex;
                 try {
                   if (!f.failed()) {
-                    auto v = f.get0();
+                    auto v = f.get();
                     _cf->set_hit_rate(ep, std::get<1>(v));
                     resolver->add_data(ep, std::get<0>(std::move(v)));
                     ++_proxy->get_stats().data_read_completed.get_ep_stat(get_topology(), ep);
@@ -4978,7 +4978,7 @@ protected:
                 std::exception_ptr ex;
                 try {
                   if (!f.failed()) {
-                    auto v = f.get0();
+                    auto v = f.get();
                     _cf->set_hit_rate(ep, std::get<2>(v));
                     resolver->add_digest(ep, std::get<0>(v), std::get<1>(v), std::get<3>(std::move(v)));
                     ++_proxy->get_stats().digest_read_completed.get_ep_stat(get_topology(), ep);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1688,7 +1688,7 @@ future<> storage_service::bootstrap(std::unordered_set<token>& bootstrap_tokens,
             // We don't do any other generation switches (unless we crash before complecting bootstrap).
             assert(!cdc_gen_id);
 
-            cdc_gen_id = _cdc_gens.local().legacy_make_new_generation(bootstrap_tokens, !is_first_node()).get0();
+            cdc_gen_id = _cdc_gens.local().legacy_make_new_generation(bootstrap_tokens, !is_first_node()).get();
 
             if (!bootstrap_rbno) {
                 // When is_repair_based_node_ops_enabled is true, the bootstrap node
@@ -2868,7 +2868,7 @@ future<std::unordered_map<sstring, std::vector<sstring>>> storage_service::descr
                 f.ignore_ready_future();
                 return std::pair<gms::inet_address, std::optional<table_schema_version>>(host, std::nullopt);
             }
-            return std::pair<gms::inet_address, std::optional<table_schema_version>>(host, f.get0());
+            return std::pair<gms::inet_address, std::optional<table_schema_version>>(host, f.get());
         });
     }, std::move(results), [] (auto results, auto host_and_version) {
         auto version = host_and_version.second ? host_and_version.second->to_sstring() : UNREACHABLE;
@@ -3038,7 +3038,7 @@ future<> storage_service::decommission() {
                 // For handling failure scenarios such as a group 0 member that is not a token ring member,
                 // there's `removenode`.
 
-                auto temp = tmptr->clone_after_all_left().get0();
+                auto temp = tmptr->clone_after_all_left().get();
                 auto num_tokens_after_all_left = temp.sorted_tokens().size();
                 temp.clear_gently().get();
                 if (num_tokens_after_all_left < 2) {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -873,8 +873,8 @@ public:
         auto rs = abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), params);
         if (auto&& tablet_rs = rs->maybe_as_tablet_aware()) {
             auto tm = _db.get_shared_token_metadata().get();
-            auto map = tablet_rs->allocate_tablets_for_new_table(s.shared_from_this(), tm, _config.initial_tablets_scale).get0();
-            muts.emplace_back(tablet_map_to_mutation(map, s.id(), s.keypace_name(), s.cf_name(), ts).get0());
+            auto map = tablet_rs->allocate_tablets_for_new_table(s.shared_from_this(), tm, _config.initial_tablets_scale).get();
+            muts.emplace_back(tablet_map_to_mutation(map, s.id(), s.keypace_name(), s.cf_name(), ts).get());
         }
     }
 

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -875,7 +875,7 @@ void writer::maybe_add_pi_block() {
 }
 
 void writer::init_file_writers() {
-    auto out = _sst._storage->make_data_or_index_sink(_sst, component_type::Data).get0();
+    auto out = _sst._storage->make_data_or_index_sink(_sst, component_type::Data).get();
 
     if (!_compression_enabled) {
         _data_writer = std::make_unique<crc32_checksummed_file_writer>(std::move(out), _sst.sstable_buffer_size, _sst.filename(component_type::Data));
@@ -887,7 +887,7 @@ void writer::init_file_writers() {
                 _schema.get_compressor_params()), _sst.filename(component_type::Data));
     }
 
-    out = _sst._storage->make_data_or_index_sink(_sst, component_type::Index).get0();
+    out = _sst._storage->make_data_or_index_sink(_sst, component_type::Index).get();
     _index_writer = std::make_unique<file_writer>(output_stream<char>(std::move(out)), _sst.filename(component_type::Index));
 }
 
@@ -967,7 +967,7 @@ void writer::maybe_record_large_partitions(const sstables::sstable& sst, const s
     auto& row_count_entry = _rows_in_partition_entry;
     size_entry.max_value = std::max(size_entry.max_value, partition_size);
     row_count_entry.max_value = std::max(row_count_entry.max_value, rows);
-    auto ret = _sst.get_large_data_handler().maybe_record_large_partitions(sst, partition_key, partition_size, rows).get0();
+    auto ret = _sst.get_large_data_handler().maybe_record_large_partitions(sst, partition_key, partition_size, rows).get();
     size_entry.above_threshold += unsigned(bool(ret.size));
     row_count_entry.above_threshold += unsigned(bool(ret.rows));
 }
@@ -978,7 +978,7 @@ void writer::maybe_record_large_rows(const sstables::sstable& sst, const sstable
     if (entry.max_value < row_size) {
         entry.max_value = row_size;
     }
-    if (_sst.get_large_data_handler().maybe_record_large_rows(sst, partition_key, clustering_key, row_size).get0()) {
+    if (_sst.get_large_data_handler().maybe_record_large_rows(sst, partition_key, clustering_key, row_size).get()) {
         entry.above_threshold++;
     };
 }
@@ -993,7 +993,7 @@ void writer::maybe_record_large_cells(const sstables::sstable& sst, const sstabl
     if (collection_elements_entry.max_value < collection_elements) {
         collection_elements_entry.max_value = collection_elements;
     }
-    if (_sst.get_large_data_handler().maybe_record_large_cells(_sst, *_partition_key, clustering_key, cdef, cell_size, collection_elements).get0()) {
+    if (_sst.get_large_data_handler().maybe_record_large_cells(_sst, *_partition_key, clustering_key, cdef, cell_size, collection_elements).get()) {
         if (cell_size > cell_size_entry.threshold) {
             cell_size_entry.above_threshold++;
         }

--- a/sstables/partition_index_cache.hh
+++ b/sstables/partition_index_cache.hh
@@ -221,7 +221,7 @@ public:
         return futurize_invoke(loader, key).then_wrapped([this, key, ptr = std::move(ptr)] (auto&& f) mutable {
             entry& e = ptr.get_entry();
             try {
-                partition_index_page&& page = f.get0();
+                partition_index_page&& page = f.get();
                 e.promise()->set_value();
                 e.set_page(std::move(page));
                 _stats.used_bytes += e.size_in_allocator();

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -575,9 +575,9 @@ future<std::pair<sstring, sstring>> sstable_directory::create_pending_deletion_l
             touch_directory(pending_delete_dir).get();
             auto oflags = open_flags::wo | open_flags::create | open_flags::exclusive;
             // Create temporary pending_delete log file.
-            auto f = open_file_dma(tmp_pending_delete_log, oflags).get0();
+            auto f = open_file_dma(tmp_pending_delete_log, oflags).get();
             // Write all toc names into the log file.
-            auto out = make_file_output_stream(std::move(f), 4096).get0();
+            auto out = make_file_output_stream(std::move(f), 4096).get();
             auto close_out = deferred_close(out);
 
             for (const auto& sst : ssts) {
@@ -589,7 +589,7 @@ future<std::pair<sstring, sstring>> sstable_directory::create_pending_deletion_l
             out.flush().get();
             close_out.close_now();
 
-            auto dir_f = open_directory(pending_delete_dir).get0();
+            auto dir_f = open_directory(pending_delete_dir).get();
             auto close_dir = deferred_close(dir_f);
             // Once flushed and closed, the temporary log file can be renamed.
             rename_file(tmp_pending_delete_log, pending_delete_log).get();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1009,7 +1009,7 @@ void sstable::do_write_simple(component_type type,
 
     file_output_stream_options options;
     options.buffer_size = buffer_size;
-    auto w = make_component_file_writer(type, std::move(options)).get0();
+    auto w = make_component_file_writer(type, std::move(options)).get();
     do_write_simple(std::move(w), std::move(write_component));
 }
 
@@ -1264,7 +1264,7 @@ void sstable::rewrite_statistics() {
     file_output_stream_options options;
     options.buffer_size = sstable_buffer_size;
     auto w = make_component_file_writer(component_type::TemporaryStatistics, std::move(options),
-            open_flags::wo | open_flags::create | open_flags::truncate).get0();
+            open_flags::wo | open_flags::create | open_flags::truncate).get();
     write(_version, w, _components->statistics);
     w.close();
     // rename() guarantees atomicity when renaming a file into place.
@@ -1546,7 +1546,7 @@ sharding_metadata
 create_sharding_metadata(schema_ptr schema, const dht::sharder& sharder, const dht::decorated_key& first_key, const dht::decorated_key& last_key, shard_id shard) {
     auto prange = dht::partition_range::make(dht::ring_position(first_key), dht::ring_position(last_key));
     auto sm = sharding_metadata();
-    auto&& ranges = dht::split_range_to_single_shard(*schema, sharder, prange, shard).get0();
+    auto&& ranges = dht::split_range_to_single_shard(*schema, sharder, prange, shard).get();
     if (ranges.empty()) {
         auto split_ranges_all_shards = dht::split_range_to_shards(prange, *schema, sharder);
         sstlog.warn("create_sharding_metadata: range={} has no intersection with shard={} first_key={} last_key={} ranges_single_shard={} ranges_all_shards={}",

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -129,7 +129,7 @@ future<file> filesystem_storage::open_component(const sstable& sst, component_ty
 }
 
 void filesystem_storage::open(sstable& sst) {
-    touch_temp_dir(sst).get0();
+    touch_temp_dir(sst).get();
     auto file_path = sst.filename(component_type::TemporaryTOC);
 
     // Writing TOC content to temporary file.
@@ -142,10 +142,10 @@ void filesystem_storage::open(sstable& sst) {
                                     open_flags::wo |
                                     open_flags::create |
                                     open_flags::exclusive,
-                                    options).get0();
+                                    options).get();
     auto w = file_writer(output_stream<char>(std::move(sink)), std::move(file_path));
 
-    bool toc_exists = file_exists(sst.filename(component_type::TOC)).get0();
+    bool toc_exists = file_exists(sst.filename(component_type::TOC)).get();
     if (toc_exists) {
         // TOC will exist at this point if write_components() was called with
         // the generation of a sstable that exists.
@@ -253,7 +253,7 @@ future<> filesystem_storage::check_create_links_replay(const sstable& sst, const
                         sstlog.error("Error while linking SSTable: {} to {}: {}", src, dst, eptr);
                         return make_exception_future<>(eptr);
                     }
-                    auto same = fut.get0();
+                    auto same = fut.get();
                     if (!same) {
                         auto msg = format("Error while linking SSTable: {} to {}: File exists", src, dst);
                         sstlog.error("{}", msg);

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -217,7 +217,7 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
                     sslog.log(level, "[Stream #{}] Failed to handle STREAM_MUTATION_FRAGMENTS (receive and distribute phase) for ks={}, cf={}, peer={}: {}",
                             plan_id, s->ks_name(), s->cf_name(), from.addr, ex);
                 } else {
-                    received_partitions = f.get0();
+                    received_partitions = f.get();
                 }
                 if (received_partitions) {
                     sslog.info("[Stream #{}] Write to sstable for ks={}, cf={}, estimated_partitions={}, received_partitions={}",
@@ -298,7 +298,7 @@ future<> stream_session::on_initialization_complete() {
     sslog.debug("[Stream #{}] SEND PREPARE_MESSAGE to {}", plan_id(), id);
     return manager().ms().send_prepare_message(id, std::move(prepare), plan_id(), description(), get_reason(), topo_guard()).then_wrapped([this, id] (auto&& f) {
         try {
-            auto msg = f.get0();
+            auto msg = f.get();
             sslog.debug("[Stream #{}] GOT PREPARE_MESSAGE Reply from {}", this->plan_id(), this->peer);
             this->dst_cpu_id = msg.dst_cpu_id;
             for (auto& summary : msg.summaries) {

--- a/test/boost/aggregate_fcts_test.cc
+++ b/test/boost/aggregate_fcts_test.cc
@@ -62,7 +62,7 @@ SEASTAR_TEST_CASE(test_aggregate_avg) {
                                  "avg(f), "
                                  "avg(g_0), "
                                  "avg(g_2), "
-                                 "avg(h) FROM test").get0();
+                                 "avg(h) FROM test").get();
 
         assert_that(msg).is_rows().with_size(1).with_row({{byte_type->decompose(int8_t(1))},
                                                           {short_type->decompose(int16_t(1))},
@@ -88,7 +88,7 @@ SEASTAR_TEST_CASE(test_aggregate_sum) {
                                  "sum(f), "
                                  "sum(g_0), "
                                  "sum(g_2), "
-                                 "sum(h) FROM test").get0();
+                                 "sum(h) FROM test").get();
 
         assert_that(msg).is_rows().with_size(1).with_row({{byte_type->decompose(int8_t(3))},
                                                           {short_type->decompose(int16_t(3))},
@@ -120,7 +120,7 @@ SEASTAR_TEST_CASE(test_aggregate_max) {
                                  "max(tm), "
                                  "max(tu), "
                                  "max(bl), "
-                                 "max(bo) FROM test").get0();
+                                 "max(bo) FROM test").get();
 
         assert_that(msg).is_rows().with_size(1).with_row({{byte_type->decompose(int8_t(2))},
                                                           {short_type->decompose(int16_t(2))},
@@ -159,7 +159,7 @@ SEASTAR_TEST_CASE(test_aggregate_min) {
                                  "min(tm), "
                                  "min(tu), "
                                  "min(bl), "
-                                 "min(bo) FROM test").get0();
+                                 "min(bo) FROM test").get();
 
         assert_that(msg).is_rows().with_size(1).with_row({{byte_type->decompose(int8_t(1))},
                                                           {short_type->decompose(int16_t(1))},
@@ -189,27 +189,27 @@ SEASTAR_TEST_CASE(test_aggregate_count) {
         e.execute_cql("INSERT INTO test(a, c, bl) VALUES (3, 3, 0x03)").get();
 
         {
-            auto msg = e.execute_cql("SELECT count(*) FROM test").get0();
+            auto msg = e.execute_cql("SELECT count(*) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{long_type->decompose(int64_t(3))}});
         }
         {
-            auto msg = e.execute_cql("SELECT count(a) FROM test").get0();
+            auto msg = e.execute_cql("SELECT count(a) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{long_type->decompose(int64_t(3))}});
         }
         {
-            auto msg = e.execute_cql("SELECT count(b) FROM test").get0();
+            auto msg = e.execute_cql("SELECT count(b) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{long_type->decompose(int64_t(1))}});
         }
         {
-            auto msg = e.execute_cql("SELECT count(c) FROM test").get0();
+            auto msg = e.execute_cql("SELECT count(c) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{long_type->decompose(int64_t(2))}});
         }
         {
-            auto msg = e.execute_cql("SELECT count(bo) FROM test").get0();
+            auto msg = e.execute_cql("SELECT count(bo) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{long_type->decompose(int64_t(2))}});
         }
         {
-            auto msg = e.execute_cql("SELECT count(a), count(b), count(c), count(bl), count(bo), count(*) FROM test").get0();
+            auto msg = e.execute_cql("SELECT count(a), count(b), count(c), count(bl), count(bo), count(*) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{long_type->decompose(int64_t(3))},
                                                               {long_type->decompose(int64_t(1))},
                                                               {long_type->decompose(int64_t(2))},
@@ -218,7 +218,7 @@ SEASTAR_TEST_CASE(test_aggregate_count) {
                                                               {long_type->decompose(int64_t(3))}});
         }
         {
-            auto msg = e.execute_cql("SELECT count(a), count(b), count(c), count(bo), count(*) FROM test LIMIT 1").get0();
+            auto msg = e.execute_cql("SELECT count(a), count(b), count(c), count(bo), count(*) FROM test LIMIT 1").get();
             assert_that(msg).is_rows().with_size(1).with_row({{long_type->decompose(int64_t(3))},
                                                               {long_type->decompose(int64_t(1))},
                                                               {long_type->decompose(int64_t(2))},
@@ -236,12 +236,12 @@ SEASTAR_TEST_CASE(test_reverse_type_aggregation) {
 
         {
             auto tp = db_clock::from_time_t(0) + std::chrono::milliseconds(1);
-            auto msg = e.execute_cql("SELECT min(c) FROM test").get0();
+            auto msg = e.execute_cql("SELECT min(c) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{timestamp_type->decompose(tp)}});
         }
         {
             auto tp = db_clock::from_time_t(0) + std::chrono::milliseconds(2);
-            auto msg = e.execute_cql("SELECT max(c) FROM test").get0();
+            auto msg = e.execute_cql("SELECT max(c) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{timestamp_type->decompose(tp)}});
         }
     });
@@ -257,14 +257,14 @@ SEASTAR_TEST_CASE(test_minmax_on_set) {
         const auto set_type_int = set_type_impl::get_instance(int32_type, true);
         const auto set_type_blob = set_type_impl::get_instance(bytes_type, true);
         {
-            const auto msg = e.execute_cql("SELECT max(s1), max(s2) FROM test;").get0();
+            const auto msg = e.execute_cql("SELECT max(s1), max(s2) FROM test;").get();
             assert_that(msg).is_rows().with_size(1).with_row({
                     set_type_int->decompose(make_set_value(set_type_int, {-1, 1})),
                     set_type_blob->decompose(make_set_value(set_type_blob, {"\x02", "\xfe"}))
             });
         }
         {
-            const auto msg = e.execute_cql("SELECT min(s1), min(s2) FROM test;").get0();
+            const auto msg = e.execute_cql("SELECT min(s1), min(s2) FROM test;").get();
             assert_that(msg).is_rows().with_size(1).with_row({
                     set_type_int->decompose(make_set_value(set_type_int, {-2, 2})),
                     set_type_blob->decompose(make_set_value(set_type_blob, {"\x01", "\xff"}))

--- a/test/boost/broken_sstable_test.cc
+++ b/test/boost/broken_sstable_test.cc
@@ -31,7 +31,7 @@ static future<> broken_sst(sstring dir, sstables::generation_type::int_t generat
     sstable_version_types version = la) {
   return sstables::test_env::do_with_async([=] (sstables::test_env& env) {
     try {
-        sstable_ptr sstp = env.reusable_sst(s, dir, generation, version).get0();
+        sstable_ptr sstp = env.reusable_sst(s, dir, generation, version).get();
         auto r = sstp->make_reader(s, env.make_reader_permit(), query::full_partition_range, s->full_slice());
         auto close_r = deferred_close(r);
         r.consume(my_consumer{}).get();
@@ -62,7 +62,7 @@ SEASTAR_TEST_CASE(test_empty_index) {
                  .set_compressor_params(compression_parameters::no_compression())
                  .build();
     future<sstable_ptr> fut = env.reusable_sst(s, "test/resource/sstables/empty_index", 36, sstable_version_types::mc);
-    BOOST_REQUIRE_EXCEPTION(fut.get0(), malformed_sstable_exception, exception_predicate::message_matches(
+    BOOST_REQUIRE_EXCEPTION(fut.get(), malformed_sstable_exception, exception_predicate::message_matches(
         "index_consume_entry_context \\(state=.*\\): cannot finish parsing current entry, no more data in sstable test/resource/sstables/empty_index/mc-36-big-Index.db"));
   });
 }

--- a/test/boost/cached_file_test.cc
+++ b/test/boost/cached_file_test.cc
@@ -28,7 +28,7 @@ static lru cf_lru;
 
 static sstring read_to_string(cached_file::stream& s, size_t limit = std::numeric_limits<size_t>::max()) {
     sstring b;
-    while (auto buf = s.next().get0()) {
+    while (auto buf = s.next().get()) {
         b += sstring(buf.get(), buf.size());
         if (b.size() >= limit) {
             break;
@@ -38,7 +38,7 @@ static sstring read_to_string(cached_file::stream& s, size_t limit = std::numeri
 }
 
 static void read_to_void(cached_file::stream& s, size_t limit = std::numeric_limits<size_t>::max()) {
-    while (auto buf = s.next().get0()) {
+    while (auto buf = s.next().get()) {
         if (buf.size() >= limit) {
             break;
         }
@@ -49,7 +49,7 @@ static void read_to_void(cached_file::stream& s, size_t limit = std::numeric_lim
 static sstring read_to_string(file& f, size_t start, size_t len) {
     file_input_stream_options opt;
     auto in = make_file_input_stream(f, start, len, opt);
-    auto buf = in.read_exactly(len).get0();
+    auto buf = in.read_exactly(len).get();
     return sstring(buf.get(), buf.size());
 }
 
@@ -79,16 +79,16 @@ test_file make_test_file(size_t size) {
     auto contents = tests::random::get_sstring(size);
 
     auto path = dir.path() / "file";
-    file f = open_file_dma(path.c_str(), open_flags::create | open_flags::rw).get0();
+    file f = open_file_dma(path.c_str(), open_flags::create | open_flags::rw).get();
 
     testlog.debug("file contents: {}", contents);
 
-    output_stream<char> out = make_file_output_stream(f).get0();
+    output_stream<char> out = make_file_output_stream(f).get();
     auto close_out = defer([&] { out.close().get(); });
     out.write(contents.begin(), contents.size()).get();
     out.flush().get();
 
-    f = open_file_dma(path.c_str(), open_flags::ro).get0();
+    f = open_file_dma(path.c_str(), open_flags::ro).get();
 
     return test_file{
         .dir = std::move(dir),

--- a/test/boost/castas_fcts_test.cc
+++ b/test/boost/castas_fcts_test.cc
@@ -65,7 +65,7 @@ auto test_explicit_type_casting_in_avg_function() {
             "  INSERT INTO air_quality_data(sensor_id, time, co_ppm) VALUES ('my_home', '2016-08-30 07:01:05', 31); \n"
             "  INSERT INTO air_quality_data(sensor_id, time, co_ppm) VALUES ('my_home', '2016-08-30 07:01:10', 20); \n"
             "apply batch;").get();
-            auto msg = e.execute_cql(format("select avg(CAST(co_ppm AS {})) from air_quality_data;", cql_type_name<RetType>::value)).get0();
+            auto msg = e.execute_cql(format("select avg(CAST(co_ppm AS {})) from air_quality_data;", cql_type_name<RetType>::value)).get();
             assert_that(msg).is_rows().with_size(1).with_row({{data_type_for<RetType>()->decompose( RetType(17 + 18 + 19 + 20 + 30 + 31 + 20) / RetType(7) )}});
     });
 }
@@ -113,7 +113,7 @@ SEASTAR_TEST_CASE(test_decimal_to_bigint) {
         e.execute_cql("INSERT INTO test (key, value) VALUES ('k8', -1)").get();
         e.execute_cql("INSERT INTO test (key, value) VALUES ('k9', -9223372036854775808)").get();
         e.execute_cql("INSERT INTO test (key, value) VALUES ('k10', -9223372036854775809)").get();
-        auto v = e.execute_cql("SELECT key,CAST(value as bigint) from test").get0();
+        auto v = e.execute_cql("SELECT key,CAST(value as bigint) from test").get();
         assert_that(v).is_rows().with_rows_ignore_order({
             {{utf8_type->decompose("k1")}, {long_type->decompose(std::numeric_limits<int64_t>::max())}},
             {{utf8_type->decompose("k2")}, {long_type->decompose(std::numeric_limits<int64_t>::min())}},
@@ -136,7 +136,7 @@ SEASTAR_TEST_CASE(test_decimal_to_float) {
         e.execute_cql("INSERT INTO test (key, value) VALUES ('k2', 1e1)").get();
         e.execute_cql("INSERT INTO test (key, value) VALUES ('k3', 100e-1)").get();
         e.execute_cql("INSERT INTO test (key, value) VALUES ('k4', -1e1)").get();
-        auto v = e.execute_cql("SELECT key, CAST(value as float) from test").get0();
+        auto v = e.execute_cql("SELECT key, CAST(value as float) from test").get();
         assert_that(v).is_rows().with_rows_ignore_order({
             {{serialized("k1")}, {serialized(float(10))}},
             {{serialized("k2")}, {serialized(float(10))}},
@@ -157,7 +157,7 @@ SEASTAR_TEST_CASE(test_varint_to_bigint) {
         e.execute_cql("INSERT INTO test (key, value) VALUES ('k6', -1)").get();
         e.execute_cql("INSERT INTO test (key, value) VALUES ('k7', -9223372036854775808)").get();
         e.execute_cql("INSERT INTO test (key, value) VALUES ('k8', -9223372036854775809)").get();
-        auto v = e.execute_cql("SELECT key,CAST(value as bigint) from test").get0();
+        auto v = e.execute_cql("SELECT key,CAST(value as bigint) from test").get();
         assert_that(v).is_rows().with_rows_ignore_order({
             {{utf8_type->decompose("k1")}, {long_type->decompose(std::numeric_limits<int64_t>::max())}},
             {{utf8_type->decompose("k2")}, {long_type->decompose(std::numeric_limits<int64_t>::min())}},
@@ -182,7 +182,7 @@ SEASTAR_TEST_CASE(test_varint_to_int) {
         e.execute_cql("INSERT INTO test (key, value) VALUES ('k6', -1)").get();
         e.execute_cql("INSERT INTO test (key, value) VALUES ('k7', -2147483648)").get();
         e.execute_cql("INSERT INTO test (key, value) VALUES ('k8', -2147483649)").get();
-        auto v = e.execute_cql("SELECT key,CAST(value as int) from test").get0();
+        auto v = e.execute_cql("SELECT key,CAST(value as int) from test").get();
         assert_that(v).is_rows().with_rows_ignore_order({
             {{utf8_type->decompose("k1")}, {int32_type->decompose(std::numeric_limits<int32_t>::max())}},
             {{utf8_type->decompose("k2")}, {int32_type->decompose(std::numeric_limits<int32_t>::min())}},
@@ -218,7 +218,7 @@ SEASTAR_TEST_CASE(test_numeric_casts_in_selection_clause) {
                                      "CAST(f AS tinyint), "
                                      "CAST(g AS tinyint), "
                                      "CAST(h AS tinyint), "
-                                     "CAST(i AS tinyint) FROM test").get0();
+                                     "CAST(i AS tinyint) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{byte_type->decompose(int8_t(1))},
                                                               {byte_type->decompose(int8_t(2))},
                                                               {byte_type->decompose(int8_t(3))},
@@ -238,7 +238,7 @@ SEASTAR_TEST_CASE(test_numeric_casts_in_selection_clause) {
                                      "CAST(f AS smallint), "
                                      "CAST(g AS smallint), "
                                      "CAST(h AS smallint), "
-                                     "CAST(i AS smallint) FROM test").get0();
+                                     "CAST(i AS smallint) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{short_type->decompose(int16_t(1))},
                                                               {short_type->decompose(int16_t(2))},
                                                               {short_type->decompose(int16_t(3))},
@@ -258,7 +258,7 @@ SEASTAR_TEST_CASE(test_numeric_casts_in_selection_clause) {
                                      "CAST(f AS int), "
                                      "CAST(g AS int), "
                                      "CAST(h AS int), "
-                                     "CAST(i AS int) FROM test").get0();
+                                     "CAST(i AS int) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{int32_type->decompose(int32_t(1))},
                                                               {int32_type->decompose(int32_t(2))},
                                                               {int32_type->decompose(int32_t(3))},
@@ -278,7 +278,7 @@ SEASTAR_TEST_CASE(test_numeric_casts_in_selection_clause) {
                                      "CAST(f AS bigint), "
                                      "CAST(g AS bigint), "
                                      "CAST(h AS bigint), "
-                                     "CAST(i AS bigint) FROM test").get0();
+                                     "CAST(i AS bigint) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{long_type->decompose(int64_t(1))},
                                                               {long_type->decompose(int64_t(2))},
                                                               {long_type->decompose(int64_t(3))},
@@ -298,7 +298,7 @@ SEASTAR_TEST_CASE(test_numeric_casts_in_selection_clause) {
                                      "CAST(f AS float), "
                                      "CAST(g AS float), "
                                      "CAST(h AS float), "
-                                     "CAST(i AS float) FROM test").get0();
+                                     "CAST(i AS float) FROM test").get();
             // Conversions that include floating point cannot be compared with assert_that(), because result
             //   of such conversions may be slightly different from theoretical values.
             auto cmp = [&](::size_t index, float req) {
@@ -329,7 +329,7 @@ SEASTAR_TEST_CASE(test_numeric_casts_in_selection_clause) {
                                      "CAST(f AS double), "
                                      "CAST(g AS double), "
                                      "CAST(h AS double), "
-                                     "CAST(i AS double) FROM test").get0();
+                                     "CAST(i AS double) FROM test").get();
             // Conversions that include floating points cannot be compared with assert_that(), because result
             //   of such conversions may be slightly different from theoretical values.
             auto cmp = [&](::size_t index, double req) {
@@ -360,7 +360,7 @@ SEASTAR_TEST_CASE(test_numeric_casts_in_selection_clause) {
                                      "CAST(f AS decimal), "
                                      "CAST(g AS decimal), "
                                      "CAST(h AS decimal), "
-                                     "CAST(i AS decimal) FROM test").get0();
+                                     "CAST(i AS decimal) FROM test").get();
             // Conversions that include floating points cannot be compared with assert_that(), because result
             //   of such conversions may be slightly different from theoretical values.
             auto cmp = [&](::size_t index, double req) {
@@ -391,7 +391,7 @@ SEASTAR_TEST_CASE(test_numeric_casts_in_selection_clause) {
                                      "CAST(f AS ascii), "
                                      "CAST(g AS ascii), "
                                      "CAST(h AS ascii), "
-                                     "CAST(i AS ascii) FROM test").get0();
+                                     "CAST(i AS ascii) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{ascii_type->decompose("1")},
                                                               {ascii_type->decompose("2")},
                                                               {ascii_type->decompose("3")},
@@ -411,7 +411,7 @@ SEASTAR_TEST_CASE(test_numeric_casts_in_selection_clause) {
                                      "CAST(f AS text), "
                                      "CAST(g AS text), "
                                      "CAST(h AS text), "
-                                     "CAST(i AS text) FROM test").get0();
+                                     "CAST(i AS text) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{utf8_type->decompose("1")},
                                                               {utf8_type->decompose("2")},
                                                               {utf8_type->decompose("3")},
@@ -438,7 +438,7 @@ SEASTAR_TEST_CASE(test_integers_to_decimal_casts_in_selection_clause) {
                                  "CAST(b AS decimal), "
                                  "CAST(c AS decimal), "
                                  "CAST(d AS decimal), "
-                                 "CAST(h AS decimal) FROM test").get0();
+                                 "CAST(h AS decimal) FROM test").get();
 
         auto cmp = [&](::size_t index, auto x) {
             auto row = dynamic_cast<cql_transport::messages::result_message::rows&>(*msg).rs().result_set().rows().front();
@@ -468,7 +468,7 @@ SEASTAR_TEST_CASE(test_integers_to_decimal_casts_with_avg_in_selection_clause) {
                                  "CAST(avg(CAST(b AS decimal)) AS text), "
                                  "CAST(avg(CAST(c AS decimal)) AS text), "
                                  "CAST(avg(CAST(d AS decimal)) AS text), "
-                                 "CAST(avg(CAST(h AS decimal)) AS text) FROM test").get0();
+                                 "CAST(avg(CAST(h AS decimal)) AS text) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{utf8_type->decompose("1.5")},
                                                               {utf8_type->decompose("2.5")},
                                                               {utf8_type->decompose("3.5")},
@@ -486,35 +486,35 @@ SEASTAR_TEST_CASE(test_time_casts_in_selection_clause) {
 
         e.execute_cql("INSERT INTO test (a, b, c, d) VALUES (d2177dd0-eaa2-11de-a572-001b779c76e3, '2015-05-21 11:03:02+00', '2015-05-21', '11:03:02')").get();
         {
-            auto msg = e.execute_cql("SELECT CAST(a AS timestamp), CAST(a AS date), CAST(b as date), CAST(c AS timestamp) FROM test").get0();
+            auto msg = e.execute_cql("SELECT CAST(a AS timestamp), CAST(a AS date), CAST(b as date), CAST(c AS timestamp) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{timestamp_type->from_string("2009-12-17t00:26:29.805+00")},
                                                               {simple_date_type->from_string("2009-12-17")},
                                                               {simple_date_type->from_string("2015-05-21")},
                                                               {timestamp_type->from_string("2015-05-21t00:00:00+00")}});
         }
         {
-            auto msg = e.execute_cql("SELECT CAST(CAST(a AS timestamp) AS text), CAST(CAST(a AS date) AS text), CAST(CAST(b as date) AS text), CAST(CAST(c AS timestamp) AS text) FROM test").get0();
+            auto msg = e.execute_cql("SELECT CAST(CAST(a AS timestamp) AS text), CAST(CAST(a AS date) AS text), CAST(CAST(b as date) AS text), CAST(CAST(c AS timestamp) AS text) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{utf8_type->from_string("2009-12-17T00:26:29.805Z")},
                                                               {utf8_type->from_string("2009-12-17")},
                                                               {utf8_type->from_string("2015-05-21")},
                                                               {utf8_type->from_string("2015-05-21T00:00:00.000Z")}});
         }
         {
-            auto msg = e.execute_cql("SELECT CAST(a AS text), CAST(b as text), CAST(c AS text), CAST(d AS text) FROM test").get0();
+            auto msg = e.execute_cql("SELECT CAST(a AS text), CAST(b as text), CAST(c AS text), CAST(d AS text) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{utf8_type->from_string("d2177dd0-eaa2-11de-a572-001b779c76e3")},
                                                               {utf8_type->from_string("2015-05-21T11:03:02.000Z")},
                                                               {utf8_type->from_string("2015-05-21")},
                                                               {utf8_type->from_string("11:03:02.000000000")}});
         }
         {
-            auto msg = e.execute_cql("SELECT CAST(CAST(a AS timestamp) AS ascii), CAST(CAST(a AS date) AS ascii), CAST(CAST(b as date) AS ascii), CAST(CAST(c AS timestamp) AS ascii) FROM test").get0();
+            auto msg = e.execute_cql("SELECT CAST(CAST(a AS timestamp) AS ascii), CAST(CAST(a AS date) AS ascii), CAST(CAST(b as date) AS ascii), CAST(CAST(c AS timestamp) AS ascii) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{ascii_type->from_string("2009-12-17T00:26:29.805Z")},
                                                               {ascii_type->from_string("2009-12-17")},
                                                               {ascii_type->from_string("2015-05-21")},
                                                               {ascii_type->from_string("2015-05-21T00:00:00.000Z")}});
         }
         {
-            auto msg = e.execute_cql("SELECT CAST(a AS ascii), CAST(b as ascii), CAST(c AS ascii), CAST(d AS ascii) FROM test").get0();
+            auto msg = e.execute_cql("SELECT CAST(a AS ascii), CAST(b as ascii), CAST(c AS ascii), CAST(d AS ascii) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{ascii_type->from_string("d2177dd0-eaa2-11de-a572-001b779c76e3")},
                                                               {ascii_type->from_string("2015-05-21T11:03:02.000Z")},
                                                               {ascii_type->from_string("2015-05-21")},
@@ -530,13 +530,13 @@ SEASTAR_TEST_CASE(test_other_type_casts_in_selection_clause) {
                       "c boolean)").get();
         e.execute_cql("INSERT INTO test (a, b, c) VALUES ('test', '127.0.0.1', true)").get();
         {
-            auto msg = e.execute_cql("SELECT CAST(a AS text), CAST(b as text), CAST(c AS text) FROM test").get0();
+            auto msg = e.execute_cql("SELECT CAST(a AS text), CAST(b as text), CAST(c AS text) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{utf8_type->from_string("test")},
                                                               {utf8_type->from_string("127.0.0.1")},
                                                               {utf8_type->from_string("true")}});
         }
         {
-            auto msg = e.execute_cql("SELECT CAST(a AS ascii), CAST(b as ascii), CAST(c AS ascii) FROM test").get0();
+            auto msg = e.execute_cql("SELECT CAST(a AS ascii), CAST(b as ascii), CAST(c AS ascii) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{ascii_type->from_string("test")},
                                                               {ascii_type->from_string("127.0.0.1")},
                                                               {ascii_type->from_string("true")}});
@@ -552,31 +552,31 @@ SEASTAR_TEST_CASE(test_casts_with_revrsed_order_in_selection_clause) {
                       "primary key (a, b)) WITH CLUSTERING ORDER BY (b DESC)").get();
         e.execute_cql("INSERT INTO test (a, b, c) VALUES (1, 2, 6.3)").get();
         {
-            auto msg = e.execute_cql("SELECT CAST(a AS tinyint), CAST(b as tinyint), CAST(c AS tinyint) FROM test").get0();
+            auto msg = e.execute_cql("SELECT CAST(a AS tinyint), CAST(b as tinyint), CAST(c AS tinyint) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{byte_type->from_string("1")},
                                                               {byte_type->from_string("2")},
                                                               {byte_type->from_string("6")}});
         }
         {
-            auto msg = e.execute_cql("SELECT CAST(a AS smallint), CAST(b as smallint), CAST(c AS smallint) FROM test").get0();
+            auto msg = e.execute_cql("SELECT CAST(a AS smallint), CAST(b as smallint), CAST(c AS smallint) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{short_type->from_string("1")},
                                                               {short_type->from_string("2")},
                                                               {short_type->from_string("6")}});
         }
         {
-            auto msg = e.execute_cql("SELECT CAST(a AS double), CAST(b as double), CAST(c AS double) FROM test").get0();
+            auto msg = e.execute_cql("SELECT CAST(a AS double), CAST(b as double), CAST(c AS double) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{double_type->from_string("1")},
                                                               {double_type->from_string("2")},
                                                               {double_type->from_string("6.3")}});
         }
         {
-            auto msg = e.execute_cql("SELECT CAST(a AS text), CAST(b as text), CAST(c AS text) FROM test").get0();
+            auto msg = e.execute_cql("SELECT CAST(a AS text), CAST(b as text), CAST(c AS text) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{utf8_type->from_string("1")},
                                                               {utf8_type->from_string("2")},
                                                               {utf8_type->from_string("6.3")}});
         }
         {
-            auto msg = e.execute_cql("SELECT CAST(a AS ascii), CAST(b as ascii), CAST(c AS ascii) FROM test").get0();
+            auto msg = e.execute_cql("SELECT CAST(a AS ascii), CAST(b as ascii), CAST(c AS ascii) FROM test").get();
             assert_that(msg).is_rows().with_size(1).with_row({{ascii_type->from_string("1")},
                                                               {ascii_type->from_string("2")},
                                                               {ascii_type->from_string("6.3")}});

--- a/test/boost/cell_locker_test.cc
+++ b/test/boost/cell_locker_test.cc
@@ -97,12 +97,12 @@ SEASTAR_TEST_CASE(test_simple_locking_cells) {
             make_row("two", { "r2", "r3" }),
         });
 
-        auto l1 = cl.lock_cells(m.decorated_key(), partition_cells_range(m.partition()), no_timeout).get0();
+        auto l1 = cl.lock_cells(m.decorated_key(), partition_cells_range(m.partition()), no_timeout).get();
         auto f2 = cl.lock_cells(m.decorated_key(), partition_cells_range(m.partition()), no_timeout);
         BOOST_REQUIRE(!f2.available());
 
         destroy(std::move(l1));
-        destroy(f2.get0());
+        destroy(f2.get());
     });
 }
 
@@ -124,9 +124,9 @@ SEASTAR_TEST_CASE(test_disjoint_mutations) {
         auto m3 = mutation(s, partition_key::from_single_value(*s, to_bytes("1")));
         m3.partition() = mutation_partition(*s, m1.partition());
 
-        auto l1 = cl.lock_cells(m1.decorated_key(), partition_cells_range(m1.partition()), no_timeout).get0();
-        auto l2 = cl.lock_cells(m2.decorated_key(), partition_cells_range(m2.partition()), no_timeout).get0();
-        auto l3 = cl.lock_cells(m3.decorated_key(), partition_cells_range(m3.partition()), no_timeout).get0();
+        auto l1 = cl.lock_cells(m1.decorated_key(), partition_cells_range(m1.partition()), no_timeout).get();
+        auto l2 = cl.lock_cells(m2.decorated_key(), partition_cells_range(m2.partition()), no_timeout).get();
+        auto l3 = cl.lock_cells(m3.decorated_key(), partition_cells_range(m3.partition()), no_timeout).get();
     });
 }
 
@@ -151,15 +151,15 @@ SEASTAR_TEST_CASE(test_single_cell_overlap) {
                 make_row("one", { "r2", "r3" }),
         });
 
-        auto l1 = cl.lock_cells(m1.decorated_key(), partition_cells_range(m1.partition()), no_timeout).get0();
+        auto l1 = cl.lock_cells(m1.decorated_key(), partition_cells_range(m1.partition()), no_timeout).get();
         auto f2 = cl.lock_cells(m2.decorated_key(), partition_cells_range(m2.partition()), no_timeout);
         BOOST_REQUIRE(!f2.available());
         destroy(std::move(l1));
-        auto l2 = f2.get0();
+        auto l2 = f2.get();
         auto f3 = cl.lock_cells(m3.decorated_key(), partition_cells_range(m3.partition()), no_timeout);
         BOOST_REQUIRE(!f3.available());
         destroy(std::move(l2));
-        auto l3 = f3.get0();
+        auto l3 = f3.get();
     });
 }
 
@@ -187,17 +187,17 @@ SEASTAR_TEST_CASE(test_schema_change) {
                 make_row("one", { "r1", "r3" }),
         });
 
-        auto l1 = cl.lock_cells(m1.decorated_key(), partition_cells_range(m1.partition()), no_timeout).get0();
+        auto l1 = cl.lock_cells(m1.decorated_key(), partition_cells_range(m1.partition()), no_timeout).get();
 
         destroy(std::move(m1));
         destroy(std::move(s1));
         cl.set_schema(s2);
 
-        auto l2 = cl.lock_cells(m2.decorated_key(), partition_cells_range(m2.partition()), no_timeout).get0();
+        auto l2 = cl.lock_cells(m2.decorated_key(), partition_cells_range(m2.partition()), no_timeout).get();
         auto f3 = cl.lock_cells(m3.decorated_key(), partition_cells_range(m3.partition()), no_timeout);
         BOOST_REQUIRE(!f3.available());
         destroy(std::move(l1));
-        auto l3 = f3.get0();
+        auto l3 = f3.get();
 
         auto s3 = make_schema_disjoint_with_others();
         cl.set_schema(s3);
@@ -206,7 +206,7 @@ SEASTAR_TEST_CASE(test_schema_change) {
                 make_row("one", { "r8", "r9" }),
                 make_row("two", { "r8", "r9" }),
         });
-        auto l4 = cl.lock_cells(m4.decorated_key(), partition_cells_range(m4.partition()), no_timeout).get0();
+        auto l4 = cl.lock_cells(m4.decorated_key(), partition_cells_range(m4.partition()), no_timeout).get();
     });
 }
 
@@ -225,17 +225,17 @@ SEASTAR_TEST_CASE(test_timed_out) {
                     make_row("one", { "r1", "r2" }),
             });
 
-            auto l1 = cl.lock_cells(m1.decorated_key(), partition_cells_range(m1.partition()), no_timeout).get0();
+            auto l1 = cl.lock_cells(m1.decorated_key(), partition_cells_range(m1.partition()), no_timeout).get();
 
             auto timeout = db::timeout_clock::now();
             forward_jump_clocks(1h);
-            BOOST_REQUIRE_THROW(cl.lock_cells(m2.decorated_key(), partition_cells_range(m2.partition()), timeout).get0(),
+            BOOST_REQUIRE_THROW(cl.lock_cells(m2.decorated_key(), partition_cells_range(m2.partition()), timeout).get(),
                                 timed_out_error);
 
             auto f2 = cl.lock_cells(m2.decorated_key(), partition_cells_range(m2.partition()), no_timeout);
             BOOST_REQUIRE(!f2.available());
             destroy(std::move(l1));
-            auto l2 = f2.get0();
+            auto l2 = f2.get();
         });
 }
 
@@ -255,7 +255,7 @@ SEASTAR_TEST_CASE(test_locker_stats) {
                 make_row("one", { "r2", "r3" }),
         });
 
-        auto l1 = cl.lock_cells(m1.decorated_key(), partition_cells_range(m1.partition()), no_timeout).get0();
+        auto l1 = cl.lock_cells(m1.decorated_key(), partition_cells_range(m1.partition()), no_timeout).get();
         BOOST_REQUIRE_EQUAL(cl_stats.lock_acquisitions, 4);
         BOOST_REQUIRE_EQUAL(cl_stats.operations_waiting_for_lock, 0);
 
@@ -265,7 +265,7 @@ SEASTAR_TEST_CASE(test_locker_stats) {
         BOOST_REQUIRE(!f2.available());
 
         destroy(std::move(l1));
-        destroy(f2.get0());
+        destroy(f2.get());
         BOOST_REQUIRE_EQUAL(cl_stats.lock_acquisitions, 8);
         BOOST_REQUIRE_EQUAL(cl_stats.operations_waiting_for_lock, 0);
     });

--- a/test/boost/column_mapping_test.cc
+++ b/test/boost/column_mapping_test.cc
@@ -30,14 +30,14 @@ SEASTAR_TEST_CASE(test_column_mapping_persistence) {
 
         // Check that stored column mapping is correctly serialized and deserialized
         column_mapping cm;
-        BOOST_REQUIRE_NO_THROW(cm = db::schema_tables::get_column_mapping(e.get_system_keyspace().local(), table_id, v1).get0());
+        BOOST_REQUIRE_NO_THROW(cm = db::schema_tables::get_column_mapping(e.get_system_keyspace().local(), table_id, v1).get());
         BOOST_REQUIRE_EQUAL(orig_cm, cm);
 
         // Alter the test table and check that new column mapping is also inserted for the new schema version
         cquery_nofail(e, "alter table test ADD dummy int");
         auto altered_schema = e.local_db().find_schema("ks", "test");
         column_mapping altered_cm;
-        BOOST_REQUIRE_NO_THROW(altered_cm = db::schema_tables::get_column_mapping(e.get_system_keyspace().local(), table_id, altered_schema->version()).get0());
+        BOOST_REQUIRE_NO_THROW(altered_cm = db::schema_tables::get_column_mapping(e.get_system_keyspace().local(), table_id, altered_schema->version()).get());
         BOOST_REQUIRE_EQUAL(altered_schema->get_column_mapping(), altered_cm);
     });
 }

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -946,7 +946,7 @@ SEASTAR_TEST_CASE(test_commitlog_replay_invalid_key){
         {
             auto paths = cl.get_active_segment_names();
             BOOST_REQUIRE(!paths.empty());
-            auto rp = db::commitlog_replayer::create_replayer(env.db(), env.get_system_keyspace()).get0();
+            auto rp = db::commitlog_replayer::create_replayer(env.db(), env.get_system_keyspace()).get();
             rp.recover(paths, db::commitlog::descriptor::FILENAME_PREFIX).get();
         }
 
@@ -959,11 +959,11 @@ SEASTAR_TEST_CASE(test_commitlog_replay_invalid_key){
             }
             auto rd = make_combined_reader(s, permit, std::move(readers));
             auto close_rd = deferred_close(rd);
-            auto mopt = read_mutation_from_flat_mutation_reader(rd).get0();
+            auto mopt = read_mutation_from_flat_mutation_reader(rd).get();
             BOOST_REQUIRE(mopt);
 
             mopt = {};
-            mopt = read_mutation_from_flat_mutation_reader(rd).get0();
+            mopt = read_mutation_from_flat_mutation_reader(rd).get();
             BOOST_REQUIRE(!mopt);
         }
     });
@@ -994,7 +994,7 @@ SEASTAR_TEST_CASE(test_commitlog_add_entry) {
                 std::set<segment_id_type> ids;
 
                 for (auto& w : writers) {
-                    auto h = log.add_entry(w.schema()->id(), w, db::timeout_clock::now() + 60s).get0();
+                    auto h = log.add_entry(w.schema()->id(), w, db::timeout_clock::now() + 60s).get();
                     ids.emplace(h.rp().id);
                     rps.emplace_back(h.rp());
                 }
@@ -1054,7 +1054,7 @@ SEASTAR_TEST_CASE(test_commitlog_add_entries) {
                     writers.emplace_back(gen.schema(), mutations.back(), fs);
                 }
 
-                auto res = log.add_entries(writers, db::timeout_clock::now() + 60s).get0();
+                auto res = log.add_entries(writers, db::timeout_clock::now() + 60s).get();
 
                 std::set<segment_id_type> ids;
                 for (auto& h : res) {

--- a/test/boost/cql_functions_test.cc
+++ b/test/boost/cql_functions_test.cc
@@ -128,7 +128,7 @@ struct aggregate_function_test {
         return tbl_name;
     }
     void call_function_and_expect(const char* fname, data_type type, data_value expected) {
-        auto msg = _e.execute_cql(format("select {}(value) from {}", fname, table_name())).get0();
+        auto msg = _e.execute_cql(format("select {}(value) from {}", fname, table_name())).get();
         assert_that(msg).is_rows()
             .with_size(1)
             .with_column_types({type})
@@ -150,7 +150,7 @@ public:
                     .build();
         }).get();
 
-        auto prepared = _e.prepare(format("insert into {} (pk, ck, value) values ('key1', ?, ?)", cf_name)).get0();
+        auto prepared = _e.prepare(format("insert into {} (pk, ck, value) values ('key1', ?, ?)", cf_name)).get();
         for (int i = 0; i < (int)_sorted_values.size(); i++) {
             const auto& value = _sorted_values[i];
             BOOST_ASSERT(&*value.type() == &*_column_type);

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -63,7 +63,7 @@ SEASTAR_THREAD_TEST_CASE(test_large_collection) {
         }
 
         flush(e);
-        assert_that(e.execute_cql("select partition_key, column_name from system.large_cells where table_name = 'tbl' allow filtering;").get0())
+        assert_that(e.execute_cql("select partition_key, column_name from system.large_cells where table_name = 'tbl' allow filtering;").get())
             .is_rows()
             .with_size(1)
             .with_row({"42", "b", "tbl"});
@@ -83,7 +83,7 @@ SEASTAR_THREAD_TEST_CASE(test_large_data) {
         e.execute_cql("insert into tbl (a, b) values (44, '" + blob + "');").get();
         flush(e);
 
-        shared_ptr<cql_transport::messages::result_message> msg = e.execute_cql("select partition_key, row_size from system.large_rows where table_name = 'tbl' allow filtering;").get0();
+        shared_ptr<cql_transport::messages::result_message> msg = e.execute_cql("select partition_key, row_size from system.large_rows where table_name = 'tbl' allow filtering;").get();
         auto res = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg);
         auto rows = res->rs().result_set().rows();
 
@@ -103,7 +103,7 @@ SEASTAR_THREAD_TEST_CASE(test_large_data) {
         BOOST_REQUIRE(row_size > 1024*1024 && row_size < 1025*1024);
 
         // Check that it was added to system.large_cells too
-        assert_that(e.execute_cql("select partition_key, column_name from system.large_cells where table_name = 'tbl' allow filtering;").get0())
+        assert_that(e.execute_cql("select partition_key, column_name from system.large_cells where table_name = 'tbl' allow filtering;").get())
             .is_rows()
             .with_size(1)
             .with_row({"44", "b", "tbl"});
@@ -121,10 +121,10 @@ SEASTAR_THREAD_TEST_CASE(test_large_data) {
             });
         }).get();
 
-        assert_that(e.execute_cql("select partition_key from system.large_rows where table_name = 'tbl' allow filtering;").get0())
+        assert_that(e.execute_cql("select partition_key from system.large_rows where table_name = 'tbl' allow filtering;").get())
             .is_rows()
             .is_empty();
-        assert_that(e.execute_cql("select partition_key from system.large_cells where table_name = 'tbl' allow filtering;").get0())
+        assert_that(e.execute_cql("select partition_key from system.large_cells where table_name = 'tbl' allow filtering;").get())
             .is_rows()
             .is_empty();
 
@@ -149,13 +149,13 @@ SEASTAR_TEST_CASE(test_insert_large_collection_values) {
             }).get();
             sstring long_value(std::numeric_limits<uint16_t>::max() + 10, 'x');
             e.execute_cql(format("INSERT INTO tbl (pk, l) VALUES ('Zamyatin', ['{}']);", long_value)).get();
-            assert_that(e.execute_cql("SELECT l FROM tbl WHERE pk ='Zamyatin';").get0())
+            assert_that(e.execute_cql("SELECT l FROM tbl WHERE pk ='Zamyatin';").get())
                     .is_rows().with_rows({
                             { make_list_value(list_type, list_type_impl::native_type({{long_value}})).serialize() }
                     });
             BOOST_REQUIRE_THROW(e.execute_cql(format("INSERT INTO tbl (pk, s) VALUES ('Orwell', {{'{}'}});", long_value)).get(), std::exception);
             e.execute_cql(format("INSERT INTO tbl (pk, m) VALUES ('Haksli', {{'key': '{}'}});", long_value)).get();
-            assert_that(e.execute_cql("SELECT m FROM tbl WHERE pk ='Haksli';").get0())
+            assert_that(e.execute_cql("SELECT m FROM tbl WHERE pk ='Haksli';").get())
                     .is_rows().with_rows({
                             { make_map_value(map_type, map_type_impl::native_type({{sstring("key"), long_value}})).serialize() }
                     });

--- a/test/boost/cql_query_like_test.cc
+++ b/test/boost/cql_query_like_test.cc
@@ -110,7 +110,7 @@ SEASTAR_TEST_CASE(test_like_operator_bind_marker) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         cquery_nofail(e, "create table t (s text primary key, )");
         cquery_nofail(e, "insert into t (s) values ('abc')");
-        auto stmt = e.prepare("select s from t where s like ? allow filtering").get0();
+        auto stmt = e.prepare("select s from t where s like ? allow filtering").get();
         require_rows(e, stmt, {cql3::raw_value::make_value(T("_b_"))}, {{T("abc")}});
         require_rows(e, stmt, {cql3::raw_value::make_value(T("%g"))}, {});
         require_rows(e, stmt, {cql3::raw_value::make_value(T("%c"))}, {{T("abc")}});

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -77,7 +77,7 @@ SEASTAR_TEST_CASE(test_create_table_with_id_statement) {
         BOOST_REQUIRE_THROW(e.execute_cql("SELECT * FROM tbl").get(), std::exception);
         e.execute_cql(
             format("CREATE TABLE tbl (a int, b int, PRIMARY KEY (a)) WITH id='{}'", id)).get();
-        assert_that(e.execute_cql("SELECT * FROM tbl").get0())
+        assert_that(e.execute_cql("SELECT * FROM tbl").get())
             .is_rows().with_size(0);
         BOOST_REQUIRE_THROW(
             e.execute_cql(format("CREATE TABLE tbl2 (a int, b int, PRIMARY KEY (a)) WITH id='{}'", id)).get(),
@@ -279,7 +279,7 @@ SEASTAR_TEST_CASE(test_list_elements_validation) {
         test_inline("definitely not a date value", true);
         test_inline("2015-05-03", false);
         e.execute_cql("CREATE TABLE tbl2 (a int, b list<text>, PRIMARY KEY (a))").get();
-        auto id = e.prepare("INSERT INTO tbl2 (a, b) VALUES(?, ?)").get0();
+        auto id = e.prepare("INSERT INTO tbl2 (a, b) VALUES(?, ?)").get();
         auto test_bind = [&] (sstring value, bool should_throw) {
             auto my_list_type = list_type_impl::get_instance(utf8_type, true);
             std::vector<cql3::raw_value> raw_values;
@@ -313,7 +313,7 @@ SEASTAR_TEST_CASE(test_set_elements_validation) {
         test_inline("definitely not a date value", true);
         test_inline("2015-05-03", false);
         e.execute_cql("CREATE TABLE tbl2 (a int, b set<text>, PRIMARY KEY (a))").get();
-        auto id = e.prepare("INSERT INTO tbl2 (a, b) VALUES(?, ?)").get0();
+        auto id = e.prepare("INSERT INTO tbl2 (a, b) VALUES(?, ?)").get();
         auto test_bind = [&] (sstring value, bool should_throw) {
             auto my_set_type = set_type_impl::get_instance(utf8_type, true);
             std::vector<cql3::raw_value> raw_values;
@@ -350,7 +350,7 @@ SEASTAR_TEST_CASE(test_map_elements_validation) {
         test_inline("definitely not a date value", true);
         test_inline("2015-05-03", false);
         e.execute_cql("CREATE TABLE tbl2 (a int, b map<text, text>, PRIMARY KEY (a))").get();
-        auto id = e.prepare("INSERT INTO tbl2 (a, b) VALUES(?, ?)").get0();
+        auto id = e.prepare("INSERT INTO tbl2 (a, b) VALUES(?, ?)").get();
         auto test_bind = [&] (sstring value, bool should_throw) {
             auto my_map_type = map_type_impl::get_instance(utf8_type, utf8_type, true);
             std::vector<cql3::raw_value> raw_values;
@@ -399,7 +399,7 @@ SEASTAR_TEST_CASE(test_in_clause_validation) {
         test_inline("definitely not a date value", true);
         test_inline("2015-05-03", false);
         e.execute_cql("CREATE TABLE tbl2 (p1 int, c1 int, r1 text, PRIMARY KEY (p1, c1,r1))").get();
-        auto id = e.prepare("SELECT r1 FROM tbl2 WHERE (c1,r1) IN ? ALLOW FILTERING").get0();
+        auto id = e.prepare("SELECT r1 FROM tbl2 WHERE (c1,r1) IN ? ALLOW FILTERING").get();
         auto test_bind = [&] (sstring value, bool should_throw) {
             auto my_tuple_type = tuple_type_impl::get_instance({int32_type, utf8_type});
             auto my_list_type = list_type_impl::get_instance(my_tuple_type, true);
@@ -484,7 +484,7 @@ SEASTAR_TEST_CASE(test_tuple_elements_validation) {
         test_inline("definitely not a date value", true);
         test_inline("2015-05-03", false);
         e.execute_cql("CREATE TABLE tbl2 (a int, b tuple<int, text>, PRIMARY KEY (a))").get();
-        auto id = e.prepare("INSERT INTO tbl2 (a, b) VALUES(?, ?)").get0();
+        auto id = e.prepare("INSERT INTO tbl2 (a, b) VALUES(?, ?)").get();
         auto test_bind = [&] (sstring value, bool should_throw) {
             auto my_tuple_type = tuple_type_impl::get_instance({int32_type, utf8_type});
             std::vector<cql3::raw_value> raw_values;
@@ -508,7 +508,7 @@ SEASTAR_TEST_CASE(test_tuple_elements_validation) {
 SEASTAR_TEST_CASE(test_list_of_tuples_with_bound_var) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         e.execute_cql("create table cf (pk int PRIMARY KEY, c1 list<frozen<tuple<int,int>>>);").get();
-        e.prepare("update cf SET c1 = c1 + [(?,9999)] where pk = 999;").get0();
+        e.prepare("update cf SET c1 = c1 + [(?,9999)] where pk = 999;").get();
     });
 }
 
@@ -518,12 +518,12 @@ SEASTAR_TEST_CASE(test_bound_var_in_collection_literal) {
         e.execute_cql("create table set_t (pk int PRIMARY KEY, c1 set<int>);").get();
         e.execute_cql("create table map_t (pk int PRIMARY KEY, c1 map<int, int>);").get();
 
-        auto insert_list = e.prepare("insert into list_t (pk, c1) values (112, [997, ?])").get0();
-        auto insert_set = e.prepare("insert into set_t (pk, c1) values (112, {997, ?})").get0();
-        auto insert_map_key = e.prepare("insert into map_t (pk, c1) values (112, {997: 112, ?: 112})").get0();
-        auto insert_map_value = e.prepare("insert into map_t (pk, c1) values (112, {997: 112, 112: ?})").get0();
+        auto insert_list = e.prepare("insert into list_t (pk, c1) values (112, [997, ?])").get();
+        auto insert_set = e.prepare("insert into set_t (pk, c1) values (112, {997, ?})").get();
+        auto insert_map_key = e.prepare("insert into map_t (pk, c1) values (112, {997: 112, ?: 112})").get();
+        auto insert_map_value = e.prepare("insert into map_t (pk, c1) values (112, {997: 112, 112: ?})").get();
         BOOST_REQUIRE_THROW(
-            e.prepare("insert into map_t (pk, c1) values (112, {997: 112, ?})").get0(),
+            e.prepare("insert into map_t (pk, c1) values (112, {997: 112, ?})").get(),
             exceptions::syntax_exception
         );
 
@@ -573,7 +573,7 @@ SEASTAR_TEST_CASE(test_list_append_limit) {
                 std::vector<cql3::raw_value>{},
                 cql3::query_options::specific_options{1, nullptr, {}, api::new_timestamp()});
         auto cql = fmt::format("UPDATE t SET l = l + [{}] WHERE pk = 0;", value_list);
-        BOOST_REQUIRE_THROW(e.execute_cql(cql, std::move(qo)).get0(), exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(e.execute_cql(cql, std::move(qo)).get(), exceptions::invalid_request_exception);
         e.execute_cql("DROP TABLE t;").get();
     });
 }
@@ -1250,20 +1250,20 @@ SEASTAR_TEST_CASE(test_range_deletion_scenarios) {
         e.execute_cql("delete from cf where p = 1 and c >= 8").get();
 
         e.execute_cql("delete from cf where p = 1 and c >= 0 and c <= 5").get();
-        auto msg = e.execute_cql("select * from cf").get0();
+        auto msg = e.execute_cql("select * from cf").get();
         assert_that(msg).is_rows().with_size(2);
         e.execute_cql("delete from cf where p = 1 and c > 3 and c < 10").get();
-        msg = e.execute_cql("select * from cf").get0();
+        msg = e.execute_cql("select * from cf").get();
         assert_that(msg).is_rows().with_size(0);
 
         e.execute_cql("insert into cf (p, c, v) values (1, 1, '1');").get();
         e.execute_cql("insert into cf (p, c, v) values (1, 3, '3');").get();
         e.execute_cql("delete from cf where p = 1 and c >= 2 and c <= 3").get();
         e.execute_cql("insert into cf (p, c, v) values (1, 2, '2');").get();
-        msg = e.execute_cql("select * from cf").get0();
+        msg = e.execute_cql("select * from cf").get();
         assert_that(msg).is_rows().with_size(2);
         e.execute_cql("delete from cf where p = 1 and c >= 2 and c <= 3").get();
-        msg = e.execute_cql("select * from cf").get0();
+        msg = e.execute_cql("select * from cf").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)}, {utf8_type->decompose("1")} }});
     });
 }
@@ -1539,7 +1539,7 @@ SEASTAR_TEST_CASE(test_writetime_and_ttl) {
             return async([&e] {
                 auto ts1 = the_timestamp + 1;
                 e.execute_cql(format("UPDATE cf USING TIMESTAMP {:d} SET fc = {{1}}, c = {{2}} WHERE p1 = 'key1'", ts1)).get();
-                auto msg1 = e.execute_cql("SELECT writetime(fc) FROM cf").get0();
+                auto msg1 = e.execute_cql("SELECT writetime(fc) FROM cf").get();
                 assert_that(msg1).is_rows()
                     .with_rows({{
                          {long_type->decompose(int64_t(ts1))},
@@ -2049,7 +2049,7 @@ SEASTAR_TEST_CASE(test_types) {
                 ");").get();
 
         {
-            auto msg = e.execute_cql("SELECT * FROM all_types WHERE a = 'ascii'").get0();
+            auto msg = e.execute_cql("SELECT * FROM all_types WHERE a = 'ascii'").get();
             struct tm t = { 0 };
             t.tm_year = 2001 - 1900;
             t.tm_mon = 10 - 1;
@@ -2103,7 +2103,7 @@ SEASTAR_TEST_CASE(test_types) {
                 ");").get();
 
         {
-            auto msg = e.execute_cql("SELECT * FROM all_types WHERE a = 'ascii2'").get0();
+            auto msg = e.execute_cql("SELECT * FROM all_types WHERE a = 'ascii2'").get();
             struct tm t = {0};
             t.tm_year = 2001 - 1900;
             t.tm_mon = 10 - 1;
@@ -2144,14 +2144,14 @@ SEASTAR_TEST_CASE(test_order_by) {
         e.execute_cql("insert into torder (p1, c1, c2, r1) values (0, 2, 1, 0);").get();
 
         {
-            auto msg = e.execute_cql("select  c1, c2, r1 from torder where p1 = 0 order by c1 asc;").get0();
+            auto msg = e.execute_cql("select  c1, c2, r1 from torder where p1 = 0 order by c1 asc;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(3)},
                 {int32_type->decompose(2), int32_type->decompose(1), int32_type->decompose(0)},
             });
         }
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 order by c1 desc;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 order by c1 desc;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2), int32_type->decompose(1), int32_type->decompose(0)},
                 {int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(3)},
@@ -2161,7 +2161,7 @@ SEASTAR_TEST_CASE(test_order_by) {
         e.execute_cql("insert into torder (p1, c1, c2, r1) values (0, 1, 1, 4);").get();
         e.execute_cql("insert into torder (p1, c1, c2, r1) values (0, 2, 2, 5);").get();
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 order by c1 desc, c2 desc;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 order by c1 desc, c2 desc;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2), int32_type->decompose(2), int32_type->decompose(5)},
                 {int32_type->decompose(2), int32_type->decompose(1), int32_type->decompose(0)},
@@ -2174,7 +2174,7 @@ SEASTAR_TEST_CASE(test_order_by) {
         e.execute_cql("insert into torder (p1, c1, c2, r1) values (1, 2, 3, 7);").get();
 
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 in (0, 1) order by c1 desc, c2 desc;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 in (0, 1) order by c1 desc, c2 desc;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2), int32_type->decompose(3), int32_type->decompose(7)},
                 {int32_type->decompose(2), int32_type->decompose(2), int32_type->decompose(5)},
@@ -2186,7 +2186,7 @@ SEASTAR_TEST_CASE(test_order_by) {
         }
 
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 in (0, 1) order by c1 asc, c2 asc;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 in (0, 1) order by c1 asc, c2 asc;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(1), int32_type->decompose(0), int32_type->decompose(6)},
                 {int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(4)},
@@ -2198,35 +2198,35 @@ SEASTAR_TEST_CASE(test_order_by) {
         }
 
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 in (0, 1) and c1 < 2 order by c1 desc, c2 desc limit 1;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 in (0, 1) and c1 < 2 order by c1 desc, c2 desc limit 1;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(3)},
             });
         }
 
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 in (0, 1) and c1 >= 2 order by c1 asc, c2 asc limit 1;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 in (0, 1) and c1 >= 2 order by c1 asc, c2 asc limit 1;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2), int32_type->decompose(1), int32_type->decompose(0)},
             });
         }
 
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 in (0, 1) order by c1 desc, c2 desc limit 1;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 in (0, 1) order by c1 desc, c2 desc limit 1;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2), int32_type->decompose(3), int32_type->decompose(7)},
             });
         }
 
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 in (0, 1) order by c1 asc, c2 asc limit 1;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 in (0, 1) order by c1 asc, c2 asc limit 1;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(1), int32_type->decompose(0), int32_type->decompose(6)},
             });
         }
 
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 and c1 > 1 order by c1 desc, c2 desc;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 and c1 > 1 order by c1 desc, c2 desc;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2), int32_type->decompose(2), int32_type->decompose(5)},
                 {int32_type->decompose(2), int32_type->decompose(1), int32_type->decompose(0)},
@@ -2234,7 +2234,7 @@ SEASTAR_TEST_CASE(test_order_by) {
         }
 
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 and c1 >= 2 order by c1 desc, c2 desc;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 and c1 >= 2 order by c1 desc, c2 desc;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2), int32_type->decompose(2), int32_type->decompose(5)},
                 {int32_type->decompose(2), int32_type->decompose(1), int32_type->decompose(0)},
@@ -2242,14 +2242,14 @@ SEASTAR_TEST_CASE(test_order_by) {
         }
 
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 and c1 >= 2 order by c1 desc, c2 desc limit 1;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 and c1 >= 2 order by c1 desc, c2 desc limit 1;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2), int32_type->decompose(2), int32_type->decompose(5)},
             });
         }
 
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 order by c1 desc, c2 desc limit 1;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 order by c1 desc, c2 desc limit 1;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2), int32_type->decompose(2), int32_type->decompose(5)},
             });
@@ -2257,7 +2257,7 @@ SEASTAR_TEST_CASE(test_order_by) {
         }
 
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 and c1 > 1 order by c1 asc, c2 asc;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 and c1 > 1 order by c1 asc, c2 asc;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2), int32_type->decompose(1), int32_type->decompose(0)},
                 {int32_type->decompose(2), int32_type->decompose(2), int32_type->decompose(5)},
@@ -2265,7 +2265,7 @@ SEASTAR_TEST_CASE(test_order_by) {
         }
 
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 and c1 >= 2 order by c1 asc, c2 asc;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 and c1 >= 2 order by c1 asc, c2 asc;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2), int32_type->decompose(1), int32_type->decompose(0)},
                 {int32_type->decompose(2), int32_type->decompose(2), int32_type->decompose(5)},
@@ -2273,14 +2273,14 @@ SEASTAR_TEST_CASE(test_order_by) {
         }
 
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 and c1 >= 2 order by c1 asc, c2 asc limit 1;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 and c1 >= 2 order by c1 asc, c2 asc limit 1;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2), int32_type->decompose(1), int32_type->decompose(0)},
             });
         }
 
         {
-            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 order by c1 asc, c2 asc limit 1;").get0();
+            auto msg = e.execute_cql("select c1, c2, r1 from torder where p1 = 0 order by c1 asc, c2 asc limit 1;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(4)},
             });
@@ -2320,27 +2320,27 @@ SEASTAR_TEST_CASE(test_multi_column_restrictions) {
         e.execute_cql("insert into tmcr (p1, c1, c2, c3, r1) values (0, 1, 1, 0, 6);").get();
         e.execute_cql("insert into tmcr (p1, c1, c2, c3, r1) values (0, 1, 1, 1, 7);").get();
         {
-            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2, c3) = (0, 1, 1);").get0();
+            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2, c3) = (0, 1, 1);").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(3)},
             });
         }
         {
-            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2) = (0, 1);").get0();
+            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2) = (0, 1);").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2)},
                 {int32_type->decompose(3)},
             });
         }
         {
-            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2, c3) in ((0, 1, 0), (1, 0, 1), (0, 1, 0));").get0();
+            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2, c3) in ((0, 1, 0), (1, 0, 1), (0, 1, 0));").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2)},
                 {int32_type->decompose(5)},
             });
         }
         {
-            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2) in ((0, 1), (1, 0), (0, 1));").get0();
+            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2) in ((0, 1), (1, 0), (0, 1));").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2)},
                 {int32_type->decompose(3)},
@@ -2349,7 +2349,7 @@ SEASTAR_TEST_CASE(test_multi_column_restrictions) {
             });
         }
         {
-            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2, c3) >= (1, 0, 1);").get0();
+            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2, c3) >= (1, 0, 1);").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(5)},
                 {int32_type->decompose(6)},
@@ -2357,7 +2357,7 @@ SEASTAR_TEST_CASE(test_multi_column_restrictions) {
             });
         }
         {
-            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2, c3) >= (0, 1, 1) and (c1, c2, c3) < (1, 1, 0);").get0();
+            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2, c3) >= (0, 1, 1) and (c1, c2, c3) < (1, 1, 0);").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(3)},
                 {int32_type->decompose(4)},
@@ -2365,7 +2365,7 @@ SEASTAR_TEST_CASE(test_multi_column_restrictions) {
             });
         }
         {
-            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2) >= (0, 1) and (c1, c2, c3) < (1, 0, 1);").get0();
+            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2) >= (0, 1) and (c1, c2, c3) < (1, 0, 1);").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(2)},
                 {int32_type->decompose(3)},
@@ -2373,7 +2373,7 @@ SEASTAR_TEST_CASE(test_multi_column_restrictions) {
             });
         }
         {
-            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2, c3) > (0, 1, 0) and (c1, c2) <= (0, 1);").get0();
+            auto msg = e.execute_cql("select r1 from tmcr where p1 = 0 and (c1, c2, c3) > (0, 1, 0) and (c1, c2) <= (0, 1);").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(3)},
             });
@@ -2391,14 +2391,14 @@ SEASTAR_TEST_CASE(test_select_distinct) {
         e.execute_cql("insert into tsd (p1, c1, r1) values (2, 2, 2);").get();
         e.execute_cql("insert into tsd (p1, c1, r1) values (2, 3, 3);").get();
         {
-            auto msg = e.execute_cql("select distinct p1 from tsd;").get0();
+            auto msg = e.execute_cql("select distinct p1 from tsd;").get();
             assert_that(msg).is_rows().with_size(3)
                 .with_row({int32_type->decompose(0)})
                 .with_row({int32_type->decompose(1)})
                 .with_row({int32_type->decompose(2)});
         }
         {
-            auto msg = e.execute_cql("select distinct p1 from tsd limit 3;").get0();
+            auto msg = e.execute_cql("select distinct p1 from tsd limit 3;").get();
             assert_that(msg).is_rows().with_size(3)
                 .with_row({int32_type->decompose(0)})
                 .with_row({int32_type->decompose(1)})
@@ -2414,14 +2414,14 @@ SEASTAR_TEST_CASE(test_select_distinct) {
         e.execute_cql("insert into tsd2 (p1, p2, c1, r1) values (2, 2, 0, 0);").get();
         e.execute_cql("insert into tsd2 (p1, p2, c1, r1) values (2, 2, 1, 1);").get();
         {
-            auto msg = e.execute_cql("select distinct p1, p2 from tsd2;").get0();
+            auto msg = e.execute_cql("select distinct p1, p2 from tsd2;").get();
             assert_that(msg).is_rows().with_size(3)
                 .with_row({int32_type->decompose(0), int32_type->decompose(0)})
                 .with_row({int32_type->decompose(1), int32_type->decompose(1)})
                 .with_row({int32_type->decompose(2), int32_type->decompose(2)});
         }
         {
-            auto msg = e.execute_cql("select distinct p1, p2 from tsd2 limit 3;").get0();
+            auto msg = e.execute_cql("select distinct p1, p2 from tsd2 limit 3;").get();
             assert_that(msg).is_rows().with_size(3)
                 .with_row({int32_type->decompose(0), int32_type->decompose(0)})
                 .with_row({int32_type->decompose(1), int32_type->decompose(1)})
@@ -2434,7 +2434,7 @@ SEASTAR_TEST_CASE(test_select_distinct) {
         e.execute_cql("insert into tsd3 (p1, r1) values (1, 2);").get();
         e.execute_cql("insert into tsd3 (p1, r1) values (2, 2);").get();
         {
-            auto msg = e.execute_cql("select distinct p1 from tsd3;").get0();
+            auto msg = e.execute_cql("select distinct p1 from tsd3;").get();
             assert_that(msg).is_rows().with_size(3)
                 .with_row({int32_type->decompose(0)})
                 .with_row({int32_type->decompose(1)})
@@ -2447,7 +2447,7 @@ SEASTAR_TEST_CASE(test_select_distinct) {
         e.execute_cql("insert into tsd4 (p1, s1) values (2, 1);").get();
         e.execute_cql("insert into tsd4 (p1, s1) values (3, 2);").get();
         {
-            auto msg = e.execute_cql("select distinct p1, s1 from tsd4;").get0();
+            auto msg = e.execute_cql("select distinct p1, s1 from tsd4;").get();
             assert_that(msg).is_rows().with_size(3)
                 .with_row({int32_type->decompose(0), int32_type->decompose(0)})
                 .with_row({int32_type->decompose(2), int32_type->decompose(1)})
@@ -2467,11 +2467,11 @@ SEASTAR_TEST_CASE(test_select_distinct_with_where_clause) {
         BOOST_REQUIRE_THROW(e.execute_cql("SELECT DISTINCT k FROM cf WHERE k IN (1, 2, 3) AND a = 10").get(), std::exception);
         BOOST_REQUIRE_THROW(e.execute_cql("SELECT DISTINCT k FROM cf WHERE b = 5").get(), std::exception);
 
-        assert_that(e.execute_cql("SELECT DISTINCT k FROM cf WHERE k = 1").get0())
+        assert_that(e.execute_cql("SELECT DISTINCT k FROM cf WHERE k = 1").get())
             .is_rows().with_size(1)
             .with_row({int32_type->decompose(1)});
 
-        assert_that(e.execute_cql("SELECT DISTINCT k FROM cf WHERE k IN (5, 6, 7)").get0())
+        assert_that(e.execute_cql("SELECT DISTINCT k FROM cf WHERE k IN (5, 6, 7)").get())
            .is_rows().with_size(3)
            .with_row({int32_type->decompose(5)})
            .with_row({int32_type->decompose(6)})
@@ -2483,11 +2483,11 @@ SEASTAR_TEST_CASE(test_select_distinct_with_where_clause) {
             e.execute_cql(format("INSERT INTO cf2 (k, a, b, s) VALUES ({:d}, {:d}, {:d}, {:d})", i, i, i, i)).get();
             e.execute_cql(format("INSERT INTO cf2 (k, a, b, s) VALUES ({:d}, {:d}, {:d}, {:d})", i, i * 10, i * 10, i * 10)).get();
         }
-        assert_that(e.execute_cql("SELECT DISTINCT s FROM cf2 WHERE k = 5").get0())
+        assert_that(e.execute_cql("SELECT DISTINCT s FROM cf2 WHERE k = 5").get())
             .is_rows().with_size(1)
             .with_row({int32_type->decompose(50)});
 
-        assert_that(e.execute_cql("SELECT DISTINCT s FROM cf2 WHERE k IN (5, 6, 7)").get0())
+        assert_that(e.execute_cql("SELECT DISTINCT s FROM cf2 WHERE k IN (5, 6, 7)").get())
            .is_rows().with_size(3)
            .with_row({int32_type->decompose(50)})
            .with_row({int32_type->decompose(60)})
@@ -2528,11 +2528,11 @@ SEASTAR_TEST_CASE(test_in_restriction) {
         e.execute_cql("insert into tir (p1, c1, r1) values (1, 2, 3);").get();
         e.execute_cql("insert into tir (p1, c1, r1) values (2, 3, 4);").get();
         {
-            auto msg = e.execute_cql("select * from tir where p1 in ();").get0();
+            auto msg = e.execute_cql("select * from tir where p1 in ();").get();
             assert_that(msg).is_rows().with_size(0);
         }
         {
-            auto msg = e.execute_cql("select r1 from tir where p1 in (2, 0, 2, 1);").get0();
+            auto msg = e.execute_cql("select r1 from tir where p1 in (2, 0, 2, 1);").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                 {int32_type->decompose(4)},
                 {int32_type->decompose(0)},
@@ -2542,11 +2542,11 @@ SEASTAR_TEST_CASE(test_in_restriction) {
             });
         }
         {
-            auto msg = e.execute_cql("select r1 from tir where p1 = 1 and c1 in ();").get0();
+            auto msg = e.execute_cql("select r1 from tir where p1 = 1 and c1 in ();").get();
             assert_that(msg).is_rows().with_size(0);
         }
         {
-            auto msg = e.execute_cql("select r1 from tir where p1 = 1 and c1 in (2, 0, 2, 1);").get0();
+            auto msg = e.execute_cql("select r1 from tir where p1 = 1 and c1 in (2, 0, 2, 1);").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(1)},
                 {int32_type->decompose(2)},
@@ -2554,7 +2554,7 @@ SEASTAR_TEST_CASE(test_in_restriction) {
             });
         }
         {
-            auto msg = e.execute_cql("select r1 from tir where p1 = 1 and c1 in (2, 0, 2, 1) order by c1 desc;").get0();
+            auto msg = e.execute_cql("select r1 from tir where p1 = 1 and c1 in (2, 0, 2, 1) order by c1 desc;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(3)},
                 {int32_type->decompose(2)},
@@ -2562,13 +2562,13 @@ SEASTAR_TEST_CASE(test_in_restriction) {
             });
         }
         {
-            auto prepared_id = e.prepare("select r1 from tir where p1 in ?;").get0();
+            auto prepared_id = e.prepare("select r1 from tir where p1 in ?;").get();
             auto my_list_type = list_type_impl::get_instance(int32_type, true);
             std::vector<cql3::raw_value> raw_values;
             auto in_values_list = my_list_type->decompose(make_list_value(my_list_type,
                     list_type_impl::native_type{{int(2), int(0), int(2), int(1)}}));
             raw_values.emplace_back(cql3::raw_value::make_value(in_values_list));
-            auto msg = e.execute_prepared(prepared_id,raw_values).get0();
+            auto msg = e.execute_prepared(prepared_id,raw_values).get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                 {int32_type->decompose(4)},
                 {int32_type->decompose(0)},
@@ -2586,14 +2586,14 @@ SEASTAR_TEST_CASE(test_in_restriction) {
         e.execute_cql("insert into tir2 (p1, c1, r1) values (1, 2, 3);").get();
         e.execute_cql("insert into tir2 (p1, c1, r1) values (2, 3, 4);").get();
         {
-            auto msg = e.execute_cql("select r1 from tir2 where (c1,r1) in ((0, 1),(1,2),(0,1),(1,2),(3,3)) allow filtering;").get0();
+            auto msg = e.execute_cql("select r1 from tir2 where (c1,r1) in ((0, 1),(1,2),(0,1),(1,2),(3,3)) allow filtering;").get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(1)},
                 {int32_type->decompose(2)},
             });
         }
         {
-            auto prepared_id = e.prepare("select r1 from tir2 where (c1,r1) in ? allow filtering;").get0();
+            auto prepared_id = e.prepare("select r1 from tir2 where (c1,r1) in ? allow filtering;").get();
             auto my_tuple_type = tuple_type_impl::get_instance({int32_type,int32_type});
             auto my_list_type = list_type_impl::get_instance(my_tuple_type, true);
             std::vector<tuple_type_impl::native_type> native_tuples = {
@@ -2611,7 +2611,7 @@ SEASTAR_TEST_CASE(test_in_restriction) {
             std::vector<cql3::raw_value> raw_values;
             auto in_values_list = my_list_type->decompose(make_list_value(my_list_type,tuples));
             raw_values.emplace_back(cql3::raw_value::make_value(in_values_list));
-            auto msg = e.execute_prepared(prepared_id,raw_values).get0();
+            auto msg = e.execute_prepared(prepared_id,raw_values).get();
             assert_that(msg).is_rows().with_rows({
                 {int32_type->decompose(1)},
                 {int32_type->decompose(2)},
@@ -2628,14 +2628,14 @@ SEASTAR_TEST_CASE(test_compact_storage) {
         require_column_has_value(e, "tcs", {1}, {2}, "r1", 3).get();
         e.execute_cql("update tcs set r1 = 4 where p1 = 1 and c1 = 2;").get();
         require_column_has_value(e, "tcs", {1}, {2}, "r1", 4).get();
-        auto msg = e.execute_cql("select * from tcs where p1 = 1;").get0();
+        auto msg = e.execute_cql("select * from tcs where p1 = 1;").get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(4) },
         });
         e.execute_cql("create table tcs2 (p1 int, c1 int, PRIMARY KEY (p1, c1)) with compact storage;").get();
         BOOST_REQUIRE(e.local_db().has_schema("ks", "tcs2"));
         e.execute_cql("insert into tcs2 (p1, c1) values (1, 2);").get();
-        msg = e.execute_cql("select * from tcs2 where p1 = 1;").get0();
+        msg = e.execute_cql("select * from tcs2 where p1 = 1;").get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(1), int32_type->decompose(2) },
         });
@@ -2645,7 +2645,7 @@ SEASTAR_TEST_CASE(test_compact_storage) {
         e.execute_cql("insert into tcs3 (p1, c1, r1) values (1, 3, 6);").get();
         e.execute_cql("insert into tcs3 (p1, c1, c2, r1) values (1, 3, 5, 7);").get();
         e.execute_cql("insert into tcs3 (p1, c1, c2, r1) values (1, 3, blobasint(0x), 8);").get();
-        msg = e.execute_cql("select * from tcs3 where p1 = 1;").get0();
+        msg = e.execute_cql("select * from tcs3 where p1 = 1;").get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(1), int32_type->decompose(2), {}, int32_type->decompose(5) },
             { int32_type->decompose(1), int32_type->decompose(2), int32_type->decompose(3), int32_type->decompose(4) },
@@ -2654,26 +2654,26 @@ SEASTAR_TEST_CASE(test_compact_storage) {
             { int32_type->decompose(1), int32_type->decompose(3), int32_type->decompose(5), int32_type->decompose(7) },
         });
         e.execute_cql("delete from tcs3 where p1 = 1 and c1 = 2;").get();
-        msg = e.execute_cql("select * from tcs3 where p1 = 1;").get0();
+        msg = e.execute_cql("select * from tcs3 where p1 = 1;").get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(1), int32_type->decompose(3), {}, int32_type->decompose(6) },
             { int32_type->decompose(1), int32_type->decompose(3), bytes(), int32_type->decompose(8) },
             { int32_type->decompose(1), int32_type->decompose(3), int32_type->decompose(5), int32_type->decompose(7) },
         });
         e.execute_cql("delete from tcs3 where p1 = 1 and c1 = 3 and c2 = 5;").get();
-        msg = e.execute_cql("select * from tcs3 where p1 = 1;").get0();
+        msg = e.execute_cql("select * from tcs3 where p1 = 1;").get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(1), int32_type->decompose(3), {}, int32_type->decompose(6) },
             { int32_type->decompose(1), int32_type->decompose(3), bytes(), int32_type->decompose(8) },
         });
         e.execute_cql("delete from tcs3 where p1 = 1 and c1 = 3 and c2 = blobasint(0x);").get();
-        msg = e.execute_cql("select * from tcs3 where p1 = 1;").get0();
+        msg = e.execute_cql("select * from tcs3 where p1 = 1;").get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(1), int32_type->decompose(3), {}, int32_type->decompose(6) },
         });
         e.execute_cql("create table tcs4 (p1 int PRIMARY KEY, c1 int, c2 int) with compact storage;").get();
         e.execute_cql("insert into tcs4 (p1) values (1);").discard_result().get();
-        msg = e.execute_cql("select * from tcs4;").get0();
+        msg = e.execute_cql("select * from tcs4;").get();
         assert_that(msg).is_rows().with_rows({ });
     });
 }
@@ -2861,12 +2861,12 @@ SEASTAR_TEST_CASE(test_map_query) {
         e.execute_cql("CREATE TABLE xx (k int PRIMARY KEY, m map<text, int>);").get();
         e.execute_cql("insert into xx (k, m) values (0, {'v2': 1});").get();
         auto m_type = map_type_impl::get_instance(utf8_type, int32_type, true);
-        assert_that(e.execute_cql("select m from xx where k = 0;").get0())
+        assert_that(e.execute_cql("select m from xx where k = 0;").get())
                 .is_rows().with_rows({
                     { make_map_value(m_type, map_type_impl::native_type({{sstring("v2"), 1}})).serialize() }
                 });
         e.execute_cql("delete m['v2'] from xx where k = 0;").get();
-        assert_that(e.execute_cql("select m from xx where k = 0;").get0())
+        assert_that(e.execute_cql("select m from xx where k = 0;").get())
                 .is_rows().with_rows({{{}}});
     });
 }
@@ -2901,13 +2901,13 @@ SEASTAR_TEST_CASE(test_reversed_slice_with_empty_range_before_all_rows) {
         e.execute_cql("INSERT INTO test (a, b, c, s1, s2) VALUES (99, 14, 14, 17, 42);").get();
         e.execute_cql("INSERT INTO test (a, b, c, s1, s2) VALUES (99, 15, 15, 17, 42);").get();
 
-        assert_that(e.execute_cql("select * from test WHERE a = 99 and b < 0 ORDER BY b DESC limit 2;").get0())
+        assert_that(e.execute_cql("select * from test WHERE a = 99 and b < 0 ORDER BY b DESC limit 2;").get())
             .is_rows().is_empty();
 
-        assert_that(e.execute_cql("select * from test WHERE a = 99 order by b desc;").get0())
+        assert_that(e.execute_cql("select * from test WHERE a = 99 order by b desc;").get())
             .is_rows().with_size(16);
 
-        assert_that(e.execute_cql("select * from test;").get0())
+        assert_that(e.execute_cql("select * from test;").get())
             .is_rows().with_size(16);
     });
 }
@@ -2927,7 +2927,7 @@ SEASTAR_TEST_CASE(test_reversed_slice_with_many_clustering_ranges) {
     cfg.db_config->max_memory_for_unlimited_query_hard_limit(std::numeric_limits<uint64_t>::max());
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE test (pk int, ck int, v text, PRIMARY KEY (pk, ck));").get();
-        auto id = e.prepare("INSERT INTO test (pk, ck, v) VALUES (?, ?, ?);").get0();
+        auto id = e.prepare("INSERT INTO test (pk, ck, v) VALUES (?, ?, ?);").get();
 
         const int pk = 0;
         const auto raw_pk = int32_type->decompose(data_value(pk));
@@ -2965,7 +2965,7 @@ SEASTAR_TEST_CASE(test_reversed_slice_with_many_clustering_ranges) {
                     "SELECT * FROM test WHERE pk = {} and ck IN ({}) ORDER BY ck DESC BYPASS CACHE;",
                     pk,
                     boost::algorithm::join(selected_cks | boost::adaptors::transformed([] (int ck) { return format("{}", ck); }), ", "));
-            assert_that(e.execute_cql(select_query).get0())
+            assert_that(e.execute_cql(select_query).get())
                     .is_rows()
                     .with_rows(boost::copy_range<std::vector<std::vector<bytes_opt>>>(
                                 selected_cks
@@ -2982,7 +2982,7 @@ SEASTAR_TEST_CASE(test_reversed_slice_with_many_clustering_ranges) {
                     selected_cks[0],
                     selected_cks[1]);
 
-            assert_that(e.execute_cql(select_query).get0())
+            assert_that(e.execute_cql(select_query).get())
                     .is_rows()
                     .with_rows(boost::copy_range<std::vector<std::vector<bytes_opt>>>(
                                 boost::irange(selected_cks[0], selected_cks[1] + 1)
@@ -3006,14 +3006,14 @@ SEASTAR_TEST_CASE(test_query_with_range_tombstones) {
         e.execute_cql("DELETE FROM test WHERE pk = 0 AND ck > 4 AND ck <= 8;").get();
         e.execute_cql("DELETE FROM test WHERE pk = 0 AND ck > 0 AND ck <= 1;").get();
 
-        assert_that(e.execute_cql("SELECT v FROM test WHERE pk = 0 ORDER BY ck DESC;").get0())
+        assert_that(e.execute_cql("SELECT v FROM test WHERE pk = 0 ORDER BY ck DESC;").get())
             .is_rows()
             .with_rows({
                 { int32_type->decompose(4) },
                 { int32_type->decompose(0) },
             });
 
-        assert_that(e.execute_cql("SELECT v FROM test WHERE pk = 0;").get0())
+        assert_that(e.execute_cql("SELECT v FROM test WHERE pk = 0;").get())
             .is_rows()
             .with_rows({
                { int32_type->decompose(0) },
@@ -3115,9 +3115,9 @@ SEASTAR_TEST_CASE(test_long_text_value) {
         sstring bigger_one(29123, 'y');
         e.execute_cql(format("INSERT INTO t (id, v, v2) values (1, '{}', '{}')", big_one, big_one)).get();
         e.execute_cql(format("INSERT INTO t (id, v, v2) values (2, '{}', '{}')", bigger_one, bigger_one)).get();
-        auto msg = e.execute_cql("select v, v2 from t where id = 1").get0();
+        auto msg = e.execute_cql("select v, v2 from t where id = 1").get();
         assert_that(msg).is_rows().with_rows({{utf8_type->decompose(big_one), utf8_type->decompose(big_one)}});
-        msg = e.execute_cql("select v, v2 from t where id = 2").get0();
+        msg = e.execute_cql("select v, v2 from t where id = 2").get();
         assert_that(msg).is_rows().with_rows({{utf8_type->decompose(bigger_one), utf8_type->decompose(bigger_one)}});
     });
 }
@@ -3146,7 +3146,7 @@ SEASTAR_TEST_CASE(test_time_conversions) {
         auto tp2 = db_clock::from_time_t(timegm(&t));
 
         auto msg = e.execute_cql("select todate(id), todate(ts), totimestamp(id), totimestamp(d), tounixtimestamp(id),"
-                                 "tounixtimestamp(ts), tounixtimestamp(d), tounixtimestamp(totimestamp(todate(totimestamp(todate(id))))) from time_data;").get0();
+                                 "tounixtimestamp(ts), tounixtimestamp(d), tounixtimestamp(totimestamp(todate(totimestamp(todate(id))))) from time_data;").get();
         assert_that(msg).is_rows().with_rows({{
             serialized(simple_date_native_type{0x80004518}),
             serialized(simple_date_native_type{0x80004517}),
@@ -3171,7 +3171,7 @@ SEASTAR_TEST_CASE(test_empty_partition_range_scan) {
 
         auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                 cql3::query_options::specific_options{1, nullptr, {}, api::new_timestamp()});
-        auto res = e.execute_cql("select * from empty_partition_range_scan.tb where token (a,b) > 1 and token(a,b) <= 1;", std::move(qo)).get0();
+        auto res = e.execute_cql("select * from empty_partition_range_scan.tb where token (a,b) > 1 and token(a,b) <= 1;", std::move(qo)).get();
         assert_that(res).is_rows().is_empty();
     });
 }
@@ -3190,31 +3190,31 @@ SEASTAR_TEST_CASE(test_allow_filtering_contains) {
         auto my_map_type = map_type_impl::get_instance(utf8_type, utf8_type, false);
         auto my_nonfrozen_map_type = map_type_impl::get_instance(utf8_type, utf8_type, true);
 
-        auto msg = e.execute_cql("SELECT p FROM t WHERE p CONTAINS KEY 'a' ALLOW FILTERING").get0();
+        auto msg = e.execute_cql("SELECT p FROM t WHERE p CONTAINS KEY 'a' ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {my_map_type->decompose(make_map_value(my_map_type, map_type_impl::native_type({{sstring("a"), sstring("a")}})))}
         });
 
-        msg = e.execute_cql("SELECT c1 FROM t WHERE c1 CONTAINS 3 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT c1 FROM t WHERE c1 CONTAINS 3 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {my_list_type->decompose(make_list_value(my_list_type, list_type_impl::native_type({{1, 2, 3}})))},
             {my_list_type->decompose(make_list_value(my_list_type, list_type_impl::native_type({{2, 3, 4}})))},
             {my_list_type->decompose(make_list_value(my_list_type, list_type_impl::native_type({{3, 4, 5}})))}
         });
 
-        msg = e.execute_cql("SELECT c2 FROM t WHERE c2 CONTAINS 1 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT c2 FROM t WHERE c2 CONTAINS 1 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {my_set_type->decompose(make_set_value(my_set_type, set_type_impl::native_type({{1, 5}})))},
             {my_set_type->decompose(make_set_value(my_set_type, set_type_impl::native_type({{1, 2, 3}})))}
         });
 
-        msg = e.execute_cql("SELECT v FROM t WHERE v CONTAINS KEY 'y1' ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT v FROM t WHERE v CONTAINS KEY 'y1' ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {my_nonfrozen_map_type->decompose(make_map_value(my_nonfrozen_map_type, map_type_impl::native_type({{sstring("x"), sstring("xyz")}, {sstring("y1"), sstring("abc")}})))},
             {my_nonfrozen_map_type->decompose(make_map_value(my_nonfrozen_map_type, map_type_impl::native_type({{sstring("d"), sstring("def")}, {sstring("y1"), sstring("abc")}})))}
         });
 
-        msg = e.execute_cql("SELECT c2, v FROM t WHERE v CONTAINS KEY 'y1' AND c2 CONTAINS 5 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT c2, v FROM t WHERE v CONTAINS KEY 'y1' AND c2 CONTAINS 5 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {
                 my_set_type->decompose(make_set_value(my_set_type, set_type_impl::native_type({{1, 5}}))),
@@ -3242,7 +3242,7 @@ SEASTAR_TEST_CASE(test_in_restriction_on_not_last_partition_key) {
         e.execute_cql("INSERT INTO t (a,b,c,d) VALUES (3,1,3,1300);").get();
 
         {
-            auto msg = e.execute_cql("SELECT * FROM t WHERE a IN (1,2) AND b IN (2,3) AND c>=2 AND c<=3;").get0();
+            auto msg = e.execute_cql("SELECT * FROM t WHERE a IN (1,2) AND b IN (2,3) AND c>=2 AND c<=3;").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                {
                    int32_type->decompose(1),
@@ -3265,7 +3265,7 @@ SEASTAR_TEST_CASE(test_in_restriction_on_not_last_partition_key) {
             });
         }
         {
-           auto msg = e.execute_cql("SELECT * FROM t WHERE a IN (1,3) AND b=1 AND c>=2 AND c<=3;").get0();
+           auto msg = e.execute_cql("SELECT * FROM t WHERE a IN (1,3) AND b=1 AND c>=2 AND c<=3;").get();
            assert_that(msg).is_rows().with_rows_ignore_order({
               {
                   int32_type->decompose(1),
@@ -3297,7 +3297,7 @@ SEASTAR_TEST_CASE(test_static_multi_cell_static_lists_with_ckey) {
 
         {
             e.execute_cql("UPDATE t SET slist[0] = 3, v = 3 WHERE p = 1 AND c = 1;").get();
-            auto msg = e.execute_cql("SELECT slist, v FROM t WHERE p = 1 AND c = 1;").get0();
+            auto msg = e.execute_cql("SELECT slist, v FROM t WHERE p = 1 AND c = 1;").get();
             auto slist_type = list_type_impl::get_instance(int32_type, true);
             assert_that(msg).is_rows().with_row({
                 { slist_type->decompose(make_list_value(slist_type, list_type_impl::native_type({{3}}))) },
@@ -3306,7 +3306,7 @@ SEASTAR_TEST_CASE(test_static_multi_cell_static_lists_with_ckey) {
         }
         {
             e.execute_cql("UPDATE t SET slist = [4], v = 4 WHERE p = 1 AND c = 1;").get();
-            auto msg = e.execute_cql("SELECT slist, v FROM t WHERE p = 1 AND c = 1;").get0();
+            auto msg = e.execute_cql("SELECT slist, v FROM t WHERE p = 1 AND c = 1;").get();
             auto slist_type = list_type_impl::get_instance(int32_type, true);
             assert_that(msg).is_rows().with_row({
                 { slist_type->decompose(make_list_value(slist_type, list_type_impl::native_type({{4}}))) },
@@ -3315,7 +3315,7 @@ SEASTAR_TEST_CASE(test_static_multi_cell_static_lists_with_ckey) {
         }
         {
             e.execute_cql("UPDATE t SET slist = [3] + slist , v = 5 WHERE p = 1 AND c = 1;").get();
-            auto msg = e.execute_cql("SELECT slist, v FROM t WHERE p = 1 AND c = 1;").get0();
+            auto msg = e.execute_cql("SELECT slist, v FROM t WHERE p = 1 AND c = 1;").get();
             auto slist_type = list_type_impl::get_instance(int32_type, true);
             assert_that(msg).is_rows().with_row({
                 { slist_type->decompose(make_list_value(slist_type, list_type_impl::native_type({3, 4}))) },
@@ -3324,7 +3324,7 @@ SEASTAR_TEST_CASE(test_static_multi_cell_static_lists_with_ckey) {
         }
         {
             e.execute_cql("UPDATE t SET slist = slist + [5] , v = 6 WHERE p = 1 AND c = 1;").get();
-            auto msg = e.execute_cql("SELECT slist, v FROM t WHERE p = 1 AND c = 1;").get0();
+            auto msg = e.execute_cql("SELECT slist, v FROM t WHERE p = 1 AND c = 1;").get();
             auto slist_type = list_type_impl::get_instance(int32_type, true);
             assert_that(msg).is_rows().with_row({
                 { slist_type->decompose(make_list_value(slist_type, list_type_impl::native_type({3, 4, 5}))) },
@@ -3333,7 +3333,7 @@ SEASTAR_TEST_CASE(test_static_multi_cell_static_lists_with_ckey) {
         }
         {
             e.execute_cql("DELETE slist[2] from t WHERE p = 1;").get();
-            auto msg = e.execute_cql("SELECT slist, v FROM t WHERE p = 1 AND c = 1;").get0();
+            auto msg = e.execute_cql("SELECT slist, v FROM t WHERE p = 1 AND c = 1;").get();
             auto slist_type = list_type_impl::get_instance(int32_type, true);
             assert_that(msg).is_rows().with_row({
                 { slist_type->decompose(make_list_value(slist_type, list_type_impl::native_type({3, 4}))) },
@@ -3342,7 +3342,7 @@ SEASTAR_TEST_CASE(test_static_multi_cell_static_lists_with_ckey) {
         }
         {
             e.execute_cql("UPDATE t SET slist = slist - [4] , v = 7 WHERE p = 1 AND c = 1;").get();
-            auto msg = e.execute_cql("SELECT slist, v FROM t WHERE p = 1 AND c = 1;").get0();
+            auto msg = e.execute_cql("SELECT slist, v FROM t WHERE p = 1 AND c = 1;").get();
             auto slist_type = list_type_impl::get_instance(int32_type, true);
             assert_that(msg).is_rows().with_row({
                 { slist_type->decompose(make_list_value(slist_type, list_type_impl::native_type({data_value(3)}))) },
@@ -3637,7 +3637,7 @@ SEASTAR_TEST_CASE(test_select_with_mixed_order_table) {
         generate_with_inclusiveness_permutations({0,1,2,3},{0,1,2,3});
 
         for (auto&& test_case  : test_cases) {
-            auto msg = e.execute_cql(fmt::format(fmt::runtime(select_query_template) ,test_case.generate_cql_slice_expresion(column_names))).get0();
+            auto msg = e.execute_cql(fmt::format(fmt::runtime(select_query_template) ,test_case.generate_cql_slice_expresion(column_names))).get();
             assert_that(msg).is_rows().with_rows(test_case.genrate_results_for_validation(ordering));
         }
     });
@@ -3650,7 +3650,7 @@ run_and_examine_cache_read_stats_change(cql_test_env& e, std::string_view cf_nam
             auto& t = db.find_column_family("ks", cf_name);
             auto& stats = t.get_row_cache().stats();
             return stats.reads_with_misses.count() + stats.reads_with_no_misses.count();
-        }, uint64_t(0), std::plus<uint64_t>()).get0();
+        }, uint64_t(0), std::plus<uint64_t>()).get();
     };
     auto before = read_stat();
     func(e);
@@ -3688,7 +3688,7 @@ SEASTAR_TEST_CASE(test_describe_varchar) {
         auto pos_m1 = int32_type->decompose(-1);
         auto int_t = utf8_type->decompose("int");
         auto text_t = utf8_type->decompose("text");
-        assert_that(e.execute_cql("select * from system_schema.columns where keyspace_name = 'ks';").get0())
+        assert_that(e.execute_cql("select * from system_schema.columns where keyspace_name = 'ks';").get())
             .is_rows()
             .with_rows({
                     {ks, tbl, id, none, id, partition_key, pos_0, int_t},
@@ -3739,7 +3739,7 @@ SEASTAR_TEST_CASE(test_rf_expand) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         auto get_replication = [&] (const sstring& ks) {
             auto msg = e.execute_cql(
-                format("SELECT JSON replication FROM system_schema.keyspaces WHERE keyspace_name = '{}'", ks)).get0();
+                format("SELECT JSON replication FROM system_schema.keyspaces WHERE keyspace_name = '{}'", ks)).get();
             auto res = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg);
             auto rows = res->rs().result_set().rows();
             BOOST_REQUIRE_EQUAL(rows.size(), 1);
@@ -3808,7 +3808,7 @@ SEASTAR_TEST_CASE(test_int_sum_overflow) {
         BOOST_REQUIRE_THROW(e.execute_cql(sum_query).get(), exceptions::overflow_error_exception);
 
         cquery_nofail(e, "insert into cf (pk, ck, val) values ('p2', 'c1', -1);");
-        auto result = e.execute_cql(sum_query).get0();
+        auto result = e.execute_cql(sum_query).get();
         assert_that(result)
             .is_rows()
             .with_size(1)
@@ -3818,7 +3818,7 @@ SEASTAR_TEST_CASE(test_int_sum_overflow) {
         BOOST_REQUIRE_THROW(e.execute_cql(sum_query).get(), exceptions::overflow_error_exception);
 
         cquery_nofail(e, "insert into cf (pk, ck, val) values ('p3', 'c2', -2147483648);");
-        result = e.execute_cql(sum_query).get0();
+        result = e.execute_cql(sum_query).get();
         assert_that(result)
             .is_rows()
             .with_size(1)
@@ -3835,7 +3835,7 @@ SEASTAR_TEST_CASE(test_bigint_sum_overflow) {
         BOOST_REQUIRE_THROW(e.execute_cql(sum_query).get(), exceptions::overflow_error_exception);
 
         cquery_nofail(e, "insert into cf (pk, ck, val) values ('p2', 'c1', -1);");
-        auto result = e.execute_cql(sum_query).get0();
+        auto result = e.execute_cql(sum_query).get();
         assert_that(result)
             .is_rows()
             .with_size(1)
@@ -3845,7 +3845,7 @@ SEASTAR_TEST_CASE(test_bigint_sum_overflow) {
         BOOST_REQUIRE_THROW(e.execute_cql(sum_query).get(), exceptions::overflow_error_exception);
 
         cquery_nofail(e, "insert into cf (pk, ck, val) values ('p3', 'c2', -9223372036854775808);");
-        result = e.execute_cql(sum_query).get0();
+        result = e.execute_cql(sum_query).get();
         assert_that(result)
             .is_rows()
             .with_size(1)
@@ -3859,13 +3859,13 @@ SEASTAR_TEST_CASE(test_bigint_sum) {
         cquery_nofail(e, "insert into cf (pk, val) values ('x', 2147483647);");
         cquery_nofail(e, "insert into cf (pk, val) values ('y', 2147483647);");
         auto sum_query = "select sum(val) from cf;";
-        assert_that(e.execute_cql(sum_query).get0())
+        assert_that(e.execute_cql(sum_query).get())
             .is_rows()
             .with_size(1)
             .with_row({long_type->decompose(int64_t(4294967294))});
 
         cquery_nofail(e, "insert into cf (pk, val) values ('z', -4294967295);");
-        assert_that(e.execute_cql(sum_query).get0())
+        assert_that(e.execute_cql(sum_query).get())
             .is_rows()
             .with_size(1)
             .with_row({long_type->decompose(int64_t(-1))});
@@ -3878,14 +3878,14 @@ SEASTAR_TEST_CASE(test_int_sum_with_cast) {
         cquery_nofail(e, "insert into cf (pk, val) values ('a', 2147483647);");
         cquery_nofail(e, "insert into cf (pk, val) values ('b', 2147483647);");
         auto sum_as_bigint_query = "select sum(cast(val as bigint)) from cf;";
-        assert_that(e.execute_cql(sum_as_bigint_query).get0())
+        assert_that(e.execute_cql(sum_as_bigint_query).get())
             .is_rows()
             .with_size(1)
             .with_row({long_type->decompose(int64_t(4294967294))});
 
         cquery_nofail(e, "insert into cf (pk, val) values ('a', -2147483648);");
         cquery_nofail(e, "insert into cf (pk, val) values ('b', -2147483647);");
-        assert_that(e.execute_cql(sum_as_bigint_query).get0())
+        assert_that(e.execute_cql(sum_as_bigint_query).get())
             .is_rows()
             .with_size(1)
             .with_row({long_type->decompose(int64_t(-4294967295))});
@@ -3897,28 +3897,28 @@ SEASTAR_TEST_CASE(test_float_sum_overflow) {
         cquery_nofail(e, "create table cf (pk text, val float, primary key(pk));");
         testlog.info("make sure we can sum close to the max value");
         cquery_nofail(e, "insert into cf (pk, val) values ('a', 3.4028234e+38);");
-        auto result = e.execute_cql("select sum(val) from cf;").get0();
+        auto result = e.execute_cql("select sum(val) from cf;").get();
         assert_that(result)
             .is_rows()
             .with_size(1)
             .with_row({serialized(3.4028234e+38f)});
         testlog.info("cause overflow");
         cquery_nofail(e, "insert into cf (pk, val) values ('b', 1e+38);");
-        result = e.execute_cql("select sum(val) from cf;").get0();
+        result = e.execute_cql("select sum(val) from cf;").get();
         assert_that(result)
             .is_rows()
             .with_size(1)
             .with_row({serialized(std::numeric_limits<float>::infinity())});
         testlog.info("test maximum negative value");
         cquery_nofail(e, "insert into cf (pk, val) values ('a', -3.4028234e+38);");
-        result = e.execute_cql("select sum(val) from cf;").get0();
+        result = e.execute_cql("select sum(val) from cf;").get();
         assert_that(result)
             .is_rows()
             .with_size(1)
             .with_row({serialized(-2.4028234e+38f)});
         testlog.info("cause negative overflow");
         cquery_nofail(e, "insert into cf (pk, val) values ('c', -2e+38);");
-        result = e.execute_cql("select sum(val) from cf;").get0();
+        result = e.execute_cql("select sum(val) from cf;").get();
         assert_that(result)
             .is_rows()
             .with_size(1)
@@ -3931,28 +3931,28 @@ SEASTAR_TEST_CASE(test_double_sum_overflow) {
         cquery_nofail(e, "create table cf (pk text, val double, primary key(pk));");
         testlog.info("make sure we can sum close to the max value");
         cquery_nofail(e, "insert into cf (pk, val) values ('a', 1.79769313486231570814527423732e+308);");
-        auto result = e.execute_cql("select sum(val) from cf;").get0();
+        auto result = e.execute_cql("select sum(val) from cf;").get();
         assert_that(result)
             .is_rows()
             .with_size(1)
             .with_row({serialized(1.79769313486231570814527423732E308)});
         testlog.info("cause overflow");
         cquery_nofail(e, "insert into cf (pk, val) values ('b', 0.5e+308);");
-        result = e.execute_cql("select sum(val) from cf;").get0();
+        result = e.execute_cql("select sum(val) from cf;").get();
         assert_that(result)
             .is_rows()
             .with_size(1)
             .with_row({serialized(std::numeric_limits<double>::infinity())});
         testlog.info("test maximum negative value");
         cquery_nofail(e, "insert into cf (pk, val) values ('a', -1.79769313486231570814527423732e+308);");
-        result = e.execute_cql("select sum(val) from cf;").get0();
+        result = e.execute_cql("select sum(val) from cf;").get();
         assert_that(result)
             .is_rows()
             .with_size(1)
             .with_row({serialized(-1.29769313486231570814527423732e+308)});
         testlog.info("cause negative overflow");
         cquery_nofail(e, "insert into cf (pk, val) values ('c', -1e+308);");
-        result = e.execute_cql("select sum(val) from cf;").get0();
+        result = e.execute_cql("select sum(val) from cf;").get();
         assert_that(result)
             .is_rows()
             .with_size(1)
@@ -3965,7 +3965,7 @@ SEASTAR_TEST_CASE(test_int_avg) {
         cquery_nofail(e, "create table cf (pk text, val int, primary key(pk));");
         cquery_nofail(e, "insert into cf (pk, val) values ('a', 2147483647);");
         cquery_nofail(e, "insert into cf (pk, val) values ('b', 2147483647);");
-        auto result = e.execute_cql("select avg(val) from cf;").get0();
+        auto result = e.execute_cql("select avg(val) from cf;").get();
         assert_that(result)
             .is_rows()
             .with_size(1)
@@ -3978,7 +3978,7 @@ SEASTAR_TEST_CASE(test_bigint_avg) {
         cquery_nofail(e, "create table cf (pk text, val bigint, primary key(pk));");
         cquery_nofail(e, "insert into cf (pk, val) values ('x', 9223372036854775807);");
         cquery_nofail(e, "insert into cf (pk, val) values ('y', 9223372036854775807);");
-        assert_that(e.execute_cql("select avg(val) from cf;").get0())
+        assert_that(e.execute_cql("select avg(val) from cf;").get())
             .is_rows()
             .with_size(1)
             .with_row({long_type->decompose(int64_t(9223372036854775807))});
@@ -4328,9 +4328,9 @@ shared_ptr<cql_transport::messages::result_message> cql_func_require_nofail(
     auto query = format("SELECT {}({}) FROM t;", fct, inp);
     try {
         if (qo) {
-            res = env.execute_cql(query, std::move(qo)).get0();
+            res = env.execute_cql(query, std::move(qo)).get();
         } else {
-            res = env.execute_cql(query).get0();
+            res = env.execute_cql(query).get();
         }
         testlog.info("Query '{}' succeeded as expected", query);
     } catch (...) {
@@ -4613,7 +4613,7 @@ static void prepared_on_shard(cql_test_env& e, const sstring& query,
             db::consistency_level cl = db::consistency_level::ONE) {
     auto execute = [&] () mutable {
         return seastar::async([&] () mutable {
-            auto id = e.prepare(query).get0();
+            auto id = e.prepare(query).get();
 
             std::vector<cql3::raw_value> raw_values;
             for (auto& param : params) {
@@ -4621,7 +4621,7 @@ static void prepared_on_shard(cql_test_env& e, const sstring& query,
             }
 
             auto qo = q_serial_opts(std::move(raw_values), cl);
-            auto msg = e.execute_prepared_with_qo(id, std::move(qo)).get0();
+            auto msg = e.execute_prepared_with_qo(id, std::move(qo)).get();
             if (!msg->move_to_shard()) {
                 assert_that(msg).is_rows().with_rows_ignore_order(expected_rows);
             }
@@ -4629,7 +4629,7 @@ static void prepared_on_shard(cql_test_env& e, const sstring& query,
         });
     };
 
-    auto msg = execute().get0();
+    auto msg = execute().get();
     if (msg->move_to_shard()) {
         unsigned shard = *msg->move_to_shard();
         smp::submit_to(shard, std::move(execute)).get();
@@ -4817,7 +4817,7 @@ SEASTAR_THREAD_TEST_CASE(test_query_limit) {
 
     do_with_cql_env_thread([db_config] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE test (pk int, ck int, v text, PRIMARY KEY (pk, ck));").get();
-        auto id = e.prepare("INSERT INTO test (pk, ck, v) VALUES (?, ?, ?);").get0();
+        auto id = e.prepare("INSERT INTO test (pk, ck, v) VALUES (?, ?, ?);").get();
 
         const int pk = 0;
         const auto raw_pk = int32_type->decompose(data_value(pk));
@@ -4870,7 +4870,7 @@ SEASTAR_THREAD_TEST_CASE(test_query_limit) {
                                         cql3::query_options::specific_options{page_size, paging_state, {}, api::new_timestamp()});
                             auto result = with_scheduling_group(scheduling_group, [&e] (const sstring& q, std::unique_ptr<cql3::query_options> qo) {
                                 return e.execute_cql(q, std::move(qo));
-                            }, select_query, std::move(qo)).get0();
+                            }, select_query, std::move(qo)).get();
 
                             auto rows_fetched = count_rows_fetched(result);
                             BOOST_REQUIRE(next_expected_row_idx + rows_fetched <= expected_rows.size());
@@ -5056,7 +5056,7 @@ SEASTAR_THREAD_TEST_CASE(test_twcs_optimal_query_path) {
         // Not really testing anything, just ensure that we execute the optimal
         // sstable read path of TWCS tables too, allowing ASAN to shake out any memory
         // related bugs.
-        assert_that(e.execute_cql("SELECT * FROM tbl WHERE pk = 0 BYPASS CACHE").get0())
+        assert_that(e.execute_cql("SELECT * FROM tbl WHERE pk = 0 BYPASS CACHE").get())
             .is_rows().with_size(1);
     }).get();
 }
@@ -5079,7 +5079,7 @@ SEASTAR_THREAD_TEST_CASE(test_query_unselected_columns) {
 
         const int num_rows = 20;
         const sstring val(100 * 1024, 'a');
-        const auto id = e.prepare(format("INSERT INTO tbl (pk, ck, v) VALUES (0, ?, '{}')", val)).get0();
+        const auto id = e.prepare(format("INSERT INTO tbl (pk, ck, v) VALUES (0, ?, '{}')", val)).get();
         for (int ck = 0; ck < num_rows; ++ck) {
             e.execute_prepared(id, {cql3::raw_value::make_value(int32_type->decompose(ck))}).get();
         }
@@ -5088,14 +5088,14 @@ SEASTAR_THREAD_TEST_CASE(test_query_unselected_columns) {
             testlog.info("Single partition scan");
             auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{-1, nullptr, {}, api::new_timestamp()});
-            assert_that(e.execute_cql("SELECT pk, ck FROM tbl WHERE pk = 0", std::move(qo)).get0()).is_rows().with_size(num_rows);
+            assert_that(e.execute_cql("SELECT pk, ck FROM tbl WHERE pk = 0", std::move(qo)).get()).is_rows().with_size(num_rows);
         }
 
         {
             testlog.info("Full scan");
             auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{-1, nullptr, {}, api::new_timestamp()});
-            assert_that(e.execute_cql("SELECT pk, ck FROM tbl", std::move(qo)).get0()).is_rows().with_size(num_rows);
+            assert_that(e.execute_cql("SELECT pk, ck FROM tbl", std::move(qo)).get()).is_rows().with_size(num_rows);
         }
     }, std::move(cfg)).get();
 }
@@ -5104,14 +5104,14 @@ SEASTAR_TEST_CASE(test_user_based_sla_queries) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         // test create service level with defaults
         e.execute_cql("CREATE SERVICE_LEVEL sl_1;").get();
-        auto msg = e.execute_cql("LIST SERVICE_LEVEL sl_1;").get0();
+        auto msg = e.execute_cql("LIST SERVICE_LEVEL sl_1;").get();
         assert_that(msg).is_rows().with_rows({
             {utf8_type->decompose("sl_1"), {}, {}},
         });
         e.execute_cql("CREATE SERVICE_LEVEL sl_2;").get();
         //drop service levels
         e.execute_cql("DROP SERVICE_LEVEL sl_1;").get();
-        msg = e.execute_cql("LIST ALL SERVICE_LEVELS;").get0();
+        msg = e.execute_cql("LIST ALL SERVICE_LEVELS;").get();
         assert_that(msg).is_rows().with_rows({
             {utf8_type->decompose("sl_2"), {}, {}},
         });
@@ -5126,11 +5126,11 @@ SEASTAR_TEST_CASE(test_user_based_sla_queries) {
 
         // test attach role
         e.execute_cql("ATTACH SERVICE_LEVEL sl_2 TO tester").get();
-        msg = e.execute_cql("LIST ATTACHED SERVICE_LEVEL OF tester;").get0();
+        msg = e.execute_cql("LIST ATTACHED SERVICE_LEVEL OF tester;").get();
         assert_that(msg).is_rows().with_rows({
             {utf8_type->decompose("tester"), utf8_type->decompose("sl_2")},
         });
-        msg = e.execute_cql("LIST ALL ATTACHED SERVICE_LEVELS;").get0();
+        msg = e.execute_cql("LIST ALL ATTACHED SERVICE_LEVELS;").get();
         assert_that(msg).is_rows().with_rows({
             {utf8_type->decompose("tester"), utf8_type->decompose("sl_2")},
         });
@@ -5144,35 +5144,35 @@ SEASTAR_TEST_CASE(test_user_based_sla_queries) {
         e.execute_cql("CREATE SERVICE_LEVEL sl_1;").get();
         e.execute_cql("ATTACH SERVICE_LEVEL sl_1 TO tester2;").get();
         e.execute_cql("DETACH SERVICE_LEVEL FROM tester;").get();
-        msg = e.execute_cql("LIST ATTACHED SERVICE_LEVEL OF tester2;").get0();
+        msg = e.execute_cql("LIST ATTACHED SERVICE_LEVEL OF tester2;").get();
         assert_that(msg).is_rows().with_rows({
             {utf8_type->decompose("tester2"), utf8_type->decompose("sl_1")},
         });
         BOOST_CHECK(true);
-        msg = e.execute_cql("LIST ATTACHED SERVICE_LEVEL OF tester;").get0();
+        msg = e.execute_cql("LIST ATTACHED SERVICE_LEVEL OF tester;").get();
         assert_that(msg).is_rows().with_rows({
         });
         BOOST_CHECK(true);
-        msg = e.execute_cql("LIST ALL ATTACHED SERVICE_LEVELS;").get0();
+        msg = e.execute_cql("LIST ALL ATTACHED SERVICE_LEVELS;").get();
         assert_that(msg).is_rows().with_rows({
             {utf8_type->decompose("tester2"), utf8_type->decompose("sl_1")},
         });
         BOOST_CHECK(true);
         //test implicit detach when removing role
         e.execute_cql("DROP ROLE tester2;").get();
-        msg = e.execute_cql("LIST ALL ATTACHED SERVICE_LEVELS;").get0();
+        msg = e.execute_cql("LIST ALL ATTACHED SERVICE_LEVELS;").get();
         assert_that(msg).is_rows().with_rows({
         });
         BOOST_CHECK(true);
         e.execute_cql("ATTACH SERVICE_LEVEL sl_1 TO tester;").get();
-        msg = e.execute_cql("LIST ALL ATTACHED SERVICE_LEVELS;").get0();
+        msg = e.execute_cql("LIST ALL ATTACHED SERVICE_LEVELS;").get();
         assert_that(msg).is_rows().with_rows({
             {utf8_type->decompose("tester"), utf8_type->decompose("sl_1")},
         });
         BOOST_CHECK(true);
         //test implicit detach when removing service level
         e.execute_cql("DROP SERVICE_LEVEL sl_1;").get();
-        msg = e.execute_cql("LIST ALL ATTACHED SERVICE_LEVELS;").get0();
+        msg = e.execute_cql("LIST ALL ATTACHED SERVICE_LEVELS;").get();
         assert_that(msg).is_rows().with_rows({
         });
     });
@@ -5382,27 +5382,27 @@ SEASTAR_TEST_CASE(test_parallelized_select_uda) {
                         "LANGUAGE lua "
                         "AS $$ "
                         "return acc+val "
-                        "$$;").get0();
+                        "$$;").get();
         e.execute_cql("CREATE FUNCTION reduce_fct(acc1 bigint, acc2 bigint) "
                         "RETURNS NULL ON NULL INPUT "
                         "RETURNS bigint "
                         "LANGUAGE lua "
                         "AS $$ "
                         "return acc1+acc2 "
-                        "$$;").get0();
+                        "$$;").get();
         e.execute_cql("CREATE FUNCTION final_fct(acc bigint) "
                         "RETURNS NULL ON NULL INPUT "
                         "RETURNS bigint "
                         "LANGUAGE lua "
                         "AS $$ "
                         "return -acc "
-                        "$$;").get0();
+                        "$$;").get();
         e.execute_cql("CREATE AGGREGATE aggr(int) "
                         "SFUNC row_fct "
                         "STYPE bigint "
                         "REDUCEFUNC reduce_fct "
                         "FINALFUNC final_fct "
-                        "INITCOND 0;").get0();
+                        "INITCOND 0;").get();
         e.execute_cql("CREATE TABLE tbl (k int, PRIMARY KEY (k));").get();
         int value_count = 10;
         for (int i = 0; i < value_count; i++) {
@@ -5428,19 +5428,19 @@ SEASTAR_TEST_CASE(test_not_parallelized_select_uda) {
                         "LANGUAGE lua "
                         "AS $$ "
                         "return acc+val "
-                        "$$;").get0();
+                        "$$;").get();
         e.execute_cql("CREATE FUNCTION final_fct(acc bigint) "
                         "RETURNS NULL ON NULL INPUT "
                         "RETURNS bigint "
                         "LANGUAGE lua "
                         "AS $$ "
                         "return -acc "
-                        "$$;").get0();
+                        "$$;").get();
         e.execute_cql("CREATE AGGREGATE aggr(int) "
                         "SFUNC row_fct "
                         "STYPE bigint "
                         "FINALFUNC final_fct "
-                        "INITCOND 0;").get0();
+                        "INITCOND 0;").get();
         
         e.execute_cql("CREATE TABLE tbl (k int, PRIMARY KEY (k));").get();
         int value_count = 10;
@@ -5511,10 +5511,10 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
 
 
         // Test null and unset when sent as bind marker for collection value
-        auto insert_list_with_marker = e.prepare("INSERT INTO null_in_col (p, l) VALUES (0, [1, ?, 3])").get0();
-        auto insert_set_with_marker = e.prepare("INSERT INTO null_in_col (p, s) VALUES (0, {1, ?, 3})").get0();
-        auto insert_map_with_key_marker = e.prepare("INSERT INTO null_in_col (p, m) VALUES (0, {0:1, ?:3, 4:5})").get0();
-        auto insert_map_with_value_marker = e.prepare("INSERT INTO null_in_col (p, m) VALUES (0, {0:1, 2:?, 4:5})").get0();
+        auto insert_list_with_marker = e.prepare("INSERT INTO null_in_col (p, l) VALUES (0, [1, ?, 3])").get();
+        auto insert_set_with_marker = e.prepare("INSERT INTO null_in_col (p, s) VALUES (0, {1, ?, 3})").get();
+        auto insert_map_with_key_marker = e.prepare("INSERT INTO null_in_col (p, m) VALUES (0, {0:1, ?:3, 4:5})").get();
+        auto insert_map_with_value_marker = e.prepare("INSERT INTO null_in_col (p, m) VALUES (0, {0:1, 2:?, 4:5})").get();
 
         cql3::raw_value null_value = cql3::raw_value::make_null();
 
@@ -5540,9 +5540,9 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
 
 
         // Test sending whole collections with null and unset inside as bound value
-        auto insert_list = e.prepare("INSERT INTO null_in_col (p, l) VALUES (0, ?)").get0();
-        auto insert_set = e.prepare("INSERT INTO null_in_col (p, s) VALUES (0, ?)").get0();
-        auto insert_map = e.prepare("INSERT INTO null_in_col (p, m) VALUES (0, ?)").get0();
+        auto insert_list = e.prepare("INSERT INTO null_in_col (p, l) VALUES (0, ?)").get();
+        auto insert_set = e.prepare("INSERT INTO null_in_col (p, s) VALUES (0, ?)").get();
+        auto insert_map = e.prepare("INSERT INTO null_in_col (p, m) VALUES (0, ?)").get();
 
         auto make_int = [](int val) -> cql3::raw_value {
             return cql3::raw_value::make_value(int32_type->decompose(val));
@@ -5600,10 +5600,10 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
                                 exceptions::invalid_request_exception, check_null_msg());
 
         // Update adding a collection value with bad bind marker
-        auto add_list_with_marker = e.prepare("UPDATE null_in_col SET l = l + [1, ?, 2] WHERE p = 0").get0();
-        auto add_set_with_marker = e.prepare("UPDATE null_in_col SET s = s + {1, ?, 2} WHERE p = 0").get0();
-        auto add_map_with_key_marker = e.prepare("UPDATE null_in_col SET m = m + {0:1, ?:3, 4:5} WHERE p = 0").get0();
-        auto add_map_with_value_marker = e.prepare("UPDATE null_in_col SET m = m + {0:1, 2:?, 4:5} WHERE p = 0").get0();
+        auto add_list_with_marker = e.prepare("UPDATE null_in_col SET l = l + [1, ?, 2] WHERE p = 0").get();
+        auto add_set_with_marker = e.prepare("UPDATE null_in_col SET s = s + {1, ?, 2} WHERE p = 0").get();
+        auto add_map_with_key_marker = e.prepare("UPDATE null_in_col SET m = m + {0:1, ?:3, 4:5} WHERE p = 0").get();
+        auto add_map_with_value_marker = e.prepare("UPDATE null_in_col SET m = m + {0:1, 2:?, 4:5} WHERE p = 0").get();
 
         BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_list_with_marker, {null_value}).get(),
                                 exceptions::invalid_request_exception, check_null_msg());
@@ -5624,9 +5624,9 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
                                 exceptions::invalid_request_exception, check_unset_msg());
 
         // Update adding a collection value with bad bind marker
-        auto add_list = e.prepare("UPDATE null_in_col SET l = l + ? WHERE p = 0").get0();
-        auto add_set = e.prepare("UPDATE null_in_col SET s = s + ? WHERE p = 0").get0();
-        auto add_map = e.prepare("UPDATE null_in_col SET m = m + ? WHERE p = 0").get0();
+        auto add_list = e.prepare("UPDATE null_in_col SET l = l + ? WHERE p = 0").get();
+        auto add_set = e.prepare("UPDATE null_in_col SET s = s + ? WHERE p = 0").get();
+        auto add_map = e.prepare("UPDATE null_in_col SET m = m + ? WHERE p = 0").get();
 
         BOOST_REQUIRE_EXCEPTION(e.execute_prepared(add_list, {list_with_null}).get(),
                                 exceptions::invalid_request_exception, check_null_msg());
@@ -5641,7 +5641,7 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
         auto msg1 = e.execute_cql("SELECT * FROM null_in_col WHERE p IN (1, null, 2)").get();
         assert_that(msg1).is_rows().with_rows({});
 
-        auto where_in_list_with_marker = e.prepare("SELECT * FROM null_in_col WHERE p IN (1, ?, 2)").get0();
+        auto where_in_list_with_marker = e.prepare("SELECT * FROM null_in_col WHERE p IN (1, ?, 2)").get();
 
         auto msg2 = e.execute_prepared(where_in_list_with_marker, {null_value}).get();
         assert_that(msg2).is_rows().with_rows({});
@@ -5649,7 +5649,7 @@ SEASTAR_TEST_CASE(test_null_and_unset_in_collections) {
         BOOST_REQUIRE_EXCEPTION(e.execute_prepared(where_in_list_with_marker, bind_variable_list_with_unset).get(),
                                 exceptions::invalid_request_exception, check_unset_msg());
 
-        auto where_in_list_marker = e.prepare("SELECT * FROM null_in_col WHERE p IN ?").get0();
+        auto where_in_list_marker = e.prepare("SELECT * FROM null_in_col WHERE p IN ?").get();
 
         auto msg = e.execute_prepared(where_in_list_marker, {list_with_null}).get();
         assert_that(msg).is_rows().with_rows({});
@@ -5775,7 +5775,7 @@ SEASTAR_TEST_CASE(test_sending_tablet_info_insert) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         e.execute_cql("create keyspace ks_tablet with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1 } and tablets = {'initial': 8};").get();
         e.execute_cql("create table ks_tablet.test_tablet (pk int, ck int, v int, PRIMARY KEY (pk, ck));").get();
-        auto insert = e.prepare("insert into ks_tablet.test_tablet (pk, ck, v) VALUES (?, ?, ?);").get0();
+        auto insert = e.prepare("insert into ks_tablet.test_tablet (pk, ck, v) VALUES (?, ?, ?);").get();
         
         std::vector<cql3::raw_value> raw_values;
         raw_values.emplace_back(cql3::raw_value::make_value(int32_type->decompose(int32_t{1})));
@@ -5790,7 +5790,7 @@ SEASTAR_TEST_CASE(test_sending_tablet_info_insert) {
 
         smp::submit_to(local_shard, [&] {
             return seastar::async([&] { 
-                auto result = e.execute_prepared(insert, raw_values).get0();
+                auto result = e.execute_prepared(insert, raw_values).get();
                 BOOST_ASSERT(!has_tablet_routing(result));
             });
         }).get();
@@ -5807,7 +5807,7 @@ SEASTAR_TEST_CASE(test_sending_tablet_info_insert) {
 
         smp::submit_to(foreign_shard, [&] { 
             return seastar::async([&] {
-                auto result = e.execute_prepared(insert, raw_values2).get0();
+                auto result = e.execute_prepared(insert, raw_values2).get();
                 BOOST_ASSERT(has_tablet_routing(result));
             });
         }).get();
@@ -5820,7 +5820,7 @@ SEASTAR_TEST_CASE(test_sending_tablet_info_select) {
         e.execute_cql("create table ks_tablet.test_tablet (pk int, ck int, v int, PRIMARY KEY (pk, ck));").get();
         e.execute_cql("insert into ks_tablet.test_tablet (pk, ck, v) VALUES (1, 2, 3);").get();
         
-        auto select = e.prepare("select pk, ck, v FROM ks_tablet.test_tablet WHERE pk = ?;").get0();
+        auto select = e.prepare("select pk, ck, v FROM ks_tablet.test_tablet WHERE pk = ?;").get();
         std::vector<cql3::raw_value> raw_values;
         raw_values.emplace_back(cql3::raw_value::make_value(int32_type->decompose(int32_t{1})));
 
@@ -5833,14 +5833,14 @@ SEASTAR_TEST_CASE(test_sending_tablet_info_select) {
 
         smp::submit_to(local_shard, [&] { 
             return seastar::async([&] {
-                auto result = e.execute_prepared(select, raw_values).get0();
+                auto result = e.execute_prepared(select, raw_values).get();
                 BOOST_ASSERT(!has_tablet_routing(result));
             });
         }).get();
 
         smp::submit_to(foreign_shard, [&] { 
             return seastar::async([&] {
-                auto result = e.execute_prepared(select, raw_values).get0();
+                auto result = e.execute_prepared(select, raw_values).get();
                 BOOST_ASSERT(has_tablet_routing(result));
             });
         }).get();

--- a/test/boost/data_listeners_test.cc
+++ b/test/boost/data_listeners_test.cc
@@ -91,7 +91,7 @@ results test_data_listeners(cql_test_env& e, sstring cf_name) {
             res.read += li_res.read;
             res.write += li_res.write;
             return res;
-        }).get0();
+        }).get();
 
     testlog.info("test_data_listeners: rd={} wr={}", res.read, res.write);
 

--- a/test/boost/error_injection_test.cc
+++ b/test/boost/error_injection_test.cc
@@ -386,19 +386,19 @@ SEASTAR_TEST_CASE(test_inject_cql) {
             cquery_nofail(e, "insert into  error_name (name, one_shot) values ('test1', 'true')");
 
             // Check no error injections before injecting
-            auto ret0 = e.execute_cql("select enabled_injections() from error_name limit 1").get0();
+            auto ret0 = e.execute_cql("select enabled_injections() from error_name limit 1").get();
             assert_that(ret0).is_rows().with_rows({
                 {row_empty}
             });
 
             cquery_nofail(e, "select enable_injection(name, one_shot)  from error_name where name = 'test1'");
             // enabled_injections() returns a list all injections in one call, so limit 1
-            auto ret1 = e.execute_cql("select enabled_injections() from error_name limit 1").get0();
+            auto ret1 = e.execute_cql("select enabled_injections() from error_name limit 1").get();
             assert_that(ret1).is_rows().with_rows({
                 {row_test1}
             });
             utils::get_local_injector().inject("test1", [] {}); // Noop one-shot injection
-            auto ret2 = e.execute_cql("select enabled_injections() from error_name limit 1").get0();
+            auto ret2 = e.execute_cql("select enabled_injections() from error_name limit 1").get();
             assert_that(ret2).is_rows().with_rows({
                 // Empty list after one shot executed
                 {row_empty}
@@ -407,13 +407,13 @@ SEASTAR_TEST_CASE(test_inject_cql) {
             // Again (test1,one_shot=true) but disable with CQL API
             cquery_nofail(e, "select enable_injection(name, one_shot)  from error_name where name = 'test1'");
             // enabled_injections() returns a list all injections in one call, so limit 1
-            auto ret3 = e.execute_cql("select enabled_injections() from error_name limit 1").get0();
+            auto ret3 = e.execute_cql("select enabled_injections() from error_name limit 1").get();
             assert_that(ret3).is_rows().with_rows({
                 {row_test1}
             });
             // Disable
             cquery_nofail(e, "select disable_injection(name) from error_name where name = 'test1'");
-            auto ret4 = e.execute_cql("select enabled_injections() from error_name limit 1").get0();
+            auto ret4 = e.execute_cql("select enabled_injections() from error_name limit 1").get();
             assert_that(ret4).is_rows().with_rows({
                 // Empty list after one shot disabled
                 {row_empty}
@@ -422,7 +422,7 @@ SEASTAR_TEST_CASE(test_inject_cql) {
             cquery_nofail(e, "insert into  error_name (name, one_shot) values ('test2', 'false')");
             cquery_nofail(e, "select enable_injection(name, one_shot)  from error_name where name = 'test2'");
             utils::get_local_injector().inject("test2", [] {}); // Noop injection, doesn't disable
-            auto ret5 = e.execute_cql("select enabled_injections() from error_name limit 1").get0();
+            auto ret5 = e.execute_cql("select enabled_injections() from error_name limit 1").get();
             assert_that(ret5).is_rows().with_rows({
                 {row_test2}
             });

--- a/test/boost/filtering_test.cc
+++ b/test/boost/filtering_test.cc
@@ -89,7 +89,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_pk_ck) {
         e.execute_cql("INSERT INTO t (a,b,c,d,e) VALUES (21, 22, 23, 24, 25)").get();
         e.execute_cql("INSERT INTO t (a,b,c,d,e) VALUES (31, 32, 33, 34, 35)").get();
 
-        auto msg = e.execute_cql("SELECT * FROM t WHERE a = 11 AND b = 15 AND c = 16").get0();
+        auto msg = e.execute_cql("SELECT * FROM t WHERE a = 11 AND b = 15 AND c = 16").get();
         assert_that(msg).is_rows().with_rows({{
             int32_type->decompose(11),
             int32_type->decompose(15),
@@ -100,7 +100,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_pk_ck) {
 
         BOOST_CHECK_THROW(e.execute_cql("SELECT * FROM t WHERE a = 11 AND b = 12 AND c > 13 AND d = 14").get(), exceptions::invalid_request_exception);
 
-        msg = e.execute_cql("SELECT * FROM t WHERE a = 11 AND b = 15 AND c = 16").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE a = 11 AND b = 15 AND c = 16").get();
         assert_that(msg).is_rows().with_rows({{
             int32_type->decompose(11),
             int32_type->decompose(15),
@@ -109,7 +109,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_pk_ck) {
             int32_type->decompose(18),
         }});
 
-        msg = e.execute_cql("SELECT * FROM t WHERE a = 11 AND b = 15 AND c > 13 AND d >= 17 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE a = 11 AND b = 15 AND c > 13 AND d >= 17 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({{
             int32_type->decompose(11),
             int32_type->decompose(15),
@@ -120,7 +120,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_pk_ck) {
 
         BOOST_CHECK_THROW(e.execute_cql("SELECT * FROM t WHERE a = 11 AND b = 12 AND c > 13 AND d > 17").get(), exceptions::invalid_request_exception);
 
-        msg = e.execute_cql("SELECT * FROM t WHERE a = 11 AND b = 15 AND c > 13 AND d >= 17 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE a = 11 AND b = 15 AND c > 13 AND d >= 17 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({{
             int32_type->decompose(11),
             int32_type->decompose(15),
@@ -129,7 +129,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_pk_ck) {
             int32_type->decompose(18),
         }});
 
-        msg = e.execute_cql("SELECT * FROM t WHERE a <= 11 AND c > 15 AND d >= 16 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE a <= 11 AND c > 15 AND d >= 16 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({{
             int32_type->decompose(11),
             int32_type->decompose(15),
@@ -138,7 +138,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_pk_ck) {
             int32_type->decompose(18),
         }});
 
-        msg = e.execute_cql("SELECT * FROM t WHERE a <= 11 AND b >= 15 AND c > 15 AND d >= 16 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE a <= 11 AND b >= 15 AND c > 15 AND d >= 16 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({{
             int32_type->decompose(11),
             int32_type->decompose(15),
@@ -147,7 +147,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_pk_ck) {
             int32_type->decompose(18),
         }});
 
-        msg = e.execute_cql("SELECT * FROM t WHERE a <= 100 AND b >= 15 AND c > 0 AND d <= 100 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE a <= 100 AND b >= 15 AND c > 0 AND d <= 100 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {
                 int32_type->decompose(11),
@@ -185,7 +185,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_multi_column) {
         e.execute_cql("INSERT INTO t (a,b,c,d,e) VALUES (1, 2, 1, 2, 25)").get();
         e.execute_cql("INSERT INTO t (a,b,c,d,e) VALUES (1, 2, 1, 3, 35)").get();
 
-        auto msg = e.execute_cql("SELECT * FROM t WHERE (c, d) = (1, 2) ALLOW FILTERING").get0();
+        auto msg = e.execute_cql("SELECT * FROM t WHERE (c, d) = (1, 2) ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
             {
                 int32_type->decompose(1),
@@ -203,7 +203,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_multi_column) {
             },
         });
 
-        msg = e.execute_cql("SELECT * FROM t WHERE (c, d) IN ((1, 2), (1,3), (1,4)) ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE (c, d) IN ((1, 2), (1,3), (1,4)) ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
             {
                 int32_type->decompose(1),
@@ -228,7 +228,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_multi_column) {
             },
         });
 
-        msg = e.execute_cql("SELECT * FROM t WHERE (c, d) < (1, 3) ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE (c, d) < (1, 3) ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
             {
                 int32_type->decompose(1),
@@ -253,7 +253,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_multi_column) {
             },
         });
 
-        msg = e.execute_cql("SELECT * FROM t WHERE (c, d) < (1, 3) AND (c, d) > (1, 1) ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE (c, d) < (1, 3) AND (c, d) > (1, 1) ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
             {
                 int32_type->decompose(1),
@@ -293,7 +293,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_clustering_column) {
         e.execute_cql("INSERT INTO t (k, c, v) VALUES (1, 3, 2)").get();
         e.execute_cql("INSERT INTO t (k, c, v) VALUES (2, 2, 3)").get();
 
-        auto msg = e.execute_cql("SELECT * FROM t WHERE k = 1").get0();
+        auto msg = e.execute_cql("SELECT * FROM t WHERE k = 1").get();
         assert_that(msg).is_rows().with_rows({
             {
                 int32_type->decompose(1),
@@ -307,21 +307,21 @@ SEASTAR_TEST_CASE(test_allow_filtering_clustering_column) {
            }
         });
 
-        msg = e.execute_cql("SELECT * FROM t WHERE k = 1 AND c > 2").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE k = 1 AND c > 2").get();
         assert_that(msg).is_rows().with_rows({{
             int32_type->decompose(1),
             int32_type->decompose(3),
             int32_type->decompose(2)
         }});
 
-        msg = e.execute_cql("SELECT * FROM t WHERE k = 1 AND c = 2").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE k = 1 AND c = 2").get();
         assert_that(msg).is_rows().with_rows({{
             int32_type->decompose(1),
             int32_type->decompose(2),
             int32_type->decompose(1)
         }});
 
-        msg = e.execute_cql("SELECT * FROM t WHERE c = 2 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE c = 2 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {
                 int32_type->decompose(1),
@@ -335,7 +335,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_clustering_column) {
            }
         });
 
-        msg = e.execute_cql("SELECT * FROM t WHERE c > 2 AND c <= 4 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE c > 2 AND c <= 4 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({{
             int32_type->decompose(1),
             int32_type->decompose(3),
@@ -353,7 +353,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_two_clustering_columns) {
         e.execute_cql("INSERT INTO t (p, c1, c2, data) VALUES (1, 2, 5, 3)").get();
         e.execute_cql("INSERT INTO t (p, c1, c2, data) VALUES (2, 3, 4, 4)").get();
 
-        auto res = e.execute_cql("SELECT * FROM t WHERE p = 1 and c1 < 3 and c2 > 3 ALLOW FILTERING").get0();
+        auto res = e.execute_cql("SELECT * FROM t WHERE p = 1 and c1 < 3 and c2 > 3 ALLOW FILTERING").get();
         assert_that(res).is_rows().with_rows({
             {
                 int32_type->decompose(1),
@@ -365,7 +365,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_two_clustering_columns) {
         // In issue #4121, we noticed that although with "SELECT *" filtering
         // was correct, when we select only a column *not* involved in the
         // filtering, one of the constraints was ignored.
-        res = e.execute_cql("SELECT data FROM t WHERE p = 1 and c1 < 3 and c2 > 3 ALLOW FILTERING").get0();
+        res = e.execute_cql("SELECT data FROM t WHERE p = 1 and c1 < 3 and c2 > 3 ALLOW FILTERING").get();
         assert_that(res).is_rows().with_rows({
             {
                 int32_type->decompose(3),
@@ -385,7 +385,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_two_clustering_columns) {
         e.execute_cql("INSERT INTO t2 (p, c1, c2, c3, c4, data) VALUES (1, 1, 2, 5, 4, 3)").get();
         e.execute_cql("INSERT INTO t2 (p, c1, c2, c3, c4, data) VALUES (1, 1, 4, 3, 4, 4)").get();
         e.execute_cql("INSERT INTO t2 (p, c1, c2, c3, c4, data) VALUES (1, 2, 4, 4, 2, 5)").get();
-        res = e.execute_cql("SELECT data FROM t2 WHERE p = 1 and c1 = 1 and c2 < 3 and c3 > 4 and c4 < 7 ALLOW FILTERING").get0();
+        res = e.execute_cql("SELECT data FROM t2 WHERE p = 1 and c1 = 1 and c2 < 3 and c3 > 4 and c4 < 7 ALLOW FILTERING").get();
         assert_that(res).is_rows().with_rows({
             {
                 int32_type->decompose(3),
@@ -410,7 +410,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_static_column) {
         e.execute_cql("INSERT INTO t (a, b, c, s) VALUES (2, 1, 1, 2)").get();
 
         eventually([&] {
-            auto msg = e.execute_cql("SELECT * FROM t WHERE c = 1 AND s = 2 ALLOW FILTERING").get0();
+            auto msg = e.execute_cql("SELECT * FROM t WHERE c = 1 AND s = 2 ALLOW FILTERING").get();
             assert_that(msg).is_rows().with_rows({{
                 int32_type->decompose(2),
                 int32_type->decompose(1),
@@ -420,7 +420,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_static_column) {
         });
 
         eventually([&] {
-            auto msg = e.execute_cql("SELECT * FROM t WHERE c = 1 AND s = 1 ALLOW FILTERING").get0();
+            auto msg = e.execute_cql("SELECT * FROM t WHERE c = 1 AND s = 1 ALLOW FILTERING").get();
             assert_that(msg).is_rows().with_rows({
                 {
                     int32_type->decompose(1),
@@ -459,51 +459,51 @@ SEASTAR_TEST_CASE(test_allow_filtering_multiple_regular) {
         auto my_set_type = set_type_impl::get_instance(int32_type, true);
         auto my_map_type = map_type_impl::get_instance(int32_type, utf8_type, true);
 
-        auto msg = e.execute_cql("SELECT f FROM t WHERE f contains 1 ALLOW FILTERING").get0();
+        auto msg = e.execute_cql("SELECT f FROM t WHERE f contains 1 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {my_list_type->decompose(make_list_value(my_list_type, list_type_impl::native_type{{1}}))},
             {my_list_type->decompose(make_list_value(my_list_type, list_type_impl::native_type{{1, 2}}))},
             {my_list_type->decompose(make_list_value(my_list_type, list_type_impl::native_type{{1, 2, 3}}))},
         });
 
-        msg = e.execute_cql("SELECT f FROM t WHERE f contains 2 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT f FROM t WHERE f contains 2 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {my_list_type->decompose(make_list_value(my_list_type, list_type_impl::native_type{{1, 2}}))},
             {my_list_type->decompose(make_list_value(my_list_type, list_type_impl::native_type{{1, 2, 3}}))},
         });
 
-        msg = e.execute_cql("SELECT f FROM t WHERE f contains 2 AND f contains 3 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT f FROM t WHERE f contains 2 AND f contains 3 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {my_list_type->decompose(make_list_value(my_list_type, list_type_impl::native_type{{1, 2, 3}}))},
         });
 
-        msg = e.execute_cql("SELECT g FROM t WHERE g contains 7 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT g FROM t WHERE g contains 7 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {my_set_type->decompose(make_set_value(my_set_type, set_type_impl::native_type{{1, 2, 7}}))},
         });
 
-        msg = e.execute_cql("SELECT g FROM t WHERE g contains 1 and g contains 7 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT g FROM t WHERE g contains 1 and g contains 7 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {my_set_type->decompose(make_set_value(my_set_type, set_type_impl::native_type{{1, 2, 7}}))},
         });
 
-        msg = e.execute_cql("SELECT h FROM t WHERE h contains key 3 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT h FROM t WHERE h contains key 3 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {my_map_type->decompose(make_map_value(my_map_type, map_type_impl::native_type{{{3, "three"}}}))},
             {my_map_type->decompose(make_map_value(my_map_type, map_type_impl::native_type{{{3, "three"}, {4, "four"}}}))},
         });
 
-        msg = e.execute_cql("SELECT h FROM t WHERE h contains 'four' ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT h FROM t WHERE h contains 'four' ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {my_map_type->decompose(make_map_value(my_map_type, map_type_impl::native_type{{{3, "three"}, {4, "four"}}}))},
         });
 
-        msg = e.execute_cql("SELECT h FROM t WHERE h contains key 3 and h contains 'four' ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT h FROM t WHERE h contains key 3 and h contains 'four' ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {my_map_type->decompose(make_map_value(my_map_type, map_type_impl::native_type{{{3, "three"}, {4, "four"}}}))},
         });
 
-        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c = 3 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c = 3 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({{
             int32_type->decompose(1),
             int32_type->decompose(2),
@@ -512,7 +512,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_multiple_regular) {
             int32_type->decompose(5)
         }});
 
-        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE e >= 5 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE e >= 5 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {
                 int32_type->decompose(1),
@@ -537,7 +537,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_multiple_regular) {
            }
         });
 
-        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c = 5 and e = 9 and d = 1 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c = 5 and e = 9 and d = 1 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({{
             int32_type->decompose(1),
             int32_type->decompose(3),
@@ -546,12 +546,12 @@ SEASTAR_TEST_CASE(test_allow_filtering_multiple_regular) {
             int32_type->decompose(9)
         }});
 
-        cql3::prepared_cache_key_type prepared_id = e.prepare("SELECT a, b, c, d, e FROM t WHERE a = ? and d = ? ALLOW FILTERING").get0();
+        cql3::prepared_cache_key_type prepared_id = e.prepare("SELECT a, b, c, d, e FROM t WHERE a = ? and d = ? ALLOW FILTERING").get();
         std::vector<cql3::raw_value> raw_values {
                 cql3::raw_value::make_value(int32_type->decompose(1)),
                 cql3::raw_value::make_value(int32_type->decompose(1))
         };
-        msg = e.execute_prepared(prepared_id, raw_values).get0();
+        msg = e.execute_prepared(prepared_id, raw_values).get();
         assert_that(msg).is_rows().with_rows({
             {
                 int32_type->decompose(1),
@@ -569,9 +569,9 @@ SEASTAR_TEST_CASE(test_allow_filtering_multiple_regular) {
            }
         });
 
-        prepared_id = e.prepare("SELECT a, b, c, d, e FROM t WHERE a = ? and d = ? ALLOW FILTERING").get0();
+        prepared_id = e.prepare("SELECT a, b, c, d, e FROM t WHERE a = ? and d = ? ALLOW FILTERING").get();
         raw_values[1] = cql3::raw_value::make_value(int32_type->decompose(9));
-        msg = e.execute_prepared(prepared_id, raw_values).get0();
+        msg = e.execute_prepared(prepared_id, raw_values).get();
         assert_that(msg).is_rows().with_size(0);
 
 
@@ -588,7 +588,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_desc) {
         e.execute_cql("INSERT INTO t (a, b, c, d, e) VALUES (1, 2, 5, 1, 9)").get();
         e.execute_cql("INSERT INTO t (a, b, c, d, e) VALUES (1, 2, 6, 7, 5)").get();
 
-        auto msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c > 3 ALLOW FILTERING").get0();
+        auto msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c > 3 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {
                 int32_type->decompose(1),
@@ -606,7 +606,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_desc) {
             }
         });
 
-        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c < 4 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c < 4 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({
             {
                 int32_type->decompose(1),
@@ -624,7 +624,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_desc) {
             }
         });
 
-        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c = 4 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c = 4 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_size(0);
     });
 }
@@ -640,7 +640,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_with_secondary_index) {
         e.execute_cql("INSERT INTO t (a, b, c, d, e) VALUES (1, 3, 5, 1, 9)").get();
         e.execute_cql("INSERT INTO t (a, b, c, d, e) VALUES (1, 4, 5, 7, 5)").get();
 
-        auto msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c = 3").get0();
+        auto msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c = 3").get();
         assert_that(msg).is_rows().with_rows({{
             int32_type->decompose(1),
             int32_type->decompose(2),
@@ -651,7 +651,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_with_secondary_index) {
 
         BOOST_CHECK_THROW(e.execute_cql("SELECT * FROM t WHERE c = 5 and d = 1").get(), exceptions::invalid_request_exception);
 
-        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c = 5 and d = 1 ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT a, b, c, d, e FROM t WHERE c = 5 and d = 1 ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows({{
                 int32_type->decompose(1),
                 int32_type->decompose(3),
@@ -672,12 +672,12 @@ SEASTAR_TEST_CASE(test_allow_filtering_with_secondary_index) {
         }
 
         eventually([&] {
-            auto msg = e.execute_cql("SELECT * FROM t2 WHERE pk1 = 1 AND c1 > 0 AND c1 < 5 AND c2 = 1 AND v = 3 ALLOW FILTERING;").get0();
+            auto msg = e.execute_cql("SELECT * FROM t2 WHERE pk1 = 1 AND c1 > 0 AND c1 < 5 AND c2 = 1 AND v = 3 ALLOW FILTERING;").get();
             assert_that(msg).is_rows().with_rows({});
         });
 
         eventually([&] {
-            auto msg = e.execute_cql("SELECT * FROM t2 WHERE pk1 = 1 AND  c1 > 0 AND c1 < 5 AND c2 = 3 AND v = 3 ALLOW FILTERING;").get0();
+            auto msg = e.execute_cql("SELECT * FROM t2 WHERE pk1 = 1 AND  c1 > 0 AND c1 < 5 AND c2 = 3 AND v = 3 ALLOW FILTERING;").get();
             assert_that(msg).is_rows().with_rows({
                 {
                     int32_type->decompose(1),
@@ -704,12 +704,12 @@ SEASTAR_TEST_CASE(test_allow_filtering_with_secondary_index) {
         });
 
         eventually([&] {
-            auto msg = e.execute_cql("SELECT * FROM t2 WHERE pk1 = 1 AND  c2 > 1 AND c2 < 5 AND v = 1 ALLOW FILTERING;").get0();
+            auto msg = e.execute_cql("SELECT * FROM t2 WHERE pk1 = 1 AND  c2 > 1 AND c2 < 5 AND v = 1 ALLOW FILTERING;").get();
             assert_that(msg).is_rows().with_rows({});
         });
 
         eventually([&] {
-            auto msg = e.execute_cql("SELECT * FROM t2 WHERE pk1 = 1 AND  c1 > 1 AND c2 > 2 AND v = 3 ALLOW FILTERING;").get0();
+            auto msg = e.execute_cql("SELECT * FROM t2 WHERE pk1 = 1 AND  c1 > 1 AND c2 > 2 AND v = 3 ALLOW FILTERING;").get();
             assert_that(msg).is_rows().with_rows({
                 {
                     int32_type->decompose(1),
@@ -729,7 +729,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_with_secondary_index) {
         });
 
         eventually([&] {
-            auto msg = e.execute_cql("SELECT * FROM t2 WHERE pk1 = 1 AND  pk2 > 1 AND c2 > 2 AND v = 3 ALLOW FILTERING;").get0();
+            auto msg = e.execute_cql("SELECT * FROM t2 WHERE pk1 = 1 AND  pk2 > 1 AND c2 > 2 AND v = 3 ALLOW FILTERING;").get();
             assert_that(msg).is_rows().with_rows({{
                     int32_type->decompose(1),
                     int32_type->decompose(3),
@@ -740,7 +740,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_with_secondary_index) {
         });
 
         eventually([&] {
-            auto msg = e.execute_cql("SELECT * FROM t2 WHERE pk1 >= 2 AND pk2 <=3 AND  c1 IN(0,1,2) AND c2 IN(0,1,2) AND v < 3  ALLOW FILTERING;").get0();
+            auto msg = e.execute_cql("SELECT * FROM t2 WHERE pk1 >= 2 AND pk2 <=3 AND  c1 IN(0,1,2) AND c2 IN(0,1,2) AND v < 3  ALLOW FILTERING;").get();
             assert_that(msg).is_rows().with_rows({
                 {
                     int32_type->decompose(2),
@@ -804,12 +804,12 @@ SEASTAR_TEST_CASE(test_allow_filtering_limit) {
                 "APPLY BATCH;"
         ).get();
 
-        auto msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=true ALLOW FILTERING;").get0();
+        auto msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=true ALLOW FILTERING;").get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(3), boolean_type->decompose(true)},
         });
 
-        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false ALLOW FILTERING;").get0();
+        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false ALLOW FILTERING;").get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(1), boolean_type->decompose(false)},
             { int32_type->decompose(2), boolean_type->decompose(false)},
@@ -820,14 +820,14 @@ SEASTAR_TEST_CASE(test_allow_filtering_limit) {
 
         auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                 cql3::query_options::specific_options{100, nullptr, {}, api::new_timestamp()});
-        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=true LIMIT 1 ALLOW FILTERING;", std::move(qo)).get0();
+        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=true LIMIT 1 ALLOW FILTERING;", std::move(qo)).get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(3), boolean_type->decompose(true)},
         });
 
         qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                 cql3::query_options::specific_options{100, nullptr, {}, api::new_timestamp()});
-        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false LIMIT 5 ALLOW FILTERING;", std::move(qo)).get0();
+        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false LIMIT 5 ALLOW FILTERING;", std::move(qo)).get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(1), boolean_type->decompose(false)},
             { int32_type->decompose(2), boolean_type->decompose(false)},
@@ -838,7 +838,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_limit) {
 
         qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                 cql3::query_options::specific_options{100, nullptr, {}, api::new_timestamp()});
-        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false LIMIT 2 ALLOW FILTERING;", std::move(qo)).get0();
+        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false LIMIT 2 ALLOW FILTERING;", std::move(qo)).get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(1), boolean_type->decompose(false)},
             { int32_type->decompose(2), boolean_type->decompose(false)}
@@ -846,7 +846,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_limit) {
 
         qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                 cql3::query_options::specific_options{100, nullptr, {}, api::new_timestamp()});
-        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false LIMIT 3 ALLOW FILTERING;", std::move(qo)).get0();
+        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false LIMIT 3 ALLOW FILTERING;", std::move(qo)).get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(1), boolean_type->decompose(false)},
             { int32_type->decompose(2), boolean_type->decompose(false)},
@@ -855,7 +855,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_limit) {
 
         qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                 cql3::query_options::specific_options{1, nullptr, {}, api::new_timestamp()});
-        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false LIMIT 3 ALLOW FILTERING;", std::move(qo)).get0();
+        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false LIMIT 3 ALLOW FILTERING;", std::move(qo)).get();
         auto paging_state = extract_paging_state(msg);
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(1), boolean_type->decompose(false)}
@@ -866,7 +866,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_limit) {
         while (rows_fetched == 0) {
             qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, paging_state, {}, api::new_timestamp()});
-            msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false LIMIT 3 ALLOW FILTERING;", std::move(qo)).get0();
+            msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false LIMIT 3 ALLOW FILTERING;", std::move(qo)).get();
             rows_fetched = count_rows_fetched(msg);
             paging_state = extract_paging_state(msg);
         }
@@ -878,7 +878,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_limit) {
         while (rows_fetched == 0) {
             qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, paging_state, {}, api::new_timestamp()});
-            msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false LIMIT 3 ALLOW FILTERING;", std::move(qo)).get0();
+            msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false LIMIT 3 ALLOW FILTERING;", std::move(qo)).get();
             rows_fetched = count_rows_fetched(msg);
             if (rows_fetched == 0) {
                 paging_state = extract_paging_state(msg);
@@ -894,7 +894,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_limit) {
         while (remaining > 0) {
             qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, paging_state, {}, api::new_timestamp()});
-            msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false LIMIT 3 ALLOW FILTERING;", std::move(qo)).get0();
+            msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false LIMIT 3 ALLOW FILTERING;", std::move(qo)).get();
             rows_fetched += count_rows_fetched(msg);
             paging_state = extract_paging_state(msg);
             if (!paging_state) {
@@ -930,7 +930,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_per_partition_limit) {
                 "APPLY BATCH;"
         ).get();
 
-        auto msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false PER PARTITION LIMIT 2 ALLOW FILTERING;").get0();
+        auto msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false PER PARTITION LIMIT 2 ALLOW FILTERING;").get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(1), boolean_type->decompose(false)},
             { int32_type->decompose(2), boolean_type->decompose(false)},
@@ -938,7 +938,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_per_partition_limit) {
             { int32_type->decompose(2), boolean_type->decompose(false)},
         });
 
-        msg = e.execute_cql("SELECT c, liked FROM timeline PER PARTITION LIMIT 2;").get0();
+        msg = e.execute_cql("SELECT c, liked FROM timeline PER PARTITION LIMIT 2;").get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(1), boolean_type->decompose(false)},
             { int32_type->decompose(2), boolean_type->decompose(false)},
@@ -946,14 +946,14 @@ SEASTAR_TEST_CASE(test_allow_filtering_per_partition_limit) {
             { int32_type->decompose(2), boolean_type->decompose(false)},
         });
 
-        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE user='b' PER PARTITION LIMIT 2 LIMIT 1 ALLOW FILTERING;").get0();
+        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE user='b' PER PARTITION LIMIT 2 LIMIT 1 ALLOW FILTERING;").get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(1), boolean_type->decompose(false)},
         });
 
         auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                 cql3::query_options::specific_options{100, nullptr, {}, api::new_timestamp()});
-        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=true PER PARTITION LIMIT 1 ALLOW FILTERING;", std::move(qo)).get0();
+        msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=true PER PARTITION LIMIT 1 ALLOW FILTERING;", std::move(qo)).get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(3), boolean_type->decompose(true)},
             { int32_type->decompose(3), boolean_type->decompose(true)},
@@ -961,7 +961,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_per_partition_limit) {
 
         qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
             cql3::query_options::specific_options{3, nullptr, {}, api::new_timestamp()});
-        msg = e.execute_cql("SELECT c, liked FROM timeline PER PARTITION LIMIT 1;", std::move(qo)).get0();
+        msg = e.execute_cql("SELECT c, liked FROM timeline PER PARTITION LIMIT 1;", std::move(qo)).get();
         assert_that(msg).is_rows().with_rows({
             { int32_type->decompose(1), boolean_type->decompose(false)},
         });
@@ -972,7 +972,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_per_partition_limit) {
         while (rows_fetched == 0) {
             qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, paging_state, {}, api::new_timestamp()});
-            msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false PER PARTITION LIMIT 1 ALLOW FILTERING;", std::move(qo)).get0();
+            msg = e.execute_cql("SELECT c, liked FROM timeline WHERE liked=false PER PARTITION LIMIT 1 ALLOW FILTERING;", std::move(qo)).get();
             rows_fetched = count_rows_fetched(msg);
             paging_state = extract_paging_state(msg);
         }
@@ -993,7 +993,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_per_partition_limit) {
                         sstring query = allow_filtering ?
                                 fmt::format("SELECT c, liked FROM timeline WHERE liked=false PER PARTITION LIMIT {} ALLOW FILTERING;", ppl) :
                                 fmt::format("SELECT c, liked FROM timeline PER PARTITION LIMIT {};", ppl);
-                        msg = e.execute_cql(query, std::move(qo)).get0();
+                        msg = e.execute_cql(query, std::move(qo)).get();
                         rows_fetched += count_rows_fetched(msg);
                         paging_state = extract_paging_state(msg);
                         if (!paging_state) {
@@ -1018,7 +1018,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_with_in_on_regular_column) {
         e.execute_cql("INSERT INTO t (k, c, v) VALUES (1, 3, 2)").get();
         e.execute_cql("INSERT INTO t (k, c, v) VALUES (2, 2, 3)").get();
 
-        auto msg = e.execute_cql("SELECT * FROM t WHERE v IN (1) ALLOW FILTERING").get0();
+        auto msg = e.execute_cql("SELECT * FROM t WHERE v IN (1) ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
             {
                 int32_type->decompose(1),
@@ -1027,7 +1027,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_with_in_on_regular_column) {
             }
         });
 
-        msg = e.execute_cql("SELECT * FROM t WHERE v IN (2, 3) ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE v IN (2, 3) ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
             {
                 int32_type->decompose(1),
@@ -1041,7 +1041,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_with_in_on_regular_column) {
            }
         });
 
-        msg = e.execute_cql("SELECT * FROM t WHERE c in (2, 4) AND v IN (1, 2, 3, 4, 5) ALLOW FILTERING").get0();
+        msg = e.execute_cql("SELECT * FROM t WHERE c in (2, 4) AND v IN (1, 2, 3, 4, 5) ALLOW FILTERING").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
             {
                 int32_type->decompose(1),
@@ -1102,7 +1102,7 @@ SEASTAR_TEST_CASE(test_filtering) {
 
         // test filtering on partition keys
         {
-            auto msg = e.execute_cql("SELECT k FROM cf WHERE v=3 ALLOW FILTERING;").get0();
+            auto msg = e.execute_cql("SELECT k FROM cf WHERE v=3 ALLOW FILTERING;").get();
             assert_that(msg).is_rows().with_serialized_columns_count(1).with_rows_ignore_order({
                 { int32_type->decompose(7), int32_type->decompose(3)},
                 { int32_type->decompose(8), int32_type->decompose(3) },
@@ -1115,7 +1115,7 @@ SEASTAR_TEST_CASE(test_filtering) {
 
         // test filtering on clustering keys
         {
-            auto msg = e.execute_cql("SELECT k FROM cf WHERE n=4 ALLOW FILTERING;").get0();
+            auto msg = e.execute_cql("SELECT k FROM cf WHERE n=4 ALLOW FILTERING;").get();
             assert_that(msg).is_rows().with_serialized_columns_count(1).with_rows_ignore_order({
                 { int32_type->decompose(10), int32_type->decompose(4) },
                 { int32_type->decompose(11), int32_type->decompose(4) },
@@ -1124,7 +1124,7 @@ SEASTAR_TEST_CASE(test_filtering) {
 
         //test filtering on regular columns
         {
-            auto msg = e.execute_cql("SELECT k FROM cf WHERE o>7 ALLOW FILTERING;").get0();
+            auto msg = e.execute_cql("SELECT k FROM cf WHERE o>7 ALLOW FILTERING;").get();
             assert_that(msg).is_rows().with_serialized_columns_count(1).with_rows_ignore_order({
                 { int32_type->decompose(8),  int32_type->decompose(8) },
                 { int32_type->decompose(9),  int32_type->decompose(9) },
@@ -1137,7 +1137,7 @@ SEASTAR_TEST_CASE(test_filtering) {
 
         //test filtering on static columns
         {
-            auto msg = e.execute_cql("SELECT k FROM cf WHERE p>=10 AND p<=12 ALLOW FILTERING;").get0();
+            auto msg = e.execute_cql("SELECT k FROM cf WHERE p>=10 AND p<=12 ALLOW FILTERING;").get();
             assert_that(msg).is_rows().with_serialized_columns_count(1).with_rows_ignore_order({
                 { int32_type->decompose(10), int32_type->decompose(10) },
                 { int32_type->decompose(11), int32_type->decompose(11) },
@@ -1145,7 +1145,7 @@ SEASTAR_TEST_CASE(test_filtering) {
         }
         //test filtering with count
         {
-            auto msg = e.execute_cql("SELECT COUNT(k) FROM cf WHERE n>3 ALLOW FILTERING;").get0();
+            auto msg = e.execute_cql("SELECT COUNT(k) FROM cf WHERE n>3 ALLOW FILTERING;").get();
             assert_that(msg).is_rows().with_serialized_columns_count(1).with_size(1).with_rows_ignore_order({
                 { long_type->decompose(4L), int32_type->decompose(5) },
             });

--- a/test/boost/fragmented_temporary_buffer_test.cc
+++ b/test/boost/fragmented_temporary_buffer_test.cc
@@ -414,18 +414,18 @@ SEASTAR_THREAD_TEST_CASE(test_read_fragmented_buffer) {
 
         auto in = input_stream<char>(data_source(std::make_unique<memory_data_source>(std::move(buffers))));
 
-        auto prefix = in.read_exactly(prefix_size).get0();
+        auto prefix = in.read_exactly(prefix_size).get();
         BOOST_CHECK_EQUAL(prefix.size(), prefix_size);
         BOOST_CHECK_EQUAL(bytes_view(reinterpret_cast<const bytes::value_type*>(prefix.get()), prefix.size()),
                           expected_prefix);
 
         auto reader = fragmented_temporary_buffer::reader();
-        auto fbuf = reader.read_exactly(in, size).get0();
+        auto fbuf = reader.read_exactly(in, size).get();
         auto view = fragmented_temporary_buffer::view(fbuf);
         BOOST_CHECK_EQUAL(view.size_bytes(), size);
         BOOST_CHECK_EQUAL(linearized(view), expected_data);
 
-        auto suffix = in.read_exactly(suffix_size).get0();
+        auto suffix = in.read_exactly(suffix_size).get();
         BOOST_CHECK_EQUAL(suffix.size(), suffix_size);
         BOOST_CHECK_EQUAL(bytes_view(reinterpret_cast<const bytes::value_type*>(suffix.get()), suffix.size()),
                           expected_suffix);
@@ -494,7 +494,7 @@ static void do_test_read_exactly_eof(size_t input_size) {
     auto ds = data_source(std::make_unique<memory_data_source>(std::move(data)));
     auto is = input_stream<char>(std::move(ds));
     auto reader = fragmented_temporary_buffer::reader();
-    auto result = reader.read_exactly(is, input_size + 1).get0();
+    auto result = reader.read_exactly(is, input_size + 1).get();
     BOOST_CHECK_EQUAL(result.size_bytes(), size_t(0));
 }
 

--- a/test/boost/group0_cmd_merge_test.cc
+++ b/test/boost/group0_cmd_merge_test.cc
@@ -87,7 +87,7 @@ SEASTAR_TEST_CASE(test_group0_cmd_merge) {
         };
         std::vector<canonical_mutation> cms;
         size_t size = 0;
-        auto muts = service::prepare_keyspace_drop_announcement(env.local_db(), "ks", api::new_timestamp()).get0();
+        auto muts = service::prepare_keyspace_drop_announcement(env.local_db(), "ks", api::new_timestamp()).get();
         // Maximum mutation size is 1/3 of commitlog segment size which we set
         // to 1M. Make one command a little bit larger than third of the max size.
         while (size < 150*1024) {

--- a/test/boost/index_with_paging_test.cc
+++ b/test/boost/index_with_paging_test.cc
@@ -20,7 +20,7 @@ SEASTAR_TEST_CASE(test_index_with_paging) {
 
         sstring big_string(100, 'j');
         // There should be enough rows to use multiple pages
-        auto prepared_id = e.prepare("INSERT INTO tab (pk, ck, v, v2, v3) VALUES (?, ?, 1, ?, ?)").get0();
+        auto prepared_id = e.prepare("INSERT INTO tab (pk, ck, v, v2, v3) VALUES (?, ?, 1, ?, ?)").get();
         auto big_string_v = cql3::raw_value::make_value(serialized(big_string));
         max_concurrent_for_each(boost::irange(0, 64 * 1024), 2, [&] (auto i) {
             return e.execute_prepared(prepared_id, {
@@ -40,7 +40,7 @@ SEASTAR_TEST_CASE(test_index_with_paging) {
         eventually([&] {
             auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{4321, nullptr, {}, api::new_timestamp()});
-            auto res = e.execute_cql("SELECT * FROM tab WHERE v = 1", std::move(qo)).get0();
+            auto res = e.execute_cql("SELECT * FROM tab WHERE v = 1", std::move(qo)).get();
             auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(res);
             BOOST_REQUIRE_NE(rows, nullptr);
             // It's fine to get less rows than requested due to paging limit, but never more than that
@@ -48,7 +48,7 @@ SEASTAR_TEST_CASE(test_index_with_paging) {
         });
 
         eventually([&] {
-            auto res = e.execute_cql("SELECT * FROM tab WHERE v = 1").get0();
+            auto res = e.execute_cql("SELECT * FROM tab WHERE v = 1").get();
             assert_that(res).is_rows().with_size(64 * 1024);
         });
     });

--- a/test/boost/json_cql_query_test.cc
+++ b/test/boost/json_cql_query_test.cc
@@ -82,7 +82,7 @@ SEASTAR_TEST_CASE(test_select_json_types) {
                 "    1y2mo3w4d5h6m7s8ms9us10ns"
                 ");").get();
 
-        auto msg = e.execute_cql("SELECT JSON a, b, c, d, e, f, \"G\", \"H\", \"I\", j, k, l, m, n, o, p, q, r, s, u, w, unixtimestampof(k) FROM all_types WHERE a = 'ascii'").get0();
+        auto msg = e.execute_cql("SELECT JSON a, b, c, d, e, f, \"G\", \"H\", \"I\", j, k, l, m, n, o, p, q, r, s, u, w, unixtimestampof(k) FROM all_types WHERE a = 'ascii'").get();
         assert_that(msg).is_rows().with_rows({
             {
                 utf8_type->decompose(
@@ -115,7 +115,7 @@ SEASTAR_TEST_CASE(test_select_json_types) {
         msg = e.execute_cql("SELECT toJson(a), toJson(b), toJson(c), toJson(d), toJson(e), toJson(f),"
                 "toJson(\"G\"), toJson(\"H\"), toJson(\"I\"), toJson(j), toJson(k), toJson(l), toJson(m), toJson(n),"
                 "toJson(o), toJson(p), toJson(q), toJson(r), toJson(s), toJson(u), toJson(w),"
-                "toJson(unixtimestampof(k)), toJson(toJson(toJson(p))) FROM all_types WHERE a = 'ascii'").get0();
+                "toJson(unixtimestampof(k)), toJson(toJson(toJson(p))) FROM all_types WHERE a = 'ascii'").get();
         assert_that(msg).is_rows().with_rows({
             {
                 utf8_type->decompose("\"ascii\""),
@@ -166,7 +166,7 @@ SEASTAR_TEST_CASE(test_select_json_collections) {
                 "    [[ 3 , 1, 4, 1, 5, 9 ], [ ], [ 1, 1, 2 ]]"
                 ");").get();
 
-        auto msg = e.execute_cql("SELECT JSON * FROM collections WHERE a = 'key'").get0();
+        auto msg = e.execute_cql("SELECT JSON * FROM collections WHERE a = 'key'").get();
         assert_that(msg).is_rows().with_rows({
             {
                 utf8_type->decompose(
@@ -178,7 +178,7 @@ SEASTAR_TEST_CASE(test_select_json_collections) {
             }
          });
 
-        msg = e.execute_cql("SELECT toJson(a), toJson(b), toJson(c), toJson(d) FROM collections WHERE a = 'key'").get0();
+        msg = e.execute_cql("SELECT toJson(a), toJson(b), toJson(c), toJson(d) FROM collections WHERE a = 'key'").get();
         assert_that(msg).is_rows().with_rows({
             {
                 utf8_type->decompose("\"key\""),
@@ -250,7 +250,7 @@ SEASTAR_TEST_CASE(test_insert_json_types) {
                 "\"u\": \"1y2mo25d5h6m7s8ms9us10ns\"}"
                 "'").get();
 
-        auto msg = e.execute_cql("SELECT * FROM all_types WHERE a = 'ascii'").get0();
+        auto msg = e.execute_cql("SELECT * FROM all_types WHERE a = 'ascii'").get();
         struct tm t = { 0 };
         t.tm_year = 2001 - 1900;
         t.tm_mon = 10 - 1;
@@ -285,7 +285,7 @@ SEASTAR_TEST_CASE(test_insert_json_types) {
         e.execute_cql("UPDATE all_types SET n = fromJson('\"2147483648\"') WHERE a = fromJson('\"ascii\"');").get();
         e.execute_cql("UPDATE all_types SET o = fromJson('\"3.45\"') WHERE a = fromJson('\"ascii\"');").get();
 
-        msg = e.execute_cql("SELECT a, b, \"I\", n, o FROM all_types WHERE a = 'ascii'").get0();
+        msg = e.execute_cql("SELECT a, b, \"I\", n, o FROM all_types WHERE a = 'ascii'").get();
         assert_that(msg).is_rows().with_rows({
             {
                 ascii_type->decompose(sstring("ascii")),
@@ -347,7 +347,7 @@ SEASTAR_TEST_CASE(test_insert_json_types) {
                 "\"v\": 6 "
                 "}'").get();
 
-        msg = e.execute_cql("SELECT * FROM multi_column_pk_table").get0();
+        msg = e.execute_cql("SELECT * FROM multi_column_pk_table").get();
         assert_that(msg).is_rows().with_rows({
             {
                 int32_type->decompose(1),
@@ -381,7 +381,7 @@ SEASTAR_TEST_CASE(test_insert_json_collections) {
                 "\"d\": [[3, 1, 4, 1, 5, 9], [], [1, 1, 2]]}"
                 "'").get();
 
-        auto msg = e.execute_cql("SELECT JSON * FROM collections WHERE a = 'key'").get0();
+        auto msg = e.execute_cql("SELECT JSON * FROM collections WHERE a = 'key'").get();
         assert_that(msg).is_rows().with_rows({
             {
                 utf8_type->decompose(
@@ -394,7 +394,7 @@ SEASTAR_TEST_CASE(test_insert_json_collections) {
          });
 
         e.execute_cql("INSERT INTO collections JSON '{\"a\": \"key2\"}'").get();
-        msg = e.execute_cql("SELECT JSON * FROM collections WHERE a = 'key2'").get0();
+        msg = e.execute_cql("SELECT JSON * FROM collections WHERE a = 'key2'").get();
         assert_that(msg).is_rows().with_rows({
             {
                 utf8_type->decompose(
@@ -426,7 +426,7 @@ SEASTAR_TEST_CASE(test_insert_json_null_frozen_collections) {
         e.execute_cql("INSERT INTO collections JSON '{\"k\": 0}'").get();
         e.execute_cql("INSERT INTO collections JSON '{\"k\": 1, \"m\": null, \"s\": null, \"l\": null, \"u\": null}'").get();
 
-        assert_that(e.execute_cql("SELECT JSON * FROM collections WHERE k = 0").get0()).is_rows().with_rows({
+        assert_that(e.execute_cql("SELECT JSON * FROM collections WHERE k = 0").get()).is_rows().with_rows({
             {
                 utf8_type->decompose(
                     "{\"k\": 0, "
@@ -438,7 +438,7 @@ SEASTAR_TEST_CASE(test_insert_json_null_frozen_collections) {
             }
          });
 
-        assert_that(e.execute_cql("SELECT JSON * FROM collections WHERE k = 1").get0()).is_rows().with_rows({
+        assert_that(e.execute_cql("SELECT JSON * FROM collections WHERE k = 1").get()).is_rows().with_rows({
             {
                 utf8_type->decompose(
                     "{\"k\": 1, "
@@ -579,7 +579,7 @@ SEASTAR_TEST_CASE(test_prepared_json) {
                 "  insert into json_data json ?; \n"
                 "  insert into json_data json :named_bound1; \n"
                 "  insert into json_data json ?; \n"
-                "apply batch;").get0();
+                "apply batch;").get();
 
         std::vector<cql3::raw_value> raw_values;
         raw_values.emplace_back(cql3::raw_value::make_value(utf8_type->decompose(
@@ -593,22 +593,22 @@ SEASTAR_TEST_CASE(test_prepared_json) {
 
         e.execute_prepared(prepared_id, raw_values).get();
 
-        auto msg = e.execute_cql("select json * from json_data where a='a1'").get0();
+        auto msg = e.execute_cql("select json * from json_data where a='a1'").get();
         assert_that(msg).is_rows().with_rows({{
                 utf8_type->decompose(
                     "{\"a\": \"a1\", \"b\": {\"0\": \"zero\", \"3\": \"three\", \"6\": \"six\"}, \"c\": 1.23, \"d\": [1.25, 3.75, 2.5]}")
         }});
-        msg = e.execute_cql("select json * from json_data where a='a2'").get0();
+        msg = e.execute_cql("select json * from json_data where a='a2'").get();
         assert_that(msg).is_rows().with_rows({{
                 utf8_type->decompose(
                     "{\"a\": \"a2\", \"b\": {\"0\": \"zero\", \"6\": \"six\"}, \"c\": 1.23, \"d\": [3.75, 2.5]}")
         }});
-        msg = e.execute_cql("select json * from json_data where a='a3'").get0();
+        msg = e.execute_cql("select json * from json_data where a='a3'").get();
         assert_that(msg).is_rows().with_rows({{
                 utf8_type->decompose(
                     "{\"a\": \"a3\", \"b\": {\"0\": \"zero\", \"3\": \"three\"}, \"c\": 1.23, \"d\": [1.25, 2.5]}")
         }});
-        msg = e.execute_cql("select json * from json_data where a='a4'").get0();
+        msg = e.execute_cql("select json * from json_data where a='a4'").get();
         assert_that(msg).is_rows().with_rows({{
                 utf8_type->decompose(
                     "{\"a\": \"a4\", \"b\": {\"1\": \"one\"}, \"c\": 1.23, \"d\": [1]}")
@@ -631,7 +631,7 @@ SEASTAR_TEST_CASE(test_json_default_unset) {
 
         e.execute_cql("INSERT INTO json_data JSON '{\"a\": \"abc\", \"b\": 2, \"c\": 1}'").get();
 
-        auto msg = e.execute_cql("select * from json_data where a='abc'").get0();
+        auto msg = e.execute_cql("select * from json_data where a='abc'").get();
         assert_that(msg).is_rows().with_rows({{
             {utf8_type->decompose(sstring("abc"))},
             {int32_type->decompose(2)},
@@ -641,7 +641,7 @@ SEASTAR_TEST_CASE(test_json_default_unset) {
 
         e.execute_cql("INSERT INTO json_data JSON '{\"a\": \"abc\", \"b\": 2, \"d\": 5}' DEFAULT UNSET").get();
 
-        msg = e.execute_cql("select * from json_data where a='abc'").get0();
+        msg = e.execute_cql("select * from json_data where a='abc'").get();
         assert_that(msg).is_rows().with_rows({{
             {utf8_type->decompose(sstring("abc"))},
             {int32_type->decompose(2)},
@@ -651,7 +651,7 @@ SEASTAR_TEST_CASE(test_json_default_unset) {
 
         e.execute_cql("INSERT INTO json_data JSON '{\"a\": \"abc\", \"b\": 2, \"d\": 4}' DEFAULT NULL").get();
 
-        msg = e.execute_cql("select * from json_data where a='abc'").get0();
+        msg = e.execute_cql("select * from json_data where a='abc'").get();
         assert_that(msg).is_rows().with_rows({{
             {utf8_type->decompose(sstring("abc"))},
             {int32_type->decompose(2)},
@@ -673,7 +673,7 @@ SEASTAR_TEST_CASE(test_json_insert_null) {
 
        e.execute_cql("INSERT INTO mytable JSON '{\"myid\" : \"id2\", \"mytext\" : \"text234\", \"mytext1\" : \"text235\", \"mytext2\" : null}';").get();
 
-        auto msg = e.execute_cql("SELECT * FROM mytable;").get0();
+        auto msg = e.execute_cql("SELECT * FROM mytable;").get();
         assert_that(msg).is_rows().with_rows({{
             {utf8_type->decompose(sstring("id2"))},
             {utf8_type->decompose(sstring("text234"))},
@@ -696,7 +696,7 @@ SEASTAR_TEST_CASE(test_json_tuple) {
 
         auto tt = tuple_type_impl::get_instance({int32_type, utf8_type, float_type});
 
-        auto msg = e.execute_cql("SELECT * FROM t;").get0();
+        auto msg = e.execute_cql("SELECT * FROM t;").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(7)},
             {tt->decompose(make_tuple_value(tt, tuple_type_impl::native_type({int32_t(5), sstring("test123"), float(2.5)})))},
@@ -704,7 +704,7 @@ SEASTAR_TEST_CASE(test_json_tuple) {
 
         e.execute_cql("INSERT INTO t (id, v) VALUES (3, (5, 'test543', 4.5));").get();
 
-        msg = e.execute_cql("SELECT JSON * FROM t WHERE id = 3;").get0();
+        msg = e.execute_cql("SELECT JSON * FROM t WHERE id = 3;").get();
         assert_that(msg).is_rows().with_rows({{
             utf8_type->decompose(sstring("{\"id\": 3, \"v\": [5, \"test543\", 4.5]}"))
         }});
@@ -724,7 +724,7 @@ static future<> test_json_udt(bool frozen) {
 
         auto ut = user_type_impl::get_instance("ks", "utype", std::vector{bytes("first"), bytes("second"), bytes("third")}, {int32_type, utf8_type, float_type}, !frozen);
 
-        auto msg = e.execute_cql("SELECT * FROM t;").get0();
+        auto msg = e.execute_cql("SELECT * FROM t;").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(7)},
             {ut->decompose(make_user_value(ut, user_type_impl::native_type({int32_t(5), sstring("test123"), float(2.5)})))},
@@ -732,14 +732,14 @@ static future<> test_json_udt(bool frozen) {
 
         e.execute_cql("INSERT INTO t (id, v) VALUES (3, (5, 'test543', 4.5));").get();
 
-        msg = e.execute_cql("SELECT JSON * FROM t WHERE id = 3;").get0();
+        msg = e.execute_cql("SELECT JSON * FROM t WHERE id = 3;").get();
         assert_that(msg).is_rows().with_rows({{
             utf8_type->decompose(sstring("{\"id\": 3, \"v\": {\"first\": 5, \"second\": \"test543\", \"third\": 4.5}}"))
         }});
 
         e.execute_cql("INSERT INTO t (id, v) VALUES (3, {\"first\": 3, \"third\": 4.5});").get();
 
-        msg = e.execute_cql("SELECT JSON * FROM t WHERE id = 3;").get0();
+        msg = e.execute_cql("SELECT JSON * FROM t WHERE id = 3;").get();
         assert_that(msg).is_rows().with_rows({{
             utf8_type->decompose(sstring("{\"id\": 3, \"v\": {\"first\": 3, \"second\": null, \"third\": 4.5}}"))
         }});
@@ -752,7 +752,7 @@ static future<> test_json_udt(bool frozen) {
         e.execute_cql(format("CREATE TABLE t2(id int PRIMARY KEY, v {});", frozen ? "frozen<utype2>" : "utype2")).get();
 
         e.execute_cql("INSERT INTO t2 (id, v) VALUES (1, (7));").get();
-        msg = e.execute_cql("SELECT JSON * FROM t2 WHERE id = 1;").get0();
+        msg = e.execute_cql("SELECT JSON * FROM t2 WHERE id = 1;").get();
         assert_that(msg).is_rows().with_rows({{
             utf8_type->decompose(sstring("{\"id\": 1, \"v\": {\"WeirdNameThatNeedsEscaping\\\\n,)\": 7}}"))
         }});
@@ -785,7 +785,7 @@ SEASTAR_TEST_CASE(test_unpack_decimal){
         auto lt = list_type_impl::get_instance(ut, true);
         auto lt_val = lt->decompose(make_list_value(lt, list_type_impl::native_type{{ut_val}}));
 
-        auto msg = e.execute_cql("select * from t where id = 1;").get0();
+        auto msg = e.execute_cql("select * from t where id = 1;").get();
         assert_that(msg).is_rows().with_rows({{int32_type->decompose(1), lt_val}});
     });
 }

--- a/test/boost/large_paging_state_test.cc
+++ b/test/boost/large_paging_state_test.cc
@@ -41,7 +41,7 @@ static bool has_more_pages(::shared_ptr<cql_transport::messages::result_message>
 SEASTAR_TEST_CASE(test_use_high_bits_of_remaining_rows_in_paging_state) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE test (pk int, ck int, PRIMARY KEY (pk, ck));").get();
-        auto id = e.prepare("INSERT INTO test (pk, ck) VALUES (?, ?);").get0();
+        auto id = e.prepare("INSERT INTO test (pk, ck) VALUES (?, ?);").get();
         const auto raw_pk = int32_type->decompose(data_value(0));
         const auto cql3_pk = cql3::raw_value::make_value(raw_pk);
 
@@ -52,7 +52,7 @@ SEASTAR_TEST_CASE(test_use_high_bits_of_remaining_rows_in_paging_state) {
 
         auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{5, nullptr, {}, api::new_timestamp()});
-        auto msg = e.execute_cql("select * from test;", std::move(qo)).get0();
+        auto msg = e.execute_cql("select * from test;", std::move(qo)).get();
         auto paging_state = extract_paging_state(msg);
         uint64_t rows_fetched = count_rows_fetched(msg);
         BOOST_REQUIRE_EQUAL(paging_state->get_remaining() + rows_fetched, query::max_rows);
@@ -64,7 +64,7 @@ SEASTAR_TEST_CASE(test_use_high_bits_of_remaining_rows_in_paging_state) {
         while (has_more_pages(msg)) {
             qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{5, paging_state, {}, api::new_timestamp()});
-            msg = e.execute_cql("SELECT * FROM test;", std::move(qo)).get0();
+            msg = e.execute_cql("SELECT * FROM test;", std::move(qo)).get();
             rows_fetched = count_rows_fetched(msg);
             test_remaining = test_remaining - rows_fetched;
             if (has_more_pages(msg)) {
@@ -79,7 +79,7 @@ SEASTAR_TEST_CASE(test_use_high_bits_of_remaining_rows_in_paging_state) {
 SEASTAR_TEST_CASE(test_use_high_bits_of_remaining_rows_in_paging_state_filtering) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("CREATE TABLE test (pk int, ck int, PRIMARY KEY (pk, ck));").get();
-        auto id = e.prepare("INSERT INTO test (pk, ck) VALUES (?, ?);").get0();
+        auto id = e.prepare("INSERT INTO test (pk, ck) VALUES (?, ?);").get();
         const auto raw_pk = int32_type->decompose(data_value(0));
         const auto cql3_pk = cql3::raw_value::make_value(raw_pk);
 
@@ -90,7 +90,7 @@ SEASTAR_TEST_CASE(test_use_high_bits_of_remaining_rows_in_paging_state_filtering
 
         auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{5, nullptr, {}, api::new_timestamp()});
-        auto msg = e.execute_cql("select * from test where ck > 10 allow filtering;", std::move(qo)).get0();
+        auto msg = e.execute_cql("select * from test where ck > 10 allow filtering;", std::move(qo)).get();
         auto paging_state = extract_paging_state(msg);
         uint64_t rows_fetched = count_rows_fetched(msg);
         BOOST_REQUIRE_EQUAL(paging_state->get_remaining() + rows_fetched, query::max_rows);
@@ -102,7 +102,7 @@ SEASTAR_TEST_CASE(test_use_high_bits_of_remaining_rows_in_paging_state_filtering
         while (has_more_pages(msg)) {
             qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{5, paging_state, {}, api::new_timestamp()});
-            msg = e.execute_cql("SELECT * FROM test where ck > 10 allow filtering;", std::move(qo)).get0();
+            msg = e.execute_cql("SELECT * FROM test where ck > 10 allow filtering;", std::move(qo)).get();
             rows_fetched = count_rows_fetched(msg);
             test_remaining = test_remaining - rows_fetched;
             if (has_more_pages(msg)) {

--- a/test/boost/limiting_data_source_test.cc
+++ b/test/boost/limiting_data_source_test.cc
@@ -55,7 +55,7 @@ void test_get(unsigned limit) {
     auto tested = make_limiting_data_source(std::move(src), [limit] { return limit; });
     char expected = 0;
     auto test_get = [&] {
-        auto buf = tested.get().get0();
+        auto buf = tested.get().get();
         BOOST_REQUIRE(buf.size() <= limit);
         for (unsigned i = 0; i < buf.size(); ++i) {
             BOOST_REQUIRE_EQUAL(expected++, buf[i]);
@@ -69,7 +69,7 @@ void test_get(unsigned limit) {
 data_source prepare_test_skip() {
     auto src = create_test_data_source();
     auto tested = make_limiting_data_source(std::move(src), [] { return 1; });
-    auto buf = tested.get().get0();
+    auto buf = tested.get().get();
     BOOST_REQUIRE_EQUAL(1, buf.size());
     BOOST_REQUIRE_EQUAL(0, buf[0]);
     // At this point we have 9 chars buffered in limiting_data_source_impl
@@ -93,21 +93,21 @@ SEASTAR_THREAD_TEST_CASE(test_get_smaller_bigger_than_limit) {
 
 SEASTAR_THREAD_TEST_CASE(test_skip_smaller_than_buffered_data) {
     auto tested = prepare_test_skip();
-    auto buf = tested.skip(8).get0();
+    auto buf = tested.skip(8).get();
     BOOST_REQUIRE_EQUAL(1, buf.size());
     BOOST_REQUIRE_EQUAL(9, buf[0]);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_skip_equal_to_buffered_data) {
     auto tested = prepare_test_skip();
-    auto buf = tested.skip(9).get0();
+    auto buf = tested.skip(9).get();
     BOOST_REQUIRE_EQUAL(1, buf.size());
     BOOST_REQUIRE_EQUAL(10, buf[0]);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_skip_bigger_than_buffered_data) {
     auto tested = prepare_test_skip();
-    auto buf = tested.skip(10).get0();
+    auto buf = tested.skip(10).get();
     BOOST_REQUIRE_EQUAL(1, buf.size());
     BOOST_REQUIRE_EQUAL(11, buf[0]);
 }

--- a/test/boost/loading_cache_test.cc
+++ b/test/boost/loading_cache_test.cc
@@ -713,20 +713,20 @@ SEASTAR_THREAD_TEST_CASE(test_loading_cache_remove_leaves_no_old_entries_behind)
         BOOST_REQUIRE_EQUAL(loading_cache.find(0), nullptr);
         BOOST_REQUIRE_EQUAL(loading_cache.size(), 0);
 
-        auto ptr1 = f.get0();
+        auto ptr1 = f.get();
         BOOST_REQUIRE_EQUAL(*ptr1, "v1");
 
         BOOST_REQUIRE_EQUAL(loading_cache.find(0), nullptr);
         BOOST_REQUIRE_EQUAL(loading_cache.size(), 0);
 
-        ptr1 = loading_cache.get_ptr(0, load_v2).get0();
+        ptr1 = loading_cache.get_ptr(0, load_v2).get();
         loading_cache.remove(0);
         BOOST_REQUIRE_EQUAL(*ptr1, "v2");
 
         //
         // Test that live ptr1, removed from cache, does not prevent reload of new value
         //
-        auto ptr2 = loading_cache.get_ptr(0, load_v3).get0();
+        auto ptr2 = loading_cache.get_ptr(0, load_v3).get();
         ptr1 = nullptr;
         BOOST_REQUIRE_EQUAL(*ptr2, "v3");
     }
@@ -750,20 +750,20 @@ SEASTAR_THREAD_TEST_CASE(test_loading_cache_remove_leaves_no_old_entries_behind)
         BOOST_REQUIRE_EQUAL(loading_cache.find(0), nullptr);
         BOOST_REQUIRE_EQUAL(loading_cache.size(), 0);
 
-        auto ptr1 = f.get0();
+        auto ptr1 = f.get();
         BOOST_REQUIRE_EQUAL(*ptr1, "v1");
 
         BOOST_REQUIRE_EQUAL(loading_cache.find(0), nullptr);
         BOOST_REQUIRE_EQUAL(loading_cache.size(), 0);
 
-        ptr1 = loading_cache.get_ptr(0, load_v2).get0();
+        ptr1 = loading_cache.get_ptr(0, load_v2).get();
         loading_cache.remove_if([] (auto&& v) { return v == "v2"; });
         BOOST_REQUIRE_EQUAL(*ptr1, "v2");
 
         //
         // Test that live ptr1, removed from cache, does not prevent reload of new value
         //
-        auto ptr2 = loading_cache.get_ptr(0, load_v3).get0();
+        auto ptr2 = loading_cache.get_ptr(0, load_v3).get();
         ptr1 = nullptr;
         BOOST_REQUIRE_EQUAL(*ptr2, "v3");
         ptr2 = nullptr;
@@ -786,7 +786,7 @@ SEASTAR_TEST_CASE(test_prepared_statement_small_cache) {
         // filling "privileged section" of loading_cache.
         std::vector<cql3::prepared_cache_key_type> prepared_ids_privileged;
         for (int i = 0; i < 100; i++) {
-            auto prepared_id = e.prepare(fmt::format("SELECT * FROM tbl1 WHERE a = {}", current_uid++)).get0();
+            auto prepared_id = e.prepare(fmt::format("SELECT * FROM tbl1 WHERE a = {}", current_uid++)).get();
             e.execute_prepared(prepared_id, {}).get();
             e.execute_prepared(prepared_id, {}).get();
             prepared_ids_privileged.push_back(prepared_id);
@@ -809,7 +809,7 @@ SEASTAR_TEST_CASE(test_prepared_statement_small_cache) {
         // which will occupy "unprivileged section" of loading_cache.
         std::vector<cql3::prepared_cache_key_type> prepared_ids_unprivileged;
         for (int i = 0; i < 5; i++) {
-            auto prepared_id = e.prepare(fmt::format("SELECT * FROM tbl1 WHERE a = {}", current_uid++)).get0();
+            auto prepared_id = e.prepare(fmt::format("SELECT * FROM tbl1 WHERE a = {}", current_uid++)).get();
             e.execute_prepared(prepared_id, {}).get();
             prepared_ids_unprivileged.push_back(prepared_id);
         }
@@ -827,7 +827,7 @@ SEASTAR_TEST_CASE(test_prepared_statement_small_cache) {
 
         // Prepare 500 queries and execute them a random number of times.
         for (int i = 0; i < 500; i++) {
-            auto prepared_id = e.prepare(fmt::format("SELECT * FROM tbl1 WHERE a = {}", current_uid++)).get0();
+            auto prepared_id = e.prepare(fmt::format("SELECT * FROM tbl1 WHERE a = {}", current_uid++)).get();
             auto times = rand_int(4);
             for (int j = 0; j < times; j++) {
                 e.execute_prepared(prepared_id, {}).get();
@@ -839,7 +839,7 @@ SEASTAR_TEST_CASE(test_prepared_statement_small_cache) {
         for (int i = 0; i < 100; i++) {
             std::vector<cql3::prepared_cache_key_type> prepared_ids_batch;
             for (int j = 0; j < 5; j++) {
-                auto prepared_id = e.prepare(fmt::format("SELECT * FROM tbl1 WHERE a = {}", current_uid++)).get0();
+                auto prepared_id = e.prepare(fmt::format("SELECT * FROM tbl1 WHERE a = {}", current_uid++)).get();
                 prepared_ids_batch.push_back(prepared_id);
             }
             auto times = rand_int(4);

--- a/test/boost/logalloc_test.cc
+++ b/test/boost/logalloc_test.cc
@@ -728,7 +728,7 @@ SEASTAR_THREAD_TEST_CASE(background_reclaim) {
 
     // Set up the background reclaimer
 
-    auto background_reclaim_scheduling_group = create_scheduling_group("background_reclaim", 100).get0();
+    auto background_reclaim_scheduling_group = create_scheduling_group("background_reclaim", 100).get();
     auto kill_sched_group = defer([&] () noexcept {
         destroy_scheduling_group(background_reclaim_scheduling_group).get();
     });

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -329,7 +329,7 @@ SEASTAR_TEST_CASE(test_unspooled_dirty_accounting_on_flush) {
         flush_reader_check.produces_partition(current_ring[1]);
         unspooled_dirty_values.push_back(mgr.unspooled_dirty_memory());
 
-        while ((*rd1)().get0()) ;
+        while ((*rd1)().get()) ;
         close_rd1.close_now();
 
         logalloc::shard_tracker().full_compaction();
@@ -447,17 +447,17 @@ SEASTAR_TEST_CASE(test_segment_migration_during_flush) {
         auto close_rd = deferred_close(rd);
 
         for (int i = 0; i < partitions; ++i) {
-            auto mfopt = rd().get0();
+            auto mfopt = rd().get();
             BOOST_REQUIRE(bool(mfopt));
             BOOST_REQUIRE(mfopt->is_partition_start());
             while (!mfopt->is_end_of_partition()) {
                 logalloc::shard_tracker().full_compaction();
-                mfopt = rd().get0();
+                mfopt = rd().get();
             }
             BOOST_REQUIRE_LE(mgr.unspooled_dirty_memory(), mgr.real_dirty_memory());
         }
 
-        BOOST_REQUIRE(!rd().get0());
+        BOOST_REQUIRE(!rd().get());
     });
 }
 
@@ -807,8 +807,8 @@ SEASTAR_TEST_CASE(test_hash_is_cached) {
         {
             auto rd = mt->make_flat_reader(s, semaphore.make_permit());
             auto close_rd = deferred_close(rd);
-            rd().get0()->as_partition_start();
-            clustering_row row = std::move(*rd().get0()).as_clustering_row();
+            rd().get()->as_partition_start();
+            clustering_row row = std::move(*rd().get()).as_clustering_row();
             BOOST_REQUIRE(!row.cells().cell_hash_for(0));
         }
 
@@ -817,16 +817,16 @@ SEASTAR_TEST_CASE(test_hash_is_cached) {
             slice.options.set<query::partition_slice::option::with_digest>();
             auto rd = mt->make_flat_reader(s, semaphore.make_permit(), query::full_partition_range, slice);
             auto close_rd = deferred_close(rd);
-            rd().get0()->as_partition_start();
-            clustering_row row = std::move(*rd().get0()).as_clustering_row();
+            rd().get()->as_partition_start();
+            clustering_row row = std::move(*rd().get()).as_clustering_row();
             BOOST_REQUIRE(row.cells().cell_hash_for(0));
         }
 
         {
             auto rd = mt->make_flat_reader(s, semaphore.make_permit());
             auto close_rd = deferred_close(rd);
-            rd().get0()->as_partition_start();
-            clustering_row row = std::move(*rd().get0()).as_clustering_row();
+            rd().get()->as_partition_start();
+            clustering_row row = std::move(*rd().get()).as_clustering_row();
             BOOST_REQUIRE(row.cells().cell_hash_for(0));
         }
 
@@ -836,8 +836,8 @@ SEASTAR_TEST_CASE(test_hash_is_cached) {
         {
             auto rd = mt->make_flat_reader(s, semaphore.make_permit());
             auto close_rd = deferred_close(rd);
-            rd().get0()->as_partition_start();
-            clustering_row row = std::move(*rd().get0()).as_clustering_row();
+            rd().get()->as_partition_start();
+            clustering_row row = std::move(*rd().get()).as_clustering_row();
             BOOST_REQUIRE(!row.cells().cell_hash_for(0));
         }
 
@@ -846,16 +846,16 @@ SEASTAR_TEST_CASE(test_hash_is_cached) {
             slice.options.set<query::partition_slice::option::with_digest>();
             auto rd = mt->make_flat_reader(s, semaphore.make_permit(), query::full_partition_range, slice);
             auto close_rd = deferred_close(rd);
-            rd().get0()->as_partition_start();
-            clustering_row row = std::move(*rd().get0()).as_clustering_row();
+            rd().get()->as_partition_start();
+            clustering_row row = std::move(*rd().get()).as_clustering_row();
             BOOST_REQUIRE(row.cells().cell_hash_for(0));
         }
 
         {
             auto rd = mt->make_flat_reader(s, semaphore.make_permit());
             auto close_rd = deferred_close(rd);
-            rd().get0()->as_partition_start();
-            clustering_row row = std::move(*rd().get0()).as_clustering_row();
+            rd().get()->as_partition_start();
+            clustering_row row = std::move(*rd().get()).as_clustering_row();
             BOOST_REQUIRE(row.cells().cell_hash_for(0));
         }
     });
@@ -1025,7 +1025,7 @@ SEASTAR_TEST_CASE(sstable_compaction_does_not_resurrect_data) {
         t.compact_all_sstables().get();
 
         // If we get additional row (1, 2, 4), that means the tombstone was purged and data was resurrected
-        assert_that(env.execute_cql(format("SELECT * FROM {}.{};", ks_name, table_name)).get0())
+        assert_that(env.execute_cql(format("SELECT * FROM {}.{};", ks_name, table_name)).get())
             .is_rows()
             .with_rows_ignore_order({
                 {serialized(1), serialized(3), serialized(3)}, 

--- a/test/boost/multishard_combining_reader_as_mutation_source_test.cc
+++ b/test/boost/multishard_combining_reader_as_mutation_source_test.cc
@@ -56,7 +56,7 @@ static auto make_populate(bool evict_paused_readers, bool single_fragment_buffer
                 }
 
                 return make_foreign(mt);
-            }).get0();
+            }).get();
             remote_memtables->emplace_back(std::move(remote_mt));
         }
         keep_alive_sharder.push_back(sharder);

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -163,7 +163,7 @@ static uint64_t aggregate_querier_cache_stat(distributed<replica::database>& db,
             auto& stats = local_db.get_querier_cache_stats();
             return stats.*stat;
         });
-    }, 0, std::plus<size_t>()).get0();
+    }, 0, std::plus<size_t>()).get();
 }
 
 static void check_cache_population(distributed<replica::database>& db, size_t queriers,
@@ -175,7 +175,7 @@ static void check_cache_population(distributed<replica::database>& db, size_t qu
             auto& stats = local_db.get_querier_cache_stats();
             tests::require_equal(stats.population, queriers);
         });
-    }).get0();
+    }).get();
 }
 
 static void require_eventually_empty_caches(distributed<replica::database>& db,
@@ -234,9 +234,9 @@ static std::vector<mutation> read_all_partitions_one_by_one(distributed<replica:
                         query::max_result_size(query::result_memory_limiter::unlimited_result_size), query::tombstone_limit::max);
                 const auto range = dht::partition_range::make_singular(pkey);
                 return make_foreign(std::make_unique<reconcilable_result>(
-                    std::get<0>(db.query_mutations(std::move(s), cmd, range, nullptr, db::no_timeout).get0())));
+                    std::get<0>(db.query_mutations(std::move(s), cmd, range, nullptr, db::no_timeout).get())));
             });
-        }).get0();
+        }).get();
 
         tests::require_equal(res->partitions().size(), 1u);
         results.emplace_back(res->partitions().front().mut().unfreeze(s));

--- a/test/boost/mutation_fragment_test.cc
+++ b/test/boost/mutation_fragment_test.cc
@@ -339,7 +339,7 @@ SEASTAR_TEST_CASE(test_schema_upgrader_is_equivalent_with_mutation_upgrade) {
 
                 auto reader = transform(make_flat_mutation_reader_from_mutations_v2(m1.schema(), semaphore.make_permit(), {m1}), schema_upgrader_v2(m2.schema()));
                 auto close_reader = deferred_close(reader);
-                auto from_upgrader = read_mutation_from_flat_mutation_reader(reader).get0();
+                auto from_upgrader = read_mutation_from_flat_mutation_reader(reader).get();
 
                 auto regular = m1;
                 regular.upgrade(m2.schema());

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -1249,7 +1249,7 @@ SEASTAR_THREAD_TEST_CASE(test_foreign_reader_as_mutation_source) {
                 }
 
                 return make_foreign(mt);
-            }).get0();
+            }).get();
 
             auto reader_factory = [&env, remote_shard, remote_mt = std::move(remote_mt)] (schema_ptr s,
                     reader_permit permit,
@@ -1267,7 +1267,7 @@ SEASTAR_THREAD_TEST_CASE(test_foreign_reader_as_mutation_source) {
                             trace_state.get(),
                             fwd_sm,
                             fwd_mr)));
-                }).get0();
+                }).get();
                 return make_foreign_reader(s, std::move(permit), std::move(remote_reader), fwd_sm);
             };
 
@@ -1814,7 +1814,7 @@ SEASTAR_THREAD_TEST_CASE(test_stopping_reader_with_pending_read_ahead) {
                     std::vector<uint32_t>{0, 1})));
 
             return make_ready_future<std::tuple<control_type, reader_type>>(std::tuple(std::move(control), std::move(reader)));
-        }).get0();
+        }).get();
 
         auto& remote_control = std::get<0>(remote_control_remote_reader);
         auto& remote_reader = std::get<1>(remote_control_remote_reader);
@@ -1830,7 +1830,7 @@ SEASTAR_THREAD_TEST_CASE(test_stopping_reader_with_pending_read_ahead) {
 
         BOOST_REQUIRE(!smp::submit_to(shard_of_interest, [remote_control = remote_control.get()] {
             return remote_control->destroyed;
-        }).get0());
+        }).get());
 
         bool buffer_filled = false;
         auto destroyed_after_close = reader.close().then([&] {
@@ -1846,9 +1846,9 @@ SEASTAR_THREAD_TEST_CASE(test_stopping_reader_with_pending_read_ahead) {
         smp::submit_to(shard_of_interest, [remote_control = remote_control.get(), &buffer_filled] {
             buffer_filled = true;
             remote_control->buffer_filled.set_value();
-        }).get0();
+        }).get();
 
-        BOOST_REQUIRE(destroyed_after_close.get0());
+        BOOST_REQUIRE(destroyed_after_close.get());
 
         return make_ready_future<>();
     }).get();
@@ -2090,7 +2090,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_destroyed_with_pending
             return smp::submit_to(multishard_reader_for_read_ahead::blocked_shard,
                     [control = remote_controls.at(multishard_reader_for_read_ahead::blocked_shard).get()] {
                 return control->pending;
-            }).get0();
+            }).get();
         }));
 
         // Destroy reader.
@@ -2113,7 +2113,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_destroyed_with_pending
                     });
                 },
                 true,
-                std::logical_and<bool>()).get0();
+                std::logical_and<bool>()).get();
         }));
 
         return make_ready_future<>();
@@ -2146,7 +2146,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_fast_forwarded_with_pe
             return smp::submit_to(multishard_reader_for_read_ahead::blocked_shard,
                     [control = remote_controls.at(multishard_reader_for_read_ahead::blocked_shard).get()] {
                 return control->pending;
-            }).get0();
+            }).get();
         }));
 
         auto end_token = dht::token(pr->end()->value().token());
@@ -2170,7 +2170,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_fast_forwarded_with_pe
                     });
                 },
                 true,
-                std::logical_and<bool>()).get0();
+                std::logical_and<bool>()).get();
 
         BOOST_REQUIRE(all_shard_fast_forwarded);
 
@@ -2188,7 +2188,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_fast_forwarded_with_pe
                     });
                 },
                 true,
-                std::logical_and<bool>()).get0();
+                std::logical_and<bool>()).get();
         }));
 
         return make_ready_future<>();
@@ -2201,7 +2201,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_next_partition) {
                 " WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1};").get();
         env.execute_cql("CREATE TABLE multishard_combining_reader_next_partition_ks.test (pk int, v int, PRIMARY KEY(pk));").get();
 
-        const auto insert_id = env.prepare("INSERT INTO multishard_combining_reader_next_partition_ks.test (\"pk\", \"v\") VALUES (?, ?);").get0();
+        const auto insert_id = env.prepare("INSERT INTO multishard_combining_reader_next_partition_ks.test (\"pk\", \"v\") VALUES (?, ?);").get();
 
         const auto partition_count = 1000;
 
@@ -2286,7 +2286,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_streaming_reader) {
         env.execute_cql("CREATE KEYSPACE multishard_streaming_reader_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1};").get();
         env.execute_cql("CREATE TABLE multishard_streaming_reader_ks.test (pk int, v int, PRIMARY KEY(pk));").get();
 
-        const auto insert_id = env.prepare("INSERT INTO multishard_streaming_reader_ks.test (\"pk\", \"v\") VALUES (?, ?);").get0();
+        const auto insert_id = env.prepare("INSERT INTO multishard_streaming_reader_ks.test (\"pk\", \"v\") VALUES (?, ?);").get();
 
         const auto partition_count = 10000;
 
@@ -2335,12 +2335,12 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_streaming_reader) {
         auto close_reference_reader = deferred_close(reference_reader);
 
         std::vector<mutation> reference_muts;
-        while (auto mut_opt = read_mutation_from_flat_mutation_reader(reference_reader).get0()) {
+        while (auto mut_opt = read_mutation_from_flat_mutation_reader(reference_reader).get()) {
             reference_muts.push_back(std::move(*mut_opt));
         }
 
         std::vector<mutation> tested_muts;
-        while (auto mut_opt = read_mutation_from_flat_mutation_reader(tested_reader).get0()) {
+        while (auto mut_opt = read_mutation_from_flat_mutation_reader(tested_reader).get()) {
             tested_muts.push_back(std::move(*mut_opt));
         }
 
@@ -2367,7 +2367,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
         auto read_all = [] (flat_mutation_reader_v2& reader, std::vector<mutation>& muts) {
             return async([&reader, &muts] {
                 auto close_reader = deferred_close(reader);
-                while (auto mut_opt = read_mutation_from_flat_mutation_reader(reader).get0()) {
+                while (auto mut_opt = read_mutation_from_flat_mutation_reader(reader).get()) {
                     muts.emplace_back(std::move(*mut_opt));
                 }
             });
@@ -2377,7 +2377,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
             return async([&] {
                 auto reader = make_flat_mutation_reader_from_mutations_v2(muts.front().schema(), semaphore.make_permit(), muts);
                 auto close_reader = deferred_close(reader);
-                while (auto mf_opt = reader().get0()) {
+                while (auto mf_opt = reader().get()) {
                     handle.push(std::move(*mf_opt)).get();
                 }
                 handle.push_end_of_stream();
@@ -2409,7 +2409,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
         auto expected_reader = make_flat_mutation_reader_from_mutations_v2(expected_muts.front().schema(), semaphore.make_permit(), expected_muts);
         auto close_expected_reader = deferred_close(expected_reader);
 
-        handle.push(std::move(*expected_reader().get0())).get();
+        handle.push(std::move(*expected_reader().get())).get();
 
         BOOST_REQUIRE(!fill_buffer_fut.available());
 
@@ -2433,7 +2433,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
 
         auto push_fut = make_ready_future<>();
         while (push_fut.available()) {
-            push_fut = handle.push(std::move(*expected_reader().get0()));
+            push_fut = handle.push(std::move(*expected_reader().get()));
         }
 
         BOOST_REQUIRE(!push_fut.available());
@@ -2473,7 +2473,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
         auto expected_reader = make_flat_mutation_reader_from_mutations_v2(expected_muts.front().schema(), semaphore.make_permit(), expected_muts);
         auto close_expected_reader = deferred_close(expected_reader);
 
-        handle.push(std::move(*expected_reader().get0())).get();
+        handle.push(std::move(*expected_reader().get())).get();
 
         BOOST_REQUIRE(!fill_buffer_fut.available());
 
@@ -2501,7 +2501,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
         auto expected_reader = make_flat_mutation_reader_from_mutations_v2(expected_muts.front().schema(), semaphore.make_permit(), expected_muts);
         auto close_expected_reader = deferred_close(expected_reader);
 
-        handle.push(std::move(*expected_reader().get0())).get();
+        handle.push(std::move(*expected_reader().get())).get();
 
         BOOST_REQUIRE(!fill_buffer_fut.available());
 
@@ -2852,7 +2852,7 @@ flat_mutation_reader_v2 create_evictable_reader_and_evict_after_first_buffer(
 
     rd.set_max_buffer_size(max_buffer_size);
 
-    rd.fill_buffer().get0();
+    rd.fill_buffer().get();
 
     const auto eq_cmp = position_in_partition::equal_compare(*schema);
     BOOST_REQUIRE(rd.is_buffer_full());
@@ -2913,7 +2913,7 @@ void check_evictable_reader_validation_is_triggered(
     const bool fail = !error_prefix.empty();
 
     try {
-        rd.fill_buffer().get0();
+        rd.fill_buffer().get();
     } catch (std::runtime_error& e) {
         if (fail) {
             if (error_prefix == std::string_view(e.what(), error_prefix.size())) {
@@ -4210,7 +4210,7 @@ SEASTAR_THREAD_TEST_CASE(test_clustering_combining_of_empty_readers) {
             std::make_unique<simple_position_reader_queue>(*s, std::move(rs)));
     auto close_r = deferred_close(r);
 
-    auto mf = r().get0();
+    auto mf = r().get();
     if (mf) {
         BOOST_FAIL(format("reader combined of empty readers returned fragment {}", mutation_fragment_v2::printer(*s, *mf)));
     }

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -86,7 +86,7 @@ static mutation_partition get_partition(reader_permit permit, replica::memtable&
     auto range = dht::partition_range::make_singular(dk);
     auto reader = mt.make_flat_reader(mt.schema(), std::move(permit), range);
     auto close_reader = deferred_close(reader);
-    auto mo = read_mutation_from_flat_mutation_reader(reader).get0();
+    auto mo = read_mutation_from_flat_mutation_reader(reader).get();
     BOOST_REQUIRE(bool(mo));
     return std::move(mo->partition());
 }
@@ -451,7 +451,7 @@ SEASTAR_THREAD_TEST_CASE(test_large_collection_allocation) {
 
         auto rd = mt->make_flat_reader(schema, semaphore.make_permit());
         auto close_rd = deferred_close(rd);
-        auto res_mut_opt = read_mutation_from_flat_mutation_reader(rd).get0();
+        auto res_mut_opt = read_mutation_from_flat_mutation_reader(rd).get();
         BOOST_REQUIRE(res_mut_opt);
 
         res_mut_opt->partition().compact_for_query(*schema, res_mut_opt->decorated_key(), gc_clock::now(), {query::full_clustering_range}, true, false,
@@ -2775,7 +2775,7 @@ void run_compaction_data_stream_split_test(const schema& schema, reader_permit p
             survived_compacted_fragments_consumer(schema, query_time, get_max_purgeable),
             purged_compacted_fragments_consumer(schema, query_time, get_max_purgeable));
 
-    auto [survived_muts, purged_muts] = reader.consume(std::move(consumer)).get0();
+    auto [survived_muts, purged_muts] = reader.consume(std::move(consumer)).get();
 
     auto survived_muts_it = survived_muts.begin();
     const auto survived_muts_end = survived_muts.end();
@@ -2833,7 +2833,7 @@ SEASTAR_THREAD_TEST_CASE(test_compaction_data_stream_split) {
             return tests::expiry_info{ttl, query_time + gc_clock::duration{offset_dist(engine)}};
         };
         const auto mutations = tests::generate_random_mutations(random_schema, ts_gen, exp_gen, partition_count_dist,
-                clustering_row_count_dist).get0();
+                clustering_row_count_dist).get();
         run_compaction_data_stream_split_test(schema, semaphore.make_permit(), query_time, mutations);
     }
 
@@ -2868,7 +2868,7 @@ SEASTAR_THREAD_TEST_CASE(test_compaction_data_stream_split) {
             return tests::expiry_info{ttl, query_time + gc_clock::duration{offset_dist(engine)}};
         };
         const auto mutations = tests::generate_random_mutations(random_schema, ts_gen, all_purged_exp_gen, partition_count_dist,
-                clustering_row_count_dist).get0();
+                clustering_row_count_dist).get();
         run_compaction_data_stream_split_test(schema, semaphore.make_permit(), query_time, mutations);
     }
 
@@ -2897,7 +2897,7 @@ SEASTAR_THREAD_TEST_CASE(test_compaction_data_stream_split) {
             }
         };
         const auto mutations = tests::generate_random_mutations(random_schema, ts_gen, tests::no_expiry_expiry_generator(), partition_count_dist,
-                clustering_row_count_dist).get0();
+                clustering_row_count_dist).get();
         run_compaction_data_stream_split_test(schema, semaphore.make_permit(), query_time, mutations);
     }
 }

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -92,7 +92,7 @@ SEASTAR_TEST_CASE(test_multishard_writer) {
                           });
                         });
                     }
-                ).get0();
+                ).get();
                 BOOST_REQUIRE_EQUAL(partitions_received, partition_nr);
                 BOOST_REQUIRE_EQUAL(shards_after, shards_before);
             }
@@ -162,7 +162,7 @@ SEASTAR_TEST_CASE(test_multishard_writer_producer_aborts) {
                           });
                         });
                     }
-                ).get0();
+                ).get();
             } catch (...) {
                 // The distribute_reader_and_consume_on_shards is expected to fail and not block forever
             }
@@ -369,7 +369,7 @@ SEASTAR_THREAD_TEST_CASE(test_timestamp_based_splitting_mutation_writer) {
         return underlying(engine, ts_dest, min_timestamp);
     };
 
-    auto muts = tests::generate_random_mutations(random_schema, ts_gen).get0();
+    auto muts = tests::generate_random_mutations(random_schema, ts_gen).get();
 
     auto classify_fn = [] (api::timestamp_type ts) {
         return int64_t(ts % 2);
@@ -403,7 +403,7 @@ static void assert_that_segregator_produces_correct_data(const bucket_map_t& buc
     }
 
     std::vector<mutation> combined_mutations;
-    while (auto m = read_mutation_from_flat_mutation_reader(reader).get0()) {
+    while (auto m = read_mutation_from_flat_mutation_reader(reader).get()) {
         m->partition().compact_for_compaction(*random_schema.schema(), always_gc, m->decorated_key(), now, tombstone_gc_state(nullptr));
         combined_mutations.emplace_back(std::move(*m));
     }
@@ -440,7 +440,7 @@ SEASTAR_THREAD_TEST_CASE(test_timestamp_based_splitting_mutation_writer_abort) {
         return underlying(engine, ts_dest, min_timestamp);
     };
 
-    auto muts = tests::generate_random_mutations(random_schema, ts_gen).get0();
+    auto muts = tests::generate_random_mutations(random_schema, ts_gen).get();
 
     auto classify_fn = [] (api::timestamp_type ts) {
         return int64_t(ts % 2);
@@ -563,7 +563,7 @@ SEASTAR_THREAD_TEST_CASE(test_token_group_based_splitting_mutation_writer) {
 
     size_t partition_count = many_partitions();
 
-    auto muts = tests::generate_random_mutations(random_schema, partition_count).get0();
+    auto muts = tests::generate_random_mutations(random_schema, partition_count).get();
 
     auto classify_fn = [] (dht::token t) -> mutation_writer::token_group_id {
         return dht::compaction_group_of(1, t);

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -161,7 +161,7 @@ void full_ring_check(const std::vector<ring_point>& ring_points,
     const auto& topo = tm.get_topology();
     strategy_sanity_check(ars_ptr, tmptr, options);
 
-    auto erm = calculate_effective_replication_map(ars_ptr, tmptr).get0();
+    auto erm = calculate_effective_replication_map(ars_ptr, tmptr).get();
 
     for (auto& rp : ring_points) {
         double cur_point1 = rp.point - 0.5;
@@ -447,7 +447,7 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
         .with_column("v", utf8_type)
         .build();
 
-    auto tmap = tab_awr_ptr->allocate_tablets_for_new_table(s, stm.get(), 1).get0();
+    auto tmap = tab_awr_ptr->allocate_tablets_for_new_table(s, stm.get(), 1).get();
     full_ring_check(tmap, options323, ars_ptr, stm.get());
 
     ///////////////
@@ -464,7 +464,7 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
     tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
     BOOST_REQUIRE(tab_awr_ptr);
 
-    tmap = tab_awr_ptr->allocate_tablets_for_new_table(s, stm.get(), 1).get0();
+    tmap = tab_awr_ptr->allocate_tablets_for_new_table(s, stm.get(), 1).get();
     full_ring_check(tmap, options320, ars_ptr, stm.get());
 
     // Test the case of not enough nodes to meet RF in DC 102
@@ -480,7 +480,7 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
     tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
     BOOST_REQUIRE(tab_awr_ptr);
 
-    tmap = tab_awr_ptr->allocate_tablets_for_new_table(s, stm.get(), 1).get0();
+    tmap = tab_awr_ptr->allocate_tablets_for_new_table(s, stm.get(), 1).get();
     full_ring_check(tmap, options324, ars_ptr, stm.get());
 }
 
@@ -657,7 +657,7 @@ static void test_equivalence(const shared_token_metadata& stm, const locator::to
     for (size_t i = 0; i < 1000; ++i) {
         auto token = dht::token::get_random_token();
         auto expected = calculate_natural_endpoints(token, tm, topo, datacenters);
-        auto actual = nts.calculate_natural_endpoints(token, *stm.get()).get0();
+        auto actual = nts.calculate_natural_endpoints(token, *stm.get()).get();
 
         // Because the old algorithm does not put the nodes in the correct order in the case where more replicas
         // are required than there are racks in a dc, we accept different order as long as the primary

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -447,7 +447,7 @@ static
 void
 do_test_split_range_to_single_shard(const schema& s, const dht::sharder& sharder_, const dht::partition_range& pr) {
     for (auto shard : boost::irange(0u, sharder_.shard_count())) {
-        auto ranges = dht::split_range_to_single_shard(s, sharder_, pr, shard).get0();
+        auto ranges = dht::split_range_to_single_shard(s, sharder_, pr, shard).get();
         auto sharder = dht::ring_position_range_sharder(sharder_, pr);
         auto x = sharder.next(s);
         auto cmp = dht::ring_position_comparator(s);

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -216,7 +216,7 @@ public:
         const auto cache_key = make_cache_key(key);
 
         auto querier = make_querier<Querier>(range);
-        auto dk_ck = querier.consume_page(dummy_result_builder{}, row_limit, std::numeric_limits<uint32_t>::max(), gc_clock::now()).get0();
+        auto dk_ck = querier.consume_page(dummy_result_builder{}, row_limit, std::numeric_limits<uint32_t>::max(), gc_clock::now()).get();
         auto&& dk = dk_ck.first;
         auto&& ck = dk_ck.second;
         auto permit = querier.permit();
@@ -648,7 +648,7 @@ SEASTAR_THREAD_TEST_CASE(test_resources_based_cache_eviction) {
 
         BOOST_REQUIRE(env.local_db().has_schema("querier_cache", "test"));
 
-        auto insert_id = env.prepare("INSERT INTO querier_cache.test (pk, ck, value) VALUES (?, ?, ?);").get0();
+        auto insert_id = env.prepare("INSERT INTO querier_cache.test (pk, ck, value) VALUES (?, ?, ?);").get();
         auto pk = cql3::raw_value::make_value(serialized(0));
         for (int i = 0; i < 100; ++i) {
             auto ck = cql3::raw_value::make_value(serialized(i));
@@ -737,7 +737,7 @@ SEASTAR_THREAD_TEST_CASE(test_immediate_evict_on_insert) {
     test_querier_cache t;
 
     auto& sem = t.get_semaphore();
-    auto permit1 = sem.obtain_permit(t.get_schema(), get_name(), 0, db::no_timeout, {}).get0();
+    auto permit1 = sem.obtain_permit(t.get_schema(), get_name(), 0, db::no_timeout, {}).get();
 
     auto resources = permit1.consume_resources(reader_resources(sem.available_resources().count, 0));
 

--- a/test/boost/role_manager_test.cc
+++ b/test/boost/role_manager_test.cc
@@ -26,7 +26,7 @@ auto make_manager(cql_test_env& env) {
 SEASTAR_TEST_CASE(create_role) {
     return do_with_cql_env_thread([](auto&& env) {
         auto m = make_manager(env);
-        m->start().get0();
+        m->start().get();
 
         const auto anon = auth::authenticated_user();
 
@@ -38,26 +38,26 @@ SEASTAR_TEST_CASE(create_role) {
         c.is_superuser = true;
 
         m->create("admin", c).get();
-        BOOST_REQUIRE_EQUAL(m->exists("admin").get0(), true);
-        BOOST_REQUIRE_EQUAL(m->can_login("admin").get0(), false);
-        BOOST_REQUIRE_EQUAL(m->is_superuser("admin").get0(), true);
+        BOOST_REQUIRE_EQUAL(m->exists("admin").get(), true);
+        BOOST_REQUIRE_EQUAL(m->can_login("admin").get(), false);
+        BOOST_REQUIRE_EQUAL(m->is_superuser("admin").get(), true);
 
         BOOST_REQUIRE_EQUAL(
-                m->query_granted("admin", auth::recursive_role_query::yes).get0(),
+                m->query_granted("admin", auth::recursive_role_query::yes).get(),
                 std::unordered_set<sstring>{"admin"});
 
         //
         // Creating a role that already exists is an error.
         //
 
-        BOOST_REQUIRE_THROW(m->create("admin", c).get0(), auth::role_already_exists);
+        BOOST_REQUIRE_THROW(m->create("admin", c).get(), auth::role_already_exists);
     });
 }
 
 SEASTAR_TEST_CASE(drop_role) {
     return do_with_cql_env_thread([](auto&& env) {
         auto m = make_manager(env);
-        m->start().get0();
+        m->start().get();
 
         const auto anon = auth::authenticated_user();
 
@@ -67,145 +67,145 @@ SEASTAR_TEST_CASE(drop_role) {
 
         m->create("lord", auth::role_config()).get();
         m->drop("lord").get();
-        BOOST_REQUIRE_EQUAL(m->exists("lord").get0(), false);
+        BOOST_REQUIRE_EQUAL(m->exists("lord").get(), false);
 
         //
         // Dropping a role revokes it from other roles and revokes other roles from it.
         //
 
-        m->create("peasant", auth::role_config()).get0();
-        m->create("lord", auth::role_config()).get0();
-        m->create("king", auth::role_config()).get0();
+        m->create("peasant", auth::role_config()).get();
+        m->create("lord", auth::role_config()).get();
+        m->create("king", auth::role_config()).get();
 
         auth::role_config tim_config;
         tim_config.is_superuser = false;
         tim_config.can_login = true;
-        m->create("tim", tim_config).get0();
+        m->create("tim", tim_config).get();
 
-        m->grant("lord", "peasant").get0();
-        m->grant("king", "lord").get0();
-        m->grant("tim", "lord").get0();
+        m->grant("lord", "peasant").get();
+        m->grant("king", "lord").get();
+        m->grant("tim", "lord").get();
 
-        m->drop("lord").get0();
+        m->drop("lord").get();
 
         BOOST_REQUIRE_EQUAL(
-                m->query_granted("tim", auth::recursive_role_query::yes).get0(),
+                m->query_granted("tim", auth::recursive_role_query::yes).get(),
                 std::unordered_set<sstring>{"tim"});
 
         BOOST_REQUIRE_EQUAL(
-                m->query_granted("king", auth::recursive_role_query::yes).get0(),
+                m->query_granted("king", auth::recursive_role_query::yes).get(),
                 std::unordered_set<sstring>{"king"});
 
         //
         // Dropping a role that does not exist is an error.
         //
 
-        BOOST_REQUIRE_THROW(m->drop("emperor").get0(), auth::nonexistant_role);
+        BOOST_REQUIRE_THROW(m->drop("emperor").get(), auth::nonexistant_role);
     });
 }
 
 SEASTAR_TEST_CASE(grant_role) {
     return do_with_cql_env_thread([](auto&& env) {
         auto m = make_manager(env);
-        m->start().get0();
+        m->start().get();
 
         const auto anon = auth::authenticated_user();
 
         auth::role_config jsnow_config;
         jsnow_config.is_superuser = false;
         jsnow_config.can_login = true;
-        m->create("jsnow", jsnow_config).get0();
+        m->create("jsnow", jsnow_config).get();
 
-        m->create("lord", auth::role_config()).get0();
-        m->create("king", auth::role_config()).get0();
+        m->create("lord", auth::role_config()).get();
+        m->create("king", auth::role_config()).get();
 
         //
         // All kings have the rights of lords, and 'jsnow' is a king.
         //
 
-        m->grant("king", "lord").get0();
-        m->grant("jsnow", "king").get0();
+        m->grant("king", "lord").get();
+        m->grant("jsnow", "king").get();
 
         BOOST_REQUIRE_EQUAL(
-                m->query_granted("king", auth::recursive_role_query::yes).get0(),
+                m->query_granted("king", auth::recursive_role_query::yes).get(),
                 (std::unordered_set<sstring>{"king", "lord"}));
 
         BOOST_REQUIRE_EQUAL(
-                m->query_granted("jsnow", auth::recursive_role_query::no).get0(),
+                m->query_granted("jsnow", auth::recursive_role_query::no).get(),
                (std::unordered_set<sstring>{"jsnow", "king"}));
 
         BOOST_REQUIRE_EQUAL(
-                m->query_granted("jsnow", auth::recursive_role_query::yes).get0(),
+                m->query_granted("jsnow", auth::recursive_role_query::yes).get(),
                 (std::unordered_set<sstring>{"jsnow", "king", "lord"}));
 
         // A non-existing role cannot be granted.
-        BOOST_REQUIRE_THROW(m->grant("jsnow", "doctor").get0(), auth::nonexistant_role);
+        BOOST_REQUIRE_THROW(m->grant("jsnow", "doctor").get(), auth::nonexistant_role);
 
         // A role cannot be granted to a non-existing role.
-        BOOST_REQUIRE_THROW(m->grant("hpotter", "lord").get0(), auth::nonexistant_role);
+        BOOST_REQUIRE_THROW(m->grant("hpotter", "lord").get(), auth::nonexistant_role);
     });
 }
 
 SEASTAR_TEST_CASE(revoke_role) {
     return do_with_cql_env_thread([](auto&& env) {
         auto m = make_manager(env);
-        m->start().get0();
+        m->start().get();
 
         const auto anon = auth::authenticated_user();
 
         auth::role_config rrat_config;
         rrat_config.is_superuser = false;
         rrat_config.can_login = true;
-        m->create("rrat", rrat_config).get0();
+        m->create("rrat", rrat_config).get();
 
-        m->create("chef", auth::role_config()).get0();
-        m->create("sous_chef", auth::role_config()).get0();
+        m->create("chef", auth::role_config()).get();
+        m->create("sous_chef", auth::role_config()).get();
 
-        m->grant("chef", "sous_chef").get0();
-        m->grant("rrat", "chef").get0();
+        m->grant("chef", "sous_chef").get();
+        m->grant("rrat", "chef").get();
 
-        m->revoke("chef", "sous_chef").get0();
+        m->revoke("chef", "sous_chef").get();
         BOOST_REQUIRE_EQUAL(
-                m->query_granted("rrat", auth::recursive_role_query::yes).get0(),
+                m->query_granted("rrat", auth::recursive_role_query::yes).get(),
                 (std::unordered_set<sstring>{"chef", "rrat"}));
 
-        m->revoke("rrat", "chef").get0();
+        m->revoke("rrat", "chef").get();
         BOOST_REQUIRE_EQUAL(
-                m->query_granted("rrat", auth::recursive_role_query::yes).get0(),
+                m->query_granted("rrat", auth::recursive_role_query::yes).get(),
                 std::unordered_set<sstring>{"rrat"});
 
         // A non-existing role cannot be revoked.
-        BOOST_REQUIRE_THROW(m->revoke("rrat", "taster").get0(), auth::nonexistant_role);
+        BOOST_REQUIRE_THROW(m->revoke("rrat", "taster").get(), auth::nonexistant_role);
 
         // A role cannot be revoked from a non-existing role.
-        BOOST_REQUIRE_THROW(m->revoke("ccasper", "chef").get0(), auth::nonexistant_role);
+        BOOST_REQUIRE_THROW(m->revoke("ccasper", "chef").get(), auth::nonexistant_role);
 
         // Revoking a role not granted is an error.
-        BOOST_REQUIRE_THROW(m->revoke("rrat", "sous_chef").get0(), auth::revoke_ungranted_role);
+        BOOST_REQUIRE_THROW(m->revoke("rrat", "sous_chef").get(), auth::revoke_ungranted_role);
     });
 }
 
 SEASTAR_TEST_CASE(alter_role) {
     return do_with_cql_env_thread([](auto&& env) {
         auto m = make_manager(env);
-        m->start().get0();
+        m->start().get();
 
         const auto anon = auth::authenticated_user();
 
         auth::role_config tsmith_config;
         tsmith_config.is_superuser = true;
         tsmith_config.can_login = true;
-        m->create("tsmith", tsmith_config).get0();
+        m->create("tsmith", tsmith_config).get();
 
         auth::role_config_update u;
         u.can_login = false;
 
-        m->alter("tsmith", u).get0();
+        m->alter("tsmith", u).get();
 
-        BOOST_REQUIRE_EQUAL(m->is_superuser("tsmith").get0(), true);
-        BOOST_REQUIRE_EQUAL(m->can_login("tsmith").get0(), false);
+        BOOST_REQUIRE_EQUAL(m->is_superuser("tsmith").get(), true);
+        BOOST_REQUIRE_EQUAL(m->can_login("tsmith").get(), false);
 
         // Altering a non-existing role is an error.
-        BOOST_REQUIRE_THROW(m->alter("hjones", u).get0(), auth::nonexistant_role);
+        BOOST_REQUIRE_THROW(m->alter("hjones", u).get(), auth::nonexistant_role);
     });
 }

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -510,7 +510,7 @@ SEASTAR_TEST_CASE(test_merging_creates_a_table_even_if_keyspace_was_recreated) {
             {
                 auto group0_guard = mm.start_group0_operation().get();
                 const auto ts = group0_guard.write_timestamp();
-                auto muts = service::prepare_keyspace_drop_announcement(e.local_db(), "ks", ts).get0();
+                auto muts = service::prepare_keyspace_drop_announcement(e.local_db(), "ks", ts).get();
                 boost::copy(muts, std::back_inserter(all_muts));
                 mm.announce(muts, std::move(group0_guard), "").get();
             }
@@ -529,7 +529,7 @@ SEASTAR_TEST_CASE(test_merging_creates_a_table_even_if_keyspace_was_recreated) {
                 auto group0_guard = mm.start_group0_operation().get();
                 const auto ts = group0_guard.write_timestamp();
 
-                auto muts = service::prepare_new_column_family_announcement(mm.get_storage_proxy(), s0, ts).get0();
+                auto muts = service::prepare_new_column_family_announcement(mm.get_storage_proxy(), s0, ts).get();
                 boost::copy(muts, std::back_inserter(all_muts));
 
                 mm.announce(all_muts, std::move(group0_guard), "").get();
@@ -725,7 +725,7 @@ SEASTAR_TEST_CASE(test_prepared_statement_is_invalidated_by_schema_change) {
             logging::logger_registry().set_logger_level("query_processor", logging::log_level::debug);
             e.execute_cql("create keyspace tests with replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 };").get();
             e.execute_cql("create table tests.table1 (pk int primary key, c1 int, c2 int);").get();
-            auto id = e.prepare("select * from tests.table1;").get0();
+            auto id = e.prepare("select * from tests.table1;").get();
 
             e.execute_cql("alter table tests.table1 add s1 int;").get();
 
@@ -810,7 +810,7 @@ future<> test_schema_digest_does_not_change_with_disabled_features(sstring data_
             // with highest timestamp will win and be sent to other nodes.
             // Thus, system_distributed.* tables are officially not taken into account,
             // which makes it less likely that this test case would need to be needlessly regenerated.
-            auto actual = calculate_schema_digest(e.get_storage_proxy(), sf, std::not_fn(&is_internal_keyspace)).get0();
+            auto actual = calculate_schema_digest(e.get_storage_proxy(), sf, std::not_fn(&is_internal_keyspace)).get();
             if (regenerate) {
                 std::cout << format("        utils::UUID(\"{}\"),", actual) << "\n";
             } else {

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -65,7 +65,7 @@ SEASTAR_TEST_CASE(test_async_loading) {
 
         auto s1_loaded = local_schema_registry().get_or_load(s1->version(), [s1] (table_schema_version) {
             return make_ready_future<frozen_schema>(frozen_schema(s1));
-        }).get0();
+        }).get();
 
         BOOST_REQUIRE(s1_loaded);
         BOOST_REQUIRE(s1_loaded->version() == s1->version());
@@ -74,7 +74,7 @@ SEASTAR_TEST_CASE(test_async_loading) {
 
         auto s2_loaded = local_schema_registry().get_or_load(s2->version(), [s2] (table_schema_version) {
             return yield().then([s2] { return frozen_schema(s2); });
-        }).get0();
+        }).get();
 
         BOOST_REQUIRE(s2_loaded);
         BOOST_REQUIRE(s2_loaded->version() == s2->version());
@@ -223,7 +223,7 @@ SEASTAR_THREAD_TEST_CASE(test_table_is_attached) {
         s3_entered.get();
         local_schema_registry().learn(s3);
         s3_thr.unblock();
-        auto s3_s = learned_s3.get0();
+        auto s3_s = learned_s3.get();
         BOOST_REQUIRE(s3_s->maybe_table() == s0->maybe_table());
         BOOST_REQUIRE(s3->maybe_table() == s0->maybe_table());
 
@@ -240,7 +240,7 @@ SEASTAR_THREAD_TEST_CASE(test_table_is_attached) {
         s4_entered.get();
         s4 = local_schema_registry().get_or_load(s4->version(), [&, fs = frozen_schema(s4)] (table_schema_version) { return fs; });
         s4_thr.unblock();
-        auto s4_s = learned_s4.get0();
+        auto s4_s = learned_s4.get();
         BOOST_REQUIRE(s4_s->maybe_table() == s0->maybe_table());
         BOOST_REQUIRE(s4->maybe_table() == s0->maybe_table());
 

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -150,7 +150,7 @@ SEASTAR_TEST_CASE(test_secondary_index_case_compound_partition_key) {
         eventually([&] {
             // We expect this search to find the single row, with the compound
             // partition key (a, b) = (1, 2).
-            auto res = e.execute_cql("SELECT * from tab WHERE c = 3").get0();
+            auto res = e.execute_cql("SELECT * from tab WHERE c = 3").get();
             assert_that(res).is_rows()
                     .with_size(1)
                     .with_row({
@@ -246,7 +246,7 @@ SEASTAR_TEST_CASE(test_many_columns) {
         // we inserted above.
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-            auto res = e.execute_cql("SELECT * from tab WHERE a = 1").get0();
+            auto res = e.execute_cql("SELECT * from tab WHERE a = 1").get();
             assert_that(res).is_rows().with_size(3)
                 .with_rows({
                 {{int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}},
@@ -256,7 +256,7 @@ SEASTAR_TEST_CASE(test_many_columns) {
         });
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-            auto res = e.execute_cql("SELECT * from tab WHERE b = 2").get0();
+            auto res = e.execute_cql("SELECT * from tab WHERE b = 2").get();
             assert_that(res).is_rows().with_size(3)
                 .with_rows({
                 {{int32_type->decompose(0)}, {int32_type->decompose(2)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}},
@@ -266,7 +266,7 @@ SEASTAR_TEST_CASE(test_many_columns) {
         });
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-            auto res = e.execute_cql("SELECT * from tab WHERE c = 3").get0();
+            auto res = e.execute_cql("SELECT * from tab WHERE c = 3").get();
             assert_that(res).is_rows().with_size(3)
                 .with_rows({
                 {{int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(3)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}},
@@ -276,7 +276,7 @@ SEASTAR_TEST_CASE(test_many_columns) {
         });
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-            auto res = e.execute_cql("SELECT * from tab WHERE d = 4").get0();
+            auto res = e.execute_cql("SELECT * from tab WHERE d = 4").get();
             assert_that(res).is_rows().with_size(2)
                 .with_rows({
                 {{int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(4)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}},
@@ -285,7 +285,7 @@ SEASTAR_TEST_CASE(test_many_columns) {
         });
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-            auto res = e.execute_cql("SELECT * from tab WHERE e = 5").get0();
+            auto res = e.execute_cql("SELECT * from tab WHERE e = 5").get();
             assert_that(res).is_rows().with_size(3)
                 .with_rows({
                 {{int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(5)}, {int32_type->decompose(0)}},
@@ -295,7 +295,7 @@ SEASTAR_TEST_CASE(test_many_columns) {
         });
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-            auto res = e.execute_cql("SELECT * from tab WHERE f = 6").get0();
+            auto res = e.execute_cql("SELECT * from tab WHERE f = 6").get();
             assert_that(res).is_rows().with_size(2)
                 .with_rows({
                 {{int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(7)}, {int32_type->decompose(0)}, {int32_type->decompose(6)}},
@@ -327,7 +327,7 @@ SEASTAR_TEST_CASE(test_index_with_partition_key) {
 
         // Queries that restrict the whole partition key and an index should not require filtering - they are not performance-heavy
         eventually([&] {
-            auto res = e.execute_cql("SELECT * from tab WHERE a = 1 and b = 2 and e = 5").get0();
+            auto res = e.execute_cql("SELECT * from tab WHERE a = 1 and b = 2 and e = 5").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(4)}, {int32_type->decompose(5)}, {int32_type->decompose(6)}},
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(7)}, {int32_type->decompose(5)}, {int32_type->decompose(0)}}
@@ -340,7 +340,7 @@ SEASTAR_TEST_CASE(test_index_with_partition_key) {
 
         // Indexed queries with full primary key are allowed without filtering as well
         eventually([&] {
-            auto res = e.execute_cql("SELECT * from tab WHERE a = 1 and b = 2 and c = 3 and d = 4 and e = 5").get0();
+            auto res = e.execute_cql("SELECT * from tab WHERE a = 1 and b = 2 and c = 3 and d = 4 and e = 5").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(4)}, {int32_type->decompose(5)}, {int32_type->decompose(6)}}
             });
@@ -348,7 +348,7 @@ SEASTAR_TEST_CASE(test_index_with_partition_key) {
 
         // And it's also sufficient if only full partition key + clustering key prefix is present
         eventually([&] {
-            auto res = e.execute_cql("SELECT * from tab WHERE a = 1 and b = 2 and c = 3 and e = 5").get0();
+            auto res = e.execute_cql("SELECT * from tab WHERE a = 1 and b = 2 and c = 3 and e = 5").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(4)}, {int32_type->decompose(5)}, {int32_type->decompose(6)}},
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(7)}, {int32_type->decompose(5)}, {int32_type->decompose(0)}}
@@ -358,14 +358,14 @@ SEASTAR_TEST_CASE(test_index_with_partition_key) {
         // This query needs filtering, because clustering key restrictions do not form a prefix
         BOOST_REQUIRE_THROW(e.execute_cql("SELECT * from tab WHERE a = 1 and b = 2 and d = 4 and e = 5").get(), exceptions::invalid_request_exception);
         eventually([&] {
-            auto res = e.execute_cql("SELECT * from tab WHERE a = 1 and b = 2 and d = 4 and e = 5 ALLOW FILTERING").get0();
+            auto res = e.execute_cql("SELECT * from tab WHERE a = 1 and b = 2 and d = 4 and e = 5 ALLOW FILTERING").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(4)}, {int32_type->decompose(5)}, {int32_type->decompose(6)}}
             });
         });
 
         eventually([&] {
-            auto res = e.execute_cql("SELECT * from tab WHERE a = 1 and b IN (2, 3) and d IN (4, 5, 6, 7) and e = 5 ALLOW FILTERING").get0();
+            auto res = e.execute_cql("SELECT * from tab WHERE a = 1 and b IN (2, 3) and d IN (4, 5, 6, 7) and e = 5 ALLOW FILTERING").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(4)}, {int32_type->decompose(5)}, {int32_type->decompose(6)}},
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(7)}, {int32_type->decompose(5)}, {int32_type->decompose(0)}}
@@ -373,7 +373,7 @@ SEASTAR_TEST_CASE(test_index_with_partition_key) {
         });
 
         eventually([&] {
-            auto res = e.execute_cql("SELECT * from tab WHERE a = 1 and b = 2 and (c, d) in ((3, 4), (1, 1), (3, 7)) and e = 5 ALLOW FILTERING").get0();
+            auto res = e.execute_cql("SELECT * from tab WHERE a = 1 and b = 2 and (c, d) in ((3, 4), (1, 1), (3, 7)) and e = 5 ALLOW FILTERING").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(4)}, {int32_type->decompose(5)}, {int32_type->decompose(6)}},
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(7)}, {int32_type->decompose(5)}, {int32_type->decompose(0)}}
@@ -400,19 +400,19 @@ SEASTAR_TEST_CASE(test_index_on_pk_ck_with_paging) {
         eventually([&] {
             auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{101, nullptr, {}, api::new_timestamp()});
-            auto res = e.execute_cql("SELECT * FROM tab WHERE v = 1", std::move(qo)).get0();
+            auto res = e.execute_cql("SELECT * FROM tab WHERE v = 1", std::move(qo)).get();
             assert_that(res).is_rows().with_size(101);
         });
 
         eventually([&] {
-            auto res = e.execute_cql("SELECT * FROM tab WHERE v = 1").get0();
+            auto res = e.execute_cql("SELECT * FROM tab WHERE v = 1").get();
             assert_that(res).is_rows().with_size(2052);
         });
 
         eventually([&] {
             auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{100, nullptr, {}, api::new_timestamp()});
-            auto res = e.execute_cql("SELECT * FROM tab WHERE pk2 = 1", std::move(qo)).get0();
+            auto res = e.execute_cql("SELECT * FROM tab WHERE pk2 = 1", std::move(qo)).get();
             assert_that(res).is_rows().with_rows({{
                 {int32_type->decompose(1)}, {int32_type->decompose(1)}, {utf8_type->decompose("hello1")}, {utf8_type->decompose("world1")},
                 {int32_type->decompose(1)}, {int32_type->decompose(1)}, {utf8_type->decompose(big_string)}
@@ -422,7 +422,7 @@ SEASTAR_TEST_CASE(test_index_on_pk_ck_with_paging) {
         eventually([&] {
             auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{100, nullptr, {}, api::new_timestamp()});
-            auto res = e.execute_cql("SELECT * FROM tab WHERE ck2 = 'world8'", std::move(qo)).get0();
+            auto res = e.execute_cql("SELECT * FROM tab WHERE ck2 = 'world8'", std::move(qo)).get();
             assert_that(res).is_rows().with_rows({{
                 {int32_type->decompose(2)}, {int32_type->decompose(8)}, {utf8_type->decompose("hello8")}, {utf8_type->decompose("world8")},
                 {int32_type->decompose(1)}, {int32_type->decompose(8)}, {utf8_type->decompose("small_string")}
@@ -458,7 +458,7 @@ SEASTAR_TEST_CASE(test_simple_index_paging) {
         eventually([&] {
             auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, nullptr, {}, api::new_timestamp()});
-            auto res = e.execute_cql("SELECT * FROM tab WHERE v = 1", std::move(qo)).get0();
+            auto res = e.execute_cql("SELECT * FROM tab WHERE v = 1", std::move(qo)).get();
             auto paging_state = extract_paging_state(res);
             expect_more_pages(res, true);
 
@@ -468,7 +468,7 @@ SEASTAR_TEST_CASE(test_simple_index_paging) {
 
             qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, paging_state, {}, api::new_timestamp()});
-            res = e.execute_cql("SELECT * FROM tab WHERE v = 1", std::move(qo)).get0();
+            res = e.execute_cql("SELECT * FROM tab WHERE v = 1", std::move(qo)).get();
             expect_more_pages(res, true);
             paging_state = extract_paging_state(res);
 
@@ -478,7 +478,7 @@ SEASTAR_TEST_CASE(test_simple_index_paging) {
 
             qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, paging_state, {}, api::new_timestamp()});
-            res = e.execute_cql("SELECT * FROM tab WHERE v = 1", std::move(qo)).get0();
+            res = e.execute_cql("SELECT * FROM tab WHERE v = 1", std::move(qo)).get();
             paging_state = extract_paging_state(res);
 
             assert_that(res).is_rows().with_rows({{
@@ -493,7 +493,7 @@ SEASTAR_TEST_CASE(test_simple_index_paging) {
             } catch (...) {
                 qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                         cql3::query_options::specific_options{1, paging_state, {}, api::new_timestamp()});
-                res = e.execute_cql("SELECT * FROM tab WHERE v = 1", std::move(qo)).get0();
+                res = e.execute_cql("SELECT * FROM tab WHERE v = 1", std::move(qo)).get();
                 assert_that(res).is_rows().with_size(0);
                 expect_more_pages(res, false);
             }
@@ -503,7 +503,7 @@ SEASTAR_TEST_CASE(test_simple_index_paging) {
         eventually([&] {
             auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, nullptr, {}, api::new_timestamp()});
-            auto res = e.execute_cql("SELECT * FROM tab WHERE c = 2", std::move(qo)).get0();
+            auto res = e.execute_cql("SELECT * FROM tab WHERE c = 2", std::move(qo)).get();
             auto paging_state = extract_paging_state(res);
 
             assert_that(res).is_rows().with_rows({{
@@ -512,7 +512,7 @@ SEASTAR_TEST_CASE(test_simple_index_paging) {
 
             qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, paging_state, {}, api::new_timestamp()});
-            res = e.execute_cql("SELECT * FROM tab WHERE c = 2", std::move(qo)).get0();
+            res = e.execute_cql("SELECT * FROM tab WHERE c = 2", std::move(qo)).get();
 
             assert_that(res).is_rows().with_rows({{
                 {int32_type->decompose(3)}, {int32_type->decompose(2)}, {int32_type->decompose(1)},
@@ -522,7 +522,7 @@ SEASTAR_TEST_CASE(test_simple_index_paging) {
         {
             auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, nullptr, {}, api::new_timestamp()});
-            auto res = e.execute_cql("SELECT * FROM tab WHERE c = 2", std::move(qo)).get0();
+            auto res = e.execute_cql("SELECT * FROM tab WHERE c = 2", std::move(qo)).get();
             auto paging_state = extract_paging_state(res);
 
             assert_that(res).is_rows().with_rows({{
@@ -540,7 +540,7 @@ SEASTAR_TEST_CASE(test_simple_index_paging) {
 
             qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, paging_state, {}, api::new_timestamp()});
-            res = e.execute_cql("SELECT * FROM tab WHERE c = 2", std::move(qo)).get0();
+            res = e.execute_cql("SELECT * FROM tab WHERE c = 2", std::move(qo)).get();
 
             assert_that(res).is_rows().with_size(0);
         }
@@ -553,7 +553,7 @@ SEASTAR_TEST_CASE(test_simple_index_paging) {
                     1, query_id::create_random_id(), service::pager::paging_state::replicas_per_token_range{}, std::nullopt, 1);
             auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, paging_state, {}, api::new_timestamp()});
-            auto res = e.execute_cql("SELECT * FROM tab WHERE v = 1", std::move(qo)).get0();
+            auto res = e.execute_cql("SELECT * FROM tab WHERE v = 1", std::move(qo)).get();
 
             assert_that(res).is_rows().with_size(0);
         }
@@ -618,50 +618,50 @@ SEASTAR_TEST_CASE(test_secondary_index_collections) {
         e.execute_cql(insert_into + "(2, {2},    {3: 'three', 7: 'five'},             [3, 4, 5], {2}, {3: 'three'},            [3, 4, 5])").get();
         e.execute_cql(insert_into + "(3, {2, 3}, {3: 'three', 5: 'five', 7: 'seven'}, [2, 8, 9], {3}, {5: 'five', 7: 'seven'}, [7, 8, 9])").get();
 
-        auto res = e.execute_cql("SELECT p from t where s1 CONTAINS 2").get0();
+        auto res = e.execute_cql("SELECT p from t where s1 CONTAINS 2").get();
         assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(2)}}}, {{{int32_type->decompose(3)}}}});
-        res = e.execute_cql("SELECT p from t where s1 CONTAINS 4").get0();
+        res = e.execute_cql("SELECT p from t where s1 CONTAINS 4").get();
         assert_that(res).is_rows().with_size(0);
 
-        res = e.execute_cql("SELECT p from t where m1 CONTAINS 'three'").get0();
+        res = e.execute_cql("SELECT p from t where m1 CONTAINS 'three'").get();
         assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(2)}}}, {{{int32_type->decompose(3)}}}});
-        res = e.execute_cql("SELECT p from t where m1 CONTAINS 'seven'").get0();
+        res = e.execute_cql("SELECT p from t where m1 CONTAINS 'seven'").get();
         assert_that(res).is_rows().with_rows({{{{int32_type->decompose(3)}}}});
-        res = e.execute_cql("SELECT p from t where m1 CONTAINS 'ten'").get0();
+        res = e.execute_cql("SELECT p from t where m1 CONTAINS 'ten'").get();
         assert_that(res).is_rows().with_size(0);
 
-        res = e.execute_cql("SELECT p from t where m1 CONTAINS KEY 3").get0();
+        res = e.execute_cql("SELECT p from t where m1 CONTAINS KEY 3").get();
         assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(2)}}}, {{{int32_type->decompose(3)}}}});
-        res = e.execute_cql("SELECT p from t where m1 CONTAINS KEY 5").get0();
+        res = e.execute_cql("SELECT p from t where m1 CONTAINS KEY 5").get();
         assert_that(res).is_rows().with_rows({{{{int32_type->decompose(3)}}}});
-        res = e.execute_cql("SELECT p from t where m1 CONTAINS KEY 10").get0();
+        res = e.execute_cql("SELECT p from t where m1 CONTAINS KEY 10").get();
         assert_that(res).is_rows().with_size(0);
 
-        res = e.execute_cql("SELECT p from t where m1[3] = 'three'").get0();
+        res = e.execute_cql("SELECT p from t where m1[3] = 'three'").get();
         assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(3)}}}, {{{int32_type->decompose(2)}}}});
-        res = e.execute_cql("SELECT p from t where m1[7] = 'seven'").get0();
+        res = e.execute_cql("SELECT p from t where m1[7] = 'seven'").get();
         assert_that(res).is_rows().with_rows({{{{int32_type->decompose(3)}}}});
-        res = e.execute_cql("SELECT p from t where m1[3] = 'five'").get0();
+        res = e.execute_cql("SELECT p from t where m1[3] = 'five'").get();
         assert_that(res).is_rows().with_size(0);
 
-        res = e.execute_cql("SELECT p from t where l1 CONTAINS 2").get0();
+        res = e.execute_cql("SELECT p from t where l1 CONTAINS 2").get();
         assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(1)}}}, {{{int32_type->decompose(3)}}}});
-        res = e.execute_cql("SELECT p from t where l1 CONTAINS 1").get0();
+        res = e.execute_cql("SELECT p from t where l1 CONTAINS 1").get();
         assert_that(res).is_rows().with_size(0);
 
-        res = e.execute_cql("SELECT p from t where s2 = {2}").get0();
+        res = e.execute_cql("SELECT p from t where s2 = {2}").get();
         assert_that(res).is_rows().with_rows({{{int32_type->decompose(2)}}});
-        res = e.execute_cql("SELECT p from t where s2 = {}").get0();
+        res = e.execute_cql("SELECT p from t where s2 = {}").get();
         assert_that(res).is_rows().with_size(0);
 
-        res = e.execute_cql("SELECT p from t where m2 = {5: 'five', 7: 'seven'}").get0();
+        res = e.execute_cql("SELECT p from t where m2 = {5: 'five', 7: 'seven'}").get();
         assert_that(res).is_rows().with_rows({{{int32_type->decompose(3)}}});
-        res = e.execute_cql("SELECT p from t where m2 = {1: 'one', 2: 'three'}").get0();
+        res = e.execute_cql("SELECT p from t where m2 = {1: 'one', 2: 'three'}").get();
         assert_that(res).is_rows().with_size(0);
 
-        res = e.execute_cql("SELECT p from t where l2 = [2]").get0();
+        res = e.execute_cql("SELECT p from t where l2 = [2]").get();
         assert_that(res).is_rows().with_rows({{{int32_type->decompose(1)}}});
-        res = e.execute_cql("SELECT p from t where l2 = [3]").get0();
+        res = e.execute_cql("SELECT p from t where l2 = [3]").get();
         assert_that(res).is_rows().with_size(0);
     });
 }
@@ -704,7 +704,7 @@ SEASTAR_TEST_CASE(test_secondary_index_contains_virtual_columns) {
         e.execute_cql("create index on cf (c)").get();
         e.execute_cql("update cf set v = 1 where p = 1 and c = 1").get();
         eventually([&] {
-            auto res = e.execute_cql("select * from cf where c = 1").get0();
+            auto res = e.execute_cql("select * from cf where c = 1").get();
             assert_that(res).is_rows().with_rows({{{int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}}});
         });
         // Similar test to the above, just indexing a partition-key column
@@ -713,7 +713,7 @@ SEASTAR_TEST_CASE(test_secondary_index_contains_virtual_columns) {
         e.execute_cql("create index on cf2 (p1)").get();
         e.execute_cql("update cf2 set v = 1 where p1 = 1 and p2 = 1 and c = 1").get();
         eventually([&] {
-            auto res = e.execute_cql("select * from cf2 where p1 = 1").get0();
+            auto res = e.execute_cql("select * from cf2 where p1 = 1").get();
             assert_that(res).is_rows().with_rows({{{int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}}});
         });
     });
@@ -738,12 +738,12 @@ SEASTAR_TEST_CASE(test_local_secondary_index) {
         auto get_local_index_read_count = [&] {
             return e.db().map_reduce0([] (replica::database& local_db) {
                 return local_db.find_column_family("ks", "local_t_v1_index").get_stats().reads.hist.count;
-            }, 0, std::plus<int64_t>()).get0();
+            }, 0, std::plus<int64_t>()).get();
         };
 
         int64_t expected_read_count = 0;
         eventually([&] {
-            auto res = e.execute_cql("select * from t where p = 1 and v1 = 3").get0();
+            auto res = e.execute_cql("select * from t where p = 1 and v1 = 3").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(2)}},
                 {{int32_type->decompose(1)}, {int32_type->decompose(3)}, {int32_type->decompose(3)}, {int32_type->decompose(3)}},
@@ -753,7 +753,7 @@ SEASTAR_TEST_CASE(test_local_secondary_index) {
         });
 
         // Even with local indexes present, filtering should work without issues
-        auto res = e.execute_cql("select * from t where v1 = 1 ALLOW FILTERING").get0();
+        auto res = e.execute_cql("select * from t where v1 = 1 ALLOW FILTERING").get();
         assert_that(res).is_rows().with_rows({
             {{int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}},
         });
@@ -777,19 +777,19 @@ SEASTAR_TEST_CASE(test_local_and_global_secondary_index) {
         auto get_local_index_read_count = [&] {
             return e.db().map_reduce0([] (replica::database& local_db) {
                 return local_db.find_column_family("ks", "local_t_v1_index").get_stats().reads.hist.count;
-            }, 0, std::plus<int64_t>()).get0();
+            }, 0, std::plus<int64_t>()).get();
         };
         auto get_global_index_read_count = [&] {
             return e.db().map_reduce0([] (replica::database& local_db) {
                 return local_db.find_column_family("ks", "global_t_v1_index").get_stats().reads.hist.count;
-            }, 0, std::plus<int64_t>()).get0();
+            }, 0, std::plus<int64_t>()).get();
         };
 
         int64_t expected_local_index_read_count = 0;
         int64_t expected_global_index_read_count = 0;
 
         eventually([&] {
-            auto res = e.execute_cql("select * from t where p = 1 and v1 = 3").get0();
+            auto res = e.execute_cql("select * from t where p = 1 and v1 = 3").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(2)}},
                 {{int32_type->decompose(1)}, {int32_type->decompose(3)}, {int32_type->decompose(3)}, {int32_type->decompose(3)}},
@@ -800,7 +800,7 @@ SEASTAR_TEST_CASE(test_local_and_global_secondary_index) {
         });
 
         eventually([&] {
-            auto res = e.execute_cql("select * from t where v1 = 3").get0();
+            auto res = e.execute_cql("select * from t where v1 = 3").get();
             ++expected_global_index_read_count;
             BOOST_REQUIRE_EQUAL(get_local_index_read_count(), expected_local_index_read_count);
             BOOST_REQUIRE_EQUAL(get_global_index_read_count(), expected_global_index_read_count);
@@ -835,7 +835,7 @@ SEASTAR_TEST_CASE(test_local_index_paging) {
         eventually([&] {
             auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, nullptr, {}, api::new_timestamp()});
-            auto res = e.execute_cql("SELECT * FROM tab WHERE p = 1 and v = 1", std::move(qo)).get0();
+            auto res = e.execute_cql("SELECT * FROM tab WHERE p = 1 and v = 1", std::move(qo)).get();
             auto paging_state = extract_paging_state(res);
 
             assert_that(res).is_rows().with_rows({{
@@ -844,7 +844,7 @@ SEASTAR_TEST_CASE(test_local_index_paging) {
 
             qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, paging_state, {}, api::new_timestamp()});
-            res = e.execute_cql("SELECT * FROM tab WHERE p = 1 and v = 1", std::move(qo)).get0();
+            res = e.execute_cql("SELECT * FROM tab WHERE p = 1 and v = 1", std::move(qo)).get();
 
             assert_that(res).is_rows().with_rows({{
                 {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(1)},
@@ -854,7 +854,7 @@ SEASTAR_TEST_CASE(test_local_index_paging) {
         eventually([&] {
             auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, nullptr, {}, api::new_timestamp()});
-            auto res = e.execute_cql("SELECT * FROM tab WHERE p = 1 and c2 = 2", std::move(qo)).get0();
+            auto res = e.execute_cql("SELECT * FROM tab WHERE p = 1 and c2 = 2", std::move(qo)).get();
             auto paging_state = extract_paging_state(res);
 
             assert_that(res).is_rows().with_rows({{
@@ -863,7 +863,7 @@ SEASTAR_TEST_CASE(test_local_index_paging) {
 
             qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, paging_state, {}, api::new_timestamp()});
-            res = e.execute_cql("SELECT * FROM tab WHERE p = 1 and c2 = 2", std::move(qo)).get0();
+            res = e.execute_cql("SELECT * FROM tab WHERE p = 1 and c2 = 2", std::move(qo)).get();
 
             assert_that(res).is_rows().with_rows({{
                 {int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(2)}, {int32_type->decompose(4)},
@@ -904,7 +904,7 @@ SEASTAR_TEST_CASE(test_local_index_multi_pk_columns) {
         e.execute_cql("INSERT INTO tab (p1, p2, c1, c2, v) VALUES (3, 3, 1, 2, 1)").get();
 
         eventually([&] {
-            auto res = e.execute_cql("select * from tab where p1 = 1 and p2 = 2 and v = 4").get0();
+            auto res = e.execute_cql("select * from tab where p1 = 1 and p2 = 2 and v = 4").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(2)}, {int32_type->decompose(4)}},
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(7)}, {int32_type->decompose(4)}},
@@ -912,7 +912,7 @@ SEASTAR_TEST_CASE(test_local_index_multi_pk_columns) {
         });
 
         eventually([&] {
-            auto res = e.execute_cql("select * from tab where p1 = 1 and p2 = 2 and v = 5").get0();
+            auto res = e.execute_cql("select * from tab where p1 = 1 and p2 = 2 and v = 5").get();
             assert_that(res).is_rows().with_size(0);
         });
 
@@ -1016,20 +1016,20 @@ SEASTAR_TEST_CASE(test_local_index_prefix_optimization) {
         e.execute_cql("INSERT INTO t (p1,p2,c1,c2,v) VALUES (3,4,5,6,7);").get();
 
         eventually([&] {
-            auto res = e.execute_cql("select * from t where p1 = 1 and p2 = 2 and c1 = 3 and v = 5").get0();
+            auto res = e.execute_cql("select * from t where p1 = 1 and p2 = 2 and c1 = 3 and v = 5").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(4)}, {int32_type->decompose(5)}},
             });
         });
         eventually([&] {
-            auto res = e.execute_cql("select * from t where p1 = 1 and p2 = 2 and c1 = 3 and c2 = 4 and v = 5").get0();
+            auto res = e.execute_cql("select * from t where p1 = 1 and p2 = 2 and c1 = 3 and c2 = 4 and v = 5").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(4)}, {int32_type->decompose(5)}},
             });
         });
         BOOST_REQUIRE_THROW(e.execute_cql("select * from t where p1 = 1 and p2 = 2 and c2 = 4 and v = 5").get(), exceptions::invalid_request_exception);
         eventually([&] {
-            auto res = e.execute_cql("select * from t where p1 = 2 and p2 = 3 and c2 = 5 and v = 6 ALLOW FILTERING").get0();
+            auto res = e.execute_cql("select * from t where p1 = 2 and p2 = 3 and c2 = 5 and v = 6 ALLOW FILTERING").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(4)}, {int32_type->decompose(5)}, {int32_type->decompose(6)}},
             });
@@ -1054,7 +1054,7 @@ SEASTAR_TEST_CASE(test_secondary_index_single_value_in) {
         // An ordinary "p=3 and a=4" query should work
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-            auto res = e.execute_cql("select * from cf where p = 3 and a = 4").get0();
+            auto res = e.execute_cql("select * from cf where p = 3 and a = 4").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(3)}, {int32_type->decompose(4)}}});
         });
@@ -1062,7 +1062,7 @@ SEASTAR_TEST_CASE(test_secondary_index_single_value_in) {
         // IN with multiple values isn't yet supported. Before fixing
         // #4455, this wasn't supported.
         BOOST_TEST_PASSPOINT();
-        auto res = e.execute_cql("select * from cf where p IN (3) and a = 4").get0();
+        auto res = e.execute_cql("select * from cf where p IN (3) and a = 4").get();
         assert_that(res).is_rows().with_rows({
             {{int32_type->decompose(3)}, {int32_type->decompose(4)}}});
 
@@ -1073,11 +1073,11 @@ SEASTAR_TEST_CASE(test_secondary_index_single_value_in) {
         // queries over the indexed column: Since "a=4" works, so
         // should "a IN (4)":
         BOOST_TEST_PASSPOINT();
-        res = e.execute_cql("select * from cf where a = 4").get0();
+        res = e.execute_cql("select * from cf where a = 4").get();
         assert_that(res).is_rows().with_rows({
             {{int32_type->decompose(3)}, {int32_type->decompose(4)}}});
         BOOST_TEST_PASSPOINT();
-        res = e.execute_cql("select * from cf where a IN (4)").get0();
+        res = e.execute_cql("select * from cf where a IN (4)").get();
         assert_that(res).is_rows().with_rows({
             {{int32_type->decompose(3)}, {int32_type->decompose(4)}}});
 
@@ -1088,10 +1088,10 @@ SEASTAR_TEST_CASE(test_secondary_index_single_value_in) {
         e.execute_cql("create table cf2 (p int, c1 int, c2 int, primary key (p, c1, c2))").get();
         e.execute_cql("insert into cf2 (p, c1, c2) VALUES (1, 2, 3)").get();
         e.execute_cql("insert into cf2 (p, c1, c2) VALUES (4, 5, 6)").get();
-        res = e.execute_cql("select * from cf2 where p = 1 and (c1, c2) = (2, 3)").get0();
+        res = e.execute_cql("select * from cf2 where p = 1 and (c1, c2) = (2, 3)").get();
         assert_that(res).is_rows().with_rows({
             {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}}});
-        res = e.execute_cql("select * from cf2 where p = 1 and (c1, c2) IN ((2, 3))").get0();
+        res = e.execute_cql("select * from cf2 where p = 1 and (c1, c2) IN ((2, 3))").get();
         assert_that(res).is_rows().with_rows({
             {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}}});
 
@@ -1114,16 +1114,16 @@ SEASTAR_TEST_CASE(test_secondary_index_allow_some_column_drops) {
         e.execute_cql("create index on cf (a)").get();
         e.execute_cql("insert into cf (p, a, b) VALUES (1, 2, 3)").get();
         BOOST_TEST_PASSPOINT();
-        auto res = e.execute_cql("select * from cf").get0();
+        auto res = e.execute_cql("select * from cf").get();
         assert_that(res).is_rows().with_rows({
             {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}}});
         e.execute_cql("alter table cf drop b").get();
         BOOST_TEST_PASSPOINT();
-        res = e.execute_cql("select * from cf").get0();
+        res = e.execute_cql("select * from cf").get();
         assert_that(res).is_rows().with_rows({
             {{int32_type->decompose(1)}, {int32_type->decompose(2)}}});
         eventually([&] {
-            auto res = e.execute_cql("select * from cf where a = 2").get0();
+            auto res = e.execute_cql("select * from cf where a = 2").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}}});
         });
@@ -1148,7 +1148,7 @@ SEASTAR_TEST_CASE(test_secondary_index_allow_some_column_drops) {
         e.execute_cql("create index on cf2 (c)").get();
         e.execute_cql("insert into cf2 (p, c, a, b) VALUES (1, 2, 3, 4)").get();
         BOOST_TEST_PASSPOINT();
-        res = e.execute_cql("select * from cf2").get0();
+        res = e.execute_cql("select * from cf2").get();
         assert_that(res).is_rows().with_rows({
             {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(4)}}});
         BOOST_REQUIRE_THROW(e.execute_cql("alter table cf2 drop b").get(), exceptions::invalid_request_exception);
@@ -1171,7 +1171,7 @@ SEASTAR_TEST_CASE(test_secondary_index_on_partition_key_with_filtering) {
         e.execute_cql("CREATE INDEX ON test_a(a);").get();
         e.execute_cql("INSERT INTO test_a (a, b, c) VALUES (1, 2, 3);").get();
         eventually([&] {
-            auto res = e.execute_cql("SELECT * FROM test_a WHERE a = 1 AND b = 2 AND c = 3 ALLOW FILTERING;").get0();
+            auto res = e.execute_cql("SELECT * FROM test_a WHERE a = 1 AND b = 2 AND c = 3 ALLOW FILTERING;").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}}});
         });
@@ -1541,7 +1541,7 @@ SEASTAR_TEST_CASE(test_computed_columns) {
         BOOST_REQUIRE(global1->get_column_definition(token_column_name)->is_computed());
         BOOST_REQUIRE(global2->get_column_definition(token_column_name)->is_computed());
 
-        auto msg = e.execute_cql("SELECT computation FROM system_schema.computed_columns WHERE keyspace_name='ks'").get0();
+        auto msg = e.execute_cql("SELECT computation FROM system_schema.computed_columns WHERE keyspace_name='ks'").get();
         assert_that(msg).is_rows().with_rows({
             {{bytes_type->decompose(token_computation)}},
             {{bytes_type->decompose(token_computation)}}
@@ -1659,15 +1659,15 @@ SEASTAR_TEST_CASE(test_select_with_token_range_cases) {
             assert_that(q("token(pk) < 5 AND token(pk) > 100")).is_rows().with_size(0);
 
             // prepared statement
-            auto prepared_id = e.prepare(get_query("token(pk) >= ? AND token(pk) <= ?")).get0();
+            auto prepared_id = e.prepare(get_query("token(pk) >= ? AND token(pk) <= ?")).get();
             auto msg = e.execute_prepared(prepared_id, {
                 cql3::raw_value::make_value(long_type->decompose(testset_tokens[1])), cql3::raw_value::make_value(long_type->decompose(testset_tokens[5]))
-            }).get0();
+            }).get();
             assert_that(msg).is_rows().with_rows(get_result_rows(1, 5));
 
             msg = e.execute_prepared(prepared_id, {
                 cql3::raw_value::make_value(long_type->decompose(testset_tokens[2])), cql3::raw_value::make_value(long_type->decompose(testset_tokens[6]))
-            }).get0();
+            }).get();
             assert_that(msg).is_rows().with_rows(get_result_rows(2, 6));
         };
 
@@ -1979,7 +1979,7 @@ SEASTAR_TEST_CASE(test_returning_failure_from_ghost_rows_deletion) {
         if (!utils::get_local_injector().enabled_injections().empty()) {
             // Test that when a single query to the base table fails, it is propagated
             // to the user
-            BOOST_REQUIRE_THROW(e.execute_cql("PRUNE MATERIALIZED VIEW tv").get0(), std::runtime_error);
+            BOOST_REQUIRE_THROW(e.execute_cql("PRUNE MATERIALIZED VIEW tv").get(), std::runtime_error);
         }
     });
 }

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -2694,7 +2694,7 @@ SEASTAR_TEST_CASE(test_uncompressed_simple_load) {
 SEASTAR_TEST_CASE(test_uncompressed_simple_read_index) {
   return test_env::do_with_async([] (test_env& env) {
     sstable_assertions sst(env, UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
-    auto vec = sst.read_index().get0();
+    auto vec = sst.read_index().get();
     BOOST_REQUIRE_EQUAL(5, vec.size());
   });
 }
@@ -2999,7 +2999,7 @@ SEASTAR_TEST_CASE(test_uncompressed_collections_read) {
 }
 
 static sstables::shared_sstable open_sstable(test_env& env, schema_ptr schema, sstring dir, sstables::generation_type generation) {
-    return env.reusable_sst(std::move(schema), dir, generation, sstables::sstable::version_types::mc).get0();
+    return env.reusable_sst(std::move(schema), dir, generation, sstables::sstable::version_types::mc).get();
 }
 
 static std::vector<sstables::shared_sstable> open_sstables(test_env& env, schema_ptr s, sstring dir, std::vector<sstables::generation_type> generations) {
@@ -3089,7 +3089,7 @@ SEASTAR_TEST_CASE(compact_deleted_row) {
      */
     mutation_opt m = with_closeable(compacted_sstable_reader(env, s, table_name, {1, 2}), [&] (flat_mutation_reader_v2& reader) {
         return read_mutation_from_flat_mutation_reader(reader);
-    }).get0();
+    }).get();
     BOOST_REQUIRE(m);
     BOOST_REQUIRE(m->key().equal(*s, partition_key::from_singular(*s, data_value(sstring("key")))));
     BOOST_REQUIRE(!m->partition().partition_tombstone());
@@ -3161,7 +3161,7 @@ SEASTAR_TEST_CASE(compact_deleted_cell) {
      */
     mutation_opt m = with_closeable(compacted_sstable_reader(env, s, table_name, {1, 2}), [&] (flat_mutation_reader_v2& reader) {
         return read_mutation_from_flat_mutation_reader(reader);
-    }).get0();
+    }).get();
     BOOST_REQUIRE(m);
     BOOST_REQUIRE(m->key().equal(*s, partition_key::from_singular(*s, data_value(sstring("key")))));
     BOOST_REQUIRE(!m->partition().partition_tombstone());
@@ -3189,7 +3189,7 @@ static void compare_sstables(const std::filesystem::path& result_path, sstring t
                                   "ks", table_name, sstables::sstable_version_types::mc, generation_from_value(1), big, file_type);
         auto result_filename =
                 sstable::filename(result_path.string(), "ks", table_name, sst->get_version(), sst->generation(), big, file_type);
-        auto eq = tests::compare_files(orig_filename, result_filename).get0();
+        auto eq = tests::compare_files(orig_filename, result_filename).get();
         BOOST_REQUIRE(eq);
     }
 }
@@ -3278,7 +3278,7 @@ static constexpr api::timestamp_type write_timestamp = 1525385507816568;
 static constexpr gc_clock::time_point write_time_point = gc_clock::time_point{} + gc_clock::duration{1525385507};
 
 static void do_validate_stats_metadata(schema_ptr s, sstable_assertions& written_sst, sstring table_name) {
-    auto orig_sst = written_sst.get_env().reusable_sst(s, get_write_test_path(table_name), 1, sstable_version_types::mc).get0();
+    auto orig_sst = written_sst.get_env().reusable_sst(s, get_write_test_path(table_name), 1, sstable_version_types::mc).get();
 
     const auto& orig_stats = orig_sst->get_stats_metadata();
     const auto& written_stats = written_sst.get_stats_metadata();
@@ -4542,7 +4542,7 @@ static std::unique_ptr<index_reader> get_index_reader(shared_sstable sst, reader
 }
 
 shared_sstable make_test_sstable(test_env& env, schema_ptr schema, const sstring& table_name) {
-    return env.reusable_sst(schema, get_read_index_test_path(table_name), sstables::generation_type{1}).get0();
+    return env.reusable_sst(schema, get_read_index_test_path(table_name), sstables::generation_type{1}).get();
 }
 
 /*

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -37,7 +37,7 @@ mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr
 }
 
 static void consume_all(flat_mutation_reader_v2& rd) {
-    while (auto mfopt = rd().get0()) {}
+    while (auto mfopt = rd().get()) {}
 }
 
 // It is assumed that src won't change.

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -185,7 +185,7 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_simple_empty_directory_scan) {
 
         with_sstable_directory(env, [] (sharded<sstables::sstable_directory>& sstdir) {
             distributed_loader_for_tests::process_sstable_dir(sstdir, {}).get();
-            auto max_generation_seen = highest_generation_seen(sstdir).get0();
+            auto max_generation_seen = highest_generation_seen(sstdir).get();
             // No generation found on empty directory.
             BOOST_REQUIRE(!max_generation_seen);
         });
@@ -457,7 +457,7 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_lock_works) {
                 std::unordered_map<bool, size_t> res;
                 for (const auto& [shard, files] : sstables) {
                     for (const auto& f : files) {
-                        res[file_exists(f).get0()]++;
+                        res[file_exists(f).get()]++;
                     }
                 }
                 return res;
@@ -514,7 +514,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly) {
         verify_that_all_sstables_are_local(sstdir, 0).get();
 
         sharded<sstables::sstable_generation_generator> sharded_gen;
-        auto max_generation_seen = highest_generation_seen(sstdir).get0();
+        auto max_generation_seen = highest_generation_seen(sstdir).get();
         sharded_gen.start(max_generation_seen.as_int()).get();
         auto stop_generator = deferred_stop(sharded_gen);
 
@@ -567,7 +567,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly_with_owned
         verify_that_all_sstables_are_local(sstdir, 0).get();
 
         sharded<sstables::sstable_generation_generator> sharded_gen;
-        auto max_generation_seen = highest_generation_seen(sstdir).get0();
+        auto max_generation_seen = highest_generation_seen(sstdir).get();
         sharded_gen.start(max_generation_seen.as_int()).get();
         auto stop_generator = deferred_stop(sharded_gen);
 
@@ -620,7 +620,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_distributes_well_eve
         verify_that_all_sstables_are_local(sstdir, 0).get();
 
         sharded<sstables::sstable_generation_generator> sharded_gen;
-        auto max_generation_seen = highest_generation_seen(sstdir).get0();
+        auto max_generation_seen = highest_generation_seen(sstdir).get();
         sharded_gen.start(max_generation_seen.as_int()).get();
         auto stop_generator = deferred_stop(sharded_gen);
 
@@ -671,7 +671,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_respect_max_threshol
         verify_that_all_sstables_are_local(sstdir, 0).get();
 
         sharded<sstables::sstable_generation_generator> sharded_gen;
-        auto max_generation_seen = highest_generation_seen(sstdir).get0();
+        auto max_generation_seen = highest_generation_seen(sstdir).get();
         sharded_gen.start(max_generation_seen.as_int()).get();
         auto stop_generator = deferred_stop(sharded_gen);
 
@@ -793,7 +793,7 @@ SEASTAR_TEST_CASE(test_pending_log_garbage_collection) {
         // Now start atomic deletion -- create the pending deletion log for all
         // three sstables, move TOC file for one of them into temporary-TOC, and 
         // partially delete another
-        sstable_directory::create_pending_deletion_log(ssts_to_remove).get0();
+        sstable_directory::create_pending_deletion_log(ssts_to_remove).get();
         rename_file(test(ssts_to_remove[1]).filename(sstables::component_type::TOC).native(), test(ssts_to_remove[1]).filename(sstables::component_type::TemporaryTOC).native()).get();
         rename_file(test(ssts_to_remove[2]).filename(sstables::component_type::TOC).native(), test(ssts_to_remove[2]).filename(sstables::component_type::TemporaryTOC).native()).get();
         remove_file(test(ssts_to_remove[2]).filename(sstables::component_type::Data).native()).get();

--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -20,14 +20,14 @@ namespace fs = std::filesystem;
 
 // Must be called from a seastar thread
 static auto copy_sst_to_tmpdir(fs::path tmp_path, test_env& env, sstables::schema_ptr schema_ptr, fs::path src_path, sstables::generation_type gen) {
-    auto sst = env.reusable_sst(schema_ptr, src_path.native(), gen).get0();
+    auto sst = env.reusable_sst(schema_ptr, src_path.native(), gen).get();
     auto dst_path = tmp_path / src_path.filename() / format("gen-{}", gen);
     recursive_touch_directory(dst_path.native()).get();
     for (auto p : sst->all_components()) {
         auto src_path = test(sst).filename(p.first);
         copy_file(src_path, dst_path / src_path.filename());
     }
-    return std::make_pair(env.reusable_sst(schema_ptr, dst_path.native(), gen).get0(), dst_path.native());
+    return std::make_pair(env.reusable_sst(schema_ptr, dst_path.native(), gen).get(), dst_path.native());
 }
 
 SEASTAR_THREAD_TEST_CASE(test_sstable_move) {
@@ -51,7 +51,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move) {
 
     // close  the sst and make we can load it from the new directory.
     sst->close_files().get();
-    sst = env.reusable_sst(uncompressed_schema(), cur_dir, gen).get0();
+    sst = env.reusable_sst(uncompressed_schema(), cur_dir, gen).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_sstable_move_idempotent) {

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -794,7 +794,7 @@ static schema_ptr buffer_overflow_schema() {
 SEASTAR_TEST_CASE(buffer_overflow) {
   return test_env::do_with_async([] (test_env& env) {
     auto s = buffer_overflow_schema();
-    auto sstp = ka_sst(env, s, "test/resource/sstables/buffer_overflow", 5).get0();
+    auto sstp = ka_sst(env, s, "test/resource/sstables/buffer_overflow", 5).get();
     auto r = sstp->make_reader(s, env.make_reader_permit(), query::full_partition_range, s->full_slice());
     auto pk1 = partition_key::from_exploded(*s, { int32_type->decompose(4) });
     auto dk1 = dht::decorate_key(*s, pk1);
@@ -848,7 +848,7 @@ SEASTAR_TEST_CASE(test_non_compound_table_row_is_not_marked_as_static) {
         auto sst = make_sstable_containing(env.make_sstable(s, version), {std::move(m)});
         auto mut = with_closeable(sst->make_reader(s, env.make_reader_permit(), query::full_partition_range, s->full_slice()), [] (auto& mr) {
             return read_mutation_from_flat_mutation_reader(mr);
-        }).get0();
+        }).get();
         BOOST_REQUIRE(bool(mut));
       }
     });
@@ -874,12 +874,12 @@ SEASTAR_TEST_CASE(test_has_partition_key) {
             auto hk = sstables::sstable::make_hashed_key(*s, dk.key());
             auto mr = sst->make_reader(s, env.make_reader_permit(), query::full_partition_range, s->full_slice());
             auto close_mr = deferred_close(mr);
-            auto res =  sst->has_partition_key(hk, dk).get0();
+            auto res =  sst->has_partition_key(hk, dk).get();
             BOOST_REQUIRE(bool(res));
 
             auto dk2 = dht::decorate_key(*s, partition_key::from_nodetool_style_string(s, "xx"));
             auto hk2 = sstables::sstable::make_hashed_key(*s, dk2.key());
-            res =  sst->has_partition_key(hk2, dk2).get0();
+            res =  sst->has_partition_key(hk2, dk2).get();
             BOOST_REQUIRE(! bool(res));
         }
     });
@@ -1373,13 +1373,13 @@ SEASTAR_TEST_CASE(test_large_index_pages_do_not_cause_large_allocations) {
 
     mutation expected = *with_closeable(mt->make_flat_reader(s, env.make_reader_permit(), pr), [] (auto& mt_reader) {
         return read_mutation_from_flat_mutation_reader(mt_reader);
-    }).get0();
+    }).get();
 
     auto t0 = std::chrono::steady_clock::now();
     auto large_allocs_before = memory::stats().large_allocations();
     mutation actual = *with_closeable(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), pr), [] (auto& sst_reader) {
         return read_mutation_from_flat_mutation_reader(sst_reader);
-    }).get0();
+    }).get();
     auto large_allocs_after = memory::stats().large_allocations();
     auto duration = std::chrono::steady_clock::now() - t0;
 

--- a/test/boost/sstable_partition_index_cache_test.cc
+++ b/test/boost/sstable_partition_index_cache_test.cc
@@ -87,8 +87,8 @@ SEASTAR_THREAD_TEST_CASE(test_caching) {
         lru.evict_all();
     });
 
-    partition_index_cache::entry_ptr ptr0 = f0.get0();
-    partition_index_cache::entry_ptr ptr1 = f1.get0();
+    partition_index_cache::entry_ptr ptr0 = f0.get();
+    partition_index_cache::entry_ptr ptr1 = f1.get();
 
     r.full_compaction();
     with_allocator(r.allocator(), [&] {
@@ -131,7 +131,7 @@ SEASTAR_THREAD_TEST_CASE(test_caching) {
     }
 
     {
-        auto ptr4 = cache.get_or_load(0, page0_loader).get0();
+        auto ptr4 = cache.get_or_load(0, page0_loader).get();
         has_page0(ptr4);
 
         BOOST_REQUIRE_EQUAL(stats.misses, old_stats.misses + 2);
@@ -177,7 +177,7 @@ SEASTAR_THREAD_TEST_CASE(test_exception_while_loading) {
         f1.get();
     });
 
-    auto ptr = cache.get_or_load(0, page0_loader).get0();
+    auto ptr = cache.get_or_load(0, page0_loader).get();
     has_page0(ptr);
 }
 

--- a/test/boost/stall_free_test.cc
+++ b/test/boost/stall_free_test.cc
@@ -123,7 +123,7 @@ SEASTAR_THREAD_TEST_CASE(test_clear_gently_foreign_ptr) {
             cleared_gently++;
         });
         return make_foreign<lw_shared_ptr<clear_gently_tracker<int>>>(std::move(p));
-    }).get0();
+    }).get();
 
     utils::clear_gently(p0).get();
     BOOST_CHECK(p0);

--- a/test/boost/storage_proxy_test.cc
+++ b/test/boost/storage_proxy_test.cc
@@ -119,11 +119,11 @@ SEASTAR_THREAD_TEST_CASE(test_split_stats) {
     // instantiate group-local split_stats.
     with_scheduling_group(sg1, [&] {
         stats1.emplace("tuta", "nils", "en nils", "nilsa", true);
-    }).get0();
+    }).get();
 
     with_scheduling_group(sg2, [&] {
         stats2.emplace("tuta", "nils", "en nils", "nilsa", true);
-    }).get0();
+    }).get();
 
     // simulating the calling of storage_proxy::on_down, from gossip
     // on node dropping out. If inside a write operation, we'll pick up

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -42,7 +42,7 @@ namespace {
         dc_rack_fn get_dc_rack_fn = get_dc_rack;
         tmptr->update_topology_change_info(get_dc_rack_fn).get();
         auto strategy = seastar::make_shared<Strategy>(replication_strategy_params(opts, std::nullopt));
-        return calculate_effective_replication_map(std::move(strategy), tmptr).get0();
+        return calculate_effective_replication_map(std::move(strategy), tmptr).get();
     }
 }
 

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -75,11 +75,11 @@ SEASTAR_TEST_CASE(test_builder_with_large_partition) {
                       "primary key (v, c, p)").get();
 
         f.get();
-        auto built = e.get_system_keyspace().local().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get();
         BOOST_REQUIRE_EQUAL(built.size(), 1);
         BOOST_REQUIRE_EQUAL(built[0].second, sstring("vcf"));
 
-        auto msg = e.execute_cql("select count(*) from vcf where v = 0").get0();
+        auto msg = e.execute_cql("select count(*) from vcf where v = 0").get();
         assert_that(msg).is_rows().with_size(1);
         assert_that(msg).is_rows().with_rows({{{long_type->decompose(1024L)}}});
     });
@@ -110,11 +110,11 @@ SEASTAR_TEST_CASE(test_builder_with_large_partition_2) {
                       "primary key (p, c)").get();
 
         f.get();
-        auto built = e.get_system_keyspace().local().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get();
         BOOST_REQUIRE_EQUAL(built.size(), 1);
         BOOST_REQUIRE_EQUAL(built[0].second, sstring("vcf"));
 
-        auto msg = e.execute_cql("select count(*) from vcf").get0();
+        auto msg = e.execute_cql("select count(*) from vcf").get();
         assert_that(msg).is_rows().with_size(1);
         assert_that(msg).is_rows().with_rows({{{long_type->decompose(long(nrows))}}});
     });
@@ -135,11 +135,11 @@ SEASTAR_TEST_CASE(test_builder_with_multiple_partitions) {
                       "primary key (v, c, p)").get();
 
         f.get();
-        auto built = e.get_system_keyspace().local().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get();
         BOOST_REQUIRE_EQUAL(built.size(), 1);
         BOOST_REQUIRE_EQUAL(built[0].second, sstring("vcf"));
 
-        auto msg = e.execute_cql("select count(*) from vcf where v = 0").get0();
+        auto msg = e.execute_cql("select count(*) from vcf where v = 0").get();
         assert_that(msg).is_rows().with_size(1);
         assert_that(msg).is_rows().with_rows({{{long_type->decompose(1024L)}}});
     });
@@ -159,11 +159,11 @@ SEASTAR_TEST_CASE(test_builder_with_multiple_partitions_of_batch_size_rows) {
                       "primary key (v, c, p)").get();
 
         f.get();
-        auto built = e.get_system_keyspace().local().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get();
         BOOST_REQUIRE_EQUAL(built.size(), 1);
         BOOST_REQUIRE_EQUAL(built[0].second, sstring("vcf"));
 
-        auto msg = e.execute_cql("select count(*) from vcf where v = 0").get0();
+        auto msg = e.execute_cql("select count(*) from vcf where v = 0").get();
         assert_that(msg).is_rows().with_size(1);
         assert_that(msg).is_rows().with_rows({{{long_type->decompose(1024L)}}});
     });
@@ -192,14 +192,14 @@ SEASTAR_TEST_CASE(test_builder_view_added_during_ongoing_build) {
 
         f2.get();
         f1.get();
-        auto built = e.get_system_keyspace().local().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get();
         BOOST_REQUIRE_EQUAL(built.size(), 2);
 
-        auto msg = e.execute_cql("select count(*) from vcf1 where v = 0").get0();
+        auto msg = e.execute_cql("select count(*) from vcf1 where v = 0").get();
         assert_that(msg).is_rows().with_size(1);
         assert_that(msg).is_rows().with_rows({{{long_type->decompose(5000L)}}});
 
-        msg = e.execute_cql("select count(*) from vcf2 where v = 0").get0();
+        msg = e.execute_cql("select count(*) from vcf2 where v = 0").get();
         assert_that(msg).is_rows().with_size(1);
         assert_that(msg).is_rows().with_rows({{{long_type->decompose(5000L)}}});
     });
@@ -250,14 +250,14 @@ SEASTAR_TEST_CASE(test_builder_across_tokens_with_large_partitions) {
 
         f2.get();
         f1.get();
-        auto built = e.get_system_keyspace().local().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get();
         BOOST_REQUIRE_EQUAL(built.size(), 2);
 
-        auto msg = e.execute_cql("select count(*) from vcf1 where v = 0").get0();
+        auto msg = e.execute_cql("select count(*) from vcf1 where v = 0").get();
         assert_that(msg).is_rows().with_size(1);
         assert_that(msg).is_rows().with_rows({{{long_type->decompose(4000L)}}});
 
-        msg = e.execute_cql("select count(*) from vcf2 where v = 0").get0();
+        msg = e.execute_cql("select count(*) from vcf2 where v = 0").get();
         assert_that(msg).is_rows().with_size(1);
         assert_that(msg).is_rows().with_rows({{{long_type->decompose(4000L)}}});
     });
@@ -293,14 +293,14 @@ SEASTAR_TEST_CASE(test_builder_across_tokens_with_small_partitions) {
         f2.get();
         f1.get();
 
-        auto built = e.get_system_keyspace().local().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get();
         BOOST_REQUIRE_EQUAL(built.size(), 2);
 
-        auto msg = e.execute_cql("select count(*) from vcf1 where v = 0").get0();
+        auto msg = e.execute_cql("select count(*) from vcf1 where v = 0").get();
         assert_that(msg).is_rows().with_size(1);
         assert_that(msg).is_rows().with_rows({{{long_type->decompose(4000L)}}});
 
-        msg = e.execute_cql("select count(*) from vcf2 where v = 0").get0();
+        msg = e.execute_cql("select count(*) from vcf2 where v = 0").get();
         assert_that(msg).is_rows().with_size(1);
         assert_that(msg).is_rows().with_rows({{{long_type->decompose(4000L)}}});
     });
@@ -323,10 +323,10 @@ SEASTAR_TEST_CASE(test_builder_with_tombstones) {
                       "primary key ((v, p), c1, c2)").get();
 
         f.get();
-        auto built = e.get_system_keyspace().local().load_built_views().get0();
+        auto built = e.get_system_keyspace().local().load_built_views().get();
         BOOST_REQUIRE_EQUAL(built.size(), 1);
 
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_size(25);
     });
 }
@@ -368,7 +368,7 @@ SEASTAR_TEST_CASE(test_builder_with_concurrent_writes) {
 
         f.get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf").get0();
+            auto msg = e.execute_cql("select * from vcf").get();
             assert_that(msg).is_rows().with_size(rows);
         });
     });
@@ -394,13 +394,13 @@ SEASTAR_TEST_CASE(test_builder_with_concurrent_drop) {
         e.execute_cql("drop materialized view vcf").get();
 
         eventually([&] {
-            auto msg = e.execute_cql("select * from system.scylla_views_builds_in_progress").get0();
+            auto msg = e.execute_cql("select * from system.scylla_views_builds_in_progress").get();
             assert_that(msg).is_rows().is_empty();
-            msg = e.execute_cql("select * from system.built_views").get0();
+            msg = e.execute_cql("select * from system.built_views").get();
             assert_that(msg).is_rows().is_empty();
-            msg = e.execute_cql("select * from system.views_builds_in_progress").get0();
+            msg = e.execute_cql("select * from system.views_builds_in_progress").get();
             assert_that(msg).is_rows().is_empty();
-            msg = e.execute_cql("select * from system_distributed.view_build_status").get0();
+            msg = e.execute_cql("select * from system_distributed.view_build_status").get();
             assert_that(msg).is_rows().is_empty();
         });
     });
@@ -560,7 +560,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_deadlock) {
 
         auto& sem = *with_scheduling_group(e.local_db().get_streaming_scheduling_group(), [&] () {
             return &e.local_db().get_reader_concurrency_semaphore();
-        }).get0();
+        }).get();
 
         // consume all units except what is needed to admit a single reader.
         auto sponge_permit = sem.make_tracking_only_permit(s, "sponge", db::no_timeout, {});
@@ -726,7 +726,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
         void check(mutation mut) {
             // First we check that we would be able to create a reader, even
             // though the staging reader consumed all resources.
-            auto permit = _semaphore.obtain_permit(_schema, "consumer_verifier", replica::new_reader_base_cost, db::timeout_clock::now(), {}).get0();
+            auto permit = _semaphore.obtain_permit(_schema, "consumer_verifier", replica::new_reader_base_cost, db::timeout_clock::now(), {}).get();
 
             const size_t current_rows = rows_in_mut(mut);
             const auto total_rows = _partition_rows.at(mut.decorated_key());
@@ -835,7 +835,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
             return less(a.decorated_key(), b.decorated_key());
         });
 
-        auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}).get0();
+        auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}).get();
 
         auto mt = make_memtable(schema, muts);
         auto p = make_manually_paused_evictable_reader_v2(
@@ -875,7 +875,7 @@ SEASTAR_TEST_CASE(test_load_view_build_progress_with_values_missing) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         cquery_nofail(e, format("INSERT INTO system.{} (keyspace_name, view_name, cpu_id) VALUES ('ks', 'v', {})",
                 db::system_keyspace::v3::SCYLLA_VIEWS_BUILDS_IN_PROGRESS, this_shard_id()));
-        BOOST_REQUIRE(e.get_system_keyspace().local().load_view_build_progress().get0().empty());
+        BOOST_REQUIRE(e.get_system_keyspace().local().load_view_build_progress().get().empty());
     });
 }
 
@@ -936,7 +936,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering_with_random_mutati
     auto stop_sem = deferred_stop(sem);
     const abort_source as;
     auto mt = make_memtable(schema, {mut});
-    auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}).get0();
+    auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}).get();
     auto p = make_manually_paused_evictable_reader_v2(
             mt->as_data_source(),
             schema,

--- a/test/boost/view_complex_test.cc
+++ b/test/boost/view_complex_test.cc
@@ -36,7 +36,7 @@ void test_partial_delete_unselected_column(cql_test_env& e, std::function<void()
     e.execute_cql("update cf using timestamp 10 set b = 1 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
     });
 
@@ -48,7 +48,7 @@ void test_partial_delete_unselected_column(cql_test_env& e, std::function<void()
     // disappear from the view as well:
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().is_empty();
     });
 
@@ -59,7 +59,7 @@ void test_partial_delete_unselected_column(cql_test_env& e, std::function<void()
     // we have a row in the base table (and accordingly, in the view).
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
     });
 
@@ -67,7 +67,7 @@ void test_partial_delete_unselected_column(cql_test_env& e, std::function<void()
     e.execute_cql("update cf using timestamp 18 set a = 1 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
     });
 
@@ -80,7 +80,7 @@ void test_partial_delete_unselected_column(cql_test_env& e, std::function<void()
     e.execute_cql("update cf using timestamp 20 set a = null where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().is_empty();
     });
 
@@ -92,7 +92,7 @@ void test_partial_delete_unselected_column(cql_test_env& e, std::function<void()
     // exists in the base table, so should also exist in the view table.
     e.execute_cql("insert into cf (p, c) values (1, 1) using timestamp 15").get();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
     });
 }
@@ -123,7 +123,7 @@ void test_partial_delete_selected_column(cql_test_env& e, std::function<void()>&
     e.execute_cql("update cf using timestamp 10 set b = 1 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -136,7 +136,7 @@ void test_partial_delete_selected_column(cql_test_env& e, std::function<void()>&
     e.execute_cql("delete b from cf using timestamp 11 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().is_empty();
     });
 
@@ -144,7 +144,7 @@ void test_partial_delete_selected_column(cql_test_env& e, std::function<void()>&
     e.execute_cql("update cf using timestamp 1 set a = 1 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -157,14 +157,14 @@ void test_partial_delete_selected_column(cql_test_env& e, std::function<void()>&
     e.execute_cql("delete a from cf using timestamp 1 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     BOOST_TEST_PASSPOINT();
     e.execute_cql("insert into cf (p, c) values (1, 1) using timestamp 0").get();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -177,7 +177,7 @@ void test_partial_delete_selected_column(cql_test_env& e, std::function<void()>&
     e.execute_cql("update cf using timestamp 12 set b = 1 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -190,7 +190,7 @@ void test_partial_delete_selected_column(cql_test_env& e, std::function<void()>&
     e.execute_cql("delete b from cf using timestamp 13 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -203,14 +203,14 @@ void test_partial_delete_selected_column(cql_test_env& e, std::function<void()>&
     e.execute_cql("delete from cf using timestamp 14 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     BOOST_TEST_PASSPOINT();
     e.execute_cql("insert into cf (p, c) values (1, 1) using timestamp 15").get();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -223,7 +223,7 @@ void test_partial_delete_selected_column(cql_test_env& e, std::function<void()>&
     e.execute_cql("update cf using timestamp 15 and ttl 100 set b = 1 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -236,7 +236,7 @@ void test_partial_delete_selected_column(cql_test_env& e, std::function<void()>&
 
     BOOST_TEST_PASSPOINT();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -249,7 +249,7 @@ void test_partial_delete_selected_column(cql_test_env& e, std::function<void()>&
     e.execute_cql("delete from cf using timestamp 15 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().is_empty();
     });
 
@@ -258,7 +258,7 @@ void test_partial_delete_selected_column(cql_test_env& e, std::function<void()>&
     e.execute_cql("update cf using timestamp 18 set e = 1 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -271,7 +271,7 @@ void test_partial_delete_selected_column(cql_test_env& e, std::function<void()>&
     e.execute_cql("update cf using timestamp 18 set e = null where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().is_empty();
     });
 
@@ -279,7 +279,7 @@ void test_partial_delete_selected_column(cql_test_env& e, std::function<void()>&
     e.execute_cql("update cf using timestamp 16 set a = 1 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -314,7 +314,7 @@ void test_update_column_in_view_pk_with_ttl(cql_test_env& e, std::function<void(
     e.execute_cql("update cf set a = 1 where p = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -325,20 +325,20 @@ void test_update_column_in_view_pk_with_ttl(cql_test_env& e, std::function<void(
     e.execute_cql("delete a from cf where p = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     e.execute_cql("insert into cf (p) values (1)").get();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     e.execute_cql("update cf using ttl 100 set a = 10 where p = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(10)},
             {int32_type->decompose(1)},
@@ -349,7 +349,7 @@ void test_update_column_in_view_pk_with_ttl(cql_test_env& e, std::function<void(
     e.execute_cql("update cf set b = 100 where p = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(10)},
             {int32_type->decompose(1)},
@@ -360,7 +360,7 @@ void test_update_column_in_view_pk_with_ttl(cql_test_env& e, std::function<void(
     forward_jump_clocks(101s);
 
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 }
@@ -392,7 +392,7 @@ SEASTAR_TEST_CASE(test_unselected_column_can_preserve_ttld_row_maker) {
         e.execute_cql("update cf using ttl 0 set v = 0 where p = 0 and c = 0").get();
         forward_jump_clocks(101s);
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf").get0();
+            auto msg = e.execute_cql("select * from vcf").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)}, {int32_type->decompose(0)}, }});
         });
     });
@@ -407,7 +407,7 @@ void test_update_column_not_in_view(cql_test_env& e, std::function<void()>&& may
     e.execute_cql("update cf using timestamp 0 set v1 = 1 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(0)},
             {int32_type->decompose(0)}
@@ -417,21 +417,21 @@ void test_update_column_not_in_view(cql_test_env& e, std::function<void()>&& may
     e.execute_cql("delete v1 from cf using timestamp 1 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     e.execute_cql("update cf using timestamp 1 set v1 = 1 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     e.execute_cql("update cf using timestamp 2 set v2 = 1 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(0)},
             {int32_type->decompose(0)}
@@ -441,7 +441,7 @@ void test_update_column_not_in_view(cql_test_env& e, std::function<void()>&& may
     e.execute_cql("delete v1 from cf using timestamp 3 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(0)},
             {int32_type->decompose(0)}
@@ -451,14 +451,14 @@ void test_update_column_not_in_view(cql_test_env& e, std::function<void()>&& may
     e.execute_cql("delete v2 from cf using timestamp 4 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     e.execute_cql("update cf using ttl 100 set v2 = 1 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(0)},
             {int32_type->decompose(0)}
@@ -468,14 +468,14 @@ void test_update_column_not_in_view(cql_test_env& e, std::function<void()>&& may
     forward_jump_clocks(101s);
 
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     e.execute_cql("update cf set v2 = 1 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(0)},
             {int32_type->decompose(0)}
@@ -510,7 +510,7 @@ e.execute_cql("create table cf (p int, c int, a int, b int, l list<int>, s set<i
     e.execute_cql("update cf set l=l+[1,2,3] where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -522,7 +522,7 @@ e.execute_cql("create table cf (p int, c int, a int, b int, l list<int>, s set<i
     e.execute_cql("update cf set l=l-[1,2] where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -534,7 +534,7 @@ e.execute_cql("create table cf (p int, c int, a int, b int, l list<int>, s set<i
     e.execute_cql("update cf set b = 3 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -546,14 +546,14 @@ e.execute_cql("create table cf (p int, c int, a int, b int, l list<int>, s set<i
     e.execute_cql("update cf set b=null, l=l-[3], s=s-{3} where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     e.execute_cql("update cf set m=m+{3:'text'}, l=l-[1], s=s-{2} where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -575,7 +575,7 @@ void test_partial_update_with_unselected_udt(cql_test_env& e, std::function<void
     e.execute_cql("update cf set u.a = 1 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -587,7 +587,7 @@ void test_partial_update_with_unselected_udt(cql_test_env& e, std::function<void
     e.execute_cql("update cf set b = 3 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -599,14 +599,14 @@ void test_partial_update_with_unselected_udt(cql_test_env& e, std::function<void
     e.execute_cql("update cf set b=null, u.a = null where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     e.execute_cql("update cf set u = (1, 1) where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -663,7 +663,7 @@ void test_unselected_columns_ttl(cql_test_env& e, std::function<void()>&& maybe_
     forward_jump_clocks(101s);
 
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)}
@@ -673,7 +673,7 @@ void test_unselected_columns_ttl(cql_test_env& e, std::function<void()>&& maybe_
     e.execute_cql("delete v from cf where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 
@@ -684,19 +684,19 @@ void test_unselected_columns_ttl(cql_test_env& e, std::function<void()>&& maybe_
     forward_jump_clocks(101s);
 
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)}
         }});
-        msg = e.execute_cql("select * from vcf where p = 3 and c = 3").get0();
+        msg = e.execute_cql("select * from vcf where p = 3 and c = 3").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     e.execute_cql("update cf set v = 0 where p = 3 and c = 3").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 3 and c = 3").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 3 and c = 3").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(3)},
             {int32_type->decompose(3)}
@@ -729,7 +729,7 @@ void test_partition_deletion(cql_test_env& e, std::function<void()>&& maybe_flus
     e.execute_cql("insert into cf (p, a, b, c) values (1, 1, 1, 1) using timestamp 0").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -741,21 +741,21 @@ void test_partition_deletion(cql_test_env& e, std::function<void()>&& maybe_flus
     e.execute_cql("update cf using timestamp 1 set a = null where p = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     e.execute_cql("delete from cf using timestamp 2 where p = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     e.execute_cql("update cf using timestamp 3 set a = 1, b = 1 where p = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -790,7 +790,7 @@ void test_commutative_row_deletion(cql_test_env& e, std::function<void()>&& mayb
     e.execute_cql("insert into cf (p, v1, v2) values (3, 1, 3) using timestamp 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select v2, writetime(v2) from vcf").get0();
+        auto msg = e.execute_cql("select v2, writetime(v2) from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(3)},
             {long_type->decompose(1L)}
@@ -800,14 +800,14 @@ void test_commutative_row_deletion(cql_test_env& e, std::function<void()>&& mayb
     e.execute_cql("delete from cf using timestamp 2 where p = 3").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select v2, writetime(v2) from vcf").get0();
+        auto msg = e.execute_cql("select v2, writetime(v2) from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     e.execute_cql("insert into cf (p, v1) values (3, 1) using timestamp 3").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select v1, p, v2, writetime(v2) from vcf").get0();
+        auto msg = e.execute_cql("select v1, p, v2, writetime(v2) from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(3)},
@@ -819,7 +819,7 @@ void test_commutative_row_deletion(cql_test_env& e, std::function<void()>&& mayb
     e.execute_cql("update cf using timestamp 4 set v1 = 2 where p = 3").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select v1, p, v2, writetime(v2) from vcf").get0();
+        auto msg = e.execute_cql("select v1, p, v2, writetime(v2) from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(2)},
             {int32_type->decompose(3)},
@@ -831,7 +831,7 @@ void test_commutative_row_deletion(cql_test_env& e, std::function<void()>&& mayb
     e.execute_cql("update cf using timestamp 5 set v1 = 1 where p = 3").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select v1, p, v2, writetime(v2) from vcf").get0();
+        auto msg = e.execute_cql("select v1, p, v2, writetime(v2) from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(3)},
@@ -871,7 +871,7 @@ SEASTAR_TEST_CASE(test_unselected_column_with_expired_marker) {
         e.execute_cql("insert into cf (p, c) values (1, 1) using ttl 100").get();
         e.local_db().flush_all_memtables().get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf").get0();
+            auto msg = e.execute_cql("select * from vcf").get();
             assert_that(msg).is_rows().with_rows({{
                 {int32_type->decompose(1)},
                 {int32_type->decompose(1)},
@@ -882,7 +882,7 @@ SEASTAR_TEST_CASE(test_unselected_column_with_expired_marker) {
         forward_jump_clocks(101s);
 
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf").get0();
+            auto msg = e.execute_cql("select * from vcf").get();
             assert_that(msg).is_rows().with_rows({{
                 {int32_type->decompose(1)},
                 {int32_type->decompose(1)},
@@ -893,14 +893,14 @@ SEASTAR_TEST_CASE(test_unselected_column_with_expired_marker) {
         e.execute_cql("update cf set a = null where p = 1 and c = 1").get();
         e.local_db().flush_all_memtables().get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf").get0();
+            auto msg = e.execute_cql("select * from vcf").get();
             assert_that(msg).is_rows().is_empty();
         });
 
         e.execute_cql("update cf using timestamp 1 set b = 1 where p = 1 and c = 1").get();
         e.local_db().flush_all_memtables().get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf").get0();
+            auto msg = e.execute_cql("select * from vcf").get();
             assert_that(msg).is_rows().with_rows({{
                 {int32_type->decompose(1)},
                 {int32_type->decompose(1)},
@@ -920,7 +920,7 @@ void test_update_with_column_timestamp_smaller_than_pk(cql_test_env& e, std::fun
     e.execute_cql("insert into cf (p, v1, v2) values (3, 1, 3) using timestamp 6").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select v1, p, v2, writetime(v2) from vcf").get0();
+        auto msg = e.execute_cql("select v1, p, v2, writetime(v2) from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(3)},
@@ -932,7 +932,7 @@ void test_update_with_column_timestamp_smaller_than_pk(cql_test_env& e, std::fun
     e.execute_cql("insert into cf (p) values (3) using timestamp 20").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select v1, p, v2, writetime(v2) from vcf").get0();
+        auto msg = e.execute_cql("select v1, p, v2, writetime(v2) from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(3)},
@@ -944,7 +944,7 @@ void test_update_with_column_timestamp_smaller_than_pk(cql_test_env& e, std::fun
     e.execute_cql("update cf using timestamp 7 set v1 = 2 where p = 3").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select v1, p, v2, writetime(v2) from vcf").get0();
+        auto msg = e.execute_cql("select v1, p, v2, writetime(v2) from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(2)},
             {int32_type->decompose(3)},
@@ -956,7 +956,7 @@ void test_update_with_column_timestamp_smaller_than_pk(cql_test_env& e, std::fun
     e.execute_cql("update cf using timestamp 8 set v1 = 1 where p = 3").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select v1, p, v2, writetime(v2) from vcf").get0();
+        auto msg = e.execute_cql("select v1, p, v2, writetime(v2) from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(3)},
@@ -1004,11 +1004,11 @@ void test_expired_marker_with_limit(cql_test_env& e, std::function<void()>&& may
 
     for (auto view : {"vcf1", "vcf2"}) {
         eventually([&] {
-            auto msg = e.execute_cql(format("select * from {} limit 1", view)).get0();
+            auto msg = e.execute_cql(format("select * from {} limit 1", view)).get();
             assert_that(msg).is_rows().with_size(1);
-            msg = e.execute_cql(format("select * from {} limit 2", view)).get0();
+            msg = e.execute_cql(format("select * from {} limit 2", view)).get();
             assert_that(msg).is_rows().with_size(2);
-            msg = e.execute_cql(format("select * from {}", view)).get0();
+            msg = e.execute_cql(format("select * from {}", view)).get();
             assert_that(msg).is_rows().with_rows({
                 {{int32_type->decompose(50)}, {int32_type->decompose(50)}, {int32_type->decompose(50)}},
                 {{int32_type->decompose(100)}, {int32_type->decompose(100)}, {int32_type->decompose(100)}},
@@ -1046,7 +1046,7 @@ void test_update_with_column_timestamp_bigger_than_pk(cql_test_env& e, std::func
     e.execute_cql("insert into cf (p, a, b) values (1, 1, 1) using timestamp 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -1057,7 +1057,7 @@ void test_update_with_column_timestamp_bigger_than_pk(cql_test_env& e, std::func
     e.execute_cql("update cf using timestamp 10 set b = 2 where p = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -1068,7 +1068,7 @@ void test_update_with_column_timestamp_bigger_than_pk(cql_test_env& e, std::func
     e.execute_cql("update cf using timestamp 2 set a = 2 where p = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(2)},
@@ -1078,7 +1078,7 @@ void test_update_with_column_timestamp_bigger_than_pk(cql_test_env& e, std::func
 
     e.local_db().get_compaction_manager().perform_major_compaction(e.local_db().find_column_family("ks", "vcf").as_table_state()).get();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf limit 1").get0();
+        auto msg = e.execute_cql("select * from vcf limit 1").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(2)},
@@ -1089,7 +1089,7 @@ void test_update_with_column_timestamp_bigger_than_pk(cql_test_env& e, std::func
     e.execute_cql("update cf using timestamp 11 set a = 1 where p = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf limit 1").get0();
+        auto msg = e.execute_cql("select * from vcf limit 1").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -1100,14 +1100,14 @@ void test_update_with_column_timestamp_bigger_than_pk(cql_test_env& e, std::func
     e.execute_cql("update cf using timestamp 12 set a = null where p = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf limit 1").get0();
+        auto msg = e.execute_cql("select * from vcf limit 1").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     e.execute_cql("update cf using timestamp 13 set a = 1 where p = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf limit 1").get0();
+        auto msg = e.execute_cql("select * from vcf limit 1").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -1141,7 +1141,7 @@ void test_no_regular_base_column_in_view_pk(cql_test_env& e, std::function<void(
     e.execute_cql("update cf using timestamp 1 set v1 = 1 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -1153,7 +1153,7 @@ void test_no_regular_base_column_in_view_pk(cql_test_env& e, std::function<void(
     e.execute_cql("update cf using timestamp 2 set v1 = null, v2 = 1 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -1165,14 +1165,14 @@ void test_no_regular_base_column_in_view_pk(cql_test_env& e, std::function<void(
     e.execute_cql("update cf using timestamp 2 set v2 = null where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     e.execute_cql("insert into cf (p, c) values (1, 1) using timestamp 3").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -1184,14 +1184,14 @@ void test_no_regular_base_column_in_view_pk(cql_test_env& e, std::function<void(
     e.execute_cql("delete from cf using timestamp 4 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 
     e.execute_cql("update cf using timestamp 5 set v2 = 1 where p = 1 and c = 1").get();
     maybe_flush();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{
             {int32_type->decompose(1)},
             {int32_type->decompose(1)},
@@ -1229,14 +1229,14 @@ SEASTAR_TEST_CASE(test_shadowing_row_marker) {
         e.execute_cql("update cf set v1 = null where p = 1").get();
         e.local_db().flush_all_memtables().get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf").get0();
+            auto msg = e.execute_cql("select * from vcf").get();
             assert_that(msg).is_rows().is_empty();
         });
 
         e.execute_cql("update cf using ttl 100 set v1 = 1 where p = 1").get();
         e.local_db().flush_all_memtables().get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf").get0();
+            auto msg = e.execute_cql("select * from vcf").get();
             assert_that(msg).is_rows().with_rows({{
                 {int32_type->decompose(1)},
                 {int32_type->decompose(1)},
@@ -1247,7 +1247,7 @@ SEASTAR_TEST_CASE(test_shadowing_row_marker) {
         forward_jump_clocks(101s);
 
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf").get0();
+            auto msg = e.execute_cql("select * from vcf").get();
             assert_that(msg).is_rows().is_empty();
         });
     });
@@ -1267,7 +1267,7 @@ void test_marker_timestamp_is_not_shadowed_by_previous_update(cql_test_env& e, s
     maybe_flush();
     forward_jump_clocks(101s);
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().is_empty();
     });
 }
@@ -1309,14 +1309,14 @@ SEASTAR_TEST_CASE(test_3362_no_ttls) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf using timestamp 10 set b = 1 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
 
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf using timestamp 20 set a = 1 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
 
@@ -1326,7 +1326,7 @@ SEASTAR_TEST_CASE(test_3362_no_ttls) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("delete a from cf using timestamp 21 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
 
@@ -1337,7 +1337,7 @@ SEASTAR_TEST_CASE(test_3362_no_ttls) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("delete b from cf using timestamp 11 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().is_empty();
         });
 
@@ -1354,7 +1354,7 @@ SEASTAR_TEST_CASE(test_3362_no_ttls) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf using timestamp 12 set b = 1 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
     });
@@ -1379,13 +1379,13 @@ SEASTAR_TEST_CASE(test_3362_with_ttls) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf using timestamp 2 and ttl 100 set a = 1 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf using timestamp 1 set b = 1 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
         // Pass the time 101 seconds forward. Cell 'a' will have expired, but
@@ -1395,14 +1395,14 @@ SEASTAR_TEST_CASE(test_3362_with_ttls) {
         BOOST_TEST_PASSPOINT();
         // verify that the base row still exists (cell b didn't expire)
         eventually([&] {
-            auto msg = e.execute_cql("select * from cf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from cf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)}, {}, {{int32_type->decompose(1)}} }});
         });
         BOOST_TEST_PASSPOINT();
         // verify that the view row still exists too.
         // This check failing is issue #3362.
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
     });
@@ -1438,12 +1438,12 @@ void do_test_3362_no_ttls_with_collections(cql_test_env& e, collection_kind t) {
             "primary key (p, c)").get();
     e.execute_cql(format("update cf using timestamp 10 set a = a + {}2{} where p = 1 and c = 1", pref, suf)).get();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
     });
     e.execute_cql(format("update cf using timestamp 20 set a = a + {}1{} where p = 1 and c = 1", pref, suf)).get();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
     });
     if (t == collection_kind::map) {
@@ -1452,7 +1452,7 @@ void do_test_3362_no_ttls_with_collections(cql_test_env& e, collection_kind t) {
         e.execute_cql(format("update cf using timestamp 21 set a = a - {}1{} where p = 1 and c = 1", pref, suf)).get();
     }
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
     });
     if (t == collection_kind::map) {
@@ -1461,12 +1461,12 @@ void do_test_3362_no_ttls_with_collections(cql_test_env& e, collection_kind t) {
         e.execute_cql(format("update cf using timestamp 11 set a = a - {}2{} where p = 1 and c = 1", pref, suf)).get();
     }
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().is_empty();
     });
     e.execute_cql(format("update cf using timestamp 12 set a = a + {}2{} where p = 1 and c = 1", pref, suf)).get();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
     });
 }
@@ -1511,17 +1511,17 @@ void do_test_3362_with_ttls_with_collections(cql_test_env& e, collection_kind t)
             "primary key (p, c)").get();
     e.execute_cql(format("update cf using timestamp 2 and ttl 100 set a = a + {}1{} where p = 1 and c = 1", pref, suf)).get();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
     });
     e.execute_cql(format("update cf using timestamp 1 set a = a + {}2{} where p = 1 and c = 1", pref, suf)).get();
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
     });
     forward_jump_clocks(101s);
     eventually([&] {
-        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
     });
 }
@@ -1554,19 +1554,19 @@ SEASTAR_TEST_CASE(test_3362_with_ttls_frozen) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf using timestamp 2 and ttl 100 set a = {1,2} where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf using timestamp 1 set b = {3,4} where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
         forward_jump_clocks(101s);
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
     });
@@ -1593,24 +1593,24 @@ SEASTAR_TEST_CASE(test_3362_with_ttls_alter_add) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf using timestamp 2 and ttl 100 set a = 1 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf using timestamp 1 set b = 1 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
         forward_jump_clocks(101s);
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-            auto msg = e.execute_cql("select * from cf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from cf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)}, {}, {{int32_type->decompose(1)}} }});
         });
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
     });
@@ -1655,28 +1655,28 @@ SEASTAR_TEST_CASE(test_3362_row_deletion_1) {
         // step 1:
         e.execute_cql("update cf using timestamp 2 set a = 1 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
         BOOST_TEST_PASSPOINT();
         // step 2:
         e.execute_cql("delete a from cf using timestamp 10 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().is_empty();
         });
         // step 3:
         BOOST_TEST_PASSPOINT();
         e.execute_cql("insert into cf (p, c) values (1, 1) using timestamp 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
         BOOST_TEST_PASSPOINT();
         // step 4:
         e.execute_cql("delete b from cf using timestamp 3 where p = 1 and c = 1").get();
         // the base row should now be empty but still exist (there's still the row marker)
-        auto msg = e.execute_cql("select * from cf where p = 1 and c = 1").get0();
+        auto msg = e.execute_cql("select * from cf where p = 1 and c = 1").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)}, {}, {} }});
         // FIXME: Testing this is hard - we want to check that the already
         // existing view row does NOT disappear, so "eventually()" doesn't
@@ -1685,7 +1685,7 @@ SEASTAR_TEST_CASE(test_3362_row_deletion_1) {
         // I think we need a testing-only feature to be able to wait until the
         // backlog of view updates is fully consumed.
         seastar::sleep(std::chrono::seconds(1)).get();
-        msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+        msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
         // The row should still exists, because the row marker is still
         // alive. It was a bug that the row marker was deleted too,
         // because of a wrong row marker deletion set for timestamp 10.
@@ -1705,13 +1705,13 @@ SEASTAR_TEST_CASE(test_3362_row_deletion_2) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf using timestamp 1 set b = 1 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf using timestamp 2 set a = 1 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
         // Delete the entire base row, with timestamp 10. The view row should
@@ -1719,7 +1719,7 @@ SEASTAR_TEST_CASE(test_3362_row_deletion_2) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("delete from cf using timestamp 10 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().is_empty();
         });
         // Reinsert an (unselected) cell in row p=1 c=1 at timestamp 3.
@@ -1733,7 +1733,7 @@ SEASTAR_TEST_CASE(test_3362_row_deletion_2) {
         // deciding that as expected, no row was added???
         seastar::sleep(std::chrono::seconds(2)).get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().is_empty();
         });
         BOOST_TEST_PASSPOINT();
@@ -1741,7 +1741,7 @@ SEASTAR_TEST_CASE(test_3362_row_deletion_2) {
         // row will re-emerge, and so should the view row
         e.execute_cql("update cf using timestamp 11 set b = 1 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get0();
+            auto msg = e.execute_cql("select * from vcf where p = 1 and c = 1").get();
             assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
     });

--- a/test/boost/view_schema_ckey_test.cc
+++ b/test/boost/view_schema_ckey_test.cc
@@ -32,7 +32,7 @@ SEASTAR_TEST_CASE(test_delete_single_column_in_view_clustering_key) {
 
         e.execute_cql("insert into cf (a, b, c, d) values (0, 0, 0, 0)").get();
         eventually([&] {
-        auto msg = e.execute_cql("select a, d, b, c from mv").get0();
+        auto msg = e.execute_cql("select a, d, b, c from mv").get();
         assert_that(msg).is_rows()
             .with_size(1)
             .with_row({ {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} });
@@ -40,7 +40,7 @@ SEASTAR_TEST_CASE(test_delete_single_column_in_view_clustering_key) {
 
         e.execute_cql("delete c from cf where a = 0 and b = 0").get();
         eventually([&] {
-        auto msg = e.execute_cql("select a, d, b, c from mv").get0();
+        auto msg = e.execute_cql("select a, d, b, c from mv").get();
         assert_that(msg).is_rows()
             .with_size(1)
             .with_row({ {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, { } });
@@ -48,7 +48,7 @@ SEASTAR_TEST_CASE(test_delete_single_column_in_view_clustering_key) {
 
         e.execute_cql("delete d from cf where a = 0 and b = 0").get();
         eventually([&] {
-        auto msg = e.execute_cql("select a, d, b from mv").get0();
+        auto msg = e.execute_cql("select a, d, b from mv").get();
         assert_that(msg).is_rows()
             .with_size(0);
         });
@@ -73,7 +73,7 @@ SEASTAR_TEST_CASE(test_clustering_key_eq_restrictions) {
             e.execute_cql("insert into cf (a, b, c, d) values (1, 1, 1, 0)").get();
 
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -83,7 +83,7 @@ SEASTAR_TEST_CASE(test_clustering_key_eq_restrictions) {
 
             e.execute_cql("update cf set d = 1 where a = 1 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -93,7 +93,7 @@ SEASTAR_TEST_CASE(test_clustering_key_eq_restrictions) {
 
             e.execute_cql("update cf set d = 1 where a = 0 and b = 1 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -103,7 +103,7 @@ SEASTAR_TEST_CASE(test_clustering_key_eq_restrictions) {
 
             e.execute_cql("delete from cf where a = 0 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -113,7 +113,7 @@ SEASTAR_TEST_CASE(test_clustering_key_eq_restrictions) {
 
             e.execute_cql("delete from cf where a = 1 and b = 1 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -122,7 +122,7 @@ SEASTAR_TEST_CASE(test_clustering_key_eq_restrictions) {
 
             e.execute_cql("delete from cf where a in (0, 1) and b = 1").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_size(0);
             });
 
@@ -150,7 +150,7 @@ SEASTAR_TEST_CASE(test_clustering_key_slice_restrictions) {
             e.execute_cql("insert into cf (a, b, c, d) values (1, 2, 1, 0)").get();
 
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -160,7 +160,7 @@ SEASTAR_TEST_CASE(test_clustering_key_slice_restrictions) {
 
             e.execute_cql("update cf set d = 1 where a = 1 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -170,7 +170,7 @@ SEASTAR_TEST_CASE(test_clustering_key_slice_restrictions) {
 
             e.execute_cql("update cf set d = 1 where a = 0 and b = 1 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -180,7 +180,7 @@ SEASTAR_TEST_CASE(test_clustering_key_slice_restrictions) {
 
             e.execute_cql("delete from cf where a = 0 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -190,7 +190,7 @@ SEASTAR_TEST_CASE(test_clustering_key_slice_restrictions) {
 
             e.execute_cql("delete from cf where a = 1 and b = 1 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -199,7 +199,7 @@ SEASTAR_TEST_CASE(test_clustering_key_slice_restrictions) {
 
             e.execute_cql("delete from cf where a in (0, 1) and b >= 1 and b <= 4").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_size(0);
             });
 
@@ -228,7 +228,7 @@ SEASTAR_TEST_CASE(test_clustering_key_in_restrictions) {
             e.execute_cql("insert into cf (a, b, c, d) values (1, 2, 1, 0)").get();
 
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -238,7 +238,7 @@ SEASTAR_TEST_CASE(test_clustering_key_in_restrictions) {
 
             eventually([&] {
             e.execute_cql("update cf set d = 1 where a = 1 and b = 0 and c = 0").get();
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -248,7 +248,7 @@ SEASTAR_TEST_CASE(test_clustering_key_in_restrictions) {
 
             e.execute_cql("update cf set d = 1 where a = 0 and b = 1 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -258,7 +258,7 @@ SEASTAR_TEST_CASE(test_clustering_key_in_restrictions) {
 
             e.execute_cql("delete from cf where a = 0 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -268,7 +268,7 @@ SEASTAR_TEST_CASE(test_clustering_key_in_restrictions) {
 
             e.execute_cql("delete from cf where a = 1 and b = 1 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -277,7 +277,7 @@ SEASTAR_TEST_CASE(test_clustering_key_in_restrictions) {
 
             e.execute_cql("delete from cf where a in (0, 1) and b >= 1 and b <= 4").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_size(0);
             });
 
@@ -306,7 +306,7 @@ SEASTAR_TEST_CASE(test_clustering_key_multi_column_restrictions) {
             e.execute_cql("insert into cf (a, b, c, d) values (1, 1, 1, 0)").get();
 
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -316,7 +316,7 @@ SEASTAR_TEST_CASE(test_clustering_key_multi_column_restrictions) {
 
             e.execute_cql("update cf set d = 1 where a = 1 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -326,7 +326,7 @@ SEASTAR_TEST_CASE(test_clustering_key_multi_column_restrictions) {
 
             e.execute_cql("update cf set d = 1 where a = 0 and b = 1 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -336,7 +336,7 @@ SEASTAR_TEST_CASE(test_clustering_key_multi_column_restrictions) {
 
             e.execute_cql("delete from cf where a = 0 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -346,7 +346,7 @@ SEASTAR_TEST_CASE(test_clustering_key_multi_column_restrictions) {
 
             e.execute_cql("delete from cf where a = 1 and b = 1 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)} },
                             { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -355,7 +355,7 @@ SEASTAR_TEST_CASE(test_clustering_key_multi_column_restrictions) {
 
             e.execute_cql("delete from cf where a in (0, 1)").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_size(0);
             });
 
@@ -384,7 +384,7 @@ SEASTAR_TEST_CASE(test_clustering_key_filtering_restrictions) {
             e.execute_cql("insert into cf (a, b, c, d) values (1, 1, 1, 0)").get();
 
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -394,7 +394,7 @@ SEASTAR_TEST_CASE(test_clustering_key_filtering_restrictions) {
 
             e.execute_cql("update cf set d = 1 where a = 1 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -404,7 +404,7 @@ SEASTAR_TEST_CASE(test_clustering_key_filtering_restrictions) {
 
             e.execute_cql("update cf set d = 1 where a = 0 and b = 1 and c = 1").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)} },
@@ -414,7 +414,7 @@ SEASTAR_TEST_CASE(test_clustering_key_filtering_restrictions) {
 
             e.execute_cql("delete from cf where a = 0 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)} },
@@ -424,7 +424,7 @@ SEASTAR_TEST_CASE(test_clustering_key_filtering_restrictions) {
 
             e.execute_cql("delete from cf where a = 1 and b = 1 and c = 1").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)} },
@@ -433,7 +433,7 @@ SEASTAR_TEST_CASE(test_clustering_key_filtering_restrictions) {
 
             e.execute_cql("delete from cf where a in (0, 1)").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_size(0);
             });
 
@@ -458,12 +458,12 @@ SEASTAR_TEST_CASE(test_no_clustering_key_1) {
         // view, it also works as expected:
         e.execute_cql("insert into cf (a, b, c) values (1, 2, 3)").get();
         BOOST_TEST_PASSPOINT();
-        auto msg = e.execute_cql("select * from cf").get0();
+        auto msg = e.execute_cql("select * from cf").get();
         assert_that(msg).is_rows().with_size(1)
                 .with_row({{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}});
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-            auto msg = e.execute_cql("select * from mv").get0();
+            auto msg = e.execute_cql("select * from mv").get();
             assert_that(msg).is_rows().with_size(1)
                     .with_row({{int32_type->decompose(1)}, {int32_type->decompose(2)}});
         });
@@ -485,12 +485,12 @@ SEASTAR_TEST_CASE(test_no_clustering_key_2) {
         // view, it also works as expected:
         e.execute_cql("insert into cf (a, b, c) values (1, 2, 3)").get();
         BOOST_TEST_PASSPOINT();
-        auto msg = e.execute_cql("select * from cf").get0();
+        auto msg = e.execute_cql("select * from cf").get();
         assert_that(msg).is_rows().with_size(1)
                 .with_row({{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}});
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-            auto msg = e.execute_cql("select * from mv where a = 1 and b = 2").get0();
+            auto msg = e.execute_cql("select * from mv where a = 1 and b = 2").get();
             assert_that(msg).is_rows().with_size(1)
                     .with_row({{int32_type->decompose(1)}, {int32_type->decompose(2)}});
         });

--- a/test/boost/view_schema_pkey_test.cc
+++ b/test/boost/view_schema_pkey_test.cc
@@ -63,7 +63,7 @@ SEASTAR_TEST_CASE(test_compound_partition_key) {
         e.execute_cql("insert into cf (p1, p2, v) values (0, 2, 5)").get();
 
         eventually([&] {
-        auto msg = e.execute_cql("select p1, v from mv1_p2 where p2 = 2").get0();
+        auto msg = e.execute_cql("select p1, v from mv1_p2 where p2 = 2").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({
@@ -73,7 +73,7 @@ SEASTAR_TEST_CASE(test_compound_partition_key) {
         });
 
         eventually([&] {
-        auto msg = e.execute_cql("select p1, v from mv2_p1 where p2 = 2 and p1 = 0").get0();
+        auto msg = e.execute_cql("select p1, v from mv2_p1 where p2 = 2 and p1 = 0").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({
@@ -83,7 +83,7 @@ SEASTAR_TEST_CASE(test_compound_partition_key) {
         });
 
         eventually([&] {
-        auto msg = e.execute_cql("select p1 from mv1_v where v = 5").get0();
+        auto msg = e.execute_cql("select p1 from mv1_v where v = 5").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({
@@ -92,7 +92,7 @@ SEASTAR_TEST_CASE(test_compound_partition_key) {
         });
 
         eventually([&] {
-        auto msg = e.execute_cql("select p2 from mv3_v where v = 5 and p1 = 0").get0();
+        auto msg = e.execute_cql("select p2 from mv3_v where v = 5 and p1 = 0").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({
@@ -103,7 +103,7 @@ SEASTAR_TEST_CASE(test_compound_partition_key) {
         e.execute_cql("insert into cf (p1, p2, v) values (0, 2, 8)").get();
 
         eventually([&] {
-        auto msg = e.execute_cql("select p1, v from mv1_p2 where p2 = 2").get0();
+        auto msg = e.execute_cql("select p1, v from mv1_p2 where p2 = 2").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({
@@ -113,7 +113,7 @@ SEASTAR_TEST_CASE(test_compound_partition_key) {
         });
 
         eventually([&] {
-        auto msg = e.execute_cql("select p1, v from mv2_p1 where p2 = 2 and p1 = 0").get0();
+        auto msg = e.execute_cql("select p1, v from mv2_p1 where p2 = 2 and p1 = 0").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({
@@ -123,18 +123,18 @@ SEASTAR_TEST_CASE(test_compound_partition_key) {
         });
 
         eventually([&] {
-        auto msg = e.execute_cql("select p1 from mv1_v where v = 5").get0();
+        auto msg = e.execute_cql("select p1 from mv1_v where v = 5").get();
         assert_that(msg).is_rows()
                 .with_size(0);
         });
 
         eventually([&] {
-        auto msg = e.execute_cql("select p2 from mv3_v where v = 5 and p1 = 0").get0();
+        auto msg = e.execute_cql("select p2 from mv3_v where v = 5 and p1 = 0").get();
         assert_that(msg).is_rows()
                 .with_size(0);
         });
         eventually([&] {
-        auto msg = e.execute_cql("select p2 from mv3_v where v = 8 and p1 = 0").get0();
+        auto msg = e.execute_cql("select p2 from mv3_v where v = 8 and p1 = 0").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({
@@ -152,7 +152,7 @@ SEASTAR_TEST_CASE(test_partition_key_only_table) {
 
         e.execute_cql("insert into cf (p1, p2) values (1, 1)").get();
         eventually([&] {
-        auto msg = e.execute_cql("select * from mv").get0();
+        auto msg = e.execute_cql("select * from mv").get();
         assert_that(msg).is_rows()
             .with_size(1)
             .with_row({ {int32_type->decompose(1)}, {int32_type->decompose(1)} });
@@ -169,7 +169,7 @@ SEASTAR_TEST_CASE(test_delete_single_column_in_view_partition_key) {
 
         e.execute_cql("insert into cf (a, b, c, d) values (0, 0, 0, 0)").get();
         eventually([&] {
-        auto msg = e.execute_cql("select a, d, b, c from mv").get0();
+        auto msg = e.execute_cql("select a, d, b, c from mv").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} });
@@ -177,7 +177,7 @@ SEASTAR_TEST_CASE(test_delete_single_column_in_view_partition_key) {
 
         e.execute_cql("delete c from cf where a = 0 and b = 0").get();
         eventually([&] {
-        auto msg = e.execute_cql("select a, d, b, c from mv").get0();
+        auto msg = e.execute_cql("select a, d, b, c from mv").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, { } });
@@ -186,7 +186,7 @@ SEASTAR_TEST_CASE(test_delete_single_column_in_view_partition_key) {
 
         e.execute_cql("delete d from cf where a = 0 and b = 0").get();
         eventually([&] {
-        auto msg = e.execute_cql("select a, d, b from mv").get0();
+        auto msg = e.execute_cql("select a, d, b from mv").get();
         assert_that(msg).is_rows()
                 .with_size(0);
         });
@@ -210,7 +210,7 @@ SEASTAR_TEST_CASE(test_partition_key_filtering_unrestricted_part) {
             e.execute_cql("insert into cf (a, b, c, d) values (1, 1, 1, 0)").get();
 
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                                 { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -220,7 +220,7 @@ SEASTAR_TEST_CASE(test_partition_key_filtering_unrestricted_part) {
 
             e.execute_cql("update cf set d = 1 where a = 0 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                                 { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -230,7 +230,7 @@ SEASTAR_TEST_CASE(test_partition_key_filtering_unrestricted_part) {
 
             e.execute_cql("update cf set d = 1 where a = 1 and b = 1 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                                 { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -240,7 +240,7 @@ SEASTAR_TEST_CASE(test_partition_key_filtering_unrestricted_part) {
 
             e.execute_cql("delete from cf where a = 0 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                                 { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -250,7 +250,7 @@ SEASTAR_TEST_CASE(test_partition_key_filtering_unrestricted_part) {
 
             e.execute_cql("delete from cf where a = 1 and b = 1 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                                 { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -259,14 +259,14 @@ SEASTAR_TEST_CASE(test_partition_key_filtering_unrestricted_part) {
 
             e.execute_cql("delete from cf where a = 1 and b = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} }});
             });
 
             e.execute_cql("delete from cf where a = 1 and b = 1").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_size(0);
             });
 
@@ -334,7 +334,7 @@ SEASTAR_TEST_CASE(test_partition_key_filtering_with_slice) {
             e.execute_cql("insert into cf (a, b, c, d) values (2, 10, 3, 2)").get();
 
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(10)}, {int32_type->decompose(2)}, {int32_type->decompose(2)} },
                                 { {int32_type->decompose(2)}, {int32_type->decompose(10)}, {int32_type->decompose(3)}, {int32_type->decompose(2)} }});
@@ -342,7 +342,7 @@ SEASTAR_TEST_CASE(test_partition_key_filtering_with_slice) {
 
             e.execute_cql("insert into cf (a, b, c, d) values (3, 10, 4, 2)").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(10)}, {int32_type->decompose(2)}, {int32_type->decompose(2)} },
                                 { {int32_type->decompose(2)}, {int32_type->decompose(10)}, {int32_type->decompose(3)}, {int32_type->decompose(2)} },
@@ -352,7 +352,7 @@ SEASTAR_TEST_CASE(test_partition_key_filtering_with_slice) {
 
             e.execute_cql("update cf set d = 1 where a = 0 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(10)}, {int32_type->decompose(2)}, {int32_type->decompose(2)} },
                                 { {int32_type->decompose(2)}, {int32_type->decompose(10)}, {int32_type->decompose(3)}, {int32_type->decompose(2)} },
@@ -361,7 +361,7 @@ SEASTAR_TEST_CASE(test_partition_key_filtering_with_slice) {
 
             e.execute_cql("update cf set d = 100 where a = 3 and b = 10 and c = 4").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(10)}, {int32_type->decompose(2)}, {int32_type->decompose(2)} },
                                 { {int32_type->decompose(2)}, {int32_type->decompose(10)}, {int32_type->decompose(3)}, {int32_type->decompose(2)} },
@@ -370,7 +370,7 @@ SEASTAR_TEST_CASE(test_partition_key_filtering_with_slice) {
 
             e.execute_cql("delete from cf where a = 0 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(10)}, {int32_type->decompose(2)}, {int32_type->decompose(2)} },
                                 { {int32_type->decompose(2)}, {int32_type->decompose(10)}, {int32_type->decompose(3)}, {int32_type->decompose(2)} },
@@ -379,7 +379,7 @@ SEASTAR_TEST_CASE(test_partition_key_filtering_with_slice) {
 
             e.execute_cql("delete from cf where a = 3 and b = 10 and c = 4").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(10)}, {int32_type->decompose(2)}, {int32_type->decompose(2)} },
                                 { {int32_type->decompose(2)}, {int32_type->decompose(10)}, {int32_type->decompose(3)}, {int32_type->decompose(2)} }});
@@ -407,7 +407,7 @@ SEASTAR_TEST_CASE(test_partition_key_restrictions) {
             e.execute_cql("insert into cf (a, b, c, d) values (1, 1, 1, 0)").get();
 
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -417,7 +417,7 @@ SEASTAR_TEST_CASE(test_partition_key_restrictions) {
 
             e.execute_cql("update cf set d = 1 where a = 0 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -427,7 +427,7 @@ SEASTAR_TEST_CASE(test_partition_key_restrictions) {
 
             e.execute_cql("update cf set d = 1 where a = 1 and b = 1 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -437,7 +437,7 @@ SEASTAR_TEST_CASE(test_partition_key_restrictions) {
 
             e.execute_cql("delete from cf where a = 0 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -447,7 +447,7 @@ SEASTAR_TEST_CASE(test_partition_key_restrictions) {
 
             e.execute_cql("delete from cf where a = 1 and b = 1 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -456,14 +456,14 @@ SEASTAR_TEST_CASE(test_partition_key_restrictions) {
 
             e.execute_cql("delete from cf where a = 1 and b = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} }});
             });
 
             e.execute_cql("delete from cf where a = 1 and b = 1").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_size(0);
             });
 
@@ -491,7 +491,7 @@ SEASTAR_TEST_CASE(test_partition_key_compound_restrictions) {
             e.execute_cql("insert into cf (a, b, c, d) values (1, 1, 1, 0)").get();
 
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                                 { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} }});
@@ -499,7 +499,7 @@ SEASTAR_TEST_CASE(test_partition_key_compound_restrictions) {
 
             e.execute_cql("update cf set d = 1 where a = 1 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} },
                                 { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} }});
@@ -507,7 +507,7 @@ SEASTAR_TEST_CASE(test_partition_key_compound_restrictions) {
 
             e.execute_cql("update cf set d = 1 where a = 1 and b = 1 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)} },
                                 { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} }});
@@ -515,7 +515,7 @@ SEASTAR_TEST_CASE(test_partition_key_compound_restrictions) {
 
             e.execute_cql("delete from cf where a = 1 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)} },
                                 { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} }});
@@ -523,14 +523,14 @@ SEASTAR_TEST_CASE(test_partition_key_compound_restrictions) {
 
             e.execute_cql("delete from cf where a = 1 and b = 1 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                                 { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} }});
             });
 
             e.execute_cql("delete from cf where a = 1 and b = 1").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_size(0);
             });
 
@@ -557,7 +557,7 @@ SEASTAR_TEST_CASE(test_partition_key_restrictions_not_include_all) {
         e.execute_cql("insert into cf (a, b, c, d) values (1, 1, 1, 0)").get();
 
         eventually([&] {
-        auto msg = e.execute_cql("select a, b, c from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
@@ -565,7 +565,7 @@ SEASTAR_TEST_CASE(test_partition_key_restrictions_not_include_all) {
 
         eventually([&] {
         e.execute_cql("update cf set d = 1 where a = 1 and b = 0 and c = 0").get();
-        auto msg = e.execute_cql("select a, b, c from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
@@ -573,7 +573,7 @@ SEASTAR_TEST_CASE(test_partition_key_restrictions_not_include_all) {
 
         eventually([&] {
         e.execute_cql("update cf set d = 1 where a = 1 and b = 1 and c = 0").get();
-        auto msg = e.execute_cql("select a, b, c from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
@@ -581,7 +581,7 @@ SEASTAR_TEST_CASE(test_partition_key_restrictions_not_include_all) {
 
         eventually([&] {
         e.execute_cql("delete from cf where a = 1 and b = 0 and c = 0").get();
-        auto msg = e.execute_cql("select a, b, c from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                             { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
@@ -589,14 +589,14 @@ SEASTAR_TEST_CASE(test_partition_key_restrictions_not_include_all) {
 
         eventually([&] {
         e.execute_cql("delete from cf where a = 1 and b = 1 and c = 0").get();
-        auto msg = e.execute_cql("select a, b, c from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                             { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
 
         eventually([&] {
         e.execute_cql("delete from cf where a = 1 and b = 1").get();
-        auto msg = e.execute_cql("select a, b, c from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c from vcf").get();
         assert_that(msg).is_rows().with_size(0);
         });
     });
@@ -621,7 +621,7 @@ SEASTAR_TEST_CASE(test_partition_key_and_clustering_key_filtering_restrictions) 
             e.execute_cql("insert into cf (a, b, c, d) values (1, 1, 1, 0)").get();
 
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} }});
@@ -629,7 +629,7 @@ SEASTAR_TEST_CASE(test_partition_key_and_clustering_key_filtering_restrictions) 
 
             e.execute_cql("update cf set d = 1 where a = 0 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} }});
@@ -637,7 +637,7 @@ SEASTAR_TEST_CASE(test_partition_key_and_clustering_key_filtering_restrictions) 
 
             e.execute_cql("update cf set d = 1 where a = 1 and b = 1 and c = 1").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
@@ -645,7 +645,7 @@ SEASTAR_TEST_CASE(test_partition_key_and_clustering_key_filtering_restrictions) 
 
             e.execute_cql("delete from cf where a = 0 and b = 0 and c = 0").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
@@ -653,14 +653,14 @@ SEASTAR_TEST_CASE(test_partition_key_and_clustering_key_filtering_restrictions) 
 
             e.execute_cql("delete from cf where a = 1 and b = 1 and c = 1").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} }});
             });
 
             e.execute_cql("delete from cf where a = 1").get();
             eventually([&] {
-            auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c, d from vcf").get();
             assert_that(msg).is_rows().with_size(0);
             });
 
@@ -704,7 +704,7 @@ SEASTAR_TEST_CASE(test_base_non_pk_columns_in_view_partition_key_are_non_emtpy) 
             auto f = e.local_view_builder().wait_until_built("ks", name);
             e.execute_cql(fmt::format(fmt::runtime(view), name)).get();
             f.get();
-            auto msg = e.execute_cql(format("select p1, p2, c, v from {}", name)).get0();
+            auto msg = e.execute_cql(format("select p1, p2, c, v from {}", name)).get();
             assert_that(msg).is_rows()
                     .with_size(1)
                     .with_row({

--- a/test/boost/view_schema_test.cc
+++ b/test/boost/view_schema_test.cc
@@ -48,7 +48,7 @@ SEASTAR_TEST_CASE(test_case_sensitivity) {
 
         for (auto view : {"mv_test", "mv_test2"}) {
             eventually([&] {
-            auto msg = e.execute_cql(format("select \"theKey\", \"theClustering\", \"theValue\" from {} ", view)).get0();
+            auto msg = e.execute_cql(format("select \"theKey\", \"theClustering\", \"theValue\" from {} ", view)).get();
             assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({
@@ -63,7 +63,7 @@ SEASTAR_TEST_CASE(test_case_sensitivity) {
 
         for (auto view : {"mv_test", "mv_test2"}) {
             eventually([&] {
-            auto msg = e.execute_cql(format("select \"theKey\", \"Col\", \"theValue\" from {} ", view)).get0();
+            auto msg = e.execute_cql(format("select \"theKey\", \"Col\", \"theValue\" from {} ", view)).get();
             assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({
@@ -90,7 +90,7 @@ SEASTAR_TEST_CASE(test_access_and_schema) {
         e.execute_cql("alter table cf add foo text;").get();
         e.execute_cql("insert into cf (p, c, v, foo) values (0, 'foo', 1, 'bar');").get();
         eventually([&] {
-        auto msg = e.execute_cql("select foo from vcf").get0();
+        auto msg = e.execute_cql("select foo from vcf").get();
         assert_that(msg).is_rows()
             .with_size(1)
             .with_row({
@@ -98,7 +98,7 @@ SEASTAR_TEST_CASE(test_access_and_schema) {
             });
         });
         e.execute_cql("alter table cf rename c to bar;").get();
-        auto msg = e.execute_cql("select bar from vcf").get0();
+        auto msg = e.execute_cql("select bar from vcf").get();
         assert_that(msg).is_rows()
             .with_size(1)
             .with_row({
@@ -116,7 +116,7 @@ SEASTAR_TEST_CASE(test_column_dropped_from_base) {
         e.execute_cql("alter table cf drop a;").get();
         e.execute_cql("insert into cf (p, c, v) values (0, 'foo', 1);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select v from vcf").get0();
+        auto msg = e.execute_cql("select v from vcf").get();
         assert_that(msg).is_rows()
             .with_size(1)
             .with_row({
@@ -133,26 +133,26 @@ SEASTAR_TEST_CASE(test_updates) {
                        "where k is not null and v is not null primary key (v, k)").get();
 
         e.execute_cql("insert into base (k, v) values (0, 0);").get();
-        auto msg = e.execute_cql("select k, v from base where k = 0").get0();
+        auto msg = e.execute_cql("select k, v from base where k = 0").get();
         assert_that(msg).is_rows()
             .with_size(1)
             .with_row({ {int32_type->decompose(0)}, {int32_type->decompose(0)} });
         eventually([&] {
-        auto msg = e.execute_cql("select k, v from mv where v = 0").get0();
+        auto msg = e.execute_cql("select k, v from mv where v = 0").get();
         assert_that(msg).is_rows()
             .with_size(1)
             .with_row({ {int32_type->decompose(0)}, {int32_type->decompose(0)} });
         });
 
         e.execute_cql("insert into base (k, v) values (0, 1);").get();
-        msg = e.execute_cql("select k, v from base where k = 0").get0();
+        msg = e.execute_cql("select k, v from base where k = 0").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {int32_type->decompose(1)} });
         eventually([&] {
-        auto msg = e.execute_cql("select k, v from mv where v = 0").get0();
+        auto msg = e.execute_cql("select k, v from mv where v = 0").get();
         assert_that(msg).is_rows().with_size(0);
-        msg = e.execute_cql("select k, v from mv where v = 1").get0();
+        msg = e.execute_cql("select k, v from mv where v = 1").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {int32_type->decompose(1)} });
@@ -167,24 +167,24 @@ SEASTAR_TEST_CASE(test_updates_no_read_before_update) {
                               "where k is not null and c is not null primary key (k, c)").get();
 
         e.execute_cql("insert into base (k, c, v) values (0, 0, 0);").get();
-        auto msg = e.execute_cql("select k, v from base where k = 0").get0();
+        auto msg = e.execute_cql("select k, v from base where k = 0").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {int32_type->decompose(0)} });
         eventually([&] {
-        auto msg = e.execute_cql("select k, v from mv where k = 0").get0();
+        auto msg = e.execute_cql("select k, v from mv where k = 0").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {int32_type->decompose(0)} });
         });
 
         e.execute_cql("insert into base (k, c, v) values (0, 0, 1);").get();
-        msg = e.execute_cql("select k, v from base where k = 0").get0();
+        msg = e.execute_cql("select k, v from base where k = 0").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {int32_type->decompose(1)} });
         eventually([&] {
-        msg = e.execute_cql("select k, v from mv where k = 0").get0();
+        msg = e.execute_cql("select k, v from mv where k = 0").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {int32_type->decompose(1)} });
@@ -251,7 +251,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ ascii ================
         e.execute_cql("insert into cf (k, asciival) values (0, 'ascii text');").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, asciival, udtval from mv_asciival where asciival = 'ascii text'").get0();
+        auto msg = e.execute_cql("select k, asciival, udtval from mv_asciival where asciival = 'ascii text'").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {ascii_type->decompose("ascii text")}, { } });
@@ -260,7 +260,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ bigint ================
         e.execute_cql("insert into cf (k, bigintval) values (0, 12121212);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, bigintval, asciival from mv_bigintval where bigintval = 12121212").get0();
+        auto msg = e.execute_cql("select k, bigintval, asciival from mv_bigintval where bigintval = 12121212").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {long_type->decompose(12121212L)}, {ascii_type->decompose("ascii text")} });
@@ -269,7 +269,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ blob ================
         e.execute_cql("insert into cf (k, blobval) values (0, 0x000001);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, blobval, asciival from mv_blobval where blobval = 0x000001").get0();
+        auto msg = e.execute_cql("select k, blobval, asciival from mv_blobval where blobval = 0x000001").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {bytes_type->from_string("000001")}, {ascii_type->decompose("ascii text")} });
@@ -278,17 +278,17 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ boolean ================
         e.execute_cql("insert into cf (k, booleanval) values (0, true);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, booleanval, asciival from mv_booleanval where booleanval = true").get0();
+        auto msg = e.execute_cql("select k, booleanval, asciival from mv_booleanval where booleanval = true").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {boolean_type->decompose(true)}, {ascii_type->decompose("ascii text")} });
         });
         e.execute_cql("insert into cf (k, booleanval) values (0, false);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, booleanval, asciival from mv_booleanval where booleanval = true").get0();
+        auto msg = e.execute_cql("select k, booleanval, asciival from mv_booleanval where booleanval = true").get();
         assert_that(msg).is_rows()
                 .with_size(0);
-        msg = e.execute_cql("select k, booleanval, asciival from mv_booleanval where booleanval = false").get0();
+        msg = e.execute_cql("select k, booleanval, asciival from mv_booleanval where booleanval = false").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {boolean_type->decompose(false)}, {ascii_type->decompose("ascii text")} });
@@ -297,7 +297,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ date ================
         e.execute_cql("insert into cf (k, dateval) values (0, '1986-01-19');").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, dateval, asciival from mv_dateval where dateval = '1986-01-19'").get0();
+        auto msg = e.execute_cql("select k, dateval, asciival from mv_dateval where dateval = '1986-01-19'").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {simple_date_type->from_string("1986-01-19")}, {ascii_type->decompose("ascii text")} });
@@ -306,7 +306,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ decimal ================
         e.execute_cql("insert into cf (k, decimalval) values (0, 123123.123123);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, decimalval, asciival from mv_decimalval where decimalval = 123123.123123").get0();
+        auto msg = e.execute_cql("select k, decimalval, asciival from mv_decimalval where decimalval = 123123.123123").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {decimal_type->from_string("123123.123123")}, {ascii_type->decompose("ascii text")} });
@@ -315,7 +315,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ double ================
         e.execute_cql("insert into cf (k, doubleval) values (0, 123123.123123);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, doubleval, asciival from mv_doubleval where doubleval = 123123.123123").get0();
+        auto msg = e.execute_cql("select k, doubleval, asciival from mv_doubleval where doubleval = 123123.123123").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {double_type->from_string("123123.123123")}, {ascii_type->decompose("ascii text")} });
@@ -324,7 +324,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ float ================
         e.execute_cql("insert into cf (k, floatval) values (0, 123123.123123);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, floatval, asciival from mv_floatval where floatval = 123123.123123").get0();
+        auto msg = e.execute_cql("select k, floatval, asciival from mv_floatval where floatval = 123123.123123").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {float_type->from_string("123123.123123")}, {ascii_type->decompose("ascii text")} });
@@ -333,7 +333,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ inet ================
         e.execute_cql("insert into cf (k, inetval) values (0, '127.0.0.1');").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, inetval, asciival from mv_inetval where inetval = '127.0.0.1'").get0();
+        auto msg = e.execute_cql("select k, inetval, asciival from mv_inetval where inetval = '127.0.0.1'").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {inet_addr_type->from_string("127.0.0.1")}, {ascii_type->decompose("ascii text")} });
@@ -342,7 +342,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ int ================
         e.execute_cql("insert into cf (k, intval) values (0, 456);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, intval, asciival from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, intval, asciival from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {int32_type->decompose(456)}, {ascii_type->decompose("ascii text")} });
@@ -351,7 +351,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ utf8 ================
         e.execute_cql("insert into cf (k, textval) values (0, '\"some \" text');").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, textval, asciival from mv_textval where textval = '\"some \" text'").get0();
+        auto msg = e.execute_cql("select k, textval, asciival from mv_textval where textval = '\"some \" text'").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {utf8_type->from_string("\"some \" text")}, {ascii_type->decompose("ascii text")} });
@@ -360,7 +360,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ time ================
         e.execute_cql("insert into cf (k, timeval) values (0, '07:35:07.000111222');").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, timeval, asciival from mv_timeval where timeval = '07:35:07.000111222'").get0();
+        auto msg = e.execute_cql("select k, timeval, asciival from mv_timeval where timeval = '07:35:07.000111222'").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {time_type->from_string("07:35:07.000111222")}, {ascii_type->decompose("ascii text")} });
@@ -369,7 +369,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ timestamp ================
         e.execute_cql("insert into cf (k, timestampval) values (0, '123123123123');").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, timestampval, asciival from mv_timestampval where timestampval = '123123123123'").get0();
+        auto msg = e.execute_cql("select k, timestampval, asciival from mv_timestampval where timestampval = '123123123123'").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {timestamp_type->from_string("123123123123")}, {ascii_type->decompose("ascii text")} });
@@ -378,7 +378,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ timeuuid ================
         e.execute_cql("insert into cf (k, timeuuidval) values (0, D2177dD0-EAa2-11de-a572-001B779C76e3);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, timeuuidval, asciival from mv_timeuuidval where timeuuidval = D2177dD0-EAa2-11de-a572-001B779C76e3").get0();
+        auto msg = e.execute_cql("select k, timeuuidval, asciival from mv_timeuuidval where timeuuidval = D2177dD0-EAa2-11de-a572-001B779C76e3").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {timeuuid_type->from_string("D2177dD0-EAa2-11de-a572-001B779C76e3")}, {ascii_type->decompose("ascii text")} });
@@ -387,7 +387,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ uuid ================
         e.execute_cql("insert into cf (k, uuidval) values (0, 6bddc89a-5644-11e4-97fc-56847afe9799);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, uuidval, asciival from mv_uuidval where uuidval = 6bddc89a-5644-11e4-97fc-56847afe9799").get0();
+        auto msg = e.execute_cql("select k, uuidval, asciival from mv_uuidval where uuidval = 6bddc89a-5644-11e4-97fc-56847afe9799").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {uuid_type->from_string("6bddc89a-5644-11e4-97fc-56847afe9799")}, {ascii_type->decompose("ascii text")} });
@@ -396,7 +396,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // ================ varint ================
         e.execute_cql("insert into cf (k, varintval) values (0, 1234567890123456789012345678901234567890);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, varintval, asciival from mv_varintval where varintval = 1234567890123456789012345678901234567890").get0();
+        auto msg = e.execute_cql("select k, varintval, asciival from mv_varintval where varintval = 1234567890123456789012345678901234567890").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {varint_type->from_string("1234567890123456789012345678901234567890")}, {ascii_type->decompose("ascii text")} });
@@ -406,7 +406,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         auto list_type = s->get_column_definition(bytes("listval"))->type;
         e.execute_cql("insert into cf (k, listval) values (0, [1, 2, 3]);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, listval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, listval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_list_value(list_type, list_type_impl::native_type({1, 2, 3})).serialize() });
@@ -414,7 +414,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("insert into cf (k, listval) values (0, [1]);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, listval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, listval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_list_value(list_type, list_type_impl::native_type({data_value(1)})).serialize() });
@@ -422,7 +422,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("update cf set listval = listval + [2] where k = 0;").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, listval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, listval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_list_value(list_type, list_type_impl::native_type({1, 2})).serialize() });
@@ -430,7 +430,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("update cf set listval = [0] + listval where k = 0;").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, listval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, listval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_list_value(list_type, list_type_impl::native_type({0, 1, 2})).serialize() });
@@ -438,7 +438,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("update cf set listval[1] = 10 where k = 0;").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, listval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, listval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_list_value(list_type, list_type_impl::native_type({0, 10, 2})).serialize() });
@@ -446,18 +446,18 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("delete listval[1] from cf where k = 0;").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, listval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, listval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_list_value(list_type, list_type_impl::native_type({0, 2})).serialize() });
         });
 
         e.execute_cql("insert into cf (k, listval) values (0, []);").get();
-        auto msg = e.execute_cql("select k, listval from cf where k = 0").get0();
+        auto msg = e.execute_cql("select k, listval from cf where k = 0").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)}, {} }});
 
         eventually([&] {
-        auto msg = e.execute_cql("select k, listval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, listval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_rows({{ {int32_type->decompose(0)}, {} }});
@@ -466,7 +466,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // frozen
         e.execute_cql("insert into cf (k, frozenlistval) values (0, [1, 2, 3]);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, frozenlistval, asciival from mv_frozenlistval where frozenlistval = [1, 2, 3]").get0();
+        auto msg = e.execute_cql("select k, frozenlistval, asciival from mv_frozenlistval where frozenlistval = [1, 2, 3]").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_list_value(list_type, list_type_impl::native_type({1, 2, 3})).serialize(), {ascii_type->decompose("ascii text")} });
@@ -474,7 +474,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("insert into cf (k, frozenlistval) values (0, [3, 2, 1]);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, frozenlistval, asciival from mv_frozenlistval where frozenlistval = [3, 2, 1]").get0();
+        auto msg = e.execute_cql("select k, frozenlistval, asciival from mv_frozenlistval where frozenlistval = [3, 2, 1]").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_list_value(list_type, list_type_impl::native_type({3, 2, 1})).serialize(), {ascii_type->decompose("ascii text")} });
@@ -482,7 +482,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("insert into cf (k, frozenlistval) values (0, []);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, frozenlistval, asciival from mv_frozenlistval where frozenlistval = []").get0();
+        auto msg = e.execute_cql("select k, frozenlistval, asciival from mv_frozenlistval where frozenlistval = []").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)}, make_list_value(list_type, list_type_impl::native_type({})).serialize() , {ascii_type->decompose("ascii text")} }});
         });
 
@@ -490,7 +490,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         auto set_type = s->get_column_definition(bytes("setval"))->type;
         e.execute_cql("insert into cf (k, setval) values (0, {6bddc89a-5644-11e4-97fc-56847afe9798, 6bddc89a-5644-11e4-97fc-56847afe9799});").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, setval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, setval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_set_value(set_type, set_type_impl::native_type({
@@ -500,7 +500,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("insert into cf (k, setval) values (0, {6bddc89a-5644-11e4-97fc-56847afe9798, 6bddc89a-5644-11e4-97fc-56847afe9798, 6bddc89a-5644-11e4-97fc-56847afe9799});").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, setval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, setval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_set_value(set_type, set_type_impl::native_type({
@@ -510,7 +510,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("update cf set setval = setval + {6bddc89a-5644-0000-97fc-56847afe9799} where k = 0;").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, setval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, setval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_set_value(set_type, set_type_impl::native_type({
@@ -521,7 +521,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("update cf set setval = setval - {6bddc89a-5644-0000-97fc-56847afe9799} where k = 0;").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, setval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, setval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_set_value(set_type, set_type_impl::native_type({
@@ -531,7 +531,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("insert into cf (k, setval) values (0, {});").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, setval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, setval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {} });
@@ -540,7 +540,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // frozen
         e.execute_cql("insert into cf (k, frozensetval) values (0, {});").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, frozensetval from mv_frozensetval  where frozensetval = {}").get0();
+        auto msg = e.execute_cql("select k, frozensetval from mv_frozensetval  where frozensetval = {}").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_set_value(set_type, set_type_impl::native_type({})).serialize() });
@@ -548,7 +548,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("insert into cf (k, frozensetval) values (0, {6bddc89a-5644-11e4-97fc-56847afe9798, 6bddc89a-5644-11e4-97fc-56847afe9799});").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, frozensetval, asciival from mv_frozensetval where frozensetval = {6bddc89a-5644-11e4-97fc-56847afe9798, 6bddc89a-5644-11e4-97fc-56847afe9799}").get0();
+        auto msg = e.execute_cql("select k, frozensetval, asciival from mv_frozensetval where frozensetval = {6bddc89a-5644-11e4-97fc-56847afe9798, 6bddc89a-5644-11e4-97fc-56847afe9799}").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_set_value(set_type, set_type_impl::native_type({
@@ -558,7 +558,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("insert into cf (k, frozensetval) values (0, {6bddc89a-0000-11e4-97fc-56847afe9799, 6bddc89a-5644-11e4-97fc-56847afe9798});").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, frozensetval, asciival from mv_frozensetval where frozensetval = {6bddc89a-0000-11e4-97fc-56847afe9799, 6bddc89a-5644-11e4-97fc-56847afe9798}").get0();
+        auto msg = e.execute_cql("select k, frozensetval, asciival from mv_frozensetval where frozensetval = {6bddc89a-0000-11e4-97fc-56847afe9799, 6bddc89a-5644-11e4-97fc-56847afe9798}").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_set_value(set_type, set_type_impl::native_type({
@@ -570,7 +570,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         auto map_type = s->get_column_definition(bytes("mapval"))->type;
         e.execute_cql("insert into cf (k, mapval) values (0, {'a': 1, 'b': 2});").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, mapval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, mapval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_map_value(map_type, map_type_impl::native_type({
@@ -579,7 +579,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("update cf set mapval['c'] = 3 where k = 0;").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, mapval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, mapval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_map_value(map_type, map_type_impl::native_type({
@@ -588,7 +588,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("update cf set mapval['b'] = 10 where k = 0;").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, mapval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, mapval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_map_value(map_type, map_type_impl::native_type({
@@ -597,7 +597,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("delete mapval['b'] from cf where k = 0;").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, mapval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, mapval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_map_value(map_type, map_type_impl::native_type({
@@ -606,7 +606,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("insert into cf (k, mapval) values (0, {});").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, mapval from mv_intval where intval = 456").get0();
+        auto msg = e.execute_cql("select k, mapval from mv_intval where intval = 456").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {} });
@@ -615,7 +615,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         // frozen
         e.execute_cql("insert into cf (k, frozenmapval) values (0, {'a': 1, 'b': 2});").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, frozenmapval, asciival from mv_frozenmapval where frozenmapval = {'a': 1, 'b': 2}").get0();
+        auto msg = e.execute_cql("select k, frozenmapval, asciival from mv_frozenmapval where frozenmapval = {'a': 1, 'b': 2}").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_map_value(map_type, map_type_impl::native_type({
@@ -624,7 +624,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("insert into cf (k, frozenmapval) values (0, {'a': 1, 'b': 2, 'c': 3});").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, frozenmapval, asciival from mv_frozenmapval where frozenmapval = {'a': 1, 'b': 2, 'c': 3}").get0();
+        auto msg = e.execute_cql("select k, frozenmapval, asciival from mv_frozenmapval where frozenmapval = {'a': 1, 'b': 2, 'c': 3}").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_map_value(map_type, map_type_impl::native_type({
@@ -635,7 +635,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         auto tuple_type = s->get_column_definition(bytes("tupleval"))->type;
         e.execute_cql("insert into cf (k, tupleval) values (0, (1, 'foobar', 6bddc89a-5644-11e4-97fc-56847afe9799));").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, tupleval, asciival from mv_tupleval where tupleval = (1, 'foobar', 6bddc89a-5644-11e4-97fc-56847afe9799)").get0();
+        auto msg = e.execute_cql("select k, tupleval, asciival from mv_tupleval where tupleval = (1, 'foobar', 6bddc89a-5644-11e4-97fc-56847afe9799)").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_tuple_value(tuple_type, tuple_type_impl::native_type({
@@ -645,9 +645,9 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("insert into cf (k, tupleval) values (0, (1, null, 6bddc89a-5644-11e4-97fc-56847afe9799));").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, tupleval, asciival from mv_tupleval where tupleval = (1, 'foobar', 6bddc89a-5644-11e4-97fc-56847afe9799)").get0();
+        auto msg = e.execute_cql("select k, tupleval, asciival from mv_tupleval where tupleval = (1, 'foobar', 6bddc89a-5644-11e4-97fc-56847afe9799)").get();
         assert_that(msg).is_rows().with_size(0);
-        msg = e.execute_cql("select k, tupleval, asciival from mv_tupleval where tupleval = (1, null, 6bddc89a-5644-11e4-97fc-56847afe9799)").get0();
+        msg = e.execute_cql("select k, tupleval, asciival from mv_tupleval where tupleval = (1, null, 6bddc89a-5644-11e4-97fc-56847afe9799)").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_tuple_value(tuple_type, tuple_type_impl::native_type({
@@ -660,7 +660,7 @@ SEASTAR_TEST_CASE(test_all_types) {
         auto udt_set_type = static_pointer_cast<const user_type_impl>(udt_type)->field_type(2);
         e.execute_cql("insert into cf (k, udtval) values (0, (1, 6bddc89a-5644-11e4-97fc-56847afe9799, {'foo', 'bar'}));").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, udtval.a, udtval.b, udtval.c, asciival from mv_udtval where udtval = (1, 6bddc89a-5644-11e4-97fc-56847afe9799, {'foo', 'bar'})").get0();
+        auto msg = e.execute_cql("select k, udtval.a, udtval.b, udtval.c, asciival from mv_udtval where udtval = (1, 6bddc89a-5644-11e4-97fc-56847afe9799, {'foo', 'bar'})").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_rows({{ {int32_type->decompose(0)}, {int32_type->decompose(1)}, {uuid_type->from_string("6bddc89a-5644-11e4-97fc-56847afe9799")},
@@ -670,7 +670,7 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("insert into cf (k, udtval) values (0, {b: 6bddc89a-5644-11e4-97fc-56847afe9799, a: 1, c: {'foo', 'bar'}});").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, udtval.a, udtval.b, udtval.c, asciival from mv_udtval where udtval = {b: 6bddc89a-5644-11e4-97fc-56847afe9799, a: 1, c: {'foo', 'bar'}}").get0();
+        auto msg = e.execute_cql("select k, udtval.a, udtval.b, udtval.c, asciival from mv_udtval where udtval = {b: 6bddc89a-5644-11e4-97fc-56847afe9799, a: 1, c: {'foo', 'bar'}}").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_rows({{ {int32_type->decompose(0)}, {int32_type->decompose(1)}, {uuid_type->from_string("6bddc89a-5644-11e4-97fc-56847afe9799")},
@@ -680,9 +680,9 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("insert into cf (k, udtval) values (0, {a: null, b: 6bddc89a-5644-11e4-97fc-56847afe9799, c: {'foo', 'bar'}});").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, udtval.a, udtval.b, udtval.c, asciival from mv_udtval where udtval = {a: 1, b: 6bddc89a-5644-11e4-97fc-56847afe9799, c: {'foo', 'bar'}}").get0();
+        auto msg = e.execute_cql("select k, udtval.a, udtval.b, udtval.c, asciival from mv_udtval where udtval = {a: 1, b: 6bddc89a-5644-11e4-97fc-56847afe9799, c: {'foo', 'bar'}}").get();
         assert_that(msg).is_rows().with_size(0);
-        msg = e.execute_cql("select k, udtval.a, udtval.b, udtval.c, asciival from mv_udtval where udtval = {a: null, b: 6bddc89a-5644-11e4-97fc-56847afe9799, c: {'foo', 'bar'}}").get0();
+        msg = e.execute_cql("select k, udtval.a, udtval.b, udtval.c, asciival from mv_udtval where udtval = {a: null, b: 6bddc89a-5644-11e4-97fc-56847afe9799, c: {'foo', 'bar'}}").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_rows({{ {int32_type->decompose(0)}, {}, {uuid_type->from_string("6bddc89a-5644-11e4-97fc-56847afe9799")},
@@ -692,9 +692,9 @@ SEASTAR_TEST_CASE(test_all_types) {
 
         e.execute_cql("insert into cf (k, udtval) values (0, {a: 1, b: 6bddc89a-5644-11e4-97fc-56847afe9799});").get();
         eventually([&] {
-        auto msg = e.execute_cql("select k, udtval.a, udtval.b, udtval.c, asciival from mv_udtval where udtval = {a: 1, b: 6bddc89a-5644-11e4-97fc-56847afe9799, c: {'foo', 'bar'}}").get0();
+        auto msg = e.execute_cql("select k, udtval.a, udtval.b, udtval.c, asciival from mv_udtval where udtval = {a: 1, b: 6bddc89a-5644-11e4-97fc-56847afe9799, c: {'foo', 'bar'}}").get();
         assert_that(msg).is_rows().with_size(0);
-        msg = e.execute_cql("select k, udtval.a, udtval.b, udtval.c, asciival from mv_udtval where udtval = {a: 1, b: 6bddc89a-5644-11e4-97fc-56847afe9799}").get0();
+        msg = e.execute_cql("select k, udtval.a, udtval.b, udtval.c, asciival from mv_udtval where udtval = {a: 1, b: 6bddc89a-5644-11e4-97fc-56847afe9799}").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_rows({{ {int32_type->decompose(0)}, {int32_type->decompose(1)}, {uuid_type->from_string("6bddc89a-5644-11e4-97fc-56847afe9799")},
@@ -792,7 +792,7 @@ SEASTAR_TEST_CASE(test_create_mv_with_unrestricted_pk_parts) {
                        "primary key (v, p, c)").get();
         e.execute_cql("insert into cf (p, c, v) values (0, 'foo', 1);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows()
             .with_size(1)
             .with_row({ {long_type->decompose(1L)}, {int32_type->decompose(0)}, {utf8_type->decompose(sstring("foo"))} });
@@ -809,12 +809,12 @@ SEASTAR_TEST_CASE(test_partition_tombstone) {
         e.execute_cql("insert into cf (p, c, v) values (1, 2, 200);").get();
         e.execute_cql("insert into cf (p, c, v) values (1, 3, 300);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_size(2);
         });
         e.execute_cql("delete from cf where p = 1;").get();
         eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_size(0);
         });
     });
@@ -829,12 +829,12 @@ SEASTAR_TEST_CASE(test_ck_tombstone) {
         e.execute_cql("insert into cf (p, c, v) values (1, 2, 200);").get();
         e.execute_cql("insert into cf (p, c, v) values (1, 3, 300);").get();
         eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_size(2);
         });
         e.execute_cql("delete from cf where p = 1 and c = 3;").get();
         eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_size(1);
         });
     });
@@ -865,7 +865,7 @@ SEASTAR_TEST_CASE(test_static_table) {
         }
 
         eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_size(2);
         });
         try {
@@ -883,24 +883,24 @@ SEASTAR_TEST_CASE(test_static_data) {
                        "where a is not null and b is not null primary key (b,a) with clustering order by (a asc);").get();
 
         e.execute_cql("insert into ab (a, b) values (1, 2);").get();
-        auto msg = e.execute_cql("select a, b from ab where a = 1;").get0();
+        auto msg = e.execute_cql("select a, b from ab where a = 1;").get();
         assert_that(msg).is_rows()
             .with_size(1)
             .with_row({ {int32_type->decompose(1)}, {int32_type->decompose(2)} });
         eventually([&] {
-        auto msg = e.execute_cql("select a, b from ba where b = 2;").get0();
+        auto msg = e.execute_cql("select a, b from ba where b = 2;").get();
         assert_that(msg).is_rows()
             .with_size(1)
             .with_row({ {int32_type->decompose(1)}, {int32_type->decompose(2)} });
         });
 
         e.execute_cql("insert into ab (a , b , c) values (3, 4, 5);").get();
-        auto msg2 = e.execute_cql("select a, b from ab where a = 3;").get0();
+        auto msg2 = e.execute_cql("select a, b from ab where a = 3;").get();
         assert_that(msg2).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(3)}, {int32_type->decompose(4)} });
         eventually([&] {
-        auto msg = e.execute_cql("select a, b from ba where b = 4;").get0();
+        auto msg = e.execute_cql("select a, b from ba where b = 4;").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(3)}, {int32_type->decompose(4)} });
@@ -922,27 +922,27 @@ SEASTAR_TEST_CASE(test_old_timestamps) {
         }
 
         eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_size(2);
-        msg = e.execute_cql("select c from vcf where p = 0 and v = 1").get0();
+        msg = e.execute_cql("select c from vcf where p = 0 and v = 1").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)} }, { {int32_type->decompose(1)} }});
         });
 
         //Make sure an old TS does nothing
         e.execute_cql("update cf using timestamp 100 set v = 5 where p = 0 and c = 0").get();
         eventually([&] {
-        auto msg = e.execute_cql("select c from vcf where p = 0 and v = 1").get0();
+        auto msg = e.execute_cql("select c from vcf where p = 0 and v = 1").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)} }, { {int32_type->decompose(1)} }});
-        msg = e.execute_cql("select c from vcf where p = 0 and v = 5").get0();
+        msg = e.execute_cql("select c from vcf where p = 0 and v = 5").get();
         assert_that(msg).is_rows().with_size(0);
         });
 
         //Latest TS
         e.execute_cql("update cf set v = 5 where p = 0 and c = 0").get();
         eventually([&] {
-        auto msg = e.execute_cql("select c from vcf where p = 0 and v = 5").get0();
+        auto msg = e.execute_cql("select c from vcf where p = 0 and v = 5").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)} }});
-        msg = e.execute_cql("select c from vcf where p = 0 and v = 1").get0();
+        msg = e.execute_cql("select c from vcf where p = 0 and v = 1").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)} }});
         });
     });
@@ -959,7 +959,7 @@ SEASTAR_TEST_CASE(test_regular_column_timestamp_updates) {
         e.execute_cql("update cf using timestamp 1 set v2 = 1 where p = 0").get();
         e.execute_cql("update cf using timestamp 1 set v1 = 1 where p = 0").get();
         eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
 
@@ -971,7 +971,7 @@ SEASTAR_TEST_CASE(test_regular_column_timestamp_updates) {
         e.execute_cql("update cf using timestamp 6 set v1 = 2 where p = 0").get();
         e.execute_cql("update cf using timestamp 7 set v2 = 2 where p = 0").get();
         eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)}, {int32_type->decompose(2)}, {int32_type->decompose(2)} }});
         });
     });
@@ -996,7 +996,7 @@ void do_test_complex_timestamp_updates(cql_test_env& e, std::function<void()>&& 
     // Set initial values TS=0, leaving v3 null and verify view
     e.execute_cql("insert into cf (p, c, v1, v2) values (0, 0, 1, 0) using timestamp 0").get();
     eventually([&] {
-    auto msg = e.execute_cql("select * from vcf").get0();
+    auto msg = e.execute_cql("select * from vcf").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {} }});
     });
 
@@ -1004,7 +1004,7 @@ void do_test_complex_timestamp_updates(cql_test_env& e, std::function<void()>&& 
     e.execute_cql("update cf using timestamp 2 set v1 = 1 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get0();
+    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)} }});
     });
 
@@ -1012,7 +1012,7 @@ void do_test_complex_timestamp_updates(cql_test_env& e, std::function<void()>&& 
     e.execute_cql("update cf using timestamp 3 set v1 = 0 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get0();
+    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get();
     assert_that(msg).is_rows().with_size(0);
     });
 
@@ -1020,7 +1020,7 @@ void do_test_complex_timestamp_updates(cql_test_env& e, std::function<void()>&& 
     e.execute_cql("update cf using timestamp 4 set v1 = 1 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v2, v3 from vcf where v1 = 1 and p = 0 and c = 0").get0();
+    auto msg = e.execute_cql("select v2, v3 from vcf where v1 = 1 and p = 0 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)}, {} }});
     });
 
@@ -1028,7 +1028,7 @@ void do_test_complex_timestamp_updates(cql_test_env& e, std::function<void()>&& 
     e.execute_cql("update cf using timestamp 1 set v3 = 1 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v2, v3 from vcf where v1 = 1 and p = 0 and c = 0").get0();
+    auto msg = e.execute_cql("select v2, v3 from vcf where v1 = 1 and p = 0 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)}, {int32_type->decompose(1)} }});
     });
 
@@ -1036,7 +1036,7 @@ void do_test_complex_timestamp_updates(cql_test_env& e, std::function<void()>&& 
     e.execute_cql("update cf using timestamp 2 set v2 = 2 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get0();
+    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(2)} }});
     });
 
@@ -1044,14 +1044,14 @@ void do_test_complex_timestamp_updates(cql_test_env& e, std::function<void()>&& 
     e.execute_cql("update cf using timestamp 3 set v2 = 4 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get0();
+    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(4)} }});
     });
 
     // Tombstone v1
     e.execute_cql("delete from cf using timestamp 5 where p = 0 and c = 0").get();
     eventually([&] {
-    auto msg = e.execute_cql("select v2 from vcf").get0();
+    auto msg = e.execute_cql("select v2 from vcf").get();
     assert_that(msg).is_rows().with_size(0);
     });
 
@@ -1059,7 +1059,7 @@ void do_test_complex_timestamp_updates(cql_test_env& e, std::function<void()>&& 
     e.execute_cql("insert into cf (p, c, v1) values (0, 0, 1) using timestamp 6").get();
     // Make sure v2 doesn't pop back in.
     eventually([&] {
-    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get0();
+    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {} }});
     });
 
@@ -1073,7 +1073,7 @@ void do_test_complex_timestamp_updates(cql_test_env& e, std::function<void()>&& 
     // Delete @ TS=0 (which should only delete v2)
     e.execute_cql("delete from cf using timestamp 0 where p = 1 and c = 0").get();
     eventually([&] {
-    auto msg = e.execute_cql("select * from vcf where v1 = 0 and p = 1 and c = 0").get0();
+    auto msg = e.execute_cql("select * from vcf where v1 = 0 and p = 1 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {}, {int32_type->decompose(0)} }});
     });
 
@@ -1082,14 +1082,14 @@ void do_test_complex_timestamp_updates(cql_test_env& e, std::function<void()>&& 
     e.execute_cql("update cf using timestamp 3 set v1 = 0 where p = 1 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select * from vcf where v1 = 0 and p = 1 and c = 0").get0();
+    auto msg = e.execute_cql("select * from vcf where v1 = 0 and p = 1 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {}, {int32_type->decompose(0)} }});
     });
 
     e.execute_cql("update cf using timestamp 3 set v2 = 0 where p = 1 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select * from vcf where v1 = 0 and p = 1 and c = 0").get0();
+    auto msg = e.execute_cql("select * from vcf where v1 = 0 and p = 1 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} }});
     });
 }
@@ -1122,19 +1122,19 @@ SEASTAR_TEST_CASE(test_range_tombstone) {
         }
 
         eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_size(100);
         });
 
         e.execute_cql("delete from cf where p = 0 and c1 = 0").get();
         eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_size(50);
         });
 
         e.execute_cql("delete from cf where p = 0 and c1 = 1 and c2 >= 50 and c2 < 101").get();
         eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_size(25);
         });
     });
@@ -1151,7 +1151,7 @@ SEASTAR_TEST_CASE(test_collections) {
         auto s = e.local_db().find_schema(sstring("ks"), sstring("cf"));
         auto list_type = s->get_column_definition(bytes("lv"))->type;
         eventually([&] {
-        auto msg = e.execute_cql("select p, lv from mv where v = 0").get0();
+        auto msg = e.execute_cql("select p, lv from mv where v = 0").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, make_list_value(list_type, list_type_impl::native_type({1, 2, 3})).serialize() });
@@ -1160,7 +1160,7 @@ SEASTAR_TEST_CASE(test_collections) {
         e.execute_cql("insert into cf (p, v) values (1, 1)").get();
         e.execute_cql("insert into cf (p, lv) values (1, [1, 2, 3])").get();
         eventually([&] {
-        auto msg = e.execute_cql("select p, lv from mv where v = 1").get0();
+        auto msg = e.execute_cql("select p, lv from mv where v = 1").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(1)}, make_list_value(list_type, list_type_impl::native_type({1, 2, 3})).serialize() });
@@ -1176,7 +1176,7 @@ SEASTAR_TEST_CASE(test_update) {
 
         e.execute_cql("insert into cf (p, v) values (0, 0)").get();
         eventually([&] {
-        auto msg = e.execute_cql("select * from mv where v = 0").get0();
+        auto msg = e.execute_cql("select * from mv where v = 0").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(0)}, {int32_type->decompose(0)} });
@@ -1184,7 +1184,7 @@ SEASTAR_TEST_CASE(test_update) {
 
         e.execute_cql("insert into cf (p, v) values (0, 1)").get();
         eventually([&] {
-        auto msg = e.execute_cql("select * from mv where v = 1").get0();
+        auto msg = e.execute_cql("select * from mv where v = 1").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(1)}, {int32_type->decompose(0)} });
@@ -1200,17 +1200,17 @@ SEASTAR_TEST_CASE(test_ttl) {
 
         e.execute_cql("insert into cf (p, c, v1, v2, v3) values (0, 0, 0, 0, 0) using ttl 3").get();
         eventually([&] {
-        auto msg = e.execute_cql("select * from mv").get0();
+        auto msg = e.execute_cql("select * from mv").get();
         assert_that(msg).is_rows().with_size(1);
         forward_jump_clocks(4s);
-        msg = e.execute_cql("select * from mv").get0();
+        msg = e.execute_cql("select * from mv").get();
         assert_that(msg).is_rows().with_size(0);
         });
 
         e.execute_cql("insert into cf (p, c, v1, v2, v3) values (1, 1, 1, 1, 1) using ttl 3").get();
         forward_jump_clocks(1s);
         eventually([&] {
-        auto msg = e.execute_cql("select v2 from mv").get0();
+        auto msg = e.execute_cql("select v2 from mv").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ {int32_type->decompose(1)} });
@@ -1219,7 +1219,7 @@ SEASTAR_TEST_CASE(test_ttl) {
         e.execute_cql("insert into cf (p, c, v1) values (1, 1, 1)").get();
         forward_jump_clocks(4s);
         eventually([&] {
-        auto msg = e.execute_cql("select v2 from mv").get0();
+        auto msg = e.execute_cql("select v2 from mv").get();
         assert_that(msg).is_rows()
                 .with_size(1)
                 .with_row({ { } });
@@ -1227,16 +1227,16 @@ SEASTAR_TEST_CASE(test_ttl) {
 
         e.execute_cql("insert into cf (p, c, v1, v2, v3) values (2, 2, 2, 2, 2) using ttl 3").get();
         eventually([&] {
-        auto msg = e.execute_cql("select * from mv where v1 = 2").get0();
+        auto msg = e.execute_cql("select * from mv where v1 = 2").get();
         assert_that(msg).is_rows().with_size(1);
         });
         forward_jump_clocks(2s);
         e.execute_cql("update cf using ttl 8 set v3 = 4 where p = 2 and c = 2").get();
         forward_jump_clocks(2s);
         eventually([&] {
-        auto msg = e.execute_cql("select * from mv where v1 = 2").get0();
+        auto msg = e.execute_cql("select * from mv where v1 = 2").get();
         assert_that(msg).is_rows().with_size(0);
-        msg = e.execute_cql("select * from cf where p = 2 and c = 2").get0();
+        msg = e.execute_cql("select * from cf where p = 2 and c = 2").get();
         assert_that(msg).is_rows()
             .with_size(1)
             .with_row({ {int32_type->decompose(2)}, {int32_type->decompose(2)}, { }, { }, {int32_type->decompose(4)} });
@@ -1253,7 +1253,7 @@ SEASTAR_TEST_CASE(test_row_deletion) {
         e.execute_cql("delete from cf using timestamp 6 where p = 1 and c = 1;").get();
         e.execute_cql("insert into cf (p, c, v1, v2) values (1, 1, 1, 1) using timestamp 3").get();
         eventually([&] {
-        auto msg = e.execute_cql("select * from mv").get0();
+        auto msg = e.execute_cql("select * from mv").get();
         assert_that(msg).is_rows().with_size(0);
         });
     });
@@ -1269,7 +1269,7 @@ SEASTAR_TEST_CASE(test_conflicting_timestamp) {
             e.execute_cql(format("insert into cf (p, c, v) values (1, 1, {:d})", i)).get();
         }
         eventually([&] {
-        auto msg = e.execute_cql("select * from mv").get0();
+        auto msg = e.execute_cql("select * from mv").get();
         assert_that(msg).is_rows()
             .with_size(1)
             .with_row({ {int32_type->decompose(49)}, {int32_type->decompose(1)}, {int32_type->decompose(1)} });
@@ -1293,7 +1293,7 @@ SEASTAR_TEST_CASE(test_clustering_order) {
         e.execute_cql("insert into cf (a, b, c, d) values (1, 2, 2, 2)").get();
 
         eventually([&] {
-        auto msg = e.execute_cql("select b from mv1").get0();
+        auto msg = e.execute_cql("select b from mv1").get();
         assert_that(msg).is_rows()
             .with_size(2)
             .with_rows({{ {int32_type->decompose(2)} },
@@ -1301,7 +1301,7 @@ SEASTAR_TEST_CASE(test_clustering_order) {
         });
 
         eventually([&] {
-        auto msg = e.execute_cql("select c from mv2").get0();
+        auto msg = e.execute_cql("select c from mv2").get();
         assert_that(msg).is_rows()
             .with_size(2)
             .with_rows({{ {int32_type->decompose(1)} },
@@ -1309,7 +1309,7 @@ SEASTAR_TEST_CASE(test_clustering_order) {
         });
 
         eventually([&] {
-        auto msg = e.execute_cql("select b from mv3").get0();
+        auto msg = e.execute_cql("select b from mv3").get();
         assert_that(msg).is_rows()
             .with_size(2)
             .with_rows({{ {int32_type->decompose(1)} },
@@ -1317,7 +1317,7 @@ SEASTAR_TEST_CASE(test_clustering_order) {
         });
 
         eventually([&] {
-        auto msg = e.execute_cql("select c from mv4").get0();
+        auto msg = e.execute_cql("select c from mv4").get();
         assert_that(msg).is_rows()
             .with_size(2)
             .with_rows({{ {int32_type->decompose(2)} },
@@ -1337,7 +1337,7 @@ SEASTAR_TEST_CASE(test_multiple_deletes) {
         e.execute_cql("insert into cf (p, c) values (1, 3)").get();
 
         eventually([&] {
-        auto msg = e.execute_cql("select p, c from mv").get0();
+        auto msg = e.execute_cql("select p, c from mv").get();
         assert_that(msg).is_rows()
             .with_size(3)
             .with_rows({ { {int32_type->decompose(1)}, {int32_type->decompose(1)} },
@@ -1347,7 +1347,7 @@ SEASTAR_TEST_CASE(test_multiple_deletes) {
 
         e.execute_cql("delete from cf where p = 1 and c > 1 and c < 3").get();
         eventually([&] {
-        auto msg = e.execute_cql("select p, c from mv").get0();
+        auto msg = e.execute_cql("select p, c from mv").get();
         assert_that(msg).is_rows()
             .with_size(2)
             .with_rows({ { {int32_type->decompose(1)}, {int32_type->decompose(1)} },
@@ -1356,7 +1356,7 @@ SEASTAR_TEST_CASE(test_multiple_deletes) {
 
         e.execute_cql("delete from cf where p = 1").get();
         eventually([&] {
-        auto msg = e.execute_cql("select p, c from mv").get0();
+        auto msg = e.execute_cql("select p, c from mv").get();
         assert_that(msg).is_rows().with_size(0);
         });
     });
@@ -1385,19 +1385,19 @@ SEASTAR_TEST_CASE(test_null_in_clustering_columns) {
 
         e.execute_cql("insert into cf (p, c, v1, v2) values (0, 1, 2, 3)").get();
         eventually([&] {
-        auto msg = e.execute_cql("select p, c, v1, v2 from vcf").get0();
+        auto msg = e.execute_cql("select p, c, v1, v2 from vcf").get();
         assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)} }});
         });
 
         e.execute_cql("update cf set v1 = null where p = 0 and c = 1").get();
         eventually([&] {
-        auto msg = e.execute_cql("select p, c, v1, v2 from vcf").get0();
+        auto msg = e.execute_cql("select p, c, v1, v2 from vcf").get();
         assert_that(msg).is_rows().with_size(0);
         });
 
         e.execute_cql("update cf set v2 = 9 where p = 0 and c = 1").get();
         eventually([&] {
-        auto msg = e.execute_cql("select p, c, v1, v2 from vcf").get0();
+        auto msg = e.execute_cql("select p, c, v1, v2 from vcf").get();
         assert_that(msg).is_rows().with_size(0);
         });
     });
@@ -1458,14 +1458,14 @@ SEASTAR_TEST_CASE(test_filter_with_function) {
         e.execute_cql("insert into cf (p, c, v) values (1, 1, 3)").get();
 
         eventually([&] {
-        auto msg = e.execute_cql("select p, c, v from vcf").get0();
+        auto msg = e.execute_cql("select p, c, v from vcf").get();
         assert_that(msg).is_rows()
                 .with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(2)} },
                             { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(3)} }});
         });
 
         e.execute_cql("alter table cf rename p to foo").get();
-        auto msg = e.execute_cql("select foo, c, v from vcf").get0();
+        auto msg = e.execute_cql("select foo, c, v from vcf").get();
         assert_that(msg).is_rows()
                 .with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(2)} },
                             { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(3)} }});
@@ -1485,14 +1485,14 @@ SEASTAR_TEST_CASE(test_filter_with_type_cast) {
         e.execute_cql("insert into cf (p, c, v) values (1, 1, 3)").get();
 
         eventually([&] {
-        auto msg = e.execute_cql("select p, c, v from vcf").get0();
+        auto msg = e.execute_cql("select p, c, v from vcf").get();
         assert_that(msg).is_rows()
                 .with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(2)} },
                             { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(3)} }});
         });
 
         e.execute_cql("alter table cf rename p to foo").get();
-        auto msg = e.execute_cql("select foo, c, v from vcf").get0();
+        auto msg = e.execute_cql("select foo, c, v from vcf").get();
         assert_that(msg).is_rows()
                 .with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(2)} },
                             { {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(3)} }});
@@ -1599,7 +1599,7 @@ SEASTAR_TEST_CASE(test_restrictions_on_all_types) {
                 "{{a: 1, b: 6BDDC89A-5644-11E4-97FC-56847AFE9799, c: {{'foo', 'bar'}}}})", fmt::join(column_names, ", "))).get();
 
         eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_size(1);
         });
     });
@@ -1628,7 +1628,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions) {
 
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-        auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c, d from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -1642,7 +1642,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions) {
         e.execute_cql("insert into cf (a, b, c, d) values (2, 0, 0, 0)").get();
         e.execute_cql("insert into cf (a, b, c, d) values (2, 1, 2, 0)").get();
         eventually([&] {
-        auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c, d from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -1657,7 +1657,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions) {
         e.execute_cql("insert into cf (a, b, c, d) values (1, 2, 1, 0)").get();
         e.execute_cql("insert into cf (a, b, c, d) values (1, 3, 1, 0)").get();
         eventually([&] {
-        auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c, d from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -1672,7 +1672,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("delete from cf where a = 1 and b = 2").get();
         eventually([&] {
-        auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c, d from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -1689,7 +1689,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf set c = 0 where a = 1 and b = 3").get();
         eventually([&] {
-        auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c, d from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -1702,7 +1702,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf set c = 1 where a = 1 and b = 3").get();
         eventually([&] {
-        auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c, d from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -1716,7 +1716,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("delete from cf where a = 1 and b = 3").get();
         eventually([&] {
-        auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c, d from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -1730,7 +1730,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf set d = 1 where a = 0 and b = 2").get();
         eventually([&] {
-        auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c, d from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -1744,7 +1744,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions) {
         e.execute_cql("update cf set d = 1 where a = 1 and b = 1").get();
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-        auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c, d from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -1758,7 +1758,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions) {
         e.execute_cql("delete from cf where a = 0 and b = 2").get();
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-        auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c, d from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -1771,7 +1771,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions) {
         e.execute_cql("delete from cf where a = 1 and b = 1").get();
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-        auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c, d from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
                         { {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} },
@@ -1783,7 +1783,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions) {
         e.execute_cql("delete from cf where a = 0").get();
         BOOST_TEST_PASSPOINT();
         eventually([&] {
-        auto msg = e.execute_cql("select a, b, c, d from vcf").get0();
+        auto msg = e.execute_cql("select a, b, c, d from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({
                         { {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(1)}, {int32_type->decompose(0)} }});
         });
@@ -1836,20 +1836,20 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions_update) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("insert into cf (a, b, c) values (1, 11, 0)").get();
         eventually([&] {
-            auto msg = e.execute_cql("select a, b, c from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c from vcf").get();
             assert_that(msg).is_rows().is_empty();
         });
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf set c = 1 where a = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select a, b, c from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                 { {int32_type->decompose(1)}, {int32_type->decompose(11)}, {int32_type->decompose(1)} }});
         });
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf set c = 0 where a = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select a, b, c from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c from vcf").get();
             assert_that(msg).is_rows().is_empty();
         });
         BOOST_TEST_PASSPOINT();
@@ -1857,7 +1857,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions_update) {
         // view row re-added. And it isn't.
         e.execute_cql("update cf set c = 1 where a = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select a, b, c from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                 { {int32_type->decompose(1)}, {int32_type->decompose(11)}, {int32_type->decompose(1)} }});
         });
@@ -1884,13 +1884,13 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions_ttl) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("insert into cf (a, b, c) values (1, 11, 0)").get();
         eventually([&] {
-            auto msg = e.execute_cql("select a, b, c from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c from vcf").get();
             assert_that(msg).is_rows().is_empty();
         });
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf using ttl 5 set c = 1 where a = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select a, b, c from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                 { {int32_type->decompose(1)}, {int32_type->decompose(11)}, {int32_type->decompose(1)} }});
         });
@@ -1900,7 +1900,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions_ttl) {
         // expired.
         forward_jump_clocks(6s);
         eventually([&] {
-            auto msg = e.execute_cql("select a, b, c from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c from vcf").get();
             assert_that(msg).is_rows().is_empty();
         });
         BOOST_TEST_PASSPOINT();
@@ -1908,7 +1908,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions_ttl) {
         // view row back to life by setting c = 1.
         e.execute_cql("update cf set c = 1 where a = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select a, b, c from vcf").get0();
+            auto msg = e.execute_cql("select a, b, c from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                 { {int32_type->decompose(1)}, {int32_type->decompose(11)}, {int32_type->decompose(1)} }});
         });
@@ -1939,20 +1939,20 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions_update_vk) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("insert into cf (a, c) values (1, 0)").get();
         eventually([&] {
-            auto msg = e.execute_cql("select a, c from vcf").get0();
+            auto msg = e.execute_cql("select a, c from vcf").get();
             assert_that(msg).is_rows().is_empty();
         });
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf set c = 1 where a = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select a, c from vcf").get0();
+            auto msg = e.execute_cql("select a, c from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                 { {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf set c = 0 where a = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select a, c from vcf").get0();
+            auto msg = e.execute_cql("select a, c from vcf").get();
             assert_that(msg).is_rows().is_empty();
         });
         BOOST_TEST_PASSPOINT();
@@ -1960,7 +1960,7 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions_update_vk) {
         // view row re-added. And it isn't.
         e.execute_cql("update cf set c = 1 where a = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select a, c from vcf").get0();
+            auto msg = e.execute_cql("select a, c from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                 { {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
@@ -1979,26 +1979,26 @@ SEASTAR_TEST_CASE(test_non_primary_key_restrictions_ttl_vk) {
         BOOST_TEST_PASSPOINT();
         e.execute_cql("insert into cf (a, c) values (1, 0)").get();
         eventually([&] {
-            auto msg = e.execute_cql("select a, c from vcf").get0();
+            auto msg = e.execute_cql("select a, c from vcf").get();
             assert_that(msg).is_rows().is_empty();
         });
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf using ttl 5 set c = 1 where a = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select a, c from vcf").get0();
+            auto msg = e.execute_cql("select a, c from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                 { {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
         BOOST_TEST_PASSPOINT();
         forward_jump_clocks(6s);
         eventually([&] {
-            auto msg = e.execute_cql("select a, c from vcf").get0();
+            auto msg = e.execute_cql("select a, c from vcf").get();
             assert_that(msg).is_rows().is_empty();
         });
         BOOST_TEST_PASSPOINT();
         e.execute_cql("update cf set c = 1 where a = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select a, c from vcf").get0();
+            auto msg = e.execute_cql("select a, c from vcf").get();
             assert_that(msg).is_rows().with_rows_ignore_order({
                 { {int32_type->decompose(1)}, {int32_type->decompose(1)} }});
         });
@@ -2019,7 +2019,7 @@ SEASTAR_TEST_CASE(test_restricted_regular_column_timestamp_updates) {
         e.execute_cql("update cf using timestamp 4 set c = 1 where k = 0").get();
         e.execute_cql("update cf using timestamp 3 set val = 2 where k = 0").get();
         eventually([&] {
-        auto msg = e.execute_cql("select c, k, val from vcf").get0();
+        auto msg = e.execute_cql("select c, k, val from vcf").get();
         assert_that(msg).is_rows().with_rows_ignore_order({{ {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(2)} }});
         });
     });
@@ -2037,27 +2037,27 @@ SEASTAR_TEST_CASE(test_old_timestamps_with_restrictions) {
         }
 
         eventually([&] {
-        auto msg = e.execute_cql("select * from vcf").get0();
+        auto msg = e.execute_cql("select * from vcf").get();
         assert_that(msg).is_rows().with_size(2);
-        msg = e.execute_cql("select c from vcf where val = 'baz'").get0();
+        msg = e.execute_cql("select c from vcf where val = 'baz'").get();
         assert_that(msg).is_rows().with_rows({ {{int32_type->decompose(0)}}, {{int32_type->decompose(1)}} });
         });
 
         // Make sure an old TS does nothing
         e.execute_cql("update cf using timestamp 100 set val = 'bar' where k = 0 and c = 1").get();
         eventually([&] {
-        auto msg = e.execute_cql("select c from vcf where val = 'baz'").get0();
+        auto msg = e.execute_cql("select c from vcf where val = 'baz'").get();
         assert_that(msg).is_rows().with_rows({ {{int32_type->decompose(0)}}, {{int32_type->decompose(1)}} });
-        msg = e.execute_cql("select c from vcf where val = 'bar'").get0();
+        msg = e.execute_cql("select c from vcf where val = 'bar'").get();
         assert_that(msg).is_rows().with_size(0);
         });
 
         // Latest TS
         e.execute_cql("update cf using timestamp 500 set val = 'bar' where k = 0 and c = 1").get();
         eventually([&] {
-        auto msg = e.execute_cql("select c from vcf where val = 'baz'").get0();
+        auto msg = e.execute_cql("select c from vcf where val = 'baz'").get();
         assert_that(msg).is_rows().with_rows({ {{int32_type->decompose(0)}} });
-        msg = e.execute_cql("select c from vcf where val = 'bar'").get0();
+        msg = e.execute_cql("select c from vcf where val = 'bar'").get();
         assert_that(msg).is_rows().with_rows({ {{int32_type->decompose(1)}} });
         });
     });
@@ -2072,7 +2072,7 @@ void do_complex_restricted_timestamp_update_test(cql_test_env& e, std::function<
     // Set initial values TS=0, matching the restriction and verify view
     e.execute_cql("insert into cf (p, c, v1, v2) values (0, 0, 1, 0) using timestamp 0").get();
     eventually([&] {
-    auto msg = e.execute_cql("select * from vcf").get0();
+    auto msg = e.execute_cql("select * from vcf").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {} }});
     });
 
@@ -2080,7 +2080,7 @@ void do_complex_restricted_timestamp_update_test(cql_test_env& e, std::function<
     e.execute_cql("update cf using timestamp 2 set v1 = 1 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get0();
+    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)} }});
     });
 
@@ -2088,7 +2088,7 @@ void do_complex_restricted_timestamp_update_test(cql_test_env& e, std::function<
     e.execute_cql("update cf using timestamp 3 set v1 = 0 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v2 from vcf where v1 = 0 and p = 0 and c = 0").get0();
+    auto msg = e.execute_cql("select v2 from vcf where v1 = 0 and p = 0 and c = 0").get();
     assert_that(msg).is_rows().with_size(1);
     });
 
@@ -2096,7 +2096,7 @@ void do_complex_restricted_timestamp_update_test(cql_test_env& e, std::function<
     e.execute_cql("update cf using timestamp 4 set v1 = 1 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v2, v3 from vcf where v1 = 1 and p = 0 and c = 0").get0();
+    auto msg = e.execute_cql("select v2, v3 from vcf where v1 = 1 and p = 0 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)}, {} }});
     });
 
@@ -2104,7 +2104,7 @@ void do_complex_restricted_timestamp_update_test(cql_test_env& e, std::function<
     e.execute_cql("update cf using timestamp 1 set v3 = 1 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v2, v3 from vcf where v1 = 1 and p = 0 and c = 0").get0();
+    auto msg = e.execute_cql("select v2, v3 from vcf where v1 = 1 and p = 0 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(0)}, {int32_type->decompose(1)} }});
     });
 
@@ -2112,7 +2112,7 @@ void do_complex_restricted_timestamp_update_test(cql_test_env& e, std::function<
     e.execute_cql("update cf using timestamp 2 set v2 = 2 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get0();
+    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(2)} }});
     });
 
@@ -2120,14 +2120,14 @@ void do_complex_restricted_timestamp_update_test(cql_test_env& e, std::function<
     e.execute_cql("update cf using timestamp 3 set v2 = 1 where p = 0 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get0();
+    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)} }});
     });
 
     // Tombstone v1
     e.execute_cql("delete from cf using timestamp 5 where p = 0 and c = 0").get();
     eventually([&] {
-    auto msg = e.execute_cql("select v2 from vcf").get0();
+    auto msg = e.execute_cql("select v2 from vcf").get();
     assert_that(msg).is_rows().with_size(0);
     });
 
@@ -2135,7 +2135,7 @@ void do_complex_restricted_timestamp_update_test(cql_test_env& e, std::function<
     e.execute_cql("insert into cf (p, c, v1) values (0, 0, 1) using timestamp 6").get();
     // Make sure v2 doesn't pop back in.
     eventually([&] {
-    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get0();
+    auto msg = e.execute_cql("select v2 from vcf where v1 = 1 and p = 0 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {} }});
     });
 
@@ -2149,7 +2149,7 @@ void do_complex_restricted_timestamp_update_test(cql_test_env& e, std::function<
     // Delete @ TS=0 (which should only delete v2)
     e.execute_cql("delete from cf using timestamp 0 where p = 1 and c = 0").get();
     eventually([&] {
-    auto msg = e.execute_cql("select * from vcf where v1 = 1 and p = 1 and c = 0").get0();
+    auto msg = e.execute_cql("select * from vcf where v1 = 1 and p = 1 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {}, {int32_type->decompose(0)} }});
     });
 
@@ -2158,14 +2158,14 @@ void do_complex_restricted_timestamp_update_test(cql_test_env& e, std::function<
     e.execute_cql("update cf using timestamp 3 set v1 = 1 where p = 1 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select * from vcf where v1 = 1 and p = 1 and c = 0").get0();
+    auto msg = e.execute_cql("select * from vcf where v1 = 1 and p = 1 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {}, {int32_type->decompose(0)} }});
     });
 
     e.execute_cql("update cf using timestamp 3 set v2 = 0 where p = 1 and c = 0").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select * from vcf where v1 = 1 and p = 1 and c = 0").get0();
+    auto msg = e.execute_cql("select * from vcf where v1 = 1 and p = 1 and c = 0").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(1)}, {int32_type->decompose(0)}, {int32_type->decompose(0)}, {int32_type->decompose(0)} }});
     });
 }
@@ -2196,7 +2196,7 @@ void complex_timestamp_with_base_pk_columns_in_view_pk_deletion_test(cql_test_en
     e.execute_cql("insert into cf (p, c, v1, v2) values (1, 2, 3, 4) using timestamp 1").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v1, v2, WRITETIME(v2) from vcf where p = 1 and c = 2").get0();
+    auto msg = e.execute_cql("select v1, v2, WRITETIME(v2) from vcf where p = 1 and c = 2").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(3)}, {int32_type->decompose(4)}, {long_type->decompose(1L)} }});
     });
 
@@ -2204,7 +2204,7 @@ void complex_timestamp_with_base_pk_columns_in_view_pk_deletion_test(cql_test_en
     e.execute_cql("delete from cf using timestamp 2 where p = 1 and c = 2").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select * from vcf").get0();
+    auto msg = e.execute_cql("select * from vcf").get();
     assert_that(msg).is_rows().with_size(0);
     });
 
@@ -2212,7 +2212,7 @@ void complex_timestamp_with_base_pk_columns_in_view_pk_deletion_test(cql_test_en
     e.execute_cql("insert into cf (p, c) values (1, 2) using timestamp 3").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select * from vcf").get0();
+    auto msg = e.execute_cql("select * from vcf").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(2)}, {int32_type->decompose(1)}, {}, {} }});
     });
 
@@ -2220,7 +2220,7 @@ void complex_timestamp_with_base_pk_columns_in_view_pk_deletion_test(cql_test_en
     e.execute_cql("insert into cf (p, c, v1, v2) values (1, 2, 3, 4) using timestamp 10").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v1, v2, WRITETIME(v2) from vcf where p = 1 and c = 2").get0();
+    auto msg = e.execute_cql("select v1, v2, WRITETIME(v2) from vcf where p = 1 and c = 2").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(3)}, {int32_type->decompose(4)}, {long_type->decompose(10L)} }});
     });
 
@@ -2228,7 +2228,7 @@ void complex_timestamp_with_base_pk_columns_in_view_pk_deletion_test(cql_test_en
     e.execute_cql("update cf using timestamp 20 set v2 = 5 where p = 1 and c = 2").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v1, v2, WRITETIME(v2) from vcf where p = 1 and c = 2").get0();
+    auto msg = e.execute_cql("select v1, v2, WRITETIME(v2) from vcf where p = 1 and c = 2").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(3)}, {int32_type->decompose(5)}, {long_type->decompose(20L)} }});
     });
 
@@ -2236,7 +2236,7 @@ void complex_timestamp_with_base_pk_columns_in_view_pk_deletion_test(cql_test_en
     e.execute_cql("delete from cf using timestamp 10 where p = 1 and c = 2").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v1, v2, WRITETIME(v2) from vcf").get0();
+    auto msg = e.execute_cql("select v1, v2, WRITETIME(v2) from vcf").get();
     assert_that(msg).is_rows().with_rows({{ { }, {int32_type->decompose(5)}, {long_type->decompose(20L)} }});
     });
 
@@ -2254,7 +2254,7 @@ void complex_timestamp_with_base_non_pk_columns_in_view_pk_deletion_test(cql_tes
     e.execute_cql("insert into cf (p, v1, v2) values (3, 1, 5) using timestamp 1").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v2, WRITETIME(v2) from vcf where v1 = 1 and p = 3").get0();
+    auto msg = e.execute_cql("select v2, WRITETIME(v2) from vcf where v1 = 1 and p = 3").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(5)}, {long_type->decompose(1L)} }});
     });
 
@@ -2262,7 +2262,7 @@ void complex_timestamp_with_base_non_pk_columns_in_view_pk_deletion_test(cql_tes
     e.execute_cql("delete from cf using timestamp 2 where p = 3").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select * from vcf").get0();
+    auto msg = e.execute_cql("select * from vcf").get();
     assert_that(msg).is_rows().with_size(0);
     });
 
@@ -2270,7 +2270,7 @@ void complex_timestamp_with_base_non_pk_columns_in_view_pk_deletion_test(cql_tes
     e.execute_cql("insert into cf (p, v1) values (3, 1) using timestamp 3").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select * from vcf").get0();
+    auto msg = e.execute_cql("select * from vcf").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(3)}, {} }});
     });
 
@@ -2278,7 +2278,7 @@ void complex_timestamp_with_base_non_pk_columns_in_view_pk_deletion_test(cql_tes
     e.execute_cql("insert into cf (p, v1, v2) values (3, 1, 4) using timestamp 2").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select * from vcf").get0();
+    auto msg = e.execute_cql("select * from vcf").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(3)}, {} }});
     });
 
@@ -2286,7 +2286,7 @@ void complex_timestamp_with_base_non_pk_columns_in_view_pk_deletion_test(cql_tes
     e.execute_cql("update cf using timestamp 3 set v2 = 4 where p = 3").get();
     maybe_flush();
     eventually([&] {
-    auto msg = e.execute_cql("select v1, p, v2, WRITETIME(v2) from vcf").get0();
+    auto msg = e.execute_cql("select v1, p, v2, WRITETIME(v2) from vcf").get();
     assert_that(msg).is_rows().with_rows({{ {int32_type->decompose(1)}, {int32_type->decompose(3)}, {int32_type->decompose(4)}, {long_type->decompose(3L)} }});
     });
 
@@ -2484,7 +2484,7 @@ SEASTAR_TEST_CASE(test_alter_table_with_updates) {
         e.execute_cql("alter table cf add z int;").get();
         e.execute_cql("update cf set v2 = 7 where p = 1 and c = 1").get();
         eventually([&] {
-            auto msg = e.execute_cql("select p, c, v1, v2 from vcf").get0();
+            auto msg = e.execute_cql("select p, c, v1, v2 from vcf").get();
             assert_that(msg).is_rows()
                     .with_size(1)
                     .with_row({
@@ -2509,14 +2509,14 @@ SEASTAR_TEST_CASE(test_unselected_column) {
                       "primary key (c, p)").get();
         e.execute_cql("insert into cf (p, c, x) values (1, 2, 3)").get();
         BOOST_TEST_PASSPOINT();
-        auto msg = e.execute_cql("select * from cf").get0();
+        auto msg = e.execute_cql("select * from cf").get();
         assert_that(msg).is_rows().with_size(1)
                 .with_row({{int32_type->decompose(1)}, {int32_type->decompose(2)}, {}, {int32_type->decompose(3)}, {}, {}});
         BOOST_TEST_PASSPOINT();
         // Check that when we ask for all of vcf's columns, we only get the
         // ones we actually selected - c and p, not x, y, z, or w:
         eventually([&] {
-            auto msg = e.execute_cql("select * from vcf").get0();
+            auto msg = e.execute_cql("select * from vcf").get();
             assert_that(msg).is_rows().with_size(1)
                     .with_row({{int32_type->decompose(2)}, {int32_type->decompose(1)}});
         });
@@ -2609,12 +2609,12 @@ SEASTAR_TEST_CASE(test_no_base_column_in_view_pk_complex_timestamp) {
         // update unselected, view row should be alive
         e.execute_cql("UPDATE t USING TIMESTAMP 1 SET e=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, {}, int32_type->decompose(1), {} },
             });
 
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, {} },
             });
@@ -2623,12 +2623,12 @@ SEASTAR_TEST_CASE(test_no_base_column_in_view_pk_complex_timestamp) {
         // remove unselected, add selected column, view row should be alive
         e.execute_cql("UPDATE t USING TIMESTAMP 2 SET e=null, b=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, int32_type->decompose(1), {}, {} },
             });
 
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, int32_type->decompose(1) },
             });
@@ -2637,20 +2637,20 @@ SEASTAR_TEST_CASE(test_no_base_column_in_view_pk_complex_timestamp) {
         // remove selected column, view row is removed
         e.execute_cql("UPDATE t USING TIMESTAMP 2 SET e=null, b=null WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_size(0);
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_size(0);
         });
 
         // update unselected with ts=3, view row should be alive
         e.execute_cql("UPDATE t USING TIMESTAMP 3 SET f=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, {}, {}, int32_type->decompose(1) },
             });
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, {} },
             });
@@ -2659,11 +2659,11 @@ SEASTAR_TEST_CASE(test_no_base_column_in_view_pk_complex_timestamp) {
         // insert livenesssInfo, view row should be alive
         e.execute_cql("INSERT INTO t(k,c) VALUES(1,1) USING TIMESTAMP 3").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, {}, {}, int32_type->decompose(1) },
             });
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, {} },
             });
@@ -2672,11 +2672,11 @@ SEASTAR_TEST_CASE(test_no_base_column_in_view_pk_complex_timestamp) {
         // remove unselected, view row should be alive because of base livenessInfo alive
         e.execute_cql("UPDATE t USING TIMESTAMP 3 SET f=null WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, {}, {}, {} },
             });
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, {} },
             });
@@ -2685,11 +2685,11 @@ SEASTAR_TEST_CASE(test_no_base_column_in_view_pk_complex_timestamp) {
         // add selected column, view row should be alive
         e.execute_cql("UPDATE t USING TIMESTAMP 3 SET a=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {}, {}, {} },
             });
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {} },
             });
@@ -2698,11 +2698,11 @@ SEASTAR_TEST_CASE(test_no_base_column_in_view_pk_complex_timestamp) {
         // update unselected, view row should be alive
         e.execute_cql("UPDATE t USING TIMESTAMP 4 SET f=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {}, {}, int32_type->decompose(1) },
             });
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {} },
             });
@@ -2711,12 +2711,12 @@ SEASTAR_TEST_CASE(test_no_base_column_in_view_pk_complex_timestamp) {
         // delete with ts=3, view row should be alive due to unselected@ts4
         e.execute_cql("DELETE FROM t USING TIMESTAMP 3 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, {}, {}, int32_type->decompose(1) },
             });
 
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, {} },
             });
@@ -2725,20 +2725,20 @@ SEASTAR_TEST_CASE(test_no_base_column_in_view_pk_complex_timestamp) {
         // remove unselected, view row should be removed
         e.execute_cql("UPDATE t USING TIMESTAMP 4 SET f=null WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_size(0);
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_size(0);
         });
 
         // add selected with ts=7, view row is alive
         e.execute_cql("UPDATE t USING TIMESTAMP 7 SET b=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, int32_type->decompose(1), {}, {} },
             });
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, int32_type->decompose(1) },
             });
@@ -2747,20 +2747,20 @@ SEASTAR_TEST_CASE(test_no_base_column_in_view_pk_complex_timestamp) {
         // remove selected with ts=7, view row is dead
         e.execute_cql("UPDATE t USING TIMESTAMP 7 SET b=null WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_size(0);
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_size(0);
         });
 
         // add selected with ts=5, view row is alive (selected column should not affects each other)
         e.execute_cql("UPDATE t USING TIMESTAMP 5 SET a=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {}, {}, {} },
             });
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {} },
             });
@@ -2769,11 +2769,11 @@ SEASTAR_TEST_CASE(test_no_base_column_in_view_pk_complex_timestamp) {
         // add selected with ttl=1
         e.execute_cql("UPDATE t USING TTL 30 SET a=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {}, {}, {} },
             });
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {} },
             });
@@ -2782,7 +2782,7 @@ SEASTAR_TEST_CASE(test_no_base_column_in_view_pk_complex_timestamp) {
         forward_jump_clocks(31s);
 
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_size(0);
         });
 
@@ -2790,11 +2790,11 @@ SEASTAR_TEST_CASE(test_no_base_column_in_view_pk_complex_timestamp) {
         e.execute_cql("UPDATE t USING TTL 30 SET f=1 WHERE k=1 AND c=1;").get();
 
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, {}, {}, int32_type->decompose(1) },
             });
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), {}, {} },
             });
@@ -2803,9 +2803,9 @@ SEASTAR_TEST_CASE(test_no_base_column_in_view_pk_complex_timestamp) {
         forward_jump_clocks(31s);
 
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_size(0);
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_size(0);
         });
     });
@@ -2823,19 +2823,19 @@ SEASTAR_TEST_CASE(test_base_column_in_view_pk_complex_timestamp) {
         // update unselected, view row should not be here
         e.execute_cql("UPDATE t USING TIMESTAMP 1 SET e=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_size(0);
         });
 
         // Set selected, view row should appear
         e.execute_cql("UPDATE t USING TIMESTAMP 1 SET a=1, e=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {}, int32_type->decompose(1), {} },
             });
 
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {} },
             });
@@ -2844,12 +2844,12 @@ SEASTAR_TEST_CASE(test_base_column_in_view_pk_complex_timestamp) {
         // remove unselected, add selected column, view row should be alive
         e.execute_cql("UPDATE t USING TIMESTAMP 2 SET e=null, b=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {}, {} },
             });
 
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1) },
             });
@@ -2858,20 +2858,20 @@ SEASTAR_TEST_CASE(test_base_column_in_view_pk_complex_timestamp) {
         // remove selected column, view row is removed
         e.execute_cql("UPDATE t USING TIMESTAMP 2 SET a=null, e=null, b=null WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_size(0);
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_size(0);
         });
 
         // update unselected with ts=3, view row should be alive
         e.execute_cql("UPDATE t USING TIMESTAMP 3 SET a=1, f=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {}, {}, int32_type->decompose(1) },
             });
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {} },
             });
@@ -2880,11 +2880,11 @@ SEASTAR_TEST_CASE(test_base_column_in_view_pk_complex_timestamp) {
         // insert livenesssInfo, view row should be alive
         e.execute_cql("INSERT INTO t(k,c,a) VALUES(1,1,1) USING TIMESTAMP 3").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {}, {}, int32_type->decompose(1) },
             });
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {} },
             });
@@ -2893,11 +2893,11 @@ SEASTAR_TEST_CASE(test_base_column_in_view_pk_complex_timestamp) {
         // remove unselected, view row should be alive because of base livenessInfo alive
         e.execute_cql("UPDATE t USING TIMESTAMP 3 SET a=1, f=null WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {}, {}, {} },
             });
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {} },
             });
@@ -2906,11 +2906,11 @@ SEASTAR_TEST_CASE(test_base_column_in_view_pk_complex_timestamp) {
         // update unselected, view row should be alive
         e.execute_cql("UPDATE t USING TIMESTAMP 4 SET a=1, f=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {}, {}, int32_type->decompose(1) },
             });
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {} },
             });
@@ -2919,12 +2919,12 @@ SEASTAR_TEST_CASE(test_base_column_in_view_pk_complex_timestamp) {
         // delete with ts=3, view row should be alive due to unselected@ts4
         e.execute_cql("DELETE FROM t USING TIMESTAMP 3 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {}, {}, int32_type->decompose(1) },
             });
 
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {} },
             });
@@ -2933,20 +2933,20 @@ SEASTAR_TEST_CASE(test_base_column_in_view_pk_complex_timestamp) {
         // remove unselected, view row should be removed
         e.execute_cql("UPDATE t USING TIMESTAMP 4 SET a=null, f=null WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_size(0);
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_size(0);
         });
 
         // add selected with ts=7, view row is alive
         e.execute_cql("UPDATE t USING TIMESTAMP 7 SET a=1, b=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {}, {} },
             });
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1) },
             });
@@ -2955,20 +2955,20 @@ SEASTAR_TEST_CASE(test_base_column_in_view_pk_complex_timestamp) {
         // remove selected with ts=7, view row is dead
         e.execute_cql("UPDATE t USING TIMESTAMP 7 SET a=null, b=null WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_size(0);
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_size(0);
         });
 
         // add selected with ttl=1
         e.execute_cql("UPDATE t USING TTL 30 SET a=1, b=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM t").get0();
+            msg = e.execute_cql("SELECT * FROM t").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), {}, {} },
             });
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1), int32_type->decompose(1) },
             });
@@ -2977,7 +2977,7 @@ SEASTAR_TEST_CASE(test_base_column_in_view_pk_complex_timestamp) {
         forward_jump_clocks(31s);
 
         eventually([&] {
-            msg = e.execute_cql("SELECT * FROM mv").get0();
+            msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_size(0);
         });
     });
@@ -2996,19 +2996,19 @@ SEASTAR_TEST_CASE(test_view_update_generating_writetime) {
             return e.db().map_reduce0([] (replica::database& local_db) {
                 const db::view::stats& local_stats = local_db.find_column_family("ks", "t").get_view_stats();
                 return local_stats.view_updates_pushed_local + local_stats.view_updates_pushed_remote;
-            }, 0, std::plus<int64_t>()).get0();
+            }, 0, std::plus<int64_t>()).get();
         };
 
         auto total_mv1_updates = [&] {
             return e.db().map_reduce0([] (replica::database& local_db) {
                 return local_db.find_column_family("ks", "mv1").get_stats().writes.hist.count;
-            }, 0, std::plus<int64_t>()).get0();
+            }, 0, std::plus<int64_t>()).get();
         };
 
         auto total_mv2_updates = [&] {
             return e.db().map_reduce0([] (replica::database& local_db) {
                 return local_db.find_column_family("ks", "mv2").get_stats().writes.hist.count;
-            }, 0, std::plus<int64_t>()).get0();
+            }, 0, std::plus<int64_t>()).get();
         };
 
         ::shared_ptr<cql_transport::messages::result_message> msg;
@@ -3018,7 +3018,7 @@ SEASTAR_TEST_CASE(test_view_update_generating_writetime) {
         e.execute_cql("UPDATE t USING TIMESTAMP 1 SET e=1 WHERE k=1 AND c=1;").get();
         e.execute_cql("UPDATE t USING TIMESTAMP 2 SET e=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT WRITETIME(e) FROM t").get0();
+            msg = e.execute_cql("SELECT WRITETIME(e) FROM t").get();
             assert_that(msg).is_rows().with_row({long_type->decompose(int64_t(2))});
             BOOST_REQUIRE_EQUAL(total_t_view_updates(), 1);
             BOOST_REQUIRE_EQUAL(total_mv1_updates(), 1);
@@ -3028,7 +3028,7 @@ SEASTAR_TEST_CASE(test_view_update_generating_writetime) {
         // Updating timestamp for a selected column will propagate for existing columns
         e.execute_cql("UPDATE t USING TIMESTAMP 3 SET b=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT WRITETIME(b) FROM t").get0();
+            msg = e.execute_cql("SELECT WRITETIME(b) FROM t").get();
             assert_that(msg).is_rows().with_row({long_type->decompose(int64_t(3))});
             BOOST_REQUIRE_EQUAL(total_t_view_updates(), 2);
             BOOST_REQUIRE_EQUAL(total_mv1_updates(), 2);
@@ -3037,7 +3037,7 @@ SEASTAR_TEST_CASE(test_view_update_generating_writetime) {
         // After instantiating view row a, selected column's timestamp from previous example will propagate to mv2
         e.execute_cql("UPDATE t USING TIMESTAMP 4 SET a=1 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT WRITETIME(b) FROM t").get0();
+            msg = e.execute_cql("SELECT WRITETIME(b) FROM t").get();
             assert_that(msg).is_rows().with_row({long_type->decompose(int64_t(3))});
             BOOST_REQUIRE_EQUAL(total_t_view_updates(), 4);
             BOOST_REQUIRE_EQUAL(total_mv1_updates(), 3);
@@ -3049,7 +3049,7 @@ SEASTAR_TEST_CASE(test_view_update_generating_writetime) {
         e.execute_cql("UPDATE t USING TIMESTAMP 5 SET f=40 WHERE k=1 AND c=1;").get();
         e.execute_cql("UPDATE t USING TIMESTAMP 6 SET f=40 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT WRITETIME(f) FROM t").get0();
+            msg = e.execute_cql("SELECT WRITETIME(f) FROM t").get();
             assert_that(msg).is_rows().with_row({long_type->decompose(int64_t(6))});
             BOOST_REQUIRE_EQUAL(total_t_view_updates(), 6);
             BOOST_REQUIRE_EQUAL(total_mv1_updates(), 4); // only one update for creation, update does not generate one
@@ -3060,7 +3060,7 @@ SEASTAR_TEST_CASE(test_view_update_generating_writetime) {
         e.execute_cql("UPDATE t USING TIMESTAMP 7 SET g=40 WHERE k=1 AND c=1;").get();
         e.execute_cql("UPDATE t USING TTL 10 AND TIMESTAMP 8 SET g=40 WHERE k=1 AND c=1;").get();
         eventually([&] {
-            msg = e.execute_cql("SELECT WRITETIME(g) FROM t").get0();
+            msg = e.execute_cql("SELECT WRITETIME(g) FROM t").get();
             assert_that(msg).is_rows().with_row({long_type->decompose(int64_t(8))});
             BOOST_REQUIRE_EQUAL(total_t_view_updates(), 10);
             BOOST_REQUIRE_EQUAL(total_mv1_updates(), 6); // two updates - one for creation, one for updating the TTL
@@ -3080,7 +3080,7 @@ SEASTAR_TEST_CASE(test_conflicting_batch) {
 
         e.execute_cql("INSERT INTO t (p, c, v) VALUES (0, 0, 0)").get();
         eventually([&] {
-            auto msg = e.execute_cql("SELECT * FROM mv").get0();
+            auto msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().with_rows({
                 { int32_type->decompose(0), int32_type->decompose(0), int32_type->decompose(0) },
             });
@@ -3095,13 +3095,13 @@ SEASTAR_TEST_CASE(test_conflicting_batch) {
             "  DELETE FROM t WHERE p = 0 AND c = 0; \n"
             "apply batch;").get();
 
-        auto msg = e.execute_cql("SELECT * FROM t").get0();
+        auto msg = e.execute_cql("SELECT * FROM t").get();
         assert_that(msg).is_rows().is_empty();
 
         BOOST_TEST_PASSPOINT();
 
         eventually([&] {
-            auto msg = e.execute_cql("SELECT * FROM mv").get0();
+            auto msg = e.execute_cql("SELECT * FROM mv").get();
             assert_that(msg).is_rows().is_empty();
         });
     });
@@ -3126,16 +3126,16 @@ SEASTAR_TEST_CASE(test_mv_allow_some_column_drops) {
         e.execute_cql("create materialized view mv as select c from cf where a is not null primary key (a, p)").get();
         e.execute_cql("insert into cf (p, a, b, c) VALUES (1, 2, 3, 4)").get();
         BOOST_TEST_PASSPOINT();
-        auto res = e.execute_cql("select * from cf").get0();
+        auto res = e.execute_cql("select * from cf").get();
         assert_that(res).is_rows().with_rows({
             {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(3)}, {int32_type->decompose(4)}}});
         e.execute_cql("alter table cf drop b").get();
         BOOST_TEST_PASSPOINT();
-        res = e.execute_cql("select * from cf").get0();
+        res = e.execute_cql("select * from cf").get();
         assert_that(res).is_rows().with_rows({
             {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(4)}}});
         eventually([&] {
-            auto res = e.execute_cql("select * from mv where a = 2").get0();
+            auto res = e.execute_cql("select * from mv where a = 2").get();
             assert_that(res).is_rows().with_rows({
                 {{int32_type->decompose(2)}, {int32_type->decompose(1)}, {int32_type->decompose(4)}}});
         });

--- a/test/boost/virtual_reader_test.cc
+++ b/test/boost/virtual_reader_test.cc
@@ -33,7 +33,7 @@ using namespace std::literals::chrono_literals;
 
 SEASTAR_TEST_CASE(test_query_size_estimates_virtual_table) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
-        auto ranges = db::size_estimates::test_get_local_ranges(e.local_db(), e.get_system_keyspace().local()).get0();
+        auto ranges = db::size_estimates::test_get_local_ranges(e.local_db(), e.get_system_keyspace().local()).get();
         auto start_token1 = utf8_type->to_string(ranges[3].start);
         auto start_token2 = utf8_type->to_string(ranges[5].start);
         auto end_token1 = utf8_type->to_string(ranges[3].end);
@@ -42,132 +42,132 @@ SEASTAR_TEST_CASE(test_query_size_estimates_virtual_table) {
         // Should not timeout.
         e.execute_cql("select * from system.size_estimates;").discard_result().get();
 
-        auto rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks';").get0();
+        auto rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks';").get();
         assert_that(rs).is_rows().with_size(0);
 
         e.execute_cql("create table cf1(pk text PRIMARY KEY, v int);").discard_result().get();
         e.execute_cql("create table cf2(pk text PRIMARY KEY, v int);").discard_result().get();
 
-        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks';").get0();
+        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks';").get();
         assert_that(rs).is_rows().with_size(512);
 
-        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' limit 100;").get0();
+        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' limit 100;").get();
         assert_that(rs).is_rows().with_size(100);
 
-        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name = 'cf1';").get0();
+        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name = 'cf1';").get();
         assert_that(rs).is_rows().with_size(256);
 
-        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name > 'cf1';").get0();
+        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name > 'cf1';").get();
         assert_that(rs).is_rows().with_size(256);
 
-        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name >= 'cf1';").get0();
+        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name >= 'cf1';").get();
         assert_that(rs).is_rows().with_size(512);
 
-        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name < 'cf2';").get0();
+        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name < 'cf2';").get();
         assert_that(rs).is_rows().with_size(256);
 
-        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name <= 'cf2';").get0();
+        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name <= 'cf2';").get();
         assert_that(rs).is_rows().with_size(512);
 
-        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name in ('cf1', 'cf2');").get0();
+        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name in ('cf1', 'cf2');").get();
         assert_that(rs).is_rows().with_size(512);
 
-        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name >= 'cf1' and table_name <= 'cf1';").get0();
+        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name >= 'cf1' and table_name <= 'cf1';").get();
         assert_that(rs).is_rows().with_size(256);
 
-        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name >= 'cf1' and table_name <= 'cf2';").get0();
+        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name >= 'cf1' and table_name <= 'cf2';").get();
         assert_that(rs).is_rows().with_size(512);
 
-        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name > 'cf1' and table_name < 'cf2';").get0();
+        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks' and table_name > 'cf1' and table_name < 'cf2';").get();
         assert_that(rs).is_rows().with_size(0);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start = '{}';", start_token1)).get0();
+                                      "and table_name = 'cf1' and range_start = '{}';", start_token1)).get();
         assert_that(rs).is_rows().with_size(1);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start >= '{}';", start_token1)).get0();
+                                      "and table_name = 'cf1' and range_start >= '{}';", start_token1)).get();
         assert_that(rs).is_rows().with_size(253);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start > '{}';", start_token1)).get0();
+                                      "and table_name = 'cf1' and range_start > '{}';", start_token1)).get();
         assert_that(rs).is_rows().with_size(252);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start <= '{}';", start_token1)).get0();
+                                      "and table_name = 'cf1' and range_start <= '{}';", start_token1)).get();
         assert_that(rs).is_rows().with_size(4);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start < '{}';", start_token1)).get0();
+                                      "and table_name = 'cf1' and range_start < '{}';", start_token1)).get();
         assert_that(rs).is_rows().with_size(3);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start >= '{}' and range_start <= '{}';", start_token1, start_token1)).get0();
+                                      "and table_name = 'cf1' and range_start >= '{}' and range_start <= '{}';", start_token1, start_token1)).get();
         assert_that(rs).is_rows().with_size(1);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start >= '{}' and range_start <= '{}';", start_token1, start_token2)).get0();
+                                      "and table_name = 'cf1' and range_start >= '{}' and range_start <= '{}';", start_token1, start_token2)).get();
         assert_that(rs).is_rows().with_size(3);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start > '{}' and range_start < '{}';", start_token1, start_token2)).get0();
+                                      "and table_name = 'cf1' and range_start > '{}' and range_start < '{}';", start_token1, start_token2)).get();
         assert_that(rs).is_rows().with_size(1);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start in ('{}', '{}');", start_token1, start_token2)).get0();
+                                      "and table_name = 'cf1' and range_start in ('{}', '{}');", start_token1, start_token2)).get();
         assert_that(rs).is_rows().with_size(2);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start > '{}' and range_start <= '{}';", start_token1, start_token2)).get0();
+                                      "and table_name = 'cf1' and range_start > '{}' and range_start <= '{}';", start_token1, start_token2)).get();
         assert_that(rs).is_rows().with_size(2);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start >= '{}' and range_start < '{}';", start_token1, start_token2)).get0();
+                                      "and table_name = 'cf1' and range_start >= '{}' and range_start < '{}';", start_token1, start_token2)).get();
         assert_that(rs).is_rows().with_size(2);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start = '{}' and range_end = '{}';", start_token1, end_token1)).get0();
+                                      "and table_name = 'cf1' and range_start = '{}' and range_end = '{}';", start_token1, end_token1)).get();
         assert_that(rs).is_rows().with_size(1);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start = '{}' and range_end >= '{}';", start_token1, end_token1)).get0();
+                                      "and table_name = 'cf1' and range_start = '{}' and range_end >= '{}';", start_token1, end_token1)).get();
         assert_that(rs).is_rows().with_size(1);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start = '{}' and range_end > '{}';", start_token1, end_token1)).get0();
+                                      "and table_name = 'cf1' and range_start = '{}' and range_end > '{}';", start_token1, end_token1)).get();
         assert_that(rs).is_rows().with_size(0);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start = '{}' and range_end <= '{}';", start_token1, end_token1)).get0();
+                                      "and table_name = 'cf1' and range_start = '{}' and range_end <= '{}';", start_token1, end_token1)).get();
         assert_that(rs).is_rows().with_size(1);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start = '{}' and range_end < '{}';", start_token1, end_token1)).get0();
+                                      "and table_name = 'cf1' and range_start = '{}' and range_end < '{}';", start_token1, end_token1)).get();
         assert_that(rs).is_rows().with_size(0);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start = '{}' and range_end >= '{}' and range_end <= '{}';", start_token1, end_token1, end_token1)).get0();
+                                      "and table_name = 'cf1' and range_start = '{}' and range_end >= '{}' and range_end <= '{}';", start_token1, end_token1, end_token1)).get();
         assert_that(rs).is_rows().with_size(1);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and table_name = 'cf1' and range_start = '{}' and range_end > '{}' and range_end < '{}';", start_token1, end_token1, end_token1)).get0();
+                                      "and table_name = 'cf1' and range_start = '{}' and range_end > '{}' and range_end < '{}';", start_token1, end_token1, end_token1)).get();
         assert_that(rs).is_rows().with_size(0);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and (table_name, range_start, range_end) = ('cf1', '{}', '{}');", start_token1, end_token1)).get0();
+                                      "and (table_name, range_start, range_end) = ('cf1', '{}', '{}');", start_token1, end_token1)).get();
         assert_that(rs).is_rows().with_size(1);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and (table_name, range_start, range_end) >= ('cf1', '{}', '{}') and (table_name) <= ('cf2');", start_token1, end_token1)).get0();
+                                      "and (table_name, range_start, range_end) >= ('cf1', '{}', '{}') and (table_name) <= ('cf2');", start_token1, end_token1)).get();
         assert_that(rs).is_rows().with_size(509);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
                                       "and (table_name, range_start, range_end) >= ('cf1', '{}', '{}') "
-                                      "and (table_name, range_start) <= ('cf2', '{}');", start_token1, end_token1, start_token2)).get0();
+                                      "and (table_name, range_start) <= ('cf2', '{}');", start_token1, end_token1, start_token2)).get();
         assert_that(rs).is_rows().with_size(259);
 
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
-                                      "and (table_name, range_start) < ('cf2', '{}');", start_token1)).get0();
+                                      "and (table_name, range_start) < ('cf2', '{}');", start_token1)).get();
         assert_that(rs).is_rows().with_size(259);
     });
 }
@@ -187,34 +187,34 @@ SEASTAR_TEST_CASE(test_query_view_built_progress_virtual_table) {
         e.get_system_keyspace().local().register_view_for_building("ks", "v6", rand()).get();
         e.get_system_keyspace().local().remove_view_build_progress_across_all_shards("ks", "v5").get();
         e.get_system_keyspace().local().remove_view_build_progress_across_all_shards("ks", "v6").get();
-        auto rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks'").get0();
+        auto rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks'").get();
         assert_that(rs).is_rows().with_rows_ignore_order({
                 { {utf8_type->decompose(sstring("ks"))}, {utf8_type->decompose(sstring("v1"))}, {int32_type->decompose(0)}, { } },
                 { {utf8_type->decompose(sstring("ks"))}, {utf8_type->decompose(sstring("v2"))}, {int32_type->decompose(0)}, { } },
                 { {utf8_type->decompose(sstring("ks"))}, {utf8_type->decompose(sstring("v3"))}, {int32_type->decompose(0)}, {utf8_type->decompose(next_token_str)} },
                 { {utf8_type->decompose(sstring("ks"))}, {utf8_type->decompose(sstring("v4"))}, {int32_type->decompose(0)}, {utf8_type->decompose(next_token_str)} }
         });
-        rs = e.execute_cql("select * from system.views_builds_in_progress").get0();
+        rs = e.execute_cql("select * from system.views_builds_in_progress").get();
         assert_that(rs).is_rows().with_size(4);
-        rs = e.execute_cql("select * from system.views_builds_in_progress limit 1").get0();
+        rs = e.execute_cql("select * from system.views_builds_in_progress limit 1").get();
         assert_that(rs).is_rows().with_size(1);
-        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name = 'v2'").get0();
+        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name = 'v2'").get();
         assert_that(rs).is_rows().with_size(1);
-        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name > 'v2'").get0();
+        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name > 'v2'").get();
         assert_that(rs).is_rows().with_size(2);
-        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name >= 'v2'").get0();
+        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name >= 'v2'").get();
         assert_that(rs).is_rows().with_size(3);
-        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name  < 'v2'").get0();
+        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name  < 'v2'").get();
         assert_that(rs).is_rows().with_size(1);
-        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name  <= 'v2'").get0();
+        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name  <= 'v2'").get();
         assert_that(rs).is_rows().with_size(2);
-        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name in ('v1', 'v2', 'v3')").get0();
+        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name in ('v1', 'v2', 'v3')").get();
         assert_that(rs).is_rows().with_size(3);
-        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name >= 'v2' and view_name  <= 'v2'").get0();
+        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name >= 'v2' and view_name  <= 'v2'").get();
         assert_that(rs).is_rows().with_size(1);
-        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name >= 'v2' and view_name  <= 'v3'").get0();
+        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name >= 'v2' and view_name  <= 'v3'").get();
         assert_that(rs).is_rows().with_size(2);
-        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name > 'v1' and view_name  < 'v2'").get0();
+        rs = e.execute_cql("select * from system.views_builds_in_progress where keyspace_name = 'ks' and view_name > 'v1' and view_name  < 'v2'").get();
         assert_that(rs).is_rows().with_size(0);
     });
 }
@@ -231,18 +231,18 @@ SEASTAR_TEST_CASE(test_query_built_indexes_virtual_table) {
         e.execute_cql("create index idx on cf (v)").get();
         f1.get();
         f2.get();
-        auto rs = e.execute_cql("select * from system.built_views").get0();
+        auto rs = e.execute_cql("select * from system.built_views").get();
         assert_that(rs).is_rows().with_rows_ignore_order({
                 { {utf8_type->decompose(sstring("ks"))}, {utf8_type->decompose(idx)} },
                 { {utf8_type->decompose(sstring("ks"))}, {"vcf"} },
         });
-        rs = e.execute_cql("select * from system.\"IndexInfo\"").get0();
+        rs = e.execute_cql("select * from system.\"IndexInfo\"").get();
         assert_that(rs).is_rows().with_rows_ignore_order({
                 { {utf8_type->decompose(sstring("ks"))}, {utf8_type->decompose(sstring("idx"))} },
         });
-        rs = e.execute_cql("select * from system.\"IndexInfo\" where table_name = 'ks' and index_name = 'idx'").get0();
+        rs = e.execute_cql("select * from system.\"IndexInfo\" where table_name = 'ks' and index_name = 'idx'").get();
         assert_that(rs).is_rows().with_size(1);
-        rs = e.execute_cql("select * from system.\"IndexInfo\" where table_name = 'ks' and index_name = 'vcf'").get0();
+        rs = e.execute_cql("select * from system.\"IndexInfo\" where table_name = 'ks' and index_name = 'vcf'").get();
         assert_that(rs).is_rows().with_size(0);
     });
 }

--- a/test/boost/virtual_table_test.cc
+++ b/test/boost/virtual_table_test.cc
@@ -64,7 +64,7 @@ SEASTAR_TEST_CASE(test_set_cell) {
 
 SEASTAR_THREAD_TEST_CASE(test_system_config_table_read) {
     do_with_cql_env_thread([] (cql_test_env& env) {
-        auto res = env.execute_cql("SELECT * FROM system.config WHERE name = 'partitioner';").get0();
+        auto res = env.execute_cql("SELECT * FROM system.config WHERE name = 'partitioner';").get();
         assert_that(res).is_rows().with_size(1).with_row({
             { utf8_type->decompose(sstring("partitioner")) },
             { utf8_type->decompose(sstring("default")) },

--- a/test/lib/cql_assertions.cc
+++ b/test/lib/cql_assertions.cc
@@ -190,9 +190,9 @@ shared_ptr<cql_transport::messages::result_message> cquery_nofail(
         cql_test_env& env, sstring_view query, std::unique_ptr<cql3::query_options>&& qo, const seastar::compat::source_location& loc) {
     try {
         if (qo) {
-            return env.execute_cql(query, std::move(qo)).get0();
+            return env.execute_cql(query, std::move(qo)).get();
         } else {
-            return env.execute_cql(query).get0();
+            return env.execute_cql(query).get();
         }
     } catch (...) {
         BOOST_FAIL(format("query '{}' failed: {}\n{}:{}: originally from here",
@@ -232,7 +232,7 @@ void require_rows(cql_test_env& e,
                   const std::vector<std::vector<bytes_opt>>& expected,
                   const seastar::compat::source_location& loc) {
     try {
-        assert_that(e.execute_prepared(id, values).get0()).is_rows().with_rows_ignore_order(expected);
+        assert_that(e.execute_prepared(id, values).get()).is_rows().with_rows_ignore_order(expected);
     } catch (const std::exception& e) {
         BOOST_FAIL(format("execute_prepared failed: {}\n{}:{}: originally from here",
                           e.what(), loc.file_name(), loc.line()));

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -490,7 +490,7 @@ private:
             auto notify_set = init_configurables
                 ? configurable::init_all(*cfg, init_configurables->extensions, service_set(
                     _db, _ss, _mm, _proxy, _feature_service, _ms, _qp, _batchlog_manager
-                )).get0()
+                )).get()
                 : configurable::notify_set{}
                 ;
 
@@ -597,7 +597,7 @@ private:
             db::view::node_update_backlog b(smp::count, 10ms);
             scheduling_group_key_config sg_conf =
                     make_scheduling_group_key_config<service::storage_proxy_stats::stats>();
-            _proxy.start(std::ref(_db), spcfg, std::ref(b), scheduling_group_key_create(sg_conf).get0(), std::ref(_feature_service), std::ref(_token_metadata), std::ref(_erm_factory)).get();
+            _proxy.start(std::ref(_db), spcfg, std::ref(b), scheduling_group_key_create(sg_conf).get(), std::ref(_feature_service), std::ref(_token_metadata), std::ref(_erm_factory)).get();
             auto stop_proxy = defer([this] { _proxy.stop().get(); });
 
             _cql_config.start(cql3::cql_config::default_tag{}).get();
@@ -638,7 +638,7 @@ private:
 
             auto host_id = cfg_in.host_id;
             if (!host_id) {
-                auto linfo = _sys_ks.local().load_local_info().get0();
+                auto linfo = _sys_ks.local().load_local_info().get();
                 if (!linfo.host_id) {
                     linfo.host_id = locator::host_id::create_random_id();
                 }
@@ -961,7 +961,7 @@ private:
                         _auth_service.local(),
                         testing_superuser,
                         config,
-                        auth::authentication_options()).get0();
+                        auth::authentication_options()).get();
             } catch (const auth::role_already_exists&) {
                 // The default user may already exist if this `cql_test_env` is starting with previously populated data.
             }

--- a/test/lib/eventually.hh
+++ b/test/lib/eventually.hh
@@ -22,7 +22,7 @@ void eventually(noncopyable_function<void ()> f, size_t max_attempts = 17) {
             break;
         } catch (...) {
             if (++attempts < max_attempts) {
-                sleep(std::chrono::milliseconds(1 << attempts)).get0();
+                sleep(std::chrono::milliseconds(1 << attempts)).get();
             } else {
                 throw;
             }
@@ -40,7 +40,7 @@ bool eventually_true(noncopyable_function<bool ()> f) {
         }
 
         if (++attempts < max_attempts) {
-            seastar::sleep(std::chrono::milliseconds(1 << attempts)).get0();
+            seastar::sleep(std::chrono::milliseconds(1 << attempts)).get();
         } else {
             return false;
         }

--- a/test/lib/index_reader_assertions.hh
+++ b/test/lib/index_reader_assertions.hh
@@ -45,7 +45,7 @@ public:
 
             sstables::clustered_index_cursor* cur = _r->current_clustered_cursor();
             std::optional<sstables::promoted_index_block_position> prev_end;
-            while (auto ei_opt = cur->next_entry().get0()) {
+            while (auto ei_opt = cur->next_entry().get()) {
                 sstables::clustered_index_cursor::entry_info& ei = *ei_opt;
                 if (prev_end && pos_cmp(ei.start, sstables::to_view(*prev_end))) {
                     BOOST_FAIL(format("Index blocks are not monotonic: {} > {}", *prev_end, ei.start));

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -390,7 +390,7 @@ static void test_streamed_mutation_forwarding_is_consistent_with_slicing(tests::
         }
         auto fwd_m = forwardable_reader_to_mutation(std::move(fwd_reader), position_ranges);
 
-        mutation_opt sliced_m = read_mutation_from_flat_mutation_reader(sliced_reader).get0();
+        mutation_opt sliced_m = read_mutation_from_flat_mutation_reader(sliced_reader).get();
         BOOST_REQUIRE(bool(sliced_m));
         assert_that(*sliced_m).is_equal_to(fwd_m, slice_with_ranges.row_ranges(*m.schema(), m.key()));
     }
@@ -1587,7 +1587,7 @@ void test_reader_conversions(tests::reader_concurrency_semaphore_wrapper& semaph
         {
             auto rd = ms.make_fragment_v1_stream(m.schema(), semaphore.make_permit());
             auto close_rd = deferred_close(rd);
-            match_compacted_mutation(read_mutation_from_flat_mutation_reader(rd).get0(), m_compacted, query_time);
+            match_compacted_mutation(read_mutation_from_flat_mutation_reader(rd).get(), m_compacted, query_time);
         }
     });
 }

--- a/test/manual/enormous_table_scan_test.cc
+++ b/test/manual/enormous_table_scan_test.cc
@@ -220,7 +220,7 @@ SEASTAR_TEST_CASE(scan_enormous_table_test) {
         do {
             qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{10000, paging_state, {}, api::new_timestamp()});
-            msg = e.execute_cql("select * from enormous_table;", std::move(qo)).get0();
+            msg = e.execute_cql("select * from enormous_table;", std::move(qo)).get();
             rows_fetched += count_rows_fetched(msg);
             paging_state = extract_paging_state(msg);
             if (rows_fetched >= fetched_rows_log_counter){
@@ -244,7 +244,7 @@ SEASTAR_TEST_CASE(count_enormous_table_test) {
         auto& db = e.local_db();
         db.find_column_family("ks", "enormous_table").set_virtual_reader(mutation_source(enormous_virtual_reader()));
 
-        auto msg = e.execute_cql("select count(*) from enormous_table").get0();
+        auto msg = e.execute_cql("select count(*) from enormous_table").get();
         assert_that(msg).is_rows().with_rows({{{long_type->decompose(int64_t(enormous_table_reader::CLUSTERING_ROW_COUNT))}}});
     });
 }

--- a/test/manual/row_locker_test.cc
+++ b/test/manual/row_locker_test.cc
@@ -50,27 +50,27 @@ SEASTAR_TEST_CASE(test_nonblock_exclusive) {
         row_locker rl(s);
         auto pk = make_pk(s, "pk1");
         auto ck = make_ck(s, "ck1") ;
-        auto lock = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        auto lock = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         auto ignore = [] (auto) { };
         // move out the lock object, thereby releasing the lock
         ignore(std::move(lock));
         // after we released the lock, we can take it again.
-        lock = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         ignore(std::move(lock));
         // now do the same, but locking an entire partition. Should
         // be fine after we unlocked the row.
-        lock = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         ignore(std::move(lock));
-        lock = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         ignore(std::move(lock));
         // After we unlock the partition, we can lock the row
-        lock = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         ignore(std::move(lock));
         // Check that we can hold an exclusive lock for two rows in the
         // same partition, and it doesn't hang.
         auto ck2 = make_ck(s, "ck2") ;
-        lock = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
-        auto lock2 = rl.lock_ck(pk, ck2, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
+        auto lock2 = rl.lock_ck(pk, ck2, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         ignore(std::move(lock));
         ignore(std::move(lock2));
         BOOST_REQUIRE(rl.empty() == true);
@@ -88,39 +88,39 @@ SEASTAR_TEST_CASE(test_nonblock_shared) {
         auto pk = make_pk(s, "pk1");
         auto ck = make_ck(s, "ck1") ;
         // Check that we can lock the same row multiple times with a shared lock:
-        auto lock1 = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats).get0();
-        auto lock2 = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats).get0();
-        auto lock3 = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        auto lock1 = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats).get();
+        auto lock2 = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats).get();
+        auto lock3 = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats).get();
         auto ignore = [] (auto) { };
         ignore(std::move(lock1));
         ignore(std::move(lock2));
         ignore(std::move(lock3));
         // Check that after unlocking, we can lock again. Also for exclusive lock:
-        lock1 = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock1 = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats).get();
         ignore(std::move(lock1));
-        lock1 = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock1 = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         ignore(std::move(lock1));
         // Same test but for the partition lock level
-        lock1 = rl.lock_pk(pk, false, db::timeout_clock::time_point::max(), row_locker_stats).get0();
-        lock2 = rl.lock_pk(pk, false, db::timeout_clock::time_point::max(), row_locker_stats).get0();
-        lock3 = rl.lock_pk(pk, false, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock1 = rl.lock_pk(pk, false, db::timeout_clock::time_point::max(), row_locker_stats).get();
+        lock2 = rl.lock_pk(pk, false, db::timeout_clock::time_point::max(), row_locker_stats).get();
+        lock3 = rl.lock_pk(pk, false, db::timeout_clock::time_point::max(), row_locker_stats).get();
         ignore(std::move(lock1));
         ignore(std::move(lock2));
         ignore(std::move(lock3));
-        lock1 = rl.lock_pk(pk, false, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock1 = rl.lock_pk(pk, false, db::timeout_clock::time_point::max(), row_locker_stats).get();
         ignore(std::move(lock1));
-        lock1 = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock1 = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         ignore(std::move(lock1));
         // Check that we can hold a shared lock for a partition and a row
         // in it concurrently.
-        lock1 = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats).get0();
-        lock2 = rl.lock_pk(pk, false, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock1 = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats).get();
+        lock2 = rl.lock_pk(pk, false, db::timeout_clock::time_point::max(), row_locker_stats).get();
         ignore(std::move(lock1));
         ignore(std::move(lock2));
         // Check that the above is fine also if the row lock is exclusive
         // (the "exclusivity" is only for the row).
-        lock1 = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
-        lock2 = rl.lock_pk(pk, false, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock1 = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
+        lock2 = rl.lock_pk(pk, false, db::timeout_clock::time_point::max(), row_locker_stats).get();
         ignore(std::move(lock1));
         ignore(std::move(lock2));
         BOOST_REQUIRE(rl.empty() == true);
@@ -140,7 +140,7 @@ SEASTAR_TEST_CASE(test_nonblock_many) {
         for (int i = 0; i < N; i++) {
             if (i % 2) {
                 // lock the entire partition
-                auto lock = rl.lock_pk(make_pk(s, to_sstring(i)), true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+                auto lock = rl.lock_pk(make_pk(s, to_sstring(i)), true, db::timeout_clock::time_point::max(), row_locker_stats).get();
                 if (i % 4) {
                     // drop half of locks immediately, half kept until end.
                     locks.push_back(std::move(lock));
@@ -149,7 +149,7 @@ SEASTAR_TEST_CASE(test_nonblock_many) {
                 // lock M rows, drop half of the locks immediately, keep half
                 // until the end.
                 for (int j = 0; j < M; j++) {
-                    auto lock = rl.lock_ck(make_pk(s, to_sstring(i)), make_ck(s, to_sstring(j)), true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+                    auto lock = rl.lock_ck(make_pk(s, to_sstring(i)), make_ck(s, to_sstring(j)), true, db::timeout_clock::time_point::max(), row_locker_stats).get();
                     if (j % 2) {
                         locks.push_back(std::move(lock));
                     }
@@ -180,21 +180,21 @@ SEASTAR_TEST_CASE(test_nonblock_upgrade) {
         auto s = make_schema();
         auto s2 = make_alternative_schema();
         row_locker rl(s);
-        auto lock = rl.lock_ck(make_pk(s, "pk1"), make_ck(s, "ck1"), true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        auto lock = rl.lock_ck(make_pk(s, "pk1"), make_ck(s, "ck1"), true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         auto ignore = [] (auto) { };
         ignore(std::move(lock));
         rl.upgrade(s2);
         // verify that the row_locker does not not keep a reference to s any
         // more, so the only remaining reference is ours.
         BOOST_REQUIRE(s.use_count() == 1);
-        lock = rl.lock_ck(make_pk(s2, "pk1"), make_ck(s2, "ck1"), true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock = rl.lock_ck(make_pk(s2, "pk1"), make_ck(s2, "ck1"), true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         ignore(std::move(lock));
         // Same test, but upgrade the schema while a lock is still taken
-        lock = rl.lock_ck(make_pk(s2, "pk1"), make_ck(s2, "ck1"), true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock = rl.lock_ck(make_pk(s2, "pk1"), make_ck(s2, "ck1"), true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         rl.upgrade(s);
         BOOST_REQUIRE(s2.use_count() == 1);
         ignore(std::move(lock));
-        lock = rl.lock_ck(make_pk(s, "pk1"), make_ck(s, "ck1"), true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock = rl.lock_ck(make_pk(s, "pk1"), make_ck(s, "ck1"), true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         ignore(std::move(lock));
         BOOST_REQUIRE(rl.empty() == true);
     });
@@ -213,15 +213,15 @@ SEASTAR_TEST_CASE(test_block_exclusive_twice_row) {
         row_locker rl(s);
         auto pk = make_pk(s, "pk1");
         auto ck = make_ck(s, "ck1") ;
-        auto lock = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        auto lock = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         // If we try to lock again *cannot* be ready now. It will
-        // become ready (and get0() won't hang) when we drop
+        // become ready (and get() won't hang) when we drop
         // the first lock
         auto flock1 = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats);
         BOOST_REQUIRE(!flock1.available());
         auto ignore = [] (auto) { };
         ignore(std::move(lock));
-        flock1.get0();
+        flock1.get();
     });
 }
 // Trying to lock the same partition a second time with an exclusive lock should
@@ -231,12 +231,12 @@ SEASTAR_TEST_CASE(test_block_exclusive_twice_partition) {
         auto s = make_schema();
         row_locker rl(s);
         auto pk = make_pk(s, "pk1");
-        auto lock = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        auto lock = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         auto flock1 = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats);
         BOOST_REQUIRE(!flock1.available());
         auto ignore = [] (auto) { };
         ignore(std::move(lock));
-        flock1.get0();
+        flock1.get();
     });
 }
 // Trying to shared lock together with an exclusive lock (in either order)
@@ -248,18 +248,18 @@ SEASTAR_TEST_CASE(test_block_exclusive_and_shared_row) {
         auto pk = make_pk(s, "pk1");
         auto ck = make_ck(s, "ck1") ;
         // shared lock first, exclusive lock second:
-        auto lock = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        auto lock = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats).get();
         auto flock1 = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats);
         BOOST_REQUIRE(!flock1.available());
         auto ignore = [] (auto) { };
         ignore(std::move(lock));
-        flock1.get0();
+        flock1.get();
         // exclusive lock first, shared lock second
-        lock = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         flock1 = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats);
         BOOST_REQUIRE(!flock1.available());
         ignore(std::move(lock));
-        flock1.get0();
+        flock1.get();
     });
 }
 SEASTAR_TEST_CASE(test_block_exclusive_and_shared_partition) {
@@ -267,17 +267,17 @@ SEASTAR_TEST_CASE(test_block_exclusive_and_shared_partition) {
         auto s = make_schema();
         row_locker rl(s);
         auto pk = make_pk(s, "pk1");
-        auto lock = rl.lock_pk(pk, false, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        auto lock = rl.lock_pk(pk, false, db::timeout_clock::time_point::max(), row_locker_stats).get();
         auto flock1 = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats);
         BOOST_REQUIRE(!flock1.available());
         auto ignore = [] (auto) { };
         ignore(std::move(lock));
-        flock1.get0();
-        lock = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        flock1.get();
+        lock = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         flock1 = rl.lock_pk(pk, false, db::timeout_clock::time_point::max(), row_locker_stats);
         BOOST_REQUIRE(!flock1.available());
         ignore(std::move(lock));
-        flock1.get0();
+        flock1.get();
     });
 }
 // Trying to lock the a row either exclusive or shared while its partition
@@ -288,28 +288,28 @@ SEASTAR_TEST_CASE(test_block_partition_row) {
         row_locker rl(s);
         auto pk = make_pk(s, "pk1");
         auto ck = make_ck(s, "ck1") ;
-        auto lock = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        auto lock = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         auto flock1 = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats); // try exclusive row lock
         BOOST_REQUIRE(!flock1.available());
         auto ignore = [] (auto) { };
         ignore(std::move(lock));
-        flock1.get0();
-        lock = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        flock1.get();
+        lock = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         flock1 = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats); // also try shared row lock
         BOOST_REQUIRE(!flock1.available());
         ignore(std::move(lock));
-        flock1.get0();
+        flock1.get();
         // Now try the same in opposite order (the row lock first, then the
         // partition lock).
-        lock = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        lock = rl.lock_ck(pk, ck, true, db::timeout_clock::time_point::max(), row_locker_stats).get();
         flock1 = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats);
         BOOST_REQUIRE(!flock1.available());
         ignore(std::move(lock));
-        flock1.get0();
-        lock = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats).get0();
+        flock1.get();
+        lock = rl.lock_ck(pk, ck, false, db::timeout_clock::time_point::max(), row_locker_stats).get();
         flock1 = rl.lock_pk(pk, true, db::timeout_clock::time_point::max(), row_locker_stats);
         BOOST_REQUIRE(!flock1.available());
         ignore(std::move(lock));
-        flock1.get0();
+        flock1.get();
     });
 }

--- a/test/manual/sstable_scan_footprint_test.cc
+++ b/test/manual/sstable_scan_footprint_test.cc
@@ -123,8 +123,8 @@ public:
             return make_ready_future<>();
         }
         return seastar::async([this] {
-            auto f = open_file_dma(_params->output_file, open_flags::create | open_flags::wo).get0();
-            auto os = make_file_output_stream(f, file_output_stream_options{}).get0();
+            auto f = open_file_dma(_params->output_file, open_flags::create | open_flags::wo).get();
+            auto os = make_file_output_stream(f, file_output_stream_options{}).get();
 
             {
                 const auto header = "lsa_used_memory,lsa_free_memory,non_lsa_used_memory,non_lsa_free_memory,reads_memory_consumption,reads\n";

--- a/test/perf/perf.hh
+++ b/test/perf/perf.hh
@@ -201,7 +201,7 @@ std::vector<Res> time_parallel_ex(Func func, unsigned concurrency_per_core, int 
             exec.stop().get();
         });
         auto stats = exec.map_reduce0(std::mem_fn(&executor<Func>::run),
-                executor_shard_stats(), std::plus<executor_shard_stats>()).get0();
+                executor_shard_stats(), std::plus<executor_shard_stats>()).get();
         auto end = clk::now();
         auto duration = std::chrono::duration<double>(end - start).count();
 

--- a/test/perf/perf_cache_eviction.cc
+++ b/test/perf/perf_cache_eviction.cc
@@ -141,7 +141,7 @@ int main(int argc, char** argv) {
                 if (!reads_enabled) {
                     return;
                 }
-                auto id = env.prepare("select * from ks.cf where pk = 'key1' limit 10;").get0();
+                auto id = env.prepare("select * from ks.cf where pk = 'key1' limit 10;").get();
                 while (!cancelled) {
                     auto t0 = clock::now();
                     env.execute_prepared(id, {}).get();

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -756,7 +756,7 @@ public:
 
 static
 uint64_t consume_all(flat_mutation_reader_v2& rd) {
-    return rd.consume(counting_consumer()).get0();
+    return rd.consume(counting_consumer()).get();
 }
 
 static
@@ -771,7 +771,7 @@ uint64_t consume_all_with_next_partition(flat_mutation_reader_v2& rd) {
 }
 
 static void assert_partition_start(flat_mutation_reader_v2& rd) {
-    auto mfopt = rd().get0();
+    auto mfopt = rd().get();
     assert(mfopt);
     assert(mfopt->is_partition_start());
 }
@@ -1165,7 +1165,7 @@ static
 table_config read_config(cql_test_env& env, const sstring& name) {
     auto msg = std::invoke([&] {
         try {
-            return env.execute_cql(format("select n_rows, value_size from ks.config where name = '{}'", name)).get0();
+            return env.execute_cql(format("select n_rows, value_size from ks.config where name = '{}'", name)).get();
         } catch (const exceptions::invalid_request_exception& e) {
             throw std::runtime_error(fmt::format("Could not read config (exception: `{}`). Did you run --populate ?", e.what()));
         }

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -136,7 +136,7 @@ static std::vector<perf_result> test_read(cql_test_env& env, test_config& cfg) {
     if (!cfg.timeout.empty()) {
         query += " using timeout " + cfg.timeout;
     }
-    auto id = env.prepare(query).get0();
+    auto id = env.prepare(query).get();
     return time_parallel([&env, &cfg, id] {
             bytes key = make_random_key(cfg);
             return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}).discard_result();
@@ -155,7 +155,7 @@ static std::vector<perf_result> test_write(cql_test_env& env, test_config& cfg) 
             "\"C3\" = 0x62bcb1dbc0ff953abc703bcb63ea954f437064c0c45366799658bd6b91d0f92908d7,"
             "\"C4\" = 0x222fcbe31ffa1e689540e1499b87fa3f9c781065fccd10e4772b4c7039c2efd0fb27 "
             "WHERE \"KEY\" = ?", usings);
-    auto id = env.prepare(query).get0();
+    auto id = env.prepare(query).get();
     return time_parallel([&env, &cfg, id] {
             bytes key = make_random_key(cfg);
             return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}).discard_result();
@@ -169,7 +169,7 @@ static std::vector<perf_result> test_delete(cql_test_env& env, test_config& cfg)
         usings += "USING TIMEOUT " + cfg.timeout;
     }
     sstring query = format("DELETE \"C0\", \"C1\", \"C2\", \"C3\", \"C4\" FROM cf {}WHERE \"KEY\" = ?", usings);
-    auto id = env.prepare(query).get0();
+    auto id = env.prepare(query).get();
     return time_parallel([&env, &cfg, id] {
             bytes key = make_random_key(cfg);
             return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}).discard_result();
@@ -188,7 +188,7 @@ static std::vector<perf_result> test_counter_update(cql_test_env& env, test_conf
             "\"C3\" = \"C3\" + 4,"
             "\"C4\" = \"C4\" + 5 "
             "WHERE \"KEY\" = ?", usings);
-    auto id = env.prepare(query).get0();
+    auto id = env.prepare(query).get();
     return time_parallel([&env, &cfg, id] {
             bytes key = make_random_key(cfg);
             return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}).discard_result();

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -240,7 +240,7 @@ public:
                 descriptor.replacer = sstables::replacer_fn_no_op();
                 auto cdata = compaction_manager::create_compaction_data();
                 compaction_progress_monitor progress_monitor;
-                auto ret = sstables::compact_sstables(std::move(descriptor), cdata, cf->as_table_state(), progress_monitor).get0();
+                auto ret = sstables::compact_sstables(std::move(descriptor), cdata, cf->as_table_state(), progress_monitor).get();
                 auto end = perf_sstable_test_env::now();
 
                 auto partitions_per_sstable = _cfg.partitions / _cfg.sstables;

--- a/test/perf/perf_tablets.cc
+++ b/test/perf/perf_tablets.cc
@@ -68,7 +68,7 @@ static future<> test_basic_operations(app_template& app) {
         std::vector<table_id> ids;
         ids.resize(nr_tables);
         for (int i = 0; i < nr_tables; ++i) {
-            ids[i] = add_table(e).get0();
+            ids[i] = add_table(e).get();
         }
 
         testlog.info("Generating tablet metadata");
@@ -116,7 +116,7 @@ static future<> test_basic_operations(app_template& app) {
         testlog.info("Saved in {:.6f} [ms]", time_to_save.count() * 1000);
 
         auto time_to_read = duration_in_seconds([&] {
-            tm2 = read_tablet_metadata(e.local_qp()).get0();
+            tm2 = read_tablet_metadata(e.local_qp()).get();
         });
         assert(tm == tm2);
 
@@ -124,7 +124,7 @@ static future<> test_basic_operations(app_template& app) {
 
         std::vector<canonical_mutation> muts;
         auto time_to_read_muts = duration_in_seconds([&] {
-            muts = replica::read_tablet_mutations(e.local_qp().proxy().get_db()).get0();
+            muts = replica::read_tablet_mutations(e.local_qp().proxy().get_db()).get();
         });
 
         testlog.info("Read mutations in {:.6f} [ms]", time_to_read_muts.count() * 1000);

--- a/test/raft/raft_server_test.cc
+++ b/test/raft/raft_server_test.cc
@@ -18,17 +18,17 @@ SEASTAR_THREAD_TEST_CASE(test_check_abort_on_client_api) {
             0,
             0,
             0, false, tick_delay, rpc_config{});
-    cluster.start_all().get0();
+    cluster.start_all().get();
 
-    cluster.stop_server(0, "test crash").get0();
+    cluster.stop_server(0, "test crash").get();
 
     auto check_error = [](const raft::stopped_error& e) {
         return sstring(e.what()) == sstring("Raft instance is stopped, reason: \"test crash\"");
     };
-    BOOST_CHECK_EXCEPTION(cluster.add_entries(1, 0).get0(), raft::stopped_error, check_error);
-    BOOST_CHECK_EXCEPTION(cluster.get_server(0).modify_config({}, {to_raft_id(0)}, nullptr).get0(), raft::stopped_error, check_error);
-    BOOST_CHECK_EXCEPTION(cluster.get_server(0).read_barrier(nullptr).get0(), raft::stopped_error, check_error);
-    BOOST_CHECK_EXCEPTION(cluster.get_server(0).set_configuration({}, nullptr).get0(), raft::stopped_error, check_error);
+    BOOST_CHECK_EXCEPTION(cluster.add_entries(1, 0).get(), raft::stopped_error, check_error);
+    BOOST_CHECK_EXCEPTION(cluster.get_server(0).modify_config({}, {to_raft_id(0)}, nullptr).get(), raft::stopped_error, check_error);
+    BOOST_CHECK_EXCEPTION(cluster.get_server(0).read_barrier(nullptr).get(), raft::stopped_error, check_error);
+    BOOST_CHECK_EXCEPTION(cluster.get_server(0).set_configuration({}, nullptr).get(), raft::stopped_error, check_error);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_release_memory_if_add_entry_throws) {
@@ -52,18 +52,18 @@ SEASTAR_THREAD_TEST_CASE(test_release_memory_if_add_entry_throws) {
             0,
             0,
             0, false, tick_delay, rpc_config{});
-    cluster.start_all().get0();
+    cluster.start_all().get();
     auto stop = defer([&cluster] { cluster.stop_all().get(); });
 
     utils::get_local_injector().enable("fsm::add_entry/test-failure", true);
     auto check_error = [](const std::runtime_error& e) {
         return sstring(e.what()) == sstring("fsm::add_entry/test-failure");
     };
-    BOOST_CHECK_EXCEPTION(cluster.add_entries(1, 0).get0(), std::runtime_error, check_error);
+    BOOST_CHECK_EXCEPTION(cluster.add_entries(1, 0).get(), std::runtime_error, check_error);
 
     // we would block forever if the memory wasn't released
     // when the exception was thrown from the first add_entry
-    cluster.add_entries(1, 0).get0();
+    cluster.add_entries(1, 0).get();
     cluster.read(read_value{0, 1}).get();
 #endif
 }

--- a/test/unit/cross_shard_barrier_test.cc
+++ b/test/unit/cross_shard_barrier_test.cc
@@ -109,9 +109,9 @@ int main(int argc, char **argv) {
                 try {
                     w.invoke_on_all(&worker::loop_with_error).get();
                 } catch (...) {
-                    auto ph = w.invoke_on(0, [] (auto& w) { return w.get_phase(); }).get0();
+                    auto ph = w.invoke_on(0, [] (auto& w) { return w.get_phase(); }).get();
                     for (size_t c = 1; c < smp::count; c++) {
-                        auto ph_2 = w.invoke_on(c, [] (auto& w) { return w.get_phase(); }).get0();
+                        auto ph_2 = w.invoke_on(c, [] (auto& w) { return w.get_phase(); }).get();
                         if (ph_2 != ph) {
                             fmt::print("aborted barrier passed shard through\n");
                             abort();

--- a/test/unit/row_cache_alloc_stress_test.cc
+++ b/test/unit/row_cache_alloc_stress_test.cc
@@ -179,7 +179,7 @@ int main(int argc, char** argv) {
                 auto range = dht::partition_range::make_singular(key);
                 auto reader = cache.make_reader(s, semaphore.make_permit(), range);
                 auto close_reader = deferred_close(reader);
-                auto mo = read_mutation_from_flat_mutation_reader(reader).get0();
+                auto mo = read_mutation_from_flat_mutation_reader(reader).get();
                 assert(mo);
                 assert(mo->partition().live_row_count(*s) ==
                        row_count + 1 /* one row was already in cache before update()*/);
@@ -197,7 +197,7 @@ int main(int argc, char** argv) {
                 auto range = dht::partition_range::make_singular(key);
                 auto reader = cache.make_reader(s, semaphore.make_permit(), range);
                 auto close_reader = deferred_close(reader);
-                auto mfopt = reader().get0();
+                auto mfopt = reader().get();
                 assert(mfopt);
                 assert(mfopt->is_partition_start());
             }
@@ -236,7 +236,7 @@ int main(int argc, char** argv) {
                 try {
                     auto reader = cache.make_reader(s, semaphore.make_permit(), range);
                     auto close_reader = deferred_close(reader);
-                    assert(!reader().get0());
+                    assert(!reader().get());
                     auto evicted_from_cache = logalloc::segment_size + large_cell_size;
                     // GCC's -fallocation-dce can remove dead calls to new and malloc, so
                     // assign the result to a global variable to disable it.

--- a/test/unit/row_cache_stress_test.cc
+++ b/test/unit/row_cache_stress_test.cc
@@ -334,7 +334,7 @@ int main(int argc, char** argv) {
                 while (!cancelled) {
                     testlog.trace("{}: starting read", id);
                     auto rd = t.make_single_key_reader(pk, ck_range);
-                    auto row_count = rd->rd->consume(validating_consumer(t, id, t.s.schema())).get0();
+                    auto row_count = rd->rd->consume(validating_consumer(t, id, t.s.schema())).get();
                     if (row_count != len) {
                         throw std::runtime_error(format("Expected {:d} fragments, got {:d}", len, row_count));
                     }
@@ -346,7 +346,7 @@ int main(int argc, char** argv) {
                 while (!cancelled) {
                     testlog.trace("{}: starting read", id);
                     auto rd = t.make_scanning_reader();
-                    auto row_count = rd->rd->consume(validating_consumer(t, id, t.s.schema())).get0();
+                    auto row_count = rd->rd->consume(validating_consumer(t, id, t.s.schema())).get();
                     if (row_count != expected_row_count) {
                         throw std::runtime_error(format("Expected {:d} fragments, got {:d}", expected_row_count, row_count));
                     }

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -126,7 +126,7 @@ with_cob(thrift_fn::function<void (const T& ret)>&& cob,
         return noexcept_movable<T>::wrap(func());
     }).then_wrapped([cob = std::move(cob), exn_cob = std::move(exn_cob)] (auto&& f) {
         try {
-            cob(noexcept_movable<T>::unwrap(f.get0()));
+            cob(noexcept_movable<T>::unwrap(f.get()));
         } catch (...) {
             delayed_exception_wrapper dew(std::current_exception());
             exn_cob(&dew);

--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -156,7 +156,7 @@ int tool_app_template::run_async(int argc, char** argv, noncopyable_function<int
             configurable::notify_set ns;
 
             if (_cfg.db_cfg_ext) {
-                ns = configurable::init_all(*_cfg.db_cfg_ext->db_cfg, *_cfg.db_cfg_ext->extensions).get0();
+                ns = configurable::init_all(*_cfg.db_cfg_ext->db_cfg, *_cfg.db_cfg_ext->extensions).get();
             }
 
             ns.notify_all(configurable::system_state::started).get();

--- a/tracing/traced_file.cc
+++ b/tracing/traced_file.cc
@@ -48,7 +48,7 @@ traced_file_impl::write_dma(uint64_t pos, const void* buf, size_t len, io_intent
     tracing::trace(_trace_state, "{} scheduling DMA write of {} bytes at position {}", _trace_prefix, len, pos);
     return get_file_impl(_f)->write_dma(pos, buf, len, intent).then_wrapped([this, pos, len] (future<size_t> f) {
         try {
-            auto ret = f.get0();
+            auto ret = f.get();
             tracing::trace(_trace_state, "{} finished DMA write of {} bytes at position {}, successfully wrote {} bytes", _trace_prefix, len, pos, ret);
             return ret;
         } catch (...) {
@@ -63,7 +63,7 @@ traced_file_impl::write_dma(uint64_t pos, std::vector<iovec> iov, io_intent* int
     tracing::trace(_trace_state, "{} scheduling DMA write at position {}", _trace_prefix, pos);
     return get_file_impl(_f)->write_dma(pos, std::move(iov), intent).then_wrapped([this, pos] (future<size_t> f) {
         try {
-            auto ret = f.get0();
+            auto ret = f.get();
             tracing::trace(_trace_state, "{} finished DMA write at position {}, successfully wrote {} bytes", _trace_prefix, pos, ret);
             return ret;
         } catch (...) {
@@ -78,7 +78,7 @@ traced_file_impl::read_dma(uint64_t pos, void* buf, size_t len, io_intent* inten
     tracing::trace(_trace_state, "{} scheduling DMA read of {} bytes at position {}", _trace_prefix, len, pos);
     return get_file_impl(_f)->read_dma(pos, buf, len, intent).then_wrapped([this, pos, len] (future<size_t> f) {
         try {
-            auto ret = f.get0();
+            auto ret = f.get();
             tracing::trace(_trace_state, "{} finished DMA read of {} bytes at position {}, successfully read {} bytes", _trace_prefix, len, pos, ret);
             return ret;
         } catch (...) {
@@ -93,7 +93,7 @@ traced_file_impl::read_dma(uint64_t pos, std::vector<iovec> iov, io_intent* inte
     tracing::trace(_trace_state, "{} scheduling DMA read at position {}", _trace_prefix, pos);
     return get_file_impl(_f)->read_dma(pos, std::move(iov), intent).then_wrapped([this, pos] (future<size_t> f) {
         try {
-            auto ret = f.get0();
+            auto ret = f.get();
             tracing::trace(_trace_state, "{} finished DMA read at position {}, successfully read {} bytes", _trace_prefix, pos, ret);
             return ret;
         } catch (...) {
@@ -122,7 +122,7 @@ traced_file_impl::stat(void) {
     tracing::trace(_trace_state, "{} scheduling file status retrieval", _trace_prefix);
     return get_file_impl(_f)->stat().then_wrapped([this] (future<struct stat> f) {
         try {
-            auto s = f.get0();
+            auto s = f.get();
             tracing::trace(_trace_state, "{} finished file status retrieval", _trace_prefix);
             return s;
         } catch (...) {
@@ -179,7 +179,7 @@ traced_file_impl::size(void) {
     tracing::trace(_trace_state, "{} scheduling size retrieval", _trace_prefix);
     return get_file_impl(_f)->size().then_wrapped([this] (future<uint64_t> f) {
         try {
-            auto ret = f.get0();
+            auto ret = f.get();
             tracing::trace(_trace_state, "{} retrieved size = {}", _trace_prefix, ret);
             return ret;
         } catch (...) {
@@ -218,7 +218,7 @@ traced_file_impl::dma_read_bulk(uint64_t offset, size_t range_size, io_intent* i
     tracing::trace(_trace_state, "{} scheduling bulk DMA read of size {} at offset {}", _trace_prefix, range_size, offset);
     return get_file_impl(_f)->dma_read_bulk(offset, range_size, intent).then_wrapped([this, offset, range_size] (future<temporary_buffer<uint8_t>> f) {
         try {
-            auto ret = f.get0();
+            auto ret = f.get();
             tracing::trace(_trace_state, "{} finished bulk DMA read of size {} at offset {}, successfully read {} bytes",
                     _trace_prefix, range_size, offset, ret.size());
             return ret;

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -80,7 +80,7 @@ future<> controller::do_start_server() {
         auto keepalive = cfg.rpc_keepalive();
         smp_service_group_config cql_server_smp_service_group_config;
         cql_server_smp_service_group_config.max_nonlocal_requests = 5000;
-        auto bounce_request_smp_service_group = create_smp_service_group(cql_server_smp_service_group_config).get0();
+        auto bounce_request_smp_service_group = create_smp_service_group(cql_server_smp_service_group_config).get();
         auto get_cql_server_config = sharded_parameter([&] {
             std::optional<uint16_t> shard_aware_transport_port;
             if (cfg.native_shard_aware_transport_port.is_set()) {
@@ -114,7 +114,7 @@ future<> controller::do_start_server() {
         std::vector<listen_cfg> configs;
 
         if (!_used_by_maintenance_socket) {
-            const seastar::net::inet_address ip = utils::resolve(cfg.rpc_address, family, preferred).get0();
+            const seastar::net::inet_address ip = utils::resolve(cfg.rpc_address, family, preferred).get();
             int native_port_idx = -1, native_shard_aware_port_idx = -1;
 
             if (cfg.native_transport_port.is_set() ||

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -482,7 +482,7 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
         --_server._stats.requests_serving;
 
         return utils::result_into_future<result_with_foreign_response_ptr>(utils::result_try([&] () -> result_with_foreign_response_ptr {
-            result_with_foreign_response_ptr res = f.get0();
+            result_with_foreign_response_ptr res = f.get();
             if (!res) {
                 return res;
             }
@@ -664,7 +664,7 @@ void cql_server::connection::handle_error(future<>&& f) {
 
 future<> cql_server::connection::process_request() {
     return read_frame().then_wrapped([this] (future<std::optional<cql_binary_frame_v3>>&& v) {
-        auto maybe_frame = v.get0();
+        auto maybe_frame = v.get();
         if (!maybe_frame) {
             // eof
             return make_ready_future<>();
@@ -723,7 +723,7 @@ future<> cql_server::connection::process_request() {
         auto fut = allow_shedding
                 ? get_units(_server._memory_available, mem_estimate, shedding_timeout).then_wrapped([this, length = f.length] (auto f) {
                     try {
-                        return make_ready_future<semaphore_units<>>(f.get0());
+                        return make_ready_future<semaphore_units<>>(f.get());
                     } catch (semaphore_timed_out& sto) {
                         // Cancel shedding in case no more requests are going to do that on completion
                         if (_pending_requests_gate.get_count() == 0) {
@@ -748,7 +748,7 @@ future<> cql_server::connection::process_request() {
               mem_permit_fut.ignore_ready_future();
               return make_ready_future<>();
           }
-          semaphore_units<> mem_permit = mem_permit_fut.get0();
+          semaphore_units<> mem_permit = mem_permit_fut.get();
           return this->read_and_decompress_frame(length, flags).then([this, op, stream, tracing_requested, mem_permit = make_service_permit(std::move(mem_permit))] (fragmented_temporary_buffer buf) mutable {
 
             ++_server._stats.requests_served;
@@ -783,7 +783,7 @@ future<> cql_server::connection::process_request() {
                                                   message,
                                                   tracing::trace_state_ptr()));
                     } else {
-                        write_response(response_f.get0(), std::move(mem_permit), _compression);
+                        write_response(response_f.get(), std::move(mem_permit), _compression);
                     }
                     _ready_to_respond = _ready_to_respond.finally([leave = std::move(leave)] {});
                 } catch (...) {

--- a/utils/flush_queue.hh
+++ b/utils/flush_queue.hh
@@ -59,7 +59,7 @@ private:
     static auto call_helper(Func&& func, future<Arg> f) {
         using futurator = futurize<std::result_of_t<Func(Arg&&)>>;
         try {
-            return futurator::invoke(std::forward<Func>(func), f.get0());
+            return futurator::invoke(std::forward<Func>(func), f.get());
         } catch (...) {
             return futurator::make_exception_future(std::current_exception());
         }

--- a/utils/loading_cache.hh
+++ b/utils/loading_cache.hh
@@ -538,7 +538,7 @@ private:
             // will be propagated up to the user and will fail the
             // corresponding query.
             try {
-                *ts_value_ptr = f.get0();
+                *ts_value_ptr = f.get();
             } catch (std::exception& e) {
                 _logger.debug("{}: reload failed: {}", key, e.what());
             } catch (...) {

--- a/utils/loading_shared_values.hh
+++ b/utils/loading_shared_values.hh
@@ -238,7 +238,7 @@ public:
                     if (val_fut.failed()) {
                         e->loaded().set_exception(val_fut.get_exception());
                     } else {
-                        e->set_value(val_fut.get0());
+                        e->set_value(val_fut.get());
                         e->loaded().set_value();
                     }
                 });

--- a/utils/result_loop.hh
+++ b/utils/result_loop.hh
@@ -182,13 +182,13 @@ requires requires (Iterator i, Mapper mapper, Reducer reduce) {
     *i++;
     { i != i } -> std::convertible_to<bool>;
     { mapper(*i) } -> ExceptionContainerResultFuture<>;
-    { seastar::futurize_invoke(reduce, seastar::futurize_invoke(mapper, *i).get0().value()) }
+    { seastar::futurize_invoke(reduce, seastar::futurize_invoke(mapper, *i).get().value()) }
             -> std::same_as<seastar::future<>>;
 }
 inline
 auto
 result_map_reduce(Iterator begin, Iterator end, Mapper&& mapper, Reducer&& reducer) {
-    using exception_container_type = typename decltype(seastar::futurize_invoke(mapper, *begin).get0())::error_type;
+    using exception_container_type = typename decltype(seastar::futurize_invoke(mapper, *begin).get())::error_type;
     using adapter_type = internal::result_map_reduce_unary_adapter<Reducer, exception_container_type>;
     return seastar::map_reduce(
             std::move(begin),
@@ -232,15 +232,15 @@ requires requires (Iterator i, Mapper mapper, Initial initial, Reducer reduce) {
     *i++;
     { i != i } -> std::convertible_to<bool>;
     { mapper(*i) } -> ExceptionContainerResultFuture<>;
-    { reduce(std::move(initial), mapper(*i).get0().value()) }
-            -> std::convertible_to<rebind_result<Initial, decltype(mapper(*i).get0())>>;
+    { reduce(std::move(initial), mapper(*i).get().value()) }
+            -> std::convertible_to<rebind_result<Initial, decltype(mapper(*i).get())>>;
 }
 inline
 auto
 result_map_reduce(Iterator begin, Iterator end, Mapper&& mapper, Initial initial, Reducer reduce)
-        -> seastar::future<rebind_result<Initial, decltype(mapper(*begin).get0())>>{
+        -> seastar::future<rebind_result<Initial, decltype(mapper(*begin).get())>>{
 
-    using right_type = decltype(mapper(*begin).get0());
+    using right_type = decltype(mapper(*begin).get());
     using left_type = rebind_result<Initial, right_type>;
 
     return seastar::map_reduce(

--- a/utils/rjson.cc
+++ b/utils/rjson.cc
@@ -246,7 +246,7 @@ public:
 
     void Flush() {
         if (f.failed()) {
-            f.get0();
+            f.get();
         }
         if (_pos == 0) {
             return;


### PR DESCRIPTION
get0() dates back from the days where Seastar futures carried tuples, and get0() was a way to get the first (and usually only) element. Now it's a distraction, and Seastar is likely to deprecate and remove it.

Replace with seastar::future::get(), which does the same thing.