### PR TITLE
test/cql-pytest: avoid spurious guardrail warnings

### DIFF
--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -325,6 +325,8 @@ def run_scylla_cmd(pid, dir):
         '--shutdown-announce-in-ms', '0',
         '--maintenance-socket', 'workdir',
         '--service-levels-interval-ms', '500',
+        # Avoid unhelpful "guardrails" warnings
+        '--minimum-replication-factor-warn-threshold', '-1',
         ], env)
 
 # Same as run_scylla_cmd, just use SSL encryption for the CQL port (same


### PR DESCRIPTION
All cql-pytest tests use one node, and unsuprisingly most use RF=1. By default, as part of the "guardrails" feature, we print a warning when creating a keyspace with RF=1. This warning gets printed on every cql-pytest run, which creates a "boy who cried wolf" effect whereby developers get used to seeing these warnings, and won't care if new warnings start appearing.

The fix is easy - in run.py start Scylla with minimum-replication-factor- warn-threshold set to -1 instead of the default 3.

Note that we do have cql-pytest tests for this guardrail, but those don't rely on the default setting of this variable (they can't, cql-pytest tests can also be run on a Scylla instance run manually by a developer). Those tests temporarily set the threshold during the test.