### PR TITLE
create-relocatable-package.py: add --debian-dir option

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -71,6 +71,8 @@ ap.add_argument('--build-dir', default='build/release',
                 help='Build dir ("build/debug" or "build/release") to use')
 ap.add_argument('--node-exporter-dir', default='build/node_exporter',
                 help='the directory where node_exporter is located')
+ap.add_argument('--debian-dir', default='build/debian/debian',
+                help='the directory where debian packaging is located')
 ap.add_argument('--stripped', action='store_true',
                 help='use stripped binaries')
 ap.add_argument('--print-libexec', action='store_true',
@@ -169,7 +171,7 @@ ar.reloc_add('swagger-ui')
 ar.reloc_add('api')
 ar.reloc_add('tools/scyllatop')
 ar.reloc_add('scylla-gdb.py')
-ar.reloc_add('build/debian/debian', arcname='debian')
+ar.reloc_add(args.debian_dir, arcname='debian')
 node_exporter_dir = args.node_exporter_dir
 if args.stripped:
     ar.reloc_add(f'{node_exporter_dir}', arcname='node_exporter')


### PR DESCRIPTION
before this change, we assume that debian packaging directory is always located under `build/debian/debian`. which is hardwired by `configure.py`. but this might hold anymore, if we want to have a self-contained build, in the sense that different builds do not share the same build directory. this could be a waste for the non-mult-config build, but `configure.py` uses mult-config generator when building with CMake. so in that case, all builds still share the same $build_dir/debian/ directory.

in order to work with the out-of-source build, where the build directory is not necessarily "build", a new option is added to `create-relocatable-package.py`, this allows us to specify the directory where "debian" artifacts are located.

Refs #15241