### PR TITLE
tree: remove unnecessary yields around for_each_tablet()

### DIFF
--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -76,7 +76,6 @@ public:
             auto& tmap = tmap_;
             co_await tmap.for_each_tablet([&] (tablet_id tid, const tablet_info& ti) -> future<> {
                 for (auto&& replica : get_replicas_for_tablet_load(ti, tmap.get_tablet_transition_info(tid))) {
-                    co_await coroutine::maybe_yield();
                     if (host && *host != replica.host) {
                         continue;
                     }
@@ -88,6 +87,7 @@ public:
                         n._shards[replica.shard].load += 1;
                     }
                 }
+                return make_ready_future<>();
             });
         }
         for (auto&& n : _nodes) {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -454,11 +454,11 @@ future<bool> check_tablet_replica_shards(const tablet_metadata& tm, host_id this
     for (const auto& [table_id, tmap] : tm.all_tables()) {
         co_await tmap.for_each_tablet([this_host, &valid] (locator::tablet_id tid, const tablet_info& tinfo) -> future<> {
             for (const auto& replica : tinfo.replicas) {
-                co_await coroutine::maybe_yield();
                 if (replica.host == this_host) {
                     valid &= replica.shard < smp::count;
                 }
             }
+            return make_ready_future<>();
         });
         if (!valid) {
             break;

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -2071,7 +2071,6 @@ future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_nam
             shard_id master_shard_id;
             // Repair all tablets belong to this node
             for (auto& r : replicas) {
-                co_await coroutine::maybe_yield();
                 if (r.host == myhostid) {
                     master_shard_id = r.shard;
                     found = true;
@@ -2084,6 +2083,7 @@ future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_nam
             if (found) {
                 metas.push_back(repair_tablet_meta{id, range, myhostid, master_shard_id, replicas});
             }
+            return make_ready_future<>();
         });
 
         size_t nr = 0;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4661,7 +4661,6 @@ storage_service::describe_ring_for_table(const sstring& keyspace_name, const sst
             tr._end_token = range.end()->value().to_sstring();
         }
         for (auto& r : replicas) {
-            co_await coroutine::maybe_yield();
             dht::endpoint_details details;
             auto& hostid = r.host;
             auto endpoint = host2ip(hostid);
@@ -4673,6 +4672,7 @@ storage_service::describe_ring_for_table(const sstring& keyspace_name, const sst
             tr._endpoint_details.push_back(std::move(details));
         }
         ranges.push_back(std::move(tr));
+        return make_ready_future<>();
     });
     co_return ranges;
 }

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -636,7 +636,6 @@ public:
                 // We reflect migrations in the load as if they already happened,
                 // optimistically assuming that they will succeed.
                 for (auto&& replica : get_replicas_for_tablet_load(ti, trinfo)) {
-                    co_await coroutine::maybe_yield();
                     if (nodes.contains(replica.host)) {
                         nodes[replica.host].tablet_count += 1;
                         // This invariant is assumed later.
@@ -646,6 +645,8 @@ public:
                         }
                     }
                 }
+
+                return make_ready_future<>();
             });
         }
 
@@ -767,7 +768,6 @@ public:
                 }
 
                 for (auto&& replica : get_replicas_for_tablet_load(ti, trinfo)) {
-                    co_await coroutine::maybe_yield();
                     if (!nodes.contains(replica.host)) {
                         continue;
                     }
@@ -781,6 +781,8 @@ public:
                         shard_load_info.candidates.emplace(global_tablet_id {table, tid});
                     }
                 }
+
+                return make_ready_future<>();
             });
         }
 

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1019,7 +1019,7 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_two_racks) {
                 auto rack1 = tm->get_topology().get_rack(tinfo.replicas[0].host);
                 auto rack2 = tm->get_topology().get_rack(tinfo.replicas[1].host);
                 BOOST_REQUIRE(rack1 != rack2);
-                co_return;
+                return make_ready_future<>();
             }).get();
         }
     }).get();


### PR DESCRIPTION
Commit 904bafd069a5fc94e473113ff9fb8703f433a8e5 consolidated the two existing for_each_tablet() overloads, to the one which has a future<> returning callback. It also added yields to the bodies of said callbacks. This is unnecessary, the loop in for_each_tablet() already has a yield per tablet, which should be enough to prevent stalls.

This patch is a follow-up to #17118