### PR TITLE
build: cmake: include table_check.cc in repair library

### DIFF
--- a/repair/CMakeLists.txt
+++ b/repair/CMakeLists.txt
@@ -2,7 +2,8 @@ add_library(repair STATIC)
 target_sources(repair
   PRIVATE
     repair.cc
-    row_level.cc)
+    row_level.cc
+    table_check.cc)
 target_include_directories(repair
   PUBLIC
     ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
Include table_check.cc source file, introduced by commit 5202bb9d, in the repair library when building with cmake.