### PR TITLE
api: storage_service/natural_endpoints: add tablets support

### DIFF
--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -488,7 +488,7 @@ bool cluster_describe_statement::should_add_range_ownership(replica::database& d
     //TODO: produce range ownership for tables using tablets too
     bool uses_tablets = false;
     try {
-        uses_tablets = !ks.empty() && db.find_keyspace(ks).get_replication_strategy().uses_tablets();
+        uses_tablets = !ks.empty() && db.find_keyspace(ks).uses_tablets();
     } catch (const data_dictionary::no_such_keyspace&) {
         // ignore
     }

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1710,7 +1710,7 @@ future<> view_update_generator::mutate_MV(
         // are more frequent and backward compatibility is less important.
         // TODO: Maybe allow users to set use_legacy_self_pairing explicitly
         // on a view, like we have the synchronous_updates_flag.
-        bool use_legacy_self_pairing = !ks.get_replication_strategy().uses_tablets();
+        bool use_legacy_self_pairing = !ks.uses_tablets();
         auto target_endpoint = get_view_natural_endpoint(base_ermp, view_ermp, network_topology, base_token, view_token, use_legacy_self_pairing);
         auto remote_endpoints = view_ermp->get_pending_endpoints(view_token);
         auto sem_units = pending_view_updates.split(mut.fm.representation().size());

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1318,6 +1318,10 @@ public:
 
     locator::vnode_effective_replication_map_ptr get_vnode_effective_replication_map() const;
 
+    bool uses_tablets() const {
+        return _replication_strategy->uses_tablets();
+    }
+
     column_family::config make_column_family_config(const schema& s, const database& db) const;
     void add_or_update_column_family(const schema_ptr& s);
     void add_user_type(const user_type ut);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6250,12 +6250,7 @@ storage_service::get_natural_endpoints(const sstring& keyspace,
     auto schema = _db.local().find_schema(keyspace, cf);
     partition_key pk = partition_key::from_nodetool_style_string(schema, key);
     dht::token token = schema->get_partitioner().get_token(*schema, pk.view());
-    return get_natural_endpoints(keyspace, token);
-}
-
-inet_address_vector_replica_set
-storage_service::get_natural_endpoints(const sstring& keyspace, const token& pos) const {
-    return _db.local().find_keyspace(keyspace).get_vnode_effective_replication_map()->get_natural_endpoints(pos);
+    return _db.local().find_keyspace(keyspace).get_vnode_effective_replication_map()->get_natural_endpoints(token);
 }
 
 future<> endpoint_lifecycle_notifier::notify_down(gms::inet_address endpoint) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4635,7 +4635,7 @@ future<> storage_service::move(token new_token) {
 
 future<std::vector<storage_service::token_range_endpoints>>
 storage_service::describe_ring(const sstring& keyspace, bool include_only_local_dc) const {
-    if (_db.local().find_keyspace(keyspace).get_replication_strategy().uses_tablets()) {
+    if (_db.local().find_keyspace(keyspace).uses_tablets()) {
         throw std::runtime_error(fmt::format("The keyspace {} has tablet table. Query describe_ring with the table parameter!", keyspace));
     }
     co_return co_await locator::describe_ring(_db.local(), _gossiper, keyspace, include_only_local_dc);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -604,16 +604,6 @@ public:
             const sstring& cf, const sstring& key) const;
 
     /**
-     * This method returns the N endpoints that are responsible for storing the
-     * specified key i.e for replication.
-     *
-     * @param keyspaceName keyspace name also known as keyspace
-     * @param pos position for which we need to find the endpoint
-     * @return the endpoint responsible for this token
-     */
-    inet_address_vector_replica_set  get_natural_endpoints(const sstring& keyspace, const token& pos) const;
-
-    /**
      * @return Vector of Token ranges (_not_ keys!) together with estimated key count,
      *      breaking up the data this node is responsible for into pieces of roughly keys_per_split
      */


### PR DESCRIPTION
This API endpoint currently returns with status 500 if attempted to be called for a table which uses tablets. This series adds tablet support. No change in usage semantics is required, the endpoint already has a table parameter.
This endpoint is the backend of `nodetool getendpoints` which should now work, after this PR.

Fixes: #17313