### PR TITLE
data_dictionary: drop unused friend declaration

### DIFF
--- a/data_dictionary/user_types_metadata.hh
+++ b/data_dictionary/user_types_metadata.hh
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <unordered_map>
-#include <ostream>
 
 #include "bytes.hh"
 #include "types/user.hh"
@@ -36,7 +35,6 @@ public:
     bool has_type(const bytes& name) const {
         return _user_types.contains(name);
     }
-    friend std::ostream& operator<<(std::ostream& os, const user_types_metadata& m);
 };
 
 class user_types_storage {


### PR DESCRIPTION
the corresponding implementation of operator<< was dropped in a40d3fc25b0dea8bfcf5905922152b0b5fb5dab1, so there is no needs to keep this friend declaration anymore.

also, drop `include <ostream>`, as this header does not reference any of the ostream types with the change above.