### PR TITLE
Add specialized tablet_sstable_set

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -145,7 +145,7 @@ public:
     void set_maintenance_sstables(lw_shared_ptr<sstables::sstable_set> new_maintenance_sstables);
 
     // Makes a compound set, which includes main and maintenance sets
-    lw_shared_ptr<sstables::sstable_set> make_compound_sstable_set();
+    lw_shared_ptr<sstables::sstable_set> make_compound_sstable_set() const;
 
     const std::vector<sstables::shared_sstable>& compacted_undeleted_sstables() const noexcept;
     // Triggers regular compaction.

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -222,12 +222,51 @@ public:
 using storage_group_vector = utils::chunked_vector<std::unique_ptr<storage_group>>;
 
 class storage_group_manager {
+protected:
+    // The compaction group list is only a helper for accessing the groups managed by the storage groups.
+    // The list entries are unlinked automatically when the storage group, they belong to, is removed.
+    compaction_group_list _compaction_groups;
+    storage_group_vector _storage_groups;
+
 public:
-    virtual ~storage_group_manager() {}
+    virtual ~storage_group_manager();
+
+    const compaction_group_list& compaction_groups() const noexcept {
+        return _compaction_groups;
+    }
+    compaction_group_list& compaction_groups() noexcept {
+        return _compaction_groups;
+    }
+
+    const storage_group_vector& storage_groups() const noexcept {
+        return _storage_groups;
+    }
+    storage_group_vector& storage_groups() noexcept {
+        return _storage_groups;
+    }
+
+    compaction_group* single_compaction_group_if_available() noexcept {
+        return _compaction_groups.size() == 1 ? &_compaction_groups.front() : nullptr;
+    }
+
+    // Caller must keep the current effective_replication_map_ptr valid
+    // until the storage_group_manager finishes update_effective_replication_map
     virtual future<> update_effective_replication_map(const locator::effective_replication_map& erm) = 0;
-    virtual storage_group_vector make_storage_groups(compaction_group_list& list) const = 0;
+
+    virtual compaction_group& compaction_group_for_token(dht::token token) const noexcept = 0;
+    virtual utils::chunked_vector<compaction_group*> compaction_groups_for_token_range(dht::token_range tr) const = 0;
+    virtual compaction_group& compaction_group_for_key(partition_key_view key, const schema_ptr& s) const noexcept = 0;
+    virtual compaction_group& compaction_group_for_sstable(const sstables::shared_sstable& sst) const noexcept = 0;
+
     virtual std::pair<size_t, locator::tablet_range_side> storage_group_of(dht::token) const = 0;
     virtual size_t log2_storage_groups() const = 0;
+    virtual size_t storage_group_id_for_token(dht::token) const noexcept = 0;
+    virtual storage_group* storage_group_for_token(dht::token) const noexcept = 0;
+
+    virtual locator::resize_decision::seq_number_t split_ready_seq_number() const noexcept = 0;
+    virtual bool all_storage_groups_split() = 0;
+    virtual future<> split_all_storage_groups() = 0;
+    virtual future<> maybe_split_compaction_group_of(size_t idx) = 0;
 };
 
 }

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -217,6 +217,9 @@ public:
     //  2) Compacts all sstables which overlap with the split point
     // Returns a future which resolves when this process is complete.
     future<> split(compaction_group_list&, sstables::compaction_type_options::split opt);
+
+    // Make an sstable set spanning all sstables in the storage_group
+    lw_shared_ptr<sstables::sstable_set> make_sstable_set() const;
 };
 
 using storage_group_vector = utils::chunked_vector<std::unique_ptr<storage_group>>;
@@ -267,6 +270,8 @@ public:
     virtual bool all_storage_groups_split() = 0;
     virtual future<> split_all_storage_groups() = 0;
     virtual future<> maybe_split_compaction_group_of(size_t idx) = 0;
+
+    virtual lw_shared_ptr<sstables::sstable_set> make_sstable_set() const = 0;
 };
 
 }

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -20,6 +20,10 @@
 
 #pragma once
 
