### PR TITLE
transport: do not include unused headers

### DIFF
--- a/transport/cql_protocol_extension.hh
+++ b/transport/cql_protocol_extension.hh
@@ -10,8 +10,6 @@
 #include <seastar/core/sstring.hh>
 #include "enum_set.hh"
 
-#include <map>
-
 namespace cql_transport {
 
 /**

--- a/transport/event.hh
+++ b/transport/event.hh
@@ -15,9 +15,6 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/net/api.hh>
 
-#include <optional>
-#include <stdexcept>
-
 namespace cql_transport {
 
 class event {

--- a/transport/event_notifier.cc
+++ b/transport/event_notifier.cc
@@ -8,7 +8,6 @@
 
 #include "transport/server.hh"
 #include <seastar/core/gate.hh>
-#include "service/migration_listener.hh"
 #include "transport/response.hh"
 #include "gms/gossiper.hh"
 

--- a/transport/messages/result_message.hh
+++ b/transport/messages/result_message.hh
@@ -17,7 +17,6 @@
 
 #include "transport/messages/result_message_base.hh"
 #include "transport/event.hh"
-#include "exceptions/exceptions.hh"
 #include "exceptions/coordinator_result.hh"
 
 #include <seastar/core/shared_ptr.hh>

--- a/transport/messages/result_message_base.hh
+++ b/transport/messages/result_message_base.hh
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <map>
 #include <vector>
 #include <seastar/core/sstring.hh>
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -29,7 +29,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/seastar.hh>
-#include "utils/UUID.hh"
 #include <seastar/net/byteorder.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/net/byteorder.hh>


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.