### PR TITLE
locator::topology: add structured datacenter and rack classes

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -4485,7 +4485,7 @@ static std::map<sstring, sstring> get_network_topology_options(service::storage_
     sstring rf_str = std::to_string(rf);
     auto& topology = sp.get_token_metadata_ptr()->get_topology();
     for (const gms::inet_address& addr : gossiper.get_live_members()) {
-        options.emplace(topology.get_datacenter(addr), rf_str);
+        options.emplace(topology.get_datacenter(addr)->name(), rf_str);
     };
     return options;
 }

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -208,7 +208,8 @@ protected:
         // just the list of live nodes in this DC needs more elaborate code:
         auto& topology = _proxy.get_token_metadata_ptr()->get_topology();
         sstring local_dc = topology.get_datacenter();
-        std::unordered_set<gms::inet_address> local_dc_nodes = topology.get_datacenter_endpoints().at(local_dc);
+        auto dc_endpoints_map = topology.get_datacenter_endpoints();
+        const auto& local_dc_nodes = dc_endpoints_map.at(local_dc);
         for (auto& ip : local_dc_nodes) {
             if (_gossiper.is_alive(ip)) {
                 rjson::push_back(results, rjson::from_string(ip.to_sstring()));

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -207,14 +207,12 @@ protected:
         // using _gossiper().get_live_members(). But getting
         // just the list of live nodes in this DC needs more elaborate code:
         auto& topology = _proxy.get_token_metadata_ptr()->get_topology();
-        sstring local_dc = topology.get_datacenter();
-        auto dc_endpoints_map = topology.get_datacenter_endpoints();
-        const auto& local_dc_nodes = dc_endpoints_map.at(local_dc);
-        for (auto& ip : local_dc_nodes) {
-            if (_gossiper.is_alive(ip)) {
-                rjson::push_back(results, rjson::from_string(ip.to_sstring()));
+        auto local_dc = topology.get_datacenter();
+        local_dc->for_each_node([&] (const locator::node* node) {
+            if (_gossiper.is_alive(node->endpoint())) {
+                rjson::push_back(results, rjson::from_string(node->endpoint().to_sstring()));
             }
-        }
+        });
         rep->set_status(reply::status_type::ok);
         rep->set_content_type("json");
         rep->_content = rjson::print(results);

--- a/api/token_metadata.cc
+++ b/api/token_metadata.cc
@@ -84,7 +84,7 @@ void set_token_metadata(http_context& ctx, routes& r, sharded<locator::shared_to
             // info about just-left node and not handle it nicely
             return locator::endpoint_dc_rack::default_location.dc;
         }
-        return topology.get_datacenter(ep);
+        return topology.get_datacenter(ep)->name();
     });
 
     httpd::endpoint_snitch_info_json::get_rack.set(r, [&tm](const_req req) {
@@ -95,7 +95,7 @@ void set_token_metadata(http_context& ctx, routes& r, sharded<locator::shared_to
             // info about just-left node and not handle it nicely
             return locator::endpoint_dc_rack::default_location.rack;
         }
-        return topology.get_rack(ep);
+        return topology.get_rack(ep)->name();
     });
 }
 

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -161,7 +161,7 @@ std::vector<sstring> check_against_restricted_replication_strategies(
         } else if (simple_strategy_restriction == db::tri_mode_restriction_t::mode::WARN) {
             rs_warn_list.emplace_back(locator::replication_strategy_type::simple);
         } else if (auto &topology = qp.proxy().get_token_metadata_ptr()->get_topology();
-                topology.get_datacenter_endpoints().size() > 1) {
+                topology.get_datacenter_names().size() > 1) {
             // Scylla was configured to allow SimpleStrategy, but let's warn
             // if it's used on a cluster which *already* has multiple DCs:
             warnings.emplace_back("Using SimpleStrategy in a multi-datacenter environment is not recommended.");

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -63,7 +63,7 @@ static std::map<sstring, sstring> prepare_options(
             }
         }
 
-        for (const auto& dc : tm.get_topology().get_datacenters()) {
+        for (const auto& dc : tm.get_topology().get_datacenter_names()) {
             options.emplace(dc, *rf);
         }
     }

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -80,7 +80,7 @@ public:
                 }
 
                 if (hostid && tm.is_normal_token_owner(*hostid)) {
-                    sstring dc = tm.get_topology().get_location(endpoint).dc;
+                    sstring dc = tm.get_topology().get_location(endpoint).dc()->name();
                     set_cell(cr, "dc", dc);
                 }
 

