### PR TITLE
data_value: delete data_value(T*) constructor

### DIFF
--- a/types/types.hh
+++ b/types/types.hh
@@ -219,6 +219,16 @@ public:
     // to explicitly call `make_null()` instead.
     data_value(std::nullptr_t) = delete;
 
+    // Do not allow construction of a data_value from pointers. The reason is
+    // that this is error prone since pointers are implicitly converted to `bool`
+    // deriving the data_value(bool) constructor.
+    // In this case, comparisons between unrelated types, like `sstring` and `something*`
+    // implicitly select operator==(const data_value&, const data_value&), as
+    // `sstring` is implicitly convertible to `data_value`, and so is `something*`
+    // via `data_value(bool)`.
+    template <typename T>
+    data_value(const T*) = delete;
+
     data_value(ascii_native_type);
     data_value(bool);
     data_value(int8_t);


### PR DESCRIPTION
Currently, since the data_value(bool) ctor
is implicit, pointers of any kind are implicitly
convertible to data_value via intermediate conversion to `bool`.

This is error prone, since it allows unsafe comparison between e.g. an `sstring` with `some*` by implicit conversion of both sides to `data_value`.

For example:
```
    sstring name = "dc1";
    struct X {
        sstring s;
    };
    X x(name);
    auto p = &x;
    if (name == p) {}
```

Refs #17261