### PR TITLE
db: commitlog: add fmt::formatter for commitlog types

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -350,14 +350,6 @@ public:
                 .bytes_flush_requested = bytes_flush_requested / d,
             };
         }
-
-        friend std::ostream& operator<<(std::ostream& os, const byte_flow& r) {
-            return os << std::fixed
-                << "[written=" << r.bytes_written
-                << ", released=" << r.bytes_released
-                << ", flush_req=" << r.bytes_flush_requested
-                << "]";
-        }
     };
 
     struct stats : public byte_flow<uint64_t> {
@@ -794,7 +786,7 @@ public:
     struct cf_mark {
         const segment& s;
     };
-    friend std::ostream& operator<<(std::ostream&, const cf_mark&);
+    friend struct fmt::formatter<cf_mark>;
 
     // The commit log entry overhead in bytes (int: length + int: head checksum)
     static constexpr size_t entry_overhead_size = 2 * sizeof(uint32_t);
@@ -2058,17 +2050,21 @@ std::ostream& operator<<(std::ostream& out, const db::commitlog::segment& s) {
     return out << s._desc.filename();
 }
 
-std::ostream& operator<<(std::ostream& out, const db::commitlog::segment::cf_mark& m) {
-    fmt::print(out, "{}", m.s._cf_dirty | boost::adaptors::map_keys);
-    return out;
-}
-
 }
 
 auto fmt::formatter<db::replay_position>::format(const db::replay_position& p,
                                                  fmt::format_context& ctx) const -> decltype(ctx.out()) {
     return fmt::format_to(ctx.out(), "{{{}, {}, {}}}", p.shard_id(), p.base_id(), p.pos);
 }
+
+template <>
+struct fmt::formatter<db::commitlog::segment::cf_mark> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const db::commitlog::segment::cf_mark& m, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", fmt::join(m.s._cf_dirty | boost::adaptors::map_keys, ", "));
+    }
+};
 
 void db::commitlog::segment_manager::discard_unused_segments() noexcept {
     clogger.trace("Checking for unused segments ({} active)", _segments.size());
@@ -2245,29 +2241,49 @@ void db::commitlog::segment_manager::abort_recycled_list(std::exception_ptr ep) 
     _recycled_segments = queue<named_file>(std::numeric_limits<size_t>::max());
 }
 
-namespace db {
-
-std::ostream& operator<<(std::ostream& os, const commitlog::segment_manager::named_file& f) {
-    return os << f.name() << " (" << f.known_size() << ")";
-}
-
-std::ostream& operator<<(std::ostream& os, commitlog::segment_manager::dispose_mode mode) {
-    using dispose_mode = db::commitlog::segment_manager::dispose_mode;
-
-    switch (mode) {
-        case dispose_mode::Delete: os << "Delete"; break;
-        case dispose_mode::ForceDelete: os << "Force Delete"; break;
-        case dispose_mode::Keep: os << "Keep"; break;
-        default: break;
+template <>
+struct fmt::formatter<db::commitlog::segment_manager::named_file> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const db::commitlog::segment_manager::named_file& f, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{} ({})", f.name(), f.known_size());
     }
-    return os;
-}
+};
 
-std::ostream& operator<<(std::ostream& os, const std::pair<commitlog::segment_manager::named_file, db::commitlog::segment_manager::dispose_mode>& p) {
-    return os << p.first << " (" << p.second << ")";
-}
+template <>
+struct fmt::formatter<db::commitlog::segment_manager::dispose_mode> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(db::commitlog::segment_manager::dispose_mode mode, fmt::format_context& ctx) const {
+        using enum db::commitlog::segment_manager::dispose_mode;
+        string_view name;
+        switch (mode) {
+        case Delete: name = "Delete"; break;
+        case ForceDelete: name = "Force Delete"; break;
+        case Keep: name = "Keep"; break;
+        default: break;
+        }
+        return fmt::format_to(ctx.out(), "{}", name);
+    }
+};
 
-}
+template <typename T>
+struct fmt::formatter<db::commitlog::segment_manager::byte_flow<T>> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(db::commitlog::segment_manager::byte_flow<T> f, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "[written={}, released={}, flush_req={}]",
+                              f.bytes_written, f.bytes_released, f.bytes_flush_requested);
+    }
+};
+
+using file_to_dispose_t = std::pair<db::commitlog::segment_manager::named_file,
+                                    db::commitlog::segment_manager::dispose_mode>;
+template <>
+struct fmt::formatter<file_to_dispose_t> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const file_to_dispose_t& p, fmt::format_context& ctx) const {
+        auto& [file, mode] = p;
+        return fmt::format_to(ctx.out(), "{} ({})", file, mode);
+    }
+};
 
 future<> db::commitlog::segment_manager::do_pending_deletes() {
     auto ftd = std::exchange(_files_to_dispose, {});
@@ -2351,6 +2367,20 @@ future<> db::commitlog::segment_manager::do_pending_deletes() {
     }
     co_await std::move(pending_deletes);
     deleting_done.set_value();
+}
+
+namespace db {
+
+std::ostream& operator<<(std::ostream& os, const commitlog::segment_manager::named_file& f) {
+    fmt::print(os, "{}", f);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, commitlog::segment_manager::dispose_mode mode) {
+    fmt::print(os, "{}", mode);
+    return os;
+}
+
 }
 
 future<> db::commitlog::segment_manager::orphan_all() {


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for

* db::commitlog::segment::cf_mark
* db::commitlog::segment_manager::named_file
* db::commitlog::segment_manager::dispose_mode
* db::commitlog::segment_manager::byte_flow<T>

please note, the formatter of `db::commitlog::segment` is not included in this commit, as we are formatting it in the inline definition of this class. so we cannot define the specialization of `fmt::formatter` for this class before its callers -- we'd either use `format_as()` provided by {fmt} v10, or use `fmt::streamed`. either way, it's different from the theme of this commit, and we will handle it in a separated commit.

Refs #13245