### PR TITLE
sstables_manager: decouple from system_keyspace

### DIFF
--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -19,6 +19,7 @@
 #include "db_clock.hh"
 #include "mutation_query.hh"
 #include "system_keyspace_view_types.hh"
+#include "sstables/sstables_registry.hh"
 #include <seastar/core/distributed.hh>
 #include "cdc/generation_id.hh"
 #include "locator/host_id.hh"
@@ -571,7 +572,7 @@ public:
     future<> sstables_registry_update_entry_status(sstring location, sstables::generation_type gen, sstring status);
     future<> sstables_registry_update_entry_state(sstring location, sstables::generation_type gen, sstables::sstable_state state);
     future<> sstables_registry_delete_entry(sstring location, sstables::generation_type gen);
-    using sstable_registry_entry_consumer = noncopyable_function<future<>(sstring status, sstables::sstable_state state, sstables::entry_descriptor desc)>;
+    using sstable_registry_entry_consumer = sstables::sstables_registry::entry_consumer;
     future<> sstables_registry_list(sstring location, sstable_registry_entry_consumer consumer);
 
     future<std::optional<sstring>> load_group0_upgrade_state();

--- a/db/system_keyspace_sstables_registry.hh
+++ b/db/system_keyspace_sstables_registry.hh
@@ -1,0 +1,37 @@
+// Copyright (C) 2024-present ScyllaDB
+// SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
+
+#include "system_keyspace.hh"
+#include "sstables/sstables_registry.hh"
+
+// Implement the sstables_registry interface using system_keyspace.
+
+namespace db {
+
+class system_keyspace_sstables_registry : public sstables::sstables_registry {
+    shared_ptr<system_keyspace> _keyspace;
+public:
+    system_keyspace_sstables_registry(system_keyspace& keyspace) : _keyspace(keyspace.shared_from_this()) {}
+
+    virtual seastar::future<> create_entry(sstring location, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) override {
+        return _keyspace->sstables_registry_create_entry(location, status, state, desc);
+    }
+
+    virtual seastar::future<> update_entry_status(sstring location, sstables::generation_type gen, sstring status) override {
+        return _keyspace->sstables_registry_update_entry_status(location, gen, status);
+    }
+
+    virtual seastar::future<> update_entry_state(sstring location, sstables::generation_type gen, sstables::sstable_state state) override {
+        return _keyspace->sstables_registry_update_entry_state(location, gen, state);
+    }
+
+    virtual seastar::future<> delete_entry(sstring location, sstables::generation_type gen) override {
+        return _keyspace->sstables_registry_delete_entry(location, gen);
+    }
+
+    virtual seastar::future<> sstables_registry_list(sstring location, entry_consumer consumer) override {
+        return _keyspace->sstables_registry_list(location, std::move(consumer));
+    }
+};
+
+}

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -13,6 +13,7 @@
 #include <seastar/core/future-util.hh>
 #include "db/system_auth_keyspace.hh"
 #include "db/system_keyspace.hh"
+#include "db/system_keyspace_sstables_registry.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "db/commitlog/commitlog.hh"
 #include "db/config.hh"
