### PR TITLE
mutation: add fmt::formatter for mutation types

### DIFF
--- a/mutation/frozen_mutation.cc
+++ b/mutation/frozen_mutation.cc
@@ -147,10 +147,6 @@ mutation_partition_view frozen_mutation::partition() const {
     return mutation_partition_view::from_view(mutation_view().partition());
 }
 
-std::ostream& operator<<(std::ostream& out, const frozen_mutation::printer& pr) {
-    return out << pr.self.unfreeze(pr.schema);
-}
-
 frozen_mutation::printer frozen_mutation::pretty_printer(schema_ptr s) const {
     return { *this, std::move(s) };
 }

--- a/mutation/frozen_mutation.hh
+++ b/mutation/frozen_mutation.hh
@@ -222,7 +222,6 @@ public:
     struct printer {
         const frozen_mutation& self;
         schema_ptr schema;
-        friend std::ostream& operator<<(std::ostream&, const printer&);
     };
 
     // Same requirements about the schema as unfreeze().
@@ -323,3 +322,9 @@ auto frozen_mutation::consume_gently(schema_ptr s, Consumer& consumer) const -> 
     frozen_mutation_consumer_adaptor adaptor(s, consumer);
     co_return co_await consume_gently(s, adaptor);
 }
+
+template <> struct fmt::formatter<frozen_mutation::printer> : fmt::formatter<std::string_view> {
+    auto format(const frozen_mutation::printer& pr, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", pr.self.unfreeze(pr.schema));
+    }
+};

--- a/mutation/mutation.hh
+++ b/mutation/mutation.hh
@@ -185,8 +185,6 @@ public:
     mutation compacted() const;
 
     size_t memory_usage(const ::schema& s) const;
-private:
-    friend std::ostream& operator<<(std::ostream& os, const mutation& m);
 };
 
 template<consume_in_reverse reverse, FlattenedConsumerV2 Consumer>
@@ -457,3 +455,9 @@ boost::iterator_range<std::vector<mutation>::const_iterator> slice(
 // Reverses the mutation as if it was created with a schema with reverse
 // clustering order. The resulting mutation will contain a reverse schema too.
 mutation reverse(mutation mut);
+
+template <> struct fmt::formatter<mutation> : fmt::formatter<std::string_view> {
+    auto format(const mutation&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+std::ostream& operator<<(std::ostream& os, const mutation& m);

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -127,9 +127,9 @@ public:
         printer(const printer&) = delete;
         printer(printer&&) = delete;
 
-        friend std::ostream& operator<<(std::ostream& os, const printer& p);
+        friend fmt::formatter<printer>;
     };
-    friend std::ostream& operator<<(std::ostream& os, const printer& p);
+    friend fmt::formatter<printer>;
 public:
     // Makes sure there is a dummy entry after all clustered rows. Doesn't affect continuity.
     // Doesn't invalidate iterators.
@@ -281,3 +281,7 @@ mutation_partition_v2& mutation_partition_v2::container_of(rows_type& rows) {
 // Returns true iff the mutation contains dummy rows which are redundant,
 // meaning that they can be removed without affecting the set of writes represented by the mutation.
 bool has_redundant_dummies(const mutation_partition_v2&);
+
+template <> struct fmt::formatter<mutation_partition_v2::printer> : fmt::formatter<std::string_view> {
+    auto format(const mutation_partition_v2::printer&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -715,7 +715,8 @@ std::ostream& operator<<(std::ostream& out, const partition_entry::printer& p) {
                 }
                 out << ") ";
             }
-            out << fmt::ptr(v) << ": " << mutation_partition_v2::printer(*v->get_schema(), v->partition());
+            fmt::print(out, "{}: {}",
+                       fmt::ptr(v), mutation_partition_v2::printer(*v->get_schema(), v->partition()));
             v = v->next();
             first = false;
         }

--- a/schema_mutations.cc
+++ b/schema_mutations.cc
@@ -140,13 +140,13 @@ bool schema_mutations::is_view() const {
 
 std::ostream& operator<<(std::ostream& out, const schema_mutations& sm) {
     out << "schema_mutations{\n";
-    out << " tables=" << sm.columnfamilies_mutation() << ",\n";
-    out << " scylla_tables=" << sm.scylla_tables() << ",\n";
-    out << " columns=" << sm.columns_mutation() << ",\n";
-    out << " dropped_columns=" << sm.dropped_columns_mutation() << ",\n";
-    out << " indices=" << sm.indices_mutation() << ",\n";
-    out << " computed_columns=" << sm.computed_columns_mutation() << ",\n";
-    out << " view_virtual_columns=" << sm.view_virtual_columns_mutation() << "\n";
+    fmt::print(out, " tables={},\n", sm.columnfamilies_mutation());
+    fmt::print(out, " scylla_tables={},\n", sm.scylla_tables());
+    fmt::print(out, " tables={},\n", sm.columns_mutation());
+    fmt::print(out, " dropped_columns={},\n", sm.dropped_columns_mutation());
+    fmt::print(out, " indices={},\n", sm.indices_mutation());
+    fmt::print(out, " computed_columns={},\n", sm.computed_columns_mutation());
+    fmt::print(out, " view_virtual_columns={},\n", sm.view_virtual_columns_mutation());
     out << "}";
     return out;
 }


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for

* mutation_partition_v2::printer
* frozen_mutation::printer
* mutation

their operator<<:s are dropped.

Refs #13245