### PR TITLE
clustering_bounds_comparator: add fmt::formtter for bound_{kind,view}

### DIFF
--- a/clustering_bounds_comparator.hh
+++ b/clustering_bounds_comparator.hh
@@ -152,8 +152,14 @@ public:
         bool inclusive = bv._kind != bound_kind::excl_end && bv._kind != bound_kind::excl_start;
         return {typename R<clustering_key_prefix_view>::bound(bv._prefix.get().view(), inclusive)};
     }
-    friend std::ostream& operator<<(std::ostream& out, const bound_view& b) {
-        fmt::print(out, "{{bound: prefix={}, kind={}}}", b._prefix.get(), b._kind);
-        return out;
+    friend fmt::formatter<bound_view>;
+};
+
+template <> struct fmt::formatter<bound_kind> : fmt::formatter<std::string_view> {
+    auto format(bound_kind, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+template <> struct fmt::formatter<bound_view> : fmt::formatter<std::string_view> {
+    auto format(const bound_view& b, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{{bound: prefix={},kind={}}}", b._prefix.get(), b._kind);
     }
 };

--- a/keys.cc
+++ b/keys.cc
@@ -53,17 +53,28 @@ partition_key partition_key::from_nodetool_style_string(const schema_ptr s, cons
 }
 
 std::ostream& operator<<(std::ostream& out, const bound_kind k) {
+    fmt::print(out, "{}", k);
+    return out;
+}
+
+auto fmt::formatter<bound_kind>::format(bound_kind k, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    std::string_view name;
     switch (k) {
     case bound_kind::excl_end:
-        return out << "excl end";
+        name = "excl end";
+        break;
     case bound_kind::incl_start:
-        return out << "incl start";
+        name = "incl start";
+        break;
     case bound_kind::incl_end:
-        return out << "incl end";
+        name = "incl end";
+        break;
     case bound_kind::excl_start:
-        return out << "excl start";
+        name = "excl start";
+        break;
     }
-    abort();
+    return fmt::format_to(ctx.out(), "{}", name);
 }
 
 bound_kind invert_kind(bound_kind k) {

--- a/test/boost/range_tombstone_list_test.cc
+++ b/test/boost/range_tombstone_list_test.cc
@@ -486,7 +486,7 @@ static std::vector<range_tombstone> make_random() {
              */
             start_b = bound_view(start_key, bound_kind::incl_start);
             if (less(end_b, start_b)) {
-                std::cout << "Unfixable slice " << start_b << " ... " << end_b << std::endl;
+                fmt::print("Unfixable slice {} ... {}\n", start_b, end_b);
                 std::abort();
             }
         }


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `bound_kind` and `bound_view`, and drop their operator<<:s.

Refs #13245