### PR TITLE
exceptions: s/#warn/#warning/

### DIFF
--- a/utils/exceptions.hh
+++ b/utils/exceptions.hh
@@ -18,7 +18,7 @@
   #if defined(OPTIMIZED_EXCEPTION_HANDLING_AVAILABLE)
     #define USE_OPTIMIZED_EXCEPTION_HANDLING
   #else
-    #warn "Fast implementation of some of the exception handling routines is not available for this platform. Expect poor exception handling performance."
+    #warning "Fast implementation of some of the exception handling routines is not available for this platform. Expect poor exception handling performance."
   #endif
 #endif
 


### PR DESCRIPTION
`#warning` is a preprocessor macro in C/C++, while `#warn` is not. the reason we haven't run into the build failure caused by this is likely that we are only building on amd64/aarch64 with libstdc++ at the time of writing.