### PR TITLE
build: cmake: add table_check.cc to repair/CMakeLists.txt

### DIFF
--- a/repair/CMakeLists.txt
+++ b/repair/CMakeLists.txt
@@ -2,7 +2,8 @@ add_library(repair STATIC)
 target_sources(repair
   PRIVATE
     repair.cc
-    row_level.cc)
+    row_level.cc
+    table_check.cc)
 target_include_directories(repair
   PUBLIC
     ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
in 5202bb9d, we introduced repair/table_check.cc, but we didn't update repair/CMakeLists.txt accordingly. but the symbols defined by this compilation unit are referenced by other source files when building scylla.

so, in this change, we add this table_check.cc to the "repair" target.