### PR TITLE
tools/scylla-nodetool: snapshot: handle ks.tbl positional args correctly

### DIFF
--- a/test/nodetool/test_snapshot.py
+++ b/test/nodetool/test_snapshot.py
@@ -9,6 +9,7 @@ import pytest
 import re
 import time
 import utils
+from typing import NamedTuple
 
 
 def test_clearnapshot(nodetool):
@@ -118,6 +119,7 @@ def check_snapshot_out(res, tag, ktlist, skip_flush):
                          f" and options \\{{skipFlush={str(skip_flush).lower()}\\}}")
 
     print(res)
+    print(pattern)
 
     lines = res.split("\n")
     assert len(lines) == 3
@@ -170,6 +172,36 @@ def test_snapshot_keyspace_with_table(nodetool, option_name):
     check_snapshot_out(res, tag, ["ks1"], False)
 
 
+class kn_param(NamedTuple):
+    args: tuple[str]
+    kn: str
+    cf: str
+    snapshot_keyspaces: list[str]
+
+
+@pytest.mark.parametrize("param", (
+    kn_param(("ks1.tbl1",), "ks1", "tbl1", ["ks1.tbl1"]),
+    kn_param(("ks1.tbl1", "ks1.tbl2"), "ks1.tbl1,ks1.tbl2", "", ["ks1.tbl1", "ks1.tbl2"]),
+    kn_param(("ks1.tbl1", "ks2.tbl2"), "ks1.tbl1,ks2.tbl2", "", ["ks1.tbl1", "ks2.tbl2"]),
+    kn_param(("ks1.1/tbl1",), "ks1.1", "tbl1", ["ks1.1/tbl1"]),
+    kn_param(("ks1.1/tbl1", "ks1.2/tbl2"), "ks1.1/tbl1,ks1.2/tbl2", "", ["ks1.1/tbl1", "ks1.2/tbl2"]),
+    kn_param(("--kt-list", "ks1.1/tbl1",), "ks1.1", "tbl1", ["ks1.1/tbl1"]),
+    kn_param(("--kt-list", "ks1.1/tbl1,ks1.2/tbl2"), "ks1.1/tbl1,ks1.2/tbl2", "",
+             ["ks1.1/tbl1", "ks1.2/tbl2"]),
+))
+def test_snapshot_keyspace_table_single_arg(nodetool, param, scylla_only):
+    tag = "my_snapshot"
+
+    req_params = {"tag": tag, "sf": "false", "kn": param.kn}
+    if param.cf:
+        req_params["cf"] = param.cf
+
+    res = nodetool("snapshot", "--tag", tag, *param.args, expected_requests=[
+        expected_request("POST", "/storage_service/snapshots", params=req_params)
+    ])
+    check_snapshot_out(res, tag, param.snapshot_keyspaces, False)
+
+
 @pytest.mark.parametrize("option_name", ("-kt", "--kt-list", "-kc", "--kc.list"))
 def test_snapshot_ktlist(nodetool, option_name):
     tag = "my_snapshot"
@@ -185,6 +217,12 @@ def test_snapshot_ktlist(nodetool, option_name):
                          params={"tag": tag, "sf": "false", "kn": "ks1.tbl1,ks2.tbl2"})
     ])
     check_snapshot_out(res, tag, ["ks1.tbl1", "ks2.tbl2"], False)
+
+    res = nodetool("snapshot", "--tag", tag, option_name, "ks1,ks2", expected_requests=[
+        expected_request("POST", "/storage_service/snapshots",
+                         params={"tag": tag, "sf": "false", "kn": "ks1,ks2"})
+    ])
+    check_snapshot_out(res, tag, ["ks1" ,"ks2"], False)
 
 
 @pytest.mark.parametrize("tag", [None, "my_snapshot_tag"])
@@ -282,21 +320,3 @@ def test_snapshot_keyspace_with_tables(nodetool, scylla_only):
             ("snapshot", "--table", "tbl1", "-cf", "tbl2", "ks1"),
             {"expected_requests": []},
             ["error: option '--table' cannot be specified more than once"])
