### PR TITLE
row_cache: add fmt::formatter for cache_entry

### DIFF
--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1467,9 +1467,9 @@ future<> row_cache::do_update(row_cache::external_updater eu, row_cache::interna
   });
 }
 
-std::ostream& operator<<(std::ostream& out, const cache_entry& e) {
-    fmt::print(out, "{{cache_entry: {}, cont={}, dummy={}, {}}}",
+auto fmt::formatter<cache_entry>::format(const cache_entry& e, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{{cache_entry: {}, cont={}, dummy={}, {}}}",
                e.position(), e.continuous(), e.is_dummy_entry(),
                partition_entry::printer(e.partition()));
-    return out;
 }

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -137,8 +137,6 @@ public:
     void set_continuous(bool value) noexcept { _flags._continuous = value; }
 
     bool is_dummy_entry() const noexcept { return _flags._dummy_entry; }
-
-    friend std::ostream& operator<<(std::ostream&, const cache_entry&);
 };
 
 //
@@ -524,3 +522,7 @@ public:
 };
 
 }
+
+template <> struct fmt::formatter<cache_entry> : fmt::formatter<std::string_view> {
+    auto format(const cache_entry&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for cache_entry, and drop its operator<<.

Refs #13245