### PR TITLE
sstables: close index_reader in has_partition_key

### DIFF
--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -949,6 +949,7 @@ public:
     // If upper_bound is provided, the upper bound within position is looked up
     future<bool> advance_lower_and_check_if_present(
             dht::ring_position_view key, std::optional<position_in_partition_view> pos = {}) {
+        utils::get_local_injector().inject("advance_lower_and_check_if_present", [] { throw std::runtime_error("advance_lower_and_check_if_present"); });
         return advance_to(_lower_bound, key).then([this, key, pos] {
             if (eof()) {
                 return make_ready_future<bool>(false);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2776,11 +2776,15 @@ future<bool> sstable::has_partition_key(const utils::hashed_key& hk, const dht::
     std::exception_ptr ex;
     auto sem = reader_concurrency_semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::has_partition_key()",
             reader_concurrency_semaphore::register_metrics::no);
+    std::unique_ptr<sstables::index_reader> lh_index_ptr = nullptr;
     try {
-        auto lh_index_ptr = std::make_unique<sstables::index_reader>(s, sem.make_tracking_only_permit(_schema, s->get_filename(), db::no_timeout, {}));
+        lh_index_ptr = std::make_unique<sstables::index_reader>(s, sem.make_tracking_only_permit(_schema, s->get_filename(), db::no_timeout, {}));
         present = co_await lh_index_ptr->advance_lower_and_check_if_present(dk);
     } catch (...) {
         ex = std::current_exception();
+    }
+    if (auto lhi_ptr = std::move(lh_index_ptr)) {
+        co_await lhi_ptr->close();
     }
     co_await sem.stop();
     if (ex) {

--- a/test/rest_api/test_column_family.py
+++ b/test/rest_api/test_column_family.py
@@ -11,6 +11,7 @@ import time
 # Use the util.py library from ../cql-pytest:
 sys.path.insert(1, sys.path[0] + '/../cql-pytest')
 from util import new_test_table, new_test_keyspace
+from rest_util import scylla_inject_error
 
 def do_test_column_family_attribute_api_table(cql, this_dc, rest_api, api_name):
     ksdef = f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : '1' }}"
@@ -105,3 +106,22 @@ def test_column_family_major_compaction(cql, this_dc, rest_api):
             resp.raise_for_status()
             resp = rest_api.send("POST", f"column_family/major_compaction/{test_keyspace}:{test_table}", params={"flush_memtables": "false"})
             resp.raise_for_status()
+
+def test_sstables_by_key_reader_closed(cql, this_dc, rest_api):
+    ksdef = f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : '1' }}"
+    with new_test_keyspace(cql, ksdef) as test_keyspace:
+        with new_test_table(cql, test_keyspace, "a int, PRIMARY KEY (a)") as t:
+            test_table = t.split('.')[1]
+
+            cql.execute(f"INSERT INTO {test_keyspace}.{test_table} (a) VALUES (1)")
+            resp = rest_api.send("POST", f"storage_service/keyspace_flush/{test_keyspace}")
+            resp.raise_for_status()
+
+            # Check if index reader is closed on happy path.
+            resp = rest_api.send("GET", f"column_family/sstables/by_key/{test_keyspace}:{test_table}?key=1")
+            resp.raise_for_status()
+
+            # Check if index reader is closed if exception is thrown.
+            with scylla_inject_error(rest_api, "advance_lower_and_check_if_present"):
+                resp = rest_api.send("GET", f"column_family/sstables/by_key/{test_keyspace}:{test_table}?key=1")
+                assert resp.status_code == 500


### PR DESCRIPTION
If index_reader isn't closed before it is destroyed, then ongoing
sstables reads won't be awaited and assertion will be triggered.

Close index_reader in has_partition_key before destroying it.

Fixes: #17232.