### PR TITLE
configure.py: add -Wextra to cflags

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1533,13 +1533,17 @@ def get_warning_options(cxx):
     warnings = [
         '-Wall',
         '-Werror',
+        '-Wextra',
         '-Wimplicit-fallthrough',
         '-Wignored-qualifiers',
         '-Wno-mismatched-tags',  # clang-only
         '-Wno-c++11-narrowing',
         '-Wno-overloaded-virtual',
         '-Wno-unused-command-line-argument',
+        '-Wno-unused-parameter',
         '-Wno-unsupported-friend',
+        '-Wno-missing-field-initializers',
+        '-Wno-deprecated-copy',
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77728
         '-Wno-psabi',
         '-Wno-enum-constexpr-conversion',

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1597,7 +1597,7 @@ SEASTAR_THREAD_TEST_CASE(basic_tablet_storage_splitting_test) {
         e.execute_cql(
                 "CREATE TABLE cf (pk int, ck int, v int, PRIMARY KEY (pk, ck))").get();
 
-        for (int i = 0; i < smp::count * 20; i++) {
+        for (unsigned i = 0; i < smp::count * 20; i++) {
             e.execute_cql(format("INSERT INTO cf (pk, ck, v) VALUES ({}, 0, 0)", i)).get();
         }
 


### PR DESCRIPTION
also disable some more warnings which are failing the build after `-Wextra` is enabled. we can fix them on a case-by-case basis, if they are geniune issues. but before that, we just disable them.

this goal of this change is to reduce the discrepancies between the compile options used by CMake and those used by configure.py. the side effect is that we enable some more warning enabeld by `-Wextra`, for instance, `-Wsign-compare` is enable now. for the full list of the enabled warnings when building with Clang, please see https://clang.llvm.org/docs/DiagnosticsReference.html#wextra.