### PR TITLE
raft timeouts: better handling of lost quorum

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -68,6 +68,9 @@ future<> set_server_init(http_context& ctx) {
                 "The system related API");
         rb02->add_definitions_file(r, "metrics");
         set_system(ctx, r);
+        rb->register_function(r, "error_injection",
+            "The error injection API");
+        set_error_injection(ctx, r);
     });
 }
 
@@ -275,9 +278,6 @@ future<> set_server_done(http_context& ctx) {
         rb->register_function(r, "collectd",
                 "The collectd API");
         set_collectd(ctx, r);
-        rb->register_function(r, "error_injection",
-                "The error injection API");
-        set_error_injection(ctx, r);
     });
 }
 

--- a/auth/common.hh
+++ b/auth/common.hh
@@ -93,7 +93,8 @@ future<> announce_mutations_with_batching(
         // function here
         start_operation_func_t start_operation_func,
         std::function<mutations_generator(api::timestamp_type& t)> gen,
-        seastar::abort_source* as);
+        seastar::abort_source* as,
+        std::optional<::service::raft_timeout> timeout);
 
 // Execute update query via group0 mechanism, mutations will be applied on all nodes.
 future<> announce_mutations(
@@ -101,6 +102,7 @@ future<> announce_mutations(
         ::service::raft_group0_client& group0_client,
         const sstring query_string,
         std::vector<data_value_or_unset> values,
-        seastar::abort_source* as);
+        seastar::abort_source* as,
+        std::optional<::service::raft_timeout> timeout);
 
 }

--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -196,7 +196,7 @@ default_authorizer::modify(
                 cql3::query_processor::cache_internal::no).discard_result();
     }
     co_return co_await announce_mutations(_qp, _group0_client, query,
-        {permissions::to_strings(set), sstring(role_name), resource.name()}, &_as);
+        {permissions::to_strings(set), sstring(role_name), resource.name()}, &_as, ::service::raft_timeout{});
 }
 
 
@@ -249,7 +249,7 @@ future<> default_authorizer::revoke_all(std::string_view role_name) {
                     {sstring(role_name)},
                     cql3::query_processor::cache_internal::no).discard_result();
         } else {
-            co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name)}, &_as);
+            co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name)}, &_as, ::service::raft_timeout{});
         }
     } catch (exceptions::request_execution_exception& e) {
         alogger.warn("CassandraAuthorizer failed to revoke all permissions of {}: {}", role_name, e);
@@ -336,11 +336,13 @@ future<> default_authorizer::revoke_all(const resource& resource) {
                 co_yield std::move(muts[0]);
             }
         };
+        const auto timeout = ::service::raft_timeout{};
         co_await announce_mutations_with_batching(
                 _group0_client,
-                [this](abort_source* as) { return _group0_client.start_operation(as); },
+                [this, timeout](abort_source* as) { return _group0_client.start_operation(as, timeout); },
                 std::move(gen),
-                &_as);
+                &_as,
+            timeout);
     } catch (exceptions::request_execution_exception& e) {
         alogger.warn("CassandraAuthorizer failed to revoke all permissions on {}: {}", name, e);
     }

--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -338,7 +338,7 @@ future<> default_authorizer::revoke_all(const resource& resource) {
         };
         co_await announce_mutations_with_batching(
                 _group0_client,
-                std::bind_front(&::service::raft_group0_client::start_operation, &_group0_client),
+                [this](abort_source* as) { return _group0_client.start_operation(as); },
                 std::move(gen),
                 &_as);
     } catch (exceptions::request_execution_exception& e) {

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -137,7 +137,7 @@ future<> password_authenticator::create_default_if_missing() {
         });
     } else {
         co_await announce_mutations(_qp, _group0_client, query,
-            {salted_pwd, _superuser}, &_as).then([]() {
+            {salted_pwd, _superuser}, &_as, ::service::raft_timeout{}).then([]() {
             plogger.info("Created default superuser authentication record.");
         });
     }
@@ -271,7 +271,7 @@ future<> password_authenticator::create(std::string_view role_name, const authen
                 cql3::query_processor::cache_internal::no).discard_result();
     } else {
         co_await announce_mutations(_qp, _group0_client, query,
-                {passwords::hash(*options.password, rng_for_salt), sstring(role_name)}, &_as);
+                {passwords::hash(*options.password, rng_for_salt), sstring(role_name)}, &_as, ::service::raft_timeout{});
     }
 }
 
@@ -294,7 +294,7 @@ future<> password_authenticator::alter(std::string_view role_name, const authent
                 cql3::query_processor::cache_internal::no).discard_result();
     } else {
         co_await announce_mutations(_qp, _group0_client, query,
-            {passwords::hash(*options.password, rng_for_salt), sstring(role_name)}, &_as);
+            {passwords::hash(*options.password, rng_for_salt), sstring(role_name)}, &_as, ::service::raft_timeout{});
     }
 }
 
@@ -311,7 +311,7 @@ future<> password_authenticator::drop(std::string_view name) {
                 {sstring(name)},
                 cql3::query_processor::cache_internal::no).discard_result();
     } else {
-        co_await announce_mutations(_qp, _group0_client, query, {sstring(name)}, &_as);
+        co_await announce_mutations(_qp, _group0_client, query, {sstring(name)}, &_as, ::service::raft_timeout{});
     }
 }
 

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -705,7 +705,8 @@ future<> migrate_to_auth_v2(cql3::query_processor& qp, ::service::raft_group0_cl
     co_await announce_mutations_with_batching(g0,
             start_operation_func,
             std::move(gen),
-            &as);
+            &as,
+            std::nullopt);
 }
 
 }

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -190,7 +190,7 @@ future<> standard_role_manager::create_default_role_if_missing() {
                     {_superuser},
                     cql3::query_processor::cache_internal::no).discard_result();
         } else {
-            co_await announce_mutations(_qp, _group0_client, query, {_superuser}, &_as);
+            co_await announce_mutations(_qp, _group0_client, query, {_superuser}, &_as, ::service::raft_timeout{});
         }
         log.info("Created default superuser role '{}'.", _superuser);
     } catch(const exceptions::unavailable_exception& e) {
@@ -279,7 +279,7 @@ future<> standard_role_manager::create_or_replace(std::string_view role_name, co
                 {sstring(role_name), c.is_superuser, c.can_login},
                 cql3::query_processor::cache_internal::yes).discard_result();
     } else {
-        co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name), c.is_superuser, c.can_login}, &_as);
+        co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name), c.is_superuser, c.can_login}, &_as, ::service::raft_timeout{});
     }
 }
 
