### PR TITLE
add repair_history ttl param

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1312,6 +1312,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Use separate schema commit log unconditionally rater than after restart following discovery of cluster-wide support for it.")
     , task_ttl_seconds(this, "task_ttl_in_seconds", liveness::LiveUpdate, value_status::Used, 0, "Time for which information about finished task started internally stays in memory.")
     , user_task_ttl_seconds(this, "user_task_ttl_in_seconds", liveness::LiveUpdate, value_status::Used, 3600, "Time for which information about finished task started by user stays in memory.")
+    , repair_history_ttl_seconds(this, "repair_history_ttl_in_seconds", liveness::LiveUpdate, value_status::Used, 24*60*60*360, "Time for repair history table ttl.")
     , nodeops_watchdog_timeout_seconds(this, "nodeops_watchdog_timeout_seconds", liveness::LiveUpdate, value_status::Used, 120, "Time in seconds after which node operations abort when not hearing from the coordinator.")
     , nodeops_heartbeat_interval_seconds(this, "nodeops_heartbeat_interval_seconds", liveness::LiveUpdate, value_status::Used, 10, "Period of heartbeat ticks in node operations.")
     , cache_index_pages(this, "cache_index_pages", liveness::LiveUpdate, value_status::Used, true,

--- a/db/config.hh
+++ b/db/config.hh
@@ -468,6 +468,7 @@ public:
 
     named_value<uint32_t> task_ttl_seconds;
     named_value<uint32_t> user_task_ttl_seconds;
+    named_value<uint32_t> repair_history_ttl_seconds;
     named_value<uint32_t> nodeops_watchdog_timeout_seconds;
     named_value<uint32_t> nodeops_heartbeat_interval_seconds;
 


### PR DESCRIPTION
we add an option for repair_history ttl.
I found if I use gcmode='repair' scylla will create many record in table system.repair_history.
And this record will not be deleted, this table will grow without bounds.
And scylla will read this table when scylla launch.
It takes a long time to read system.repair_history will.
This option add ttl to record in system.repair_history when the record be inserted.
  
https://github.com/scylladb/scylladb/issues/16976