### PR TITLE
Purge old ip on change

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1874,6 +1874,12 @@ static data_value_or_unset make_data_value_or_unset(const std::optional<std::uno
 }
 
 future<> system_keyspace::update_peer_info(gms::inet_address ep, locator::host_id hid, const peer_info& info) {
+    if (ep == gms::inet_address{}) {
+        on_internal_error(slogger, format("update_peer_info called with empty inet_address, host_id {}", hid));
+    }
+    if (!hid) {
+        on_internal_error(slogger, format("update_peer_info called with empty host_id, ep {}", ep));
+    }
     if (_db.get_token_metadata().get_topology().is_me(ep)) {
         on_internal_error(slogger, format("update_peer_info called for this node: {}", ep));
     }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1873,7 +1873,7 @@ static data_value_or_unset make_data_value_or_unset(const std::optional<std::uno
 };
 }
 
-future<> system_keyspace::update_peer_info(gms::inet_address ep, const peer_info& info) {
+future<> system_keyspace::update_peer_info(gms::inet_address ep, locator::host_id hid, const peer_info& info) {
     if (_db.get_token_metadata().get_topology().is_me(ep)) {
         on_internal_error(slogger, format("update_peer_info called for this node: {}", ep));
     }
@@ -1881,7 +1881,7 @@ future<> system_keyspace::update_peer_info(gms::inet_address ep, const peer_info
     data_value_list values = {
         data_value_or_unset(data_value(ep.addr())),
         make_data_value_or_unset(info.data_center),
-        make_data_value_or_unset(info.host_id),
+        data_value_or_unset(hid.id),
         make_data_value_or_unset(info.preferred_ip),
         make_data_value_or_unset(info.rack),
         make_data_value_or_unset(info.release_version),

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1855,18 +1855,16 @@ future<std::unordered_map<gms::inet_address, gms::inet_address>> system_keyspace
 
 namespace {
 template <typename T>
-static data_value_or_unset make_data_value_or_unset(const std::optional<T>& opt, bool& any_set) {
+static data_value_or_unset make_data_value_or_unset(const std::optional<T>& opt) {
     if (opt) {
-        any_set = true;
         return data_value(*opt);
     } else {
         return unset_value{};
     }
 };
 
-static data_value_or_unset make_data_value_or_unset(const std::optional<std::unordered_set<dht::token>>& opt, bool& any_set) {
+static data_value_or_unset make_data_value_or_unset(const std::optional<std::unordered_set<dht::token>>& opt) {
     if (opt) {
-        any_set = true;
         auto set_type = set_type_impl::get_instance(utf8_type, true);
         return make_set_value(set_type, prepare_tokens(*opt));
     } else {
@@ -1880,23 +1878,18 @@ future<> system_keyspace::update_peer_info(gms::inet_address ep, const peer_info
         on_internal_error(slogger, format("update_peer_info called for this node: {}", ep));
     }
 
-    bool any_set = false;
     data_value_list values = {
         data_value_or_unset(data_value(ep.addr())),
-        make_data_value_or_unset(info.data_center, any_set),
-        make_data_value_or_unset(info.host_id, any_set),
-        make_data_value_or_unset(info.preferred_ip, any_set),
-        make_data_value_or_unset(info.rack, any_set),
-        make_data_value_or_unset(info.release_version, any_set),
-        make_data_value_or_unset(info.rpc_address, any_set),
-        make_data_value_or_unset(info.schema_version, any_set),
-        make_data_value_or_unset(info.tokens, any_set),
-        make_data_value_or_unset(info.supported_features, any_set),
+        make_data_value_or_unset(info.data_center),
+        make_data_value_or_unset(info.host_id),
+        make_data_value_or_unset(info.preferred_ip),
+        make_data_value_or_unset(info.rack),
+        make_data_value_or_unset(info.release_version),
+        make_data_value_or_unset(info.rpc_address),
+        make_data_value_or_unset(info.schema_version),
+        make_data_value_or_unset(info.tokens),
+        make_data_value_or_unset(info.supported_features),
     };
-
-    if (!any_set) {
-        co_return;
-    }
 
     auto query = fmt::format("INSERT INTO system.{} "
             "(peer,data_center,host_id,preferred_ip,rack,release_version,rpc_address,schema_version,tokens,supported_features) VALUES"

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -275,7 +275,6 @@ public:
 public:
     struct peer_info {
         std::optional<sstring> data_center;
-        std::optional<utils::UUID> host_id;
         std::optional<net::inet_address> preferred_ip;
         std::optional<sstring> rack;
         std::optional<sstring> release_version;
@@ -285,7 +284,7 @@ public:
         std::optional<sstring> supported_features;
     };
 
-    future<> update_peer_info(gms::inet_address ep, const peer_info& info);
+    future<> update_peer_info(gms::inet_address ep, locator::host_id hid, const peer_info& info);
 
     future<> remove_endpoint(gms::inet_address ep);
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -114,6 +114,7 @@ class system_keyspace : public seastar::peering_sharded_service<system_keyspace>
     replica::database& _db;
     std::unique_ptr<local_cache> _cache;
     virtual_tables_registry _virtual_tables_registry;
+    bool _peers_table_read_fixup_done = false;
 
     static schema_ptr raft_snapshot_config();
     static schema_ptr local();
@@ -128,6 +129,15 @@ class system_keyspace : public seastar::peering_sharded_service<system_keyspace>
     static schema_ptr large_cells();
     static schema_ptr scylla_local();
     future<> force_blocking_flush(sstring cfname);
+    // This function is called when the system.peers table is read,
+    // and it fixes some types of inconsistencies that can occur
+    // due to node crashes:
+    //  * missing host_id. This is possible in the old versions of the code. Such records
+    //  are removed and the warning is written to the log.
+    //  * duplicate IPs for a given host_id. This is possible when some node changes its IP
+    //  and this node crashes after adding a new IP but before removing the old one. The
+    //  record with older timestamp is removed, the warning is written to the log.
+    future<> peers_table_read_fixup();
 public:
     static schema_ptr size_estimates();
 public:

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -355,10 +355,6 @@ private:
     // Retries on raft::commit_status_unknown.
     future<> make_raft_config_nonvoter(raft::server_id);
 
-    // Load the initial Raft <-> IP address map as seen by
-    // the gossiper.
-    void load_initial_raft_address_map();
-
     // Returns true if raft is enabled
     future<bool> use_raft();
 };

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -347,11 +347,11 @@ public:
             const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features);
 
     future<> join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy,
-            sharded<gms::gossiper>& gossiper_ptr, start_hint_manager start_hm);
+            sharded<gms::gossiper>& gossiper_ptr, start_hint_manager start_hm, gms::generation_type new_generation);
 
     void set_group0(service::raft_group0&, bool raft_experimental_topology);
 
-    future<> init_address_map(raft_address_map& address_map);
+    future<> init_address_map(raft_address_map& address_map, gms::generation_type new_generation);
 
     future<> uninit_address_map();
     bool is_topology_coordinator_enabled() const;
@@ -373,7 +373,8 @@ private:
             std::unordered_set<gms::inet_address> loaded_endpoints,
             std::unordered_map<gms::inet_address, sstring> loaded_peer_features,
             std::chrono::milliseconds,
-            start_hint_manager start_hm);
+            start_hint_manager start_hm,
+            gms::generation_type new_generation);
     future<> start_sys_dist_ks();
 public:
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -888,8 +888,10 @@ private:
 
             _ss.local().set_group0(group0_service, raft_topology_change_enabled);
 
+            const auto generation_number = gms::generation_type(_sys_ks.local().increment_and_get_generation().get());
+
             // Load address_map from system.peers and subscribe to gossiper events to keep it updated.
-            _ss.local().init_address_map(_raft_address_map.local()).get();
+            _ss.local().init_address_map(_raft_address_map.local(), generation_number).get();
             auto cancel_address_map_subscription = defer([this] {
                 _ss.local().uninit_address_map().get();
             });
@@ -899,7 +901,7 @@ private:
             });
 
             try {
-                _ss.local().join_cluster(_sys_dist_ks, _proxy, _gossiper, service::start_hint_manager::no).get();
+                _ss.local().join_cluster(_sys_dist_ks, _proxy, _gossiper, service::start_hint_manager::no, generation_number).get();
             } catch (std::exception& e) {
                 // if any of the defers crashes too, we'll never see
                 // the error

--- a/test/topology/test_change_ip.py
+++ b/test/topology/test_change_ip.py
@@ -8,56 +8,123 @@ Test clusters can restart fine after an IP address change.
 """
 
 import logging
-import pytest
-from test.pylib.util import wait_for_cql_and_get_hosts, wait_for
-from test.pylib.random_tables import Column, IntType, TextType
 import time
+
+import pytest
+import uuid
+from cassandra.pool import Host  # type: ignore # pylint: disable=no-name-in-module
+from test.pylib.internal_types import ServerInfo
+from test.pylib.random_tables import Column, IntType, TextType
+from test.pylib.util import wait_for_cql_and_get_hosts, wait_for
+from test.topology.util import reconnect_driver
+
 logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
-async def test_change_two(manager, random_tables):
+async def test_change_two(manager, random_tables, mode):
     """Stop two nodes, change their IPs and start, check the cluster is
     functional"""
     servers = await manager.running_servers()
+    host_ids = {s.server_id: await manager.get_host_id(s.server_id) for s in servers}
     table = await random_tables.add_table(name='t1', pks=1, columns=[
         Column("pk", IntType),
         Column('int_c', IntType)
     ])
-    s_1 = servers[1].server_id
-    s_2 = servers[2].server_id
-    logger.info("Gracefully stopping servers %s and %s to change ips", s_1, s_2)
-    await manager.server_stop_gracefully(s_1)
-    await manager.server_stop_gracefully(s_2)
-    await manager.server_change_ip(s_1)
-    await manager.server_change_ip(s_2)
-    await manager.server_start(s_1)
-    await manager.server_start(s_2)
 
-    manager.driver_close()
-    await manager.driver_connect()
-    cql = manager.get_cql()
-    servers = await manager.running_servers()
+    logger.info(f"Servers {servers}, gracefully stopping servers {servers[1]} and {servers[2]} to change ips")
+    await manager.server_stop_gracefully(servers[1].server_id)
+    await manager.server_stop_gracefully(servers[2].server_id)
+    s1_new_ip = await manager.server_change_ip(servers[1].server_id)
+    s2_new_ip = await manager.server_change_ip(servers[2].server_id)
+    logger.info(f"s1 new ip {s1_new_ip}, s2 new ip {s2_new_ip}")
+
+    async def wait_proper_ips(alive_servers: list[ServerInfo]):
+        hosts = {h.address: h for h in await wait_for_cql_and_get_hosts(manager.get_cql(), alive_servers, time.time() + 60)}
+        expected_alive_ips = {s.rpc_address for s in alive_servers}
+        expected_down_ips = {s.rpc_address for s in servers if s not in alive_servers}
+        expected_host_id_map = {host_ids[s.server_id]: s.rpc_address for s in servers}
+        logger.info(f"wait for proper ips, servers {servers}, alive servers {alive_servers}, expected host id map {expected_host_id_map}")
+        for server in alive_servers:
+            ip = server.rpc_address
+            host = hosts[ip]
+            host_id = host_ids[server.server_id]
+            expected_peers = {uuid.UUID(host_ids[s.server_id]): s.rpc_address for s in servers if s.server_id != server.server_id}
+            logger.info(f"waiting for {ip}/{host_id} to see the proper ips, expected peers {expected_peers}")
+
+            async def see_proper_ips():
+                local_rows = await manager.get_cql().run_async("select host_id, listen_address, rpc_address, broadcast_address from system.local", host=host)
+                if len(local_rows) != 1:
+                    logger.info(f"len(system.local) == {len(local_rows)} != 1")
+                    return None
+                local_row = local_rows[0]
+                local_vals = (local_row.host_id, local_row.listen_address, local_row.rpc_address, local_row.broadcast_address)
+                local_expected_vals = (uuid.UUID(host_id), ip, ip, ip)
+                if local_vals != local_expected_vals:
+                    logger.info(f"local vals {local_vals} doesn't match expected vals {local_expected_vals}")
+                    return None
+
+                current_peers = {r.host_id: r.peer for r in await manager.get_cql().run_async("select peer, host_id from system.peers", host=host)}
+                if current_peers != expected_peers:
+                    logger.info(f"host {host} current peers {current_peers} doesn't match the expected_peers {expected_peers}, continue waiting")
+                    return None
+
+                alive_eps = set(await manager.api.get_alive_endpoints(ip))
+                if alive_eps != expected_alive_ips:
+                    logger.info(f"host {host} alive endpoints {alive_eps} doesn't match the expected alive ips {expected_alive_ips}, continue waiting")
+                    return None
+
+                down_eps = set(await manager.api.get_down_endpoints(ip))
+                if down_eps != expected_down_ips:
+                    logger.info(f"host {host} down endpoints {down_eps} doesn't match the expected down ips {expected_down_ips}, continue waiting")
+                    return None
+
+                actual_host_id_map = {x['value']: x['key'] for x in await manager.api.get_host_id_map(host.address)}
+                if expected_host_id_map != actual_host_id_map:
+                    logger.info(f"host {host} id map {actual_host_id_map} doesn't match the expected host id map {expected_host_id_map}, continue waiting")
+                    return None
+
+                return True
+
+            await wait_for(see_proper_ips, time.time() + 60)
+
+    # We're checking the crash scenario here - the servers[0] crashes just after
+    # saving s1_new_ip but before removing s1_old_ip. After its restart we should
+    # see s1_new_ip.
+    if mode != 'release':
+        await manager.api.enable_injection(servers[0].ip_addr, 'crash-before-prev-ip-removed', one_shot=True)
+        # There is a code in raft_ip_address_updater::on_endpoint_change which
+        # calls gossiper.force_remove_endpoint for an endpoint if it sees
+        # that the current generation of host_id -> ip mapping in raft_address_map
+        # is greater than the generation of the endpoint.
+        # We need to inject a delay ip-change-raft-sync-delay
+        # before old IP is removed. Otherwise, servers[0] removes the old
+        # IP-s before they are send back to servers[1] and servers[2],
+        # and the mentioned above code is not exercised by this test.
+        await manager.api.enable_injection(servers[0].ip_addr, 'ip-change-raft-sync-delay', one_shot=False)
+    await manager.server_start(servers[1].server_id)
+    servers[1] = ServerInfo(servers[1].server_id, s1_new_ip, s1_new_ip)
+    if mode != 'release':
+        s0_logs = await manager.server_open_log(servers[0].server_id)
+        await s0_logs.wait_for('crash-before-prev-ip-removed hit, killing the node')
+        await manager.server_stop(servers[0].server_id)
+        await manager.server_start(servers[0].server_id)
+        await manager.api.enable_injection(servers[0].ip_addr, 'ip-change-raft-sync-delay', one_shot=False)
+    await reconnect_driver(manager)
+    await wait_proper_ips([servers[0], servers[1]])
+
+    await manager.server_start(servers[2].server_id)
+    servers[2] = ServerInfo(servers[2].server_id, s2_new_ip, s2_new_ip)
+    await reconnect_driver(manager)
+    await wait_proper_ips([servers[0], servers[1], servers[2]])
 
     await table.add_column(column=Column("str_c", TextType))
     await random_tables.verify_schema()
 
-    host0 = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 60))[0]
-    all_ips = set([s.rpc_address for s in servers])
-    logger.info(f"waiting for {servers[0]} to see its peers, all ips {all_ips}")
-    async def see_peers():
-        peers = set()
-        for r in await cql.run_async("select peer from system.peers", host=host0):
-            peers.add(r.peer)
-        remaining = all_ips - {servers[0].rpc_address} - peers
-        if not remaining:
-            return True
-        logger.info(f"waiting for {host0} to see its peers, all_ips {all_ips}, peers {peers}, remaining {remaining}")
-    await wait_for(see_peers, time.time() + 60)
-
-    await cql.run_async(f"USE {random_tables.keyspace}")
-    await cql.run_async("insert into t1(pk, int_c, str_c) values (1, 2, 'test-val')", host=host0)
-    rows = list(await cql.run_async("select * from t1", host=host0))
+    host0 = (await wait_for_cql_and_get_hosts(manager.get_cql(), [servers[0]], time.time() + 60))[0]
+    await manager.get_cql().run_async(f"USE {random_tables.keyspace}")
+    await manager.get_cql().run_async("insert into t1(pk, int_c, str_c) values (1, 2, 'test-val')", host=host0)
+    rows = list(await manager.get_cql().run_async("select * from t1", host=host0))
     assert len(rows) == 1
     row = rows[0]
     assert row.pk == 1


### PR DESCRIPTION
When a node changes IP address we need to remove its old IP from `system.peers` and gossiper.

We do this in `sync_raft_topology_nodes` when the new IP is saved into `system.peers` to avoid losing the mapping if the node crashes between deleting and saving the new IP. We also handle the possible duplicates in this case by dropping them on the read path when the node is restarted.

The PR also fixes the problem with old IPs getting resurrected when a node changes its IP address.
The following scenario is possible: a node `A` changes its IP from `ip1` to `ip2` with restart, other nodes are not yet aware of `ip2` so they keep gossiping `ip1`. After restart `A` receives `ip1` in a gossip message and calls `handle_major_state_change` since it considers it as a new node. Then `on_join` event is called on the gossiper notification handlers, we receive such event in `raft_ip_address_updater` and reverts the IP of the node A back to ip1.

To fix this we ensure that the new gossiper generation number is used when a node registers its IP address in `raft_address_map` at startup.

The `test_change_ip` is adjusted to ensure that the old IPs are properly removed in all cases, even if the node crashes.

Fixes #16886
Fixes #16691
Fixes #17199