### PR TITLE
dist: drop scylla-jmx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,9 +9,6 @@
 [submodule "abseil"]
 	path = abseil
 	url = ../abseil-cpp
-[submodule "scylla-jmx"]
-	path = tools/jmx
-	url = ../scylla-jmx
 [submodule "scylla-tools"]
 	path = tools/java
 	url = ../scylla-tools-java

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -103,7 +103,6 @@ def interactive_choose_swap_size():
             print(f'"{s}" is not valid number, input again')
 
 pkg_files = {
-        f'{PRODUCT}-jmx': scylladir_p() / 'jmx/scylla-jmx',
         f'{PRODUCT}-tools': scylladir_p() / 'share/cassandra/bin/cqlsh',
         f'{PRODUCT}-node-exporter': scylladir_p() / 'node_exporter/node_exporter'
         }

--- a/docs/getting-started/install-scylla/index.rst
+++ b/docs/getting-started/install-scylla/index.rst
@@ -10,6 +10,7 @@ Install ScyllaDB
    /getting-started/install-scylla/launch-on-azure
    /getting-started/installation-common/scylla-web-installer
    /getting-started/install-scylla/install-on-linux
+   /getting-started/install-scylla/install-jmx
    /getting-started/install-scylla/run-in-docker
    /getting-started/installation-common/unified-installer
    /getting-started/installation-common/air-gapped-install
@@ -35,6 +36,7 @@ Keep your versions up-to-date. The two latest versions are supported. Also, alwa
 
   * :doc:`Install ScyllaDB with Web Installer (recommended) </getting-started/installation-common/scylla-web-installer>`
   * :doc:`Install ScyllaDB Linux Packages </getting-started/install-scylla/install-on-linux>`
+  * :doc:`Install scylla-jmx Package </getting-started/install-scylla/install-jmx>`
   * :doc:`Install ScyllaDB Without root Privileges </getting-started/installation-common/unified-installer>`
   * :doc:`Air-gapped Server Installation </getting-started/installation-common/air-gapped-install>`
   * :doc:`ScyllaDB Developer Mode </getting-started/installation-common/dev-mod>`

--- a/docs/getting-started/install-scylla/install-jmx.rst
+++ b/docs/getting-started/install-scylla/install-jmx.rst
@@ -1,0 +1,78 @@
+
+======================================
+Install scylla-jmx Package
+======================================
+
+scylla-jmx becomes optional package from ScyllaDB 6.2, not installed by default.
+If you need JMX server you can still install it from scylla-jmx GitHub page.
+
+.. tabs::
+
+   .. group-tab:: Debian/Ubuntu
+        #. Download .deb package from scylla-jmx page.
+
+            Access to https://github.com/scylladb/scylla-jmx, select latest
+            release from "releases", download a file end with ".deb".
+
+        #. (Optional) Transfer the downloaded package to the install node.
+
+            If the pc from which you downloaded the package is different from
+            the node where you install scylladb, you will need to transfer
+            the files to the node.
+
+        #. Install scylla-jmx package.
+
+            .. code-block:: console
+    
+               sudo apt install -y ./scylla-jmx_<version>_all.deb
+
+
+   .. group-tab:: Centos/RHEL
+
+        #. Download .rpm package from scylla-jmx page.
+
+            Access to https://github.com/scylladb/scylla-jmx, select latest
+            release from "releases", download a file end with ".rpm".
+
+        #. (Optional) Transfer the downloaded package to the install node.
+
+            If the pc from which you downloaded the package is different from
+            the node where you install scylladb, you will need to transfer
+            the files to the node.
+
+        #. Install scylla-jmx package.
+
+            .. code-block:: console
+    
+               sudo yum install -y ./scylla-jmx-<version>.noarch.rpm
+
+
+   .. group-tab:: Install without root privileges
+
+        #. Download .tar.gz package from scylla-jmx page.
+
+            Access to https://github.com/scylladb/scylla-jmx, select latest
+            release from "releases", download a file end with ".tar.gz".
+
+        #. (Optional) Transfer the downloaded package to the install node.
+
+            If the pc from which you downloaded the package is different from
+            the node where you install scylladb, you will need to transfer
+            the files to the node.
+
+        #. Install scylla-jmx package.
+
+            .. code:: console
+    
+                tar xpf scylla-jmx-<version>.noarch.tar.gz
+                cd scylla-jmx
+                ./install.sh --nonroot
+
+Next Steps
+-----------
+
+* :doc:`Configure ScyllaDB </getting-started/system-configuration>`
+* Manage your clusters with `ScyllaDB Manager <https://manager.docs.scylladb.com/>`_
+* Monitor your cluster and data with `ScyllaDB Monitoring <https://monitoring.docs.scylladb.com/>`_
+* Get familiar with ScyllaDB’s :doc:`command line reference guide </operating-scylla/nodetool>`.
+* Learn about ScyllaDB at `ScyllaDB University <https://university.scylladb.com/>`_

