### PR TITLE
tools: toolchain: update frozen toolchain for python driver 3.26.7

### DIFF
--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-38-20240212
+docker.io/scylladb/scylla-toolchain:fedora-38-20240303


### PR DESCRIPTION
Fixes scylladb/scylladb#16709
Fixes scylladb/scylladb#17353