### PR TITLE
Point to KB about RF update from ALTER KEYSPACE reference

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -289,6 +289,14 @@ For instance::
 
 The supported options are the same as :ref:`creating a keyspace <create-keyspace-statement>`.
 
+
+.. note::
+
+   To guarantee data consistency during RF alter:
+
+     * Increment or decrement RF per DC by **one** at a time.
+     * See :doc:`How to Safely Increase the Replication Factor </kb/rf-increase>`.
+
 .. _drop-keyspace-statement:
 
 DROP KEYSPACE

--- a/docs/kb/rf-increase.rst
+++ b/docs/kb/rf-increase.rst
@@ -27,6 +27,8 @@ As a result, in order to make sure that you can keep on reading the old data wit
 
 After you run a repair, you can decrease the CL. If RF has only been changed in a particular Data Center (DC) only the nodes in that DC have to be repaired.
 
+It is recommended to increment RF per a DC by **one** at a time.
+
 Example
 =======
 


### PR DESCRIPTION
This PR adds a two disclaimers to ALTER KEYSPCAE regarding RF update:
- Update RF by one per DC at a time
- Point to KB article How to Safely Increase the Replication Factor


related to https://github.com/scylladb/scylladb/issues/12224