### PR TITLE
Update frozen toolchain

### DIFF
--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-38-20240303
+docker.io/scylladb/scylla-toolchain:fedora-38-20240321


### PR DESCRIPTION
For Python driver 3.26.8, fixing continuous integration failures.

Fixes #17662