### PR TITLE
sstables: partition_index_cache: evict entries within a page gently

### DIFF
--- a/sstables/index_entry.hh
+++ b/sstables/index_entry.hh
@@ -297,6 +297,10 @@ public:
     bool empty() const { return _entries.empty(); }
     size_t size() const { return _entries.size(); }
 
+    void clear_one_entry() {
+        _entries.pop_back();
+    }
+
     size_t external_memory_usage() const {
         size_t size = _entries.external_memory_usage();
         for (auto&& e : _entries) {


### PR DESCRIPTION
When the partition_index_cache is evicted, we yield for preemption between pages, but not within a page.

Commit 3b2890e1db77 ("sstables: Switch index_list to chunked_vector to avoid large allocations") recognized that index pages can be large enough to overflow a 128k alignment block (this was before the index cache and index entries were not stored in LSA then). However, it did not go as far as to gently free individual entries; either the problem was not recognized or wasn't as bad.

As the referenced issue shows, a fairly large stall can happen when freeing the page. The workload had a large number of tombstones, so index selectivity was poor.

Fix by evicting individual rows gently.

The fix ignores the case where rows are still references: it is unlikely that all index pages will be referenced, and in any case skipping over a referenced page takes an insignificant amount of time, compared to freeing a page.

Fixes #17605