### PR TITLE
db/virtual_tables: make token_ring_table tablet aware

### DIFF
--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -133,6 +133,7 @@ public:
         auto id = generate_legacy_id(system_keyspace::NAME, "token_ring");
         return schema_builder(system_keyspace::NAME, "token_ring", std::make_optional(id))
             .with_column("keyspace_name", utf8_type, column_kind::partition_key)
+            .with_column("table_name", utf8_type, column_kind::clustering_key)
             .with_column("start_token", utf8_type, column_kind::clustering_key)
             .with_column("endpoint", inet_addr_type, column_kind::clustering_key)
             .with_column("end_token", utf8_type)
@@ -146,14 +147,15 @@ public:
         return dht::decorate_key(*_s, partition_key::from_single_value(*_s, data_value(name).serialize_nonnull()));
     }
 
-    clustering_key make_clustering_key(sstring start_token, gms::inet_address host) {
+    clustering_key make_clustering_key(const sstring& table_name, sstring start_token, gms::inet_address host) {
         return clustering_key::from_exploded(*_s, {
+            data_value(table_name).serialize_nonnull(),
             data_value(start_token).serialize_nonnull(),
             data_value(host).serialize_nonnull()
         });
     }
 
-    future<> emit_ring(result_collector& result, const dht::decorated_key& dk, std::vector<dht::token_range_endpoints> ranges) {
+    future<> emit_ring(result_collector& result, const dht::decorated_key& dk, const sstring& table_name, std::vector<dht::token_range_endpoints> ranges) {
 
         co_await result.emit_partition_start(dk);
         boost::sort(ranges, [] (const dht::token_range_endpoints& l, const dht::token_range_endpoints& r) {
@@ -164,7 +166,7 @@ public:
             boost::sort(range._endpoint_details, endpoint_details_cmp());
 
             for (const dht::endpoint_details& detail : range._endpoint_details) {
-                clustering_row cr(make_clustering_key(range._start_token, detail._host));
+                clustering_row cr(make_clustering_key(table_name, range._start_token, detail._host));
                 set_cell(cr.cells(), "end_token", sstring(range._end_token));
                 set_cell(cr.cells(), "dc", sstring(detail._datacenter));
                 set_cell(cr.cells(), "rack", sstring(detail._rack));
@@ -211,7 +213,7 @@ public:
             }
 
             std::vector<dht::token_range_endpoints> ranges = co_await _ss.describe_ring(e.name);
-            co_await emit_ring(result, e.key, std::move(ranges));
+            co_await emit_ring(result, e.key, "<ALL>", std::move(ranges));
         }
     }
 };

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4813,12 +4813,11 @@ storage_service::describe_ring_for_table(const sstring& keyspace_name, const sst
         }
         for (auto& r : replicas) {
             dht::endpoint_details details;
-            auto& hostid = r.host;
-            auto endpoint = host2ip(hostid);
-            details._datacenter = topology.get_datacenter(hostid);
-            details._rack = topology.get_rack(hostid);
-            details._host = endpoint;
-            tr._rpc_endpoints.push_back(_gossiper.get_rpc_address(endpoint));
+            const auto& node = topology.get_node(r.host);
+            details._datacenter = node.dc_rack().dc;
+            details._rack = node.dc_rack().rack;
+            details._host = node.endpoint();
+            tr._rpc_endpoints.push_back(_gossiper.get_rpc_address(node.endpoint()));
             tr._endpoints.push_back(fmt::to_string(details._host));
             tr._endpoint_details.push_back(std::move(details));
         }

--- a/test/cql-pytest/test_describe.py
+++ b/test/cql-pytest/test_describe.py
@@ -405,7 +405,7 @@ def test_desc_cluster(scylla_only, cql, test_keyspace):
         for endpoint in endpoints:
             desc_endpoints.append((end_token, endpoint))
 
-    result = cql.execute(f"SELECT end_token, endpoint FROM system.token_ring WHERE keyspace_name='{test_keyspace}' ORDER BY start_token")
+    result = cql.execute(f"SELECT end_token, endpoint FROM system.token_ring WHERE keyspace_name='{test_keyspace}' ORDER BY table_name, start_token")
     ring_endpoints = [(r.end_token, r.endpoint) for r in result]
     
     assert sorted(desc_endpoints) == sorted(ring_endpoints)


### PR DESCRIPTION
The token ring table is a virtual table (`system.token_ring`), which contains the ring information for all keyspaces in the system. This is essentially an alternative to `nodetool describering`, but since it is a virtual table, it allows for all the usual filtering/aggregation/etc. that CQL supports.
Up until now, this table only supported keyspaces which use vnodes. This PR adds support for tablet keyspaces. To accommodate these keyspaces a new `table_name` column is added, which is set to `ALL` for vnodes keyspaces. For tablet keyspaces, this contains the name of the table.
Simple sanity tests are added for this virtual table (it had none).

Fixes: #16850