### PR TITLE
sstables: let state_to_dir(sstable_state) return string_view

### DIFF
--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -140,7 +140,7 @@ enum class sstable_state {
     upload,
 };
 
-inline sstring state_to_dir(sstable_state state) {
+inline std::string_view state_to_dir(sstable_state state) {
     switch (state) {
     case sstable_state::normal:
         return normal_dir;
@@ -178,7 +178,7 @@ inline std::ostream& operator<<(std::ostream& o, sstable_state s) {
 inline fs::path make_path(std::string_view table_dir, sstable_state state) {
     fs::path ret(table_dir);
     if (state != sstable_state::normal) {
-        ret /= state_to_dir(state).c_str();
+        ret /= state_to_dir(state);
     }
     return ret;
 }


### PR DESCRIPTION
state_to_dir(sstable_state) translate the enum to the corresponding directory component. and it returns a `seastar::sstring`. not all the callers of this function expect a full-blown sstring instance, on the contrary, quite a few of them just want a string-alike object which represents the directory component, so they can use it, for instance to compose a path, or just format the given `state` enum.

so to avoid the overhead of creating/destroying the `seastar::sstring` instance, let's switch to `std::string_view`. with this change, we will be able to implement the fmt::formatter for `sstable_state` without the help of the formatter of sstring.