--- a/docs/getting-started/install-scylla/install-on-linux.rst
+++ b/docs/getting-started/install-scylla/install-on-linux.rst
@@ -72,7 +72,7 @@ Install ScyllaDB
 
             .. code-block:: console
     
-               apt-get install scylla{,-server,-jmx,-tools,-tools-core,-kernel-conf,-node-exporter,-conf,-python3}=<your patch version>
+               apt-get install scylla{,-server,-tools,-tools-core,-kernel-conf,-node-exporter,-conf,-python3}=<your patch version>
           
             The following example shows installing ScyllaDB 5.2.3.
 
@@ -88,7 +88,7 @@ Install ScyllaDB
             .. code-block:: console
                :class: hide-copy-button
     
-               apt-get install scylla{,-server,-jmx,-tools,-tools-core,-kernel-conf,-node-exporter,-conf,-python3}=5.2.3-0.20230608.ea08d409f155-1
+               apt-get install scylla{,-server,-tools,-tools-core,-kernel-conf,-node-exporter,-conf,-python3}=5.2.3-0.20230608.ea08d409f155-1
 
 
         #. (Ubuntu only) Set Java 11.
@@ -152,6 +152,13 @@ Install ScyllaDB
                :class: hide-copy-button
     
                sudo yum install scylla-5.2.3
+
+(Optional) Install scylla-jmx
+-------------------------------
+
+    scylla-jmx becomes optional package from ScyllaDB 6.2, not installed by default.
+    If you need JMX server, see :doc:`Install scylla-jmx Package </getting-started/install-scylla/install-jmx>`
+
 
 
 .. include:: /getting-started/_common/setup-after-install.rst

--- a/docs/getting-started/installation-common/unified-installer.rst
+++ b/docs/getting-started/installation-common/unified-installer.rst
@@ -50,6 +50,11 @@ Download and Install
 
     ./install.sh --nonroot --python3 ~/scylladb/python3/bin/python3
 
+#. (Optional) Install scylla-jmx
+
+    scylla-jmx becomes optional package from ScyllaDB 6.2, not installed by default.
+    If you need JMX server, see :doc:`Install scylla-jmx Package </getting-started/install-scylla/install-jmx>`
+
 Configure and Run ScyllaDB
 ----------------------------
 

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-6.1-to-6.2/upgrade-guide-from-6.1-to-6.2-generic.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-6.1-to-6.2/upgrade-guide-from-6.1-to-6.2-generic.rst
@@ -171,6 +171,15 @@ You should take note of the current version in case you want to |ROLLBACK|_ the 
                sudo apt-get update
                sudo apt-get dist-upgrade scylla
 
+        #. Remove old scylla-jmx package since the package is not used anymore:
+
+            .. code-block:: console
+
+               sudo apt-get purge scylla-jmx
+
+            scylla-jmx becomes optional package from ScyllaDB 6.2.
+            If you still need JMX server, see :doc:`Install scylla-jmx Package </getting-started/install-scylla/install-jmx>` and get new version.
+
 
         Answer ‘y’ to the first two questions.
 
@@ -183,6 +192,16 @@ You should take note of the current version in case you want to |ROLLBACK|_ the 
 
                sudo yum clean all
                sudo yum update scylla\* -y
+
+        #. Remove old scylla-jmx package since the package is not used anymore:
+
+            .. code:: sh
+
+               sudo yum remove scylla-jmx
+
+            scylla-jmx becomes optional package from ScyllaDB 6.2.
+            If you still need JMX server, see :doc:`Install scylla-jmx Package </getting-started/install-scylla/install-jmx>` and get new version.
+
 
    .. group-tab:: EC2/GCP/Azure Ubuntu Image
 
@@ -201,6 +220,16 @@ You should take note of the current version in case you want to |ROLLBACK|_ the 
                sudo apt-get update
                sudo apt-get dist-upgrade scylla
                sudo apt-get dist-upgrade scylla-machine-image
+
+      #. Remove old scylla-jmx package since the package is not used anymore:
+
+            .. code-block:: console
+
+               sudo apt-get purge scylla-jmx
+
+            scylla-jmx becomes optional package from ScyllaDB 6.2.
+            If you still need JMX server, see :doc:`Install scylla-jmx Package </getting-started/install-scylla/install-jmx>` and get new version.
+
 
       #. Run ``scylla_setup`` without ``running io_setup``.
       #. Run ``sudo /opt/scylladb/scylla-machine-image/scylla_cloud_io_setup``.

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-6.x.y-to-6.x.z.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-6.x.y-to-6.x.z.rst
@@ -215,7 +215,7 @@ Downgrade to the previous release
             .. code-block:: console
                :substitutions:
 
