### PR TITLE
test/cql-pytest: add --omit-scylla-output to Cassandra test runs

### DIFF
--- a/test/cql-pytest/run
+++ b/test/cql-pytest/run
@@ -31,8 +31,6 @@ if "-h" in sys.argv or "--help" in sys.argv:
     run.run_pytest(sys.path[0], sys.argv)
     exit(0)
 
-run.omit_scylla_output = "--omit-scylla-output" in sys.argv
-
 pid = run.run_with_temporary_dir(cmd)
 ip = run.pid_to_ip(pid)
 

--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -156,7 +156,7 @@ def abort_run_with_dir(pid, tmpdir):
 def abort_run_with_temporary_dir(pid):
     return abort_run_with_dir(pid, pid_to_dir(pid))
 
-omit_scylla_output = False
+omit_scylla_output = "--omit-scylla-output" in sys.argv
 summary=''
 run_pytest_pids = set()
 


### PR DESCRIPTION
Currently, the tests in test/cql-pytest can be run against both ScyllaDB and Cassandra. Running the test for either will first output the test results, and subsequently print the stdout output of the process under test. Using the command line option --omit-scylla-output it is possible to disable this print for Scylla, but it is not possible for tests run against Cassandra.

This change adds the option to suppress output for Cassandra tests, too. By default, the stdout of the Cassandra run will still be printed after the test results, but this can now be disabled with --omit-scylla-output