### PR TITLE
dht: add formatter for dht::ring_position

### DIFF
--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -149,16 +149,6 @@ decorated_key::less_comparator::operator()(const decorated_key& lhs, const ring_
     return lhs.tri_compare(*s, rhs) < 0;
 }
 
-std::ostream& operator<<(std::ostream& out, const ring_position& pos) {
-    out << "{" << pos.token();
-    if (pos.has_key()) {
-        out << ", " << *pos.key();
-    } else {
-        out << ", " << ((pos.relation_to_keys() < 0) ? "start" : "end");
-    }
-    return out << "}";
-}
-
 std::ostream& operator<<(std::ostream& out, const i_partitioner& p) {
     out << "{partitioner name = " << p.name();
     return out << "}";
@@ -515,4 +505,16 @@ auto fmt::formatter<dht::ring_position_view>::format(const dht::ring_position_vi
         out = fmt::format_to(out, ", {}", *pos._key);
     }
     return fmt::format_to(out, ", w={}}}", static_cast<int>(pos._weight));
+}
+
+auto fmt::formatter<dht::ring_position>::format(const dht::ring_position& pos, fmt::format_context& ctx) const
+    -> decltype(ctx.out()) {
+    auto out = ctx.out();
+    out = fmt::format_to(out, "{{{}", pos.token());
+    if (pos.has_key()) {
+        out = fmt::format_to(out, ", {}", *pos.key());
+    } else {
+        out = fmt::format_to(out, ", {}", (pos.relation_to_keys() < 0) ? "start" : "end");
+    }
+    return fmt::format_to(out, "}}");
 }

--- a/dht/ring_position.hh
+++ b/dht/ring_position.hh
@@ -136,8 +136,6 @@ public:
 
     // "less" comparator corresponding to tri_compare()
     bool less_compare(const schema&, const ring_position&) const;
-
-    friend std::ostream& operator<<(std::ostream&, const ring_position&);
 };
 
 // Non-owning version of ring_position and ring_position_ext.
@@ -504,4 +502,10 @@ struct fmt::formatter<dht::ring_position_ext> {
     auto format(const dht::ring_position_ext& pos, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", (dht::ring_position_view)pos);
     }
+};
+
+template<>
+struct fmt::formatter<dht::ring_position> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const dht::ring_position& pos, fmt::format_context& ctx) const -> decltype(ctx.out());
 };


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `dht::ring_posittion`, and drop its operator<<.

Refs #13245