### PR TITLE
reader_concurrency_semaphore.cc: move stringstream content instead of copying it

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -835,7 +835,7 @@ void maybe_dump_reader_permit_diagnostics(const reader_concurrency_semaphore& se
     rcslog.log(log_level::info, rate_limit, "{}", value_of([&] {
         std::ostringstream os;
         do_dump_reader_permit_diagnostics(os, semaphore, problem);
-        return os.str();
+        return std::move(os).str();
     }));
 }
 
@@ -1594,7 +1594,7 @@ void reader_concurrency_semaphore::broken(std::exception_ptr ex) {
 std::string reader_concurrency_semaphore::dump_diagnostics(unsigned max_lines) const {
     std::ostringstream os;
     do_dump_reader_permit_diagnostics(os, *this, "user request", max_lines);
-    return os.str();
+    return std::move(os).str();
 }
 
 void reader_concurrency_semaphore::foreach_permit(noncopyable_function<void(const reader_permit::impl&)> func) const {


### PR DESCRIPTION
C++20 introduced a new overload of std::stringstream::str() that is selected when the mentioned member function is called on r-value.

The new overload returns a string, that is move-constructed from the underlying string instead of being copy-constructed.

This change applies std::move() on stringstream objects before calling str() member function to avoid copying of the underlying buffer.