### PR TITLE
test/pylib: return better error if self.create_server() raises

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -813,6 +813,7 @@ class ScyllaCluster:
             cmdline_from_test = cmdline or []
         )
 
+        server = None
         try:
             server = self.create_server(params)
             self.logger.info("Cluster %s adding server...", self)
@@ -821,8 +822,9 @@ class ScyllaCluster:
             else:
                 await server.install()
         except Exception as exc:
+            workdir = '<unknown>' if server is None else server.workdir.name
             self.logger.error("Failed to start Scylla server at host %s in %s: %s",
-                          ip_addr, server.workdir.name, str(exc))
+                          ip_addr, workdir, str(exc))
             if not replace_cfg or not replace_cfg.reuse_ip_addr:
                 self.leased_ips.remove(ip_addr)
                 await self.host_registry.release_host(Host(ip_addr))


### PR DESCRIPTION
in `ScyllaServer::add_server()`, `self.create_server()` is called to create a server, but if it raises, we would reference a local variable of `server` which is not bound to any value, as `server` is not assigned at that moment. if `ScyllaServer` is used by `ScyllaClusterManager`, we would not be able to see the real exception apart from the error like

```
cannot access local variable 'server' where it is not associated with a
value
```

which is but the error from Python runtime.

in this change, `server` is always initialized, and we check for None, before dereferencing it.