### PR TITLE
auth: don't run legacy migrations in auth-v2 mode

### DIFF
--- a/auth/common.cc
+++ b/auth/common.cc
@@ -65,7 +65,7 @@ future<> do_after_system_ready(seastar::abort_source& as, seastar::noncopyable_f
     }).discard_result();
 }
 
-static future<> create_metadata_table_if_missing_impl(
+static future<> create_legacy_metadata_table_if_missing_impl(
         std::string_view table_name,
         cql3::query_processor& qp,
         std::string_view cql,
@@ -98,12 +98,12 @@ static future<> create_metadata_table_if_missing_impl(
     }
 }
 
-future<> create_metadata_table_if_missing(
+future<> create_legacy_metadata_table_if_missing(
         std::string_view table_name,
         cql3::query_processor& qp,
         std::string_view cql,
         ::service::migration_manager& mm) noexcept {
-    return futurize_invoke(create_metadata_table_if_missing_impl, table_name, qp, cql, mm);
+    return futurize_invoke(create_legacy_metadata_table_if_missing_impl, table_name, qp, cql, mm);
 }
 
 ::service::query_state& internal_distributed_query_state() noexcept {

--- a/auth/common.hh
+++ b/auth/common.hh
@@ -70,7 +70,7 @@ future<> once_among_shards(Task&& f) {
 // Func must support being invoked more than once.
 future<> do_after_system_ready(seastar::abort_source& as, seastar::noncopyable_function<future<>()> func);
 
-future<> create_metadata_table_if_missing(
+future<> create_legacy_metadata_table_if_missing(
         std::string_view table_name,
         cql3::query_processor&,
         std::string_view cql,

--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -103,7 +103,7 @@ future<> default_authorizer::migrate_legacy_metadata() {
     });
 }
 
-future<> default_authorizer::start() {
+future<> default_authorizer::start_legacy() {
     static const sstring create_table = fmt::format(
             "CREATE TABLE {}.{} ("
             "{} text,"
@@ -121,7 +121,7 @@ future<> default_authorizer::start() {
             90 * 24 * 60 * 60); // 3 months.
 
     return once_among_shards([this] {
-        return create_metadata_table_if_missing(
+        return create_legacy_metadata_table_if_missing(
                 PERMISSIONS_CF,
                 _qp,
                 create_table,
@@ -142,6 +142,13 @@ future<> default_authorizer::start() {
             });
         });
     });
+}
+
+future<> default_authorizer::start() {
+    if (legacy_mode(_qp)) {
+        return start_legacy();
+    }
+    return make_ready_future<>();
 }
 
 future<> default_authorizer::stop() {

--- a/auth/default_authorizer.hh
+++ b/auth/default_authorizer.hh
@@ -60,6 +60,8 @@ public:
     virtual const resource_set& protected_resources() const override;
 
 private:
+    future<> start_legacy();
+
     bool legacy_metadata_exists() const;
 
     future<> revoke_all_legacy(const resource&);

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -144,36 +144,36 @@ future<> password_authenticator::create_default_if_missing() {
 }
 
 future<> password_authenticator::start() {
-     return once_among_shards([this] {
-         auto f = create_metadata_table_if_missing(
-                 meta::roles_table::name,
-                 _qp,
-                 meta::roles_table::creation_query(),
-                 _migration_manager);
+    return once_among_shards([this] {
+        auto f = create_metadata_table_if_missing(
+                meta::roles_table::name,
+                _qp,
+                meta::roles_table::creation_query(),
+                _migration_manager);
 
-         _stopped = do_after_system_ready(_as, [this] {
-             return async([this] {
-                 _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as).get();
+        _stopped = do_after_system_ready(_as, [this] {
+            return async([this] {
+                _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as).get();
 
-                 if (any_nondefault_role_row_satisfies(_qp, &has_salted_hash, _superuser).get()) {
-                     if (legacy_metadata_exists()) {
-                         plogger.warn("Ignoring legacy authentication metadata since nondefault data already exist.");
-                     }
+                if (any_nondefault_role_row_satisfies(_qp, &has_salted_hash, _superuser).get()) {
+                    if (legacy_metadata_exists()) {
+                        plogger.warn("Ignoring legacy authentication metadata since nondefault data already exist.");
+                    }
 
-                     return;
-                 }
+                    return;
+                }
 
-                 if (legacy_metadata_exists()) {
-                     migrate_legacy_metadata().get();
-                     return;
-                 }
+                if (legacy_metadata_exists()) {
+                    migrate_legacy_metadata().get();
+                    return;
+                }
 
-                 create_default_if_missing().get();
-             });
-         });
+                create_default_if_missing().get();
+            });
+        });
 
-         return f;
-     });
+        return f;
+    });
  }
 
 future<> password_authenticator::stop() {

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -145,34 +145,36 @@ future<> password_authenticator::create_default_if_missing() {
 
 future<> password_authenticator::start() {
     return once_among_shards([this] {
-        auto f = create_metadata_table_if_missing(
-                meta::roles_table::name,
-                _qp,
-                meta::roles_table::creation_query(),
-                _migration_manager);
-
         _stopped = do_after_system_ready(_as, [this] {
             return async([this] {
-                _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as).get();
+                if (legacy_mode(_qp)) {
+                    _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as).get();
 
-                if (any_nondefault_role_row_satisfies(_qp, &has_salted_hash, _superuser).get()) {
-                    if (legacy_metadata_exists()) {
-                        plogger.warn("Ignoring legacy authentication metadata since nondefault data already exist.");
+                    if (any_nondefault_role_row_satisfies(_qp, &has_salted_hash, _superuser).get()) {
+                        if (legacy_metadata_exists()) {
+                            plogger.warn("Ignoring legacy authentication metadata since nondefault data already exist.");
+                        }
+
+                        return;
                     }
 
-                    return;
+                    if (legacy_metadata_exists()) {
+                        migrate_legacy_metadata().get();
+                        return;
+                    }
                 }
-
-                if (legacy_metadata_exists()) {
-                    migrate_legacy_metadata().get();
-                    return;
-                }
-
                 create_default_if_missing().get();
             });
         });
 
-        return f;
+        if (legacy_mode(_qp)) {
+            return create_legacy_metadata_table_if_missing(
+                    meta::roles_table::name,
+                    _qp,
+                    meta::roles_table::creation_query(),
+                    _migration_manager);
+        }
+        return make_ready_future<>();
     });
  }
 

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -175,8 +175,6 @@ public:
     }
 
 private:
-    future<bool> has_existing_legacy_users() const;
-
     future<> create_keyspace_if_missing(::service::migration_manager& mm) const;
 };
 

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -175,7 +175,7 @@ public:
     }
 
 private:
-    future<> create_keyspace_if_missing(::service::migration_manager& mm) const;
+    future<> create_legacy_keyspace_if_missing(::service::migration_manager& mm) const;
 };
 
 future<bool> has_superuser(const service&, const authenticated_user&);

--- a/auth/standard_role_manager.hh
+++ b/auth/standard_role_manager.hh
@@ -79,7 +79,7 @@ public:
 private:
     enum class membership_change { add, remove };
 
-    future<> create_metadata_tables_if_missing() const;
+    future<> create_legacy_metadata_tables_if_missing() const;
 
     bool legacy_metadata_exists();
 

--- a/test/auth_cluster/test_auth_v2_migration.py
+++ b/test/auth_cluster/test_auth_v2_migration.py
@@ -187,6 +187,7 @@ async def test_auth_v2_during_recovery(manager: ManagerClient):
     logging.info("Poison with auth_v1 look a like data")
     # this will verify that old roles are not brought back during recovery
     # as it runs very similar code path as during v1->v2 migration
+    await cql.run_async(f"CREATE TABLE system_auth.roles (role text PRIMARY KEY, can_login boolean, is_superuser boolean, member_of set<text>, salted_hash text)")
     v1_ro_name = "v1_ro" + unique_name()
     await cql.run_async(f"INSERT INTO system_auth.roles (role) VALUES ('{v1_ro_name}')")
 


### PR DESCRIPTION
We won't run:
- old pre auth-v1 migration code
- code creating auth-v1 tables

We will keep running:
- code creating default rows
- code creating auth-v1 keyspace (needed due to cqlsh legacy hack,
  it errors when executing `list roles` or `list users` if
  there is no system_auth keyspace, it does support case when
  there is no expected tables)

Fixes https://github.com/scylladb/scylladb/issues/17737