### PR TITLE
scylla-nodetool: make command-line parsing fully compatible with the legacy nodetool

### DIFF
--- a/test/nodetool/test_nodetool.py
+++ b/test/nodetool/test_nodetool.py
@@ -97,3 +97,16 @@ def test_jvm_options(nodetool_path, rest_api_mock_server, scylla_only):
     subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", port, jvm_opt], check=True)
     subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, jvm_opt, "-p", port], check=True)
     subprocess.run([nodetool_path, "nodetool", jvm_opt, "compact", "-h", ip, "-p", port], check=True)
+
+
+def test_alternative_api_port(nodetool_path, rest_api_mock_server, scylla_only):
+    set_expected_requests(rest_api_mock_server, [
+        expected_request("POST", "/storage_service/compact", multiple=expected_request.MULTIPLE)])
+
+    ip, port = rest_api_mock_server
+    port = str(port)
+
+    subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", "1", "--rest-api-port", port], check=True)
+    subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", "1", f"--rest-api-port={port}"], check=True)
+    subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", "1", f"-Dcom.scylladb.apiPort={port}"],
+                   check=True)

--- a/test/nodetool/test_nodetool.py
+++ b/test/nodetool/test_nodetool.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 
-from rest_api_mock import expected_request
+from rest_api_mock import expected_request, set_expected_requests
 import subprocess
 import utils
 
@@ -67,3 +67,19 @@ def test_nodetool_nonexistent_command(nodetool, scylla_only):
             ("non-existent-command",),
             {},
             ["error: unrecognized operation argument: expected one of"])
+
+
+def test_global_options_order(nodetool_path, rest_api_mock_server, scylla_only):
+    set_expected_requests(rest_api_mock_server, [
+        expected_request("POST", "/storage_service/compact", multiple=expected_request.MULTIPLE)])
+
+    ip, port = rest_api_mock_server
+    port = str(port)
+
+    subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", port], check=True)
+    subprocess.run([nodetool_path, "nodetool", "-h", ip, "compact", "-p", port], check=True)
+    subprocess.run([nodetool_path, "nodetool", "-h", ip, "-p", port, "compact"], check=True)
+
+    # Also add some compatibility args to the mix
+    subprocess.run([nodetool_path, "nodetool", "-h", ip, "-p", port, "-u", "us3r", "compact"], check=True)
+    subprocess.run([nodetool_path, "nodetool", "-h", ip, "-p", port, "compact", "-u", "us3r"], check=True)

--- a/test/nodetool/test_nodetool.py
+++ b/test/nodetool/test_nodetool.py
@@ -83,3 +83,17 @@ def test_global_options_order(nodetool_path, rest_api_mock_server, scylla_only):
     # Also add some compatibility args to the mix
     subprocess.run([nodetool_path, "nodetool", "-h", ip, "-p", port, "-u", "us3r", "compact"], check=True)
     subprocess.run([nodetool_path, "nodetool", "-h", ip, "-p", port, "compact", "-u", "us3r"], check=True)
