### PR TITLE
test: unit: add fmt::formatter for test_data in tests

### DIFF
--- a/test/unit/bptree_stress_test.cc
+++ b/test/unit/bptree_stress_test.cc
@@ -9,9 +9,7 @@
 #include <seastar/core/app-template.hh>
 #include <seastar/core/thread.hh>
 #include <map>
-#include <iostream>
 #include <fmt/core.h>
-#include <fmt/ostream.h>
 
 constexpr int TEST_NODE_SIZE = 16;
 
@@ -35,10 +33,11 @@ public:
     bool match_key(const test_key& k) const { return _value == (int)k + 10; }
 };
 
-std::ostream& operator<<(std::ostream& os, test_data d) {
-    os << (unsigned long)d;
-    return os;
-}
+template <> struct fmt::formatter<test_data> : fmt::formatter<std::string_view> {
+    auto format(test_data d, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", static_cast<unsigned long>(d));
+    }
+};
 
 using test_tree = tree<test_key, test_data, test_key_compare, TEST_NODE_SIZE, key_search::both, with_debug::yes>;
 using test_node = typename test_tree::node;

--- a/test/unit/radix_tree_compaction_test.cc
+++ b/test/unit/radix_tree_compaction_test.cc
@@ -41,10 +41,11 @@ public:
     }
 };
 
-std::ostream& operator<<(std::ostream& out, const test_data& d) {
-    out << d.value();
-    return out;
-}
+template <> struct fmt::formatter<test_data> : fmt::formatter<std::string_view> {
+    auto format(const test_data& d, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", d.value());
+    }
+};
 
 using test_tree = tree<test_data>;
 

--- a/test/unit/row_cache_stress_test.cc
+++ b/test/unit/row_cache_stress_test.cc
@@ -18,6 +18,7 @@
 #include "utils/div_ceil.hh"
 #include "test/lib/memtable_snapshot_source.hh"
 #include <seastar/core/reactor.hh>
+#include <fmt/core.h>
 
 static thread_local bool cancelled = false;
 
@@ -181,11 +182,18 @@ struct table {
 
 struct reader_id {
     sstring name;
+};
 
-    friend std::ostream& operator<<(std::ostream& out, reader_id id) {
-        return out << id.name;
+} // namespace row_cache_stress_test
+
+// TODO: use format_as() after {fmt} v10
+template <> struct fmt::formatter<row_cache_stress_test::reader_id> : fmt::formatter<std::string_view> {
+    auto format(const row_cache_stress_test::reader_id& id, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", id.name);
     }
 };
+
+namespace row_cache_stress_test {
 
 class validating_consumer {
     table& _t;


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we define formatters for

* test_data in two different tests
* row_cache_stress_test::reader_id

and drop its operator<<.

Refs #13245