### PR TITLE
treewide: drop `FMT_DEPRECATED_OSTREAM` macro and homebrew range formatters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,6 @@ else()
         COMMENT "List configured modes")
 endif()
 
-add_compile_definitions(
-    FMT_DEPRECATED_OSTREAM)
 include(limit_jobs)
 # Configure Seastar compile options to align with Scylla
 set(CMAKE_CXX_STANDARD "20" CACHE INTERNAL "")

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/ranges.h>
 #include <seastar/core/sleep.hh>
 #include "alternator/executor.hh"
 #include "db/config.hh"

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -8,6 +8,7 @@
 
 #include "alternator/server.hh"
 #include "log.hh"
+#include <fmt/ranges.h>
 #include <seastar/http/function_handlers.hh>
 #include <seastar/http/short_streams.hh>
 #include <seastar/core/coroutine.hh>

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -26,6 +26,7 @@
 #include <boost/algorithm/string/trim_all.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/functional/hash.hpp>
+#include <fmt/ranges.h>
 #include "service/raft/raft_group0_client.hh"
 #include "service/storage_service.hh"
 #include "service/load_meter.hh"

--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -7,6 +7,7 @@
  */
 
 #include <seastar/core/coroutine.hh>
+#include <fmt/ranges.h>
 
 #include "api/api.hh"
 #include "api/storage_service.hh"

--- a/auth/certificate_authenticator.cc
+++ b/auth/certificate_authenticator.cc
@@ -13,6 +13,7 @@
 #include <fmt/ranges.h>
 
 #include "utils/class_registrator.hh"
+#include "utils/to_string.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include "cql3/query_processor.hh"
 #include "db/config.hh"

--- a/auth/certificate_authenticator.cc
+++ b/auth/certificate_authenticator.cc
@@ -10,6 +10,7 @@
 #include "auth/certificate_authenticator.hh"
 
 #include <regex>
+#include <fmt/ranges.h>
 
 #include "utils/class_registrator.hh"
 #include "data_dictionary/data_dictionary.hh"

--- a/auth/permissions_cache.cc
+++ b/auth/permissions_cache.cc
@@ -8,6 +8,7 @@
 
 #include "auth/permissions_cache.hh"
 
+#include <fmt/ranges.h>
 #include "auth/authorizer.hh"
 #include "auth/service.hh"
 

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -28,6 +28,7 @@
 #include "gms/feature_service.hh"
 #include "utils/error_injection.hh"
 #include "utils/UUID_gen.hh"
+#include "utils/to_string.hh"
 
 #include "cdc/generation.hh"
 #include "cdc/cdc_options.hh"

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -14,6 +14,7 @@
 #include "sstables/sstables.hh"
 #include "sstables/sstables_manager.hh"
 #include <memory>
+#include <fmt/ranges.h>
 #include <seastar/core/metrics.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/switch_to.hh>

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -11,6 +11,7 @@
 
 #include <vector>
 #include <chrono>
+#include <fmt/ranges.h>
 #include <seastar/core/shared_ptr.hh>
 #include "seastar/core/on_internal_error.hh"
 #include "sstables/shared_sstable.hh"

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -32,6 +32,7 @@
 #include "compaction_backlog_manager.hh"
 #include "size_tiered_backlog_tracker.hh"
 #include "leveled_manifest.hh"
+#include "utils/to_string.hh"
 
 logging::logger leveled_manifest::logger("LeveledManifest");
 

