### PR TITLE
gms: inet_address: make constructors explicit

### DIFF
--- a/api/messaging_service.cc
+++ b/api/messaging_service.cc
@@ -114,7 +114,7 @@ void set_messaging_service(http_context& ctx, routes& r, sharded<netw::messaging
     }));
 
     get_version.set(r, [&ms](const_req req) {
-        return ms.local().get_raw_version(req.get_query_param("addr"));
+        return ms.local().get_raw_version(gms::inet_address(req.get_query_param("addr")));
     });
 
     get_dropped_messages_by_ver.set(r, [&ms](std::unique_ptr<request> req) {

--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -26,7 +26,7 @@ private:
     net::inet_address _addr;
 public:
     inet_address() = default;
-    inet_address(int32_t ip) noexcept
+    explicit inet_address(int32_t ip) noexcept
         : inet_address(uint32_t(ip)) {
     }
     explicit inet_address(uint32_t ip) noexcept
@@ -47,7 +47,7 @@ public:
     }
 
     // throws std::invalid_argument if sstring is invalid
-    inet_address(const sstring& addr) {
+    explicit inet_address(const sstring& addr) {
         // FIXME: We need a real DNS resolver
         if (addr == "localhost") {
             _addr = net::ipv4_address("127.0.0.1");

--- a/message/msg_addr.hh
+++ b/message/msg_addr.hh
@@ -22,6 +22,7 @@ struct msg_addr {
         size_t operator()(const msg_addr& id) const noexcept;
     };
     explicit msg_addr(gms::inet_address ip) noexcept : addr(ip), cpu_id(0) { }
+    explicit msg_addr(const sstring& addr) noexcept : addr(addr), cpu_id(0) { }
     msg_addr(gms::inet_address ip, uint32_t cpu) noexcept : addr(ip), cpu_id(cpu) { }
 };
 

--- a/test/raft/discovery_test.cc
+++ b/test/raft/discovery_test.cc
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(test_basic) {
 
     // Must supply an Internet address for self
     BOOST_CHECK_THROW(discovery(addr1, {}), std::logic_error);
-    discovery_peer addr2 = {id(), seastar::sstring("192.168.1.2")};
+    discovery_peer addr2 = {id(), gms::inet_address("192.168.1.2")};
     BOOST_CHECK_NO_THROW(discovery(addr2, {}));
     // Must supply an Internet address for each peer
     BOOST_CHECK_THROW(discovery(addr2, {addr1}), std::logic_error);
@@ -76,8 +76,8 @@ BOOST_AUTO_TEST_CASE(test_basic) {
 
 BOOST_AUTO_TEST_CASE(test_discovery) {
 
-    discovery_peer addr1 = {id(), seastar::sstring("192.168.1.1")};
-    discovery_peer addr2 = {id(), seastar::sstring("192.168.1.2")};
+    discovery_peer addr1 = {id(), gms::inet_address("192.168.1.1")};
+    discovery_peer addr2 = {id(), gms::inet_address("192.168.1.2")};
 
     discovery d1(addr1, {addr2});
     discovery d2(addr2, {addr1});
@@ -88,9 +88,9 @@ BOOST_AUTO_TEST_CASE(test_discovery) {
 
 BOOST_AUTO_TEST_CASE(test_discovery_fullmesh) {
 
-    discovery_peer addr1 = {id(), seastar::sstring("127.0.0.13")};
-    discovery_peer addr2 = {id(), seastar::sstring("127.0.0.19")};
-    discovery_peer addr3 = {id(), seastar::sstring("127.0.0.21")};
+    discovery_peer addr1 = {id(), gms::inet_address("127.0.0.13")};
+    discovery_peer addr2 = {id(), gms::inet_address("127.0.0.19")};
+    discovery_peer addr3 = {id(), gms::inet_address("127.0.0.21")};
 
     auto seeds = std::vector<discovery_peer>({addr1, addr2, addr3});
 


### PR DESCRIPTION
In particular, `inet_address(const sstring& addr)` is dangerous, since a function like
`topology::get_datacenter(inet_address ep)`
might accidentally convert a `sstring` argument
into an `inet_address` (which would most likely
throw an obscure std::invalid_argument if the datacenter name does not look like an inet_address).