### PR TITLE
docs: quote CQL keywords

### DIFF
--- a/docs/dev/timestamp-conflict-resolution.md
+++ b/docs/dev/timestamp-conflict-resolution.md
@@ -30,8 +30,8 @@ and the one that was written at a later time prevails.
 Finally, if both cells are live and have no expiration, or have the same expiration time and time-to-live,
 the cell with the lexicographically bigger value prevails.
 
-Note that when multiple columns are INSERTed or UPDATEed using the same timestamp,
-SELECTing those columns might return a result that mixes cells from either upsert.
+Note that when multiple columns are `INSERT`ed or `UPDATE`ed using the same timestamp,
+`SELECT`ing those columns might return a result that mixes cells from either upsert.
 This may happen when both upserts have no expiration time, or both their expiration time and TTL are the
 same, respectively (in whole second resolution). In such a case, cell selection would be based on the cell values
 in each column, independently of each other.


### PR DESCRIPTION
this "misspelling" was identified by codespell. actually, it's not quite a misspelling, as "UPDATE" and "INSERT" are keywords in CQL.  so we intended to emaphasis them, so to make codespell more useful,  and to preserve the intention, let's quote the keywords with backticks.