### PR TITLE
Handle tablet migration failure in wrapping-up stages

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5525,6 +5525,11 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
 }
 
 future<> storage_service::cleanup_tablet(locator::global_tablet_id tablet) {
+    utils::get_local_injector().inject("cleanup_tablet_crash", [] {
+        slogger.info("Crashing tablet cleanup");
+        _exit(1);
+    });
+
     return do_tablet_operation(tablet, "Cleanup", [this, tablet] (locator::tablet_metadata_guard& guard) {
         shard_id shard;
 

--- a/test/topology_custom/test_tablets_migration.py
+++ b/test/topology_custom/test_tablets_migration.py
@@ -86,11 +86,12 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
             else:
                 assert False
 
-        async def stop(self):
+        async def stop(self, via=0):
             logger.info(f"Stop {self.replica} {host_ids[self.fail_idx]}")
             await manager.server_stop(servers[self.fail_idx].server_id)
-            logger.info(f"Remove {self.replica} {host_ids[self.fail_idx]}")
-            await manager.remove_node(servers[0].server_id, servers[self.fail_idx].server_id)
+            logger.info(f"Remove {self.replica} {host_ids[self.fail_idx]} via {host_ids[via]}")
+            await manager.remove_node(servers[via].server_id, servers[self.fail_idx].server_id)
+            logger.info(f"Done with {self.replica} {host_ids[self.fail_idx]}")
 
 
     failer = node_failer(fail_stage, fail_replica)

--- a/test/topology_custom/test_tablets_migration.py
+++ b/test/topology_custom/test_tablets_migration.py
@@ -71,7 +71,8 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
                 self.log = await manager.server_open_log(servers[2].server_id)
                 self.mark = await self.log.mark()
             elif self.stage in [ "allow_write_both_read_old", "write_both_read_old", "write_both_read_new", "use_new" ]:
-                await manager.api.enable_injection(servers[self.fail_idx].ip_addr, "raft_topology_barrier_and_drain_fail", one_shot=False, parameters={'keyspace': 'test', 'table': 'test', 'last_token': last_token, 'stage': self.stage})
+                await manager.api.enable_injection(servers[self.fail_idx].ip_addr, "raft_topology_barrier_and_drain_fail", one_shot=False,
+                        parameters={'keyspace': 'test', 'table': 'test', 'last_token': last_token, 'stage': self.stage.removeprefix('do_')})
                 self.log = await manager.server_open_log(servers[self.fail_idx].server_id)
                 self.mark = await self.log.mark()
             else:


### PR DESCRIPTION
There are four stages left to handle: cleanup, cleanup_target, end_migration and revert_migration. All are handling removed nodes already, so the PR just extends the test.

fixes: #16527 