### PR TITLE
dht: add formatter for paritition_range_view and i_partition

### DIFF
--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -73,8 +73,6 @@ public:
     }
 };
 
-std::ostream& operator<<(std::ostream& out, const i_partitioner& p);
-
 // Returns the owning shard number for vnode-based replication strategies.
 // Use table::shard_of() for the general case.
 unsigned static_shard_of(const schema&, const token&);
@@ -120,3 +118,10 @@ dht::token first_token(const dht::partition_range&);
 std::optional<shard_id> is_single_shard(const dht::sharder&, const schema&, const dht::partition_range&);
 
 } // dht
+
+template <> struct fmt::formatter<dht::i_partitioner> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const dht::i_partitioner& p, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{{partitioner name = {}}}", p.name());
+    }
+};

--- a/dht/ring_position.hh
+++ b/dht/ring_position.hh
@@ -486,8 +486,6 @@ public:
     const dht::partition_range* end() const { return _data + _size; }
 };
 
-std::ostream& operator<<(std::ostream& out, partition_ranges_view v);
-
 } // namespace dht
 
 template<>
@@ -508,4 +506,9 @@ template<>
 struct fmt::formatter<dht::ring_position> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     auto format(const dht::ring_position& pos, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <> struct fmt::formatter<dht::partition_ranges_view> : fmt::formatter<std::string_view> {
+    auto format(const dht::partition_ranges_view&, fmt::format_context& ctx) const
+      -> decltype(ctx.out());
 };


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for
`partition_range_view` and `i_partition`, and drop their operator<<:s.

Refs #13245