### PR TITLE
configure.py: disable stack-use-after-scope check only when ASan is e…

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2186,7 +2186,7 @@ def write_build_file(f,
                     # Unoptimized parsers end up using huge amounts of stack space and overflowing their stack
                     flags += ' -O1' if modes[mode]['optimization-level'] in ['0', 'g', 's'] else ''
 
-                    if has_sanitize_address_use_after_scope:
+                    if '-DSANITIZE' in modeval['cxxflags'] and has_sanitize_address_use_after_scope:
                         flags += ' -fno-sanitize-address-use-after-scope'
                 f.write(f'  obj_cxxflags = {flags}\n')
         f.write(f'build $builddir/{mode}/gen/empty.cc: gen\n')


### PR DESCRIPTION
…nabled

`-fno-sanitize-address-use-after-scope` is used to disable the check for stack-use-after-scope bugs, but this check is only performed when ASan is enabled. if we pass this option when ASan is not enabled, we'd have following warning, so let's apply it only when ASan is enabled.

```
clang-16: error: argument unused during compilation:
'-fno-sanitize-address-use-after-scope' [-Werror,-Wunused-command-line-argument]
```