### PR TITLE
scylla-nodetool: implement the repair command

### DIFF
--- a/test/nodetool/test_repair.py
+++ b/test/nodetool/test_repair.py
@@ -1,0 +1,525 @@
+#
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import pytest
+from rest_api_mock import expected_request
+import utils
+
+
+JMX_COLUMN_FAMILIES_REQUEST = expected_request(
+        "GET",
+        "/column_family/",
+        multiple=expected_request.ANY,
+        response=[{"ks": "system_schema",
+                   "cf": "columns",
+                   "type": "ColumnFamilies"},
+                  {"ks": "system_schema",
+                   "cf": "computed_columns",
+                   "type": "ColumnFamilies"}])
+
+JMX_STREAM_MANAGER_REQUEST = expected_request(
+        "GET",
+        "/stream_manager/",
+        multiple=expected_request.ANY,
+        response=[])
+
+
+def _remove_log_timestamp(res):
+    """ Log timestamp[1] is impossible to match accurately, so just remove it
+
+    E.g. for:
+
+        [2023-12-22 09:18:06,615] Repair session 1
+
+    We drop the [2023-12-22 09:18:06,615] part
+
+    Also strip trailing the whitespace, that nodetool loves to add randomly.
+    """
+    rebuilt_res = []
+    for line in res.split('\n'):
+        if not line:
+            rebuilt_res.append('')
+            continue
+        print(line)
+        rebuilt_res.append(line.split('] ')[1].strip())
+    return "\n".join(rebuilt_res)
+
+
+def test_repair_all_single_keyspace(nodetool):
+    res = nodetool("repair", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", params={"type": "non_local_strategy"}, response=["ks1"]),
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1"], multiple=expected_request.ANY),
+        JMX_COLUMN_FAMILIES_REQUEST,
+        JMX_STREAM_MANAGER_REQUEST,
+        expected_request(
+            "POST",
+            "/storage_service/repair_async/ks1",
+            params={
+                "trace": "false",
+                "ignoreUnreplicatedKeyspaces": "false",
+                "parallelism": "parallel",
+                "incremental": "false",
+                "pullRepair": "false",
+                "primaryRange": "false",
+                "jobThreads": "1"},
+            response=1),
+        expected_request("GET", "/storage_service/repair_async/ks1", params={"id": "1"}, response="SUCCESSFUL")])
+
+    assert _remove_log_timestamp(res) == """\
+Starting repair command #1, repairing 1 ranges for keyspace ks1 (parallelism=SEQUENTIAL, full=true)
+Repair session 1
+Repair session 1 finished
+"""
+
+
+def test_repair_all_two_keyspaces(nodetool):
+    res = nodetool("repair", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", params={"type": "non_local_strategy"},
+                         response=["ks1", "ks2"]),
+        expected_request("GET", "/storage_service/keyspaces", multiple=expected_request.ANY, response=["ks1", "ks2"]),
+        JMX_COLUMN_FAMILIES_REQUEST,
+        JMX_STREAM_MANAGER_REQUEST,
+        expected_request(
+            "POST",
+            "/storage_service/repair_async/ks1",
+            params={
+                "trace": "false",
+                "ignoreUnreplicatedKeyspaces": "false",
+                "parallelism": "parallel",
+                "incremental": "false",
+                "pullRepair": "false",
+                "primaryRange": "false",
+                "jobThreads": "1"},
+            response=3),
+        expected_request("GET", "/storage_service/repair_async/ks1", params={"id": "3"}, response="RUNNING"),
+        expected_request("GET", "/storage_service/repair_async/ks1", params={"id": "3"}, response="SUCCESSFUL"),
+        JMX_COLUMN_FAMILIES_REQUEST,
+        JMX_STREAM_MANAGER_REQUEST,
+        expected_request(
+            "POST",
+            "/storage_service/repair_async/ks2",
+            params={
+                "trace": "false",
+                "ignoreUnreplicatedKeyspaces": "false",
+                "parallelism": "parallel",
+                "incremental": "false",
+                "pullRepair": "false",
+                "primaryRange": "false",
+                "jobThreads": "1"},
+            response=4),
+        expected_request("GET", "/storage_service/repair_async/ks2", params={"id": "4"}, response="SUCCESSFUL")])
+
+    assert _remove_log_timestamp(res) == """\
+Starting repair command #3, repairing 1 ranges for keyspace ks1 (parallelism=SEQUENTIAL, full=true)
+Repair session 3
+Repair session 3 finished
+Starting repair command #4, repairing 1 ranges for keyspace ks2 (parallelism=SEQUENTIAL, full=true)
+Repair session 4
+Repair session 4 finished
+"""
+
+
+def test_repair_keyspace(nodetool):
+    res = nodetool("repair", "ks", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        JMX_COLUMN_FAMILIES_REQUEST,
+        JMX_STREAM_MANAGER_REQUEST,
+        expected_request(
+            "POST",
+            "/storage_service/repair_async/ks",
+            params={
+                "trace": "false",
+                "ignoreUnreplicatedKeyspaces": "false",
+                "parallelism": "parallel",
+                "incremental": "false",
+                "pullRepair": "false",
+                "primaryRange": "false",
+                "jobThreads": "1"},
+            response=1),
+        expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="SUCCESSFUL")])
+
+    assert _remove_log_timestamp(res) == """\
+Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
+Repair session 1
+Repair session 1 finished
+"""
+
+
+def test_repair_one_table(nodetool):
+    res = nodetool("repair", "ks", "table1", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        JMX_COLUMN_FAMILIES_REQUEST,
+        JMX_STREAM_MANAGER_REQUEST,
+        expected_request(
+            "POST",
+            "/storage_service/repair_async/ks",
+            params={
+                "columnFamilies": "table1",
+                "trace": "false",
+                "ignoreUnreplicatedKeyspaces": "false",
+                "parallelism": "parallel",
+                "incremental": "false",
+                "pullRepair": "false",
+                "primaryRange": "false",
+                "jobThreads": "1"},
+            response=1),
+        expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="SUCCESSFUL")])
+
+    assert _remove_log_timestamp(res) == """\
+Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
+Repair session 1
+Repair session 1 finished
+"""
+
+
+def test_repair_two_tables(nodetool):
+    res = nodetool("repair", "ks", "table1", "table2", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        JMX_COLUMN_FAMILIES_REQUEST,
+        JMX_STREAM_MANAGER_REQUEST,
+        expected_request(
+            "POST",
+            "/storage_service/repair_async/ks",
+            params={
+                "columnFamilies": "table1,table2",
+                "trace": "false",
+                "ignoreUnreplicatedKeyspaces": "false",
+                "parallelism": "parallel",
+                "incremental": "false",
+                "pullRepair": "false",
+                "primaryRange": "false",
+                "jobThreads": "1"},
+            response=1),
+        expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="SUCCESSFUL")])
+
+    assert _remove_log_timestamp(res) == """\
+Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
+Repair session 1
+Repair session 1 finished
+"""
+
+
+def test_repair_long_progress(nodetool):
+    res = nodetool("repair", "ks", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        JMX_COLUMN_FAMILIES_REQUEST,
+        JMX_STREAM_MANAGER_REQUEST,
+        expected_request(
+            "POST",
+            "/storage_service/repair_async/ks",
+            params={
+                "trace": "false",
+                "ignoreUnreplicatedKeyspaces": "false",
+                "parallelism": "parallel",
+                "incremental": "false",
+                "pullRepair": "false",
+                "primaryRange": "false",
+                "jobThreads": "1"},
+            response=1),
+        expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="RUNNING"),
+        expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="RUNNING"),
+        expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="SUCCESSFUL")])
+
+    assert _remove_log_timestamp(res) == """\
+Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
+Repair session 1
+Repair session 1 finished
+"""
+
+
+def test_repair_failed(nodetool):
+    utils.check_nodetool_fails_with_error_contains(
+        nodetool,
+        ("repair", "ks"),
+        {"expected_requests": [
+            expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+            JMX_COLUMN_FAMILIES_REQUEST,
+            JMX_STREAM_MANAGER_REQUEST,
+            expected_request(
+                "POST",
+                "/storage_service/repair_async/ks",
+                params={
+                    "trace": "false",
+                    "ignoreUnreplicatedKeyspaces": "false",
+                    "parallelism": "parallel",
+                    "incremental": "false",
+                    "pullRepair": "false",
+                    "primaryRange": "false",
+                    "jobThreads": "1"},
+                response=1),
+            expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="FAILED")]
+         },
+        ["error: Repair job has failed with the error message: ",
+         "Repair session 1 failed"])
+
+
+def _do_test_repair_options(
+        nodetool,
+        table=[],
+        trace=None,
+        datacenter=None,
+        token=None,
+        ignore_unreplicated_ks=None,
+        parallelism=None,
+        pull=None,
+        primary_range=None,
+        hosts=None):
+
+    args = ["repair", "ks"] + table
+
+    # We add params in the same order that java nodetool does, to make param comparison easier to read
+    expected_params = {}
+
+    expected_requests = [
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+    ]
+
+    if trace is None:
+        expected_params["trace"] = "false"
+    else:
+        args.append(trace)
+        expected_params["trace"] = "true"
+
+    if token is not None:
+        st, et = token
+        if st != '':
+            args += ['-st', st]
+        if et != '':
+            args += ['-et', et]
+        expected_params["ranges"] = f"{st}:{et}"
+
+    if ignore_unreplicated_ks is None:
+        expected_params["ignoreUnreplicatedKeyspaces"] = "false"
+    else:
+        args.append(ignore_unreplicated_ks)
+        expected_params["ignoreUnreplicatedKeyspaces"] = "true"
+
+    if hosts is not None:
+        host_params = []
+        for arg, host in hosts:
+            host_params.append(host)
+            args += [arg, host]
+        expected_params["hosts"] = ",".join(host_params)
+
+    if parallelism is None:
+        expected_params["parallelism"] = "parallel"
+    elif parallelism == "-seq" or parallelism == "--sequential":
+        args.append(parallelism)
+        expected_params["parallelism"] = "sequential"
+    elif parallelism == "-dcpar" or parallelism == "--dc-parallel":
+        args.append(parallelism)
+        expected_params["parallelism"] = "dc_parallel"
+
+    if datacenter is not None:
+        dcs = []
+        for dc in datacenter:
+            if len(dc) == 2:
+                dcs.append(dc[1])
+
+            args += list(dc)
+
+            if dc[0] == "-local" or dc[0] == "--in-local-dc":
+                # Looks like JMX caches the response to this, so we have to make it optional
+                expected_requests += [
+                    expected_request("GET", "/snitch/datacenter", response="DC_local", multiple=expected_request.ANY),
+                ]
+                dcs.append("DC_local")
+
+        expected_params["dataCenters"] = ",".join(dcs)
+
+    expected_params["incremental"] = "false"
+
+    if pull is None:
+        expected_params["pullRepair"] = "false"
+    else:
+        args.append(pull)
+        expected_params["pullRepair"] = "true"
+
+    if primary_range is None:
+        expected_params["primaryRange"] = "false"
+    else:
+        args.append(primary_range)
+        expected_params["primaryRange"] = "true"
+
+    expected_params["jobThreads"] = "1"
+
+    expected_requests += [
+        JMX_COLUMN_FAMILIES_REQUEST,
+        JMX_STREAM_MANAGER_REQUEST,
+        expected_request(
+            "POST",
+            "/storage_service/repair_async/ks",
+            params=expected_params,
+            response=1),
+        expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="SUCCESSFUL")
+    ]
+
+    res = nodetool(*args, expected_requests=expected_requests)
+
+    assert _remove_log_timestamp(res) == """\
+Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
+Repair session 1
+Repair session 1 finished
+"""
+
+
+@pytest.mark.parametrize("trace", [None, "-tr", "--trace"])
+def test_repair_options_trace(nodetool, trace):
+    _do_test_repair_options(nodetool, trace=trace)
+
+
+@pytest.mark.parametrize("token", [None, ('10', ''), ('', '20'), ('10', '20')])
+def test_repair_options_token(nodetool, token):
+    _do_test_repair_options(nodetool, token=token)
+
+
+@pytest.mark.parametrize("ignore_unreplicated_ks", [None, "-iuk", "--ignore-unreplicated-keyspaces"])
+def test_repair_options_ignore_unreplicated_ks(nodetool, ignore_unreplicated_ks):
+    _do_test_repair_options(nodetool, ignore_unreplicated_ks=ignore_unreplicated_ks)
+
+
+@pytest.mark.parametrize("parallelism", [None, "-seq", "--sequential", "-dcpar", "--dc-parallel"])
+def test_repair_options_parallelism(nodetool, parallelism):
+    _do_test_repair_options(nodetool, parallelism=parallelism)
+
+
+@pytest.mark.parametrize("datacenter", [None,
+                                        [("-dc", "DC1")],
+                                        [("--in-dc", "DC1")],
+                                        [("-dc", "DC1"), ("--in-dc", "DC2")],
+                                        [("-local",)],
+                                        [("--in-local-dc",)]])
+def test_repair_options_datacenter(nodetool, datacenter):
+    _do_test_repair_options(nodetool, datacenter=datacenter)
+
+
+@pytest.mark.parametrize("pull", [None, "-pl", "--pull"])
+def test_repair_options_pull(nodetool, pull):
+    _do_test_repair_options(nodetool, pull=pull)
+
+
+@pytest.mark.parametrize("primary_range", [None, "-pr", "--partitioner-range"])
+def test_repair_options_primary_range(nodetool, primary_range):
+    _do_test_repair_options(nodetool, primary_range=primary_range)
+
+
+@pytest.mark.parametrize("hosts", [None,
+                                   [("-hosts", "HOST1")],
+                                   [("--in-hosts", "HOST1"), ("--in-hosts", "HOST2")]])
+def test_repair_options_hosts(nodetool, hosts):
+    _do_test_repair_options(nodetool, hosts=hosts)
+
+
+def test_repair_parallelism_precedence(nodetool):
+    res = nodetool("repair", "ks", "--dc-parallel", "--sequential", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        JMX_COLUMN_FAMILIES_REQUEST,
+        JMX_STREAM_MANAGER_REQUEST,
+        expected_request(
+            "POST",
+            "/storage_service/repair_async/ks",
+            params={
+                "trace": "false",
+                "ignoreUnreplicatedKeyspaces": "false",
+                "parallelism": "sequential",
+                "incremental": "false",
+                "pullRepair": "false",
+                "primaryRange": "false",
+                "jobThreads": "1"},
+            response=1),
+        expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="SUCCESSFUL")])
+
+    assert _remove_log_timestamp(res) == """\
+Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
+Repair session 1
+Repair session 1 finished
+"""
+
+
+def test_repair_dc_precedence(nodetool):
+    res = nodetool("repair", "ks", "--in-dc", "DC1", "-dc", "DC2", "--in-local-dc", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        JMX_COLUMN_FAMILIES_REQUEST,
+        JMX_STREAM_MANAGER_REQUEST,
+        expected_request("GET", "/snitch/datacenter", response="DC_local", multiple=expected_request.ANY),
+        expected_request(
+            "POST",
+            "/storage_service/repair_async/ks",
+            params={
+                "trace": "false",
+                "ignoreUnreplicatedKeyspaces": "false",
+                "parallelism": "parallel",
+                "dataCenters": "DC_local",
+                "incremental": "false",
+                "pullRepair": "false",
+                "primaryRange": "false",
+                "jobThreads": "1"},
+            response=1),
+        expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="SUCCESSFUL")])
+
+    assert _remove_log_timestamp(res) == """\
+Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
+Repair session 1
+Repair session 1 finished
+"""
+
+
+@pytest.mark.parametrize("jobs", [None, ("-j", 2), ("--job-threads", 2)])
+@pytest.mark.parametrize("full", [None, "-full", "--full"])
+def test_repair_unused_options(request, nodetool, jobs, full):
+    args = ["repair", "ks"]
+
+    if jobs:
+        args += list(jobs)
+
+    if full:
+        args.append(full)
+
+    res = nodetool("repair", "ks", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        JMX_COLUMN_FAMILIES_REQUEST,
+        JMX_STREAM_MANAGER_REQUEST,
+        expected_request(
+            "POST",
+            "/storage_service/repair_async/ks",
+            params={
+                "trace": "false",
+                "ignoreUnreplicatedKeyspaces": "false",
+                "parallelism": "parallel",
+                "incremental": "false",
+                "pullRepair": "false",
+                "primaryRange": "false",
+                "jobThreads": "1"},
+            response=1),
+        expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="SUCCESSFUL")])
+
+    assert _remove_log_timestamp(res) == """\
+Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
+Repair session 1
+Repair session 1 finished
+"""
+
+
+def test_repair_pr_and_dcs(nodetool):
+    utils.check_nodetool_fails_with(
+        nodetool,
+        ("repair", "ks", "-pr", "-dc", "DC1"),
+        {"expected_requests": [
+                expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        ]},
+        ["error: Primary range repair should be performed on all nodes in the cluster.",
+         "error processing arguments: primary range repair should be performed on all nodes in the cluster"])
+
+
+def test_repair_pr_and_hosts(nodetool):
+    utils.check_nodetool_fails_with(
+        nodetool,
+        ("repair", "ks", "-pr", "-hosts", "127.0.0.2"),
+        {"expected_requests": [
+                expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        ]},
+        ["error: Primary range repair should be performed on all nodes in the cluster.",
+         "error processing arguments: primary range repair should be performed on all nodes in the cluster"])

