### PR TITLE
tools: lua_sstable_consumer.cc: load os and math libs

### DIFF
--- a/tools/lua_sstable_consumer.cc
+++ b/tools/lua_sstable_consumer.cc
@@ -77,6 +77,8 @@ void* lua_alloc(void* ud, void* ptr, size_t osize, size_t nsize) {
 
 static const luaL_Reg loadedlibs[] = {
     {"base", luaopen_base},
+    {LUA_MATHLIBNAME, luaopen_math},
+    {LUA_OSLIBNAME, luaopen_os},
     {LUA_STRLIBNAME, luaopen_string},
     {LUA_TABLIBNAME, luaopen_table},
     {NULL, NULL},


### PR DESCRIPTION
The amount of standard Lua libraries loaded for the sstable-script was limited, due to fears that some libraries (like the io library) could expose methods, which if used from the script could interfere with seastar's asynchronous arhitecture. So initially only the table and string libraries were loaded.
This patch adds two more libraries to be loaded: match and os. The former is self-explanatory and the latter contains methods to work with date/time, obtain the values of environment variables as well as launch external processes. None of these should interfere with seastar, on the other hand the facilities they provide can come very handy for sstable scripts.