### PR TITLE
thrift: remove unused namespace definition

### DIFF
--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -58,7 +58,6 @@ namespace thrift_fn = std;
 
 using namespace ::apache::thrift;
 using namespace ::apache::thrift::protocol;
-namespace thrift_transport = ::apache::thrift::transport;
 using namespace ::apache::thrift::async;
 
 using namespace  ::cassandra;


### PR DESCRIPTION
thrift_transport is never used, so drop it.