### PR TITLE
sstables: fix a use-after-free in key_view::explode()

### DIFF
--- a/sstables/key.hh
+++ b/sstables/key.hh
@@ -29,14 +29,10 @@ public:
         return ::with_linearized(_bytes, func);
     }
 
-    std::vector<bytes_view> explode(const schema& s) const {
-        return with_linearized([&] (bytes_view v) {
-            return composite_view(v, s.partition_key_size() > 1).explode();
-        });
-    }
-
     partition_key to_partition_key(const schema& s) const {
-        return partition_key::from_exploded_view(explode(s));
+        return with_linearized([&] (bytes_view v) {
+            return partition_key::from_exploded_view(composite_view(v, s.partition_key_size() > 1).explode());
+        });
     }
 
     bool operator==(const key_view& k) const = default;

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -412,7 +412,7 @@ public:
         if (!_is_mutation_end) {
             return proceed::yes;
         }
-        auto pk = partition_key::from_exploded(key.explode(*_schema));
+        auto pk = key.to_partition_key(*_schema);
         setup_for_partition(pk);
         auto dk = dht::decorate_key(*_schema, pk);
         _reader->on_next_partition(std::move(dk), tombstone(deltime));

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -309,7 +309,7 @@ public:
         if (!_is_mutation_end) {
             return data_consumer::proceed::yes;
         }
-        auto pk = partition_key::from_exploded(key.explode(*_schema));
+        auto pk = key.to_partition_key(*_schema);
         setup_for_partition(pk);
         auto dk = dht::decorate_key(*_schema, pk);
         _reader->on_next_partition(std::move(dk), tombstone(deltime));
@@ -1941,7 +1941,7 @@ public:
     }
 
     data_consumer::proceed consume_partition_start(sstables::key_view key, sstables::deletion_time deltime) {
-        auto pk = partition_key::from_exploded(key.explode(*_schema));
+        auto pk = key.to_partition_key(*_schema);
         auto dk = dht::decorate_key(*_schema, pk);
         _current_pos = position_in_partition(position_in_partition::partition_start_tag_t{});
         sstlog.trace("validating_consumer {}: {}({}) _expected_pkey={}", fmt::ptr(this), __FUNCTION__, pk, _expected_pkey);


### PR DESCRIPTION
key_view::explode() contains a blatant use-after-free: unless the input is already linearized, it returns a view to a local temporary buffer.

This is rare, because partition keys are usually not large enough to be fragmented. But for a sufficiently large key, this bug causes a corrupted partition_key down the line.

Fixes #17625