### PR TITLE
main: Skip tablet metadata loading in maintenance mode

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1501,7 +1501,14 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }).get();
 
             supervisor::notify("loading tablet metadata");
-            ss.local().load_tablet_metadata().get();
+            try {
+                ss.local().load_tablet_metadata().get();
+            } catch (...) {
+                if (!cfg->maintenance_mode()) {
+                    throw;
+                }
+                startlog.error("Failed to load tablet metadata (ignoring due to maintenance mode): {}", std::current_exception());
+            }
 
             // We do not support tablet re-sharding yet, see https://github.com/scylladb/scylladb/issues/16739.
             // To avoid undefined behaviour due to violated assumptions, that


### PR DESCRIPTION
If system.tablets is corrupted, the node would not boot in maintenance mode, which is needed to fix system.tablets.

Skip loading of tablet metadata to allow fixing it.
