### PR TITLE
[mergify] set draft PR when conflicts

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,4 +1,12 @@
 pull_request_rules:
+  - name: put PR in draft if conflicts
+    conditions:
+      - label = conflicts
+      - author = mergify[bot]
+      - head ~= ^mergify/
+    actions:
+      edit:
+         draft: true
   - name: Automate backport pull request 5.2
     conditions:
       - or:


### PR DESCRIPTION
When Mergify opens a backport PR and identifies conflicts, it adds the `conflicts` label. Since GitHub can't identify conflicts in PR, setting a role to move PR to draft, this way we will not trigger CI

Once we resolve the conflicts, the developer should make the PR `ready for
review` (which is not a draft) and then CI will be triggered

The `conflict` label can also be removed
