### PR TITLE
storage_service: pass non-empty keyspace when performing cleanup_all

### DIFF
--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -447,7 +447,7 @@ future<> global_cleanup_compaction_task_impl::run() {
             auto& module = db.get_compaction_manager().get_task_manager_module();
             const tasks::task_info task_info{_status.id, _status.shard};
             auto task = co_await module.make_and_start_task<shard_cleanup_keyspace_compaction_task_impl>(
-                task_info, _status.keyspace, _status.id, db, std::move(tables));
+                task_info, ks, _status.id, db, std::move(tables));
             co_await task->done();
         });
     });


### PR DESCRIPTION
this change addresses the regression introduced by 5e0b3671, which fall backs to local cleanup in cleanup_all. but 5e0b3671 failed to pass the keyspace to the `shard_cleanup_keyspace_compaction_task_impl` is its constructor parameter, that's why the test fails like
```
error executing POST request to http://localhost:10000/storage_service/cleanup_all with parameters {}: remote replied with status code 400 Bad Request:
Can't find a keyspace

```

where the string after "Can't find a keyspace" is empty.

in this change, the keyspace name of the keyspace to be cleaned is passed to `shard_cleanup_keyspace_compaction_task_impl`.

we always enable the topology coordinator when performing testing, that's why this issue does not pop up until the longevity test.

Fixes #17302
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>