### PR TITLE
test: topology: increase max reconnection retries in cql driver

### DIFF
--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -139,7 +139,7 @@ def cluster_con(hosts: List[IPAddress | EndPoint], port: int, use_ssl: bool, aut
                    # where a node can be unavailable for an extended period of time,
                    # this can cause the reconnection retry interval to get very large,
                    # longer than a test timeout.
-                   reconnection_policy = ExponentialReconnectionPolicy(1.0, 4.0),
+                   reconnection_policy = ExponentialReconnectionPolicy(1.0, 4.0, 512),
 
                    auth_provider=auth_provider,
                    # Capture messages for debugging purposes.


### PR DESCRIPTION
Previous max_retries default value was 64 which means we gave up after ~4s * 64 = ~4mins. But we have TOPOLOGY_TIMEOUT = 1000 (seconds) which is a bit larger.

So now we set new default limit to around 34 mins.

Some indicator that it may help with failing tests is that I observed 'Will not continue to retry reconnection attempts due to an exhausted retry schedule' warning in the logs of failed test in debug mode.