### PR TITLE
[RFC] locator: topology: use frozen_sstring for dc_name and rack_name

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -4504,7 +4504,7 @@ static std::map<sstring, sstring> get_network_topology_options(service::storage_
     sstring rf_str = std::to_string(rf);
     auto& topology = sp.get_token_metadata_ptr()->get_topology();
     for (const gms::inet_address& addr : gossiper.get_live_members()) {
-        options.emplace(topology.get_datacenter(addr), rf_str);
+        options.emplace(topology.get_datacenter(addr).str(), rf_str);
     };
     return options;
 }

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -207,7 +207,7 @@ protected:
         // using _gossiper().get_live_members(). But getting
         // just the list of live nodes in this DC needs more elaborate code:
         auto& topology = _proxy.get_token_metadata_ptr()->get_topology();
-        sstring local_dc = topology.get_datacenter();
+        const auto& local_dc = topology.get_datacenter();
         std::unordered_set<gms::inet_address> local_dc_nodes = topology.get_datacenter_endpoints().at(local_dc);
         for (auto& ip : local_dc_nodes) {
             if (_gossiper.is_alive(ip)) {

--- a/api/storage_proxy.cc
+++ b/api/storage_proxy.cc
@@ -212,8 +212,9 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_pr
         std::vector<sstring> res;
         const auto& filter = proxy.local().get_hints_host_filter();
         const auto& dcs = filter.get_dcs();
-        res.reserve(res.size());
-        std::copy(dcs.begin(), dcs.end(), std::back_inserter(res));
+        res = boost::copy_range<std::vector<sstring>>(dcs | boost::adaptors::transformed([] (const auto& dc_name) {
+            return dc_name.str();
+        }));
         return make_ready_future<json::json_return_type>(res);
     });
 

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1112,7 +1112,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     ss::rebuild.set(r, [&ss](std::unique_ptr<http::request> req) {
         auto source_dc = req->get_query_param("source_dc");
         apilog.info("rebuild: source_dc={}", source_dc);
-        return ss.local().rebuild(std::move(source_dc)).then([] {
+        return ss.local().rebuild(locator::dc_name(std::move(source_dc))).then([] {
             return make_ready_future<json::json_return_type>(json_void());
         });
     });

--- a/api/token_metadata.cc
+++ b/api/token_metadata.cc
@@ -82,9 +82,9 @@ void set_token_metadata(http_context& ctx, routes& r, sharded<locator::shared_to
         if (!topology.has_endpoint(ep)) {
             // Cannot return error here, nodetool status can race, request
             // info about just-left node and not handle it nicely
-            return locator::endpoint_dc_rack::default_location.dc;
+            return locator::endpoint_dc_rack::default_location.dc.str();
         }
-        return topology.get_datacenter(ep);
+        return topology.get_datacenter(ep).str();
     });
 
     httpd::endpoint_snitch_info_json::get_rack.set(r, [&tm](const_req req) {
@@ -93,9 +93,9 @@ void set_token_metadata(http_context& ctx, routes& r, sharded<locator::shared_to
         if (!topology.has_endpoint(ep)) {
             // Cannot return error here, nodetool status can race, request
             // info about just-left node and not handle it nicely
-            return locator::endpoint_dc_rack::default_location.rack;
+            return locator::endpoint_dc_rack::default_location.rack.str();
         }
-        return topology.get_rack(ep);
+        return topology.get_rack(ep).str();
     });
 }
 

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -64,7 +64,7 @@ static std::map<sstring, sstring> prepare_options(
         }
 
         for (const auto& dc : tm.get_topology().get_datacenters()) {
-            options.emplace(dc, *rf);
+            options.emplace(dc.str(), *rf);
         }
     }
 

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -32,12 +32,12 @@ size_t quorum_for(const locator::effective_replication_map& erm) {
     return replication_factor ? (replication_factor / 2) + 1 : 0;
 }
 
