### PR TITLE
utils: Mark chunked_vector::max_chunk_capacity with constexpr

### DIFF
--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -71,7 +71,7 @@ class chunked_vector {
     size_t _capacity = 0;
 public:
     // Maximum number of T elements fitting in a single chunk.
-    static size_t max_chunk_capacity() {
+    static constexpr size_t max_chunk_capacity() {
         return std::max(max_contiguous_allocation / sizeof(T), size_t(1));
     }
 private:


### PR DESCRIPTION
It uses only compile-time constants to produce the value, so deserves this marking