### PR TITLE
 tools/scylla-nodetool: repair: abort on first failed repair

### DIFF
--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -210,9 +210,12 @@ def nodetool(request, jmx, nodetool_path, rest_api_mock_server):
             expected_requests = [r for r in rest_api_mock.get_expected_requests(rest_api_mock_server)
                                  if not r.exhausted()]
 
+            unexpected_requests = rest_api_mock.get_unexpected_requests(rest_api_mock_server)
+
             # Check the return-code first, if the command failed probably not all requests were consumed
             res.check_returncode()
             assert len(expected_requests) == 0, ''.join(str(r) for r in expected_requests)
+            assert unexpected_requests == 0
 
             return res.stdout
 

--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -191,7 +191,7 @@ def cassandra_only(request):
 
 @pytest.fixture(scope="module")
 def nodetool(request, jmx, nodetool_path, rest_api_mock_server):
-    def invoker(method, *args, expected_requests=None):
+    def invoker(method, *args, expected_requests=None, check_return_code=True):
         with rest_api_mock.expected_requests(rest_api_mock_server, expected_requests or []):
             if request.config.getoption("nodetool") == "scylla":
                 api_ip, api_port = rest_api_mock_server
@@ -213,7 +213,8 @@ def nodetool(request, jmx, nodetool_path, rest_api_mock_server):
             unexpected_requests = rest_api_mock.get_unexpected_requests(rest_api_mock_server)
 
             # Check the return-code first, if the command failed probably not all requests were consumed
-            res.check_returncode()
+            if check_return_code:
+                res.check_returncode()
             assert len(expected_requests) == 0, ''.join(str(r) for r in expected_requests)
             assert unexpected_requests == 0
 

--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -217,6 +217,6 @@ def nodetool(request, jmx, nodetool_path, rest_api_mock_server):
             assert len(expected_requests) == 0, ''.join(str(r) for r in expected_requests)
             assert unexpected_requests == 0
 
-            return res.stdout
+            return res
 
     return invoker

--- a/test/nodetool/test_backup.py
+++ b/test/nodetool/test_backup.py
@@ -18,10 +18,10 @@ def test_enablebackup(nodetool):
 
 
 def test_statusbackup(nodetool):
