### PR TITLE
test.py: test_topology_upgrade_basic: make ring_delay_ms nonzero

### DIFF
--- a/test/topology/util.py
+++ b/test/topology/util.py
@@ -12,11 +12,12 @@ import functools
 import operator
 import pytest
 import time
-from cassandra.cluster import Session  # type: ignore # pylint: disable=no-name-in-module
-from cassandra.pool import Host        # type: ignore # pylint: disable=no-name-in-module
+from cassandra.cluster import ConnectionException, ConsistencyLevel, NoHostAvailable, Session  # type: ignore # pylint: disable=no-name-in-module
+from cassandra.pool import Host                          # type: ignore # pylint: disable=no-name-in-module
+from cassandra.util import datetime_from_uuid1           # type: ignore # pylint: disable=no-name-in-module
 from test.pylib.internal_types import ServerInfo, HostID
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, read_barrier, get_available_host
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, read_barrier, get_available_host, unique_name
 
 
 logger = logging.getLogger(__name__)
@@ -241,6 +242,56 @@ async def check_system_topology_and_cdc_generations_v3_consistency(manager: Mana
         # Check that the contents fetched from the current host are the same as for other nodes
         assert topo_results[0] == topo_res
 
+async def start_writes_to_cdc_table(cql: Session, concurrency: int = 3):
+    logger.info(f"Starting to asynchronously write, concurrency = {concurrency}")
+
+    stop_event = asyncio.Event()
+
+    ks_name = unique_name()
+    await cql.run_async(f"CREATE KEYSPACE {ks_name} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}} AND tablets = {{ 'enabled': false }}")
+    await cql.run_async(f"CREATE TABLE {ks_name}.tbl (pk int PRIMARY KEY, v int) WITH cdc = {{'enabled':true}}")
+
+    stmt = cql.prepare(f"INSERT INTO {ks_name}.tbl (pk, v) VALUES (?, 0)")
+    stmt.consistency_level = ConsistencyLevel.ONE
+
+    async def do_writes():
+        iteration = 0
+        while not stop_event.is_set():
+            start_time = time.time()
+            try:
+                await cql.run_async(stmt, [iteration])
+            except NoHostAvailable as e:
+                for _, err in e.errors.items():
+                    # ConnectionException can be raised when the node is shutting down.
+                    if not isinstance(err, ConnectionException):
+                        logger.error(f"Write started {time.time() - start_time}s ago failed: {e}")
+                        raise
+            except Exception as e:
+                logger.error(f"Write started {time.time() - start_time}s ago failed: {e}")
+                raise
+            iteration += 1
+            await asyncio.sleep(0.01)
+
+    tasks = [asyncio.create_task(do_writes()) for _ in range(concurrency)]
+
+    async def verify():
+        generations = await cql.run_async("SELECT * FROM system_distributed.cdc_streams_descriptions_v2")
+
+        stream_to_timestamp = { stream: gen.time for gen in generations for stream in gen.streams}
+
+        cdc_log = await cql.run_async(f"SELECT * FROM {ks_name}.tbl_scylla_cdc_log")
+        for log_entry in cdc_log:
+            assert log_entry.cdc_stream_id in stream_to_timestamp
+            timestamp = stream_to_timestamp[log_entry.cdc_stream_id]
+            assert timestamp <= datetime_from_uuid1(log_entry.cdc_time)
+
+    async def finish_and_verify():
+        logger.info("Stopping write workers")
+        stop_event.set()
+        await asyncio.gather(*tasks)
+        await verify()
+
+    return finish_and_verify
 
 def log_run_time(f):
     @functools.wraps(f)


### PR DESCRIPTION
Test.py uses `ring_delay_ms = 0` by default. CDC creates generation's timestamp by adding `ring_delay_ms` to it.

In this test, nodes are learning about new generations (introduced by upgrade procedure and then by node bootstrap) concurrently with doing writes that should go to these generations.

Because of `ring_delay_ms = 0', the generation could have been committed when it should have already been in use.

This can be seen in the following logs from a node:
```
ERROR 2024-03-22 12:29:55,431 [shard 0:strm] cdc - just learned about a CDC generation newer than the one used the last time streams were retrieved. This generation, or some newer one, should have been used instead (new generation's timestamp: 2024/03/22 12:29:54, last time streams were retrieved: 2024/03/22 12:29:55). The new generation probably arrived too late due to a network partition and we've made a write using the wrong set streams.
```

Creating writes during such a generation can result in assigning them a wrong generation or a failure. Failure may occur if it hits short time window when `generation_service::handle_cdc_generation(cdc::generation_id_v2)` has executed
`svc._cdc_metadata.prepare(...)` but`_cdc_metadata.insert(...)` has not yet been executed. With a nonzero ring_delay_ms it's not a problem, because during this time window, the generation should not be in use.

Write can fail with the following response from a node:
```
cdc: attempted to get a stream from a generation that we know about, but weren't able to retrieve (generation timestamp: 2024/03/22 12:29:54, write timestamp: 2024/03/22 12:29:55). Make sure that the replicas which contain this generation's data are alive and reachable from this node.
```

Set ring_delay_ms to 15000 for the debug mode and 5000 in other modes. Wait for the last generation to be in use and sleep one second to make sure there are writes to the CDC table in this generation.

Fixes #17977

Reapply https://github.com/scylladb/scylladb/commit/b4144d14c62d11ab3870dfb8fa1e7dded479b381.