### PR TITLE
Fix mintimeuuid() call that could crash Scylla

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -849,6 +849,7 @@ scylla_core = (['message/messaging_service.cc',
                 'utils/rjson.cc',
                 'utils/human_readable.cc',
                 'utils/histogram_metrics_helper.cc',
+                'utils/on_internal_error.cc',
                 'utils/pretty_printers.cc',
                 'converting_mutation_partition_applier.cc',
                 'readers/combined.cc',
@@ -1464,7 +1465,7 @@ deps['test/boost/bytes_ostream_test'] = [
     "test/lib/log.cc",
 ]
 deps['test/boost/input_stream_test'] = ['test/boost/input_stream_test.cc']
-deps['test/boost/UUID_test'] = ['utils/UUID_gen.cc', 'test/boost/UUID_test.cc', 'utils/uuid.cc', 'utils/dynamic_bitset.cc', 'utils/hashers.cc']
+deps['test/boost/UUID_test'] = ['utils/UUID_gen.cc', 'test/boost/UUID_test.cc', 'utils/uuid.cc', 'utils/dynamic_bitset.cc', 'utils/hashers.cc', 'utils/on_internal_error.cc']
 deps['test/boost/murmur_hash_test'] = ['bytes.cc', 'utils/murmur_hash.cc', 'test/boost/murmur_hash_test.cc']
 deps['test/boost/allocation_strategy_test'] = ['test/boost/allocation_strategy_test.cc', 'utils/logalloc.cc', 'utils/dynamic_bitset.cc']
 deps['test/boost/log_heap_test'] = ['test/boost/log_heap_test.cc']

--- a/test/cql-pytest/test_native_functions.py
+++ b/test/cql-pytest/test_native_functions.py
@@ -72,3 +72,52 @@ def test_blobas_wrong_size(cql, table1):
     # value 0x0000007b is not a valid binary representation for type bigint".
     with pytest.raises(InvalidRequest, match='blobasbigint'):
         cql.execute(f"SELECT blobasbigint(intasblob(i)) FROM {table1} WHERE p={p}")
+
+# The mintimeuuid() function works with valid "timestamp"-type values, which
+# are 64-bit *signed* integers representing milliseconds since the epoch.
+# In particular, negative timestamps are allowed and should not be rejected.
+# The function tounixtimestamp can be used to extract the timestamp back from
+# the timeuuid. In this test we use "reasonably"-low timestamps (referring
+# to dates in this and the previous century - not to the age of the
+# dinosaurs). The test that follows will look at extreme, not-useful-in-
+# practice, timestamp values.
+@pytest.mark.parametrize("timestamp", [-1706638779000, -123, 123, 1706638779000])
+def test_mintimeuuid_reasonable(cql, table1, timestamp):
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, {timestamp})")
+    assert [(timestamp,)] == list(cql.execute(f"SELECT tounixtimestamp(mintimeuuid(t)) FROM {table1} WHERE p={p}"))
+
+# The "timestamp" column type stores a 64-bit number of milliseconds, but
+# Scylla's and Cassandra's implementation of timeuuids cannot store this
+# entire range. This test expects mintimeuuid() to either return the *right*
+# thing (converted back to the original timestamp via tounixtimestamp),
+# or to throw an exception. Crashing is not acceptable (reproduces #17035),
+# and so is returning a value, but it having the wrong timestamp (this
+# happens in Cassandra, so this test is marked a cassandra_bug)
+@pytest.mark.parametrize("timestamp", [-2**63+123, -2**62, -2**58, 2**62, 2**63-123])
+def test_mintimeuuid_extreme(cql, table1, timestamp, cassandra_bug):
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, t) VALUES ({p}, {timestamp})")
+    try:
+        res = list(cql.execute(f"SELECT tounixtimestamp(mintimeuuid(t)) FROM {table1} WHERE p={p}"))
+    except:
+        # If mintimeuuid() refuses these extreme values, it's fine.
+        # The real bug is to return something, which is wrong (the
+        # assert below), or to crash the server (issue #17035).
+        pass
+    else:
+        assert [(timestamp,)] == res
+
+# An example of an extreme negative timestamp is what totimestamp(123)
+# returns: As shown in test_type_date.py, the number "123" is converted to
+# a date very long in the past (2**31 is the day of the epoch), and results
+# in a very negative timestamp.
+# We don't expect much from this test - it may report strange errors (this
+# happens in both Cassandra and Scylla), but it mustn't crash as it did in
+# issue #17035.
+def test_mintimeuuid_extreme_from_totimestamp(cql, table1):
+    p = unique_key_int()
+    try:
+        cql.execute(f"SELECT * FROM {table1} WHERE p={p} and u < mintimeuuid(totimestamp(123)) ALLOW FILTERING")
+    except:
+        pass

