### PR TITLE
Regenerate frozen toolchain

### DIFF
--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-38-20240117
+docker.io/scylladb/scylla-toolchain:fedora-38-20240212


### PR DESCRIPTION
For gnutls 3.8.3 and clang clang-16.0.6-4.

Fixes #17285.