### PR TITLE
query-request: use default-generated operator==

### DIFF
--- a/query-request.hh
+++ b/query-request.hh
@@ -367,14 +367,9 @@ public:
     max_result_size without_page_limit() const {
         return max_result_size(soft_limit, hard_limit, 0);
     }
-    friend bool operator==(const max_result_size&, const max_result_size&);
+    bool operator==(const max_result_size&) const = default;
     friend class ser::serializer<query::max_result_size>;
 };
-
-inline bool operator==(const max_result_size& a, const max_result_size& b) {
-    return a.soft_limit == b.soft_limit && a.hard_limit == b.hard_limit && a.page_size == b.page_size;
-}
-
 
 // Full specification of a query to the database.
 // Intended for passing across replicas.


### PR DESCRIPTION
instead of using the hand-crafted operator==, use the default-generated one, which is equivalent to the former.

regarding the difference between global operator== and member operator==, the default-generated operator in C++20 is now symmetric. so we don't need to worry about the problem of `max_result_size` being lhs or rhs. but neither do we need to worry about the implicit conversion, because all constructors of `max_result_size` are marked explicit. so we don't gain any advantage by making the operator== global instead of a member operator.