### PR TITLE
Docs: fix RF type in the consistency-calculator

### DIFF
--- a/docs/cql/consistency-calculator-raw.html
+++ b/docs/cql/consistency-calculator-raw.html
@@ -66,7 +66,7 @@
             const nodes = Number.parseInt(document.querySelector("#nodes").value);
             const readConsistency = document.querySelector("#read-consistency").value;
             const writeConsistency = document.querySelector("#write-consistency").value;
-            const replicationFactor = document.querySelector("#replication-factor").value;
+            const replicationFactor = Number.parseInt(document.querySelector("#replication-factor").value);
             const writeConsistencyN = consistency(writeConsistency, replicationFactor);
             const readConsistencyN = consistency(readConsistency, replicationFactor);
 


### PR DESCRIPTION
Properly case "replicationFactor" variable from String to Number

Fix #17542 
