### PR TITLE
db: config: drop unused operator<<(., error_injection_at_startup&)

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1224,11 +1224,6 @@ std::istream& operator>>(std::istream& is, db::seed_provider_type& s) {
     return is;
 }
 
-std::ostream& operator<<(std::ostream& os, const error_injection_at_startup& eias) {
-    fmt::print(os, "{}", eias);
-    return os;
-}
-
 std::istream& operator>>(std::istream& is, error_injection_at_startup& eias) {
     eias = error_injection_at_startup();
     is >> eias.name;

--- a/db/config.hh
+++ b/db/config.hh
@@ -78,7 +78,6 @@ struct error_injection_at_startup {
     }
 };
 
-std::ostream& operator<<(std::ostream& os, const error_injection_at_startup&);
 std::istream& operator>>(std::istream& is, error_injection_at_startup&);
 
 }


### PR DESCRIPTION
since it's not used, let's drop it.