### PR TITLE
raft topology: implement upgrade and recovery procedure

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2685,6 +2685,33 @@
                ]
             }
          ]
+      },
+      {
+         "path":"/storage_service/raft_topology/upgrade",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Trigger the upgrade to topology on raft.",
+               "type":"void",
+               "nickname":"upgrade_to_raft_topology",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+               ]
+            },
+            {
+               "method":"GET",
+               "summary":"Get information about the current upgrade status of topology on raft.",
+               "type":"string",
+               "nickname":"raft_topology_upgrade_status",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+               ]
+            }
+         ]
       }
    ],
    "models":{

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -463,8 +463,28 @@ static std::optional<cdc::generation_id> get_generation_id_for(const gms::inet_a
     return gms::versioned_value::cdc_generation_id_from_string(gen_id_string);
 }
 
+static future<std::optional<cdc::topology_description>> retrieve_generation_data_v2(
+        cdc::generation_id_v2 id,
+        bool raft_experimental_topology,
+        db::system_keyspace& sys_ks,
+        db::system_distributed_keyspace& sys_dist_ks) {
+    auto cdc_gen = co_await sys_dist_ks.read_cdc_generation(id.id);
+
+    if (raft_experimental_topology && !cdc_gen) {
+        // If we entered legacy mode due to recovery, we (or some other node)
+        // might gossip about a generation that was previously propagated
+        // through raft. If that's the case, it will sit in
+        // the system.cdc_generations_v3 table.
+        cdc_gen = co_await sys_ks.read_cdc_generation_opt(id.id);
+    }
+
+    co_return cdc_gen;
+}
+
 static future<std::optional<cdc::topology_description>> retrieve_generation_data(
         cdc::generation_id gen_id,
+        bool raft_experimental_topology,
+        db::system_keyspace& sys_ks,
         db::system_distributed_keyspace& sys_dist_ks,
         db::system_distributed_keyspace::context ctx) {
     return std::visit(make_visitor(
@@ -472,13 +492,15 @@ static future<std::optional<cdc::topology_description>> retrieve_generation_data
         return sys_dist_ks.read_cdc_topology_description(id, ctx);
     },
     [&] (const cdc::generation_id_v2& id) {
-        return sys_dist_ks.read_cdc_generation(id.id);
+        return retrieve_generation_data_v2(id, raft_experimental_topology, sys_ks, sys_dist_ks);
     }
     ), gen_id);
 }
 
 static future<> do_update_streams_description(
         cdc::generation_id gen_id,
+        bool raft_experimental_topology,
+        db::system_keyspace& sys_ks,
         db::system_distributed_keyspace& sys_dist_ks,
         db::system_distributed_keyspace::context ctx) {
     if (co_await sys_dist_ks.cdc_desc_exists(get_ts(gen_id), ctx)) {
@@ -488,7 +510,7 @@ static future<> do_update_streams_description(
 
     // We might race with another node also inserting the description, but that's ok. It's an idempotent operation.
 
-    auto topo = co_await retrieve_generation_data(gen_id, sys_dist_ks, ctx);
+    auto topo = co_await retrieve_generation_data(gen_id, raft_experimental_topology, sys_ks, sys_dist_ks, ctx);
     if (!topo) {
         throw no_generation_data_exception(gen_id);
     }
@@ -507,11 +529,13 @@ static future<> do_update_streams_description(
  */
 static future<> update_streams_description(
         cdc::generation_id gen_id,
+        bool raft_experimental_topology,
+        db::system_keyspace& sys_ks,
         shared_ptr<db::system_distributed_keyspace> sys_dist_ks,
         noncopyable_function<unsigned()> get_num_token_owners,
         abort_source& abort_src) {
     try {
-        co_await do_update_streams_description(gen_id, *sys_dist_ks, { get_num_token_owners() });
+        co_await do_update_streams_description(gen_id, raft_experimental_topology, sys_ks, *sys_dist_ks, { get_num_token_owners() });
     } catch (...) {
         cdc_log.warn(
             "Could not update CDC description table with generation {}: {}. Will retry in the background.",
@@ -519,6 +543,8 @@ static future<> update_streams_description(
 
         // It is safe to discard this future: we keep system distributed keyspace alive.
         (void)(([] (cdc::generation_id gen_id,
+                    bool raft_experimental_topology,
+                    db::system_keyspace& sys_ks,
                     shared_ptr<db::system_distributed_keyspace> sys_dist_ks,
                     noncopyable_function<unsigned()> get_num_token_owners,
                     abort_source& abort_src) -> future<> {
@@ -530,7 +556,7 @@ static future<> update_streams_description(
                     co_return;
                 }
                 try {
-                    co_await do_update_streams_description(gen_id, *sys_dist_ks, { get_num_token_owners() });
+                    co_await do_update_streams_description(gen_id, raft_experimental_topology, sys_ks, *sys_dist_ks, { get_num_token_owners() });
                     co_return;
                 } catch (...) {
                     cdc_log.warn(
@@ -538,7 +564,7 @@ static future<> update_streams_description(
                         gen_id, std::current_exception());
                 }
             }
-        })(gen_id, std::move(sys_dist_ks), std::move(get_num_token_owners), abort_src));
+        })(gen_id, raft_experimental_topology, sys_ks, std::move(sys_dist_ks), std::move(get_num_token_owners), abort_src));
     }
 }
 
@@ -576,6 +602,8 @@ struct time_and_ttl {
  */
 static future<std::optional<cdc::generation_id_v1>> rewrite_streams_descriptions(
         std::vector<time_and_ttl> times_and_ttls,
+        bool raft_experimental_topology,
+        db::system_keyspace& sys_ks,
         shared_ptr<db::system_distributed_keyspace> sys_dist_ks,
         noncopyable_function<unsigned()> get_num_token_owners,
         abort_source& abort_src) {
@@ -619,7 +647,7 @@ static future<std::optional<cdc::generation_id_v1>> rewrite_streams_descriptions
     co_await max_concurrent_for_each(first, tss.end(), 10, [&] (db_clock::time_point ts) -> future<> {
         while (true) {
             try {
-                co_return co_await do_update_streams_description(cdc::generation_id_v1{ts}, *sys_dist_ks, { get_num_token_owners() });
+                co_return co_await do_update_streams_description(cdc::generation_id_v1{ts}, raft_experimental_topology, sys_ks, *sys_dist_ks, { get_num_token_owners() });
             } catch (const no_generation_data_exception& e) {
                 cdc_log.error("Failed to rewrite streams for generation {}: {}. Giving up.", ts, e);
                 each_success = false;
@@ -695,6 +723,8 @@ future<> generation_service::maybe_rewrite_streams_descriptions() {
     cdc_log.info("Rewriting stream tables in the background...");
     auto last_rewritten = co_await rewrite_streams_descriptions(
             std::move(times_and_ttls),
+            _cfg.raft_experimental_topology,
+            _sys_ks.local(),
             _sys_dist_ks.local_shared(),
             std::move(get_num_token_owners),
             _abort_src);
@@ -869,7 +899,7 @@ future<> generation_service::check_and_repair_cdc_streams() {
 
         std::optional<topology_description> gen;
         try {
-            gen = co_await retrieve_generation_data(*latest, *sys_dist_ks, { tmptr->count_normal_token_owners() });
+            gen = co_await retrieve_generation_data(*latest, _cfg.raft_experimental_topology, _sys_ks.local(), *sys_dist_ks, { tmptr->count_normal_token_owners() });
         } catch (exceptions::request_timeout_exception& e) {
             cdc_log.error("{}: \"{}\". {}.", timeout_msg, e.what(), exception_translating_msg);
             throw exceptions::request_execution_exception(exceptions::exception_code::READ_TIMEOUT,
@@ -985,7 +1015,7 @@ future<> generation_service::legacy_handle_cdc_generation(std::optional<cdc::gen
 
     if (using_this_gen) {
         cdc_log.info("Starting to use generation {}", *gen_id);
-        co_await update_streams_description(*gen_id, get_sys_dist_ks(),
+        co_await update_streams_description(*gen_id, _cfg.raft_experimental_topology, _sys_ks.local(), get_sys_dist_ks(),
                 [tmptr = _token_metadata.get()] { return tmptr->count_normal_token_owners(); },
                 _abort_src);
     }
@@ -1002,7 +1032,7 @@ void generation_service::legacy_async_handle_cdc_generation(cdc::generation_id g
                 bool using_this_gen = co_await svc->legacy_do_handle_cdc_generation_intercept_nonfatal_errors(gen_id);
                 if (using_this_gen) {
                     cdc_log.info("Starting to use generation {}", gen_id);
-                    co_await update_streams_description(gen_id, svc->get_sys_dist_ks(),
+                    co_await update_streams_description(gen_id, svc->_cfg.raft_experimental_topology, svc->_sys_ks.local(), svc->get_sys_dist_ks(),
                             [tmptr = svc->_token_metadata.get()] { return tmptr->count_normal_token_owners(); },
                             svc->_abort_src);
                 }
@@ -1071,7 +1101,7 @@ future<bool> generation_service::legacy_do_handle_cdc_generation(cdc::generation
     assert_shard_zero(__PRETTY_FUNCTION__);
 
     auto sys_dist_ks = get_sys_dist_ks();
-    auto gen = co_await retrieve_generation_data(gen_id, *sys_dist_ks, { _token_metadata.get()->count_normal_token_owners() });
+    auto gen = co_await retrieve_generation_data(gen_id, _cfg.raft_experimental_topology, _sys_ks.local(), *sys_dist_ks, { _token_metadata.get()->count_normal_token_owners() });
     if (!gen) {
         throw std::runtime_error(format(
             "Could not find CDC generation {} in distributed system tables (current time: {}),"

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -77,12 +77,18 @@ private:
      */
     std::optional<cdc::generation_id> _gen_id;
     future<> _cdc_streams_rewrite_complete = make_ready_future<>();
+
+    /* Returns true if raft topology changes are enabled.
+     * Can only be called from shard 0.
+     */
+    std::function<bool()> _raft_topology_change_enabled;
 public:
     generation_service(config cfg, gms::gossiper&,
             sharded<db::system_distributed_keyspace>&,
             sharded<db::system_keyspace>& sys_ks,
             abort_source&, const locator::shared_token_metadata&,
-            gms::feature_service&, replica::database& db);
+            gms::feature_service&, replica::database& db,
+            std::function<bool()> raft_topology_change_enabled);
 
     future<> stop();
     ~generation_service();

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -41,6 +41,7 @@ public:
         unsigned ignore_msb_bits;
         std::chrono::milliseconds ring_delay;
         bool dont_rewrite_streams = false;
+        bool raft_experimental_topology = false;
     };
 
 private:

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -523,7 +523,7 @@ public:
     future<bool> group0_history_contains(utils::UUID state_id);
 
     future<service::topology> load_topology_state();
-    future<service::topology_features> load_topology_features_state();
+    future<std::optional<service::topology_features>> load_topology_features_state();
 
     // Read CDC generation data with the given UUID as key.
     // Precondition: the data is known to be present in the table (because it was committed earlier through group 0).
@@ -569,7 +569,7 @@ public:
 
     future<service::topology_request_state> get_topology_request_state(utils::UUID id);
 private:
-    static service::topology_features decode_topology_features_state(::shared_ptr<cql3::untyped_result_set> rs);
+    static std::optional<service::topology_features> decode_topology_features_state(::shared_ptr<cql3::untyped_result_set> rs);
 
 public:
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -529,6 +529,13 @@ public:
     // Precondition: the data is known to be present in the table (because it was committed earlier through group 0).
     future<cdc::topology_description> read_cdc_generation(utils::UUID id);
 
+    // Read CDC generation data with the given UUID as key.
+    // Unlike `read_cdc_generation`, does not require the data to be present.
+    // This method is meant to be used after switching back to legacy mode due to raft recovery,
+    // as the node will need to fetch definition of a CDC generation that was
+    // previously created in raft topology mode.
+    future<std::optional<cdc::topology_description>> read_cdc_generation_opt(utils::UUID id);
+
     // Loads the current clean-up candidate for the CDC generation data. If there is no candidate, returns std::nullopt.
     future<std::optional<cdc::generation_id_v2>> get_cdc_generations_cleanup_candidate();
 

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -343,12 +343,18 @@ There are also a few static columns for cluster-global properties:
 - `unpublished_cdc_generations` - the IDs of the committed yet unpublished CDC generations
 - `global_topology_request` - if set, contains one of the supported global topology requests
 - `new_cdc_generation_data_uuid` - used in `commit_cdc_generation` state, the time UUID of the generation to be committed
+- `upgrade_state` - describes the progress of the upgrade to raft-based topology.
 
 # Join procedure
 
 In topology on raft mode, new nodes need to go through a new handshake procedure
 before they can join the cluster, including joining group 0. The handshake
 happens during raft discovery and replaced the old `GROUP0_MODIFY_CONFIG`.
+
+Because the upgrade procedure to raft-based topology is not fully automatic,
+we support joining the cluster in the old way if the cluster is not upgraded yet.
+The [relevant section](#choosing-how-to-join-a-cluster) describes how a node
+decides which operation to use.
 
 Two RPC verbs are introduced:
 
@@ -405,3 +411,72 @@ In case of failures like timeouts, connection issues, etc., the topology
 coordinator keeps retrying. Eventually, it can give up and just move the new
 node to the `left` state, either due to a timeout or an operator intervention,
 but this is not implemented yet.
+
+# Choosing how to join a cluster
+
+A bootstrapping node needs to determine whether to use raft topology operations
+or not. In order to do so, group 0 discovery is performed which establishes
+whether the node is supposed to create a new cluster or join an existing one:
+
+- If the node creates a new cluster, it bootstraps in raft topology mode.
+- If the node joins an existing cluster, it learns about a node which is already
+  a part of the group 0. Such a node will already know whether the cluster
+  operates in raft topology mode or not. It then issues `JOIN_NODE_QUERY`
+  RPC which tells the new node how it should join the cluster.
+
+# Upgrade from legacy topology to raft-based topology
+
+Upgrading existing clusters to use raft-based topology operations is supported.
+The process is not fully automatic because it needs to be triggered by the administrator
+after making sure that no topology operations are running at the moment. This
+limitation might be lifted in the future, and the procedure will trigger
+automatically after making sure that it's safe to do so.
+
+From the admin's point of view, the steps are as follows:
+
+- Upgrade all nodes in the cluster to the newest version
+- Wait until the `SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES` feature becomes enabled
+  and an appropriate message about the cluster being ready for upgrade is printed
+- Trigger the upgrade via `POST /storage_service/raft_topology/upgrade` HTTP route
+- Monitor progress of the upgrade via `GET /storage_service/raft_topology/upgrade`
+  or via observing the logs
+- After all nodes report `done` via the GET endpoint, the upgrade has fully finished
+
+The `upgrade_state` static column in `system.topology` serves the key role
+in coordinating the upgrade. It goes through the following states in the following
+order:
+
+- `not_upgraded` (or just null) - in this state, nodes wait for upgrade to be
+  started by the administrator. Invoking the `POST /storage_service/raft_topology/upgrade`
+  route changes the state from `not_upgraded` to `build_coordinator_state`
+
+After going out of the `not_upgraded` state, the current raft leader starts its
+topology coordinator fiber and coordinates the remaining steps:
+
+- `build_coordinator_state` - the topology coordinator reads the contents
+  of the local gossiper state and builds the initial state of `system.topology`.
+  A new CDC generation is created in and inserted to `system.cdc_generations_v3`.
+- `done` - upgrade is done and the state is fully built, the topology coordinator
+  can perform topology operations.
+
+# Raft topology recovery
+
+If a disaster happens and a majority of nodes are lost, changes to the group 0
+state are no longer possible and a manual recovery procedure needs to be performed.
+Our current procedure starts by switching all nodes to a special "recovery" mode
+in which nodes do not use raft at all. In this mode, dead nodes are supposed
+to be removed from the cluster via `nodetool removenode`. After all dead nodes
+are removed, state related to group 0 is deleted and nodes are restarted in
+regular mode, allowing the cluster to re-form group 0.
+
+Topology on raft fits into this procedure in the following way:
+
+- When nodes are restarted in recovery mode, they revert to gossiper-based
+  operations. This allows to perform `nodetool removenode` without having
+  a majority of nodes. In this mode, `system.topology` is *not* updated, so
+  it becomes outdated at the end.
+- Before disabling recovery mode on the nodes, the `system.topology` table
+  needs to be truncated on all nodes. This will cause nodes to revert to
+  legacy topology operations after exiting recovery mode.
+- After re-forming group 0, the cluster needs to be upgraded again to raft
+  topology by the administrator.

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -18,6 +18,7 @@
 #include "gms/gossiper.hh"
 #include "gms/i_endpoint_state_change_subscriber.hh"
 #include "utils/error_injection.hh"
+#include "service/storage_service.hh"
 
 namespace gms {
 
@@ -214,12 +215,14 @@ class persistent_feature_enabler : public i_endpoint_state_change_subscriber {
     gossiper& _g;
     feature_service& _feat;
     db::system_keyspace& _sys_ks;
+    service::storage_service& _ss;
 
 public:
-    persistent_feature_enabler(gossiper& g, feature_service& f, db::system_keyspace& s)
+    persistent_feature_enabler(gossiper& g, feature_service& f, db::system_keyspace& s, service::storage_service& ss)
             : _g(g)
             , _feat(f)
             , _sys_ks(s)
+            , _ss(ss)
     {
     }
     future<> on_join(inet_address ep, endpoint_state_ptr state, gms::permit_id) override {
@@ -239,8 +242,8 @@ public:
     future<> enable_features();
 };
 
-future<> feature_service::enable_features_on_join(gossiper& g, db::system_keyspace& sys_ks) {
-    auto enabler = make_shared<persistent_feature_enabler>(g, *this, sys_ks);
+future<> feature_service::enable_features_on_join(gossiper& g, db::system_keyspace& sys_ks, service::storage_service& ss) {
+    auto enabler = make_shared<persistent_feature_enabler>(g, *this, sys_ks, ss);
     g.register_(enabler);
     return enabler->enable_features();
 }
@@ -330,6 +333,10 @@ void feature_service::check_features(const std::set<sstring>& enabled_features,
 }
 
 future<> persistent_feature_enabler::enable_features() {
+    if (_ss.raft_topology_change_enabled()) {
+        co_return;
+    }
+
     auto loaded_peer_features = co_await _sys_ks.load_peer_features();
     auto&& features = _g.get_supported_features(loaded_peer_features, gossiper::ignore_features_of_local_node::no);
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -77,6 +77,9 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
     if (!cfg.check_experimental(db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS)) {
         fcfg._disabled_features.insert("KEYSPACE_STORAGE_OPTIONS"s);
     }
+    if (!cfg.check_experimental(db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES)) {
+        fcfg._disabled_features.insert("SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES"s);
+    }
     if (!cfg.check_experimental(db::experimental_features_t::feature::TABLETS)) {
         fcfg._disabled_features.insert("TABLETS"s);
     }

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -137,6 +137,7 @@ public:
     // tombstones and flags to schema tables when performing schema changes, allowing us to
     // revert to the digest method when necessary (if we must perform a schema change during RECOVERY).
     gms::feature group0_schema_versioning { *this, "GROUP0_SCHEMA_VERSIONING"sv };
+    gms::feature supports_consistent_topology_changes { *this, "SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES"sv };
 
     // A feature just for use in tests. It must not be advertised unless
     // the "features_enable_test_feature" injection is enabled.

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -31,6 +31,7 @@ namespace gms {
 
 class gossiper;
 class feature_service;
+class i_endpoint_state_change_subscriber;
 
 struct feature_config {
     bool use_raft_cluster_features = false;
@@ -149,7 +150,7 @@ public:
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;
 
     static std::set<sstring> to_feature_set(sstring features_string);
-    future<> enable_features_on_join(gossiper&, db::system_keyspace&);
+    future<> enable_features_on_join(gossiper&, db::system_keyspace&, service::storage_service&);
     future<> on_system_tables_loaded(db::system_keyspace& sys_ks);
 
     // Performs the feature check.

--- a/idl/join_node.idl.hh
+++ b/idl/join_node.idl.hh
@@ -8,6 +8,17 @@
 
 namespace service {
 
+struct join_node_query_params {};
+
+struct join_node_query_result {
+    enum class topology_mode : uint8_t {
+        legacy = 0,
+        raft = 1,
+    };
+
+    service::join_node_query_result::topology_mode topo_mode;
+};
+
 struct join_node_request_params {
     raft::server_id host_id;
     std::optional<raft::server_id> replaced_id;
@@ -51,6 +62,7 @@ struct join_node_response_params {
 
 struct join_node_response_result {};
 
+verb join_node_query (raft::server_id dst_id, service::join_node_query_params) -> service::join_node_query_result;
 verb join_node_request (raft::server_id dst_id, service::join_node_request_params) -> service::join_node_request_result;
 verb join_node_response (raft::server_id dst_id, service::join_node_response_params) -> service::join_node_response_result;
 

--- a/main.cc
+++ b/main.cc
@@ -1620,6 +1620,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             cdc_config.ignore_msb_bits = cfg->murmur3_partitioner_ignore_msb_bits();
             cdc_config.ring_delay = std::chrono::milliseconds(cfg->ring_delay_ms());
             cdc_config.dont_rewrite_streams = cfg->cdc_dont_rewrite_streams();
+            cdc_config.raft_experimental_topology = raft_topology_change_enabled;
             cdc_generation_service.start(std::move(cdc_config), std::ref(gossiper), std::ref(sys_dist_ks), std::ref(sys_ks),
                     std::ref(stop_signal.as_sharded_abort_source()), std::ref(token_metadata), std::ref(feature_service), std::ref(db),
                     [&ss] () -> bool { return ss.local().raft_topology_change_enabled(); }).get();

--- a/main.cc
+++ b/main.cc
@@ -1806,7 +1806,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // Need to do it before allowing incoming messaging service connections since
             // storage proxy's and migration manager's verbs may access group0.
             // This will also disable migration manager schema pulls if needed.
-            group0_service.setup_group0_if_exist(sys_ks.local(), ss.local(), qp.local(), mm.local(), raft_topology_change_enabled).get();
+            group0_service.setup_group0_if_exist(sys_ks.local(), ss.local(), qp.local(), mm.local()).get();
 
             with_scheduling_group(maintenance_scheduling_group, [&] {
                 return messaging.invoke_on_all(&netw::messaging_service::start_listen, std::ref(token_metadata));

--- a/main.cc
+++ b/main.cc
@@ -1621,7 +1621,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             cdc_config.ring_delay = std::chrono::milliseconds(cfg->ring_delay_ms());
             cdc_config.dont_rewrite_streams = cfg->cdc_dont_rewrite_streams();
             cdc_generation_service.start(std::move(cdc_config), std::ref(gossiper), std::ref(sys_dist_ks), std::ref(sys_ks),
-                    std::ref(stop_signal.as_sharded_abort_source()), std::ref(token_metadata), std::ref(feature_service), std::ref(db)).get();
+                    std::ref(stop_signal.as_sharded_abort_source()), std::ref(token_metadata), std::ref(feature_service), std::ref(db),
+                    [&ss] () -> bool { return ss.local().raft_topology_change_enabled(); }).get();
             auto stop_cdc_generation_service = defer_verbose_shutdown("CDC Generation Management service", [] {
                 cdc_generation_service.stop().get();
             });

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -578,6 +578,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::RAFT_TOPOLOGY_CMD:
     case messaging_verb::JOIN_NODE_REQUEST:
     case messaging_verb::JOIN_NODE_RESPONSE:
+    case messaging_verb::JOIN_NODE_QUERY:
         // See comment above `TOPOLOGY_INDEPENDENT_IDX`.
         // DO NOT put any 'hot' (e.g. data path) verbs in this group,
         // only verbs which are 'rare' and 'cheap'.

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -193,7 +193,8 @@ enum class messaging_verb : int32_t {
     TABLET_STREAM_FILES = 70,
     STREAM_BLOB = 71,
     TABLE_LOAD_STATS = 72,
-    LAST = 73,
+    JOIN_NODE_QUERY = 73,
+    LAST = 74,
 };
 
 } // namespace netw

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -16,6 +16,11 @@
 #include "utils/UUID_gen.hh"
 #include "mutation/canonical_mutation.hh"
 #include "service/raft/raft_state_machine.hh"
+#include "gms/feature.hh"
+
+namespace gms {
+class feature_service;
+}
 
 namespace service {
 class raft_group0_client;
@@ -91,11 +96,11 @@ class group0_state_machine : public raft_state_machine {
     seastar::gate _gate;
     abort_source _abort_source;
     bool _topology_change_enabled;
+    gms::feature::listener_registration _topology_on_raft_support_listener;
 
     future<> merge_and_apply(group0_state_machine_merger& merger);
 public:
-    group0_state_machine(raft_group0_client& client, migration_manager& mm, storage_proxy& sp, storage_service& ss, raft_address_map& address_map, bool topology_change_enabled)
-            : _client(client), _mm(mm), _sp(sp), _ss(ss), _address_map(address_map), _topology_change_enabled(topology_change_enabled) {}
+    group0_state_machine(raft_group0_client& client, migration_manager& mm, storage_proxy& sp, storage_service& ss, raft_address_map& address_map, gms::feature_service& feat, bool topology_change_enabled);
     future<> apply(std::vector<raft::command_cref> command) override;
     future<raft::snapshot_id> take_snapshot() override;
     void drop_snapshot(raft::snapshot_id id) override;

--- a/service/raft/join_node.hh
+++ b/service/raft/join_node.hh
@@ -14,6 +14,20 @@
 
 namespace service {
 
+struct join_node_query_params {};
+
+struct join_node_query_result {
+    enum class topology_mode : uint8_t {
+        // The cluster uses legacy, gossiper-based topology operations
+        legacy = 0,
+
+        // The cluster uses raft-based topology operations
+        raft = 1,
+    };
+
+    topology_mode topo_mode;
+};
+
 struct join_node_request_params {
     raft::server_id host_id;
     std::optional<raft::server_id> replaced_id;

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -240,7 +240,9 @@ raft_group0::discover_group0(const std::vector<gms::inet_address>& seeds, cql3::
     auto my_id = load_my_id();
     discovery::peer_list peers;
     for (auto& ip: seeds) {
-        peers.emplace_back(discovery_peer{raft::server_id{}, ip});
+        if (ip != _gossiper.get_broadcast_address()) {
+            peers.emplace_back(discovery_peer{raft::server_id{}, ip});
+        }
     }
     discovery_peer my_addr = {my_id, _gossiper.get_broadcast_address()};
 
@@ -695,9 +697,7 @@ future<> raft_group0::setup_group0(
 
     std::vector<gms::inet_address> seeds;
     for (auto& addr: initial_contact_nodes) {
-        if (addr != _gossiper.get_broadcast_address()) {
-            seeds.push_back(addr);
-        }
+        seeds.push_back(addr);
     }
 
     group0_log.info("setup_group0: joining group 0...");

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -90,7 +90,7 @@ static logging::logger group0_log("raft_group0");
 static logging::logger upgrade_log("raft_group0_upgrade");
 
 // TODO: change the links from master to stable/5.2 after 5.2 is released
-static const auto raft_upgrade_doc = "https://docs.scylladb.com/master/architecture/raft.html#verifying-that-the-internal-raft-upgrade-procedure-finished-successfully";
+const char* const raft_upgrade_doc = "https://docs.scylladb.com/master/architecture/raft.html#verifying-that-the-internal-raft-upgrade-procedure-finished-successfully";
 static const auto raft_manual_recovery_doc = "https://docs.scylladb.com/master/architecture/raft.html#raft-manual-recovery-procedure";
 
 // {{{ group0_rpc Maintain failure detector subscription whenever

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -236,7 +236,8 @@ raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, 
 }
 
 future<group0_info>
-raft_group0::discover_group0(raft::server_id my_id, const std::vector<gms::inet_address>& seeds, cql3::query_processor& qp) {
+raft_group0::discover_group0(const std::vector<gms::inet_address>& seeds, cql3::query_processor& qp) {
+    auto my_id = load_my_id();
     discovery::peer_list peers;
     for (auto& ip: seeds) {
         peers.emplace_back(discovery_peer{raft::server_id{}, ip});
@@ -448,7 +449,7 @@ future<> raft_group0::join_group0(std::vector<gms::inet_address> seeds, shared_p
     auto my_id = load_my_id();
     group0_log.info("server {} found no local group 0. Discovering...", my_id);
     while (true) {
-        auto g0_info = co_await discover_group0(my_id, seeds, qp);
+        auto g0_info = co_await discover_group0(seeds, qp);
         group0_log.info("server {} found group 0 with group id {}, leader {}", my_id, g0_info.group0_id, g0_info.id);
 
         if (server && group0_id != g0_info.group0_id) {

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -147,6 +147,15 @@ public:
     // Call before destroying the object.
     future<> abort();
 
+    // Run the discovery algorithm.
+    //
+    // Discovers an existing group 0 cluster or elects a server (called a 'leader')
+    // responsible for creating a new group 0 cluster if one doesn't exist
+    // (in particular, we may become that leader).
+    //
+    // See 'raft-in-scylla.md', 'Establishing group 0 in a fresh cluster'.
+    future<group0_info> discover_group0(const std::vector<gms::inet_address>& seeds, cql3::query_processor& qp);
+
     // Call during the startup procedure, after gossiping has started.
     //
     // If we're performing the replace operation, pass the IP and Raft ID of the replaced node
@@ -280,15 +289,6 @@ private:
 
     raft_server_for_group create_server_for_group0(raft::group_id id, raft::server_id my_id, service::storage_service& ss, cql3::query_processor& qp,
         service::migration_manager& mm, bool topology_change_enabled);
-
-    // Run the discovery algorithm.
-    //
-    // Discovers an existing group 0 cluster or elects a server (called a 'leader')
-    // responsible for creating a new group 0 cluster if one doesn't exist
-    // (in particular, we may become that leader).
-    //
-    // See 'raft-in-scylla.md', 'Establishing group 0 in a fresh cluster'.
-    future<group0_info> discover_group0(const std::vector<gms::inet_address>& seeds, cql3::query_processor& qp);
 
     // Creates or joins group 0 and switches schema/topology changes to use group 0.
     // Can be restarted after a crash. Does nothing if the procedure was already finished once.

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -20,6 +20,8 @@ namespace gms { class gossiper; class feature_service; }
 
 namespace service {
 
+extern const char* const raft_upgrade_doc;
+
 class migration_manager;
 class raft_group0_client;
 class storage_service;

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -288,8 +288,7 @@ private:
     // (in particular, we may become that leader).
     //
     // See 'raft-in-scylla.md', 'Establishing group 0 in a fresh cluster'.
-    future<group0_info> discover_group0(raft::server_id my_id,
-        const std::vector<gms::inet_address>& seeds, cql3::query_processor& qp);
+    future<group0_info> discover_group0(const std::vector<gms::inet_address>& seeds, cql3::query_processor& qp);
 
     // Creates or joins group 0 and switches schema/topology changes to use group 0.
     // Can be restarted after a crash. Does nothing if the procedure was already finished once.

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -261,6 +261,10 @@ public:
     // or when joining an old cluster which does not support JOIN_NODE RPC).
     shared_ptr<group0_handshaker> make_legacy_handshaker(bool can_vote);
 
+    // Waits until all upgrade to raft group 0 finishes and all nodes switched
+    // to use_post_raft_procedures.
+    future<> wait_for_all_nodes_to_finish_upgrade(abort_source& as);
+
     raft_group0_client& client() {
         return _client;
     }

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -182,7 +182,7 @@ public:
     //
     // Cannot be called twice.
     //
-    future<> setup_group0_if_exist(db::system_keyspace&, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, bool topology_change_enabled);
+    future<> setup_group0_if_exist(db::system_keyspace&, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm);
 
     // Call at the end of the startup procedure, after the node entered NORMAL state.
     // `setup_group0()` must have finished earlier.

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -437,6 +437,10 @@ db::system_keyspace& raft_group0_client::sys_ks() {
     return _sys_ks;
 }
 
+bool raft_group0_client::in_recovery() const {
+    return _upgrade_state == group0_upgrade_state::recovery;
+}
+
 raft_group0_client::query_result_guard::query_result_guard(utils::UUID query_id, raft_group0_client& client)
     : _query_id{query_id}, _client{&client} {
     auto [_, emplaced] = _client->_results.emplace(_query_id, std::nullopt);

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -178,6 +178,8 @@ public:
 
     db::system_keyspace& sys_ks();
 
+    bool in_recovery() const;
+
     // for test only
     void set_history_gc_duration(gc_clock::duration d);
     semaphore& operation_mutex();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1468,9 +1468,8 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
         });
     }
     
-    // TODO: Look at the group 0 upgrade state and use it to decide whether to attach or not
     if (!raft_topology_change_enabled()) {
-        co_await _feature_service.enable_features_on_join(_gossiper, _sys_ks.local());
+        co_await _feature_service.enable_features_on_join(_gossiper, _sys_ks.local(), *this);
     }
 
     set_mode(mode::JOINING);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -418,6 +418,7 @@ future<> storage_service::sync_raft_topology_nodes(mutable_token_metadata_ptr tm
             info.rack = rs.rack;
             info.host_id = id.uuid();
             info.release_version = rs.release_version;
+            info.supported_features = fmt::to_string(fmt::join(rs.supported_features, ","));
             co_await _sys_ks.local().update_peer_info(*ip, info);
             if (!prev_normal.contains(id)) {
                 co_await notify_joined(*ip);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1013,7 +1013,8 @@ future<> storage_service::raft_initialize_discovery_leader(raft::server& raft_se
         // We are the first node and we define the cluster.
         // Set the enabled_features field to our features.
         topology_mutation_builder builder(guard.write_timestamp());
-        builder.add_enabled_features(boost::copy_range<std::set<sstring>>(params.supported_features));
+        builder.add_enabled_features(boost::copy_range<std::set<sstring>>(params.supported_features))
+                .set_upgrade_state(topology::upgrade_state_type::done); // Skip upgrade, start right in the topology-on-raft mode
         auto enable_features_mutation = builder.build();
 
         insert_join_request_mutations.push_back(std::move(enable_features_mutation));

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -839,6 +839,13 @@ public:
 
     future<> do_cluster_cleanup();
 
+    // Starts the upgrade procedure to topology on raft.
+    // Must be called on shard 0.
+    future<> start_upgrade_to_raft_topology();
+
+    // Must be called on shard 0.
+    topology::upgrade_state_type get_topology_upgrade_state() const;
+
 private:
     // Tracks progress of the upgrade to topology coordinator.
     future<> _upgrade_to_topology_coordinator_fiber = make_ready_future<>();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -825,6 +825,12 @@ public:
     future<> topology_transition();
 
     future<> do_cluster_cleanup();
+
+private:
+    // Tracks progress of the upgrade to topology coordinator.
+    future<> _upgrade_to_topology_coordinator_fiber = make_ready_future<>();
+    future<> track_upgrade_progress_to_topology_coordinator(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy);
+
 public:
     future<> move_tablet(table_id, dht::token, locator::tablet_replica src, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> set_tablet_balancing_enabled(bool);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -763,6 +763,12 @@ private:
     };
     topology_change_kind _topology_change_kind_enabled = topology_change_kind::unknown;
 
+    // Throws an exception if the node is either starting and didn't determine which
+    // topology operations to use, or if it is in the process of upgrade to topology
+    // on raft. The name only serves for display purposes (i.e. it will be included
+    // in the exception, if one is thrown).
+    void check_ability_to_perform_topology_operation(std::string_view operation_name) const;
+
 public:
     bool raft_topology_change_enabled() const {
         return _topology_change_kind_enabled == topology_change_kind::raft;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -441,7 +441,6 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             if (binfo && binfo->bootstrap_tokens.contains(end)) {
                 return {binfo->rs.shard_count, binfo->rs.ignore_msb};
             } else {
-                // FIXME: token metadata should directly return host ID for given token. See #12279
                 auto ep = tmptr->get_endpoint(end);
                 if (!ep) {
                     // get_sharding_info is only called for bootstrap tokens

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -224,6 +224,10 @@ topology_mutation_builder& topology_mutation_builder::set_global_topology_reques
     return apply_atomic("global_topology_request", ::format("{}", value));
 }
 
+topology_mutation_builder& topology_mutation_builder::set_upgrade_state(topology::upgrade_state_type value) {
+    return apply_atomic("upgrade_state", ::format("{}", value));
+}
+
 topology_mutation_builder& topology_mutation_builder::add_enabled_features(const std::set<sstring>& features) {
     return apply_set("enabled_features", collection_apply_mode::update, features | boost::adaptors::transformed([] (const auto& f) { return sstring(f); }));
 }

--- a/service/topology_mutation.hh
+++ b/service/topology_mutation.hh
@@ -116,6 +116,7 @@ public:
     topology_mutation_builder& set_new_cdc_generation_data_uuid(const utils::UUID& value);
     topology_mutation_builder& set_unpublished_cdc_generations(const std::vector<cdc::generation_id_v2>& values);
     topology_mutation_builder& set_global_topology_request(global_topology_request);
+    topology_mutation_builder& set_upgrade_state(topology::upgrade_state_type);
     topology_mutation_builder& add_enabled_features(const std::set<sstring>& value);
     topology_mutation_builder& add_unpublished_cdc_generation(const cdc::generation_id_v2& value);
     topology_mutation_builder& del_transition_state();

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -295,9 +295,29 @@ cleanup_status cleanup_status_from_string(const sstring& s) {
     throw std::runtime_error(fmt::format("cannot map name {} to cleanup_status", s));
 }
 
+static const std::unordered_map<topology::upgrade_state_type, sstring> upgrade_state_to_name_map = {
+    {topology::upgrade_state_type::not_upgraded, "not_upgraded"},
+    {topology::upgrade_state_type::build_coordinator_state, "build_coordinator_state"},
+    {topology::upgrade_state_type::done, "done"},
+};
+
+topology::upgrade_state_type upgrade_state_from_string(const sstring& s) {
+    for (const auto& e : upgrade_state_to_name_map) {
+        if (e.second == s) {
+            return e.first;
+        }
+    }
+    on_internal_error(tsmlogger, format("cannot map name {} to upgrade_state", s));
+}
+
 }
 
 auto fmt::formatter<service::cleanup_status>::format(service::cleanup_status status,
                                                      fmt::format_context& ctx) const -> decltype(ctx.out()) {
     return fmt::format_to(ctx.out(), "{}", service::cleanup_status_to_name_map[status]);
+}
+
+auto fmt::formatter<service::topology::upgrade_state_type>::format(service::topology::upgrade_state_type state,
+                                                     fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", service::upgrade_state_to_name_map.at(state));
 }

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -120,6 +120,14 @@ struct topology {
 
     std::optional<transition_state> tstate;
 
+    enum class upgrade_state_type: uint16_t {
+        not_upgraded,
+        build_coordinator_state,
+        done,
+    };
+
+    upgrade_state_type upgrade_state = upgrade_state_type::not_upgraded;
+
     using version_t = int64_t;
     static constexpr version_t initial_version = 1;
     version_t version = initial_version;
@@ -263,6 +271,7 @@ std::ostream& operator<<(std::ostream&, const global_topology_request&);
 global_topology_request global_topology_request_from_string(const sstring&);
 std::ostream& operator<<(std::ostream& os, const raft_topology_cmd::command& cmd);
 cleanup_status cleanup_status_from_string(const sstring& s);
+topology::upgrade_state_type upgrade_state_from_string(const sstring&);
 }
 
 template <> struct fmt::formatter<service::cleanup_status> {
@@ -270,3 +279,7 @@ template <> struct fmt::formatter<service::cleanup_status> {
     auto format(service::cleanup_status status, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
+template <> struct fmt::formatter<service::topology::upgrade_state_type> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(service::topology::upgrade_state_type status, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -869,6 +869,7 @@ private:
              * and would only slow down tests (by having them wait).
              */
             cdc_config.ring_delay = std::chrono::milliseconds(0);
+            cdc_config.raft_experimental_topology = raft_topology_change_enabled;
             _cdc_generation_service.start(std::ref(cdc_config), std::ref(_gossiper), std::ref(_sys_dist_ks), std::ref(_sys_ks), std::ref(abort_sources), std::ref(_token_metadata), std::ref(_feature_service), std::ref(_db), [raft_topology_change_enabled] { return raft_topology_change_enabled; }).get();
             auto stop_cdc_generation_service = defer([this] {
                 _cdc_generation_service.stop().get();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -857,6 +857,9 @@ private:
                 return service.set_distributed_data_accessor(std::move(service_level_data_accessor));
             }).get();
 
+            const bool raft_topology_change_enabled =
+                    cfg->check_experimental(db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES);
+
             cdc::generation_service::config cdc_config;
             cdc_config.ignore_msb_bits = cfg->murmur3_partitioner_ignore_msb_bits();
             /*
@@ -881,9 +884,6 @@ private:
             auto stop_group0_service = defer([&group0_service] {
                 group0_service.abort().get();
             });
-
-            const bool raft_topology_change_enabled =
-                    cfg->check_experimental(db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES);
 
             _ss.local().set_group0(group0_service, raft_topology_change_enabled);
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -869,7 +869,7 @@ private:
              * and would only slow down tests (by having them wait).
              */
             cdc_config.ring_delay = std::chrono::milliseconds(0);
-            _cdc_generation_service.start(std::ref(cdc_config), std::ref(_gossiper), std::ref(_sys_dist_ks), std::ref(_sys_ks), std::ref(abort_sources), std::ref(_token_metadata), std::ref(_feature_service), std::ref(_db)).get();
+            _cdc_generation_service.start(std::ref(cdc_config), std::ref(_gossiper), std::ref(_sys_dist_ks), std::ref(_sys_ks), std::ref(abort_sources), std::ref(_token_metadata), std::ref(_feature_service), std::ref(_db), [raft_topology_change_enabled] { return raft_topology_change_enabled; }).get();
             auto stop_cdc_generation_service = defer([this] {
                 _cdc_generation_service.stop().get();
             });

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -288,6 +288,16 @@ class ScyllaRESTAPIClient():
         url = "/system/dump_llvm_profile"
         await self.client.post(url, host=node_ip)
 
+    async def upgrade_to_raft_topology(self, node_ip: str) -> None:
+        """Start the upgrade to raft topology"""
+        await self.client.post("/storage_service/raft_topology/upgrade", host=node_ip)
+
+    async def raft_topology_upgrade_status(self, node_ip: str) -> str:
+        """Returns the current state of upgrade to raft topology"""
+        data = await self.client.get_json("/storage_service/raft_topology/upgrade", host=node_ip)
+        assert(type(data) == str)
+        return data
+
     async def repair(self, node_ip: str, keyspace: str, table: str) -> None:
         """Repair the given table and wait for it to complete"""
         sequence_number = await self.client.post_json(f"/storage_service/repair_async/{keyspace}", host=node_ip, params={"columnFamilies": table})

--- a/test/topology_experimental_raft/suite.yaml
+++ b/test/topology_experimental_raft/suite.yaml
@@ -17,6 +17,7 @@ skip_in_release:
   - test_cdc_generation_publishing
   - test_raft_cluster_features
   - test_raft_ignore_nodes
+  - test_topology_upgrade
 skip_in_debug:
   - test_cdc_generation_clearing
   - test_cdc_generation_publishing

--- a/test/topology_experimental_raft/test_topology_recovery_basic.py
+++ b/test/topology_experimental_raft/test_topology_recovery_basic.py
@@ -1,0 +1,77 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import asyncio
+import logging
+import pytest
+import time
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for_cql_and_get_hosts
+from test.topology.util import reconnect_driver, restart, enter_recovery_state, \
+        delete_raft_data_and_upgrade_state, log_run_time, wait_until_upgrade_finishes as wait_until_schema_upgrade_finishes, \
+        wait_until_topology_upgrade_finishes, delete_raft_topology_state, check_system_topology_and_cdc_generations_v3_consistency
+
+
+@pytest.mark.asyncio
+@log_run_time
+async def test_topology_recovery_basic(request, manager: ManagerClient):
+    servers = await manager.servers_add(3)
+    cql = manager.cql
+    assert(cql)
+
+    logging.info("Waiting until driver connects to every server")
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logging.info(f"Restarting hosts {hosts} in recovery mode")
+    await asyncio.gather(*(enter_recovery_state(cql, h) for h in hosts))
+    # Restart sequentially, as it tests how nodes operating in legacy mode
+    # react to raft topology mode nodes and vice versa
+    for srv in servers:
+        await restart(manager, srv)
+    cql = await reconnect_driver(manager)
+
+    logging.info("Cluster restarted, waiting until driver reconnects to every server")
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    logging.info(f"Driver reconnected, hosts: {hosts}")
+
+    logging.info(f"Deleting Raft data and upgrade state on {hosts}")
+    await asyncio.gather(*(delete_raft_topology_state(cql, h) for h in hosts))
+    await asyncio.gather(*(delete_raft_data_and_upgrade_state(cql, h) for h in hosts))
+
+    logging.info(f"Restarting hosts {hosts}")
+    for srv in servers:
+        await restart(manager, srv)
+
+    logging.info("Cluster restarted, waiting until driver reconnects to every server")
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logging.info("Waiting until upgrade to raft schema finishes")
+    await asyncio.gather(*(wait_until_schema_upgrade_finishes(cql, h, time.time() + 60) for h in hosts))
+
+    logging.info("Checking the topology upgrade state on all nodes")
+    for host in hosts:
+        status = await manager.api.raft_topology_upgrade_status(host.address)
+        assert status == "not_upgraded"
+
+    logging.info("Waiting until all nodes see others as alive")
+    await manager.servers_see_each_other(servers)
+
+    logging.info("Triggering upgrade to raft topology")
+    await manager.api.upgrade_to_raft_topology(hosts[0].address)
+
+    logging.info("Waiting until upgrade finishes")
+    await asyncio.gather(*(wait_until_topology_upgrade_finishes(manager, h.address, time.time() + 60) for h in hosts))
+
+    logging.info("Checking consistency of data in system.topology and system.cdc_generations_v3")
+    await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)
+
+    logging.info("Booting new node")
+    servers += [await manager.server_add()]
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logging.info("Checking consistency of data in system.topology and system.cdc_generations_v3")
+    await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)

--- a/test/topology_experimental_raft/test_topology_recovery_majority_loss.py
+++ b/test/topology_experimental_raft/test_topology_recovery_majority_loss.py
@@ -1,0 +1,75 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import asyncio
+import logging
+import pytest
+import time
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for_cql_and_get_hosts
+from test.topology.util import reconnect_driver, restart, enter_recovery_state, \
+        delete_raft_data_and_upgrade_state, log_run_time, wait_until_upgrade_finishes as wait_until_schema_upgrade_finishes, \
+        wait_until_topology_upgrade_finishes, delete_raft_topology_state, check_system_topology_and_cdc_generations_v3_consistency
+
+
+@pytest.mark.asyncio
+@log_run_time
+async def test_topology_recovery_after_majority_loss(request, manager: ManagerClient):
+    servers = await manager.servers_add(3)
+    cql = manager.cql
+    assert(cql)
+
+    logging.info("Waiting until driver connects to every server")
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    srv1, *others = servers
+
+    logging.info(f"Killing all nodes except {srv1}")
+    await asyncio.gather(*(manager.server_stop_gracefully(srv.server_id) for srv in others))
+
+    logging.info(f"Entering recovery state on {srv1}")
+    host1 = next(h for h in hosts if h.address == srv1.ip_addr)
+    await enter_recovery_state(cql, host1)
+    await restart(manager, srv1)
+    cql = await reconnect_driver(manager)
+
+    logging.info("Node restarted, waiting until driver connects")
+    host1 = (await wait_for_cql_and_get_hosts(cql, [srv1], time.time() + 60))[0]
+
+    for i in range(len(others)):
+        to_remove = others[i]
+        ignore_dead_ips = [srv.ip_addr for srv in others[i+1:]]
+        logging.info(f"Removing {to_remove} using {srv1} with ignore_dead: {ignore_dead_ips}")
+        await manager.remove_node(srv1.server_id, to_remove.server_id, ignore_dead_ips)
+
+    logging.info(f"Deleting old Raft data and upgrade state on {host1} and restarting")
+    await delete_raft_topology_state(cql, host1)
+    await delete_raft_data_and_upgrade_state(cql, host1)
+    await restart(manager, srv1)
+    cql = await reconnect_driver(manager)
+
+    logging.info("Node restarted, waiting until driver connects")
+    host1 = (await wait_for_cql_and_get_hosts(cql, [srv1], time.time() + 60))[0]
+
+    logging.info("Waiting until upgrade to raft schema finishes.")
+    await wait_until_schema_upgrade_finishes(cql, host1, time.time() + 60)
+
+    logging.info("Triggering upgrade to raft topology")
+    await manager.api.upgrade_to_raft_topology(host1.address)
+
+    logging.info("Waiting until upgrade to raft topology finishes")
+    await wait_until_topology_upgrade_finishes(manager, host1.address, time.time() + 60)
+
+    logging.info("Checking consistency of data in system.topology and system.cdc_generations_v3")
+    await check_system_topology_and_cdc_generations_v3_consistency(manager, [host1])
+
+    logging.info("Add two more nodes")
+    servers = [srv1] + await manager.servers_add(2)
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logging.info("Checking consistency of data in system.topology and system.cdc_generations_v3")
+    await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)

--- a/test/topology_experimental_raft/test_topology_upgrade.py
+++ b/test/topology_experimental_raft/test_topology_upgrade.py
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import asyncio
+import logging
+import pytest
+import time
+
+from test.pylib.rest_client import HTTPError
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for_cql_and_get_hosts
+from test.topology.util import log_run_time, wait_until_topology_upgrade_finishes, \
+        check_system_topology_and_cdc_generations_v3_consistency
+
+
+@pytest.mark.asyncio
+@log_run_time
+async def test_topology_upgrade_basic(request, manager: ManagerClient):
+    # First, force the first node to start in legacy mode due to the error injection
+    cfg = {'error_injections_at_startup': ['force_gossip_based_join']}
+
+    servers = [await manager.server_add(config=cfg)]
+    # Disable injections for the subsequent nodes - they should fall back to
+    # using gossiper-based node operations
+    del cfg['error_injections_at_startup']
+
+    servers += [await manager.server_add(config=cfg) for _ in range(2)]
+    cql = manager.cql
+    assert(cql)
+
+    logging.info("Waiting until driver connects to every server")
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logging.info("Checking the upgrade state on all nodes")
+    for host in hosts:
+        status = await manager.api.raft_topology_upgrade_status(host.address)
+        assert status == "not_upgraded"
+
+    logging.info("Triggering upgrade to raft topology")
+    await manager.api.upgrade_to_raft_topology(hosts[0].address)
+
+    logging.info("Check that triggering upgrade is idempotent")
+    await manager.api.upgrade_to_raft_topology(hosts[0].address)
+
+    logging.info("Waiting until upgrade finishes")
+    await asyncio.gather(*(wait_until_topology_upgrade_finishes(manager, h.address, time.time() + 60) for h in hosts))
+
+    logging.info("Checking consistency of data in system.topology and system.cdc_generations_v3")
+    await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)
+
+    logging.info("Booting new node")
+    await manager.server_add(config=cfg)
+
+    logging.info("Waiting until driver connects to every server")
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logging.info("Checking consistency of data in system.topology and system.cdc_generations_v3")
+    await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)


### PR DESCRIPTION
This PR implements a procedure that upgrades existing clusters to use raft-based topology operations. The procedure does not start automatically, it must be triggered manually by the administrator after making sure that no topology operations are currently running.

Upgrade is triggered by sending `POST /storage_service/raft_topology/upgrade` request. This causes the topology coordinator to start who drives the rest of the process: it builds the `system.topology` state based on information observed in gossip and tells all nodes to switch to raft mode. Then, topology coordinator runs normally.

Upgrade progress is tracked in a new static column `upgrade_state` in `system.topology`.

The procedure also serves as an extension to the current recovery procedure on raft. The current recovery procedure requires restarting nodes in a special mode which disables raft, perform `nodetool removenode` on the dead nodes, clean up some state on the nodes and restart them so that they automatically rebuild the group 0. Raft topology fits into existing procedure by falling back to legacy topology operations after disabling raft. After rebuilding the group 0, upgrade needs to be triggered again.

Because upgrade is manual and it might not be convenient for administrators to run it right after upgrading the cluster, we allow the cluster to operate in legacy topology operations mode until upgrade, which includes allowing new nodes to join. In order to allow it, nodes now ask the cluster about the mode they should use to join before proceeding by using a new `JOIN_NODE_QUERY` RPC.

The procedure is explained in more detail in `topology-over-raft.md`.

Fixes: https://github.com/scylladb/scylladb/issues/15008