### PR TITLE
configure.py: remove -Wno-unused-command-line-argument

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1538,7 +1538,6 @@ def get_warning_options(cxx):
         '-Wno-mismatched-tags',  # clang-only
         '-Wno-c++11-narrowing',
         '-Wno-overloaded-virtual',
-        '-Wno-unused-command-line-argument',
         '-Wno-unused-parameter',
         '-Wno-unsupported-friend',
         '-Wno-missing-field-initializers',


### PR DESCRIPTION
`-Wno-unused-command-line-argument` is used to disable the warning of
`-Wunused-command-line-argument`, which is in turn used to split
warnings if any of the command line arguments passed to the compiler
driver is not used. see
https://clang.llvm.org/docs/DiagnosticsReference.html#wunused-command-line-argument
but it seems we are not passing unused command line arguments to
the compiler anymore. so let's drop this option.

this change helps to

* reduce the discrepencies between the compiling options used by
  CMake-generated rules and those generated directly using
  `configure.py`
* reenable the warning so we are aware if any of the options
  is not used by compiler. this could a sign that the option fails
  to serve its purpose.