### PR TITLE
docs: fix logging in images extensions

### DIFF
--- a/docs/_ext/scylladb_aws_images.py
+++ b/docs/_ext/scylladb_aws_images.py
@@ -8,7 +8,6 @@ from scylladb_common_images import FileDownloader, BaseVersionsTemplateDirective
 
 LOGGER = logging.getLogger(__name__)
 
-
 class CloudFormationProcessor:
     FILENAME_REGEX = r"^.+_(\d+\.\d+\.\d+)_(\w+)(\.yaml)?$"
 
@@ -46,7 +45,7 @@ class CloudFormationProcessor:
                 if matching_csv:
                     csv_path = os.path.join(download_directory, matching_csv)
                     self._append_to_csv(csv_path, link, architecture)
-        print("Appended cloudformation information to AWS images CSVs.")
+        LOGGER.info("Appended cloudformation information to AWS images CSVs.")
 
 
 class AMIInformationDownloader:
@@ -54,19 +53,19 @@ class AMIInformationDownloader:
     def run(self, app, exception=None):  
         config = app.config
         base_url = config.scylladb_aws_images_base_url
-        ami_bucket_directory = config.scylladb_aws_images_ami_bucket_directory
-        ami_download_directory = os.path.join(app.builder.srcdir, config.scylladb_aws_images_ami_download_directory)
+        bucket_directory = config.scylladb_aws_images_ami_bucket_directory
+        download_directory = os.path.join(app.builder.srcdir, config.scylladb_aws_images_ami_download_directory)
         cloudformation_bucket_directory = config.scylladb_aws_images_cloudformation_bucket_directory
 
-        if os.path.exists(ami_download_directory) and os.listdir(ami_download_directory):
-            print(f"Files already exist in {ami_download_directory}. Skipping download.")
+        if os.path.exists(download_directory) and os.listdir(download_directory):
+            LOGGER.info(f"Files already exist in {download_directory}. Skipping download.")
 
         else:
             downloader = FileDownloader(base_url)
-            downloader.download_files(ami_bucket_directory, ami_download_directory)
+            downloader.download_files(bucket_directory, download_directory)
             processor = CloudFormationProcessor()
             links = downloader.get_links(cloudformation_bucket_directory, "yaml")
-            processor.process_files(ami_download_directory, links)
+            processor.process_files(download_directory, links)
 
 
 class AMIVersionsTemplateDirective(BaseVersionsTemplateDirective):

--- a/docs/_ext/scylladb_azure_images.py
+++ b/docs/_ext/scylladb_azure_images.py
@@ -12,13 +12,13 @@ class AzureImagesInformationDownloader:
     def run(self, app, exception=None):  
         config = app.config
         base_url = config.scylladb_azure_images_base_url
-        ami_bucket_directory = config.scylladb_azure_images_ami_bucket_directory
-        ami_download_directory = os.path.join(app.builder.srcdir, config.scylladb_azure_images_download_directory)
-        if os.path.exists(ami_download_directory) and os.listdir(ami_download_directory):
-            print(f"Files already exist in {ami_download_directory}. Skipping download.")
+        bucket_directory = config.scylladb_azure_images_ami_bucket_directory
+        download_directory = os.path.join(app.builder.srcdir, config.scylladb_azure_images_download_directory)
+        if os.path.exists(download_directory) and os.listdir(download_directory):
+            LOGGER.info(f"Files already exist in {download_directory}. Skipping download.")
         else:
             downloader = FileDownloader(base_url)
-            downloader.download_files(ami_bucket_directory, ami_download_directory)
+            downloader.download_files(bucket_directory, download_directory)
 
 class AzureImagesVersionsTemplateDirective(BaseVersionsTemplateDirective):
     FILENAME_REGEX = re.compile(r"azure_image_ids_(\d+(?:\.\d+)?(?:\.\d+)?)(?:.*?)\.csv")

--- a/docs/_ext/scylladb_common_images.py
+++ b/docs/_ext/scylladb_common_images.py
@@ -7,6 +7,7 @@ from docutils.parsers.rst import Directive, directives
 from sphinxcontrib.datatemplates.directive import DataTemplateCSV
 from sphinx.util import logging
 
+LOGGER = logging.getLogger(__name__)
 
 class FileDownloader:
     def __init__(self, base_url, session=None):

--- a/docs/_ext/scylladb_gcp_images.py
+++ b/docs/_ext/scylladb_gcp_images.py
@@ -13,14 +13,14 @@ class GCPImagesInformationDownloader:
     def run(self, app, exception=None):  
         config = app.config
         base_url = config.scylladb_gcp_images_base_url
-        ami_bucket_directory = config.scylladb_gcp_images_bucket_directory
-        ami_download_directory = os.path.join(app.builder.srcdir, config.scylladb_gcp_images_download_directory)
+        bucket_directory = config.scylladb_gcp_images_bucket_directory
+        download_directory = os.path.join(app.builder.srcdir, config.scylladb_gcp_images_download_directory)
 
-        if os.path.exists(ami_download_directory) and os.listdir(ami_download_directory):
-            print(f"Files already exist in {ami_download_directory}. Skipping download.")
+        if os.path.exists(download_directory) and os.listdir(download_directory):
+            LOGGER.info(f"Files already exist in {download_directory}. Skipping download.")
         else:
             downloader = FileDownloader(base_url)
-            downloader.download_files(ami_bucket_directory, ami_download_directory)
+            downloader.download_files(bucket_directory, download_directory)
 
 
 class GCPImagesVersionsTemplateDirective(BaseVersionsTemplateDirective):


### PR DESCRIPTION
Adds a missing logging import in the file `scylladb_common_images extension,` which prevents the enterprise build from the building.

Additionally, it standardizes logging handling across the extensions and removes "ami" references in Azure and GCP extensions.

## How to test

Docs build and render without errors.