### PR TITLE
Docs: Add link from migration tools page to nodetool refresh load and stream

### DIFF
--- a/docs/operating-scylla/nodetool-commands/refresh.rst
+++ b/docs/operating-scylla/nodetool-commands/refresh.rst
@@ -21,6 +21,8 @@ For example:
 
 ``nodetool refresh nba player_stats``
 
+.. _nodetool-refresh-load-and-stream:
+
 
 Load and Stream
 ---------------

--- a/docs/using-scylla/mig-tool-review.rst
+++ b/docs/using-scylla/mig-tool-review.rst
@@ -6,7 +6,7 @@ The following migration tools are available for migrating to ScyllaDB from compa
 such as Apache Cassandra, or from other Scylla clusters (ScyllaDB Open Source or Enterprise):
 
 * From SSTable to SSTable
-    - Based on ScyllaDB refresh
+    - Using nodetool refresh, :ref:`Load and Stream <nodetool-refresh-load-and-stream>` option.
     - On a large scale, it requires tooling to upload / transfer files from location to location.
 * From SSTable to CQL.
     - :doc:`sstableloader</operating-scylla/admin-tools/sstableloader/>`


### PR DESCRIPTION
Add link from migration tools page to nodetool refresh load and stream

Fix  #17991