### PR TITLE
Docs: rename the select-from-mutation-fragments page name

### DIFF
--- a/docs/operating-scylla/_common/tools_index.rst
+++ b/docs/operating-scylla/_common/tools_index.rst
@@ -13,7 +13,7 @@
 * `scyllatop <https://www.scylladb.com/2016/03/22/scyllatop/>`_ - A terminal base top-like tool for scylladb collectd/prometheus metrics.
 * :doc:`scylla_dev_mode_setup</getting-started/installation-common/dev-mod>` - run Scylla in Developer Mode.
 * :doc:`perftune</operating-scylla/admin-tools/perftune>` - performance configuration.
-* :doc:`SELECT * FROM MUTATION_FRAGMENTS() Statement </operating-scylla/admin-tools/select-from-mutation-fragments/>` - dump the underlying mutation data from tables.
+* :doc:`Reading mutation fragments</operating-scylla/admin-tools/select-from-mutation-fragments/>` - dump the underlying mutation data from tables.
 * :doc:`Maintenance socket </operating-scylla/admin-tools/maintenance-socket/>` - a Unix domain socket for full-permission CQL connection.
 * :doc:`Maintenance mode </operating-scylla/admin-tools/maintenance-mode/>` - a mode for performing maintenance tasks on an offline Scylla node.
 

--- a/docs/operating-scylla/admin-tools/index.rst
+++ b/docs/operating-scylla/admin-tools/index.rst
@@ -18,7 +18,7 @@ Admin Tools
    Scylla Logs </getting-started/logging/>
    perftune
    Virtual Tables </operating-scylla/admin-tools/virtual-tables/>
-   SELECT * FROM MUTATION_FRAGMENTS() Statement </operating-scylla/admin-tools/select-from-mutation-fragments/>
+   Reading mutation fragments </operating-scylla/admin-tools/select-from-mutation-fragments/>
    Maintenance socket </operating-scylla/admin-tools/maintenance-socket/>
    Maintenance mode </operating-scylla/admin-tools/maintenance-mode/>
 

--- a/docs/operating-scylla/admin-tools/select-from-mutation-fragments.rst
+++ b/docs/operating-scylla/admin-tools/select-from-mutation-fragments.rst
@@ -1,6 +1,6 @@
-============================================
-SELECT * FROM MUTATION_FRAGMENTS() Statement
-============================================
+==========================
+Reading mutation fragments
+==========================
 
 .. warning:: This statement is not final and is subject to change without notice and in backwards-incompatible ways.
 


### PR DESCRIPTION
Fix #17324 

### before
![image](https://github.com/scylladb/scylladb/assets/170200/2b2967b1-efa1-4152-9d3f-e06b408bab4b)


### After
![image](https://github.com/scylladb/scylladb/assets/170200/0e78a996-b7a2-4e76-83ad-7b9fbb302658)

