### PR TITLE
[Backport 5.2] sstables: fix a use-after-free in key_view::explode()

### DIFF
--- a/sstables/key.hh
+++ b/sstables/key.hh
@@ -29,14 +29,10 @@ public:
         return ::with_linearized(_bytes, func);
     }
 
-    std::vector<bytes_view> explode(const schema& s) const {
-        return with_linearized([&] (bytes_view v) {
-            return composite_view(v, s.partition_key_size() > 1).explode();
-        });
-    }
-
     partition_key to_partition_key(const schema& s) const {
-        return partition_key::from_exploded_view(explode(s));
+        return with_linearized([&] (bytes_view v) {
+            return partition_key::from_exploded_view(composite_view(v, s.partition_key_size() > 1).explode());
+        });
     }
 
     bool operator==(const key_view& k) const { return k._bytes == _bytes; }

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -415,7 +415,7 @@ public:
         if (!_is_mutation_end) {
             return proceed::yes;
         }
-        auto pk = partition_key::from_exploded(key.explode(*_schema));
+        auto pk = key.to_partition_key(*_schema);
         setup_for_partition(pk);
         auto dk = dht::decorate_key(*_schema, pk);
         _reader->on_next_partition(std::move(dk), tombstone(deltime));

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -313,7 +313,7 @@ public:
         if (!_is_mutation_end) {
             return proceed::yes;
         }
-        auto pk = partition_key::from_exploded(key.explode(*_schema));
+        auto pk = key.to_partition_key(*_schema);
         setup_for_partition(pk);
         auto dk = dht::decorate_key(*_schema, pk);
         _reader->on_next_partition(std::move(dk), tombstone(deltime));


### PR DESCRIPTION
key_view::explode() contains a blatant use-after-free: unless the input is already linearized, it returns a view to a local temporary buffer.

This is rare, because partition keys are usually not large enough to be fragmented. But for a sufficiently large key, this bug causes a corrupted partition_key down the line.

Fixes #17625

(cherry picked from commit 7a7b8972e54c3776435011533164f84bdae85e06)