### PR TITLE
tablets: Make sure topology has enough endpoints for RF

### DIFF
--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -95,7 +95,7 @@ public:
     virtual sstring keypace_name() const override { return name(); }
     virtual sstring element_name() const override { return name(); }
     virtual sstring element_type() const override { return "keyspace"; }
-    virtual std::ostream& describe(std::ostream& os) const override;
+    virtual std::ostream& describe(replica::database& db, std::ostream& os, bool with_internals) const override;
 };
 
 }

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -466,22 +466,6 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
 
     tmap = tab_awr_ptr->allocate_tablets_for_new_table(s, stm.get(), 1).get();
     full_ring_check(tmap, options320, ars_ptr, stm.get());
-
-    // Test the case of not enough nodes to meet RF in DC 102
-    std::map<sstring, sstring> options324 = {
-            {"100", "3"},
-            {"101", "4"},
-            {"102", "2"},
-    };
-    locator::replication_strategy_params params324(options324, 100);
-
-    ars_ptr = abstract_replication_strategy::create_replication_strategy(
-            "NetworkTopologyStrategy", params324);
-    tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
-    BOOST_REQUIRE(tab_awr_ptr);
-
-    tmap = tab_awr_ptr->allocate_tablets_for_new_table(s, stm.get(), 1).get();
-    full_ring_check(tmap, options324, ars_ptr, stm.get());
 }
 
 /**

--- a/test/cql-pytest/test_describe.py
+++ b/test/cql-pytest/test_describe.py
@@ -835,9 +835,12 @@ def new_random_keyspace(cql):
     options["class"] = random.choice(strategies)
     options["replication_factor"] = random.randrange(1, 6)
     options_str = ", ".join([f"'{k}': '{v}'" for (k, v) in options.items()])
+    extra = ""
+    if options["class"] == "NetworkTopologyStrategy" and options["replication_factor"] != 1:
+        extra = " and tablets = { 'enabled': false }"
 
     write = random.choice(writes)
-    return new_test_keyspace(cql, f"with replication = {{{options_str}}} and durable_writes = {write}")
+    return new_test_keyspace(cql, f"with replication = {{{options_str}}} and durable_writes = {write}{extra}")
 
 # A utility function for creating random table. `udts` argument represents
 # UDTs that can be used to create the table. The function uses `new_test_table`

--- a/test/cql-pytest/test_tablets.py
+++ b/test/cql-pytest/test_tablets.py
@@ -98,3 +98,12 @@ def test_alter_changes_initial_tablets(cql, skip_without_tablets):
         cql.execute(f"ALTER KEYSPACE {keyspace} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': 2}};")
         res = cql.execute(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{keyspace}'").one()
         assert res.initial_tablets == 2
+
+
+# Test that initial number of tablets is preserved in describe
+def test_describe_initial_tablets(cql, skip_without_tablets):
+    ksdef = "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : '1' } " \
+            "AND TABLETS = { 'initial' : 1 }"
+    with new_test_keyspace(cql, ksdef) as keyspace:
+        desc = cql.execute(f"DESCRIBE KEYSPACE {keyspace}")
+        assert "and tablets = {'initial': 1}" in desc.one().create_statement.lower()

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from cassandra.protocol import ConfigurationException
+from test.pylib.manager_client import ManagerClient
+import pytest
+import logging
+import asyncio
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_tablet_replication_factor_enough_nodes(manager: ManagerClient):
+    cfg = {'enable_user_defined_functions': False,
+           'experimental_features': ['tablets', 'consistent-topology-changes']}
+    servers = await manager.servers_add(2, config=cfg)
+
+    cql = manager.get_cql()
+    res = await cql.run_async("SELECT data_center FROM system.local")
+    this_dc = res[0].data_center
+
+    await cql.run_async(f"CREATE KEYSPACE test WITH replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': 3}}")
+    with pytest.raises(ConfigurationException, match=f"Datacenter {this_dc} doesn't have enough nodes"):
+        await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+
+    await cql.run_async(f"ALTER KEYSPACE test WITH replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': 2}}")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")


### PR DESCRIPTION
When creating a keyspace, scylla allows setting RF value smaller than there are nodes in the DC. With vnodes, when new nodes are bootstrapped, new tokens are inserted thus catching up with RF. With tablets, it's not the case as replica set remains unchanged.

With tablets it's good chance not to mimic the vnodes behavior and require as many nodes to be up and running as the requested RF is. This patch implementes this in a lazy manned -- when creating a keyspace RF can be any, but when a new table is created the topology should meet RF requirements. If not met, user can bootstrap new nodes or ALTER KEYSPACE.

closes: #16529