### PR TITLE
build: cmake: put server deb packages under build/dist/$<CONFIG>/debian

### DIFF
--- a/cmake/build_submodule.cmake
+++ b/cmake/build_submodule.cmake
@@ -26,7 +26,7 @@ function(build_submodule name dir)
     COMMAND reloc/build_deb.sh --reloc-pkg ${reloc_pkg}
     DEPENDS ${reloc_pkg}
     WORKING_DIRECTORY "${working_dir}")
-  add_custom_target(dist-${name}
+  add_custom_target(dist-${name} ALL
     DEPENDS dist-${name}-tar dist-${name}-rpm dist-${name}-deb)
 endfunction()
 

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -14,7 +14,7 @@ add_custom_command(
     ${CMAKE_BINARY_DIR}/debian
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-add_custom_target(dist-server-deb
+add_custom_target(dist-server-deb ALL
   # the --builddir should match the paths specified by
   # "packages" in dist/docker/debian/build_docker.sh
   COMMAND reloc/build_deb.sh
@@ -22,12 +22,14 @@ add_custom_target(dist-server-deb
     --builddir ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/debian
   DEPENDS ${unstripped_dist_pkg}
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-add_custom_target(dist-server-rpm
+add_custom_target(dist-server-rpm ALL
   COMMAND reloc/build_rpm.sh
     --reloc-pkg ${unstripped_dist_pkg}
     --builddir ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/redhat
   DEPENDS ${unstripped_dist_pkg}
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_custom_target(dist-server
+  DEPENDS dist-server-deb dist-server-rpm)
 
 function(add_stripped name)
   # ${name} must be an absolute path

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -15,15 +15,17 @@ add_custom_command(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 add_custom_target(dist-server-deb
+  # the --builddir should match the paths specified by
+  # "packages" in dist/docker/debian/build_docker.sh
   COMMAND reloc/build_deb.sh
     --reloc-pkg ${unstripped_dist_pkg}
-    --builddir ${CMAKE_BINARY_DIR}/$<CONFIG>/debian
+    --builddir ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/debian
   DEPENDS ${unstripped_dist_pkg}
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_custom_target(dist-server-rpm
   COMMAND reloc/build_rpm.sh
     --reloc-pkg ${unstripped_dist_pkg}
-    --builddir ${CMAKE_CURRENT_BINARY_DIR}
+    --builddir ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/redhat
   DEPENDS ${unstripped_dist_pkg}
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 


### PR DESCRIPTION
this change is a follow up of ca7f7bf8e2, which changed the output path to build/$<CONFIG>/debian. but what dist/docker/debian/build_docker.sh expects is `build/dist/$config/debian/*.deb`, where `$config` is the normalized mode, when the debian packages are built using CMake generated rules, `$mode` is CMake configuration name, i.e., `$<CONFIG>`. so, ca7f7bf8e2 made a mistake, as it does not match the expectation of `build_docker.sh`.

in this change, this issue is addressed. so we use the same path in both `dist/CMakeLists.txt` and `dist/docker/debian/build_docker.sh`.