### PR TITLE
compaction: upgrade: handle keyspaces that use tablets

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2591,6 +2591,16 @@ dht::token_range_vector database::get_keyspace_local_ranges(sstring ks) {
     return find_keyspace(ks).get_vnode_effective_replication_map()->get_ranges(my_address);
 }
 
+std::optional<dht::token_range_vector> database::maybe_get_keyspace_local_ranges(sstring ks) {
+    const auto& keyspace = find_keyspace(ks);
+    if (keyspace.get_replication_strategy().is_per_table()) {
+        // return nullopt if each tables have their own effective_replication_map
+        return std::nullopt;
+    }
+    auto my_address = get_token_metadata().get_topology().my_address();
+    return keyspace.get_vnode_effective_replication_map()->get_ranges(my_address);
+}
+
 /*!
  * \brief a helper function that gets a table name and returns a prefix
  * of the directory name of the table.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1796,6 +1796,7 @@ public:
     // Returns the list of ranges held by this endpoint
     // The returned list is sorted, and its elements are non overlapping and non wrap-around.
     dht::token_range_vector get_keyspace_local_ranges(sstring ks);
+    std::optional<dht::token_range_vector> maybe_get_keyspace_local_ranges(sstring ks);
 
     void set_format(sstables::sstable_version_types format) noexcept;
     void set_format_by_config();


### PR DESCRIPTION
Tables in keyspaces governed by replication strategy that uses tablets, have separate effective_replication_maps. Update the upgrade compaction task to handle this when getting owned key ranges for a keyspace.

Fixes #16848