### PR TITLE
.github: skip "raison" when running codespell workflow

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -13,5 +13,5 @@ jobs:
       - uses: codespell-project/actions-codespell@master
         with:
           only_warn: 1
-          ignore_words_list: "ans,datas,fo,ser,ue,crate,nd,reenable,strat,stap,te"
+          ignore_words_list: "ans,datas,fo,ser,ue,crate,nd,reenable,strat,stap,te,raison"
           skip: "./.git,./build,./tools,*.js,*.thrift,*.lock,./test,./licenses,./redis/lolwut.cc,*.svg"


### PR DESCRIPTION
codespell workflow checks for misspellings to identify common mispellings. it considers "raison" in "raison d'etre" (the accent mark over "e" is removed , so the commit message can be encoded in ASCII), to the misspelling of "reason" or "raisin". apparently, the dictionary it uses does not include les mots francais les plus utilises.

so, in this change, let's ignore "raison" for this very use case, before we start the l10n support of the document.