### PR TITLE
treewide: add fmt::formatter for exception types

### DIFF
--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -185,3 +185,13 @@ future<utils::chunked_vector<mutation>> get_cdc_generation_mutations_v3(
     size_t mutation_size_threshold, api::timestamp_type mutation_timestamp);
 
 } // namespace cdc
+
+#if FMT_VERSION < 100000
+// fmt v10 introduced formatter for std::exception
+template <>
+struct fmt::formatter<cdc::no_generation_data_exception> : fmt::formatter<std::string_view> {
+    auto format(const cdc::no_generation_data_exception& e, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", e.what());
+    }
+};
+#endif

--- a/data_dictionary/data_dictionary.hh
+++ b/data_dictionary/data_dictionary.hh
@@ -128,3 +128,20 @@ public:
 };
 
 }
+
+#if FMT_VERSION < 100000
+// fmt v10 introduced formatter for std::exception
+template <>
+struct fmt::formatter<data_dictionary::no_such_keyspace> : fmt::formatter<std::string_view> {
+    auto format(const data_dictionary::no_such_keyspace& e, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", e.what());
+    }
+};
+
+template <>
+struct fmt::formatter<data_dictionary::no_such_column_family> : fmt::formatter<std::string_view> {
+    auto format(const data_dictionary::no_such_column_family& e, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", e.what());
+    }
+};
+#endif

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -13,6 +13,7 @@
 #include "db/consistency_level_type.hh"
 #include "db/write_type.hh"
 #include "db/operation_type.hh"
+#include <concepts>
 #include <stdexcept>
 #include <seastar/core/sstring.hh>
 #include "bytes.hh"
@@ -312,3 +313,13 @@ public:
 };
 
 }
+
+#if FMT_VERSION < 100000
+// fmt v10 introduced formatter for std::exception
+template <std::derived_from<exceptions::cassandra_exception> T>
+struct fmt::formatter<T> : fmt::formatter<std::string_view> {
+    auto format(const T& e, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", e.what());
+    }
+};
+#endif

--- a/sstables/exceptions.hh
+++ b/sstables/exceptions.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <seastar/core/print.hh>
 
 #include "seastarx.hh"
@@ -58,3 +59,13 @@ public:
 };
 
 }
+
+#if FMT_VERSION < 100000
+ // fmt v10 introduced formatter for std::exception
+ template <std::derived_from<sstables::malformed_sstable_exception> T>
+ struct fmt::formatter<T> : fmt::formatter<std::string_view> {
+     auto format(const T& e, fmt::format_context& ctx) const {
+         return fmt::format_to(ctx.out(), "{}", e.what());
+     }
+ };
+ #endif

--- a/utils/exception_container.hh
+++ b/utils/exception_container.hh
@@ -152,6 +152,16 @@ concept ExceptionContainer = is_exception_container<T>::value;
 
 }
 
+#if FMT_VERSION < 100000
+// fmt v10 introduced formatter for std::exception
+template <>
+struct fmt::formatter<utils::bad_exception_container_access> : fmt::formatter<std::string_view> {
+    auto format(const utils::bad_exception_container_access& e, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", e.what());
+    }
+};
+#endif
+
 template <typename... Exs> struct fmt::formatter<utils::exception_container<Exs...>> : fmt::formatter<std::string_view> {
     auto format(const auto& ec, fmt::format_context& ctx) const {
         auto out = ctx.out();


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated
formatter.

in this change, `fmt::formatter` is added for following types for backward compatibility with {fmt} < 10:

* `utils::bad_exception_container_access`
* `cdc::no_generation_data_exception`
* classes derived from `sstables::malformed_sstable_exception`
* classes derived from `cassandra_exception`

Refs https://github.com/scylladb/scylladb/issues/13245