### PR TITLE
cql_server::connection: process: rebounce msg if needed

### DIFF
--- a/transport/server.cc
+++ b/transport/server.cc
@@ -999,14 +999,13 @@ cql_server::connection::process(uint16_t stream, request_reader in, service::cli
 
     auto msg = co_await process_fn(client_state, _server._query_processor, in, stream,
             _version, permit, trace_state, true, {});
-        // FIXME: indentation
-        auto* bounce_msg = std::get_if<result_with_bounce_to_shard>(&msg);
-        if (bounce_msg) {
-            auto shard = (*bounce_msg)->move_to_shard().value();
-            auto&& cached_vals = (*bounce_msg)->take_cached_pk_function_calls();
-            co_return co_await process_on_shard(shard, stream, is, client_state, trace_state, std::move(cached_vals), process_fn);
-        }
-        co_return std::get<cql_server::result_with_foreign_response_ptr>(std::move(msg));
+    auto* bounce_msg = std::get_if<result_with_bounce_to_shard>(&msg);
+    if (bounce_msg) {
+        auto shard = (*bounce_msg)->move_to_shard().value();
+        auto&& cached_vals = (*bounce_msg)->take_cached_pk_function_calls();
+        co_return co_await process_on_shard(shard, stream, is, client_state, trace_state, std::move(cached_vals), process_fn);
+    }
+    co_return std::get<cql_server::result_with_foreign_response_ptr>(std::move(msg));
 }
 
 static future<cql_server::process_fn_return_type>

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -960,6 +960,8 @@ make_result(int16_t stream, messages::result_message& msg, const tracing::trace_
         cql_protocol_version_type version, bool skip_metadata = false);
 
 template<typename Process>
+requires std::same_as<std::invoke_result_t<Process, service::client_state&, distributed<cql3::query_processor>&, request_reader,
+        uint16_t, cql_protocol_version_type, service_permit, tracing::trace_state_ptr, bool, cql3::computed_function_values>, future<cql_server::process_fn_return_type>>
 future<cql_server::result_with_foreign_response_ptr>
 cql_server::connection::process_on_shard(::shared_ptr<messages::result_message::bounce_to_shard> bounce_msg, uint16_t stream, fragmented_temporary_buffer::istream is,
         service::client_state& cs, service_permit permit, tracing::trace_state_ptr trace_state, Process process_fn) {
@@ -988,6 +990,8 @@ static inline cql_server::result_with_foreign_response_ptr convert_error_message
 }
 
 template<typename Process>
