### PR TITLE
storage_service: Fix indentation for stream_ranges

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4913,7 +4913,6 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                          raft_server.id(), rs.state));
                     break;
                     }
-                    co_return;
                 }));
             }
             break;


### PR DESCRIPTION
This is a follow up of "storage_service: Run stream_ranges cmd in streaming group" to fix indentation and drop a unnecessary co_return. 

Refs: #17090