### PR TITLE
cql: avoid undefined behavior in totimestamp() of extreme dates

### DIFF
--- a/cql3/functions/castas_fcts.cc
+++ b/cql3/functions/castas_fcts.cc
@@ -11,6 +11,7 @@
 #include "utils/UUID_gen.hh"
 #include "cql3/functions/native_scalar_function.hh"
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <chrono>
 
 namespace cql3 {
 namespace functions {
@@ -133,11 +134,11 @@ simple_date_native_type time_point_to_date(const db_clock::time_point& tp) {
 }
 
 db_clock::time_point date_to_time_point(const uint32_t date) {
-    const auto epoch = boost::posix_time::from_time_t(0);
-    const auto target_date = epoch + boost::gregorian::days(int64_t(date) - (1UL<<31));
-    boost::posix_time::time_duration duration = target_date - epoch;
-    const auto millis = std::chrono::milliseconds(duration.total_milliseconds());
-    return db_clock::time_point(std::chrono::duration_cast<db_clock::duration>(millis));
+    // "date" counts the number of days since the epoch, where the middle
+    // of the unsigned range, 2^31, signifies the epoch itself.
+    int64_t millis_since_epoch = (int64_t(date) - (1UL<<31)) * 24 * 60 * 60 * 1000;
+    return db_clock::time_point(std::chrono::duration_cast<db_clock::duration>(
+        std::chrono::milliseconds(millis_since_epoch)));
 }
 
 static data_value castas_fctn_from_timestamp_to_date(data_value from) {


### PR DESCRIPTION
This patch fixes a UBSAN-reported integer overflow during one of our existing tests,

   test_native_functions.py::test_mintimeuuid_extreme_from_totimestamp

when attempting to convert an extreme "date" value, millions of years in the past, into a "timestamp" value. When UBSAN crashing is enabled, this test crashes before this patch, and succeeds after this patch.

The "date" CQL type is 32-bit count of *days* from the epoch, which can span 2^31 days (5 million years) before or after the epoch. Meanwhile, the "timestamp" type measures the number of milliseconds from the same epoch, in 64 bits. Luckily (or intentionally), every "date", however extreme, can be converted into a "timestamp": This is because 2^31 days is 1.85e17 milliseconds, well below timestamp's limit of 2^63 milliseconds (9.2e18).

But it turns out that our conversion function, date_to_time_point(), used some boost::gregorian library code, which carried out these calculations in **microsecond** resolution. The extra conversion to microseconds wasn't just wasteful, it also caused an integer overflow in the extreme case: 2^31 days is 1.85e20 microseconds, which does NOT fit in a 64-bit integer. UBSAN notices this overflow, and complains (plus, the conversion is incorrect).

The fix is to do the trivial conversion on our own (a day is, by convention, exactly 86400 seconds - no fancy library is needed), without the grace of Boost. The result is simpler, faster, correct for the Pliocene-age dates, and fixes the UBSAN crash in the test.

Fixes #17516