### PR TITLE
replica/mutation_dump.cc: move stringstream content instead of copying it

### DIFF
--- a/replica/mutation_dump.cc
+++ b/replica/mutation_dump.cc
@@ -263,8 +263,8 @@ private:
                 break;
         }
 
-        if (!ss.str().empty()) {
-            set_cell(*_schema, r, cdef, ss.str());
+        if (!ss.view().empty()) {
+            set_cell(*_schema, r, cdef, std::move(ss).str());
         }
     }
 
@@ -302,7 +302,7 @@ private:
 
         writer.writer().EndObject();
 
-        set_cell(*_schema, r, cdef, ss.str());
+        set_cell(*_schema, r, cdef, std::move(ss).str());
     }
 
     mutation_fragment_v2 transform_mutation_fragment(mutation_fragment_v2& mf, const sstring& data_source_name) {


### PR DESCRIPTION
C++20 introduced a new overload of std::stringstream::str() that is selected when the mentioned member function is called on r-value.

The new overload returns a string, that is move-constructed from the underlying string instead of being copy-constructed.

This change applies std::move() on stringstream objects before calling str() member function to avoid copying of the underlying buffer.

Moreover, it introduces usage of std::stringstream::view() when checking if the stream contains some characters. It skips another copy of the underlying string, because std::string_view is returned.