### PR TITLE
api: /storage_service/tablets/balancing: fix incorrect operation summary

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2580,7 +2580,7 @@
             {
                "nickname":"tablet_balancing_enable",
                "method":"POST",
-               "summary":"Moves a tablet replica",
+               "summary":"Controls tablet load-balancing",
                "type":"void",
                "produces":[
                   "application/json"


### PR DESCRIPTION
It was probably copy-pasted from /storage_service/tablets/move