### PR TITLE
Sanitize replication factor parsing by strategies

### DIFF
--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -54,7 +54,7 @@ static std::map<sstring, sstring> prepare_options(
     if (rf.has_value()) {
         // The code below may end up not using "rf" at all (if all the DCs
         // already have rf settings), so let's validate it once (#8880).
-        locator::abstract_replication_strategy::validate_replication_factor(*rf);
+        locator::abstract_replication_strategy::parse_replication_factor(*rf);
 
         // We keep previously specified DC factors for safety.
         for (const auto& opt : old_options) {

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -182,14 +182,14 @@ const tablet_aware_replication_strategy* abstract_replication_strategy::maybe_as
     return dynamic_cast<const tablet_aware_replication_strategy*>(this);
 }
 
-void abstract_replication_strategy::validate_replication_factor(sstring rf)
+long abstract_replication_strategy::parse_replication_factor(sstring rf)
 {
     if (rf.empty() || std::any_of(rf.begin(), rf.end(), [] (char c) {return !isdigit(c);})) {
         throw exceptions::configuration_exception(
                 format("Replication factor must be numeric and non-negative, found '{}'", rf));
     }
     try {
-        std::stol(rf);
+        return std::stol(rf);
     } catch (...) {
         throw exceptions::configuration_exception(
             sstring("Replication factor must be numeric; found ") + rf);

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -118,7 +118,7 @@ public:
                                               replication_strategy_params params,
                                               const gms::feature_service& fs,
                                               const topology& topology);
-    static void validate_replication_factor(sstring rf);
+    static long parse_replication_factor(sstring rf);
 
     static sstring to_qualified_class_name(std::string_view strategy_class_name);
 

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -37,6 +37,7 @@ network_topology_strategy::network_topology_strategy(replication_strategy_params
     auto opts = _config_options;
     process_tablet_options(*this, opts, params);
 
+    size_t rep_factor = 0;
     for (auto& config_pair : opts) {
         auto& key = config_pair.first;
         auto& val = config_pair.second;
@@ -56,15 +57,12 @@ network_topology_strategy::network_topology_strategy(replication_strategy_params
         }
 
         auto rf = parse_replication_factor(val);
+        rep_factor += rf;
         _dc_rep_factor.emplace(key, rf);
         _datacenteres.push_back(key);
     }
 
-    _rep_factor = 0;
-
-    for (auto& one_dc_rep_factor : _dc_rep_factor) {
-        _rep_factor += one_dc_rep_factor.second;
-    }
+    _rep_factor = rep_factor;
 
     rslogger.debug("Configured datacenter replicas are: {}", _dc_rep_factor);
 }

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -55,7 +55,7 @@ network_topology_strategy::network_topology_strategy(replication_strategy_params
                 "NetworkTopologyStrategy");
         }
 
-        validate_replication_factor(val);
+        parse_replication_factor(val);
         _dc_rep_factor.emplace(key, std::stol(val));
         _datacenteres.push_back(key);
     }
@@ -265,7 +265,7 @@ void network_topology_strategy::validate_options(const gms::feature_service& fs)
                 "replication_factor is an option for simple_strategy, not "
                 "network_topology_strategy");
         }
-        validate_replication_factor(c.second);
+        parse_replication_factor(c.second);
     }
 }
 

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -55,8 +55,8 @@ network_topology_strategy::network_topology_strategy(replication_strategy_params
                 "NetworkTopologyStrategy");
         }
 
-        parse_replication_factor(val);
-        _dc_rep_factor.emplace(key, std::stol(val));
+        auto rf = parse_replication_factor(val);
+        _dc_rep_factor.emplace(key, rf);
         _datacenteres.push_back(key);
     }
 

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -23,9 +23,7 @@ simple_strategy::simple_strategy(replication_strategy_params params) :
         auto& val = config_pair.second;
 
         if (boost::iequals(key, "replication_factor")) {
-            parse_replication_factor(val);
-            _replication_factor = std::stol(val);
-
+            _replication_factor = parse_replication_factor(val);
             break;
         }
     }

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -23,7 +23,7 @@ simple_strategy::simple_strategy(replication_strategy_params params) :
         auto& val = config_pair.second;
 
         if (boost::iequals(key, "replication_factor")) {
-            validate_replication_factor(val);
+            parse_replication_factor(val);
             _replication_factor = std::stol(val);
 
             break;
@@ -70,7 +70,7 @@ void simple_strategy::validate_options(const gms::feature_service&) const {
     if (it == _config_options.end()) {
         throw exceptions::configuration_exception("SimpleStrategy requires a replication_factor strategy option.");
     }
-    validate_replication_factor(it->second);
+    parse_replication_factor(it->second);
 }
 
 std::optional<std::unordered_set<sstring>>simple_strategy::recognized_options(const topology&) const {


### PR DESCRIPTION
RF values appear as strings and strategies classes convert them to integers. This PR removes some duplication of efforts in converting code.