### PR TITLE
docs: add collapsible for images

### DIFF
--- a/docs/_ext/scylladb_common_images.py
+++ b/docs/_ext/scylladb_common_images.py
@@ -39,10 +39,12 @@ class FileDownloader:
 class BaseTemplateDirective(DataTemplateCSV):
     option_spec = DataTemplateCSV.option_spec.copy()
     option_spec["version"] = lambda x: x
+    option_spec["latest"] = lambda x: x
 
     def _make_context(self, data, config, env):
         context = super()._make_context(data, config, env)
         context["version"] = self.options.get("version")
+        context["latest"] = self.options.get("latest")
         return context
 
     def run(self):
@@ -78,7 +80,7 @@ class BaseVersionsTemplateDirective(Directive):
             reverse=True
         )
 
-    def _process_file(self, file, relative_path_from_current_rst):
+    def _process_file(self, file, relative_path_from_current_rst, is_latest=False):
         data_directive = BaseTemplateDirective(
             name=self.name,
             arguments=[os.path.join(relative_path_from_current_rst, file)],
@@ -92,6 +94,7 @@ class BaseVersionsTemplateDirective(Directive):
         )
         data_directive.options["template"] = self.TEMPLATE
         data_directive.options["version"] = self._extract_version_from_filename(file)
+        data_directive.options["latest"] = is_latest
         return data_directive.run()
 
     def _get_exclude_patterns(self):
@@ -155,7 +158,8 @@ class BaseVersionsTemplateDirective(Directive):
             files = [files[0]]
 
         output = []
-        for file in files:
-            output.extend(self._process_file(file, relative_path_from_current_rst))
+        for i, file in enumerate(files):
+            is_latest = i == 0
+            output.extend(self._process_file(file, relative_path_from_current_rst, is_latest))
         return output
 

--- a/docs/_templates/aws_image.tmpl
+++ b/docs/_templates/aws_image.tmpl
@@ -3,18 +3,21 @@
 {{version}}
 {{ '-' * version|length }}
 
-.. list-table::
-   :header-rows: 1
+.. collapse:: View image details
+  {% if latest %}:open:{% endif %}
+  
+  .. list-table::
+    :header-rows: 1
 
-   * - Region
-     - x86 AMI ID
-     - Launch x86
-     - ARM AMI ID
-     - Launch ARM
-{% for row in data[1:] %}
-   * - {{ row[0] }}
-     - {{ row[2] }}
-     - `Node <https://console.aws.amazon.com/ec2/v2/home?region={{ row[1] }}#LaunchInstanceWizard:ami={{ row[2] }}>`__ {% if row|length > 4 %} / `Cluster <https://{{ row[1] }}.console.aws.amazon.com/cloudformation/home?region={{ row[1] }}#/stacks/quickcreate?templateURL=http://downloads.scylladb.com.s3.amazonaws.com/{{ row[4] }}&stackName=scylla-cluster&param_ScyllaDBAmi={{ row[2] }}>`__{% endif %}
-     - {{ row[3] }}
-     - `Node <https://console.aws.amazon.com/ec2/v2/home?region={{ row[1] }}#LaunchInstanceWizard:ami={{ row[3] }}>`__ {% if row|length > 5 %} / `Cluster <https://{{ row[1] }}.console.aws.amazon.com/cloudformation/home?region={{ row[1] }}#/stacks/quickcreate?templateURL=http://downloads.scylladb.com.s3.amazonaws.com/{{ row[5] }}&stackName=scylla-cluster&param_ScyllaDBAmi={{ row[3] }}>`__{% endif %}
-{% endfor %}
+    * - Region
+      - x86 AMI ID
+      - Launch x86
+      - ARM AMI ID
+      - Launch ARM
+  {% for row in data[1:] %}
+    * - {{ row[0] }}
+      - {{ row[2] }}
+      - `Node <https://console.aws.amazon.com/ec2/v2/home?region={{ row[1] }}#LaunchInstanceWizard:ami={{ row[2] }}>`__ {% if row|length > 4 %} / `Cluster <https://{{ row[1] }}.console.aws.amazon.com/cloudformation/home?region={{ row[1] }}#/stacks/quickcreate?templateURL=http://downloads.scylladb.com.s3.amazonaws.com/{{ row[4] }}&stackName=scylla-cluster&param_ScyllaDBAmi={{ row[2] }}>`__{% endif %}
+      - {{ row[3] }}
+      - `Node <https://console.aws.amazon.com/ec2/v2/home?region={{ row[1] }}#LaunchInstanceWizard:ami={{ row[3] }}>`__ {% if row|length > 5 %} / `Cluster <https://{{ row[1] }}.console.aws.amazon.com/cloudformation/home?region={{ row[1] }}#/stacks/quickcreate?templateURL=http://downloads.scylladb.com.s3.amazonaws.com/{{ row[5] }}&stackName=scylla-cluster&param_ScyllaDBAmi={{ row[3] }}>`__{% endif %}
+  {% endfor %}

--- a/docs/_templates/azure_image.tmpl
+++ b/docs/_templates/azure_image.tmpl
@@ -3,14 +3,17 @@
 {{version}}
 {{ '-' * version|length }}
 
-.. list-table::
-   :header-rows: 1
+.. collapse:: View image details
+  {% if latest %}:open:{% endif %}
 
-   * - Gallery Image Definition
-     - Gallery Image Version
-     - Public Gallery Name
-{% for row in data[1:] %}
-   * - {{ row[0] }}
-     - {{ row[1] }}
-     - {{ row[2] }}
-{% endfor %}
+  .. list-table::
+    :header-rows: 1
+
+    * - Gallery Image Definition
+      - Gallery Image Version
+      - Public Gallery Name
+  {% for row in data[1:] %}
+    * - {{ row[0] }}
+      - {{ row[1] }}
+      - {{ row[2] }}
+  {% endfor %}

--- a/docs/_templates/gcp_image.tmpl
+++ b/docs/_templates/gcp_image.tmpl
@@ -3,12 +3,15 @@
 {{version}}
 {{ '-' * version|length }}
 
-.. list-table::
-   :header-rows: 1
+.. collapse:: View image details
+  {% if latest %}:open:{% endif %}
 
-   * - Image Name
-     - Image ID
-{% for row in data[1:] %}
-   * - {{ row[0] }}
-     - {{ row[1] }}
-{% endfor %}
+  .. list-table::
+    :header-rows: 1
+
+    * - Image Name
+      - Image ID
+  {% for row in data[1:] %}
+    * - {{ row[0] }}
+      - {{ row[1] }}
+  {% endfor %}

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -16,6 +16,7 @@ Sphinx = "7.2.6"
 sphinx-multiversion-scylla = "~0.3.1"
 sphinxcontrib-datatemplates = "^0.9.2"
 sphinx-scylladb-markdown = "^0.1.2"
+sphinx_collapse ="^0.1.3"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
## Motivation

Introduces collapsible dropdowns for images reference docs. With this update, only the latest version's details will be displayed open by default. Information about previous versions will be hidden under dropdowns, which users can expand as needed. This enhancement aims to make pages shorter and easier to navigate.

## How to test

1. Build the docs.
2. Open http://127.0.0.1:5500/reference/aws-images/
3. You should see all verisons collapsed, except the latest one.