### PR TITLE
service:qos: add fmt::formatter for service_level_options::workload_type

### DIFF
--- a/service/qos/qos_common.hh
+++ b/service/qos/qos_common.hh
@@ -85,3 +85,9 @@ public:
 };
 
 }
+
+template <> struct fmt::formatter<qos::service_level_options::workload_type> : fmt::formatter<std::string_view> {
+    auto format(qos::service_level_options::workload_type wt, fmt::format_context& ctx) const {
+        return formatter<std::string_view>::format(qos::service_level_options::to_string(wt), ctx);
+    }
+};


### PR DESCRIPTION
this change prepares for the fmt::formatter based formatter used by tests, which will use {fmt} to print the elements in a container, so we need to define the formatter using fmt::formatter for these element. the operator<< for service_level_options::workload_type is preserved, as the tests are still using it.

Refs #13245