### PR TITLE
[action sync labels] improve pr search when labeling an issue

### DIFF
--- a/.github/scripts/sync_labels.py
+++ b/.github/scripts/sync_labels.py
@@ -38,11 +38,12 @@ def copy_labels_from_linked_issues(repo, pr_number):
 
 def get_linked_pr_from_issue_number(repo, number):
     linked_prs = []
-    for pr in repo.get_pulls(state='all'):
-        if f'{number}' in pr.body:
+    for pr in repo.get_pulls(state='all', base='master'):
+        if pr.body and f'{number}' in pr.body:
             linked_prs.append(pr.number)
-        else:
             break
+        else:
+            continue
     return linked_prs
 
 

--- a/.github/workflows/sync_labels.yaml
+++ b/.github/workflows/sync_labels.yaml
@@ -29,13 +29,13 @@ jobs:
         run: python .github/scripts/sync_labels.py --repo ${{ github.repository }} --number ${{ github.event.number }} --action ${{ github.event.action }}
 
       - name: Pull request labeled or unlabeled event
-        if: github.event_name == 'pull_request' && startsWith(github.event.label.name, 'backport')
+        if: github.event_name == 'pull_request' && startsWith(github.event.label.name, 'backport/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python .github/scripts/sync_labels.py --repo ${{ github.repository }} --number ${{ github.event.number }} --action ${{ github.event.action }} --label ${{ github.event.label.name }}
 
       - name: Issue labeled or unlabeled event
-        if: github.event_name == 'issues' && startsWith(github.event.label.name, 'backport')
+        if: github.event_name == 'issues' && startsWith(github.event.label.name, 'backport/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python .github/scripts/sync_labels.py --repo ${{ github.repository }} --number ${{ github.event.issue.number }} --action ${{ github.event.action }} --is_issue --label ${{ github.event.label.name }}


### PR DESCRIPTION
This PR contains a few fixes and improvements seen during the https://github.com/scylladb/scylladb/issues/15902 label addition

When we add a label to an issue, we go through all PR.
1) Setting PR base to `master` (release PR is not relevant) 
2) Since for each Issue we have only one PR, ending the search after a match was found
3) Make sure to skip PR with an empty body (mainly debug one)
4) Set backport label prefix to `backport/`