### PR TITLE
db/hints: Log when ignoring invalid hint directories

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -571,6 +571,8 @@ future<> manager::change_host_filter(host_filter filter) {
             });
 
             if (!maybe_host_id_and_ip) {
+                manager_logger.warn("Encountered a hint directory of invalid name while changing the host filter: {}. "
+                        "Hints stored in it won't be replayed.", de.name);
                 co_return;
             }
 
@@ -752,6 +754,8 @@ future<> manager::initialize_endpoint_managers() {
 
         // The directory is invalid, so there's nothing more to do.
         if (!maybe_host_id_or_ep) {
+            manager_logger.warn("Encountered a hint directory of invalid name while initializing endpoint managers: {}. "
+                    "Hints stored in it won't be replayed", de.name);
             co_return;
         }
 

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -173,6 +173,8 @@ void space_watchdog::on_timer() {
                 // Case 3: The directory isn't managed by an endpoint manager, and it represents neither an IP address,
                 //         nor a host ID.
                 else {
+                    // We use trace here to prevent flooding logs with unnecessary information.
+                    resource_manager_logger.trace("Encountered a hint directory of invalid name while scanning: {}", de.name);
                     return scan_one_ep_dir(dir / de.name, shard_manager, {});
                 }
             }).get();


### PR DESCRIPTION
In 58784cd, aa4b06a and other commits migrating hinted handoff from IPs to host IDs (scylladb/scylladb#15567), we started ignoring hint directories of invalid names, i.e. those that represent neither an IP address, nor a host ID. They remain on disk and are taken into account while computing, e.g. the total size of hints, but they're not used in any way.

These changes add logs informing the user when Scylla encounters such a directory.