### PR TITLE
configure.py: do not pass include cxx_ldflags in cxxflags

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1946,7 +1946,7 @@ def write_build_file(f,
         f.write(textwrap.dedent('''\
             cxx_ld_flags_{mode} = {cxx_ld_flags}
             ld_flags_{mode} = $cxx_ld_flags_{mode} {lib_ldflags}
-            cxxflags_{mode} = $cxx_ld_flags_{mode} {lib_cflags} {cxxflags} -iquote. -iquote $builddir/{mode}/gen
+            cxxflags_{mode} = {lib_cflags} {cxxflags} -iquote. -iquote $builddir/{mode}/gen
             libs_{mode} = -l{fmt_lib}
             seastar_libs_{mode} = {seastar_libs}
             seastar_testing_libs_{mode} = {seastar_testing_libs}


### PR DESCRIPTION
ldflags are passed to ld (the linker), while cxxflags are passed to the C++ compiler. the compiler does not understand the ldflags. if we pass ldflags to it, it complains if `-Wunused-command-line-argument` is enabled.

in this change, we do not include the ldflags in cxxflags, this helps us to enable the warning option of `-Wunused-command-line-argument`, so we don't need to disabled it.