### PR TITLE
treewide: don't #include "gms/feature_service.hh" from other headers

### DIFF
--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -14,6 +14,7 @@
 #include "locator/token_metadata.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "exceptions/exceptions.hh"
+#include "gms/feature_service.hh"
 
 namespace cql3 {
 

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -12,6 +12,7 @@
 #include "keyspace_metadata.hh"
 #include "schema/schema.hh"
 #include "cql3/util.hh"
+#include "gms/feature_service.hh"
 #include <fmt/core.h>
 #include <ios>
 #include <ostream>

--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -18,7 +18,10 @@
 #include "data_dictionary/user_types_metadata.hh"
 #include "data_dictionary/storage_options.hh"
 #include "data_dictionary/keyspace_element.hh"
-#include "gms/feature_service.hh"
+
+namespace gms {
+class feature_service;
+}
 
 namespace data_dictionary {
 

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -13,7 +13,6 @@
 #include "schema/schema_fwd.hh"
 #include "schema_features.hh"
 #include "utils/hashing.hh"
-#include "gms/feature_service.hh"
 #include "schema_mutations.hh"
 #include "types/map.hh"
 #include "query-result-set.hh"

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -14,7 +14,6 @@
 #include <boost/icl/interval.hpp>
 #include <boost/icl/interval_map.hpp>
 #include "gms/inet_address.hh"
-#include "gms/feature_service.hh"
 #include "locator/snitch_base.hh"
 #include "locator/token_range_splitter.hh"
 #include "dht/token-sharding.hh"
@@ -30,6 +29,10 @@
 namespace replica {
 class database;
 class keyspace;
+}
+
+namespace gms {
+class feature_service;
 }
 
 namespace locator {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -14,6 +14,7 @@
 #include "db/system_keyspace.hh"
 #include "replica/database.hh"
 #include "utils/stall_free.hh"
+#include "gms/feature_service.hh"
 
 #include <algorithm>
 #include <iterator>

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -13,6 +13,7 @@
 #include "streaming/stream_reason.hh"
 #include "gms/inet_address.hh"
 #include "gms/gossiper.hh"
+#include "gms/feature_service.hh"
 #include "message/messaging_service.hh"
 #include "repair/table_check.hh"
 #include "replica/database.hh"

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -66,6 +66,10 @@ class gossiper;
 class feature_service;
 }
 
+namespace db {
+class system_keyspace;
+}
+
 namespace service {
 
 namespace paxos {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -20,6 +20,7 @@
 #include "db/system_keyspace.hh"
 #include "dht/boot_strapper.hh"
 #include "gms/gossiper.hh"
+#include "gms/feature_service.hh"
 #include "locator/tablets.hh"
 #include "locator/token_metadata.hh"
 #include "locator/network_topology_strategy.hh"

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -20,6 +20,7 @@
 #include "types/list.hh"
 #include "utils/throttle.hh"
 #include "test/lib/cql_test_env.hh"
+#include "gms/feature_service.hh"
 
 static bytes random_column_name() {
     return to_bytes(to_hex(make_blob(32)));


### PR DESCRIPTION
feature_service.hh is a high-level header that integrates much of the system functionality, so including it in lower-level headers causes unnecessary rebuilds. Specifically, when retiring features.

Fix by removing feature_service.hh from headers, and supply forward declarations and includes in .cc where needed.