### PR TITLE
add fmt::formatter for reader_permit::state and reader_resources

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -69,9 +69,9 @@ void maybe_dump_reader_permit_diagnostics(const reader_concurrency_semaphore& se
 
 }
 
-std::ostream& operator<<(std::ostream& os , const reader_resources& r) {
-    os << "{" << r.count << ", " << r.memory << "}";
-    return os;
+auto fmt::formatter<reader_resources>::format(const reader_resources& r, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{{{}, {}}}", r.count, r.memory);
 }
 
 reader_permit::resource_units::resource_units(reader_permit permit, reader_resources res, already_consumed_tag)
@@ -652,34 +652,36 @@ void reader_permit::on_finish_sstable_read() noexcept {
     _impl->on_finish_sstable_read();
 }
 
-std::ostream& operator<<(std::ostream& os, reader_permit::state s) {
+auto fmt::formatter<reader_permit::state>::format(reader_permit::state s, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    std::string_view name;
     switch (s) {
         case reader_permit::state::waiting_for_admission:
-            os << "waiting_for_admission";
+            name = "waiting_for_admission";
             break;
         case reader_permit::state::waiting_for_memory:
-            os << "waiting_for_memory";
+            name = "waiting_for_memory";
             break;
         case reader_permit::state::waiting_for_execution:
-            os << "waiting_for_execution";
+            name = "waiting_for_execution";
             break;
         case reader_permit::state::active:
-            os << "active";
+            name = "active";
             break;
         case reader_permit::state::active_need_cpu:
-            os << "active/need_cpu";
+            name = "active/need_cpu";
             break;
         case reader_permit::state::active_await:
-            os << "active/await";
+            name = "active/await";
             break;
         case reader_permit::state::inactive:
-            os << "inactive";
+            name= "inactive";
             break;
         case reader_permit::state::evicted:
-            os << "evicted";
+            name = "evicted";
             break;
     }
-    return os;
+    return formatter<std::string_view>::format(name, ctx);
 }
 
 namespace {

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -67,8 +67,6 @@ inline bool operator==(const reader_resources& a, const reader_resources& b) {
     return a.count == b.count && a.memory == b.memory;
 }
 
-std::ostream& operator<<(std::ostream& os, const reader_resources& r);
-
 class reader_concurrency_semaphore;
 
 /// A permit for a specific read.
@@ -212,8 +210,6 @@ public:
     reader_resources resources() const { return _resources; }
 };
 
-std::ostream& operator<<(std::ostream& os, reader_permit::state s);
-
 /// Mark a permit as needing CPU.
 ///
 /// Conceptually, a permit is considered as needing CPU, when at least one reader
@@ -325,3 +321,10 @@ template <typename T>
 bool operator==(const tracking_allocator<T>& a, const tracking_allocator<T>& b) {
     return a._semaphore == b._semaphore;
 }
+
+template <> struct fmt::formatter<reader_permit::state> : fmt::formatter<std::string_view> {
+    auto format(reader_permit::state, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+template <> struct fmt::formatter<reader_resources> : fmt::formatter<std::string_view> {
+    auto format(const reader_resources&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -30,6 +30,16 @@
 #include "replica/database.hh" // new_reader_base_cost is there :(
 #include "db/config.hh"
 
+std::ostream& boost_test_print_type(std::ostream& os, const reader_resources& r) {
+    fmt::print(os, "{}", r);
+    return os;
+}
+
+std::ostream& boost_test_print_type(std::ostream& os, reader_permit::state s) {
+    fmt::print(os, "{}", s);
+    return os;
+}
+
 SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_clear_inactive_reads) {
     simple_schema s;
     std::vector<reader_permit> permits;


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for

* reader_permit::state
* reader_resources

Refs #13245