+namespace locator {
+class effective_replication_map;
+}
+
 namespace replica {
 
 using enable_backlog_tracker = bool_class<class enable_backlog_tracker_tag>;
@@ -220,6 +224,7 @@ using storage_group_vector = utils::chunked_vector<std::unique_ptr<storage_group
 class storage_group_manager {
 public:
     virtual ~storage_group_manager() {}
+    virtual future<> update_effective_replication_map(const locator::effective_replication_map& erm) = 0;
     virtual storage_group_vector make_storage_groups(compaction_group_list& list) const = 0;
     virtual std::pair<size_t, locator::tablet_range_side> storage_group_of(dht::token) const = 0;
     virtual size_t log2_storage_groups() const = 0;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1240,6 +1240,8 @@ public:
     friend class compaction_group;
 };
 
+lw_shared_ptr<sstables::sstable_set> make_tablet_sstable_set(schema_ptr, const storage_group_manager& sgm, const locator::tablet_map&);
+
 using user_types_metadata = data_dictionary::user_types_metadata;
 
 using keyspace_metadata = data_dictionary::keyspace_metadata;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -662,7 +662,7 @@ private:
                                         const sstables::sstable_predicate& = sstables::default_sstable_predicate()) const;
 
     lw_shared_ptr<sstables::sstable_set> make_maintenance_sstable_set() const;
-    lw_shared_ptr<sstables::sstable_set> make_compound_sstable_set();
+    lw_shared_ptr<sstables::sstable_set> make_compound_sstable_set() const;
     // Compound sstable set must be refreshed whenever any of its managed sets are changed
     void refresh_compound_sstable_set();
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -593,7 +593,7 @@ private:
     // Called when coordinator executes tablet splitting, i.e. commit the new tablet map with
     // each tablet split into two, so this replica will remap all of its compaction groups
     // that were previously split.
-    void handle_tablet_split_completion(size_t old_tablet_count, const locator::tablet_map& new_tmap);
+    future<> handle_tablet_split_completion(size_t old_tablet_count, const locator::tablet_map& new_tmap);
 
     sstables::compaction_type_options::split split_compaction_options() const noexcept;
 
@@ -846,7 +846,7 @@ public:
     void set_schema(schema_ptr);
     db::commitlog* commitlog() const;
     const locator::effective_replication_map_ptr& get_effective_replication_map() const { return _erm; }
-    void update_effective_replication_map(locator::effective_replication_map_ptr);
+    future<> update_effective_replication_map(locator::effective_replication_map_ptr);
     [[gnu::always_inline]] bool uses_tablets() const;
     future<> cleanup_tablet(database&, db::system_keyspace&, locator::tablet_id);
     future<const_mutation_partition_ptr> find_partition(schema_ptr, reader_permit permit, const dht::decorated_key& key) const;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -449,11 +449,9 @@ private:
 
     compaction_manager& _compaction_manager;
     sstables::compaction_strategy _compaction_strategy;
+    // The storage_group_manager manages either a single storage_group for vnodes or per-tablet storage_group for tablets.
+    // It contains and manages both the compaction_groups list and the storage_groups vector.
     std::unique_ptr<storage_group_manager> _sg_manager;
-    // The compaction group list is only a helper for accessing the groups managed by the storage groups.
-    // The list entries are unlinked automatically when the storage group, they belong to, is removed.
-    mutable compaction_group_list _compaction_groups;
-    storage_group_vector _storage_groups;
     // Compound SSTable set for all the compaction groups, which is useful for operations spanning all of them.
     lw_shared_ptr<sstables::sstable_set> _sstables;
     // Control background fibers waiting for sstables to be deleted
@@ -536,11 +534,6 @@ private:
     bool _is_bootstrap_or_replace = false;
     sstables::shared_sstable make_sstable(sstables::sstable_state state);
 
-    // Every table replica that completes split work will load the seq number from tablet metadata into its local
-    // state. So when coordinator pull the local state of a table, it will know whether the table is ready for the
-    // current split, and not a previously revoked (stale) decision.
-    // The minimum value, which is a negative number, is not used by coordinator for first decision.
-    locator::resize_decision::seq_number_t _split_ready_seq_number = std::numeric_limits<locator::resize_decision::seq_number_t>::min();
 public:
     void deregister_metrics();
 
