### PR TITLE
test/boost: add formatter for BOOST_REQUIRE_EQUAL

### DIFF
--- a/test/boost/enum_set_test.cc
+++ b/test/boost/enum_set_test.cc
@@ -14,19 +14,30 @@
 #include <unordered_set>
 
 #include <boost/test/unit_test.hpp>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
 
-#include "utils/to_string.hh"
 
 enum class fruit { apple = 3, pear = 7, banana = 8 };
 
-static std::ostream& operator<<(std::ostream& os, fruit f) {
-    switch (f) {
-        case fruit::apple: os << "apple"; break;
-        case fruit::pear: os << "pear"; break;
-        case fruit::banana: os << "banana"; break;
+template <> struct fmt::formatter<fruit> : fmt::formatter<std::string_view> {
+    auto format(fruit f, fmt::format_context& ctx) const {
+        std::string_view name;
+        using enum fruit;
+        switch (f) {
+            case apple: name = "apple"; break;
+            case pear: name = "pear"; break;
+            case banana: name = "banana"; break;
+        }
+        return formatter<string_view>::format(name, ctx);
     }
+};
 
+namespace std {
+std::ostream& boost_test_print_type(std::ostream& os, const std::unordered_set<fruit>& fruits) {
+    fmt::print(os, "{}", fruits);
     return os;
+}
 }
 
 using fruit_enum = super_enum<fruit, fruit::apple, fruit::pear, fruit::banana>;


### PR DESCRIPTION
before this change, we rely on the homebrew generic formatter to print unordered_set<>, which in turn uses operator<< to format the elements in the `unordered_set`, but we intend to remove this formatter in future, as the last step of #13245 .

so enable Boost.test to print out lhs and rhs when `BOOST_REQUIRE_EQUAL` check fails, we are adding `boost_test_print_type()` for `unordered_set<fruit>`. the helper function uses {fmt} to print the `unordered_set<>`, so we are adding a fmt::formatter for `fruit`, the operator<< for this type is dropped, as it is not used anymore.

Refs #13245