### PR TITLE
Docs: rename doc page from REST to Admin REST API

### DIFF
--- a/docs/operating-scylla/_common/tools_index.rst
+++ b/docs/operating-scylla/_common/tools_index.rst
@@ -1,6 +1,6 @@
 * :doc:`Nodetool Reference</operating-scylla/nodetool>` - Scylla commands for managing Scylla node or cluster using the command-line nodetool utility.
 * :doc:`CQLSh - the CQL shell</cql/cqlsh>`.
-* :doc:`REST - Scylla REST/HTTP Admin API</operating-scylla/rest>`.
+* :doc:`Admin REST API - ScyllaDB Node Admin API</operating-scylla/rest>`.
 * :doc:`Tracing </using-scylla/tracing>` - a ScyllaDB tool for debugging and analyzing internal flows in the server. 
 * :doc:`SSTableloader </operating-scylla/admin-tools/sstableloader>` - Bulk load the sstables found in the directory to a Scylla cluster
 * :doc:`Scylla SStable </operating-scylla/admin-tools/scylla-sstable>` - Validates and dumps the content of SStables, generates a histogram, dumps the content of the SStable index.

--- a/docs/operating-scylla/admin-tools/index.rst
+++ b/docs/operating-scylla/admin-tools/index.rst
@@ -7,7 +7,7 @@ Admin Tools
    
    Nodetool Reference </operating-scylla/nodetool>
    CQLSh </cql/cqlsh>
-   REST </operating-scylla/rest>
+   Admin REST API </operating-scylla/rest>
    Tracing </using-scylla/tracing>
    Scylla SStable </operating-scylla/admin-tools/scylla-sstable/>
    Scylla Types </operating-scylla/admin-tools/scylla-types/>

--- a/docs/operating-scylla/rest.rst
+++ b/docs/operating-scylla/rest.rst
@@ -1,6 +1,6 @@
 
-REST
-----
+Admin REST API
+--------------
 
 ScyllaDB exposes a REST API to retrieve administrative information from a node and execute 
 administrative operations. For example, it allows you to check or update configuration, 


### PR DESCRIPTION
"Admin REST API" is more descriptive and more aligned with similar APIs.

Fix #17325