### PR TITLE
tools/scylla-nodetool: implement the getsstables and sstableinfo commands

### DIFF
--- a/test/nodetool/rest_api_mock.py
+++ b/test/nodetool/rest_api_mock.py
@@ -7,6 +7,7 @@
 import aiohttp
 import aiohttp.web
 import asyncio
+import contextlib
 import collections
 import json
 import logging
@@ -282,6 +283,16 @@ def set_expected_requests(server, expected_requests):
     payload = json.dumps([r.as_json() for r in expected_requests])
     r = requests.post(f"http://{ip}:{port}/{rest_server.EXPECTED_REQUESTS_PATH}", data=payload)
     r.raise_for_status()
+
+
+@contextlib.contextmanager
+def expected_requests(server, expected_requests):
+    clear_expected_requests(server)
+    set_expected_requests(server, expected_requests)
+    try:
+        yield
+    finally:
+        clear_expected_requests(server)
 
 
 if __name__ == '__main__':

--- a/test/nodetool/test_nodetool.py
+++ b/test/nodetool/test_nodetool.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 
-from rest_api_mock import expected_request, set_expected_requests
+from rest_api_mock import expected_request, expected_requests
 import subprocess
 import utils
 
@@ -70,43 +70,44 @@ def test_nodetool_nonexistent_command(nodetool, scylla_only):
 
 
 def test_global_options_order(nodetool_path, rest_api_mock_server, scylla_only):
-    set_expected_requests(rest_api_mock_server, [
-        expected_request("POST", "/storage_service/compact", multiple=expected_request.MULTIPLE)])
+    with expected_requests(rest_api_mock_server, [
+            expected_request("POST", "/storage_service/compact", multiple=expected_request.MULTIPLE)]):
 
-    ip, port = rest_api_mock_server
-    port = str(port)
+        ip, port = rest_api_mock_server
+        port = str(port)
 
-    subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", port], check=True)
-    subprocess.run([nodetool_path, "nodetool", "-h", ip, "compact", "-p", port], check=True)
-    subprocess.run([nodetool_path, "nodetool", "-h", ip, "-p", port, "compact"], check=True)
+        subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", port], check=True)
+        subprocess.run([nodetool_path, "nodetool", "-h", ip, "compact", "-p", port], check=True)
+        subprocess.run([nodetool_path, "nodetool", "-h", ip, "-p", port, "compact"], check=True)
 
-    # Also add some compatibility args to the mix
-    subprocess.run([nodetool_path, "nodetool", "-h", ip, "-p", port, "-u", "us3r", "compact"], check=True)
-    subprocess.run([nodetool_path, "nodetool", "-h", ip, "-p", port, "compact", "-u", "us3r"], check=True)
+        # Also add some compatibility args to the mix
+        subprocess.run([nodetool_path, "nodetool", "-h", ip, "-p", port, "-u", "us3r", "compact"], check=True)
+        subprocess.run([nodetool_path, "nodetool", "-h", ip, "-p", port, "compact", "-u", "us3r"], check=True)
 
 
 def test_jvm_options(nodetool_path, rest_api_mock_server, scylla_only):
-    set_expected_requests(rest_api_mock_server, [
-        expected_request("POST", "/storage_service/compact", multiple=expected_request.MULTIPLE)])
+    with expected_requests(rest_api_mock_server, [
+            expected_request("POST", "/storage_service/compact", multiple=expected_request.MULTIPLE)]):
 
-    ip, port = rest_api_mock_server
-    port = str(port)
+        ip, port = rest_api_mock_server
+        port = str(port)
 
-    jvm_opt = "-Dcom.sun.jndi.rmiURLParsing=legacy"
+        jvm_opt = "-Dcom.sun.jndi.rmiURLParsing=legacy"
 
-    subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", port, jvm_opt], check=True)
-    subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, jvm_opt, "-p", port], check=True)
-    subprocess.run([nodetool_path, "nodetool", jvm_opt, "compact", "-h", ip, "-p", port], check=True)
+        subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", port, jvm_opt], check=True)
+        subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, jvm_opt, "-p", port], check=True)
+        subprocess.run([nodetool_path, "nodetool", jvm_opt, "compact", "-h", ip, "-p", port], check=True)
 
 
 def test_alternative_api_port(nodetool_path, rest_api_mock_server, scylla_only):
