### PR TITLE
test/boost: add formatter for BOOST_REQUIRE_EQUAL

### DIFF
--- a/test/boost/gossiping_property_file_snitch_test.cc
+++ b/test/boost/gossiping_property_file_snitch_test.cc
@@ -19,6 +19,15 @@
 
 static std::filesystem::path test_files_subdir("test/resource/snitch_property_files");
 
+namespace std {
+
+std::ostream& boost_test_print_type(std::ostream& os, const std::pair<sstring, sstring>& p) {
+    fmt::print(os, "{}:{}", p.first, p.second);
+    return os;
+}
+
+}
+
 future<> one_test(const std::string& property_fname, bool exp_result) {
     using namespace locator;
 


### PR DESCRIPTION
in gossiping_property_file_snitch_test, we use
`BOOST_REQUIRE_EQUAL(dc_racks[i], dc_racks[0])` to check the equality of two instances of `pair<sstring, sstring`, like:
```c++
BOOST_REQUIRE_EQUAL(dc_racks[i], dc_racks[0])
```

since the standard library does not provide the formatter for printing `std::pair<>`, we rely on the homebrew generic formatter to print `std::pair<>`, which in turn uses operator<< to format the elements in the `pair`, but we intend to remove this formatter in future, as the last step of #13245 .

so in order to enable Boost.test to print out lhs and rhs when `BOOST_REQUIRE_EQUAL` check fails, we are adding
`boost_test_print_type()` for `pair<sstring,sstring>`. the helper function uses {fmt} to print the `pair<>`.

Refs #13245