--- a/dht/range_streamer.hh
+++ b/dht/range_streamer.hh
@@ -72,7 +72,7 @@ public:
             : _source_dc(source_dc) {
         }
         virtual bool should_include(const locator::topology& topo, inet_address endpoint) override {
-            return topo.get_datacenter(endpoint) == _source_dc;
+            return topo.get_datacenter(endpoint)->name() == _source_dc;
         }
     };
 

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -315,7 +315,8 @@ dht::token_range_vector
 vnode_effective_replication_map::get_primary_ranges_within_dc(inet_address ep) const {
     const topology& topo = _tmptr->get_topology();
     sstring local_dc = topo.get_datacenter(ep);
-    std::unordered_set<inet_address> local_dc_nodes = topo.get_datacenter_endpoints().at(local_dc);
+    auto dc_endpoints_map = topo.get_datacenter_endpoints();
+    const auto& local_dc_nodes = dc_endpoints_map.at(local_dc);
     // The callback function below is called for each endpoint
     // in each token natural endpoints.
     // Add the range if `ep` is the datacenter primary replica in the token's natural endpoints.

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -314,9 +314,11 @@ vnode_effective_replication_map::get_primary_ranges(inet_address ep) const {
 dht::token_range_vector
 vnode_effective_replication_map::get_primary_ranges_within_dc(inet_address ep) const {
     const topology& topo = _tmptr->get_topology();
-    sstring local_dc = topo.get_datacenter(ep);
-    auto dc_endpoints_map = topo.get_datacenter_endpoints();
-    const auto& local_dc_nodes = dc_endpoints_map.at(local_dc);
+    std::unordered_set<inet_address> local_dc_nodes;
+    const auto* local_dc = topo.get_datacenter(ep);
+    local_dc->for_each_node([&] (const node* node) {
+        local_dc_nodes.insert(node->endpoint());
+    });
     // The callback function below is called for each endpoint
     // in each token natural endpoints.
     // Add the range if `ep` is the datacenter primary replica in the token's natural endpoints.

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -213,7 +213,7 @@ public:
     }
 
     bool add_endpoint_and_check_if_done(host_id ep) {
-        auto& loc = _tp.get_location(ep);
+        auto loc = _tp.get_location(ep);
         auto i = _dcs.find(loc.dc);
         if (i != _dcs.end() && i->second.add_endpoint_and_check_if_done(ep, loc)) {
             --_dcs_to_fill;

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -282,7 +282,7 @@ void network_topology_strategy::validate_options(const gms::feature_service& fs)
 
 std::optional<std::unordered_set<sstring>> network_topology_strategy::recognized_options(const topology& topology) const {
     // We only allow datacenter names as options
-    auto opts = topology.get_datacenters();
+    auto opts = topology.get_datacenter_names();
     opts.merge(recognized_tablet_options());
     return opts;
 }

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -155,7 +155,6 @@ class natural_endpoints_tracker {
 
     const token_metadata& _tm;
     const topology& _tp;
-    std::unordered_map<sstring, size_t> _dc_rep_factor;
 
     //
     // We want to preserve insertion order so that the first added endpoint
@@ -165,19 +164,7 @@ class natural_endpoints_tracker {
     // tracks the racks we have already placed replicas in
     endpoint_dc_rack_set _seen_racks;
 
-    //
-    // all endpoints in each DC, so we can check when we have exhausted all
-    // the members of a DC
-    //
-    std::unordered_map<sstring, std::unordered_set<inet_address>> _all_endpoints;
-
-    //
-    // all racks in a DC so we can check when we have exhausted all racks in a
-    // DC
-    //
-    std::unordered_map<sstring, std::unordered_map<sstring, std::unordered_set<inet_address>>> _racks;
-
-    std::unordered_map<sstring_view, data_center_endpoints> _dcs;
+    std::unordered_map<sstring, data_center_endpoints> _dcs;
 
     size_t _dcs_to_fill;
 
@@ -185,29 +172,32 @@ public:
     natural_endpoints_tracker(const token_metadata& tm, const std::unordered_map<sstring, size_t>& dc_rep_factor)
         : _tm(tm)
         , _tp(_tm.get_topology())
-        , _dc_rep_factor(dc_rep_factor)
-        , _all_endpoints(_tp.get_datacenter_endpoints())
-        , _racks(_tp.get_datacenter_racks())
     {
-        // not aware of any cluster members
-        assert(!_all_endpoints.empty() && !_racks.empty());
-
-        auto size_for = [](auto& map, auto& k) {
-            auto i = map.find(k);
-            return i != map.end() ? i->second.size() : size_t(0);
-        };
-
-        // Create a data_center_endpoints object for each non-empty DC.
-        for (auto& p : _dc_rep_factor) {
-            auto& dc = p.first;
-            auto rf = p.second;
-            auto node_count = size_for(_all_endpoints, dc);
-
-            if (rf == 0 || node_count == 0) {
+        for (const auto& [name, rf] : dc_rep_factor) {
+            if (!rf) {
+                continue;
+            }
+            const auto* dc = _tp.find_datacenter(name);
+            if (!dc) {
+                rslogger.debug("datacenter {} with rf={} not found", name, rf);
                 continue;
             }
 
-            _dcs.emplace(dc, data_center_endpoints(rf, size_for(_racks, dc), node_count, _replicas, _seen_racks));
+            size_t racks = 0;
+            size_t nodes = 0;
+            dc->for_each_rack([&] (const rack* rack) {
+                if (auto n = rack->nodes().size()) {
+                    ++racks;
+                    nodes += n;
+                }
+            });
+            if (!racks) {
+                rslogger.debug("datacenter {} with rf={} is empty", name, rf);
+                continue;
+            }
+
+            // Create a data_center_endpoints object for each non-empty DC.
+            _dcs.emplace(dc->name(), data_center_endpoints(rf, racks, nodes, _replicas, _seen_racks));
             _dcs_to_fill = _dcs.size();
         }
     }

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -67,7 +67,7 @@ network_topology_strategy::network_topology_strategy(replication_strategy_params
     rslogger.debug("Configured datacenter replicas are: {}", _dc_rep_factor);
 }
 
-using endpoint_dc_rack_set = std::unordered_set<endpoint_dc_rack>;
+using rack_set = std::unordered_set<const rack*>;
 
 class natural_endpoints_tracker {
     /**
@@ -82,13 +82,13 @@ class natural_endpoints_tracker {
          * For efficiency the set is shared between the instances, using the location pair (dc, rack) to make sure
          * clashing names aren't a problem.
          */
-        endpoint_dc_rack_set& _racks;
+        rack_set& _racks;
 
         /** Number of replicas left to fill from this DC. */
         size_t _rf_left;
         ssize_t _acceptable_rack_repeats;
 
-        data_center_endpoints(size_t rf, size_t rack_count, size_t node_count, host_id_set& endpoints, endpoint_dc_rack_set& racks)
+        data_center_endpoints(size_t rf, size_t rack_count, size_t node_count, host_id_set& endpoints, rack_set& racks)
             : _endpoints(endpoints)
             , _racks(racks)
             // If there aren't enough nodes in this DC to fill the RF, the number of nodes is the effective RF.
@@ -102,12 +102,12 @@ class natural_endpoints_tracker {
          * Attempts to add an endpoint to the replicas for this datacenter, adding to the endpoints set if successful.
          * Returns true if the endpoint was added, and this datacenter does not require further replicas.
          */
-        bool add_endpoint_and_check_if_done(const host_id& ep, const endpoint_dc_rack& location) {
+        bool add_endpoint_and_check_if_done(const host_id& ep, const location& location) {
             if (done()) {
                 return false;
             }
 
-            if (_racks.emplace(location).second) {
+            if (_racks.emplace(location.rack()).second) {
                 // New rack.
                 --_rf_left;
                 auto added = _endpoints.insert(ep).second;
@@ -162,9 +162,9 @@ class natural_endpoints_tracker {
     //
     host_id_set _replicas;
     // tracks the racks we have already placed replicas in
-    endpoint_dc_rack_set _seen_racks;
+    rack_set _seen_racks;
 
-    std::unordered_map<sstring, data_center_endpoints> _dcs;
+    std::unordered_map<const datacenter*, data_center_endpoints> _dcs;
 
     size_t _dcs_to_fill;
 
@@ -197,14 +197,18 @@ public:
             }
 
             // Create a data_center_endpoints object for each non-empty DC.
-            _dcs.emplace(dc->name(), data_center_endpoints(rf, racks, nodes, _replicas, _seen_racks));
+            _dcs.emplace(dc, data_center_endpoints(rf, racks, nodes, _replicas, _seen_racks));
             _dcs_to_fill = _dcs.size();
         }
     }
 
     bool add_endpoint_and_check_if_done(host_id ep) {
-        auto loc = _tp.get_location(ep);
-        auto i = _dcs.find(loc.dc);
+        const auto* node = _tp.find_node(ep);
+        if (!node) {
+            on_internal_error(rslogger, format("Node {} not found", ep));
+        }
+        const auto& loc = node->location();
+        auto i = _dcs.find(loc.dc());
         if (i != _dcs.end() && i->second.add_endpoint_and_check_if_done(ep, loc)) {
             --_dcs_to_fill;
         }

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -519,7 +519,7 @@ bool topology::has_endpoint(inet_address ep) const
     return has_node(ep);
 }
 
-const endpoint_dc_rack& topology::get_location(const inet_address& ep) const {
+endpoint_dc_rack topology::get_location(const inet_address& ep) const {
     if (auto node = find_node(ep)) {
         return node->dc_rack();
     }

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -63,19 +63,51 @@ std::string node::to_string(node::state s) {
 
 future<> topology::clear_gently() noexcept {
     _this_node = nullptr;
-    co_await utils::clear_gently(_datacenters);
+    // Keep the default dc and rack even if empty
+    // since _default_location points to them
+    for (auto dc_it = _datacenters.begin(); dc_it != _datacenters.end(); ) {
+        auto* dc = const_cast<datacenter*>(dc_it->second.get());
+        for (auto rack_it = dc->racks().begin(); rack_it != dc->racks().end(); ) {
+            auto* rack = const_cast<locator::rack*>(rack_it->second.get());
+            rack->_nodes.clear();
+            if (rack != _default_location.rack()) {
+                rack_it = dc->racks().erase(rack_it);
+            } else {
+                ++rack_it;
+            }
+            co_await coroutine::maybe_yield();
+        }
+        if (dc != _default_location.dc()) {
+            dc_it = _datacenters.erase(dc_it);
+        } else {
+            ++dc_it;
+        }
+    }
     _nodes_by_endpoint.clear();
     _nodes_by_host_id.clear();
     co_await utils::clear_gently(_nodes);
 }
 
-topology::topology(config cfg)
+topology::topology(config cfg, set_default_location set_default_location)
         : _shard(this_shard_id())
         , _cfg(cfg)
         , _sort_by_proximity(!cfg.disable_proximity_sorting)
 {
+    if (_cfg.local_dc_rack.dc.empty()) {
+        _cfg.local_dc_rack = endpoint_dc_rack::default_location;
+    } else if (_cfg.local_dc_rack.rack.empty()) {
+        _cfg.local_dc_rack.rack = endpoint_dc_rack::default_location.rack;
+    }
     tlogger.trace("topology[{}]: constructing using config: endpoint={} dc={} rack={}", fmt::ptr(this),
-            cfg.this_endpoint, cfg.local_dc_rack.dc, cfg.local_dc_rack.rack);
+            _cfg.this_endpoint, _cfg.local_dc_rack.dc, _cfg.local_dc_rack.rack);
+
+    if (set_default_location) {
+        auto dc = std::make_unique<locator::datacenter>(_cfg.local_dc_rack.dc);
+        auto rack = std::make_unique<locator::rack>(_cfg.local_dc_rack.rack);
+        _default_location = location(dc.get(), rack.get());
+        dc->racks().emplace(rack->name(), std::move(rack));
+        _datacenters.emplace(dc->name(), std::move(dc));
+    }
 }
 
 topology::topology(topology&& o) noexcept
@@ -87,6 +119,7 @@ topology::topology(topology&& o) noexcept
     , _nodes_by_endpoint(std::move(o._nodes_by_endpoint))
     , _sort_by_proximity(o._sort_by_proximity)
     , _datacenters(std::move(o._datacenters))
+    , _default_location(std::exchange(o._default_location, location{}))
 {
     assert(_shard == this_shard_id());
     tlogger.trace("topology[{}]: move from [{}]", fmt::ptr(this), fmt::ptr(&o));
@@ -107,18 +140,26 @@ topology& topology::operator=(topology&& o) noexcept {
 }
 
 future<topology> topology::clone_gently() const {
-    topology ret(_cfg);
+    topology ret(_cfg, set_default_location::no);
     tlogger.debug("topology[{}]: clone_gently to {} from shard {}", fmt::ptr(this), fmt::ptr(&ret), _shard);
     // Copy the dc/rack tree structure to preserve their respective id:s
     // The nodes are added and indexed one at a time below
     for (const auto& [dc_name, dc] : _datacenters) {
         auto new_dc = std::make_unique<datacenter>(dc->name(), dc->id());
+        if (_default_location.dc() == dc.get()) {
+            ret._default_location.set_dc(new_dc.get());
+        }
         for (const auto& [rack_name, rack] : dc->racks()) {
-            if (!rack->empty()) {
+            if (!rack->empty() || _default_location.rack() == rack.get()) {
                 auto new_rack = std::make_unique<locator::rack>(rack->name(), rack->id());
+                if (_default_location.rack() == rack.get()) {
+                    ret._default_location.set_rack(new_rack.get());
+                }
                 new_dc->_racks.emplace(new_rack->name(), std::move(new_rack));
             }
+            co_await coroutine::maybe_yield();
         }
+        // Note that the default dc must have at least one rack
         if (!new_dc->racks().empty()) {
             ret._datacenters.emplace(new_dc->name(), std::move(new_dc));
         }
@@ -137,8 +178,24 @@ std::string topology::debug_format(const node* node) {
     if (!node) {
         return format("node={}", fmt::ptr(node));
     }
+    const auto& loc = node->location();
+    auto dc_rack = endpoint_dc_rack{
+        .dc = loc.dc() ? loc.dc()->name() : "(null)",
+        .rack = loc.rack() ? loc.rack()->name() : "(null)"
+    };
     return format("node={} idx={} host_id={} endpoint={} dc={} rack={} state={} shards={} this_node={}", fmt::ptr(node),
-            node->idx(), node->host_id(), node->endpoint(), node->dc_rack().dc, node->dc_rack().rack, node::to_string(node->get_state()), node->get_shard_count(), bool(node->is_this_node()));
+            node->idx(), node->host_id(), node->endpoint(), dc_rack.dc, dc_rack.rack, node::to_string(node->get_state()), node->get_shard_count(), bool(node->is_this_node()));
+}
+
+endpoint_dc_rack location::get_dc_rack() const {
+     return endpoint_dc_rack{
+        .dc = _dc ? _dc->name() : endpoint_dc_rack::default_location.dc,
+        .rack = _rack ? _rack->name() : endpoint_dc_rack::default_location.rack
+     };
+ }
+ 
+endpoint_dc_rack node::dc_rack() const {
+    return _location.get_dc_rack();
 }
 
 const node* topology::add_node(host_id id, const inet_address& ep, const endpoint_dc_rack& dr, node::state state, shard_id shard_count) {
@@ -233,14 +290,15 @@ const node* topology::update_node(node* node, std::optional<host_id> opt_id, std
             opt_ep.reset();
         }
     }
+    auto node_dc_rack = node->dc_rack();
     if (opt_dr) {
         if (opt_dr->dc.empty() || opt_dr->dc == production_snitch_base::default_dc) {
-            opt_dr->dc = node->dc_rack().dc;
+            opt_dr->dc = node_dc_rack.dc;
         }
         if (opt_dr->rack.empty() || opt_dr->rack == production_snitch_base::default_rack) {
-            opt_dr->rack = node->dc_rack().rack;
+            opt_dr->rack = node_dc_rack.rack;
         }
-        if (*opt_dr != node->dc_rack()) {
+        if (*opt_dr != node_dc_rack) {
             changed = true;
         }
     }
@@ -258,7 +316,7 @@ const node* topology::update_node(node* node, std::optional<host_id> opt_id, std
     // Populate opt_dr even if it is set for update.
     // It is used for reindexing the node below.
     if (!opt_dr) {
-        opt_dr = node->dc_rack();
+        opt_dr = std::move(node_dc_rack);
     }
 
     unindex_node(node);
@@ -339,39 +397,37 @@ void topology::index_node(node* node, const endpoint_dc_rack& dr) {
         }
     }
 
-    endpoint_dc_rack loc = dr;
+    location loc;
     if (dr.dc.empty() || dr.dc == production_snitch_base::default_dc) {
-        loc.dc = _cfg.local_dc_rack.dc;
+        loc.set_dc(_default_location.dc());
         if (dr.rack.empty() || dr.rack == production_snitch_base::default_rack) {
-            loc.rack = _cfg.local_dc_rack.rack;
+            loc.set_rack(_default_location.rack());
         }
-    }
-
-    datacenter* dc = nullptr;
-    if (auto dc_it = _datacenters.find(loc.dc); dc_it != _datacenters.end()) {
-        dc = const_cast<datacenter*>(dc_it->second.get());
+    } else if (auto it = _datacenters.find(dr.dc); it != _datacenters.end()) {
+        loc.set_dc(it->second.get());
     } else {
-        auto new_dc = std::make_unique<datacenter>(loc.dc);
-        dc = new_dc.get();
+        auto new_dc = std::make_unique<datacenter>(dr.dc);
+        loc.set_dc(new_dc.get());
         _datacenters.emplace(new_dc->name(), std::move(new_dc));
     }
 
-    rack* rack = nullptr;
-    if (auto rack_it = dc->racks().find(loc.rack); rack_it != dc->racks().end()) {
-        rack = const_cast<locator::rack*>(rack_it->second.get());
-    } else {
-        auto new_rack = std::make_unique<locator::rack>(loc.rack);
-        rack = new_rack.get();
-        dc->racks().emplace(new_rack->name(), std::move(new_rack));
+    if (!loc.rack()) {
+        if (auto it = loc.dc()->racks().find(dr.rack); it != loc.dc()->racks().end()) {
+            loc.set_rack(it->second.get());
+        } else {
+            auto new_rack = std::make_unique<locator::rack>(dr.rack);
+            loc.set_rack(new_rack.get());
+            const_cast<datacenter*>(loc.dc())->racks().emplace(new_rack->name(), std::move(new_rack));
+        }
     }
 
     // Provide strong exception safety guarantees.
     // No exceptions are allowed after insertion of node succeeded
     // Note: it is okay to leave behind empty dc/rack since they are ignored
-    rack->nodes().insert(node);
+    const_cast<rack*>(loc.rack())->nodes().insert(node);
 
     try {
-        node->_dc_rack = std::move(loc);
+        node->_location = std::move(loc);
 
         if (node->is_this_node()) {
             _this_node = node;
@@ -386,21 +442,17 @@ void topology::unindex_node(const node* node) {
         tlogger.trace("topology[{}]: unindex_node: {}, at {}", fmt::ptr(this), debug_format(node), current_backtrace());
     }
 
-    const auto& dc_name = node->dc_rack().dc;
-    const auto& rack_name = node->dc_rack().rack;
-    if (auto dc_it = _datacenters.find(dc_name); dc_it != _datacenters.end()) {
-        auto& dc = const_cast<datacenter&>(*dc_it->second);
-        auto& racks = dc.racks();
-        if (auto rack_it = racks.find(rack_name); rack_it != racks.end()) {
-            auto& rack = const_cast<locator::rack&>(*rack_it->second);
-            auto& nodes = rack.nodes();
-            nodes.erase(node);
-            if (nodes.empty()) {
-                racks.erase(rack_it);
+    // Keep the default dc and rack even if empty
+    // since _default_location points to them
+    if (auto* dc = const_cast<datacenter*>(node->location().dc())) {
+        if (auto* r = const_cast<rack*>(node->location().rack())) {
+            r->nodes().erase(node);
+            if (r != _default_location.rack() && r->empty()) {
+                dc->racks().erase(r->name());
             }
         }
-        if (racks.empty()) {
-            _datacenters.erase(dc_it);
+        if (dc != _default_location.dc() && dc->empty()) {
+            _datacenters.erase(dc->name());
         }
     }
     auto host_it = _nodes_by_host_id.find(node->host_id());

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -14,6 +14,7 @@
 #include "log.hh"
 #include "locator/topology.hh"
 #include "locator/production_snitch_base.hh"
+#include "locator/types.hh"
 #include "utils/stall_free.hh"
 
 namespace locator {
@@ -25,23 +26,22 @@ thread_local const endpoint_dc_rack endpoint_dc_rack::default_location = {
     .rack = locator::production_snitch_base::default_rack,
 };
 
-node::node(const locator::topology* topology, locator::host_id id, inet_address endpoint, endpoint_dc_rack dc_rack, state state, shard_id shard_count, this_node is_this_node, node::idx_type idx)
+node::node(const locator::topology* topology, locator::host_id id, inet_address endpoint, state state, shard_id shard_count, this_node is_this_node, node::idx_type idx)
     : _topology(topology)
     , _host_id(id)
     , _endpoint(endpoint)
-    , _dc_rack(std::move(dc_rack))
     , _state(state)
     , _shard_count(std::move(shard_count))
     , _is_this_node(is_this_node)
     , _idx(idx)
 {}
 
-node_holder node::make(const locator::topology* topology, locator::host_id id, inet_address endpoint, endpoint_dc_rack dc_rack, state state, shard_id shard_count, node::this_node is_this_node, node::idx_type idx) {
-    return std::make_unique<node>(topology, std::move(id), std::move(endpoint), std::move(dc_rack), std::move(state), shard_count, is_this_node, idx);
+node_holder node::make(const locator::topology* topology, locator::host_id id, inet_address endpoint, state state, shard_id shard_count, node::this_node is_this_node, node::idx_type idx) {
+    return std::make_unique<node>(topology, std::move(id), std::move(endpoint), std::move(state), shard_count, is_this_node, idx);
 }
 
 node_holder node::clone() const {
-    return make(nullptr, host_id(), endpoint(), dc_rack(), get_state(), get_shard_count(), is_this_node());
+    return make(nullptr, host_id(), endpoint(), get_state(), get_shard_count(), is_this_node());
 }
 
 std::string node::to_string(node::state s) {
@@ -116,7 +116,7 @@ future<topology> topology::clone_gently() const {
     tlogger.debug("topology[{}]: clone_gently to {} from shard {}", fmt::ptr(this), fmt::ptr(&ret), _shard);
     for (const auto& nptr : _nodes) {
         if (nptr) {
-            ret.add_node(nptr->clone());
+            ret.add_node(nptr->clone(), nptr->dc_rack());
         }
         co_await coroutine::maybe_yield();
     }
@@ -133,10 +133,7 @@ std::string topology::debug_format(const node* node) {
 }
 
 const node* topology::add_node(host_id id, const inet_address& ep, const endpoint_dc_rack& dr, node::state state, shard_id shard_count) {
-    if (dr.dc.empty() || dr.rack.empty()) {
-        on_internal_error(tlogger, "Node must have valid dc and rack");
-    }
-    return add_node(node::make(this, id, ep, dr, state, shard_count));
+    return add_node(node::make(this, id, ep, state, shard_count), dr);
 }
 
 bool topology::is_configured_this_node(const node& n) const {
@@ -149,8 +146,8 @@ bool topology::is_configured_this_node(const node& n) const {
     return false; // No selection;
 }
 
-const node* topology::add_node(node_holder nptr) {
-    const node* node = nptr.get();
+const node* topology::add_node(node_holder nptr, const endpoint_dc_rack& dr) {
+    node* node = nptr.get();
 
     if (nptr->topology() != this) {
         if (nptr->topology()) {
@@ -174,16 +171,13 @@ const node* topology::add_node(node_holder nptr) {
             }
             locator::node& n = *_nodes.back();
             n._is_this_node = node::this_node::yes;
-            if (n._dc_rack == endpoint_dc_rack::default_location) {
-                n._dc_rack = _cfg.local_dc_rack;
-            }
         }
 
         if (tlogger.is_enabled(log_level::debug)) {
             tlogger.debug("topology[{}]: add_node: {}, at {}", fmt::ptr(this), debug_format(node), current_backtrace());
         }
 
-        index_node(node);
+        index_node(node, dr);
     } catch (...) {
         pop_node(make_mutable(node));
         throw;
@@ -239,8 +233,6 @@ const node* topology::update_node(node* node, std::optional<host_id> opt_id, std
         }
         if (*opt_dr != node->dc_rack()) {
             changed = true;
-        } else {
-            opt_dr.reset();
         }
     }
     if (opt_st) {
@@ -254,6 +246,12 @@ const node* topology::update_node(node* node, std::optional<host_id> opt_id, std
         return node;
     }
 
+    // Populate opt_dr even if it is set for update.
+    // It is used for reindexing the node below.
+    if (!opt_dr) {
+        opt_dr = node->dc_rack();
+    }
+
     unindex_node(node);
     // The following block must not throw
     try {
@@ -264,9 +262,6 @@ const node* topology::update_node(node* node, std::optional<host_id> opt_id, std
         if (opt_ep) {
             mutable_node->_endpoint = *opt_ep;
         }
-        if (opt_dr) {
-            mutable_node->_dc_rack = std::move(*opt_dr);
-        }
         if (opt_st) {
             mutable_node->set_state(*opt_st);
         }
@@ -276,7 +271,7 @@ const node* topology::update_node(node* node, std::optional<host_id> opt_id, std
     } catch (...) {
         std::terminate();
     }
-    index_node(node);
+    index_node(node, *opt_dr);
     return node;
 }
 
@@ -294,9 +289,9 @@ void topology::remove_node(const node* node) {
     pop_node(node);
 }
 
-void topology::index_node(const node* node) {
+void topology::index_node(node* node, const endpoint_dc_rack& dr) {
     if (tlogger.is_enabled(log_level::trace)) {
-        tlogger.trace("topology[{}]: index_node: {}, at {}", fmt::ptr(this), debug_format(node), current_backtrace());
+        tlogger.trace("topology[{}]: index_node: {} into dc={} rack={}, at {}", fmt::ptr(this), debug_format(node), dr.dc, dr.rack, current_backtrace());
     }
 
     if (node->idx() < 0) {
@@ -335,14 +330,24 @@ void topology::index_node(const node* node) {
         }
     }
 
-    const auto& dc = node->dc_rack().dc;
-    const auto& rack = node->dc_rack().rack;
+    endpoint_dc_rack loc = dr;
+    if (dr.dc.empty() || dr.dc == production_snitch_base::default_dc) {
+        loc.dc = _cfg.local_dc_rack.dc;
+        if (dr.rack.empty() || dr.rack == production_snitch_base::default_rack) {
+            loc.rack = _cfg.local_dc_rack.rack;
+        }
+    }
     const auto& endpoint = node->endpoint();
+    // FIXME: provide storing exception safety guarantees
+    auto& dc = loc.dc;
+    auto& rack = loc.rack;
     _dc_nodes[dc].emplace(node);
     _dc_rack_nodes[dc][rack].emplace(node);
     _dc_endpoints[dc].insert(endpoint);
     _dc_racks[dc][rack].insert(endpoint);
     _datacenters.insert(dc);
+
+    node->_dc_rack = std::move(loc);
 
     if (node->is_this_node()) {
         _this_node = node;

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -571,9 +571,9 @@ bool topology::has_endpoint(inet_address ep) const
     return has_node(ep);
 }
 
-endpoint_dc_rack topology::get_location(const inet_address& ep) const {
+const location topology::get_location(const inet_address& ep) const noexcept {
     if (auto node = find_node(ep)) {
-        return node->dc_rack();
+        return node->location();
     }
     // We should do the following check after lookup in nodes.
     // In tests, there may be no config for local node, so fall back to get_location()
@@ -585,8 +585,9 @@ endpoint_dc_rack topology::get_location(const inet_address& ep) const {
     // FIXME -- this shouldn't happen. After topology is stable and is
     // correctly populated with endpoints, this should be replaced with
     // on_internal_error()
+    // However, this is still required by some unit tests, like network_topology_stratgy_test.
     tlogger.warn("Requested location for node {} not in topology. backtrace {}", ep, current_backtrace());
-    return endpoint_dc_rack::default_location;
+    return _default_location;
 }
 
 void topology::sort_by_proximity(inet_address address, inet_address_vector_replica_set& addresses) const {

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -73,7 +73,6 @@ public:
     node(const locator::topology* topology,
          locator::host_id id,
          inet_address endpoint,
-         endpoint_dc_rack dc_rack,
          state state,
          shard_id shard_count = 0,
          this_node is_this_node = this_node::no,
@@ -153,7 +152,6 @@ private:
     static node_holder make(const locator::topology* topology,
                             locator::host_id id,
                             inet_address endpoint,
-                            endpoint_dc_rack dc_rack,
                             state state,
                             shard_id shard_count = 0,
                             node::this_node is_this_node = this_node::no,
@@ -365,12 +363,12 @@ public:
 
 private:
     bool is_configured_this_node(const node&) const;
-    const node* add_node(node_holder node);
+    const node* add_node(node_holder node, const endpoint_dc_rack& dc_rack);
     void remove_node(const node* node);
 
     static std::string debug_format(const node*);
 
-    void index_node(const node* node);
+    void index_node(node* node, const endpoint_dc_rack& dr);
     void unindex_node(const node* node);
     node_holder pop_node(const node* node);
 

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -258,21 +258,21 @@ public:
      */
     bool has_endpoint(inet_address) const;
 
-    const std::unordered_map<sstring,
-                           std::unordered_set<inet_address>>&
+    std::unordered_map<sstring,
+                           std::unordered_set<inet_address>>
     get_datacenter_endpoints() const {
         return _dc_endpoints;
     }
 
-    const std::unordered_map<sstring,
-                            std::unordered_set<const node*>>&
+    std::unordered_map<sstring,
+                            std::unordered_set<const node*>>
     get_datacenter_nodes() const {
         return _dc_nodes;
     }
 
-    const std::unordered_map<sstring,
+    std::unordered_map<sstring,
                        std::unordered_map<sstring,
-                                          std::unordered_set<inet_address>>>&
+                                          std::unordered_set<inet_address>>>
     get_datacenter_racks() const {
         return _dc_racks;
     }

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -412,10 +412,7 @@ private:
 
     bool _sort_by_proximity = true;
 
-    // pre-calculated
     std::unordered_set<sstring> _datacenters;
-
-    void calculate_datacenters();
 
     const std::unordered_map<inet_address, const node*>& get_nodes_by_endpoint() const noexcept {
         return _nodes_by_endpoint;

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -277,7 +277,7 @@ public:
         return _dc_racks;
     }
 
-    const std::unordered_set<sstring>& get_datacenters() const noexcept {
+    std::unordered_set<sstring> get_datacenter_names() const noexcept {
         return _datacenters;
     }
 

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -94,7 +94,7 @@ public:
         return _endpoint;
     }
 
-    const endpoint_dc_rack& dc_rack() const noexcept {
+    endpoint_dc_rack dc_rack() const noexcept {
         return _dc_rack;
     }
 
@@ -357,45 +357,45 @@ public:
     std::unordered_set<sstring> get_datacenter_names() const;
 
     // Get dc/rack location of this node
-    const endpoint_dc_rack& get_location() const noexcept {
+    endpoint_dc_rack get_location() const {
         return _this_node ? _this_node->dc_rack() : _cfg.local_dc_rack;
     }
     // Get dc/rack location of a node identified by host_id
     // The specified node must exist.
-    const endpoint_dc_rack& get_location(host_id id) const {
+    endpoint_dc_rack get_location(host_id id) const {
         return find_node(id)->dc_rack();
     }
     // Get dc/rack location of a node identified by endpoint
     // The specified node must exist.
-    const endpoint_dc_rack& get_location(const inet_address& ep) const;
+    endpoint_dc_rack get_location(const inet_address& ep) const;
 
     // Get datacenter of this node
-    const sstring& get_datacenter() const noexcept {
+    sstring get_datacenter() const {
         return get_location().dc;
     }
     // Get datacenter of a node identified by host_id
     // The specified node must exist.
-    const sstring& get_datacenter(host_id id) const {
+    sstring get_datacenter(host_id id) const {
         return get_location(id).dc;
     }
     // Get datacenter of a node identified by endpoint
     // The specified node must exist.
-    const sstring& get_datacenter(inet_address ep) const {
+    sstring get_datacenter(inet_address ep) const {
         return get_location(ep).dc;
     }
 
     // Get rack of this node
-    const sstring& get_rack() const noexcept {
+    sstring get_rack() const {
         return get_location().rack;
     }
     // Get rack of a node identified by host_id
     // The specified node must exist.
-    const sstring& get_rack(host_id id) const {
+    sstring get_rack(host_id id) const {
         return get_location(id).rack;
     }
     // Get rack of a node identified by endpoint
     // The specified node must exist.
-    const sstring& get_rack(inet_address ep) const {
+    sstring get_rack(inet_address ep) const {
         return get_location(ep).rack;
     }
 

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -370,6 +370,8 @@ public:
 
     void for_each_datacenter(std::function<void(const datacenter*)> func) const;
 
+    future<> for_each_datacenter_gently(std::function<future<>(const datacenter*)> func) const;
+
     const datacenter* find_datacenter(sstring_view name) const noexcept;
 
     const std::unordered_map<sstring_view, std::unique_ptr<const datacenter>>& get_datacenters() const noexcept {

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -392,46 +392,49 @@ public:
     std::unordered_set<sstring> get_datacenter_names() const;
 
     // Get dc/rack location of this node
-    endpoint_dc_rack get_location() const {
-        return _this_node ? _this_node->dc_rack() : _cfg.local_dc_rack;
+    const location get_location() const noexcept {
+        if (!_this_node) {
+            return _default_location;
+        }
+        return _this_node->location();
     }
     // Get dc/rack location of a node identified by host_id
     // The specified node must exist.
-    endpoint_dc_rack get_location(host_id id) const {
-        return find_node(id)->dc_rack();
+    const location get_location(host_id id) const noexcept {
+        return find_node(id)->location();
     }
     // Get dc/rack location of a node identified by endpoint
     // The specified node must exist.
-    endpoint_dc_rack get_location(const inet_address& ep) const;
+    const location get_location(const inet_address& ep) const noexcept;
 
     // Get datacenter of this node
-    sstring get_datacenter() const {
-        return get_location().dc;
+    const datacenter* get_datacenter() const noexcept {
+        return get_location().dc();
     }
     // Get datacenter of a node identified by host_id
     // The specified node must exist.
-    sstring get_datacenter(host_id id) const {
-        return get_location(id).dc;
+    const datacenter* get_datacenter(host_id id) const noexcept {
+        return get_location(id).dc();
     }
     // Get datacenter of a node identified by endpoint
     // The specified node must exist.
-    sstring get_datacenter(inet_address ep) const {
-        return get_location(ep).dc;
+    const datacenter* get_datacenter(inet_address ep) const noexcept {
+        return get_location(ep).dc();
     }
 
     // Get rack of this node
-    sstring get_rack() const {
-        return get_location().rack;
+    const rack* get_rack() const noexcept {
+        return get_location().rack();
     }
     // Get rack of a node identified by host_id
     // The specified node must exist.
-    sstring get_rack(host_id id) const {
-        return get_location(id).rack;
+    const rack* get_rack(host_id id) const noexcept {
+        return get_location(id).rack();
     }
     // Get rack of a node identified by endpoint
     // The specified node must exist.
-    sstring get_rack(inet_address ep) const {
-        return get_location(ep).rack;
+    const rack* get_rack(inet_address ep) const noexcept {
+        return get_location(ep).rack();
     }
 
     auto get_local_dc_filter() const noexcept {

--- a/locator/util.cc
+++ b/locator/util.cc
@@ -119,8 +119,8 @@ describe_ring(const replica::database& db, const gms::gossiper& gossiper, const 
         for (auto endpoint : addresses) {
             dht::endpoint_details details;
             details._host = endpoint;
-            details._datacenter = topology.get_datacenter(endpoint);
-            details._rack = topology.get_rack(endpoint);
+            details._datacenter = topology.get_datacenter(endpoint)->name();
+            details._rack = topology.get_rack(endpoint)->name();
             tr._rpc_endpoints.push_back(gossiper.get_rpc_address(endpoint));
             tr._endpoints.push_back(fmt::to_string(details._host));
             tr._endpoint_details.push_back(details);

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -302,7 +302,7 @@ sstring messaging_service::client_metrics_domain(unsigned idx, inet_address addr
     if (_token_metadata) {
         const auto& topo = _token_metadata->get()->get_topology();
         if (topo.has_endpoint(addr)) {
-            ret += ":" + topo.get_datacenter(addr);
+            ret += ":" + topo.get_datacenter(addr)->name();
         }
     }
     return ret;

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -150,7 +150,7 @@ public:
     future<> replace_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::unordered_set<gms::inet_address> ignore_nodes);
 private:
     future<> do_decommission_removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
-    future<> do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, sstring source_dc, streaming::stream_reason reason, std::unordered_set<gms::inet_address> ignore_nodes);
+    future<> do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, const locator::datacenter* source_dc, streaming::stream_reason reason, std::unordered_set<gms::inet_address> ignore_nodes);
 
     // Must be called on shard 0
     future<> sync_data_using_repair(sstring keyspace,

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3692,7 +3692,8 @@ storage_proxy::mutate_atomically_result(std::vector<mutation> mutations, db::con
                             auto local_addr = _p.my_address();
                             auto& topology = _ermp->get_topology();
                             auto local_dc = topology.get_datacenter();
-                            auto& local_endpoints = topology.get_datacenter_racks().at(local_dc);
+                            auto dc_racks_map = topology.get_datacenter_racks();
+                            auto& local_endpoints = dc_racks_map.at(local_dc);
                             auto local_rack = topology.get_rack();
                             auto chosen_endpoints = endpoint_filter(std::bind_front(&storage_proxy::is_alive, &_p), local_addr,
                                                                     local_rack, local_endpoints);

--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -12,6 +12,7 @@
 #include "utils/estimated_histogram.hh"
 #include "utils/histogram.hh"
 #include <seastar/core/metrics.hh>
+#include "locator/topology.hh"
 
 namespace locator { class topology; }
 
@@ -31,7 +32,7 @@ private:
     // counter of operations performed on a local Node
     stats_counter _local;
     // counters of operations performed on external Nodes aggregated per Nodes' DCs
-    std::unordered_map<sstring, stats_counter> _dc_stats;
+    std::unordered_map<locator::datacenter_id, stats_counter> _dc_stats;
     // collectd registrations container
     seastar::metrics::metric_groups _metrics;
     // a prefix string that will be used for a collectd counters' description
@@ -54,7 +55,7 @@ public:
     split_stats(const sstring& category, const sstring& short_description_prefix, const sstring& long_description_prefix, const sstring& op_type, bool auto_register_metrics = true);
 
     void register_metrics_local();
-    void register_metrics_for(sstring dc, gms::inet_address ep);
+    void register_metrics_for(locator::datacenter_id dc, gms::inet_address ep);
 
     /**
      * Get a reference to the statistics counter corresponding to the given

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -444,7 +444,7 @@ public:
         migration_plan plan;
 
         // Prepare plans for each DC separately and combine them to be executed in parallel.
-        for (auto&& dc : topo.get_datacenters()) {
+        for (auto&& dc : topo.get_datacenter_names()) {
             auto dc_plan = co_await make_plan(dc);
             lblogger.info("Prepared {} migrations in DC {}", dc_plan.size(), dc);
             plan.merge(std::move(dc_plan));

--- a/test/boost/locator_topology_test.cc
+++ b/test/boost/locator_topology_test.cc
@@ -52,7 +52,6 @@ SEASTAR_THREAD_TEST_CASE(test_add_node) {
     BOOST_REQUIRE_THROW(topo.add_node(id2, ep1, endpoint_dc_rack::default_location, node::state::normal), std::runtime_error);
     BOOST_REQUIRE_THROW(topo.add_node(id2, ep2, endpoint_dc_rack::default_location, node::state::normal), std::runtime_error);
     BOOST_REQUIRE_THROW(topo.add_node(id2, ep3, endpoint_dc_rack::default_location, node::state::normal), std::runtime_error);
-    BOOST_REQUIRE_THROW(topo.add_node(id3, ep3, endpoint_dc_rack{}, node::state::normal), std::runtime_error);
 
     nodes.insert(topo.add_node(id3, ep3, endpoint_dc_rack::default_location, node::state::normal));
 

--- a/test/boost/locator_topology_test.cc
+++ b/test/boost/locator_topology_test.cc
@@ -234,17 +234,17 @@ SEASTAR_THREAD_TEST_CASE(test_remove_endpoint) {
 
     BOOST_REQUIRE_EQUAL(topo.get_datacenter_endpoints(), (dc_endpoints_t{{"dc1", {ep1, ep2}}}));
     BOOST_REQUIRE_EQUAL(topo.get_datacenter_racks(), (dc_racks_t{{"dc1", {{"rack1", {ep1}}, {"rack2", {ep2}}}}}));
-    BOOST_REQUIRE_EQUAL(topo.get_datacenters(), (dcs_t{"dc1"}));
+    BOOST_REQUIRE_EQUAL(topo.get_datacenter_names(), (dcs_t{"dc1"}));
 
     topo.remove_endpoint(id2);
     BOOST_REQUIRE_EQUAL(topo.get_datacenter_endpoints(), (dc_endpoints_t{{"dc1", {ep1}}}));
     BOOST_REQUIRE_EQUAL(topo.get_datacenter_racks(), (dc_racks_t{{"dc1", {{"rack1", {ep1}}}}}));
-    BOOST_REQUIRE_EQUAL(topo.get_datacenters(), (dcs_t{"dc1"}));
+    BOOST_REQUIRE_EQUAL(topo.get_datacenter_names(), (dcs_t{"dc1"}));
 
     topo.remove_endpoint(id1);
     BOOST_REQUIRE_EQUAL(topo.get_datacenter_endpoints(), (dc_endpoints_t{}));
     BOOST_REQUIRE_EQUAL(topo.get_datacenter_racks(), (dc_racks_t{}));
-    BOOST_REQUIRE_EQUAL(topo.get_datacenters(), (dcs_t{}));
+    BOOST_REQUIRE_EQUAL(topo.get_datacenter_names(), (dcs_t{}));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_load_sketch) {

--- a/test/boost/locator_topology_test.cc
+++ b/test/boost/locator_topology_test.cc
@@ -131,14 +131,14 @@ SEASTAR_THREAD_TEST_CASE(test_update_node) {
     auto dc_rack1 = endpoint_dc_rack{"DC1", "RACK1"};
     node = topo.update_node(mutable_node, std::nullopt, std::nullopt, dc_rack1, std::nullopt);
     mutable_node = const_cast<locator::node*>(node);
-    BOOST_REQUIRE(topo.get_location(id1) == dc_rack1);
-    BOOST_REQUIRE(topo.get_location(ep1) == dc_rack1);
+    BOOST_REQUIRE(topo.get_location(id1).get_dc_rack() == dc_rack1);
+    BOOST_REQUIRE(topo.get_location(ep1).get_dc_rack() == dc_rack1);
 
     auto dc_rack2 = endpoint_dc_rack{"DC2", "RACK2"};
     node = topo.update_node(mutable_node, std::nullopt, std::nullopt, dc_rack2, std::nullopt);
     mutable_node = const_cast<locator::node*>(node);
-    BOOST_REQUIRE(topo.get_location(id1) == dc_rack2);
-    BOOST_REQUIRE(topo.get_location(ep1) == dc_rack2);
+    BOOST_REQUIRE(topo.get_location(id1).get_dc_rack() == dc_rack2);
+    BOOST_REQUIRE(topo.get_location(ep1).get_dc_rack() == dc_rack2);
 
     BOOST_REQUIRE_NE(node->get_state(), locator::node::state::being_decommissioned);
     node = topo.update_node(mutable_node, std::nullopt, std::nullopt, std::nullopt, locator::node::state::being_decommissioned);
@@ -154,9 +154,10 @@ SEASTAR_THREAD_TEST_CASE(test_update_node) {
     BOOST_REQUIRE_EQUAL(topo.find_node(ep1), nullptr);
     BOOST_REQUIRE_EQUAL(topo.find_node(ep2), nullptr);
     BOOST_REQUIRE_EQUAL(topo.find_node(ep3), node);
-    BOOST_REQUIRE(topo.get_location(id1) == dc_rack3);
-    BOOST_REQUIRE(topo.get_location(ep2) == endpoint_dc_rack::default_location);
-    BOOST_REQUIRE(topo.get_location(ep3) == dc_rack3);
+    BOOST_REQUIRE(topo.get_location(id1).get_dc_rack() == dc_rack3);
+    BOOST_REQUIRE(!topo.get_location(ep1));
+    BOOST_REQUIRE(!topo.get_location(ep2));
+    BOOST_REQUIRE(topo.get_location(ep3).get_dc_rack() == dc_rack3);
     BOOST_REQUIRE_EQUAL(node->get_state(), locator::node::state::being_decommissioned);
 
     // In state::left the node will remain indexed only by its host_id
@@ -165,9 +166,10 @@ SEASTAR_THREAD_TEST_CASE(test_update_node) {
     BOOST_REQUIRE_EQUAL(topo.find_node(ep1), nullptr);
     BOOST_REQUIRE_EQUAL(topo.find_node(ep2), nullptr);
     BOOST_REQUIRE_EQUAL(topo.find_node(ep3), nullptr);
-    BOOST_REQUIRE(topo.get_location(id1) == dc_rack3);
-    BOOST_REQUIRE(topo.get_location(ep2) == endpoint_dc_rack::default_location);
-    BOOST_REQUIRE(topo.get_location(ep3) == endpoint_dc_rack::default_location);
+    BOOST_REQUIRE(topo.get_location(id1).get_dc_rack() == dc_rack3);
+    BOOST_REQUIRE(!topo.get_location(ep1));
+    BOOST_REQUIRE(!topo.get_location(ep2));
+    BOOST_REQUIRE(!topo.get_location(ep3));
     BOOST_REQUIRE_EQUAL(node->get_state(), locator::node::state::left);
 }
 

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -888,7 +888,7 @@ SEASTAR_THREAD_TEST_CASE(test_topology_tracks_local_node) {
     BOOST_REQUIRE(!bool(n2->is_this_node()));
     BOOST_REQUIRE_EQUAL(n2->host_id(), host2);
     BOOST_REQUIRE_EQUAL(n2->endpoint(), ip2);
-    BOOST_REQUIRE(n2->dc_rack() == endpoint_dc_rack::default_location);
+    BOOST_REQUIRE(n2->dc_rack() == ip1_dc_rack);
 
     // Removing local node
 
@@ -936,7 +936,7 @@ SEASTAR_THREAD_TEST_CASE(test_topology_tracks_local_node) {
     BOOST_REQUIRE(!bool(n2->is_this_node()));
     BOOST_REQUIRE_EQUAL(n2->host_id(), host2);
     BOOST_REQUIRE_EQUAL(n2->endpoint(), ip2);
-    BOOST_REQUIRE(n2->dc_rack() == endpoint_dc_rack::default_location);
+    BOOST_REQUIRE(n2->dc_rack() == ip1_dc_rack);
 
     // get_location() should pick up endpoint_dc_rack from node info
 

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -99,7 +99,7 @@ void endpoints_check(
     const inet_address_vector_replica_set& endpoints,
     const locator::topology& topo) {
 
-    auto&& nodes_per_dc = tm->get_topology().get_datacenter_endpoints();
+    auto nodes_per_dc = tm->get_topology().get_datacenter_endpoints();
     const network_topology_strategy* nts_ptr =
             dynamic_cast<const network_topology_strategy*>(ars_ptr.get());
 

--- a/test/boost/storage_proxy_test.cc
+++ b/test/boost/storage_proxy_test.cc
@@ -8,6 +8,7 @@
 
 
 #include <seastar/core/thread.hh>
+#include "locator/topology.hh"
 #include "test/lib/scylla_test_case.hh"
 
 #include "test/lib/cql_test_env.hh"
@@ -129,6 +130,7 @@ SEASTAR_THREAD_TEST_CASE(test_split_stats) {
     // Point being is that either the above should not happen, or 
     // split_stats should be resilient to being called from different
     // scheduling group.
-    stats1->register_metrics_for("DC1", ep1);
-    stats2->register_metrics_for("DC1", ep1);
+    auto dc_id = locator::datacenter_id::create_random_id();
+    stats1->register_metrics_for(dc_id, ep1);
+    stats2->register_metrics_for(dc_id, ep1);
 }


### PR DESCRIPTION
Instead of index the nodes into racks and datacenters using their names,
keep a map of `datacenter` objects, indexed by name, each holding a map of `rack` objects,
also index by name, each holding an unordered set of `node` objects.

This structured organization of datacenters and racks allows more efficient lookups using naked `const datacenter*` pointers.  Also, this series adds iteration helpers like `topology::for_each_datacenter`, `datacenter::for_each_rack`, and `{datacenter,rack}::for_each_node` to help callers traverse the topology efficiently.

perf-simple-query results:

**Before** (f990ea9678)
median 1478908.07 tps ( 64.3 allocs/op,  17.6 tasks/op,   52804 insns/op,        0 errors)
median absolute deviation: 5123.42
maximum: 1489368.29
minimum: 1408047.93

**After** (44f3d1d196)
median 2157285.39 tps ( 64.1 allocs/op,  17.2 tasks/op,   44715 insns/op,        0 errors)
median absolute deviation: 8909.33
maximum: 2211432.07
minimum: 2127760.95
