### PR TITLE
test_raft_snapshot_request: fix flakiness (again)

### DIFF
--- a/test/topology_custom/test_raft_snapshot_request.py
+++ b/test/topology_custom/test_raft_snapshot_request.py
@@ -23,7 +23,7 @@ async def get_raft_log_size(cql, host) -> int:
 
 
 async def get_raft_snap_id(cql, host) -> str:
-    query = "select snapshot_id from system.raft_snapshots"
+    query = "select snapshot_id from system.raft limit 1"
     return (await cql.run_async(query, host=host))[0].snapshot_id
 
 


### PR DESCRIPTION
At the end of the test, we wait until a restarted node receives a snapshot from the leader, and then verify that the log has been truncated.

To check the snapshot, the test used the `system.raft_snapshots` table, while the log is stored in `system.raft`.

Unfortunately, the two tables are not updated atomically when Raft persists a snapshot (scylladb/scylladb#9603). We first update `system.raft_snapshots`, then `system.raft` (see
`raft_sys_table_storage::store_snapshot_descriptor`). So after the wait finishes, there's no guarantee the log has been truncated yet -- there's a race between the test's last check and Scylla doing that last delete.

But we can check the snapshot using `system.raft` instead of `system.raft_snapshots`, as `system.raft` has the latest ID. And since 1640f83fdc31959ff64f910aaa67b6af536967ca, storing that ID and truncating the log in `system.raft` happens atomically.