### PR TITLE
cql3: statements: change default tombstone_gc mode for tablets

### DIFF
--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -340,7 +340,7 @@ std::pair<schema_builder, std::vector<view_ptr>> alter_table_statement::prepare_
                 throw exceptions::invalid_request_exception(format("The synchronous_updates option is only applicable to materialized views, not to base tables"));
             }
 
-            _properties->apply_to_builder(cfm, std::move(schema_extensions));
+            _properties->apply_to_builder(cfm, std::move(schema_extensions), db, keyspace());
         }
         break;
 

--- a/cql3/statements/alter_view_statement.cc
+++ b/cql3/statements/alter_view_statement.cc
@@ -56,7 +56,7 @@ view_ptr alter_view_statement::prepare_view(data_dictionary::database db) const 
     _properties->validate(db, keyspace(), schema_extensions);
 
     auto builder = schema_builder(schema);
-    _properties->apply_to_builder(builder, std::move(schema_extensions));
+    _properties->apply_to_builder(builder, std::move(schema_extensions), db, keyspace());
 
     if (builder.get_gc_grace_seconds() == 0) {
         throw exceptions::invalid_request_exception(

--- a/cql3/statements/cf_prop_defs.hh
+++ b/cql3/statements/cf_prop_defs.hh
@@ -103,7 +103,7 @@ public:
     std::optional<table_id> get_id() const;
     bool get_synchronous_updates_flag() const;
 
-    void apply_to_builder(schema_builder& builder, schema::extensions_map schema_extensions) const;
+    void apply_to_builder(schema_builder& builder, schema::extensions_map schema_extensions, const data_dictionary::database& db, sstring ks_name) const;
     void validate_minimum_int(const sstring& field, int32_t minimum_value, int32_t default_value) const;
 };
 

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -122,7 +122,7 @@ void create_table_statement::apply_properties_to(schema_builder& builder, const 
         addColumnMetadataFromAliases(cfmd, Collections.singletonList(valueAlias), defaultValidator, ColumnDefinition.Kind.COMPACT_VALUE);
 #endif
 
-    _properties->apply_to_builder(builder, _properties->make_schema_extensions(db.extensions()));
+    _properties->apply_to_builder(builder, _properties->make_schema_extensions(db.extensions()), db, keyspace());
 }
 
 void create_table_statement::add_column_metadata_from_aliases(schema_builder& builder, std::vector<bytes> aliases, const std::vector<data_type>& types, column_kind kind) const

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -345,7 +345,7 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
             db::view::create_virtual_column(builder, def->name(), def->type);
         }
     }
