### PR TITLE
sstables: add fmt::formatter for sstable types

### DIFF
--- a/sstables/m_format_read_helpers.cc
+++ b/sstables/m_format_read_helpers.cc
@@ -11,6 +11,7 @@
 #include "sstables/exceptions.hh"
 #include "sstables/random_access_reader.hh"
 #include "sstables/mx/types.hh"
+#include <fmt/format.h>
 
 namespace sstables {
 
@@ -45,36 +46,39 @@ future<int64_t> read_signed_vint(random_access_reader& in) {
     return read_vint_impl<int64_t>(in);
 }
 
-std::ostream& operator<<(std::ostream& out, sstables::bound_kind_m kind) {
+}  // namespace sstables
+
+auto fmt::formatter<sstables::bound_kind_m>::format(sstables::bound_kind_m kind, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    std::string_view name;
     switch (kind) {
-    case sstables::bound_kind_m::excl_end:
-        out << "excl_end";
+    using enum sstables::bound_kind_m;
+    case excl_end:
+        name = "excl_end";
         break;
-    case sstables::bound_kind_m::incl_start:
-        out << "incl_start";
+    case incl_start:
+        name = "incl_start";
         break;
-    case sstables::bound_kind_m::excl_end_incl_start:
-        out << "excl_end_incl_start";
+    case excl_end_incl_start:
+        name = "excl_end_incl_start";
         break;
-    case sstables::bound_kind_m::static_clustering:
-        out << "static_clustering";
+    case static_clustering:
+        name = "static_clustering";
         break;
-    case sstables::bound_kind_m::clustering:
-        out << "clustering";
+    case clustering:
+        name = "clustering";
         break;
-    case sstables::bound_kind_m::incl_end_excl_start:
-        out << "incl_end_excl_start";
+    case incl_end_excl_start:
+        name = "incl_end_excl_start";
         break;
-    case sstables::bound_kind_m::incl_end:
-        out << "incl_end";
+    case incl_end:
+        name = "incl_end";
         break;
-    case sstables::bound_kind_m::excl_start:
-        out << "excl_start";
+    case excl_start:
+        name = "excl_start";
         break;
     default:
-        out << static_cast<unsigned>(kind);
+        return fmt::format_to(ctx.out(), "{}", underlying(kind));
     }
-    return out;
+    return fmt::format_to(ctx.out(), "{}", name);
 }
-
-}  // namespace sstables

--- a/sstables/mx/types.hh
+++ b/sstables/mx/types.hh
@@ -82,6 +82,8 @@ inline bound_kind boundary_to_end_bound(bound_kind_m kind) {
     return (kind == bound_kind_m::incl_end_excl_start) ? bound_kind::incl_end : bound_kind::excl_end;
 }
 
-std::ostream& operator<<(std::ostream& out, sstables::bound_kind_m kind);
-
 }
+
+template <> struct fmt::formatter<sstables::bound_kind_m> : fmt::formatter<std::string_view> {
+    auto format(sstables::bound_kind_m, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -170,10 +170,6 @@ inline sstable_state state_from_dir(std::string_view dir) {
     throw std::runtime_error(format("Unknown sstable state dir {}", dir));
 }
 
-inline std::ostream& operator<<(std::ostream& o, sstable_state s) {
-    return o << state_to_dir(s);
-}
-
 // FIXME -- temporary, move to fs storage after patching the rest
 inline fs::path make_path(std::string_view table_dir, sstable_state state) {
     fs::path ret(table_dir);
@@ -1041,3 +1037,9 @@ struct sstable_files_snapshot {
 };
 
 } // namespace sstables
+
+template <> struct fmt::formatter<sstables::sstable_state> : fmt::formatter<std::string_view> {
+    auto format(sstables::sstable_state state, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", state_to_dir(state));
+    }
+};

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -74,7 +74,6 @@ struct deletion_time {
     explicit operator tombstone() {
         return !live() ? tombstone(marked_for_delete_at, gc_clock::time_point(gc_clock::duration(local_deletion_time))) : tombstone();
     }
-    friend std::ostream& operator<<(std::ostream&, const deletion_time&);
 };
 
 struct option {
@@ -783,3 +782,12 @@ public:
 };
 }
 
+template <>
+struct fmt::formatter<sstables::deletion_time> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const sstables::deletion_time& dt, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(),
+                              "{{timestamp={}, deletion_time={}}}",
+                              dt.marked_for_delete_at, dt.marked_for_delete_at);
+    }
+};

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -112,9 +112,8 @@ enum class indexable_element {
     cell
 };
 
-inline std::ostream& operator<<(std::ostream& o, indexable_element e) {
-    o << static_cast<std::underlying_type_t<indexable_element>>(e);
-    return o;
+inline auto format_as(indexable_element e) {
+    return fmt::underlying(e);
 }
 
 class summary_entry {


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter
created from operator<<, but fmt v10 dropped the default-generated
formatter.

in this change, we define formatters for

* bound_kind_m
* sstable_state
* indexable_element
* deletion_time

drop their operator<<:s

Refs #13245