### PR TITLE
version: kill version::release()

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1429,7 +1429,7 @@ future<> system_keyspace::save_local_info(local_info sysinfo, locator::endpoint_
     return execute_cql(req, sstring(db::system_keyspace::LOCAL),
                             sysinfo.host_id.uuid(),
                             sysinfo.cluster_name,
-                            version::release(),
+                            scylla_version(),
                             cql3::query_processor::CQL_VERSION,
                             ::cassandra::thrift_version,
                             to_sstring(unsigned(cql_serialization_format::latest().protocol_version())),

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -18,7 +18,7 @@
 #include "dht/token.hh"
 #include "schema/schema_fwd.hh"
 #include "utils/to_string.hh"
-#include "version.hh"
+#include "release.hh"
 #include "cdc/generation_id.hh"
 #include <unordered_set>
 
@@ -170,7 +170,7 @@ public:
     }
 
     static versioned_value release_version() {
-        return versioned_value(version::release());
+        return versioned_value(scylla_version());
     }
 
     static versioned_value network_version();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -48,7 +48,7 @@
 #include <seastar/core/thread.hh>
 #include <algorithm>
 #include "locator/local_strategy.hh"
-#include "version.hh"
+#include "release.hh"
 #include "dht/range_streamer.hh"
 #include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
@@ -1169,7 +1169,7 @@ future<> storage_service::update_topology_with_local_metadata(raft::server& raft
     // TODO: include more metadata here
     auto local_shard_count = smp::count;
     auto local_ignore_msb = _db.local().get_config().murmur3_partitioner_ignore_msb_bits();
-    auto local_release_version = version::release();
+    auto local_release_version = scylla_version();
     auto local_supported_features = boost::copy_range<std::set<sstring>>(_feature_service.supported_feature_set());
 
     auto synchronized = [&] () {
@@ -1539,7 +1539,7 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
         .snitch_name = _db.local().get_snitch_name(),
         .datacenter = _snitch.local()->get_datacenter(),
         .rack = _snitch.local()->get_rack(),
-        .release_version = version::release(),
+        .release_version = scylla_version(),
         .num_tokens = _db.local().get_config().num_tokens(),
         .shard_count = smp::count,
         .ignore_msb =  _db.local().get_config().murmur3_partitioner_ignore_msb_bits(),
@@ -3203,7 +3203,7 @@ void storage_service::set_mode(mode m) {
 }
 
 sstring storage_service::get_release_version() {
-    return version::release();
+    return scylla_version();
 }
 
 sstring storage_service::get_schema_version() {

--- a/version.hh
+++ b/version.hh
@@ -23,16 +23,6 @@ public:
         return seastar::format("{:d}.{:d}.{:d}", std::get<0>(_version), std::get<1>(_version), std::get<2>(_version));
     }
 
-    static version current() {
-        static version v(3, 0, 8);
-        return v;
-    }
-
     std::strong_ordering operator<=>(const version&) const = default;
 };
-
-inline const seastar::sstring& release() {
-    static thread_local auto str_ver = version::current().to_sstring();
-    return str_ver;
-}
 }


### PR DESCRIPTION
This method returns an arbitrary version of Cassandra, we consider ourselves most compatible with. At least that is the theory behind it, but saw no update in years, so it is probably stale. This method appears in the output of `nodetool version`, in the system.versions virtual table, among others. It is even gossiped around and stored in topology metadata for some reason.
It is a regular source of confusion as users and even developers confuse it with the real scylla version. To end the confusion, kill version::release(), replacing all its usage with the version of ScyllaDB proper.

Fixes: scylladb/scylla-tools-java#45