### PR TITLE
configure.py, cmake: do not pass -Wignored-qualifiers explicitly

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -17,7 +17,6 @@ add_compile_options(
   "-Werror"
   "-Wno-error=deprecated-declarations"
   "-Wimplicit-fallthrough"
-  "-Wignored-qualifiers"
   ${_supported_warnings})
 
 function(default_target_arch arch)

--- a/configure.py
+++ b/configure.py
@@ -1535,7 +1535,6 @@ def get_warning_options(cxx):
         '-Werror',
         '-Wextra',
         '-Wimplicit-fallthrough',
-        '-Wignored-qualifiers',
         '-Wno-mismatched-tags',  # clang-only
         '-Wno-c++11-narrowing',
         '-Wno-overloaded-virtual',


### PR DESCRIPTION
we recently added -Wextra to configure.py, and this option enables a bunch of warning options, including `-Wignored-qualifiers`. so there is no need to enable this specific warning anymore. this change remove ths option from both `configure.py` and the CMake building system.