### PR TITLE
redis: do not include unused headers

### DIFF
--- a/redis/commands.cc
+++ b/redis/commands.cc
@@ -10,9 +10,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include "redis/request.hh"
 #include "redis/reply.hh"
-#include "types/types.hh"
 #include "service_permit.hh"
-#include "service/client_state.hh"
 #include "redis/options.hh"
 #include "redis/query_utils.hh"
 #include "redis/mutation_utils.hh"

--- a/redis/exceptions.hh
+++ b/redis/exceptions.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <stdexcept>
 #include <seastar/core/print.hh>
 
 #include "bytes.hh"

--- a/redis/keyspace_utils.cc
+++ b/redis/keyspace_utils.cc
@@ -11,10 +11,8 @@
 #include "redis/keyspace_utils.hh"
 #include "schema/schema_builder.hh"
 #include "types/types.hh"
-#include "exceptions/exceptions.hh"
 #include "cql3/statements/ks_prop_defs.hh"
 #include <seastar/core/future.hh>
-#include <memory>
 #include "log.hh"
 #include "auth/service.hh"
 #include "service/migration_manager.hh"

--- a/redis/lolwut.hh
+++ b/redis/lolwut.hh
@@ -7,7 +7,11 @@
  */
 
 #pragma once
-#include "types/types.hh"
+
+#include <seastar/core/future.hh>
+
+#include "bytes.hh"
+#include "seastarx.hh"
 
 namespace redis {
 

--- a/redis/mutation_utils.hh
+++ b/redis/mutation_utils.hh
@@ -7,7 +7,10 @@
  */
 
 #pragma once
-#include "types/types.hh"
+#include <vector>
+#include <seastar/core/future.hh>
+#include "bytes.hh"
+#include "seastarx.hh"
 
 class service_permit;
 

--- a/redis/options.cc
+++ b/redis/options.cc
@@ -7,10 +7,8 @@
  */
 
 #include "redis/options.hh"
-#include "types/types.hh"
 #include "service/storage_proxy.hh"
 #include "data_dictionary/data_dictionary.hh"
-#include "schema/schema.hh"
 #include <seastar/core/print.hh>
 #include "redis/keyspace_utils.hh"
 

--- a/redis/options.hh
+++ b/redis/options.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <stdexcept>
 #include "timeout_config.hh"
 #include "db/consistency_level_type.hh"
 #include <seastar/core/sstring.hh>

--- a/redis/query_processor.cc
+++ b/redis/query_processor.cc
@@ -10,7 +10,6 @@
 #include "redis/request.hh"
 #include "redis/reply.hh"
 #include "redis/command_factory.hh"
-#include "timeout_config.hh"
 #include "redis/options.hh"
 #include "service_permit.hh"
 

--- a/redis/query_utils.cc
+++ b/redis/query_utils.cc
@@ -8,9 +8,7 @@
 
 
 #include "redis/query_utils.hh"
-#include "db/per_partition_rate_limit_info.hh"
 #include "redis/options.hh"
-#include "timeout_config.hh"
 #include "service/client_state.hh"
 #include "service/storage_proxy.hh"
 #include "dht/i_partitioner.hh"

--- a/redis/server.cc
+++ b/redis/server.cc
@@ -11,12 +11,7 @@
 #include "redis/request.hh"
 #include "redis/reply.hh"
 
-#include "auth/authenticator.hh"
-#include "db/config.hh"
 #include "db/consistency_level_type.hh"
-#include "db/write_type.hh"
-#include "exceptions/exceptions.hh"
-#include "service/query_state.hh"
 
 #include <seastar/core/future-util.hh>
 #include <seastar/core/seastar.hh>
@@ -25,7 +20,6 @@
 #include <seastar/util/defer.hh>
 
 #include <cassert>
-#include <string>
 #include <unordered_map>
 
 namespace redis_transport {

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -15,14 +15,9 @@
 #include "redis/request.hh"
 #include "redis/stats.hh"
 
-#include "auth/authenticator.hh"
 #include "auth/service.hh"
-#include "cql3/values.hh"
-#include "service/client_state.hh"
 #include "service_permit.hh"
 #include "timeout_config.hh"
-#include "utils/estimated_histogram.hh"
-#include "utils/fragmented_temporary_buffer.hh"
 #include "generic_server.hh"
 
 #include <seastar/core/seastar.hh>

--- a/redis/stats.hh
+++ b/redis/stats.hh
@@ -11,7 +11,6 @@
 #include <cstdint>
 
 #include <seastar/core/metrics_registration.hh>
-#include "seastarx.hh"
 #include "utils/estimated_histogram.hh"
 #include "utils/histogram.hh"
 

--- a/redis/version.hh
+++ b/redis/version.hh
@@ -7,7 +7,7 @@
  */
 
 #pragma once
-#include "types/types.hh"
+#include "bytes.hh"
 
 namespace redis {
 


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.