### PR TITLE
partition_version: add fmt::formatter for partition_entry::printer

### DIFF
--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -704,9 +704,9 @@ public:
         printer(const printer&) = delete;
         printer(printer&&) = delete;
 
-        friend std::ostream& operator<<(std::ostream& os, const printer& p);
+        friend fmt::formatter<printer>;
     };
-    friend std::ostream& operator<<(std::ostream& os, const printer& p);
+    friend fmt::formatter<printer>;
 };
 
 // Monotonic exception guarantees
@@ -729,3 +729,7 @@ inline const partition_version_ref& partition_snapshot::version() const
         return _entry->_version;
     }
 }
+
+template <> struct fmt::formatter<partition_entry::printer> : fmt::formatter<std::string_view> {
+    auto format(const partition_entry::printer&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `parition_entry::printer`, and drop its operator<< .

Refs #13245