### PR TITLE
api/storage_service: drop /storage_service/describe_ring/ API

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -369,25 +369,6 @@
          ]
       },
       {
-         "path":"/storage_service/describe_ring/",
-         "operations":[
-            {
-               "method":"GET",
-               "summary":"The TokenRange for an arbitrary keyspace",
-               "type":"array",
-               "items":{
-                  "type":"token_range"
-               },
-               "nickname":"describe_any_ring",
-               "produces":[
-                  "application/json"
-               ],
-               "parameters":[
-               ]
-            }
-         ]
-      },
-      {
          "path":"/storage_service/describe_ring/{keyspace}",
          "operations":[
             {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -662,16 +662,6 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         return make_ready_future<json::json_return_type>(res);
     });
 
-    ss::describe_any_ring.set(r, [&ctx, &ss](std::unique_ptr<http::request> req) {
-        // Find an arbitrary non-system keyspace.
-        auto keyspaces = ctx.db.local().get_non_local_vnode_based_strategy_keyspaces();
-        if (keyspaces.empty()) {
-            throw std::runtime_error("No keyspace provided and no non system kespace exist");
-        }
-        auto ks = keyspaces[0];
-        return describe_ring_as_json(ss, ks);
-    });
-
     ss::describe_ring.set(r, [&ctx, &ss](std::unique_ptr<http::request> req) {
         return describe_ring_as_json(ss, validate_keyspace(ctx, req->param));
     });
@@ -1520,7 +1510,6 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::get_saved_caches_location.unset(r);
     ss::get_range_to_endpoint_map.unset(r);
     ss::get_pending_range_to_endpoint_map.unset(r);
-    ss::describe_any_ring.unset(r);
     ss::describe_ring.unset(r);
     ss::get_load.unset(r);
     ss::get_load_map.unset(r);

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -429,9 +429,6 @@ def test_range_to_endpoint_map(cql, this_dc, rest_api):
         resp.raise_for_status()
 
 def test_describe_ring(cql, this_dc, rest_api):
-    resp = rest_api.send("GET", "storage_service/describe_ring")
-    resp.raise_for_status()
-
     with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
         resp = rest_api.send("GET", f"storage_service/describe_ring/{keyspace}")
         resp.raise_for_status()


### PR DESCRIPTION
per its description, "`/storage_service/describe_ring/`" returns the token ranges of an arbitrary keyspace. actually, it returns the first keyspace which is of non-local-vnode-based-strategy. this API is not used by nodetool, neither is it exercised in dtest. scylla-manager has a wrapper for this API though, but that wrapper is not used anywhere.

in this change, this API is dropped.