### PR TITLE
tasks: do not include unused headers

### DIFF
--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -12,7 +12,6 @@
 #include <seastar/core/gate.hh>
 
 #include "task_manager.hh"
-#include "test_module.hh"
 
 namespace tasks {
 

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -18,7 +18,6 @@
 #include "db_clock.hh"
 #include "log.hh"
 #include "tasks/types.hh"
-#include "utils/UUID.hh"
 #include "utils/serialized_action.hh"
 #include "utils/updateable_value.hh"
 


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.