### PR TITLE
Enhance perf-simple-query test

### DIFF
--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -427,6 +427,12 @@ static std::vector<perf_result> do_cql_test(cql_test_env& env, test_config& cfg)
                 .build();
     }).get();
 
+    std::cout << "Disabling auto compaction" << std::endl;
+    env.db().invoke_on_all([] (auto& db) {
+        auto& cf = db.find_column_family("ks", "cf");
+        return cf.disable_auto_compaction();
+    }).get();
+
     switch (cfg.mode) {
     case test_config::run_mode::read:
         return test_read(env, cfg);


### PR DESCRIPTION
While measuring #17149 with this test some changes were applied, here they are

- keep initial_tablets number in output json's parameters section
- disable auto compaction
- add control over the amount of sstables generated for --bypass-cache case