### PR TITLE
utils: Remove unused operator<< for file_lock object

### DIFF
--- a/utils/file_lock.cc
+++ b/utils/file_lock.cc
@@ -62,7 +62,3 @@ future<utils::file_lock> utils::file_lock::acquire(fs::path path) {
         return make_exception_future<utils::file_lock>(std::current_exception());
     }
 }
-
-std::ostream& utils::operator<<(std::ostream& out, const file_lock& f) {
-    return out << "file lock '" << f.path() << "'";
-}

--- a/utils/file_lock.hh
+++ b/utils/file_lock.hh
@@ -39,7 +39,5 @@ namespace utils {
         file_lock(fs::path);
         std::unique_ptr<impl> _impl;
     };
-
-    std::ostream& operator<<(std::ostream& out, const file_lock& f);
 }
 


### PR DESCRIPTION
The lock itself is only used by utils/directories code