### PR TITLE
docs: add dynamic substitutions

### DIFF
--- a/docs/_ext/scylladb_dynamic_substitutions.py
+++ b/docs/_ext/scylladb_dynamic_substitutions.py
@@ -1,0 +1,45 @@
+import os
+from sphinx.application import Sphinx
+from sphinx.util import logging
+
+LOGGER = logging.getLogger(__name__)
+
+class DynamicSubstitutions:
+
+    def _get_current_version(self, app):
+        current_version = os.environ.get('SPHINX_MULTIVERSION_NAME', '')
+        stable_version = app.config.smv_latest_version
+        prefix = 'branch-'
+        version = current_version
+
+        if current_version.startswith(prefix):
+            version = current_version
+        elif not stable_version.startswith(prefix):
+            LOGGER.error("Invalid stable_version format in conf.py. It should start with 'branch-'")
+        else:
+            version = stable_version
+
+        return version.replace(prefix, '')
+
+    def run(self, app):
+        current_version = self._get_current_version(app)
+        
+        if not hasattr(app.config, 'rst_prolog') or app.config.rst_prolog is None:
+            app.config.rst_prolog = ""
+        elif not app.config.rst_prolog.endswith('\n'):
+            app.config.rst_prolog += '\n'
+
+        app.config.rst_prolog += f"""
+.. |CURRENT_VERSION| replace:: {current_version}
+.. |UBUNTU_SCYLLADB_LIST| replace:: scylla-{current_version}.list
+.. |CENTOS_SCYLLADB_REPO| replace:: scylla-{current_version}.repo
+"""
+
+def setup(app: Sphinx):
+    app.connect("builder-inited",  DynamicSubstitutions().run)
+   
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,8 @@ extensions = [
     "scylladb_aws_images",
     "scylladb_azure_images",
     "scylladb_gcp_images",
-    "scylladb_include_flag"
+    "scylladb_include_flag",
+    "scylladb_dynamic_substitutions"
 ]
 
 # The suffix(es) of source filenames.

--- a/docs/getting-started/install-scylla/install-on-linux.rst
+++ b/docs/getting-started/install-scylla/install-on-linux.rst
@@ -1,6 +1,3 @@
-.. |UBUNTU_SCYLLADB_LIST| replace:: scylla-5.4.list
-.. |CENTOS_SCYLLADB_REPO| replace:: scylla-5.4.repo
-
 .. The |RHEL_EPEL| variable needs to be adjuster per release, depending on support for RHEL.
 .. 5.2 supports Rocky/RHEL 8 only
 .. 5.4 supports Rocky/RHEL 8 and 9


### PR DESCRIPTION
## Motivation

> The [Installation on Linux](https://opensource.docs.scylladb.com/stable/getting-started/install-scylla/install-on-linux.html) page must be updated each release, as uses two variables that include the version number: [|UBUNTU_SCYLLADB_LIST| and |CENTOS_SCYLLADB_REPO|](https://opensource.docs.scylladb.com/stable/getting-started/install-scylla/install-on-linux.html). The Scylla version variable I tried to configure with rst_prolog doesn’t work, as it would be a part of a string, e.g.scylla-|SCYLLA_VERSION|.list.

This pull request adds dynamic substitutions for the following variables:

* `.. |CURRENT_VERSION| replace:: {current_version}`
* `.. |UBUNTU_SCYLLADB_LIST| replace:: scylla-{current_version}.list`
* `.. |CENTOS_SCYLLADB_REPO| replace:: scylla-{current_version}.repo`


As a result, it is no longer needed to update the "Installation on Linux" page manually after every new release.

## How to test

1. Build the docs with `make preview`
2. The variables should render as follows on the Installation on Linux page:

* `CENTOS_SCYLLADB_REPO`: scylla-5.4.repo 
* `UBUNTU_SCYLLADB_LIST`: scylla-5.4.list