### PR TITLE
mv: fix missing view deletions in some cases of range tombstones

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -491,7 +491,7 @@ mutation_partition& view_updates::partition_for(partition_key&& key) {
 }
 
 size_t view_updates::op_count() const {
-    return _op_count++;;
+    return _op_count;
 }
 
 row_marker view_updates::compute_row_marker(const clustering_or_static_row& base_row) const {
@@ -1308,11 +1308,12 @@ void view_update_builder::generate_update(static_row&& update, const tombstone& 
 
 future<stop_iteration> view_update_builder::on_results() {
     constexpr size_t max_rows_for_view_updates = 100;
-    size_t rows_for_view_updates = std::accumulate(_view_updates.begin(), _view_updates.end(), 0, [] (size_t acc, const view_updates& vu) {
-        return acc + vu.op_count();
-    });
-    const bool stop_updates = rows_for_view_updates >= max_rows_for_view_updates;
-
+    auto should_stop_updates = [this] () -> bool {
+        size_t rows_for_view_updates = std::accumulate(_view_updates.begin(), _view_updates.end(), 0, [] (size_t acc, const view_updates& vu) {
+            return acc + vu.op_count();
+        });
+        return rows_for_view_updates >= max_rows_for_view_updates;
+    };
     if (_update && !_update->is_end_of_partition() && _existing && !_existing->is_end_of_partition()) {
         auto cmp = position_in_partition::tri_compare(*_schema)(_update->position(), _existing->position());
         if (cmp < 0) {
@@ -1335,7 +1336,7 @@ future<stop_iteration> view_update_builder::on_results() {
                               : std::nullopt;
                 generate_update(std::move(update), _update_partition_tombstone, std::move(existing), _existing_partition_tombstone);
             }
-            return stop_updates ? stop() : advance_updates();
+            return should_stop_updates() ? stop() : advance_updates();
         }
         if (cmp > 0) {
             // We have something existing but no update (which will happen either because it's a range tombstone marker in
@@ -1371,7 +1372,7 @@ future<stop_iteration> view_update_builder::on_results() {
                     generate_update(std::move(update), _update_partition_tombstone, { std::move(existing) }, _existing_partition_tombstone);
                 }
             }
-            return stop_updates ? stop () : advance_existings();
+            return should_stop_updates() ? stop () : advance_existings();
         }
         // We're updating a row that had pre-existing data
         if (_update->is_range_tombstone_change()) {
@@ -1393,8 +1394,9 @@ future<stop_iteration> view_update_builder::on_results() {
                                                   mutation_fragment_v2::printer(*_schema, *_update), mutation_fragment_v2::printer(*_schema, *_existing)));
             }
             generate_update(std::move(*_update).as_static_row(), _update_partition_tombstone, { std::move(*_existing).as_static_row() }, _existing_partition_tombstone);
+
         }
-        return stop_updates ? stop() : advance_all();
+        return should_stop_updates() ? stop() : advance_all();
     }
 
     auto tombstone = std::max(_update_partition_tombstone, _update_current_tombstone);
@@ -1409,7 +1411,7 @@ future<stop_iteration> view_update_builder::on_results() {
             auto update = static_row();
             generate_update(std::move(update), _update_partition_tombstone, { std::move(existing) }, _existing_partition_tombstone);
         }
-        return stop_updates ? stop() : advance_existings();
+        return should_stop_updates() ? stop() : advance_existings();
     }
 
     // If we have updates and it's a range tombstone, it removes nothing pre-exisiting, so we can ignore it
@@ -1430,7 +1432,7 @@ future<stop_iteration> view_update_builder::on_results() {
                           : std::nullopt;
             generate_update(std::move(*_update).as_static_row(), _update_partition_tombstone, std::move(existing), _existing_partition_tombstone);
         }
