### PR TITLE
collection_mutation: add formatter for collection_mutation_view::printer

### DIFF
--- a/collection_mutation.hh
+++ b/collection_mutation.hh
@@ -101,7 +101,7 @@ public:
     public:
         printer(const abstract_type& type, const collection_mutation_view& cmv)
                 : _type(type), _cmv(cmv) {}
-        friend std::ostream& operator<<(std::ostream& os, const printer& cmvp);
+        friend fmt::formatter<printer>;
     };
 };
 
@@ -130,3 +130,9 @@ collection_mutation difference(const abstract_type&, collection_mutation_view, c
 
 // Serializes the given collection of cells to a sequence of bytes ready to be sent over the CQL protocol.
 bytes_ostream serialize_for_cql(const abstract_type&, collection_mutation_view);
+
+template <>
+struct fmt::formatter<collection_mutation_view::printer> : fmt::formatter<std::string_view> {
+    auto format(const collection_mutation_view::printer&, fmt::format_context& ctx) const
+      -> decltype(ctx.out());
+};

--- a/mutation/atomic_cell.cc
+++ b/mutation/atomic_cell.cc
@@ -234,7 +234,7 @@ std::ostream& operator<<(std::ostream& os, const atomic_cell_or_collection::prin
     if (p._cdef.type->is_multi_cell()) {
         os << "collection ";
         auto cmv = p._cell.as_collection_mutation();
-        os << collection_mutation_view::printer(*p._cdef.type, cmv);
+        fmt::print(os, "{}", collection_mutation_view::printer(*p._cdef.type, cmv));
     } else {
         fmt::print(os, "{}", atomic_cell_view::printer(*p._cdef.type, p._cell.as_atomic_cell(p._cdef)));
     }


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for
`collection_mutation_view::printer`, and drop its
operator<<.

Refs #13245