-    out = nodetool("statusbackup", expected_requests=[
+    res = nodetool("statusbackup", expected_requests=[
         expected_request("GET", "/storage_service/incremental_backups", response=False)])
-    assert out == "not running\n"
+    assert res.stdout == "not running\n"
 
-    out = nodetool("statusbackup", expected_requests=[
+    res = nodetool("statusbackup", expected_requests=[
         expected_request("GET", "/storage_service/incremental_backups", response=True)])
-    assert out == "running\n"
+    assert res.stdout == "running\n"

--- a/test/nodetool/test_binary.py
+++ b/test/nodetool/test_binary.py
@@ -18,10 +18,10 @@ def test_enablebinary(nodetool):
 
 
 def test_statusbinary(nodetool):
-    out = nodetool("statusbinary", expected_requests=[
+    res = nodetool("statusbinary", expected_requests=[
         expected_request("GET", "/storage_service/native_transport", response=False)])
-    assert out == "not running\n"
+    assert res.stdout == "not running\n"
 
-    out = nodetool("statusbinary", expected_requests=[
+    res = nodetool("statusbinary", expected_requests=[
         expected_request("GET", "/storage_service/native_transport", response=True)])
-    assert out == "running\n"
+    assert res.stdout == "running\n"

--- a/test/nodetool/test_compact.py
+++ b/test/nodetool/test_compact.py
@@ -37,8 +37,7 @@ def test_nonexistent_keyspace(nodetool):
             ("compact", "non_existent_ks"),
             {"expected_requests": [
                 expected_request("GET", "/storage_service/keyspaces", multiple=expected_request.MULTIPLE,
-                                 response=["system"]),
-                expected_request("POST", "/storage_service/keyspace_compaction/non_existent_ks")]},
+                                 response=["system"])]},
             ["nodetool: Keyspace [non_existent_ks] does not exist.",
              "error processing arguments: keyspace non_existent_ks does not exist"])
 

--- a/test/nodetool/test_compactionhistory.py
+++ b/test/nodetool/test_compactionhistory.py
@@ -65,9 +65,9 @@ edde9300-5e9c-11ee-a8f6-7d85dcfeb8f4 system        peers             {}    11714
         res = nodetool(*cmd, expected_requests=[EXPECTED_REQUEST])
 
         if request.config.getoption("nodetool") == "scylla":
-            assert res == expected_res_scylla
+            assert res.stdout == expected_res_scylla
         else:
-            assert res == expected_res_cassandra
+            assert res.stdout == expected_res_cassandra
 
 
 def test_json(nodetool):
@@ -97,7 +97,7 @@ def test_json(nodetool):
     for cmd in [("compactionhistory", "--format", "json"), ("compactionhistory", "-F", "json")]:
         res = nodetool(*cmd, expected_requests=[EXPECTED_REQUEST])
 
-        assert json.loads(res) == expected_res
+        assert json.loads(res.stdout) == expected_res
 
 
 def test_yaml(nodetool):
@@ -127,7 +127,7 @@ def test_yaml(nodetool):
     for cmd in [("compactionhistory", "--format", "yaml"), ("compactionhistory", "-F", "yaml")]:
         res = nodetool(*cmd, expected_requests=[EXPECTED_REQUEST])
 
-        assert yaml.load(res, Loader=yaml.Loader) == expected_res
+        assert yaml.load(res.stdout, Loader=yaml.Loader) == expected_res
 
 
 def test_invalid_format(nodetool):

--- a/test/nodetool/test_compactionstats.py
+++ b/test/nodetool/test_compactionstats.py
@@ -65,7 +65,8 @@ def test_compactionstats(nodetool, request, num_compactions, throughput):
         expected_requests.append(
             expected_request("GET", "/storage_service/compaction_throughput",
                              response=throughput))
-    actual_output = nodetool("compactionstats", expected_requests=expected_requests)
+    res = nodetool("compactionstats", expected_requests=expected_requests)
+    actual_output = res.stdout
     expected_output = f"pending tasks: {num_compactions}\n"
     for task in pending_tasks:
         expected_output += format_task(task)

--- a/test/nodetool/test_describecluster.py
+++ b/test/nodetool/test_describecluster.py
@@ -53,12 +53,13 @@ def test_describecluster(nodetool, num_schema_versions, num_schema_versions_host
         schema_versions_fmt += f"{version}: [{hosts}]\n\n"
     schema_versions_fmt = indent(schema_versions_fmt, "\t")
 
-    actual_output = nodetool("describecluster", expected_requests=[
+    res = nodetool("describecluster", expected_requests=[
         expected_request("GET", "/storage_service/cluster_name", response=cluster_name),
         expected_request("GET", "/snitch/name", response=snitch_name),
         expected_request("GET", "/storage_service/partitioner_name", response=partitioner),
         expected_request("GET", "/storage_proxy/schema_versions", response=schema_versions),
     ])
+    actual_output = res.stdout
 
     expected_cluster_info = indent(f"""\
 Name: {cluster_name}

--- a/test/nodetool/test_describering.py
+++ b/test/nodetool/test_describering.py
@@ -54,7 +54,7 @@ def test_describering(nodetool):
     res = nodetool("describering", "ks", expected_requests=[
         expected_request("GET", "/storage_service/schema_version", response=schema_version),
         expected_request("GET", "/storage_service/describe_ring/ks", response=ring)])
-    assert res == f"""Schema Version:{schema_version}
+    assert res.stdout == f"""Schema Version:{schema_version}
 TokenRange: 
 \tTokenRange(start_token:-9153143965931359657, end_token:-9105705820509211664, endpoints:[127.0.0.1, 127.0.0.2], rpc_endpoints:[127.0.0.1, 127.0.0.2], endpoint_details:[EndpointDetails(host:127.0.0.1, datacenter:datacenter1, rack:rack1), EndpointDetails(host:127.0.0.2, datacenter:datacenter2, rack:rack2)])
 \tTokenRange(start_token:9213626581013704850, end_token:-9153143965931359657, endpoints:[127.0.0.1], rpc_endpoints:[127.0.0.1], endpoint_details:[EndpointDetails(host:127.0.0.1, datacenter:datacenter1, rack:rack1)])
@@ -84,7 +84,7 @@ def test_describering_table(nodetool, scylla_only):
     res = nodetool("describering", "ks", "tbl", expected_requests=[
         expected_request("GET", "/storage_service/schema_version", response=schema_version),
         expected_request("GET", "/storage_service/describe_ring/ks", params={"table": "tbl"}, response=ring)])
-    assert res == f"""Schema Version:{schema_version}
+    assert res.stdout == f"""Schema Version:{schema_version}
 TokenRange: 
 \tTokenRange(start_token:9213626581013704850, end_token:-9153143965931359657, endpoints:[127.0.0.1], rpc_endpoints:[127.0.0.1], endpoint_details:[EndpointDetails(host:127.0.0.1, datacenter:datacenter1, rack:rack1)])
 """

--- a/test/nodetool/test_getendpoints.py
+++ b/test/nodetool/test_getendpoints.py
@@ -14,11 +14,12 @@ def test_getendpoints(nodetool, num_endpoints):
     table = 'cf0'
     key = '42'
     endpoints = [f"127.0.0.{i}" for i in range(num_endpoints)]
-    actual_output = nodetool("getendpoints", keyspace, table, key, expected_requests=[
+    res = nodetool("getendpoints", keyspace, table, key, expected_requests=[
         expected_request("GET", f"/storage_service/natural_endpoints/{keyspace}",
                          params={"cf": table, "key": key},
                          response=endpoints),
     ])
+    actual_output = res.stdout
 
     expected_output = ''.join(f"{endpoint}\n" for endpoint in endpoints)
     assert actual_output == expected_output

--- a/test/nodetool/test_gossip.py
+++ b/test/nodetool/test_gossip.py
@@ -18,10 +18,10 @@ def test_enablegossip(nodetool):
 
 
 def test_statusgossip(nodetool):
-    out = nodetool("statusgossip", expected_requests=[
+    res = nodetool("statusgossip", expected_requests=[
         expected_request("GET", "/storage_service/gossiping", response=False)])
-    assert out == "not running\n"
+    assert res.stdout == "not running\n"
 
-    out = nodetool("statusgossip", expected_requests=[
+    res = nodetool("statusgossip", expected_requests=[
         expected_request("GET", "/storage_service/gossiping", response=True)])
-    assert out == "running\n"
+    assert res.stdout == "running\n"

--- a/test/nodetool/test_gossipinfo.py
+++ b/test/nodetool/test_gossipinfo.py
@@ -123,9 +123,10 @@ def format_endpoint_info(endpoint):
 @pytest.mark.parametrize("num_endpoints", [1, 2])
 def test_gossipinfo(nodetool, num_endpoints):
     endpoints = [create_endpoint_info(i) for i in range(num_endpoints)]
-    actual_output = nodetool('gossipinfo', expected_requests=[
+    res = nodetool('gossipinfo', expected_requests=[
         expected_request('GET', '/failure_detector/endpoints',
                          response=[endpoint_to_jsonable(endpoint) for endpoint in endpoints])
     ])
+    actual_output = res.stdout
     expected_output = ''.join(format_endpoint_info(endpoint) for endpoint in endpoints)
     assert normalize_endpoints(actual_output) == normalize_endpoints(expected_output)

--- a/test/nodetool/test_help.py
+++ b/test/nodetool/test_help.py
@@ -15,18 +15,18 @@ import utils
 
 
 def test_help(nodetool):
-    out = nodetool("help", expected_requests=[
+    res = nodetool("help", expected_requests=[
         # These requests are sometimes sent by Cassandra nodetool when invoking help
         # This looks like a new connection to JMX.
         expected_request("GET", "/column_family/", response=[], multiple=expected_request.ANY),
         expected_request("GET", "/stream_manager/", response=[], multiple=expected_request.ANY),
     ])
-    assert out
+    assert res.stdout
 
 
 def test_help_command(nodetool):
-    out = nodetool("help", "version")
-    assert out
+    res = nodetool("help", "version")
+    assert res.stdout
 
 
 def test_help_nonexistent_command(request, nodetool):
@@ -37,8 +37,8 @@ def test_help_nonexistent_command(request, nodetool):
                 {},
                 ["error processing arguments: unknown command foo"])
     else:
-        out = nodetool("help", "foo")
-        assert out == "Unknown command foo\n\n"
+        res = nodetool("help", "foo")
+        assert res.stdout == "Unknown command foo\n\n"
 
 
 def test_help_command_too_many_args(nodetool, scylla_only):
@@ -51,10 +51,10 @@ def test_help_command_too_many_args(nodetool, scylla_only):
 
 def test_help_consistent(nodetool, scylla_only):
     for command in ("version", "compact", "settraceprobability"):
-        out1 = nodetool("help", command)
+        res1 = nodetool("help", command)
         # seastar returns 1 when --help is invoked
         with pytest.raises(subprocess.CalledProcessError) as e:
             nodetool(command, "--help")
         assert e.value.returncode == 1
         out2 = e.value.stdout
-        assert out1 == out2
+        assert res1.stdout == out2

--- a/test/nodetool/test_help.py
+++ b/test/nodetool/test_help.py
@@ -5,6 +5,7 @@
 #
 
 import pytest
+from rest_api_mock import expected_request
 import subprocess
 
 import utils
@@ -14,7 +15,12 @@ import utils
 
 
 def test_help(nodetool):
-    out = nodetool("help")
+    out = nodetool("help", expected_requests=[
+        # These requests are sometimes sent by Cassandra nodetool when invoking help
+        # This looks like a new connection to JMX.
+        expected_request("GET", "/column_family/", response=[], multiple=expected_request.ANY),
+        expected_request("GET", "/stream_manager/", response=[], multiple=expected_request.ANY),
+    ])
     assert out
 
 

--- a/test/nodetool/test_info.py
+++ b/test/nodetool/test_info.py
@@ -210,5 +210,5 @@ def test_info(request, nodetool, display_all_tokens):
     args = []
     if display_all_tokens:
         args.append('--tokens')
-    actual_output = nodetool("info", *args, expected_requests=expected_requests)
-    assert normalize_output(actual_output) == normalize_output(expected_output)
+    res = nodetool("info", *args, expected_requests=expected_requests)
+    assert normalize_output(res.stdout) == normalize_output(expected_output)

--- a/test/nodetool/test_logging.py
+++ b/test/nodetool/test_logging.py
@@ -13,7 +13,7 @@ def test_getlogginglevels(nodetool):
         expected_request("GET", "/storage_service/logging_level",
                          response=[{"key": "sstable", "value": "info"}, {"key": "cache", "value": "trace"}])])
 
-    assert res == \
+    assert res.stdout == \
 """
 Logger Name                                        Log Level
 sstable                                                 info

--- a/test/nodetool/test_netstats.py
+++ b/test/nodetool/test_netstats.py
@@ -402,7 +402,7 @@ def test_netstats(nodetool, flag):
     res = nodetool(*args, expected_requests=expected_requests)
 
     _check_output(
-            res,
+            res.stdout,
             human_readable,
             mode,
             streams,

--- a/test/nodetool/test_nodeops.py
+++ b/test/nodetool/test_nodeops.py
@@ -54,14 +54,14 @@ def test_removenode_ignore_nodes_two_nodes(nodetool):
 def test_removenode_status(nodetool):
     res = nodetool("removenode", "status", expected_requests=[
         expected_request("GET", "/storage_service/removal_status", response="SOME STATUS")])
-    assert res == "RemovalStatus: SOME STATUS\n"
+    assert res.stdout == "RemovalStatus: SOME STATUS\n"
 
 
 def test_removenode_force(nodetool):
     res = nodetool("removenode", "force", expected_requests=[
         expected_request("GET", "/storage_service/removal_status", response="SOME STATUS"),
         expected_request("POST", "/storage_service/force_remove_completion")])
-    assert res == "RemovalStatus: SOME STATUS\n"
+    assert res.stdout == "RemovalStatus: SOME STATUS\n"
 
 
 def test_removenode_status_with_ignore_dead_nodes(nodetool, scylla_only):

--- a/test/nodetool/test_proxyhistograms.py
+++ b/test/nodetool/test_proxyhistograms.py
@@ -38,7 +38,7 @@ def test_proxyhistograms(nodetool):
 
     res = nodetool("proxyhistograms", expected_requests=expected_requests)
 
-    assert res == """proxy histograms
+    assert res.stdout == """proxy histograms
 Percentile       Read Latency      Write Latency      Range Latency   CAS Read Latency  CAS Write Latency View Write Latency
                      (micros)           (micros)           (micros)           (micros)           (micros)           (micros)
 50%                     32.00              31.50              32.00              33.00              33.00               4.00
@@ -71,7 +71,7 @@ def test_proxyhistograms_empty_histogram(nodetool):
 
     res = nodetool("proxyhistograms", expected_requests=expected_requests)
 
-    assert res == """proxy histograms
+    assert res.stdout == """proxy histograms
 Percentile       Read Latency      Write Latency      Range Latency   CAS Read Latency  CAS Write Latency View Write Latency
                      (micros)           (micros)           (micros)           (micros)           (micros)           (micros)
 50%                      0.00               0.00               0.00               0.00               0.00               0.00

--- a/test/nodetool/test_repair.py
+++ b/test/nodetool/test_repair.py
@@ -68,7 +68,7 @@ def test_repair_all_single_keyspace(nodetool):
             response=1),
         expected_request("GET", "/storage_service/repair_async/ks1", params={"id": "1"}, response="SUCCESSFUL")])
 
-    assert _remove_log_timestamp(res) == """\
+    assert _remove_log_timestamp(res.stdout) == """\
 Starting repair command #1, repairing 1 ranges for keyspace ks1 (parallelism=SEQUENTIAL, full=true)
 Repair session 1
 Repair session 1 finished
@@ -112,7 +112,7 @@ def test_repair_all_two_keyspaces(nodetool):
             response=4),
         expected_request("GET", "/storage_service/repair_async/ks2", params={"id": "4"}, response="SUCCESSFUL")])
 
-    assert _remove_log_timestamp(res) == """\
+    assert _remove_log_timestamp(res.stdout) == """\
 Starting repair command #3, repairing 1 ranges for keyspace ks1 (parallelism=SEQUENTIAL, full=true)
 Repair session 3
 Repair session 3 finished
@@ -141,7 +141,7 @@ def test_repair_keyspace(nodetool):
             response=1),
         expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="SUCCESSFUL")])
 
-    assert _remove_log_timestamp(res) == """\
+    assert _remove_log_timestamp(res.stdout) == """\
 Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
 Repair session 1
 Repair session 1 finished
@@ -168,7 +168,7 @@ def test_repair_one_table(nodetool):
             response=1),
         expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="SUCCESSFUL")])
 
-    assert _remove_log_timestamp(res) == """\
+    assert _remove_log_timestamp(res.stdout) == """\
 Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
 Repair session 1
 Repair session 1 finished
@@ -195,7 +195,7 @@ def test_repair_two_tables(nodetool):
             response=1),
         expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="SUCCESSFUL")])
 
-    assert _remove_log_timestamp(res) == """\
+    assert _remove_log_timestamp(res.stdout) == """\
 Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
 Repair session 1
 Repair session 1 finished
@@ -223,7 +223,7 @@ def test_repair_long_progress(nodetool):
         expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="RUNNING"),
         expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="SUCCESSFUL")])
 
-    assert _remove_log_timestamp(res) == """\
+    assert _remove_log_timestamp(res.stdout) == """\
 Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
 Repair session 1
 Repair session 1 finished
@@ -359,7 +359,7 @@ def _do_test_repair_options(
 
     res = nodetool(*args, expected_requests=expected_requests)
 
-    assert _remove_log_timestamp(res) == """\
+    assert _remove_log_timestamp(res.stdout) == """\
 Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
 Repair session 1
 Repair session 1 finished
@@ -432,7 +432,7 @@ def test_repair_parallelism_precedence(nodetool):
             response=1),
         expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="SUCCESSFUL")])
 
-    assert _remove_log_timestamp(res) == """\
+    assert _remove_log_timestamp(res.stdout) == """\
 Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
 Repair session 1
 Repair session 1 finished
@@ -460,7 +460,7 @@ def test_repair_dc_precedence(nodetool):
             response=1),
         expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="SUCCESSFUL")])
 
-    assert _remove_log_timestamp(res) == """\
+    assert _remove_log_timestamp(res.stdout) == """\
 Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
 Repair session 1
 Repair session 1 finished
@@ -501,7 +501,7 @@ def test_repair_unused_options(request, nodetool, jobs, full):
             response=1),
         expected_request("GET", "/storage_service/repair_async/ks", params={"id": "1"}, response="SUCCESSFUL")])
 
-    assert _remove_log_timestamp(res) == """\
+    assert _remove_log_timestamp(res.stdout) == """\
 Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
 Repair session 1
 Repair session 1 finished

--- a/test/nodetool/test_ring.py
+++ b/test/nodetool/test_ring.py
@@ -140,7 +140,8 @@ def test_ring(request, nodetool, keyspace, resolve_ip, host_status, host_state):
         args.append(keyspace)
     if resolve_ip:
         args.append(resolve_ip)
-    actual_output = nodetool('ring', *args, expected_requests=expected_requests)
+    res = nodetool('ring', *args, expected_requests=expected_requests)
+    actual_output = res.stdout
 
     expected_output = f'''
 Datacenter: {host.dc}

--- a/test/nodetool/test_ring.py
+++ b/test/nodetool/test_ring.py
@@ -13,6 +13,10 @@ from rest_api_mock import expected_request
 from utils import format_size
 
 
+null_ownership_error = ("Non-system keyspaces don't have the same replication settings, "
+                        "effective ownership information is meaningless")
+
+
 class Host(NamedTuple):
     dc: str
     rack: str
@@ -99,6 +103,13 @@ def test_ring(request, nodetool, keyspace, resolve_ip, host_status, host_state):
         # specified
         pass
     else:
+        expected_requests.append(
+            expected_request(
+                    "GET",
+                    "/storage_service/ownership/null",
+                    response_status=500,
+                    multiple=expected_request.ANY,
+                    response={"message": f"std::runtime_error({null_ownership_error})", "code": 500}))
         expected_requests.append(
             expected_request('GET', f'/storage_service/ownership/{keyspace}',
                              response=map_to_json(endpoint_to_ownership, str)))

--- a/test/nodetool/test_snapshot.py
+++ b/test/nodetool/test_snapshot.py
@@ -87,7 +87,7 @@ Snapshot name Keyspace name Column family name True size Size on disk
 Total TrueDiskSpaceUsed: 923.08 KiB
 
 """
-    assert res == expected_output
+    assert res.stdout == expected_output
 
 
 def test_listsnapshots_no_snapshots(nodetool, request):
@@ -95,9 +95,9 @@ def test_listsnapshots_no_snapshots(nodetool, request):
         expected_request("GET", "/storage_service/snapshots", response=[]),
         ])
     if request.config.getoption("nodetool") == "scylla":
-        assert res == "There are no snapshots\n"
+        assert res.stdout == "There are no snapshots\n"
     else:
-        assert res == "Snapshot Details: \nThere are no snapshots\n"
+        assert res.stdout == "Snapshot Details: \nThere are no snapshots\n"
 
 
 def check_snapshot_out(res, tag, ktlist, skip_flush):
@@ -141,13 +141,13 @@ def test_snapshot_keyspace(nodetool):
         expected_request("POST", "/storage_service/snapshots",
                          params={"tag": tag, "sf": "false", "kn": "ks1"})
     ])
-    check_snapshot_out(res, tag, ["ks1"], False)
+    check_snapshot_out(res.stdout, tag, ["ks1"], False)
 
     res = nodetool("snapshot", "--tag", tag, "ks1", "ks2", expected_requests=[
         expected_request("POST", "/storage_service/snapshots",
                          params={"tag": tag, "sf": "false", "kn": "ks1,ks2"})
     ])
-    check_snapshot_out(res, tag, ["ks1", "ks2"], False)
+    check_snapshot_out(res.stdout, tag, ["ks1", "ks2"], False)
 
 
 @pytest.mark.parametrize("option_name", ("-cf", "--column-family", "--table"))
@@ -158,13 +158,13 @@ def test_snapshot_keyspace_with_table(nodetool, option_name):
         expected_request("POST", "/storage_service/snapshots",
                          params={"tag": tag, "sf": "false", "kn": "ks1", "cf": "tbl"})
     ])
-    check_snapshot_out(res, tag, ["ks1"], False)
+    check_snapshot_out(res.stdout, tag, ["ks1"], False)
 
     res = nodetool("snapshot", "--tag", tag, "ks1", option_name, "tbl1,tbl2", expected_requests=[
         expected_request("POST", "/storage_service/snapshots",
                          params={"tag": tag, "sf": "false", "kn": "ks1", "cf": "tbl1,tbl2"})
     ])
-    check_snapshot_out(res, tag, ["ks1"], False)
+    check_snapshot_out(res.stdout, tag, ["ks1"], False)
 
 
 class kn_param(NamedTuple):
@@ -194,7 +194,7 @@ def test_snapshot_keyspace_table_single_arg(nodetool, param, scylla_only):
     res = nodetool("snapshot", "--tag", tag, *param.args, expected_requests=[
         expected_request("POST", "/storage_service/snapshots", params=req_params)
     ])
-    check_snapshot_out(res, tag, param.snapshot_keyspaces, False)
+    check_snapshot_out(res.stdout, tag, param.snapshot_keyspaces, False)
 
 
 @pytest.mark.parametrize("option_name", ("-kt", "--kt-list", "-kc", "--kc.list"))
@@ -205,19 +205,19 @@ def test_snapshot_ktlist(nodetool, option_name):
         expected_request("POST", "/storage_service/snapshots",
                          params={"tag": tag, "sf": "false", "kn": "ks1", "cf": "tbl1"})
     ])
-    check_snapshot_out(res, tag, ["ks1.tbl1"], False)
+    check_snapshot_out(res.stdout, tag, ["ks1.tbl1"], False)
 
     res = nodetool("snapshot", "--tag", tag, option_name, "ks1.tbl1,ks2.tbl2", expected_requests=[
         expected_request("POST", "/storage_service/snapshots",
                          params={"tag": tag, "sf": "false", "kn": "ks1.tbl1,ks2.tbl2"})
     ])
-    check_snapshot_out(res, tag, ["ks1.tbl1", "ks2.tbl2"], False)
+    check_snapshot_out(res.stdout, tag, ["ks1.tbl1", "ks2.tbl2"], False)
 
     res = nodetool("snapshot", "--tag", tag, option_name, "ks1,ks2", expected_requests=[
         expected_request("POST", "/storage_service/snapshots",
                          params={"tag": tag, "sf": "false", "kn": "ks1,ks2"})
     ])
-    check_snapshot_out(res, tag, ["ks1" ,"ks2"], False)
+    check_snapshot_out(res.stdout, tag, ["ks1" ,"ks2"], False)
 
 
 @pytest.mark.parametrize("tag", [None, "my_snapshot_tag"])
@@ -274,7 +274,7 @@ def test_snapshot_options_matrix(nodetool, tag, ktlist, skip_flush):
         expected_request("POST", "/storage_service/snapshots", params=params)
     ])
 
-    check_snapshot_out(res, tag, keyspaces, skip_flush)
+    check_snapshot_out(res.stdout, tag, keyspaces, skip_flush)
 
 
 def test_snapshot_multiple_keyspace_with_table(nodetool):

--- a/test/nodetool/test_sstable.py
+++ b/test/nodetool/test_sstable.py
@@ -28,7 +28,7 @@ def test_getsstables(nodetool, key_option):
                 "/var/lib/scylla/data/ks/tbl-3ca78460d61611eea0b49524e39553c0/me-3gec_0mu7_7bz0024x96bfm476r6-big-Data.db",
                 ]),
     ])
-    assert res == (
+    assert res.stdout == (
 """/var/lib/scylla/data/ks/tbl-3ca78460d61611eea0b49524e39553c0/me-3gec_0mu7_5az0024x96bfm476r6-big-Data.db
 /var/lib/scylla/data/ks/tbl-3ca78460d61611eea0b49524e39553c0/me-3gec_0mu7_7bz0024x96bfm476r6-big-Data.db
 """)
@@ -207,7 +207,7 @@ def test_sstableinfo(nodetool, request):
             "/storage_service/sstable_info",
             response=info),
     ])
