### PR TITLE
Fix node replace with tablets for RF=N

### DIFF
--- a/api/api-doc/raft.json
+++ b/api/api-doc/raft.json
@@ -38,6 +38,30 @@
                ]
             }
          ]
+      },
+      {
+         "path":"/raft/leader_host",
+         "operations":[
+            {
+               "method":"GET",
+               "summary":"Returns host ID of the current leader of the given Raft group",
+               "type":"string",
+               "nickname":"get_leader_host",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"group_id",
+                     "description":"The ID of the group. When absent, group0 is used.",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  }
+               ]
+            }
+         ]
       }
    ]
 }

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -535,7 +535,9 @@ public:
     // Assumes that the history table exists, i.e. Raft experimental feature is enabled.
     future<bool> group0_history_contains(utils::UUID state_id);
 
-    future<service::topology> load_topology_state();
+    // force_load_hosts is a set of hosts which must be loaded even if they are in the left state.
+    future<service::topology> load_topology_state(const std::unordered_set<locator::host_id>& force_load_hosts);
+
     future<std::optional<service::topology_features>> load_topology_features_state();
 
     // Read CDC generation data with the given UUID as key.

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -492,14 +492,24 @@ auto vnode_effective_replication_map::clone_data_gently() const -> future<std::u
     co_return std::move(result);
 }
 