@@ -2943,11 +2944,11 @@ database::as_data_dictionary() const {
 void database::plug_system_keyspace(db::system_keyspace& sys_ks) noexcept {
     _compaction_manager.plug_system_keyspace(sys_ks);
     _large_data_handler->plug_system_keyspace(sys_ks);
-    _user_sstables_manager->plug_system_keyspace(sys_ks);
+    _user_sstables_manager->plug_sstables_registry(std::make_unique<db::system_keyspace_sstables_registry>(sys_ks));
 }
 
 void database::unplug_system_keyspace() noexcept {
-    _user_sstables_manager->unplug_system_keyspace();
+    _user_sstables_manager->unplug_sstables_registry();
     _compaction_manager.unplug_system_keyspace();
     _large_data_handler->unplug_system_keyspace();
 }

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -24,9 +24,9 @@
 #include "utils/phased_barrier.hh"
 #include "utils/disk-error-handler.hh"
 #include "sstables/generation_type.hh"
+#include "sstables/sstables_registry.hh"
 
 class compaction_manager;
-namespace db { class system_keyspace; }
 
 namespace sstables {
 
@@ -113,14 +113,14 @@ public:
         virtual future<> prepare(sstable_directory&, process_flags, storage&) override;
     };
 
-    class system_keyspace_components_lister final : public components_lister {
-        db::system_keyspace& _sys_ks;
+    class sstables_registry_components_lister final : public components_lister {
+        sstables_registry& _sstables_registry;
         sstring _location;
 
         future<> garbage_collect(storage&);
 
     public:
-        system_keyspace_components_lister(db::system_keyspace& sys_ks, sstring location);
+        sstables_registry_components_lister(sstables::sstables_registry& sstables_registry, sstring location);
 
         virtual future<> process(sstable_directory& directory, process_flags flags) override;
         virtual future<> commit() override;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -12,6 +12,7 @@
 #include "version.hh"
 #include "shared_sstable.hh"
 #include "open_info.hh"
+#include "sstables_registry.hh"
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>
 #include <seastar/core/future.hh>
@@ -132,13 +133,6 @@ constexpr auto table_subdirectories = std::to_array({
     quarantine_dir,
     pending_delete_dir,
 });
-
-enum class sstable_state {
-    normal,
-    staging,
-    quarantine,
-    upload,
-};
 
 inline std::string_view state_to_dir(sstable_state state) {
     switch (state) {

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -26,7 +26,6 @@
 
 namespace db {
 
-class system_keyspace;
 class large_data_handler;
 class config;
 
@@ -103,7 +102,7 @@ private:
 
     reader_concurrency_semaphore _sstable_metadata_concurrency_sem;
     directory_semaphore& _dir_semaphore;
-    seastar::shared_ptr<db::system_keyspace> _sys_ks;
+    std::unique_ptr<sstables::sstables_registry> _sstables_registry;
     // This function is bound to token_metadata.get_my_id() in the database constructor,
     // it can return unset value (bool(host_id) == false) until host_id is loaded
     // after system_keyspace initialization.
@@ -156,13 +155,13 @@ public:
     future<> close();
     directory_semaphore& dir_semaphore() noexcept { return _dir_semaphore; }
 
-    void plug_system_keyspace(db::system_keyspace& sys_ks) noexcept;
-    void unplug_system_keyspace() noexcept;
+    void plug_sstables_registry(std::unique_ptr<sstables_registry>) noexcept;
+    void unplug_sstables_registry() noexcept;
 
     // Only for sstable::storage usage
-    db::system_keyspace& system_keyspace() const noexcept {
-        assert(_sys_ks && "System keyspace is not plugged");
-        return *_sys_ks;
+    sstables::sstables_registry& sstables_registry() const noexcept {
+        assert(_sstables_registry && "sstables_registry is not plugged");
+        return *_sstables_registry;
     }
 
     future<> delete_atomically(std::vector<shared_sstable> ssts);

--- a/sstables/sstables_registry.hh
+++ b/sstables/sstables_registry.hh
@@ -1,0 +1,36 @@
+// Copyright (C) 2024-present ScyllaDB
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+#include "open_info.hh"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/core/future.hh>
+#include "seastarx.hh"
+
+namespace sstables {
+
+enum class sstable_state {
+    normal,
+    staging,
+    quarantine,
+    upload,
+};
+
+// sstables_manager needs to store the names of its sstables somewhere, when
+// using object storage. This is system_keyspace, but for modularity we hide
+// it behind this interface.
+
+class sstables_registry {
+public:
+    virtual ~sstables_registry();
+    virtual future<> create_entry(sstring location, sstring status, sstable_state state, sstables::entry_descriptor desc) = 0;
+    virtual future<> update_entry_status(sstring location, sstables::generation_type gen, sstring status) = 0;
+    virtual future<> update_entry_state(sstring location, sstables::generation_type gen, sstables::sstable_state state) = 0;
+    virtual future<> delete_entry(sstring location, sstables::generation_type gen) = 0;
+    using entry_consumer = noncopyable_function<future<>(sstring status, sstables::sstable_state state, sstables::entry_descriptor desc)>;
+    virtual future<> sstables_registry_list(sstring location, entry_consumer consumer) = 0;
+};
+
+} // namespace sstables

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -13,6 +13,7 @@
 #include "test/lib/test_utils.hh"
 #include "db/config.hh"
 #include "db/large_data_handler.hh"
+#include "db/system_keyspace_sstables_registry.hh"
 #include "dht/i_partitioner.hh"
 #include "gms/feature_service.hh"
 #include "repair/row_level.hh"
@@ -233,8 +234,8 @@ future<> test_env::do_with_async(noncopyable_function<void (test_env&)> func, te
         return do_with_cql_env_thread([wrap = std::move(wrap)] (auto& cql_env) mutable {
             test_env env(std::move(wrap->cfg), &cql_env.get_sstorage_manager().local());
             auto close_env = defer([&] { env.stop().get(); });
-            env.manager().plug_system_keyspace(cql_env.get_system_keyspace().local());
-            auto unplu = defer([&env] { env.manager().unplug_system_keyspace(); });
+            env.manager().plug_sstables_registry(std::make_unique<db::system_keyspace_sstables_registry>(cql_env.get_system_keyspace().local()));
+            auto unplu = defer([&env] { env.manager().unplug_sstables_registry(); });
             wrap->func(env);
         }, std::move(db_cfg));
     }


### PR DESCRIPTION
sstables_manager now depends on system_keyspace for access to the system.sstables table, needed by object storage. This violates modularity, since sstables_manager is a relatively low-level leaf module while system_keyspace integrates large parts of the system (including, indirectly, sstables_manager).

One area where this is grating is sstables::test_env, which has to include the much higher level cql_test_env to accommodate it.

Fix this by having sstables_manager expose its dependency on system_keyspace as an interface, sstables_registry, and have system_keyspace implement the glue logic in
system_keyspace_sstables_manager.