### PR TITLE
Simplify error_injection::inject_with_handler()

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1187,7 +1187,7 @@ protected:
 
     virtual future<compaction_manager::compaction_stats_opt> do_run() override {
         if (!is_system_keyspace(_status.keyspace)) {
-            co_await utils::get_local_injector().inject_with_handler("compaction_regular_compaction_task_executor_do_run",
+            co_await utils::get_local_injector().inject("compaction_regular_compaction_task_executor_do_run",
                 [] (auto& handler) { return handler.wait_for_message(db::timeout_clock::now() + 10s); });
         }
 

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -371,7 +371,7 @@ future<> global_major_compaction_task_impl::run() {
 }
 
 future<> major_keyspace_compaction_task_impl::run() {
-    co_await utils::get_local_injector().inject_with_handler("compaction_major_keyspace_compaction_task_impl_run",
+    co_await utils::get_local_injector().inject("compaction_major_keyspace_compaction_task_impl_run",
             [] (auto& handler) { return handler.wait_for_message(db::timeout_clock::now() + 10s); });
 
     if (_cv) {

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1668,7 +1668,7 @@ void gossiper::mark_alive(inet_address addr) {
 }
 
 future<> gossiper::real_mark_alive(inet_address addr) {
-    co_await utils::get_local_injector().inject_with_handler("gossiper::real_mark_alive", [this, endpoint = addr] (auto& handler) -> future<> {
+    co_await utils::get_local_injector().inject("gossiper::real_mark_alive", [this, endpoint = addr] (auto& handler) -> future<> {
         auto app_state_ptr = get_application_state_ptr(endpoint, application_state::HOST_ID);
         if (!app_state_ptr) {
             co_return;

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1035,7 +1035,7 @@ future<> repair::shard_repair_task_impl::do_repair_ranges() {
             auto user_permit = _user_ranges_parallelism ? co_await seastar::get_units(*_user_ranges_parallelism, 1) : semaphore_units<>();
             co_await repair_range(range, table_info);
             if (2 * (_ranges_complete + 1) > ranges_size()) {
-                co_await utils::get_local_injector().inject_with_handler("repair_shard_repair_task_impl_do_repair_ranges",
+                co_await utils::get_local_injector().inject("repair_shard_repair_task_impl_do_repair_ranges",
                 [] (auto& handler) { return handler.wait_for_message(db::timeout_clock::now() + 10s); });
             }
             ++_ranges_complete;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -714,7 +714,7 @@ private:
         }
         schema_ptr s = f_s.get();
 
-        co_await utils::get_local_injector().inject_with_handler("storage_proxy::handle_read", [s] (auto& handler) -> future<> {
+        co_await utils::get_local_injector().inject("storage_proxy::handle_read", [s] (auto& handler) -> future<> {
             const auto cf_name = handler.get("cf_name");
             assert(cf_name);
             if (s->cf_name() != cf_name) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5135,7 +5135,7 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                     rtlogger.debug("raft_topology_cmd::barrier_and_drain done");
                 });
 
-                co_await utils::get_local_injector().inject_with_handler("raft_topology_barrier_and_drain_fail", [this] (auto& handler) -> future<> {
+                co_await utils::get_local_injector().inject("raft_topology_barrier_and_drain_fail", [this] (auto& handler) -> future<> {
                     auto ks = handler.get("keyspace");
                     auto cf = handler.get("table");
                     auto last_token = dht::token::from_int64(std::atoll(handler.get("last_token")->data()));

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -643,7 +643,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
         rtlogger.debug("start CDC generation publisher fiber");
 
         while (!_as.abort_requested()) {
-            co_await utils::get_local_injector().inject_with_handler("cdc_generation_publisher_fiber", [] (auto& handler) -> future<> {
+            co_await utils::get_local_injector().inject("cdc_generation_publisher_fiber", [] (auto& handler) -> future<> {
                 rtlogger.info("CDC generation publisher fiber sleeps after injection");
                 co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{5});
                 rtlogger.info("CDC generation publisher fiber finishes sleeping after injection");
@@ -2625,7 +2625,7 @@ future<> topology_coordinator::run() {
     while (!_as.abort_requested()) {
         bool sleep = false;
         try {
-            co_await utils::get_local_injector().inject_with_handler("topology_coordinator_pause_before_processing_backlog",
+            co_await utils::get_local_injector().inject("topology_coordinator_pause_before_processing_backlog",
                 [] (auto& handler) { return handler.wait_for_message(db::timeout_clock::now() + std::chrono::minutes(1)); });
             auto guard = co_await cleanup_group0_config_if_needed(co_await start_operation());
 

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -163,7 +163,7 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
                         sm.local().update_progress(plan_id, from.addr, progress_info::direction::IN, sz);
                         offstrategy_update->update();
 
-                        return utils::get_local_injector().inject_with_handler("stream_mutation_fragments", [&guard, &as] (auto& handler) -> future<> {
+                        return utils::get_local_injector().inject("stream_mutation_fragments", [&guard, &as] (auto& handler) -> future<> {
                             auto& guard_ = guard;
                             auto& as_ = as;
                             sslog.info("stream_mutation_fragments: waiting");

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -98,7 +98,7 @@ using error_injection_parameters = std::unordered_map<sstring, sstring>;
  *          }, f);
  *    Expected use case: emulate custom errors like timeouts.
  *
- * 4. inject_with_handler(name, func)
+ * 4. inject(name, future<> func(injection_handler&))
  *    Inserts code that can wait for an event.
  *    Requires func to be a function taking an injection_handler reference and
  *    returning a future<>.
@@ -127,7 +127,7 @@ class error_injection {
 public:
     /**
      * The injection handler class is used to wait for events inside the injected code.
-     * If multiple inject_with_handler are called concurrently for the same injection_name,
+     * If multiple inject (with handler) are called concurrently for the same injection_name,
      * all of them will have separate handlers.
      */
     class injection_handler: public bi::list_base_hook<bi::link_mode<bi::auto_unlink>> {
@@ -393,7 +393,7 @@ public:
     // \param func function returning a future and taking an injection handler
     template <typename Func>
     requires std::is_invocable_r_v<future<>, Func, injection_handler&>
-    future<> inject_with_handler(const std::string_view& name,
+    future<> inject(const std::string_view& name,
                                  Func&& func) {
         auto* data = get_data(name);
         if (!data) {
@@ -537,7 +537,7 @@ public:
     template <typename Func>
     requires std::is_invocable_r_v<future<>, Func, error_injection<true>::injection_handler&>
     [[gnu::always_inline]]
-    future<> inject_with_handler(const std::string_view& name,
+    future<> inject(const std::string_view& name,
                                  Func&& func) {
         return make_ready_future<>();
     }


### PR DESCRIPTION
The method in question can have a shorter name that matches all other injections in this class, and can be non-template