-inet_address_vector_replica_set vnode_effective_replication_map::do_get_natural_endpoints(const token& tok,
+host_id_vector_replica_set vnode_effective_replication_map::do_get_replicas(const token& tok,
     bool is_vnode) const
 {
     const token& key_token = _rs->natural_endpoints_depend_on_token()
         ? (is_vnode ? tok : _tmptr->first_token(tok))
         : default_replication_map_key;
     const auto it = _replication_map.find(key_token);
-    return resolve_endpoints<inet_address_vector_replica_set>(it->second, *_tmptr);
+    return it->second;
+}
+
+inet_address_vector_replica_set vnode_effective_replication_map::do_get_natural_endpoints(const token& tok,
+    bool is_vnode) const
+{
+    return resolve_endpoints<inet_address_vector_replica_set>(do_get_replicas(tok, is_vnode), *_tmptr);
+}
+
+host_id_vector_replica_set vnode_effective_replication_map::get_replicas(const token& tok) const {
+    return do_get_replicas(tok, false);
 }
 
 inet_address_vector_replica_set vnode_effective_replication_map::get_natural_endpoints(const token& search_token) const {

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -231,6 +231,12 @@ public:
     /// Returns a list of nodes to which a read request should be directed.
     virtual inet_address_vector_replica_set get_endpoints_for_reading(const token& search_token) const = 0;
 
+    /// Returns replicas for a given token.
+    /// During topology change returns replicas which should be targets for writes, excluding the pending replica.
+    /// Unlike get_natural_endpoints(), the replica set may include nodes in the left state which were
+    /// replaced but not yet rebuilt.
+    virtual host_id_vector_replica_set get_replicas(const token& search_token) const = 0;
+
     virtual std::optional<tablet_routing_info> check_locality(const token& token) const = 0;
 
 
@@ -318,6 +324,7 @@ public: // effective_replication_map
     inet_address_vector_replica_set get_natural_endpoints_without_node_being_replaced(const token& search_token) const override;
     inet_address_vector_topology_change get_pending_endpoints(const token& search_token) const override;
     inet_address_vector_replica_set get_endpoints_for_reading(const token& search_token) const override;
+    host_id_vector_replica_set get_replicas(const token& search_token) const override;
     std::optional<tablet_routing_info> check_locality(const token& token) const override;
     bool has_pending_ranges(locator::host_id endpoint) const override;
     std::unique_ptr<token_range_splitter> make_splitter() const override;
@@ -378,6 +385,7 @@ public:
 private:
     dht::token_range_vector do_get_ranges(noncopyable_function<stop_iteration(bool& add_range, const inet_address& natural_endpoint)> consider_range_for_endpoint) const;
     inet_address_vector_replica_set do_get_natural_endpoints(const token& tok, bool is_vnode) const;
+    host_id_vector_replica_set do_get_replicas(const token& tok, bool is_vnode) const;
     stop_iteration for_each_natural_endpoint_until(const token& vnode_tok, const noncopyable_function<stop_iteration(const inet_address&)>& func) const;
 
 public:

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -210,10 +210,17 @@ public:
     /// operation which adds a replica which has the same address as the replaced replica.
     /// Use get_natural_endpoints_without_node_being_replaced() to get replicas without any pending replicas.
     /// This won't be necessary after we implement https://github.com/scylladb/scylladb/issues/6403.
+    ///
+    /// Excludes replicas which are in the left state. After replace, the replaced replica may
+    /// still be in the replica set of the tablet until tablet scheduler rebuilds the replacing replica.
+    /// The old replica will not be listed here. This is necessary to support replace-with-the-same-ip
+    /// scenario. Since we return IPs here, writes to the old replica would be incorrectly routed to the
+    /// new replica.
+    ///
+    /// The returned addresses are present in the topology object associated with this instance.
     virtual inet_address_vector_replica_set get_natural_endpoints(const token& search_token) const = 0;
 
-    /// Returns addresses of replicas for a given token.
-    /// Does not include pending replicas.
+    /// Returns a subset of replicas returned by get_natural_endpoints() without the pending replica.
     virtual inet_address_vector_replica_set get_natural_endpoints_without_node_being_replaced(const token& search_token) const = 0;
 
     /// Returns the set of pending replicas for a given token.

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -481,6 +481,17 @@ size_t tablet_metadata::external_memory_usage() const {
     return result;
 }
 
+bool tablet_metadata::has_replica_on(host_id host) const {
+    for (auto&& [id, map] : _tablets) {
+        for (auto&& tablet : map.tablet_ids()) {
+            if (map.get_shard(tablet, host)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 future<bool> check_tablet_replica_shards(const tablet_metadata& tm, host_id this_host) {
     bool valid = true;
     for (const auto& [table_id, tmap] : tm.all_tables()) {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -451,6 +451,7 @@ public:
     const table_to_tablet_map& all_tables() const { return _tablets; }
     table_to_tablet_map& all_tables() { return _tablets; }
     size_t external_memory_usage() const;
+    bool has_replica_on(host_id) const;
 public:
     void set_balancing_enabled(bool value) { _balancing_enabled = value; }
     void set_tablet_map(table_id, tablet_map);

--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -64,6 +64,9 @@ future<> save_tablet_metadata(replica::database&, const locator::tablet_metadata
 /// Reads tablet metadata from system.tablets.
 future<locator::tablet_metadata> read_tablet_metadata(cql3::query_processor&);
 
+/// Reads the set of hosts referenced by tablet replicas.
+future<std::unordered_set<locator::host_id>> read_required_hosts(cql3::query_processor&);
+
 /// Reads tablet metadata from system.tablets in the form of mutations.
 future<std::vector<canonical_mutation>> read_tablet_mutations(seastar::sharded<database>&);
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1317,6 +1317,19 @@ topology::upgrade_state_type storage_service::get_topology_upgrade_state() const
     return _topology_state_machine._topology.upgrade_state;
 }
 
+future<> storage_service::await_tablets_rebuilt(raft::server_id replaced_id) {
+    auto is_drained = [&] {
+        return !get_token_metadata().tablets().has_replica_on(locator::host_id(replaced_id.uuid()));
+    };
+    if (!is_drained()) {
+        slogger.info("Waiting for tablet replicas from the replaced node to be rebuilt");
+        co_await _topology_state_machine.event.wait([&] {
+            return is_drained();
+        });
+    }
+    slogger.info("Tablet replicas from the replaced node have been rebuilt");
+}
+
 future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspace>& sys_dist_ks,
         sharded<service::storage_proxy>& proxy,
         sharded<gms::gossiper>& gossiper,
@@ -1620,18 +1633,19 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
         supervisor::notify("starting system distributed keyspace");
         co_await sys_dist_ks.invoke_on_all(&db::system_distributed_keyspace::start);
 
-        sstring err;
-
         if (_sys_ks.local().bootstrap_complete()) {
             if (_topology_state_machine._topology.left_nodes.contains(raft_server->id())) {
                 throw std::runtime_error("A node that already left the cluster cannot be restarted");
             }
         } else {
-            err = co_await wait_for_topology_request_completion(join_params.request_id);
-        }
+            auto err = co_await wait_for_topology_request_completion(join_params.request_id);
+            if (!err.empty()) {
+                throw std::runtime_error(fmt::format("{} failed. See earlier errors ({})", raft_replace_info ? "Replace" : "Bootstrap", err));
+            }
 
-        if (!err.empty()) {
-            throw std::runtime_error(fmt::format("{} failed. See earlier errors ({})", raft_replace_info ? "Replace" : "Bootstrap", err));
+            if (raft_replace_info) {
+                co_await await_tablets_rebuilt(raft_replace_info->raft_id);
+            }
         }
 
         // If we were the first node in the cluster, at this point `upgrade_state` will be

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -839,6 +839,10 @@ public:
     topology::upgrade_state_type get_topology_upgrade_state() const;
 
     node_state get_node_state(locator::host_id id);
+
+    // Waits for topology state in which none of tablets has replaced_id as a replica.
+    // Must be called on shard 0.
+    future<> await_tablets_rebuilt(raft::server_id replaced_id);
 private:
     // Tracks progress of the upgrade to topology coordinator.
     future<> _upgrade_to_topology_coordinator_fiber = make_ready_future<>();

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1202,6 +1202,11 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
         // which happens outside the topology coordinator.
         bool has_updates = !updates.empty();
         if (has_updates) {
+            co_await utils::get_local_injector().inject("tablet_transition_updates", [] (auto& handler) {
+                rtlogger.info("tablet_transition_updates: start");
+                return handler.wait_for_message(db::timeout_clock::now() + std::chrono::minutes(2));
+            });
+
             updates.emplace_back(
                 topology_mutation_builder(guard.write_timestamp())
                     .set_version(_topo_sm._topology.version + 1)

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -74,7 +74,11 @@ std::optional<request_param> topology::get_request_param(raft::server_id id) con
 };
 
 std::unordered_set<raft::server_id> topology::get_excluded_nodes() const {
-    return ignored_nodes;
+    auto result = ignored_nodes;
+    for (auto& [id, rs] : left_nodes_rs) {
+        result.insert(id);
+    }
+    return result;
 }
 
 std::set<sstring> calculate_not_yet_enabled_features(const std::set<sstring>& enabled_features, const auto& supported_features) {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -132,6 +132,8 @@ struct topology {
     std::unordered_map<raft::server_id, replica_state> normal_nodes;
     // Nodes that are left
     std::unordered_set<raft::server_id> left_nodes;
+    // Left nodes for which we need topology information.
+    std::unordered_map<raft::server_id, replica_state> left_nodes_rs;
     // Nodes that are waiting to be joined by the topology coordinator
     std::unordered_map<raft::server_id, replica_state> new_nodes;
     // Nodes that are in the process to be added to the ring

--- a/test/perf/perf_tablets.cc
+++ b/test/perf/perf_tablets.cc
@@ -129,6 +129,12 @@ static future<> test_basic_operations(app_template& app) {
 
         testlog.info("Read mutations in {:.6f} [ms]", time_to_read_muts.count() * 1000);
 
+        auto time_to_read_hosts = duration_in_seconds([&] {
+            replica::read_required_hosts(e.local_qp()).get();
+        });
+
+        testlog.info("Read required hosts in {:.6f} [ms]", time_to_read_hosts.count() * 1000);
+
         auto cm_size = 0;
         for (auto&& cm : muts) {
             cm_size += cm.representation().size();

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -313,6 +313,15 @@ class ScyllaRESTAPIClient():
         assert(type(data) == str)
         return data
 
+    async def get_raft_leader(self, node_ip: str, group_id: Optional[str] = None) -> HostID:
+        """Returns host ID of the current leader of the given raft group as seen by the registry on the contact node.
+           When group_id is not specified, group0 is used."""
+        params = {}
+        if group_id:
+            params["group_id"] = group_id
+        data = await self.client.get_json("/raft/leader_host", host=node_ip, params=params)
+        return HostID(data)
+
     async def repair(self, node_ip: str, keyspace: str, table: str, ranges: str = '') -> None:
         """Repair the given table and wait for it to complete"""
         if ranges:

--- a/test/topology_experimental_raft/test_mv_tablets_replace.py
+++ b/test/topology_experimental_raft/test_mv_tablets_replace.py
@@ -1,0 +1,99 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from typing import List
+
+from cassandra import ConsistencyLevel
+from cassandra.query import SimpleStatement
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.scylla_cluster import ReplaceConfig
+from test.pylib.internal_types import ServerInfo, HostID
+
+import pytest
+import asyncio
+import logging
+
+from test.topology.conftest import skip_mode
+from test.topology.util import get_topology_coordinator
+from test.topology_experimental_raft.test_mv_tablets import get_tablet_replicas
+
+logger = logging.getLogger(__name__)
+
+
+async def find_server_by_host_id(manager: ManagerClient, servers: List[ServerInfo], host_id: HostID) -> ServerInfo:
+    for s in servers:
+        if await manager.get_host_id(s.server_id) == host_id:
+            return s
+    raise Exception(f"Host ID {host_id} not found in {servers}")
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient):
+    """
+    Verifies that view replica pairing is stable in the case of node replace.
+    After replace, the node is in left state, but still present in the replica set.
+    If view pairing code would use get_natural_endpoints(), which excludes left nodes,
+    the pairing would be shifted during replace.
+    """
+
+    servers = await manager.servers_add(4)
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}"
+                        " AND tablets = {'initial': 1}")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int)")
+    await cql.run_async("CREATE MATERIALIZED VIEW test.tv AS SELECT * FROM test.test WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (c, pk) WITH SYNCHRONOUS_UPDATES = TRUE")
+
+    # Disable migrations concurrent with replace since we don't handle nodes going down during migration yet.
+    # See https://github.com/scylladb/scylladb/issues/16527
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    base_replicas = await get_tablet_replicas(manager, servers[0], "test", "test", 0)
+    logger.info(f'test.test replicas: {base_replicas}')
+    view_replicas = await get_tablet_replicas(manager, servers[0], "test", "tv", 0)
+    logger.info(f'test.tv replicas: {view_replicas}')
+    server_to_replace = await find_server_by_host_id(manager, servers, HostID(str(view_replicas[0][0])))
+    server_to_down = await find_server_by_host_id(manager, servers, HostID(str(base_replicas[0][0])))
+
+    logger.info('Downing a node to be replaced')
+    await manager.server_stop(server_to_replace.server_id)
+
+    logger.info('Blocking tablet rebuild')
+    coord = await get_topology_coordinator(manager)
+    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    await manager.api.enable_injection(coord_serv.ip_addr, "tablet_transition_updates", one_shot=True)
+    coord_log = await manager.server_open_log(coord_serv.server_id)
+    coord_mark = await coord_log.mark()
+
+    logger.info('Replacing the node')
+    replace_cfg = ReplaceConfig(replaced_id = server_to_replace.server_id, reuse_ip_addr = False, use_host_id = True)
+    replace_task = asyncio.create_task(manager.server_add(replace_cfg))
+
+    await coord_log.wait_for('tablet_transition_updates: start', from_mark=coord_mark)
+
+    if server_to_down.server_id != server_to_replace.server_id:
+        await manager.server_stop(server_to_down.server_id)
+
+    # The update is supposed to go to the second replica only, since the other one is downed.
+    # If pairing would shift, the update to the view would be lost because the first replica
+    # is the one which is in the left state.
+    logger.info('Updating base table')
+    await cql.run_async(SimpleStatement("INSERT INTO test.test (pk, c) VALUES (3, 4)", consistency_level=ConsistencyLevel.ONE))
+    logger.info('Querying the view')
+    assert [(4,3)] == list(await cql.run_async(SimpleStatement("SELECT * FROM test.tv WHERE c=4", consistency_level=ConsistencyLevel.ONE)))
+
+    if server_to_down.server_id != server_to_replace.server_id:
+        await manager.server_start(server_to_down.server_id)
+
+    logger.info('Unblocking tablet rebuild')
+    if coord_serv.server_id != server_to_down.server_id:
+        await manager.api.message_injection(coord_serv.ip_addr, "tablet_transition_updates")
+
+    logger.info('Waiting for replace')
+    await replace_task
+
+    logger.info('Querying')
+    assert [(4,3)] == list(await cql.run_async("SELECT * FROM test.tv WHERE c=4"))

--- a/test/topology_experimental_raft/test_tablets_removenode.py
+++ b/test/topology_experimental_raft/test_tablets_removenode.py
@@ -30,20 +30,24 @@ async def run_async_cl_all(cql, query: str):
 @pytest.mark.asyncio
 async def test_replace(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
-    cmdline = ['--logger-log-level', 'storage_service=trace']
+    cmdline = [
+        '--logger-log-level', 'storage_service=trace',
+        '--logger-log-level', 'raft_topology=trace',
+    ]
 
-    # 4 nodes so that we can find new tablet replica for the RF=3 table on removenode
-    servers = await manager.servers_add(4, cmdline=cmdline)
+    servers = await manager.servers_add(3, cmdline=cmdline)
 
     cql = manager.get_cql()
 
     await create_keyspace(cql, "test", 32, rf=1)
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
 
+    # We want RF=2 table to validate that quorum reads work after replacing node finishes
+    # bootstrap which indicates that bootstrap waits for rebuilt.
+    # Otherwise, some reads would fail to find a quorum.
     await create_keyspace(cql, "test2", 32, rf=2)
     await cql.run_async("CREATE TABLE test2.test (pk int PRIMARY KEY, c int);")
 
-    # RF=3
     await create_keyspace(cql, "test3", 32, rf=3)
     await cql.run_async("CREATE TABLE test3.test (pk int PRIMARY KEY, c int);")
 
@@ -54,23 +58,19 @@ async def test_replace(manager: ManagerClient):
     await asyncio.gather(*[run_async_cl_all(cql, f"INSERT INTO test2.test (pk, c) VALUES ({k}, {k});") for k in keys])
     await asyncio.gather(*[run_async_cl_all(cql, f"INSERT INTO test3.test (pk, c) VALUES ({k}, {k});") for k in keys])
 
+    async def check_ks(ks):
+        logger.info(f"Checking {ks}")
+        query = SimpleStatement(f"SELECT * FROM {ks}.test;", consistency_level=ConsistencyLevel.QUORUM)
+        rows = await cql.run_async(query)
+        assert len(rows) == len(keys)
+        for r in rows:
+            assert r.c == r.pk
+
     async def check():
-        # RF=1 table "test" will experience data loss so don't check it.
-        # We include it to check that the system doesn't crash.
-
-        logger.info("Checking table test2")
-        query = SimpleStatement("SELECT * FROM test2.test;", consistency_level=ConsistencyLevel.ONE)
-        rows = await cql.run_async(query)
-        assert len(rows) == len(keys)
-        for r in rows:
-            assert r.c == r.pk
-
-        logger.info("Checking table test3")
-        query = SimpleStatement("SELECT * FROM test3.test;", consistency_level=ConsistencyLevel.ONE)
-        rows = await cql.run_async(query)
-        assert len(rows) == len(keys)
-        for r in rows:
-            assert r.c == r.pk
+        # RF=1 keyspace will experience data loss so don't check it.
+        # We include it in the test only to check that the system doesn't crash.
+        await check_ks("test2")
+        await check_ks("test3")
 
     await check()
 
@@ -81,10 +81,20 @@ async def test_replace(manager: ManagerClient):
     logger.info('Replacing a node')
     await manager.server_stop(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = True)
-    await manager.server_add(replace_cfg)
+    servers.append(await manager.server_add(replace_cfg))
     servers = servers[1:]
 
     await check()
+
+    # Verify that QUORUM reads from RF=3 table work when replacing finished and we down a single node.
+    # This validates that replace waits for tablet rebuilt before finishing bootstrap, otherwise some reads
+    # would fail to find a quorum.
+    logger.info('Downing a node')
+    await manager.server_stop_gracefully(servers[0].server_id)
+    await manager.server_not_sees_other_server(servers[1].ip_addr, servers[0].ip_addr)
+    await manager.server_not_sees_other_server(servers[2].ip_addr, servers[0].ip_addr)
+
+    await check_ks("test3")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR fixes a problem with replacing a node with tablets when
RF=N. Currently, this will fail because tablet replica allocation for 
rebuild will not be able to find a viable destination, as the replacing node
is not considered to be a candidate. It cannot be a candidate because
replace rolls back on failure and we cannot roll back after tablets
were migrated.

The solution taken here is to not drain tablet replicas from replaced
node during topology request but leave it to happen later after the
replaced node is in left state and replacing node is in normal state.

The replacing node waits for this draining to be complete on boot
before the node is considered booted.

Fixes https://github.com/scylladb/scylladb/issues/17025

Nodes in the left state will be kept in tablet replica sets for a while after node
replace is done, until the new replica is rebuilt. So we need to know
about those node's location (dc, rack) for two reasons:

 1) algorithms which work with replica sets filter nodes based on their location. For example materialized views code which pairs base replicas with view replicas filters by datacenter first.

 2) tablet scheduler needs to identify each node's location in order to make decisions about new replica placement.

It's ok to not know the IP, and we don't keep it. Those nodes will not
be present in the IP-based replica sets, e.g. those returned by
get_natural_endpoints(), only in host_id-based replica
sets. storage_proxy request coordination is not affected.

Nodes in the left state are still not present in token ring, and not
considered to be members of the ring (datacanter endpoints excludes them).

In the future we could make the change even more transparent by only
loading locator::node* for those nodes and keeping node* in tablet replica sets.

Currently left nodes are never removed from topology, so will
accumulate in memory. We could garbage-collect them from topology
coordinator if a left node is absent in any replica set. That means we
need a new state - left_for_real.


