### PR TITLE
Rename keyspace::get_effective_replication_map()

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -433,7 +433,7 @@ public:
     token_ranges_owned_by_this_shard(replica::database& db, gms::gossiper& g, schema_ptr s)
         :  _s(s)
         , _erm(s->table().get_effective_replication_map())
-        , _token_ranges(db.find_keyspace(s->ks_name()).get_effective_replication_map(),
+        , _token_ranges(db.find_keyspace(s->ks_name()).get_vnode_effective_replication_map(),
                 g, _erm->get_topology().my_address())
         , _range_idx(random_offset(0, _token_ranges.size() - 1))
         , _end_idx(_range_idx + _token_ranges.size())

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -62,7 +62,7 @@ range_streamer::get_range_fetch_map(const std::unordered_map<dht::token_range, s
 
         if (!found_source) {
             auto& ks = _db.local().find_keyspace(keyspace);
-            auto rf = ks.get_effective_replication_map()->get_replication_factor();
+            auto rf = ks.get_vnode_effective_replication_map()->get_replication_factor();
             // When a replacing node replaces a dead node with keyspace of RF
             // 1, it is expected that replacing node could not find a peer node
             // that contains data to stream from.

--- a/locator/util.cc
+++ b/locator/util.cc
@@ -86,7 +86,7 @@ get_range_to_address_map_in_local_dc(
 
 // static future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>>
 // get_range_to_address_map(const replica::database& db, const sstring& keyspace) {
-//     return get_range_to_address_map(db.find_keyspace(keyspace).get_effective_replication_map());
+//     return get_range_to_address_map(db.find_keyspace(keyspace).get_vnode_effective_replication_map());
 // }
 
 static future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>>
@@ -98,7 +98,7 @@ future<std::vector<dht::token_range_endpoints>>
 describe_ring(const replica::database& db, const gms::gossiper& gossiper, const sstring& keyspace, bool include_only_local_dc) {
     std::vector<dht::token_range_endpoints> ranges;
 
-    auto erm = db.find_keyspace(keyspace).get_effective_replication_map();
+    auto erm = db.find_keyspace(keyspace).get_vnode_effective_replication_map();
     std::unordered_map<dht::token_range, inet_address_vector_replica_set> range_to_address_map = co_await (
             include_only_local_dc
                     ? get_range_to_address_map_in_local_dc(erm)

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1316,7 +1316,7 @@ public:
         return _replication_strategy;
     }
 
-    locator::vnode_effective_replication_map_ptr get_effective_replication_map() const;
+    locator::vnode_effective_replication_map_ptr get_vnode_effective_replication_map() const;
 
     column_family::config make_column_family_config(const schema& s, const database& db) const;
     void add_or_update_column_family(const schema_ptr& s);


### PR DESCRIPTION
This commit renames keyspace::get_effective_replication_map() to keyspace::get_vnode_effective_replication_map(). This change is required to ease the analysis of the usage of this function.

When tablets are enabled, then this function shall not be used. Instead of per-keyspace, per-table replication map should be used. The rename was performed to distinguish between those two calls. The next step will be an audit of usages of keyspace::get_vnode_effective_replication_map().

Refs: scylladb#16626