### PR TITLE
row_cache: update _prev_snapshot_pos even if apply_to_incomplete() is preempted

### DIFF
--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1069,7 +1069,7 @@ future<> row_cache::do_update(external_updater eu, replica::memtable& m, Updater
                             // this layer has a chance to restore invariants before deferring,
                             // in particular set _prev_snapshot_pos to the correct value.
                             if (update.run() == stop_iteration::no) {
-                                return;
+                                break;
                             }
                             update = {};
                             real_dirty_acc.unpin_memory(size_entry);


### PR DESCRIPTION
Commit e81fc1f095f0d39f4bbc6503960450b7fda3ba1b accidentally broke the control flow of row_cache::do_update().

Before that commit, the body of the loop was wrapped in a lambda. Thus, to break out of the loop, `return` was used.

The bad commit removed the lambda, but didn't update the `return` accordingly. Thus, since the commit, the statement doesn't just break out of the loop as intended, but also skips the code after the loop, which updates `_prev_snapshot_pos` to reflect the work done by the loop.

As a result, whenever `apply_to_incomplete()` (the `updater`) is preempted, `do_update()` fails to update `_prev_snapshot_pos`. It remains in a stale state, until `do_update()` runs again and either finishes or is preempted outside of `updater`.

If we read a partition processed by `do_update()` but not covered by `_prev_snapshot_pos`, we will read stale data (from the previous snapshot), which will be remembered in the cache as the current data.

This results in outdated data being returned by the replica. (And perhaps in something worse if range tombstones are involved. I didn't investigate this possibility in depth).

Note: for queries with CL>1, occurences of this bug are likely to be hidden by reconciliation, because the reconciled query will only see stale data if the queried partition is affected by the bug on on *all* queried replicas at the time of the query.

Fixes #16759