### PR TITLE
docs: document nodetool {getsstables, sstableinfo}

### DIFF
--- a/docs/operating-scylla/nodetool-commands/getsstables.rst
+++ b/docs/operating-scylla/nodetool-commands/getsstables.rst
@@ -1,0 +1,41 @@
+Nodetool getsstables
+====================
+
+**getsstables** ``[-hf | --hex-format] <keyspace> <table> <key>`` - Gets the SStables that contain the given key.
+
+Syntax
+------
+
+.. code-block:: console
+
+   nodetool getsstables [-hf | --hex-format] <keyspace> <table> <key>
+
+Options
+-------
+
+====================================================================  ==================================================================================================================
+Parameter                                                             Description
+====================================================================  ==================================================================================================================
+-hf / --hex-format                                                    Specify the key in hexadecimal string format
+====================================================================  ==================================================================================================================
+
+Examples
+--------
+
+For example:
+
+.. code-block:: shell
+
+   nodetool getsstables ks tbl mykey
+
+Example output:
+
+.. code-block:: shell
+
+   /var/lib/scylla/data/ks/tbl-3ca78460d61611eea0b49524e39553c0/me-3gec_0mu7_5az0024x96bfm476r6-big-Data.db
+   /var/lib/scylla/data/ks/tbl-3ca78460d61611eea0b49524e39553c0/me-3gec_0mu7_7bz0024x96bfm476r6-big-Data.db
+
+See Also
+--------
+
+.. include:: nodetool-index.rst

--- a/docs/operating-scylla/nodetool-commands/sstableinfo.rst
+++ b/docs/operating-scylla/nodetool-commands/sstableinfo.rst
@@ -1,0 +1,73 @@
+Nodetool sstableinfo
+====================
+
+**sstableinfo** ``[<keyspace> <table>...]`` - Gets information about SStables per keyspace/table.
+
+Syntax
+------
+
+.. code-block:: console
+
+   nodetool sstableinfo [<keyspace> <table>...]
+
+Examples
+--------
+
+For example:
+
+.. code-block:: shell
+
+   nodetool sstableinfo
+
+Example output:
+
+.. code-block:: shell
+
+   keyspace : ks
+      table : tbl
+   sstables :
+          0 :
+                 data size : 90
+               filter size : 332
+                index size : 24
+                     level : 0
+                      size : 5746
+                generation : 3gec_0mu7_5az0024x96bfm476r6
+                   version : me
+                 timestamp : 2024-03-11T08:13:19Z
+       extended properties :
+                compression_parameters :
+                           sstable_compression : org.apache.cassandra.io.compress.LZ4Compressor
+          1 :
+                 data size : 290
+               filter size : 232
+                index size : 124
+                     level : 0
+                      size : 6746
+                generation : 3gec_0mu7_6bz0024x96bfm476r6
+                   version : me
+                 timestamp : 2024-03-10T08:13:19Z
+                properties :
+                foo : bar
+   keyspace : ks
+      table : tbl2
+   sstables :
+          0 :
+                 data size : 44
+               filter size : 172
+                index size : 8
+                     level : 0
+                      size : 5481
+                generation : 3gec_0mu8_5vrgh24x96bfm476r6
+                   version : me
+                 timestamp : 2024-03-11T08:13:20Z
+       extended properties :
+                compression_parameters :
+                           sstable_compression : org.apache.cassandra.io.compress.LZ4Compressor
+   keyspace : ks2
+      table : tbl
+
+See Also
+--------
+
+.. include:: nodetool-index.rst

--- a/docs/operating-scylla/nodetool.rst
+++ b/docs/operating-scylla/nodetool.rst
@@ -46,6 +46,7 @@ Nodetool
    nodetool-commands/settraceprobability
    nodetool-commands/setlogginglevel
    nodetool-commands/snapshot
+   nodetool-commands/sstableinfo
    nodetool-commands/statusbackup
    nodetool-commands/statusbinary
    nodetool-commands/statusgossip
@@ -125,6 +126,7 @@ Operations that are not listed below are currently not available.
 * :doc:`setlogginglevel</operating-scylla/nodetool-commands/setlogginglevel>` - sets the logging level threshold for Scylla classes
 * :doc:`settraceprobability </operating-scylla/nodetool-commands/settraceprobability/>` ``<value>`` - Sets the probability for tracing a request. race probability value
 * :doc:`snapshot </operating-scylla/nodetool-commands/snapshot>` :code:`[-t tag] [-cf column_family] <keyspace>`  - Take a snapshot of specified keyspaces or a snapshot of the specified table.
+* :doc:`sstableinfo </operating-scylla/nodetool-commands/sstableinfo>` - Get information about sstables per keyspace/table.
 * :doc:`statusbackup </operating-scylla/nodetool-commands/statusbackup/>` - Status of incremental backup.
 * :doc:`statusbinary </operating-scylla/nodetool-commands/statusbinary/>` - Status of native transport (binary protocol).
 * :doc:`statusgossip </operating-scylla/nodetool-commands/statusgossip/>` - Status of gossip.

--- a/docs/operating-scylla/nodetool.rst
+++ b/docs/operating-scylla/nodetool.rst
@@ -29,6 +29,7 @@ Nodetool
    nodetool-commands/enablegossip
    nodetool-commands/flush
    nodetool-commands/getendpoints
+   nodetool-commands/getsstables
    nodetool-commands/gettraceprobability
    nodetool-commands/gossipinfo
    nodetool-commands/help
@@ -105,6 +106,7 @@ Operations that are not listed below are currently not available.
 * :doc:`flush </operating-scylla/nodetool-commands/flush/>` - Flush one or more column families.
 * :doc:`getendpoints <nodetool-commands/getendpoints/>` :code:`<keyspace>` :code:`<table>` :code:`<key>`- Print the end points that owns the key.
 * **getlogginglevels** - Get the runtime logging levels.
+* :doc:`getsstables </operating-scylla/nodetool-commands/getsstables>` - Print the sstable filenames that own the key.
 * :doc:`gettraceprobability </operating-scylla/nodetool-commands/gettraceprobability>` - Displays the current trace probability value. 0 is disabled 1 is enabled.
 * :doc:`gossipinfo </operating-scylla/nodetool-commands/gossipinfo/>` - Shows the gossip information for the cluster.
 * :doc:`help </operating-scylla/nodetool-commands/help/>` - Display list of available nodetool commands.


### PR DESCRIPTION
these two subcommands are provided by cassandra, and are also implemented natively in scylla. so let's document them.