### PR TITLE
db: add fmt::formatter for db::functions::function

### DIFF
--- a/db/functions/function.hh
+++ b/db/functions/function.hh
@@ -13,6 +13,7 @@
 #include "types/types.hh"
 #include <vector>
 #include <optional>
+#include <fmt/ostream.h>
 
 namespace db {
 namespace functions {
@@ -73,3 +74,5 @@ operator<<(std::ostream& os, const function& f) {
 
 }
 }
+
+template <std::derived_from<db::functions::function> T> struct fmt::formatter<T> : fmt::ostream_formatter {};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for `db::functions::function`. please note, because we use `std::ostream` as the parameter of the polymorphism implementation of `function::print()`. without an intrusive change, we have to use `fmt::ostream_formatter` or at least use similar technique to format the `function` instance into an instance of `ostream` first. so instead of implementing a "native" `fmt::formatter`, in this change, we just use `fmt::ostream_formatter`.

Refs #13245