### PR TITLE
gossiper: do_status_check: allow evicting dead nodes from membership with no host_id

### DIFF
--- a/gms/endpoint_state.cc
+++ b/gms/endpoint_state.cc
@@ -51,6 +51,13 @@ bool endpoint_state::is_cql_ready() const noexcept {
     }
 }
 
+locator::host_id endpoint_state::get_host_id() const noexcept {
+    if (auto app_state = get_application_state_ptr(application_state::HOST_ID)) {
+        return locator::host_id(utils::UUID(app_state->value()));
+    }
+    return locator::host_id::create_null_id();
+}
+
 future<> i_endpoint_state_change_subscriber::on_application_state_change(inet_address endpoint,
         const gms::application_state_map& states, application_state app_state, permit_id pid,
         std::function<future<>(inet_address, const gms::versioned_value&, permit_id)> func) {

--- a/gms/endpoint_state.hh
+++ b/gms/endpoint_state.hh
@@ -13,6 +13,7 @@
 #include "gms/heart_beat_state.hh"
 #include "gms/application_state.hh"
 #include "gms/versioned_value.hh"
+#include "locator/host_id.hh"
 #include <optional>
 #include <chrono>
 
@@ -148,6 +149,10 @@ public:
     }
 
     bool is_cql_ready() const noexcept;
+
+    // Return the value of the HOST_ID application state
+    // or a null host_id if the application state is not found.
+    locator::host_id get_host_id() const noexcept;
 
     friend fmt::formatter<endpoint_state>;
 };

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -762,11 +762,10 @@ future<> gossiper::do_status_check() {
             if (!host_id) {
                 on_internal_error_noexcept(logger, format("Endpoint {} is dead and expired, but unexpecteduly, it has no HOST_ID in endpoint state", endpoint));
             }
-          // FIXME: indentation
-          if (!host_id || !get_token_metadata_ptr()->is_normal_token_owner(host_id)) {
-            logger.debug("time is expiring for endpoint : {} ({})", endpoint, expire_time.time_since_epoch().count());
-            co_await evict_from_membership(endpoint, pid);
-          }
+            if (!host_id || !get_token_metadata_ptr()->is_normal_token_owner(host_id)) {
+                logger.debug("time is expiring for endpoint : {} ({})", endpoint, expire_time.time_since_epoch().count());
+                co_await evict_from_membership(endpoint, pid);
+            }
         }
     }
 

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -757,11 +757,16 @@ future<> gossiper::do_status_check() {
 
         // check for dead state removal
         auto expire_time = get_expire_time_for_endpoint(endpoint);
-        const auto host_id = get_host_id(endpoint);
-        if (!is_alive && (now > expire_time)
-             && (!get_token_metadata_ptr()->is_normal_token_owner(host_id))) {
+        if (!is_alive && (now > expire_time)) {
+            const auto host_id = eps->get_host_id();
+            if (!host_id) {
+                on_internal_error_noexcept(logger, format("Endpoint {} is dead and expired, but unexpecteduly, it has no HOST_ID in endpoint state", endpoint));
+            }
+          // FIXME: indentation
+          if (!host_id || !get_token_metadata_ptr()->is_normal_token_owner(host_id)) {
             logger.debug("time is expiring for endpoint : {} ({})", endpoint, expire_time.time_since_epoch().count());
             co_await evict_from_membership(endpoint, pid);
+          }
         }
     }
 

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -715,7 +715,7 @@ future<> gossiper::remove_endpoint(inet_address endpoint, permit_id pid) {
 
     if (was_alive && state) {
         try {
-            logger.info("InetAddress {} is now DOWN, status = {}", endpoint, get_gossip_status(*state));
+            logger.info("InetAddress {}/{} is now DOWN, status = {}", state->get_host_id(), endpoint, get_gossip_status(*state));
             co_await do_on_dead_notifications(endpoint, std::move(state), pid);
         } catch (...) {
             logger.warn("Fail to call on_dead callback: {}", std::current_exception());
@@ -1734,7 +1734,7 @@ future<> gossiper::real_mark_alive(inet_address addr) {
     }
 
     if (!is_in_shadow_round()) {
-        logger.info("InetAddress {} is now UP, status = {}", addr, status);
+        logger.info("InetAddress {}/{} is now UP, status = {}", es->get_host_id(), addr, status);
     }
 
     co_await _subscribers.for_each([addr, es, pid = permit.id()] (shared_ptr<i_endpoint_state_change_subscriber> subscriber) -> future<> {
@@ -1750,7 +1750,7 @@ future<> gossiper::mark_dead(inet_address addr, endpoint_state_ptr state, permit
         data.live.erase(addr);
         data.unreachable[addr] = now();
     });
-    logger.info("InetAddress {} is now DOWN, status = {}", addr, get_gossip_status(*state));
+    logger.info("InetAddress {}/{} is now DOWN, status = {}", state->get_host_id(), addr, get_gossip_status(*state));
     co_await do_on_dead_notifications(addr, std::move(state), pid);
 }
 

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1539,11 +1539,15 @@ bool gossiper::is_cql_ready(const inet_address& endpoint) const {
 }
 
 locator::host_id gossiper::get_host_id(inet_address endpoint) const {
-    auto app_state = get_application_state_ptr(endpoint, application_state::HOST_ID);
-    if (!app_state) {
+    auto eps = get_endpoint_state_ptr(endpoint);
+    if (!eps) {
+        throw std::runtime_error(format("Could not get host_id for endpoint {}: endpoint state not found", endpoint));
+    }
+    auto host_id = eps->get_host_id();
+    if (!host_id) {
         throw std::runtime_error(format("Host {} does not have HOST_ID application_state", endpoint));
     }
-    return locator::host_id(utils::UUID(app_state->value()));
+    return host_id;
 }
 
 std::set<gms::inet_address> gossiper::get_nodes_with_host_id(locator::host_id host_id) const {

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -752,6 +752,7 @@ future<> gossiper::do_status_check() {
             logger.info("FatClient {} has been silent for {}ms, removing from gossip", endpoint, fat_client_timeout.count());
             co_await remove_endpoint(endpoint, pid); // will put it in _just_removed_endpoints to respect quarantine delay
             co_await evict_from_membership(endpoint, pid); // can get rid of the state immediately
+            continue;
         }
 
         // check for dead state removal


### PR DESCRIPTION
The short series allows do_status_check to handle down nodes that don't have HOST_ID application state.

Fixes #16936