### PR TITLE
test: add fmt::formatters

### DIFF
--- a/test/boost/cache_flat_mutation_reader_test.cc
+++ b/test/boost/cache_flat_mutation_reader_test.cc
@@ -131,9 +131,11 @@ struct expected_row {
     position_in_partition key() const {
         return pos;
     }
+};
 
-    friend std::ostream& operator<<(std::ostream& out, const expected_row& e) {
-        return out << "{pos=" << e.key() << ", cont=" << bool(e.continuous) << ", dummy=" << bool(e.dummy) << "}";
+template <> struct fmt::formatter<expected_row> : fmt::formatter<std::string_view> {
+    auto format(const expected_row& e, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{{pos={}, cont={}, dummy={}}}", e.key(), bool(e.continuous), bool(e.dummy));
     }
 };
 

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -26,6 +26,14 @@ using namespace cql3;
 using namespace cql3::expr;
 using namespace cql3::expr::test_utils;
 
+namespace cql3::expr {
+// required by BOOST_REQUIRE_EQUAL
+std::ostream& boost_test_print_type(std::ostream& os, const std::vector<cql3::expr::expression>& v) {
+    fmt::print(os, "{{{}}}", fmt::join(v, ", "));
+    return os;
+}
+}
+
 bind_variable new_bind_variable(int bind_index, data_type type = int32_type) {
     return bind_variable {
         .bind_index = bind_index,

--- a/test/lib/expr_test_utils.hh
+++ b/test/lib/expr_test_utils.hh
@@ -147,14 +147,25 @@ std::pair<data_dictionary::database, std::unique_ptr<data_dictionary::impl>> mak
 
 raw_value evaluate_with_bind_variables(const expression& e, std::vector<raw_value> bind_variable_values);
 
-// FIXME: convert to formatter, but got into a template loop since fmt prefers the fallback formatter for
-// sstring rather than the actual formatter -> std::pair formatting fails -> loop.
-inline
-std::ostream&
-operator<<(std::ostream& os, const mutation_column_value& mcv) {
-    return os << fmt::format("{{{}/ts={}/ttl={}}}", mcv.value, mcv.timestamp, mcv.ttl);
-}
 
 }  // namespace test_utils
 }  // namespace expr
 }  // namespace cql3
+
+template <> struct fmt::formatter<cql3::expr::test_utils::mutation_column_value> : fmt::formatter<std::string_view> {
+    auto format(const cql3::expr::test_utils::mutation_column_value& mcv, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{{{}/ts={}/ttl={}}}", mcv.value, mcv.timestamp, mcv.ttl);
+
+    }
+};
+
+namespace cql3::expr::test_utils {
+
+inline
+std::ostream&
+operator<<(std::ostream& os, const mutation_column_value& mcv) {
+    fmt::print(os, "{}", mcv);
+    return os;
+}
+
+}

--- a/test/perf/perf.cc
+++ b/test/perf/perf.cc
@@ -30,11 +30,12 @@ void scheduling_latency_measurer::schedule_tick() {
     }));
 }
 
-std::ostream& operator<<(std::ostream& out, const scheduling_latency_measurer& slm) {
+auto fmt::formatter<scheduling_latency_measurer>::format(const scheduling_latency_measurer& slm, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
     auto to_ms = [] (int64_t nanos) {
         return float(nanos) / 1e6;
     };
-    return out << fmt::format("{{count: {}, "
+    return fmt::format_to(ctx.out(), "{{count: {}, "
                          //"min: {:.6f} [ms], "
                          //"50%: {:.6f} [ms], "
                          //"90%: {:.6f} [ms], "
@@ -48,11 +49,10 @@ std::ostream& operator<<(std::ostream& out, const scheduling_latency_measurer& s
         to_ms(slm.max().count()));
 }
 
-std::ostream&
-operator<<(std::ostream& os, const perf_result& result) {
-    fmt::print(os, "{:.2f} tps ({:5.1f} allocs/op, {:5.1f} tasks/op, {:7.0f} insns/op, {:8} errors)",
+auto fmt::formatter<perf_result>::format(const perf_result& result, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{:.2f} tps ({:5.1f} allocs/op, {:5.1f} tasks/op, {:7.0f} insns/op, {:8} errors)",
             result.throughput, result.mallocs_per_op, result.tasks_per_op, result.instructions_per_op, result.errors);
-    return os;
 }
 
 aio_writes_result_mixin::aio_writes_result_mixin()

--- a/test/perf/perf.hh
+++ b/test/perf/perf.hh
@@ -157,8 +157,6 @@ struct perf_result {
     uint64_t errors;
 };
 
-std::ostream& operator<<(std::ostream& os, const perf_result& result);
-
 // Use to make a perf_result with aio_writes added. Need to give "update" as
 // update-func to time_parallel_ex to make it work.
 struct aio_writes_result_mixin {
@@ -213,7 +211,7 @@ std::vector<Res> time_parallel_ex(Func func, unsigned concurrency_per_core, int 
 
         uf(result, stats);
 
-        std::cout << result << std::endl;
+        fmt::print("{}\n", result);
         results.emplace_back(result);
     }
     return results;
@@ -282,3 +280,11 @@ public:
 };
 
 } // namespace perf
+
+template <> struct fmt::formatter<scheduling_latency_measurer> : fmt::formatter<std::string_view> {
+    auto format(const scheduling_latency_measurer&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <> struct fmt::formatter<perf_result> : fmt::formatter<std::string_view> {
+    auto format(const perf_result&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/test/unit/tree_test_key.hh
+++ b/test/unit/tree_test_key.hh
@@ -114,3 +114,5 @@ struct test_key_tri_compare {
     std::strong_ordering operator()(const tree_test_key_base& a, const tree_test_key_base& b) const noexcept { return a.compare(b) <=> 0; }
     std::strong_ordering operator()(const int a, const tree_test_key_base& b) const noexcept { return -b.compare(a) <=> 0; }
 };
+
+template <std::derived_from<tree_test_key_base> T> struct fmt::formatter<T> : fmt::formatter<int> {};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter. in this change, we define formatters for some types used in testing.

Refs #13245
