### PR TITLE
api: Fix stats reported for row cache

### DIFF
--- a/api/cache_service.cc
+++ b/api/cache_service.cc
@@ -197,7 +197,7 @@ void set_cache_service(http_context& ctx, routes& r) {
 
     cs::get_row_capacity.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return ctx.db.map_reduce0([](replica::database& db) -> uint64_t {
-            return db.row_cache_tracker().region().occupancy().used_space();
+            return memory::stats().total_memory();
         }, uint64_t(0), std::plus<uint64_t>()).then([](const int64_t& res) {
             return make_ready_future<json::json_return_type>(res);
         });
@@ -240,9 +240,9 @@ void set_cache_service(http_context& ctx, routes& r) {
 
     cs::get_row_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         // In origin row size is the weighted size.
-        // We currently do not support weights, so we use num entries instead
+        // We currently do not support weights, so we use raw size in bytes instead
         return ctx.db.map_reduce0([](replica::database& db) -> uint64_t {
-            return db.row_cache_tracker().partitions();
+            return db.row_cache_tracker().region().occupancy().used_space();
         }, uint64_t(0), std::plus<uint64_t>()).then([](const int64_t& res) {
             return make_ready_future<json::json_return_type>(res);
         });


### PR DESCRIPTION
Here are three endpoints in the api/cache_service that report "metrics" for the row cache and the values they return

    - entries:  number of partitions
    - size:     number of partitions
    - capacity: used space

The size and capacity seem very inaccurate.

Comment says, that in C* the size should be weighted, but scylla doesn't support weight of entries in cache. Also, capacity is configurable via row_cache_size_in_mb config option or set_row_cache_capacity_in_mb API call, but Scylla doesn't support both either.

This patch suggestes changing return values for size and capacity endpoints.

Despite row cache doesn't support weights, it's natural to return used_space in bytes as the value, which is more accurate to what "size" means rather than number of entries.

The capacity may return back total memory size, because this is what Scylla really does -- row cache growth is only limited by other memory consumers, not by configured limits.

fixes: #9418