### PR TITLE
data_dictionary: Add formatter for keyspace-metadata

### DIFF
--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -362,33 +362,14 @@ std::ostream& keyspace_metadata::describe(std::ostream& os) const {
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const keyspace_metadata& m) {
-    os << "KSMetaData{";
-    os << "name=" << m._name;
-    os << ", strategyClass=" << m._strategy_name;
-    os << ", strategyOptions={";
-    int n = 0;
-    for (auto& p : m._strategy_options) {
-        if (n++ != 0) {
-            os << ", ";
-        }
-        os << p.first << "=" << p.second;
-    }
-    os << "}";
-    os << ", cfMetaData={";
-    n = 0;
-    for (auto& p : m._cf_meta_data) {
-        if (n++ != 0) {
-            os << ", ";
-        }
-        os << p.first << "=" << p.second;
-    }
-    os << "}";
-    os << ", durable_writes=" << m._durable_writes;
-    os << ", userTypes=" << m._user_types;
-    os << "}";
-    return os;
 }
+
+auto fmt::formatter<data_dictionary::keyspace_metadata>::format(const data_dictionary::keyspace_metadata& m, fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "KSMetaData{{name={}, strategyClass={}, strategyOptions={{{}}}, cfMetaData={{{}}}, durable_writes={}, userTypes={}}}",
+            m.name(), m.strategy_name(), fmt::join(m.strategy_options(), ", "), fmt::join(m.cf_meta_data(), ", "), m.durable_writes(), m.user_types());
+}
+
+namespace data_dictionary {
 
 std::ostream& operator<<(std::ostream& os, const user_types_metadata& m) {
     os << "org.apache.cassandra.config.UTMetaData@" << &m;

--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -96,7 +96,12 @@ public:
     virtual sstring element_name() const override { return name(); }
     virtual sstring element_type() const override { return "keyspace"; }
     virtual std::ostream& describe(std::ostream& os) const override;
-    friend std::ostream& operator<<(std::ostream& os, const keyspace_metadata& m);
 };
 
 }
+
+template <>
+struct fmt::formatter<data_dictionary::keyspace_metadata> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const data_dictionary::keyspace_metadata& ksm, fmt::format_context& ctx) const -> decltype(ctx.out());
+};


### PR DESCRIPTION
Other than being fmt v10 compatible, it's also shorter and easier to read, thanks to fmt::join() helper