### PR TITLE
Add wrapper for asyncio.gather() to catch the exceptions in the tasks

### DIFF
--- a/test/auth_cluster/test_auth_v2_migration.py
+++ b/test/auth_cluster/test_auth_v2_migration.py
@@ -10,7 +10,7 @@ import pytest
 import time
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import read_barrier, wait_for_cql_and_get_hosts
+from test.pylib.util import read_barrier, wait_for_cql_and_get_hosts, gather_safely
 from test.topology.util import wait_until_topology_upgrade_finishes
 from cassandra.cluster import ConsistencyLevel
 
@@ -47,7 +47,7 @@ async def populate_test_data(manager: ManagerClient, data):
     for d in data:
         stmt = cql.prepare(d["statement"])
         stmt.consistency_level = ConsistencyLevel.ALL
-        await asyncio.gather(*(
+        await gather_safely(*(
             cql.run_async(stmt.bind(row_data)) for row_data in d["rows"]))
 
 
@@ -78,14 +78,14 @@ async def warmup_v1_static_values(manager: ManagerClient, hosts):
     # verify later that after migration properly formed query
     # executes (query has to change because keyspace name changes)
     cql = manager.get_cql()
-    await asyncio.gather(*(cql.run_async("LIST ROLES", host=host) for host in hosts))
+    await gather_safely(*(cql.run_async("LIST ROLES", host=host) for host in hosts))
 
 
 async def check_auth_v2_data_migration(manager: ManagerClient, hosts):
     cql = manager.get_cql()
     # auth reads are eventually consistent so we need to make sure hosts are up-to-date
     assert hosts
-    await asyncio.gather(*(read_barrier(cql, host) for host in hosts))
+    await gather_safely(*(read_barrier(cql, host) for host in hosts))
 
     data = auth_data()
 
@@ -118,12 +118,12 @@ async def check_auth_v2_works(manager: ManagerClient, hosts):
     assert set([user1_roles[0].role, user1_roles[1].role]) == set(["users",  "user 1"])
 
     await cql.run_async("CREATE ROLE IF NOT EXISTS user_after_migration")
-    await asyncio.gather(*(read_barrier(cql, host) for host in hosts))
+    await gather_safely(*(read_barrier(cql, host) for host in hosts))
     # see warmup_v1_static_values for background about checks below
     # check if it was added to a new table
     assert len(await cql.run_async("SELECT role FROM system_auth_v2.roles WHERE role = 'user_after_migration'")) == 1
     # check whether list roles statement sees it also via new table (on all nodes)
-    await asyncio.gather(*(cql.run_async("LIST ROLES OF user_after_migration", host=host) for host in hosts))
+    await gather_safely(*(cql.run_async("LIST ROLES OF user_after_migration", host=host) for host in hosts))
     await cql.run_async("DROP ROLE user_after_migration")
 
 
@@ -156,7 +156,7 @@ async def test_auth_v2_migration(request, manager: ManagerClient):
     await manager.api.upgrade_to_raft_topology(hosts[0].address)
 
     logging.info("Waiting until upgrade finishes")
-    await asyncio.gather(*(wait_until_topology_upgrade_finishes(manager, h.address, time.time() + 60) for h in hosts))
+    await gather_safely(*(wait_until_topology_upgrade_finishes(manager, h.address, time.time() + 60) for h in hosts))
 
     logging.info("Checking migrated data in system_auth_v2")
     await check_auth_v2_data_migration(manager, hosts)

--- a/test/pylib/coverage_utils.py
+++ b/test/pylib/coverage_utils.py
@@ -35,6 +35,8 @@ import logging
 import sys
 import inspect
 
+from test.pylib.util import gather_safely
+
 # So the module can be imported outside of this directory
 sys.path.insert(0, os.path.dirname(__file__))
 import lcov_utils
@@ -344,7 +346,7 @@ async def gather_limited_concurrency(
 
     coros = [asyncio.ensure_future(with_semaphore(coro)) for coro in args]
     try:
-        return await asyncio.gather(*coros, **kwargs)
+        return await gather_safely(*coros, **kwargs)
     except:
         raise
     finally:
@@ -733,7 +735,7 @@ async def lcov_combine_traces(
                 ]
                 merge_funcs = [partial(merge_lcovs, chunk) for chunk in files_to_merge]
                 # We use "normal" gather here since we have the concurrency limited by the executor
-                files_to_merge = await asyncio.gather(
+                files_to_merge = await gather_safely(
                     *(loop.run_in_executor(executor, func) for func in merge_funcs)
                 )
             result: List[lcov_utils.LcovFile] = await loop.run_in_executor(

--- a/test/pylib/random_tables.py
+++ b/test/pylib/random_tables.py
@@ -40,8 +40,7 @@ from typing import Optional, Type, List, Set, Union, TYPE_CHECKING
 if TYPE_CHECKING:
     from cassandra.cluster import Session as CassandraSession            # type: ignore
     from test.pylib.manager_client import ManagerClient
-from test.pylib.util import get_available_host, read_barrier
-
+from test.pylib.util import get_available_host, read_barrier, gather_safely
 
 logger = logging.getLogger('random_tables')
 
@@ -275,7 +274,7 @@ class RandomTables():
         ntables specifies how many tables.
         ncolumns specifies how many random columns per table."""
         tables = [RandomTable(self.manager, self.keyspace, ncolumns) for _ in range(ntables)]
-        await asyncio.gather(*(t.create(if_not_exists) for t in tables))
+        await gather_safely(*(t.create(if_not_exists) for t in tables))
         self.tables.extend(tables)
 
     async def add_table(self, ncolumns: int = None, columns: List[Column] = None,

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -5,7 +5,6 @@
 #
 # This file configures pytest for all tests in this directory, and also
 # defines common test fixtures for all of them to use
-
 import ssl
 import platform
 from typing import List, Optional

--- a/test/topology/test_concurrent_schema.py
+++ b/test/topology/test_concurrent_schema.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 import pytest
 from test.pylib.random_tables import Column, UUIDType, IntType
-
+from test.pylib.util import gather_safely
 
 logger = logging.getLogger('schema-test')
 
@@ -57,7 +57,7 @@ async def test_cassandra_issue_10250(random_tables):
             aws.append(tables_i[n].add_index(f"c{a}", f"ix_index_me_{n}_c{a}"))
 
     # Run everything in parallel
-    await asyncio.gather(*aws)
+    await gather_safely(*aws)
     logger.debug("Done running concurrent schema changes")
     # Sleep to settle; original Cassandra issue repro sleeps 20 seconds
     await asyncio.sleep(1)

--- a/test/topology/test_coordinator_queue_management.py
+++ b/test/topology/test_coordinator_queue_management.py
@@ -8,6 +8,8 @@ import pytest
 import logging
 import asyncio
 
+from test.pylib.util import gather_safely
+
 logger = logging.getLogger(__name__)
 
 @pytest.mark.asyncio
@@ -44,7 +46,7 @@ async def test_coordinator_queue_management(manager: ManagerClient):
 
     [await manager.api.message_injection(s.ip_addr, inj) for s in servers[:3]]
 
-    await asyncio.gather(*tasks)
+    await gather_safely(*tasks)
 
     servers = await manager.running_servers()
     await manager.server_stop_gracefully(servers[3].server_id)
@@ -65,4 +67,4 @@ async def test_coordinator_queue_management(manager: ManagerClient):
 
     [await manager.api.message_injection(s.ip_addr, inj) for s in servers[:3]]
 
-    await asyncio.gather(*tasks)
+    await gather_safely(*tasks)

--- a/test/topology/test_mutation_schema_change.py
+++ b/test/topology/test_mutation_schema_change.py
@@ -10,7 +10,7 @@ import asyncio
 import logging
 import time
 from test.pylib.rest_client import inject_error_one_shot, inject_error
-from test.pylib.util import wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for_cql_and_get_hosts, gather_safely
 import pytest
 from cassandra.cluster import ConsistencyLevel           # type: ignore # pylint: disable=no-name-in-module
 from cassandra.query import SimpleStatement              # type: ignore # pylint: disable=no-name-in-module
@@ -37,7 +37,7 @@ async def test_mutation_schema_change(manager, random_tables):
     await manager.mark_dirty()
     errs = [inject_error_one_shot(manager.api, s.ip_addr, 'raft_server_snapshot_reduce_threshold')
             for s in [server_a, server_b, server_c]]
-    await asyncio.gather(*errs)
+    await gather_safely(*errs)
 
 
     logger.info("Stopping C %s", server_c)
@@ -98,7 +98,7 @@ async def test_mutation_schema_change_restart(manager, random_tables):
     await manager.mark_dirty()
     errs = [inject_error_one_shot(manager.api, s.ip_addr, 'raft_server_snapshot_reduce_threshold')
             for s in [server_a, server_b, server_c]]
-    await asyncio.gather(*errs)
+    await gather_safely(*errs)
 
     logger.info("Stopping C %s", server_c)
     await manager.server_stop_gracefully(server_c.server_id)

--- a/test/topology/test_random_tables.py
+++ b/test/topology/test_random_tables.py
@@ -8,6 +8,8 @@ import time
 import pytest
 from cassandra.protocol import InvalidRequest, ReadFailure                         # type: ignore
 from cassandra.query import SimpleStatement                                        # type: ignore
+
+from test.pylib.util import gather_safely
 from test.topology.util import wait_for_token_ring_and_group0_consistency
 
 
@@ -111,7 +113,7 @@ async def test_paged_result(manager, random_tables):
                 f"({','.join(c.name for c in table.columns)})"
                 f"VALUES ({', '.join(['%s'] * len(table.columns))})",
                 parameters=[c.val(i) for c in table.columns]))
-    await asyncio.gather(*inserts)
+    await gather_safely(*inserts)
 
     # Check only 1 page
     stmt = SimpleStatement(f"SELECT * FROM {table} ALLOW FILTERING", fetch_size = fetch_size)

--- a/test/topology/test_replace_alive_node.py
+++ b/test/topology/test_replace_alive_node.py
@@ -8,12 +8,14 @@ from test.pylib.manager_client import ManagerClient
 import asyncio
 import pytest
 
+from test.pylib.util import gather_safely
+
 
 @pytest.mark.asyncio
 async def test_replacing_alive_node_fails(manager: ManagerClient) -> None:
     """Try replacing an alive node and check that it fails"""
     servers = await manager.running_servers()
-    await asyncio.gather(*(manager.server_sees_others(srv.server_id, len(servers) - 1) for srv in servers))
+    await gather_safely(*(manager.server_sees_others(srv.server_id, len(servers) - 1) for srv in servers))
 
     # We test for every server because we expect a different error depending on
     # whether we try to replace the topology coordinator. We want to test both cases.

--- a/test/topology/test_snapshot.py
+++ b/test/topology/test_snapshot.py
@@ -12,6 +12,7 @@ from test.pylib.rest_client import inject_error_one_shot, inject_error
 import pytest
 from cassandra.query import SimpleStatement              # type: ignore # pylint: disable=no-name-in-module
 
+from test.pylib.util import gather_safely
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +30,7 @@ async def test_snapshot(manager, random_tables):
     # Reduce the snapshot thresholds
     errs = [inject_error_one_shot(manager.api, s.ip_addr, 'raft_server_snapshot_reduce_threshold')
             for s in [server_a, server_b, server_c]]
-    await asyncio.gather(*errs)
+    await gather_safely(*errs)
 
     t = await random_tables.add_table(ncolumns=5, pks=1)
 
@@ -41,8 +42,8 @@ async def test_snapshot(manager, random_tables):
     logger.info("Started D %s", server_d)
 
     logger.info("Stopping A %s, B %s, and C %s", server_a, server_b, server_c)
-    await asyncio.gather(*[manager.server_stop_gracefully(s.server_id)
-                           for s in [server_a, server_b, server_c]])
+    await gather_safely(*[manager.server_stop_gracefully(s.server_id)
+                          for s in [server_a, server_b, server_c]])
 
     logger.info("Driver connecting to D %s", server_d)
     await manager.driver_connect()

--- a/test/topology/test_topology_failure_recovery.py
+++ b/test/topology/test_topology_failure_recovery.py
@@ -10,11 +10,13 @@ import pytest
 import logging
 import asyncio
 
+from test.pylib.util import gather_safely
+
 logger = logging.getLogger(__name__)
 
 async def inject_error_on(manager, error_name, servers):
     errs = [manager.api.enable_injection(s.ip_addr, error_name, True) for s in servers]
-    await asyncio.gather(*errs)
+    await gather_safely(*errs)
 
 @pytest.mark.asyncio
 async def test_topology_streaming_failure(request, manager: ManagerClient):

--- a/test/topology/test_topology_remove_decom.py
+++ b/test/topology/test_topology_remove_decom.py
@@ -10,7 +10,7 @@ import logging
 import asyncio
 import random
 import time
-from test.pylib.util import wait_for
+from test.pylib.util import wait_for, gather_safely
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.topology.util import check_token_ring_and_group0_consistency,            \
@@ -101,7 +101,7 @@ async def test_remove_node_with_concurrent_ddl(manager: ManagerClient, random_ta
                 logger.debug(f'do_remove_node [{i}], ddl failed, exiting')
                 break
             server_infos = await manager.running_servers()
-            host_ids = await asyncio.gather(*(manager.get_host_id(s.server_id) for s in server_infos))
+            host_ids = await gather_safely(*(manager.get_host_id(s.server_id) for s in server_infos))
             initiator_index, target_index = random.sample(range(len(server_infos)), 2)
             initiator_info = server_infos[initiator_index]
             target_info = server_infos[target_index]

--- a/test/topology/util.py
+++ b/test/topology/util.py
@@ -16,7 +16,7 @@ from cassandra.cluster import Session  # type: ignore # pylint: disable=no-name-
 from cassandra.pool import Host        # type: ignore # pylint: disable=no-name-in-module
 from test.pylib.internal_types import ServerInfo, HostID
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, read_barrier, get_available_host
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, read_barrier, get_available_host, gather_safely
 
 
 logger = logging.getLogger(__name__)
@@ -194,7 +194,7 @@ async def wait_for_cdc_generations_publishing(cql: Session, hosts: list[Host], d
 async def check_system_topology_and_cdc_generations_v3_consistency(manager: ManagerClient, hosts: list[Host]):
     assert len(hosts) != 0
 
-    topo_results = await asyncio.gather(*(manager.cql.run_async("SELECT * FROM system.topology", host=host) for host in hosts))
+    topo_results = await gather_safely(*(manager.cql.run_async("SELECT * FROM system.topology", host=host) for host in hosts))
 
     for host, topo_res in zip(hosts, topo_results):
         logging.info(f"Dumping the state of system.topology as seen by {host}:")

--- a/test/topology_custom/test_change_rpc_address.py
+++ b/test/topology_custom/test_change_rpc_address.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from test.pylib.util import gather_safely
 from test.topology.util import wait_for_token_ring_and_group0_consistency
 
 if TYPE_CHECKING:
@@ -73,8 +74,8 @@ async def test_change_rpc_address(two_nodes_cluster: list[ServerNum],
 
     manager.driver_close()
 
-    await asyncio.gather(*[manager.server_stop_gracefully(server_id) for server_id in two_nodes_cluster])
-    await asyncio.gather(*[manager.server_change_rpc_address(server_id) for server_id in two_nodes_cluster])
+    await gather_safely(*[manager.server_stop_gracefully(server_id) for server_id in two_nodes_cluster])
+    await gather_safely(*[manager.server_change_rpc_address(server_id) for server_id in two_nodes_cluster])
     for server_id in two_nodes_cluster:
         await manager.server_start(server_id)
 

--- a/test/topology_custom/test_commitlog.py
+++ b/test/topology_custom/test_commitlog.py
@@ -10,7 +10,7 @@ import logging
 import time
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
-from test.pylib.util import wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for_cql_and_get_hosts, gather_safely
 from test.topology.util import reconnect_driver
 from test.topology.conftest import skip_mode
 from test.pylib.random_tables import Column, TextType
@@ -58,7 +58,7 @@ async def test_reboot(request, manager: ManagerClient):
     futures = []
     for i in range(0, test_rows_count):
         futures.append(save_table(f'key_{i}', f'value_{i}'))
-    await asyncio.gather(*futures)
+    await gather_safely(*futures)
     logger.info("Some data is written into test table")
 
     await cql.run_async("truncate table ks.t")
@@ -76,7 +76,7 @@ async def test_reboot(request, manager: ManagerClient):
     futures = []
     for i in range(0, test_rows_count):
         futures.append(save_table(f'new_key_{i}', f'new_value_{i}'))
-    await asyncio.gather(*futures)
+    await gather_safely(*futures)
     logger.info("Some new data is written into test table")
 
     table_content_before_crash = await load_table()

--- a/test/topology_custom/test_data_resurrection_after_cleanup.py
+++ b/test/topology_custom/test_data_resurrection_after_cleanup.py
@@ -6,6 +6,7 @@
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot
+from test.pylib.util import gather_safely
 from test.topology.conftest import skip_mode
 from test.topology.util import check_token_ring_and_group0_consistency
 
@@ -32,7 +33,7 @@ async def test_data_resurrection_after_cleanup(manager: ManagerClient):
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int) WITH gc_grace_seconds=0;")
 
     keys = range(256)
-    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await gather_safely(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
 
     async def check(expected_keys):
         logger.info("Checking table")
@@ -56,7 +57,7 @@ async def test_data_resurrection_after_cleanup(manager: ManagerClient):
     await manager.api.cleanup_keyspace(servers[0].ip_addr, "test")
 
     deleted_keys = range(128)
-    await asyncio.gather(*[cql.run_async(f"DELETE FROM test.test WHERE pk={k};") for k in deleted_keys])
+    await gather_safely(*[cql.run_async(f"DELETE FROM test.test WHERE pk={k};") for k in deleted_keys])
     # Make sures tombstones are gone
     await manager.api.flush_keyspace(servers[1].ip_addr, "test")
     time.sleep(1)

--- a/test/topology_custom/test_raft_recovery_basic.py
+++ b/test/topology_custom/test_raft_recovery_basic.py
@@ -11,7 +11,7 @@ import time
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
-from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
+from test.pylib.util import unique_name, wait_for_cql_and_get_hosts, gather_safely
 from test.topology.util import reconnect_driver, restart, enter_recovery_state, \
         wait_until_upgrade_finishes, delete_raft_data_and_upgrade_state, log_run_time
 
@@ -29,8 +29,8 @@ async def test_raft_recovery_basic(request, manager: ManagerClient):
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
     logging.info(f"Setting recovery state on {hosts}")
-    await asyncio.gather(*(enter_recovery_state(cql, h) for h in hosts))
-    await asyncio.gather(*(restart(manager, srv) for srv in servers))
+    await gather_safely(*(enter_recovery_state(cql, h) for h in hosts))
+    await gather_safely(*(restart(manager, srv) for srv in servers))
     cql = await reconnect_driver(manager)
 
     logging.info("Cluster restarted, waiting until driver reconnects to every server")
@@ -38,17 +38,17 @@ async def test_raft_recovery_basic(request, manager: ManagerClient):
     logging.info(f"Driver reconnected, hosts: {hosts}")
 
     logging.info(f"Deleting Raft data and upgrade state on {hosts}")
-    await asyncio.gather(*(delete_raft_data_and_upgrade_state(cql, h) for h in hosts))
+    await gather_safely(*(delete_raft_data_and_upgrade_state(cql, h) for h in hosts))
 
     logging.info(f"Restarting {servers}")
-    await asyncio.gather(*(restart(manager, srv) for srv in servers))
+    await gather_safely(*(restart(manager, srv) for srv in servers))
     cql = await reconnect_driver(manager)
 
     logging.info(f"Cluster restarted, waiting until driver reconnects to every server")
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
     logging.info(f"Driver reconnected, hosts: {hosts}. Waiting until upgrade finishes")
-    await asyncio.gather(*(wait_until_upgrade_finishes(cql, h, time.time() + 60) for h in hosts))
+    await gather_safely(*(wait_until_upgrade_finishes(cql, h, time.time() + 60) for h in hosts))
 
     logging.info("Upgrade finished. Creating a new table")
     random_tables = RandomTables(request.node.name, manager, unique_name(), 1)

--- a/test/topology_custom/test_raft_snapshot_request.py
+++ b/test/topology_custom/test_raft_snapshot_request.py
@@ -10,7 +10,7 @@ import time
 import logging
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, read_barrier
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, read_barrier, gather_safely
 from test.topology.util import reconnect_driver, trigger_snapshot
 
 
@@ -62,7 +62,7 @@ async def test_raft_snapshot_request(manager: ManagerClient):
     await manager.server_stop_gracefully(s2.server_id)
     logger.info(f"Stopped {s2}")
     # Restarting the two servers will cause a newly elected leader to append a dummy command.
-    await asyncio.gather(*(manager.server_restart(s.server_id) for s in servers[:2]))
+    await gather_safely(*(manager.server_restart(s.server_id) for s in servers[:2]))
     logger.info(f"Restarted {servers[:2]}")
     cql = await reconnect_driver(manager)
     # Wait for one server to append the command and do a read_barrier on the other

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -12,6 +12,8 @@ import pytest
 import logging
 import asyncio
 
+from test.pylib.util import gather_safely
+
 logger = logging.getLogger(__name__)
 
 
@@ -46,7 +48,7 @@ async def test_tablet_cannot_decommision_below_replication_factor(manager: Manag
 
     logger.info("Populating table")
     keys = range(256)
-    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await gather_safely(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
 
     logger.info("Decommission some node")
     await manager.decommission_node(servers[0].server_id)
@@ -80,7 +82,7 @@ async def test_reshape_with_tablets(manager: ManagerClient):
     logger.info("Populating table")
     loop_count = 32
     for _ in range(loop_count):
-        await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in range(64)])
+        await gather_safely(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in range(64)])
         await manager.api.keyspace_flush(server.ip_addr, "test", "test")
     # After populating the table, expect loop_count number of sstables per tablet
     sstable_info = await manager.api.get_sstable_info(server.ip_addr, "test", "test")

--- a/test/topology_custom/test_tablets_migration.py
+++ b/test/topology_custom/test_tablets_migration.py
@@ -3,10 +3,9 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
-from cassandra.query import SimpleStatement, ConsistencyLevel
 from test.pylib.manager_client import ManagerClient
-from test.pylib.rest_client import HTTPError
 from test.pylib.tablets import get_all_tablet_replicas
+from test.pylib.util import gather_safely
 from test.topology.conftest import skip_mode
 import pytest
 import logging
@@ -44,7 +43,7 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
 
     keys = range(256)
-    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await gather_safely(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
     await make_server()
 
     if fail_stage in ["cleanup_target", "revert_migration"]:

--- a/test/topology_custom/test_topology_failure_recovery.py
+++ b/test/topology_custom/test_topology_failure_recovery.py
@@ -10,11 +10,13 @@ import pytest
 import logging
 import asyncio
 
+from test.pylib.util import gather_safely
+
 logger = logging.getLogger(__name__)
 
 async def inject_error_on(manager, error_name, servers):
     errs = [manager.api.enable_injection(s.ip_addr, error_name, True) for s in servers]
-    await asyncio.gather(*errs)
+    await gather_safely(*errs)
 
 @pytest.mark.asyncio
 async def test_tablet_drain_failure_during_decommission(manager: ManagerClient):
@@ -32,7 +34,7 @@ async def test_tablet_drain_failure_during_decommission(manager: ManagerClient):
     logger.info("Populating table")
 
     keys = range(256)
-    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await gather_safely(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
 
     await inject_error_on(manager, "stream_tablet_fail_on_drain", servers)
 

--- a/test/topology_experimental_raft/test_cdc_generation_publishing.py
+++ b/test/topology_experimental_raft/test_cdc_generation_publishing.py
@@ -5,7 +5,7 @@
 #
 from test.pylib.manager_client import ManagerClient, ServerInfo
 from test.pylib.rest_client import inject_error
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, gather_safely
 
 from cassandra.cluster import ConsistencyLevel # type: ignore # pylint: disable=no-name-in-module
 from cassandra.query import SimpleStatement # type: ignore # pylint: disable=no-name-in-module
@@ -69,7 +69,7 @@ async def test_cdc_generations_are_published(request, manager: ManagerClient):
     # Performing multiple cdc_streams_check_and_repair requests concurrently after removing a node should result
     # in creating exactly one CDC generation, because cdc_streams_check_and_repair doesn't create a new generation
     # if the current one is optimal.
-    await asyncio.gather(*[manager.api.client.post("/storage_service/cdc_streams_check_and_repair", servers[i % 2].ip_addr)
+    await gather_safely(*[manager.api.client.post("/storage_service/cdc_streams_check_and_repair", servers[i % 2].ip_addr)
                           for i in range(10)])
     gen_timestamps = await wait_for(new_gen_appeared, time.time() + 60)
     logger.info(f"Timestamps after check_and_repair: {gen_timestamps}")

--- a/test/topology_experimental_raft/test_mv_tablets.py
+++ b/test/topology_experimental_raft/test_mv_tablets.py
@@ -7,7 +7,7 @@
 # Tests for interaction of materialized views with *tablets*
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for_cql_and_get_hosts, read_barrier
+from test.pylib.util import wait_for_cql_and_get_hosts, read_barrier, gather_safely
 from test.pylib.internal_types import ServerInfo
 from test.topology.conftest import skip_mode
 
@@ -168,7 +168,7 @@ def full_query(table, ConsistentRead=True, **kwargs):
 
 async def inject_error_on(manager, error_name, servers):
     errs = [manager.api.enable_injection(s.ip_addr, error_name, False) for s in servers]
-    await asyncio.gather(*errs)
+    await gather_safely(*errs)
 
 # FIXME: boto3 is NOT async. So this test is not async. We could use
 # the aioboto3 library to write a really asynchronous test, or implement

--- a/test/topology_experimental_raft/test_raft_cluster_features.py
+++ b/test/topology_experimental_raft/test_raft_cluster_features.py
@@ -12,7 +12,7 @@ import time
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error
-from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_feature
+from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_feature, gather_safely
 from test.topology import test_cluster_features
 import pytest
 
@@ -85,4 +85,4 @@ async def test_cannot_disable_cluster_feature_after_all_declare_support(manager:
     # Nodes should start supporting the feature
     cql = cql = manager.get_cql()
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
-    await asyncio.gather(*(wait_for_feature('TEST_ONLY_FEATURE', cql, h, time.time() + 60) for h in hosts))
+    await gather_safely(*(wait_for_feature('TEST_ONLY_FEATURE', cql, h, time.time() + 60) for h in hosts))

--- a/test/topology_experimental_raft/test_tablets_removenode.py
+++ b/test/topology_experimental_raft/test_tablets_removenode.py
@@ -13,6 +13,7 @@ import asyncio
 import logging
 
 from test.pylib.scylla_cluster import ReplaceConfig
+from test.pylib.util import gather_safely
 
 logger = logging.getLogger(__name__)
 
@@ -54,9 +55,9 @@ async def test_replace(manager: ManagerClient):
     logger.info("Populating table")
 
     keys = range(256)
-    await asyncio.gather(*[run_async_cl_all(cql, f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
-    await asyncio.gather(*[run_async_cl_all(cql, f"INSERT INTO test2.test (pk, c) VALUES ({k}, {k});") for k in keys])
-    await asyncio.gather(*[run_async_cl_all(cql, f"INSERT INTO test3.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await gather_safely(*[run_async_cl_all(cql, f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await gather_safely(*[run_async_cl_all(cql, f"INSERT INTO test2.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await gather_safely(*[run_async_cl_all(cql, f"INSERT INTO test3.test (pk, c) VALUES ({k}, {k});") for k in keys])
 
     async def check_ks(ks):
         logger.info(f"Checking {ks}")
@@ -122,9 +123,9 @@ async def test_removenode(manager: ManagerClient):
     logger.info("Populating table")
 
     keys = range(256)
-    await asyncio.gather(*[run_async_cl_all(cql, f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
-    await asyncio.gather(*[run_async_cl_all(cql, f"INSERT INTO test2.test (pk, c) VALUES ({k}, {k});") for k in keys])
-    await asyncio.gather(*[run_async_cl_all(cql, f"INSERT INTO test3.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await gather_safely(*[run_async_cl_all(cql, f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await gather_safely(*[run_async_cl_all(cql, f"INSERT INTO test2.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await gather_safely(*[run_async_cl_all(cql, f"INSERT INTO test3.test (pk, c) VALUES ({k}, {k});") for k in keys])
 
     async def check():
         # RF=1 table "test" will experience data loss so don't check it.
@@ -177,7 +178,7 @@ async def test_removenode_with_ignored_node(manager: ManagerClient):
     logger.info("Populating table")
 
     keys = range(512)
-    await asyncio.gather(*[run_async_cl_all(cql, f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await gather_safely(*[run_async_cl_all(cql, f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
 
     async def check():
         logger.info("Checking")

--- a/test/topology_experimental_raft/test_topology_ops.py
+++ b/test/topology_experimental_raft/test_topology_ops.py
@@ -6,7 +6,7 @@
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.manager_client import ManagerClient
 from test.pylib.internal_types import ServerInfo
-from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
+from test.pylib.util import unique_name, wait_for_cql_and_get_hosts, gather_safely
 from test.topology.util import check_token_ring_and_group0_consistency, reconnect_driver
 
 from cassandra.cluster import Session, ConsistencyLevel
@@ -121,6 +121,6 @@ async def start_writes(cql: Session, concurrency: int = 3):
     async def finish():
         logger.info("Stopping write workers")
         stop_event.set()
-        await asyncio.gather(*tasks)
+        await gather_safely(*tasks)
 
     return finish

--- a/test/topology_experimental_raft/test_topology_recovery_basic.py
+++ b/test/topology_experimental_raft/test_topology_recovery_basic.py
@@ -10,7 +10,7 @@ import pytest
 import time
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for_cql_and_get_hosts, gather_safely
 from test.topology.util import reconnect_driver, restart, enter_recovery_state, \
         delete_raft_data_and_upgrade_state, log_run_time, wait_until_upgrade_finishes as wait_until_schema_upgrade_finishes, \
         wait_until_topology_upgrade_finishes, delete_raft_topology_state, wait_for_cdc_generations_publishing, \
@@ -28,7 +28,7 @@ async def test_topology_recovery_basic(request, manager: ManagerClient):
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
     logging.info(f"Restarting hosts {hosts} in recovery mode")
-    await asyncio.gather(*(enter_recovery_state(cql, h) for h in hosts))
+    await gather_safely(*(enter_recovery_state(cql, h) for h in hosts))
     # Restart sequentially, as it tests how nodes operating in legacy mode
     # react to raft topology mode nodes and vice versa
     for srv in servers:
@@ -40,8 +40,8 @@ async def test_topology_recovery_basic(request, manager: ManagerClient):
     logging.info(f"Driver reconnected, hosts: {hosts}")
 
     logging.info(f"Deleting Raft data and upgrade state on {hosts}")
-    await asyncio.gather(*(delete_raft_topology_state(cql, h) for h in hosts))
-    await asyncio.gather(*(delete_raft_data_and_upgrade_state(cql, h) for h in hosts))
+    await gather_safely(*(delete_raft_topology_state(cql, h) for h in hosts))
+    await gather_safely(*(delete_raft_data_and_upgrade_state(cql, h) for h in hosts))
 
     logging.info(f"Restarting hosts {hosts}")
     for srv in servers:
@@ -52,7 +52,7 @@ async def test_topology_recovery_basic(request, manager: ManagerClient):
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
     logging.info("Waiting until upgrade to raft schema finishes")
-    await asyncio.gather(*(wait_until_schema_upgrade_finishes(cql, h, time.time() + 60) for h in hosts))
+    await gather_safely(*(wait_until_schema_upgrade_finishes(cql, h, time.time() + 60) for h in hosts))
 
     logging.info("Checking the topology upgrade state on all nodes")
     for host in hosts:
@@ -66,7 +66,7 @@ async def test_topology_recovery_basic(request, manager: ManagerClient):
     await manager.api.upgrade_to_raft_topology(hosts[0].address)
 
     logging.info("Waiting until upgrade finishes")
-    await asyncio.gather(*(wait_until_topology_upgrade_finishes(manager, h.address, time.time() + 60) for h in hosts))
+    await gather_safely(*(wait_until_topology_upgrade_finishes(manager, h.address, time.time() + 60) for h in hosts))
 
     logging.info("Waiting for CDC generations publishing")
     await wait_for_cdc_generations_publishing(cql, hosts, time.time() + 60)

--- a/test/topology_experimental_raft/test_topology_recovery_majority_loss.py
+++ b/test/topology_experimental_raft/test_topology_recovery_majority_loss.py
@@ -10,7 +10,7 @@ import pytest
 import time
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for_cql_and_get_hosts, gather_safely
 from test.topology.util import reconnect_driver, restart, enter_recovery_state, \
         delete_raft_data_and_upgrade_state, log_run_time, wait_until_upgrade_finishes as wait_until_schema_upgrade_finishes, \
         wait_until_topology_upgrade_finishes, delete_raft_topology_state, wait_for_cdc_generations_publishing, \
@@ -30,7 +30,7 @@ async def test_topology_recovery_after_majority_loss(request, manager: ManagerCl
     srv1, *others = servers
 
     logging.info(f"Killing all nodes except {srv1}")
-    await asyncio.gather(*(manager.server_stop_gracefully(srv.server_id) for srv in others))
+    await gather_safely(*(manager.server_stop_gracefully(srv.server_id) for srv in others))
 
     logging.info(f"Entering recovery state on {srv1}")
     host1 = next(h for h in hosts if h.address == srv1.ip_addr)

--- a/test/topology_experimental_raft/test_topology_upgrade.py
+++ b/test/topology_experimental_raft/test_topology_upgrade.py
@@ -11,7 +11,7 @@ import time
 
 from test.pylib.rest_client import HTTPError
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for_cql_and_get_hosts, gather_safely
 from test.topology.util import log_run_time, wait_until_topology_upgrade_finishes, \
         wait_for_cdc_generations_publishing, check_system_topology_and_cdc_generations_v3_consistency
 
@@ -46,7 +46,7 @@ async def test_topology_upgrade_basic(request, manager: ManagerClient):
     await manager.api.upgrade_to_raft_topology(hosts[0].address)
 
     logging.info("Waiting until upgrade finishes")
-    await asyncio.gather(*(wait_until_topology_upgrade_finishes(manager, h.address, time.time() + 60) for h in hosts))
+    await gather_safely(*(wait_until_topology_upgrade_finishes(manager, h.address, time.time() + 60) for h in hosts))
 
     logging.info("Waiting for CDC generations publishing")
     await wait_for_cdc_generations_publishing(cql, hosts, time.time() + 60)


### PR DESCRIPTION
Fixes #16472
Fixes #17348

Developers using asyncio.gather() often assume that it waits for all futures (awaitables) givens. But this isn't true when the return_exceptions parameter is False (which is the default): In that case, as soon as one future completes with an exception, the gather() call will return this exception immediately, and some of the finished tasks may continue to run in the background. This is bad for applications that use gather() to ensure that a list of background tasks has all completed. So such applications must use asyncio.gather() with return_exceptions=True, to wait for all given futures to complete (either successfully or unsuccessfully).

Alternatively, this gather_safely is a wrapper for asyncio.gather() which fixes the return_exceptions=False implementation to be more useful: If return_exceptions=False, gather_safely waits for all futures to complete, but then if any of them returned an exception, the first one will be thrown (asyncio.gather() returns the results in the same order as awaitables were given).

To reduce confusion gather_safely() should be used instead of the asyncio.gather() method. Wrapper still allows handling the exceptions by your own with return_exceptions=True parameter.