### PR TITLE
repair: Add ranges option support for tablet repair

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1162,9 +1162,6 @@ future<int> repair_service::do_repair_start(sstring keyspace, std::unordered_map
         }
         if (is_tablet) {
             // Reject unsupported options for tablet repair
-            if (!options.ranges.empty()) {
-                throw std::runtime_error("The ranges option is not supported for tablet repair");
-            }
             if (!options.hosts.empty()) {
                 throw std::runtime_error("The hosts option is not supported for tablet repair");
             }
@@ -1192,7 +1189,7 @@ future<int> repair_service::do_repair_start(sstring keyspace, std::unordered_map
                 co_return *ip;
             };
             bool primary_replica_only = options.primary_range;
-            co_await repair_tablets(id, keyspace, cfs, host2ip, primary_replica_only);
+            co_await repair_tablets(id, keyspace, cfs, host2ip, primary_replica_only, options.ranges);
             co_return id.id;
         }
     }
@@ -2051,7 +2048,7 @@ future<> repair_service::replace_with_repair(locator::token_metadata_ptr tmptr, 
 }
 
 // Repair all tablets belong to this node for the given table
-future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_name, std::vector<sstring> table_names, host2ip_t host2ip, bool primary_replica_only) {
+future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_name, std::vector<sstring> table_names, host2ip_t host2ip, bool primary_replica_only, dht::token_range_vector ranges_specified) {
     std::vector<tablet_repair_task_meta> task_metas;
     for (auto& table_name : table_names) {
         lw_shared_ptr<replica::table> t;
@@ -2090,7 +2087,11 @@ future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_nam
                     found = true;
                     break;
                 }
-                if (primary_replica_only) {
+                // If users use both the primary_replica_only and the ranges
+                // option to select which ranges to repair, prefer the more
+                // sophisticated ranges option, since the ranges the requested
+                // explicitly.
+                if (primary_replica_only && ranges_specified.empty()) {
                     break;
                 }
             }
@@ -2108,6 +2109,35 @@ future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_nam
             std::vector<gms::inet_address> nodes;
             auto master_shard_id = m.master_shard_id;
             auto range = m.range;
+            dht::token_range_vector intersection_ranges;
+            if (!ranges_specified.empty()) {
+                for (auto& r : ranges_specified) {
+                    // When the management tool, e.g., scylla manager, uses
+                    // ranges option to select which ranges to repair for a
+                    // tablet table to schedule repair work, it needs to
+                    // disable tablet migration to make sure the node and token
+                    // range mapping does not change.
+                    //
+                    // If the migration is not disabled, the ranges provided by
+                    // the user might not match exactly with the token range of the
+                    // tablets. We do the intersection of the ranges to repair
+                    // as a best effort.
+                    auto intersection_opt = range.intersection(r, dht::token_comparator());
+                    if (intersection_opt) {
+                        intersection_ranges.push_back(intersection_opt.value());
+                        rlogger.debug("repair[{}] Select tablet table={}.{} tablet_id={} range={} replicas={} primary_replica_only={} ranges_specified={} intersection_ranges={}",
+                            rid.uuid(), keyspace_name, table_name, m.id, m.range, m.replicas, primary_replica_only, ranges_specified, intersection_opt.value());
+                    }
+                    co_await coroutine::maybe_yield();
+                }
+            } else {
+                intersection_ranges.push_back(range);
+            }
+            if (intersection_ranges.empty()) {
+                rlogger.debug("repair[{}] Skip tablet table={}.{} tablet_id={} range={} replicas={} primary_replica_only={} ranges_specified={}",
+                    rid.uuid(), keyspace_name, table_name, m.id, m.range, m.replicas, primary_replica_only, ranges_specified);
+                continue;
+            }
             std::vector<shard_id> shards;
             for (auto& r : m.replicas) {
                 auto shard = r.shard;
@@ -2119,7 +2149,10 @@ future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_nam
                     nodes.push_back(ip);
                 }
             }
-            task_metas.push_back(tablet_repair_task_meta{keyspace_name, table_name, tid, master_shard_id, range, repair_neighbors(nodes, shards), m.replicas});
+            for (auto& r : intersection_ranges) {
+                task_metas.push_back(tablet_repair_task_meta{keyspace_name, table_name, tid, master_shard_id, r, repair_neighbors(nodes, shards), m.replicas});
+                co_await coroutine::maybe_yield();
+            }
         }
     }
     auto task = co_await _repair_module->make_and_start_task<repair::tablet_repair_task_impl>({}, rid, keyspace_name, table_names, streaming::stream_reason::repair, std::move(task_metas));

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -162,7 +162,7 @@ private:
             shared_ptr<node_ops_info> ops_info);
 
 public:
-    future<> repair_tablets(repair_uniq_id id, sstring keyspace_name, std::vector<sstring> table_names, host2ip_t host2ip, bool primary_replica_only = true);
+    future<> repair_tablets(repair_uniq_id id, sstring keyspace_name, std::vector<sstring> table_names, host2ip_t host2ip, bool primary_replica_only = true, dht::token_range_vector ranges_specified = {});
 
 private:
 

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -302,9 +302,13 @@ class ScyllaRESTAPIClient():
         assert(type(data) == str)
         return data
 
