### PR TITLE
replica/table: add tablet count metric

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -344,6 +344,7 @@ struct table_stats {
     int64_t memtable_partition_hits = 0;
     int64_t memtable_range_tombstone_reads = 0;
     int64_t memtable_row_tombstone_reads = 0;
+    int64_t tablet_count = 0;
     mutation_application_stats memtable_app_stats;
     utils::timed_rate_moving_average_summary_and_histogram reads{256};
     utils::timed_rate_moving_average_summary_and_histogram writes{256};
@@ -1172,6 +1173,9 @@ private:
     future<> seal_active_memtable(compaction_group& cg, flush_permit&&) noexcept;
 
     void check_valid_rp(const db::replay_position&) const;
+
+    void recalculate_tablet_count_stats();
+    int64_t calculate_tablet_count() const;
 public:
     // Iterate over all partitions.  Protocol is the same as std::all_of(),
     // so that iteration can be stopped by returning false.


### PR DESCRIPTION
This change introduces a new metric called tablet_count
that is recalculated during construction of table object
and on each call to table::update_effective_replication_map().

To get the count of tablet per current shard, tablet map
is traversed and for each tablet_id tablet_map::get_shard()
is called. Its return value is compared with this_shard_id().

The new metric is maintained and exposed only for tables
that uses tablets.

Sample output from run with  `--enable-keyspace-column-family-metrics true`:
```
# HELP scylla_column_family_tablet_count Tablet count
# TYPE scylla_column_family_tablet_count gauge
scylla_column_family_tablet_count{cf="mytable",ks="testing",shard="0"} 1.000000
scylla_column_family_tablet_count{cf="mytable2",ks="testing",shard="0"} 1.000000
scylla_column_family_tablet_count{cf="mytable3",ks="testing",shard="0"} 1.000000
scylla_column_family_tablet_count{cf="mytable",ks="testing",shard="1"} 1.000000
scylla_column_family_tablet_count{cf="mytable2",ks="testing",shard="1"} 1.000000
scylla_column_family_tablet_count{cf="mytable3",ks="testing",shard="1"} 1.000000
scylla_column_family_tablet_count{cf="mytable",ks="testing",shard="2"} 1.000000
scylla_column_family_tablet_count{cf="mytable2",ks="testing",shard="2"} 1.000000
scylla_column_family_tablet_count{cf="mytable3",ks="testing",shard="2"} 1.000000
scylla_column_family_tablet_count{cf="mytable",ks="testing",shard="3"} 1.000000
scylla_column_family_tablet_count{cf="mytable2",ks="testing",shard="3"} 1.000000
scylla_column_family_tablet_count{cf="mytable3",ks="testing",shard="3"} 1.000000
```

Sample output from run without it:
```
# HELP scylla_column_family_tablet_count Tablet count
# TYPE scylla_column_family_tablet_count gauge
scylla_column_family_tablet_count{shard="3"} 3.000000
scylla_column_family_tablet_count{shard="2"} 3.000000
scylla_column_family_tablet_count{shard="1"} 3.000000
scylla_column_family_tablet_count{shard="0"} 3.000000
```

Refs: scylladb#16131