### PR TITLE
test: fix regular compaction tasks check

### DIFF
--- a/test/rest_api/test_compaction_task.py
+++ b/test/rest_api/test_compaction_task.py
@@ -1,3 +1,4 @@
+import requests
 import sys
 import threading
 
@@ -9,6 +10,11 @@ from task_manager_utils import wait_for_task, list_tasks, check_child_parent_rel
 
 module_name = "compaction"
 long_time = 1000000000
+
+def get_status_if_exists(rest_api, task_id):
+    resp = rest_api.send("GET", f"task_manager/task_status/{task_id}")
+    if resp.status_code == requests.codes.ok:
+        return resp.json()
 
 # depth parameter means the number of edges in the longest path from root to leaves in task tree.
 def check_compaction_task(cql, rest_api, keyspace, run_compaction, compaction_type, depth, allow_no_children=False):
@@ -119,7 +125,8 @@ def test_regular_compaction_task(cql, this_dc, rest_api):
                     resp = rest_api.send("POST", f"column_family/autocompaction/{keyspace}:{table}")
                     resp.raise_for_status()
 
-                    statuses = [get_task_status(rest_api, task["task_id"]) for task in list_tasks(rest_api, "compaction", internal=True) if task["type"] == "regular compaction" and task["keyspace"] == keyspace and task["table"] == table]
+                    statuses = [get_status_if_exists(rest_api, task["task_id"]) for task in list_tasks(rest_api, "compaction", internal=True) if task["type"] == "regular compaction" and task["keyspace"] == keyspace and task["table"] == table]
+                    statuses = [s for s in statuses if s is not None]
                     assert statuses, f"regular compaction task for {t0} was not created"
                     assert all([s["state"] != "done" and s["state"] != "failed" for s in statuses]), "Regular compaction task isn't unregiatered after it completes"
 


### PR DESCRIPTION
Since 6b87778 regular compaction tasks are removed from task manager immediately after they are finished.

test_regular_compaction_task lists compaction tasks and then requests their statuses. Only one regular compaction task is guaranteed to still be running at that time, the rest of them may finish before their status is requested and so it will no longer be in task manager, causing the test to fail.

Fix statuses check to consider the possibility of a regular compaction task being removed from task manager.

Fixes: #17776.