### PR TITLE
github: sync_labels: match issue number with better pattern

### DIFF
--- a/.github/scripts/sync_labels.py
+++ b/.github/scripts/sync_labels.py
@@ -48,14 +48,14 @@ def get_linked_pr_from_issue_number(repo, number):
 
 def get_linked_issues_based_on_pr_body(repo, number):
     pr = repo.get_pull(number)
-    pattern = fr'Fixes:? (?:#|{repo}#|https://github.com/{repo}/issues/)(\d+)'
-    matches = re.findall(pattern, pr.body)
-    if not matches:
-        raise RuntimeError("No regex matches found in the body!")
+    repo_name = repo.full_name
+    pattern = rf"(?:fix(?:|es|ed)|resolve(?:|d|s))\s*:?\s*(?:(?:(?:{repo_name})?#)|https://github\.com/{repo_name}/issues/)(\d+)"
+    matches = re.findall(pattern, pr.body, re.IGNORECASE)
     issue_number_from_pr_body = []
-    for match in matches:
-        issue_number_from_pr_body.append(match)
-        print(f"Found issue number: {match}")
+    if matches:
+        for match in matches:
+            issue_number_from_pr_body.append(match)
+            print(f"Found issue number: {match}")
     return issue_number_from_pr_body
 
 
@@ -69,7 +69,6 @@ def sync_labels(repo, number, label, action, is_issue=False):
             target = repo.get_issue(pr_or_issue_number)
         else:
             target = repo.get_issue(int(pr_or_issue_number))
-        print(pr_or_issue_number)
         if action == 'labeled':
             target.add_to_labels(label)
             print(f"Label '{label}' successfully added.")


### PR DESCRIPTION
Seen in https://github.com/scylladb/scylladb/actions/runs/8357352616/job/22876314535

```
python .github/scripts/sync_labels.py --repo scylladb/scylladb --number 17309 --action labeled --label backport/none
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_TOKEN: ***

Found issue number: ('', '', '15465')
Traceback (most recent call last):
  File "/home/runner/work/scylladb/scylladb/.github/scripts/sync_labels.py", line 9[3](https://github.com/scylladb/scylladb/actions/runs/8357352616/job/22876314535#step:5:3), in <module>
    main()
  File "/home/runner/work/scylladb/scylladb/.github/scripts/sync_labels.py", line 89, in main
    sync_labels(repo, args.number, args.label, args.action, args.is_issue)
  File "/home/runner/work/scylladb/scylladb/.github/scripts/sync_labels.py", line [7](https://github.com/scylladb/scylladb/actions/runs/8357352616/job/22876314535#step:5:8)1, in sync_labels
    target = repo.get_issue(int(pr_or_issue_number))
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'tuple'
Error: Process completed with exit code 1.
```

Fixing the pattern to catch all GitHub-supported close keywords as describe in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword


Fixed: https://github.com/scylladb/scylladb/issues/17917

Fixed: https://github.com/scylladb/scylladb/issues/17921