### PR TITLE
tools/scylla-nodetool: use constexpr for compile-time format check

### DIFF
--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -689,14 +689,14 @@ void getendpoints_operation(scylla_rest_client& client, const bpo::variables_map
 
 void getlogginglevels_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     auto res = client.get("/storage_service/logging_level");
-    const auto row_format = "{:<50}{:>10}\n";
+    constexpr auto row_format = "{:<50}{:>10}\n";
     fmt::print(std::cout, "\n");
-    fmt::print(std::cout, fmt::runtime(row_format), "Logger Name", "Log Level");
+    fmt::print(std::cout, row_format, "Logger Name", "Log Level");
     for (const auto& element : res.GetArray()) {
         const auto& logger_obj = element.GetObject();
         fmt::print(
                 std::cout,
-                fmt::runtime(row_format),
+                row_format,
                 rjson::to_string_view(logger_obj["key"]),
                 rjson::to_string_view(logger_obj["value"]));
     }
@@ -1264,7 +1264,7 @@ void print_dc(scylla_rest_client& client,
     fmt::print("\n"
                "Datacenter: {}\n"
                "==========\n", dc);
-    const auto fmt_str = fmt::runtime("{:<{}}  {:<12}{:<7}{:<8}{:<16}{:<20}{:<44}\n");
+    constexpr auto fmt_str = "{:<{}}  {:<12}{:<7}{:<8}{:<16}{:<20}{:<44}\n";
     const auto max_endpoint_width = std::invoke([&] {
         auto stat_with_max_addr_width = std::ranges::max_element(
             host_stats,


### PR DESCRIPTION
instead of using fmt::runtime format string, use compile-time format string, so that we can have compile-time format check provided by {fmt}.