### PR TITLE
compaction: handle nullptr owned_ranges in get_ranges_for_invalidation

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1291,6 +1291,11 @@ private:
     // Called in a seastar thread
     dht::partition_range_vector
     get_ranges_for_invalidation(const std::vector<shared_sstable>& sstables) {
+        if (!_owned_ranges) {
+            // return empty ranges for keyspaces with tablets whose owned_ranges is null
+            return {};
+        }
+
         auto owned_ranges = dht::to_partition_ranges(*_owned_ranges, utils::can_yield::yes);
 
         auto non_owned_ranges = boost::copy_range<dht::partition_range_vector>(sstables


### PR DESCRIPTION
Commit 7a988777 sets owned_ranges_ptr to null when initiating an upgrade on keyspaces with tablets. owned_ranges_ptr is set to null because cleanup is not required for tables using tablets. As a result, cache invalidation is also not required for any ranges. Update get_ranges_for_invalidation to handle null values of owned_ranges_ptr by returning empty ranges for cache invalidation.

Fixes #17452