### PR TITLE
tools/scylla-nodetool: fixes to address the test failure with dtest

### DIFF
--- a/test/nodetool/test_toppartitions.py
+++ b/test/nodetool/test_toppartitions.py
@@ -112,7 +112,7 @@ def test_toppartitions(nodetool, request, empty_samplings):
         # scylla sends list_size, while cassandra's nodetool does not.
         params['list_size'] = str(list_size)
     actual_output = nodetool("toppartitions", *args, expected_requests=[
-        expected_request("GET", "/storage_service/toppartitions",
+        expected_request("GET", "/storage_service/toppartitions/",
                          params=params,
                          response=response),
     ])

--- a/test/nodetool/test_toppartitions.py
+++ b/test/nodetool/test_toppartitions.py
@@ -60,8 +60,12 @@ def normalize_samplings(samplings):
     return sorted(normalized.items())
 
 
-@pytest.mark.parametrize("empty_samplings", [True, False])
-def test_toppartitions(nodetool, request, empty_samplings):
+@pytest.mark.parametrize("empty_samplings,samplers", [(True, "READS"),
+                                                      (True, "READS,WRITES"),
+                                                      (True, ""),
+                                                      (False, "WRITES"),
+                                                      (False, "")])
+def test_toppartitions(nodetool, request, empty_samplings, samplers):
 
     if empty_samplings:
         samplings = {
@@ -100,6 +104,10 @@ def test_toppartitions(nodetool, request, empty_samplings):
         "-k": list_size,
         "--cf-filters": table_filters,
     }
+    if samplers:
+        options["-a"] = samplers
+    else:
+        samplers = "WRITES,READS"
     args = []
     for name, value in options.items():
         args.extend([name, str(value)])
@@ -119,7 +127,9 @@ def test_toppartitions(nodetool, request, empty_samplings):
 
     expected_output = ''
     first = True
-    for operation in ('read', 'write'):
+    for sampler in samplers.lower().split(','):
+        # remove the trailing "s"
+        operation = sampler[:-1]
         operation_upper = operation.upper()
         cardinality = samplings[f'{operation}_cardinality']
         expected_output += f'''\

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1955,16 +1955,21 @@ void toppartitions_operation(scylla_rest_client& client, const bpo::variables_ma
     if (list_size >= capacity) {
         throw std::invalid_argument("TopK count (-k) option must be smaller than the summary capacity (-s)");
     }
+    std::vector<std::string> operations;
     {
-        // scylla's API server does not use samplers, but let's verify them anyway
+        // the API of /storage_service/toppartition/ does not use samplers, but
+        // we need to check and normalize them
         std::vector<sstring> samplers;
         boost::split(samplers, vm["samplers"].as<sstring>(), boost::algorithm::is_any_of(","));
         for (auto& sampler : samplers) {
-            auto sampler_lo = boost::to_lower_copy(sampler);
-            if (sampler_lo != "reads" && sampler_lo != "writes") {
+            boost::to_lower(sampler);
+            if (sampler != "reads" && sampler != "writes") {
                 throw std::invalid_argument(
                     fmt::format("{} is not a valid sampler, choose one of: READS, WRITES", sampler));
             }
+            // remove the trailing "s"
+            sampler.resize(sampler.size() - 1);
+            operations.push_back(sampler);
         }
     }
     // prepare the query params
@@ -1988,9 +1993,10 @@ void toppartitions_operation(scylla_rest_client& client, const bpo::variables_ma
     };
     // format the query result
     bool first = true;
-    for (auto operation : {"read", "write"}) {
+    for (const auto& operation : operations) {
+        // add a separator
         auto cardinality = toppartitions[fmt::format("{}_cardinality", operation)].GetInt64();
-        fmt::print("{}S Sampler:\n", boost::to_upper_copy(std::string(operation)));
+        fmt::print("{}S Sampler:\n", boost::to_upper_copy(operation));
         fmt::print("  Cardinality: ~{} ({} capacity)\n", cardinality, capacity);
         fmt::print("  Top {} partitions:\n", list_size);
 

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1995,6 +1995,9 @@ void toppartitions_operation(scylla_rest_client& client, const bpo::variables_ma
     bool first = true;
     for (const auto& operation : operations) {
         // add a separator
+        if (!std::exchange(first, false)) {
+            fmt::print("\n");
+        }
         auto cardinality = toppartitions[fmt::format("{}_cardinality", operation)].GetInt64();
         fmt::print("{}S Sampler:\n", boost::to_upper_copy(operation));
         fmt::print("  Cardinality: ~{} ({} capacity)\n", cardinality, capacity);
@@ -2027,9 +2030,6 @@ void toppartitions_operation(scylla_rest_client& client, const bpo::variables_ma
             for (auto& record : topk) {
                 fmt::print("\t{:<{}}{:>10}{:>10}\n", record.partition, width, record.count, record.error);
             }
-        }
-        if (std::exchange(first, false)) {
-            fmt::print("\n");
         }
     }
 }

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1979,7 +1979,7 @@ void toppartitions_operation(scylla_rest_client& client, const bpo::variables_ma
     if (!table_filters.empty()) {
         params.emplace("table_filters", table_filters);
     }
-    auto res = client.get("/storage_service/toppartitions", std::move(params));
+    auto res = client.get("/storage_service/toppartitions/", std::move(params));
     const auto& toppartitions = res.GetObject();
     struct record {
         std::string_view partition;


### PR DESCRIPTION
- use API endpoint of /storage_service/toppartition/
- only print out the specified samplings.
- print "\n" separator between samplings