### PR TITLE
cdc: metadata: allow sending writes to the previous generations

### DIFF
--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -46,6 +46,8 @@ namespace gms {
 
 namespace cdc {
 
+api::timestamp_clock::duration get_generation_leeway();
+
 class stream_id final {
     bytes _value;
 public:

--- a/cdc/metadata.cc
+++ b/cdc/metadata.cc
@@ -86,27 +86,43 @@ cdc::stream_id cdc::metadata::get_stream(api::timestamp_type ts, dht::token tok)
         // Nothing protects us from that until we start using transactions for generation switching.
     }
 
-    auto it = gen_used_at(now);
-    if (it == _gens.end()) {
+    auto it = gen_used_at(now - generation_leeway.count());
+
+    if (it != _gens.end()) {
+        // Garbage-collect generations that will no longer be used.
+        it = _gens.erase(_gens.begin(), it);
+    }
+
+    if (ts <= now - generation_leeway.count()) {
+        // We reject the write if `ts <= now - generation_leeway` and the write is not to the current generation, which
+        // happens iff one of the following is true:
+        // - the write is to no generation,
+        // - the write is to a generation older than the generation under `it`,
+        // - the write is to the generation under `it` and that generation is not the current generation.
+        // Note that we cannot distinguish the first and second cases because we garbage-collect obsolete generations,
+        // but we can check if one of them takes place (`it == _gens.end() || ts < it->first`). These three conditions
+        // are sufficient. The write with `ts <= now - generation_leeway` cannot be to one of the generations following
+        // the generation under `it` because that generation was operating at `now - generation_leeway`.
+        bool is_previous_gen = it != _gens.end() && std::next(it) != _gens.end() && std::next(it)->first <= now;
+        if (it == _gens.end() || ts < it->first || is_previous_gen) {
+            throw exceptions::invalid_request_exception(format(
+                    "cdc: attempted to get a stream \"from the past\" ({}; current server time: {})."
+                    " With CDC you cannot send writes with timestamps too far into the past, because that would break"
+                    " consistency properties.\n"
+                    "We *do* allow sending writes into the near past, but our ability to do that is limited."
+                    " Are you using client-side timestamps? Make sure your clocks are well-synchronized"
+                    " with the database's clocks.", format_timestamp(ts), format_timestamp(now)));
+        }
+    }
+
+    it = _gens.begin();
+    if (it == _gens.end() || ts < it->first) {
         throw std::runtime_error(format(
-                "cdc::metadata::get_stream: could not find any CDC stream (current time: {})."
-                " Are we in the middle of a cluster upgrade?", format_timestamp(now)));
+                "cdc::metadata::get_stream: could not find any CDC stream for timestamp {}."
+                " Are we in the middle of a cluster upgrade?", format_timestamp(ts)));
     }
 
-    // Garbage-collect generations that will no longer be used.
-    it = _gens.erase(_gens.begin(), it);
-
-    if (it->first > ts) {
-        throw exceptions::invalid_request_exception(format(
-                "cdc: attempted to get a stream from an earlier generation than the currently used one."
-                " With CDC you cannot send writes with timestamps too far into the past, because that would break"
-                " consistency properties (write timestamp: {}, current generation started at: {})",
-                format_timestamp(ts), format_timestamp(it->first)));
-    }
-
-    // With `generation_leeway` we allow sending writes to the near future. It might happen
-    // that `ts` doesn't belong to the current generation ("current" according to our clock),
-    // but to the next generation. Adjust for this case:
+    // Find the generation operating at `ts`.
     {
         auto next_it = std::next(it);
         while (next_it != _gens.end() && next_it->first <= ts) {
@@ -147,8 +163,8 @@ bool cdc::metadata::known_or_obsolete(db_clock::time_point tp) const {
         ++it;
     }
 
-    // Check if some new generation has already superseded this one.
-    return it != _gens.end() && it->first <= api::new_timestamp();
+    // Check if the generation is obsolete.
+    return it != _gens.end() && it->first <= api::new_timestamp() - generation_leeway.count();
 }
 
 bool cdc::metadata::insert(db_clock::time_point tp, topology_description&& gen) {
@@ -157,7 +173,7 @@ bool cdc::metadata::insert(db_clock::time_point tp, topology_description&& gen) 
     }
 
     auto now = api::new_timestamp();
-    auto it = gen_used_at(now);
+    auto it = gen_used_at(now - generation_leeway.count());
 
     if (it != _gens.end()) {
         // Garbage-collect generations that will no longer be used.

--- a/cdc/metadata.hh
+++ b/cdc/metadata.hh
@@ -42,7 +42,9 @@ class metadata final {
 
     container_t::const_iterator gen_used_at(api::timestamp_type ts) const;
 public:
-    /* Is a generation with the given timestamp already known or superseded by a newer generation? */
+    /* Is a generation with the given timestamp already known or obsolete? It is obsolete if and only if
+     * it is older than the generation operating at `now - cdc::generation_leeway`.
+     */
     bool known_or_obsolete(db_clock::time_point) const;
 
     /* Are there streams available. I.e. valid for time == now. If this is false, any writes to 
@@ -54,8 +56,9 @@ public:
      *
      * If the provided timestamp is too far away "into the future" (where "now" is defined according to our local clock),
      * we reject the get_stream query. This is because the resulting stream might belong to a generation which we don't
-     * yet know about. The amount of leeway (how much "into the future" we allow `ts` to be) is defined
-     * by the `cdc::generation_leeway` constant.
+     * yet know about. Similarly, we reject queries to the previous generations if the timestamp is too far away "into
+     * the past". The amount of leeway (how much "into the future" or "into the past" we allow `ts` to be) is defined by
+     * the `cdc::generation_leeway` constant.
      */
     stream_id get_stream(api::timestamp_type ts, dht::token tok);
 

--- a/cdc/metadata.hh
+++ b/cdc/metadata.hh
@@ -43,7 +43,7 @@ class metadata final {
     container_t::const_iterator gen_used_at(api::timestamp_type ts) const;
 public:
     /* Is a generation with the given timestamp already known or obsolete? It is obsolete if and only if
-     * it is older than the generation operating at `now - cdc::generation_leeway`.
+     * it is older than the generation operating at `now - get_generation_leeway()`.
      */
     bool known_or_obsolete(db_clock::time_point) const;
 
@@ -58,7 +58,7 @@ public:
      * we reject the get_stream query. This is because the resulting stream might belong to a generation which we don't
      * yet know about. Similarly, we reject queries to the previous generations if the timestamp is too far away "into
      * the past". The amount of leeway (how much "into the future" or "into the past" we allow `ts` to be) is defined by
-     * the `cdc::generation_leeway` constant.
+     * `get_generation_leeway()`.
      */
     stream_id get_stream(api::timestamp_type ts, dht::token tok);
 

--- a/test/topology_custom/test_writes_to_previous_cdc_generations.py
+++ b/test/topology_custom/test_writes_to_previous_cdc_generations.py
@@ -1,0 +1,147 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from test.pylib.manager_client import ManagerClient, ServerInfo
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from test.topology.conftest import skip_mode
+
+from cassandra.cluster import ConsistencyLevel, NoHostAvailable, Session
+from cassandra.protocol import InvalidRequest
+from cassandra.query import SimpleStatement
+
+import asyncio
+import pytest
+import logging
+import time
+from datetime import datetime
+from typing import Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+async def wait_for_publishing_generations(cql: Session, servers: list[ServerInfo]) -> Optional[set[datetime]]:
+    query_gen_timestamps = SimpleStatement(
+        "SELECT tounixtimestamp(time) AS t FROM system_distributed.cdc_generation_timestamps WHERE key = 'timestamps'",
+        consistency_level = ConsistencyLevel.ONE)
+
+    async def generations_published() -> Optional[set[datetime]]:
+        # Multiply by 1000 because USING TIMESTAMP expects microseconds.
+        gen_timestamps = {r.t * 1000 for r in await cql.run_async(query_gen_timestamps)}
+        assert len(gen_timestamps) <= len(servers)
+        if len(gen_timestamps) == len(servers):
+            return gen_timestamps
+        return None
+
+    logger.info("Waiting for publishing CDC generations")
+    gen_timestamps = await wait_for(generations_published, time.time() + 60)
+    logger.info(f"CDC generations' timestamps: {gen_timestamps}")
+    return gen_timestamps
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_writes_to_recent_previous_cdc_generations(request, manager: ManagerClient):
+    """
+    Test that writes to previous CDC generations succeed if the timestamp of the generation being written to
+    is greater than (now - generation_leeway)
+
+    The test starts 3 nodes, and thus, it creates 3 generations. Let's denote their timestamps by ts1, ts2, ts3,
+    where ts1 is the timestamp of the first (and oldest) generation, and so on. We create a scenario where
+    now - generation_leeway < ts1 < ts2 < ts3 < now.
+    We check that writes with a timestamp from the interval [ts1, now] succeed.
+
+    The value of generation_leeway is 5 s. So, the condition
+    now - generation_leeway < ts1
+    might be false if the test runs too slowly. To avoid this, we increase generation_leeway to 5 min
+    through the error injection.
+    """
+    logger.info("Bootstrapping nodes")
+    servers = await manager.servers_add(3, config={
+        'error_injections_at_startup': ['increase_cdc_generation_leeway']
+    })
+
+    cql = manager.get_cql()
+
+    logger.info("Waiting for driver")
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    gen_timestamps = await wait_for_publishing_generations(cql, servers)
+
+    logger.info("Ceating a test table")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int) WITH cdc = {'enabled': true}")
+
+    async def do_write(timestamp: int):
+        await cql.run_async(f"INSERT INTO test.test (pk, c) VALUES (0, 0) USING TIMESTAMP {timestamp}")
+
+    logger.info("Executing writes to all generations")
+    for ts in gen_timestamps:
+        # Writes to all three generations should succeed.
+        await do_write(ts + 1)
+        await do_write(ts)
+        # A write with a timestamp smaller than the oldest generation's one should fail.
+        if ts == min(gen_timestamps):
+            with pytest.raises(NoHostAvailable):
+                await do_write(ts - 1)
+        else:
+            await do_write(ts - 1)
+
+
+@pytest.mark.asyncio
+@skip_mode('debug', 'test requires nodes to be started quickly')
+async def test_writes_to_old_previous_cdc_generation(request, manager: ManagerClient):
+    """
+    Test that writes to a previous CDC generation succeed if the write's timestamp is greater than
+    (now - generation_leeway) even if the generation's timestamp is not greater than (now - generation_leeway).
+
+    The test starts 2 nodes, and thus, it creates 2 generations. Let's denote their timestamps by ts1 and ts2, where
+    ts1 is the timestamp of the first (and oldest) generation. We create a scenario where
+    ts1 < now - generation_leeway < ts2 < now.
+    We check that writes with a timestamp from the interval (now - generation_leeway, ts2) succeed.
+
+    ts2 might already be much smaller than now after we finish adding the second node. Then, a write with a timestamp
+    smaller than ts2 could unexpectedly fail because we reject writes to previous generations with timestamps not
+    greater than (now - generation_leeway). To make this situation less likely, we increase ring-delay to 5 s, which
+    increases ts2 by 15 s (see cdc::new_generation_timestamp). If this situation still happens, the test detects it and
+    doesn't fail. We don't want to increase ring-delay more as it would slow down the test even more. To sum up, the
+    test shouldn't be flaky, but there is no guarantee that it will always test what it's supposed to test. We also
+    ignore it in debug mode due to the reasons above.
+    """
+    logger.info("Bootstrapping nodes")
+    servers = await manager.servers_add(2, cmdline=['--ring-delay', '5000'])
+
+    cql = manager.get_cql()
+
+    logger.info("Waiting for driver")
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    gen_timestamps = await wait_for_publishing_generations(cql, servers)
+
+    logger.info("Ceating a test table")
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int) WITH cdc = {'enabled': true}")
+
+    ts2 = max(gen_timestamps)
+    time_diff = (ts2 / (1000 * 1000)) - time.time()
+    if time_diff > 0:
+        logger.info("Waiting for the second generation to become active")
+        await asyncio.sleep(time_diff)
+
+    try:
+        # Writes with timestamps from the interval (now - generation_leeway, ts2) should succeed.
+        await cql.run_async(f"INSERT INTO test.test (pk, c) VALUES (0, 0) USING TIMESTAMP {ts2 - 1}")
+    except InvalidRequest:
+        # If the write has failed, we check that its timestamp is not greater than (now - generation_leeway). Then,
+        # the failure is expected. This situation can happen if the test is running too slowly.
+        # We use time.time() because we don't know "the real now" used by the node for verification. time.time() is for
+        # sure not lower, so if the assertion below fails, it would also fail for "the real now". However, if the
+        # assertion doesn't fail, we don't know if the write has been correct. We prefer a non-flaky test that catches
+        # some bugs over a flaky one that catches more bugs.
+        assert (ts2 - 1) / (1000 * 1000) <= time.time() - 5
+
+    # Writes with timestamps not greater than (now - generation_leeway) should fail.
+    with pytest.raises(InvalidRequest):
+        await cql.run_async(f"INSERT INTO test.test (pk, c) VALUES (0, 0) USING TIMESTAMP {ts2 - 5 * 1000 * 1000}")


### PR DESCRIPTION
Before this PR, writes to the previous CDC generations would
always be rejected. After this PR, they will be accepted if the
write's timestamp is greater than `now - generation_leeway`.

This change was proposed around 3 years ago. The motivation was
to improve user experience. If a client generates timestamps by
itself and its clock is desynchronized with the clock of the node
the client is connected to, there could be a period during
generation switching when writes fail. We didn't consider this
problem critical because the client could simply retry a failed
write with a higher timestamp. Eventually, it would succeed. This
approach is safe because these failed writes cannot have any side
effects. However, it can be inconvenient. Writing to previous
generations was proposed to improve it.

The idea was rejected 3 years ago. Recently, it turned out that
there is a case when the client cannot retry a write with the
increased timestamp. It happens when a table uses CDC and LWT,
which makes timestamps permanent. Once Paxos commits an entry
with a given timestamp, Scylla will keep trying to apply that entry
until it succeeds, with the same timestamp. Applying the entry
involves writing to the CDC log table. If it fails, we get stuck.
It's a major bug with an unknown perfect solution.

Allowing writes to previous generations for `generation_leeway` is
a probabilistic fix that should solve the problem in practice.

Apart from this change, this PR adds tests for it and updates
the documentation.

This PR is sufficient to enable writes to the previous generations
only in the gossiper-based topology. The Raft-based topology
needs some adjustments in loading and cleaning CDC generations.
These changes won't interfere with the changes introduced in this
PR, so they are left for a follow-up.

Fixes scylladb/scylladb#7251
Fixes scylladb/scylladb#15260