### PR TITLE
[Backport 5.4] migration_manager: take group0 lock during raft snapshot taking

### DIFF
--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -149,6 +149,10 @@ void migration_manager::init_messaging_service()
         auto features = self._feat.cluster_schema_features();
         auto& proxy = self._storage_proxy.container();
         auto& db = proxy.local().get_db();
+        semaphore_units<> guard;
+        if (options->group0_snapshot_transfer) {
+            guard = co_await self._group0_client.hold_read_apply_mutex(self._as);
+        }
         auto cm = co_await db::schema_tables::convert_schema_to_mutations(proxy, features);
         if (options->group0_snapshot_transfer) {
             // if `group0_snapshot_transfer` is `true`, the sender must also understand canonical mutations

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -145,38 +145,38 @@ void migration_manager::init_messaging_service()
         return container().invoke_on(0, std::bind_front(
             [] (netw::msg_addr, rpc::optional<netw::schema_pull_options> options, migration_manager& self)
                 -> future<rpc::tuple<std::vector<frozen_mutation>, std::vector<canonical_mutation>>> {
-        const auto cm_retval_supported = options && options->remote_supports_canonical_mutation_retval;
+            const auto cm_retval_supported = options && options->remote_supports_canonical_mutation_retval;
 
-        auto features = self._feat.cluster_schema_features();
-        auto& proxy = self._storage_proxy.container();
-        auto& db = proxy.local().get_db();
-        semaphore_units<> guard;
-        if (options->group0_snapshot_transfer) {
-            guard = co_await self._group0_client.hold_read_apply_mutex(self._as);
-        }
-        auto cm = co_await db::schema_tables::convert_schema_to_mutations(proxy, features);
-        if (options->group0_snapshot_transfer) {
-            // if `group0_snapshot_transfer` is `true`, the sender must also understand canonical mutations
-            // (`group0_snapshot_transfer` was added more recently).
-            if (!cm_retval_supported) {
-                on_internal_error(mlogger,
-                    "migration request handler: group0 snapshot transfer requested, but canonical mutations not supported");
+            auto features = self._feat.cluster_schema_features();
+            auto& proxy = self._storage_proxy.container();
+            auto& db = proxy.local().get_db();
+            semaphore_units<> guard;
+            if (options->group0_snapshot_transfer) {
+                guard = co_await self._group0_client.hold_read_apply_mutex(self._as);
             }
-            cm.emplace_back(co_await db::system_keyspace::get_group0_history(db));
-            if (proxy.local().local_db().get_config().check_experimental(db::experimental_features_t::feature::TABLETS)) {
-                for (auto&& m: co_await replica::read_tablet_mutations(db)) {
-                    cm.emplace_back(std::move(m));
+            auto cm = co_await db::schema_tables::convert_schema_to_mutations(proxy, features);
+            if (options->group0_snapshot_transfer) {
+                // if `group0_snapshot_transfer` is `true`, the sender must also understand canonical mutations
+                // (`group0_snapshot_transfer` was added more recently).
+                if (!cm_retval_supported) {
+                    on_internal_error(mlogger,
+                        "migration request handler: group0 snapshot transfer requested, but canonical mutations not supported");
+                }
+                cm.emplace_back(co_await db::system_keyspace::get_group0_history(db));
+                if (proxy.local().local_db().get_config().check_experimental(db::experimental_features_t::feature::TABLETS)) {
+                    for (auto&& m: co_await replica::read_tablet_mutations(db)) {
+                        cm.emplace_back(std::move(m));
+                    }
                 }
             }
-        }
-        if (cm_retval_supported) {
-            co_return rpc::tuple(std::vector<frozen_mutation>{}, std::move(cm));
-        }
-        auto fm = boost::copy_range<std::vector<frozen_mutation>>(cm | boost::adaptors::transformed([&db = db.local()] (const canonical_mutation& cm) {
-            return cm.to_mutation(db.find_column_family(cm.column_family_id()).schema());
-        }));
-        co_return rpc::tuple(std::move(fm), std::move(cm));
-    }, netw::messaging_service::get_source(cinfo), std::move(options)));
+            if (cm_retval_supported) {
+                co_return rpc::tuple(std::vector<frozen_mutation>{}, std::move(cm));
+            }
+            auto fm = boost::copy_range<std::vector<frozen_mutation>>(cm | boost::adaptors::transformed([&db = db.local()] (const canonical_mutation& cm) {
+                return cm.to_mutation(db.find_column_family(cm.column_family_id()).schema());
+            }));
+            co_return rpc::tuple(std::move(fm), std::move(cm));
+        }, netw::messaging_service::get_source(cinfo), std::move(options)));
     });
     _messaging.register_schema_check([this] {
         return make_ready_future<table_schema_version>(_storage_proxy.get_db().local().get_version());

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -141,8 +141,9 @@ void migration_manager::init_messaging_service()
         });
         return netw::messaging_service::no_wait();
     });
-    _messaging.register_migration_request(std::bind_front(
-            [] (migration_manager& self, const rpc::client_info& cinfo, rpc::optional<netw::schema_pull_options> options)
+    _messaging.register_migration_request([this] (const rpc::client_info& cinfo, rpc::optional<netw::schema_pull_options> options) {
+        return container().invoke_on(0, std::bind_front(
+            [] (netw::msg_addr, rpc::optional<netw::schema_pull_options> options, migration_manager& self)
                 -> future<rpc::tuple<std::vector<frozen_mutation>, std::vector<canonical_mutation>>> {
         const auto cm_retval_supported = options && options->remote_supports_canonical_mutation_retval;
 
@@ -175,7 +176,8 @@ void migration_manager::init_messaging_service()
             return cm.to_mutation(db.find_column_family(cm.column_family_id()).schema());
         }));
         co_return rpc::tuple(std::move(fm), std::move(cm));
-    }, std::ref(*this)));
+    }, netw::messaging_service::get_source(cinfo), std::move(options)));
+    });
     _messaging.register_schema_check([this] {
         return make_ready_future<table_schema_version>(_storage_proxy.get_db().local().get_version());
     });

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -423,6 +423,10 @@ future<semaphore_units<>> raft_group0_client::hold_read_apply_mutex() {
 }
 
 future<semaphore_units<>> raft_group0_client::hold_read_apply_mutex(abort_source& as) {
+    if (this_shard_id() != 0) {
+        on_internal_error(logger, "hold_read_apply_mutex: must run on shard 0");
+    }
+
     return get_units(_read_apply_mutex, 1, as);
 }
 


### PR DESCRIPTION
This is a backport of 0c376043ebe0d72364ed45763b0717aa4bd1955e and follow-up fix 57b14580f0985e27e3700f9a4256bf9f663ef1c1 to 5.4.

We haven't identified any specific issues in test or field in 5.4/2024.1 releases, but the bug should be fixed either way, it might bite us in unexpected ways.

For 5.4 it's even more important than 5.2 because in 5.4 in Raft mode schema pulls are disabled.