### PR TITLE
[action] Sync labels from an Issue to linked PR

### DIFF
--- a/.github/scripts/sync_labels.py
+++ b/.github/scripts/sync_labels.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import sys
+from github import Github
+import re
+
+try:
+    github_token = os.environ["GITHUB_TOKEN"]
+except KeyError:
+    print("Please set the 'GITHUB_TOKEN' environment variable")
+    sys.exit(1)
+
+
+def parser():
+    parse = argparse.ArgumentParser()
+    parse.add_argument('--repo', type=str, required=True, help='Github repository name (e.g., scylladb/scylladb)')
+    parse.add_argument('--number', type=int, required=True, help='Pull request or issue number to sync labels from')
+    parse.add_argument('--label', type=str, default=None, help='Label to add/remove from an issue or PR')
+    parse.add_argument('--is_issue', action='store_true', help='Determined if label change is in Issue or not')
+    parse.add_argument('--action', type=str, choices=['opened', 'labeled', 'unlabeled'], required=True, help='Sync labels action')
+    return parse.parse_args()
+
+
+def copy_labels_from_linked_issues(repo, pr_number):
+    pr = repo.get_pull(pr_number)
+    if pr.body:
+        linked_issue_numbers = set(re.findall(r'Fixes:? (?:#|https.*?/issues/)(\d+)', pr.body))
+        for issue_number in linked_issue_numbers:
+            try:
+                issue = repo.get_issue(int(issue_number))
+                for label in issue.labels:
+                    pr.add_to_labels(label.name)
+                print(f"Labels from issue #{issue_number} copied to PR #{pr_number}")
+            except Exception as e:
+                print(f"Error processing issue #{issue_number}: {e}")
+
+
+def get_linked_pr_from_issue_number(repo, number):
+    linked_prs = []
+    for pr in repo.get_pulls(state='all'):
+        if f'{number}' in pr.body:
+            linked_prs.append(pr.number)
+        else:
+            break
+    return linked_prs
+
+
+def get_linked_issues_based_on_pr_body(repo, number):
+    pr = repo.get_pull(number)
+    pattern = fr'Fixes:? (?:#|{repo}#|https://github.com/{repo}/issues/)(\d+)'
+    matches = re.findall(pattern, pr.body)
+    if not matches:
+        raise RuntimeError("No regex matches found in the body!")
+    issue_number_from_pr_body = []
+    for match in matches:
+        issue_number_from_pr_body.append(match)
+        print(f"Found issue number: {match}")
+    return issue_number_from_pr_body
+
+
+def sync_labels(repo, number, label, action, is_issue=False):
+    if is_issue:
+        linked_prs_or_issues = get_linked_pr_from_issue_number(repo, number)
+    else:
+        linked_prs_or_issues = get_linked_issues_based_on_pr_body(repo, number)
+    for pr_or_issue_number in linked_prs_or_issues:
+        if is_issue:
+            target = repo.get_issue(pr_or_issue_number)
+        else:
+            target = repo.get_issue(int(pr_or_issue_number))
+        print(pr_or_issue_number)
+        if action == 'labeled':
+            target.add_to_labels(label)
+            print(f"Label '{label}' successfully added.")
+        elif action == 'unlabeled':
+            target.remove_from_labels(label)
+            print(f"Label '{label}' successfully removed.")
+        elif action == 'opened':
+            copy_labels_from_linked_issues(repo, number)
+        else:
+            print("Invalid action. Use 'labeled', 'unlabeled' or 'opened'.")
+
+
+def main():
+    args = parser()
+    github = Github(github_token)
+    repo = github.get_repo(args.repo)
+    sync_labels(repo, args.number, args.label, args.action, args.is_issue)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/sync_labels.yaml
+++ b/.github/workflows/sync_labels.yaml
@@ -1,0 +1,41 @@
+name: Sync labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled]
+    branches: [master, next]
+  issues:
+    types: [labeled, unlabeled]
+
+jobs:
+  label-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for all tags and branches
+
+      - name: Install dependencies
+        run: sudo apt-get install -y python3-github
+
+      - name: Pull request opened event
+        if: github.event.action == 'opened'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python .github/scripts/sync_labels.py --repo ${{ github.repository }} --number ${{ github.event.number }} --action ${{ github.event.action }}
+
+      - name: Pull request labeled or unlabeled event
+        if: github.event_name == 'pull_request' && startsWith(github.event.label.name, 'backport')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python .github/scripts/sync_labels.py --repo ${{ github.repository }} --number ${{ github.event.number }} --action ${{ github.event.action }} --label ${{ github.event.label.name }}
+
+      - name: Issue labeled or unlabeled event
+        if: github.event_name == 'issues' && startsWith(github.event.label.name, 'backport')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python .github/scripts/sync_labels.py --repo ${{ github.repository }} --number ${{ github.event.issue.number }} --action ${{ github.event.action }} --is_issue --label ${{ github.event.label.name }}


### PR DESCRIPTION
After merging https://github.com/scylladb/scylladb/pull/17365, all backport labels should be added to PR (before we used to add backport labels to the issues).

Adding a GitHub action which will be triggered in the following conditions only:

1) The base branch is `master` or `next`
2) Pull request events:
- opened: For every new PR that someone opens, we will sync all labels from the linked issue (if available)
- labeled: This role only applies to labels with the `backport/` prefix. When we add a new label for the backport we will update the relevant issue or PR to get them both to sync
- unlabeled: Same as `labeled` only applies to the `backport/` prefix. When we remove a label for backport we will update the relevant issue or pr

Ref: https://github.com/scylladb/scylla-pkg/issues/3685