### PR TITLE
Fix leaking file descriptor in test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -409,6 +409,8 @@ class PythonTestSuite(TestSuite):
                which would delete the log file and directory - we might want to preserve
                these if it came from a failed test.
             """
+            for srv in cluster.running.values():
+                srv.log_file.close()
             await cluster.stop()
             await cluster.release_ips()
 

--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -180,6 +180,7 @@ def cleanup_all():
             print('\nSubprocess output:\n')
             sys.stdout.flush()
             shutil.copyfileobj(f, sys.stdout.buffer)
+        f.close()
     scylla_set = set()
     print(summary)
 


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/17569

Tests are not closing the file descriptor after it finishes. This leads to the inability to continue tests since the default value for opened files in Linux is 1024. Issue easy to reproduce with the next command:
```
$ ./test.py --mode debug test_native_transport --repeat 1500
```
After the fix is applied all tests are passed with the next command:
```
$ ./test.py --mode debug test_native_transport --repeat 10000
```