### PR TITLE
test.py: improve readability of failures resulting in empty XML

### DIFF
--- a/test.py
+++ b/test.py
@@ -718,6 +718,9 @@ class BoostTest(UnitTest):
             os.unlink(self.xmlout)
         except ET.ParseError as e:
             message = palette.crit(f"failed to parse XML output '{self.xmlout}': {e}")
+            if e.msg.__contains__("no element found"):
+                message = palette.crit(f"Empty testcase XML output, possibly caused by a crash in the cql_test_env.cc, "
+                                       f"details: '{self.xmlout}': {e}")
             print(f"error: {self.name}: {message}")
 
     def check_log(self, trim: bool) -> None:


### PR DESCRIPTION
Before the change, when a test failed because of some error in the `cql_test_env.cc`, we were getting:
```
error: boost/virtual_table_test: failed to parse XML output '/home/piotrs/src/scylla2/testlog/debug/xml/boost.virtual_table_test.test_system_config_table_read.1.xunit.xml': no element found: line 1, column 0
```
After the change we're getting:
```
error: boost/virtual_table_test: Empty testcase XML output, possibly caused by a crash in the cql_test_env.cc, details: '/home/piotrs/src/scylla2/testlog/debug/xml/boost.virtual_table_test.test_system_config_table_read.1.xunit.xml': no element found: line 1, column 0
```