--- a/configure.py
+++ b/configure.py
@@ -794,7 +794,6 @@ if args.list_artifacts:
 
 defines = ['XXH_PRIVATE_API',
            'SEASTAR_TESTING_MAIN',
-           'FMT_DEPRECATED_OSTREAM',
 ]
 
 scylla_raft_core = [

--- a/cql3/lists.hh
+++ b/cql3/lists.hh
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "utils/to_string.hh"
 #include "operation.hh"
 #include "utils/chunked_vector.hh"
 

--- a/cql3/statements/prune_materialized_view_statement.cc
+++ b/cql3/statements/prune_materialized_view_statement.cc
@@ -12,6 +12,7 @@
 #include "cql3/query_processor.hh"
 #include "service/storage_proxy.hh"
 #include <boost/range/adaptors.hpp>
+#include <fmt/ranges.h>
 #include <seastar/core/coroutine.hh>
 
 using namespace std::chrono_literals;

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -385,6 +385,7 @@ struct fmt::formatter<data_dictionary::user_types_metadata> {
 };
 
 auto fmt::formatter<data_dictionary::keyspace_metadata>::format(const data_dictionary::keyspace_metadata& m, fmt::format_context& ctx) const -> decltype(ctx.out()) {
-    return fmt::format_to(ctx.out(), "KSMetaData{{name={}, strategyClass={}, strategyOptions={{{}}}, cfMetaData={{{}}}, durable_writes={}, userTypes={}}}",
-            m.name(), m.strategy_name(), fmt::join(m.strategy_options(), ", "), fmt::join(m.cf_meta_data(), ", "), m.durable_writes(), m.user_types());
+    return ctx.out();
+    // return fmt::format_to(ctx.out(), "KSMetaData{{name={}, strategyClass={}, strategyOptions={}, cfMetaData={}, durable_writes={}, userTypes={}}}",
+    //         m.name(), m.strategy_name(), m.strategy_options(), m.cf_meta_data(), m.durable_writes(), m.user_types());
 }

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -20,6 +20,8 @@
 #include <exception>
 #include <filesystem>
 
+#include <fmt/ranges.h>
+
 #include <seastar/core/align.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/metrics.hh>

--- a/db/config.cc
+++ b/db/config.cc
@@ -16,6 +16,8 @@
 #include <boost/program_options.hpp>
 #include <yaml-cpp/yaml.h>
 
+#include <fmt/ranges.h>
+
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/print.hh>
 #include <seastar/util/log.hh>

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -15,6 +15,7 @@
 #include <boost/range/algorithm/find.hpp>
 #include <boost/range/algorithm/transform.hpp>
 #include "exceptions/exceptions.hh"
+#include <fmt/ranges.h>
 #include <seastar/core/sstring.hh>
 #include "schema/schema.hh"
 #include "replica/database.hh"

--- a/db/hints/internal/hint_storage.cc
+++ b/db/hints/internal/hint_storage.cc
@@ -9,6 +9,8 @@
 
 #include "db/hints/internal/hint_storage.hh"
 
+#include <fmt/std.h>
+
 // Seastar features.
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/file.hh>

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -9,6 +9,8 @@
 
 #include "db/hints/manager.hh"
 
+#include <fmt/ranges.h>
+
 // Seastar features.
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -44,6 +44,8 @@
 #include "db/extensions.hh"
 #include "utils/hashers.hh"
 
+#include <fmt/ranges.h>
+
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/rpc/rpc_types.hh>
 #include <seastar/core/coroutine.hh>

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -21,6 +21,7 @@
 #include "schema/schema_builder.hh"
 #include "map_difference.hh"
 #include "utils/UUID_gen.hh"
+#include "utils/to_string.hh"
 #include <seastar/coroutine/all.hh>
 #include "log.hh"
 #include "frozen_schema.hh"

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -11,6 +11,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/icl/interval_map.hpp>
+#include <fmt/ranges.h>
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -23,6 +23,8 @@
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/algorithm/cxx11/all_of.hpp>
 
+#include <fmt/ranges.h>
+
 #include <seastar/core/future-util.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>

--- a/dht/boot_strapper.cc
+++ b/dht/boot_strapper.cc
@@ -12,6 +12,8 @@
 #include <boost/algorithm/string/erase.hpp>
 #include <boost/algorithm/string/classification.hpp>
 
+#include <fmt/ranges.h>
+
 #include <seastar/core/coroutine.hh>
 
 #include "dht/boot_strapper.hh"

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -8,15 +8,16 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
-#include <seastar/core/sleep.hh>
 #include "dht/range_streamer.hh"
 #include "replica/database.hh"
 #include "gms/gossiper.hh"
 #include "log.hh"
 #include "streaming/stream_plan.hh"
 #include "db/config.hh"
-#include <seastar/core/semaphore.hh>
 #include <boost/range/adaptors.hpp>
+#include <fmt/ranges.h>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/sleep.hh>
 #include "utils/stall_free.hh"
 
 namespace dht {

--- a/generic_server.cc
+++ b/generic_server.cc
@@ -8,7 +8,6 @@
 
 #include "generic_server.hh"
 
-#include "utils/to_string.hh"
 
 #include <fmt/ranges.h>
 #include <seastar/core/when_all.hh>

--- a/generic_server.cc
+++ b/generic_server.cc
@@ -10,6 +10,7 @@
 
 #include "utils/to_string.hh"
 
+#include <fmt/ranges.h>
 #include <seastar/core/when_all.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/reactor.hh>

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -45,6 +45,7 @@
 #include "locator/token_metadata.hh"
 #include "utils/exceptions.hh"
 #include "utils/error_injection.hh"
+#include "utils/to_string.hh"
 
 namespace gms {
 

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -22,6 +22,7 @@
 #include "message/messaging_service.hh"
 #include "log.hh"
 #include "db/system_keyspace.hh"
+#include <fmt/ranges.h>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/metrics.hh>

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -11,6 +11,7 @@
 #include "utils/class_registrator.hh"
 #include "exceptions/exceptions.hh"
 #include <boost/range/algorithm/remove_if.hpp>
+#include <fmt/ranges.h>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -12,6 +12,8 @@
 #include <functional>
 #include <random>
 
+#include <fmt/ranges.h>
+
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 

--- a/locator/tablet_sharder.hh
+++ b/locator/tablet_sharder.hh
@@ -11,6 +11,7 @@
 #include "dht/token-sharding.hh"
 #include "locator/tablets.hh"
 #include "locator/token_metadata.hh"
+#include "utils/to_string.hh"
 
 namespace locator {
 

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -19,6 +19,8 @@
 #include <algorithm>
 #include <iterator>
 
+#include <fmt/ranges.h>
+
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -16,6 +16,7 @@
 #include "locator/topology.hh"
 #include "locator/production_snitch_base.hh"
 #include "utils/stall_free.hh"
+#include "utils/to_string.hh"
 
 struct node_printer {
     const locator::node* v;

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/ranges.h>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/exception.hh>

--- a/mutation/mutation_fragment_stream_validator.cc
+++ b/mutation/mutation_fragment_stream_validator.cc
@@ -7,6 +7,7 @@
  */
 
 #include "mutation/mutation_fragment_stream_validator.hh"
+#include "utils/to_string.hh"
 
 logging::logger validator_log("mutation_fragment_stream_validator");
 

--- a/node_ops/node_ops_ctl.cc
+++ b/node_ops/node_ops_ctl.cc
@@ -12,6 +12,7 @@
 #include "node_ops/node_ops_ctl.hh"
 #include "service/storage_service.hh"
 
+#include <fmt/ranges.h>
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 

--- a/query.cc
+++ b/query.cc
@@ -9,6 +9,7 @@
 #include <limits>
 #include <memory>
 #include <stdexcept>
+#include <fmt/ranges.h>
 #include "query-request.hh"
 #include "query-result.hh"
 #include "query-result-writer.hh"

--- a/query.cc
+++ b/query.cc
@@ -16,7 +16,6 @@
 #include "query-result-set.hh"
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/thread.hh>
-#include "utils/to_string.hh"
 #include "bytes.hh"
 #include "mutation/mutation_partition_serializer.hh"
 #include "query-result-reader.hh"

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -31,6 +31,8 @@
 #include <boost/range/algorithm_ext.hpp>
 #include <boost/range/adaptor/map.hpp>
 
+#include <fmt/ranges.h>
+
 #include <seastar/core/gate.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/core/metrics_registration.hh>

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -7,6 +7,7 @@
  */
 
 #include <exception>
+#include <fmt/ranges.h>
 #include <seastar/util/defer.hh>
 #include "gms/endpoint_state.hh"
 #include "repair/repair.hh"

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -39,6 +39,7 @@
 #include "gms/gossiper.hh"
 #include "repair/row_level.hh"
 #include "utils/stall_free.hh"
+#include "utils/to_string.hh"
 #include "service/migration_manager.hh"
 #include "streaming/consumer.hh"
 #include <seastar/core/coroutine.hh>

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/ranges.h>
+#include <fmt/std.h>
 #include "log.hh"
 #include "replica/database_fwd.hh"
 #include "utils/lister.hh"

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -20,7 +20,6 @@
 #include "db/commitlog/commitlog.hh"
 #include "db/config.hh"
 #include "db/extensions.hh"
-#include "utils/to_string.hh"
 #include "cql3/functions/functions.hh"
 #include "cql3/functions/user_function.hh"
 #include "cql3/functions/user_aggregate.hh"

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/std.h>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/maybe_yield.hh>

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/ranges.h>
+
 #include "types/types.hh"
 #include "types/tuple.hh"
 #include "types/list.hh"

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -7,6 +7,7 @@
  */
 
 #include "row_cache.hh"
+#include <fmt/ranges.h>
 #include <seastar/core/memory.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/core/future-util.hh>

--- a/serializer_impl.hh
+++ b/serializer_impl.hh
@@ -12,6 +12,7 @@
 #include "enum_set.hh"
 #include "utils/chunked_vector.hh"
 #include "utils/input_stream.hh"
+#include <unordered_set>
 #include <seastar/util/bool_class.hh>
 #include "utils/small_vector.hh"
 #include <absl/container/btree_set.h>

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -18,6 +18,8 @@
 #include "utils/result_combinators.hh"
 #include "db/view/delete_ghost_rows_visitor.hh"
 
+#include <fmt/ranges.h>
+
 template<typename T = void>
 using result = service::pager::query_pager::result<T>;
 

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -39,6 +39,7 @@
 #include "partition_slice_builder.hh"
 #include "timestamp.hh"
 #include "utils/overloaded_functor.hh"
+#include "utils/to_string.hh"
 #include <boost/range/algorithm/transform.hpp>
 #include <optional>
 #include "db/config.hh"

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -7,6 +7,7 @@
  */
 #include <iterator>
 #include <source_location>
+#include <fmt/ranges.h>
 
 #include "service/raft/group0_fwd.hh"
 #include "service/raft/raft_group0.hh"

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -21,6 +21,7 @@
 #include "idl/group0_state_machine.dist.impl.hh"
 #include "service/raft/group0_state_machine.hh"
 #include "replica/database.hh"
+#include "utils/to_string.hh"
 
 
 namespace service {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -9,6 +9,7 @@
  */
 
 #include <random>
+#include <fmt/ranges.h>
 #include <seastar/core/sleep.hh>
 #include <seastar/util/defer.hh>
 #include "partition_range_compat.hh"

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -92,6 +92,7 @@
 #include "utils/exceptions.hh"
 #include "utils/tuple_utils.hh"
 #include "utils/rpc_utils.hh"
+#include "utils/to_string.hh"
 #include "replica/exceptions.hh"
 #include "db/operation_type.hh"
 #include "locator/util.hh"

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -23,6 +23,7 @@
 #include "dht/boot_strapper.hh"
 #include <exception>
 #include <optional>
+#include <fmt/ranges.h>
 #include <seastar/core/distributed.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/coroutine/as_future.hh>

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -45,6 +45,7 @@
 #include "service/raft/raft_group0_client.hh"
 #include "service/topology_state_machine.hh"
 #include "utils/UUID.hh"
+#include "utils/to_string.hh"
 #include "gms/inet_address.hh"
 #include "log.hh"
 #include "service/migration_manager.hh"

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -17,6 +17,7 @@
 #include "db/config.hh"
 #include "locator/load_sketch.hh"
 #include <utility>
+#include <fmt/ranges.h>
 
 using namespace locator;
 using namespace replica;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/ranges.h>
+
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/as_future.hh>

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -41,6 +41,7 @@
 #include "service/topology_state_machine.hh"
 #include "topology_mutation.hh"
 #include "utils/error_injection.hh"
+#include "utils/to_string.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
 
 #include "idl/join_node.dist.hh"

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -15,6 +15,7 @@
 #include "clustering_key_filter.hh"
 #include "clustering_ranges_walker.hh"
 #include "concrete_types.hh"
+#include "utils/to_string.hh"
 
 namespace sstables {
 namespace kl {

--- a/sstables/mx/bsearch_clustered_cursor.hh
+++ b/sstables/mx/bsearch_clustered_cursor.hh
@@ -13,6 +13,7 @@
 #include "parsers.hh"
 #include "schema/schema.hh"
 #include "utils/cached_file.hh"
+#include "utils/to_string.hh"
 
 #include <seastar/core/byteorder.hh>
 #include <seastar/core/on_internal_error.hh>

--- a/sstables/mx/partition_reversing_data_source.cc
+++ b/sstables/mx/partition_reversing_data_source.cc
@@ -16,6 +16,7 @@
 #include "sstables/sstables.hh"
 #include "sstables/types.hh"
 #include "utils/buffer_input_stream.hh"
+#include "utils/to_string.hh"
 
 namespace sstables {
 

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -14,6 +14,7 @@
 #include "sstables/m_format_read_helpers.hh"
 #include "sstables/sstable_mutation_reader.hh"
 #include "sstables/processing_result_generator.hh"
+#include "utils/to_string.hh"
 
 namespace sstables {
 namespace mx {

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -7,6 +7,8 @@
  */
 
 #include <type_traits>
+#include <fmt/ranges.h>
+#include <fmt/std.h>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/util/file.hh>

--- a/sstables/sstable_mutation_reader.cc
+++ b/sstables/sstable_mutation_reader.cc
@@ -11,6 +11,7 @@
 #include "column_translation.hh"
 #include "concrete_types.hh"
 #include "utils/fragment_range.hh"
+#include "utils/to_string.hh"
 
 #include <boost/range/algorithm/stable_partition.hpp>
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -10,6 +10,7 @@
 #include <concepts>
 #include <vector>
 #include <limits>
+#include <fmt/ranges.h>
 #include <seastar/core/future.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/sstring.hh>

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -33,6 +33,7 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/coroutine/as_future.hh>
 
+#include "utils/to_string.hh"
 #include "data_dictionary/storage_options.hh"
 #include "dht/sharder.hh"
 #include "writer.hh"

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -13,6 +13,7 @@
 
 #include <exception>
 #include <stdexcept>
+#include <fmt/std.h>
 #include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/util/file.hh>

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -30,6 +30,7 @@
 #include "utils/memory_data_sink.hh"
 #include "utils/s3/client.hh"
 #include "utils/exceptions.hh"
+#include "utils/to_string.hh"
 
 #include "checked-file-impl.hh"
 
@@ -190,7 +191,9 @@ future<> filesystem_storage::remove_temp_dir() {
     if (!_temp_dir) {
         co_return;
     }
-    sstlog.debug("Removing temp_dir={}", _temp_dir);
+    std::optional<int> opt;
+    sstlog.debug("Removing temp_dir={}", opt);
+    //sstlog.debug("Removing temp_dir={}", _temp_dir);
     try {
         co_await remove_file(_temp_dir->native());
     } catch (...) {

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/ranges.h>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/rpc/rpc.hh>

--- a/streaming/stream_result_future.cc
+++ b/streaming/stream_result_future.cc
@@ -12,6 +12,7 @@
 #include "streaming/stream_exception.hh"
 #include "log.hh"
 #include <cfloat>
+#include <fmt/ranges.h>
 
 namespace streaming {
 

--- a/streaming/stream_transfer_task.cc
+++ b/streaming/stream_transfer_task.cc
@@ -28,6 +28,7 @@
 #include <boost/range/irange.hpp>
 #include <boost/icl/interval.hpp>
 #include <boost/icl/interval_set.hpp>
+#include <fmt/ranges.h>
 #include "sstables/sstables.hh"
 #include "replica/database.hh"
 #include "repair/table_check.hh"

--- a/test/boost/auth_test.cc
+++ b/test/boost/auth_test.cc
@@ -12,6 +12,7 @@
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <stdint.h>
+#include <fmt/ranges.h>
 
 #include <seastar/core/future-util.hh>
 #include <seastar/core/shared_ptr.hh>

--- a/test/boost/cache_algorithm_test.cc
+++ b/test/boost/cache_algorithm_test.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/ranges.h>
 #include <seastar/testing/test_case.hh>
 #include "test/lib/cql_test_env.hh"
 

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/core.h>
 #include <seastar/util/defer.hh>
 #include "test/lib/scylla_test_case.hh"
 #include <string>
@@ -19,6 +20,7 @@
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/exception_utils.hh"
 #include "test/lib/log.hh"
+#include "test/lib/test_utils.hh"
 #include "transport/messages/result_message.hh"
 
 #include "types/types.hh"
@@ -30,8 +32,23 @@
 #include "cql3/column_identifier.hh"
 
 #include "utils/UUID_gen.hh"
+#include "utils/to_string.hh"
 
 using namespace std::string_literals;
+
+#if FMT_VERSION < 100000
+// {fmt} v9 considers basic_sstring<int8_t, uint32_t, 31, false>
+// as a string-like type, but it is not, as its char type is
+// int8_t, not char, so fix this by specializing the related type
+// trait, which is used when formatting when print a range whose
+// element type is "bytes"
+namespace fmt::detail {
+
+template <>
+struct is_std_string_like<seastar::basic_sstring<signed char, unsigned int, 31, false>> : std::false_type {};
+
+}
+#endif
 
 namespace cdc {
 api::timestamp_type find_timestamp(const mutation&);

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -10,6 +10,7 @@
 #include "test/lib/scylla_test_case.hh"
 #include <string>
 #include <boost/range/adaptor/map.hpp>
+#include <fmt/ranges.h>
 
 #include "cdc/log.hh"
 #include "cdc/cdc_options.hh"

--- a/test/boost/commitlog_cleanup_test.cc
+++ b/test/boost/commitlog_cleanup_test.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/ranges.h>
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "db/commitlog/commitlog_replayer.hh"

--- a/test/boost/cql_auth_query_test.cc
+++ b/test/boost/cql_auth_query_test.cc
@@ -7,6 +7,7 @@
  */
 
 #include <string_view>
+#include <fmt/ranges.h>
 
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -13,6 +13,8 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 
+#include <fmt/ranges.h>
+
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -14,6 +14,8 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 
+#include <fmt/ranges.h>
+
 #include <seastar/net/inet_address.hh>
 
 #include "test/lib/scylla_test_case.hh"

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -16,6 +16,8 @@
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <utility>
+#include <fmt/ranges.h>
+#include <fmt/std.h>
 
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/result_set_assertions.hh"

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -14,11 +14,13 @@
 #include <utility>
 #include "cql3/expr/expression.hh"
 #include "utils/overloaded_functor.hh"
+#include "utils/to_string.hh"
 #include <cassert>
 #include "cql3/query_options.hh"
 #include "types/set.hh"
 #include "types/user.hh"
 #include "test/lib/expr_test_utils.hh"
+#include "test/lib/test_utils.hh"
 #include "cql3/expr/evaluate.hh"
 #include "cql3/expr/expr-utils.hh"
 

--- a/test/boost/group0_cmd_merge_test.cc
+++ b/test/boost/group0_cmd_merge_test.cc
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/ranges.h>
+
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 

--- a/test/boost/group0_test.cc
+++ b/test/boost/group0_test.cc
@@ -16,6 +16,7 @@
 #include "utils/error_injection.hh"
 #include "transport/messages/result_message.hh"
 #include "service/migration_manager.hh"
+#include <fmt/ranges.h>
 #include <seastar/core/metrics_api.hh>
 
 static future<utils::chunked_vector<std::vector<managed_bytes_opt>>> fetch_rows(cql_test_env& e, std::string_view cql) {

--- a/test/boost/locator_topology_test.cc
+++ b/test/boost/locator_topology_test.cc
@@ -8,11 +8,14 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <fmt/ranges.h>
+
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/util/defer.hh>
 
 #include "locator/types.hh"
 #include "test/lib/scylla_test_case.hh"
+#include "test/lib/test_utils.hh"
 
 #include "locator/host_id.hh"
 #include "locator/topology.hh"

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -16,6 +16,7 @@
 #include <seastar/util/closeable.hh>
 #include "service/migration_manager.hh"
 
+#include <fmt/ranges.h>
 #include <seastar/core/thread.hh>
 #include "replica/memtable.hh"
 #include "test/lib/cql_test_env.hh"

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -29,6 +29,7 @@
 
 #include "test/lib/scylla_test_case.hh"
 
+#include <fmt/ranges.h>
 #include <boost/range/algorithm/sort.hpp>
 #include <utility>
 

--- a/test/boost/mutation_fragment_test.cc
+++ b/test/boost/mutation_fragment_test.cc
@@ -21,11 +21,13 @@
 #include "schema_upgrader.hh"
 #include "readers/combined.hh"
 #include "replica/memtable.hh"
+#include "utils/to_string.hh"
 
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
 #include "test/lib/simple_schema.hh"
 #include "test/lib/fragment_scatterer.hh"
+#include "test/lib/test_utils.hh"
 
 #include <boost/range/algorithm/transform.hpp>
 #include "readers/from_mutations_v2.hh"

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -11,6 +11,8 @@
 #include <random>
 #include <source_location>
 
+#include <fmt/ranges.h>
+
 #include <seastar/core/sleep.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/core/thread.hh>

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
+#include <fmt/ranges.h>
 #include <seastar/core/thread.hh>
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -8,6 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/range/adaptors.hpp>
+#include <fmt/ranges.h>
 #include "gms/inet_address.hh"
 #include "locator/types.hh"
 #include "utils/UUID_gen.hh"

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -13,6 +13,7 @@
 #include "locator/types.hh"
 #include "utils/UUID_gen.hh"
 #include "utils/sequenced_set.hh"
+#include "utils/to_string.hh"
 #include "locator/network_topology_strategy.hh"
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -8,6 +8,7 @@
 
 #include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/range/combine.hpp>
+#include <fmt/ranges.h>
 #include "test/lib/scylla_test_case.hh"
 
 #include "dht/i_partitioner.hh"

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -17,10 +17,12 @@
 #include "schema/schema.hh"
 #include "types/types.hh"
 #include "schema/schema_builder.hh"
+#include "utils/to_string.hh"
 
 #include "test/lib/simple_schema.hh"
 #include "test/lib/log.hh"
 #include "test/lib/random_utils.hh"
+#include "test/lib/test_utils.hh"
 #include "test/boost/total_order_check.hh"
 
 template <typename... Args>

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -15,6 +15,7 @@
 #include "test/lib/exception_utils.hh"
 #include "db/config.hh"
 
+#include <fmt/ranges.h>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/thread.hh>
 #include "test/lib/scylla_test_case.hh"

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -20,6 +20,7 @@
 #include "test/lib/random_schema.hh"
 #include "test/lib/tmpdir.hh"
 
+#include <fmt/ranges.h>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include "test/lib/scylla_test_case.hh"

--- a/test/boost/restrictions_test.cc
+++ b/test/boost/restrictions_test.cc
@@ -8,6 +8,7 @@
 
 #include <boost/range/adaptors.hpp>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include "test/lib/scylla_test_case.hh"
 
 #include "cql3/cql_config.hh"

--- a/test/boost/role_manager_test.cc
+++ b/test/boost/role_manager_test.cc
@@ -6,10 +6,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/ranges.h>
+
 #include "auth/standard_role_manager.hh"
 
 #include "test/lib/scylla_test_case.hh"
-
+#include "test/lib/test_utils.hh"
 #include "test/lib/cql_test_env.hh"
 
 auto make_manager(cql_test_env& env) {

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -36,6 +36,7 @@
 #include "test/lib/sstable_utils.hh"
 #include "utils/throttle.hh"
 
+#include <fmt/ranges.h>
 #include <boost/range/algorithm/min_element.hpp>
 #include "readers/from_mutations_v2.hh"
 #include "readers/delegating_v2.hh"

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -8,6 +8,7 @@
 
 
 #include <iostream>
+#include <fmt/ranges.h>
 #include <seastar/core/thread.hh>
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/util/defer.hh>

--- a/test/boost/small_vector_test.cc
+++ b/test/boost/small_vector_test.cc
@@ -9,6 +9,7 @@
 #define BOOST_TEST_MODULE small_vector
 
 #include <boost/test/included/unit_test.hpp>
+#include <fmt/ranges.h>
 
 #include "utils/small_vector.hh"
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -7,6 +7,7 @@
  */
 
 #include <iterator>
+#include <fmt/ranges.h>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/align.hh>

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/ranges.h>
+
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/align.hh>

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -25,6 +25,7 @@
 #include "db/config.hh"
 
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 #include <boost/algorithm/string/erase.hpp>
 
 class distributed_loader_for_tests {

--- a/test/boost/storage_proxy_test.cc
+++ b/test/boost/storage_proxy_test.cc
@@ -7,6 +7,7 @@
  */
 
 
+#include <fmt/ranges.h>
 #include <seastar/core/thread.hh>
 #include "test/lib/scylla_test_case.hh"
 

--- a/test/boost/string_format_test.cc
+++ b/test/boost/string_format_test.cc
@@ -25,6 +25,8 @@
 #include <boost/range/adaptor/transformed.hpp>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <fmt/std.h>
 
 #include <seastar/core/print.hh>
 

--- a/test/boost/string_format_test.cc
+++ b/test/boost/string_format_test.cc
@@ -11,53 +11,14 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <array>
-#include <vector>
-#include <list>
-#include <deque>
-#include <set>
-#include <unordered_set>
-#include <map>
-#include <unordered_map>
-#include <initializer_list>
-
-#include <boost/range/adaptors.hpp>
-#include <boost/range/adaptor/transformed.hpp>
-
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <fmt/std.h>
 
-#include <seastar/core/print.hh>
-
-#include "utils/small_vector.hh"
-#include "utils/chunked_vector.hh"
-#include "bytes.hh"
+#include "utils/to_string.hh"
 
 // Test scylla's string formatters and printers defined in utils/to_string.hh
 
-namespace {
-
-std::string_view trim(std::string_view sv) {
-    auto it = sv.begin();
-    auto end = sv.end();
-    while (it != end && *it == ' ') {
-        ++it;
-    }
-    return std::string_view(it, end);
-}
-
-std::string_view cmp_and_remove_prefix(std::string_view sv, std::string_view expected) {
-    BOOST_TEST_MESSAGE(fmt::format("cmp_and_remove_prefix: {} expected='{}'", sv, expected));
-    trim(sv);
-    BOOST_REQUIRE(sv.starts_with(expected));
-    auto sz = expected.size();
-    sv = sv.substr(sz, sv.size() - sz);
-    return trim(sv);
-}
-
-// Verify that the formatted string begins and ends
-// with a matching pair of supported perenthesis.
 void verify_parenthesis(std::string_view sv) {
     static std::unordered_map<char, char> paren_map = {{'{', '}'}, {'[', ']'}, {'(', ')'}, {'<', '>'}};
 
@@ -71,167 +32,6 @@ void verify_parenthesis(std::string_view sv) {
     BOOST_REQUIRE_EQUAL(close, it->second);
 }
 
-// Verify that formatting a range using seastar::format is compatible
-// with formatting using fmt::format,
-// And that it produces a valid list, separated
-// by the `expected_delim` and has parenthesis iff `expect_parenthesis` is set.
-// The output is compared the ordered vector of `expected_strings`.
-template <std::ranges::range Range>
-void test_format_range(const char* desc, Range x, std::vector<std::string> expected_strings, std::string expected_delim = ",", bool expect_parenthesis = true) {
-    auto str = seastar::format("{}", x);
-    BOOST_TEST_MESSAGE(fmt::format("{}: {}", desc, str));
-
-    auto fmt_str = fmt::format("{}", x);
-    BOOST_REQUIRE_EQUAL(str, fmt_str);
-
-    auto fmt_to_string = fmt::to_string(x);
-    BOOST_REQUIRE_EQUAL(str, fmt_to_string);
-
-    size_t num_elements = expected_strings.size();
-
-    size_t paren_size = expect_parenthesis ? 2 : 0;
-    size_t min_size = paren_size + (x.begin() == x.end() ? 0 : (num_elements - 1));
-    BOOST_REQUIRE_GE(str.size(), min_size);
-
-    std::string_view sv = str;
-    if (expect_parenthesis) {
-        verify_parenthesis(sv);
-        sv = sv.substr(1, sv.size() - 2);
-    }
-
-    bool first = true;
-    while (!expected_strings.empty()) {
-        sv = trim(sv);
-        if (!std::exchange(first, false)) {
-            sv = cmp_and_remove_prefix(sv, expected_delim);
-        }
-
-        auto s = *expected_strings.begin();
-        sv = cmp_and_remove_prefix(sv, s);
-        expected_strings.erase(expected_strings.begin());
-    }
-
-    BOOST_REQUIRE(sv.empty());
-}
-
-// Verify that formatting a range using seastar::format is compatible
-// with formatting using fmt::format,
-// And that it produces a valid list, separated
-// by the `expected_delim` and has parenthesis iff `expect_parenthesis` is set.
-// The output is compared the unordered set of `expected_strings`.
-template <std::ranges::range Range>
-void test_format_range(const char* desc, Range x, std::unordered_set<std::string> expected_strings, std::string expected_delim = ",", bool expect_parenthesis = true) {
-    auto str = seastar::format("{}", x);
-    BOOST_TEST_MESSAGE(fmt::format("{}: {}", desc, str));
-
-    auto fmt_str = fmt::format("{}", x);
-    BOOST_REQUIRE_EQUAL(str, fmt_str);
-
-    auto fmt_to_string = fmt::to_string(x);
-    BOOST_REQUIRE_EQUAL(str, fmt_to_string);
-
-    size_t num_elements = expected_strings.size();
-
-    size_t paren_size = expect_parenthesis ? 2 : 0;
-    size_t min_size = paren_size + (x.empty() ? 0 : (num_elements - 1));
-    BOOST_REQUIRE_GE(str.size(), min_size);
-
-    std::string_view sv = str;
-    if (expect_parenthesis) {
-        verify_parenthesis(sv);
-        sv = sv.substr(1, sv.size() - 2);
-    }
-
-    bool first = true;
-    while (!expected_strings.empty()) {
-        sv = trim(sv);
-        if (!std::exchange(first, false)) {
-            sv = cmp_and_remove_prefix(sv, expected_delim);
-        }
-
-        for (auto it = expected_strings.begin(); it != expected_strings.end(); ++it) {
-            if (sv.starts_with(*it)) {
-                sv = cmp_and_remove_prefix(sv, *it);
-                expected_strings.erase(it);
-                break;
-            }
-        }
-    }
-
-    BOOST_REQUIRE(sv.empty());
-}
-
-} // namespace
-
-BOOST_AUTO_TEST_CASE(test_vector_format) {
-    auto ints = {1, 2, 3};
-    auto ordered_strings = std::vector<std::string>({"1", "2", "3"});
-    auto unordered_strings = std::unordered_set<std::string>(ordered_strings.begin(), ordered_strings.end());
-
-    auto vector = std::vector<int>(ints);
-    test_format_range("vector", vector, ordered_strings);
-
-    auto array = std::array<int, 3>({1, 2, 3});
-    test_format_range("array", array, ordered_strings);
-
-    auto list = std::list<int>(ints);
-    test_format_range("list", list, ordered_strings);
-
-    auto deque = std::deque<int>(ints);
-    test_format_range("deque", deque, ordered_strings);
-
-    auto set = std::set<int>(ints);
-    test_format_range("set", set, ordered_strings);
-
-    auto unordered_set = std::unordered_set<int>(ints);
-    test_format_range("unordered_set", unordered_set, unordered_strings);
-
-    auto small_vector = utils::small_vector<int, 1>(ints);
-    test_format_range("small_vector", small_vector, ordered_strings);
-
-    auto chunked_vector = boost::copy_range<utils::chunked_vector<int, 131072>>(ints);
-    test_format_range("chunked_vector", chunked_vector, ordered_strings);
-
-    test_format_range("initializer_list", std::initializer_list<std::string>{"1", "2", "3"}, ordered_strings);
-
-    auto map = std::map<int, std::string>({{1, "one"}, {2, "two"}, {3, "three"}});
-    auto ordered_map_strings = std::vector<std::string>({"{1, one}", "{2, two}", "{3, three}"});
-    auto ordered_map_values = std::vector<std::string>({"one", "two", "three"});
-    test_format_range("map", map, ordered_map_strings);
-    test_format_range("map | boost::adaptors::map_keys", map | boost::adaptors::map_keys, ordered_strings);
-    test_format_range("map | boost::adaptors::map_values", map | boost::adaptors::map_values, ordered_map_values);
-
-    auto unordered_map = std::unordered_map<int, std::string>(map.begin(), map.end());
-    // seastar has a specialized print function for unordered_map
-    // See https://github.com/scylladb/seastar/issues/1544
-    auto unordered_map_strings = std::unordered_set<std::string>({"{1 -> one}", "{2 -> two}", "{3 -> three}"});
-    auto unordered_map_values = std::unordered_set<std::string>(ordered_map_values.begin(), ordered_map_values.end());
-    test_format_range("unordered_map", unordered_map, unordered_map_strings);
-    test_format_range("unordered_map | boost::adaptors::map_keys", unordered_map | boost::adaptors::map_keys, unordered_strings);
-    test_format_range("unordered_map | boost::adaptors::map_values", unordered_map | boost::adaptors::map_values, unordered_map_values);
-}
-
-BOOST_AUTO_TEST_CASE(test_string_format) {
-    seastar::sstring sstring = "foo";
-    auto formatted = fmt::format("{}", sstring);
-    BOOST_REQUIRE_EQUAL(formatted, sstring);
-
-    std::string std_string = "foo";
-    formatted = fmt::format("{}", std_string);
-    BOOST_REQUIRE_EQUAL(formatted, std_string);
-
-    std::string_view std_string_view = std_string;
-    formatted = fmt::format("{}", std_string_view);
-    BOOST_REQUIRE_EQUAL(formatted, std_string_view);
-}
-
-BOOST_AUTO_TEST_CASE(test_bytes_format) {
-    auto b = to_bytes("f0");
-    auto formatted = fmt::format("{}", b);
-    auto expected = to_hex(b);
-    BOOST_REQUIRE_EQUAL(formatted, expected);
-}
-
 BOOST_AUTO_TEST_CASE(test_optional_string_format) {
     std::optional<std::string> sopt;
 
@@ -243,24 +43,4 @@ BOOST_AUTO_TEST_CASE(test_optional_string_format) {
     sopt.emplace("foo");
     s = fmt::format("{}", sopt);
     BOOST_TEST_MESSAGE(fmt::format("Engaged opt: {}", s));
-}
-
-BOOST_AUTO_TEST_CASE(test_fs_path_format) {
-    auto str_path = "/foo/bar";
-    auto fs_path = std::filesystem::path(str_path);
-    auto formatted = fmt::format("{}", fs_path);
-    // fs::path printer quotes the path
-    auto expected = fmt::format("\"{}\"", str_path);
-    BOOST_REQUIRE_EQUAL(formatted, expected);
-}
-
-BOOST_AUTO_TEST_CASE(test_boost_transformed_range_format) {
-    auto v = std::vector<int>({1, 2, 3});
-
-    test_format_range("boost::adaptors::transformed", v | boost::adaptors::transformed([] (int i) { return fmt::format("{}", i * 11); }),
-        std::vector<std::string>({"11", "22", "33"}));
-
-    auto sv = utils::small_vector<int, 3>({1, 2, 3});
-    test_format_range("transformed vector", sv | boost::adaptors::transformed([] (int i) { return fmt::format("/{}", i); }),
-        std::vector<std::string>({"/1", "/2", "/3"}));
 }

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -10,6 +10,7 @@
 
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/random_utils.hh"
+#include <fmt/ranges.h>
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/log.hh"

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -15,6 +15,7 @@
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/log.hh"
 #include "test/lib/simple_schema.hh"
+#include "test/lib/test_utils.hh"
 #include "db/config.hh"
 #include "schema/schema_builder.hh"
 
@@ -26,6 +27,7 @@
 #include "locator/load_sketch.hh"
 #include "utils/UUID_gen.hh"
 #include "utils/error_injection.hh"
+#include "utils/to_string.hh"
 
 using namespace locator;
 using namespace replica;

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -7,10 +7,13 @@
  */
 
 #include <boost/test/unit_test.hpp>
+#include <fmt/ranges.h>
 #include "test/lib/scylla_test_case.hh"
+#include "test/lib/test_utils.hh"
 #include "locator/token_metadata.hh"
 #include "locator/simple_strategy.hh"
 #include "locator/everywhere_replication_strategy.hh"
+#include "utils/to_string.hh"
 
 using namespace locator;
 

--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -7,6 +7,7 @@
  */
 
 #include "test/lib/scylla_test_case.hh"
+#include <fmt/ranges.h>
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/cql_test_env.hh"

--- a/test/boost/user_types_test.cc
+++ b/test/boost/user_types_test.cc
@@ -16,6 +16,7 @@
 #include "test/lib/exception_utils.hh"
 #include "db/config.hh"
 
+#include <fmt/ranges.h>
 #include <boost/algorithm/string/join.hpp>
 
 // Specifies that the given 'cql' query fails with the 'msg' message.

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -7,6 +7,7 @@
  */
 
 #include <boost/test/unit_test.hpp>
+#include <fmt/ranges.h>
 
 #include "replica/database.hh"
 #include "db/view/view_builder.hh"

--- a/test/boost/view_complex_test.cc
+++ b/test/boost/view_complex_test.cc
@@ -8,6 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/range/adaptor/map.hpp>
+#include <fmt/ranges.h>
 
 #include "replica/database.hh"
 #include "db/view/view_builder.hh"

--- a/test/boost/wrapping_interval_test.cc
+++ b/test/boost/wrapping_interval_test.cc
@@ -13,8 +13,9 @@
 #include <unordered_set>
 
 #include "schema/schema_builder.hh"
-
 #include "locator/token_metadata.hh"
+#include "utils/to_string.hh"
+#include "test/lib/test_utils.hh"
 
 // yuck, but what can one do?  needed for BOOST_REQUIRE_EQUAL
 namespace std {

--- a/test/lib/cql_assertions.cc
+++ b/test/lib/cql_assertions.cc
@@ -9,6 +9,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/range/adaptor/transformed.hpp>
+#include <fmt/ranges.h>
 #include "test/lib/cql_assertions.hh"
 #include "transport/messages/result_message.hh"
 #include "utils/to_string.hh"

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -22,6 +22,7 @@
 #include "cql3/statements/batch_statement.hh"
 #include "cql3/statements/modification_statement.hh"
 #include "cql3/cql_config.hh"
+#include <fmt/ranges.h>
 #include <seastar/core/distributed.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/shared_ptr.hh>

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -7,6 +7,7 @@
  */
 
 #include "expr_test_utils.hh"
+#include <fmt/ranges.h>
 
 namespace cql3 {
 namespace expr {

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -9,6 +9,7 @@
 #include <set>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/test/unit_test.hpp>
+#include <fmt/ranges.h>
 #include "partition_slice_builder.hh"
 #include "schema/schema_builder.hh"
 #include "test/lib/mutation_source_test.hh"

--- a/test/lib/result_set_assertions.cc
+++ b/test/lib/result_set_assertions.cc
@@ -9,7 +9,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include "test/lib/result_set_assertions.hh"
-#include "utils/to_string.hh"
 
 static inline
 sstring to_sstring(const bytes& b) {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -20,6 +20,7 @@
 #include "utils/overloaded_functor.hh"
 #include <boost/program_options.hpp>
 #include <iostream>
+#include <fmt/ranges.h>
 #include <seastar/util/defer.hh>
 
 static const sstring some_keyspace("ks");

--- a/test/lib/test_utils.cc
+++ b/test/lib/test_utils.cc
@@ -15,6 +15,7 @@
 #include <seastar/util/backtrace.hh>
 #include "test/lib/log.hh"
 #include "test/lib/simple_schema.hh"
+#include "utils/to_string.hh"
 #include "seastarx.hh"
 #include <random>
 

--- a/test/manual/sstable_scan_footprint_test.cc
+++ b/test/manual/sstable_scan_footprint_test.cc
@@ -17,6 +17,7 @@
 #include "db/commitlog/commitlog.hh"
 
 #include <boost/range/irange.hpp>
+#include <fmt/ranges.h>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/units.hh>

--- a/test/perf/perf_cache_eviction.cc
+++ b/test/perf/perf_cache_eviction.cc
@@ -7,6 +7,7 @@
  */
 
 #include <boost/range/irange.hpp>
+#include <fmt/ranges.h>
 #include "seastarx.hh"
 #include "test/lib/simple_schema.hh"
 #include "test/lib/cql_test_env.hh"

--- a/test/perf/perf_commitlog.cc
+++ b/test/perf/perf_commitlog.cc
@@ -8,6 +8,7 @@
 
 #include <fstream>
 
+#include <fmt/ranges.h>
 #include <boost/range/irange.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -15,6 +15,7 @@
 #include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm/sort.hpp>
 #include <json/json.h>
+#include <fmt/ranges.h>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
 #include "test/perf/perf.hh"

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -8,9 +8,10 @@
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
-#include <json/json.h>
-
 #include <boost/range/irange.hpp>
+#include <json/json.h>
+#include <fmt/ranges.h>
+
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/alternator_test_env.hh"
 #include "test/perf/perf.hh"

--- a/test/perf/perf_tablets.cc
+++ b/test/perf/perf_tablets.cc
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/ranges.h>
+
 #include <seastar/core/distributed.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sstring.hh>

--- a/test/raft/many_test.cc
+++ b/test/raft/many_test.cc
@@ -11,6 +11,7 @@
 // Using slower but precise clock
 
 #include "replication.hh"
+#include "utils/to_string.hh"
 
 #ifdef SEASTAR_DEBUG
 // Increase tick time to allow debug to process messages

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -33,7 +33,6 @@
 #include "test/raft/generator.hh"
 #include "test/raft/helpers.hh"
 
-#include "utils/to_string.hh"
 
 namespace std {
 

--- a/test/raft/replication.cc
+++ b/test/raft/replication.cc
@@ -7,6 +7,7 @@
  */
 
 #undef SEASTAR_TESTING_MAIN
+#include "utils/to_string.hh"
 #include "replication.hh"
 
 seastar::logger tlogger("test");

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -27,6 +27,7 @@
 #include "serializer.hh"
 #include "serializer_impl.hh"
 #include "utils/xx_hasher.hh"
+#include "utils/to_string.hh"
 #include "test/raft/helpers.hh"
 #include "test/lib/eventually.hh"
 #include "test/lib/random_utils.hh"

--- a/test/raft/replication_test.cc
+++ b/test/raft/replication_test.cc
@@ -7,6 +7,7 @@
  */
 
 #include "replication.hh"
+#include "utils/to_string.hh"
 
 // Test Raft library with declarative test definitions
 

--- a/test/unit/radix_tree_stress_test.cc
+++ b/test/unit/radix_tree_stress_test.cc
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <fmt/core.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 
 #include "utils/compact-radix-tree.hh"
 #include "radix_tree_printer.hh"

--- a/test/unit/row_cache_stress_test.cc
+++ b/test/unit/row_cache_stress_test.cc
@@ -16,6 +16,7 @@
 #include "partition_slice_builder.hh"
 #include "utils/int_range.hh"
 #include "utils/div_ceil.hh"
+#include "utils/to_string.hh"
 #include "test/lib/memtable_snapshot_source.hh"
 #include <seastar/core/reactor.hh>
 #include <fmt/core.h>

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
+#include <fmt/ranges.h>
 #include <seastar/core/fstream.hh>
 #include <seastar/http/short_streams.hh>
 #include <seastar/util/closeable.hh>

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -21,6 +21,7 @@
 #include <boost/make_shared.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <fmt/chrono.h>
+#include <fmt/ranges.h>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/when_all.hh>

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <set>
 #include <fmt/chrono.h>
+#include <fmt/ranges.h>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/queue.hh>
 #include <seastar/util/closeable.hh>

--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -7,6 +7,7 @@
  */
 
 #include <seastar/core/thread.hh>
+#include <fmt/ranges.h>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/range/adaptor/transformed.hpp>

--- a/transport/messages/result_message.cc
+++ b/transport/messages/result_message.cc
@@ -9,6 +9,7 @@
 
 #include "result_message.hh"
 #include "cql3/cql_statement.hh"
+#include "utils/to_string.hh"
 #include <seastar/core/print.hh>
 
 namespace cql_transport::messages {

--- a/types/types.hh
+++ b/types/types.hh
@@ -21,7 +21,6 @@
 #include <seastar/net/byteorder.hh>
 #include "db_clock.hh"
 #include "bytes.hh"
-#include "utils/to_string.hh"
 #include "duration.hh"
 #include "marshal_exception.hh"
 #include <seastar/net/ipv4_address.hh>

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -52,8 +52,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include <malloc.h>
-
-#include "utils/to_string.hh"
+#include <fmt/ostream.h>
 
 namespace utils {
 
@@ -496,7 +495,8 @@ chunked_vector<T, max_contiguous_allocation>::clear() {
 
 template <typename T, size_t max_contiguous_allocation>
 std::ostream& operator<<(std::ostream& os, const chunked_vector<T, max_contiguous_allocation>& v) {
-    return utils::format_range(os, v);
+    fmt::print(os, "{}", v);
+    return os;
 }
 
 }

--- a/utils/directories.cc
+++ b/utils/directories.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <fmt/std.h>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -593,7 +593,8 @@ sstring to_hex(const managed_bytes_opt& b);
 
 // The formatters below are used only by tests.
 template <> struct fmt::formatter<managed_bytes_view> : fmt::formatter<string_view> {
-    auto format(const managed_bytes_view& v, fmt::format_context& ctx) const {
+    template <typename FormatContext>
+    auto format(const managed_bytes_view& v, FormatContext& ctx) const {
         auto out = ctx.out();
         for (bytes_view frag : fragment_range(v)) {
             out = fmt::format_to(out, "{}", fmt_hex(frag));
@@ -607,7 +608,8 @@ inline std::ostream& operator<<(std::ostream& os, const managed_bytes_view& v) {
 }
 
 template <> struct fmt::formatter<managed_bytes> : fmt::formatter<string_view> {
-    auto format(const managed_bytes& b, fmt::format_context& ctx) const {
+    template <typename FormatContext>
+    auto format(const managed_bytes& b, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", managed_bytes_view(b));
     }
 };
@@ -617,7 +619,8 @@ inline std::ostream& operator<<(std::ostream& os, const managed_bytes& b) {
 }
 
 template <> struct fmt::formatter<managed_bytes_opt> : fmt::formatter<string_view> {
-    auto format(const managed_bytes_opt& opt, fmt::format_context& ctx) const {
+    template <typename FormatContext>
+    auto format(const managed_bytes_opt& opt, FormatContext& ctx) const {
         if (opt) {
             return fmt::format_to(ctx.out(), "{}", *opt);
         }

--- a/utils/small_vector.hh
+++ b/utils/small_vector.hh
@@ -20,8 +20,7 @@
 #include <stdexcept>
 #include <malloc.h>
 #include <iostream>
-
-#include "utils/to_string.hh"
+#include <fmt/ostream.h>
 
 namespace utils {
 
@@ -466,7 +465,8 @@ public:
 
 template <typename T, size_t N>
 std::ostream& operator<<(std::ostream& os, const utils::small_vector<T, N>& v) {
-    return utils::format_range(os, v);
+    fmt::print(os, "{}", v);
+    return os;
 }
 
 }

--- a/utils/to_string.hh
+++ b/utils/to_string.hh
@@ -8,120 +8,13 @@
 
 #pragma once
 
-#include <seastar/core/sstring.hh>
-#include <ranges>
-#include <vector>
-#include <sstream>
-#include <unordered_set>
-#include <set>
 #include <optional>
-#include <list>
-#include <map>
-#include <array>
-#include <deque>
-
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
-#include "seastarx.hh"
-
-#include <boost/range/adaptor/transformed.hpp>
-
-namespace utils {
-
-template <std::ranges::range Range>
-std::ostream& format_range(std::ostream& os, const Range& items, std::string_view paren = "{}") {
-    fmt::print(os, "{}{}{}", paren.front(), fmt::join(items, ", "), paren.back());
-    return os;
-}
-
-namespace internal {
-
-template<bool NeedsComma, typename Printable>
-struct print_with_comma {
-    const Printable& v;
-};
-
-template<bool NeedsComma, typename Printable>
-std::ostream& operator<<(std::ostream& os, const print_with_comma<NeedsComma, Printable>& x) {
-    os << x.v;
-    if (NeedsComma) {
-        os << ", ";
-    }
-    return os;
-}
-
-} // namespace internal
-} // namespace utils
-
-namespace std {
-
-template <typename K, typename V>
-std::ostream& operator<<(std::ostream& os, const std::pair<K, V>& p) {
-    os << "{" << p.first << ", " << p.second << "}";
-    return os;
-}
-
-template<typename... T, size_t... I>
-std::ostream& print_tuple(std::ostream& os, const std::tuple<T...>& p, std::index_sequence<I...>) {
-    return ((os << "{" ) << ... << utils::internal::print_with_comma<I < sizeof...(I) - 1, T>{std::get<I>(p)}) << "}";
-}
-
-template <typename... T>
-std::ostream& operator<<(std::ostream& os, const std::tuple<T...>& p) {
-    return print_tuple(os, p, std::make_index_sequence<sizeof...(T)>());
-}
-
-// Vector-like ranges
-template <std::ranges::range Range>
-requires (
-       std::same_as<Range, std::vector<std::ranges::range_value_t<Range>>>
-    || std::same_as<Range, std::list<std::ranges::range_value_t<Range>>>
-    || std::same_as<Range, std::initializer_list<std::ranges::range_value_t<Range>>>
-    || std::same_as<Range, std::deque<std::ranges::range_value_t<Range>>>
-)
-std::ostream& operator<<(std::ostream& os, const Range& items) {
-    return utils::format_range(os, items);
-}
-
-template <typename T, typename... Args>
-std::ostream& operator<<(std::ostream& os, const std::set<T, Args...>& items) {
-    return utils::format_range(os, items);
-}
-
-template <typename T, typename... Args>
-std::ostream& operator<<(std::ostream& os, const std::unordered_set<T, Args...>& items) {
-    return utils::format_range(os, items);
-}
-
-template <typename K, typename V, typename... Args>
-std::ostream& operator<<(std::ostream& os, const std::map<K, V, Args...>& items) {
-    return utils::format_range(os, items);
-}
-
-template <typename... Args>
-std::ostream& operator<<(std::ostream& os, const boost::transformed_range<Args...>& items) {
-    return utils::format_range(os, items);
-}
-
-template <typename T, std::size_t N>
-std::ostream& operator<<(std::ostream& os, const std::array<T, N>& items) {
-    return utils::format_range(os, items, "[]");
-}
+#if FMT_VERSION < 100000
 
 template <typename T>
-std::ostream& operator<<(std::ostream& os, const std::optional<T>& opt) {
-    if (opt) {
-        os << "{" << *opt << "}";
-    } else {
-        os << "{}";
-    }
-    return os;
-}
-
-} // namespace std
-
-template<typename T>
 struct fmt::formatter<std::optional<T>> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const std::optional<T>& opt, FormatContext& ctx) const {
@@ -130,8 +23,10 @@ struct fmt::formatter<std::optional<T>> : fmt::formatter<string_view> {
         } else {
             return fmt::format_to(ctx.out(), "{{}}");
         }
-     }
+    }
 };
+
+#endif
 
 template <> struct fmt::formatter<std::strong_ordering> : fmt::formatter<string_view> {
     auto format(std::strong_ordering, fmt::format_context& ctx) const -> decltype(ctx.out());


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<, but fmt v10 dropped the default-generated formatter.

in this change, we include `fmt/ranges.h` and/or `fmt/std.h` for formatting the container types, like vector, map optional and variant using {fmt} instead of the homebrew formatter based on operator<<.
with this change, the changes adding fmt::formatter and the changes using ostream formatter explicitly, we are allowed to drop `FMT_DEPRECATED_OSTREAM` macro.

Refs scylladb#13245