### PR TITLE
test/cql-pytest: remove unused function

### DIFF
--- a/test/cql-pytest/test_using_timeout.py
+++ b/test/cql-pytest/test_using_timeout.py
@@ -10,9 +10,6 @@ from cassandra.protocol import InvalidRequest, ReadTimeout, WriteTimeout, Syntax
 from cassandra.cluster import NoHostAvailable
 from cassandra.util import Duration
 
-def r(regex):
-    return re.compile(regex, re.IGNORECASE)
-
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()


### PR DESCRIPTION
Remove an unused function from test/cql-pytest/test_using_timeout.py. Some linters can complain that this function used re.compile(), but the "re" package was never imported. Since this function isn't used, the right fix is to remove it - and not add the missing import.