### PR TITLE
mutation: add fmt::formatter for mutation types

### DIFF
--- a/mutation/mutation_fragment.cc
+++ b/mutation/mutation_fragment.cc
@@ -28,20 +28,6 @@ partition_region parse_partition_region(std::string_view s) {
     }
 }
 
-std::ostream& operator<<(std::ostream& out, position_in_partition_view pos) {
-    fmt::print(out, "{}", pos);
-    return out;
-}
-
-std::ostream& operator<<(std::ostream& out, const position_in_partition& pos) {
-    fmt::print(out, "{}", pos);
-    return out;
-}
-
-std::ostream& operator<<(std::ostream& out, const position_range& range) {
-    return out << "{" << range.start() << ", " << range.end() << "}";
-}
-
 mutation_fragment::mutation_fragment(const schema& s, reader_permit permit, static_row&& r)
     : _kind(kind::static_row), _data(std::make_unique<data>(std::move(permit)))
 {

--- a/mutation/mutation_fragment.cc
+++ b/mutation/mutation_fragment.cc
@@ -238,16 +238,22 @@ position_range mutation_fragment::range(const schema& s) const {
     abort();
 }
 
-std::ostream& operator<<(std::ostream& os, mutation_fragment::kind k)
-{
+auto fmt::formatter<mutation_fragment::kind>::format(mutation_fragment::kind k, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    std::string_view name;
     switch (k) {
-    case mutation_fragment::kind::static_row: return os << "static row";
-    case mutation_fragment::kind::clustering_row: return os << "clustering row";
-    case mutation_fragment::kind::range_tombstone: return os << "range tombstone";
-    case mutation_fragment::kind::partition_start: return os << "partition start";
-    case mutation_fragment::kind::partition_end: return os << "partition end";
+    case mutation_fragment::kind::static_row:
+        name = "static row"; break;
+    case mutation_fragment::kind::clustering_row:
+        name = "clustering row"; break;
+    case mutation_fragment::kind::range_tombstone:
+        name = "range tombstone"; break;
+    case mutation_fragment::kind::partition_start:
+        name = "partition start"; break;
+    case mutation_fragment::kind::partition_end:
+        name = "partition end"; break;
     }
-    abort();
+    return fmt::format_to(ctx.out(), "{}", name);
 }
 
 auto fmt::formatter<mutation_fragment::printer>::format(const mutation_fragment::printer& p, fmt::format_context& ctx) const
@@ -411,11 +417,6 @@ bool mutation_fragment_v2::relevant_for_range(const schema& s, position_in_parti
         return true;
     }
     return false;
-}
-
-std::ostream& operator<<(std::ostream& out, const range_tombstone_stream& rtl) {
-    fmt::print(out, "{}", rtl._list);
-    return out;
 }
 
 std::ostream& operator<<(std::ostream& out, const clustering_interval_set& set) {

--- a/mutation/mutation_fragment.hh
+++ b/mutation/mutation_fragment.hh
@@ -526,9 +526,6 @@ inline position_in_partition_view partition_end::position() const
     return position_in_partition_view::for_partition_end();
 }
 
-std::ostream& operator<<(std::ostream&, mutation_fragment::kind);
-
-
 // range_tombstone_stream is a helper object that simplifies producing a stream
 // of range tombstones and merging it with a stream of clustering rows.
 // Tombstones are added using apply() and retrieved using get_next().
@@ -569,7 +566,7 @@ public:
     }
     void reset();
     bool empty() const;
-    friend std::ostream& operator<<(std::ostream& out, const range_tombstone_stream&);
+    friend fmt::formatter<range_tombstone_stream>;
 };
 
 // F gets a stream element as an argument and returns the new value which replaces that element
@@ -617,3 +614,11 @@ template <> struct fmt::formatter<mutation_fragment::printer> : fmt::formatter<s
     auto format(const mutation_fragment::printer&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
+template <> struct fmt::formatter<mutation_fragment::kind> : fmt::formatter<std::string_view> {
+    auto format(mutation_fragment::kind, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+template <> struct fmt::formatter<range_tombstone_stream> : fmt::formatter<std::string_view> {
+    auto format(const range_tombstone_stream& rtl, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", rtl._list);
+    }
+};

--- a/mutation/mutation_fragment_v2.hh
+++ b/mutation/mutation_fragment_v2.hh
@@ -358,14 +358,18 @@ public:
         printer(const printer&) = delete;
         printer(printer&&) = delete;
 
-        friend std::ostream& operator<<(std::ostream& os, const printer& p);
+        friend fmt::formatter<printer>;
     };
-    friend std::ostream& operator<<(std::ostream& os, const printer& p);
+    friend fmt::formatter<printer>;
 
 private:
     size_t calculate_memory_usage(const schema& s) const {
         return sizeof(data) + visit([&s] (auto& mf) -> size_t { return mf.external_memory_usage(s); });
     }
+};
+
+template <> struct fmt::formatter<mutation_fragment_v2::printer> : fmt::formatter<std::string_view> {
+    auto format(const mutation_fragment_v2::printer&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
 std::ostream& operator<<(std::ostream&, mutation_fragment_v2::kind);

--- a/mutation/position_in_partition.hh
+++ b/mutation/position_in_partition.hh
@@ -634,7 +634,6 @@ public:
             return compare(a, b);
         }
     };
-    friend std::ostream& operator<<(std::ostream&, const position_in_partition&);
 
     // Create a position which is the same as this one but governed by a schema with reversed clustering key order.
     position_in_partition reversed() const& {
@@ -784,8 +783,6 @@ public:
     // Returns true iff this range contains all keys contained by position_range(start, end).
     bool contains(const schema& s, position_in_partition_view start, position_in_partition_view end) const;
     bool is_all_clustered_rows(const schema&) const;
-
-    friend std::ostream& operator<<(std::ostream&, const position_range&);
 };
 
 class clustering_interval_set;
@@ -818,3 +815,9 @@ bool position_range::is_all_clustered_rows(const schema& s) const {
 //
 // If `r` does not contain any keys, returns nullopt.
 std::optional<query::clustering_range> position_range_to_clustering_range(const position_range& r, const schema&);
+
+template <> struct fmt::formatter<position_range> : fmt::formatter<std::string_view> {
+    auto format(const position_range& range, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{{{}, {}}}", range.start(), range.end());
+    }
+};

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -3659,7 +3659,7 @@ SEASTAR_THREAD_TEST_CASE(test_compactor_validator) {
                     expected_is_valid,
                     is_valid,
                     fmt::join(frag_refs | boost::adaptors::transformed([&] (std::reference_wrapper<const mutation_fragment_v2> mf) {
-                        return fmt::to_string(mutation_fragment_v2::printer(*s, mf.get()));
+                        return fmt::format("{}", mutation_fragment_v2::printer(*s, mf.get()));
                     }), "\n"));
             BOOST_FAIL(msg);
         }


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for

* position_range
* mutation_fragment
* range_tombstone_stream
* mutation_fragment_v2::printer

Refs #13245
