### PR TITLE
Update docs wrt auth-v2 feature

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -117,9 +117,9 @@ request. Alternator can then validate the authenticity and authorization of
 each request using a known list of authorized key pairs.
 
 In the current implementation, the user stores the list of allowed key pairs
-in the `system_auth.roles` table: The access key ID is the `role` column, and
+in the `system_auth_v2.roles` table: The access key ID is the `role` column, and
 the secret key is the `salted_hash`, i.e., the secret key can be found by
-`SELECT salted_hash from system_auth.roles WHERE role = ID;`.
+`SELECT salted_hash from system_auth_v2.roles WHERE role = ID;`.
 
 By default, authorization is not enforced at all. It can be turned on
 by providing an entry in Scylla configuration:

--- a/docs/dev/docker-hub.md
+++ b/docs/dev/docker-hub.md
@@ -341,7 +341,7 @@ The `--authenticator` command lines option allows to provide the authenticator c
 
 #### `--authorizer AUTHORIZER`
 
-The `--authorizer` command lines option allows to provide the authorizer class ScyllaDB will use. By default ScyllaDB uses the `AllowAllAuthorizer` which allows any action to any user. The second option is using the `CassandraAuthorizer` parameter, which stores permissions in `system_auth.permissions` table.
+The `--authorizer` command lines option allows to provide the authorizer class ScyllaDB will use. By default ScyllaDB uses the `AllowAllAuthorizer` which allows any action to any user. The second option is using the `CassandraAuthorizer` parameter, which stores permissions in `system_auth_v2.permissions` table.
 
 **Since: 2.3**
 

--- a/docs/dev/service_levels.md
+++ b/docs/dev/service_levels.md
@@ -6,7 +6,7 @@ There are two system tables that are used to facilitate the service level featur
 ### Service Level Attachment Table
 
 ```
-    CREATE TABLE system_auth.role_attributes (
+    CREATE TABLE system_auth_v2.role_attributes (
     role text,
     attribute_name text,
     attribute_value text,
@@ -23,7 +23,7 @@ So for example in order to find out which `service_level` is attached to role `r
 one can run the following query:
 
 ```
-SELECT * FROM  system_auth.role_attributes WHERE role='r' and attribute_name='service_level'
+SELECT * FROM  system_auth_v2.role_attributes WHERE role='r' and attribute_name='service_level'
 
 ```
 

--- a/docs/operating-scylla/procedures/cluster-management/_common/prereq.rst
+++ b/docs/operating-scylla/procedures/cluster-management/_common/prereq.rst
@@ -3,13 +3,3 @@
 * endpoint_snitch - ``grep endpoint_snitch /etc/scylla/scylla.yaml``
 * Scylla version - ``scylla --version``
 * Authenticator - ``grep authenticator /etc/scylla/scylla.yaml``
-
-.. Note:: 
-
-   If ``authenticator`` is set to ``PasswordAuthenticator`` - increase the replication factor of the ``system_auth`` keyspace.
-
-   For example:
-
-   ``ALTER KEYSPACE system_auth WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'dc1' : <new_replication_factor>};``
-
-   It is recommended to set ``system_auth`` replication factor to the number of nodes in each DC.

--- a/docs/operating-scylla/procedures/cluster-management/add-dc-to-existing-dc.rst
+++ b/docs/operating-scylla/procedures/cluster-management/add-dc-to-existing-dc.rst
@@ -160,7 +160,7 @@ Add New DC
 #. When all nodes are up and running ``ALTER`` the following Keyspaces in the new nodes:
 
    * Keyspace created by the user (which needed to replicate to the new DC).
-   * System: ``system_auth``, ``system_distributed``, ``system_traces`` For example, replicate the data to three nodes in the new DC.
+   * System: ``system_distributed``, ``system_traces`` For example, replicate the data to three nodes in the new DC.
 
    For example:
 
@@ -177,7 +177,6 @@ Add New DC
    .. code-block:: cql
 
       ALTER KEYSPACE mykeyspace WITH replication = { 'class' : 'NetworkTopologyStrategy', '<exiting_dc>' : 3, <new_dc> : 3};
-      ALTER KEYSPACE system_auth WITH replication = { 'class' : 'NetworkTopologyStrategy', '<exiting_dc>' : 3, <new_dc> : 3};
       ALTER KEYSPACE system_distributed WITH replication = { 'class' : 'NetworkTopologyStrategy', '<exiting_dc>' : 3, <new_dc> : 3};
       ALTER KEYSPACE system_traces WITH replication = { 'class' : 'NetworkTopologyStrategy', '<exiting_dc>' : 3, <new_dc> : 3};
 