--- a/test/nodetool/utils.py
+++ b/test/nodetool/utils.py
@@ -6,6 +6,7 @@
 
 import pytest
 import subprocess
+import itertools
 
 
 def _do_check_nodetool_fails_with(
@@ -52,5 +53,24 @@ def check_nodetool_fails_with_all(
             if expected_error in err_lines or expected_error in out_lines:
                 match += 1
         assert match == len(expected_errors)
+
+    _do_check_nodetool_fails_with(nodetool, nodetool_args, nodetool_kwargs, matcher)
+
+
+def check_nodetool_fails_with_error_contains(
+        nodetool,
+        nodetool_args: tuple,
+        nodetool_kwargs: dict,
+        expected_errors: list[str]):
+
+    def matcher(out_lines, err_lines):
+        match = False
+        for expected_error in expected_errors:
+            for err_line in itertools.chain(out_lines, err_lines):
+                if expected_error in err_line:
+                    match = True
+                    break
+
+        assert match
 
     _do_check_nodetool_fails_with(nodetool, nodetool_args, nodetool_kwargs, matcher)

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -14,7 +14,9 @@
 #include <boost/range/adaptor/map.hpp>
 #include <chrono>
 #include <fmt/chrono.h>
+#include <seastar/core/sleep.hh>
 #include <seastar/core/thread.hh>
+#include <seastar/core/when_all.hh>
 #include <seastar/http/exception.hh>
 #include <seastar/http/request.hh>
 #include <seastar/util/short_streams.hh>
@@ -37,6 +39,7 @@
 
 namespace bpo = boost::program_options;
 
+using namespace std::chrono_literals;
 using namespace tools::utils;
 
 namespace {
@@ -867,6 +870,120 @@ void removenode_operation(scylla_rest_client& client, const bpo::variables_map& 
     }
 }
 
+void repair_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    std::vector<sstring> keyspaces, tables;
+    if (vm.contains("keyspace")) {
+        auto res = parse_keyspace_and_tables(client, vm, true);
+        keyspaces.push_back(std::move(res.keyspace));
+        tables = std::move(res.tables);
+    } else {
+        keyspaces = get_keyspaces(client, "non_local_strategy");
+    }
+
+    if (vm.contains("partitioner-range") && (vm.contains("in-dc") || vm.contains("in-hosts"))) {
+        throw std::invalid_argument("primary range repair should be performed on all nodes in the cluster");
+    }
+
+    // Use the same default param-set that the legacy nodetool uses, makes testing easier.
+    std::unordered_map<sstring, sstring> repair_params{
+            {"trace", "false"},
+            {"ignoreUnreplicatedKeyspaces", "false"},
+            {"parallelism", "parallel"},
+            {"incremental", "false"},
+            {"pullRepair", "false"},
+            {"primaryRange", "false"},
+            {"jobThreads", "1"}};
+
+    if (!tables.empty()) {
+        repair_params["columnFamilies"] = fmt::to_string(fmt::join(tables.begin(), tables.end(), ","));
+    }
+
+    if (vm.contains("trace")) {
+        repair_params["trace"] = "true";
+    }
+
+    if (vm.contains("start-token") || vm.contains("end-token")) {
+        const auto st = vm.contains("start-token") ? fmt::to_string(vm["start-token"].as<uint64_t>()) : "";
+        const auto et = vm.contains("end-token") ? fmt::to_string(vm["end-token"].as<uint64_t>()) : "";
+        repair_params["ranges"] = format("{}:{}", st, et);
+    }
+
+    if (vm.contains("ignore-unreplicated-keyspaces")) {
+        repair_params["ignoreUnreplicatedKeyspaces"] = "true";
+    }
+
+    if (vm.contains("in-hosts")) {
+        const auto hosts = vm["in-hosts"].as<std::vector<sstring>>();
+        repair_params["hosts"] = fmt::to_string(fmt::join(hosts.begin(), hosts.end(), ","));
+    }
+
+    if (vm.contains("sequential")) {
+        repair_params["parallelism"] = "sequential";
+    } else if (vm.contains("dc-parallel")) {
+        repair_params["parallelism"] = "dc_parallel";
+    }
+
+    if (vm.contains("in-local-dc")) {
+        const auto res = client.get("/snitch/datacenter");
+        repair_params["dataCenters"] = sstring(rjson::to_string_view(res));
+    } else if (vm.contains("in-dc")) {
+        const auto dcs = vm["in-dc"].as<std::vector<sstring>>();
+        repair_params["dataCenters"] = fmt::to_string(fmt::join(dcs.begin(), dcs.end(), ","));
+    }
+
+    if (vm.contains("pull")) {
+        repair_params["pullRepair"] = "true";
+    }
+
+    if (vm.contains("partitioner-range")) {
+        repair_params["primaryRange"] = "true";
+    }
+
+    auto log = [&] (const char* fmt, auto&&... param) {
+        const auto msg = fmt::format(fmt::runtime(fmt), param...);
+        using clock = std::chrono::system_clock;
+        const auto n = clock::now();
+        const auto t = clock::to_time_t(n);
+        const auto ms = (n - clock::from_time_t(t)) / 1ms;
+        fmt::print("[{:%F %T},{:03d}] {}\n", fmt::localtime(t), ms, msg);
+    };
+
+    size_t failed = 0;
+    for (const auto& keyspace : keyspaces) {
+        const auto url = format("/storage_service/repair_async/{}", keyspace);
+
+        const auto id = client.post(url, repair_params).GetInt();
+
+        log("Starting repair command #{}, repairing 1 ranges for keyspace {} (parallelism=SEQUENTIAL, full=true)", id, keyspace);
+        log("Repair session {}", id);
+
+        std::unordered_map<sstring, sstring> poll_params{{"id", fmt::to_string(id)}};
+
+        auto get_status = [&] {
+            const auto res = client.get(url, poll_params);
+            return sstring(rjson::to_string_view(res));
+        };
+
+        auto status = get_status();
+
+        while (status == "RUNNING") {
+            sleep(std::chrono::milliseconds(200)).get();
+            status = get_status();
+        }
+
+        if (status == "SUCCESSFUL") {
+            log("Repair session {} finished", id);
+        } else {
+            log("Repair session {} failed", id);
+            ++failed;
+        }
+    }
+
+    if (failed) {
+        throw operation_failed_on_scylladb(format("{} out of {} repair session(s) failed", failed, keyspaces.size()));
+    }
+}
+
 void scrub_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     const auto [keyspace, tables] = parse_keyspace_and_tables(client, vm, false);
     if (keyspace.empty()) {
@@ -1119,6 +1236,15 @@ const std::map<std::string_view, std::string_view> option_substitutions{
     {"-pro", "--primary-replica-only"},
     {"-ns", "--no-snapshot"},
     {"-m", "--mode"}, // FIXME: this clashes with seastar option for memory
+    {"-tr", "--trace"},
+    {"-iuk", "--ignore-unreplicated-keyspaces"},
+    {"-seq", "--sequential"},
+    {"-dcpar", "--dc-parallel"},
+    {"-dc", "--in-dc"},
+    {"-local", "--in-local-dc"},
+    {"-pl", "--pull"},
+    {"-pr", "--partitioner-range"},
+    {"-hosts", "--in-hosts"},
 };
 
 std::map<operation, operation_func> get_operations_with_func() {
@@ -1541,6 +1667,43 @@ Fore more information, see: https://opensource.docs.scylladb.com/stable/operatin
                 },
             },
             removenode_operation
+        },
+        {
+            {
+                "repair",
+                "Synchronize data between nodes in the background",
+R"(
+When running nodetool repair on a single node, it acts as the repair master.
+Only the data contained in the master node and its replications will be
+repaired. Typically, this subset of data is replicated on many nodes in
+the cluster, often all, and the repair process syncs between all the
+replicas until the master data subset is in-sync.
+
+To repair all of the data in the cluster, you need to run a repair on
+all of the nodes in the cluster, or let ScyllaDB Manager do it for you.
+
+Fore more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/repair.html
+)",
+                {
+                    typed_option<>("dc-parallel", "Repair datacenters in parallel"),
+                    typed_option<uint64_t>("end-token", "Repair data up to this token"),
+                    typed_option<std::vector<sstring>>("in-dc", "Constrain repair to specific datacenter(s)"),
+                    typed_option<>("in-local-dc", "Constrain repair to the local datacenter only"),
+                    typed_option<std::vector<sstring>>("in-hosts", "Constrain repair to the specific host(s)"),
+                    typed_option<>("ignore-unreplicated-keyspaces", "Ignore keyspaces which are not replicated, without this repair will fail on such keyspaces"),
+                    typed_option<unsigned>("jobs", "Number of threads to run repair on. "),
+                    typed_option<>("partitioner-range", "Repair only the first range returned by the partitioner"),
+                    typed_option<>("pull", "Fix local node only"),
+                    typed_option<>("sequential", "Perform repair sequentially"),
+                    typed_option<uint64_t>("start-token", "Repair data starting from this token"),
+                    typed_option<>("trace", "Trace repair, traces are stored in system.traces"),
+                },
+                {
+                    typed_option<sstring>("keyspace", "The keyspace to repair, if missing all keyspaces are repaired", 1),
+                    typed_option<std::vector<sstring>>("table", "The table(s) to repair, if missing all tables are repaired", -1),
+                },
+            },
+            repair_operation
         },
         {
             {


### PR DESCRIPTION
As usual, the new command is covered with tests, which pass with both the legacy and the new native implementation.

Refs: #15588