### PR TITLE
test: rest_api: mark tests failing with tablets with xfail

### DIFF
--- a/test/rest_api/suite.yaml
+++ b/test/rest_api/suite.yaml
@@ -4,3 +4,8 @@ pool_size: 1
 skip_in_release:
     - test_task_manager
     - test_compaction_task
+
+extra_scylla_cmdline_options:
+  - '--experimental-features=udf'
+  - '--experimental-features=consistent-topology-changes'
+  - '--experimental-features=tablets'

--- a/test/rest_api/test_compaction_task.py
+++ b/test/rest_api/test_compaction_task.py
@@ -1,3 +1,4 @@
+import pytest
 import sys
 import threading
 
@@ -82,6 +83,7 @@ def test_major_keyspace_compaction_task(cql, this_dc, rest_api):
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, table: rest_api.send("POST", f"column_family/major_compaction/{keyspace}:{table}?flush_memtables=true"), "major compaction", task_tree_depth)
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, table: rest_api.send("POST", f"column_family/major_compaction/{keyspace}:{table}?flush_memtables=false"), "major compaction", task_tree_depth)
 
+@pytest.mark.xfail(reason="rest_api suite doesn't support tablets yet (#17338), run test manually")
 def test_cleanup_keyspace_compaction_task(cql, this_dc, rest_api):
     task_tree_depth = 3
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("POST", f"storage_service/keyspace_cleanup/{keyspace}"), "cleanup compaction", task_tree_depth, True)
@@ -97,10 +99,12 @@ def test_rewrite_sstables_keyspace_compaction_task(cql, this_dc, rest_api):
     # scrub sstables compaction
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, _: rest_api.send("GET", f"storage_service/keyspace_scrub/{keyspace}"), "scrub sstables compaction", task_tree_depth)
 
+@pytest.mark.xfail(reason="rest_api suite doesn't support tablets yet (#17338), run test manually")
 def test_reshaping_compaction_task(cql, this_dc, rest_api):
     task_tree_depth = 2
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, table: rest_api.send("POST", f"storage_service/sstables/{keyspace}", {'cf': table, 'load_and_stream': False}), "reshaping compaction", task_tree_depth, True)
 
+@pytest.mark.xfail(reason="rest_api suite doesn't support tablets yet (#17338), run test manually")
 def test_resharding_compaction_task(cql, this_dc, rest_api):
     task_tree_depth = 2
     check_compaction_task(cql, this_dc, rest_api, lambda keyspace, table: rest_api.send("POST", f"storage_service/sstables/{keyspace}", {'cf': table, 'load_and_stream': False}), "resharding compaction", task_tree_depth, True)
@@ -164,6 +168,7 @@ def test_compaction_task_abort(cql, this_dc, rest_api):
 def test_major_keyspace_compaction_task_async(cql, this_dc, rest_api):
     checkout_async_task(cql, this_dc, rest_api, lambda keyspace: rest_api.send("POST", f"tasks/compaction/keyspace_compaction/{keyspace}"), "major compaction")
 
+@pytest.mark.xfail(run=False, reason="rest_api suite doesn't support tablets yet (#17338), run test manually")
 def test_cleanup_keyspace_compaction_task_async(cql, this_dc, rest_api):
     checkout_async_task(cql, this_dc, rest_api, lambda keyspace: rest_api.send("POST", f"tasks/compaction/keyspace_cleanup/{keyspace}"), "cleanup compaction")
 

--- a/test/rest_api/test_repair_task.py
+++ b/test/rest_api/test_repair_task.py
@@ -1,3 +1,4 @@
+import pytest
 import sys
 
 # Use the util.py library from ../cql-pytest:
@@ -76,6 +77,7 @@ def test_repair_task_tree(cql, this_dc, rest_api):
                     check_child_parent_relationship(rest_api, top_level_task, False, repair_tree_depth)
     drain_module_tasks(rest_api, module_name)
 
+@pytest.mark.xfail(run=False, reason="rest_api suite doesn't support tablets yet (#17338), run test manually")
 def test_repair_task_progress(cql, this_dc, rest_api):
     drain_module_tasks(rest_api, module_name)
     with set_tmp_task_ttl(rest_api, long_time):

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -40,8 +40,7 @@ def test_storage_service_keyspaces(cql, this_dc, rest_api):
         resp.raise_for_status()
         assert keyspace in resp.json()
 
-@pytest.mark.xfail(reason="rest_api suite doesn't support tablets yet (#17338), run test manually")
-def test_storage_service_keyspaces_replication(cql, this_dc, rest_api):
+def test_storage_service_keyspaces_replication(cql, this_dc, rest_api, skip_without_tablets):
     def get_keyspaces(replication):
         resp = rest_api.send("GET", "storage_service/keyspaces", { "type": "user", "replication": replication })
         resp.raise_for_status()
@@ -572,9 +571,8 @@ def test_storage_service_system_keyspace_repair(rest_api):
     resp.raise_for_status()
     assert not [stats for stats in resp.json() if stats["sequence_number"] == sequence_number], "Repair task for keyspace with local replication strategy was created"
 
