### PR TITLE
build: cmake: do not link randomized_nemesis_test with replication.cc

### DIFF
--- a/test/raft/CMakeLists.txt
+++ b/test/raft/CMakeLists.txt
@@ -1,9 +1,17 @@
+add_library(test-raft-helper OBJECT)
+target_sources(test-raft-helper
+  PRIVATE
+    helpers.cc)
+target_link_libraries(test-raft-helper
+  test-lib
+  Seastar::seastar_testing)
+
 add_library(test-raft)
 target_sources(test-raft
   PRIVATE
-    helpers.cc
     replication.cc)
 target_link_libraries(test-raft
+  test-raft-helper
   test-lib
   Seastar::seastar_testing)
 
@@ -31,7 +39,7 @@ add_scylla_test(raft_sys_table_storage_test
   KIND SEASTAR)
 add_scylla_test(randomized_nemesis_test
   KIND SEASTAR
-  LIBRARIES test-raft)
+  LIBRARIES test-raft-helper)
 add_scylla_test(replication_test
   KIND SEASTAR
   LIBRARIES test-raft)


### PR DESCRIPTION
test/raft/replication.cc defines a symbol named `tlogger`, while test/raft/randomized_nemesis_test.cc also defines a symbol with the same name. when linking the test with mold, it identified the ODR violation.

in this change, we extract test-raft-helper out, so that randomized_nemesis_test can selectively only link against this library. this also matches with the behavior of the rules generated by `configure.py`.