### PR TITLE
cql_test_env.cc: remove dead code

### DIFF
--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -76,11 +76,6 @@
 
 using namespace std::chrono_literals;
 
-namespace {
-
-
-} // anonymous namespace
-
 future<scheduling_groups> get_scheduling_groups() {
     static std::optional<scheduling_groups> _scheduling_groups;
     if (!_scheduling_groups) {


### PR DESCRIPTION
This change removes empty anonymous namespace
that is a dead code.