### PR TITLE
clustering_interval_set: add fmt::formatter for clustering_interval_set

### DIFF
--- a/clustering_interval_set.hh
+++ b/clustering_interval_set.hh
@@ -122,6 +122,10 @@ public:
     }
     position_range_iterator begin() const { return {_set.begin()}; }
     position_range_iterator end() const { return {_set.end()}; }
-    friend std::ostream& operator<<(std::ostream&, const clustering_interval_set&);
 };
 
+template <> struct fmt::formatter<clustering_interval_set> : fmt::formatter<std::string_view> {
+    auto format(const clustering_interval_set& set, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{{{}}}", fmt::join(set, ",\n  "));
+    }
+};

--- a/mutation/mutation_fragment.cc
+++ b/mutation/mutation_fragment.cc
@@ -405,11 +405,6 @@ bool mutation_fragment_v2::relevant_for_range(const schema& s, position_in_parti
     return false;
 }
 
-std::ostream& operator<<(std::ostream& out, const clustering_interval_set& set) {
-    fmt::print(out, "{{{}}}", fmt::join(set, ",\n  "));
-    return out;
-}
-
 template<typename Hasher>
 void appending_hash<mutation_fragment>::operator()(Hasher& h, const mutation_fragment& mf, const schema& s) const {
     auto hash_cell = [&] (const column_definition& col, const atomic_cell_or_collection& cell) {


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `clustering_interval_set`

their operator<<:s are dropped

Refs #13245