### PR TITLE
cdc: should_propose_first_generation: get my_host_id from caller

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -194,10 +194,9 @@ static std::vector<stream_id> create_stream_ids(
     return result;
 }
 
-bool should_propose_first_generation(const gms::inet_address& me, const gms::gossiper& g) {
-    auto my_host_id = g.get_host_id(me);
-    return g.for_each_endpoint_state_until([&] (const gms::inet_address& node, const gms::endpoint_state& eps) {
-        return stop_iteration(my_host_id < g.get_host_id(node));
+bool should_propose_first_generation(const locator::host_id& my_host_id, const gms::gossiper& g) {
+    return g.for_each_endpoint_state_until([&] (const gms::inet_address&, const gms::endpoint_state& eps) {
+        return stop_iteration(my_host_id < eps.get_host_id());
     }) == stop_iteration::no;
 }
 

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -133,7 +133,7 @@ public:
  * The chosen condition is arbitrary, it only tries to make sure that no two nodes propose a generation of streams
  * when upgrading, and nothing bad happens if they for some reason do (it's mostly an optimization).
  */
-bool should_propose_first_generation(const gms::inet_address& me, const gms::gossiper&);
+bool should_propose_first_generation(const locator::host_id& me, const gms::gossiper&);
 
 /*
  * Checks if the CDC generation is optimal, which is true if its `topology_description` is consistent

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1798,7 +1798,7 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
 
         if (!is_replacing()
                 && (!_sys_ks.local().bootstrap_complete()
-                    || cdc::should_propose_first_generation(get_broadcast_address(), _gossiper))) {
+                    || cdc::should_propose_first_generation(my_host_id(), _gossiper))) {
             try {
                 cdc_gen_id = co_await _cdc_gens.local().legacy_make_new_generation(bootstrap_tokens, !is_first_node());
             } catch (...) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6701,7 +6701,7 @@ future<> storage_service::start_maintenance_mode() {
     set_mode(mode::MAINTENANCE);
 
     return mutate_token_metadata([this] (mutable_token_metadata_ptr token_metadata) -> future<> {
-        return token_metadata->update_normal_tokens({ dht::token{} }, get_token_metadata_ptr()->get_topology().my_host_id());
+        return token_metadata->update_normal_tokens({ dht::token{} }, my_host_id());
     }, acquire_merge_lock::yes);
 }
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -284,6 +284,9 @@ private:
     inet_address get_broadcast_address() const noexcept {
         return get_token_metadata_ptr()->get_topology().my_address();
     }
+    locator::host_id my_host_id() const noexcept {
+        return get_token_metadata_ptr()->get_topology().my_host_id();
+    }
     bool is_me(inet_address addr) const noexcept {
         return get_token_metadata_ptr()->get_topology().is_me(addr);
     }


### PR DESCRIPTION
There is no need to map this node's inet_address to host_id. The storage_service can easily just pass the local host_id. While at it, get the other node's host_id directly from their endpoint_state instead of looking it up yet again in the gossiper, using the nodes' address.

Refs #12283