### PR TITLE
row_cache: test cache consistency during multi-partition cache updates

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -420,7 +420,7 @@ modes = {
         'description': 'a mode with optimizations and no debug checks, used for production builds',
     },
     'dev': {
-        'cxxflags': '-DDEVEL -DSEASTAR_ENABLE_ALLOC_FAILURE_INJECTION -DSCYLLA_ENABLE_ERROR_INJECTION',
+        'cxxflags': '-DDEVEL -DSEASTAR_ENABLE_ALLOC_FAILURE_INJECTION -DSCYLLA_ENABLE_ERROR_INJECTION -DSCYLLA_ENABLE_PREEMPTION_SOURCE',
         'cxx_ld_flags': '',
         'stack-usage-threshold': 1024*21,
         'optimization-level': '2',

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -651,7 +651,8 @@ public:
         logalloc::region&,
         cache_tracker& this_tracker,
         partition_snapshot::phase_type,
-        real_dirty_memory_accounter&);
+        real_dirty_memory_accounter&,
+        preemption_source&);
 
     // If this entry is evictable, cache_tracker must be provided.
     // Must not be called when is_locked().

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -35,6 +35,7 @@ using namespace std::chrono_literals;
 
 static thread_local mutation_application_stats app_stats_for_tests;
 
+static thread_local preemption_source default_preemption_source;
 
 // Reads the rest of the partition into a mutation_partition object.
 // There must be at least one entry ahead of the cursor.
@@ -197,7 +198,7 @@ void mvcc_partition::apply_to_evictable(partition_entry&& src, schema_ptr src_sc
                 src.upgrade(region(), _s, src_cleaner, no_cache_tracker);
             }
             return _e.apply_to_incomplete(*schema(), std::move(src), src_cleaner, as, region(),
-                *_container.tracker(), _container.next_phase(), _container.accounter());
+                *_container.tracker(), _container.next_phase(), _container.accounter(), default_preemption_source);
         });
         repeat([&] {
             return c.run();

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -4707,3 +4707,110 @@ SEASTAR_THREAD_TEST_CASE(test_cache_reader_semaphore_oom_kill) {
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().total_reads_killed_due_to_kill_limit, ++kill_limit_before);
     }
 }
