### PR TITLE
 test: remove skip annotation for multi-DC test with 5 DCs with one node in each

### DIFF
--- a/test/topology_custom/test_multidc.py
+++ b/test/topology_custom/test_multidc.py
@@ -20,12 +20,11 @@ logger = logging.getLogger(__name__)
 CONFIG = {"endpoint_snitch": "GossipingPropertyFileSnitch"}
 
 
-# Checks a cluster boot/operations in multi-dc environment with 30 nodes each in a separate DC
+# Checks a cluster boot/operations in multi-dc environment with 5 nodes each in a separate DC
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="Too heavy for CI, but OK for local run")
 async def test_multidc(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     logger.info("Creating a new cluster")
-    for i in range(30):
+    for i in range(5):
         s_info = await manager.server_add(
             config=CONFIG,
             property_file={'dc': f'dc{i}', 'rack': 'myrack1'}


### PR DESCRIPTION
As a follow-up of the https://github.com/scylladb/scylladb/pull/17503 remove skip annotation for the multi-DC test with a reduced amount of the DC used in it: from 30 DCs to 5 DCs