### PR TITLE
gms: add add formatter for gms::gossip_*

### DIFF
--- a/gms/gossip_digest.hh
+++ b/gms/gossip_digest.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <seastar/core/sstring.hh>
+#include <fmt/core.h>
 #include "gms/inet_address.hh"
 #include "gms/generation-number.hh"
 #include "gms/version_generator.hh"
@@ -55,10 +56,13 @@ public:
         return x._max_version <  y._max_version;
     }
 
-    friend inline std::ostream& operator<<(std::ostream& os, const gossip_digest& d) {
-        fmt::print(os, "{}:{}:{}", d._endpoint, d._generation, d._max_version);
-        return os;
-    }
+    friend fmt::formatter<gossip_digest>;
 }; // class gossip_digest
 
 } // namespace gms
+
+template <> struct fmt::formatter<gms::gossip_digest> : fmt::formatter<std::string_view> {
+    auto format(const gms::gossip_digest& d, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}:{}:{}", d._endpoint, d._generation, d._max_version);
+    }
+};

--- a/gms/gossip_digest_ack.cc
+++ b/gms/gossip_digest_ack.cc
@@ -9,21 +9,18 @@
  */
 
 #include "gms/gossip_digest_ack.hh"
-#include <ostream>
 
-namespace gms {
-
-std::ostream& operator<<(std::ostream& os, const gossip_digest_ack& ack) {
-    os << "digests:{";
+auto fmt::formatter<gms::gossip_digest_ack>::format(const gms::gossip_digest_ack& ack, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    auto out = ctx.out();
+    out = fmt::format_to(out, "digests:{{");
     for (auto& d : ack._digests) {
-        os << d << " ";
+        out = fmt::format_to(out, "{} ", d);
     }
-    os << "} ";
-    os << "endpoint_state:{";
+    out = fmt::format_to(out, "}} ");
+    out = fmt::format_to(out, "endpoint_state:{{");
     for (auto& d : ack._map) {
-        fmt::print(os, "[{}->{}]", d.first, d.second);
+        out = fmt::format_to(out, "[{}->{}]", d.first, d.second);
     }
-    return os << "}";
+    return fmt::format_to(out, "}}");
 }
-
-} // namespace gms

--- a/gms/gossip_digest_ack.hh
+++ b/gms/gossip_digest_ack.hh
@@ -15,6 +15,7 @@
 #include "gms/inet_address.hh"
 #include "gms/endpoint_state.hh"
 #include "utils/chunked_vector.hh"
+#include <fmt/core.h>
 
 namespace gms {
 
@@ -48,7 +49,11 @@ public:
         return _map;
     }
 
-    friend std::ostream& operator<<(std::ostream& os, const gossip_digest_ack& ack);
+    friend fmt::formatter<gossip_digest_ack>;
 };
 
 }
+
+template <> struct fmt::formatter<gms::gossip_digest_ack> : fmt::formatter<std::string_view> {
+    auto format(const gms::gossip_digest_ack&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/gms/gossip_digest_syn.cc
+++ b/gms/gossip_digest_syn.cc
@@ -9,17 +9,15 @@
  */
 
 #include "gms/gossip_digest_syn.hh"
-#include <ostream>
 
-namespace gms {
-
-std::ostream& operator<<(std::ostream& os, const gossip_digest_syn& syn) {
-    os << "cluster_id:" << syn._cluster_id << ",partioner:" << syn._partioner << ",group0_id:" << syn._group0_id << ",";
-    os << "digests:{";
+auto fmt::formatter<gms::gossip_digest_syn>::format(const gms::gossip_digest_syn& syn, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    auto out = ctx.out();
+    // out = fmt::format_to(out, "cluster_id:{},partioner:{},group0_id{},"
+    //                      syn._cluster_id, syn._partioner, syn._group0_id);
+    out = fmt::format_to(out, "digests:{{");
     for (auto& d : syn._digests) {
-        os << d << " ";
+        out = fmt::format_to(out, "{} ", d);
     }
-    return os << "}";
+    return fmt::format_to(out, "}}");
 }
-
-} // namespace gms

--- a/gms/gossip_digest_syn.hh
+++ b/gms/gossip_digest_syn.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <seastar/core/sstring.hh>
+#include <fmt/core.h>
 #include "utils/serialization.hh"
 #include "gms/gossip_digest.hh"
 #include "utils/chunked_vector.hh"
@@ -67,7 +68,11 @@ public:
         return _digests;
     }
 
-    friend std::ostream& operator<<(std::ostream& os, const gossip_digest_syn& syn);
+    friend fmt::formatter<gossip_digest_syn>;
 };
 
 }
+
+template <> struct fmt::formatter<gms::gossip_digest_syn> : fmt::formatter<std::string_view> {
+    auto format(const gms::gossip_digest_syn&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for

- gms::gossip_digest
- gms::gossip_digest_ack
- gms::gossip_digest_syn

and drop their operator<<:s

Refs #13245