-    _check_sstableinfo_output(res, info, request.config.getoption("nodetool") == "cassandra")
+    _check_sstableinfo_output(res.stdout, info, request.config.getoption("nodetool") == "cassandra")
 
 
 def test_sstableinfo_keyspace(nodetool, request):
@@ -219,7 +219,7 @@ def test_sstableinfo_keyspace(nodetool, request):
             params={"keyspace": "ks"},
             response=info),
     ])
-    _check_sstableinfo_output(res, info, request.config.getoption("nodetool") == "cassandra")
+    _check_sstableinfo_output(res.stdout, info, request.config.getoption("nodetool") == "cassandra")
 
 
 def test_sstableinfo_keyspace_table(nodetool, request):
@@ -231,7 +231,7 @@ def test_sstableinfo_keyspace_table(nodetool, request):
             params={"keyspace": "ks", "cf": "tbl"},
             response=info),
     ])
-    _check_sstableinfo_output(res, info, request.config.getoption("nodetool") == "cassandra")
+    _check_sstableinfo_output(res.stdout, info, request.config.getoption("nodetool") == "cassandra")
 
 
 def test_sstableinfo_keyspace_tables(nodetool, request):
@@ -248,4 +248,4 @@ def test_sstableinfo_keyspace_tables(nodetool, request):
             params={"keyspace": "ks", "cf": "tbl2"},
             response=[ks_tbl2_sstable_info]),
     ])
