### PR TITLE
test/boost/tablets: Use verbose BOOST_REQUIRE checkers

### DIFF
--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -837,10 +837,10 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_empty_node) {
 
         for (auto h : {host1, host2, host3}) {
             testlog.debug("Checking host {}", h);
-            BOOST_REQUIRE(load.get_load(h) <= 3);
-            BOOST_REQUIRE(load.get_load(h) > 1);
-            BOOST_REQUIRE(load.get_avg_shard_load(h) <= 2);
-            BOOST_REQUIRE(load.get_avg_shard_load(h) > 0);
+            BOOST_REQUIRE_LE(load.get_load(h), 3);
+            BOOST_REQUIRE_GT(load.get_load(h), 1);
+            BOOST_REQUIRE_LE(load.get_avg_shard_load(h), 2);
+            BOOST_REQUIRE_GT(load.get_avg_shard_load(h), 0);
         }
     }
   }).get();
@@ -1010,9 +1010,9 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_met) {
         {
             load_sketch load(stm.get());
             load.populate().get();
-            BOOST_REQUIRE(load.get_avg_shard_load(host1) == 2);
-            BOOST_REQUIRE(load.get_avg_shard_load(host2) == 2);
-            BOOST_REQUIRE(load.get_avg_shard_load(host3) == 0);
+            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host1), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host2), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
         }
 
         stm.mutate_token_metadata([&](token_metadata& tm) {
@@ -1025,9 +1025,9 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_met) {
         {
             load_sketch load(stm.get());
             load.populate().get();
-            BOOST_REQUIRE(load.get_avg_shard_load(host1) == 2);
-            BOOST_REQUIRE(load.get_avg_shard_load(host2) == 2);
-            BOOST_REQUIRE(load.get_avg_shard_load(host3) == 0);
+            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host1), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host2), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
         }
     }).get();
 }
@@ -1114,10 +1114,10 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_two_racks) {
         {
             load_sketch load(stm.get());
             load.populate().get();
-            BOOST_REQUIRE(load.get_avg_shard_load(host1) >= 2);
-            BOOST_REQUIRE(load.get_avg_shard_load(host2) >= 2);
-            BOOST_REQUIRE(load.get_avg_shard_load(host3) >= 2);
-            BOOST_REQUIRE(load.get_avg_shard_load(host4) == 0);
+            BOOST_REQUIRE_GE(load.get_avg_shard_load(host1), 2);
+            BOOST_REQUIRE_GE(load.get_avg_shard_load(host2), 2);
+            BOOST_REQUIRE_GE(load.get_avg_shard_load(host3), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host4), 0);
         }
 
         // Verify replicas are not collocated on racks
@@ -1127,7 +1127,7 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_two_racks) {
             tmap.for_each_tablet([&](auto tid, auto& tinfo) -> future<> {
                 auto rack1 = tm->get_topology().get_rack(tinfo.replicas[0].host);
                 auto rack2 = tm->get_topology().get_rack(tinfo.replicas[1].host);
-                BOOST_REQUIRE(rack1 != rack2);
+                BOOST_REQUIRE_NE(rack1, rack2);
                 return make_ready_future<>();
             }).get();
         }
@@ -1337,7 +1337,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_works_with_in_progress_transitions)
 
         for (auto h : {host1, host2, host3}) {
             testlog.debug("Checking host {}", h);
-            BOOST_REQUIRE(load.get_avg_shard_load(h) == 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(h), 2);
         }
     }
   }).get();
@@ -1460,7 +1460,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_two_empty_nodes) {
 
         for (auto h : {host1, host2, host3, host4}) {
             testlog.debug("Checking host {}", h);
-            BOOST_REQUIRE(load.get_avg_shard_load(h) == 4);
+            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(h), 4);
         }
     }
   }).get();
@@ -1800,7 +1800,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
             };
 
             do_rebalance_tablets(std::move(load_stats));
-            BOOST_REQUIRE(tablet_count() == initial_tablets);
+            BOOST_REQUIRE_EQUAL(tablet_count(), initial_tablets);
             BOOST_REQUIRE(std::holds_alternative<locator::resize_decision::merge>(resize_decision().way));
         }
 
@@ -1813,7 +1813,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
             };
 
             do_rebalance_tablets(std::move(load_stats));
-            BOOST_REQUIRE(tablet_count() == initial_tablets);
+            BOOST_REQUIRE_EQUAL(tablet_count(), initial_tablets);
             BOOST_REQUIRE(std::holds_alternative<locator::resize_decision::none>(resize_decision().way));
         }
 
@@ -1826,9 +1826,9 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
             };
 
             do_rebalance_tablets(std::move(load_stats));
-            BOOST_REQUIRE(tablet_count() == initial_tablets);
+            BOOST_REQUIRE_EQUAL(tablet_count(), initial_tablets);
             BOOST_REQUIRE(std::holds_alternative<locator::resize_decision::split>(resize_decision().way));
-            BOOST_REQUIRE(resize_decision().sequence_number > 0);
+            BOOST_REQUIRE_GT(resize_decision().sequence_number, 0);
         }
 
         // replicas set their split status as ready, and load balancer finalizes split generating a new
@@ -1842,7 +1842,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
 
             do_rebalance_tablets(std::move(load_stats));
 
-            BOOST_REQUIRE(tablet_count() == initial_tablets * 2);
+            BOOST_REQUIRE_EQUAL(tablet_count(), initial_tablets * 2);
             BOOST_REQUIRE(std::holds_alternative<locator::resize_decision::none>(resize_decision().way));
         }
     }).get();


### PR DESCRIPTION
Lot's of BOOST_REQUIRES in this test require some integers to be in some eq/gt/le relations to each other. And one place that compares rack names as strings. Using more verbose boost checkers is preferred in such cases