### PR TITLE
gms/versioned_value: impl operator<<(.., const gms::versioned_value) …

### DIFF
--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -85,10 +85,6 @@ public:
         : _version(-1) {
     }
 
-    friend inline std::ostream& operator<<(std::ostream& os, const versioned_value& x) {
-        return os << "Value(" << x.value() << "," << x.version() <<  ")";
-    }
-
     static sstring version_string(const std::initializer_list<sstring>& args) {
         return fmt::to_string(fmt::join(args, std::string_view(versioned_value::DELIMITER_STR)));
     }
@@ -215,3 +211,10 @@ template <> struct fmt::formatter<gms::versioned_value> : fmt::formatter<std::st
         return fmt::format_to(ctx.out(), "Value({},{})", v.value(), v.version());
     }
  };
+
+namespace gms {
+inline std::ostream& operator<<(std::ostream& os, const versioned_value& v) {
+    fmt::print(os, "{}", v);
+    return os;
+}
+}


### PR DESCRIPTION
…using fmt

less repeatings this way. this is also a follow-up change of cb781c0ff7af13fe8b63246ed28577aa61df432b.