-    _check_sstableinfo_output(res, info, request.config.getoption("nodetool") == "cassandra")
+    _check_sstableinfo_output(res.stdout, info, request.config.getoption("nodetool") == "cassandra")

--- a/test/nodetool/test_status.py
+++ b/test/nodetool/test_status.py
@@ -262,7 +262,7 @@ def _do_test_status(request, nodetool, status_query_target, node_list, resolve=N
     res = nodetool(*args, expected_requests=expected_requests)
 
     effective_ownership_unknown = keyspace is None or (table is None and keyspace_uses_tablets)
-    validate_status_output(res, keyspace, nodes, ownership, bool(resolve), effective_ownership_unknown)
+    validate_status_output(res.stdout, keyspace, nodes, ownership, bool(resolve), effective_ownership_unknown)
 
 
 def test_status_no_keyspace_single_dc(request, nodetool):

--- a/test/nodetool/test_stop.py
+++ b/test/nodetool/test_stop.py
@@ -36,6 +36,7 @@ def test_stop_unsupported(nodetool):
                 "POST",
                 "/compaction_manager/stop_compaction",
                 params={"type": compaction_type},
+                multiple=expected_request.ANY,
                 response={"code": 500,
                           "message": f"std::runtime_error (Compaction type {compaction_type} is unsupported)"},
                 response_status=500)

