### PR TITLE
topology_coordinator: Demote log level for advance_in_background() er…

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -843,7 +843,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             holder = futurize_invoke(action).then_wrapped([this, gid, name] (future<> f) {
                 if (f.failed()) {
                     auto ep = f.get_exception();
-                    rtlogger.error("{} for tablet {} failed: {}", name, gid, ep);
+                    rtlogger.warn("{} for tablet {} failed: {}", name, gid, ep);
                     return seastar::sleep_abortable(std::chrono::seconds(1), _as).then([ep] () mutable {
                         std::rethrow_exception(ep);
                     });


### PR DESCRIPTION
…rors

The helper in question is supposed to spawn a background fiber with tablet migration stage action and repeat it in case action fails (until operator intervention, but that's another story). In case action fails a message with ERROR level is logger about the failure.

This error confuses some tests that scan scylla log messages for ERROR-s at the end, treat most of them (if not all) as ciritical and fail. But this particular message is not in fact an error -- topology coordinator would re-execute this action anyway, so let's demote the message to be WARN instead.

refs: #17027