-        return stop_updates ? stop() : advance_updates();
+        return should_stop_updates() ? stop() : advance_updates();
     }
 
     return stop();

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -208,7 +208,7 @@ class view_updates final {
     schema_ptr _base;
     base_info_ptr _base_info;
     std::unordered_map<partition_key, mutation_partition, partition_key::hashing, partition_key::equality> _updates;
-    mutable size_t _op_count = 0;
+    size_t _op_count = 0;
 public:
     explicit view_updates(view_and_base vab)
             : _view(std::move(vab.view))

--- a/test/cql-pytest/test_materialized_view.py
+++ b/test/cql-pytest/test_materialized_view.py
@@ -822,3 +822,173 @@ def test_mv_prepared_statement_with_altered_base(cql, test_keyspace):
             cql.execute(f"ALTER TABLE {base} ADD (v2 int)")
             cql.execute(f"INSERT INTO {base} (id,v1,v2) VALUES (1,1,1)")
             assert list(cql.execute(base_query,[1])) == list(cql.execute(view_query,[1]))
+
+# A reproducer for issue #17117:
+# When a single base update generates many view updates to the same partition,
+# instead of processing the entire huge partition at once Scylla processes the
+# view updates in chunks of 100 rows each (max_rows_for_view_updates).
+# We had a bug with *range tombstones* which were mis-counted for this limit,
+# and moreover - could cause a chunk to end in the middle of a range
+# tombstone, which causes the range tombstone in this case to be lost and not
+# reach the view.
+# This test is a simple reproducer for this case. Because IN are limited
+# in size to max_clustering_key_restrictions_per_query (100), we use a
+# BATCH in this test to generate more than 100 (max_rows_for_view_updates)
+# view updates from just one mutation.
+def test_many_range_tombstone_base_update(cql, test_keyspace):
+    # This test inserts N rows and deletes all of them in one batch.
+    N = 234
+    # We need two clustering key columns in this test, so that deleting
+    # each "WHERE c1=?" will cause a *range* tombstone - which is what
+    # we want to reproduce in this test.
+    with new_test_table(cql, test_keyspace, 'p int, c1 int, c2 int, primary key (p, c1, c2)') as table:
+        # For simplicity, the view is identical to the base. This is good
+        # enough and still reproduces the bug. Remember that range tombstones
+        # on the base are not copied to the view as-is - they are translated
+        # to row tombstones in the view for the specific rows that really
+        # exist in the base table.
+        with new_materialized_view(cql, table, '*', 'p, c1, c2', 'p is not null and c1 is not null and c2 is not null') as mv:
+            insert = cql.prepare(f'INSERT INTO {table} (p, c1, c2) VALUES (?,?,?)')
+            # We need all of the rows to end up in the same view
+            # partition, so all the deletions will be in the same
+            # partition and will be divided into chunks. Hence we'll
+            # use the same partition key 42 for all rows:
+            p = 42
+            for i in range(N):
+                cql.execute(insert, [p, i, i])
+            # Remove all N rows using N *range* tombstones (deleting based
+            # on p,c1 but not c2), all in one write to the base (a batch):
+            cmd = 'BEGIN BATCH '
+            for i in range(N):
+                cmd += f'DELETE FROM {table} WHERE p={p} AND c1={i} '
+            cmd += 'APPLY BATCH;'
+            cql.execute(cmd)
+            # At this point, both base table and view tables should be
+            # empty.
+            assert [] == list(cql.execute(f'SELECT c1 FROM {table}'))
+            assert [] == list(cql.execute(f'SELECT c1 FROM {mv}'))
+
+# Another more elaborate reproducer for issue #17117, which is closer to the
+# original use where we encountered this bug. It uses IN instead of BATCH, so
+# it it is limited to deletions of max_clustering_key_restrictions_per_query
+# (100) clustering ranges, but that's enough to reproduce this bug because
+# anything more than 25 reproduced it. The view in this reproducer is also
+# a bit more interesting than in the previous test (the view is not identical
+# to the base, rather it combines several base partitions into one
+# view partition).
+def test_many_range_tombstone_base_update_2(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, 'p1 int, p2 int, c1 int, c2 int, v1 int, v2 int, primary key ((p1,p2),c1,c2)') as table:
+        with new_materialized_view(cql, table, '*', '(v1,p2),c1,p1,c2', 'v1 is not null and p2 is not null and c1 is not null and p1 is not null and c2 is not null') as mv:
+            insert = cql.prepare(f'INSERT INTO {table} (p1,p2,c1,c2,v1,v2) VALUES (?,?,?,?,?,?)')
+            # Insert N items, with:
+            #    * p1 cycles between NP1 different values.
+            #    * c1 is unique per item.
+            #    * p2, c2, v1, and v2, are the same for all items.
+            N = 500
+            NP1 = 3
+            # fixed values:
+            p2 = 123
+            v1 = 456
+            v2 = 678
+            c2 = 987
+            for i in range(N):
+                p1 = i % NP1
+                c1 = i
+                cql.execute(insert, [p1,p2,c1,c2,v1,v2])
+            # Delete slice with prefix p1,p2,c1 for multiple c1's (any c2)
+            delete_slices = cql.prepare(f'DELETE FROM {table} WHERE p1=? AND p2=? AND c1 in ?')
+            # This test appears fail due to #17117 for any K>25 - the 26th
+            # and every multiple of 26th deletion in the batch doesn't reach
+            # the view.
+            K=80
+            for p1 in range(NP1):
+                # c1's for this p1 are i's such that i%NP1 = p1.
+                # Only take the c1's that are after N//2, to delete
+                # only the later half of the items.
+                start = N//2
+                start -= start % NP1
+                c1s = range(start + p1, N, NP1)
+                # split c1s into chunks of length K
+                chunks = []
+                for x in range(0, len(c1s), K):
+                    slice_item = slice(x, x + K, 1)
+                    chunks.append(c1s[slice_item])
+                for chunk in chunks:
+                    cql.execute(delete_slices, [p1, p2, chunk])
+            # The deletions above are pretty hard to follow, but no matter
+            # what we deleted above, it should have been deleted from
+            # both base and view. If the base and view differ, we have a bug.
+            list_base = sorted([x.c1 for x in cql.execute(f"SELECT c1 FROM {table}")])
+            list_view = sorted([x.c1 for x in cql.execute(f"SELECT c1 FROM {mv}")])
+            print("Remaining base rows: ", len(list_base))
+            print("Remaining base rows: ", len(list_view))
+            print("Only in base: ", sorted(list(set(list_base)-set(list_view))))
+            print("Only in view: ", sorted(list(set(list_view)-set(list_base))))
+            assert list_base == list_view
+
+# Test that deleting a base partion works fine, even if it produces a
+# large batch of individual view updates. After issue #8852 was fixed,
+# this large batch is no longer done together, but rather split to smaller
+# batches, and this split can be done wrongly (e.g., see issue #17117)
+# and we want to confirm that all the deletions are actually done.
+#
+# We have the related test for secondary indexes (test_secondary_index.py::
+# test_partition_deletion), but this one uses materialized views directly
+# instead of the secondary-index wrapper, and works on Cassandra as well.
+# This test also exercises a more difficult scenario, where all view
+# deletions end up in the same view partition, so the code is "tempted" to
+# keep them all in the same output mutation and needs to break up this
+# output mutation correctly (the test doesn't check that this breaking up
+# happens, but rather that if it happens - it doesn't break correctness).
+def test_base_partition_deletion(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, 'p int, c int, v int, primary key (p,c)') as table:
+        # All inserts go to the same base partition,  that we'll then delete
+        p = 1
+        v = 42
+        insert = cql.prepare(f'INSERT INTO {table} (p,c,v) VALUES ({p},?,{v})')
+        # Case where all view-row deletions go to the same view partition:
+        with new_materialized_view(cql, table, '*', 'p,v,c', 'p is not null and v is not null and c is not null') as mv:
+            N = 345
+            for i in range(N):
+                cql.execute(insert, [i])
+            # Before the deletion, all N rows should exist in the base and the
+            # view
+            allN = list(range(N))
+            assert allN == [x.c for x in cql.execute(f"SELECT c FROM {table}")]
+            assert allN == sorted([x.c for x in cql.execute(f"SELECT c FROM {mv}")])
+            cql.execute(f"DELETE FROM {table} WHERE p=1")
+            # After the deletion, all data should be gone from both base and view
+            assert [] == list(cql.execute(f"SELECT c FROM {table}"))
+            assert [] == list(cql.execute(f"SELECT c FROM {mv}"))
+
+# Same as above test, just for a range tombstone, e.g., in a composite
+# clustering key c1,c2 deleting in the base all rows with some c1.
+# Here too Scylla generates a long list of view updates (individual row
+# deletions), and if it's split into smaller batches, this needs to be
+# done correctly and no view update missed.
+# This test is related to issue #17117 - it doesn't reproduce that issue
+# (we have reproducers for it above), but it's important to confirm that
+# after fixing that issue, we don't break this case and can still split
+# a large clustering prefix deletion into multiple batches without losing
+# any view deletions.
+def test_base_clustering_prefix_deletion(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, 'p int, c1 int, c2 int, v int, primary key (p,c1,c2)') as table:
+        # All inserts go to the same base c1, that we'll then delete
+        p = 1
+        c1 = 2
+        v = 42
+        insert = cql.prepare(f'INSERT INTO {table} (p,c1,c2,v) VALUES ({p},{c1},?,{v})')
+        # Case where all view-row deletions go to the same view partition:
+        with new_materialized_view(cql, table, '*', 'p,v,c1,c2', 'p is not null and v is not null and c1 is not null and c2 is not null') as mv:
+            N = 345
+            for i in range(N):
+                cql.execute(insert, [i])
+            # Before the deletion, all N rows should exist in the base and the
+            # view
+            allN = list(range(N))
+            assert allN == [x.c2 for x in cql.execute(f"SELECT c2 FROM {table}")]
+            assert allN == sorted([x.c2 for x in cql.execute(f"SELECT c2 FROM {mv}")])
+            cql.execute(f"DELETE FROM {table} WHERE p=1")
+            # After the deletion, all data should be gone from both base and view
+            assert [] == list(cql.execute(f"SELECT c2 FROM {table}"))
+            assert [] == list(cql.execute(f"SELECT c2 FROM {mv}"))


### PR DESCRIPTION
For efficiency, if a base-table update generates many view updates that go the same partition, they are collected as one mutation. If this mutation grows too big it can lead to memory exhaustion, so since commit 7d214800d0ea3ec21d40ac7a10f2fbf2c11c6098 we split the output mutation to mutations no longer than 100 rows (max_rows_for_view_updates) each.

This patch fixes a bug where this split was done incorrectly when the update involved range tombstones, a bug which was discovered by a user in a real use case (#17117).

Range tombstones are read in two parts, a beginning and an end, and the code could split the processing between these two parts and the result that some of the range tombstones in update could be missed - and the view could miss some deletions that happened in the base table.

This patch fixes the code in two places to avoid breaking up the processing between range tombstones:

1. The counter "_op_count" that decides where to break the output mutation should only be incremented when adding rows to this output mutation. The existing code strangely incrmented it on every read (!?) which resulted in the counter being incremented on every *input* fragment, and in particular could reach the limit 100 between two range tombstone pieces.

2. Moreover, the length of output was checked in the wrong place... The existing code could get to 100 rows, not check at that point, read the next input - half a range tombstone - and only *then* check that we reached 100 rows and stop. The fix is to calculate the number of rows in the right place - exactly when it's needed, not before the step.

The first change needs more justification: The old code, that incremented _op_count on every input fragment and not just output fragments did not fit the stated goal of its introduction - to avoid large allocations. In one test it resulted in breaking up the output mutation to chunks of 25 rows instead of the intended 100 rows. But, maybe there was another goal, to stop the iteration after 100 *input* rows and avoid the possibility of stalls if there are no output rows? It turns out the answer is no - we don't need this _op_count increment to avoid stalls: The function build_some() uses `co_await on_results()` to run one step of processing one input fragment - and `co_await` always checks for preemption. I verfied that indeed no stalls happen by using the existing test test_long_skipped_view_update_delete_with_timestamp. It generates a very long base update where all the view updates go to the same partition, but all but the last few updates don't generate any view updates. I confirmed that the fixed code loops over all these input rows without increasing _op_count and without generating any view update yet, but it does NOT stall.

This patch also includes two tests reproducing this bug and confirming its fixed, and also two additional tests for breaking up long deletions that I wanted to make sure doesn't fail after this patch (it doesn't).

By the way, this fix would have also fixed issue #12297 - which we fixed a year ago in a different way. That issue happend when the code went through 100 input rows without generating *any* output rows, and incorrectly concluding that there's no view update to send. With this fix, the code no longer stops generating the view update just because it saw 100 input rows - it would have waited until it generated 100 output rows in the view update (or the input is really done).

Fixes #17117