### PR TITLE
alternator: add fmt::formatter for alternator::parsed::path

### DIFF
--- a/alternator/expressions.cc
+++ b/alternator/expressions.cc
@@ -133,21 +133,6 @@ void path::check_depth_limit() {
     }
 }
 
-std::ostream& operator<<(std::ostream& os, const path& p) {
-    os << p.root();
-    for (const auto& op : p.operators()) {
-        std::visit(overloaded_functor {
-            [&] (const std::string& member) {
-                os << '.' << member;
-            },
-            [&] (unsigned index) {
-                os << '[' << index << ']';
-            }
-        }, op);
-    }
-    return os;
-}
-
 } // namespace parsed
 
 // The following resolve_*() functions resolve references in parsed
@@ -756,3 +741,20 @@ rjson::value calculate_value(const parsed::set_rhs& rhs,
 }
 
 } // namespace alternator
+
+auto fmt::formatter<alternator::parsed::path>::format(const alternator::parsed::path& p, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    auto out = ctx.out();
+    out = fmt::format_to(out, "{}", p.root());
+    for (const auto& op : p.operators()) {
+        std::visit(overloaded_functor {
+            [&] (const std::string& member) {
+                out = fmt::format_to(out, ".{}", member);
+            },
+            [&] (unsigned index) {
+                out = fmt::format_to(out, "[{}]", index);
+            }
+        }, op);
+    }
+    return out;
+}

--- a/alternator/expressions_types.hh
+++ b/alternator/expressions_types.hh
@@ -255,3 +255,7 @@ public:
 
 } // namespace parsed
 } // namespace alternator
+
+template <> struct fmt::formatter<alternator::parsed::path> : fmt::formatter<std::string_view> {
+    auto format(const alternator::parsed::path&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `alternator::parsed::path`, and drop its operator<<.

Refs #13245