### PR TITLE
test: generate core dumps on crashes in debug clusters

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -464,6 +464,9 @@ class ScyllaServer:
         env = os.environ.copy()
         env.clear()     # pass empty env to make user user's SCYLLA_HOME has no impact
         env.update(self.append_env)
+        env['UBSAN_OPTIONS'] = f'halt_on_error=1:abort_on_error=1:suppressions={os.getcwd()}/ubsan-suppressions.supp'
+        env['ASAN_OPTIONS'] = f'disable_coredump=0:abort_on_error=1:detect_stack_use_after_return=1'
+
         self.cmd = await asyncio.create_subprocess_exec(
             self.exe,
             *self.cmdline_options,


### PR DESCRIPTION
The cluster manager library doesn't set the asan/ubsan options to abort on error and create core dumps; this makes debugging much harder.

Fix by preparing the environment correctly.

Fixes scylladb/scylladb#17510