### PR TITLE
topology_coordinator: s/sate/state/

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1639,7 +1639,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
 
                 rtbuilder.done();
 
-                co_await update_topology_state(take_guard(std::move(node)), {rtbuilder.build()}, "report request completion in left_token_ring sate");
+                co_await update_topology_state(take_guard(std::move(node)), {rtbuilder.build()}, "report request completion in left_token_ring state");
 
                 // Tell the node to shut down.
                 // This is done to improve user experience when there are no failures.


### PR DESCRIPTION
fix a typo in the logging message.