### PR TITLE
storage_service: Add describe_ring support for tablet table

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -409,6 +409,14 @@
                      "allowMultiple":false,
                      "type":"string",
                      "paramType":"path"
+                  },
+                  {
+                     "name":"table",
+                     "description":"The name of table to fetch information about",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
                   }
                ]
             }

--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -74,8 +74,9 @@ public:
         co_await utils::clear_gently(_nodes);
         for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
             auto& tmap = tmap_;
-            co_await tmap.for_each_tablet([&] (tablet_id tid, const tablet_info& ti) {
+            co_await tmap.for_each_tablet([&] (tablet_id tid, const tablet_info& ti) -> future<> {
                 for (auto&& replica : get_replicas_for_tablet_load(ti, tmap.get_tablet_transition_info(tid))) {
+                    co_await coroutine::maybe_yield();
                     if (host && *host != replica.host) {
                         continue;
                     }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -235,6 +235,14 @@ future<> tablet_map::for_each_tablet(seastar::noncopyable_function<void(tablet_i
     }
 }
 
+future<> tablet_map::for_each_tablet_gently(seastar::noncopyable_function<future<>(tablet_id, const tablet_info&)> func) const {
+    std::optional<tablet_id> tid = first_tablet();
+    for (const tablet_info& ti : tablets()) {
+        co_await func(*tid, ti);
+        tid = next_tablet(*tid);
+    }
+}
+
 void tablet_map::clear_transitions() {
     _transitions.clear();
 }

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -375,8 +375,7 @@ public:
     }
 
     /// Calls a given function for each tablet in the map in token ownership order.
-    future<> for_each_tablet(seastar::noncopyable_function<void(tablet_id, const tablet_info&)> func) const;
-    future<> for_each_tablet_gently(seastar::noncopyable_function<future<>(tablet_id, const tablet_info&)> func) const;
+    future<> for_each_tablet(seastar::noncopyable_function<future<>(tablet_id, const tablet_info&)> func) const;
 
     const auto& transitions() const {
         return _transitions;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -376,6 +376,7 @@ public:
 
     /// Calls a given function for each tablet in the map in token ownership order.
     future<> for_each_tablet(seastar::noncopyable_function<void(tablet_id, const tablet_info&)> func) const;
+    future<> for_each_tablet_gently(seastar::noncopyable_function<future<>(tablet_id, const tablet_info&)> func) const;
 
     const auto& transitions() const {
         return _transitions;

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -2064,13 +2064,14 @@ future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_nam
         std::vector<repair_tablet_meta> metas;
         auto myhostid = erm->get_token_metadata_ptr()->get_my_id();
         auto myip = erm->get_topology().my_address();
-        co_await tmap.for_each_tablet([&] (locator::tablet_id id, const locator::tablet_info& info) {
+        co_await tmap.for_each_tablet([&] (locator::tablet_id id, const locator::tablet_info& info) -> future<> {
             auto range = tmap.get_token_range(id);
             auto& replicas = info.replicas;
             bool found = false;
             shard_id master_shard_id;
             // Repair all tablets belong to this node
             for (auto& r : replicas) {
+                co_await coroutine::maybe_yield();
                 if (r.host == myhostid) {
                     master_shard_id = r.shard;
                     found = true;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4431,7 +4431,7 @@ storage_service::describe_ring_for_table(const sstring& keyspace_name, const sst
     auto& tmap = erm->get_token_metadata_ptr()->tablets().get_tablet_map(tid);
     const auto& topology = erm->get_topology();
     std::vector<dht::token_range_endpoints> ranges;
-    co_await tmap.for_each_tablet_gently([&] (locator::tablet_id id, const locator::tablet_info& info) -> future<> {
+    co_await tmap.for_each_tablet([&] (locator::tablet_id id, const locator::tablet_info& info) -> future<> {
         auto range = tmap.get_token_range(id);
         auto& replicas = info.replicas;
         dht::token_range_endpoints tr;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4412,7 +4412,50 @@ future<> storage_service::move(token new_token) {
 
 future<std::vector<storage_service::token_range_endpoints>>
 storage_service::describe_ring(const sstring& keyspace, bool include_only_local_dc) const {
-    return locator::describe_ring(_db.local(), _gossiper, keyspace, include_only_local_dc);
+    if (_db.local().find_keyspace(keyspace).get_replication_strategy().uses_tablets()) {
+        throw std::runtime_error(format("The keyspace {} has tablet table. Query describe_ring with the table parameter!", keyspace));
+    }
+    co_return co_await locator::describe_ring(_db.local(), _gossiper, keyspace, include_only_local_dc);
+}
+
+future<std::vector<dht::token_range_endpoints>>
+storage_service::describe_ring_for_table(const sstring& keyspace_name, const sstring& table_name) const {
+    slogger.debug("describe_ring for table {}.{}", keyspace_name, table_name);
+    auto& t = _db.local().find_column_family(keyspace_name, table_name);
+    if (!t.uses_tablets()) {
+        auto ranges = co_await describe_ring(keyspace_name);
+        co_return ranges;
+    }
+    table_id tid = t.schema()->id();
+    auto erm = t.get_effective_replication_map();
+    auto& tmap = erm->get_token_metadata_ptr()->tablets().get_tablet_map(tid);
+    const auto& topology = erm->get_topology();
+    std::vector<dht::token_range_endpoints> ranges;
+    co_await tmap.for_each_tablet_gently([&] (locator::tablet_id id, const locator::tablet_info& info) -> future<> {
+        auto range = tmap.get_token_range(id);
+        auto& replicas = info.replicas;
+        dht::token_range_endpoints tr;
+        if (range.start()) {
+            tr._start_token = range.start()->value().to_sstring();
+        }
+        if (range.end()) {
+            tr._end_token = range.end()->value().to_sstring();
+        }
+        for (auto& r : replicas) {
+            co_await coroutine::maybe_yield();
+            dht::endpoint_details details;
+            auto& hostid = r.host;
+            auto endpoint = host2ip(hostid);
+            details._datacenter = topology.get_datacenter(hostid);
+            details._rack = topology.get_rack(hostid);
+            details._host = endpoint;
+            tr._rpc_endpoints.push_back(_gossiper.get_rpc_address(endpoint));
+            tr._endpoints.push_back(fmt::to_string(details._host));
+            tr._endpoint_details.push_back(std::move(details));
+        }
+        ranges.push_back(std::move(tr));
+    });
+    co_return ranges;
 }
 
 future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>>

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4947,7 +4947,7 @@ future<> storage_service::update_fence_version(token_metadata::version_t new_ver
     });
 }
 
-inet_address storage_service::host2ip(locator::host_id host) {
+inet_address storage_service::host2ip(locator::host_id host) const {
     auto ip = _group0->address_map().find(raft::server_id(host.uuid()));
     if (!ip) {
         throw std::runtime_error(::format("Cannot map host {} to ip", host));

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -413,6 +413,8 @@ public:
 
     future<std::vector<token_range_endpoints>> describe_ring(const sstring& keyspace, bool include_only_local_dc = false) const;
 
+    future<std::vector<dht::token_range_endpoints>> describe_ring_for_table(const sstring& keyspace_name, const sstring& table_name) const;
+
     /**
      * Retrieve a map of tokens to endpoints, including the bootstrapping ones.
      *

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -175,7 +175,7 @@ private:
                                  std::function<future<>(locator::tablet_metadata_guard&)> op);
     future<> stream_tablet(locator::global_tablet_id);
     future<> cleanup_tablet(locator::global_tablet_id);
-    inet_address host2ip(locator::host_id);
+    inet_address host2ip(locator::host_id) const;
     // Handler for table load stats RPC.
     future<locator::load_stats> load_stats_for_tablet_based_tables();
     future<> process_tablet_split_candidate(table_id);

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1016,10 +1016,11 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_two_racks) {
         {
             auto tm = stm.get();
             auto& tmap = tm->tablets().get_tablet_map(table1);
-            tmap.for_each_tablet([&](auto tid, auto& tinfo) {
+            tmap.for_each_tablet([&](auto tid, auto& tinfo) -> future<> {
                 auto rack1 = tm->get_topology().get_rack(tinfo.replicas[0].host);
                 auto rack2 = tm->get_topology().get_rack(tinfo.replicas[1].host);
                 BOOST_REQUIRE(rack1 != rack2);
+                co_return;
             }).get();
         }
     }).get();


### PR DESCRIPTION
The table query param is added to get the describe_ring result for a
given table.

Both vnode table and tablet table can use this table param, so it is
easier for users to user.

If the table param is not provided by user and the keyspace contains
tablet table, the request will be rejected.

E.g.,
curl "http://127.0.0.1:10000/storage_service/describe_ring/system_auth?table=roles"
curl "http://127.0.0.1:10000/storage_service/describe_ring/ks1?table=standard1"

Refs #16509
