### PR TITLE
main: print pid (process id) at start

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -471,6 +471,7 @@ void print_starting_message(int ac, char** av, const bpo::parsed_options& opts) 
         }
         fmt::print("\"\n");
     }
+    fmt::print("pid: {}\n", getpid());
 
     fmt::print("parsed command line options: {}\n", format_parsed_options(opts.options));
 }


### PR DESCRIPTION
Print process id to the log at start.
It aids debugging/administering the instance if you have multiple instances running on the same machine.