### PR TITLE
data_dictionary: do not include unused headers

### DIFF
--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -11,7 +11,6 @@
 #include "user_types_metadata.hh"
 #include "keyspace_metadata.hh"
 #include "schema/schema.hh"
-#include "utils/overloaded_functor.hh"
 #include "cql3/util.hh"
 #include <fmt/core.h>
 #include <ios>

--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <string>
 #include <map>
 #include <seastar/core/sstring.hh>
 #include "seastarx.hh"


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.