### PR TITLE
test: Reduce mem footprint of test_token_group_based_splitting_mutation_writer

### DIFF
--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -563,7 +563,12 @@ SEASTAR_THREAD_TEST_CASE(test_token_group_based_splitting_mutation_writer) {
 
     size_t partition_count = many_partitions();
 
-    auto muts = tests::generate_random_mutations(random_schema, partition_count).get();
+    auto muts = tests::generate_random_mutations(
+            random_schema,
+            tests::default_timestamp_generator(),
+            tests::no_expiry_expiry_generator(),
+            std::uniform_int_distribution<size_t>(partition_count, partition_count),
+            std::uniform_int_distribution<size_t>(1, 1)).get(); // only 1 row
 
     auto classify_fn = [] (dht::token t) -> mutation_writer::token_group_id {
         return dht::compaction_group_of(1, t);


### PR DESCRIPTION
Reduces footprint from hundreds of MB to a very few MB.

Issue could be reproduced with:
./build/dev/test/boost/mutation_writer_test --run_test=test_token_group_based_splitting_mutation_writer -- -m 500M --smp 1 --random-seed 1848215131

Fixes #17076.