### PR TITLE
.git: skip redis/lolwut.cc when scanning spelling errors

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -14,4 +14,4 @@ jobs:
         with:
           only_warn: 1
           ignore_words_list: "ans,datas,fo,ser,ue,crate,nd,reenable,strat,stap,te"
-          skip: "./.git,./build,./tools,*.js,*.thrift,*.lock,./test,./licenses,*.svg"
+          skip: "./.git,./build,./tools,*.js,*.thrift,*.lock,./test,./licenses,./redis/lolwut.cc,*.svg"


### PR DESCRIPTION
codespell reports "Nees" should be "Needs" but "Nees" is the last name of Georg Nees. so it is not a misspelling. and should not be fixed.

since the purpose of lolwut.cc is to display Redis version and print a generative computer art. the one included by our version was created by Georg Nees. since the LOLWUT command does not contain business logic connected with scylladb, we don't lose a lot if skip it when scanning for spelling errors. so, in this change, let's skip it, this should silence one more warning from the github codespell workflow.