### PR TITLE
Regenerate frozen toolchain

### DIFF
--- a/tools/toolchain/Dockerfile
+++ b/tools/toolchain/Dockerfile
@@ -8,7 +8,9 @@ RUN dnf -y update \
     && dnf -y install 'dnf-command(copr)' \
     && dnf -y install ccache \
     && dnf -y install devscripts debhelper fakeroot file rpm-build \
-    && ./install-dependencies.sh && dnf clean all \
+    && ./install-dependencies.sh \
+    && dnf -y --releasever 38 update gnutls gnutls-c++ gnutls-dane gnutls-devel libunistring libunistring-devel \
+    && dnf clean all \
     && echo 'ALL ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers \
     && cp system-auth /etc/pam.d \
     && echo 'Defaults !requiretty' >> /etc/sudoers

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-37-branch-5.2-20240115
+docker.io/scylladb/scylla-toolchain:fedora-37-branch-5.2-20240219


### PR DESCRIPTION
For gnutls 3.8.3.

Since Fedora 37 is end-of-life, pick the package from Fedora 38. libunistring needs to be updated to satisfy the dependency solver.

Fixes #17285.

Closes scylladb/scylladb#17287