-
-
-def test_snapshot_keyspace_bad_ktlist_too_many_dots(nodetool, scylla_only):
-    utils.check_nodetool_fails_with(
-            nodetool,
-            ("snapshot", "-kt", "ks1.tbl2.ss,ks2.tbl2"),
-            {"expected_requests": []},
-            ["error processing arguments: invalid keyspace.table: ks1.tbl2.ss, "
-             "keyspace and table must be separated by exactly one dot"])
-
-
-def test_snapshot_keyspace_bad_ktlist_no_dot(nodetool, scylla_only):
-    utils.check_nodetool_fails_with(
-            nodetool,
-            ("snapshot", "-kt", "ks1.tbl1,ks2"),
-            {"expected_requests": []},
-            ["error processing arguments: invalid keyspace.table: ks2, "
-             "keyspace and table must be separated by exactly one dot"])

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1410,6 +1410,21 @@ void snapshot_operation(scylla_rest_client& client, const bpo::variables_map& vm
 
     sstring kn_msg;
 
+    auto split_kt = [] (const std::string_view kt) -> std::optional<std::pair<sstring, sstring>> {
+        std::vector<sstring> components;
+        boost::split(components, kt, boost::algorithm::is_any_of("/"));
+        if (components.size() == 2) {
+            return std::pair(components[0], components[1]);
+        }
+        components.clear();
+        boost::split(components, kt, boost::algorithm::is_any_of("."));
+        if (components.size() == 2) {
+            return std::pair(components[0], components[1]);
+        }
+        return {};
+    };
+
+    std::vector<sstring> kt_list;
     if (vm.count("keyspace-table-list")) {
         if (vm.count("table")) {
             throw std::invalid_argument("when specifying the keyspace-table list for a snapshot, you should not specify table(s)");
@@ -1419,40 +1434,28 @@ void snapshot_operation(scylla_rest_client& client, const bpo::variables_map& vm
         }
 
         const auto kt_list_str = vm["keyspace-table-list"].as<sstring>();
-        std::vector<sstring> kt_list;
         boost::split(kt_list, kt_list_str, boost::algorithm::is_any_of(","));
+    } else if (vm.count("keyspaces")) {
+        kt_list = vm["keyspaces"].as<std::vector<sstring>>();
 
-        std::vector<sstring> components;
-        for (const auto& kt : kt_list) {
-            components.clear();
-            boost::split(components, kt, boost::algorithm::is_any_of("."));
-            if (components.size() != 2) {
-                throw std::invalid_argument(fmt::format("invalid keyspace.table: {}, keyspace and table must be separated by exactly one dot", kt));
-            }
+        if (kt_list.size() > 1 && vm.count("table")) {
+            throw std::invalid_argument("when specifying the table for the snapshot, you must specify one and only one keyspace");
         }
+    }
 
-        if (kt_list.size() == 1) {
-            params["kn"] = components[0];
-            params["cf"] = components[1];
-            kn_msg = format("{}.{}", params["kn"], params["cf"]);
-        } else {
-            params["kn"] = kt_list_str;
-        }
+    if (kt_list.empty()) {
+        kn_msg = "all keyspaces";
     } else {
-        if (vm.count("keyspaces")) {
-            const auto keyspaces = vm["keyspaces"].as<std::vector<sstring>>();
-
-            if (keyspaces.size() > 1 && vm.count("table")) {
-                throw std::invalid_argument("when specifying the table for the snapshot, you must specify one and only one keyspace");
-            }
-
-            params["kn"] = fmt::to_string(fmt::join(keyspaces.begin(), keyspaces.end(), ","));
+        if (kt_list.size() == 1 && split_kt(kt_list.front())) {
+            auto res = split_kt(kt_list.front());
+            params["kn"] = std::move(res->first);
+            params["cf"] = std::move(res->second);
+            kn_msg = kt_list.front();
         } else {
-            kn_msg = "all keyspaces";
-        }
-
-        if (vm.count("table")) {
-            params["cf"] = vm["table"].as<sstring>();
+            params["kn"] = fmt::to_string(fmt::join(kt_list.begin(), kt_list.end(), ","));
+            if (vm.count("table")) {
+                params["cf"] = vm["table"].as<sstring>();
+            }
         }
     }
 


### PR DESCRIPTION
Nodetool currently assumes that positional arguments are only keyspaces. ks.tbl pairs are only provided when --kt-list or friends are used. This is not the case however. So check positional args too, and if they look like ks.tbl, handle them accordingly.