### PR TITLE
Typos: more/less then -> more/less than

### DIFF
--- a/docs/dev/IDL.md
+++ b/docs/dev/IDL.md
@@ -167,7 +167,7 @@ functions. In case `[[with_timeout]]` attribute is set, the argument list is ext
 beginning of the parameter list to specify an RPC timeout when sending or handling the message.
 
 The return value type is calculated as `future<return_type>` if only one type is present and
-`future<rpc::tuple<type1, type2, ...>>` if there are more then one. It is used as return type for message handler and `send`
+`future<rpc::tuple<type1, type2, ...>>` if there are more than one. It is used as return type for message handler and `send`
 function. If the `-> return type` clause is omitted, the return type is assumed to be `future<>`. If `[[one_way]]`
 attribute is specified, handler function return type is fixed to `future<rpc::no_wait_type>`, and the return type
 clause should not be used, otherwise an exception will be thrown during  IDL generation process.

--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -871,7 +871,7 @@ the usual suspects. Sometimes just looking at these is enough to
 determine what is the cause of the OOM. If not, one has to look at the
 last section: the dump of the state of the small pools and the page
 spans. What we are looking for is a small pool or a span size that owns
-excessive amounts of memory. Once found (there can be more then one) the
+excessive amounts of memory. Once found (there can be more than one) the
 next task is to identify what the objects owning that memory are. Note
 that in the case of smaller allocations, the memory is usually occupied
 directly by some C++ object, why in the case of larger allocations, these are

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5193,7 +5193,7 @@ public:
                         auto delta = int64_t(digest_resolver->last_modified()) - int64_t(exec->_cmd->read_timestamp);
                         if (std::abs(delta) <= write_timeout) {
                             exec->_proxy->get_stats().global_read_repairs_canceled_due_to_concurrent_write++;
-                            // if CL is local and non matching data is modified less then write_timeout ms ago do only local repair
+                            // if CL is local and non matching data is modified less than write_timeout ms ago do only local repair
                             auto local_dc_filter = exec->_effective_replication_map_ptr->get_topology().get_local_dc_filter();
                             auto i = boost::range::remove_if(exec->_targets, std::not_fn(std::cref(local_dc_filter)));
                             exec->_targets.erase(i, exec->_targets.end());

--- a/tools/schema_loader.hh
+++ b/tools/schema_loader.hh
@@ -36,7 +36,7 @@ future<std::vector<schema_ptr>> load_schemas(const db::config& dbcfg, std::strin
 
 /// Load exactly one schema from the specified path
 ///
-/// If the file at the specified path contains more or less then one schema,
+/// If the file at the specified path contains more or less than one schema,
 /// an exception will be thrown. See \ref load_schemas().
 future<schema_ptr> load_one_schema_from_file(const db::config& dbcfg, std::filesystem::path path);
 


### PR DESCRIPTION
Fix repated typos in comments: more then -> more than, less then -> less than