### PR TITLE
topology_coordinator: do not clear unpublished CDC generation's data

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -626,7 +626,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
         builder.set_committed_cdc_generations(std::move(new_committed_gens));
         updates.push_back(builder.build());
 
-        reason += ::format("deleted data of CDC generations with time UUID not exceeding {}", id_upper_bound);
+        reason += ::format("deleted data of CDC generations with time UUID lower than {}", id_upper_bound);
     }
 
     // If there are some unpublished CDC generations, publishes the one with the oldest timestamp

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -663,7 +663,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 rtlogger.info("CDC generation publisher fiber sleeps after injection");
                 co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{5});
                 rtlogger.info("CDC generation publisher fiber finishes sleeping after injection");
-            });
+            }, false);
 
             bool sleep = false;
             try {

--- a/test/topology_experimental_raft/test_cdc_generation_clearing.py
+++ b/test/topology_experimental_raft/test_cdc_generation_clearing.py
@@ -6,7 +6,8 @@
 from test.pylib.rest_client import inject_error
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
-from test.topology.util import check_system_topology_and_cdc_generations_v3_consistency
+from test.topology.util import wait_for_cdc_generations_publishing, \
+        check_system_topology_and_cdc_generations_v3_consistency
 
 from cassandra.cluster import ConsistencyLevel # type: ignore # pylint: disable=no-name-in-module
 from cassandra.pool import Host # type: ignore # pylint: disable=no-name-in-module
@@ -82,3 +83,63 @@ async def test_cdc_generation_clearing(manager: ManagerClient):
         logger.info(f"Generations after fourth clearing attempt: {gen_ids}")
         assert len(gen_ids) == 1 and third_gen_id not in gen_ids
         await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)
+
+
+@pytest.mark.asyncio
+async def test_unpublished_cdc_generations_arent_cleared(manager: ManagerClient):
+    """Test that unpublished CDC generations aren't removed from CDC_GENERATIONS_V3 and
+       TOPOLOGY.committed_cdc_generations regardless of their timestamps."""
+    logger.info("Bootstrapping first node")
+    servers = await manager.servers_add(1, config={
+        'error_injections_at_startup': ['clean_obsolete_cdc_generations_change_ts_ub']
+    })
+
+    cql = manager.get_cql()
+    logger.info("Waiting for driver")
+    [host1] = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logging.info("Waiting for the first CDC generation publishing")
+    await wait_for_cdc_generations_publishing(cql, [host1], time.time() + 60)
+
+    query_gen_ids = SimpleStatement(
+        "SELECT id FROM system.cdc_generations_v3 WHERE key = 'cdc_generations'",
+        consistency_level = ConsistencyLevel.ONE)
+
+    async def get_gen_ids() -> set[str]:
+        return {r.id for r in await cql.run_async(query_gen_ids, host=host1)}
+
+    gen_ids = await get_gen_ids()
+    assert len(gen_ids) == 1
+    first_gen_id = next(iter(gen_ids))
+
+    async with inject_error(manager.api, servers[0].ip_addr, "cdc_generation_publisher_fiber") as handler:
+        logger.info("Bootstrapping second and third nodes")
+        servers += await manager.servers_add(2)
+
+        log_file1 = await manager.server_open_log(servers[0].server_id)
+        await log_file1.wait_for(f"CDC generation publisher fiber sleeps after injection")
+        mark = await log_file1.mark()
+
+        # The second and third generations are committed but unpublished due to the cdc_generation_publisher_fiber
+        # injection. After unblocking the CDC generation publisher below, it should publish the second generation and
+        # delete only the first generation. Note that all three generations are old enough to be deleted due to the
+        # clean_obsolete_cdc_generations_change_ts_ub injection. So, only the third generation wouldn't be deleted (as
+        # it is the last committed generation) if the CDC generation publisher didn't care whether a generation was
+        # published.
+        #
+        # The message below will allow the CDC generation publisher to execute only one step of its loop so we can check
+        # what it has done in this step. Eventually, the CDC generation publisher will publish all generations and
+        # delete the first and second ones.
+        await handler.message()
+        await log_file1.wait_for(f"CDC generation publisher fiber sleeps after injection", mark)
+        mark = await log_file1.mark()
+        gen_ids = await get_gen_ids()
+        assert len(gen_ids) == 2 and first_gen_id not in gen_ids
+        await check_system_topology_and_cdc_generations_v3_consistency(manager, [host1])
+
+        # Allow the CDC generation publisher to finish its job. One generation should remain.
+        await handler.message()
+        await log_file1.wait_for(f"CDC generation publisher fiber has nothing to do. Sleeping.", mark)
+        gen_ids = await get_gen_ids()
+        assert len(gen_ids) == 1
+        await check_system_topology_and_cdc_generations_v3_consistency(manager, [host1])

--- a/test/topology_experimental_raft/test_cdc_generation_publishing.py
+++ b/test/topology_experimental_raft/test_cdc_generation_publishing.py
@@ -111,7 +111,8 @@ async def test_multiple_unpublished_cdc_generations(request, manager: ManagerCli
             return None
 
         # Check that all 4 CDC generations are eventually published in the correct order.
-        await handler.message()
+        for _ in range(4):
+            await handler.message()
         while len(gen_timestamps) < 4:
             # We prefer to detect CDC generation publications one-by-one, because it increases our chances of catching
             # potential bugs like incorrect order of publications. Therefore, we use very short period - 0.01 s.


### PR DESCRIPTION
In this PR, we ensure unpublished CDC generation's data is
never removed, which was theoretically possible. If it happened,
it could cause problems. CDC generation publisher would then try
to publish the generation with its data removed. In particular, the
precondition of calling `_sys_ks.read_cdc_generation` wouldn't be
satisfied.

We also add a test that passes only after the fix. However, this test
needs to block execution of the CDC generation publisher's loop
twice. Currently, error injections with handlers do not allow it
because handlers always share received messages. Apart from the
first created handler, all handlers would be instantly unblocked by
a message from the past that has already unblocked the first
handler. This seems like a general limitation that could cause
problems in the future, so in this PR, we extend injections with
handlers to solve it once and for all. We add the `share_messages`
parameter to the `inject` (with handler) function. Depending on its
value, handlers will share messages (as before) or not.

Fixes scylladb/scylladb#17497