### PR TITLE
join_cluster: move was_decommissioned check earlier

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1240,13 +1240,6 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
      */
     std::optional<cdc::generation_id> cdc_gen_id;
 
-    if (_sys_ks.local().was_decommissioned()) {
-        auto msg = sstring("This node was decommissioned and will not rejoin the ring unless "
-                           "all existing data is removed and the node is bootstrapped again");
-        slogger.error("{}", msg);
-        throw std::runtime_error(msg);
-    }
-
     bool replacing_a_node_with_same_ip = false;
     bool replacing_a_node_with_diff_ip = false;
     std::optional<replacement_info> ri;
@@ -2573,6 +2566,13 @@ bool storage_service::is_topology_coordinator_enabled() const {
 future<> storage_service::join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy,
         sharded<gms::gossiper>& gossiper, start_hint_manager start_hm) {
     assert(this_shard_id() == 0);
+
+    if (_sys_ks.local().was_decommissioned()) {
+        auto msg = sstring("This node was decommissioned and will not rejoin the ring unless "
+                           "all existing data is removed and the node is bootstrapped again");
+        slogger.error("{}", msg);
+        throw std::runtime_error(msg);
+    }
 
     set_mode(mode::STARTING);
 

--- a/test/topology_custom/test_decommission.py
+++ b/test/topology_custom/test_decommission.py
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import logging
+
+import pytest
+from test.pylib.manager_client import ManagerClient
+from test.topology.util import check_token_ring_and_group0_consistency
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_decommissioned_node_cant_rejoin(request, manager: ManagerClient):
+    # This a regression test for #17282.
+
+    logger.info("Bootstrapping a leader node")
+    servers = [await manager.server_add()]
+
+    logger.info(f"Bootstrapping second node")
+    servers += [await manager.server_add()]
+
+    # It's important that we decommission a node which is not a leader.
+    # We want to check the case when after restart the node needs
+    # to communicate with other nodes to discover a leader.
+    logger.info(f"Decommissioning node {servers[1]}")
+    await manager.decommission_node(servers[1].server_id)
+    await check_token_ring_and_group0_consistency(manager)
+    logger.info(f"huj1")
+    await manager.server_start(servers[1].server_id,
+                               expected_error='This node was decommissioned and will not rejoin the ring')
+    logger.info(f"huj2")


### PR DESCRIPTION
When a decommissioned node tries to restart, it calls `_group0->discover_group0` first in `join_cluster`, which hangs since decommissioned nodes are banned and other nodes don't respond to their discovering requests.

We fix the problem by checking `was_decommissioned()` flag before calling `discover_group0`.

fixes scylladb/scylladb#17282