### PR TITLE
db: add formatter for gms::gossip_digest_ack2

### DIFF
--- a/gms/gossip_digest_ack2.cc
+++ b/gms/gossip_digest_ack2.cc
@@ -9,16 +9,13 @@
  */
 
 #include "gms/gossip_digest_ack2.hh"
-#include <ostream>
 
-namespace gms {
-
-std::ostream& operator<<(std::ostream& os, const gossip_digest_ack2& ack2) {
-    os << "endpoint_state:{";
-    for (auto& d : ack2._map) {
-        fmt::print(os, "[{}->{}]", d.first, d.second);
+auto fmt::formatter<gms::gossip_digest_ack2>::format(const gms::gossip_digest_ack2& ack2, fmt::format_context& ctx) const
+    -> decltype(ctx.out()) {
+    auto out = ctx.out();
+    out = fmt::format_to(out, "endpoint_state:{{");
+    for (auto& [addr, state] : ack2.get_endpoint_state_map()) {
+        out = fmt::format_to(out, "[{}->{}]", addr, state);
     }
-    return os << "}";
+    return fmt::format_to(out, "}}");
 }
-
-} // namespace gms

--- a/gms/gossip_digest_ack2.hh
+++ b/gms/gossip_digest_ack2.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <fmt/core.h>
 #include "utils/serialization.hh"
 #include "gms/gossip_digest.hh"
 #include "gms/inet_address.hh"
@@ -39,8 +40,13 @@ public:
     const std::map<inet_address, endpoint_state>& get_endpoint_state_map() const {
         return _map;
     }
-
-    friend std::ostream& operator<<(std::ostream& os, const gossip_digest_ack2& ack2);
 };
 
 } // gms
+
+template <>
+struct fmt::formatter<gms::gossip_digest_ack2> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const gms::gossip_digest_ack2& ack2, fmt::format_context& ctx) const
+        -> decltype(ctx.out());
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `gms::gossip_digest_ack2`, and drop its operator<<.

Refs #13245