### PR TITLE
view_builder: Complete build step early if reader produces nothing

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2422,6 +2422,9 @@ public:
 
     stop_iteration consume_new_partition(const dht::decorated_key& dk) {
         inject_failure("view_builder_consume_new_partition");
+        if (dk.key().is_empty()) {
+            on_internal_error(vlogger, format("Trying to consume empty partition key {}", dk));
+        }
         _step.current_key = std::move(dk);
         check_for_built_views();
         _views_to_build.clear();
@@ -2514,6 +2517,14 @@ public:
                           _step.base->schema()->cf_name(), _step.current_token(), view_names);
         }
         if (_step.reader.is_end_of_stream() && _step.reader.is_buffer_empty()) {
+            if (_step.current_key.key().is_empty()) {
+                // consumer got end-of-stream without consuming a single partition
+                vlogger.debug("Reader didn't produce anything, marking views as built");
+                while (!_step.build_status.empty()) {
+                    _built_views.views.push_back(std::move(_step.build_status.back()));
+                    _step.build_status.pop_back();
+                }
+            }
             _step.current_key = {dht::minimum_token(), partition_key::make_empty()};
             for (auto&& vs : _step.build_status) {
                 vs.next_token = dht::minimum_token();


### PR DESCRIPTION
Builder works in "steps". Each step runs for a given base table, when a new view is created it either initiates a step or appends to currently running step.

Running a step means reading mutations from local sstables reader and applying them to all views that has jumped into this step so far. When a view is added to the step it remembers the current token value the step is on. When step receives end-of-stream it rewinds to minimal-token. Rewinding is done by closing current reader and creating a new one. Each time token is advanced, all the views that meet the new token value for the second time (i.e. -- scan full round) are marked as built and are removed from step. When no views are left on step, it finishes.

The above machinery can break when rewinding the end-of-stream reader. The trick is that a running step silently assumes that if the reader once produced some token (and there can be a view that remembered this token as its starting one), then after rewinding the reader would generate the same token or greater. With tablets, however, that's not the case. When a node is decommissioned tablets are cleaned and all sstables are removed. Rewinding a reader after it makes empty reader that produces no tokens from now on. Respectively, any build steps that had captured tokens prior to cleanup would get stuck forever.

The fix is to check if the mutation consumer stepped at least one step forward after rewind, and if no -- complete all the attached views.

fixes: #17293

Similar thing should happen if the base table is truncated with views being built from it. Testing it steps on compaction assertion elsewhere and needs more research.

refs: #17543