-    async def repair(self, node_ip: str, keyspace: str, table: str) -> None:
+    async def repair(self, node_ip: str, keyspace: str, table: str, ranges: str = '') -> None:
         """Repair the given table and wait for it to complete"""
-        sequence_number = await self.client.post_json(f"/storage_service/repair_async/{keyspace}", host=node_ip, params={"columnFamilies": table})
+        if ranges:
+            params = {"columnFamilies": table, "ranges": ranges}
+        else:
+            params = {"columnFamilies": table}
+        sequence_number = await self.client.post_json(f"/storage_service/repair_async/{keyspace}", host=node_ip, params=params)
         status = await self.client.get_json(f"/storage_service/repair_status", host=node_ip, params={"id": str(sequence_number)})
         if status != 'SUCCESSFUL':
             raise Exception(f"Repair id {sequence_number} on node {node_ip} for table {keyspace}.{table} failed: status={status}")

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -32,7 +32,7 @@ async def inject_error_on(manager, error_name, servers):
     errs = [manager.api.enable_injection(s.ip_addr, error_name, False) for s in servers]
     await asyncio.gather(*errs)
 
-async def repair_on_node(manager: ManagerClient, server: ServerInfo, servers: list[ServerInfo]):
+async def repair_on_node(manager: ManagerClient, server: ServerInfo, servers: list[ServerInfo], ranges: str = ''):
     node = server.ip_addr
     await manager.servers_see_each_other(servers)
     live_nodes_wanted = [s.ip_addr for s in servers]
@@ -41,7 +41,7 @@ async def repair_on_node(manager: ManagerClient, server: ServerInfo, servers: li
     live_nodes.sort()
     assert live_nodes == live_nodes_wanted
     logger.info(f"Repair table on node {node} live_nodes={live_nodes} live_nodes_wanted={live_nodes_wanted}")
-    await manager.api.repair(node, "test", "test")
+    await manager.api.repair(node, "test", "test", ranges)
 
 @pytest.mark.asyncio
 async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(manager: ManagerClient):
@@ -459,6 +459,55 @@ async def test_tablet_repair_history(manager: ManagerClient):
         for row in all_rows:
             logging.info(f"Got repair_history_entry={row}")
         assert len(all_rows) == rf * tablets
+
+    await check_repair_history()
+
+    await cql.run_async("DROP KEYSPACE test;")
+
+@pytest.mark.repair
+@pytest.mark.asyncio
+async def test_tablet_repair_ranges_selection(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    servers = [await manager.server_add(), await manager.server_add()]
+
+    rf = 2
+    tablets = 4
+    nr_ranges = 0;
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {{'class': 'NetworkTopologyStrategy', "
+                  "'replication_factor': {}}} AND tablets = {{'initial': {}}};".format(rf, tablets))
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int) WITH tombstone_gc = {'mode':'repair'};")
+
+    logger.info("Populating table")
+
+    keys = range(256)
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    logging.info(f'Got hosts={hosts}');
+
+    await repair_on_node(manager, servers[0], servers, ranges='-4611686018427387905:-1,4611686018427387903:9223372036854775807')
+    nr_ranges = nr_ranges + 2
+    await repair_on_node(manager, servers[0], servers, ranges='-2000:-1000,1000:2000')
+    nr_ranges = nr_ranges + 2
+    await repair_on_node(manager, servers[0], servers, ranges='3000:-3000')
+    # The wrap around range (3000, -3000] will produce the following intersection range
+    # range=(minimum token,-4611686018427387905] ranges_specified={(3000,+inf), (-inf, -3000]} intersection_ranges=(minimum token,-4611686018427387905]
+    # range=(-4611686018427387905,-1] ranges_specified={(3000,+inf), (-inf, -3000]} intersection_ranges=(-4611686018427387905,-3000]
+    # range=(-1,4611686018427387903] ranges_specified={(3000,+inf), (-inf, -3000]} intersection_ranges=(3000,4611686018427387903]
+    # range=(4611686018427387903,9223372036854775807] ranges_specified={(3000,+inf), (-inf, -3000]} intersection_ranges=(4611686018427387903,9223372036854775807]
+    nr_ranges = nr_ranges + 4
+
+    async def check_repair_history():
+        all_rows = []
+        for host in hosts:
+            logging.info(f'Query hosts={host}');
+            rows = await cql.run_async("SELECT * from system.repair_history", host=host)
+            all_rows += rows
+        for row in all_rows:
+            logging.info(f"Got repair_history_entry={row}")
+        assert len(all_rows) == rf * nr_ranges;
 
     await check_repair_history()
 


### PR DESCRIPTION
The management tool, e.g., scylla manager, needs the ranges option to select which ranges to repair on a node to schedule repair jobs.

This patch adds ranges option support.

E.g.,

curl -X POST "http://127.0.0.1:10000/storage_service/repair_async/ks1?ranges=-4611686018427387905:-1,4611686018427387903:9223372036854775807"

Fixes: #17416
Tests: test_tablet_repair_ranges_selection