### PR TITLE
[test.py]fix aiohttp usage issue in python 3.12

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -47,15 +47,26 @@ class ManagerClient():
         self.ccluster: Optional[CassandraCluster] = None
         self.cql: Optional[CassandraSession] = None
         # A client for communicating with ScyllaClusterManager (server)
-        self.client = UnixRESTClient(sock_path)
+        self.sock_path = sock_path
+        self.client_for_asyncio_loop = {asyncio.get_running_loop(): UnixRESTClient(sock_path)}
         self.api = ScyllaRESTAPIClient()
         self.metrics = ScyllaMetricsClient()
         self.thread_pool = ThreadPoolExecutor()
 
+    @property
+    def client(self):
+        _client = self.client_for_asyncio_loop.get(asyncio.get_running_loop(), None)
+        if _client is None:
+            _client = UnixRESTClient(self.sock_path)
+            self.client_for_asyncio_loop[asyncio.get_running_loop()] = _client
+        return _client
+
     async def stop(self):
         """Close driver"""
         self.driver_close()
-        await self.client.shutdown()
+        # TODO: good candidate for safe_gather  https://github.com/scylladb/scylladb/pull/17781
+        #  to make sure tha all connections is closed
+        await asyncio.gather(*[client.shutdown() for client in self.client_for_asyncio_loop.values()])
 
     async def driver_connect(self, server: Optional[ServerInfo] = None, auth_provider: Optional[AuthProvider] = None) -> None:
         """Connect to cluster"""


### PR DESCRIPTION
fix aiohttp usage issue in python 3.12
"Timeout context manager should be used " "inside a task"
this occurs due to
UnixRESTClient created in one event loop (created inside pytest)
but used in another(created in rewriten event_loop fixture)
now it is fixed by updating UnixRESTClient object for every new loop

related issue https://github.com/scylladb/scylladb/issues/16676
