### PR TITLE
api: storage_service/keyspaces: add replication filter

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -1514,6 +1514,15 @@
                      "type":"string",
                      "enum": [ "all", "user", "non_local_strategy" ],
                      "paramType":"query"
+                  },
+                  {
+                     "name":"replication",
+                     "description":"Filter keyspaces for the replication used: vnodes or tablets (default: all)",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "enum": [ "all", "vnodes", "tablets" ],
+                     "paramType":"query"
                   }
                ]
             }


### PR DESCRIPTION
To allow to filter the returned keyspaces based by the replication they use: tablets or vnodes.
The filter can be disabled by omitting the parameter or passing "all". The default is "all".

Fixes: #16509