### PR TITLE
tools/scylla-nodetool: print bpo::options_description with fmt::streamed

### DIFF
--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1199,7 +1199,7 @@ void help_operation(const tool_app_template::config& cfg, const bpo::variables_m
             opts_desc.add(op_opts_desc);
         }
 
-        fmt::print(std::cout, "{}\n", opts_desc);
+        fmt::print(std::cout, "{}\n", fmt::streamed(opts_desc));
     } else {
         fmt::print(std::cout, "usage: nodetool [(-p <port> | --port <port>)] [(-h <host> | --host <host>)] <command> [<args>]\n\n");
         fmt::print(std::cout, "The most commonly used nodetool commands are:\n");


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, since boost::program_options::options_description is defined by boost.program_options library, and it only provides the operator<< overload. we're inclined to not specializing `fmt::formatter` for it at this moment, because

* this class is not in defined by scylla project. we would have to find a home for this formatter.
* we are not likely to reuse the formatter in multiple places

so, in this change we just print it using `fmt::streamed`.

Refs #13245