### PR TITLE
build: docker: clean up after docker build

### DIFF
--- a/dist/docker/debian/build_docker.sh
+++ b/dist/docker/debian/build_docker.sh
@@ -109,6 +109,6 @@ bconfig --label summary="NoSQL data store using the seastar framework, compatibl
 
 mkdir -p build/$mode/dist/docker/
 image="oci-archive:build/$mode/dist/docker/$product-$version-$release"
-buildah commit "$container" "$image"
+buildah commit --rm "$container" "$image"
 
 echo "Image is now available in $image."


### PR DESCRIPTION
The `buildah commit` command doesn't remove the working container. These accumulate in ~/.local/container/storage until something bad happens.

Fix by adding the `--rm` flag to remove the container and volume.