### PR TITLE
tools/utils: configure tools to use the epoll reactor backend

### DIFF
--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -69,6 +69,7 @@ void configure_tool_mode(app_template::seastar_options& opts, const sstring& log
     opts.reactor_opts.relaxed_dma.set_value();
     opts.reactor_opts.unsafe_bypass_fsync.set_value(true);
     opts.reactor_opts.kernel_page_cache.set_value(true);
+    opts.reactor_opts.reactor_backend.select_candidate("epoll");
     opts.smp_opts.thread_affinity.set_value(false);
     opts.smp_opts.mbind.set_value(false);
     opts.smp_opts.smp.set_value(1);


### PR DESCRIPTION
The default AIO backend requires AIO blocks. On production systems, all available AIO blocks could have been already taken by ScyllaDB. Even though the tools only require a single unit, we have seen cases where not even that is available, ScyllDB having siphoned all of the available blocks.
We could try to ensure all deployments have some spare blocks, but it is just less friction to not have to deal with this problem at all, by just using the epoll backend. We don't care about performance in the case of the tools anyway, so long as they are not unreasonably slow. And since these tools are replacing legacy tools written in Java, the bar is low.