### PR TITLE
fmt: add formatter for mutation_fragment_v2::kind

### DIFF
--- a/mutation/mutation_fragment.cc
+++ b/mutation/mutation_fragment.cc
@@ -325,14 +325,8 @@ position_in_partition_view mutation_fragment_v2::position() const
 
 std::ostream& operator<<(std::ostream& os, mutation_fragment_v2::kind k)
 {
-    switch (k) {
-    case mutation_fragment_v2::kind::static_row: return os << "static row";
-    case mutation_fragment_v2::kind::clustering_row: return os << "clustering row";
-    case mutation_fragment_v2::kind::range_tombstone_change: return os << "range tombstone change";
-    case mutation_fragment_v2::kind::partition_start: return os << "partition start";
-    case mutation_fragment_v2::kind::partition_end: return os << "partition end";
-    }
-    abort();
+    fmt::print(os, "{}", k);
+    return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const mutation_fragment_v2::printer& p) {

--- a/mutation/mutation_fragment_v2.hh
+++ b/mutation/mutation_fragment_v2.hh
@@ -370,6 +370,31 @@ private:
 
 std::ostream& operator<<(std::ostream&, mutation_fragment_v2::kind);
 
+template <> struct fmt::formatter<mutation_fragment_v2::kind> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(mutation_fragment_v2::kind k, FormatContext& ctx) const {
+        string_view name = "UNEXPECTED";
+        switch (k) {
+        case mutation_fragment_v2::kind::static_row:
+            name = "static row";
+            break;
+        case mutation_fragment_v2::kind::clustering_row:
+            name = "clustering row";
+            break;
+       case mutation_fragment_v2::kind::range_tombstone_change:
+            name = "range tombstone change";
+            break;
+        case mutation_fragment_v2::kind::partition_start:
+            name = "partition start";
+            break;
+        case mutation_fragment_v2::kind::partition_end:
+            name = "partition end";
+            break;
+        }
+        return formatter<string_view>::format(name, ctx);
+    }
+};
+
 // F gets a stream element as an argument and returns the new value which replaces that element
 // in the transformed stream.
 template<typename F>


### PR DESCRIPTION
Unfortunately, fmt v10 dropped support for operator<< formatters, forcing us to replace the huge number of operator<< implementations in our code by uglier and templated fmt::formatter implementations to get Scylla to compile on modern distros (such as Fedora 39) :-(

Kefu has already started doing this migration, here is my small contribution - the formatter for mutation_fragment_v2::kind. This patch is need to compile, for example,
build/dev/mutation/mutation_fragment_stream_validator.o.

Refs #13245