### PR TITLE
test: wait for CDC generations publishing before checking CDC-topology consistency

### DIFF
--- a/test/topology_experimental_raft/test_topology_recovery_majority_loss.py
+++ b/test/topology_experimental_raft/test_topology_recovery_majority_loss.py
@@ -13,7 +13,8 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts
 from test.topology.util import reconnect_driver, restart, enter_recovery_state, \
         delete_raft_data_and_upgrade_state, log_run_time, wait_until_upgrade_finishes as wait_until_schema_upgrade_finishes, \
-        wait_until_topology_upgrade_finishes, delete_raft_topology_state, check_system_topology_and_cdc_generations_v3_consistency
+        wait_until_topology_upgrade_finishes, delete_raft_topology_state, wait_for_cdc_generations_publishing, \
+        check_system_topology_and_cdc_generations_v3_consistency
 
 
 @pytest.mark.asyncio
@@ -64,12 +65,18 @@ async def test_topology_recovery_after_majority_loss(request, manager: ManagerCl
     logging.info("Waiting until upgrade to raft topology finishes")
     await wait_until_topology_upgrade_finishes(manager, host1.address, time.time() + 60)
 
+    logging.info("Waiting for CDC generations publishing")
+    await wait_for_cdc_generations_publishing(cql, [host1], time.time() + 60)
+
     logging.info("Checking consistency of data in system.topology and system.cdc_generations_v3")
     await check_system_topology_and_cdc_generations_v3_consistency(manager, [host1])
 
     logging.info("Add two more nodes")
     servers = [srv1] + await manager.servers_add(2)
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logging.info("Waiting for the new CDC generations publishing")
+    await wait_for_cdc_generations_publishing(cql, hosts, time.time() + 60)
 
     logging.info("Checking consistency of data in system.topology and system.cdc_generations_v3")
     await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)

--- a/test/topology_experimental_raft/test_topology_upgrade.py
+++ b/test/topology_experimental_raft/test_topology_upgrade.py
@@ -13,7 +13,7 @@ from test.pylib.rest_client import HTTPError
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts
 from test.topology.util import log_run_time, wait_until_topology_upgrade_finishes, \
-        check_system_topology_and_cdc_generations_v3_consistency
+        wait_for_cdc_generations_publishing, check_system_topology_and_cdc_generations_v3_consistency
 
 
 @pytest.mark.asyncio
@@ -48,6 +48,9 @@ async def test_topology_upgrade_basic(request, manager: ManagerClient):
     logging.info("Waiting until upgrade finishes")
     await asyncio.gather(*(wait_until_topology_upgrade_finishes(manager, h.address, time.time() + 60) for h in hosts))
 
+    logging.info("Waiting for CDC generations publishing")
+    await wait_for_cdc_generations_publishing(cql, hosts, time.time() + 60)
+
     logging.info("Checking consistency of data in system.topology and system.cdc_generations_v3")
     await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)
 
@@ -56,6 +59,9 @@ async def test_topology_upgrade_basic(request, manager: ManagerClient):
 
     logging.info("Waiting until driver connects to every server")
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logging.info("Waiting for the new CDC generation publishing")
+    await wait_for_cdc_generations_publishing(cql, hosts, time.time() + 60)
 
     logging.info("Checking consistency of data in system.topology and system.cdc_generations_v3")
     await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)


### PR DESCRIPTION
Tests that verify upgrading to the raft-based topology
(`test_topology_upgrade`, `test_topology_recovery_basic`,
`test_topology_recovery_majority_loss`) have flaky
`check_system_topology_and_cdc_generations_v3_consistency` calls.
`assert topo_results[0] == topo_res` can fail because of different
`unpublished_cdc_generations` on different nodes.

The upgrade procedure creates a new CDC generation, which is later
published by the CDC generation publisher. However, this can happen
after the upgrade procedure finishes. In tests, if publishing
happens just before querying `system.topology` in
`check_system_topology_and_cdc_generations_v3_consistency`, we can
observe different `unpublished_cdc_generations` on different nodes.
It is an expected and temporary inconsistency.

For the same reasons,
`check_system_topology_and_cdc_generations_v3_consistency` can
fail after adding a new node.

To make the tests not flaky, we wait until the CDC generation
publisher finishes its job. Then, all nodes should always have
equal (and empty) `unpublished_cdc_generations`.

Fixes scylladb/scylladb#17587
Fixes scylladb/scylladb#17600
Fixes scylladb/scylladb#17621