### PR TITLE
cql3: only provide fmt::formatter for cql3_type::raw for {fmt} < 10

### DIFF
--- a/cql3/cql3_type.hh
+++ b/cql3/cql3_type.hh
@@ -371,9 +371,11 @@ struct fmt::formatter<cql3::cql3_type>: fmt::formatter<std::string_view> {
     }
 };
 
+#if FMT_VERSION < 100000
 template <std::derived_from<cql3::cql3_type::raw> T>
 struct fmt::formatter<T>: fmt::formatter<std::string_view> {
     auto format(const T& t, fmt::format_context& ctx) const {
         return formatter<std::string_view>::format(format_as(t), ctx);
     }
 };
+#endif


### PR DESCRIPTION
since we already have `format_as()` for `cql3_type::raw`, there is no need to provide `cql3_type::raw` if the tree is compiled with {fmt} >= 10, otherwise compiler is not able to figure out which one to match, see the errror at the end of this commit message. so, in this change, we only provide the specialized `fmt::formatter` for `cql3_type::raw` when {fmt} < 10. this should address the FTBFS with {fmt} >= 10.

```
/usr/lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/type_traits:1040:25: error: ambiguous partial specializations of 'formatter<cql3::cql3_type::raw>'
 1040 |       = __bool_constant<__is_constructible(_Tp, _Args...)>;
      |                         ^
/usr/lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/type_traits:1046:16: note: in instantiation of template type alias '__is_constructible_impl' requested here
 1046 |       : public __is_constructible_impl<_Tp, _Args...>
      |                ^
/usr/include/fmt/core.h:1420:13: note: in instantiation of template class 'std::is_constructible<fmt::formatter<cql3::cql3_type::raw>>' requested here
 1420 |            !has_formatter<T, Context>::value))>
      |             ^
/usr/include/fmt/core.h:1421:22: note: while substituting prior template arguments into non-type template parameter [with T = cql3::cql3_type::raw]
 1421 |   FMT_CONSTEXPR auto map(const T&) -> unformattable_pointer {
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1422 |     return {};
      |     ~~~~~~~~~~
 1423 |   }
      |   ~
```

Refs #13245