### PR TITLE
docs: fix image sorting for reference docs

### DIFF
--- a/docs/_ext/scylladb_common_images.py
+++ b/docs/_ext/scylladb_common_images.py
@@ -73,7 +73,8 @@ class BaseVersionsTemplateDirective(Directive):
         return sorted(
             [file for file in os.listdir(download_directory) if file.endswith('.csv') and 
              self._matches_version(file, version_pattern) and not self._excluded(file, exclude_patterns)],
-            key=self._version_key
+            key=self._version_key,
+            reverse=True
         )
 
     def _process_file(self, file, relative_path_from_current_rst):


### PR DESCRIPTION
## Motivation

This PR fixes an issue that caused the images in the reference docs to render in an incorrect order. Prior to this fix, the images were listed as 4.0.0, 4.0.1, and 4.0.2, but they should be sorted in reverse order (4.0.2, 4.0.1, 4.0.0).
    
The changes made in this PR resolve the issue introduced in https://github.com/scylladb/scylladb/pull/16942 when common functions for Azure and GCP were extracted into a separate file without reversing the list [as defined in the original extension](https://github.com/scylladb/scylladb/pull/16942/files#diff-b8f6253ea8fdcca681deb556ca61cd1f3feb3b7aeb7e856b145ef9b685aad460L185).

## How to test

1. Build the docs.
2. Open http://127.0.0.1:5500/reference/aws-images/
3. Images should display in the correct order:

![image](https://github.com/scylladb/scylladb/assets/9107969/7f9948d5-6ced-4c47-a28f-047d96a94d35)
