### PR TITLE
Handle tablet migration failure in barrier stages

### DIFF
--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -67,4 +67,7 @@ future<locator::tablet_metadata> read_tablet_metadata(cql3::query_processor&);
 /// Reads tablet metadata from system.tablets in the form of mutations.
 future<std::vector<canonical_mutation>> read_tablet_mutations(seastar::sharded<database>&);
 
+/// Reads tablet transition stage (if any)
+future<std::optional<locator::tablet_transition_stage>> read_tablet_transition_stage(cql3::query_processor& qp, table_id tid, dht::token last_token);
+
 } // namespace replica

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1042,6 +1042,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     }
                     break;
                 case locator::tablet_transition_stage::write_both_read_old:
+                    if (action_failed(tablet_state.barriers[trinfo.stage])) {
+                        if (check_excluded_replicas()) {
+                            transition_to_with_barrier(locator::tablet_transition_stage::cleanup_target);
+                            break;
+                        }
+                    }
                     transition_to_with_barrier(locator::tablet_transition_stage::streaming);
                     break;
                 // The state "streaming" is needed to ensure that stale stream_tablet() RPC doesn't

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1025,6 +1025,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
 
             switch (trinfo.stage) {
                 case locator::tablet_transition_stage::allow_write_both_read_old:
+                    if (action_failed(tablet_state.barriers[trinfo.stage])) {
+                        if (check_excluded_replicas()) {
+                            transition_to_with_barrier(locator::tablet_transition_stage::revert_migration);
+                            break;
+                        }
+                    }
                     if (do_barrier()) {
                         rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::write_both_read_old);
                         updates.emplace_back(get_mutation_builder()

--- a/test/topology_custom/test_tablets_migration.py
+++ b/test/topology_custom/test_tablets_migration.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("fail_replica", ["source", "destination"])
-@pytest.mark.parametrize("fail_stage", ["streaming", "allow_write_both_read_old", "write_both_read_old", "write_both_read_new"])
+@pytest.mark.parametrize("fail_stage", ["streaming", "allow_write_both_read_old", "write_both_read_old", "write_both_read_new", "use_new"])
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail_replica, fail_stage):

--- a/test/topology_custom/test_tablets_migration.py
+++ b/test/topology_custom/test_tablets_migration.py
@@ -48,6 +48,7 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
     logger.info(f"Tablet is on [{replicas}]")
     assert len(replicas) == 1 and len(replicas[0].replicas) == 2
 
+    last_token = replicas[0].last_token
     old_replica = None
     for r in replicas[0].replicas:
         assert r[0] != host_ids[2], "Tablet got migrated to node2"
@@ -64,6 +65,10 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
         await manager.api.enable_injection(servers[2].ip_addr, "stream_mutation_fragments", one_shot=True)
         s2_log = await manager.server_open_log(servers[2].server_id)
         s2_mark = await s2_log.mark()
+    elif fail_stage in [ "allow_write_both_read_old", "write_both_read_old", "write_both_read_new", "use_new" ]:
+        await manager.api.enable_injection(servers[fail_idx].ip_addr, "raft_topology_barrier_and_drain_fail", one_shot=False, parameters={'keyspace': 'test', 'table': 'test', 'last_token': last_token, 'stage': fail_stage})
+        sx_log = await manager.server_open_log(servers[fail_idx].server_id)
+        sx_mark = await sx_log.mark()
     else:
         assert False, f"Unknown stage {fail_stage}"
 
@@ -73,6 +78,8 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
     logger.info(f"Wait for {fail_stage} to happen")
     if fail_stage == "streaming":
         await s2_log.wait_for('stream_mutation_fragments: waiting', from_mark=s2_mark)
+    elif fail_stage in [ "allow_write_both_read_old", "write_both_read_old", "write_both_read_new", "use_new" ]:
+        await sx_log.wait_for('raft_topology_cmd: barrier handler waits', from_mark=sx_mark);
     else:
         assert False
 

--- a/test/topology_custom/test_tablets_migration.py
+++ b/test/topology_custom/test_tablets_migration.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("fail_replica", ["source", "destination"])
-@pytest.mark.parametrize("fail_stage", ["streaming"])
+@pytest.mark.parametrize("fail_stage", ["streaming", "allow_write_both_read_old"])
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail_replica, fail_stage):

--- a/test/topology_custom/test_tablets_migration.py
+++ b/test/topology_custom/test_tablets_migration.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("fail_replica", ["source", "destination"])
-@pytest.mark.parametrize("fail_stage", ["streaming", "allow_write_both_read_old"])
+@pytest.mark.parametrize("fail_stage", ["streaming", "allow_write_both_read_old", "write_both_read_old"])
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail_replica, fail_stage):

--- a/test/topology_custom/test_tablets_migration.py
+++ b/test/topology_custom/test_tablets_migration.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("fail_replica", ["source", "destination"])
-@pytest.mark.parametrize("fail_stage", ["streaming", "allow_write_both_read_old", "write_both_read_old"])
+@pytest.mark.parametrize("fail_stage", ["streaming", "allow_write_both_read_old", "write_both_read_old", "write_both_read_new"])
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail_replica, fail_stage):


### PR DESCRIPTION
There are 4 barrier-only stages when migrating a tablet and the test needs to fail pending/leaving replica that handles it in order to validate how coordinator handles dead node. Failing the barrier is done by suspending it with injection code and stopping the node without waking it up. The main difficulty here is how to tell one barrier RPC call from another, because they don't have anything onboard that could tell which stage the barrier is run for. This PR suggests that barrier injection code looks directly into the system.tablets table for the transition stage, the stage is already there by the time barrier is about to ack itself over RPC.

refs: #16527