### PR TITLE
Skip the backport-label workflow for draft pull requests

### DIFF
--- a/.github/workflows/pr-require-backport-label.yaml
+++ b/.github/workflows/pr-require-backport-label.yaml
@@ -7,6 +7,7 @@ on:
       - next
 jobs:
   label:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
It's not necessary (and annoying) when this workflow runs and fails against PRs in draft mode