### PR TITLE
raft topology: harden IP related tests

### DIFF
--- a/test/topology_custom/test_replace.py
+++ b/test/topology_custom/test_replace.py
@@ -80,6 +80,8 @@ async def test_replace_reuse_ip(manager: ManagerClient) -> None:
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = True, use_host_id = False)
     await manager.server_add(replace_cfg)
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+    await manager.server_sees_other_server(servers[1].ip_addr, servers[0].ip_addr)
+    await manager.server_sees_other_server(servers[2].ip_addr, servers[0].ip_addr)
 
 @pytest.mark.asyncio
 async def test_replace_reuse_ip_using_host_id(manager: ManagerClient) -> None:

--- a/test/topology_experimental_raft/test_topology_ops.py
+++ b/test/topology_experimental_raft/test_topology_ops.py
@@ -37,7 +37,12 @@ async def test_topology_ops(request, manager: ManagerClient):
     #finish_writes = await start_writes(cql)
 
     logger.info("Bootstrapping other nodes")
-    servers += await manager.servers_add(2)
+    servers += await manager.servers_add(3)
+
+    logger.info(f"Decommissioning node {servers[0]}")
+    await manager.decommission_node(servers[0].server_id)
+    await check_token_ring_and_group0_consistency(manager)
+    servers = servers[1:]
 
     logger.info(f"Restarting node {servers[0]} when other nodes have bootstrapped")
     await manager.server_stop_gracefully(servers[0].server_id)
@@ -60,10 +65,6 @@ async def test_topology_ops(request, manager: ManagerClient):
     await manager.remove_node(servers[1].server_id, servers[0].server_id)
     await check_token_ring_and_group0_consistency(manager)
     servers = servers[1:]
-
-    logger.info(f"Decommissioning node {servers[0]}")
-    await manager.decommission_node(servers[0].server_id)
-    await check_token_ring_and_group0_consistency(manager)
 
     logger.info("Checking results of the background writes")
     #await finish_writes()


### PR DESCRIPTION
In this PR we add the tests for two scenarios, related to the use of IPs in raft topology.

* When the replaced node transitions to the `LEFT` state we used to remove the IP of such node from gossiper. If we replace with same IP, this caused the IP of the new node to be removed from gossiper. This problem was fixed by #16820, this PR adds a regression test for it.
* When a node is restarted after decommissioning some other node, the restarting node tries to apply the raft log, this log contains a record about the decommissioned node, and we got stuck trying
to resolve its IP. This was fixed by #16639 - we excluded IPs from the RAFt log application code and moved it entirely to host_id-s. This PR adds a regression test for this case.

closes #15967
closes #14803