### PR TITLE
utils: add fmt::formatter for utils types

### DIFF
--- a/test/boost/flat_mutation_reader_test.cc
+++ b/test/boost/flat_mutation_reader_test.cc
@@ -29,6 +29,7 @@
 #include "test/lib/reader_concurrency_semaphore.hh"
 #include "test/lib/random_utils.hh"
 #include "test/lib/random_schema.hh"
+#include "test/lib/test_utils.hh"
 
 #include "readers/from_mutations_v2.hh"
 #include "readers/from_fragments_v2.hh"

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -31,6 +31,7 @@
 #include "test/lib/log.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/random_utils.hh"
+#include "test/lib/test_utils.hh"
 #include <seastar/core/coroutine.hh>
 #include "db/schema_tables.hh"
 

--- a/test/lib/test_utils.cc
+++ b/test/lib/test_utils.cc
@@ -101,3 +101,22 @@ future<> touch_file(std::string name) {
 std::mutex boost_logger_mutex;
 
 }
+
+namespace std {
+
+std::ostream& boost_test_print_type(std::ostream& os, const std::strong_ordering& order) {
+    fmt::print(os, "{}", order);
+    return os;
+}
+
+std::ostream& boost_test_print_type(std::ostream& os, const std::weak_ordering& order) {
+    fmt::print(os, "{}", order);
+    return os;
+}
+
+std::ostream& boost_test_print_type(std::ostream& os, const std::partial_ordering& order) {
+    fmt::print(os, "{}", order);
+    return os;
+}
+
+} // namespace std

--- a/test/lib/test_utils.hh
+++ b/test/lib/test_utils.hh
@@ -111,3 +111,11 @@ extern std::mutex boost_logger_mutex;
 #define THREADSAFE_BOOST_REQUIRE_EQUAL( L, R ) THREADSAFE_BOOST_CHECK(BOOST_REQUIRE_EQUAL( L, R ))
 
 }
+
+namespace std {
+
+std::ostream& boost_test_print_type(std::ostream& os, const std::strong_ordering& order);
+std::ostream& boost_test_print_type(std::ostream& os, const std::weak_ordering& order);
+std::ostream& boost_test_print_type(std::ostream& os, const std::partial_ordering& order);
+
+}

--- a/utils/exception_container.hh
+++ b/utils/exception_container.hh
@@ -141,12 +141,6 @@ public:
     }
 };
 
-template<typename... Exs>
-inline std::ostream& operator<<(std::ostream& os, const exception_container<Exs...>& ec) {
-    ec.accept([&os] (const auto& ex) { os << ex; });
-    return os;
-}
-
 template<typename T>
 struct is_exception_container : std::false_type {};
 
@@ -157,3 +151,11 @@ template<typename T>
 concept ExceptionContainer = is_exception_container<T>::value;
 
 }
+
+template <typename... Exs> struct fmt::formatter<utils::exception_container<Exs...>> : fmt::formatter<std::string_view> {
+    auto format(const auto& ec, fmt::format_context& ctx) const {
+        auto out = ctx.out();
+        ec.accept([&out] (const auto& ex) { out = fmt::format_to(out, "{}", ex); });
+        return out;
+    }
+};