-static size_t local_quorum_for(const locator::network_topology_strategy& nrs, const sstring& dc) {
+static size_t local_quorum_for(const locator::network_topology_strategy& nrs, const locator::dc_name& dc) {
     size_t replication_factor = nrs.get_replication_factor(dc);
     return replication_factor ? (replication_factor / 2) + 1 : 0;
 }
 
-size_t local_quorum_for(const locator::effective_replication_map& erm, const sstring& dc) {
+size_t local_quorum_for(const locator::effective_replication_map& erm, const locator::dc_name& dc) {
     using namespace locator;
 
     auto& rs = erm.get_replication_strategy();
@@ -119,7 +119,7 @@ bool is_datacenter_local(consistency_level l) {
 }
 
 template <typename Range, typename PendingRange = std::array<gms::inet_address, 0>>
-std::unordered_map<sstring, dc_node_count> count_per_dc_endpoints(
+std::unordered_map<locator::dc_name, dc_node_count> count_per_dc_endpoints(
         const locator::effective_replication_map& erm,
         const Range& live_endpoints,
         const PendingRange& pending_endpoints = std::array<gms::inet_address, 0>()) {
@@ -131,7 +131,7 @@ std::unordered_map<sstring, dc_node_count> count_per_dc_endpoints(
     const network_topology_strategy* nrs =
             static_cast<const network_topology_strategy*>(&rs);
 
-    std::unordered_map<sstring, dc_node_count> dc_endpoints;
+    std::unordered_map<locator::dc_name, dc_node_count> dc_endpoints;
     for (auto& dc : nrs->get_datacenters()) {
         dc_endpoints.emplace(dc, dc_node_count());
     }

--- a/db/consistency_level.hh
+++ b/db/consistency_level.hh
@@ -17,6 +17,7 @@
 #include "inet_address_vectors.hh"
 #include "log.hh"
 #include "replica/database_fwd.hh"
+#include "locator/types.hh"
 
 #include <iosfwd>
 #include <vector>
@@ -36,7 +37,7 @@ extern logging::logger cl_logger;
 
 size_t quorum_for(const locator::effective_replication_map& erm);
 
-size_t local_quorum_for(const locator::effective_replication_map& erm, const sstring& dc);
+size_t local_quorum_for(const locator::effective_replication_map& erm, const locator::dc_name& dc);
 
 size_t block_for_local_serial(const locator::effective_replication_map& erm);
 

--- a/db/hints/host_filter.cc
+++ b/db/hints/host_filter.cc
@@ -23,7 +23,7 @@ host_filter::host_filter(host_filter::disabled_for_all_tag)
         : _enabled_kind(host_filter::enabled_kind::disabled_for_all) {
 }
 
-host_filter::host_filter(std::unordered_set<sstring> allowed_dcs)
+host_filter::host_filter(std::unordered_set<locator::dc_name> allowed_dcs)
         : _enabled_kind(allowed_dcs.empty() ? enabled_kind::disabled_for_all : enabled_kind::enabled_selectively)
         , _dcs(std::move(allowed_dcs)) {
 }
@@ -65,7 +65,9 @@ host_filter host_filter::parse_from_dc_list(sstring opt) {
         }
     });
 
-    return host_filter(std::unordered_set<sstring>(dcs.begin(), dcs.end()));
+    return host_filter(boost::copy_range<std::unordered_set<locator::dc_name>>(dcs | boost::adaptors::transformed([] (const auto& dc) {
+        return locator::dc_name(dc);
+    })));
 }
 
 std::istream& operator>>(std::istream& is, host_filter& f) {

--- a/db/hints/host_filter.hh
+++ b/db/hints/host_filter.hh
@@ -15,6 +15,7 @@
 
 #include <seastar/core/sstring.hh>
 #include "seastarx.hh"
+#include "locator/types.hh"
 
 namespace gms {
     class inet_address;
@@ -35,7 +36,7 @@ private:
     };
 
     enabled_kind _enabled_kind;
-    std::unordered_set<sstring> _dcs;
+    std::unordered_set<locator::dc_name> _dcs;
 
     static std::string_view enabled_kind_to_string(host_filter::enabled_kind ek);
 
@@ -50,7 +51,7 @@ public:
     host_filter(disabled_for_all_tag);
 
     // Creates a filter that allows sending hints to specified DCs.
-    explicit host_filter(std::unordered_set<sstring> allowed_dcs);
+    explicit host_filter(std::unordered_set<locator::dc_name> allowed_dcs);
 
     // Parses hint filtering configuration from the hinted_handoff_enabled option.
     static host_filter parse_from_config_string(sstring opt);
@@ -60,7 +61,7 @@ public:
 
     bool can_hint_for(const locator::topology& topo, gms::inet_address ep) const;
 
-    inline const std::unordered_set<sstring>& get_dcs() const {
+    inline const std::unordered_set<locator::dc_name>& get_dcs() const {
         return _dcs;
     }
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1441,8 +1441,8 @@ future<> system_keyspace::save_local_info(local_info sysinfo, locator::endpoint_
                             cql3::query_processor::CQL_VERSION,
                             ::cassandra::thrift_version,
                             to_sstring(unsigned(cql_serialization_format::latest().protocol_version())),
-                            location.dc,
-                            location.rack,
+                            location.dc.str(),
+                            location.rack.str(),
                             sstring(cfg.partitioner()),
                             broadcast_rpc_address,
                             broadcast_address,
@@ -2816,7 +2816,7 @@ future<service::topology> system_keyspace::load_topology_state() {
         }
         if (map) {
             map->emplace(host_id, service::replica_state{
-                nstate, std::move(datacenter), std::move(rack), std::move(release_version),
+                nstate, locator::dc_name(datacenter), locator::rack_name(rack), std::move(release_version),
                 ring_slice, shard_count, ignore_msb, std::move(supported_features),
                 service::cleanup_status_from_string(cleanup_status), request_id});
         }

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -80,7 +80,7 @@ public:
                 }
 
                 if (hostid && tm.is_normal_token_owner(*hostid)) {
-                    sstring dc = tm.get_topology().get_location(endpoint).dc;
+                    const auto& dc = tm.get_topology().get_location(endpoint).dc.str();
                     set_cell(cr, "dc", dc);
                 }
 

--- a/dht/range_streamer.hh
+++ b/dht/range_streamer.hh
@@ -66,10 +66,10 @@ public:
      */
     class single_datacenter_filter : public i_source_filter {
     private:
-        sstring _source_dc;
+        locator::dc_name _source_dc;
     public:
-        single_datacenter_filter(const sstring& source_dc)
-            : _source_dc(source_dc) {
+        single_datacenter_filter(locator::dc_name source_dc)
+            : _source_dc(std::move(source_dc)) {
         }
         virtual bool should_include(const locator::topology& topo, inet_address endpoint) override {
             return topo.get_datacenter(endpoint) == _source_dc;

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -314,7 +314,7 @@ vnode_effective_replication_map::get_primary_ranges(inet_address ep) const {
 dht::token_range_vector
 vnode_effective_replication_map::get_primary_ranges_within_dc(inet_address ep) const {
     const topology& topo = _tmptr->get_topology();
-    sstring local_dc = topo.get_datacenter(ep);
+    const auto& local_dc = topo.get_datacenter(ep);
     std::unordered_set<inet_address> local_dc_nodes = topo.get_datacenter_endpoints().at(local_dc);
     // The callback function below is called for each endpoint
     // in each token natural endpoints.

--- a/locator/ec2_multi_region_snitch.cc
+++ b/locator/ec2_multi_region_snitch.cc
@@ -82,8 +82,8 @@ void ec2_multi_region_snitch::set_local_private_addr(const sstring& addr_str) {
 
 gms::application_state_map ec2_multi_region_snitch::get_app_states() const {
     return {
-        {gms::application_state::DC, gms::versioned_value::datacenter(_my_dc)},
-        {gms::application_state::RACK, gms::versioned_value::rack(_my_rack)},
+        {gms::application_state::DC, gms::versioned_value::datacenter(_my_dc.str())},
+        {gms::application_state::RACK, gms::versioned_value::rack(_my_rack.str())},
         {gms::application_state::INTERNAL_IP, gms::versioned_value::internal_ip(_local_private_address)},
     };
 }

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -110,8 +110,8 @@ void gossiping_property_file_snitch::periodic_reader_callback() {
 
 gms::application_state_map gossiping_property_file_snitch::get_app_states() const {
     gms::application_state_map ret = {
-        {gms::application_state::DC, gms::versioned_value::datacenter(_my_dc)},
-        {gms::application_state::RACK, gms::versioned_value::rack(_my_rack)},
+        {gms::application_state::DC, gms::versioned_value::datacenter(_my_dc.str())},
+        {gms::application_state::RACK, gms::versioned_value::rack(_my_rack.str())},
     };
     if (_listen_address.has_value()) {
         sstring ip = format("{}", *_listen_address);
@@ -147,16 +147,16 @@ future<> gossiping_property_file_snitch::read_property_file() {
 future<> gossiping_property_file_snitch::reload_configuration() {
     // "prefer_local" is FALSE by default
     bool new_prefer_local = false;
-    sstring new_dc;
-    sstring new_rack;
+    locator::dc_name new_dc;
+    locator::rack_name new_rack;
 
     // Rack and Data Center have to be defined in the properties file!
     if (!_prop_values.contains(dc_property_key) || !_prop_values.contains(rack_property_key)) {
         throw_incomplete_file();
     }
 
-    new_dc   = _prop_values[dc_property_key];
-    new_rack = _prop_values[rack_property_key];
+    new_dc   = locator::dc_name(_prop_values[dc_property_key]);
+    new_rack = locator::rack_name(_prop_values[rack_property_key]);
 
     if (_prop_values.contains(prefer_local_property_key)) {
         if (_prop_values[prefer_local_property_key] == "false") {

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -27,12 +27,12 @@ public:
         return _rep_factor;
     }
 
-    size_t get_replication_factor(const sstring& dc) const {
+    size_t get_replication_factor(const locator::dc_name& dc) const {
         auto dc_factor = _dc_rep_factor.find(dc);
         return (dc_factor == _dc_rep_factor.end()) ? 0 : dc_factor->second;
     }
 
-    const std::vector<sstring>& get_datacenters() const {
+    const std::vector<locator::dc_name>& get_datacenters() const {
         return _datacenteres;
     }
 
@@ -57,9 +57,9 @@ protected:
 
 private:
     // map: data centers -> replication factor
-    std::unordered_map<sstring, size_t> _dc_rep_factor;
+    std::unordered_map<locator::dc_name, size_t> _dc_rep_factor;
 
-    std::vector<sstring> _datacenteres;
+    std::vector<locator::dc_name> _datacenteres;
     size_t _rep_factor;
 };
 } // namespace locator

--- a/locator/production_snitch_base.cc
+++ b/locator/production_snitch_base.cc
@@ -33,11 +33,11 @@ production_snitch_base::production_snitch_base(snitch_config cfg)
 }
 
 
-sstring production_snitch_base::get_rack() const {
+locator::rack_name production_snitch_base::get_rack() const {
     return _my_rack;
 }
 
-sstring production_snitch_base::get_datacenter() const {
+locator::dc_name production_snitch_base::get_datacenter() const {
     return _my_dc;
 }
 
@@ -45,18 +45,18 @@ void production_snitch_base::set_backreference(snitch_ptr& d) {
     _backreference = &d;
 }
 
-void production_snitch_base::set_my_dc_and_rack(const sstring& new_dc, const sstring& new_rack) {
+void production_snitch_base::set_my_dc_and_rack(const dc_name& new_dc, const rack_name& new_rack) {
     if (!new_dc.empty()) {
         _my_dc = new_dc;
     } else {
-        _my_dc = default_dc;
+        _my_dc = locator::dc_name(default_dc);
         logger().warn("{} snitch attempted to set DC to an empty string, falling back to {}.", get_name(), default_dc);
     }
 
     if (!new_rack.empty()) {
         _my_rack = new_rack;
     } else {
-        _my_rack = default_rack;
+        _my_rack = locator::rack_name(default_rack);
         logger().warn("{} snitch attempted to set rack to an empty string, falling back to {}.", get_name(), default_rack);
     }
 }

--- a/locator/production_snitch_base.hh
+++ b/locator/production_snitch_base.hh
@@ -38,12 +38,12 @@ public:
 
     explicit production_snitch_base(snitch_config);
 
-    virtual sstring get_rack() const override;
-    virtual sstring get_datacenter() const override;
+    virtual locator::rack_name get_rack() const override;
+    virtual locator::dc_name get_datacenter() const override;
     virtual void set_backreference(snitch_ptr& d) override;
 
 private:
-    virtual void set_my_dc_and_rack(const sstring& new_dc, const sstring& new_rack) override;
+    virtual void set_my_dc_and_rack(const dc_name& new_dc, const rack_name& new_rack) override;
     virtual void set_prefer_local(bool prefer_local) override;
     void parse_property_file();
 

--- a/locator/rack_inferring_snitch.hh
+++ b/locator/rack_inferring_snitch.hh
@@ -33,14 +33,14 @@ struct rack_inferring_snitch : public snitch_base {
         set_snitch_ready();
     }
 
-    virtual sstring get_rack() const override {
+    virtual locator::rack_name get_rack() const override {
         auto& endpoint = _cfg.broadcast_address;
-        return std::to_string(uint8_t(endpoint.bytes()[2]));
+        return locator::rack_name(std::to_string(uint8_t(endpoint.bytes()[2])));
     }
 
-    virtual sstring get_datacenter() const override {
+    virtual locator::dc_name get_datacenter() const override {
         auto& endpoint = _cfg.broadcast_address;
-        return std::to_string(uint8_t(endpoint.bytes()[1]));
+        return locator::dc_name(std::to_string(uint8_t(endpoint.bytes()[1])));
     }
 
     virtual sstring get_name() const override {

--- a/locator/simple_snitch.hh
+++ b/locator/simple_snitch.hh
@@ -29,12 +29,12 @@ struct simple_snitch : public snitch_base {
         set_snitch_ready();
     }
 
-    virtual sstring get_rack() const override {
-        return "rack1";
+    virtual locator::rack_name get_rack() const override {
+        return locator::rack_name("rack1");
     }
 
-    virtual sstring get_datacenter() const override {
-        return "datacenter1";
+    virtual locator::dc_name get_datacenter() const override {
+        return locator::dc_name("datacenter1");
     }
 
     virtual sstring get_name() const override {

--- a/locator/snitch_base.cc
+++ b/locator/snitch_base.cc
@@ -16,8 +16,8 @@ namespace locator {
 
 gms::application_state_map snitch_base::get_app_states() const {
     return {
-        {gms::application_state::DC, gms::versioned_value::datacenter(_my_dc)},
-        {gms::application_state::RACK, gms::versioned_value::rack(_my_rack)},
+        {gms::application_state::DC, gms::versioned_value::datacenter(_my_dc.str())},
+        {gms::application_state::RACK, gms::versioned_value::rack(_my_rack.str())},
     };
 }
 

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -20,10 +20,10 @@ namespace locator {
 
 static logging::logger tlogger("topology");
 
-thread_local const endpoint_dc_rack endpoint_dc_rack::default_location = {
-    .dc = locator::production_snitch_base::default_dc,
-    .rack = locator::production_snitch_base::default_rack,
-};
+thread_local const endpoint_dc_rack endpoint_dc_rack::default_location(
+    locator::production_snitch_base::default_dc,
+    locator::production_snitch_base::default_rack
+);
 
 node::node(const locator::topology* topology, locator::host_id id, inet_address endpoint, endpoint_dc_rack dc_rack, state state, shard_id shard_count, this_node is_this_node, node::idx_type idx)
     : _topology(topology)
@@ -231,10 +231,10 @@ const node* topology::update_node(node* node, std::optional<host_id> opt_id, std
         }
     }
     if (opt_dr) {
-        if (opt_dr->dc.empty() || opt_dr->dc == production_snitch_base::default_dc) {
+        if (opt_dr->dc.empty() || opt_dr->dc == endpoint_dc_rack::default_location.dc) {
             opt_dr->dc = node->dc_rack().dc;
         }
-        if (opt_dr->rack.empty() || opt_dr->rack == production_snitch_base::default_rack) {
+        if (opt_dr->rack.empty() || opt_dr->rack == endpoint_dc_rack::default_location.rack) {
             opt_dr->rack = node->dc_rack().rack;
         }
         if (*opt_dr != node->dc_rack()) {
@@ -560,8 +560,8 @@ namespace std {
 
 std::ostream& operator<<(std::ostream& out, const locator::topology& t) {
     out << "{this_endpoint: " << t._cfg.this_endpoint
-        << ", dc: " << t._cfg.local_dc_rack.dc
-        << ", rack: " << t._cfg.local_dc_rack.rack
+        << ", dc: " << t._cfg.local_dc_rack.dc.str()
+        << ", rack: " << t._cfg.local_dc_rack.rack.str()
         << ", nodes:\n";
     for (auto&& node : t._nodes) {
         out << "  " << locator::topology::debug_format(&*node) << "\n";

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -16,12 +16,12 @@
 #include <iostream>
 
 #include <seastar/core/future.hh>
-#include <seastar/core/sstring.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/util/bool_class.hh>
 
 #include "locator/types.hh"
 #include "inet_address_vectors.hh"
+#include "utils/frozen_sstring.hh"
 
 using namespace seastar;
 
@@ -258,26 +258,26 @@ public:
      */
     bool has_endpoint(inet_address) const;
 
-    const std::unordered_map<sstring,
+    const std::unordered_map<dc_name,
                            std::unordered_set<inet_address>>&
     get_datacenter_endpoints() const {
         return _dc_endpoints;
     }
 
-    const std::unordered_map<sstring,
+    const std::unordered_map<dc_name,
                             std::unordered_set<const node*>>&
     get_datacenter_nodes() const {
         return _dc_nodes;
     }
 
-    const std::unordered_map<sstring,
-                       std::unordered_map<sstring,
+    const std::unordered_map<dc_name,
+                       std::unordered_map<rack_name,
                                           std::unordered_set<inet_address>>>&
     get_datacenter_racks() const {
         return _dc_racks;
     }
 
-    const std::unordered_set<sstring>& get_datacenters() const noexcept {
+    const std::unordered_set<dc_name>& get_datacenters() const noexcept {
         return _datacenters;
     }
 
@@ -295,32 +295,32 @@ public:
     const endpoint_dc_rack& get_location(const inet_address& ep) const;
 
     // Get datacenter of this node
-    const sstring& get_datacenter() const noexcept {
+    const dc_name& get_datacenter() const noexcept {
         return get_location().dc;
     }
     // Get datacenter of a node identified by host_id
     // The specified node must exist.
-    const sstring& get_datacenter(host_id id) const {
+    const dc_name& get_datacenter(host_id id) const {
         return get_location(id).dc;
     }
     // Get datacenter of a node identified by endpoint
     // The specified node must exist.
-    const sstring& get_datacenter(inet_address ep) const {
+    const dc_name& get_datacenter(inet_address ep) const {
         return get_location(ep).dc;
     }
 
     // Get rack of this node
-    const sstring& get_rack() const noexcept {
+    const rack_name& get_rack() const noexcept {
         return get_location().rack;
     }
     // Get rack of a node identified by host_id
     // The specified node must exist.
-    const sstring& get_rack(host_id id) const {
+    const rack_name& get_rack(host_id id) const {
         return get_location(id).rack;
     }
     // Get rack of a node identified by endpoint
     // The specified node must exist.
-    const sstring& get_rack(inet_address ep) const {
+    const rack_name& get_rack(inet_address ep) const {
         return get_location(ep).rack;
     }
 
@@ -396,24 +396,24 @@ private:
     std::unordered_map<host_id, const node*> _nodes_by_host_id;
     std::unordered_map<inet_address, const node*> _nodes_by_endpoint;
 
-    std::unordered_map<sstring, std::unordered_set<const node*>> _dc_nodes;
-    std::unordered_map<sstring, std::unordered_map<sstring, std::unordered_set<const node*>>> _dc_rack_nodes;
+    std::unordered_map<dc_name, std::unordered_set<const node*>> _dc_nodes;
+    std::unordered_map<dc_name, std::unordered_map<rack_name, std::unordered_set<const node*>>> _dc_rack_nodes;
 
     /** multi-map: DC -> endpoints in that DC */
-    std::unordered_map<sstring,
+    std::unordered_map<dc_name,
                        std::unordered_set<inet_address>>
         _dc_endpoints;
 
     /** map: DC -> (multi-map: rack -> endpoints in that rack) */
-    std::unordered_map<sstring,
-                       std::unordered_map<sstring,
+    std::unordered_map<dc_name,
+                       std::unordered_map<rack_name,
                                           std::unordered_set<inet_address>>>
         _dc_racks;
 
     bool _sort_by_proximity = true;
 
     // pre-calculated
-    std::unordered_set<sstring> _datacenters;
+    std::unordered_set<dc_name> _datacenters;
 
     void calculate_datacenters();
 

--- a/locator/types.hh
+++ b/locator/types.hh
@@ -14,6 +14,7 @@
 
 #include "gms/inet_address.hh"
 #include "locator/host_id.hh"
+#include "utils/frozen_sstring.hh"
 
 using namespace seastar;
 
@@ -21,10 +22,25 @@ namespace locator {
 
 using inet_address = gms::inet_address;
 
+using dc_name = utils::basic_frozen_sstring<struct dc_name_tag, char, uint32_t, 15, true>;
+using rack_name = utils::basic_frozen_sstring<struct rack_name_tag, char, uint32_t, 15, true>;
+
 // Endpoint Data Center and Rack names
 struct endpoint_dc_rack {
-    sstring dc;
-    sstring rack;
+    dc_name dc;
+    rack_name rack;
+
+    endpoint_dc_rack() = default;
+
+    endpoint_dc_rack(dc_name dc, rack_name rack) noexcept
+        : dc(std::move(dc))
+        , rack(std::move(rack))
+    {}
+
+    endpoint_dc_rack(sstring dc, sstring rack) noexcept
+        : dc(std::move(dc))
+        , rack(std::move(rack))
+    {}
 
     static thread_local const endpoint_dc_rack default_location;
 

--- a/locator/util.cc
+++ b/locator/util.cc
@@ -119,8 +119,8 @@ describe_ring(const replica::database& db, const gms::gossiper& gossiper, const 
         for (auto endpoint : addresses) {
             dht::endpoint_details details;
             details._host = endpoint;
-            details._datacenter = topology.get_datacenter(endpoint);
-            details._rack = topology.get_rack(endpoint);
+            details._datacenter = topology.get_datacenter(endpoint).str();
+            details._rack = topology.get_rack(endpoint).str();
             tr._rpc_endpoints.push_back(gossiper.get_rpc_address(endpoint));
             tr._endpoints.push_back(fmt::to_string(details._host));
             tr._endpoint_details.push_back(details);

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -302,7 +302,8 @@ sstring messaging_service::client_metrics_domain(unsigned idx, inet_address addr
     if (_token_metadata) {
         const auto& topo = _token_metadata->get()->get_topology();
         if (topo.has_endpoint(addr)) {
-            ret += ":" + topo.get_datacenter(addr);
+            ret += ":";
+            ret += topo.get_datacenter(addr).str();
         }
     }
     return ret;

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -146,11 +146,11 @@ public:
     future<> bootstrap_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> bootstrap_tokens);
     future<> decommission_with_repair(locator::token_metadata_ptr tmptr);
     future<> removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
-    future<> rebuild_with_repair(locator::token_metadata_ptr tmptr, sstring source_dc);
+    future<> rebuild_with_repair(locator::token_metadata_ptr tmptr, locator::dc_name source_dc);
     future<> replace_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> replacing_tokens, std::unordered_set<gms::inet_address> ignore_nodes);
 private:
     future<> do_decommission_removenode_with_repair(locator::token_metadata_ptr tmptr, gms::inet_address leaving_node, shared_ptr<node_ops_info> ops);
-    future<> do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, sstring source_dc, streaming::stream_reason reason, std::unordered_set<gms::inet_address> ignore_nodes);
+    future<> do_rebuild_replace_with_repair(locator::token_metadata_ptr tmptr, sstring op, locator::dc_name source_dc, streaming::stream_reason reason, std::unordered_set<gms::inet_address> ignore_nodes);
 
     // Must be called on shard 0
     future<> sync_data_using_repair(sstring keyspace,

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -45,7 +45,7 @@ private:
     std::vector<sstring> _cfs;
     dht::token_range_vector _ranges;
     std::vector<sstring> _hosts;
-    std::vector<sstring> _data_centers;
+    std::vector<locator::dc_name> _data_centers;
     std::unordered_set<gms::inet_address> _ignore_nodes;
     bool _small_table_optimization;
     std::optional<int> _ranges_parallelism;
@@ -56,7 +56,9 @@ public:
         , _cfs(std::move(cfs))
         , _ranges(std::move(ranges))
         , _hosts(std::move(hosts))
-        , _data_centers(std::move(data_centers))
+        , _data_centers(boost::copy_range<std::vector<locator::dc_name>>(data_centers | boost::adaptors::transformed([] (const auto& dc) {
+                return locator::dc_name(std::move(dc));
+            })))
         , _ignore_nodes(std::move(ignore_nodes))
         , _small_table_optimization(small_table_optimization)
         , _ranges_parallelism(ranges_parallelism)
@@ -138,7 +140,7 @@ public:
     std::vector<sstring> cfs;
     std::vector<table_id> table_ids;
     repair_uniq_id global_repair_id;
-    std::vector<sstring> data_centers;
+    std::vector<locator::dc_name> data_centers;
     std::vector<sstring> hosts;
     std::unordered_set<gms::inet_address> ignore_nodes;
     std::unordered_map<dht::token_range, repair_neighbors> neighbors;
@@ -165,7 +167,7 @@ public:
             const dht::token_range_vector& ranges_,
             std::vector<table_id> table_ids_,
             repair_uniq_id parent_id_,
-            const std::vector<sstring>& data_centers_,
+            const std::vector<locator::dc_name>& data_centers_,
             const std::vector<sstring>& hosts_,
             const std::unordered_set<gms::inet_address>& ignore_nodes_,
             streaming::stream_reason reason_,

--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -12,6 +12,7 @@
 #include "utils/estimated_histogram.hh"
 #include "utils/histogram.hh"
 #include <seastar/core/metrics.hh>
+#include "locator/types.hh"
 
 namespace locator { class topology; }
 
@@ -31,7 +32,7 @@ private:
     // counter of operations performed on a local Node
     stats_counter _local;
     // counters of operations performed on external Nodes aggregated per Nodes' DCs
-    std::unordered_map<sstring, stats_counter> _dc_stats;
+    std::unordered_map<locator::dc_name, stats_counter> _dc_stats;
     // collectd registrations container
     seastar::metrics::metric_groups _metrics;
     // a prefix string that will be used for a collectd counters' description
@@ -54,7 +55,7 @@ public:
     split_stats(const sstring& category, const sstring& short_description_prefix, const sstring& long_description_prefix, const sstring& op_type, bool auto_register_metrics = true);
 
     void register_metrics_local();
-    void register_metrics_for(sstring dc, gms::inet_address ep);
+    void register_metrics_for(const locator::dc_name& dc, gms::inet_address ep);
 
     /**
      * Get a reference to the statistics counter corresponding to the given

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -378,7 +378,7 @@ private:
     future<> start_sys_dist_ks();
 public:
 
-    future<> rebuild(sstring source_dc);
+    future<> rebuild(locator::dc_name source_dc);
 
 private:
     void set_mode(mode m);
@@ -819,7 +819,7 @@ private:
     future<> raft_initialize_discovery_leader(raft::server&, const join_node_request_params& params);
     future<> raft_decommission();
     future<> raft_removenode(locator::host_id host_id, std::list<locator::host_id_or_endpoint> ignore_nodes_params);
-    future<> raft_rebuild(sstring source_dc);
+    future<> raft_rebuild(locator::dc_name source_dc);
     future<> raft_check_and_repair_cdc_streams();
     future<> update_topology_with_local_metadata(raft::server&);
 

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -22,6 +22,7 @@
 #include "utils/UUID.hh"
 #include "service/session.hh"
 #include "mutation/canonical_mutation.hh"
+#include "locator/types.hh"
 
 namespace service {
 
@@ -79,8 +80,8 @@ struct ring_slice {
 
 struct replica_state {
     node_state state;
-    seastar::sstring datacenter;
-    seastar::sstring rack;
+    locator::dc_name datacenter;
+    locator::rack_name rack;
     seastar::sstring release_version;
     std::optional<ring_slice> ring; // if engaged contain the set of tokens the node owns together with their state
     size_t shard_count;

--- a/test/boost/gossiping_property_file_snitch_test.cc
+++ b/test/boost/gossiping_property_file_snitch_test.cc
@@ -53,8 +53,8 @@ future<> one_test(const std::string& property_fname, bool exp_result) {
                                 "configuration file");
                     return snitch.stop();
                 }
-                auto cpu0_dc = make_lw_shared<sstring>();
-                auto cpu0_rack = make_lw_shared<sstring>();
+                auto cpu0_dc = make_lw_shared<dc_name>();
+                auto cpu0_rack = make_lw_shared<rack_name>();
                 auto res = make_lw_shared<bool>(true);
 
                 return snitch.invoke_on(0,

--- a/test/boost/snitch_reset_test.cc
+++ b/test/boost/snitch_reset_test.cc
@@ -30,10 +30,10 @@ future<> one_test(const std::string& property_fname1,
            (exp_result ? "success" : "failure"));
 
     return seastar::async([&property_fname1, &property_fname2, exp_result] {
-        auto cpu0_dc = make_lw_shared<sstring>();
-        auto cpu0_rack = make_lw_shared<sstring>();
-        auto cpu0_dc_new = make_lw_shared<sstring>();
-        auto cpu0_rack_new = make_lw_shared<sstring>();
+        auto cpu0_dc = make_lw_shared<dc_name>();
+        auto cpu0_rack = make_lw_shared<rack_name>();
+        auto cpu0_dc_new = make_lw_shared<dc_name>();
+        auto cpu0_rack_new = make_lw_shared<rack_name>();
         sharded<snitch_ptr> snitch;
         auto my_address = gms::inet_address("localhost");
 

--- a/test/boost/storage_proxy_test.cc
+++ b/test/boost/storage_proxy_test.cc
@@ -129,6 +129,6 @@ SEASTAR_THREAD_TEST_CASE(test_split_stats) {
     // Point being is that either the above should not happen, or 
     // split_stats should be resilient to being called from different
     // scheduling group.
-    stats1->register_metrics_for("DC1", ep1);
-    stats2->register_metrics_for("DC1", ep1);
+    stats1->register_metrics_for(locator::dc_name("DC1"), ep1);
+    stats2->register_metrics_for(locator::dc_name("DC1"), ep1);
 }

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1462,7 +1462,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
     };
 
     for (int i = 0; i < 13; ++i) {
-        std::unordered_map<sstring, std::vector<host_id>> hosts_by_rack;
+        std::unordered_map<locator::rack_name, std::vector<host_id>> hosts_by_rack;
 
         semaphore sem(1);
         shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -22,10 +22,7 @@ namespace {
     }
 
     endpoint_dc_rack get_dc_rack(host_id) {
-        return {
-            .dc = "unk-dc",
-            .rack = "unk-rack"
-        };
+        return endpoint_dc_rack("unk-dc", "unk-rack");
     }
 
     mutable_token_metadata_ptr create_token_metadata(host_id this_host_id) {

--- a/test/manual/ec2_snitch_test.cc
+++ b/test/manual/ec2_snitch_test.cc
@@ -49,8 +49,8 @@ future<> one_test(const std::string& property_fname, bool exp_result) {
                                 "configuration file");
                     return snitch.stop();
                 }
-                auto cpu0_dc = make_lw_shared<sstring>();
-                auto cpu0_rack = make_lw_shared<sstring>();
+                auto cpu0_dc = make_lw_shared<locator::dc_name>();
+                auto cpu0_rack = make_lw_shared<locator::rack_name>();
                 auto res = make_lw_shared<bool>(true);
 
                 return snitch.invoke_on(0,

--- a/test/manual/gce_snitch_test.cc
+++ b/test/manual/gce_snitch_test.cc
@@ -95,8 +95,8 @@ future<> one_test(const std::string& property_fname, bool exp_result) {
                 }
                 return;
             }
-            auto cpu0_dc = make_lw_shared<sstring>();
-            auto cpu0_rack = make_lw_shared<sstring>();
+            auto cpu0_dc = make_lw_shared<dc_name>();
+            auto cpu0_rack = make_lw_shared<rack_name>();
             auto res = make_lw_shared<bool>(true);
 
             snitch.invoke_on(0, [cpu0_dc, cpu0_rack, res] (snitch_ptr& inst) {

--- a/types/types.hh
+++ b/types/types.hh
@@ -36,6 +36,7 @@
 #include "utils/chunked_vector.hh"
 #include "utils/lexicographical_compare.hh"
 #include "utils/overloaded_functor.hh"
+#include "utils/frozen_sstring.hh"
 #include "tasks/types.hh"
 
 class tuple_type_impl;

--- a/utils/frozen_sstring.hh
+++ b/utils/frozen_sstring.hh
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <seastar/core/sstring.hh>
+
+using namespace seastar;
+
+namespace utils {
+
+template <typename tag, typename char_type, typename Size, Size max_size, bool NulTerminate>
+class basic_frozen_sstring {
+    using basic_sstring =  basic_sstring<char_type, Size, max_size, NulTerminate>;
+    using basic_string_view = std::basic_string_view<char_type>;
+    using basic_string = std::basic_string<char_type>;
+
+    basic_sstring _str;
+    size_t _hash;
+
+public:
+    using value_type = basic_sstring::value_type;
+    using traits_type = basic_sstring::traits_type;
+    using allocator_type = basic_sstring::allocator_type;
+    using reference = basic_sstring::const_reference;
+    using const_reference = basic_sstring::const_reference;
+    using pointer = basic_sstring::const_pointer;
+    using const_pointer = basic_sstring::const_pointer;
+    using iterator = basic_sstring::const_iterator;
+    using const_iterator = basic_sstring::const_iterator;
+    using difference_type = basic_sstring::difference_type;
+    using size_type = basic_sstring::size_type;
+
+    static constexpr size_type npos = basic_sstring::npos;
+
+    basic_frozen_sstring() noexcept : _str(), _hash(0) {}
+    basic_frozen_sstring(const basic_frozen_sstring& o) : _str(o._str) , _hash(o._hash) {}
+    basic_frozen_sstring(basic_frozen_sstring&& o) noexcept : _str(std::move(o._str)), _hash(std::exchange(o._hash, 0)) {}
+
+    explicit basic_frozen_sstring(const char_type* s) noexcept : _str(s), _hash(std::hash<basic_sstring>()(_str)) {}
+    explicit basic_frozen_sstring(const char_type* s, size_type size) noexcept : _str(s, size), _hash(std::hash<basic_sstring>()(_str)) {}
+    explicit basic_frozen_sstring(const basic_string_view& x) : _str(x), _hash(std::hash<basic_sstring>()(_str)) {}
+    explicit basic_frozen_sstring(const basic_string& x) : _str(x), _hash(std::hash<basic_sstring>()(_str)) {}
+    explicit basic_frozen_sstring(const basic_sstring& x) : _str(x), _hash(std::hash<basic_sstring>()(_str)) {}
+    explicit basic_frozen_sstring(basic_string&& x) : _str(std::move(x)), _hash(std::hash<basic_sstring>()(_str)) {}
+    explicit basic_frozen_sstring(basic_sstring&& x) : _str(std::move(x)), _hash(std::hash<basic_sstring>()(_str)) {}
+
+    basic_frozen_sstring& operator=(const basic_frozen_sstring& x) {
+        if (this != &x) {
+            _str = x._str;
+            _hash = x._hash;
+        }
+        return *this;
+    }
+    basic_frozen_sstring& operator=(basic_frozen_sstring&& x) noexcept {
+        if (this != &x) {
+            _str = std::move(x._str);
+            _hash = std::exchange(x._hash, 0);
+        }
+        return *this;
+    }
+
+    bool operator==(const basic_frozen_sstring& x) const noexcept {
+        return hash() == x.hash() && str() == x.str();
+    }
+
+    constexpr std::strong_ordering operator<=>(const basic_frozen_sstring& x) const noexcept {
+        return str() <=> x.str();
+    }
+
+    const basic_sstring& str() const noexcept { return _str; }
+    const_pointer c_str() const noexcept { return str().c_str(); }
+    const_pointer data() const noexcept { return str().data(); }
+    size_t hash() const noexcept { return _hash; }
+
+    bool empty() const noexcept { return str().empty(); }
+    size_t size() const noexcept { return str().size(); }
+
+private:
+    auto format(fmt::format_context& ctx) const {
+        return fmt::formatter<basic_sstring>().format(str(), ctx);
+    }
+
+    friend fmt::formatter<basic_frozen_sstring>;
+};
+
+using frozen_sstring = basic_frozen_sstring<struct untagged_frozen_sstring, char, uint32_t, 15, true>;
+
+} // namespace utils
+
+template <typename tag, typename char_type, typename size_type, size_type max_size, bool NulTerminate>
+struct fmt::formatter<utils::basic_frozen_sstring<tag, char_type, size_type, max_size, NulTerminate>> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const utils::basic_frozen_sstring<tag, char_type, size_type, max_size, NulTerminate>& s, fmt::format_context& ctx) const {
+        return s.format(ctx);
+    }
+};
+
+namespace std {
+
+template <typename tag, typename char_type, typename size_type, size_type max_size, bool NulTerminate>
+struct hash<utils::basic_frozen_sstring<tag, char_type, size_type, max_size, NulTerminate>> {
+    size_t operator()(const utils::basic_frozen_sstring<tag, char_type, size_type, max_size, NulTerminate>& s) const {
+        return s.hash();
+    }
+};
+
+template <typename tag, typename char_type, typename size_type, size_type max_size, bool NulTerminate>
+std::ostream& operator<<(std::ostream& os, const utils::basic_frozen_sstring<tag, char_type, size_type, max_size, NulTerminate>& s) {
+    return os << s.str();
+}
+
+} // namespace std


### PR DESCRIPTION
The datacenter and rack names never change.
We can take advantage of that by keeping a frozen_sstring
that pre-calculates their hash value so they are more
efficient to use as map keys and fast to compare
(against strings of the same size which is typical
for datacenter and rack names).

The change ripples everywhere, but the change is mechanical
and the risk is low.  On the contrary, having dc_name
and rack_name be stringly typed reduces the risk of an sstring
holding a dc name used to compare against a rack name.

FWIW, the change does not affect perf_simple_query.
We probably need a test with a large number of datacenters
and racks to see any difference.

Before (f990ea9678):
```
    median 124269.34 tps ( 61.1 allocs/op,  13.1 tasks/op,   41728 insns/op,        0 errors)
```
    
After:
```
    median 125765.35 tps ( 61.1 allocs/op,  13.1 tasks/op,   41731 insns/op,        0 errors)
``` 
* Used `build/release/scylla perf-simple-query -c 1`
   under `sudo cpupower frequency-set -g userspace`

Refs #17100