### PR TITLE
doc: add missing redirections

### DIFF
--- a/docs/_utils/redirects.yaml
+++ b/docs/_utils/redirects.yaml
@@ -1,6 +1,14 @@
 ### a dictionary of redirections
 #old path: new path
 
+# Moving pages from the install-scylla folder
+
+/stable/getting-started/install-scylla/scylla-web-installer.html: /stable/getting-started/installation-common/scylla-web-installer.html
+/stable/getting-started/install-scylla/unified-installer.html: /stable/getting-started/installation-common/unified-installer.html
+/stable/getting-started/install-scylla/air-gapped-install.html: /stable/getting-started/installation-common/air-gapped-install.html
+/stable/getting-started/install-scylla/disable-housekeeping.html: /stable/getting-started/installation-common/disable-housekeeping.html
+/stable/getting-started/install-scylla/dev-mod.html: /stable/getting-started/installation-common/dev-mod.html
+/stable/getting-started/install-scylla/config-commands.html: /stable/getting-started/config-commands.html
 
 # remove the Open Source vs. Enterprise Matrix from the Open Source docs
 


### PR DESCRIPTION
This PR adds the missing redirections to the pages whose source files were previously stored in the _install-scylla_ folder and were moved to another location.

This PR must be backported to branch-5.4 to fix 404 in the current stable documentation, for example: https://opensource.docs.scylladb.com/stable/getting-started/install-scylla/scylla-web-installer.html 