### PR TITLE
sstables_loader: Don't discard sstable that is not fully exhausted

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -239,8 +239,8 @@ future<> tablet_sstable_streamer::stream(bool primary_replica_only) {
             sstable_it++;
         }
 
-        for (; sstable_it != _sstables.rend(); sstable_it++) {
-            auto sst_token_range = sstable_token_range(*sstable_it);
+        for (auto sst_it = sstable_it; sst_it != _sstables.rend(); sst_it++) {
+            auto sst_token_range = sstable_token_range(*sst_it);
             // sstables are sorted by first key, so we're done with current tablet when
             // the next sstable doesn't overlap with its owned token range.
             if (!tablet_range.overlaps(sst_token_range, dht::token_comparator{})) {
@@ -248,9 +248,9 @@ future<> tablet_sstable_streamer::stream(bool primary_replica_only) {
             }
 
             if (tablet_range.contains(sst_token_range, dht::token_comparator{})) {
-                sstables_fully_contained.push_back(*sstable_it);
+                sstables_fully_contained.push_back(*sst_it);
             } else {
-                sstables_partially_contained.push_back(*sstable_it);
+                sstables_partially_contained.push_back(*sst_it);
             }
             co_await coroutine::maybe_yield();
         }

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -812,43 +812,52 @@ async def test_tablet_load_and_stream(manager: ManagerClient):
     await manager.api.disable_tablet_balancing(servers[0].ip_addr)
 
     cql = manager.get_cql()
-    # Creates multiple tablets in the same shard
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}" \
-                        " AND tablets = {'initial': 5};") # 5 is rounded up to next power-of-two
-    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+
+    async def create_table(ks_name : str, tablet_count : int):
+        # Creates multiple tablets in the same shard
+        await cql.run_async(f"CREATE KEYSPACE {ks_name} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}" \
+                            f" AND tablets = {{ 'initial': {tablet_count} }};")
+        await cql.run_async(f"CREATE TABLE {ks_name}.test (pk int PRIMARY KEY, c int);")
+
+    await create_table("test", 5) # 5 is rounded up to next power-of-two
 
     # Populate tablets
     keys = range(256)
     await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
 
-    async def check():
+    async def check(ks_name: str):
         logger.info("Checking table")
         cql = manager.get_cql()
-        rows = await cql.run_async("SELECT * FROM test.test BYPASS CACHE;")
+        rows = await cql.run_async(f"SELECT * FROM {ks_name}.test BYPASS CACHE;")
         assert len(rows) == len(keys)
         for r in rows:
             assert r.c == r.pk
 
     await manager.api.flush_keyspace(servers[0].ip_addr, "test")
-    await check()
+    await check("test")
 
     node_workdir = await manager.server_get_workdir(servers[0].server_id)
+
+    await create_table("test2", 16)
 
     await manager.server_stop_gracefully(servers[0].server_id)
 
     table_dir = glob.glob(os.path.join(node_workdir, "data", "test", "test-*"))[0]
     logger.info(f"Table dir: {table_dir}")
 
-    def move_sstables_to_upload(table_dir: str):
-        logger.info("Moving sstables to upload dir")
-        table_upload_dir = os.path.join(table_dir, "upload")
+    dst_table_dir = glob.glob(os.path.join(node_workdir, "data", "test2", "test-*"))[0]
+    logger.info(f"Dst table dir: {dst_table_dir}")
+
+    def move_sstables_to_upload(table_dir: str, dst_table_dir: str):
+        logger.info("Moving sstables to upload dir of destination table")
+        table_upload_dir = os.path.join(dst_table_dir, "upload")
         for sst in glob.glob(os.path.join(table_dir, "*-Data.db")):
             for src_path in glob.glob(os.path.join(table_dir, sst.removesuffix("-Data.db") + "*")):
                 dst_path = os.path.join(table_upload_dir, os.path.basename(src_path))
                 logger.info(f"Moving sstable file {src_path} to {dst_path}")
                 os.rename(src_path, dst_path)
 
-    move_sstables_to_upload(table_dir)
+    move_sstables_to_upload(table_dir, dst_table_dir)
 
     await manager.server_start(servers[0].server_id)
     cql = manager.get_cql()
@@ -866,11 +875,11 @@ async def test_tablet_load_and_stream(manager: ManagerClient):
 
     await manager.api.enable_tablet_balancing(servers[0].ip_addr)
 
-    await manager.api.load_new_sstables(servers[0].ip_addr, "test", "test")
+    await manager.api.load_new_sstables(servers[0].ip_addr, "test2", "test")
 
     time.sleep(1)
 
-    await check()
+    await check("test2")
 
 @pytest.mark.asyncio
 async def test_storage_service_api_uneven_ownership_keyspace_and_table_params_used(manager: ManagerClient):


### PR DESCRIPTION
Affects load-and-stream for tablets only.

The intention is that only this loop is responsible for detecting exhausted sstables and then discarding them for next iterations:
        while (sstable_it != _sstables.rend() && exhausted(*sstable_it)) {
            sstable_it++;
        }

But the loop which consumes non exhausted sstables, on behalf of each tablet, was incorrectly advancing the iterator, despite the sstable wasn't considered exhausted.

Fixes #17733.