### PR TITLE
api: add /storage_service/describe_ring/{keyspace}/{table}

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -415,6 +415,41 @@
          ]
       },
       {
+         "path":"/storage_service/describe_ring/{keyspace}/{cf}",
+         "operations":[
+            {
+               "method":"GET",
+               "summary":"The TokenRange(s) for a given table",
+               "type":"array",
+               "items":{
+                  "type":"token_range"
+               },
+               "nickname":"describe_ring_for_table",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"keyspace",
+                     "description":"The keyspace",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  },
+                  {
+                     "name":"cf",
+                     "description":"column family name",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  }
+               ]
+            }
+         ]
+      },
+      {
          "path":"/storage_service/ownership/{keyspace}",
          "operations":[
             {

--- a/locator/util.cc
+++ b/locator/util.cc
@@ -149,7 +149,6 @@ map_to_endpoints(locator::effective_replication_map_ptr erm,
 
 future<std::vector<dht::token_range_endpoints>>
 describe_ring(const replica::database& db, const gms::gossiper& gossiper, const sstring& keyspace, bool include_only_local_dc) {
-    //Token.TokenFactory tf = getPartitioner().getTokenFactory();
     auto erm = db.find_keyspace(keyspace).get_effective_replication_map();
     return map_to_endpoints(erm, gossiper, include_only_local_dc);
 }

--- a/locator/util.cc
+++ b/locator/util.cc
@@ -154,4 +154,15 @@ describe_ring(const replica::database& db, const gms::gossiper& gossiper, const 
     return map_to_endpoints(erm, gossiper, include_only_local_dc);
 }
 
+future<std::vector<dht::token_range_endpoints>> describe_ring_for_table(
+    const replica::database& db,
+    const gms::gossiper& gossiper,
+    std::string_view ks_name,
+    std::string_view cf_name) {
+    const auto table_id = db.find_uuid(ks_name, cf_name);
+    const auto& table = db.find_column_family(table_id);
+    auto erm = table.get_effective_replication_map();
+    return map_to_endpoints(erm, gossiper, false);
+}
+
 }

--- a/locator/util.hh
+++ b/locator/util.hh
@@ -20,4 +20,9 @@ namespace gms {
 
 namespace locator {
     future<std::vector<dht::token_range_endpoints>> describe_ring(const replica::database& db, const gms::gossiper& gossiper, const sstring& keyspace, bool include_only_local_dc = false);
+    future<std::vector<dht::token_range_endpoints>> describe_ring_for_table(
+        const replica::database& db,
+        const gms::gossiper& gossiper,
+        std::string_view ks_name,
+        std::string_view cf_name);
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4409,6 +4409,11 @@ storage_service::describe_ring(const sstring& keyspace, bool include_only_local_
     return locator::describe_ring(_db.local(), _gossiper, keyspace, include_only_local_dc);
 }
 
+future<std::vector<storage_service::token_range_endpoints>>
+storage_service::describe_ring_for_table(std::string_view ks_name, std::string_view cf_name) const {
+    return locator::describe_ring_for_table(_db.local(), _gossiper, ks_name, cf_name);
+}
+
 future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>>
 storage_service::construct_range_to_endpoint_map(
         locator::vnode_effective_replication_map_ptr erm,

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -413,6 +413,8 @@ public:
 
     future<std::vector<token_range_endpoints>> describe_ring(const sstring& keyspace, bool include_only_local_dc = false) const;
 
+    future<std::vector<token_range_endpoints>> describe_ring_for_table(std::string_view ks_name, std::string_view cf_name) const;
+
     /**
      * Retrieve a map of tokens to endpoints, including the bootstrapping ones.
      *


### PR DESCRIPTION
this API is added to support the tablet keyspace, which is a
per-table replica strategy, with which each table is composed
of multiple tablets, each of which is replicated on its own
replicas. so, in order to schedule repair, scylla manager needs
to understand the topology of keyspace on a per-table basis instead
of on a per-keyspace basis.

in this change, the new RESTful API of
`/storage_service/describe_ring/{keyspace}/{table}` enables us to
retrieve a list of token range and its corresponding endpoints with
given table.

Refs https://github.com/scylladb/scylladb/issues/16509