### PR TITLE
tools/utils: fix use-after-free when printing error message for unknown operation

### DIFF
--- a/test/nodetool/test_nodetool.py
+++ b/test/nodetool/test_nodetool.py
@@ -59,3 +59,11 @@ def test_nodetool_api_request_failed(nodetool, scylla_only, rest_api_mock_server
                                                 response={"message": "ERROR MESSAGE", "code": 500},
                                                 response_status=500)]},
         error_messages)
+
+
+def test_nodetool_nonexistent_command(nodetool, scylla_only):
+    utils.check_nodetool_fails_with_error_contains(
+            nodetool,
+            ("non-existent-command",),
+            {},
+            ["error: unrecognized operation argument: expected one of"])

--- a/tools/utils.hh
+++ b/tools/utils.hh
@@ -114,7 +114,7 @@ public:
     {}
 
     const std::string& name() const { return _name; }
-    const std::vector<std::string> aliases() const { return _aliases; }
+    const std::vector<std::string>& aliases() const { return _aliases; }
     const std::string& summary() const { return _summary; }
     const std::string& description() const { return _description; }
     const std::vector<operation_option>& options() const { return _options; }


### PR DESCRIPTION
When a tool application is invoked with an unknown operation, an error message is printed, which includes all the known operations, with all their aliases. This is collected in `std::vector<std::string_view>`. The problem is that the vector containing alias names, is returned as a value, so the code ends up creating views to temporaries. Fix this by returning alias vector with const&.

Fixes: #17584