### PR TITLE
docs: add experimental tag

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -167,3 +167,7 @@ html_baseurl = BASE_URL
 
 # Dictionary of values to pass into the template engine’s context for all pages
 html_context = {"html_baseurl": html_baseurl}
+
+def setup(app):
+    if 'opensource' in app.tags:
+        app.tags.add('experimental')


### PR DESCRIPTION
## Motivation

This PR introduces an alias for the `opensource` tag, labeling it as `experimental`. This change aims to streamline the maintenance and integration process of open-source content that may eventually be migrated to the enterprise repository.

## How to test this PR

1. Clone this PR.
2. Use the `only:: experimental` directive in a RST page. Example:

    ```
    .. only:: experimental
    
        Experimental content goes here.
    ```
3. Build the docs. You should see the experimental content on this repo.