### PR TITLE
tombstone_gc_options: add fmt::formatter for tombstone_gc_mode

### DIFF
--- a/tombstone_gc_options.cc
+++ b/tombstone_gc_options.cc
@@ -56,12 +56,14 @@ seastar::sstring tombstone_gc_options::to_sstring() const {
     return rjson::print(rjson::from_string_map(to_map()));
 }
 
-std::ostream& operator<<(std::ostream& os, const tombstone_gc_mode& mode) {
+auto fmt::formatter<tombstone_gc_mode>::format(tombstone_gc_mode mode, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    std::string_view name = "unknown";
     switch (mode) {
-    case tombstone_gc_mode::timeout:     return os << "timeout";
-    case tombstone_gc_mode::disabled:    return os << "disabled";
-    case tombstone_gc_mode::immediate:   return os << "immediate";
-    case tombstone_gc_mode::repair:      return os << "repair";
+    case tombstone_gc_mode::timeout:     name = "timeout"; break;
+    case tombstone_gc_mode::disabled:    name = "disabled"; break;
+    case tombstone_gc_mode::immediate:   name = "immediate"; break;
+    case tombstone_gc_mode::repair:      name = "repair"; break;
     }
-    return os << "unknown";
+    return formatter<std::string_view>::format(name, ctx);
 }

--- a/tombstone_gc_options.hh
+++ b/tombstone_gc_options.hh
@@ -10,6 +10,7 @@
 
 #include <map>
 #include <chrono>
+#include <fmt/core.h>
 #include <seastar/core/sstring.hh>
 
 enum class tombstone_gc_mode : uint8_t { timeout, disabled, immediate, repair };
@@ -30,4 +31,6 @@ public:
     bool operator==(const tombstone_gc_options&) const = default;
 };
 
-std::ostream& operator<<(std::ostream& os, const tombstone_gc_mode& m);
+template <> struct fmt::formatter<tombstone_gc_mode> : fmt::formatter<std::string_view> {
+    auto format(tombstone_gc_mode mode, fmt::format_context& ctx) const -> decltype(ctx.out());
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `tombstone_gc_mode`, and drop its operator<<.

Refs #13245