### PR TITLE
[RFC] compaction: introduce bloom filter compaction

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -965,6 +965,54 @@
          ]
       },
       {
+         "path":"/storage_service/keyspace_regenerate_sstable_bloom_filters/{keyspace}",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Regenerate the bloom filters of sstables",
+               "type": "long",
+               "nickname":"regenerate_sstable_bloom_filters",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"keyspace",
+                     "description":"The keyspace",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  },
+                  {
+                     "name":"cf",
+                     "description":"Comma-separated column family names",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"force",
+                     "description":"Regenerate all filters unconditionally",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"boolean",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"filter_size_mismatch_tolerance",
+                     "description":"Regenerate the bloom filter if calculated size differes from actual size more than this tolerance (default to 0.5)",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"double",
+                     "paramType":"query"
+                  }
+               ]
+            }
+         ]
+      },
+      {
          "path":"/storage_service/flush",
          "operations":[
             {

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -77,6 +77,7 @@ struct compaction_stats {
     std::chrono::time_point<db_clock> ended_at;
     uint64_t start_size = 0;
     uint64_t end_size = 0;
+    uint64_t compacted_sstables = 0;
     uint64_t validation_errors = 0;
     // Bloom filter checks during max purgeable calculation
     uint64_t bloom_filter_checks = 0;
@@ -85,6 +86,7 @@ struct compaction_stats {
         ended_at = std::max(ended_at, r.ended_at);
         start_size += r.start_size;
         end_size += r.end_size;
+        compacted_sstables += r.compacted_sstables;
         validation_errors += r.validation_errors;
         bloom_filter_checks += r.bloom_filter_checks;
         return *this;

--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -31,6 +31,7 @@ enum class compaction_type {
     Upgrade = 6,
     Reshape = 7,
     Split = 8,
+    BloomFilterRegeneration = 9,
 };
 
 struct compaction_completion_desc {
@@ -84,8 +85,10 @@ public:
     struct split {
         mutation_writer::classify_by_token_group classifier;
     };
+    struct bloom_filter_regeneration {
+    };
 private:
-    using options_variant = std::variant<regular, cleanup, upgrade, scrub, reshard, reshape, split>;
+    using options_variant = std::variant<regular, cleanup, upgrade, scrub, reshard, reshape, split, bloom_filter_regeneration>;
 
 private:
     options_variant _options;
@@ -121,6 +124,10 @@ public:
 
     static compaction_type_options make_split(mutation_writer::classify_by_token_group classifier) {
         return compaction_type_options(split{std::move(classifier)});
+    }
+
+    static compaction_type_options make_bloom_filter_regeneration() {
+        return compaction_type_options(bloom_filter_regeneration{});
     }
 
     template <typename... Visitor>

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -350,6 +350,14 @@ public:
     // or user aborted splitting using stop API.
     future<compaction_stats_opt> perform_split_compaction(compaction::table_state& t, sstables::compaction_type_options::split opt, std::optional<tasks::task_info> info = std::nullopt);
 
+    // Submit a table for bloom-filter compaction and wait for its termination.
+    // Regenerate the filter of sstable, for which the conditions below do not hold.
+    // If no conditions are specified, all filters are generated unconditionally.
+    // Can be used to force a changed schema bloom_filter_fp_chance to take effect.
+    // Sstables are not compacted in fact, the only component which is re-written is the filter.
+    future<compaction_stats_opt> perform_bloom_filter_regeneration(compaction::table_state& t, std::optional<bloom_filter_regeneration_conditions> conditions,
+            std::optional<tasks::task_info> info = std::nullopt);
+
     // Run a custom job for a given table, defined by a function
     // it completes when future returned by job is ready or returns immediately
     // if manager was asked to stop.

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -576,6 +576,41 @@ future<> table_scrub_sstables_compaction_task_impl::run() {
     });
 }
 
+future<> regenerate_bloom_filters_compaction_task_impl::run() {
+    auto res = co_await _db.map_reduce0([&] (replica::database& db) -> future<sstables::compaction_stats> {
+        sstables::compaction_stats stats;
+        tasks::task_info parent_info{_status.id, _status.shard};
+        auto& compaction_module = db.get_compaction_manager().get_task_manager_module();
+        auto task = co_await compaction_module.make_and_start_task<shard_regenerate_bloom_filters_compaction_task_impl>(parent_info, _status.keyspace, _status.id, db, _column_families, _conditions, stats);
+        co_await task->done();
+        co_return stats;
+    }, sstables::compaction_stats{}, std::plus<sstables::compaction_stats>());
+    if (_stats) {
+        *_stats = res;
+    }
+}
+
+future<> shard_regenerate_bloom_filters_compaction_task_impl::run() {
+    _stats = co_await map_reduce(_column_families, [&] (sstring cfname) -> future<sstables::compaction_stats> {
+        sstables::compaction_stats stats{};
+        tasks::task_info parent_info{_status.id, _status.shard};
+        auto& compaction_module = _db.get_compaction_manager().get_task_manager_module();
+        auto task = co_await compaction_module.make_and_start_task<table_regenerate_bloom_filters_compaction_task_impl>(parent_info, _status.keyspace, cfname, _status.id, _db, _conditions, stats);
+        co_await task->done();
+        co_return stats;
+    }, sstables::compaction_stats{}, std::plus<sstables::compaction_stats>());
+}
+
+future<> table_regenerate_bloom_filters_compaction_task_impl::run() {
+    auto& cm = _db.get_compaction_manager();
+    auto& cf = _db.find_column_family(_status.keyspace, _status.table);
+    tasks::task_info info{_status.id, _status.shard};
+    co_await cf.parallel_foreach_table_state([&] (compaction::table_state& ts) mutable -> future<> {
+        auto r = co_await cm.perform_bloom_filter_regeneration(ts, _conditions, info);
+        _stats += r.value_or(sstables::compaction_stats{});
+    });
+}
+
 future<> table_reshaping_compaction_task_impl::run() {
     auto start = std::chrono::steady_clock::now();
     auto total_size = co_await _dir.map_reduce0([&] (sstables::sstable_directory& d) -> future<uint64_t> {

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -548,6 +548,14 @@ protected:
     virtual future<> run() override;
 };
 
+struct bloom_filter_regeneration_conditions {
+    // Defines a range of acceptable filter sizes, compared to the ideal filter
+    // size, calculated based on actual number of partitions and current fp
+    // chance:
+    //      [calculated / tolerance, calculated * tolerance]
+    float filter_size_mismatch_tolerance = 1.5;
+};
+
 class reshaping_compaction_task_impl : public compaction_task_impl {
 public:
     reshaping_compaction_task_impl(tasks::task_manager::module_ptr module,

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -988,6 +988,15 @@ public:
 // Validation errors are logged individually.
 future<bool> validate_checksums(shared_sstable sst, reader_permit permit);
 
+/// Generate a new bloom filter for the sstable
+///
+/// Use the sstable's partition count estimate, the schema's bloom filter fp
+/// chance and add all partitions from the index to the filter.
+///
+/// Can be used to regenerate filters for sstables, which have too small or
+/// too large filters.
+future<utils::filter_ptr> generate_bloom_filter(schema_ptr schema, reader_permit permit, shared_sstable sst);
+
 struct index_sampling_state {
     static constexpr size_t default_summary_byte_cost = 2000;
 

--- a/utils/bloom_filter.hh
+++ b/utils/bloom_filter.hh
@@ -87,6 +87,9 @@ struct always_present_filter: public i_filter {
     }
 };
 
+// Get the size of the bitset (in bits, not bytes) for the specific parameters.
+size_t get_bitset_size(int64_t num_elements, int buckets_per);
+
 filter_ptr create_filter(int hash, large_bitset&& bitset, filter_format format);
 filter_ptr create_filter(int hash, int64_t num_elements, int buckets_per, filter_format format);
 }

--- a/utils/i_filter.cc
+++ b/utils/i_filter.cc
@@ -32,6 +32,17 @@ filter_ptr i_filter::get_filter(int64_t num_elements, double max_false_pos_proba
     return filter::create_filter(spec.K, num_elements, spec.buckets_per_element, fformat);
 }
 
+size_t i_filter::get_filter_size(int64_t num_elements, double max_false_pos_probability) {
+    if (max_false_pos_probability >= 1.0) {
+        return 0;
+    }
+
+    int buckets_per_element = bloom_calculations::max_buckets_per_element(num_elements);
+    auto spec = bloom_calculations::compute_bloom_spec(buckets_per_element, max_false_pos_probability);
+
+    return filter::get_bitset_size(num_elements, spec.buckets_per_element) / 8;
+}
+
 hashed_key make_hashed_key(bytes_view b) {
     std::array<uint64_t, 2> h;
     utils::murmur_hash::hash3_x64_128(b, 0, h);

--- a/utils/i_filter.hh
+++ b/utils/i_filter.hh
@@ -52,5 +52,10 @@ struct i_filter {
      *         filter.
      */
     static filter_ptr get_filter(int64_t num_elements, double max_false_pos_prob, filter_format format);
+
+    /**
+     * @return the size of the smallest filter (in bytes), according to the conditions described at get_filter()
+     */
+    static size_t get_filter_size(int64_t num_elements, double max_false_pos_prob);
 };
 }


### PR DESCRIPTION
Currently the database administrator has no good tools to intervene in a situation, when the bloom filters are either too large or too small. The options are major compaction and upgradesstables, combined with tweaking the `bloom_filter_fp_chance` schema parameter. The main problem with this is that both compaction types are very expensive, and they have to be run at a time when the node is already in a very degraded state, usually tethering at the verge of OOM.
This PR proposes a new compaction type: bloom filter regeneration compaction. This is a very lightweight compaction, which doesn't do any compaction at all actually. All it does is regenerate the filter of sstables. To further help reduce the candidate set, the compaction allows providing parameters, to restrict the candidate set to sstables with particularly bad filters, but leaving those with an OK filter alone.
Looking forward, this is something we would like the database to do on its own, regenerating the filters in the background. But that is a more complicated change and one that will not be backported. This PR is aimed as a stop-gap measure until the former is developed, and also aims at being simple enough to backport.  Also, hopefully the infrastructure introduced in this PR, can be reused to build the future automated bloom filter regeneration service.
Together with the also planned bloom-filter cache, this should allow us to respond to and prevent bloom-filter related disasters.

TODO:
* This PR is not fully implemented, I couldn't decide how to actually attach the regenerated filter to the sstable, see TODO in the relevant commit
* Needs tests