### PR TITLE
db: add formatter for db::write_type

### DIFF
--- a/db/write_type.hh
+++ b/db/write_type.hh
@@ -12,7 +12,7 @@
 
 #include <assert.h>
 #include <cstdint>
-#include <iosfwd>
+#include <fmt/core.h>
 
 namespace db {
 
@@ -26,8 +26,10 @@ enum class write_type : uint8_t {
     VIEW,
 };
 
-std::ostream& operator<<(std::ostream& os, const write_type& t);
-
 }
 
-
+template <>
+struct fmt::formatter<db::write_type> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(db::write_type, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2131,21 +2131,35 @@ database::make_keyspace_config(const keyspace_metadata& ksm) {
 
 } // namespace replica
 
-namespace db {
-
-std::ostream& operator<<(std::ostream& os, const write_type& t) {
+auto fmt::formatter<db::write_type>::format(db::write_type t,
+                                            fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    std::string_view name;
     switch (t) {
-        case write_type::SIMPLE: return os << "SIMPLE";
-        case write_type::BATCH: return os << "BATCH";
-        case write_type::UNLOGGED_BATCH: return os << "UNLOGGED_BATCH";
-        case write_type::COUNTER: return os << "COUNTER";
-        case write_type::BATCH_LOG: return os << "BATCH_LOG";
-        case write_type::CAS: return os << "CAS";
-        case write_type::VIEW: return os << "VIEW";
+    using enum db::write_type;
+    case SIMPLE:
+        name = "SIMPLE";
+        break;
+    case BATCH:
+        name = "BATCH";
+        break;
+    case UNLOGGED_BATCH:
+        name = "UNLOGGED_BATCH";
+        break;
+    case COUNTER:
+        name = "COUNTER";
+        break;
+    case BATCH_LOG:
+        name = "BATCH_LOG";
+        break;
+    case CAS:
+        name = "CAS";
+        break;
+    case VIEW:
+        name = "VIEW";
+        break;
     }
-    abort();
-}
-
+    return fmt::format_to(ctx.out(), "{}", name);
 }
 
 auto fmt::formatter<db::operation_type>::format(db::operation_type op_type, fmt::format_context& ctx) const -> decltype(ctx.out()) {


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `db::write_type`, and drop its operator<<.

Refs #13245