### PR TITLE
raft topology: make rollback_to_normal a transition state

### DIFF
--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -40,6 +40,8 @@ token ring), reads are using old replicas.
 - `left_token_ring` - the decommissioning node left the token ring, but we still need to wait until other
    nodes observe it and stop sending writes to this node. Then, we tell the node to shut down and remove
    it from group 0. We also use this state to rollback a failed bootstrap or decommission.
+- `rollback_to_normal` - the decommission or removenode operation failed. Rollback the operation by
+    moving the node we tried to decommission/remove back to the normal state.
 
 When a node bootstraps, we create new tokens for it and a new CDC generation
 and enter the `commit_cdc_generation` state. Once the generation is committed,

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -35,11 +35,11 @@ Additionally to specific node states, there entire topology can also be in a tra
     to start using it for CDC log table writes.
 - `write_both_read_old` - one of the nodes is in a bootstrapping/decommissioning/removing/replacing state.
     Writes are going to both new and old replicas (new replicas means calculated according to modified
-token ring), reads are using old replicas.
+    token ring), reads are using old replicas.
 - `write_both_read_new` - as above, but reads are using new replicas.
 - `left_token_ring` - the decommissioning node left the token ring, but we still need to wait until other
-   nodes observe it and stop sending writes to this node. Then, we tell the node to shut down and remove
-   it from group 0. We also use this state to rollback a failed bootstrap or decommission.
+    nodes observe it and stop sending writes to this node. Then, we tell the node to shut down and remove
+    it from group 0. We also use this state to rollback a failed bootstrap or decommission.
 - `rollback_to_normal` - the decommission or removenode operation failed. Rollback the operation by
     moving the node we tried to decommission/remove back to the normal state.
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1689,7 +1689,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 } catch (term_changed_error&) {
                     throw;
                 } catch(...) {
-                    rtlogger.warn("failed to run barrier_and_drain during rollback {}", std::current_exception());
+                    rtlogger.warn("failed to run barrier_and_drain during rollback of {} after {} failure: {}",
+                            node.id, node.rs->state, std::current_exception());
                     barrier_failed = true;
                 }
 
@@ -1707,7 +1708,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                        .set("node_state", node_state::normal);
                 rtbuilder.done();
 
-                auto str = fmt::format("complete rollback of {} to state normal", node.id);
+                auto str = fmt::format("complete rollback of {} to state normal after {} failure", node.id, node.rs->state);
 
                 rtlogger.info("{}", str);
                 co_await update_topology_state(std::move(node.guard), {builder.build(), rtbuilder.build()}, str);

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -169,6 +169,7 @@ static std::unordered_map<topology::transition_state, sstring> transition_state_
     {topology::transition_state::tablet_migration, "tablet migration"},
     {topology::transition_state::tablet_draining, "tablet draining"},
     {topology::transition_state::left_token_ring, "left token ring"},
+    {topology::transition_state::rollback_to_normal, "rollback to normal"},
 };
 
 std::ostream& operator<<(std::ostream& os, topology::transition_state s) {
@@ -197,7 +198,6 @@ static std::unordered_map<node_state, sstring> node_state_to_name_map = {
     {node_state::replacing, "replacing"},
     {node_state::rebuilding, "rebuilding"},
     {node_state::none, "none"},
-    {node_state::rollback_to_normal, "rollback_to_normal"},
 };
 
 std::ostream& operator<<(std::ostream& os, node_state s) {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -34,7 +34,6 @@ enum class node_state: uint16_t {
     rebuilding,          // the node is being rebuild and is streaming data from other replicas
     normal,              // the node does not do any streaming and serves the slice of the ring that belongs to it
     left,                // the node left the cluster and group0
-    rollback_to_normal,  // the node rolls back failed decommission/remove node operation
 };
 
 // The order of the requests is a priority
@@ -116,6 +115,7 @@ struct topology {
         write_both_read_new,
         tablet_migration,
         left_token_ring,
+        rollback_to_normal,
     };
 
     std::optional<transition_state> tstate;

--- a/test/topology/test_topology_failure_recovery.py
+++ b/test/topology/test_topology_failure_recovery.py
@@ -27,7 +27,8 @@ async def test_topology_streaming_failure(request, manager: ManagerClient):
     await manager.decommission_node(servers[2].server_id, expected_error="Decommission failed. See earlier errors")
     servers = await manager.running_servers()
     assert len(servers) == 3
-    matches = [await log.grep("raft_topology - rollback.*after decommissioning failure to state rollback_to_normal", from_mark=mark) for log, mark in zip(logs, marks)]
+    matches = [await log.grep("raft_topology - rollback.*after decommissioning failure, moving transition state to rollback to normal",
+               from_mark=mark) for log, mark in zip(logs, marks)]
     assert sum(len(x) for x in matches) == 1
     # remove failure
     marks = [await log.mark() for log in logs]
@@ -36,7 +37,8 @@ async def test_topology_streaming_failure(request, manager: ManagerClient):
     await manager.server_stop_gracefully(servers[3].server_id)
     await manager.api.enable_injection(servers[2].ip_addr, 'stream_ranges_fail', one_shot=True)
     await manager.remove_node(servers[0].server_id, servers[3].server_id, expected_error="Removenode failed. See earlier errors")
-    matches = [await log.grep("raft_topology - rollback.*after removing failure to state rollback_to_normal", from_mark=mark) for log, mark in zip(logs, marks)]
+    matches = [await log.grep("raft_topology - rollback.*after removing failure, moving transition state to rollback to normal",
+               from_mark=mark) for log, mark in zip(logs, marks)]
     assert sum(len(x) for x in matches) == 1
     await manager.server_start(servers[3].server_id)
     await manager.servers_see_each_other(servers)

--- a/test/topology_custom/test_topology_failure_recovery.py
+++ b/test/topology_custom/test_topology_failure_recovery.py
@@ -38,7 +38,8 @@ async def test_tablet_drain_failure_during_decommission(manager: ManagerClient):
 
     await manager.decommission_node(servers[2].server_id, expected_error="Decommission failed. See earlier errors")
 
-    matches = [await log.grep("raft_topology - rollback.*after decommissioning failure to state rollback_to_normal", from_mark=mark) for log, mark in zip(logs, marks)]
+    matches = [await log.grep("raft_topology - rollback.*after decommissioning failure, moving transition state to rollback to normal",
+               from_mark=mark) for log, mark in zip(logs, marks)]
     assert sum(len(x) for x in matches) == 1
 
     await cql.run_async("DROP KEYSPACE test;")


### PR DESCRIPTION
After changing `left_token_ring` from a node state to a transition
state in scylladb/scylladb#17009, we do the same for
`rollback_to_normal`. `rollback_to_normal` was created as a node
state because `left_token_ring` was a node state.

This change will allow us to distinguish a failed removenode from
a failed decommission in the `rollback_to_normal` handler.
Currently, we use the same logic for both of them, so it's not
required. However, this might change, as it has happened with the
decommission and the failed bootstrap/replace in the
`left_token_ring` state (scylladb/scylladb#16797). We are making
this change now because it would be much harder after branching.

Fixes scylladb/scylladb#17032