### PR TITLE
replica/table.cc: Align the tablet's behavior with other metrics.

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1338,13 +1338,17 @@ void table::set_metrics() {
                 ms::make_counter("read_latency_count", ms::description("Number of reads"), [this] {return _stats.reads.histogram().count();})(cf)(ks)(node_table_metrics).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
                 ms::make_counter("write_latency_count", ms::description("Number of writes"), [this] {return _stats.writes.histogram().count();})(cf)(ks)(node_table_metrics).aggregate({seastar::metrics::shard_label}).set_skip_when_empty()
             });
+            if (uses_tablets()) {
+                _metrics.add_group("column_family", {
+                    ms::make_gauge("tablet_count", ms::description("Tablet count"), _stats.tablet_count)(cf)(ks).aggregate({seastar::metrics::shard_label})
+                });
+            }
         }
-
-        if (uses_tablets()) {
-            _metrics.add_group("column_family", {
-                ms::make_gauge("tablet_count", ms::description("Tablet count"), _stats.tablet_count)(cf)(ks).aggregate({column_family_label, keyspace_label})
-            });
-        }
+    }
+    if (uses_tablets()) {
+        _metrics.add_group("tablets", {
+            ms::make_gauge("count", ms::description("Tablet count"), _stats.tablet_count)(cf)(ks).aggregate({column_family_label, keyspace_label})
+        });
     }
 }
 


### PR DESCRIPTION
Due to the potentially large number of per-table metrics, ScyllaDB uses configuration to determine what metrics will be reported.  The user can decide if they want per-table-per-shard metrics, per-table-per-instance metrics, or none.

This patch uses the same logic for tablet metrics registration. It adds a new metrics group tablets with one metric inside it - count. So, scylla_tablets_count will report the number of tablets per shard.

The existing per-table metrics will be reported aggregated or not like the other per-table metrics.