### PR TITLE
gms: add add formatter for gms::versioned_value

### DIFF
--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -209,3 +209,9 @@ public:
 }; // class versioned_value
 
 } // namespace gms
+
+template <> struct fmt::formatter<gms::versioned_value> : fmt::formatter<std::string_view> {
+    auto format(const gms::versioned_value& v, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "Value({},{})", v.value(), v.version());
+    }
+ };


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `gms::versioned_value`, and drop its operator<<.

Refs #13245