### PR TITLE
raft topology: decommission: allow only in NORMAL mode

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3443,6 +3443,9 @@ future<> storage_service::decommission() {
     return run_with_api_lock(sstring("decommission"), [] (storage_service& ss) {
         return seastar::async([&ss] {
             ss.check_ability_to_perform_topology_operation("decommission");
+            if (ss._operation_mode != mode::NORMAL) {
+                throw std::runtime_error(::format("Node in {} state; wait for status to become normal or restart", ss._operation_mode));
+            }
             std::exception_ptr leave_group0_ex;
             if (ss.raft_topology_change_enabled()) {
                 ss.raft_decommission().get();
@@ -3478,10 +3481,6 @@ future<> storage_service::decommission() {
                 temp.clear_gently().get();
                 if (num_tokens_after_all_left < 2) {
                     throw std::runtime_error("no other normal nodes in the ring; decommission would be pointless");
-                }
-
-                if (ss._operation_mode != mode::NORMAL) {
-                    throw std::runtime_error(::format("Node in {} state; wait for status to become normal or restart", ss._operation_mode));
                 }
 
                 ss.update_topology_change_info(::format("decommission {}", endpoint)).get();


### PR DESCRIPTION
We move the mode check so that the raft-based decommission also uses
it. Without this check, it hanged after the drain operation instead
of instantly failing. `test_decommission_after_drain_is_invalid` was
failing because of it with the raft-based topology enabled.

Fixes scylladb/scylladb#16761