### PR TITLE
schema: add fmt::formatter for schema

### DIFF
--- a/test/boost/column_mapping_test.cc
+++ b/test/boost/column_mapping_test.cc
@@ -14,6 +14,11 @@
 #include "db/schema_tables.hh"
 #include "transport/messages/result_message.hh"
 
+std::ostream& boost_test_print_type(std::ostream& os, const column_mapping& cm) {
+    fmt::print(os, "{}", cm);
+    return os;
+}
+
 SEASTAR_TEST_CASE(test_column_mapping_persistence) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         // Check that column mapping history is empty initially


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for

* column_definition
* column_mapping
* ordinal_column_id
* raw_view_info
* schema
* view_ptr

their operator<<:s are dropped.

Refs #13245