### PR TITLE
transport: controller: do_start_server: do not set_cql_read for maintenance port

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2217,12 +2217,7 @@ future<> gossiper::add_local_application_state(application_state_map states) {
                 co_await coroutine::return_exception(std::runtime_error(err));
             }
 
-            auto es = gossiper.get_endpoint_state_ptr(ep_addr);
-            if (!es) {
-                on_internal_error(logger, format("endpoint_state_map does not contain endpoint = {}", ep_addr));
-            }
-
-            auto local_state = *es;
+            auto local_state = *ep_state_before;
             for (auto& p : states) {
                 auto& state = p.first;
                 auto& value = p.second;

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -212,7 +212,9 @@ future<> controller::do_start_server() {
             });
         }).get();
 
-        set_cql_ready(true).get();
+        if (!_used_by_maintenance_socket) {
+            set_cql_ready(true).get();
+        }
 
         on_error.cancel();
         on_error_unsub.cancel();


### PR DESCRIPTION
RPC is not ready yet at this point, so we should not set this application state yet.

Also, simplify add_local_application_state as it contains dead code
that will never generate an internal error after 1d07a596bf23432326dadd74eb5b2857955fe15b.

Fixes #16932