@@ -327,7 +327,7 @@ standard_role_manager::alter(std::string_view role_name, const role_config_updat
                     {sstring(role_name)},
                     cql3::query_processor::cache_internal::no).discard_result();
         } else {
-            return announce_mutations(_qp, _group0_client, std::move(query), {sstring(role_name)}, &_as);
+            return announce_mutations(_qp, _group0_client, std::move(query), {sstring(role_name)}, &_as, ::service::raft_timeout{});
         }
     });
 }
@@ -377,7 +377,7 @@ future<> standard_role_manager::drop(std::string_view role_name) {
             co_await _qp.execute_internal(query, {sstring(role_name)},
                 cql3::query_processor::cache_internal::yes).discard_result();
         } else {
-            co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name)}, &_as);
+            co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name)}, &_as, ::service::raft_timeout{});
         }
     };
     // Finally, delete the role itself.
@@ -395,7 +395,7 @@ future<> standard_role_manager::drop(std::string_view role_name) {
                     {sstring(role_name)},
                     cql3::query_processor::cache_internal::no).discard_result();
         } else {
-            co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name)}, &_as);
+            co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name)}, &_as, ::service::raft_timeout{});
         }
     };
 
@@ -428,7 +428,7 @@ standard_role_manager::modify_membership(
                     cql3::query_processor::cache_internal::no).discard_result();
         } else {
             co_await announce_mutations(_qp, _group0_client, std::move(query),
-                    {role_set{sstring(role_name)}, sstring(grantee_name)}, &_as);
+                    {role_set{sstring(role_name)}, sstring(grantee_name)}, &_as, ::service::raft_timeout{});
         }
     };
 
@@ -447,7 +447,7 @@ standard_role_manager::modify_membership(
                             cql3::query_processor::cache_internal::no).discard_result();
                 } else {
                     co_return co_await announce_mutations(_qp, _group0_client, insert_query,
-                            {sstring(role_name), sstring(grantee_name)}, &_as);
+                            {sstring(role_name), sstring(grantee_name)}, &_as, ::service::raft_timeout{});
                 }
             }
 
@@ -464,7 +464,7 @@ standard_role_manager::modify_membership(
                             cql3::query_processor::cache_internal::no).discard_result();
                 } else {
                     co_return co_await announce_mutations(_qp, _group0_client, delete_query,
-                            {sstring(role_name), sstring(grantee_name)}, &_as);
+                            {sstring(role_name), sstring(grantee_name)}, &_as, ::service::raft_timeout{});
                 }
             }
         }
@@ -638,7 +638,7 @@ future<> standard_role_manager::set_attribute(std::string_view role_name, std::s
         co_await _qp.execute_internal(query, {sstring(role_name), sstring(attribute_name), sstring(attribute_value)}, cql3::query_processor::cache_internal::yes).discard_result();
     } else {
         co_await announce_mutations(_qp, _group0_client, query,
-                {sstring(role_name), sstring(attribute_name), sstring(attribute_value)}, &_as);
+                {sstring(role_name), sstring(attribute_name), sstring(attribute_value)}, &_as, ::service::raft_timeout{});
     }
 }
 
@@ -653,7 +653,7 @@ future<> standard_role_manager::remove_attribute(std::string_view role_name, std
         co_await _qp.execute_internal(query, {sstring(role_name), sstring(attribute_name)}, cql3::query_processor::cache_internal::yes).discard_result();
     } else {
         co_await announce_mutations(_qp, _group0_client, query,
-                {sstring(role_name), sstring(attribute_name)}, &_as);
+                {sstring(role_name), sstring(attribute_name)}, &_as, ::service::raft_timeout{});
     }
 }
 }

--- a/db/config.cc
+++ b/db/config.cc
@@ -284,6 +284,8 @@ struct convert<db::config::error_injection_at_startup> {
                     rhs.name = n.second.as<sstring>();
                 } else if (key == "one_shot") {
                     rhs.one_shot = n.second.as<bool>();
+                } else {
+                    rhs.parameters.insert({key, n.second.as<sstring>()});
                 }
             }
             return !rhs.name.empty();
