### PR TITLE
test: fix flakiness of the multi_dc tests

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -103,13 +103,6 @@ class ManagerClient():
         hosts = await wait_for_cql_and_get_hosts(cql, servers, time() + 60)
         return cql, hosts
 
-    @staticmethod
-    def connect_to_node(server: ServerInfo) -> CassandraSession:
-        """Connect cql to the specific node in the cluster"""
-        logger.info(f"Establishing connection to {server.ip_addr}")
-        profile = ExecutionProfile(load_balancing_policy=WhiteListRoundRobinPolicy([server.ip_addr]))
-        return CassandraCluster([server.ip_addr], execution_profiles={EXEC_PROFILE_DEFAULT: profile}).connect()
-
     # Make driver update endpoints from remote connection
     def _driver_update(self) -> None:
         if self.ccluster is not None:

--- a/test/topology_custom/test_multidc.py
+++ b/test/topology_custom/test_multidc.py
@@ -7,6 +7,8 @@ import logging
 import sys
 
 import pytest
+from cassandra.policies import WhiteListRoundRobinPolicy
+
 
 sys.path.insert(0, sys.path[0] + "/test/cql-pytest")
 import nodetool
@@ -15,6 +17,7 @@ from cassandra.query import SimpleStatement
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables, TextType, Column
 from test.pylib.util import unique_name
+from test.topology.conftest import cluster_con
 
 logger = logging.getLogger(__name__)
 CONFIG = {"endpoint_snitch": "GossipingPropertyFileSnitch"}
@@ -35,6 +38,7 @@ async def test_multidc(request: pytest.FixtureRequest, manager: ManagerClient) -
     logger.info("Creating new tables")
     await random_tables.add_tables(ntables=3, ncolumns=3)
     await random_tables.verify_schema()
+
 
 cluster_config = [
     ([1, 2], 1),
@@ -123,14 +127,17 @@ async def test_query_dc_with_rf_0_does_not_crash_db(request: pytest.FixtureReque
             property_file={"dc": f"dc{i}", "rack": "myrack"},
         ))
 
-    dc1_connection = manager.connect_to_node(servers[0])
-    dc2_connection = manager.connect_to_node(servers[1])
+    dc1_connection = cluster_con([servers[0].ip_addr], 9042, False,
+                                 load_balancing_policy=WhiteListRoundRobinPolicy([servers[0].ip_addr])).connect()
+    dc2_connection = cluster_con([servers[1].ip_addr], 9042, False,
+                                 load_balancing_policy=WhiteListRoundRobinPolicy([servers[1].ip_addr])).connect()
+
     random_tables = RandomTables(request.node.name, manager, ks, 1, dc_replication)
     await random_tables.add_table(ncolumns=2, columns=columns, pks=1, name=table_name)
     dc1_connection.execute(
         f"INSERT INTO  {ks}.{table_name} ({columns[0].name}, {columns[1].name}) VALUES ('{expected[0]}', '{expected[1]}');")
     select_query = SimpleStatement(f"SELECT * from {ks}.{table_name};",
-                                            consistency_level=ConsistencyLevel.LOCAL_QUORUM)
+                                   consistency_level=ConsistencyLevel.LOCAL_QUORUM)
     nodetool.flush(dc1_connection, "{ks}.{table_name}")
     first_node_results = list(dc1_connection.execute(select_query).one())
     second_node_result = dc2_connection.execute(select_query).one()


### PR DESCRIPTION
Fixes #17914

The initial version used a redundant method, and it did not cover all cases. So that leads to the flakiness of the test that used this method. Switching to the cluster_con() method removes flakiness since it's written more robustly.