### PR TITLE
Docs: Add ignore_dead_nodes_for_replace config param to rebuild-node page v2

### DIFF
--- a/docs/operating-scylla/procedures/cluster-management/rebuild-node.rst
+++ b/docs/operating-scylla/procedures/cluster-management/rebuild-node.rst
@@ -1,19 +1,22 @@
 ============================================
-Rebuild a Node After Losing the Data Volume
+Recover a Node After Losing the Data Volume
 ============================================
 
-When running in Scylla on EC2, it is recommended to use i3 type instances, storing the data on fast, ephemeral SSD drives.
-Stopping the node and starting it for whatever reason means the data on the node is lost.
-This data loss applies not only to i3 type instances but to the i2 type as well.
-The good news is Scylla is a HA database, and replicas of the data are stored on additional nodes.
-This is also why it's highly recommended to use a replication factor of at least three per Data Center (for example, 1 DC, RF = 3, 2 DCs RF = 6).
+When running in Scylla on EC2, it is recommended to use instances with fast, ephemeral SSD drives.
+Stopping and starting the instance for whatever reason means the data on the node is lost.
 
-To recover the data and rebuild the node, follow this procedure:
+The good news is that ScyllaDB is an HA database, and replicas of the data are stored on multiple nodes. 
+This is also why it's highly recommended to use a replication factor of at least three per datacenter, for example, ``replication = {'class': 'NetworkTopologyStrategy', 'DC1' : 3, 'DC2' : 3}``.
+
+The following procedure is a particular use case of :doc:`Replace a Dead Node in a ScyllaDB Cluster Procedure </operating-scylla/procedures/cluster-management/replace-dead-node>`, when a node replaces itself using its previous identity (Host ID) and IP address.
 
 #. Open the ``/etc/scylla/scylla.yaml`` file.
 
-#. Add, if not present, else edit, the ``replace_node_first_boot`` parameter and change it to the
+#. Add, if not present, else edit the ``replace_node_first_boot`` parameter and change it to the
    Host ID of the node before it restarted.
+
+#. If you know of dead nodes in the cluster, for example, from :doc:`nodetool status </operating-scylla/nodetool-commands/status>`, use :ref:`ignore_dead_nodes_for_replace <confprop_ignore_dead_nodes_for_replace>` to list them.
+
 #. Stop Scylla Server
 
    .. include:: /rst_include/scylla-commands-stop-index.rst
@@ -23,6 +26,5 @@ To recover the data and rebuild the node, follow this procedure:
 
    .. include:: /rst_include/scylla-commands-start-index.rst
 
-#. Revert the ``replace_node_first_boot`` setting to what they were before you ran this procedure.
+#. Revert the ``replace_node_first_boot`` and ``ignore_dead_nodes_for_replace`` parameters to what they were before you ran this procedure.
    For ease of use, you can comment out the ``replace_node_first_boot`` parameter.
-


### PR DESCRIPTION
This commit updates the documentation of a node rebuild-node page, recommending to the user to list dead nodes in operation. Dead nodes will not participate in streaming to the rebuild-node.

Fix #17637

v2 of https://github.com/scylladb/scylladb/pull/17645