@@ -1239,8 +1241,8 @@ std::istream& operator>>(std::istream& is, error_injection_at_startup& eias) {
 
 auto fmt::formatter<db::error_injection_at_startup>::format(const db::error_injection_at_startup& eias, fmt::format_context& ctx) const
     -> decltype(ctx.out()) {
-    return fmt::format_to(ctx.out(), "error_injection_at_startup{{name={}, one_short={}}}",
-                          eias.name, eias.one_shot);
+    return fmt::format_to(ctx.out(), "error_injection_at_startup{{name={}, one_short={}, parameters={}}}",
+                          eias.name, eias.one_shot, eias.parameters);
 }
 
 namespace utils {

--- a/db/config.hh
+++ b/db/config.hh
@@ -26,6 +26,7 @@
 #include "db/hints/host_filter.hh"
 #include "utils/updateable_value.hh"
 #include "utils/s3/creds.hh"
+#include "utils/error_injection.hh"
 
 namespace seastar {
 class file;
@@ -71,10 +72,12 @@ inline std::istream& operator>>(std::istream& is, seed_provider_type&);
 struct error_injection_at_startup {
     sstring name;
     bool one_shot = false;
+    utils::error_injection_parameters parameters;
 
     bool operator==(const error_injection_at_startup& other) const {
         return name == other.name
-            && one_shot == other.one_shot;
+            && one_shot == other.one_shot
+            && parameters == other.parameters;
     }
 };
 

--- a/main.cc
+++ b/main.cc
@@ -258,7 +258,7 @@ enable_initial_error_injections(const db::config& cfg) {
     return smp::invoke_on_all([&cfg] {
         auto& injector = utils::get_local_injector();
         for (const auto& inj : cfg.error_injections_at_startup()) {
-            injector.enable(inj.name, inj.one_shot);
+            injector.enable(inj.name, inj.one_shot, inj.parameters);
         }
     });
 }

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -969,7 +969,7 @@ future<> migration_manager::announce_with_raft(std::vector<mutation> schema, gro
         },
         guard, std::move(description));
 
-    co_return co_await _group0_client.add_entry(std::move(group0_cmd), std::move(guard), &_as);
+    co_return co_await _group0_client.add_entry(std::move(group0_cmd), std::move(guard), &_as, raft_timeout{});
 }
 
 future<> migration_manager::announce_without_raft(std::vector<mutation> schema, group0_guard guard) {
@@ -1046,7 +1046,7 @@ future<> migration_manager::announce(std::vector<mutation> schema, group0_guard 
 
 future<group0_guard> migration_manager::start_group0_operation() {
     assert(this_shard_id() == 0);
-    return _group0_client.start_operation(&_as);
+    return _group0_client.start_operation(&_as, raft_timeout{});
 }
 
 /**

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -802,7 +802,7 @@ bool raft_group0::is_member(raft::server_id id, bool include_voters_only) {
     return cfg.contains(id) && (!include_voters_only || cfg.can_vote(id));
 }
 
-future<> raft_group0::become_nonvoter() {
+future<> raft_group0::become_nonvoter(abort_source& as) {
     if (!(co_await raft_upgrade_complete())) {
         on_internal_error(group0_log, "called become_nonvoter before Raft upgrade finished");
     }
@@ -810,15 +810,15 @@ future<> raft_group0::become_nonvoter() {
     auto my_id = load_my_id();
     group0_log.info("becoming a non-voter (my id = {})...", my_id);
 
-    co_await make_raft_config_nonvoter({my_id});
+    co_await make_raft_config_nonvoter({my_id}, as);
     group0_log.info("became a non-voter.", my_id);
 }
 
-future<> raft_group0::make_nonvoter(raft::server_id node) {
-    co_return co_await make_nonvoters({node});
+future<> raft_group0::make_nonvoter(raft::server_id node, abort_source& as) {
+    co_return co_await make_nonvoters({node}, as);
 }
 
-future<> raft_group0::make_nonvoters(const std::unordered_set<raft::server_id>& nodes) {
+future<> raft_group0::make_nonvoters(const std::unordered_set<raft::server_id>& nodes, abort_source& as) {
     if (!(co_await raft_upgrade_complete())) {
         on_internal_error(group0_log, "called make_nonvoters before Raft upgrade finished");
     }
@@ -829,7 +829,7 @@ future<> raft_group0::make_nonvoters(const std::unordered_set<raft::server_id>& 
 
     group0_log.info("making servers {} non-voters...", nodes);
 
-    co_await make_raft_config_nonvoter(nodes);
+    co_await make_raft_config_nonvoter(nodes, as);
 
     group0_log.info("servers {} are now non-voters.", nodes);
 }
@@ -917,19 +917,20 @@ future<bool> raft_group0::wait_for_raft() {
     co_return true;
 }
 
-future<> raft_group0::make_raft_config_nonvoter(const std::unordered_set<raft::server_id>& ids) {
+future<> raft_group0::make_raft_config_nonvoter(const std::unordered_set<raft::server_id>& ids, abort_source& as) {
     static constexpr auto max_retry_period = std::chrono::seconds{1};
     auto retry_period = std::chrono::milliseconds{10};
 
-    // FIXME: cancellability/timeout
     while (true) {
+        as.check();
+
         std::vector<raft::config_member> add;
         add.reserve(ids.size());
         std::transform(ids.begin(), ids.end(), std::back_inserter(add),
         [] (raft::server_id id) { return raft::config_member{{id, {}}, false}; });
 
         try {
-            co_await _raft_gr.group0().modify_config(std::move(add), {}, &_abort_source);
+            co_await _raft_gr.group0().modify_config(std::move(add), {}, &as);
             co_return;
         } catch (const raft::commit_status_unknown& e) {
             group0_log.info("make_raft_config_nonvoter({}): modify_config returned \"{}\", retrying", ids, e);
@@ -938,7 +939,7 @@ future<> raft_group0::make_raft_config_nonvoter(const std::unordered_set<raft::s
         if (retry_period > max_retry_period) {
             retry_period = max_retry_period;
         }
-        co_await sleep_abortable(retry_period, _abort_source);
+        co_await sleep_abortable(retry_period, as);
     }
 }
 

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -215,19 +215,19 @@ public:
     //
     // Assumes we've finished the startup procedure (`setup_group0()` finished earlier).
     // `wait_for_raft` must've also been called earlier and returned `true`.
-    future<> become_nonvoter();
+    future<> become_nonvoter(abort_source& as);
 
     // Make the given server, other than us, a non-voter in group 0.
     //
     // Assumes we've finished the startup procedure (`setup_group0()` finished earlier).
     // `wait_for_raft` must've also been called earlier and returned `true`.
-    future<> make_nonvoter(raft::server_id);
+    future<> make_nonvoter(raft::server_id, abort_source&);
 
     // Make the given servers, other than us, a non-voter in group 0.
     //
     // Assumes we've finished the startup procedure (`setup_group0()` finished earlier).
     // `wait_for_raft` must've also been called earlier and returned `true`.
-    future<> make_nonvoters(const std::unordered_set<raft::server_id>&);
+    future<> make_nonvoters(const std::unordered_set<raft::server_id>&, abort_source&);
 
     // Remove ourselves from group 0.
     //
@@ -364,7 +364,7 @@ private:
 
     // Make the given server a non-voter in Raft group 0 configuration.
     // Retries on raft::commit_status_unknown.
-    future<> make_raft_config_nonvoter(const std::unordered_set<raft::server_id>&);
+    future<> make_raft_config_nonvoter(const std::unordered_set<raft::server_id>&, abort_source& as);
 
     // Returns true if raft is enabled
     future<bool> use_raft();

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -215,19 +215,20 @@ public:
     //
     // Assumes we've finished the startup procedure (`setup_group0()` finished earlier).
     // `wait_for_raft` must've also been called earlier and returned `true`.
-    future<> become_nonvoter(abort_source& as);
+    future<> become_nonvoter(abort_source& as, std::optional<raft_timeout> timeout = std::nullopt);
 
     // Make the given server, other than us, a non-voter in group 0.
     //
     // Assumes we've finished the startup procedure (`setup_group0()` finished earlier).
     // `wait_for_raft` must've also been called earlier and returned `true`.
-    future<> make_nonvoter(raft::server_id, abort_source&);
+    future<> make_nonvoter(raft::server_id, abort_source&, std::optional<raft_timeout> timeout = std::nullopt);
 
     // Make the given servers, other than us, a non-voter in group 0.
     //
     // Assumes we've finished the startup procedure (`setup_group0()` finished earlier).
     // `wait_for_raft` must've also been called earlier and returned `true`.
-    future<> make_nonvoters(const std::unordered_set<raft::server_id>&, abort_source&);
+    future<> make_nonvoters(const std::unordered_set<raft::server_id>&, abort_source&,
+            std::optional<raft_timeout> timeout = std::nullopt);
 
     // Remove ourselves from group 0.
     //
@@ -364,7 +365,7 @@ private:
 
     // Make the given server a non-voter in Raft group 0 configuration.
     // Retries on raft::commit_status_unknown.
-    future<> make_raft_config_nonvoter(const std::unordered_set<raft::server_id>&, abort_source& as);
+    future<> make_raft_config_nonvoter(const std::unordered_set<raft::server_id>&, abort_source& as, std::optional<raft_timeout> timeout = std::nullopt);
 
     // Returns true if raft is enabled
     future<bool> use_raft();

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -283,6 +283,11 @@ public:
         return _raft_gr.group0();
     }
 
+    // Returns a wrapper for the group0_server() with timeouts support.
+    raft_server_with_timeouts group0_server_with_timeouts() {
+        return _raft_gr.group0_with_timeouts();
+    }
+
     // Returns true after the group 0 server has been started.
     bool joined_group0() const;
 

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -153,7 +153,9 @@ semaphore& raft_group0_client::operation_mutex() {
     return _operation_mutex;
 }
 
-future<> raft_group0_client::add_entry(group0_command group0_cmd, group0_guard guard, seastar::abort_source* as) {
+future<> raft_group0_client::add_entry(group0_command group0_cmd, group0_guard guard, seastar::abort_source* as,
+        std::optional<raft_timeout> timeout)
+{
     if (this_shard_id() != 0) {
         // This should not happen since all places which construct `group0_guard` also check that they are on shard 0.
         // Note: `group0_guard::impl` is private to this module, making this easy to verify.
@@ -173,7 +175,7 @@ future<> raft_group0_client::add_entry(group0_command group0_cmd, group0_guard g
         do {
             retry = false;
             try {
-                co_await _raft_gr.group0().add_entry(cmd, raft::wait_type::applied, as);
+                co_await _raft_gr.group0_with_timeouts().add_entry(cmd, raft::wait_type::applied, as, timeout);
             } catch (const raft::dropped_entry& e) {
                 logger.warn("add_entry: returned \"{}\". Retrying the command (prev_state_id: {}, new_state_id: {})",
                         e, group0_cmd.prev_state_id, group0_cmd.new_state_id);
@@ -235,7 +237,7 @@ static utils::UUID generate_group0_state_id(utils::UUID prev_state_id) {
     return utils::UUID_gen::get_random_time_UUID_from_micros(std::chrono::microseconds{ts});
 }
 
-future<group0_guard> raft_group0_client::start_operation(seastar::abort_source* as) {
+future<group0_guard> raft_group0_client::start_operation(seastar::abort_source* as, std::optional<raft_timeout> timeout) {
     if (this_shard_id() != 0) {
         on_internal_error(logger, "start_group0_operation: must run on shard 0");
     }
@@ -248,7 +250,7 @@ future<group0_guard> raft_group0_client::start_operation(seastar::abort_source* 
     switch (upgrade_state) {
         case group0_upgrade_state::use_post_raft_procedures: {
             auto operation_holder = co_await get_units(_operation_mutex, 1);
-            co_await _raft_gr.group0().read_barrier(as);
+            co_await _raft_gr.group0_with_timeouts().read_barrier(as, timeout);
 
             // Take `_group0_read_apply_mutex` *after* read barrier.
             // Read barrier may wait for `group0_state_machine::apply` which also takes this mutex.

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -107,7 +107,7 @@ public:
     // Call after `system_keyspace` is initialized.
     future<> init();
 
-    future<> add_entry(group0_command group0_cmd, group0_guard guard, seastar::abort_source* as);
+    future<> add_entry(group0_command group0_cmd, group0_guard guard, seastar::abort_source* as, std::optional<raft_timeout> timeout = std::nullopt);
 
     future<> add_entry_unguarded(group0_command group0_cmd, seastar::abort_source* as);
 
@@ -131,7 +131,7 @@ public:
     // FIXME?: this is kind of annoying for the user.
     // we could forward the call to shard 0, have group0_guard keep a foreign_ptr to the internal data structures on shard 0,
     // and add_entry would again forward to shard 0.
-    future<group0_guard> start_operation(seastar::abort_source* as);
+    future<group0_guard> start_operation(seastar::abort_source* as, std::optional<raft_timeout> timeout = std::nullopt);
 
     template<typename Command>
     requires std::same_as<Command, broadcast_table_query> || std::same_as<Command, write_mutations>

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -41,6 +41,8 @@ struct raft_destination_id_not_correct: public raft::error {
     {}
 };
 
+class raft_group_registry;
+
 // An entry in the group registry
 struct raft_server_for_group {
     raft::group_id gid;
@@ -49,6 +51,50 @@ struct raft_server_for_group {
     raft_rpc& rpc;
     raft_sys_table_storage& persistence;
     std::optional<seastar::future<>> aborted;
+    std::optional<lowres_clock::duration> default_op_timeout;
+};
+
+struct raft_timeout {
+    seastar::compat::source_location loc = seastar::compat::source_location::current();
+    std::optional<lowres_clock::time_point> value;
+};
+
+class raft_operation_timeout_error : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
+// A wrapper for raft::server that adds timeout support to the main raft methods.
+// If an operation doesn't finish in a specified amount of time, raft_operation_timeout_error
+// exception is thrown.
+// An instance can be obtained through raft_group_registry methods get_server_with_timeouts
+// and group0_with_timeouts.
+// Passing std::nullopt as a raft_timeout parameter to methods of this class is equivalent
+// to calling the original raft methods without timeout.
+// Passing raft_timeout{} means 'use default timeout for this group', which is taken
+// from raft_server_for_group::default_op_timeout. For group0 default_op_timeout
+// is set to 1 minute and can be overridden in tests through the group0-raft-op-timeout-in-ms injection.
+// A custom timeout can be passed via raft_timeout::value, it will take precedence over
+// the default timeout default_op_timeout.
+// If no default_op_timeout is configured for a group and raft_timeout{} is passed without
+// the value parameter set, on_internal_error will be triggered.
+//
+// Use methods of these class if the code is handling a client request
+// and the client expects a potential error. Don't use timeouts for background
+// fibers, such as topology coordinator, since they wouldn't add much value.
+// The only thing the background fiber can do with a timeout is to retry, and
+// this will have the same end effect as not having a timeout at all.
+class raft_server_with_timeouts {
+    raft_server_for_group& _group_server;
+    raft_group_registry& _registry;
+
+    template <std::invocable<abort_source*> Op>
+    std::invoke_result_t<Op, abort_source*>
+    run_with_timeout(Op&& op, const char* op_name, seastar::abort_source* as, std::optional<raft_timeout> timeout);
+public:
+    raft_server_with_timeouts(raft_server_for_group& group_server, raft_group_registry& registry);
+    future<> add_entry(raft::command command, raft::wait_type type, seastar::abort_source* as, std::optional<raft_timeout> timeout);
+    future<> modify_config(std::vector<raft::config_member> add, std::vector<raft::server_id> del, seastar::abort_source* as, std::optional<raft_timeout> timeout);
+    future<> read_barrier(seastar::abort_source* as, std::optional<raft_timeout> timeout);
 };
 
 class direct_fd_pinger;
@@ -115,6 +161,10 @@ public:
     // there is no such group.
     raft::server& get_server(raft::group_id gid);
 
+    // Returns a server with timeouts support for group by group id.
+    // Throws exception if there is no such group.
+    raft_server_with_timeouts get_server_with_timeouts(raft::group_id gid);
+
     // Find server for the given group.
     // Returns `nullptr` if there is no such group.
     raft::server* find_server(raft::group_id);
@@ -125,6 +175,10 @@ public:
     // Return an instance of group 0. Valid only on shard 0,
     // after boot/upgrade is complete
     raft::server& group0();
+
+    // Return an instance of group 0 server with timeouts support. Valid only on shard 0,
+    // after boot/upgrade is complete
+    raft_server_with_timeouts group0_with_timeouts();
 
     // Start raft server instance, store in the map of raft servers and
     // arm the associated timer to tick the server.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6080,9 +6080,14 @@ future<join_node_response_result> storage_service::join_node_response_handler(jo
                 // the replacing node that is alive.
                 co_await _gossiper.advertise_to_nodes({});
 
+                co_await utils::get_local_injector().inject("join-node-response_handler-before-read-barrier", [] (auto& handler) -> future<> {
+                    rtlogger.info("join-node-response_handler-before-read-barrier injection hit");
+                    co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{5});
+                    rtlogger.info("join-node-response_handler-before-read-barrier injection done");
+                });
+
                 // Do a read barrier to read/initialize the topology state
-                auto& raft_server = _group0->group0_server();
-                co_await raft_server.read_barrier(&_group0_as);
+                co_await _group0->group0_server_with_timeouts().read_barrier(&_group0_as, raft_timeout{});
 
                 // Calculate nodes to ignore
                 // TODO: ignore_dead_nodes setting for bootstrap

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3666,7 +3666,7 @@ future<> storage_service::raft_removenode(locator::host_id host_id, std::list<lo
     utils::UUID request_id;
 
     while (true) {
-        auto guard = co_await _group0->client().start_operation(&_group0_as);
+        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
 
         auto it = _topology_state_machine._topology.find(id);
 
@@ -3722,8 +3722,8 @@ future<> storage_service::raft_removenode(locator::host_id host_id, std::list<lo
         request_id = guard.new_group0_state_id();
         try {
             // Make non voter during request submission for better HA
-            co_await _group0->make_nonvoters(ignored_ids, _group0_as);
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as);
+            co_await _group0->make_nonvoters(ignored_ids, _group0_as, raft_timeout{});
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
         } catch (group0_concurrent_modification&) {
             rtlogger.info("removenode: concurrent operation is detected, retrying.");
             continue;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3334,7 +3334,7 @@ future<> storage_service::raft_decommission() {
     utils::UUID request_id;
 
     while (true) {
-        auto guard = co_await _group0->client().start_operation(&_group0_as);
+        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
 
         auto it = _topology_state_machine._topology.find(raft_server.id());
         if (!it) {
@@ -3364,7 +3364,7 @@ future<> storage_service::raft_decommission() {
 
         request_id = guard.new_group0_state_id();
         try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as);
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
         } catch (group0_concurrent_modification&) {
             rtlogger.info("decommission: concurrent operation is detected, retrying.");
             continue;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4305,7 +4305,7 @@ future<> storage_service::do_cluster_cleanup() {
     auto& raft_server = _group0->group0_server();
 
     while (true) {
-        auto guard = co_await _group0->client().start_operation(&_group0_as);
+        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
 
         auto curr_req = _topology_state_machine._topology.global_request;
         if (curr_req && *curr_req != global_topology_request::cleanup) {
@@ -4333,7 +4333,7 @@ future<> storage_service::do_cluster_cleanup() {
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, ::format("cleanup: cluster cleanup requested"));
 
         try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as);
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
         } catch (group0_concurrent_modification&) {
             rtlogger.info("cleanup: concurrent operation is detected, retrying.");
             continue;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1215,7 +1215,7 @@ future<> storage_service::update_topology_with_local_metadata(raft::server& raft
     while (true) {
         rtlogger.info("refreshing topology to check if it's synchronized with local metadata");
 
-        auto guard = co_await _group0->client().start_operation(&_group0_as);
+        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
 
         if (synchronized()) {
             break;
@@ -1250,7 +1250,7 @@ future<> storage_service::update_topology_with_local_metadata(raft::server& raft
                 std::move(change), guard, ::format("{}: update topology with local metadata", raft_server.id()));
 
         try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as);
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
         } catch (group0_concurrent_modification&) {
             rtlogger.info("update topology with local metadata:"
                          " concurrent operation is detected, retrying.");

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4367,7 +4367,7 @@ future<> storage_service::raft_rebuild(sstring source_dc) {
     utils::UUID request_id;
 
     while (true) {
-        auto guard = co_await _group0->client().start_operation(&_group0_as);
+        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
 
         auto it = _topology_state_machine._topology.find(raft_server.id());
         if (!it) {
@@ -4400,7 +4400,7 @@ future<> storage_service::raft_rebuild(sstring source_dc) {
         request_id = guard.new_group0_state_id();
 
         try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as);
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
         } catch (group0_concurrent_modification&) {
             rtlogger.info("rebuild: concurrent operation is detected, retrying.");
             continue;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1296,7 +1296,7 @@ future<> storage_service::start_upgrade_to_raft_topology() {
     }
 
     while (true) {
-        auto guard = co_await _group0->client().start_operation(&_group0_as);
+        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
 
         if (_topology_state_machine._topology.upgrade_state != topology::upgrade_state_type::not_upgraded) {
             co_return;
@@ -1309,7 +1309,7 @@ future<> storage_service::start_upgrade_to_raft_topology() {
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, "upgrade: start");
 
         try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as);
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
             break;
         } catch (group0_concurrent_modification&) {
             rtlogger.info("upgrade: concurrent operation is detected, retrying.");

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5962,7 +5962,7 @@ future<join_node_request_result> storage_service::join_node_request_handler(join
     }
 
     while (true) {
-        auto guard = co_await _group0->client().start_operation(&_group0_as);
+        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
 
         if (const auto *p = _topology_state_machine._topology.find(params.host_id)) {
             const auto& rs = p->second;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4420,7 +4420,7 @@ future<> storage_service::raft_check_and_repair_cdc_streams() {
 
     while (true) {
         rtlogger.info("request check_and_repair_cdc_streams, refreshing topology");
-        auto guard = co_await _group0->client().start_operation(&_group0_as);
+        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
         auto curr_req = _topology_state_machine._topology.global_request;
         if (curr_req && *curr_req != global_topology_request::new_cdc_generation) {
             // FIXME: replace this with a queue
@@ -4446,7 +4446,7 @@ future<> storage_service::raft_check_and_repair_cdc_streams() {
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard,
                 ::format("request check+repair CDC generation from {}", _group0->group0_server().id()));
         try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as);
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
         } catch (group0_concurrent_modification&) {
             rtlogger.info("request check+repair CDC: concurrent operation is detected, retrying.");
             continue;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -815,7 +815,7 @@ private:
 
     future<raft_topology_cmd_result> raft_topology_cmd_handler(raft::term_t term, uint64_t cmd_index, const raft_topology_cmd& cmd);
 
-    future<> raft_initialize_discovery_leader(raft::server&, const join_node_request_params& params);
+    future<> raft_initialize_discovery_leader(const join_node_request_params& params);
     future<> raft_decommission();
     future<> raft_removenode(locator::host_id host_id, std::list<locator::host_id_or_endpoint> ignore_nodes_params);
     future<> raft_rebuild(sstring source_dc);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -436,7 +436,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
 
     future<> step_down_as_nonvoter() {
         // Become a nonvoter which triggers a leader stepdown.
-        co_await _group0.become_nonvoter();
+        co_await _group0.become_nonvoter(_as);
         if (_raft.is_leader()) {
             co_await _raft.wait_for_state_change(&_as);
         }
@@ -1593,7 +1593,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     // FIXME: removenode may be aborted and the already dead node can be resurrected. We should consider
                     // restoring its voter state on the recovery path.
                     if (node.rs->state == node_state::removing) {
-                        co_await _group0.make_nonvoter(node.id);
+                        co_await _group0.make_nonvoter(node.id, _as);
                     }
 
                     // If we decommission a node when the number of nodes is even, we make it a non-voter early.
@@ -1610,7 +1610,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                                          "giving up leadership");
                             co_await step_down_as_nonvoter();
                         } else {
-                            co_await _group0.make_nonvoter(node.id);
+                            co_await _group0.make_nonvoter(node.id, _as);
                         }
                     }
                 }
@@ -1618,7 +1618,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     // We make a replaced node a non-voter early, just like a removed node.
                     auto replaced_node_id = parse_replaced_node(node.req_param);
                     if (_group0.is_member(replaced_node_id, true)) {
-                        co_await _group0.make_nonvoter(replaced_node_id);
+                        co_await _group0.make_nonvoter(replaced_node_id, _as);
                     }
                 }
 

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -349,7 +349,8 @@ class ManagerClient():
     async def remove_node(self, initiator_id: ServerNum, server_id: ServerNum,
                           ignore_dead: List[IPAddress] | List[HostID] = list[IPAddress](),
                           expected_error: str | None = None,
-                          wait_removed_dead: bool = True) -> None:
+                          wait_removed_dead: bool = True,
+                          timeout: Optional[float] = ScyllaServer.TOPOLOGY_TIMEOUT) -> None:
         """Invoke remove node Scylla REST API for a specified server"""
         logger.debug("ManagerClient remove node %s on initiator %s", server_id, initiator_id)
 
@@ -364,25 +365,27 @@ class ManagerClient():
 
         data = {"server_id": server_id, "ignore_dead": ignore_dead, "expected_error": expected_error}
         await self.client.put_json(f"/cluster/remove-node/{initiator_id}", data,
-                                   timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
+                                   timeout=timeout)
         self._driver_update()
 
     async def decommission_node(self, server_id: ServerNum,
-                                expected_error: str | None = None) -> None:
+                                expected_error: str | None = None,
+                                timeout: Optional[float] = ScyllaServer.TOPOLOGY_TIMEOUT) -> None:
         """Tell a node to decommission with Scylla REST API"""
         logger.debug("ManagerClient decommission %s", server_id)
         data = {"expected_error": expected_error}
         await self.client.put_json(f"/cluster/decommission-node/{server_id}", data,
-                                   timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
+                                   timeout=timeout)
         self._driver_update()
 
     async def rebuild_node(self, server_id: ServerNum,
-                           expected_error: str | None = None) -> None:
+                           expected_error: str | None = None,
+                           timeout: Optional[float] = ScyllaServer.TOPOLOGY_TIMEOUT) -> None:
         """Tell a node to rebuild with Scylla REST API"""
         logger.debug("ManagerClient rebuild %s", server_id)
         data = {"expected_error": expected_error}
         await self.client.put_json(f"/cluster/rebuild-node/{server_id}", data,
-                                   timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
+                                   timeout=timeout)
         self._driver_update()
 
     async def server_get_config(self, server_id: ServerNum) -> dict[str, object]:

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -189,7 +189,10 @@ class ManagerClient():
         data = {"expected_error": expected_error}
         await self.client.put_json(f"/cluster/server/{server_id}/start", data)
         await self.server_sees_others(server_id, wait_others, interval = wait_interval)
-        self._driver_update()
+        if self.cql:
+            self._driver_update()
+        else:
+            await self.driver_connect()
 
     async def server_restart(self, server_id: ServerNum, wait_others: int = 0,
                              wait_interval: float = 45) -> None:
@@ -299,7 +302,7 @@ class ManagerClient():
         logger.debug("ManagerClient added %s", s_info)
         if self.cql:
             self._driver_update()
-        else:
+        elif start:
             await self.driver_connect()
         return s_info
 
@@ -339,7 +342,7 @@ class ManagerClient():
         logger.debug("ManagerClient added %s", s_infos)
         if self.cql:
             self._driver_update()
-        else:
+        elif start:
             await self.driver_connect()
         return s_infos
 

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -183,11 +183,12 @@ class ManagerClient():
         await self.client.put_json(f"/cluster/server/{server_id}/stop_gracefully", timeout=timeout)
 
     async def server_start(self, server_id: ServerNum, expected_error: Optional[str] = None,
-                           wait_others: int = 0, wait_interval: float = 45) -> None:
+                           wait_others: int = 0, wait_interval: float = 45,
+                           timeout: Optional[float] = None) -> None:
         """Start specified server and optionally wait for it to learn of other servers"""
         logger.debug("ManagerClient starting %s", server_id)
         data = {"expected_error": expected_error}
-        await self.client.put_json(f"/cluster/server/{server_id}/start", data)
+        await self.client.put_json(f"/cluster/server/{server_id}/start", data, timeout=timeout)
         await self.server_sees_others(server_id, wait_others, interval = wait_interval)
         if self.cql:
             self._driver_update()

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -267,7 +267,8 @@ class ManagerClient():
                          config: Optional[dict[str, Any]] = None,
                          property_file: Optional[dict[str, Any]] = None,
                          start: bool = True,
-                         expected_error: Optional[str] = None) -> ServerInfo:
+                         expected_error: Optional[str] = None,
+                         timeout: Optional[float] = ScyllaServer.TOPOLOGY_TIMEOUT) -> ServerInfo:
         """Add a new server"""
         try:
             data = self._create_server_add_data(replace_cfg, cmdline, config, property_file, start, expected_error)
@@ -282,7 +283,7 @@ class ManagerClient():
                 await self.others_not_see_server(replaced_ip)
 
             server_info = await self.client.put_json("/cluster/addserver", data, response_type="json",
-                                                     timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
+                                                     timeout=timeout)
         except Exception as exc:
             raise Exception("Failed to add server") from exc
         try:

--- a/test/topology_custom/test_raft_no_quorum.py
+++ b/test/topology_custom/test_raft_no_quorum.py
@@ -43,6 +43,10 @@ async def test_cannot_add_new_node(manager: ManagerClient, raft_op_timeout: int)
             {
                 'name': 'group0-raft-op-timeout-in-ms',
                 'value': raft_op_timeout
+            },
+            {
+                'name': 'raft-group-registry-fd-threshold-in-ms',
+                'value': '500'
             }
         ]
     }
@@ -60,7 +64,7 @@ async def test_cannot_add_new_node(manager: ManagerClient, raft_op_timeout: int)
                          manager.server_stop_gracefully(servers[3].server_id))
 
     logger.info("starting a fifth node with no quorum")
-    await manager.server_add(expected_error="raft operation [read_barrier] timed out",
+    await manager.server_add(expected_error="raft operation [read_barrier] timed out, there is no raft quorum",
                              timeout=60)
 
     logger.info("done")

--- a/test/topology_custom/test_raft_no_quorum.py
+++ b/test/topology_custom/test_raft_no_quorum.py
@@ -1,0 +1,66 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import logging
+
+import pytest
+import asyncio
+from test.pylib.manager_client import ManagerClient
+from test.topology.conftest import skip_mode
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def raft_op_timeout(mode):
+    return 5000 if mode == 'debug' else 1000
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+@skip_mode('debug', 'aarch64/debug is unpredictably slow', platform_key='aarch64')
+async def test_cannot_add_new_node(manager: ManagerClient, raft_op_timeout: int) -> None:
+    # This test makes sure that trying to add a new node fails with timeout
+    # if the majority of the cluster is not available.
+    # To exercise this, we start with a cluster of four nodes. This setup lets us check two situations:
+    # one where the new node's join request goes to the leader of the cluster, and
+    # another where it goes to a non-leader. Initially, the first node we start
+    # becomes the leader. Then, we shut down the last two nodes.
+    # This means the new node's request could be handled by either of the
+    # first two nodes, depending on which one responds first to the discovery request
+    # in persistent_discovery::run.
+    # In the second case we rely on a leader in Raft to steps down
+    # if an election timeout elapses without a successful round of heartbeats to a majority
+    # of its cluster (fsm::tick_leader).
+    # This is important since execute_read_barrier_on_leader doesn't take the abort_source,
+    # it just returns 'not_a_leader' and read_barrier rechecks the abort_source in the
+    # loop inside do_on_leader_with_retries.
+
+    config = {
+        'error_injections_at_startup': [
+            {
+                'name': 'group0-raft-op-timeout-in-ms',
+                'value': raft_op_timeout
+            }
+        ]
+    }
+    logger.info("starting a first node (the leader)")
+    servers = [await manager.server_add(config=config)]
+
+    logger.info("starting a second node (a follower)")
+    servers += [await manager.server_add(config=config)]
+
+    logger.info("starting other two nodes")
+    servers += await manager.servers_add(servers_num=2)
+
+    logger.info("stopping the last two nodes")
+    await asyncio.gather(manager.server_stop_gracefully(servers[2].server_id),
+                         manager.server_stop_gracefully(servers[3].server_id))
+
+    logger.info("starting a fifth node with no quorum")
+    await manager.server_add(expected_error="raft operation [read_barrier] timed out",
+                             timeout=60)
+
+    logger.info("done")

--- a/utils/composite_abort_source.hh
+++ b/utils/composite_abort_source.hh
@@ -1,0 +1,23 @@
+#include "seastar/core/abort_source.hh"
+#include "utils/small_vector.hh"
+
+namespace utils {
+// A facility to combine several abort_source-s and expose them as a single abort_source.
+// The combined abort_source is aborted whenever any of the added abort_sources is aborted.
+// Typical use case: there are several sources of abort signal (e.g. timeout and node shutdown)
+// and we what some routine to be aborted on any of them.
+class composite_abort_source {
+    abort_source _as;
+    utils::small_vector<abort_source::subscription, 2> _subscriptions;
+public:
+    void add(abort_source& as) {
+        as.check();
+        auto sub = as.subscribe([this]() noexcept { _as.request_abort(); });
+        assert(sub);
+        _subscriptions.push_back(std::move(*sub));
+    }
+    abort_source& abort_source() noexcept {
+        return _as;
+    }
+};
+}

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -14,6 +14,7 @@
 #include <seastar/core/smp.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/on_internal_error.hh>
+#include <seastar/util/defer.hh>
 #include "seastarx.hh"
 
 #include "log.hh"


### PR DESCRIPTION
In this PR we add timeouts support to raft groups registry. We introduce the `raft_server_with_timeouts` class, which wraps the `raft::server` add exposes its interface with additional `raft_timeout` parameter. If it's set, the wrapper cancels the `abort_source` after certain amount of time. The value of the timeout can be specified either in the `raft_timeout` parameter, or the default value can be set in `the raft_server_with_timeouts` class constructor.

The `raft_group_registry` interface is extended with `group0_with_timeouts()` method. It returns an instance of `raft_server_with_timeouts` for group0 raft server. The timeout value for it is configured in `create_server_for_group0`. It's one minute by default and can be overridden for tests with `group0-raft-op-timeout-in-ms` parameter.

The new api allows the client to decide whether to use timeouts or not. In this PR we are reviewing all the group0 call sites and add `raft_timeout` if that makes sense. The general principle is that if the code is handling a client request and the client expects a potential error, we use timeouts. We don't use timeouts for background fibers (such as topology coordinator), since they wouldn't add much value. The only thing the background fiber can do with a timeout is to retry, and this will have the same end effect as not having a timeout at all.

fixes scylladb/scylladb#16604