### PR TITLE
remove_rpc_client_with_ignored_topology: recreate rpc client earlier

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -451,7 +451,6 @@ future<> storage_service::sync_raft_topology_nodes(mutable_token_metadata_ptr tm
             sys_ks_futures.push_back(_sys_ks.local().update_peer_info(*ip, host_id, info));
             if (!prev_normal.contains(id)) {
                 co_await notify_joined(*ip);
-                co_await remove_rpc_client_with_ignored_topology(*ip);
             }
 
             if (const auto it = host_id_to_ip_map.find(host_id); it != host_id_to_ip_map.end() && it->second != *ip) {
@@ -614,6 +613,7 @@ future<> storage_service::topology_state_load() {
     // is the source of truth about enabled features.
     co_await _sys_ks.local().save_local_enabled_features(_topology_state_machine._topology.enabled_features, false);
 
+    auto saved_tmpr = get_token_metadata_ptr();
     {
         auto tmlock = co_await get_token_metadata_lock();
         auto tmptr = make_token_metadata_ptr(token_metadata::config {
@@ -683,6 +683,19 @@ future<> storage_service::topology_state_load() {
         if (!_gossiper.get_endpoint_state_ptr(ep)) {
             co_await _gossiper.add_saved_endpoint(ep, permit.id());
         }
+    }
+
+    // As soon as a node joins token_metadata.topology we
+    // need to drop all its rpc connections with ignored_topology flag.
+    {
+        std::vector<future<>> futures;
+        tmptr->get_topology().for_each_node([&](const locator::node* n) {
+            const auto ep = n->endpoint();
+            if (ep != inet_address{} && !saved_tmpr->get_topology().has_endpoint(ep)) {
+                futures.push_back(remove_rpc_client_with_ignored_topology(ep));
+            }
+        });
+        co_await when_all_succeed(futures.begin(), futures.end()).discard_result();
     }
 
     for (const auto& gen_id : _topology_state_machine._topology.committed_cdc_generations) {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -729,6 +729,7 @@ private:
     future<> notify_up(inet_address endpoint);
     future<> notify_joined(inet_address endpoint);
     future<> notify_cql_change(inet_address endpoint, bool ready);
+    future<> remove_rpc_client_with_ignored_topology(inet_address endpoint);
 public:
     future<bool> is_cleanup_allowed(sstring keyspace);
     bool is_repair_based_node_ops_enabled(streaming::stream_reason reason);

--- a/test/topology_custom/test_remove_rpc_client_with_pending_requests.py
+++ b/test/topology_custom/test_remove_rpc_client_with_pending_requests.py
@@ -1,0 +1,72 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import asyncio
+import logging
+import time
+
+import pytest
+from cassandra.query import SimpleStatement, ConsistencyLevel
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.random_tables import RandomTables, Column, TextType
+from test.pylib.util import wait_for_cql_and_get_hosts
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_remove_rpc_client_with_pending_requests(request, manager: ManagerClient) -> None:
+    # Regression test for #17445
+
+    logger.info("starting first two nodes")
+    servers = await manager.servers_add(2)
+
+    logger.info(f"wait_for_cql_and_get_hosts for the first node {servers[0]}")
+    host0 = (await wait_for_cql_and_get_hosts(manager.get_cql(), [servers[0]], time.time() + 60))[0]
+
+    logger.info(f"creating test table")
+    random_tables = RandomTables(request.node.name, manager, "ks", 2)
+    await random_tables.add_table(name='test_table', pks=1, columns=[
+        Column(name="key", ctype=TextType),
+        Column(name="value", ctype=TextType)
+    ])
+
+    logger.info(f"inserting test data")
+    test_rows_count = 10
+    futures = []
+    expected_data = []
+    for i in range(0, test_rows_count):
+        k = f'key_{i}'
+        v = f'value_{i}'
+        expected_data.append((k, v))
+        futures.append(manager.get_cql().run_async("insert into ks.test_table(key, value) values (%s, %s)",
+                                                   parameters=[k, v], host=host0))
+    await asyncio.gather(*futures)
+    expected_data.sort()
+
+    logger.info(f"adding the third node")
+    servers += [await manager.server_add(start=False)]
+
+    logger.info(f"starting the third node [{servers[2]}]")
+    third_node_future = asyncio.create_task(manager.server_start(servers[2].server_id))
+
+    logger.info(f"running read requests in a loop while the third node is joining")
+    reads_count = 0
+    start_time = time.time()
+    while not third_node_future.done():
+        result_set = await manager.get_cql().run_async(SimpleStatement("select * from ks.test_table",
+                                                                       consistency_level=ConsistencyLevel.ALL),
+                                                       host=host0)
+        actual_data = []
+        for row in result_set:
+            actual_data.append((row.key, row.value))
+        actual_data.sort()
+        assert actual_data == expected_data
+        reads_count += 1
+    finish_time = time.time()
+    logger.info(f"done, reads count {reads_count}, took {finish_time - start_time} seconds")
+
+    await third_node_future


### PR DESCRIPTION
It's too late to call `remove_rpc_client_with_ignored_topology` on messaging service when a node becomes normal. Data plane requests can be routed to the node much earlier, at least when topology switches to `write_both_read_new`. The `remove_rpc_client_with_ignored_topology` function shutdowns sockets and causes such requests to timeout.

In this PR we move the `remove_rpc_client_with_ignored_topology` call to the earliest point possible when a node first appears in `token_metadata.topology`.

From the topology coordinator perspective this happens when a joining node moves to `node_state::bootstrapping` and the topology moves to `transition_state::join_group0`. In `sync_raft_topology_nodes` the node should be contained in transition_nodes. The successful `wait_for_ip` before entering `transition_state::join_group0` ensures that update_topology should find a node's IP and put it into the topology. The barrier in `commit_cdc_generation` will ensure that all nodes in the cluster are using the proper connection parameters.

Only outgoing connections are tracked by `remove_rpc_client_with_ignored_topology`, those created by the current node. This means we need to call `remove_rpc_client_with_ignored_topology` on each node of the cluster.

fixes scylladb/scylladb#17445