### PR TITLE
test: test_topology_recovery_basic: add missing driver reconnect

### DIFF
--- a/test/topology_experimental_raft/test_topology_recovery_basic.py
+++ b/test/topology_experimental_raft/test_topology_recovery_basic.py
@@ -45,6 +45,7 @@ async def test_topology_recovery_basic(request, manager: ManagerClient):
     logging.info(f"Restarting hosts {hosts}")
     for srv in servers:
         await restart(manager, srv)
+    cql = await reconnect_driver(manager)
 
     logging.info("Cluster restarted, waiting until driver reconnects to every server")
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)


### PR DESCRIPTION
Unfortunately, scylladb/python-driver#230 is not fixed yet, so it is necessary for the sake of our CI's stability to re-create the driver session after all nodes in the cluster are restarted.

There is one place in test_topology_recovery_basic where all nodes are restarted but the driver session is not re-created. Even though nodes are not restarted at once but rather sequentially, we observed a failure with similar symptoms in a CI run for scylla-enterprise.

Add the missing driver reconnect as a workaround for the issue.

Fixes: scylladb/scylladb#17277