### PR TITLE
Make it possible to run individual pytest cases with test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -279,8 +279,13 @@ class TestSuite(ABC):
                     self.pending_test_count += 1
 
             for p in patterns:
-                if p in t:
-                    pending.add(asyncio.create_task(add_test(shortname, None)))
+                pn = p.split('::', 2)
+                if len(pn) == 1:
+                    if p in t:
+                        pending.add(asyncio.create_task(add_test(shortname, None)))
+                else:
+                    if pn[0] == t:
+                        pending.add(asyncio.create_task(add_test(shortname, pn[1])))
         if len(pending) == 0:
             return
         try:
@@ -923,7 +928,11 @@ class PythonTest(Test):
             # https://docs.pytest.org/en/7.1.x/reference/exit-codes.html
             no_tests_selected_exit_code = 5
             self.valid_exit_codes = [0, no_tests_selected_exit_code]
-        self.args.append(str(self.suite.suite_path / (self.shortname + ".py")))
+
+        arg = str(self.suite.suite_path / (self.shortname + ".py"))
+        if self.casename is not None:
+            arg += '::' + self.casename
+        self.args.append(arg)
 
     def _reset(self) -> None:
         """Reset the test before a retry, if it is retried as flaky"""

--- a/test.py
+++ b/test.py
@@ -221,7 +221,7 @@ class TestSuite(ABC):
         pass
 
     @abstractmethod
-    async def add_test(self, shortname: str) -> None:
+    async def add_test(self, shortname: str, casename: str) -> None:
         pass
 
     async def run(self, test: 'Test', options: argparse.Namespace):
@@ -271,16 +271,16 @@ class TestSuite(ABC):
                 if any(skip_pattern in t for skip_pattern in options.skip_patterns):
                     continue
 
-            async def add_test(shortname) -> None:
+            async def add_test(shortname, casename) -> None:
                 # Add variants of the same test sequentially
                 # so that case cache has a chance to populate
                 for i in range(options.repeat):
-                    await self.add_test(shortname)
+                    await self.add_test(shortname, casename)
                     self.pending_test_count += 1
 
             for p in patterns:
                 if p in t:
-                    pending.add(asyncio.create_task(add_test(shortname)))
+                    pending.add(asyncio.create_task(add_test(shortname, None)))
         if len(pending) == 0:
             return
         try:
@@ -311,7 +311,7 @@ class UnitTestSuite(TestSuite):
         test = UnitTest(self.next_id((shortname, self.suite_key)), shortname, suite, args)
         self.tests.append(test)
 
-    async def add_test(self, shortname) -> None:
+    async def add_test(self, shortname, casename) -> None:
         """Create a UnitTest class with possibly custom command line
         arguments and add it to the list of tests"""
         # Skip tests which are not configured, and hence are not built
@@ -474,8 +474,8 @@ class PythonTestSuite(TestSuite):
     def pattern(self) -> str:
         assert False
 
-    async def add_test(self, shortname) -> None:
-        test = PythonTest(self.next_id((shortname, self.suite_key)), shortname, self)
+    async def add_test(self, shortname, casename) -> None:
+        test = PythonTest(self.next_id((shortname, self.suite_key)), shortname, casename, self)
         self.tests.append(test)
 
 
@@ -488,7 +488,7 @@ class CQLApprovalTestSuite(PythonTestSuite):
     def build_test_list(self) -> List[str]:
         return TestSuite.build_test_list(self)
 
-    async def add_test(self, shortname: str) -> None:
+    async def add_test(self, shortname: str, casename: str) -> None:
         test = CQLApprovalTest(self.next_id((shortname, self.suite_key)), shortname, self)
         self.tests.append(test)
 
@@ -508,9 +508,9 @@ class TopologyTestSuite(PythonTestSuite):
         """Build list of Topology python tests"""
         return TestSuite.build_test_list(self)
 
-    async def add_test(self, shortname: str) -> None:
+    async def add_test(self, shortname: str, casename: str) -> None:
         """Add test to suite"""
-        test = TopologyTest(self.next_id((shortname, 'topology', self.mode)), shortname, self)
+        test = TopologyTest(self.next_id((shortname, 'topology', self.mode)), shortname, casename, self)
         self.tests.append(test)
 
     @property
@@ -531,7 +531,7 @@ class RunTestSuite(TestSuite):
 
         self.scylla_env['SCYLLA'] = self.scylla_exe
 
-    async def add_test(self, shortname) -> None:
+    async def add_test(self, shortname, casename) -> None:
         test = RunTest(self.next_id((shortname, self.suite_key)), shortname, self)
         self.tests.append(test)
 
@@ -560,7 +560,7 @@ class ToolTestSuite(TestSuite):
     def pattern(self) -> str:
         assert False
 
-    async def add_test(self, shortname) -> None:
+    async def add_test(self, shortname, casename) -> None:
         test = ToolTest(self.next_id((shortname, self.suite_key)), shortname, self)
         self.tests.append(test)
 
@@ -900,9 +900,10 @@ class RunTest(Test):
 class PythonTest(Test):
     """Run a pytest collection of cases against a standalone Scylla"""
 
-    def __init__(self, test_no: int, shortname: str, suite) -> None:
+    def __init__(self, test_no: int, shortname: str, casename: str, suite) -> None:
         super().__init__(test_no, shortname, suite)
         self.path = "pytest"
+        self.casename = casename
         self.xmlout = os.path.join(self.suite.options.tmpdir, self.mode, "xml", self.uname + ".xunit.xml")
         self.server_log: Optional[str] = None
         self.server_log_filename: Optional[pathlib.Path] = None
@@ -983,8 +984,8 @@ class TopologyTest(PythonTest):
     """Run a pytest collection of cases against Scylla clusters handling topology changes"""
     status: bool
 
-    def __init__(self, test_no: int, shortname: str, suite) -> None:
-        super().__init__(test_no, shortname, suite)
+    def __init__(self, test_no: int, shortname: str, casename: str, suite) -> None:
+        super().__init__(test_no, shortname, casename, suite)
 
     async def run(self, options: argparse.Namespace) -> Test:
 


### PR DESCRIPTION
Today's test.py allows filtering tests to run with the `test.py --options name` syntax. The "name" argument is then considered to be some prefix, and when iterating tests only those whose name starts with that prefix are collected and executed. This has two troubles.

Minor: since it is prefix filtering, running e.g. topology_custom/test_tablets will run test_tablets _and_ test_tablets_migration from it. There's no way to exclude the latter from this selection. It's not common, but careful file names selection is welcome for better ~~user~~ testing experience.

Major: most of test files in topology and python suites contain many cases, some are extremely long. When the intent is to run a single, potentially fast, test case one needs to either wait or patch the test .py file by hand to somehow exclude unwanted test cases.

This PR adds the ability to run individual test case with test.py. The new syntax is `test.py --options name::case`. If the "::case" part is present two changes apply.

First, the test file selection is done by name match, not by prefix match. So running topology_custom/test_tablets will _not_ select test_tablets_migration from it.

Second, the "::case" part is appended to the pytest execution so that it collects and runs only the specified test case.