### PR TITLE
github: do not fail if no Fixes is found and trigger sync_labels when PR is edited

### DIFF
--- a/.github/scripts/sync_labels.py
+++ b/.github/scripts/sync_labels.py
@@ -51,7 +51,7 @@ def get_linked_issues_based_on_pr_body(repo, number):
     pattern = fr'Fixes:? (?:#|{repo}#|https://github.com/{repo}/issues/)(\d+)'
     matches = re.findall(pattern, pr.body)
     if not matches:
-        raise RuntimeError("No regex matches found in the body!")
+        return []
     issue_number_from_pr_body = []
     for match in matches:
         issue_number_from_pr_body.append(match)

--- a/.github/workflows/sync_labels.yaml
+++ b/.github/workflows/sync_labels.yaml
@@ -2,7 +2,7 @@ name: Sync labels
 
 on:
   pull_request:
-    types: [opened, labeled, unlabeled]
+    types: [opened, edited, labeled, unlabeled]
     branches: [master, next]
   issues:
     types: [labeled, unlabeled]


### PR DESCRIPTION
in addition to opened, labeled and unlabeled, we should also rerun the sync_labels workflow if the pull request is updated, as we scan the body of commit message for the fixed issue, if the updated commit message adds the fixed the issue to it, we should sync the label referencing the issue.

also, don't raise an exception if no "Fixes" is found in commit message.