### PR TITLE
 schema: column_mapping::{static,regular}_column_at(): use on_internal_error()

### DIFF
--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -87,6 +87,26 @@ bool operator==(const column_mapping& lhs, const column_mapping& rhs) {
     return true;
 }
 
+const column_mapping_entry& column_mapping::column_at(column_kind kind, column_id id) const {
+    assert(kind == column_kind::regular_column || kind == column_kind::static_column);
+    return kind == column_kind::regular_column ? regular_column_at(id) : static_column_at(id);
+}
+
+const column_mapping_entry& column_mapping::static_column_at(column_id id) const {
+    if (id >= _n_static) {
+        throw std::out_of_range(format("static column id {:d} >= {:d}", id, _n_static));
+    }
+    return _columns[id];
+}
+
+const column_mapping_entry& column_mapping::regular_column_at(column_id id) const {
+    auto n_regular = _columns.size() - _n_static;
+    if (id >= n_regular) {
+        throw std::out_of_range(format("regular column id {:d} >= {:d}", id, n_regular));
+    }
+    return _columns[id + _n_static];
+}
+
 template<typename Sequence>
 std::vector<data_type>
 get_column_types(const Sequence& column_definitions) {

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -94,7 +94,7 @@ const column_mapping_entry& column_mapping::column_at(column_kind kind, column_i
 
 const column_mapping_entry& column_mapping::static_column_at(column_id id) const {
     if (id >= _n_static) {
-        throw std::out_of_range(format("static column id {:d} >= {:d}", id, _n_static));
+        on_internal_error(dblog, format("static column id {:d} >= {:d}", id, _n_static));
     }
     return _columns[id];
 }
@@ -102,7 +102,7 @@ const column_mapping_entry& column_mapping::static_column_at(column_id id) const
 const column_mapping_entry& column_mapping::regular_column_at(column_id id) const {
     auto n_regular = _columns.size() - _n_static;
     if (id >= n_regular) {
-        throw std::out_of_range(format("regular column id {:d} >= {:d}", id, n_regular));
+        on_internal_error(dblog, format("regular column id {:d} >= {:d}", id, n_regular));
     }
     return _columns[id + _n_static];
 }

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -437,23 +437,9 @@ public:
     { }
     const std::vector<column_mapping_entry>& columns() const { return _columns; }
     column_count_type n_static() const { return _n_static; }
-    const column_mapping_entry& column_at(column_kind kind, column_id id) const {
-        assert(kind == column_kind::regular_column || kind == column_kind::static_column);
-        return kind == column_kind::regular_column ? regular_column_at(id) : static_column_at(id);
-    }
-    const column_mapping_entry& static_column_at(column_id id) const {
-        if (id >= _n_static) {
-            throw std::out_of_range(format("static column id {:d} >= {:d}", id, _n_static));
-        }
-        return _columns[id];
-    }
-    const column_mapping_entry& regular_column_at(column_id id) const {
-        auto n_regular = _columns.size() - _n_static;
-        if (id >= n_regular) {
-            throw std::out_of_range(format("regular column id {:d} >= {:d}", id, n_regular));
-        }
-        return _columns[id + _n_static];
-    }
+    const column_mapping_entry& column_at(column_kind kind, column_id id) const;
+    const column_mapping_entry& static_column_at(column_id id) const;
+    const column_mapping_entry& regular_column_at(column_id id) const;
     friend std::ostream& operator<<(std::ostream& out, const column_mapping& cm);
 };
 


### PR DESCRIPTION
Instead of std::out_of_range(). Accessing a non-existing column is a serious bug and the backtrace coming with `on_internal_error()` can be very valuable when debugging it. As can be the coredump that is possible
to trigger with `--abort-on-internal-error`.

This change follows another similar change to `schema::column_at()`.

This should help us get to the bottom of the mysterious repair failures caused by invalid column access, seen in https://github.com/scylladb/scylladb/issues/16821.

Refs: https://github.com/scylladb/scylladb/issues/16821