### PR TITLE
[RFC] tools: use fedora-minimal as the base image for dbuild (instead…

### DIFF
--- a/tools/toolchain/Dockerfile
+++ b/tools/toolchain/Dockerfile
@@ -1,13 +1,16 @@
-FROM docker.io/fedora:38
+FROM registry.fedoraproject.org/fedora-minimal:38
 ADD ./install-dependencies.sh ./
 ADD ./seastar/install-dependencies.sh ./seastar/
 ADD ./tools/jmx/install-dependencies.sh ./tools/jmx/
 ADD ./tools/java/install-dependencies.sh ./tools/java/
 ADD ./tools/toolchain/system-auth ./
+
+# hack so other files using dnf will still work with microdnf
+RUN ln -s /usr/bin/microdnf /usr/bin/dnf
+
 RUN dnf -y update \
     && dnf -y install 'dnf-command(copr)' \
-    && dnf -y install ccache \
-    && dnf -y install devscripts debhelper fakeroot file rpm-build \
+    && dnf -y install ccache devscripts debhelper fakeroot file rpm-build \
     && ./install-dependencies.sh && dnf clean all \
     && echo 'ALL ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers \
     && cp system-auth /etc/pam.d \


### PR DESCRIPTION
… of regular Fedora image)

Regretfully, it doesn't reduce the overall container size, which is dominated by the toolchain deps and especially the Java ones. Perhaps one day we'll split them to different containers - and it appears there's a chance that one day is coming soon enough.