### PR TITLE
Fix load-and-stream for tablets

### DIFF
--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -142,6 +142,7 @@ private:
     io_error_handler_gen _error_handler_gen;
     std::unique_ptr<storage> _storage;
     std::unique_ptr<components_lister> _lister;
+    std::unique_ptr<dht::sharder> _sharder_ptr;
     const dht::sharder& _sharder;
 
     generation_type _max_generation_seen;
@@ -189,6 +190,13 @@ private:
     // Retrieves sstables::foreign_sstable_open_info for a particular SSTable.
     future<foreign_sstable_open_info> get_open_info_for_this_sstable(const sstables::entry_descriptor& desc) const;
 
+    sstable_directory(sstables_manager& manager,
+          schema_ptr schema,
+          std::variant<std::unique_ptr<dht::sharder>, const dht::sharder*> sharder,
+          lw_shared_ptr<const data_dictionary::storage_options> storage_opts,
+          sstring table_dir,
+          sstable_state state,
+          io_error_handler_gen error_handler_gen);
 public:
     sstable_directory(replica::table& table,
             sstable_state state,

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -150,6 +150,7 @@ future<> sstable_streamer::stream(bool primary_replica_only) {
     while (!_sstables.empty()) {
         size_t batch_sst_nr = 16;
         std::vector<sstables::shared_sstable> sst_processed;
+        sst_processed.reserve(std::min(_sstables.size(), size_t(16)));
         while (batch_sst_nr-- && !_sstables.empty()) {
             auto sst = _sstables.back();
             sst_processed.push_back(sst);


### PR DESCRIPTION
It might happen that multiple tablets co-habit the same shard, so we want load-and-stream to jump into a new streaming session for every tablet, such that the receiver will have the data properly segregated. That's a similar treatment we gave to repair. Today, load-and-stream fails due to sstables spanning more than 1 tablet in the receiver. 

Synchronization with migration is done by taking replication map, so migrations cannot advance while streaming new data. A bug was fixed too, where data must be streamed to pending replicas too, to handle case where migration is ongoing and new data must reach both old and new replica set. A test was added stressing this synchronization path.

Another bug was fixed in sstable loading, which expected sharder to not be invalidated throughout the operation, but that breaks during migrations.

Fixes #17315.