-    set_expected_requests(rest_api_mock_server, [
-        expected_request("POST", "/storage_service/compact", multiple=expected_request.MULTIPLE)])
+    with expected_requests(rest_api_mock_server, [
+            expected_request("POST", "/storage_service/compact", multiple=expected_request.MULTIPLE)]):
 
-    ip, port = rest_api_mock_server
-    port = str(port)
+        ip, port = rest_api_mock_server
+        port = str(port)
 
-    subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", "1", "--rest-api-port", port], check=True)
-    subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", "1", f"--rest-api-port={port}"], check=True)
-    subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", "1", f"-Dcom.scylladb.apiPort={port}"],
-                   check=True)
+        subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", "1", "--rest-api-port", port], check=True)
+        subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", "1", f"--rest-api-port={port}"],
+                       check=True)
+        subprocess.run([nodetool_path, "nodetool", "compact", "-h", ip, "-p", "1", f"-Dcom.scylladb.apiPort={port}"],
+                       check=True)

--- a/test/nodetool/test_sstable.py
+++ b/test/nodetool/test_sstable.py
@@ -1,0 +1,55 @@
+#
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from rest_api_mock import expected_request
+import pytest
+import utils
+
+
+@pytest.mark.parametrize("key_option", (None, "-hf", "--hex-format"))
+def test_getsstables(nodetool, key_option):
+    cmd = ["getsstables", "ks", "tbl", "mykey"]
+    params = {"key": "mykey"}
+    if key_option:
+        cmd.append(key_option)
+        params["format"] = "hex"
+    res = nodetool(*cmd, expected_requests=[
+        expected_request("GET", "/column_family/",
+                         response=[{"ks": "ks", "cf": "tbl", "type": "ColumnFamilies"}]),
+        expected_request(
+            "GET",
+            "/column_family/sstables/by_key/ks:tbl",
+            params=params,
+            response=[
+                "/var/lib/scylla/data/ks/tbl-3ca78460d61611eea0b49524e39553c0/me-3gec_0mu7_5az0024x96bfm476r6-big-Data.db",
+                "/var/lib/scylla/data/ks/tbl-3ca78460d61611eea0b49524e39553c0/me-3gec_0mu7_7bz0024x96bfm476r6-big-Data.db",
+                ]),
+    ])
+    assert res == (
+"""/var/lib/scylla/data/ks/tbl-3ca78460d61611eea0b49524e39553c0/me-3gec_0mu7_5az0024x96bfm476r6-big-Data.db
+/var/lib/scylla/data/ks/tbl-3ca78460d61611eea0b49524e39553c0/me-3gec_0mu7_7bz0024x96bfm476r6-big-Data.db
+""")
+
+
+def test_getsstables_unknown_ks(nodetool, scylla_only):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("getsstables", "unknown_ks", "tbl", "mykey"),
+            {"expected_requests": [expected_request("GET", "/column_family/",
+                                                    response=[{"ks": "ks", "cf": "tbl", "type": "ColumnFamilies"}])]},
+            ["error processing arguments: unknown keyspace: unknown_ks"],
+    )
+
+
+def test_getsstables_unknown_tbl(nodetool):
+    utils.check_nodetool_fails_with(
+            nodetool,
+            ("getsstables", "ks", "unknown_tbl", "mykey"),
+            {"expected_requests": [expected_request("GET", "/column_family/",
+                                                    response=[{"ks": "ks", "cf": "tbl", "type": "ColumnFamilies"}])]},
+            ["error processing arguments: unknown table: unknown_tbl",
+             "ColumnFamilyStore for ks/unknown_tbl not found."]
+    )

--- a/test/nodetool/test_sstable.py
+++ b/test/nodetool/test_sstable.py
@@ -53,3 +53,199 @@ def test_getsstables_unknown_tbl(nodetool):
             ["error processing arguments: unknown table: unknown_tbl",
              "ColumnFamilyStore for ks/unknown_tbl not found."]
     )
