### PR TITLE
repair: resolve start-up deadlock

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -340,7 +340,9 @@ public:
             , _seed(seed)
             , _local_read_op(local_reader ? std::optional(cf.read_in_progress()) : std::nullopt)
             , _reader(make_reader(db, cf, local_reader))
-    { }
+    {
+        pause();
+    }
 
     future<mutation_fragment_opt>
     read_mutation_fragment() {


### PR DESCRIPTION
Repairs have to obtain a permit to the reader concurrency semaphore on
each shard they have a presence on. This is prone to deadlocks:

node1                              node2
repair1_master (takes permit)      repair1_follower (waits on permit)
repair2_master (waits for permit)  repair2_follower (takes permit)

In lieu of strong central coordination, we solved this by making permits
evictable: if repair2 can evict repair1's permit so it can obtain one
and make progress. This is not efficient as evicting a permit usually
means discarding already done work, but it prevents the deadlocks.
We recently discovered that there is a window when deadlocks can still
happen. The permit is made evictable when the disk reader is created.
This reader is an evictable one, which effectively makes the permit
evictable. But the permit is obtained when the repair constrol
structrure -- repair meta -- is create. Between creating the repair meta
and reading the first row from disk, the deadlock is still possible. And
we know that what is possible, will happen (and did happen). Fix by
making the permit evictable as soon as the repair meta is created. This
is very clunky and we should have a better API for this (refs https://github.com/scylladb/scylladb/issues/17644),
but for now we go with this simple patch, to make it easy to backport.

Refs: https://github.com/scylladb/scylladb/issues/17644
Fixes: https://github.com/scylladb/scylladb/issues/17591

Closes https://github.com/scylladb/scylladb/pull/17646

(cherry picked from commit https://github.com/scylladb/scylladb/commit/c6e108ab5ea7b0d9b44830733b596ace3e02c2e4)

Backport notes:

The fix above does not apply to 5.2, because on 5.2 the reader is
created immediately when the repair-meta is created. So we don't need
the game with a fake inactive read, we can just pause the already
created reader in the repair-reader constructor.