### PR TITLE
main: skip wait_for_gossip_to_settle if topology changes are based on raft

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1921,8 +1921,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 view_backlog_broker.stop().get();
             });
 
-            startlog.info("Waiting for gossip to settle before accepting client requests...");
-            gossiper.local().wait_for_gossip_to_settle().get();
+            if (!ss.local().raft_topology_change_enabled()) {
+                startlog.info("Waiting for gossip to settle before accepting client requests...");
+                gossiper.local().wait_for_gossip_to_settle().get();
+            }
             api::set_server_gossip_settle(ctx, gossiper).get();
 
             supervisor::notify("allow replaying hints");

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1688,7 +1688,9 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
         }
     } ();
 
-    co_await _gossiper.wait_for_gossip_to_settle();
+    if (!raft_topology_change_enabled()) {
+        co_await _gossiper.wait_for_gossip_to_settle();
+    }
 
     // This is the moment when the locator::topology has gathered information about other nodes
     // in the cluster -- either through gossiper, or by loading it from disk -- so it's safe


### PR DESCRIPTION
Waiting for gossip to settle slows down the bootstrap of the cluster. It is safe to disable it if the topology is based on the raft.

Fixes #16055