### PR TITLE
raft: add formatter for raft::log

### DIFF
--- a/raft/log.cc
+++ b/raft/log.cc
@@ -276,13 +276,10 @@ size_t log::apply_snapshot(snapshot_descriptor&& snp, size_t max_trailing_entrie
     return released_memory;
 }
 
-std::ostream& operator<<(std::ostream& os, const log& l) {
-    os << "first idx: " << l._first_idx << ", ";
-    os << "last idx: " << l.last_idx() << ", ";
-    os << "next idx: " << l.next_idx() << ", ";
-    os << "stable idx: " << l.stable_idx() << ", ";
-    os << "last term: " << l.last_term();
-    return os;
-}
-
 } // end of namespace raft
+
+auto fmt::formatter<raft::log>::format(const raft::log& log, fmt::format_context& ctx) const
+    -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "first idx: {}, last idx: {}, next idx: {}, stable idx: {}, last term: {}",
+                          log._first_idx, log.last_idx(), log.next_idx(), log.stable_idx(), log.last_term());
+}

--- a/raft/log.hh
+++ b/raft/log.hh
@@ -185,7 +185,7 @@ public:
     // @retval return an index of last appended entry
     index_t maybe_append(std::vector<log_entry_ptr>&& entries);
 
-    friend std::ostream& operator<<(std::ostream& os, const log& l);
+    friend fmt::formatter<log>;
 
     // The log keeps track of the memory it uses. This function returns the number
     // of bytes that will be marked as used when a log_entry is added to the log.
@@ -215,3 +215,7 @@ public:
 };
 
 }
+
+template <> struct fmt::formatter<raft::log> : fmt::formatter<std::string_view> {
+    auto format(const raft::log&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `raft::log`, and drop its operator<<.

Refs #13245