### PR TITLE
cql-pytest: fix skipping of tests on Cassandra or old Scylla

### DIFF
--- a/test/cql-pytest/conftest.py
+++ b/test/cql-pytest/conftest.py
@@ -91,7 +91,7 @@ def this_dc(cql):
 @pytest.fixture(scope="session")
 def test_keyspace_tablets(cql, this_dc, has_tablets):
     if not is_scylla(cql) or not has_tablets:
-        pytest.skip("tablet-specific test skipped")
+        yield None
         return
 
     name = unique_name()
@@ -120,6 +120,8 @@ def test_keyspace(request, test_keyspace_vnodes, test_keyspace_tablets, cql, thi
         if request.param == "vnodes":
             yield test_keyspace_vnodes
         elif request.param == "tablets":
+            if not test_keyspace_tablets:
+                pytest.skip("tablet-specific test skipped")
             yield test_keyspace_tablets
         else:
             pytest.fail(f"test_keyspace(): invalid request parameter: {request.param}")


### PR DESCRIPTION
Recently we added a trick to allow running cql-pytests either with or without tablets. A single fixture test_keyspace uses two separate fixtures test_keyspace_tablets or test_keyspace_vnodes, as requested.

The problem is that even if test_keyspace doesn't use its test_keyspace_tablets fixture (it doesn't, if the test isn't parameterized to ask for tablets explicitly), it's still a fixture, and it causes the test to be skipped. This causes every test to be skipped when running on Cassandra or old Scylla which doesn't support tablets.

The fix is simple - the internal fixture test_keyspace_tablets should yield None instead of skipping. It is the caller, test_keyspace, which now skips the test if tablets are requested but test_keyspace_tablets is None.

Fixes #17266