### PR TITLE
open-coredump.sh: respect http redirects

### DIFF
--- a/scripts/open-coredump.sh
+++ b/scripts/open-coredump.sh
@@ -256,7 +256,7 @@ then
     if ! [[ -f ${ARTIFACT_DIR}/${PACKAGE_FILE} ]]
     then
         log "Downloading relocatable package from ${PACKAGE_URL}"
-        curl ${CURL_QUIET_FLAG} --output ${ARTIFACT_DIR}/${PACKAGE_FILE} ${PACKAGE_URL}
+        curl -L ${CURL_QUIET_FLAG} --output ${ARTIFACT_DIR}/${PACKAGE_FILE} ${PACKAGE_URL}
     else
         log "Relocatable package ${PACKAGE_URL} already downloaded"
     fi


### PR DESCRIPTION
downloads.scylladb.com recently started redirecting from http to https (via `301 Moved Permanently`).
This broke package downloading in open-coredump.sh.

To fix this, we have to instruct curl to follow redirects.