### PR TITLE
storage_service/ownership: handle requests when tablets are enabled

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -433,6 +433,14 @@
                      "allowMultiple":false,
                      "type":"string",
                      "paramType":"path"
+                  },
+                  {
+                     "name":"cf",
+                     "description":"Column family name",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
                   }
                ]
             }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -20,6 +20,7 @@
 #include <time.h>
 #include <algorithm>
 #include <functional>
+#include <iterator>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/algorithm/string/trim_all.hpp>
@@ -88,6 +89,16 @@ static void ensure_tablets_disabled(const http_context& ctx, const sstring& ks_n
     if (ctx.db.local().find_keyspace(ks_name).uses_tablets()) {
         throw bad_param_exception{fmt::format("{} is per-table in keyspace '{}'. Please provide table name using 'cf' parameter.", api_endpoint_path, ks_name)};
     }
+}
+
+static bool any_of_keyspaces_use_tablets(const http_context& ctx) {
+    auto& db = ctx.db.local();
+    auto uses_tablets = [&db](const auto& ks_name) {
+        return db.find_keyspace(ks_name).uses_tablets();
+    };
+
+    auto keyspaces = db.get_all_keyspaces();
+    return std::any_of(std::begin(keyspaces), std::end(keyspaces), uses_tablets);
 }
 
 locator::host_id validate_host_id(const sstring& param) {
@@ -1359,7 +1370,11 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         return make_ready_future<json::json_return_type>(0);
     });
 
-    ss::get_ownership.set(r, [&ss] (std::unique_ptr<http::request> req) {
+    ss::get_ownership.set(r, [&ctx, &ss] (std::unique_ptr<http::request> req) {
+        if (any_of_keyspaces_use_tablets(ctx)) {
+            throw httpd::bad_param_exception("storage_service/ownership cannot be used when a keyspace uses tablets");
+        }
+
         return ss.local().get_ownership().then([] (auto&& ownership) {
             std::vector<storage_service_json::mapper> res;
             return make_ready_future<json::json_return_type>(map_to_key_value(ownership, res));

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -220,6 +220,18 @@ dht::token_range tablet_map::get_token_range(tablet_id id) const {
     }
 }
 
+future<std::vector<token>> tablet_map::get_sorted_tokens() const {
+    std::vector<token> tokens;
+    tokens.reserve(tablet_count());
+
+    for (auto id : tablet_ids()) {
+        tokens.push_back(get_last_token(id));
+        co_await coroutine::maybe_yield();
+    }
+
+    co_return tokens;
+}
+
 void tablet_map::set_tablet(tablet_id id, tablet_info info) {
     check_tablet_id(id);
     _tablets[size_t(id)] = std::move(info);

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -345,6 +345,9 @@ public:
     /// \throws std::logic_error If the given id does not belong to this instance.
     dht::token_range get_token_range(tablet_id id) const;
 
+    /// Returns a vector of sorted last tokens for tablets.
+    future<std::vector<token>> get_sorted_tokens() const;
+
     /// Returns the id of the first tablet.
     tablet_id first_tablet() const {
         return tablet_id(0);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -581,7 +581,7 @@ public:
      * @param ep endpoint we are interested in.
      * @return ranges for the specified endpoint.
      */
-    dht::token_range_vector get_ranges_for_endpoint(const locator::vnode_effective_replication_map_ptr& erm, const gms::inet_address& ep) const;
+    dht::token_range_vector get_ranges_for_endpoint(const locator::effective_replication_map_ptr& erm, const gms::inet_address& ep) const;
 
     /**
      * Get all ranges that span the ring given a set
@@ -680,7 +680,7 @@ public:
 
     future<std::map<gms::inet_address, float>> get_ownership();
 
-    future<std::map<gms::inet_address, float>> effective_ownership(sstring keyspace_name);
+    future<std::map<gms::inet_address, float>> effective_ownership(sstring keyspace_name, sstring table_name);
 
     // Must run on shard 0.
     future<> check_and_repair_cdc_streams();

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -162,6 +162,17 @@ class ScyllaRESTAPIClient():
         assert(type(data) == list)
         return data
 
+    async def get_ownership(self, dst_server_ip: IPAddress, keyspace: str = None, table: str = None) -> list:
+        """Retrieve the ownership"""
+        if keyspace is None and table is None:
+            api_path = f"/storage_service/ownership/"
+        elif table is None:
+            api_path = f"/storage_service/ownership/{keyspace}"
+        else:
+            api_path = f"/storage_service/ownership/{keyspace}?cf={table}"
+        data = await self.client.get_json(api_path, dst_server_ip)
+        return data
+
     async def get_down_endpoints(self, node_ip: IPAddress) -> list[IPAddress]:
         """Retrieve down endpoints from gossiper's point of view """
         data = await self.client.get_json("/gossiper/endpoint/down/", node_ip)


### PR DESCRIPTION
Before this change, when user tried to utilize
'storage_service/ownership/{keyspace}' API with
keyspace parameter that uses tablets, then internal
error was thrown. The code was calling a function,
that is intended for vnodes: get_vnode_effective_replication_map().

This commit introduces graceful handling of such scenario and
extends the API to allow passing 'cf' parameter that denotes
table name.

Now, when keyspace uses tablets and cf parameter is not passed
a descriptive error message is returned via BAD_REQUEST.
Users cannot query ownership for keyspace that uses tablets,
but they can query ownership for a table in a given keyspace that uses tablets.

Also, new tests have been added to test/rest_api/test_storage_service.py and
to test/topology_experimental_raft/test_tablets.py in order to verify the behavior
with and without tablets enabled.

Fixes: https://github.com/scylladb/scylladb/issues/17342