### PR TITLE
repair: add fmt::formatter for repair types

### DIFF
--- a/repair/hash.hh
+++ b/repair/hash.hh
@@ -2,6 +2,7 @@
 #include <absl/container/btree_set.h>
 #include <cstdint>
 #include <ostream>
+#include <fmt/core.h>
 #include "schema/schema.hh"
 
 class decorated_key_with_hash;
@@ -40,4 +41,8 @@ public:
     repair_hash do_hash_for_mf(const decorated_key_with_hash& dk_with_hash, const mutation_fragment& mf);
 };
 
-
+template <> struct fmt::formatter<repair_hash>  : fmt::formatter<std::string_view> {
+    auto format(const repair_hash& x, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", x.hash);
+    }
+};

--- a/repair/reader.hh
+++ b/repair/reader.hh
@@ -6,6 +6,7 @@
 #include "reader_permit.hh"
 #include "utils/phased_barrier.hh"
 #include "readers/mutation_fragment_v1_stream.hh"
+#include <fmt/core.h>
 
 class repair_reader {
 public:
@@ -15,17 +16,6 @@ public:
         multishard_filter
     };
 
-    friend std::ostream& operator<<(std::ostream& out, read_strategy s) {
-        switch (s) {
-            case read_strategy::local:
-                return out << "local";
-            case read_strategy::multishard_split:
-                return out << "multishard_split";
-            case read_strategy::multishard_filter:
-                return out << "multishard_filter";
-        };
-        return out << "unknown";
-    }
 private:
     schema_ptr _schema;
     reader_permit _permit;
@@ -85,4 +75,23 @@ public:
     void check_current_dk();
 
     void pause();
+};
+
+template <> struct fmt::formatter<repair_reader::read_strategy>  : fmt::formatter<std::string_view> {
+    auto format(repair_reader::read_strategy s, fmt::format_context& ctx) const {
+        using enum repair_reader::read_strategy;
+        std::string_view name = "unknown";
+        switch (s) {
+            case local:
+                name = "local";
+                break;
+            case multishard_split:
+                name = "multishard_split";
+                break;
+            case multishard_filter:
+                name = "multishard_filter";
+                break;
+        };
+        return formatter<std::string_view>::format(name, ctx);
+    }
 };

--- a/streaming/stream_summary.cc
+++ b/streaming/stream_summary.cc
@@ -10,11 +10,8 @@
 
 #include "streaming/stream_summary.hh"
 
-namespace streaming {
+auto fmt::formatter<streaming::stream_summary>::format(const streaming::stream_summary& x, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "[ cf_id={} ]", x.cf_id);
 
-std::ostream& operator<<(std::ostream& os, const stream_summary& x) {
-    os << "[ cf_id=" << x.cf_id << " ]";
-    return os;
 }
-
-} // namespace streaming

--- a/streaming/stream_summary.hh
+++ b/streaming/stream_summary.hh
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "schema/schema_fwd.hh"
-#include <ostream>
+#include <fmt/core.h>
 
 namespace streaming {
 
@@ -34,7 +34,10 @@ public:
         , files(_files)
         , total_size(_total_size) {
     }
-    friend std::ostream& operator<<(std::ostream& os, const stream_summary& r);
 };
 
 } // namespace streaming
+
+template <> struct fmt::formatter<streaming::stream_summary> : fmt::formatter<std::string_view> {
+    auto format(const streaming::stream_summary&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for

* repair_hash
* read_strategy
* streaming::stream_summary

and drop their operator<<:s

Refs #13245