### PR TITLE
cdc: s/string_view/std::string_view/

### DIFF
--- a/cdc/cdc_options.hh
+++ b/cdc/cdc_options.hh
@@ -66,10 +66,10 @@ public:
 
 } // namespace cdc
 
-template <> struct fmt::formatter<cdc::image_mode> : fmt::formatter<string_view> {
+template <> struct fmt::formatter<cdc::image_mode> : fmt::formatter<std::string_view> {
     auto format(cdc::image_mode, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<cdc::delta_mode> : fmt::formatter<string_view> {
+template <> struct fmt::formatter<cdc::delta_mode> : fmt::formatter<std::string_view> {
     auto format(cdc::delta_mode, fmt::format_context& ctx) const -> decltype(ctx.out());
 };


### PR DESCRIPTION
in af2553e8, we added formatters for cdc::image_mode and cdc::delta_mode. but in that change, we failed to qualify `string_view` with `std::` prefix. even it compiles, it depends on a `using std::string_view` or a more error-prone `using namespace std`. neither of which shold be relied on. so, in this change, we add the `std::` prefix to `string_view`.