### PR TITLE
build: cmake: use --ld-path for specifying linker for clang

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -127,11 +127,16 @@ set(Scylla_USE_LINKER
 if(Scylla_USE_LINKER)
     set(linkers "${Scylla_USE_LINKER}")
 else()
-    set(linkers "lld" "gold")
+    set(linkers "ld.lld" "gold")
 endif()
 
 foreach(linker ${linkers})
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(linker_flag "--ld-path=${linker}")
+  else()
     set(linker_flag "-fuse-ld=${linker}")
+  endif()
+
     check_linker_flag(CXX ${linker_flag} "CXX_LINKER_HAVE_${linker}")
     if(CXX_LINKER_HAVE_${linker})
         add_link_options("${linker_flag}")


### PR DESCRIPTION
Clang > 12 starts to complain like
```
warning:  '-fuse-ld=' taking a path is deprecated; use '--ld-path=' instead [-Wfuse-ld-path]'
```
this option is not supported by GCC yet. also instead of using the generic driver's name, use the specific name. otherwise ld fails like
```
lld is a generic driver.
Invoke ld.lld (Unix), ld64.lld (macOS), lld-link (Windows), wasm-ld (WebAssembly) instead
```