### PR TITLE
test/manual: do not include unused headers

### DIFF
--- a/test/manual/ec2_snitch_test.cc
+++ b/test/manual/ec2_snitch_test.cc
@@ -7,13 +7,13 @@
  */
 
 
+#include <string>
 #include <boost/test/unit_test.hpp>
-#include "locator/ec2_snitch.hh"
+#include <seastar/http/response_parser.hh>
+#include <seastar/net/api.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/util/std-compat.hh>
-#include <vector>
-#include <string>
-#include <tuple>
+#include "locator/snitch_base.hh"
 
 namespace fs = std::filesystem;
 

--- a/test/manual/enormous_table_scan_test.cc
+++ b/test/manual/enormous_table_scan_test.cc
@@ -20,12 +20,8 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm/find_if.hpp>
 
-#include "clustering_bounds_comparator.hh"
 #include "dht/i_partitioner.hh"
 #include "mutation/mutation_fragment.hh"
-#include "partition_range_compat.hh"
-#include "range.hh"
-#include "sstables/sstables.hh"
 #include "schema/schema_builder.hh"
 #include "readers/forwardable_v2.hh"
 

--- a/test/manual/hint_test.cc
+++ b/test/manual/hint_test.cc
@@ -11,14 +11,8 @@
 
 #include <stdlib.h>
 #include <iostream>
-#include <list>
-#include <unordered_set>
 
-#include "test/lib/test_services.hh"
 #include <seastar/testing/test_case.hh>
-
-#include "test/lib/mutation_source_test.hh"
-#include "test/lib/mutation_assertions.hh"
 
 #include <seastar/core/future-util.hh>
 #include <seastar/core/do_with.hh>
@@ -29,8 +23,6 @@
 #include "test/lib/tmpdir.hh"
 #include "db/commitlog/commitlog.hh"
 #include "db/commitlog/rp_set.hh"
-#include "log.hh"
-#include "schema/schema.hh"
 
 using namespace db;
 

--- a/test/manual/sstable_scan_footprint_test.cc
+++ b/test/manual/sstable_scan_footprint_test.cc
@@ -11,7 +11,6 @@
 #include "test/lib/random_utils.hh"
 #include "test/lib/log.hh"
 
-#include "schema/schema_builder.hh"
 #include "row_cache.hh"
 #include "replica/database.hh"
 #include "db/config.hh"


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.