### PR TITLE
utils: Add uuid_xor_to_uint32 helper

### DIFF
--- a/test/boost/UUID_test.cc
+++ b/test/boost/UUID_test.cc
@@ -100,6 +100,17 @@ BOOST_AUTO_TEST_CASE(test_get_time_uuid) {
     BOOST_CHECK(unix_timestamp == millis);
 }
 
+BOOST_AUTO_TEST_CASE(test_uuid_to_uint32) {
+    // (gdb) p/x 0x3123223d ^ 0x17300 ^ 0x31e31215 ^ 0x98312
+    // $2 = 0xc8c03a
+    uint64_t x = 0x173003123223d;
+    uint64_t y = 0x9831231e31215;
+    uint32_t expected_id = 0xc8c03a;
+    auto uuid = utils::UUID(x, y);
+    uint32_t id = uuid_xor_to_uint32(uuid);
+    BOOST_CHECK(id == expected_id);
+}
+
 std::strong_ordering timeuuid_legacy_tri_compare(bytes_view o1, bytes_view o2) {
     auto compare_pos = [&] (unsigned pos, int mask, std::strong_ordering ifequal) {
         auto d = (o1[pos] & mask) <=> (o2[pos] & mask);

--- a/utils/UUID.hh
+++ b/utils/UUID.hh
@@ -117,6 +117,10 @@ public:
     }
 };
 
+// Convert the uuid to a uint32_t using xor.
+// It is useful to get a uint32_t number from the uuid.
+uint32_t uuid_xor_to_uint32(const UUID& uuid);
+
 inline constexpr UUID null_uuid() noexcept {
     return UUID();
 }

--- a/utils/uuid.cc
+++ b/utils/uuid.cc
@@ -62,4 +62,9 @@ UUID::UUID(sstring_view uuid) {
     }
 }
 
+uint32_t uuid_xor_to_uint32(const UUID& uuid) {
+    size_t h = std::hash<utils::UUID>{}(uuid);
+    return uint32_t(h);
+}
+
 }


### PR DESCRIPTION
Convert the uuid to a shard_id which is 32 bits. It is useful to choose a shard from a uuid.

Refs: #16927