### PR TITLE
raft: server: print pointee of `server_impl::_fsm`

### DIFF
--- a/raft/server.cc
+++ b/raft/server.cc
@@ -1869,7 +1869,7 @@ std::unique_ptr<server> create_server(server_id uuid, std::unique_ptr<rpc> rpc,
 }
 
 std::ostream& operator<<(std::ostream& os, const server_impl& s) {
-    fmt::print(os, "[id: {}, fsm ()]\n", s._id, s._fsm);
+    fmt::print(os, "[id: {}, fsm ()]\n", s._id, *s._fsm);
     return os;
 }
 


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, instead of printing the `unique_ptr` instance, we print the pointee of it. since `server_impl` uses pimpl paradigm, `_fsm` is always valid after `server_impl::start()`, we can always deference it without checking for null.

Refs #13245