### PR TITLE
docs: remove liveness asterisks

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -24,6 +24,10 @@
     font-weight: normal;
 }
 
+.content blockquote .std-term {
+    font-weight: bold;    
+}
+
 h3 .pre {
     font-size: 16px;
     font-weight: bold;

--- a/docs/_templates/db_option.tmpl
+++ b/docs/_templates/db_option.tmpl
@@ -3,4 +3,4 @@
 
    {% if type %}* **Type:** ``{{ type }}``{% endif %}
    {% if default %}* **Default value:** ``{{ default }}``{% endif %}
-   {% if liveness %}* **Liveness** :term:`* <Liveness>` **:** ``{{ liveness }}``{% endif %}
+   {% if liveness %}* :term:`Liveness <Liveness>`: ``{{ liveness }}``{% endif %}


### PR DESCRIPTION
## Motivation

Instead of adding an asterisk next to "liveness" linking to the glossary, we will temporarily replace them with a hyperlink pending the implementation of [tooltip functionality](https://github.com/scylladb/sphinx-scylladb-theme/issues/873).

Before:

![image](https://github.com/scylladb/scylladb/assets/9107969/172b8baa-6f75-45b4-99a7-0883e94d6cb8)

Now:

![image](https://github.com/scylladb/scylladb/assets/9107969/b5d917bc-2539-4a99-ba15-486c657a5472)

## How to test

See http://previews.docs.scylladb.com/scylladb/17244/reference/configuration-parameters/
