### PR TITLE
repair: add fmt::formatter for row_level_diff_detect_algorithm

### DIFF
--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -11,6 +11,7 @@
 #include <unordered_map>
 #include <exception>
 #include <absl/container/btree_set.h>
+#include <fmt/core.h>
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/sstring.hh>
@@ -284,3 +285,9 @@ struct hash<node_repair_meta_id> {
 };
 
 }
+
+template <> struct fmt::formatter<row_level_diff_detect_algorithm> : fmt::formatter<std::string_view> {
+    auto format(row_level_diff_detect_algorithm algo, fmt::format_context& ctx) const {
+        return formatter<std::string_view>::format(format_as(algo), ctx);
+    }
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for
row_level_diff_detect_algorithm. please note, we already have `format_as()` overload for this type, but we cannot use it as a fallback of the proper `fmt::formatter<>` specialization before {fmt} v10. so before we update our CI to a distro with {fmt} v10, `fmt::formatter<row_level_diff_detect_algorithm>` is still needed.

Refs #13245