### PR TITLE
mutation: mutation_partition_v2: don't drop isolated empty rows in maybe_drop()

### DIFF
--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -1108,7 +1108,7 @@ mutation_partition_v2::maybe_drop(const schema& s,
             return next_i;
         }
     } else if (!e.continuous() && !next_continuous) {
-        if (!e.dummy() && e.range_tombstone()) {
+        if (!e.dummy()) {
             return next_i;
         }
     } else {


### PR DESCRIPTION
mutation: mutation_partition_v2: don't drop isolated empty rows in `maybe_drop()`

`maybe_drop()` drops rows entries which are discontinuous on both sides and
hold an empty row. It shouldn't do that. An empty row still carries information
and saves disk reads, so it deserves to be cached like a full row.

While this doesn't affect cache correctness, and the effect on cache
effectiveness is likely minimal in practice, it goes against the idea
of `maybe_drop()`, which isn't supposed to evict any information.

Fixes https://github.com/scylladb/scylladb/issues/13757