### PR TITLE
test: test_topology_ops: fix flakiness and reenable bg writes

### DIFF
--- a/test.py
+++ b/test.py
@@ -429,6 +429,7 @@ class PythonTestSuite(TestSuite):
                              create_cfg.config_from_test
 
             server = ScyllaServer(
+                mode=self.mode,
                 exe=self.scylla_exe,
                 vardir=os.path.join(self.options.tmpdir, self.mode),
                 logger=create_cfg.logger,


### PR DESCRIPTION
We decrease the server's request timeouts in topology tests so that
they are lower than the driver's timeout. Before, the driver could
time out its request before the server handled it successfully.
This problem caused scylladb/scylladb#15924.

Since scylladb/scylladb#15924 is the last issue mentioned in
scylladb/scylladb#15962, this PR also reenables background
writes in `test_topology_ops` with tablets disabled. The test
doesn't pass with tablets and background writes because of
scylladb/scylladb#17025. We will reenable background writes
with tablets after fixing that issue.

Fixes scylladb/scylladb#15924
Fixes scylladb/scylladb#15962