### PR TITLE
repair: Add hosts and ignore_nodes option support for tablet repair

### DIFF
--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -162,7 +162,7 @@ private:
             shared_ptr<node_ops_info> ops_info);
 
 public:
-    future<> repair_tablets(repair_uniq_id id, sstring keyspace_name, std::vector<sstring> table_names, host2ip_t host2ip, bool primary_replica_only = true, dht::token_range_vector ranges_specified = {}, std::vector<sstring> dcs = {});
+    future<> repair_tablets(repair_uniq_id id, sstring keyspace_name, std::vector<sstring> table_names, host2ip_t host2ip, bool primary_replica_only = true, dht::token_range_vector ranges_specified = {}, std::vector<sstring> dcs = {}, std::unordered_set<gms::inet_address> hosts = {}, std::unordered_set<gms::inet_address> ignore_nodes = {});
 
 private:
 


### PR DESCRIPTION
It is not supported currently.

If a user passes the option, the request will be rejected with:

    The hosts option is not supported for tablet repair
    The ignore_nodes option is not supported for tablet repair

This option is useful to select nodes to repair.

Fixes: #17742

Tests: repair_additional_test.py::TestRepairAdditional::test_repair_ignore_nodes
       repair_additional_test.py::TestRepairAdditional::test_repair_ignore_nodes_errors
       repair_additional_test.py::TestRepairAdditional::test_repair_option_pr_dc_host
