### PR TITLE
test/nodetool: parameterize test_ring

### DIFF
--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -215,7 +215,8 @@ def nodetool(request, jmx, nodetool_path, rest_api_mock_server):
 
         # Check the return-code first, if the command failed probably not all requests were consumed
         res.check_returncode()
-        assert len(unconsumed_expected_requests) == 0
+        expected_requests = [req for req in unconsumed_expected_requests if req.multiple >= 0]
+        assert len(expected_requests) == 0, ''.join(str(r) for r in expected_requests)
 
         return res.stdout
 


### PR DESCRIPTION
so we exercise the cases where state and status are not "normal" and "up".

turns out the MBean is able to cache some objects. so the requets retrieving datacenter and rack are now marked `ANY`.

* filter out the requests whose `multiple` is `ANY`
* include the unconsumed requets in the raised `AssertionError`. this
  should help with debugging.

Fixes #17401