### PR TITLE
sstable: change sstable_touch_directory_io_check() to accept fs::path

### DIFF
--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -473,9 +473,9 @@ public:
     }
 
     // required since touch_directory has an optional parameter
-    auto sstable_touch_directory_io_check(sstring name) const noexcept {
+    auto sstable_touch_directory_io_check(std::filesystem::path name) const noexcept {
         return do_io_check(_write_error_handler, [name = std::move(name)] () mutable {
-            return touch_directory(std::move(name));
+            return touch_directory(name.native());
         });
     }
     future<> close_files();

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -182,7 +182,7 @@ future<> filesystem_storage::touch_temp_dir(const sstable& sst) {
     }
     auto tmp = _dir / fmt::format("{}{}", sst._generation, tempdir_extension);
     sstlog.debug("Touching temp_dir={}", tmp);
-    co_await sst.sstable_touch_directory_io_check(tmp.native());
+    co_await sst.sstable_touch_directory_io_check(tmp);
     _temp_dir = std::move(tmp);
 }
 
@@ -340,11 +340,14 @@ future<> filesystem_storage::create_links(const sstable& sst, const sstring& dir
 }
 
 future<> filesystem_storage::snapshot(const sstable& sst, sstring dir, absolute_path abs) const {
-    if (!abs) {
-        dir = (_dir / dir).native();
+    std::filesystem::path snapshot_dir;
+    if (abs) {
+        snapshot_dir = dir;
+    } else {
+        snapshot_dir = _dir / dir;
     }
-    co_await sst.sstable_touch_directory_io_check(dir);
-    co_await create_links(sst, dir);
+    co_await sst.sstable_touch_directory_io_check(snapshot_dir);
+    co_await create_links(sst, snapshot_dir.native());
 }
 
 future<> filesystem_storage::move(const sstable& sst, sstring new_dir, generation_type new_generation, delayed_commit_changes* delay_commit) {


### PR DESCRIPTION
this change is a follow-up of 637dd730. the goal is to use std::filesystem::path for manipulating paths, and to avoid the converting between sstring and fs::path back and forth.