### PR TITLE
service: Drop unused table param from session_topology_guard

### DIFF
--- a/service/topology_guard.hh
+++ b/service/topology_guard.hh
@@ -39,9 +39,9 @@ session_manager& get_topology_session_manager();
 /// the guard's scope, then executing a token metadata barrier after invalidating the guard
 /// guarantees that there can be no side-effects from earlier stages.
 /// The token metadata barrier must contact all nodes which may have alive guards.
-template <typename T> concept TopologyGuard = requires(T guard, replica::table& t, frozen_topology_guard frozen_guard) {
+template <typename T> concept TopologyGuard = requires(T guard, frozen_topology_guard frozen_guard) {
     // Acquiring the guard.
-    { T(t, frozen_guard) } -> std::same_as<T>;
+    { T(frozen_guard) } -> std::same_as<T>;
 
     // Moving the guard.
     { T(std::move(guard)) } -> std::same_as<T>;
@@ -58,7 +58,7 @@ class session_topology_guard {
 public:
     using frozen = session_id;
 
-    session_topology_guard(replica::table& t, frozen_topology_guard g)
+    session_topology_guard(frozen_topology_guard g)
         : _guard(get_topology_session_manager().enter_session(g))
     { }
 

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -35,7 +35,7 @@ std::function<future<> (flat_mutation_reader_v2)> make_streaming_consumer(sstrin
             }
 
             auto cf = db.local().find_column_family(reader.schema()).shared_from_this();
-            auto guard = service::topology_guard(*cf, frozen_guard);
+            auto guard = service::topology_guard(frozen_guard);
             auto use_view_update_path = co_await db::view::check_needs_view_update_path(sys_dist_ks.local(), db.local().get_token_metadata(), *cf, reason);
             //FIXME: for better estimations this should be transmitted from remote
             auto metadata = mutation_source_metadata{};

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -128,7 +128,7 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
             };
             auto cmd_status = make_lw_shared<stream_mutation_fragments_cmd_status>();
             auto offstrategy_update = make_lw_shared<offstrategy_trigger>(_db, cf_id, plan_id);
-            auto guard = service::topology_guard(s->table(), topo_guard);
+            auto guard = service::topology_guard(topo_guard);
 
             // Will log a message when streaming is done. Used to synchronize tests.
             lw_shared_ptr<std::any> log_done;


### PR DESCRIPTION
The table param is not used. Dropping it so it can be used in places where the table object is not available.