### PR TITLE
repair: fix memory counting in repair

### DIFF
--- a/repair/row.hh
+++ b/repair/row.hh
@@ -50,6 +50,9 @@ public:
         }
         return *_mf;
     }
+    void reset_mutation_fragment() {
+        _mf = nullptr;
+    }
     frozen_mutation_fragment& get_frozen_mutation() {
         if (!_fm) {
             throw std::runtime_error("empty frozen_mutation_fragment");
@@ -69,7 +72,14 @@ public:
         if (!_fm) {
             throw std::runtime_error("empty size due to empty frozen_mutation_fragment");
         }
-        return _fm->representation().size();
+        auto size = sizeof(repair_row) + _fm->representation().size();
+        if (_boundary) {
+            size += _boundary->pk.external_memory_usage() + _boundary->position.external_memory_usage();
+        }
+        if (_mf) {
+            size += _mf->memory_usage();
+        }
+        return size;
     }
     const repair_sync_boundary& boundary() const {
         if (!_boundary) {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -713,6 +713,7 @@ void flush_rows(schema_ptr s, std::list<repair_row>& rows, lw_shared_ptr<repair_
             last_mf = mf;
             last_dk = r.get_dk_with_hash();
         }
+        r.reset_mutation_fragment();
     }
     if (last_mf && last_dk) {
         writer->do_write(std::move(last_dk), std::move(*last_mf)).get();
@@ -1128,10 +1129,11 @@ private:
         auto hash = _repair_hasher.do_hash_for_mf(*_repair_reader->get_current_dk(), mf);
         repair_row r(freeze(*_schema, mf), position_in_partition(mf.position()), _repair_reader->get_current_dk(), hash, is_dirty_on_master::no);
         rlogger.trace("Reading: r.boundary={}, r.hash={}", r.boundary(), r.hash());
+        auto sz = r.size();
         _metrics.row_from_disk_nr++;
-        _metrics.row_from_disk_bytes += r.size();
-        cur_size += r.size();
-        new_rows_size += r.size();
+        _metrics.row_from_disk_bytes += sz;
+        cur_size += sz;
+        new_rows_size += sz;
         cur_rows.push_back(std::move(r));
     }
 
@@ -1377,6 +1379,7 @@ private:
                     // mutation_fragment attached because we have stored it in
                     // to_repair_rows_list above where the repair_row is created.
                     mutation_fragment mf = std::move(r.get_mutation_fragment());
+                    r.reset_mutation_fragment();
                     auto dk_with_hash = r.get_dk_with_hash();
                     return _repair_writer->do_write(std::move(dk_with_hash), std::move(mf)).then([&row_diff] {
                         row_diff.pop_front();


### PR DESCRIPTION
Repair memory limit includes only the size of frozen mutation
fragments in repair row. The size of other members of repair 
row may grow uncontrollably and cause out of memory.

Modify what's counted to repair memory limit.

Fixes: #16710.