### PR TITLE
messaging: Add formatter for netw::msg_addr

### DIFF
--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -173,11 +173,6 @@ bool operator<(const msg_addr& x, const msg_addr& y) noexcept {
     }
 }
 
-std::ostream& operator<<(std::ostream& os, const msg_addr& x) {
-    fmt::print(os, "{}:{}", x.addr, x.cpu_id);
-    return os;
-}
-
 size_t msg_addr::hash::operator()(const msg_addr& id) const noexcept {
     // Ignore cpu id for now since we do not really support // shard to shard connections
     return std::hash<bytes_view>()(id.addr.bytes());

--- a/message/msg_addr.hh
+++ b/message/msg_addr.hh
@@ -18,7 +18,6 @@ struct msg_addr {
     uint32_t cpu_id;
     friend bool operator==(const msg_addr& x, const msg_addr& y) noexcept;
     friend bool operator<(const msg_addr& x, const msg_addr& y) noexcept;
-    friend std::ostream& operator<<(std::ostream& os, const msg_addr& x);
     struct hash {
         size_t operator()(const msg_addr& id) const noexcept;
     };
@@ -27,3 +26,12 @@ struct msg_addr {
 };
 
 }
+
+template <>
+struct fmt::formatter<netw::msg_addr> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const netw::msg_addr& addr, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}:{}", addr.addr, addr.cpu_id);
+    }
+};


### PR DESCRIPTION
As a part of ongoing "support fmt v10" effort