### PR TITLE
storage_service::merge_topology_snapshot: handle big mutations

### DIFF
--- a/mutation/mutation.hh
+++ b/mutation/mutation.hh
@@ -461,3 +461,15 @@ template <> struct fmt::formatter<mutation> : fmt::formatter<std::string_view> {
 };
 
 std::ostream& operator<<(std::ostream& os, const mutation& m);
+
+// Splits the source mutation into multiple mutations so that their size
+// does not exceed the max_size limit.
+// The size of a mutation is calculated as the sum of the memory_usage()
+// of its constituent mutation_fragments.
+// The function doesn't split rows into cells, one big row can
+// lead to the creation of a mutation larger than max_size.
+// Due to the difference in calculating sizes for mutations and their fragments,
+// the actual size of the output mutation may be larger than max_size. It is recommended
+// to pass half of the required value as max_size; such a margin should ensure
+// that the condition is met.
+future<> split_mutation(mutation source, std::vector<mutation>& target, size_t max_size);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -731,27 +731,27 @@ future<> storage_service::topology_transition() {
 }
 
 future<> storage_service::merge_topology_snapshot(raft_topology_snapshot snp) {
-   std::vector<mutation> muts;
-   muts.reserve(snp.topology_mutations.size() + snp.cdc_generation_mutations.size() + snp.topology_requests_mutations.size());
-   {
-       auto s = _db.local().find_schema(db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY);
-       boost::transform(snp.topology_mutations, std::back_inserter(muts), [s] (const canonical_mutation& m) {
-           return m.to_mutation(s);
-       });
-   }
-   if (snp.cdc_generation_mutations.size() > 0) {
-       auto s = _db.local().find_schema(db::system_keyspace::NAME, db::system_keyspace::CDC_GENERATIONS_V3);
-       boost::transform(snp.cdc_generation_mutations, std::back_inserter(muts), [s] (const canonical_mutation& m) {
-           return m.to_mutation(s);
-       });
-   }
-   if (snp.topology_requests_mutations.size()) {
-       auto s = _db.local().find_schema(db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY_REQUESTS);
-       boost::transform(snp.topology_requests_mutations, std::back_inserter(muts), [s] (const canonical_mutation& m) {
-           return m.to_mutation(s);
-       });
-   }
-   co_await _db.local().apply(freeze(muts), db::no_timeout);
+    std::vector<mutation> muts;
+    muts.reserve(snp.topology_mutations.size() + snp.cdc_generation_mutations.size() + snp.topology_requests_mutations.size());
+    {
+        auto s = _db.local().find_schema(db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY);
+        boost::transform(snp.topology_mutations, std::back_inserter(muts), [s] (const canonical_mutation& m) {
+            return m.to_mutation(s);
+        });
+    }
+    if (snp.cdc_generation_mutations.size() > 0) {
+        auto s = _db.local().find_schema(db::system_keyspace::NAME, db::system_keyspace::CDC_GENERATIONS_V3);
+        boost::transform(snp.cdc_generation_mutations, std::back_inserter(muts), [s] (const canonical_mutation& m) {
+            return m.to_mutation(s);
+        });
+    }
+    if (snp.topology_requests_mutations.size()) {
+        auto s = _db.local().find_schema(db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY_REQUESTS);
+        boost::transform(snp.topology_requests_mutations, std::back_inserter(muts), [s] (const canonical_mutation& m) {
+            return m.to_mutation(s);
+        });
+    }
+    co_await _db.local().apply(freeze(muts), db::no_timeout);
 }
 
 // Moves the coroutine lambda onto the heap and extends its

--- a/test/topology_experimental_raft/test_cdc_generation_data.py
+++ b/test/topology_experimental_raft/test_cdc_generation_data.py
@@ -17,7 +17,9 @@ async def test_send_data_in_parts(manager: ManagerClient):
     first_server = await manager.server_add(config=config)
 
     async with inject_error(manager.api, first_server.ip_addr, 'cdc_generation_mutations_replication'):
-        await manager.server_add(config=config)
+        async with inject_error(manager.api, first_server.ip_addr,
+                                'cdc_generation_mutations_topology_snapshot_replication'):
+            await manager.server_add(config=config)
 
     await check_token_ring_and_group0_consistency(manager)
 


### PR DESCRIPTION
The group0 state machine calls `merge_topology_snapshot` from `transfer_snapshot`. It feeds it with `raft_topology_snapshot` returned from `raft_pull_topology_snapshot`. This snapshot includes the entire `system.cdc_generations_v3` table. It can be huge and break the commitlog `max_record_size` limit.

The `system.cdc_generations_v3` is a single-partition table, so all the data is contained in one mutation object. To fit the commitlog limit we split this mutation into many smaller ones and apply them in separate `database::apply` calls. That means we give up the atomicity guarantee, but we actually don't need it for `system.cdc_generations_v3` and `system.topology_requests`.

This PR fixes the dtest `update_cluster_layout_tests.py::TestLargeScaleCluster::test_add_many_nodes_under_load`

fixes #17545