### PR TITLE
topology: print `node*` with node_printer

### DIFF
--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -175,7 +175,7 @@ const node* topology::add_node(node_holder nptr) {
     }
 
     if (node->idx() > 0) {
-        on_internal_error(tlogger, format("topology[{}]: {}: has assigned idx", fmt::ptr(this), nptr));
+        on_internal_error(tlogger, format("topology[{}]: {}: has assigned idx", fmt::ptr(this), node_printer(nptr.get())));
     }
 
     // Note that _nodes contains also the this_node()
@@ -194,7 +194,7 @@ const node* topology::add_node(node_holder nptr) {
             }
         }
 
-        tlogger.debug("topology[{}]: add_node: {}, at {}", fmt::ptr(this), nptr, lazy_backtrace());
+        tlogger.debug("topology[{}]: add_node: {}, at {}", fmt::ptr(this), node_printer(nptr.get()), lazy_backtrace());
 
         index_node(node);
     } catch (...) {


### PR DESCRIPTION
in da53854b66, we added formatter for printing a `node*`, and switched to this formatter when printing `node*`. but we failed to update some caller sites when migrating to the new formatter, where a `unique_ptr<node>` is printed instead. this is not the behavior before the change, and is not expected.

so, in this change, we explicitly instantiate `node_printer` instances with the pointer held by `unique_ptr<node>`, to restore the behavior before da53854b66.

this issue was identified when compiling the tree using {fmt} v10 and compile-time format-string check enabled, which is yet upstreamed to Seastar.