### PR TITLE
db: add formatter for gc_clock::time_point

### DIFF
--- a/gc_clock.hh
+++ b/gc_clock.hh
@@ -58,8 +58,6 @@ using ttl_opt = std::optional<gc_clock::duration>;
 // 20 years in seconds
 static constexpr gc_clock::duration max_ttl = gc_clock::duration{20 * 365 * 24 * 60 * 60};
 
-std::ostream& operator<<(std::ostream& os, gc_clock::time_point tp);
-
 template<>
 struct appending_hash<gc_clock::time_point> {
     template<typename Hasher>
@@ -107,3 +105,9 @@ struct serializer<gc_clock::duration> {
 };
 
 }
+
+template<>
+struct fmt::formatter<gc_clock::time_point> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(gc_clock::time_point, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2980,11 +2980,10 @@ flat_mutation_reader_v2 make_multishard_streaming_reader(distributed<replica::da
         full_slice);
 }
 
-std::ostream& operator<<(std::ostream& os, gc_clock::time_point tp) {
+auto fmt::formatter<gc_clock::time_point>::format(gc_clock::time_point tp, fmt::format_context& ctx) const
+    -> decltype(ctx.out()) {
     auto sec = std::chrono::duration_cast<std::chrono::seconds>(tp.time_since_epoch()).count();
-    std::ostream tmp(os.rdbuf());
-    tmp << std::setw(12) << sec;
-    return os;
+    return fmt::format_to(ctx.out(), "{:>12}", sec);
 }
 
 const timeout_config infinite_timeout_config = {


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `gc_clock::time_point`, and drop its operator<<.

Refs #13245