### PR TITLE
test/alternator: fix a test failing on Amazon DynamoDB

### DIFF
--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -452,7 +452,7 @@ def check_pre_consistent_cluster_management(dynamodb):
     from util import is_aws
     # If not running on Scylla, return false.
     if is_aws(dynamodb):
-        return false
+        return False
     # In Scylla, we check Raft mode by inspecting the configuration via a
     # system table (which is also visible in Alternator)
     config_table = dynamodb.Table('.scylla.alternator.system.config')


### PR DESCRIPTION
The test test_table.py::test_concurrent_create_and_delete_table failed on Amazon DynamoDB because of a silly typo - "false" instead of "False". A function detecting Scylla tried to return false when noticing this isn't Scylla - but had a typo, trying to return "false" instead of "False".

This patch fixes this typo, and the test now works on DynamoDB: test/alternator/run --aws test_table.py::test_concurrent_create_and_delete_table