### PR TITLE
build: cmake: use scylla build mode for rust profile name 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ include(mode.common)
 if(CMAKE_CONFIGURATION_TYPES)
     foreach(config ${CMAKE_CONFIGURATION_TYPES})
         include(mode.${config})
-        list(APPEND scylla_build_modes ${scylla_build_mode})
+        list(APPEND scylla_build_modes ${scylla_build_mode_${config}})
     endforeach()
     add_custom_target(mode_list
         COMMAND ${CMAKE_COMMAND} -E echo "$<JOIN:${scylla_build_modes}, >"

--- a/cmake/mode.Coverage.cmake
+++ b/cmake/mode.Coverage.cmake
@@ -7,9 +7,9 @@ update_cxx_flags(CMAKE_CXX_FLAGS_COVERAGE
   WITH_DEBUG_INFO
   OPTIMIZATION_LEVEL "g")
 
-set(scylla_build_mode "coverage")
+set(scylla_build_mode_Coverage "coverage")
 set(Seastar_DEFINITIONS_COVERAGE
-  SCYLLA_BUILD_MODE=${scylla_build_mode}
+  SCYLLA_BUILD_MODE=${scylla_build_mode_Coverage}
   DEBUG
   SANITIZE
   DEBUG_LSA_SANITIZER

--- a/cmake/mode.Debug.cmake
+++ b/cmake/mode.Debug.cmake
@@ -9,9 +9,9 @@ update_cxx_flags(CMAKE_CXX_FLAGS_DEBUG
   WITH_DEBUG_INFO
   OPTIMIZATION_LEVEL ${OptimizationLevel})
 
-set(scylla_build_mode "debug")
+set(scylla_build_mode_Debug "debug")
 set(Seastar_DEFINITIONS_DEBUG
-  SCYLLA_BUILD_MODE=${scylla_build_mode}
+  SCYLLA_BUILD_MODE=${scylla_build_mode_Debug}
   DEBUG
   SANITIZE
   DEBUG_LSA_SANITIZER

--- a/cmake/mode.Dev.cmake
+++ b/cmake/mode.Dev.cmake
@@ -6,9 +6,9 @@ set(CMAKE_CXX_FLAGS_DEV
 update_cxx_flags(CMAKE_CXX_FLAGS_DEV
   OPTIMIZATION_LEVEL "2")
 
-set(scylla_build_mode "dev")
+set(scylla_build_mode_Dev "dev")
 set(Seastar_DEFINITIONS_DEV
-  SCYLLA_BUILD_MODE=${scylla_build_mode}
+  SCYLLA_BUILD_MODE=${scylla_build_mode_Dev}
   DEVEL
   SEASTAR_ENABLE_ALLOC_FAILURE_INJECTION
   SCYLLA_ENABLE_ERROR_INJECTION)

--- a/cmake/mode.RelWithDebInfo.cmake
+++ b/cmake/mode.RelWithDebInfo.cmake
@@ -12,9 +12,9 @@ update_cxx_flags(CMAKE_CXX_FLAGS_RELWITHDEBINFO
   WITH_DEBUG_INFO
   OPTIMIZATION_LEVEL "3")
 
-set(scylla_build_mode "release")
+set(scylla_build_mode_RelWithDebInfo "release")
 add_compile_definitions(
-    $<$<CONFIG:RelWithDebInfo>:SCYLLA_BUILD_MODE=${scylla_build_mode}>)
+    $<$<CONFIG:RelWithDebInfo>:SCYLLA_BUILD_MODE=${scylla_build_mode_RelWithDebInfo}>)
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
   set(clang_inline_threshold 300)

--- a/cmake/mode.Sanitize.cmake
+++ b/cmake/mode.Sanitize.cmake
@@ -7,9 +7,9 @@ update_cxx_flags(CMAKE_CXX_FLAGS_SANITIZE
   WITH_DEBUG_INFO
   OPTIMIZATION_LEVEL "s")
 
-set(scylla_build_mode "sanitize")
+set(scylla_build_mode_Sanitize "sanitize")
 set(Seastar_DEFINITIONS_SANITIZE
-  SCYLLA_BUILD_MODE=${scylla_build_mode}
+  SCYLLA_BUILD_MODE=${scylla_build_mode_Sanitize}
   DEBUG
   SANITIZE
   DEBUG_LSA_SANITIZER

--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -2,14 +2,21 @@ find_program(CARGO cargo
   REQUIRED)
 
 function(add_rust_library name)
-  # use for profiles defined in Cargo.toml
-  set(mode $<LOWER_CASE:$<CONFIG>>)
+  # used for profiles defined in Cargo.toml
+  if(CMAKE_CONFIGURATION_TYPES)
+    foreach(config ${CMAKE_CONFIGURATION_TYPES})
+      string(APPEND build_mode
+        "$<$<CONFIG:${config}>:${scylla_build_mode_${config}}>")
+    endforeach()
+  else()
+    set(build_mode ${scylla_build_mode_${config}})
+  endif()
+  set(profile "rust-${build_mode}")
   set(target_dir ${CMAKE_CURRENT_BINARY_DIR})
-  set(profile "rust-${mode}")
   set(library ${target_dir}/lib${name}.a)
   add_custom_command(
     OUTPUT ${library}
-    COMMAND ${CMAKE_COMMAND} -E env CARGO_BUILD_DEP_INFO_BASEDIR=. ${CARGO} build --locked --target-dir=${target_dir} --profile=rust-${mode}
+    COMMAND ${CMAKE_COMMAND} -E env CARGO_BUILD_DEP_INFO_BASEDIR=. ${CARGO} build --locked --target-dir=${target_dir} --profile=${profile}
     COMMAND ${CMAKE_COMMAND} -E copy ${target_dir}/${profile}/lib${name}.a ${library}
     DEPENDS Cargo.lock
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
before this change, we used the lower-case CMake build configuration
name for the rust profile names. but this was wrong, because the
profiles are named with the scylla build mode.

in this change, we translate the `$<CONFIG>` to scylla build mode,
and use it for the profile name and for the output directory of
the built library.