### PR TITLE
repair: Add dc option support for tablet repair

### DIFF
--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -162,7 +162,7 @@ private:
             shared_ptr<node_ops_info> ops_info);
 
 public:
-    future<> repair_tablets(repair_uniq_id id, sstring keyspace_name, std::vector<sstring> table_names, host2ip_t host2ip, bool primary_replica_only = true, dht::token_range_vector ranges_specified = {});
+    future<> repair_tablets(repair_uniq_id id, sstring keyspace_name, std::vector<sstring> table_names, host2ip_t host2ip, bool primary_replica_only = true, dht::token_range_vector ranges_specified = {}, std::vector<sstring> dcs = {});
 
 private:
 


### PR DESCRIPTION
This patch adds the dc option support for table repair. The management
tool can use this option to select nodes in specific data centers to run
repair.

Fixes: #17550
Tests: repair_additional_test.py::TestRepairAdditional::test_repair_option_dc
