### PR TITLE
streaming: add fmt::formatter for stream_session_state and stream_request

### DIFF
--- a/streaming/stream_request.cc
+++ b/streaming/stream_request.cc
@@ -10,14 +10,7 @@
 
 #include "streaming/stream_request.hh"
 
-namespace streaming {
-
-std::ostream& operator<<(std::ostream& os, const stream_request& sr) {
-    os << "[ ks = " << sr.keyspace << " cf =  ";
-    for (auto& cf : sr.column_families) {
-        os << cf << " ";
-    }
-    return os << "]";
+auto fmt::formatter<streaming::stream_request>::format(const streaming::stream_request& sr, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "[ ks = {} cf = {} ]", sr.keyspace, fmt::join(sr.column_families, " "));
 }
-
-} // namespace streaming;

--- a/streaming/stream_request.hh
+++ b/streaming/stream_request.hh
@@ -36,7 +36,10 @@ public:
     stream_request(sstring _keyspace, std::vector<wrapping_interval<token>> _ranges, std::vector<sstring> _column_families)
         : stream_request(std::move(_keyspace), ::compat::unwrap(std::move(_ranges)), std::move(_column_families)) {
     }
-    friend std::ostream& operator<<(std::ostream& os, const stream_request& r);
 };
 
 } // namespace streaming
+
+template <> struct fmt::formatter<streaming::stream_request> : fmt::formatter<std::string_view> {
+    auto format(const streaming::stream_request&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/streaming/stream_session_state.cc
+++ b/streaming/stream_session_state.cc
@@ -8,14 +8,12 @@
  */
 
 #include "streaming/stream_session_state.hh"
-#include <ostream>
 #include <map>
-#include <seastar/core/sstring.hh>
 #include "seastarx.hh"
 
 namespace streaming {
 
-static const std::map<stream_session_state, sstring> stream_session_state_names = {
+static const std::map<stream_session_state, std::string_view> stream_session_state_names = {
     {stream_session_state::INITIALIZED,     "INITIALIZED"},
     {stream_session_state::PREPARING,       "PREPARING"},
     {stream_session_state::STREAMING,       "STREAMING"},
@@ -24,9 +22,9 @@ static const std::map<stream_session_state, sstring> stream_session_state_names 
     {stream_session_state::FAILED,          "FAILED"},
 };
 
-std::ostream& operator<<(std::ostream& os, const stream_session_state& s) {
-    os << stream_session_state_names.at(s);
-    return os;
 }
 
+auto fmt::formatter<streaming::stream_session_state>::format(streaming::stream_session_state s, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", streaming::stream_session_state_names.at(s));
 }

--- a/streaming/stream_session_state.hh
+++ b/streaming/stream_session_state.hh
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include <ostream>
+#include <fmt/core.h>
 
 namespace streaming {
 
@@ -23,6 +23,8 @@ enum class stream_session_state {
     FAILED,
 };
 
-std::ostream& operator<<(std::ostream& os, const stream_session_state& s);
-
 } // namespace
+
+template <> struct fmt::formatter<streaming::stream_session_state> : fmt::formatter<std::string_view> {
+    auto format(streaming::stream_session_state, fmt::format_context& ctx) const -> decltype(ctx.out());
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter
created from operator<<, but fmt v10 dropped the default-generated
formatter.
    
in this change, we define formatters for

* `streaming::stream_request`,
* `stream_session_state`

and drop their operator<<:s

Refs #13245
