### PR TITLE
view_info: add fmt::formatter for view_info

### DIFF
--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -776,7 +776,7 @@ std::ostream& operator<<(std::ostream& os, const schema& s) {
     }
     os << "}";
     if (s.is_view()) {
-        os << ", viewInfo=" << *s.view_info();
+        fmt::print(os, ", viewInfo={}", *s.view_info());
     }
     os << "]";
     return os;

--- a/view_info.hh
+++ b/view_info.hh
@@ -74,7 +74,11 @@ public:
     friend bool operator==(const view_info& x, const view_info& y) {
         return x._raw == y._raw;
     }
-    friend std::ostream& operator<<(std::ostream& os, const view_info& view) {
-        return os << view._raw;
+    friend fmt::formatter<view_info>;
+};
+
+template <> struct fmt::formatter<view_info> : fmt::formatter<std::string_view> {
+    auto format(const view_info& view, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", view._raw);
     }
 };


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `view_info`, and drop its operator<<.

Refs #13245