### PR TITLE
replica, tablet_allocator: do not compare unsigned with signed

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1935,7 +1935,7 @@ void table::handle_tablet_split_completion(size_t old_tablet_count, const locato
             table_id, new_tmap.tablet_count(), old_tablet_count*split_size));
     }
 
-    for (auto id = 0; id < _storage_groups.size(); id++) {
+    for (unsigned id = 0; id < _storage_groups.size(); id++) {
         auto& sg = _storage_groups[id];
         if (!sg) {
             continue;
@@ -1950,7 +1950,7 @@ void table::handle_tablet_split_completion(size_t old_tablet_count, const locato
         if (split_ready_groups.size() != split_size) {
             on_internal_error(tlogger, format("Found {} split ready compaction groups, but expected {} instead.", split_ready_groups.size(), split_size));
         }
-        for (auto i = 0; i < split_size; i++) {
+        for (unsigned i = 0; i < split_size; i++) {
             auto group_id = first_new_id + i;
             split_ready_groups[i]->update_id_and_range(group_id, new_tmap.get_token_range(locator::tablet_id(group_id)));
             new_storage_groups[group_id] = std::make_unique<storage_group>(std::move(split_ready_groups[i]), nullptr);

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -16,6 +16,7 @@
 #include "utils/stall_free.hh"
 #include "db/config.hh"
 #include "locator/load_sketch.hh"
+#include <utility>
 
 using namespace locator;
 using namespace replica;
@@ -526,7 +527,7 @@ public:
         while (resize_load.tables_need_resize.size() && resize_plan.size() < max_new_resize_requests) {
             const auto& [table, size_desc] = resize_load.tables_need_resize.front();
 
-            if (resize_plan.size() > 0 && available_shards < size_desc.shard_count) {
+            if (resize_plan.size() > 0 && std::cmp_less(available_shards, size_desc.shard_count)) {
                 break;
             }
 


### PR DESCRIPTION
this series addresses couple `-Wsign-compare` warnings surfaced in the tree.