### PR TITLE
Update seastar submodule

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1703,6 +1703,7 @@ def configure_seastar(build_dir, mode, mode_config):
         '-DCMAKE_C_COMPILER={}'.format(args.cc),
         '-DCMAKE_CXX_COMPILER={}'.format(args.cxx),
         '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON',
+        '-DCMAKE_CXX_STANDARD=20',
         '-DSeastar_CXX_FLAGS=SHELL:{}'.format(mode_config['lib_cflags']),
         '-DSeastar_LD_FLAGS={}'.format(semicolon_separated(mode_config['lib_ldflags'], seastar_cxx_ld_flags)),
         '-DSeastar_CXX_DIALECT=gnu++20',


### PR DESCRIPTION
Because Seastar now defaults to C++23, we downgrade it explicitly to C++20.

* seastar 289ad5e593...5d3ee98073 (10):
  > Update supported C++ standards to C++23 and C++20 (dropping C++17)
  > docker: install clang-tools-18
  > http: add handler_base::verify_mandatory_params()
  > coroutine/exception: document return_exception_ptr()
  > http: use structured-binding when appropriate
  > test/http: Read full server response before sending next
  > doc/lambda-coroutine-fiasco: fix a syntax error
  > util/source_location-compat: use __cpp_consteval
  > Fix incorrect class name in documentation.
  > Add support for missing HTTP PATCH method.