### PR TITLE
db: add formatter for error_injection_at_startup

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1219,7 +1219,7 @@ std::istream& operator>>(std::istream& is, db::seed_provider_type& s) {
 }
 
 std::ostream& operator<<(std::ostream& os, const error_injection_at_startup& eias) {
-    os << "error_injection_at_startup{name=" << eias.name << ", one_shot=" << eias.one_shot << "}";
+    fmt::print(os, "{}", eias);
     return os;
 }
 
@@ -1229,6 +1229,12 @@ std::istream& operator>>(std::istream& is, error_injection_at_startup& eias) {
     return is;
 }
 
+}
+
+auto fmt::formatter<db::error_injection_at_startup>::format(const db::error_injection_at_startup& eias, fmt::format_context& ctx) const
+    -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "error_injection_at_startup{{name={}, one_short={}}}",
+                          eias.name, eias.one_shot);
 }
 
 namespace utils {

--- a/db/config.hh
+++ b/db/config.hh
@@ -83,6 +83,11 @@ std::istream& operator>>(std::istream& is, error_injection_at_startup&);
 
 }
 
+template<>
+struct fmt::formatter<db::error_injection_at_startup> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const db::error_injection_at_startup&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
 
 namespace utils {
 


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `error_injection_at_startup`, and drop its operator<<.

Refs #13245