### PR TITLE
Automation of ScyllaDB backports - Phase #1: Master → OSS backports

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,47 @@
+pull_request_rules:
+  - name: Automate backport pull request 5.2
+    conditions:
+      - or:
+        - closed
+        - merged
+      - or:
+          - base=master
+          - base=next
+      - label=backport/5.2 # The PR must have this label to trigger the backport
+      - label=promoted-to-master
+    actions:
+      copy:
+        title: "[Backport 5.2] {{ title }}"
+        body: |
+          {{ body }}
+
+          {% for c in commits %}
+          (cherry picked from commit {{ c.sha }})
+          {% endfor %}
+        branches:
+          - next-5.2
+        assignees:
+          - "{{ author }}"
+  - name: Automate backport pull request 5.4
+    conditions:
+      - or:
+        - closed
+        - merged
+      - or:
+          - base=master
+          - base=next
+      - label=backport/5.4 # The PR must have this label to trigger the backport
+      - label=promoted
+    actions:
+      copy:
+        title: "[Backport 5.4] {{ title }}"
+        body: |
+          {{ body }}
+
+          {% for c in commits %}
+          (cherry picked from commit {{ c.sha }})
+          {% endfor %}
+        branches:
+          - next-5.4
+        assignees:
+          - "{{ author }}"

--- a/.github/scripts/label_promoted_commits.py
+++ b/.github/scripts/label_promoted_commits.py
@@ -1,0 +1,59 @@
+import requests
+from github import Github
+import argparse
+import re
+import sys
+import os
+
+try:
+    github_token = os.environ["GITHUB_TOKEN"]
+except KeyError:
+    print("Please set the 'GITHUB_TOKEN' environment variable")
+    sys.exit(1)
+
+
+def parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--repository', type=str, required=True,
+                        help='Github repository name (e.g., scylladb/scylladb)')
+    parser.add_argument('--commit_before_merge', type=str, required=True, help='Git commit ID to start labeling from ('
+                                                                               'newest commit).')
+    parser.add_argument('--commit_after_merge', type=str, required=True,
+                        help='Git commit ID to end labeling at (oldest '
+                             'commit, exclusive).')
+    parser.add_argument('--update_issue', type=bool, default=False, help='Set True to update issues when backport was '
+                                                                         'done')
+    parser.add_argument('--label', type=str, required=True, help='Label to use')
+    return parser.parse_args()
+
+
+def main():
+    args = parser()
+    pr_pattern = re.compile(r'Closes .*#([0-9]+)')
+    g = Github(github_token)
+    repo = g.get_repo(args.repository, lazy=False)
+
+    commits = repo.compare(head=args.commit_after_merge, base=args.commit_before_merge)
+    # Print commit information
+    for commit in commits.commits:
+        print(commit.sha)
+        match = pr_pattern.search(commit.commit.message)
+        if match:
+            pr_number = match.group(1)
+            url = f'https://api.github.com/repos/{args.repository}/issues/{pr_number}/labels'
+            data = {
+                "labels": [f'{args.label}']
+            }
+            headers = {
+                "Authorization": f"token {github_token}",
+                "Accept": "application/vnd.github.v3+json"
+            }
+            response = requests.post(url, headers=headers, json=data)
+            if response.ok:
+                print(f"Label added successfully to {url}")
+            else:
+                print(f"No label was added to {url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/add-label-when-promoted.yaml
+++ b/.github/workflows/add-label-when-promoted.yaml
@@ -1,0 +1,26 @@
+name: Check if commits are promoted
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  check-commit:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for all tags and branches
+
+      - name: Install dependencies
+        run: sudo apt-get install -y python3-github
+
+      - name: Run python script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python .github/scripts/label_promoted_commits.py --commit_before_merge ${{ github.event.before }} --commit_after_merge ${{ github.event.after }} --repository ${{ github.repository }} --label promoted-to-master

--- a/.github/workflows/pr-require-backport-label.yaml
+++ b/.github/workflows/pr-require-backport-label.yaml
@@ -1,0 +1,21 @@
+name: PR require backport label
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+    branches:
+      - master
+      - next
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: minimum
+          count: 1
+          labels: "backport/none\nbackport/\\d.\\d"
+          use_regex: true
+          add_comment: false


### PR DESCRIPTION
This PR includes 3 commits:

- **[actions] Add a check for backport labels**: As part of the Automation of ScyllaDB backports project, each PR should get either a `backport/none` or `backport/X.Y` label. Based on this label we will automatically open a backport PR for the relevant OSS release.

In this commit, I am adding a GitHub action to verify if such a label was added. This only applies to PR with a based branch of `master` or `next`. For releases, we don't need this check

- **Add Mergify (https://mergify.com/) configuration file**: In this PR we introduce the `.mergify.yml` configuration file, which
include a set of rules that we will use for automating our backport
process.

For each supported OSS release (currently 5.2 and 5.4) we have an almost
identical configuration section which includes the four conditions before
we open a backport pr:
* PR should be closed
* PR should have the proper label. for example: backport/5.4 (we can
  have multiple labels)
* Base branch should be `master`
* PR should be set with a `promoted` label - this condition will be set
  automatically once the commits are promoted to the `master` branch (passed
gating)

Once all conditions are applied, the verify bot will open a backport PR and
will assign it to the author of the original PR, then CI will start
running, and only after it pass. we merge

- **[action] Add promoted label when commits are in master**: In Scylla, we don't merge our PR but use ./script/pull_github_pr.sh` to close the pull request, adding `closes scylladb/scylladb <PR number>` remark and push changes to `next` branch.

One of the conditions for opening a backport PR is that all relevant commits are in `master` (passed gating), in this GitHub action, we will go through the list of commits once a push was made to `master` and will identify the relevant PR, and add `promoted` label to it. This will allow Mergify to start the process of backporting