@@ -187,7 +186,6 @@ Add New DC
 
       DESCRIBE KEYSPACE mykeyspace;
       CREATE KEYSPACE mykeyspace WITH REPLICATION = {'class’: 'NetworkTopologyStrategy', <exiting_dc>:3, <new_dc>: 3};
-      CREATE KEYSPACE system_auth WITH replication = { 'class' : 'NetworkTopologyStrategy', '<exiting_dc>' : 3, <new_dc> : 3};
       CREATE KEYSPACE system_distributed WITH replication = { 'class' : 'NetworkTopologyStrategy', '<exiting_dc>' : 3, <new_dc> : 3};
       CREATE KEYSPACE system_traces WITH replication = { 'class' : 'NetworkTopologyStrategy', '<exiting_dc>' : 3, <new_dc> : 3};
 

--- a/docs/operating-scylla/procedures/cluster-management/update-topology-strategy-from-simple-to-network.rst
+++ b/docs/operating-scylla/procedures/cluster-management/update-topology-strategy-from-simple-to-network.rst
@@ -21,7 +21,7 @@ Alter each Keyspace replication to use ``class : NetworkTopologyStrategy``.
 Alter the following:
 
 * Keyspace created by the user.
-* System: ``system_auth``, ``system_distributed``, ``system_traces``.
+* System: ``system_distributed``, ``system_traces``.
 
 For example:
 

--- a/docs/operating-scylla/security/authentication.rst
+++ b/docs/operating-scylla/security/authentication.rst
@@ -9,45 +9,6 @@ The procedure described below enables Authentication on the Scylla servers. It i
 
 If this downtime is not an option, you can follow the instructions in :doc:`Enable and Disable Authentication Without Downtime </operating-scylla/security/runtime-authentication>`, which using a transient state, allows clients to work with or without Authentication at the same time. In this state, you can update the clients (application using Scylla/Apache Cassandra drivers) one at the time. Once all the clients are using Authentication, you can enforce Authentication on all Scylla nodes as well.
 
-Prerequisites
---------------
-Set the ``system_auth`` keyspace replication factor to the number of nodes in the datacenter via cqlsh. It allows you to ensure that 
-the user's information is kept highly available for the cluster. If ``system_auth`` is not equal to the number of nodes
-and a node fails, the user whose information is on that node will be denied access.
-
-For **production environments** use only ``NetworkTopologyStrategy``.
-
-* Single DC (SimpleStrategy)
-
-.. code-block:: cql
-
-   ALTER KEYSPACE system_auth WITH REPLICATION =
-     { 'class' : 'SimpleStrategy', 'replication_factor' : <new_rf> };
-
-For example:
-
-.. code-block:: cql
-
-   ALTER KEYSPACE system_auth WITH REPLICATION =
-     { 'class' : 'SimpleStrategy', 'replication_factor' : 3 };
-
-* Multi - DC (NetworkTopologyStrategy)
-
-.. code-block:: cql
-
-   ALTER KEYSPACE system_auth WITH REPLICATION =
-     {'class' : 'NetworkTopologyStrategy', '<name of DC 1>' : <new RF>, '<name of DC 2>' : <new RF>};
-
-For example:
-
-.. code-block:: cql
-
-   ALTER KEYSPACE system_auth WITH REPLICATION =
-     {'class' : 'NetworkTopologyStrategy', 'dc1' : 3, 'dc2' : 3};
-
-The names of the DCs must match the datacenter names specified in the rack & DC configuration file: ``/etc/scylla/cassandra-rackdc.properties``.
-
-
 Procedure
 ----------
 
@@ -73,14 +34,6 @@ Procedure
       Before proceeding  to the next step, we highly recommend creating a custom superuser 
       to ensure security and prevent performance degradation.
       See :doc:`Creating a Custom Superuser </operating-scylla/security/create-superuser/>` for instructions.
-
-#. Run a repair on the ``system_auth`` keyspace on **all** the nodes in the cluster.
-	
-    For example:
-	
-    .. code-block:: none
-	
-       nodetool repair -pr system_auth
 
 6. If you want to create users and roles, continue to :doc:`Enable Authorization </operating-scylla/security/enable-authorization>`.
 

--- a/docs/operating-scylla/security/runtime-authentication.rst
+++ b/docs/operating-scylla/security/runtime-authentication.rst
@@ -11,29 +11,6 @@ Enable Authentication Without Downtime
 
 This procedure allows you to enable authentication on a live Scylla cluster without downtime.
 
-Prerequisites
--------------
-
-Set the ``system_auth`` keyspace replication factor to the number of nodes in the datacenter and set the class to ``NetworkTopologyStrategy`` (required in production environments):
-
-For example:
-
-* Single DC (NetworkTopologyStrategy)
-
-  .. code-block:: cql
-
-      ALTER KEYSPACE system_auth WITH REPLICATION =
-        { 'class' : 'NetworkTopologyStrategy', '<name of DC>' : <new RF> };
-
-* Multi - DC (NetworkTopologyStrategy)
-
-  .. code-block:: cql
-
-     ALTER KEYSPACE system_auth WITH REPLICATION =
-        {'class' : 'NetworkTopologyStrategy', '<name of DC 1>' : <new RF>, '<name of DC 2>' : <new RF>};
-
-The names of the DCs must match the datacenter names specified in the rack & DC configuration file: ``/etc/scylla/cassandra-rackdc.properties``.
-
 Procedure
 ---------
 
@@ -95,14 +72,6 @@ Procedure
 
    .. include:: /rst_include/scylla-commands-restart-index.rst
 
-#. Run repair on the ``system_auth`` keyspace, one node at a time on all the nodes in the cluster.
-
-   For example:
-
-   .. code-block:: cql
-
-      nodetool repair system_auth
-
 #. Verify that all the client applications are working correctly with authentication enabled.
                               
 
@@ -135,14 +104,6 @@ Procedure
 #. Restart the nodes one by one to apply the effect.
 
    .. include:: /rst_include/scylla-commands-restart-index.rst
-
-#. Run repair on the ``system_auth`` keyspace, one node at a time on all the nodes in the cluster.
-
-   For example:
-
-   .. code-block:: cql
-
-      nodetool repair system_auth
 
 #. Verify that all the client applications are working correctly with authentication disabled.
 

--- a/docs/troubleshooting/password-reset.rst
+++ b/docs/troubleshooting/password-reset.rst
@@ -2,7 +2,7 @@ Reset Authenticator Password
 ============================
 
 This procedure describes what to do when a user loses his password and can not reset it with a superuser role. 
-The procedure requires cluster downtime and as a result, all of the system_auth data is deleted.
+The procedure requires cluster downtime and as a result, all of the system_auth_v2 data is deleted.
 
 Procedure
 .........
@@ -13,11 +13,11 @@ Procedure
 
    sudo systemctl stop scylla-server
 
-| 2. Remove your tables under ``/var/lib/scylla/data/system_auth/``.
+| 2. Remove your tables under ``/var/lib/scylla/data/system_auth_v2/``.
 
 .. code-block:: shell  
 
-   rm -rf /var/lib/scylla/data/system_auth/
+   rm -rf /var/lib/scylla/data/system_auth_v2/
 
 | 3. Start Scylla nodes.
 

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology.rst
@@ -32,8 +32,8 @@ Prerequisites
 
     features - Feature SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES is enabled
 
-  Alternatively, this can be checked programmatically by checking whether ``value`` column under the key ``enabled_features`` contains the name of the feature in the ``system.scylla_local`` table.
-  For example, this can be done with the following bash command:
+  Alternatively, this can be verified programmatically by checking whether ``value`` column under the key ``enabled_features`` contains the name of the feature in the ``system.scylla_local`` table.
+  For example, this can be done with the following bash script:
 
   .. code-block:: bash
 

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology.rst
@@ -57,6 +57,9 @@ In particular, you must abstain from:
 * :doc:`Cluster management procedures </operating-scylla/procedures/cluster-management/index>` (adding, replacing, removing, decommissioning nodes etc.).
 * Running :doc:`nodetool repair </operating-scylla/nodetool-commands/repair>`.
 * Running :doc:`nodetool checkAndRepairCdcStreams </operating-scylla/nodetool-commands/checkandrepaircdcstreams>`.
+* Any modifications of :doc:`authentication </operating-scylla/security/authentication>` and :doc:`authorization </operating-scylla/security/enable-authorization>` settings.
+* Any change of authorization via :doc:`CQL API </operating-scylla/security/authorization>`.
+* Doing schema changes.
 
 Running the procedure
 =====================


### PR DESCRIPTION
This CL updates documentation with regards to auth-v2 feature.

Fixes https://github.com/scylladb/scylladb/issues/17061
Fixes https://github.com/scylladb/scylladb/issues/17718