-@pytest.mark.xfail(reason="rest_api suite doesn't support tablets yet (#17338), run test manually")
 @pytest.mark.parametrize("tablets_enabled", ["true", "false"])
-def test_storage_service_get_natural_endpoints(cql, rest_api, tablets_enabled):
+def test_storage_service_get_natural_endpoints(cql, rest_api, tablets_enabled, skip_without_tablets):
     with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }} AND TABLETS = {{ 'enabled': {tablets_enabled} }}") as keyspace:
         with new_test_table(cql, keyspace, 'p int PRIMARY KEY') as table:
             resp = rest_api.send("GET", f"storage_service/natural_endpoints/{keyspace}", params={"cf": table, "key": 1})
@@ -582,8 +580,7 @@ def test_storage_service_get_natural_endpoints(cql, rest_api, tablets_enabled):
 
             assert resp == [rest_api.host]
 
-@pytest.mark.xfail(reason="rest_api suite doesn't support tablets yet (#17338), run test manually")
-def test_range_to_endpoint_map_tablets_enabled_keyspace_param_only(cql,  rest_api):
+def test_range_to_endpoint_map_tablets_enabled_keyspace_param_only(cql,  rest_api, skip_without_tablets):
     with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 } AND TABLETS = { 'enabled': true }") as keyspace:
         with new_test_table(cql, keyspace, 'p int PRIMARY KEY') as table:
             resp = rest_api.send("GET", f"storage_service/range_to_endpoint_map/{keyspace}")
@@ -594,9 +591,8 @@ def test_range_to_endpoint_map_tablets_enabled_keyspace_param_only(cql,  rest_ap
             expected_error_reason = f"storage_service/range_to_endpoint_map is per-table in keyspace '{keyspace}'. Please provide table name using 'cf' parameter."
             assert expected_error_reason == actual_error_reason
 
-@pytest.mark.xfail(reason="rest_api suite doesn't support tablets yet (#17338), run test manually")
 @pytest.mark.parametrize("tablets_enabled", ["true", "false"])
-def test_range_to_endpoint_map_with_table_param(cql,  rest_api, tablets_enabled):
+def test_range_to_endpoint_map_with_table_param(cql,  rest_api, tablets_enabled, skip_without_tablets):
     with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }} AND TABLETS = {{ 'enabled': {tablets_enabled} }}") as keyspace:
         with new_test_table(cql, keyspace, 'p int PRIMARY KEY') as table:
             cf = table.split('.')[1]

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -453,6 +453,7 @@ def test_range_to_endpoint_map_tablets_disabled_keyspace_param_only(cql, this_dc
         resp = rest_api.send("GET", f"storage_service/range_to_endpoint_map/{keyspace}")
         resp.raise_for_status()
 
+@pytest.mark.xfail(reason="rest_api suite doesn't support tablets yet (#17338), run test manually")
 def test_describe_ring(cql, this_dc, rest_api):
     with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
         resp = rest_api.send("GET", f"storage_service/describe_ring/{keyspace}")
@@ -490,6 +491,7 @@ def test_storage_service_keyspace_cleanup(cql, this_dc, rest_api):
                 resp = rest_api.send("POST", f"storage_service/keyspace_cleanup/{keyspace}")
                 resp.raise_for_status()
 
+@pytest.mark.xfail(reason="rest_api suite doesn't support tablets yet (#17338), run test manually")
 def test_storage_service_keyspace_cleanup_with_no_owned_ranges(cql, this_dc, rest_api):
     with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
         schema = 'p int, v text, primary key (p)'
@@ -529,6 +531,7 @@ def test_storage_service_keyspace_cleanup_with_no_owned_ranges(cql, this_dc, res
                         assert snapshots[after_alter_keyspace_tag]['total'] == snapshots[after_flush_tag]['total'], f"snapshots after alter-keyspace should have the same data as after flush: {snapshots}"
                         assert snapshots[after_cleanup_tag]['total'] == 0, f"snapshots after clean should have no data: {snapshots}"
 
+@pytest.mark.xfail(run=False, reason="rest_api suite doesn't support tablets yet (#17338), run test manually")
 def test_storage_service_keyspace_upgrade_sstables(cql, this_dc, rest_api):
     with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
         schema = 'p int, v text, primary key (p)'
@@ -571,6 +574,7 @@ def test_storage_service_system_keyspace_repair(rest_api):
     resp.raise_for_status()
     assert not [stats for stats in resp.json() if stats["sequence_number"] == sequence_number], "Repair task for keyspace with local replication strategy was created"
 
+@pytest.mark.xfail(reason="rest_api suite doesn't support tablets yet (#17338), run test manually")
 @pytest.mark.parametrize("tablets_enabled", ["true", "false"])
 def test_storage_service_get_natural_endpoints(cql, rest_api, tablets_enabled, skip_without_tablets):
     with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }} AND TABLETS = {{ 'enabled': {tablets_enabled} }}") as keyspace:


### PR DESCRIPTION
When tablets are enabled, some rest_api tests fail.

Mark them as xfail temporarily. Set run=False for the tests that kill scylla, so that the tests could be run on the same instance.

Refs: #17338.