### PR TITLE
compaction: implement unchecked_tombstone_compaction

### DIFF
--- a/compaction/compaction_strategy.hh
+++ b/compaction/compaction_strategy.hh
@@ -30,7 +30,6 @@ class compaction_strategy_impl;
 class sstable;
 class sstable_set;
 struct compaction_descriptor;
-struct resharding_descriptor;
 
 class compaction_strategy {
     ::shared_ptr<compaction_strategy_impl> _compaction_strategy_impl;

--- a/compaction/compaction_strategy_impl.hh
+++ b/compaction/compaction_strategy_impl.hh
@@ -16,7 +16,6 @@
 namespace sstables {
 
 class sstable_set_impl;
-class resharding_descriptor;
 
 class compaction_strategy_impl {
 public:

--- a/compaction/compaction_strategy_impl.hh
+++ b/compaction/compaction_strategy_impl.hh
@@ -23,13 +23,16 @@ public:
     static constexpr float DEFAULT_TOMBSTONE_THRESHOLD = 0.2f;
     // minimum interval needed to perform tombstone removal compaction in seconds, default 86400 or 1 day.
     static constexpr std::chrono::seconds DEFAULT_TOMBSTONE_COMPACTION_INTERVAL() { return std::chrono::seconds(86400); }
+    static constexpr auto DEFAULT_UNCHECKED_TOMBSTONE_COMPACTION = false;
     static constexpr auto TOMBSTONE_THRESHOLD_OPTION = "tombstone_threshold";
     static constexpr auto TOMBSTONE_COMPACTION_INTERVAL_OPTION = "tombstone_compaction_interval";
+    static constexpr auto UNCHECKED_TOMBSTONE_COMPACTION_OPTION = "unchecked_tombstone_compaction";
 protected:
     bool _use_clustering_key_filter = false;
     bool _disable_tombstone_compaction = false;
     float _tombstone_threshold = DEFAULT_TOMBSTONE_THRESHOLD;
     db_clock::duration _tombstone_compaction_interval = DEFAULT_TOMBSTONE_COMPACTION_INTERVAL();
+    bool _unchecked_tombstone_compaction = DEFAULT_UNCHECKED_TOMBSTONE_COMPACTION;
 public:
     static std::optional<sstring> get_value(const std::map<sstring, sstring>& options, const sstring& name);
     static void validate_min_max_threshold(const std::map<sstring, sstring>& options, std::map<sstring, sstring>& unchecked_options);

--- a/docs/cql/compaction.rst
+++ b/docs/cql/compaction.rst
@@ -31,7 +31,8 @@ The following options are available for all compaction strategies.
      'class' : 'compaction_strategy_name', 
      'enabled' : (true | false),
      'tombstone_threshold' : ratio,
-     'tombstone_compaction_interval' : sec}
+     'tombstone_compaction_interval' : sec,
+     'unchecked_tombstone_compaction' : (true | false)}
 
 
 
@@ -62,6 +63,11 @@ The following options are available for all compaction strategies.
 
 ``tombstone_compaction_interval`` (default: 86400s (1 day))
    An SSTable that is suitable for single SSTable compaction, according to tombstone_threshold will not be compacted if it is newer than tombstone_compaction_interval. 
+
+=====
+
+``unchecked_tombstone_compaction`` (default: false)
+   If unchecked_tombstone_compaction is set to true, tombstone_threshold will be ignored, and an SSTable will be compacted according to tombstone_compaction_interval.
 
 =====
 

--- a/docs/troubleshooting/pointless-compactions.rst
+++ b/docs/troubleshooting/pointless-compactions.rst
@@ -60,4 +60,11 @@ For example this will change it to 4 days:
     ALTER table <your table name> with compaction = { 'class' : 'SizeTieredCompactionStrategy', 'tombstone_compaction_interval' : 345600 };
 
 
+2. Make sure `unchecked_tombstone_compaction` is set to false. If it is set to true, `tombstone_threshold` will be ignored,
+and compaction will be run whenever `tombstone_compaction_interval` has elapsed.
+
+.. code-block:: shell
+
+    ALTER table <your table name> with compaction = { 'class' : 'SizeTieredCompactionStrategy', 'unchecked_tombstone_compaction' : false };
+
 .. include:: /troubleshooting/_common/ts-return.rst

--- a/test/cql-pytest/test_compaction_strategy_validation.py
+++ b/test/cql-pytest/test_compaction_strategy_validation.py
@@ -27,6 +27,8 @@ def test_common_options(cql, table1):
     assert_throws(cql, table1, r"tombstone_threshold value \(-0.4\) must be between 0.0 and 1.0|tombstone_threshold must be greater than 0, but was -0.400000", "ALTER TABLE %s WITH compaction = { 'class' : 'SizeTieredCompactionStrategy', 'tombstone_threshold' : -0.4 }")
     assert_throws(cql, table1, r"tombstone_threshold value \(5.5\) must be between 0.0 and 1.0", "ALTER TABLE %s WITH compaction = { 'class' : 'TimeWindowCompactionStrategy', 'tombstone_threshold' : 5.5 }")
     assert_throws(cql, table1, r"tombstone_compaction_interval value \(-7000ms\) must be positive", "ALTER TABLE %s WITH compaction = { 'class' : 'LeveledCompactionStrategy', 'tombstone_compaction_interval' : -7 }")
+    assert_throws(cql, table1, r"unchecked_tombstone_compaction value \(maybe\) must be \"true\" or \"false\"|'unchecked_tombstone_compaction' should be either 'true' or 'false', not 'maybe'", "ALTER TABLE %s WITH compaction = { 'class' : 'LeveledCompactionStrategy', 'unchecked_tombstone_compaction' : 'maybe' }")
+    assert_throws(cql, table1, r"enabled value \(certainly\) must be \"true\" or \"false\"|enabled should either be 'true' or 'false', not certainly", "ALTER TABLE %s WITH compaction = { 'class' : 'LeveledCompactionStrategy', 'enabled' : 'certainly' }")
 
 def test_size_tiered_compaction_strategy_options(cql, table1):
     assert_throws(cql, table1, r"min_sstable_size value \(-1\) must be non negative|min_sstable_size must be non negative: -1", "ALTER TABLE %s WITH compaction = { 'class' : 'SizeTieredCompactionStrategy', 'min_sstable_size' : -1 }")


### PR DESCRIPTION
This change adds the missing Cassandra compaction option unchecked_tombstone_compaction.
Setting this option to true causes the compaction to ignore tombstone_threshold, and decide whether to do a compaction only based on the value of tombstone_compaction_interval

Fixes #1487