### PR TITLE
treewide: Use partition_slice::is_reversed()

### DIFF
--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -2294,7 +2294,7 @@ to_data_query_result(const reconcilable_result& r, schema_ptr s, const query::pa
     auto consumer = compact_for_query_v2<query_result_builder>(*s, gc_clock::time_point::min(), slice, max_rows,
             max_partitions, query_result_builder(*s, builder));
     auto compaction_state = consumer.get_state();
-    const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::yes : consume_in_reverse::no;
+    const auto reverse = slice.is_reversed() ? consume_in_reverse::yes : consume_in_reverse::no;
 
     // FIXME: frozen_mutation::consume supports only forward consumers
     if (reverse == consume_in_reverse::no) {
@@ -2326,7 +2326,7 @@ query_mutation(mutation&& m, const query::partition_slice& slice, uint64_t row_l
     auto consumer = compact_for_query_v2<query_result_builder>(*m.schema(), now, slice, row_limit,
             query::max_partitions, query_result_builder(*m.schema(), builder));
     auto compaction_state = consumer.get_state();
-    const auto reverse = slice.options.contains(query::partition_slice::option::reversed) ? consume_in_reverse::yes : consume_in_reverse::no;
+    const auto reverse = slice.is_reversed() ? consume_in_reverse::yes : consume_in_reverse::no;
     std::move(m).consume(consumer, reverse);
     return builder.build(compaction_state->current_full_position());
 }

--- a/mutation_query.hh
+++ b/mutation_query.hh
@@ -155,7 +155,7 @@ public:
     // Expects table schema (non-reversed) and half-reversed (legacy) slice when building results for reverse query.
     reconcilable_result_builder(const schema& s, const query::partition_slice& slice,
                                 query::result_memory_accounter&& accounter) noexcept
-        : _schema(s), _slice(slice), _reversed(_slice.options.contains(query::partition_slice::option::reversed))
+        : _schema(s), _slice(slice), _reversed(_slice.is_reversed())
         , _query_schema(_reversed ? _schema.make_reversed() : _schema.shared_from_this())
         , _memory_accounter(std::move(accounter))
     { }

--- a/querier.hh
+++ b/querier.hh
@@ -107,7 +107,7 @@ public:
     }
 
     bool is_reversed() const {
-        return _slice->options.contains(query::partition_slice::option::reversed);
+        return _slice->is_reversed();
     }
 
     virtual std::optional<full_position_view> current_position() const = 0;

--- a/read_context.hh
+++ b/read_context.hh
@@ -163,7 +163,7 @@ public:
         , _tombstone_gc_state(gc_state)
         , _underlying(_cache, *this)
     {
-        if (_slice.options.contains(query::partition_slice::option::reversed)) {
+        if (_slice.is_reversed()) {
             _native_slice = query::legacy_reverse_slice_to_native_reverse_slice(*_schema, _slice);
         }
         ++_cache._tracker._stats.reads;
@@ -186,7 +186,7 @@ public:
     reader_permit permit() const { return _permit; }
     const dht::partition_range& range() const { return _range; }
     const query::partition_slice& slice() const { return _slice; }
-    bool is_reversed() const { return _slice.options.contains(query::partition_slice::option::reversed); }
+    bool is_reversed() const { return _slice.is_reversed(); }
     // Returns a slice in the native format (for reversed reads, in native-reversed format).
     const query::partition_slice& native_slice() const { return is_reversed() ? *_native_slice : _slice; }
     tracing::trace_state_ptr trace_state() const { return _trace_state; }

--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -334,7 +334,7 @@ void evictable_reader_v2::update_next_position() {
 }
 
 void evictable_reader_v2::adjust_partition_slice() {
-    const auto reversed = _ps.options.contains(query::partition_slice::option::reversed);
+    const auto reversed = _ps.is_reversed();
     _slice_override = reversed ? query::legacy_reverse_slice_to_native_reverse_slice(*_schema, _ps) : _ps;
 
     auto ranges = _slice_override->default_row_ranges();
@@ -473,7 +473,7 @@ void evictable_reader_v2::validate_position_in_partition(position_in_partition_v
             pos);
 
     if (_slice_override && pos.region() == partition_region::clustered) {
-        const auto reversed = _ps.options.contains(query::partition_slice::option::reversed);
+        const auto reversed = _ps.is_reversed();
         std::optional<query::partition_slice> native_slice;
         if (reversed) {
             native_slice = query::legacy_reverse_slice_to_native_reverse_slice(*_schema, *_slice_override);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1595,7 +1595,7 @@ database::query(schema_ptr s, const query::read_command& cmd, query::result_opti
 future<std::tuple<reconcilable_result, cache_temperature>>
 database::query_mutations(schema_ptr s, const query::read_command& cmd, const dht::partition_range& range,
                           tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout) {
-    const auto reversed = cmd.slice.options.contains(query::partition_slice::option::reversed);
+    const auto reversed = cmd.slice.is_reversed();
     if (reversed) {
         s = s->make_reversed();
     }

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -36,7 +36,7 @@ using namespace std::chrono_literals;
 using namespace cache;
 
 static schema_ptr to_query_domain(const query::partition_slice& slice, schema_ptr table_domain_schema) {
-    if (slice.options.contains(query::partition_slice::option::reversed)) [[unlikely]] {
+    if (slice.is_reversed()) [[unlikely]] {
         return table_domain_schema->make_reversed();
     }
     return table_domain_schema;

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -104,7 +104,7 @@ future<result<service::storage_proxy::coordinator_query_result>> query_pager::do
         auto dpk = dht::decorate_key(*_schema, *_last_pkey);
         dht::ring_position lo(dpk);
 
-        auto reversed = _cmd->slice.options.contains<query::partition_slice::option::reversed>();
+        auto reversed = _cmd->slice.is_reversed();
 
         qlogger.trace("PKey={}, Pos={}, reversed={}", dpk, _last_pos, reversed);
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2358,7 +2358,7 @@ query::max_result_size storage_proxy::get_max_result_size(const query::partition
     // FIXME: Remove the code below once SEPARATE_PAGE_SIZE_AND_SAFETY_LIMIT
     //        cluster feature is released for more than 2 years and can be
     //        retired.
-    if (!slice.options.contains<query::partition_slice::option::allow_short_read>() || slice.options.contains<query::partition_slice::option::reversed>()) {
+    if (!slice.options.contains<query::partition_slice::option::allow_short_read>() || slice.is_reversed()) {
         return _db.local().get_query_max_result_size().without_page_limit();
     } else {
         return query::max_result_size(query::result_memory_limiter::maximum_result_size);
@@ -4613,7 +4613,7 @@ private:
         // and clustering keys of the last row that is going to be returned to the client and check if
         // it is in range of rows returned by each replicas that returned as many rows as they were
         // asked for (if a replica returned less rows it means it returned everything it has).
-        auto is_reversed = cmd.slice.options.contains(query::partition_slice::option::reversed);
+        auto is_reversed = cmd.slice.is_reversed();
 
         auto rows_left = original_row_limit;
         auto partitions_left = original_partition_limit;

--- a/test/boost/flat_mutation_reader_test.cc
+++ b/test/boost/flat_mutation_reader_test.cc
@@ -1132,7 +1132,7 @@ SEASTAR_THREAD_TEST_CASE(test_reverse_reader_v2_is_mutation_source) {
             std::vector<mutation>* selected_muts;
 
             schema = schema->make_reversed();
-            const auto reversed = slice.options.contains(query::partition_slice::option::reversed);
+            const auto reversed = slice.is_reversed();
             if (reversed) {
                 reversed_slice = std::make_unique<query::partition_slice>(query::half_reverse_slice(*schema, slice));
                 selected_muts = &muts;

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -56,7 +56,7 @@ static mutation_source make_source(std::vector<mutation> mutations) {
             tracing::trace_state_ptr, streamed_mutation::forwarding fwd, mutation_reader::forwarding fwd_mr) {
         assert(range.is_full()); // slicing not implemented yet
         for (auto&& m : mutations) {
-            if (slice.options.contains(query::partition_slice::option::reversed)) {
+            if (slice.is_reversed()) {
                 assert(m.schema()->make_reversed()->version() == s->version());
             } else {
                 assert(m.schema() == s);
@@ -86,7 +86,7 @@ static reconcilable_result mutation_query(schema_ptr s, reader_permit permit, co
 
     auto querier = query::querier(source, s, std::move(permit), range, slice, {});
     auto close_querier = deferred_close(querier);
-    auto table_schema = slice.options.contains(query::partition_slice::option::reversed) ? s->make_reversed() : s;
+    auto table_schema = slice.is_reversed() ? s->make_reversed() : s;
     auto rrb = reconcilable_result_builder(*table_schema, slice, make_accounter());
     return querier.consume_page(std::move(rrb), row_limit, partition_limit, query_time).get();
 }

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -4157,7 +4157,7 @@ SEASTAR_THREAD_TEST_CASE(clustering_combined_reader_mutation_source_test) {
                 tracing::trace_state_ptr trace_state,
                 streamed_mutation::forwarding fwd_sm,
                 mutation_reader::forwarding fwd_mr) {
-            auto reversed = slice.options.contains(query::partition_slice::option::reversed);
+            auto reversed = slice.is_reversed();
             std::map<dht::decorated_key, flat_mutation_reader_v2, dht::decorated_key::less_comparator>
                 good_readers{dht::decorated_key::less_comparator(s)};
             for (auto& [k, ms]: good) {

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -3361,7 +3361,7 @@ SEASTAR_TEST_CASE(test_concurrent_reads_and_eviction) {
 
         auto pr = dht::partition_range::make_singular(m0.decorated_key());
         auto make_reader = [&] (const query::partition_slice& slice) {
-            auto reversed = slice.options.contains<query::partition_slice::option::reversed>();
+            auto reversed = slice.is_reversed();
             auto rd = cache.make_reader(reversed ? rev_s : s, semaphore.make_permit(), pr, slice);
             rd.set_max_buffer_size(3);
             rd.fill_buffer().get();


### PR DESCRIPTION
Continuation of cc56a971e8, more noisy places detected