### PR TITLE
test: change maintenance socket location to /tmp

### DIFF
--- a/test.py
+++ b/test.py
@@ -411,6 +411,7 @@ class PythonTestSuite(TestSuite):
             """
             for srv in cluster.running.values():
                 srv.log_file.close()
+                srv.maintenance_socket_dir.cleanup()
             await cluster.stop()
             await cluster.release_ips()
 

--- a/test/auth_cluster/test_maintenance_socket.py
+++ b/test/auth_cluster/test_maintenance_socket.py
@@ -24,12 +24,11 @@ async def test_maintenance_socket(manager: ManagerClient):
     }
 
     server = await manager.server_add(config=config)
-    workdir = await manager.server_get_workdir(server.server_id)
-    socket = workdir + "/cql.m"
+    socket = await manager.server_get_maintenance_socket_path(server.server_id)
 
     try:
         cluster = Cluster([server.ip_addr])
-        session = cluster.connect()
+        cluster.connect()
     except NoHostAvailable:
         pass
     else:

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -487,5 +487,8 @@ class ManagerClient():
     async def server_get_workdir(self, server_id: ServerNum) -> str:
         return await self.client.get_json(f"/cluster/server/{server_id}/workdir")
 
+    async def server_get_maintenance_socket_path(self, server_id: ServerNum) -> str:
+        return await self.client.get_json(f"/cluster/server/{server_id}/maintenance_socket_path")
+
     async def server_get_exe(self, server_id: ServerNum) -> str:
         return await self.client.get_json(f"/cluster/server/{server_id}/exe")

--- a/test/topology_custom/test_maintenance_mode.py
+++ b/test/topology_custom/test_maintenance_mode.py
@@ -27,8 +27,7 @@ async def test_maintenance_mode(manager: ManagerClient):
     """
 
     server_a, server_b = await manager.server_add(), await manager.server_add()
-    workdir = await manager.server_get_workdir(server_a.server_id)
-    socket_endpoint = UnixSocketEndPoint(workdir + "/cql.m")
+    socket_endpoint = UnixSocketEndPoint(await manager.server_get_maintenance_socket_path(server_a.server_id))
 
     cluster = cluster_con([server_b.ip_addr], 9042, False)
     cql = cluster.connect()


### PR DESCRIPTION
Fixes #16912

By default, ScyllaDB stores the maintenance socket in the workdir. Test.py by default uses the location for the ScyllaDB workdir as testlog/{mode}/scylla-#. The Usual location for cloning the repo is the user's home folder. In some cases, it can lead the socket path being too long and the test will start to fail. The simple way is to move the maintenance socket to /tmp folder to eliminate such a possibility.