### PR TITLE
mutation: add fmt::formatter for mutation types

### DIFF
--- a/mutation/atomic_cell.cc
+++ b/mutation/atomic_cell.cc
@@ -226,17 +226,19 @@ auto fmt::formatter<atomic_cell_view::printer>::format(const atomic_cell_view::p
     }
 }
 
-std::ostream& operator<<(std::ostream& os, const atomic_cell_or_collection::printer& p) {
+auto fmt::formatter<atomic_cell_or_collection::printer>::format(const atomic_cell_or_collection::printer& p, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    auto out = ctx.out();
     if (p._cell._data.empty()) {
-        return os << "{ null atomic_cell_or_collection }";
+        return fmt::format_to(out, "{{ null atomic_cell_or_collection }}");
     }
-    os << "{ ";
+    out = fmt::format_to(out, "{{");
     if (p._cdef.type->is_multi_cell()) {
-        os << "collection ";
+        out = fmt::format_to(out, "collection ");
         auto cmv = p._cell.as_collection_mutation();
-        fmt::print(os, "{}", collection_mutation_view::printer(*p._cdef.type, cmv));
+        out = fmt::format_to(out, "{}", collection_mutation_view::printer(*p._cdef.type, cmv));
     } else {
-        fmt::print(os, "{}", atomic_cell_view::printer(*p._cdef.type, p._cell.as_atomic_cell(p._cdef)));
+        out = fmt::format_to(out, "{}", atomic_cell_view::printer(*p._cdef.type, p._cell.as_atomic_cell(p._cdef)));
     }
-    return os << " }";
+    return fmt::format_to(out, "}}");
 }

--- a/mutation/atomic_cell.cc
+++ b/mutation/atomic_cell.cc
@@ -176,10 +176,10 @@ size_t atomic_cell_or_collection::external_memory_usage(const abstract_type& t) 
     return _data.external_memory_usage();
 }
 
-std::ostream&
-operator<<(std::ostream& os, const atomic_cell_view& acv) {
+auto fmt::formatter<atomic_cell_view>::format(const atomic_cell_view& acv, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
     if (acv.is_live()) {
-        fmt::print(os, "atomic_cell{{{},ts={:d},expiry={:d},ttl={:d}}}",
+        return fmt::format_to(ctx.out(), "atomic_cell{{{},ts={:d},expiry={:d},ttl={:d}}}",
             acv.is_counter_update()
                     ? "counter_update_value=" + to_sstring(acv.counter_update_value())
                     : to_hex(to_bytes(acv.value())),
@@ -187,15 +187,9 @@ operator<<(std::ostream& os, const atomic_cell_view& acv) {
             acv.is_live_and_has_ttl() ? acv.expiry().time_since_epoch().count() : -1,
             acv.is_live_and_has_ttl() ? acv.ttl().count() : 0);
     } else {
-        fmt::print(os, "atomic_cell{{DEAD,ts={:d},deletion_time={:d}}}",
+        return fmt::format_to(ctx.out(), "atomic_cell{{DEAD,ts={:d},deletion_time={:d}}}",
             acv.timestamp(), acv.deletion_time().time_since_epoch().count());
     }
-    return os;
-}
-
-std::ostream&
-operator<<(std::ostream& os, const atomic_cell& ac) {
-    return os << atomic_cell_view(ac);
 }
 
 auto fmt::formatter<atomic_cell_view::printer>::format(const atomic_cell_view::printer& acvp,

--- a/mutation/atomic_cell.hh
+++ b/mutation/atomic_cell.hh
@@ -403,3 +403,14 @@ void merge_column(const abstract_type& def,
         atomic_cell_or_collection& old,
         const atomic_cell_or_collection& neww);
 
+template <>
+struct fmt::formatter<atomic_cell_view> : fmt::formatter<std::string_view> {
+    auto format(const atomic_cell_view&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<atomic_cell> : fmt::formatter<std::string_view> {
+    auto format(const atomic_cell& ac, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", atomic_cell_view(ac));
+    }
+};

--- a/mutation/atomic_cell_or_collection.hh
+++ b/mutation/atomic_cell_or_collection.hh
@@ -54,7 +54,12 @@ public:
         printer(const printer&) = delete;
         printer(printer&&) = delete;
 
-        friend std::ostream& operator<<(std::ostream&, const printer&);
+        friend fmt::formatter<printer>;
     };
-    friend std::ostream& operator<<(std::ostream&, const printer&);
+    friend fmt::formatter<printer>;
+};
+
+template <>
+struct fmt::formatter<atomic_cell_or_collection::printer> : fmt::formatter<std::string_view> {
+    auto format(const atomic_cell_or_collection::printer&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/mutation/canonical_mutation.hh
+++ b/mutation/canonical_mutation.hh
@@ -38,5 +38,14 @@ public:
 
     const bytes_ostream& representation() const { return _data; }
 
-    friend std::ostream& operator<<(std::ostream& os, const canonical_mutation& cm);
+    friend fmt::formatter<canonical_mutation>;
 };
+
+template <> struct fmt::formatter<canonical_mutation> : fmt::formatter<std::string_view> {
+    auto format(const canonical_mutation&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+static inline std::ostream& operator<<(std::ostream& os, const canonical_mutation& cm) {
+    fmt::print(os, "{}", cm);
+    return os;
+}

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -988,7 +988,7 @@ operator<<(std::ostream& os, const row::printer& p) {
     os << "{{row:";
     cells.walk([&] (column_id id, const cell_and_hash& cah) {
         auto& cdef = p._schema.column_at(p._kind, id);
-        os << "\n    " << cdef.name_as_text() << atomic_cell_or_collection::printer(cdef, cah.cell);
+        fmt::print(os, "\n    {}{}", cdef.name_as_text(), atomic_cell_or_collection::printer(cdef, cah.cell));
         return true;
     });
     return os << "}}";

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -762,9 +762,9 @@ operator<<(std::ostream& os, const mutation_partition_v2::printer& p) {
         const auto& srow = mp.static_row().get();
         srow.for_each_cell([&] (column_id& c_id, const atomic_cell_or_collection& cell) {
             auto& column_def = p._schema.column_at(column_kind::static_column, c_id);
-            os << indent << indent <<  "'" << column_def.name_as_text() 
-               << "': " << atomic_cell_or_collection::printer(column_def, cell) << ",\n";
-        }); 
+            fmt::print(os, "{}{}'{}': {},\n",
+                       indent, indent, column_def.name_as_text(), atomic_cell_or_collection::printer(column_def, cell));
+        });
         os << indent << "},\n";
     }
 
@@ -808,8 +808,9 @@ operator<<(std::ostream& os, const mutation_partition_v2::printer& p) {
 
         row.cells().for_each_cell([&] (column_id& c_id, const atomic_cell_or_collection& cell) {
             auto& column_def = p._schema.column_at(column_kind::regular_column, c_id);
-            os << indent << indent << indent <<  "'" << column_def.name_as_text() 
-               << "': " << atomic_cell_or_collection::printer(column_def, cell) << ",\n";
+            fmt::print(os, "{}{}{}'{}': {},\n",
+                       indent, indent, indent, column_def.name_as_text(),
+                       atomic_cell_or_collection::printer(column_def, cell));
         });
 
         os << indent << indent << "},\n";


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for 

* canonical_mutation
* atomic_cell_view
* atomic_cell
* atomic_cell_or_collection::printer

Refs #13245