### PR TITLE
raft_group0: print runtime_error by printing e.what()

### DIFF
--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -546,7 +546,7 @@ shared_ptr<service::group0_handshaker> raft_group0::make_legacy_handshaker(bool 
                 co_await ser::group0_rpc_verbs::send_group0_modify_config(&_ms, peer, timeout, g0_info.group0_id, {{my_addr, _can_vote}}, {});
                 co_return true;
             } catch (std::runtime_error& e) {
-                group0_log.warn("failed to modify config at peer {}: {}. Retrying.", g0_info.id, e);
+                group0_log.warn("failed to modify config at peer {}: {}. Retrying.", g0_info.id, e.what());
                 co_return false;
             }
         };


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter. but fortunately, fmt v10 brings the builtin formatter for classes derived from `std::exception`. but before switching to {fmt} v10, and after dropping `FMT_DEPRECATED_OSTREAM` macro, we need to print out `std::runtime_error`. so far, we don't have a shared place for formatter for `std::runtime_error`. so we are addressing the needs on a case-by-case basis.

in this change, we just print it using `e.what()`. it's behavior is identical to what we have now.

Refs #13245