### PR TITLE
mutation: add fmt::formatter for clustering_row, row_tombstone and friends

### DIFF
--- a/mutation/mutation_fragment.cc
+++ b/mutation/mutation_fragment.cc
@@ -14,30 +14,6 @@
 #include "utils/hashing.hh"
 #include "utils/xx_hasher.hh"
 
-std::ostream&
-operator<<(std::ostream& os, const clustering_row::printer& p) {
-    auto& row = p._clustering_row;
-    return os << "{clustering_row: ck " << row._ck << " dr "
-              << deletable_row::printer(p._schema, row._row) << "}";
-}
-
-std::ostream&
-operator<<(std::ostream& os, const static_row::printer& p) {
-    return os << "{static_row: "<< row::printer(p._schema, column_kind::static_column, p._static_row._cells) << "}";
-}
-
-std::ostream&
-operator<<(std::ostream& os, const partition_start& ph) {
-    fmt::print(os, "{{partition_start: pk {} partition_tombstone {}}}",
-               ph._key, ph._partition_tombstone);
-    return os;
-}
-
-std::ostream&
-operator<<(std::ostream& os, const partition_end& eop) {
-    return os << "{partition_end}";
-}
-
 partition_region parse_partition_region(std::string_view s) {
     if (s == "partition_start") {
         return partition_region::partition_start;
@@ -274,16 +250,17 @@ std::ostream& operator<<(std::ostream& os, mutation_fragment::kind k)
     abort();
 }
 
-std::ostream& operator<<(std::ostream& os, const mutation_fragment::printer& p) {
+auto fmt::formatter<mutation_fragment::printer>::format(const mutation_fragment::printer& p, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
     auto& mf = p._mutation_fragment;
-    os << "{mutation_fragment: " << mf._kind << " " << mf.position() << " ";
-    mf.visit(make_visitor(
-        [&] (const clustering_row& cr) { os << clustering_row::printer(p._schema, cr); },
-        [&] (const static_row& sr) { os << static_row::printer(p._schema, sr); },
-        [&] (const auto& what) -> void { fmt::print(os, "{}", what); }
+    auto out = ctx.out();
+    out = fmt::format_to(out, "{{mutation_fragment: {} {} ", mf._kind, mf.position());
+    out = mf.visit(make_visitor(
+        [&] (const clustering_row& cr) { return fmt::format_to(out, "{}", clustering_row::printer(p._schema, cr)); },
+        [&] (const static_row& sr) { return fmt::format_to(out, "{}", static_row::printer(p._schema, sr)); },
+        [&] (const auto& what) { return fmt::format_to(out, "{}", what); }
     ));
-    os << "}";
-    return os;
+    return fmt::format_to(out, "}}");
 }
 
 const clustering_key_prefix& mutation_fragment_v2::key() const
@@ -339,8 +316,8 @@ std::ostream& operator<<(std::ostream& os, const mutation_fragment_v2::printer& 
     auto& mf = p._mutation_fragment;
     os << "{mutation_fragment: " << mf._kind << " " << mf.position() << " ";
     mf.visit(make_visitor(
-        [&] (const clustering_row& cr) { os << clustering_row::printer(p._schema, cr); },
-        [&] (const static_row& sr) { os << static_row::printer(p._schema, sr); },
+        [&] (const clustering_row& cr) { fmt::print(os, "{}", clustering_row::printer(p._schema, cr)); },
+        [&] (const static_row& sr) { fmt::print(os, "{}", static_row::printer(p._schema, sr)); },
         [&] (const auto& what) -> void { fmt::print(os, "{}", what); }
     ));
     os << "}";

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -1505,6 +1505,11 @@ mutation_partition& mutation_partition::container_of(rows_type& rows) {
 bool has_any_live_data(const schema& s, column_kind kind, const row& cells, tombstone tomb = tombstone(),
                        gc_clock::time_point now = gc_clock::time_point::min());
 
+template <> struct fmt::formatter<row_tombstone> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<row_marker> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<deletable_row::printer> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<row::printer> : fmt::ostream_formatter {};
+
 template <> struct fmt::formatter<mutation_partition::printer> : fmt::formatter<string_view> {
     auto format(const mutation_partition::printer&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/test/boost/frozen_mutation_test.cc
+++ b/test/boost/frozen_mutation_test.cc
@@ -37,6 +37,11 @@ static tombstone new_tombstone() {
     return { new_timestamp(), gc_clock::now() };
 };
 
+std::ostream& operator<<(std::ostream& os, const mutation_fragment::printer& p) {
+    fmt::print(os, "{}", p);
+    return os;
+}
+
 template <typename UnfreezeFunc>
 requires std::same_as<std::invoke_result_t<UnfreezeFunc, const frozen_mutation&, schema_ptr>, mutation>
 static future<> _test_freeze_unfreeze(UnfreezeFunc&& unfreeze_func) {


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter
created from operator<<, but fmt v10 dropped the default-generated
formatter.

in this change, we define formatters for

* row_tombstone
* row_marker
* deletable_row::printer
* row::printer
* clustering_row::printer
* static_row::printer
* partition_start
* partition_end
* mutation_fragment::printer

and drop their operator<<:s

Refs #13245