### PR TITLE
scylla-gdb: use raw string when '\' is not used in an escape sequence

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -83,7 +83,7 @@ def downcast_vptr(ptr):
     global vtable_symbol_pattern
     global vptr_type
     if vtable_symbol_pattern is None:
-        vtable_symbol_pattern = re.compile('vtable for (.*) \+ ([0-9]+).*')
+        vtable_symbol_pattern = re.compile(r'vtable for (.*) \+ ([0-9]+).*')
         vptr_type = gdb.lookup_type('uintptr_t').pointer()
 
     if not isinstance(ptr, gdb.Value):
@@ -2414,7 +2414,7 @@ def print_tree(root_node,
 
     def print_node(node, is_last_history):
         stems = (" |   ", "     ")
-        branches = (" |-- ", " \-- ")
+        branches = (" |-- ", r" \-- ")
 
         label_lines = formatter(node).rstrip('\n').split('\n')
         prefix_without_branch = ''.join(map(stems.__getitem__, is_last_history[:-1]))


### PR DESCRIPTION
when `'\'` does not start an escape sequence, Python complains at seeing it. but it continues anyway by considering `'\'` as a separate char. but the warning message is still annoying:

```
scylla-gdb.py: 2417: SyntaxWarning: invalid escape sequence '\-'
  branches = (r" |-- ", " \-- ")
```

when sourcing this script.

so, let's mark these strings as raw strings.