### PR TITLE
topology_coordinator: add fmt::formatter for wait_for_ip_timeout

### DIFF
--- a/service/topology_coordinator.hh
+++ b/service/topology_coordinator.hh
@@ -75,3 +75,13 @@ future<> run_topology_coordinator(
         endpoint_lifecycle_notifier& lifecycle_notifier);
 
 }
+
+#if FMT_VERSION < 100000
+// fmt v10 introduced formatter for std::exception
+template <>
+struct fmt::formatter<service::wait_for_ip_timeout> : fmt::formatter<std::string_view> {
+    auto format(const service::wait_for_ip_timeout& e, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", e.what());
+    }
+};
+#endif


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<. but this depends on the `FMT_DEPRECATED_OSTREAM` macro which is not respected in {fmt} v10.

this change addresses the formatting with fmtlib < 10, and without `FMT_DEPRECATED_OSTREAM` defined. please note, in {fmt} v10 and up, it defines formatter for classes derived from `std::exception`, so our formatter is only added when compiled with {fmt} < 10.

Refs scylladb#13245