### PR TITLE
configure.py: always rebuild SCYLLA-{PRODUCT,VERSION,RELEASE}-FILE

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2362,7 +2362,7 @@ def write_build_file(f,
           command = {python} configure.py --out=build.ninja.new $configure_args && mv build.ninja.new build.ninja
           generator = 1
           description = CONFIGURE $configure_args
-        build build.ninja {build_ninja_list}: configure | configure.py SCYLLA-VERSION-GEN {args.seastar_path}/CMakeLists.txt
+        build build.ninja {build_ninja_list}: configure | configure.py SCYLLA-VERSION-GEN $builddir/SCYLLA-PRODUCT-FILE $builddir/SCYLLA-VERSION-FILE $builddir/SCYLLA-RELEASE-FILE {args.seastar_path}/CMakeLists.txt
         rule cscope
             command = find -name '*.[chS]' -o -name "*.cc" -o -name "*.hh" | cscope -bq -i-
             description = CSCOPE
@@ -2388,7 +2388,8 @@ def write_build_file(f,
         build always: phony
         rule scylla_version_gen
             command = ./SCYLLA-VERSION-GEN
-        build $builddir/SCYLLA-RELEASE-FILE $builddir/SCYLLA-VERSION-FILE: scylla_version_gen
+            restat = 1
+        build $builddir/SCYLLA-RELEASE-FILE $builddir/SCYLLA-VERSION-FILE: scylla_version_gen | always
         rule debian_files_gen
             command = ./dist/debian/debian_files_gen.py
         build $builddir/debian/debian: debian_files_gen | always


### PR DESCRIPTION
before this change, SCYLLA-{PRODUCT,VERSION,RELEASE}-FILE is generated at the first run of `configure.py`, once these files are around, they are not updated despite that `SCYLLA_VERSION_GEN` does not generate them as long as the release string retrieved from git sha1 is identical the one stored in `SCYLLA-RELEASE-FILE`, because we don't rerun `SCYLLA_VERSION_GEN` at all.

but the pain is, when performing incremental build, like other built artifacts, these generated files stay with the build directory, so even if the sha1 of the workspace changes, the SCYLLA-RELEASE-FILE keeps the same -- it still contains the original git sha1 when it was created. this could leads to confusion if developer or even our CI perform incremental build using the same workspace and build directory, as the built scylla executables always report the same version number.

in this change, we always rebuilt the said
SCYLLA-{PRODUCT,VERSION,RELEASE}-FILE files, and instruct ninja to re-stat the output files, see
https://ninja-build.org/manual.html#ref_rule, in order to avoid unnecessary rebuild. so the downside is that `SCYLLA_VERSION_GEN` is executed every time we run `ninja` even if all targets are updated. but the upside is that the release number reported by scylla is accurate even if we perform incremental build.

also, since we encode the product, version and release stored in the above files in the generated `build.ninja` file, in this change, these three files are added as dependencies of `build.ninja`, so that this file is regenerated if any of them is newer than `build.ninja`.

Fixes #8255