### PR TITLE
db/hints: Fix too_many_in_flight_hints_for

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -353,7 +353,7 @@ bool manager::too_many_in_flight_hints_for(endpoint_id ep) const noexcept {
     // There is no need to check the DC here because if there is an in-flight hint for this
     // endpoint, then this means that its DC has already been checked and found to be ok.
     return _stats.size_of_hints_in_progress > MAX_SIZE_OF_HINTS_IN_PROGRESS
-            && _proxy.local_db().get_token_metadata().get_topology().is_me(ep)
+            && !_proxy.local_db().get_token_metadata().get_topology().is_me(ep)
             && hints_in_progress_for(ep) > 0
             && local_gossiper().get_endpoint_downtime(ep) <= _max_hint_window_us;
 }


### PR DESCRIPTION
The semantics of the function was accidentally
modified in 6e79d64. The consequence of the change
was that we didn't limit memory consumption:
the function always returned false for any node
different from the local node. The returned value
is used by storage_proxy to decide whether it
is able to store a hint or not.

This commit fixes the problem by taking other
nodes into consideration again.

Fixes #17636