### PR TITLE
mutation: s/statics/static content/

### DIFF
--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -481,7 +481,7 @@ public:
             gc_consumer.consume_end_of_partition();
         }
         if (!_empty_partition) {
-            // #589 - Do not add extra row for statics unless we did a CK range-less query.
+            // #589 - Do not add extra row for static content unless we did a CK range-less query.
             // See comment in query
             if (_rows_in_current_partition == 0 && _static_row_live &&
                     _return_static_content_on_partition_with_no_rows) {

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1441,7 +1441,7 @@ uint32_t mutation_partition::do_compact(const schema& s,
         trim_rows<false>(s, row_ranges, row_callback);
     }
 
-    // #589 - Do not add extra row for statics unless we did a CK range-less query.
+    // #589 - Do not add extra row for static content unless we did a CK range-less query.
     // See comment in query
     bool return_static_content_on_partition_with_no_rows = always_return_static_content || !has_ck_selector(row_ranges);
     if (row_count == 0 && static_row_live && return_static_content_on_partition_with_no_rows) {


### PR DESCRIPTION
codespell reports that "statics" could be the misspelling of "statistics". but "static" here means the static column(s). so replace "static" with more specific wording.

Refs #589
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>