### PR TITLE
test/pylib: scylla-cluster: don't enable experimental features by default

### DIFF
--- a/test/cql/suite.yaml
+++ b/test/cql/suite.yaml
@@ -1,1 +1,4 @@
 type: Approval
+extra_scylla_cmdline_options:
+  - '--experimental-features=udf'
+  - '--enable-user-defined-functions=1'

--- a/test/cqlpy/suite.yaml
+++ b/test/cqlpy/suite.yaml
@@ -6,3 +6,4 @@ extra_scylla_cmdline_options:
   - '--experimental-features=udf'
   - '--experimental-features=keyspace-storage-options'
   - '--enable-tablets=true'
+  - '--enable-user-defined-functions=true'

--- a/test/object_store/suite.yaml
+++ b/test/object_store/suite.yaml
@@ -6,3 +6,5 @@ extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer
     enable_tablets: true
+    experimental_features:
+      - 'keyspace-storage-options'

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -94,14 +94,6 @@ def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addr
 
         'developer_mode': True,
 
-        # Allow testing experimental features. Following issue #9467, we need
-        # to add here specific experimental features as they are introduced.
-        'enable_user_defined_functions': True,
-        'experimental_features': ['udf',
-                                  'alternator-streams',
-                                  'broadcast-tables',
-                                  'keyspace-storage-options'],
-
         'skip_wait_for_gossip_to_settle': 0,
         'ring_delay_ms': 0,
         'num_tokens': 16,


### PR DESCRIPTION
Let each test-suite enable just the ones it needs.