+
+// Reproducer for #16759.
+//
+#ifdef SCYLLA_ENABLE_PREEMPTION_SOURCE
+SEASTAR_THREAD_TEST_CASE(test_preempt_cache_update) {
+    // Starts requesting preemption after the given number of checks.
+    // On the first yield, blocks on a semaphore until it's later
+    // unblocked by the test.
+    struct preempter : public custom_preemption_source::impl {
+        semaphore wait_for_block{0};
+        semaphore wait_for_unblock{0};
+        uint64_t yields = 0;
+        int64_t until_preempt;
+        preempter(uint64_t count) : until_preempt(count) {}
+        bool should_preempt() override {
+            return (--until_preempt == 0);
+        }
+        void thread_yield() override {
+            if (yields++ == 0) {
+                wait_for_block.signal();
+                wait_for_unblock.wait().get();
+            }
+        }
+    };
+
+    // Create a few mutations with multiple rows.
+    simple_schema s;
+    auto keys = s.make_pkeys(3);
+    std::vector<mutation> mutations;
+    for (const auto& pk : keys) {
+        mutation m(s.schema(), pk);
+        for (int j = 0; j < 3; ++j) {
+            s.add_row(m, s.make_ckey(j), "example_value");
+        }
+        mutations.push_back(std::move(m));
+    }
+
+    // Test all possible preemption points.
+    for (uint64_t preempt_after = 1; true; ++preempt_after) {
+        testlog.trace("preempt after {}", preempt_after);
+        auto preempt_src = custom_preemption_source{std::make_unique<preempter>(preempt_after)};
+        auto& p = dynamic_cast<preempter&>(*preempt_src._impl);
+
+        // Set up the cache and populate it with the second mutation,
+        // so that the update can be preempted in the middle of a partition.
+        // It's a condition for reproducing #16759.
+        cache_tracker tracker;
+        memtable_snapshot_source underlying(s.schema());
+        underlying.apply(mutations[1]);
+        row_cache cache(s.schema(), snapshot_source([&] { return underlying(); }), tracker);
+        cache.populate(mutations[1]);
+
+        tests::reader_concurrency_semaphore_wrapper semaphore;
+
+        // Update the cache (and the underlying source) with the mutations.
+        auto mt = make_lw_shared<replica::memtable>(s.schema());
+        for (const auto& m : mutations) {
+            mt->apply(m);
+        }
+        auto mt_copy = make_lw_shared<replica::memtable>(s.schema());
+        mt_copy->apply(*mt, semaphore.make_permit()).get();
+        auto update_fut = cache.update(row_cache::external_updater([&] { underlying.apply(mt_copy); }), *mt, preempt_src).then([&] {
+            // The update does not have to yield.
+            // We don't want the test to break if it doesn't yield.
+            // So if the test wasn't unblocked by a yield, we have to
+            // do it here.
+            p.wait_for_block.signal();
+        });
+
+        // Wait for the update thread to yield.
+        p.wait_for_block.wait().get();
+
+        {
+            // Read combined cache and memtables, and check that it produces
+            // the inserted data.
+            std::vector<flat_mutation_reader_v2> readers;
+            readers.push_back(cache.make_reader(s.schema(), semaphore.make_permit()));
+            readers.push_back(mt->make_flat_reader(s.schema(), semaphore.make_permit()));
+            auto at = assert_that(make_combined_reader(s.schema(), semaphore.make_permit(), std::move(readers)));
+            for (const auto& m : mutations) {
+                at.produces(m);
+            }
+            at.produces_end_of_stream();
+        }
+
+        // Unblock the update and wait for it to finish.
+        p.wait_for_unblock.signal();
+        update_fut.get();
+
+        {
+            // Read the cache after the update is over and check that it produces the inserted
+            // data.
+            auto at = assert_that(cache.make_reader(s.schema(), semaphore.make_permit()));
+            for (const auto& m : mutations) {
+                at.produces(m);
+            }
+            at.produces_end_of_stream();
+        }
+
+        // If a preemption request wasn't triggered in this loop, this means
+        // we have tested all preemption points and we are done.
+        if (p.until_preempt > 0) {
+            break;
+        }
+    }
+}
+#endif

--- a/utils/preempt.hh
+++ b/utils/preempt.hh
@@ -11,6 +11,7 @@
 #include <seastar/util/bool_class.hh>
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/core/preempt.hh>
+#include <seastar/core/thread.hh>
 
 #include "seastarx.hh"
 
@@ -41,3 +42,36 @@ preemption_check always_preempt() {
         return true;
     };
 }
+
+struct basic_preemption_source {
+    bool should_preempt() {
+        return seastar::need_preempt();
+    }
+    void thread_yield() {
+        seastar::thread::yield();
+    }
+};
+
+struct custom_preemption_source {
+    struct impl {
+        virtual bool should_preempt() = 0;
+        virtual void thread_yield() = 0;
+        virtual ~impl() = default;
+    };
+    std::unique_ptr<impl> _impl;
+    bool should_preempt() {
+        return _impl ? _impl->should_preempt() : seastar::need_preempt();
+    }
+    void thread_yield() {
+        _impl ? _impl->thread_yield() : seastar::thread::yield();
+    }
+    custom_preemption_source() = default;
+    custom_preemption_source(std::unique_ptr<impl> i) : _impl(std::move(i)) {}
+};
+
+#ifdef SCYLLA_ENABLE_PREEMPTION_SOURCE
+using preemption_source = custom_preemption_source;
+#else
+using preemption_source = basic_preemption_source;
+#endif
+


### PR DESCRIPTION
Adds a test reproducing https://github.com/scylladb/scylladb/issues/16759, and the instrumentation needed for it.