### PR TITLE
nodetool/scylla-nodetool: check for missing keyspace argument on describering

### DIFF
--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -534,6 +534,10 @@ void decommission_operation(scylla_rest_client& client, const bpo::variables_map
 }
 
 void describering_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    if (!vm.contains("keyspace")) {
+        throw std::invalid_argument("keyspace must be specified");
+    }
+
     const auto keyspace = vm["keyspace"].as<sstring>();
     const auto schema_version_res = client.get("/storage_service/schema_version");
 


### PR DESCRIPTION
Calling `scylla-nodetool` with option `describering` and ommiting the keyspace name argument results in a boost exception with the following error message:

`error running operation: boost::wrapexcept<boost::bad_any_cast> (boost::bad_any_cast: failed conversion using boost::any_cast)`

This change checks for the missing keyspace and outputs a more sensible error message:

`error processing arguments: keyspace must be specified`