### PR TITLE
db: add formatter for gms::application_state

### DIFF
--- a/gms/application_state.cc
+++ b/gms/application_state.cc
@@ -41,14 +41,19 @@ static const std::map<application_state, sstring> application_state_names = {
 };
 
 std::ostream& operator<<(std::ostream& os, const application_state& m) {
-    auto it = application_state_names.find(m);
-    if (it != application_state_names.end()) {
-        os << application_state_names.at(m);
-    } else {
-        os << "UNKNOWN";
-    }
+    fmt::print(os, "{}", m);
     return os;
 }
 
 }
 
+auto fmt::formatter<gms::application_state>::format(gms::application_state m,
+                                                    fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    std::string_view name = "UNKNOWN";
+    auto it = gms::application_state_names.find(m);
+    if (it != gms::application_state_names.end()) {
+        name = it->second;
+    }
+    return fmt::format_to(ctx.out(), "{}", name);
+}

--- a/gms/application_state.hh
+++ b/gms/application_state.hh
@@ -10,7 +10,8 @@
 
 #pragma once
 
-#include <ostream>
+#include <iosfwd>
+#include <fmt/core.h>
 
 namespace gms {
 
@@ -43,3 +44,9 @@ enum class application_state {
 std::ostream& operator<<(std::ostream& os, const application_state& m);
 
 }
+
+template <>
+struct fmt::formatter<gms::application_state> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(gms::application_state, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2680,7 +2680,7 @@ void gossiper::append_endpoint_state(std::stringstream& ss, const endpoint_state
         if (app_state == application_state::TOKENS) {
             continue;
         }
-        ss << "  " << app_state << ":" << versioned_val.version() << ":" << versioned_val.value() << "\n";
+        fmt::print(ss, "  {}:{}:{}\n", app_state, versioned_val.version(), versioned_val.value());
     }
     const auto& app_state_map = state.get_application_state_map();
     if (app_state_map.contains(application_state::TOKENS)) {


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `gms::application_state`, and drop its operator<<.

Refs #13245