### PR TITLE
scylla-nodetool: implement the describering command

### DIFF
--- a/test/nodetool/test_describering.py
+++ b/test/nodetool/test_describering.py
@@ -1,0 +1,90 @@
+#
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from rest_api_mock import expected_request
+
+def test_describering(nodetool):
+    schema_version = "83541f18-c1bc-11ee-b55e-4d563ca8da4b"
+    ring = [
+            {
+                "start_token": "-9153143965931359657",
+                "end_token": "-9105705820509211664",
+                "endpoints": [
+                    "127.0.0.1",
+                    "127.0.0.2"
+                ],
+                "rpc_endpoints": [
+                    "127.0.0.1",
+                    "127.0.0.2"
+                ],
+                "endpoint_details": [
+                    {
+                        "host": "127.0.0.1",
+                        "datacenter": "datacenter1",
+                        "rack": "rack1"
+                    },
+                    {
+                        "host": "127.0.0.2",
+                        "datacenter": "datacenter2",
+                        "rack": "rack2"
+                    }
+                ]
+            },
+            {
+                "start_token": "9213626581013704850",
+                "end_token": "-9153143965931359657",
+                "endpoints": [
+                    "127.0.0.1"
+                ],
+                "rpc_endpoints": [
+                    "127.0.0.1"
+                ],
+                "endpoint_details": [
+                    {
+                        "host": "127.0.0.1",
+                        "datacenter": "datacenter1",
+                        "rack": "rack1"
+                    }
+                ]
+            }
+    ]
+    res = nodetool("describering", "ks", expected_requests=[
+        expected_request("GET", "/storage_service/schema_version", response=schema_version),
+        expected_request("GET", "/storage_service/describe_ring/ks", response=ring)])
+    assert res == f"""Schema Version:{schema_version}
+TokenRange: 
+\tTokenRange(start_token:-9153143965931359657, end_token:-9105705820509211664, endpoints:[127.0.0.1, 127.0.0.2], rpc_endpoints:[127.0.0.1, 127.0.0.2], endpoint_details:[EndpointDetails(host:127.0.0.1, datacenter:datacenter1, rack:rack1), EndpointDetails(host:127.0.0.2, datacenter:datacenter2, rack:rack2)])
+\tTokenRange(start_token:9213626581013704850, end_token:-9153143965931359657, endpoints:[127.0.0.1], rpc_endpoints:[127.0.0.1], endpoint_details:[EndpointDetails(host:127.0.0.1, datacenter:datacenter1, rack:rack1)])
+"""
+
+def test_describering_table(nodetool, scylla_only):
+    schema_version = "83541f12-c1bc-11ee-b55e-4d563ca8da4b"
+    ring = [
+            {
+                "start_token": "9213626581013704850",
+                "end_token": "-9153143965931359657",
+                "endpoints": [
+                    "127.0.0.1"
+                ],
+                "rpc_endpoints": [
+                    "127.0.0.1"
+                ],
+                "endpoint_details": [
+                    {
+                        "host": "127.0.0.1",
+                        "datacenter": "datacenter1",
+                        "rack": "rack1"
+                    }
+                ]
+            }
+    ]
+    res = nodetool("describering", "ks", "tbl", expected_requests=[
+        expected_request("GET", "/storage_service/schema_version", response=schema_version),
+        expected_request("GET", "/storage_service/describe_ring/ks", params={"table": "tbl"}, response=ring)])
+    assert res == f"""Schema Version:{schema_version}
+TokenRange: 
+\tTokenRange(start_token:9213626581013704850, end_token:-9153143965931359657, endpoints:[127.0.0.1], rpc_endpoints:[127.0.0.1], endpoint_details:[EndpointDetails(host:127.0.0.1, datacenter:datacenter1, rack:rack1)])
+"""

--- a/test/nodetool/test_nodetool.py
+++ b/test/nodetool/test_nodetool.py
@@ -6,6 +6,7 @@
 
 from rest_api_mock import expected_request
 import subprocess
+import utils
 
 
 def test_jmx_compatibility_args(nodetool, scylla_only):
@@ -40,3 +41,21 @@ def test_nodetool_no_args(nodetool_path, scylla_only):
 Usage: scylla nodetool OPERATION [OPTIONS] ...
 Try `scylla nodetool --help` for more information.
 """
+
+
+def test_nodetool_api_request_failed(nodetool, scylla_only, rest_api_mock_server):
+    ip, port = rest_api_mock_server
+
+    error_messages = [
+            f"error executing POST request to http://{ip}:{port}/storage_service/compact with parameters {{}}:"
+            " remote replied with status code 500 Internal Server Error:",
+            "ERROR MESSAGE"]
+
+    utils.check_nodetool_fails_with_all(
+        nodetool,
+        ("compact",),
+        {"expected_requests": [expected_request("POST",
+                                                "/storage_service/compact",
+                                                response={"message": "ERROR MESSAGE", "code": 500},
+                                                response_status=500)]},
+        error_messages)

--- a/test/nodetool/utils.py
+++ b/test/nodetool/utils.py
@@ -6,14 +6,14 @@
 
 import pytest
 import subprocess
-import typing
 
 
-def check_nodetool_fails_with(
+def _do_check_nodetool_fails_with(
         nodetool,
         nodetool_args: tuple,
         nodetool_kwargs: dict,
-        expected_errors: typing.List[str]):
+        expected_errors: list[str],
+        match_all: bool = False):
 
     with pytest.raises(subprocess.CalledProcessError) as e:
         nodetool(*nodetool_args, **nodetool_kwargs)
@@ -21,9 +21,28 @@ def check_nodetool_fails_with(
     err_lines = e.value.stderr.rstrip().split('\n')
     out_lines = e.value.stdout.rstrip().split('\n')
 
-    match = False
+    match = 0
     for expected_error in expected_errors:
         if expected_error in err_lines or expected_error in out_lines:
-            match = True
+            match += 1
 
-    assert match
+    if match_all:
+        assert match == len(expected_errors)
+    else:
+        assert match > 0
+
+
+def check_nodetool_fails_with(
+        nodetool,
+        nodetool_args: tuple,
+        nodetool_kwargs: dict,
+        expected_errors: list[str]):
+    _do_check_nodetool_fails_with(nodetool, nodetool_args, nodetool_kwargs, expected_errors, False)
+
+
+def check_nodetool_fails_with_all(
+        nodetool,
+        nodetool_args: tuple,
+        nodetool_kwargs: dict,
+        expected_errors: list[str]):
+    _do_check_nodetool_fails_with(nodetool, nodetool_args, nodetool_kwargs, expected_errors, True)


### PR DESCRIPTION
On top of the capabilities of the java-nodetool command, tablet support is also implemented: in addition to the existing keyspace parameter, an optional table parameter is also accepted and forwarded to the REST API. For tablet keyspaces this is required to get a ring description.

The command comes with tests and all tests pass with both the new and the current nodetool implementations.

Refs: https://github.com/scylladb/scylladb/issues/15588
Refs: https://github.com/scylladb/scylladb/issues/16846