### PR TITLE
row_cache: s/fro/reader/

### DIFF
--- a/row_cache.cc
+++ b/row_cache.cc
@@ -676,9 +676,9 @@ private:
     }
 
     future<flat_mutation_reader_v2_opt> read_from_primary() {
-        auto fro = do_read_from_primary();
+        auto reader = do_read_from_primary();
         if (!_secondary_in_progress) {
-            return make_ready_future<flat_mutation_reader_v2_opt>(std::move(fro));
+            return make_ready_future<flat_mutation_reader_v2_opt>(std::move(reader));
         }
         return _secondary_reader.fast_forward_to(std::move(_secondary_range)).then([this] {
             return read_from_secondary();


### PR DESCRIPTION
"fro" is the short of "from" but the value is an
`optimized_optional<flat_mutation_reader_v2>`. codespell considers it a misspelling of "for" or "from". neither of them makes sense, so let's change it to "reader" for better readability, also for silencing the warning. so that the geniune warning can stands out, this would help to make the codespell more useful.