### PR TITLE
docs: trigger the docs-pages workflow on release branches

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - 'master'
       - 'enterprise'
+      - 'branch-**'
     paths:
       - "docs/**"
   workflow_dispatch:

--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -4,6 +4,7 @@ name: "Docs / Publish"
 
 env:
   FLAG: ${{ github.repository == 'scylladb/scylla-enterprise' && 'enterprise' || 'opensource' }}
+  DEFAULT_BRANCH: ${{ github.repository == 'scylladb/scylla-enterprise' && 'enterprise' || 'master' }}
 
 on:
   push:
@@ -22,6 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          ref: ${{ env.DEFAULT_BRANCH }}
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Python


### PR DESCRIPTION
Currently, the github docs-pages workflow is triggered only when changes are merged to the master/enterprise branches, which means that in the case of changes to a release branch, for example, a fix to branch-5.4, or a branch-5.4>branch-2024.1 merge, the docs-pages is not triggering and therefore the documentation is not updated with the new change,

In this change, I added the `branch-**` pattern, so changes to release branches will trigger the workflow