### PR TITLE
test/tablets: Add test to check how ALTER changes RF (in one DC)

### DIFF
--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -7,6 +7,7 @@ from cassandra.protocol import ConfigurationException
 from cassandra.query import SimpleStatement, ConsistencyLevel
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import HTTPError
+from test.pylib.tablets import get_all_tablet_replicas
 import pytest
 import logging
 import asyncio
@@ -95,3 +96,47 @@ async def test_reshape_with_tablets(manager: ManagerClient):
     await log.wait_for("Reshape test.test .* Reshaped 32 sstables to .*", mark, 30)
     sstable_info = await manager.api.get_sstable_info(server.ip_addr, "test", "test")
     assert len(sstable_info[0]['sstables']) == number_of_tablets
+
+
+@pytest.mark.parametrize("direction", ["up", "down", "none"])
+@pytest.mark.xfail(reason="Scaling not implemented yet")
+@pytest.mark.asyncio
+async def test_tablet_rf_change(manager: ManagerClient, direction):
+    cfg = {'enable_user_defined_functions': False,
+           'experimental_features': ['tablets', 'consistent-topology-changes']}
+    servers = await manager.servers_add(3, config=cfg)
+
+    cql = manager.get_cql()
+    res = await cql.run_async("SELECT data_center FROM system.local")
+    this_dc = res[0].data_center
+
+    if direction == 'up':
+        rf_from = 2
+        rf_to = 3
+    if direction == 'down':
+        rf_from = 3
+        rf_to = 2
+    if direction == 'none':
+        rf_from = 2
+        rf_to = 2
+
+    await cql.run_async(f"CREATE KEYSPACE test WITH replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': {rf_from}}}")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+
+    logger.info("Populating table")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in range(128)])
+
+    async def check_allocated_replica(expected: int):
+        replicas = await get_all_tablet_replicas(manager, servers[0], 'test', 'test')
+        for r in replicas:
+            logger.info(f"{r.replicas}")
+            assert len(r.replicas) == expected
+
+    logger.info(f"Checking {rf_from} allocated replicas")
+    await check_allocated_replica(rf_from)
+
+    logger.info(f"Altering RF {rf_from} -> {rf_to}")
+    await cql.run_async(f"ALTER KEYSPACE test WITH replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': {rf_to}}}")
+
+    logger.info(f"Checking {rf_to} re-allocated replicas")
+    await check_allocated_replica(rf_to)


### PR DESCRIPTION
For now test is incomplete in several ways

1. It xfails, until #17116
2. It doesn't rebuild/repair tablets
3. It doesn't check that tablet data actually exists on replicas

refs: #17575