--- a/test/nodetool/test_tablehistograms.py
+++ b/test/nodetool/test_tablehistograms.py
@@ -55,7 +55,7 @@ def test_tablehistograms(nodetool, param):
 
     res = nodetool(*param.args, expected_requests=expected_requests)
 
-    assert res == f"""{param.keyspace_name}/{param.table_name} histograms
+    assert res.stdout == f"""{param.keyspace_name}/{param.table_name} histograms
 Percentile  SSTables     Write Latency      Read Latency    Partition Size        Cell Count
                               (micros)          (micros)           (bytes)                  
 50%             2.00              4.00             32.00                 3                 2
@@ -94,7 +94,7 @@ def test_tablehistograms_empty_histogram(nodetool):
 
     res = nodetool("tablehistograms", keyspace_name, table_name, expected_requests=expected_requests)
 
-    assert res == f"""{keyspace_name}/{table_name} histograms
+    assert res.stdout == f"""{keyspace_name}/{table_name} histograms
 Percentile  SSTables     Write Latency      Read Latency    Partition Size        Cell Count
                               (micros)          (micros)           (bytes)                  
 50%             0.00              0.00              0.00                 0                 0

--- a/test/nodetool/test_tablestats.py
+++ b/test/nodetool/test_tablestats.py
@@ -465,7 +465,8 @@ Keyspace : {ks_name}
             expected_output += indent(table.format(), '\t\t')
         expected_output += '----------------\n'
 
