### PR TITLE
utils: add fmt::formatter for occupancy_stats, managed_bytes and friends 

### DIFF
--- a/clustering_bounds_comparator.hh
+++ b/clustering_bounds_comparator.hh
@@ -153,6 +153,7 @@ public:
         return {typename R<clustering_key_prefix_view>::bound(bv._prefix.get().view(), inclusive)};
     }
     friend std::ostream& operator<<(std::ostream& out, const bound_view& b) {
-        return out << "{bound: prefix=" << b._prefix.get() << ", kind=" << b._kind << "}";
+        fmt::print(out, "{{bound: prefix={}, kind={}}}", b._prefix.get(), b._kind);
+        return out;
     }
 };

--- a/test/unit/lsa_sync_eviction_test.cc
+++ b/test/unit/lsa_sync_eviction_test.cc
@@ -67,8 +67,9 @@ int main(int argc, char** argv) {
                 });
 
                 auto print_region_stats = [&r] {
-                    std::cout << "Region occupancy: " << r.occupancy()
-                        << format(", {:.2f}% of all memory", (float)r.occupancy().total_space() * 100 / memory::stats().total_memory()) << std::endl;
+                    fmt::print("Region occupancy: {}, {:.2f}% of all memory\n",
+                               r.occupancy(),
+                               (float)r.occupancy().total_space() * 100 / memory::stats().total_memory());
                 };
 
                 std::cout << "Allocated " << refs.size() << " evictable objects" << std::endl;

--- a/test/unit/row_cache_alloc_stress_test.cc
+++ b/test/unit/row_cache_alloc_stress_test.cc
@@ -104,9 +104,9 @@ int main(int argc, char** argv) {
                 return memory::stats().free_memory() + logalloc::shard_tracker().occupancy().free_space();
             };
 
-            std::cout << "memtable occupancy: " << mt->occupancy() << "\n";
-            std::cout << "Cache occupancy: " << tracker.region().occupancy() << "\n";
-            std::cout << "Reclaimable memory: " << reclaimable_memory() << "\n";
+            fmt::print("memtable occupancy: {}\n", mt->occupancy());
+            fmt::print("Cache occupancy: {}\n", tracker.region().occupancy());
+            fmt::print("Reclaimable memory: {}\n", reclaimable_memory());
 
             // We need to have enough Free memory to copy memtable into cache
             // When this assertion fails, increase amount of memory
@@ -140,16 +140,16 @@ int main(int argc, char** argv) {
                 for (auto&& key : keys) {
                     cache.touch(key);
                 }
-                std::cout << "Reclaimable memory: " << reclaimable_memory() << "\n";
-                std::cout << "Cache occupancy: " << tracker.region().occupancy() << "\n";
+                fmt::print("Reclaimable memory: {}\n", reclaimable_memory());
+                fmt::print("Cache occupancy: {}\n", tracker.region().occupancy());
             };
 
             std::deque<std::unique_ptr<char[]>> stuffing;
             auto fragment_free_space = [&] {
                 stuffing.clear();
-                std::cout << "Reclaimable memory: " << reclaimable_memory() << "\n";
-                std::cout << "Free memory: " << memory::stats().free_memory() << "\n";
-                std::cout << "Cache occupancy: " << tracker.region().occupancy() << "\n";
+                fmt::print("Reclaimable memory: {}\n", reclaimable_memory());
+                fmt::print("Free memory: {}\n", memory::stats().free_memory());
+                fmt::print("Cache occupancy: {}\n", tracker.region().occupancy());
 
                 // Induce memory fragmentation by taking down cache segments,
                 // which should be evicted in random order, and inducing high
@@ -159,10 +159,10 @@ int main(int argc, char** argv) {
                     stuffing.emplace_back(std::make_unique<char[]>(logalloc::segment_size / 2 + 1));
                 }
 
-                std::cout << "After fragmenting:\n";
-                std::cout << "Reclaimable memory: " << reclaimable_memory() << "\n";
-                std::cout << "Free memory: " << memory::stats().free_memory() << "\n";
-                std::cout << "Cache occupancy: " << tracker.region().occupancy() << "\n";
+                fmt::print("After fragmenting:\n");
+                fmt::print("Reclaimable memory: {}\n", reclaimable_memory());
+                fmt::print("Free memory: {}\n", memory::stats().free_memory());
+                fmt::print("Cache occupancy: {}\n", tracker.region().occupancy());
             };
 
             fill_cache_to_the_top();

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2451,11 +2451,6 @@ std::unordered_map<std::string, uint64_t> region::collect_stats() const {
     return get_impl().collect_stats();
 }
 
-std::ostream& operator<<(std::ostream& out, const occupancy_stats& stats) {
-    return out << format("{:.2f}%, {:d} / {:d} [B]",
-        stats.used_fraction() * 100, stats.used_space(), stats.total_space());
-}
-
 occupancy_stats tracker::impl::global_occupancy() const noexcept {
     return occupancy_stats(_segment_pool->total_free_memory(), _segment_pool->total_memory_in_use());
 }

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -287,8 +287,6 @@ public:
     explicit operator bool() const noexcept {
         return _total_space > 0;
     }
-
-    friend std::ostream& operator<<(std::ostream&, const occupancy_stats&);
 };
 
 class basic_region_impl : public allocation_strategy {
@@ -540,3 +538,10 @@ future<> prime_segment_pool(size_t available_memory, size_t min_free_memory);
 future<> use_standard_allocator_segment_pool_backend(size_t available_memory);
 
 }
+
+template <> struct fmt::formatter<logalloc::occupancy_stats> : fmt::formatter<std::string_view> {
+    auto format(const logalloc::occupancy_stats& stats, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{:.2f}%, {:d} / {:d} [B]",
+                              stats.used_fraction() * 100, stats.used_space(), stats.total_space());
+    }
+};

--- a/utils/managed_bytes.cc
+++ b/utils/managed_bytes.cc
@@ -28,16 +28,9 @@ managed_bytes_opt to_managed_bytes_opt(const bytes_opt& bo) {
 }
 
 sstring to_hex(const managed_bytes& b) {
-    return fmt::to_string(managed_bytes_view(b));
+    return seastar::format("{}", managed_bytes_view(b));
 }
 
 sstring to_hex(const managed_bytes_opt& b) {
     return !b ? "null" : to_hex(*b);
-}
-
-std::ostream& operator<<(std::ostream& os, const managed_bytes_opt& b) {
-    if (b) {
-        return os << *b;
-    }
-    return os << "null";
 }


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter
created from operator<<, but fmt v10 dropped the default-generated
formatter.

in this change, we define formatters for

* managed_bytes
* managed_bytes_view
* managed_bytes_opt
* occupancy_stats

and drop their operator<<:s

Refs https://github.com/scylladb/scylladb/issues/13245