### PR TITLE
interval, multishard_mutation_query: fix typos in comments

### DIFF
--- a/interval.hh
+++ b/interval.hh
@@ -151,7 +151,7 @@ public:
         }
         return false;
     }
-    // the other inverval is before this interval (works only for non wrapped intervals)
+    // the other interval is before this interval (works only for non wrapped intervals)
     // Comparator must define a total ordering on T.
     bool other_is_before(const wrapping_interval<T>& o, IntervalComparatorFor<T> auto&& cmp) const {
         assert(!is_wrap_around(cmp));

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -813,7 +813,7 @@ future<foreign_ptr<lw_shared_ptr<typename ResultBuilder::result_type>>> do_query
             return result_builder.query(db, gs, query_cmd, range_opt->range, gts, timeout);
         }));
 
-        // Substract result from limit, watch for underflow
+        // Subtract result from limit, watch for underflow
         query_cmd.partition_limit -= std::min(query_cmd.partition_limit, ResultBuilder::get_partition_count(r));
         query_cmd.set_row_limit(query_cmd.get_row_limit() - std::min(query_cmd.get_row_limit(), ResultBuilder::get_row_count(r)));
 


### PR DESCRIPTION
these misspellings were identified by codespell.