### PR TITLE
tablets: read_tablet_mutations: unfreeze_gently

### DIFF
--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -305,7 +305,7 @@ future<std::vector<canonical_mutation>> read_tablet_mutations(seastar::sharded<r
     std::vector<canonical_mutation> result;
     result.reserve(rs->partitions().size());
     for (auto& p: rs->partitions()) {
-        result.emplace_back(canonical_mutation(p.mut().unfreeze(s)));
+        result.emplace_back(canonical_mutation(co_await p.mut().unfreeze_gently(s)));
     }
     co_return std::move(result);
 }


### PR DESCRIPTION
Use co_await unfreeze_gently in the loop body
unfreezing each partition mutation to prevent
reactor stalls when building group0 snapshot
with lots of tablets.

Fixes #15303