-    _properties.properties()->apply_to_builder(builder, std::move(schema_extensions));
+    _properties.properties()->apply_to_builder(builder, std::move(schema_extensions), db, keyspace());
 
     if (builder.default_time_to_live().count() > 0) {
         throw exceptions::invalid_request_exception(

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -197,6 +197,10 @@ database::real_database() const {
     return _ops->real_database(*this);
 }
 
+replica::database* database::real_database_ptr() const {
+    return _ops->real_database_ptr(*this);
+}
+
 impl::~impl() = default;
 
 keyspace_metadata::keyspace_metadata(std::string_view name,

--- a/data_dictionary/data_dictionary.hh
+++ b/data_dictionary/data_dictionary.hh
@@ -125,6 +125,7 @@ public:
     const db::extensions& extensions() const;
     const gms::feature_service& features() const;
     replica::database& real_database() const; // For transition; remove
+    replica::database* real_database_ptr() const;
 };
 
 }

--- a/data_dictionary/impl.hh
+++ b/data_dictionary/impl.hh
@@ -40,6 +40,7 @@ public:
     virtual const db::extensions& get_extensions(database db) const = 0;
     virtual const gms::feature_service& get_features(database db) const = 0;
     virtual replica::database& real_database(database db) const = 0;
+    virtual replica::database* real_database_ptr(database db) const = 0;
 protected:
     // Tools for type erasing an unerasing
     static database make_database(const impl* i, const void* db) {

--- a/db/config.cc
+++ b/db/config.cc
@@ -1158,7 +1158,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , log_to_stdout(this, "log_to_stdout", value_status::Used)
     , log_to_syslog(this, "log_to_syslog", value_status::Used)
     , _extensions(std::move(exts))
-{}
+{
+    add_tombstone_gc_extension();
+}
 
 db::config::config()
     : config(std::make_shared<db::extensions>())
@@ -1177,6 +1179,10 @@ void db::config::add_per_partition_rate_limit_extension() {
 
 void db::config::add_tags_extension() {
     _extensions->add_schema_extension<db::tags_extension>(db::tags_extension::NAME);
+}
+
+void db::config::add_tombstone_gc_extension() {
+    _extensions->add_schema_extension<tombstone_gc_extension>(tombstone_gc_extension::NAME);
 }
 
 void db::config::setup_directories() {

--- a/db/config.hh
+++ b/db/config.hh
@@ -144,6 +144,7 @@ public:
     void add_cdc_extension();
     void add_per_partition_rate_limit_extension();
     void add_tags_extension();
+    void add_tombstone_gc_extension();
 
     /// True iff the feature is enabled.
     bool check_experimental(experimental_features_t::feature f) const;

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -862,7 +862,8 @@ time may result in the resurrection of deleted data.
 
 The ``tombstone_gc`` option allows you to prevent data resurrection. With the ``repair`` mode configured, :term:`tombstone` 
 are only removed after :term:`repair` is performed. Unlike  ``gc_grace_seconds``, ``tombstone_gc`` has no time constraints - when 
-the ``repair`` mode is on, tombstones garbage collection will wait until repair is run. 
+the ``repair`` mode is on, tombstones garbage collection will wait until repair is run. For tables which use tablets ``repair``
+mode is set by default.
 
 You can enable the after-repair tombstone GC by setting the ``repair`` mode using 
 ``ALTER TABLE`` or ``CREATE TABLE``. For example:

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -208,9 +208,12 @@ so that admin sees the replace as finished after availability was restored.
 ### Impact on repair
 
 When tablet is rebuilt in the background after replace, its primary replica may be on the node which is no
-longer in topology. This means that running repair -pr on all nodes will not repair such a tablet, but it's fine because
-we decided that repair can be optimistic. It's safe with regards to tombstone gc because expiry is decided per table per token range
+longer in topology. This means that running repair -pr on all nodes will not repair such a tablet, but it's safe
+with regards to tombstone gc because by default expiry is decided per table per token range
 based on actual repair time of that range. Unrepaired tablets will not have their token range marked as repaired.
+
+If tombstone gc mode is set to timeout, make sure all tablets are repaired within gc_grace_seconds
+e.g. run full table repair with tablet migration disabled.
 
 # Tablet transitions
 

--- a/replica/data_dictionary_impl.hh
+++ b/replica/data_dictionary_impl.hh
@@ -127,6 +127,9 @@ public:
     virtual replica::database& real_database(data_dictionary::database db) const override {
         return const_cast<replica::database&>(unwrap(db));
     }
+    virtual replica::database* real_database_ptr(data_dictionary::database db) const override {
+        return &real_database(db);
+    }
     virtual schema_ptr get_cdc_base_table(data_dictionary::database db, const schema& s) const override {
         return cdc::get_base_table(unwrap(db), s);
     }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -107,6 +107,7 @@ cql_test_config::cql_test_config(shared_ptr<db::config> cfg)
     db_config->add_cdc_extension();
     db_config->add_per_partition_rate_limit_extension();
     db_config->add_tags_extension();
+    db_config->add_tombstone_gc_extension();
 
     db_config->flush_schema_tables_after_modification.set(false);
     db_config->commitlog_use_o_dsync(false);

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -596,6 +596,9 @@ public:
     virtual replica::database& real_database(data_dictionary::database db) const override {
         throw std::bad_function_call();
     }
+    virtual replica::database* real_database_ptr(data_dictionary::database db) const override {
+        return nullptr;
+    }
 
     virtual ~mock_database_impl() = default;
 };

--- a/test/topology/util.py
+++ b/test/topology/util.py
@@ -20,6 +20,7 @@ from cassandra.util import datetime_from_uuid1           # type: ignore # pylint
 from test.pylib.internal_types import ServerInfo, HostID
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, read_barrier, get_available_host, unique_name
+from contextlib import asynccontextmanager
 
 
 logger = logging.getLogger(__name__)
@@ -388,3 +389,55 @@ async def wait_new_coordinator_elected(manager: ManagerClient, expected_num_of_e
         logger.warning("New coordinator was not elected %s", coordinators_ids)
 
     await wait_for(new_coordinator_elected, deadline=deadline)
+
+@asynccontextmanager
+async def new_test_keyspace(cql, opts):
+    """
+    A utility function for creating a new temporary keyspace with given
+    options. It can be used in a "async with", as:
+        async with new_test_keyspace(cql, '...') as keyspace:
+    """
+    keyspace = unique_name()
+    await cql.run_async("CREATE KEYSPACE " + keyspace + " " + opts)
+    try:
+        yield keyspace
+    finally:
+        await cql.run_async("DROP KEYSPACE " + keyspace)
+
+previously_used_table_names = []
+@asynccontextmanager
+async def new_test_table(cql, keyspace, schema, extra=""):
+    """
+    A utility function for creating a new temporary table with a given schema.
+    Because Scylla becomes slower when a huge number of uniquely-named tables
+    are created and deleted (see https://github.com/scylladb/scylla/issues/7620)
+    we keep here a list of previously used but now deleted table names, and
+    reuse one of these names when possible.
+    This function can be used in a "async with", as:
+       async with create_table(cql, test_keyspace, '...') as table:
+    """
+    global previously_used_table_names
+    if not previously_used_table_names:
+        previously_used_table_names.append(unique_name())
+    table_name = previously_used_table_names.pop()
+    table = keyspace + "." + table_name
+    await cql.run_async("CREATE TABLE " + table + "(" + schema + ")" + extra)
+    try:
+        yield table
+    finally:
+        await cql.run_async("DROP TABLE " + table)
+        previously_used_table_names.append(table_name)
+
+@asynccontextmanager
+async def new_materialized_view(cql, table, select, pk, where, extra=""):
+    """
+    A utility function for creating a new temporary materialized view in
+    an existing table.
+    """
+    keyspace = table.split('.')[0]
+    mv = keyspace + "." + unique_name()
+    await cql.run_async(f"CREATE MATERIALIZED VIEW {mv} AS SELECT {select} FROM {table} WHERE {where} PRIMARY KEY ({pk}) {extra}")
+    try:
+        yield mv
+    finally:
+        await cql.run_async(f"DROP MATERIALIZED VIEW {mv}")

--- a/test/topology_experimental_raft/test_tombstone_gc.py
+++ b/test/topology_experimental_raft/test_tombstone_gc.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import logging
+import pytest
+
+from test.topology.util import new_test_keyspace, new_test_table
+
+logger = logging.getLogger(__name__)
+
+def check_tombstone_gc_mode(cql, table, mode):
+    s = list(cql.execute(f"DESC {table}"))[0].create_statement
+    assert f"'mode': '{mode}'" in s
+
+def get_expected_tombstone_gc_mode(rf, tablets):
+    return "repair" if tablets and rf > 1 else "timeout"
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("rf", [1, 2])
+@pytest.mark.parametrize("tablets", ["true", "false"])
+async def test_default_tombstone_gc(manager, rf, tablets):
+    servers = [await manager.server_add(), await manager.server_add()]
+    cql = manager.cql
+    async with new_test_keyspace(cql, f"with replication = {{ 'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} and tablets = {{'initial': {rf}}}") as keyspace:
+        async with new_test_table(cql, keyspace, "p int primary key, x int") as table:
+            check_tombstone_gc_mode(cql, table, get_expected_tombstone_gc_mode(rf, tablets))
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("rf", [1, 2])
+@pytest.mark.parametrize("tablets", ["true", "false"])
+async def test_default_tombstone_gc_does_not_override(manager, rf, tablets):
+    servers = [await manager.server_add(), await manager.server_add()]
+    cql = manager.cql
+    async with new_test_keyspace(cql, f"with replication = {{ 'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} and tablets = {{'initial': {rf}}}") as keyspace:
+        async with new_test_table(cql, keyspace, "p int primary key, x int", " with tombstone_gc = {'mode': 'disabled'}") as table:
+            await cql.run_async(f"ALTER TABLE {table} add y int")
+            check_tombstone_gc_mode(cql, table, "disabled")

--- a/tombstone_gc.hh
+++ b/tombstone_gc.hh
@@ -71,4 +71,5 @@ public:
     void update_repair_time(table_id id, const dht::token_range& range, gc_clock::time_point repair_time);
 };
 
+std::map<sstring, sstring> get_default_tombstonesonte_gc_mode(data_dictionary::database db, sstring ks_name);
 void validate_tombstone_gc_options(const tombstone_gc_options* options, data_dictionary::database db, sstring ks_name);

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -200,6 +200,9 @@ private:
     virtual replica::database& real_database(data_dictionary::database db) const override {
         throw std::bad_function_call();
     }
+    virtual replica::database* real_database_ptr(data_dictionary::database db) const override {
+        return nullptr;
+    }
 };
 
 class user_types_storage : public data_dictionary::user_types_storage {


### PR DESCRIPTION
Repair may miss some tablets that migrated across nodes.
So if tombstones expire after some timeout, then we can
have data resurrection.

Set default tombstone_gc mode to "repair" for tables which
use tablets (if repair is required).

Fixes: #16627.