### PR TITLE
scripts/open-coredump.sh: calculate MAIN_BRANCH before cloning repo

### DIFF
--- a/scripts/open-coredump.sh
+++ b/scripts/open-coredump.sh
@@ -270,10 +270,17 @@ else
     log "Relocatable package ${PACKAGE_URL} already downloaded and extracted"
 fi
 
+if [[ "${PRODUCT}" == "scylla-enterprise" ]]
+then
+    MAIN_BRANCH=enterprise
+else
+    MAIN_BRANCH=master
+fi
+
 COMMIT_HASH=$(cut -f3 -d. <<< $RELEASE)
 if [ "$(grep -o ~dev <<< $VERSION)" == "~dev" ]
 then
-    BRANCH=master
+    BRANCH=${MAIN_BRANCH}
 else
     BASE_VERSION=$(grep -o "^[0-9]\+\.[0-9]\+" <<< $VERSION)
     BRANCH=branch-${BASE_VERSION}
@@ -302,13 +309,6 @@ if ! [[ -f ${COREDIR}/scylla-gdb.py ]]
 then
     if [[ "${SCYLLA_GDB_PY_SOURCE}" == "repo" ]]
     then
-        if [[ "${PRODUCT}" == "scylla-enterprise" ]]
-        then
-            MAIN_BRANCH=enterprise
-        else
-            MAIN_BRANCH=master
-        fi
-
         WORKDIR=$(pwd)
         cd ${SCYLLA_REPO_PATH}
         git checkout -q $MAIN_BRANCH


### PR DESCRIPTION
We need MAIN_BRANCH calculated earlier so we can use it to checkout the right branch when cloning the src repo (either `master` or `enterprise`, based on the detected `PRODUCT`)