--- a/test/cql-pytest/test_type_date.py
+++ b/test/cql-pytest/test_type_date.py
@@ -1,0 +1,90 @@
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+#############################################################################
+# Test involving the "date" column type.
+#############################################################################
+
+from util import unique_name, unique_key_int
+from cassandra.util import Date
+from cassandra.protocol import InvalidRequest
+
+import pytest
+
+@pytest.fixture(scope="module")
+def table1(cql, test_keyspace):
+    table = test_keyspace + "." + unique_name()
+    cql.execute(f"CREATE TABLE {table} (p int PRIMARY KEY, d date)")
+    yield table
+    cql.execute("DROP TABLE " + table)
+
+# According to the Cassandra documentation, a date "can be input either as an
+# integer or using a date string."
+# The documentation further explains the (surprising) encoding of that
+# integer:
+#    "Values of the date type are encoded as 32-bit unsigned integers
+#     representing a number of days with “the epoch” at the center of the
+#     range (2^31). Epoch is January 1st, 1970"
+# So the number "123" doesn't mean 123 days since the epoch - it actually
+# means 2^31-123 days before the epoch.
+# The date string should be yyyy-mm-dd, and nothing else is allowed.
+# The following tests verify that these different initialization options
+# actually work.
+def test_type_date_from_int_unprepared(cql, table1):
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, 123)")
+    ds = list(cql.execute(f"SELECT d from {table1} where p = {p}"))
+    assert len(ds) == 1
+    # The Python driver returns a "date" type as a cassandra.util.Date
+    # type, and when that is converted into a number, it strangely results
+    # in the number of days since the epoch, where the epoch is 0.
+    # So 123 is converted into "-2^31+123" days (a negative number) since
+    # the epoch.
+    assert ds[0].d == -2**31 + 123
+
+def test_type_date_from_int_prepared(cql, table1):
+    p = unique_key_int()
+    stmt = cql.prepare(f"INSERT INTO {table1} (p, d) VALUES (?, ?)")
+    cql.execute(stmt, [p, 123])
+    ds = list(cql.execute(f"SELECT d from {table1} where p = {p}"))
+    assert len(ds) == 1
+    assert ds[0].d == -2**31 + 123
+
+# As explained above, the integer used to create the date must be a
+# a 32-bit unsigned integer. An attempt to pass a negative number, or
+# one that doesn't fit 32 bits, is an error. Cassandra says:
+# "Unable to make unsigned int (for date) from: '-123'".
+# Reproduces #17066.
+@pytest.mark.xfail(reason="#17066")
+def test_type_date_from_int_unprepared_underflow(cql, table1):
+    p = unique_key_int()
+    with pytest.raises(InvalidRequest, match="unsigned int"):
+        cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, -123)")
+
+@pytest.mark.xfail(reason="#17066")
+def test_type_date_from_int_unprepared_overflow(cql, table1):
+    p = unique_key_int()
+    with pytest.raises(InvalidRequest, match="unsigned int"):
+        cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, 50000000000000000)")
+
+def test_type_date_from_string_unprepared(cql, table1):
+    p = unique_key_int()
+    for d in ["2024-01-30"]:
+        cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, '{d}')")
+        assert list(cql.execute(f"SELECT d from {table1} where p = {p}")) == [(Date(d),)]
+
+# Although the documentation suggests that yyyy-mm-dd is the only *string*
+# format allowed for creating a date, it is actually allowed to also use
+# a number string, which is treated just like the integer case above.
+# This can only be tested for the *unprepared* case - in the prepared-
+# statement case, the Python driver needs to build the integer to pass
+# to Scylla itself, and whatever it supports or doesn't support (in this
+# case, it doesn't) is its own fault - not Scylla's.
+def test_type_date_from_string_number_unprepared(cql, table1):
+    p = unique_key_int()
+    # Note the string '123', not integer 123
+    cql.execute(f"INSERT INTO {table1} (p, d) VALUES ({p}, '123')")
+    ds = list(cql.execute(f"SELECT d from {table1} where p = {p}"))
+    assert len(ds) == 1
+    assert ds[0].d == -2**31 + 123

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -36,6 +36,7 @@ target_sources(utils
     managed_bytes.cc
     multiprecision_int.cc
     murmur_hash.cc
+    on_internal_error.cc
     pretty_printers.cc
     rate_limiter.cc
     rjson.cc

--- a/utils/UUID_gen.hh
+++ b/utils/UUID_gen.hh
@@ -46,6 +46,8 @@ private:
     // UUID time must fit in 60 bits
     static constexpr milliseconds UUID_UNIXTIME_MAX = duration_cast<milliseconds>(
         decimicroseconds{0x0fffffffffffffffL} + START_EPOCH);
+    static constexpr milliseconds UUID_UNIXTIME_MIN = duration_cast<milliseconds>(
+        -decimicroseconds{0x0fffffffffffffffL} + START_EPOCH);
 
     // A random mac address for use in timeuuids
     // where we can not use clockseq to randomize the physical
@@ -361,7 +363,8 @@ public:
 
     template <std::intmax_t N, std::intmax_t D>
     static bool is_valid_unix_timestamp(std::chrono::duration<int64_t, std::ratio<N, D>> d) {
-        return duration_cast<milliseconds>(d) < UUID_UNIXTIME_MAX;
+        milliseconds dms = duration_cast<milliseconds>(d);
+        return dms > UUID_UNIXTIME_MIN && dms < UUID_UNIXTIME_MAX;
     }
 
     template <std::intmax_t N, std::intmax_t D>

--- a/utils/UUID_gen.hh
+++ b/utils/UUID_gen.hh
@@ -17,6 +17,7 @@
 #include <limits>
 
 #include "UUID.hh"
+#include "on_internal_error.hh"
 
 namespace utils {
 
@@ -383,7 +384,11 @@ public:
         auto dmc = duration_cast<decimicroseconds>(d);
         uint64_t msb = dmc.count();
         // timeuuid time must fit in 60 bits
-        assert(!(0xf000000000000000UL & msb));
+        if ((0xf000000000000000UL & msb)) {
+            // We hope callers would try to avoid this case, but they don't
+            // always do, so assert() would be bad here - and caused #17035.
+            utils::on_internal_error("timeuuid time must fit in 60 bits");
+        }
         return ((0x00000000ffffffffL & msb) << 32 |
                (0x0000ffff00000000UL & msb) >> 16 |
                (0x0fff000000000000UL & msb) >> 48 |

--- a/utils/on_internal_error.cc
+++ b/utils/on_internal_error.cc
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <seastar/core/on_internal_error.hh>
+#include <seastar/util/log.hh>
+
+#include "on_internal_error.hh"
+
+static seastar::logger on_internal_error_logger("on_internal_error");
+
+namespace utils {
+
+[[noreturn]] void on_internal_error(std::string_view reason) {
+    seastar::on_internal_error(on_internal_error_logger, reason);
+}
+
+}

--- a/utils/on_internal_error.hh
+++ b/utils/on_internal_error.hh
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+// Seastar's on_internal_error() is a replacement for assert(). Instead of
+// crashing like assert(), on_internal_error() logs a message with a
+// backtrace and throws an exception (and optionally also crashes - this can
+// be useful for testing). However, Seastar's function is inconvenient because
+// it requires specifying a logger. This makes it hard to call it from source
+// files which don't already have a logger, or in code in a header file.
+//
+// So here we provide Scylla's version of on_internal_error() which uses a
+// single logger for all internal errors - with no need to specify a logger
+// object to each call.
+
+#pragma once
+
+#include <string_view>
+
+namespace utils {
+
+/// Report an internal error
+///
+/// Depending on the value passed to seastar::set_abort_on_internal_error(),
+/// this will either abort or throw a std::runtime_error.
+/// In both cases an error will be logged, containing \p reason and the
+/// current backtrace.
+[[noreturn]] void on_internal_error(std::string_view reason);
+
+}


### PR DESCRIPTION
This PR fixes the bug of certain calls to the `mintimeuuid()` CQL function which large negative timestamps could crash Scylla. It turns out we already had protections in place against very positive timestamps, but very negative timestamps could still cause bugs.

The actual fix in this series is just a few lines, but the bigger effort was improving the test coverage in this area. I added tests for the "date" type (the original reproducer for this bug used totimestamp() which takes a date parameter), and also reproducers for this bug directly, without totimestamp() function, and one with that function.

Finally this PR also replaces the assert() which made this molehill-of-a-bug into a mountain, by a throw.

Fixes #17035