### PR TITLE
 test/cql-pytest: test_select_from_mutation_fragments.py: move away from memtables

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1761,7 +1761,7 @@ mutation_fragments_select_statement::do_execute(query_processor& qp, service::qu
                     *command, key_ranges))) {
         return do_query({}, qp.proxy(), _schema, command, std::move(key_ranges), cl,
                 {timeout, state.get_permit(), state.get_client_state(), state.get_trace_state(), {}, {}})
-        .then(wrap_result_to_error_message([&, this, erm_keepalive] (service::storage_proxy_coordinator_query_result&& qr) {
+        .then(wrap_result_to_error_message([this, erm_keepalive, now, slice = command->slice] (service::storage_proxy_coordinator_query_result&& qr) mutable {
             cql3::selection::result_set_builder builder(*_selection, now);
             query::result_view::consume(*qr.query_result, std::move(slice),
                     cql3::selection::result_set_builder::visitor(builder, *_schema, *_selection));


### PR DESCRIPTION
Memtables are fickle, they can be flushed when there is memory pressure, if there is too much commitlog or if there is too much data in them. The tests in test_select_from_mutation_fragments.py currently assume data written is in the memtable. This is tru most of the time but we have seen some odd test failures that couldn't be understood.
To make the tests more robust, flush the data to the disk and read it from the sstables. This means that some range scans need to filter to read from just a single mutation source, but this does not influence the tests.
Also fix a use-after-return found when modifying the tests.

This PR tentatively fixes the below issues, based on our best guesses on why they failed (each was seen just once):
Fixes: #16795
Fixes: #17031