### PR TITLE
docs: Implement relative link support for configuration properties

### DIFF
--- a/docs/_templates/db_config.tmpl
+++ b/docs/_templates/db_config.tmpl
@@ -2,6 +2,8 @@
 
 {% for group in data %}
 {% if group.value_status_count[value_status] > 0 %}
+.. _confgroup_{{ group.name }}:
+
 {{ group.name }}
 {{ '-' * (group.name|length) }}
 
@@ -11,6 +13,8 @@
 
 {% for item in group.properties %}
 {% if item.value_status == value_status %}
+.. _confprop_{{ item.name }}:
+
 .. confval:: {{ item.name }}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Introduces relative link support for individual properties listed on the configuration properties page.  For instance, to link to a property from a different document, use the syntax ":ref:`memtable_flush_static_shares <confprop_memtable_flush_static_shares>`".

Additionally, it also adds support for linking groups. For example, ":ref:`Ungrouped properties <confgroup_ungrouped_properties>`".

## How to test

1. Download this PR.
2. Edit a RST page. Include the link ":ref:`memtable_flush_static_shares <confprop_memtable_flush_static_shares>`".
3. Build the docs.
4. The link should point to http://127.0.0.1:5500/reference/configuration-parameters/#confval-memtable_flush_static_shares