+requires std::same_as<std::invoke_result_t<Process, service::client_state&, distributed<cql3::query_processor>&, request_reader,
+        uint16_t, cql_protocol_version_type, service_permit, tracing::trace_state_ptr, bool, cql3::computed_function_values>, future<cql_server::process_fn_return_type>>
 future<cql_server::result_with_foreign_response_ptr>
 cql_server::connection::process(uint16_t stream, request_reader in, service::client_state& client_state, service_permit permit,
         tracing::trace_state_ptr trace_state, Process process_fn) {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -963,12 +963,12 @@ template<typename Process>
 requires std::same_as<std::invoke_result_t<Process, service::client_state&, distributed<cql3::query_processor>&, request_reader,
         uint16_t, cql_protocol_version_type, service_permit, tracing::trace_state_ptr, bool, cql3::computed_function_values>, future<cql_server::process_fn_return_type>>
 future<cql_server::result_with_foreign_response_ptr>
-cql_server::connection::process_on_shard(::shared_ptr<messages::result_message::bounce_to_shard> bounce_msg, uint16_t stream, fragmented_temporary_buffer::istream is,
-        service::client_state& cs, service_permit permit, tracing::trace_state_ptr trace_state, Process process_fn) {
-    return _server.container().invoke_on(*bounce_msg->move_to_shard(), _server._config.bounce_request_smp_service_group,
+cql_server::connection::process_on_shard(shard_id shard, uint16_t stream, fragmented_temporary_buffer::istream is,
+        service::client_state& cs, service_permit permit, tracing::trace_state_ptr trace_state, cql3::computed_function_values&& cached_vals, Process process_fn) {
+    return _server.container().invoke_on(shard, _server._config.bounce_request_smp_service_group,
             [this, is = std::move(is), cs = cs.move_to_other_shard(), stream, permit = std::move(permit), process_fn,
              gt = tracing::global_trace_state_ptr(std::move(trace_state)),
-             cached_vals = std::move(bounce_msg->take_cached_pk_function_calls())] (cql_server& server) {
+             cached_vals = std::move(cached_vals)] (cql_server& server) mutable {
         service::client_state client_state = cs.get();
         return do_with(bytes_ostream(), std::move(client_state), std::move(cached_vals),
                 [this, &server, is = std::move(is), stream, process_fn,
@@ -1001,9 +1001,11 @@ cql_server::connection::process(uint16_t stream, request_reader in, service::cli
             _version, permit, trace_state, true, {})
             .then([stream, &client_state, this, is, permit, process_fn, trace_state]
                    (cql_server::process_fn_return_type msg) mutable {
-        auto* bounce_msg = std::get_if<shared_ptr<messages::result_message::bounce_to_shard>>(&msg);
+        auto* bounce_msg = std::get_if<result_with_bounce_to_shard>(&msg);
         if (bounce_msg) {
-            return process_on_shard(*bounce_msg, stream, is, client_state, std::move(permit), trace_state, process_fn);
+            auto shard = (*bounce_msg)->move_to_shard().value();
+            auto&& cached_vals = (*bounce_msg)->take_cached_pk_function_calls();
+            return process_on_shard(shard, stream, is, client_state, std::move(permit), trace_state, std::move(cached_vals), process_fn);
         }
         auto ptr = std::get<cql_server::result_with_foreign_response_ptr>(std::move(msg));
         return make_ready_future<cql_server::result_with_foreign_response_ptr>(std::move(ptr));
@@ -1036,7 +1038,7 @@ process_query_internal(service::client_state& client_state, distributed<cql3::qu
 
     return qp.local().execute_direct_without_checking_exception_message(query, query_state, options).then([q_state = std::move(q_state), stream, skip_metadata, version] (auto msg) {
         if (msg->move_to_shard()) {
-            return cql_server::process_fn_return_type(dynamic_pointer_cast<messages::result_message::bounce_to_shard>(msg));
+            return cql_server::process_fn_return_type(make_foreign(dynamic_pointer_cast<messages::result_message::bounce_to_shard>(msg)));
         } else if (msg->is_exception()) {
             return cql_server::process_fn_return_type(convert_error_message_to_coordinator_result(msg.get()));
         } else {
@@ -1140,7 +1142,7 @@ process_execute_internal(service::client_state& client_state, distributed<cql3::
     return qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization)
             .then([trace_state = query_state.get_trace_state(), skip_metadata, q_state = std::move(q_state), stream, version] (auto msg) {
         if (msg->move_to_shard()) {
-            return cql_server::process_fn_return_type(dynamic_pointer_cast<messages::result_message::bounce_to_shard>(msg));
+            return cql_server::process_fn_return_type(make_foreign(dynamic_pointer_cast<messages::result_message::bounce_to_shard>(msg)));
         } else if (msg->is_exception()) {
             return cql_server::process_fn_return_type(convert_error_message_to_coordinator_result(msg.get()));
         } else {
@@ -1261,7 +1263,7 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
     return qp.local().execute_batch_without_checking_exception_message(batch, query_state, options, std::move(pending_authorization_entries))
             .then([stream, batch, q_state = std::move(q_state), trace_state = query_state.get_trace_state(), version] (auto msg) {
         if (msg->move_to_shard()) {
-            return cql_server::process_fn_return_type(dynamic_pointer_cast<messages::result_message::bounce_to_shard>(msg));
+            return cql_server::process_fn_return_type(make_foreign(dynamic_pointer_cast<messages::result_message::bounce_to_shard>(msg)));
         } else if (msg->is_exception()) {
             return cql_server::process_fn_return_type(convert_error_message_to_coordinator_result(msg.get()));
         } else {

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -175,6 +175,8 @@ public:
 public:
     using response = cql_transport::response;
     using result_with_foreign_response_ptr = exceptions::coordinator_result<foreign_ptr<std::unique_ptr<cql_server::response>>>;
+    using process_fn_return_type = std::variant<result_with_foreign_response_ptr, ::shared_ptr<messages::result_message::bounce_to_shard>>;
+
     service::endpoint_lifecycle_subscriber* get_lifecycle_listener() const noexcept;
     service::migration_listener* get_migration_listener() const noexcept;
     cql_sg_stats::request_kind_stats& get_cql_opcode_stats(cql_binary_opcode op) {

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -277,7 +277,7 @@ private:
                 uint16_t, cql_protocol_version_type, service_permit, tracing::trace_state_ptr, bool, cql3::computed_function_values>, future<process_fn_return_type>>
         future<result_with_foreign_response_ptr>
         process_on_shard(shard_id shard, uint16_t stream, fragmented_temporary_buffer::istream is, service::client_state& cs,
-                service_permit permit, tracing::trace_state_ptr trace_state, cql3::computed_function_values&& cached_vals, Process process_fn);
+                tracing::trace_state_ptr trace_state, cql3::computed_function_values&& cached_vals, Process process_fn);
 
         void write_response(foreign_ptr<std::unique_ptr<cql_server::response>>&& response, service_permit permit = empty_service_permit(), cql_compression compression = cql_compression::none);
 

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -275,7 +275,7 @@ private:
         template<typename Process>
         requires std::same_as<std::invoke_result_t<Process, service::client_state&, distributed<cql3::query_processor>&, request_reader,
                 uint16_t, cql_protocol_version_type, service_permit, tracing::trace_state_ptr, bool, cql3::computed_function_values>, future<process_fn_return_type>>
-        future<result_with_foreign_response_ptr>
+        future<process_fn_return_type>
         process_on_shard(shard_id shard, uint16_t stream, fragmented_temporary_buffer::istream is, service::client_state& cs,
                 tracing::trace_state_ptr trace_state, cql3::computed_function_values&& cached_vals, Process process_fn);
 

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -175,7 +175,8 @@ public:
 public:
     using response = cql_transport::response;
     using result_with_foreign_response_ptr = exceptions::coordinator_result<foreign_ptr<std::unique_ptr<cql_server::response>>>;
-    using process_fn_return_type = std::variant<result_with_foreign_response_ptr, ::shared_ptr<messages::result_message::bounce_to_shard>>;
+    using result_with_bounce_to_shard = foreign_ptr<seastar::shared_ptr<messages::result_message::bounce_to_shard>>;
+    using process_fn_return_type = std::variant<result_with_foreign_response_ptr, result_with_bounce_to_shard>;
 
     service::endpoint_lifecycle_subscriber* get_lifecycle_listener() const noexcept;
     service::migration_listener* get_migration_listener() const noexcept;
@@ -275,8 +276,8 @@ private:
         requires std::same_as<std::invoke_result_t<Process, service::client_state&, distributed<cql3::query_processor>&, request_reader,
                 uint16_t, cql_protocol_version_type, service_permit, tracing::trace_state_ptr, bool, cql3::computed_function_values>, future<process_fn_return_type>>
         future<result_with_foreign_response_ptr>
-        process_on_shard(::shared_ptr<messages::result_message::bounce_to_shard> bounce_msg, uint16_t stream, fragmented_temporary_buffer::istream is, service::client_state& cs,
-                service_permit permit, tracing::trace_state_ptr trace_state, Process process_fn);
+        process_on_shard(shard_id shard, uint16_t stream, fragmented_temporary_buffer::istream is, service::client_state& cs,
+                service_permit permit, tracing::trace_state_ptr trace_state, cql3::computed_function_values&& cached_vals, Process process_fn);
 
         void write_response(foreign_ptr<std::unique_ptr<cql_server::response>>&& response, service_permit permit = empty_service_permit(), cql_compression compression = cql_compression::none);
 

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -266,10 +266,14 @@ private:
 
         // Helper functions to encapsulate bounce_to_shard processing for query, execute and batch verbs
         template<typename Process>
+        requires std::same_as<std::invoke_result_t<Process, service::client_state&, distributed<cql3::query_processor>&, request_reader,
+                uint16_t, cql_protocol_version_type, service_permit, tracing::trace_state_ptr, bool, cql3::computed_function_values>, future<process_fn_return_type>>
         future<result_with_foreign_response_ptr>
         process(uint16_t stream, request_reader in, service::client_state& client_state, service_permit permit, tracing::trace_state_ptr trace_state,
                 Process process_fn);
         template<typename Process>
+        requires std::same_as<std::invoke_result_t<Process, service::client_state&, distributed<cql3::query_processor>&, request_reader,
+                uint16_t, cql_protocol_version_type, service_permit, tracing::trace_state_ptr, bool, cql3::computed_function_values>, future<process_fn_return_type>>
         future<result_with_foreign_response_ptr>
         process_on_shard(::shared_ptr<messages::result_message::bounce_to_shard> bounce_msg, uint16_t stream, fragmented_temporary_buffer::istream is, service::client_state& cs,
                 service_permit permit, tracing::trace_state_ptr trace_state, Process process_fn);


### PR DESCRIPTION
Re-bounce the msg to another shard if needed,
e.g. in the case of tablet migration.

Fixes #15465
