### PR TITLE
storage_service: Run stream_ranges cmd in streaming group

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4654,12 +4654,13 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
             }
             break;
             case raft_topology_cmd::command::stream_ranges: {
+              co_await with_scheduling_group(_db.local().get_streaming_scheduling_group(), coroutine::lambda([&] () -> future<> {
                 const auto& rs = _topology_state_machine._topology.find(raft_server.id())->second;
                 auto tstate = _topology_state_machine._topology.tstate;
                 if (!rs.ring ||
                     (tstate != topology::transition_state::write_both_read_old && rs.state != node_state::normal && rs.state != node_state::rebuilding)) {
                     rtlogger.warn("got stream_ranges request while my tokens state is {} and node state is {}", tstate, rs.state);
-                    break;
+                    co_return;
                 }
 
                 utils::get_local_injector().inject("stream_ranges_fail",
@@ -4811,6 +4812,8 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                      raft_server.id(), rs.state));
                 break;
                 }
+                co_return;
+              }));
             }
             break;
             case raft_topology_cmd::command::wait_for_ip: {


### PR DESCRIPTION
Otherwise it will inherit the rpc verb's scheduling group which is gossip. As a result, it causes the streaming runs in the wrong scheduling group.

Fixes #17090