--- a/utils/human_readable.cc
+++ b/utils/human_readable.cc
@@ -13,14 +13,6 @@
 
 namespace utils {
 
-std::ostream& operator<<(std::ostream& os, const human_readable_value& val) {
-    os << val.value;
-    if (val.suffix) {
-        os << val.suffix;
-    }
-    return os;
-}
-
 static human_readable_value to_human_readable_value(uint64_t value, uint64_t step, uint64_t precision, const std::array<char, 5>& suffixes) {
     if (!value) {
         return {0, suffixes[0]};
@@ -48,3 +40,12 @@ human_readable_value to_hr_size(uint64_t size) {
 }
 
 } // namespace utils
+
+auto fmt::formatter<utils::human_readable_value>::format(const utils::human_readable_value& val, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    auto out = fmt::format_to(ctx.out(), "{}", val.value);
+    if (val.suffix) {
+        out = fmt::format_to(out, "{}", val.suffix);
+    }
+    return out;
+}

--- a/utils/human_readable.hh
+++ b/utils/human_readable.hh
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <cinttypes>
-#include <iosfwd>
+#include <cstdint>
+#include <fmt/core.h>
 
 namespace utils {
 
@@ -17,8 +17,6 @@ struct human_readable_value {
     uint16_t value;  // [0, 1024)
     char suffix; // 0 -> no suffix
 };
-
-std::ostream& operator<<(std::ostream& os, const human_readable_value& val);
 
 /// Convert a size to a human readable representation.
 ///
@@ -38,3 +36,7 @@ std::ostream& operator<<(std::ostream& os, const human_readable_value& val);
 human_readable_value to_hr_size(uint64_t size);
 
 } // namespace utils
+
+template <> struct fmt::formatter<utils::human_readable_value> : fmt::formatter<std::string_view> {
+    auto format(const utils::human_readable_value&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/utils/to_string.cc
+++ b/utils/to_string.cc
@@ -8,41 +8,37 @@
 
 #include "utils/to_string.hh"
 
-namespace std {
-
-std::ostream& operator<<(std::ostream& os, const std::strong_ordering& order) {
+auto fmt::formatter<std::strong_ordering>::format(std::strong_ordering order, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
     if (order > 0) {
-        os << "gt";
+        return fmt::format_to(ctx.out(), "gt");
     } else if (order < 0) {
-        os << "lt";
+        return fmt::format_to(ctx.out(), "lt");
     } else {
-        os << "eq";
+        return fmt::format_to(ctx.out(), "eq");
     }
-    return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const std::weak_ordering& order) {
+auto fmt::formatter<std::weak_ordering>::format(std::weak_ordering order, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
     if (order > 0) {
-        os << "gt";
+        return fmt::format_to(ctx.out(), "gt");
     } else if (order < 0) {
-        os << "lt";
+        return fmt::format_to(ctx.out(), "lt");
     } else {
-        os << "eq";
+        return fmt::format_to(ctx.out(), "eq");
     }
-    return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const std::partial_ordering& order) {
+auto fmt::formatter<std::partial_ordering>::format(std::partial_ordering order, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
     if (order == std::partial_ordering::unordered) {
-        os << "unordered";
+        return fmt::format_to(ctx.out(), "unordered");
     } else if (order > 0) {
-        os << "gt";
+        return fmt::format_to(ctx.out(), "gt");
     } else if (order < 0) {
-        os << "lt";
+        return fmt::format_to(ctx.out(), "lt");
     } else {
-        os << "eq";
+        return fmt::format_to(ctx.out(), "eq");
     }
-    return os;
 }
-
-} // namespace std

--- a/utils/to_string.hh
+++ b/utils/to_string.hh
@@ -118,10 +118,6 @@ std::ostream& operator<<(std::ostream& os, const std::optional<T>& opt) {
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const std::strong_ordering& order);
-std::ostream& operator<<(std::ostream& os, const std::weak_ordering& order);
-std::ostream& operator<<(std::ostream& os, const std::partial_ordering& order);
-
 } // namespace std
 
 template<typename T>
@@ -134,4 +130,16 @@ struct fmt::formatter<std::optional<T>> : fmt::formatter<std::string_view> {
             return fmt::format_to(ctx.out(), "{{}}");
         }
      }
+};
+
+template <> struct fmt::formatter<std::strong_ordering> : fmt::formatter<std::string_view> {
+    auto format(std::strong_ordering, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <> struct fmt::formatter<std::weak_ordering> : fmt::formatter<std::string_view> {
+    auto format(std::weak_ordering, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <> struct fmt::formatter<std::partial_ordering> : fmt::formatter<std::string_view> {
+    auto format(std::partial_ordering, fmt::format_context& ctx) const -> decltype(ctx.out());
 };


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created
from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for 

* utils::human_readable_value
* std::strong_ordering
* std::weak_ordering
* std::partial_ordering
* utils::exception_container

Refs https://github.com/scylladb/scylladb/issues/13245