### PR TITLE
sstables_loader: Fix loader when write selector is previous during tablet migration

### DIFF
--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -218,6 +218,7 @@ struct tablet_migration_info {
 
 /// Returns the replica set which will become the replica set of the tablet after executing a given tablet transition.
 tablet_replica_set get_new_replicas(const tablet_info&, const tablet_migration_info&);
+tablet_replica_set get_primary_replicas(const tablet_info&, const tablet_transition_info*);
 tablet_transition_info migration_to_transition_info(const tablet_info&, const tablet_migration_info&);
 
 /// Describes streaming required for a given tablet transition.

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -279,9 +279,10 @@ class ScyllaRESTAPIClient():
         """Cleanup keyspace"""
         await self.client.post(f"/storage_service/keyspace_cleanup/{ks}", host=node_ip)
 
-    async def load_new_sstables(self, node_ip: str, keyspace: str, table: str) -> None:
+    async def load_new_sstables(self, node_ip: str, keyspace: str, table: str, primary_replica : bool = False) -> None:
         """Load sstables from upload directory"""
-        await self.client.post(f"/storage_service/sstables/{keyspace}?cf={table}", host=node_ip)
+        primary_replica_value = 'true' if primary_replica else 'false'
+        await self.client.post(f"/storage_service/sstables/{keyspace}?cf={table}&primary_replica_only={primary_replica_value}", host=node_ip)
 
     async def keyspace_flush(self, node_ip: str, keyspace: str, table: Optional[str] = None) -> None:
         """Flush the specified or all tables in the keyspace"""

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -800,7 +800,8 @@ async def test_tablet_count_metric_per_shard(manager: ManagerClient):
     dest_expected_count_per_shard[3] += count_of_tokens_on_src_shard_to_move
     await assert_tablet_count_metric_value_for_shards(manager, dest_server, dest_expected_count_per_shard)
 
-async def test_tablet_load_and_stream(manager: ManagerClient):
+@pytest.mark.parametrize("primary_replica_only", [False, True])
+async def test_tablet_load_and_stream(manager: ManagerClient, primary_replica_only):
     logger.info("Bootstrapping cluster")
     cmdline = [
         '--logger-log-level', 'storage_service=debug',
@@ -875,7 +876,7 @@ async def test_tablet_load_and_stream(manager: ManagerClient):
 
     await manager.api.enable_tablet_balancing(servers[0].ip_addr)
 
-    await manager.api.load_new_sstables(servers[0].ip_addr, "test2", "test")
+    await manager.api.load_new_sstables(servers[0].ip_addr, "test2", "test", primary_replica_only)
 
     time.sleep(1)
 


### PR DESCRIPTION
The loader is writing to pending replica even when write selector is set to previous. If migration is reverted, then the writes won't be rolled back as it assumes pending replicas weren't written to yet. That can cause data resurrection if tablet is later migrated back into the same replica.

NOTE: write selector is handled correctly when set to next, because get_natural_endpoints() will return the next replica set, and none of the replicas will be considered leaving. And of course, selector set to both is also handled correctly.

Fixes #17892