### PR TITLE
sstable: replace "welp" with more descriptive words

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1983,7 +1983,7 @@ void sstable::validate_originating_host_id() const {
         // we don't know the local host id before it is loaded from
         // (or generated and written to) system.local, but some system
         // sstable reads must happen before the bootstrap process gets
-        // there, so, welp
+        // there, if that's not the case, it's a sign of bug.
         auto msg = format("Unknown local host id while validating SSTable: {}", get_filename());
         if (is_system_keyspace(_schema->ks_name())) {
             sstlog.trace("{}", msg);


### PR DESCRIPTION
despite that "welp" is more emotional expressive, it is considered a misspelling of "whelp" by codespell. that's why this comment stands out. but from a non-native speaker's point of view, probably we can use more descriptive words to explain what "welp" is for in plain English.