### PR TITLE
tablets: Introduce substract_sets()

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -98,14 +98,8 @@ tablet_migration_streaming_info get_migration_streaming_info(const locator::topo
     tablet_migration_streaming_info result;
     switch (trinfo.transition) {
         case tablet_transition_kind::migration:
-            result.read_from = std::unordered_set<tablet_replica>(tinfo.replicas.begin(), tinfo.replicas.end());
-            result.written_to = std::unordered_set<tablet_replica>(trinfo.next.begin(), trinfo.next.end());
-            for (auto&& r : trinfo.next) {
-                result.read_from.erase(r);
-            }
-            for (auto&& r : tinfo.replicas) {
-                result.written_to.erase(r);
-            }
+            result.read_from = substract_sets(tinfo.replicas, trinfo.next);
+            result.written_to = substract_sets(trinfo.next, tinfo.replicas);
             return result;
         case tablet_transition_kind::rebuild:
             result.written_to.insert(trinfo.pending_replica);
@@ -123,10 +117,7 @@ tablet_migration_streaming_info get_migration_streaming_info(const locator::topo
 }
 
 tablet_replica get_leaving_replica(const tablet_info& tinfo, const tablet_transition_info& trinfo) {
-    std::unordered_set<tablet_replica> leaving(tinfo.replicas.begin(), tinfo.replicas.end());
-    for (auto&& r : trinfo.next) {
-        leaving.erase(r);
-    }
+    auto leaving = substract_sets(tinfo.replicas, trinfo.next);
     if (leaving.empty()) {
         throw std::runtime_error(format("No leaving replicas"));
     }

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -113,6 +113,17 @@ tablet_replica_set replace_replica(const tablet_replica_set& rs, tablet_replica 
     return result;
 }
 
+/// Substracts 'sub' from 'rs' and returns the result
+/// Replicas from 'sub' that are missing in 'rs' are ignored
+inline
+std::unordered_set<tablet_replica> substract_sets(const tablet_replica_set& rs, const tablet_replica_set& sub) {
+    std::unordered_set<tablet_replica> result(rs.begin(), rs.end());
+    for (auto&& r : sub) {
+        result.erase(r);
+    }
+    return result;
+}
+
 inline
 bool contains(const tablet_replica_set& rs, host_id host) {
     for (auto replica : rs) {


### PR DESCRIPTION
There are several places in code that calculate replica sets associated with specific tablet transision. Having a helper to substract two sets improves code readability.