### PR TITLE
test/boost: use fmt to print ranges

### DIFF
--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -11,6 +11,7 @@
 
 #include <vector>
 #include <chrono>
+#include <fmt/ranges.h>
 #include <seastar/core/shared_ptr.hh>
 #include "seastar/core/on_internal_error.hh"
 #include "sstables/shared_sstable.hh"

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -36,6 +36,7 @@
 #include <boost/range/algorithm/sort.hpp>
 #include <boost/range/algorithm/min_element.hpp>
 #include <boost/container/static_vector.hpp>
+#include <fmt/ranges.h>
 #include "mutation/frozen_mutation.hh"
 #include <seastar/core/do_with.hh>
 #include "service/migration_listener.hh"

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -10,6 +10,7 @@
 #include "test/lib/scylla_test_case.hh"
 #include <string>
 #include <boost/range/adaptor/map.hpp>
+#include <fmt/std.h>
 
 #include "cdc/log.hh"
 #include "cdc/cdc_options.hh"
@@ -18,6 +19,7 @@
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/exception_utils.hh"
 #include "test/lib/log.hh"
+#include "test/lib/test_utils.hh"
 #include "transport/messages/result_message.hh"
 
 #include "types/types.hh"

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -42,6 +42,7 @@
 #include "test/lib/sstable_utils.hh"
 #include "test/lib/mutation_source_test.hh"
 #include "test/lib/key_utils.hh"
+#include "test/lib/test_utils.hh"
 
 using namespace db;
 

--- a/test/boost/compound_test.cc
+++ b/test/boost/compound_test.cc
@@ -9,6 +9,7 @@
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/random_utils.hh"
+#include "test/lib/test_utils.hh"
 
 #include "compound.hh"
 #include "compound_compat.hh"

--- a/test/boost/config_test.cc
+++ b/test/boost/config_test.cc
@@ -12,6 +12,7 @@
 #include <iostream>
 
 #include "test/lib/scylla_test_case.hh"
+#include "test/lib/test_utils.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/core/future-util.hh>
 #include "db/config.hh"

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -14,6 +14,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 
+#include <fmt/std.h>
 #include <seastar/net/inet_address.hh>
 
 #include "test/lib/scylla_test_case.hh"

--- a/test/boost/hint_test.cc
+++ b/test/boost/hint_test.cc
@@ -9,6 +9,7 @@
 #include <boost/test/unit_test.hpp>
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/core/smp.hh>
+#include <fmt/ranges.h>
 
 #include "db/hints/sync_point.hh"
 