-    actual_output = nodetool(command, *args, expected_requests=expected_requests)
+    res = nodetool(command, *args, expected_requests=expected_requests)
+    actual_output = res.stdout
     assert actual_output == expected_output
 
 
@@ -513,8 +514,9 @@ def test_output_format(request, nodetool, output_format):
         'json': json.loads
     }
 
-    actual_output = nodetool('tablestats', '--format', output_format,
-                             expected_requests=expected_requests)
+    res = nodetool('tablestats', '--format', output_format,
+                   expected_requests=expected_requests)
+    actual_output = res.stdout
     actual_dict = parsers[output_format](actual_output)
 
     assert actual_dict == expected_dict

--- a/test/nodetool/test_toppartitions.py
+++ b/test/nodetool/test_toppartitions.py
@@ -119,11 +119,12 @@ def test_toppartitions(nodetool, request, empty_samplings, samplers):
     if request.config.getoption("nodetool") == "scylla":
         # scylla sends list_size, while cassandra's nodetool does not.
         params['list_size'] = str(list_size)
-    actual_output = nodetool("toppartitions", *args, expected_requests=[
+    res = nodetool("toppartitions", *args, expected_requests=[
         expected_request("GET", "/storage_service/toppartitions/",
                          params=params,
                          response=response),
     ])
+    actual_output = res.stdout
 
     expected_output = ''
     first = True

--- a/test/nodetool/test_traceprobability.py
+++ b/test/nodetool/test_traceprobability.py
@@ -9,10 +9,10 @@ import utils
 
 
 def test_gettraceprobability(nodetool):
-    out = nodetool("gettraceprobability", expected_requests=[
+    res = nodetool("gettraceprobability", expected_requests=[
         expected_request("GET", "/storage_service/trace_probability", response=0.2)])
 
-    assert out == "Current trace probability: 0.2\n"
+    assert res.stdout == "Current trace probability: 0.2\n"
 
 
 def test_settraceprobability(nodetool):

--- a/test/nodetool/test_version.py
+++ b/test/nodetool/test_version.py
@@ -8,7 +8,7 @@ from rest_api_mock import expected_request
 
 
 def test_version(nodetool):
-    out = nodetool("version", expected_requests=[
+    res = nodetool("version", expected_requests=[
         expected_request("GET", "/storage_service/release_version", response="1.2.3")])
 
-    assert out == "ReleaseVersion: 1.2.3\n"
+    assert res.stdout == "ReleaseVersion: 1.2.3\n"

--- a/test/nodetool/test_viewbuildstatus.py
+++ b/test/nodetool/test_viewbuildstatus.py
@@ -104,7 +104,8 @@ def test_viewbuildstatus(request, nodetool, args, statuses, returncode):
         if all(status == 'SUCCESS' for status in statuses):
             # invalid argument
             with pytest.raises(CalledProcessError) as exc_info:
-                actual_output = nodetool("viewbuildstatus", *args, expected_requests=expected_requests)
+                res = nodetool("viewbuildstatus", *args, expected_requests=expected_requests)
+                actual_output = res.stdout
             assert exc_info.type is CalledProcessError
             assert exc_info.value.returncode == 1
             expected_stdout, expected_stderr = format_invalid_argument_error(is_scylla)
@@ -112,10 +113,12 @@ def test_viewbuildstatus(request, nodetool, args, statuses, returncode):
             assert expected_stderr in exc_info.value.stderr
         else:
             with pytest.raises(CalledProcessError) as exc_info:
-                actual_output = nodetool("viewbuildstatus", *args, expected_requests=expected_requests)
+                res = nodetool("viewbuildstatus", *args, expected_requests=expected_requests)
+                actual_output = res.stdout
             assert exc_info.type is CalledProcessError
             assert exc_info.value.returncode == 1
             assert exc_info.value.output == expected_output
     else:
-        actual_output = nodetool("viewbuildstatus", *args, expected_requests=expected_requests)
+        res = nodetool("viewbuildstatus", *args, expected_requests=expected_requests)
+        actual_output = res.stdout
         assert actual_output == expected_output

--- a/test/nodetool/utils.py
+++ b/test/nodetool/utils.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 
-import pytest
-import subprocess
 import itertools
 
 
@@ -15,11 +13,12 @@ def _do_check_nodetool_fails_with(
         nodetool_kwargs: dict,
         matcher):
 
-    with pytest.raises(subprocess.CalledProcessError) as e:
-        nodetool(*nodetool_args, **nodetool_kwargs)
+    res = nodetool(*nodetool_args, **nodetool_kwargs, check_return_code=False)
 
-    err_lines = e.value.stderr.rstrip().split('\n')
-    out_lines = e.value.stdout.rstrip().split('\n')
+    assert res.returncode != 0
+
+    err_lines = res.stderr.rstrip().split('\n')
+    out_lines = res.stdout.rstrip().split('\n')
 
     matcher(out_lines, err_lines)
 

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1363,7 +1363,6 @@ void repair_operation(scylla_rest_client& client, const bpo::variables_map& vm) 
         fmt::print("[{:%F %T},{:03d}] {}\n", fmt::localtime(t), ms, msg);
     };
 
-    size_t failed = 0;
     for (const auto& keyspace : keyspaces) {
         const auto url = format("/storage_service/repair_async/{}", keyspace);
 
@@ -1389,13 +1388,8 @@ void repair_operation(scylla_rest_client& client, const bpo::variables_map& vm) 
         if (status == "SUCCESSFUL") {
             log("Repair session {} finished", id);
         } else {
-            log("Repair session {} failed", id);
-            ++failed;
+            throw operation_failed_on_scylladb(format("Repair session {} failed", id));
         }
-    }
-
-    if (failed) {
-        throw operation_failed_on_scylladb(format("{} out of {} repair session(s) failed", failed, keyspaces.size()));
     }
 }
 


### PR DESCRIPTION
When repairing multiple keyspaces, bail out on the first failed keyspace repair, instead of continuing and reporting all failures at the end. This is what Origin does as well.

To be able to test this, a bit of refactoring was needed, to be able to assert that `scylla-nodetool` doesn't make repair requests, beyond the expected ones.

Refs: https://github.com/scylladb/scylla-cluster-tests/issues/7226