### PR TITLE
configure.py: s/-DBOOST_TEST_DYN_LINK/-DBOOST_ALL_DYN_LINK/

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1779,7 +1779,7 @@ libs = ' '.join([maybe_static(args.staticyamlcpp, '-lyaml-cpp'), '-latomic', '-l
                 ])
 
 if not args.staticboost:
-    user_cflags += ' -DBOOST_TEST_DYN_LINK'
+    user_cflags += ' -DBOOST_ALL_DYN_LINK'
 
 if thrift_uses_boost_share_ptr():
     user_cflags += ' -DTHRIFT_USES_BOOST'


### PR DESCRIPTION
we add `-DBOOST_TEST_DYN_LINK` to the cflags when `--static-boost` is not passed to `configure.py`. but we don't never pass this option to `configure.py` in our CI/CD. also, we don't install `boost-static` in `install-dependencies.sh`, so the linker always use the boost shared libraries when building scylla and other executables in this project. this fact has been verified with the latest master HEAD, after building scylla from `build.ninja` which was in turn created using `configure.py`.

Seastar::seastar_testing exposes `Boost::dynamic_linking` in its public interface, and `Boost::dynamic_linking` exposes `-DBOOST_ALL_DYN_LINK` as one of its cflags.

so, when building testings using CMake, the tests are compiled with `-DBOOST_ALL_DYN_LINK`, while when building tests using `configure.py`, they are compiled with `-DBOOST_TEST_DYN_LINK`. the former is exposed by `Boost::dynamic_linking`, the latter is hardwired using `configure.py`. but the net results are identical. it would be better to use identical cflags on these two building systems. so, let's use `-DBOOST_ALL_DYN_LINK` in `configure.py` also. furthermore, this is what non-static-boost implies.

please note, we don't consume the cflags exposed by `seastar-testing.pc`, so they don't override the ones we set using `configure.py`.