### PR TITLE
.git: skip *.svg when scanning spelling errors

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -14,4 +14,4 @@ jobs:
         with:
           only_warn: 1
           ignore_words_list: "ans,datas,fo,ser,ue,crate,nd,reenable,strat,stap,te"
-          skip: "./.git,./build,./tools,*.js,*.thrift,*.lock,./test,./licenses"
+          skip: "./.git,./build,./tools,*.js,*.thrift,*.lock,./test,./licenses,*.svg"


### PR DESCRIPTION
codespell reports following warnings:
```
Error: ./docs/kb/flamegraph.svg:1: writen ==> written
Error: ./docs/kb/flamegraph.svg:1: writen ==> written
Error: ./docs/kb/flamegraph.svg:1: storag ==> storage
Error: ./docs/kb/flamegraph.svg:1: storag ==> storage
```

these misspellings come from the flamgraph, which can be viewed at https://opensource.docs.scylladb.com/master/kb/flamegraph.html they are very likely to be truncated function names displayed in the frames. and the spelling of these names are not responsible of the author of the article, neither can we change them in a meaningful way. so add it to the skip list.