### PR TITLE
test_tablets: Enable table debug log in split test

### DIFF
--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -595,6 +595,7 @@ async def test_tablet_split(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cmdline = [
         '--logger-log-level', 'storage_service=debug',
+        '--logger-log-level', 'table=debug',
         '--target-tablet-size-in-bytes', '1024',
     ]
     servers = [await manager.server_add(cmdline=cmdline)]


### PR DESCRIPTION
If the test fails, it's helpful to see how split completion was handled.