+
+
+ks_tbl_sstable_info = {
+  "keyspace": "ks",
+  "table": "tbl",
+  "sstables": [
+    {
+      "size": 5746,
+      "data_size": 90,
+      "index_size": 24,
+      "filter_size": 332,
+      "timestamp": "2024-03-11T08:13:19Z",
+      "generation": "3gec_0mu7_5az0024x96bfm476r6",
+      "level": 0,
+      "version": "me",
+      "extended_properties": [
+        {
+          "group": "compression_parameters",
+          "attributes": [
+            {
+              "key": "sstable_compression",
+              "value": "org.apache.cassandra.io.compress.LZ4Compressor"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "size": 6746,
+      "data_size": 290,
+      "index_size": 124,
+      "filter_size": 232,
+      "timestamp": "2024-03-10T08:13:19Z",
+      "generation": "3gec_0mu7_6bz0024x96bfm476r6",
+      "level": 0,
+      "version": "me",
+      "properties": [
+        {
+          "key": "foo",
+          "value": "bar"
+        }
+      ]
+    }
+  ]
+}
+
+
+ks_tbl2_sstable_info = {
+  "keyspace": "ks",
+  "table": "tbl2",
+  "sstables": [
+    {
+      "size": 5481,
+      "data_size": 44,
+      "index_size": 8,
+      "filter_size": 172,
+      "timestamp": "2024-03-11T08:13:20Z",
+      "generation": "3gec_0mu8_5vrgh24x96bfm476r6",
+      "level": 0,
+      "version": "me",
+      "extended_properties": [
+        {
+          "group": "compression_parameters",
+          "attributes": [
+            {
+              "key": "sstable_compression",
+              "value": "org.apache.cassandra.io.compress.LZ4Compressor"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+
+ks2_tbl_sstable_info = {
+  "keyspace": "ks2",
+  "table": "tbl"
+}
+
+
+def _check_sstableinfo_output(res, info, is_cassandra):
+    lines = res.split('\n')
+    i = 0
+
+    assert lines[i] == ''
+    i += 1
+
+    def split(ln):
+        return tuple(part.strip() for part in ln.split(':'))
+
+    for entry in info:
+        if "sstables" not in entry and is_cassandra:
+            i += 2
+        else:
+            assert split(lines[i]) == ("keyspace", entry["keyspace"])
+            i += 1
+
+            assert split(lines[i]) == ("table", entry["table"])
+            i += 1
+
+        if "sstables" in entry:
+            assert lines[i] == "sstables :"
+            i += 1
+        else:
+            continue
+
+        for index, sstable in enumerate(entry["sstables"]):
+            assert lines[i].lstrip() == f"{index} :"
+            i += 1
+
+            for key in ["data_size", "filter_size", "index_size", "level", "size", "generation", "version",
+                        "timestamp"]:
+                print_key = key.replace("_", " ")
+                if print_key == "timestamp":
+                    parts = split(lines[i])
+                    assert parts[0] == print_key
+                    # Java nodetool does a weird reformatting of the date which I see no sense in replicating
+                    if not is_cassandra:
+                        assert ":".join(parts[1:]) == sstable[key]
+                else:
+                    assert split(lines[i]) == (print_key, str(sstable[key]))
+                i += 1
+
+            if "properties" in sstable:
+                assert lines[i].strip() == "properties :"
+                i += 1
+
+                for prop in sstable["properties"]:
+                    assert split(lines[i]) == (prop["key"], prop["value"])
+                    i += 1
+
+            if "extended_properties" in sstable:
+                assert lines[i].strip() == "extended properties :"
+                i += 1
+
+                for ext_prop in sstable["extended_properties"]:
+                    assert lines[i].strip() == f"{ext_prop['group']} :"
+                    i += 1
+
+                    for attr in ext_prop["attributes"]:
+                        assert split(lines[i]) == (attr["key"], attr["value"])
+                        i += 1
+
+
+def test_sstableinfo(nodetool, request):
+    info = [ks_tbl_sstable_info, ks_tbl2_sstable_info, ks2_tbl_sstable_info]
+    res = nodetool("sstableinfo", expected_requests=[
+        expected_request(
+            "GET",
+            "/storage_service/sstable_info",
+            response=info),
+    ])
+    _check_sstableinfo_output(res, info, request.config.getoption("nodetool") == "cassandra")
+
+
+def test_sstableinfo_keyspace(nodetool, request):
+    info = [ks_tbl_sstable_info, ks_tbl2_sstable_info]
+    res = nodetool("sstableinfo", "ks", expected_requests=[
+        expected_request(
+            "GET",
+            "/storage_service/sstable_info",
+            params={"keyspace": "ks"},
+            response=info),
+    ])
+    _check_sstableinfo_output(res, info, request.config.getoption("nodetool") == "cassandra")
+
+
+def test_sstableinfo_keyspace_table(nodetool, request):
+    info = [ks_tbl_sstable_info]
+    res = nodetool("sstableinfo", "ks", "tbl", expected_requests=[
+        expected_request(
+            "GET",
+            "/storage_service/sstable_info",
+            params={"keyspace": "ks", "cf": "tbl"},
+            response=info),
+    ])
+    _check_sstableinfo_output(res, info, request.config.getoption("nodetool") == "cassandra")
+
+
+def test_sstableinfo_keyspace_tables(nodetool, request):
+    info = [ks_tbl_sstable_info, ks_tbl2_sstable_info]
+    res = nodetool("sstableinfo", "ks", "tbl", "tbl2", expected_requests=[
+        expected_request(
+            "GET",
+            "/storage_service/sstable_info",
+            params={"keyspace": "ks", "cf": "tbl"},
+            response=[ks_tbl_sstable_info]),
+        expected_request(
+            "GET",
+            "/storage_service/sstable_info",
+            params={"keyspace": "ks", "cf": "tbl2"},
+            response=[ks_tbl2_sstable_info]),
+    ])
+    _check_sstableinfo_output(res, info, request.config.getoption("nodetool") == "cassandra")

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -255,6 +255,18 @@ std::vector<sstring> get_keyspaces(scylla_rest_client& client, std::optional<sst
     return keyspaces;
 }
 
+std::map<sstring, std::vector<sstring>> get_ks_to_cfs(scylla_rest_client& client) {
+    auto res = client.get("/column_family/");
+    std::map<sstring, std::vector<sstring>> keyspaces;
+    for (auto& element : res.GetArray()) {
+        const auto& cf_info = element.GetObject();
+        auto ks = rjson::to_string_view(cf_info["ks"]);
+        auto cf = rjson::to_string_view(cf_info["cf"]);
+        keyspaces[sstring(ks)].push_back(sstring(cf));
+    }
+    return keyspaces;
+}
+
 struct keyspace_and_tables {
     sstring keyspace;
     std::vector<sstring> tables;
@@ -837,18 +849,6 @@ void gossipinfo_operation(scylla_rest_client& client, const bpo::variables_map&)
             fmt::print("  {}:{}\n", state, rjson::to_string_view(obj["value"]));
         }
     }
-}
-
-std::map<sstring, std::vector<sstring>> get_ks_to_cfs(scylla_rest_client& client) {
-    auto res = client.get("/column_family/");
-    std::map<sstring, std::vector<sstring>> keyspaces;
-    for (auto& element : res.GetArray()) {
-        const auto& cf_info = element.GetObject();
-        auto ks = rjson::to_string_view(cf_info["ks"]);
-        auto cf = rjson::to_string_view(cf_info["cf"]);
-        keyspaces[sstring(ks)].push_back(sstring(cf));
-    }
-    return keyspaces;
 }
 
 static uint64_t get_off_heap_memory_used(scylla_rest_client& client) {


### PR DESCRIPTION
These commands manage to avoid detection because they are not documented on https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool.html.

They were discovered when running dtests, with ccm tuned to use the native nodetool directly. See https://github.com/scylladb/scylla-ccm/pull/565.

The commands come with tests, which pass with both the native and Java nodetools. I also checked that the relevant dtests pass with the native implementation.