### PR TITLE
[Backport 5.2] replica: Fix major compaction semantics by performing off-strategy first

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1183,6 +1183,9 @@ compaction_group::update_main_sstable_list_on_compaction_completion(sstables::co
 future<>
 table::compact_all_sstables() {
     co_await flush();
+    // Forces off-strategy before major, so sstables previously sitting on maintenance set will be included
+    // in the compaction's input set, to provide same semantics as before maintenance set came into existence.
+    co_await perform_offstrategy_compaction();
     co_await parallel_foreach_compaction_group([this] (compaction_group& cg) {
         return _compaction_manager.perform_major_compaction(cg.as_table_state());
     });


### PR DESCRIPTION
Major compaction semantics is that all data of a table will be compacted together, so user can expect e.g. a recently introduced tombstone to be compacted with the data it shadows.
Today, it can happen that all data in maintenance set won't be included for major, until they're promoted into main set by off-strategy. So user might be left wondering why major is not having the expected effect.
To fix this, let's perform off-strategy first, so data in maintenance set will be made available by major. A similar approach is done for data in memtable, so flush is performed before major starts. The only exception will be data in staging, which cannot be compacted until view building is done with it, to avoid inconsistency in view replicas.
The serialization in comapaction manager of reshape jobs guarantee correctness if there's an ongoing off-strategy on behalf of the table.

Fixes #11915.



Closes scylladb/scylladb#15792

(cherry picked from commit ea6c281b9f89f03e22df71c0d5132ad17b3658c0)