### PR TITLE
sstables: Fix clone semantics for runs in partitioned_sstable_set

### DIFF
--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -299,6 +299,12 @@ partitioned_sstable_set::partitioned_sstable_set(schema_ptr schema, bool use_lev
         , _use_level_metadata(use_level_metadata) {
 }
 
+static std::unordered_map<run_id, shared_sstable_run> clone_runs(const std::unordered_map<run_id, shared_sstable_run>& runs) {
+    return boost::copy_range<std::unordered_map<run_id, shared_sstable_run>>(runs | boost::adaptors::transformed([] (auto& p) {
+        return std::make_pair(p.first, make_lw_shared<sstable_run>(*p.second));
+    }));
+}
+
 partitioned_sstable_set::partitioned_sstable_set(schema_ptr schema, const std::vector<shared_sstable>& unleveled_sstables, const interval_map_type& leveled_sstables,
         const lw_shared_ptr<sstable_list>& all, const std::unordered_map<run_id, shared_sstable_run>& all_runs, bool use_level_metadata, uint64_t bytes_on_disk)
         : sstable_set_impl(bytes_on_disk)
@@ -306,7 +312,7 @@ partitioned_sstable_set::partitioned_sstable_set(schema_ptr schema, const std::v
         , _unleveled_sstables(unleveled_sstables)
         , _leveled_sstables(leveled_sstables)
         , _all(make_lw_shared<sstable_list>(*all))
-        , _all_runs(all_runs)
+        , _all_runs(clone_runs(all_runs))
         , _use_level_metadata(use_level_metadata) {
 }
 

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -40,6 +40,7 @@ private:
     bool will_introduce_overlapping(const shared_sstable& sst) const;
 public:
     sstable_run() = default;
+    sstable_run(const sstable_run&) = default;
     // Builds a sstable run with single fragment. It bypasses overlapping check done in insert().
     sstable_run(shared_sstable);
     // Returns false if sstable being inserted cannot satisfy the disjoint invariant. Then caller should pick another run for it.


### PR DESCRIPTION
When a sstable set is cloned, we don't want a change in cloned set propagating to the former one.

It happens today with partitioned_sstable_set::_all_runs, because sets are sharing ownership of runs, which is wrong.

Let's not violate clone semantics by copying all_runs when cloning.

Doesn't affect data correctness as readers work directly with sstables, which are properly cloned. Can result in a crash in ICS when it is estimating pending tasks, but should be very rare in practice.

Fixes #17878.