### PR TITLE
[action] add Fixes validation in backport PR

### DIFF
--- a/.github/workflows/backport-pr-fixes-validation.yaml
+++ b/.github/workflows/backport-pr-fixes-validation.yaml
@@ -1,0 +1,26 @@
+name: Fixes validation for backport PR
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+    branches: [branch-*]
+
+jobs:
+  check-fixes-prefix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR body for "Fixes" prefix patterns
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body;
+            const repo = context.payload.repository.full_name;
+            
+            // Regular expression pattern to check for "Fixes" prefix
+            // Adjusted to dynamically insert the repository full name
+            const pattern = `Fixes:? (?:#|${repo.replace('/', '\\/')}#|https://github\\.com/${repo.replace('/', '\\/')}/issues/)(\\d+)`;
+            const regex = new RegExp(pattern);
+            
+            if (!regex.test(body)) {
+              core.setFailed("PR body does not contain a valid 'Fixes' reference.");
+            }


### PR DESCRIPTION
When we open a backport PR we should make sure the patch contains a ref to the issue it suppose to fix in order to make sure we have more accurate backport information

This action will only be triggered when base branch is `branch-*`

If `Fixes` are missing, this action will fail and notify the author.

Ref: https://github.com/scylladb/scylla-pkg/issues/3539