### PR TITLE
db: add formatter for dht::ring_position_{ext,view}

### DIFF
--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -150,7 +150,8 @@ decorated_key::less_comparator::operator()(const decorated_key& lhs, const ring_
 }
 
 std::ostream& operator<<(std::ostream& out, const ring_position_ext& pos) {
-    return out << (ring_position_view)pos;
+    fmt::print(out, "{}", (ring_position_view)pos);
+    return out;
 }
 
 std::ostream& operator<<(std::ostream& out, const ring_position& pos) {
@@ -160,15 +161,6 @@ std::ostream& operator<<(std::ostream& out, const ring_position& pos) {
     } else {
         out << ", " << ((pos.relation_to_keys() < 0) ? "start" : "end");
     }
-    return out << "}";
-}
-
-std::ostream& operator<<(std::ostream& out, ring_position_view pos) {
-    out << "{" << *pos._token;
-    if (pos._key) {
-        out << ", " << *pos._key;
-    }
-    out << ", w=" << static_cast<int>(pos._weight);
     return out << "}";
 }
 
@@ -518,4 +510,14 @@ std::optional<shard_id> is_single_shard(const dht::sharder& sharder, const schem
     return shard;
 }
 
+}
+
+auto fmt::formatter<dht::ring_position_view>::format(const dht::ring_position_view& pos, fmt::format_context& ctx) const
+    -> decltype(ctx.out()) {
+    auto out = ctx.out();
+    out = fmt::format_to(out, "{{{}", *pos._token);
+    if (pos._key) {
+        out = fmt::format_to(out, ", {}", *pos._key);
+    }
+    return fmt::format_to(out, ", w={}}}", static_cast<int>(pos._weight));
 }

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -149,11 +149,6 @@ decorated_key::less_comparator::operator()(const decorated_key& lhs, const ring_
     return lhs.tri_compare(*s, rhs) < 0;
 }
 
-std::ostream& operator<<(std::ostream& out, const ring_position_ext& pos) {
-    fmt::print(out, "{}", (ring_position_view)pos);
-    return out;
-}
-
 std::ostream& operator<<(std::ostream& out, const ring_position& pos) {
     out << "{" << pos.token();
     if (pos.has_key()) {

--- a/dht/ring_position.hh
+++ b/dht/ring_position.hh
@@ -390,8 +390,6 @@ public:
     after_key is_after_key() const { return after_key(_weight == 1); }
 
     operator ring_position_view() const { return { _token, _key ? &*_key : nullptr, _weight }; }
-
-    friend std::ostream& operator<<(std::ostream&, const ring_position_ext&);
 };
 
 std::strong_ordering ring_position_tri_compare(const schema& s, ring_position_view lh, ring_position_view rh);
@@ -498,4 +496,12 @@ template<>
 struct fmt::formatter<dht::ring_position_view> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     auto format(const dht::ring_position_view&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template<>
+struct fmt::formatter<dht::ring_position_ext> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const dht::ring_position_ext& pos, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", (dht::ring_position_view)pos);
+    }
 };

--- a/dht/ring_position.hh
+++ b/dht/ring_position.hh
@@ -257,7 +257,7 @@ public:
     // Only when key() != nullptr
     after_key is_after_key() const { return after_key(_weight == 1); }
 
-    friend std::ostream& operator<<(std::ostream&, ring_position_view);
+    friend fmt::formatter<ring_position_view>;
     friend class optimized_optional<ring_position_view>;
 };
 
@@ -493,3 +493,9 @@ public:
 std::ostream& operator<<(std::ostream& out, partition_ranges_view v);
 
 } // namespace dht
+
+template<>
+struct fmt::formatter<dht::ring_position_view> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const dht::ring_position_view&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1466,9 +1466,8 @@ future<> row_cache::do_update(row_cache::external_updater eu, row_cache::interna
 }
 
 std::ostream& operator<<(std::ostream& out, const cache_entry& e) {
-    return out << "{cache_entry: " << e.position()
-               << ", cont=" << e.continuous()
-               << ", dummy=" << e.is_dummy_entry()
-               << ", " << partition_entry::printer(e.partition())
-               << "}";
+    fmt::print(out, "{{cache_entry: {}, cont={}, dummy={}, {}}}",
+               e.position(), e.continuous(), e.is_dummy_entry(),
+               partition_entry::printer(e.partition()));
+    return out;
 }


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter
created from operator<<, but fmt v10 dropped the default-generated
formatter.
    
in this change, we define formatters for `dht::ring_position_ext` and 
`dht::ring_position_view`, and drop their operator<<.
    
Refs #13245