@@ -595,8 +588,6 @@ private:
     // that were previously split.
     future<> handle_tablet_split_completion(size_t old_tablet_count, const locator::tablet_map& new_tmap);
 
-    sstables::compaction_type_options::split split_compaction_options() const noexcept;
-
     // Select a compaction group from a given token.
     std::pair<size_t, locator::tablet_range_side> storage_group_of(dht::token token) const noexcept;
     size_t storage_group_id_for_token(dht::token token) const noexcept;
@@ -616,6 +607,8 @@ private:
     compaction_group& compaction_group_for_sstable(const sstables::shared_sstable& sst) const noexcept;
     // Returns a list of all compaction groups.
     compaction_group_list& compaction_groups() const noexcept;
+    // Returns a list of all storage groups.
+    const storage_group_vector& storage_groups() const noexcept;
     // Safely iterate through compaction groups, while performing async operations on them.
     future<> parallel_foreach_compaction_group(std::function<future<>(compaction_group&)> action);
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -658,6 +658,7 @@ public:
     std::pair<size_t, locator::tablet_range_side> storage_group_of(dht::token t) const override {
         auto [id, side] = tablet_map().get_tablet_id_and_range_side(t);
         auto idx = id.value();
+#ifndef SCYLLA_BUILD_MODE_RELEASE
         if (idx >= storage_groups().size()) {
             on_fatal_internal_error(tlogger, format("storage_group_of: index out of range: idx={} size_log2={} size={} token={}",
                                                     idx, log2_storage_groups(), storage_groups().size(), t));
@@ -667,6 +668,7 @@ public:
             on_fatal_internal_error(tlogger, format("storage_group_of: storage_group idx={} range={} does not contain token={}",
                     idx, sg->token_range(), t));
         }
+#endif
         return { idx, side };
     }
     size_t log2_storage_groups() const override {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2000,6 +2000,7 @@ locator::table_load_stats table::table_load_stats(std::function<bool(locator::gl
 future<> tablet_storage_group_manager::handle_tablet_split_completion(const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap) {
     auto table_id = schema()->id();
     size_t old_tablet_count = old_tmap.tablet_count();
+    size_t new_tablet_count = new_tmap.tablet_count();
     storage_group_vector new_storage_groups;
     new_storage_groups.resize(new_tmap.tablet_count());
 
@@ -2010,13 +2011,13 @@ future<> tablet_storage_group_manager::handle_tablet_split_completion(const loca
     // NOTE: exception when applying replica changes to reflect token metadata will abort for obvious reasons,
     //  so exception safety is not required here.
 
-    unsigned growth_factor = log2ceil(new_tmap.tablet_count() / old_tablet_count);
+    unsigned growth_factor = log2ceil(new_tablet_count / old_tablet_count);
     unsigned split_size = 1 << growth_factor;
     tlogger.debug("Growth factor: {}, split size {}", growth_factor, split_size);
 
-    if (old_tablet_count*split_size != new_tmap.tablet_count()) {
+    if (old_tablet_count * split_size != new_tablet_count) {
         on_internal_error(tlogger, format("New tablet count for table {} is unexpected, actual: {}, expected {}.",
-            table_id, new_tmap.tablet_count(), old_tablet_count*split_size));
+            table_id, new_tablet_count, old_tablet_count * split_size));
     }
 
     // Stop the released main compaction groups asynchronously

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -688,11 +688,8 @@ public:
     future<> maybe_split_compaction_group_of(size_t idx) override;
 
     lw_shared_ptr<sstables::sstable_set> make_sstable_set() const override {
-        // TODO: switch to a specialized set for groups which assumes disjointness across compound sets and incrementally read from them.
         // FIXME: avoid recreation of compound_set for groups which had no change. usually, only one group will be changed at a time.
-        auto sstable_sets = boost::copy_range<std::vector<lw_shared_ptr<sstables::sstable_set>>>(compaction_groups()
-            | boost::adaptors::transformed(std::mem_fn(&compaction_group::make_compound_sstable_set)));
-        return make_lw_shared(sstables::make_compound_sstable_set(schema(), std::move(sstable_sets)));
+        return make_tablet_sstable_set(schema(), *this, *_tablet_map);
     }
 };
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -118,11 +118,11 @@ table::make_sstable_reader(schema_ptr s,
     }
 }
 
-lw_shared_ptr<sstables::sstable_set> compaction_group::make_compound_sstable_set() {
+lw_shared_ptr<sstables::sstable_set> compaction_group::make_compound_sstable_set() const {
     return make_lw_shared(sstables::make_compound_sstable_set(_t.schema(), { _main_sstables, _maintenance_sstables }));
 }
 
-lw_shared_ptr<sstables::sstable_set> table::make_compound_sstable_set() {
+lw_shared_ptr<sstables::sstable_set> table::make_compound_sstable_set() const {
     if (auto cg = single_compaction_group_if_available()) {
         return cg->make_compound_sstable_set();
     }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3297,7 +3297,7 @@ public:
         return _t._compaction_manager.get_backlog_tracker(*this);
     }
     const std::string get_group_id() const noexcept override {
-        return fmt::format("{}/{}", _cg.group_id(), _t._compaction_groups.size());
+        return fmt::format("{}", _cg.group_id());
     }
 
     seastar::condition_variable& get_staging_done_condition() noexcept override {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2864,7 +2864,7 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
 
     // Apply changes on all shards
     try {
-        co_await container().invoke_on_all([&] (storage_service& ss) {
+        co_await container().invoke_on_all([&] (storage_service& ss) -> future<> {
             ss._shared_token_metadata.set(std::move(pending_token_metadata_ptr[this_shard_id()]));
             auto& db = ss._db.local();
 
@@ -2878,7 +2878,7 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
             auto& table_erms = pending_table_erms[this_shard_id()];
             for (auto it = table_erms.begin(); it != table_erms.end(); ) {
                 auto& cf = db.find_column_family(it->first);
-                cf.update_effective_replication_map(std::move(it->second));
+                co_await cf.update_effective_replication_map(std::move(it->second));
                 if (cf.uses_tablets()) {
                     register_tablet_split_candidate(it->first);
                 }


### PR DESCRIPTION
Make a specialized sstable_set for tablets
via tablet_storage_group_manager::make_sstable_set.

This sstable set takes a snapshot of the storage_groups
(compound) sstable_sets and maps the selected tokens
directly into the tablet compound_sstable_set.

This sstable_set provides much more efficient access
to the table's sstable sets as it takes advantage of the disjointness
of sstable sets between tablets/storage_groups, and making it is cheaper
that rebuilding a complete partitioned_sstable_set from all sstables in the table.

Fixes #16876

Cassandra-stress setup:
```
$ sudo cpupower frequency-set -g userspace
$ build/release/scylla (developer-mode options) --smp=16 --memory=8G --experimental-features=consistent-topology-changes --experimental-features=tablets
cqlsh> CREATE KEYSPACE keyspace1 WITH replication={'class':'NetworkTopologyStrategy', 'replication_factor':1} AND tablets={'initial':2048};
$ ./tools/java/tools/bin/cassandra-stress write no-warmup n=10000000 -pop 'seq=1...10000000' -rate threads=128
$ scylla-api-client system drop_sstable_caches POST
$ ./tools/java/tools/bin/cassandra-stress read no-warmup duration=60s -pop 'dist=uniform(1..10000000)' -rate threads=128
$ scylla-api-client system drop_sstable_caches POST
$ ./tools/java/tools/bin/cassandra-stress mixed no-warmup duration=60s -pop 'dist=uniform(1..10000000)' -rate threads=128
```

Baseline (0a7854ea4d) vs. fix (0c2c00f01b)

Throughput (op/s):
workload | baseline | fix
---------|----------|----------
write | 76,806 | 100,787
read | 34,330 | 106,099
mixed | 32,195 | 79,246
