### PR TITLE
test: Update topology_custom/suite::run_first list

### DIFF
--- a/test/topology_custom/suite.yaml
+++ b/test/topology_custom/suite.yaml
@@ -6,10 +6,10 @@ extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer
 run_first:
-  - test_raft_recovery_majority_loss
   - test_raft_recovery_stuck
-  - test_read_repair
-  - test_replace
+  - test_raft_recovery_basic
+  - test_group0_schema_versioning
+  - test_tablets_migration
 skip_in_release:
   - test_raft_recovery_stuck
   - test_shutdown_hang


### PR DESCRIPTION
The recently added test_tablets_migration dominates with it run-time (10 minutes). Also update other tests, e.g. test_read_repair is not in top-7 for any mode, test_replace and test_raft_recovery_majority_loss are both not notably slower than most of other tests (~40 sec both). On the other hand, the test_raft_recovery_basic and test_group0_schema_versioning are both 1+ minute