### PR TITLE
auth: drop const from methods on write path

### DIFF
--- a/auth/allow_all_authenticator.hh
+++ b/auth/allow_all_authenticator.hh
@@ -59,15 +59,15 @@ public:
         return make_ready_future<authenticated_user>(anonymous_user());
     }
 
-    virtual future<> create(std::string_view, const authentication_options& options) const override {
+    virtual future<> create(std::string_view, const authentication_options& options) override {
         return make_ready_future();
     }
 
-    virtual future<> alter(std::string_view, const authentication_options& options) const override {
+    virtual future<> alter(std::string_view, const authentication_options& options) override {
         return make_ready_future();
     }
 
-    virtual future<> drop(std::string_view) const override {
+    virtual future<> drop(std::string_view) override {
         return make_ready_future();
     }
 

--- a/auth/allow_all_authorizer.hh
+++ b/auth/allow_all_authorizer.hh
@@ -43,12 +43,12 @@ public:
         return make_ready_future<permission_set>(permissions::ALL);
     }
 
-    virtual future<> grant(std::string_view, permission_set, const resource&) const override {
+    virtual future<> grant(std::string_view, permission_set, const resource&) override {
         return make_exception_future<>(
                 unsupported_authorization_operation("GRANT operation is not supported by AllowAllAuthorizer"));
     }
 
-    virtual future<> revoke(std::string_view, permission_set, const resource&) const override {
+    virtual future<> revoke(std::string_view, permission_set, const resource&) override {
         return make_exception_future<>(
                 unsupported_authorization_operation("REVOKE operation is not supported by AllowAllAuthorizer"));
     }
@@ -59,12 +59,12 @@ public:
                         "LIST PERMISSIONS operation is not supported by AllowAllAuthorizer"));
     }
 
-    virtual future<> revoke_all(std::string_view) const override {
+    virtual future<> revoke_all(std::string_view) override {
         return make_exception_future(
                 unsupported_authorization_operation("REVOKE operation is not supported by AllowAllAuthorizer"));
     }
 
-    virtual future<> revoke_all(const resource&) const override {
+    virtual future<> revoke_all(const resource&) override {
         return make_exception_future(
                 unsupported_authorization_operation("REVOKE operation is not supported by AllowAllAuthorizer"));
     }

--- a/auth/authenticator.hh
+++ b/auth/authenticator.hh
@@ -106,7 +106,7 @@ public:
     ///
     /// The options provided must be a subset of `supported_options()`.
     ///
-    virtual future<> create(std::string_view role_name, const authentication_options& options) const = 0;
+    virtual future<> create(std::string_view role_name, const authentication_options& options) = 0;
 
     ///
     /// Alter the authentication record of an existing user.
@@ -115,12 +115,12 @@ public:
     ///
     /// Callers must ensure that the specification of `alterable_options()` is adhered to.
     ///
-    virtual future<> alter(std::string_view role_name, const authentication_options& options) const = 0;
+    virtual future<> alter(std::string_view role_name, const authentication_options& options) = 0;
 
     ///
     /// Delete the authentication record for a user. This will disallow the user from logging in.
     ///
-    virtual future<> drop(std::string_view role_name) const = 0;
+    virtual future<> drop(std::string_view role_name) = 0;
 
     ///
     /// Query for custom options (those corresponding to \ref authentication_options::options).

--- a/auth/authorizer.hh
+++ b/auth/authorizer.hh
@@ -81,14 +81,14 @@ public:
     ///
     /// \throws \ref unsupported_authorization_operation if granting permissions is not supported.
     ///
-    virtual future<> grant(std::string_view role_name, permission_set, const resource&) const = 0;
+    virtual future<> grant(std::string_view role_name, permission_set, const resource&) = 0;
 
     ///
     /// Revoke a set of permissions from a role for a particular \ref resource.
     ///
     /// \throws \ref unsupported_authorization_operation if revoking permissions is not supported.
     ///
-    virtual future<> revoke(std::string_view role_name, permission_set, const resource&) const = 0;
+    virtual future<> revoke(std::string_view role_name, permission_set, const resource&) = 0;
 
     ///
     /// Query for all directly granted permissions.
@@ -102,14 +102,14 @@ public:
     ///
     /// \throws \ref unsupported_authorization_operation if revoking permissions is not supported.
     ///
-    virtual future<> revoke_all(std::string_view role_name) const = 0;
+    virtual future<> revoke_all(std::string_view role_name) = 0;
 
     ///
     /// Revoke all permissions granted to any role for a particular resource.
     ///
     /// \throws \ref unsupported_authorization_operation if revoking permissions is not supported.
     ///
-    virtual future<> revoke_all(const resource&) const = 0;
+    virtual future<> revoke_all(const resource&) = 0;
 
     ///
     /// System resources used internally as part of the implementation. These are made inaccessible to users.

--- a/auth/certificate_authenticator.cc
+++ b/auth/certificate_authenticator.cc
@@ -154,16 +154,16 @@ future<auth::authenticated_user> auth::certificate_authenticator::authenticate(c
     throw exceptions::authentication_exception("Cannot authenticate using attribute map");
 }
 
-future<> auth::certificate_authenticator::create(std::string_view role_name, const authentication_options& options) const {
+future<> auth::certificate_authenticator::create(std::string_view role_name, const authentication_options& options) {
     // TODO: should we keep track of roles/enforce existence? Role manager should deal with this...
     co_return;
 }
 
-future<> auth::certificate_authenticator::alter(std::string_view role_name, const authentication_options& options) const {
+future<> auth::certificate_authenticator::alter(std::string_view role_name, const authentication_options& options) {
     co_return;
 }
 
-future<> auth::certificate_authenticator::drop(std::string_view role_name) const {
+future<> auth::certificate_authenticator::drop(std::string_view role_name) {
     co_return;
 }
 

--- a/auth/certificate_authenticator.hh
+++ b/auth/certificate_authenticator.hh
@@ -46,9 +46,9 @@ public:
     future<authenticated_user> authenticate(const credentials_map& credentials) const override;
     future<std::optional<authenticated_user>> authenticate(session_dn_func) const override;
 
-    future<> create(std::string_view role_name, const authentication_options& options) const override;
-    future<> alter(std::string_view role_name, const authentication_options& options) const override;
-    future<> drop(std::string_view role_name) const override;
+    future<> create(std::string_view role_name, const authentication_options& options) override;
+    future<> alter(std::string_view role_name, const authentication_options& options) override;
+    future<> drop(std::string_view role_name) override;
 
     future<custom_options> query_custom_options(std::string_view role_name) const override;
 

--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -75,7 +75,7 @@ future<bool> default_authorizer::any_granted() const {
     });
 }
 
-future<> default_authorizer::migrate_legacy_metadata() const {
+future<> default_authorizer::migrate_legacy_metadata() {
     alogger.info("Starting migration of legacy permissions metadata.");
     static const sstring query = format("SELECT * FROM {}.{}", meta::AUTH_KS, legacy_table_name);
 
@@ -177,7 +177,7 @@ default_authorizer::modify(
         std::string_view role_name,
         permission_set set,
         const resource& resource,
-        std::string_view op) const {
+        std::string_view op) {
     return do_with(
             format("UPDATE {}.{} SET {} = {} {} ? WHERE {} = ? AND {} = ?",
                     meta::AUTH_KS,
@@ -198,11 +198,11 @@ default_authorizer::modify(
 }
 
 
-future<> default_authorizer::grant(std::string_view role_name, permission_set set, const resource& resource) const {
+future<> default_authorizer::grant(std::string_view role_name, permission_set set, const resource& resource) {
     return modify(role_name, std::move(set), resource, "+");
 }
 
-future<> default_authorizer::revoke(std::string_view role_name, permission_set set, const resource& resource) const {
+future<> default_authorizer::revoke(std::string_view role_name, permission_set set, const resource& resource) {
     return modify(role_name, std::move(set), resource, "-");
 }
 
@@ -235,7 +235,7 @@ future<std::vector<permission_details>> default_authorizer::list_all() const {
     });
 }
 
-future<> default_authorizer::revoke_all(std::string_view role_name) const {
+future<> default_authorizer::revoke_all(std::string_view role_name) {
     static const sstring query = format("DELETE FROM {}.{} WHERE {} = ?",
             meta::AUTH_KS,
             PERMISSIONS_CF,
@@ -255,7 +255,7 @@ future<> default_authorizer::revoke_all(std::string_view role_name) const {
     });
 }
 
-future<> default_authorizer::revoke_all(const resource& resource) const {
+future<> default_authorizer::revoke_all(const resource& resource) {
     static const sstring query = format("SELECT {} FROM {}.{} WHERE {} = ? ALLOW FILTERING",
             ROLE_NAME,
             meta::AUTH_KS,

--- a/auth/default_authorizer.hh
+++ b/auth/default_authorizer.hh
@@ -45,15 +45,15 @@ public:
 
     virtual future<permission_set> authorize(const role_or_anonymous&, const resource&) const override;
 
-    virtual future<> grant(std::string_view, permission_set, const resource&) const override;
+    virtual future<> grant(std::string_view, permission_set, const resource&) override;
 
-    virtual future<> revoke( std::string_view, permission_set, const resource&) const override;
+    virtual future<> revoke( std::string_view, permission_set, const resource&) override;
 
     virtual future<std::vector<permission_details>> list_all() const override;
 
-    virtual future<> revoke_all(std::string_view) const override;
+    virtual future<> revoke_all(std::string_view) override;
 
-    virtual future<> revoke_all(const resource&) const override;
+    virtual future<> revoke_all(const resource&) override;
 
     virtual const resource_set& protected_resources() const override;
 
@@ -62,9 +62,9 @@ private:
 
     future<bool> any_granted() const;
 
-    future<> migrate_legacy_metadata() const;
+    future<> migrate_legacy_metadata();
 
-    future<> modify(std::string_view, permission_set, const resource&, std::string_view) const;
+    future<> modify(std::string_view, permission_set, const resource&, std::string_view);
 };
 
 } /* namespace auth */

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -114,7 +114,7 @@ future<> password_authenticator::migrate_legacy_metadata() const {
     });
 }
 
-future<> password_authenticator::create_default_if_missing() const {
+future<> password_authenticator::create_default_if_missing() {
     return default_role_row_satisfies(_qp, &has_salted_hash, _superuser).then([this](bool exists) {
         if (!exists) {
             std::string salted_pwd(get_config_value(_qp.db().get_config().auth_superuser_salted_password(), ""));
@@ -252,7 +252,7 @@ future<authenticated_user> password_authenticator::authenticate(
     });
 }
 
-future<> password_authenticator::create(std::string_view role_name, const authentication_options& options) const {
+future<> password_authenticator::create(std::string_view role_name, const authentication_options& options) {
     if (!options.password) {
         return make_ready_future<>();
     }
@@ -265,7 +265,7 @@ future<> password_authenticator::create(std::string_view role_name, const authen
             cql3::query_processor::cache_internal::no).discard_result();
 }
 
-future<> password_authenticator::alter(std::string_view role_name, const authentication_options& options) const {
+future<> password_authenticator::alter(std::string_view role_name, const authentication_options& options) {
     if (!options.password) {
         return make_ready_future<>();
     }
@@ -283,7 +283,7 @@ future<> password_authenticator::alter(std::string_view role_name, const authent
             cql3::query_processor::cache_internal::no).discard_result();
 }
 
-future<> password_authenticator::drop(std::string_view name) const {
+future<> password_authenticator::drop(std::string_view name) {
     static const sstring query = format("DELETE {} FROM {} WHERE {} = ?",
             SALTED_HASH,
             meta::roles_table::qualified_name,

--- a/auth/password_authenticator.hh
+++ b/auth/password_authenticator.hh
@@ -62,11 +62,11 @@ public:
 
     virtual future<authenticated_user> authenticate(const credentials_map& credentials) const override;
 
-    virtual future<> create(std::string_view role_name, const authentication_options& options) const override;
+    virtual future<> create(std::string_view role_name, const authentication_options& options) override;
 
-    virtual future<> alter(std::string_view role_name, const authentication_options& options) const override;
+    virtual future<> alter(std::string_view role_name, const authentication_options& options) override;
 
-    virtual future<> drop(std::string_view role_name) const override;
+    virtual future<> drop(std::string_view role_name) override;
 
     virtual future<custom_options> query_custom_options(std::string_view role_name) const override;
 
@@ -79,7 +79,7 @@ private:
 
     future<> migrate_legacy_metadata() const;
 
-    future<> create_default_if_missing() const;
+    future<> create_default_if_missing();
 };
 
 }

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -155,11 +155,11 @@ public:
 
     future<bool> exists(const resource&) const;
 
-    const authenticator& underlying_authenticator() const {
+    authenticator& underlying_authenticator() const {
         return *_authenticator;
     }
 
-    const authorizer& underlying_authorizer() const {
+    authorizer& underlying_authorizer() const {
         return *_authorizer;
     }
 

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -175,7 +175,7 @@ future<> standard_role_manager::create_metadata_tables_if_missing() const {
                     _migration_manager)).discard_result();
 }
 
-future<> standard_role_manager::create_default_role_if_missing() const {
+future<> standard_role_manager::create_default_role_if_missing() {
     return default_role_row_satisfies(_qp, &has_can_login, _superuser).then([this](bool exists) {
         if (!exists) {
             static const sstring query = format("INSERT INTO {} ({}, is_superuser, can_login) VALUES (?, true, true)",
@@ -206,7 +206,7 @@ bool standard_role_manager::legacy_metadata_exists() {
     return _qp.db().has_schema(meta::AUTH_KS, legacy_table_name);
 }
 
-future<> standard_role_manager::migrate_legacy_metadata() const {
+future<> standard_role_manager::migrate_legacy_metadata() {
     log.info("Starting migration of legacy user metadata.");
     static const sstring query = format("SELECT * FROM {}.{}", meta::AUTH_KS, legacy_table_name);
 
@@ -267,7 +267,7 @@ future<> standard_role_manager::stop() {
     return _stopped.handle_exception_type([] (const sleep_aborted&) { }).handle_exception_type([](const abort_requested_exception&) {});;
 }
 
-future<> standard_role_manager::create_or_replace(std::string_view role_name, const role_config& c) const {
+future<> standard_role_manager::create_or_replace(std::string_view role_name, const role_config& c) {
     static const sstring query = format("INSERT INTO {} ({}, is_superuser, can_login) VALUES (?, ?, ?)",
             meta::roles_table::qualified_name,
             meta::roles_table::role_col_name);
@@ -400,7 +400,7 @@ future<>
 standard_role_manager::modify_membership(
         std::string_view grantee_name,
         std::string_view role_name,
-        membership_change ch) const {
+        membership_change ch) {
 
 
     const auto modify_roles = [this, role_name, grantee_name, ch] {

--- a/auth/standard_role_manager.hh
+++ b/auth/standard_role_manager.hh
@@ -81,13 +81,13 @@ private:
 
     bool legacy_metadata_exists();
 
-    future<> migrate_legacy_metadata() const;
+    future<> migrate_legacy_metadata();
 
-    future<> create_default_role_if_missing() const;
+    future<> create_default_role_if_missing();
 
-    future<> create_or_replace(std::string_view role_name, const role_config&) const;
+    future<> create_or_replace(std::string_view role_name, const role_config&);
 
-    future<> modify_membership(std::string_view role_name, std::string_view grantee_name, membership_change) const;
+    future<> modify_membership(std::string_view role_name, std::string_view grantee_name, membership_change);
 };
 
 }

--- a/auth/transitional.cc
+++ b/auth/transitional.cc
@@ -86,15 +86,15 @@ public:
         });
     }
 
-    virtual future<> create(std::string_view role_name, const authentication_options& options) const override {
+    virtual future<> create(std::string_view role_name, const authentication_options& options) override {
         return _authenticator->create(role_name, options);
     }
 
-    virtual future<> alter(std::string_view role_name, const authentication_options& options) const override {
+    virtual future<> alter(std::string_view role_name, const authentication_options& options) override {
         return _authenticator->alter(role_name, options);
     }
 
-    virtual future<> drop(std::string_view role_name) const override {
+    virtual future<> drop(std::string_view role_name) override {
         return _authenticator->drop(role_name);
     }
 
@@ -186,11 +186,11 @@ public:
         return make_ready_future<permission_set>(transitional_permissions);
     }
 
-    virtual future<> grant(std::string_view s, permission_set ps, const resource& r) const override {
+    virtual future<> grant(std::string_view s, permission_set ps, const resource& r)  override {
         return _authorizer->grant(s, std::move(ps), r);
     }
 
-    virtual future<> revoke(std::string_view s, permission_set ps, const resource& r) const override {
+    virtual future<> revoke(std::string_view s, permission_set ps, const resource& r) override {
         return _authorizer->revoke(s, std::move(ps), r);
     }
 
@@ -198,11 +198,11 @@ public:
         return _authorizer->list_all();
     }
 
-    virtual future<> revoke_all(std::string_view s) const override {
+    virtual future<> revoke_all(std::string_view s) override {
         return _authorizer->revoke_all(s);
     }
 
-    virtual future<> revoke_all(const resource& r) const override {
+    virtual future<> revoke_all(const resource& r) override {
         return _authorizer->revoke_all(r);
     }
 


### PR DESCRIPTION
In a follow-up patch abort_source will be used inside those methods. Current pattern is that abort_source is passed everywhere as non const so it needs to be executed in non const context.