+
+
+def test_jvm_options(nodetool_path, rest_api_mock_server, scylla_only):
+    set_expected_requests(rest_api_mock_server, [
+        expected_request("POST", "/storage_service/compact", multiple=expected_request.MULTIPLE)])
+
+    ip, port = rest_api_mock_server
+    port = str(port)
+
+    jvm_opt = "-Dcom.sun.jndi.rmiURLParsing=legacy"
+
+    subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", port, jvm_opt], check=True)
+    subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, jvm_opt, "-p", port], check=True)
+    subprocess.run([nodetool_path, "nodetool", jvm_opt, "compact", "-h", ip, "-p", port], check=True)

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1170,15 +1170,9 @@ void help_operation(const tool_app_template::config& cfg, const bpo::variables_m
         // goes in.
 
         bpo::options_description opts_desc(fmt::format("scylla-{} options", app_name));
-        opts_desc.add_options()
-                ("help,h", "show help message")
-                ;
-        opts_desc.add_options()
-                ("help-seastar", "show help message about seastar options")
-                ;
-        opts_desc.add_options()
-                ("help-loggers", "print a list of logger names and exit")
-                ;
+        for (const auto& [option, help] : tool_app_template::help_arguments) {
+            opts_desc.add_options()(option, help);
+        }
         if (cfg.global_options) {
             for (const auto& go : *cfg.global_options) {
                 go.add_option(opts_desc);

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -3495,6 +3495,11 @@ std::vector<char*> massage_argv(int argc, char** argv) {
             continue;
         }
 
+        // Java JVM options, they look like -Dkey=value, or just -Dkey
+        if (argv[i][1] == 'D') {
+            continue;
+        }
+
         std::string arg = argv[i];
         std::string arg_key;
         std::optional<std::string> arg_value;

--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -92,6 +92,12 @@ db_config_and_extensions::db_config_and_extensions()
 db_config_and_extensions::db_config_and_extensions(db_config_and_extensions&&) = default;
 db_config_and_extensions::~db_config_and_extensions() = default;
 
+const std::vector<std::pair<const char*, const char*>> tool_app_template::help_arguments{
+    {"help,h", "show help message"},
+    {"help-seastar", "show help message about seastar options"},
+    {"help-loggers", "print a list of logger names and exit"},
+};
+
 tool_app_template::tool_app_template(config cfg)
     : _cfg(std::move(cfg))
 {}

--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -8,6 +8,7 @@
 
 #include <seastar/core/thread.hh>
 #include <boost/algorithm/string/join.hpp>
+#include <boost/make_shared.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 
 #include "db/config.hh"
@@ -15,6 +16,8 @@
 #include "tools/utils.hh"
 #include "utils/logalloc.hh"
 #include "init.hh"
+
+namespace bpo = boost::program_options;
 
 namespace tools::utils {
 
@@ -26,23 +29,73 @@ namespace {
 
 // Extract the operation from the argv.
 //
-// The operation is expected to be at argv[1].If found, it is shifted out to the
-// end (effectively removed) and the corresponding operation* is returned.
-// If not found or unrecognized an error is logged and exit() is called.
-const operation& get_selected_operation(int& ac, char**& av, const std::vector<operation>& operations) {
-    if (ac < 2) {
+// Do an initial parsing of command-line options to identify the operation
+// command-line argument.
+// If found, it is shifted out to the end (effectively removed) and the
+// corresponding operation* is returned.
+// If not found:
+// * If any of the tool_app_template::help_arguments was used, nullptr is returned, to allow the tool to produce a proper help.
+// * If no help was invoked, the application exits with return-code 1.
+// If the operation is not recognized, the application exits with return-code 100.
+// If parsing the command-line arguments fails, the application exits with return-code 2.
+const operation* get_selected_operation(int& ac, char**& av, const std::vector<operation>& operations, const std::vector<operation_option>* global_options) {
+    bpo::positional_options_description pos_opts;
+    bpo::options_description opts("scylla-tool options");
+    for (const auto& [option, help] : tool_app_template::help_arguments) {
+        opts.add_options()(option, help);
+    }
+    opts.add(boost::make_shared<bpo::option_description>("operation", bpo::value<sstring>(), "Operation"));
+    pos_opts.add("operation", 1);
+    opts.add(boost::make_shared<bpo::option_description>("operation_options", bpo::value<std::vector<sstring>>(), "Operation specific options"));
+    pos_opts.add("operation_options", -1);
+
+    if (global_options) {
+        for (const auto& go : *global_options) {
+            go.add_option(opts);
+        }
+    }
+
+    bpo::variables_map vm;
+    try {
+        bpo::store(bpo::command_line_parser(ac, av)
+                    .options(opts)
+                    .positional(pos_opts)
+                    .allow_unregistered()
+                    .run()
+            , vm);
+    } catch (bpo::error& e) {
+        fmt::print("error: {}\n\nTry --help.\n", e.what());
+        exit(2);
+    }
+
+    if (!vm.count("operation")) {
+        // We allow no operation only when help was requested.
+        for (const auto& [op, _] : tool_app_template::help_arguments) {
+            std::string option(op);
+            if (auto comma_pos = option.find(","); comma_pos != sstring::npos) {
+                option = option.substr(0, comma_pos);
+            }
+            if (vm.count(option)) {
+                return nullptr;
+            }
+        }
         fmt::print(std::cerr, "error: missing mandatory operation argument\n");
         exit(1);
     }
 
-    const char* op_name = av[1];
+    sstring op_name = vm["operation"].as<sstring>();
     if (auto found = std::ranges::find_if(operations, [op_name] (auto& op) {
             return op.matches(op_name);
         });
         found != operations.end()) {
-        std::shift_left(av + 1, av + ac, 1);
-        --ac;
-        return *found;
+        for (int i = 0; i < ac; ++i) {
+            if (op_name == av[i]) {
+                std::shift_left(av + i, av + ac, 1);
+                --ac;
+                break;
+            }
+        }
+        return &*found;
     }
 
     std::vector<std::string_view> all_operation_names;
@@ -110,10 +163,7 @@ int tool_app_template::run_async(int argc, char** argv, noncopyable_function<int
         return 2;
     }
 
-    const operation* found_op = nullptr;
-    if (std::strncmp(argv[1], "--help", 6) != 0 && std::strcmp(argv[1], "-h") != 0) {
-        found_op = &tools::utils::get_selected_operation(argc, argv, _cfg.operations);
-    }
+    const operation* found_op = tools::utils::get_selected_operation(argc, argv, _cfg.operations, _cfg.global_options);
 
     app_template::seastar_options app_cfg;
     app_cfg.name = format("scylla-{}", _cfg.name);

--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -29,9 +29,9 @@ namespace {
 // The operation is expected to be at argv[1].If found, it is shifted out to the
 // end (effectively removed) and the corresponding operation* is returned.
 // If not found or unrecognized an error is logged and exit() is called.
-const operation& get_selected_operation(int& ac, char**& av, const std::vector<operation>& operations, std::string_view alias) {
+const operation& get_selected_operation(int& ac, char**& av, const std::vector<operation>& operations) {
     if (ac < 2) {
-        fmt::print(std::cerr, "error: missing mandatory {} argument\n", alias);
+        fmt::print(std::cerr, "error: missing mandatory operation argument\n");
         exit(1);
     }
 
@@ -53,7 +53,7 @@ const operation& get_selected_operation(int& ac, char**& av, const std::vector<o
         }
     }
 
-    fmt::print(std::cerr, "error: unrecognized {} argument: expected one of ({}), got {}\n", alias, all_operation_names, op_name);
+    fmt::print(std::cerr, "error: unrecognized operation argument: expected one of ({}), got {}\n", all_operation_names, op_name);
     exit(100);
 }
 
@@ -112,7 +112,7 @@ int tool_app_template::run_async(int argc, char** argv, noncopyable_function<int
 
     const operation* found_op = nullptr;
     if (std::strncmp(argv[1], "--help", 6) != 0 && std::strcmp(argv[1], "-h") != 0) {
-        found_op = &tools::utils::get_selected_operation(argc, argv, _cfg.operations, "operation");
+        found_op = &tools::utils::get_selected_operation(argc, argv, _cfg.operations);
     }
 
     app_template::seastar_options app_cfg;

--- a/tools/utils.hh
+++ b/tools/utils.hh
@@ -141,6 +141,9 @@ struct db_config_and_extensions {
 
 class tool_app_template {
 public:
+    static const std::vector<std::pair<const char*, const char*>> help_arguments;
+
+public:
     struct config {
         sstring name;
         sstring description;


### PR DESCRIPTION
There was two more things missing:
* Allow global options to be positioned before the operation/command option (https://github.com/scylladb/scylladb/issues/16695)
* Ignore JVM args (https://github.com/scylladb/scylladb/issues/16696)

This PR fixes both. With this, hopefully we are fully compatible with nodetool as far as command line parsing is concerned.
After this PR goes in, we will need another fix to tools/java/bin/nodetool-wrapper, to allow user to benefit from this fix. Namely, after this PR, we can just try to invoke scylla-nodetool first with all the command-line args as-is. If it returns with exit-code 100, we fall back to nodetool. We will not need the current trick with `--help $1`. In fact, this trick doesn't work currently, because `$1` is not guaranteed to be the command in the first place.

In addition to the above, this PR also introduces a new option, to help us in the switching process. This is `--rest-api-port`, which can also be provided as `-Dcom.scylladb.apiPort`. When provided, this option takes precedence over `--port|-p`. This is intended as a bridge for `scylla-ccm`, which currently provides the JMX port as `--port`. With this change, it can also provided the REST API port as `-Dcom.scylladb.apiPort`. The legacy nodetool will ignore this, while the native nodetool will use it to connect to the correct REST API address. After the switch we can ditch these options.

Fixes: https://github.com/scylladb/scylladb/issues/16695
Fixes: https://github.com/scylladb/scylladb/issues/16696
Refs: https://github.com/scylladb/scylladb/issues/16679
Refs: https://github.com/scylladb/scylladb/issues/15588