### PR TITLE
Drop tablets of dropped views and indices

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2759,6 +2759,7 @@ static void make_update_indices_mutations(
         schema_ptr view;
         try {
             view = db.find_schema(old_table->ks_name(), secondary_index::index_table_name(name));
+            db.get_notifier().before_drop_column_family(*view, mutations, timestamp);
         } catch (const replica::no_such_column_family&) {
             on_internal_error(slogger, format("Could not find schema for dropped index {}.{}",
                     old_table->ks_name(), secondary_index::index_table_name(name)));

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -49,6 +49,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/loop.hh>
+#include <seastar/core/on_internal_error.hh>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/range/algorithm/copy.hpp>
@@ -2755,8 +2756,13 @@ static void make_update_indices_mutations(
     for (auto&& name : diff.entries_only_on_left) {
         const index_metadata& index = old_table->all_indices().at(name);
         drop_index_from_schema_mutation(old_table, index, timestamp, mutations);
-        auto& cf = db.find_column_family(old_table);
-        auto view = cf.get_index_manager().create_view_for_index(index, new_token_column_computation);
+        schema_ptr view;
+        try {
+            view = db.find_schema(old_table->ks_name(), secondary_index::index_table_name(name));
+        } catch (const replica::no_such_column_family&) {
+            on_internal_error(slogger, format("Could not find schema for dropped index {}.{}",
+                    old_table->ks_name(), secondary_index::index_table_name(name)));
+        }
         make_drop_table_or_view_mutations(views(), view, timestamp, mutations);
     }
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1148,6 +1148,7 @@ public:
         auto rs = abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), params);
         if (auto&& tablet_rs = rs->maybe_as_tablet_aware()) {
             auto tm = _db.get_shared_token_metadata().get();
+            lblogger.debug("Creating tablets for {}.{} id={}", s.ks_name(), s.cf_name(), s.id());
             auto map = tablet_rs->allocate_tablets_for_new_table(s.shared_from_this(), tm, _config.initial_tablets_scale).get();
             muts.emplace_back(tablet_map_to_mutation(map, s.id(), s.keypace_name(), s.cf_name(), ts).get());
         }
@@ -1158,6 +1159,7 @@ public:
         auto&& rs = ks.get_replication_strategy();
         if (rs.uses_tablets()) {
             auto tm = _db.get_shared_token_metadata().get();
+            lblogger.debug("Dropping tablets for {}.{} id={}", s.ks_name(), s.cf_name(), s.id());
             muts.emplace_back(make_drop_tablet_map_mutation(s.id(), ts));
         }
     }
@@ -1166,6 +1168,7 @@ public:
         keyspace& ks = _db.find_keyspace(keyspace_name);
         auto&& rs = ks.get_replication_strategy();
         if (rs.uses_tablets()) {
+            lblogger.debug("Dropping tablets for keyspace {}", keyspace_name);
             auto tm = _db.get_shared_token_metadata().get();
             for (auto&& [name, s] : ks.metadata()->cf_meta_data()) {
                 muts.emplace_back(make_drop_tablet_map_mutation(s->id(), ts));

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1156,7 +1156,6 @@ public:
     void on_before_drop_column_family(const schema& s, std::vector<mutation>& muts, api::timestamp_type ts) override {
         keyspace& ks = _db.find_keyspace(s.ks_name());
         auto&& rs = ks.get_replication_strategy();
-        std::vector<mutation> result;
         if (rs.uses_tablets()) {
             auto tm = _db.get_shared_token_metadata().get();
             muts.emplace_back(make_drop_tablet_map_mutation(s.id(), ts));

--- a/test/cql-pytest/test_tablets.py
+++ b/test/cql-pytest/test_tablets.py
@@ -13,7 +13,7 @@
 #############################################################################
 
 import pytest
-from util import new_test_keyspace, new_test_table, unique_name
+from util import new_test_keyspace, new_test_table, unique_name, index_table_name
 from cassandra.protocol import ConfigurationException, InvalidRequest
 
 # A fixture similar to "test_keyspace", just creates a keyspace that enables
@@ -165,6 +165,37 @@ def test_tablets_are_dropped_when_dropping_table_with_view(cql, test_keyspace):
             cql.execute(f"DROP MATERIALIZED VIEW {test_keyspace}.{view_name}")
         except:
             pass
+        try:
+            cql.execute(f"DROP TABLE {test_keyspace}.{table_name}")
+        except:
+            pass
+        raise e
+
+
+# Test the following cases:
+# 1. When an index of a tablets-enabled table is dropped, all of its tablets are dropped with it.
+# 2. When a tablets-enabled table that has an index is dropped, the tablets associated with the table and index are dropped with it.
+#
+# Reproduces https://github.com/scylladb/scylladb/issues/17627
+@pytest.mark.parametrize("drop_index", [True, False])
+def test_tablets_are_dropped_when_dropping_index(cql, test_keyspace, drop_index):
+    table_name = unique_name()
+    schema = "pk int PRIMARY KEY, c int"
+    cql.execute(f"CREATE TABLE {test_keyspace}.{table_name} ({schema})")
+    try:
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {test_keyspace}.{table_name} (c)")
+        verify_tablets_presence(cql, test_keyspace, table_name)
+        verify_tablets_presence(cql, test_keyspace, index_table_name(index_name))
+
+        if drop_index:
+            cql.execute(f"DROP INDEX {test_keyspace}.{index_name}")
+            verify_tablets_presence(cql, test_keyspace, index_table_name(index_name), expected=False)
+
+        cql.execute(f"DROP TABLE {test_keyspace}.{table_name}")
+        verify_tablets_presence(cql, test_keyspace, table_name, expected=False)
+        verify_tablets_presence(cql, test_keyspace, index_table_name(index_name), expected=False)
+    except Exception as e:
         try:
             cql.execute(f"DROP TABLE {test_keyspace}.{table_name}")
         except:

--- a/test/cql-pytest/util.py
+++ b/test/cql-pytest/util.py
@@ -190,6 +190,9 @@ def new_secondary_index(cql, table, column, name='', extra=''):
     finally:
         cql.execute(f"DROP INDEX {keyspace}.{name}")
 
+def index_table_name(index_name : str):
+    return f"{index_name}_index"
+
 # Helper function for establishing a connection with given username and password
 @contextmanager
 def cql_session(host, port, is_ssl, username, password, request_timeout=120):


### PR DESCRIPTION
This series adds notification before dropping views and indices so that the
tablet_allocator can generate mutations to respectively drop all tablets associated with them from system.tablets.

Additional unit tests were added for these cases.

Note that one case is not yet tested: where a table is allowed to be dropped while having views that depend on it, when it is dropped from the alternator path.

This is tested indirectly by testing dropping a table with live secondary index as it follows the same notification path as views in this series.

Fixes #17627