### PR TITLE
 test_tablets: add test_tablet_storage_freeing

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -202,6 +202,10 @@ class ManagerClient():
         logger.debug("ManagerClient wiping sstables on %s, keyspace=%s, table=%s", server_id, keyspace, table)
         await self.client.put_json(f"/cluster/server/{server_id}/wipe_sstables", {"keyspace": keyspace, "table": table})
 
+    async def server_get_sstables_disk_usage(self, server_id: ServerNum, keyspace: str, table: str) -> int:
+        """Get the total size of all sstable files for the given table"""
+        return await self.client.get_json(f"/cluster/server/{server_id}/sstables_disk_usage", params={"keyspace": keyspace, "table": table})
+
     def _create_server_add_data(self, replace_cfg: Optional[ReplaceConfig] = None,
                                 cmdline: Optional[List[str]] = None,
                                 config: Optional[dict[str, Any]] = None,

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -32,6 +32,7 @@ import aiohttp.web
 import yaml
 import signal
 import glob
+import errno
 
 from cassandra import InvalidRequest                    # type: ignore
 from cassandra import OperationTimedOut                 # type: ignore
@@ -274,6 +275,17 @@ class ScyllaServer:
         for f in glob.iglob(f"./{keyspace}/{table}-????????????????????????????????/**/*", root_dir=root_dir, recursive=True):
             if ((root_dir/f).is_file()):
                 (root_dir/f).unlink()
+
+    def get_sstables_disk_usage(self, keyspace: str, table: str) -> int:
+        table_dir = self.workdir/"data"
+        size = 0
+        for f in table_dir.glob(f"{keyspace}/{table}-????????????????????????????????/**/*"):
+            try:
+                size += f.stat().st_size
+            except OSError as e:
+                if e.errno != errno.ENOENT:
+                    raise
+        return size
 
     async def install_and_start(self, api: ScyllaRESTAPIClient, expected_error: Optional[str] = None) -> None:
         """Setup and start this server"""
@@ -1055,6 +1067,12 @@ class ScyllaCluster:
         self.is_dirty = True
         server.wipe_sstables(keyspace, table)
 
+    def get_sstables_disk_usage(self, server_id: ServerNum, keyspace: str, table: str) -> int:
+        """Measure the disk usage of sstables for the given <node, keyspace, table>."""
+        assert server_id in self.servers, f"Server {server_id} unknown"
+        server = self.servers[server_id]
+        return server.get_sstables_disk_usage(keyspace, table)
+
 class ScyllaClusterManager:
     """Manages a Scylla cluster for running test cases
        Provides an async API for tests to request changes in the Cluster.
@@ -1186,6 +1204,7 @@ class ScyllaClusterManager:
         add_get('/cluster/server/{server_id}/workdir', self._server_get_workdir)
         add_get('/cluster/server/{server_id}/exe', self._server_get_exe)
         add_put('/cluster/server/{server_id}/wipe_sstables', self._cluster_server_wipe_sstables)
+        add_get('/cluster/server/{server_id}/sstables_disk_usage', self._server_get_sstables_disk_usage)
 
     async def _manager_up(self, _request) -> bool:
         return self.is_running
@@ -1475,6 +1494,11 @@ class ScyllaClusterManager:
         data = await request.json()
         server_id = ServerNum(int(request.match_info["server_id"]))
         return self.cluster.wipe_sstables(server_id, data["keyspace"], data["table"])
+
+    async def _server_get_sstables_disk_usage(self, request: aiohttp.web.Request) -> int:
+        data = request.query
+        server_id = ServerNum(int(request.match_info["server_id"]))
+        return self.cluster.get_sstables_disk_usage(server_id, data["keyspace"], data["table"])
 
 @asynccontextmanager
 async def get_cluster_manager(test_uname: str, clusters: Pool[ScyllaCluster], test_path: str) \


### PR DESCRIPTION
Tests that tablet storage is freed after it is migrated away.

Fixes #16946