-               sudo apt-get install scylla=|SRC_VERSION|\* scylla-server=|SRC_VERSION|\* scylla-jmx=|SRC_VERSION|\* scylla-tools=|SRC_VERSION|\* scylla-tools-core=|SRC_VERSION|\* scylla-kernel-conf=|SRC_VERSION|\* scylla-conf=|SRC_VERSION|\*
+               sudo apt-get install scylla=|SRC_VERSION|\* scylla-server=|SRC_VERSION|\* scylla-tools=|SRC_VERSION|\* scylla-tools-core=|SRC_VERSION|\* scylla-kernel-conf=|SRC_VERSION|\* scylla-conf=|SRC_VERSION|\*
                sudo apt-get install scylla-machine-image=|SRC_VERSION|\*  # only execute on AMI instance
 
 

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -301,7 +301,6 @@ fi
 umask 0022
 
 ./seastar/install-dependencies.sh
-./tools/jmx/install-dependencies.sh
 ./tools/java/install-dependencies.sh
 
 if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then

--- a/unified/build_unified.sh
+++ b/unified/build_unified.sh
@@ -63,7 +63,7 @@ if [ -z "$UNIFIED_PKG" ]; then
 fi
 UNIFIED_PKG="$(realpath -s $UNIFIED_PKG)"
 if [ -z "$PKGS" ]; then
-    PKGS="$BUILD_DIR/dist/tar/$PRODUCT-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-python3-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-jmx-$VERSION-$RELEASE.noarch.tar.gz $BUILD_DIR/dist/tar/$PRODUCT-tools-$VERSION-$RELEASE.noarch.tar.gz $BUILD_DIR/dist/tar/$PRODUCT-cqlsh-$VERSION-$RELEASE.$(arch).tar.gz"
+    PKGS="$BUILD_DIR/dist/tar/$PRODUCT-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-python3-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-tools-$VERSION-$RELEASE.noarch.tar.gz $BUILD_DIR/dist/tar/$PRODUCT-cqlsh-$VERSION-$RELEASE.$(arch).tar.gz"
 fi
 BASEDIR="$BUILD_DIR/unified/$PRODUCT-$VERSION"
 

--- a/unified/install.sh
+++ b/unified/install.sh
@@ -107,11 +107,6 @@ if ! $skip_systemd_check && [ ! -d /run/systemd/system/ ]; then
     exit 1
 fi
 
-if ! scylla-jmx/select-java -version > /dev/null; then
-    echo "Please install openjdk-8 or openjdk-11 before running install.sh."
-    exit 1
-fi
-
 if [ -z "$prefix" ]; then
     if $nonroot; then
         prefix=~/scylladb
@@ -139,7 +134,6 @@ if [ -z "$python3" ]; then
 fi
 
 scylla_args=()
-jmx_args=()
 args=()
 
 if $housekeeping; then
@@ -147,19 +141,16 @@ if $housekeeping; then
 fi
 if $nonroot; then
     scylla_args+=(--nonroot)
-    jmx_args+=(--nonroot)
     args+=(--nonroot)
 fi
 if $supervisor; then
     scylla_args+=(--supervisor)
-    jmx_args+=(--packaging)
 fi
 if $supervisor_log_to_stdout; then
     scylla_args+=(--supervisor-log-to-stdout)
 fi
 if $without_systemd; then
     scylla_args+=(--without-systemd)
-    jmx_args+=(--without-systemd)
 fi
 if $debuginfo; then
     scylla_args+=(--debuginfo)
@@ -168,8 +159,6 @@ fi
 (cd $(readlink -f scylla); ./install.sh --root "$root" --prefix "$prefix" --python3 "$python3" --sysconfdir "$sysconfdir" ${scylla_args[@]})
 
 (cd $(readlink -f scylla-python3); ./install.sh --root "$root" --prefix "$prefix" ${args[@]})
-
-(cd $(readlink -f scylla-jmx); ./install.sh --root "$root" --prefix "$prefix"  --sysconfdir "$sysconfdir" ${jmx_args[@]})
 
 (cd $(readlink -f scylla-tools); ./install.sh --root "$root" --prefix "$prefix" ${args[@]})
 


### PR DESCRIPTION
Since Java based tools and JMX server are deprecated, drop them from submodule, build system and package definition.

Related scylladb/scylla-tools-java#370
Related #14856