@@ -21,9 +22,8 @@ std::ostream& operator<<(std::ostream& out, const replay_position& p) {
 
 namespace db::hints {
 std::ostream& operator<<(std::ostream& out, const sync_point& sp) {
-    out << "{regular_per_shard_rps: " << sp.regular_per_shard_rps
-        << ", mv_per_shard_rps: " << sp.mv_per_shard_rps
-        << "}";
+    fmt::print(out, "{{regular_per_shard_rps: {}, mv_per_shard_rps: {}}}",
+               sp.regular_per_shard_rps, sp.mv_per_shard_rps);
     return out;
 }
 }

--- a/test/boost/idl_test.cc
+++ b/test/boost/idl_test.cc
@@ -15,6 +15,9 @@
 #include <vector>
 #include <optional>
 
+#include <fmt/ranges.h>
+
+#include "test/lib/test_utils.hh"
 #include "bytes.hh"
 #include "bytes_ostream.hh"
 
@@ -51,9 +54,16 @@ public:
 thread_local int non_final_composite_test_object::construction_count = 0;
 thread_local int final_composite_test_object::construction_count = 0;
 
+template <> struct fmt::formatter<simple_compound> : fmt::formatter<std::string_view> {
+    auto format(const simple_compound& sc, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), " {{ foo: {}, bar: {} }}", sc.foo, sc.bar);
+    }
+};
+
 std::ostream& operator<<(std::ostream& os, const simple_compound& sc)
 {
-    return os << " { foo: " << sc.foo << ", bar: " << sc.bar << " }";
+    fmt::print(os, "{}", sc);
+    return os;
 }
 
 struct compound_with_optional {
@@ -69,11 +79,11 @@ std::ostream& operator<<(std::ostream& os, const compound_with_optional& v)
 {
     os << " { first: ";
     if (v.first) {
-        os << *v.first;
+        fmt::print(os, "{}", *v.first);
     } else {
-        os << "<disengaged>";
+        fmt::print(os, "<disengaged>");
     }
-    os << ", second: " << v.second << " }";
+    fmt::print(os, ", second: {}}}", v.second);
     return os;
 }
 
@@ -87,7 +97,8 @@ struct wrapped_vector {
 
 std::ostream& operator<<(std::ostream& os, const wrapped_vector& v)
 {
-    return os << v.vector;
+    fmt::print(os, "{}", v.vector);
+    return os;
 }
 
 struct vectors_of_compounds {

--- a/test/boost/locator_topology_test.cc
+++ b/test/boost/locator_topology_test.cc
@@ -13,6 +13,7 @@
 
 #include "locator/types.hh"
 #include "test/lib/scylla_test_case.hh"
+#include "test/lib/test_utils.hh"
 
 #include "locator/host_id.hh"
 #include "locator/topology.hh"

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -28,6 +28,7 @@
 #include "test/lib/random_utils.hh"
 #include "test/lib/random_schema.hh"
 #include "test/lib/log.hh"
+#include "test/lib/test_utils.hh"
 
 #include <boost/range/adaptor/map.hpp>
 #include "readers/from_mutations_v2.hh"

--- a/test/boost/nonwrapping_interval_test.cc
+++ b/test/boost/nonwrapping_interval_test.cc
@@ -16,6 +16,7 @@
 #include "schema/schema_builder.hh"
 
 #include "locator/token_metadata.hh"
+#include "test/lib/test_utils.hh"
 
 using ring_position = dht::ring_position;
 

--- a/test/boost/query_processor_test.cc
+++ b/test/boost/query_processor_test.cc
@@ -17,6 +17,7 @@
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
+#include "test/lib/test_utils.hh"
 
 #include <seastar/core/future-util.hh>
 #include <seastar/core/metrics_api.hh>

--- a/test/boost/role_manager_test.cc
+++ b/test/boost/role_manager_test.cc
@@ -9,8 +9,8 @@
 #include "auth/standard_role_manager.hh"
 
 #include "test/lib/scylla_test_case.hh"
-
 #include "test/lib/cql_test_env.hh"
+#include "test/lib/test_utils.hh"
 
 auto make_manager(cql_test_env& env) {
     auto stop_role_manager = [] (auth::standard_role_manager* m) {

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -16,6 +16,7 @@
 #include "cql3/util.hh"
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/cql_test_env.hh"
+#include "test/lib/test_utils.hh"
 
 using namespace cql3;
 

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -8,6 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include "test/lib/scylla_test_case.hh"
+#include "test/lib/test_utils.hh"
 #include "locator/token_metadata.hh"
 #include "locator/simple_strategy.hh"
 #include "locator/everywhere_replication_strategy.hh"

--- a/test/boost/top_k_test.cc
+++ b/test/boost/top_k_test.cc
@@ -12,6 +12,7 @@
 #include "utils/top_k.hh"
 #include <vector>
 #include <algorithm>
+#include "test/lib/test_utils.hh"
 
 //---------------------------------------------------------------------------------------------
 

--- a/test/boost/transport_test.cc
+++ b/test/boost/transport_test.cc
@@ -12,6 +12,7 @@
 #include "transport/response.hh"
 
 #include "test/lib/random_utils.hh"
+#include "test/lib/test_utils.hh"
 
 namespace cql3 {
 

--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -20,6 +20,7 @@
 #include "db/config.hh"
 #include "test/lib/tmpdir.hh"
 #include "test/lib/exception_utils.hh"
+#include "test/lib/test_utils.hh"
 
 using ire = exceptions::invalid_request_exception;
 using exception_predicate::message_equals;

--- a/test/boost/wrapping_interval_test.cc
+++ b/test/boost/wrapping_interval_test.cc
@@ -15,6 +15,7 @@
 #include "schema/schema_builder.hh"
 
 #include "locator/token_metadata.hh"
+#include "test/lib/test_utils.hh"
 
 // yuck, but what can one do?  needed for BOOST_REQUIRE_EQUAL
 namespace std {

--- a/test/lib/test_utils.hh
+++ b/test/lib/test_utils.hh
@@ -13,6 +13,7 @@
 #include <string>
 #include <boost/test/unit_test.hpp>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 using namespace seastar;
 
@@ -117,5 +118,15 @@ namespace std {
 std::ostream& boost_test_print_type(std::ostream& os, const std::strong_ordering& order);
 std::ostream& boost_test_print_type(std::ostream& os, const std::weak_ordering& order);
 std::ostream& boost_test_print_type(std::ostream& os, const std::partial_ordering& order);
+
+template<std::ranges::range T>
+requires (!std::same_as<T, std::string> &&
+          !std::same_as<T, std::string_view> &&
+          !std::same_as<T, std::basic_string_view<int8_t>> &&
+          !std::same_as<T, sstring>)
+std::ostream& boost_test_print_type(std::ostream& os, const T& v) {
+    fmt::print(os, "{}", v);
+    return os;
+}
 
 }

--- a/utils/to_string.hh
+++ b/utils/to_string.hh
@@ -55,12 +55,6 @@ std::ostream& operator<<(std::ostream& os, const print_with_comma<NeedsComma, Pr
 
 namespace std {
 
-template <typename K, typename V>
-std::ostream& operator<<(std::ostream& os, const std::pair<K, V>& p) {
-    os << "{" << p.first << ", " << p.second << "}";
-    return os;
-}
-
 template<typename... T, size_t... I>
 std::ostream& print_tuple(std::ostream& os, const std::tuple<T...>& p, std::index_sequence<I...>) {
     return ((os << "{" ) << ... << utils::internal::print_with_comma<I < sizeof...(I) - 1, T>{std::get<I>(p)}) << "}";
@@ -90,11 +84,6 @@ std::ostream& operator<<(std::ostream& os, const std::set<T, Args...>& items) {
 
 template <typename T, typename... Args>
 std::ostream& operator<<(std::ostream& os, const std::unordered_set<T, Args...>& items) {
-    return utils::format_range(os, items);
-}
-
-template <typename K, typename V, typename... Args>
-std::ostream& operator<<(std::ostream& os, const std::map<K, V, Args...>& items) {
     return utils::format_range(os, items);
 }
 


### PR DESCRIPTION
instead of relying on the homebrew operator<< based generic formatters,
let's use {fmt}'s formatters for range-alike containers. so that

* we can remove the operator<< based formatter of the element type
* we can also remove the operator<< based formatter of the container type

Refs #13245