### PR TITLE
[Backport 5.2] migration_manager: take group0 lock during raft snapshot taking

### DIFF
--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -124,7 +124,8 @@ void migration_manager::init_messaging_service()
         return netw::messaging_service::no_wait();
     });
     _messaging.register_migration_request([this] (const rpc::client_info& cinfo, rpc::optional<netw::schema_pull_options> options) {
-        return container().invoke_on(0, std::bind_front(
+        shard_id shard = (options && options->group0_snapshot_transfer) ? 0 : this_shard_id();
+        return container().invoke_on(shard, std::bind_front(
             [] (netw::msg_addr, rpc::optional<netw::schema_pull_options> options, migration_manager& self)
                 -> future<rpc::tuple<std::vector<frozen_mutation>, std::vector<canonical_mutation>>> {
             const auto cm_retval_supported = options && options->remote_supports_canonical_mutation_retval;

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -127,32 +127,32 @@ void migration_manager::init_messaging_service()
         return container().invoke_on(0, std::bind_front(
             [] (netw::msg_addr, rpc::optional<netw::schema_pull_options> options, migration_manager& self)
                 -> future<rpc::tuple<std::vector<frozen_mutation>, std::vector<canonical_mutation>>> {
-        const auto cm_retval_supported = options && options->remote_supports_canonical_mutation_retval;
+            const auto cm_retval_supported = options && options->remote_supports_canonical_mutation_retval;
 
-        auto features = self._feat.cluster_schema_features();
-        auto& proxy = self._storage_proxy.container();
-        semaphore_units<> guard;
-        if (options->group0_snapshot_transfer) {
-            guard = co_await self._group0_client.hold_read_apply_mutex(self._as);
-        }
-        auto cm = co_await db::schema_tables::convert_schema_to_mutations(proxy, features);
-        if (options->group0_snapshot_transfer) {
-            // if `group0_snapshot_transfer` is `true`, the sender must also understand canonical mutations
-            // (`group0_snapshot_transfer` was added more recently).
-            if (!cm_retval_supported) {
-                on_internal_error(mlogger,
-                    "migration request handler: group0 snapshot transfer requested, but canonical mutations not supported");
+            auto features = self._feat.cluster_schema_features();
+            auto& proxy = self._storage_proxy.container();
+            semaphore_units<> guard;
+            if (options->group0_snapshot_transfer) {
+                guard = co_await self._group0_client.hold_read_apply_mutex(self._as);
             }
-            cm.emplace_back(co_await db::system_keyspace::get_group0_history(proxy));
-        }
-        if (cm_retval_supported) {
-            co_return rpc::tuple(std::vector<frozen_mutation>{}, std::move(cm));
-        }
-        auto fm = boost::copy_range<std::vector<frozen_mutation>>(cm | boost::adaptors::transformed([&db = proxy.local().get_db().local()] (const canonical_mutation& cm) {
-            return cm.to_mutation(db.find_column_family(cm.column_family_id()).schema());
-        }));
-        co_return rpc::tuple(std::move(fm), std::move(cm));
-    }, netw::messaging_service::get_source(cinfo), std::move(options)));
+            auto cm = co_await db::schema_tables::convert_schema_to_mutations(proxy, features);
+            if (options->group0_snapshot_transfer) {
+                // if `group0_snapshot_transfer` is `true`, the sender must also understand canonical mutations
+                // (`group0_snapshot_transfer` was added more recently).
+                if (!cm_retval_supported) {
+                    on_internal_error(mlogger,
+                        "migration request handler: group0 snapshot transfer requested, but canonical mutations not supported");
+                }
+                cm.emplace_back(co_await db::system_keyspace::get_group0_history(proxy));
+            }
+            if (cm_retval_supported) {
+                co_return rpc::tuple(std::vector<frozen_mutation>{}, std::move(cm));
+            }
+            auto fm = boost::copy_range<std::vector<frozen_mutation>>(cm | boost::adaptors::transformed([&db = proxy.local().get_db().local()] (const canonical_mutation& cm) {
+                return cm.to_mutation(db.find_column_family(cm.column_family_id()).schema());
+            }));
+            co_return rpc::tuple(std::move(fm), std::move(cm));
+        }, netw::messaging_service::get_source(cinfo), std::move(options)));
     });
     _messaging.register_schema_check([this] {
         return make_ready_future<table_schema_version>(_storage_proxy.get_db().local().get_version());

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -130,6 +130,10 @@ void migration_manager::init_messaging_service()
 
         auto features = self._feat.cluster_schema_features();
         auto& proxy = self._storage_proxy.container();
+        semaphore_units<> guard;
+        if (options->group0_snapshot_transfer) {
+            guard = co_await self._group0_client.hold_read_apply_mutex(self._as);
+        }
         auto cm = co_await db::schema_tables::convert_schema_to_mutations(proxy, features);
         if (options->group0_snapshot_transfer) {
             // if `group0_snapshot_transfer` is `true`, the sender must also understand canonical mutations

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -378,6 +378,10 @@ future<> raft_group0_client::wait_until_group0_upgraded(abort_source& as) {
     }
 }
 
+future<semaphore_units<>> raft_group0_client::hold_read_apply_mutex(abort_source& as) {
+    return get_units(_read_apply_mutex, 1, as);
+}
+
 db::system_keyspace& raft_group0_client::sys_ks() {
     return _sys_ks;
 }

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -379,6 +379,10 @@ future<> raft_group0_client::wait_until_group0_upgraded(abort_source& as) {
 }
 
 future<semaphore_units<>> raft_group0_client::hold_read_apply_mutex(abort_source& as) {
+    if (this_shard_id() != 0) {
+        on_internal_error(logger, "hold_read_apply_mutex: must run on shard 0");
+    }
+
     return get_units(_read_apply_mutex, 1, as);
 }
 

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -166,6 +166,8 @@ public:
     // Wait until group 0 upgrade enters the `use_post_raft_procedures` state.
     future<> wait_until_group0_upgraded(abort_source&);
 
+    future<semaphore_units<>> hold_read_apply_mutex(abort_source&);
+
     db::system_keyspace& sys_ks();
 
     // for test only


### PR DESCRIPTION
This is a backport of 0c376043ebe0d72364ed45763b0717aa4bd1955e and follow-up fix 57b14580f0985e27e3700f9a4256bf9f663ef1c1 to 5.2.

We haven't identified any specific issues in test or field in 5.2/2023.1 releases, but the bug should be fixed either way, it might bite us in unexpected ways.