### PR TITLE
cql3: add fmt::formatter for cql3_type and cql3_type::raw

### DIFF
--- a/cql3/cql3_type.hh
+++ b/cql3/cql3_type.hh
@@ -363,3 +363,17 @@ inline bool operator==(const cql3_type& a, const cql3_type& b) {
 #endif
 
 }
+
+template <>
+struct fmt::formatter<cql3::cql3_type>: fmt::formatter<std::string_view> {
+    auto format(const cql3::cql3_type& t, fmt::format_context& ctx) const {
+        return formatter<std::string_view>::format(format_as(t), ctx);
+    }
+};
+
+template <std::derived_from<cql3::cql3_type::raw> T>
+struct fmt::formatter<T>: fmt::formatter<std::string_view> {
+    auto format(const T& t, fmt::format_context& ctx) const {
+        return formatter<std::string_view>::format(format_as(t), ctx);
+    }
+};


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, `fmt::formatter<>` is added for following classes:

* `cql3::cql3_type`
* `cql3::cql3_type::raw`

Refs #13245