### PR TITLE
auth: keep auth version in scylla_local

### DIFF
--- a/auth/common.cc
+++ b/auth/common.cc
@@ -41,9 +41,7 @@ constinit const std::string_view AUTH_PACKAGE_NAME("org.apache.cassandra.auth.")
 static logging::logger auth_log("auth");
 
 bool legacy_mode(cql3::query_processor& qp) {
-    return !qp.db().get_config().check_experimental(
-        db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES) ||
-        qp.auth_version <= db::system_auth_keyspace::version_t::v1;
+    return qp.auth_version < db::system_auth_keyspace::version_t::v2;
 }
 
 std::string_view get_auth_ks_name(cql3::query_processor& qp) {

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -199,7 +199,10 @@ future<> service::create_keyspace_if_missing(::service::migration_manager& mm) c
     }
 }
 
-future<> service::start(::service::migration_manager& mm) {
+future<> service::start(::service::migration_manager& mm, db::system_keyspace& sys_ks) {
+    auto auth_version = co_await sys_ks.get_auth_version();
+    // version is set in query processor to be easily available in various places we call auth::legacy_mode check.
+    _qp.auth_version = auth_version;
     if (!_used_by_maintenance_socket) {
         co_await once_among_shards([this, &mm] {
             return create_keyspace_if_missing(mm);
@@ -631,10 +634,11 @@ future<std::vector<permission_details>> list_filtered_permissions(
     });
 }
 
-future<> migrate_to_auth_v2(cql3::query_processor& qp, ::service::raft_group0_client& g0, start_operation_func_t start_operation_func, abort_source& as) {
+future<> migrate_to_auth_v2(db::system_keyspace& sys_ks, ::service::raft_group0_client& g0, start_operation_func_t start_operation_func, abort_source& as) {
     // FIXME: if this function fails it may leave partial data in the new tables
     // that should be cleared
-    auto gen = [&qp] (api::timestamp_type& ts) -> mutations_generator {
+    auto gen = [&sys_ks] (api::timestamp_type& ts) -> mutations_generator {
+        auto& qp = sys_ks.query_processor();
         for (const auto& cf_name : std::vector<sstring>{
                 "roles", "role_members", "role_attributes", "role_permissions"}) {
             schema_ptr schema;
@@ -695,6 +699,8 @@ future<> migrate_to_auth_v2(cql3::query_processor& qp, ::service::raft_group0_cl
                 co_yield std::move(muts[0]);
             }
         }
+        co_yield co_await sys_ks.make_auth_version_mutation(ts,
+                db::system_auth_keyspace::version_t::v2);
     };
     co_await announce_mutations_with_batching(g0,
             start_operation_func,

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -123,7 +123,7 @@ public:
             const service_config&,
             maintenance_socket_enabled);
 
-    future<> start(::service::migration_manager&);
+    future<> start(::service::migration_manager&, db::system_keyspace&);
 
     future<> stop();
 
@@ -316,6 +316,6 @@ future<std::vector<permission_details>> list_filtered_permissions(
         const std::optional<std::pair<resource, recursive_permissions>>& resource_filter);
 
 // Migrates data from old keyspace to new one which supports linearizable writes via raft.
-future<> migrate_to_auth_v2(cql3::query_processor& qp, ::service::raft_group0_client& g0, start_operation_func_t start_operation_func, abort_source& as);
+future<> migrate_to_auth_v2(db::system_keyspace& sys_ks, ::service::raft_group0_client& g0, start_operation_func_t start_operation_func, abort_source& as);
 
 }

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -176,7 +176,7 @@ public:
 
     wasm::manager& wasm() { return _wasm; }
 
-    db::system_auth_keyspace::version_t auth_version = db::system_auth_keyspace::version_t::v1;
+    db::system_auth_keyspace::version_t auth_version;
 
     statements::prepared_statement::checked_weak_ptr get_prepared(const std::optional<auth::authenticated_user>& user, const prepared_cache_key_type& key) {
         if (user) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2668,10 +2668,25 @@ future<std::optional<mutation>> system_keyspace::get_group0_schema_version() {
     return get_scylla_local_mutation(_db, "group0_schema_version");
 }
 
-static constexpr auto SERVICE_LEVELS_VERSION_KEY = "service_level_version";
+static constexpr auto AUTH_VERSION_KEY = "auth_version";
 
-future<std::optional<mutation>> system_keyspace::get_service_levels_version_mutation() {
-    return get_scylla_local_mutation(_db, SERVICE_LEVELS_VERSION_KEY);
+future<system_auth_keyspace::version_t> system_keyspace::get_auth_version() {
+    auto str_opt = co_await get_scylla_local_param(AUTH_VERSION_KEY);
+    if (!str_opt) {
+        co_return db::system_auth_keyspace::version_t::v1;
+    }
+    auto& str = *str_opt;
+    if (str == "" || str == "1") {
+        co_return db::system_auth_keyspace::version_t::v1;
+    }
+    if (str == "2") {
+        co_return db::system_auth_keyspace::version_t::v2;
+    }
+    on_internal_error(slogger, fmt::format("unexpected auth_version in scylla_local got {}", str));
+}
+
+future<std::optional<mutation>> system_keyspace::get_auth_version_mutation() {
+    return get_scylla_local_mutation(_db, AUTH_VERSION_KEY);
 }
 
 static service::query_state& internal_system_query_state() {
@@ -2682,6 +2697,21 @@ static service::query_state& internal_system_query_state() {
     static thread_local service::query_state qs(cs, empty_service_permit());
     return qs;
 };
+
+future<mutation> system_keyspace::make_auth_version_mutation(api::timestamp_type ts, db::system_auth_keyspace::version_t version) {
+    static sstring query = format("INSERT INTO {}.{} (key, value) VALUES (?, ?);", db::system_keyspace::NAME, db::system_keyspace::SCYLLA_LOCAL);
+    auto muts = co_await _qp.get_mutations_internal(query, internal_system_query_state(), ts, {AUTH_VERSION_KEY, std::to_string(int64_t(version))});
+    if (muts.size() != 1) {
+         on_internal_error(slogger, fmt::format("expected 1 auth_version mutation got {}", muts.size()));
+    }
+    co_return std::move(muts[0]);
+}
+
+static constexpr auto SERVICE_LEVELS_VERSION_KEY = "service_level_version";
+
+future<std::optional<mutation>> system_keyspace::get_service_levels_version_mutation() {
+    return get_scylla_local_mutation(_db, SERVICE_LEVELS_VERSION_KEY);
+}
 
 future<mutation> system_keyspace::make_service_levels_version_mutation(int8_t version, const service::group0_guard& guard) {
     static sstring query = format("INSERT INTO {}.{} (key, value) VALUES (?, ?);", db::system_keyspace::NAME, db::system_keyspace::SCYLLA_LOCAL);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -14,6 +14,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include "db/system_auth_keyspace.hh"
 #include "schema/schema_fwd.hh"
 #include "utils/UUID.hh"
 #include "query-result-set.hh"
@@ -574,6 +575,12 @@ public:
     // If the `group0_schema_version` key in `system.scylla_local` is present (either live or tombstone),
     // returns the corresponding mutation. Otherwise returns nullopt.
     future<std::optional<mutation>> get_group0_schema_version();
+
+    // If the `auth_version` key in `system.scylla_local` is present (either live or tombstone),
+    // returns the corresponding mutation. Otherwise returns nullopt.
+    future<std::optional<mutation>> get_auth_version_mutation();
+    future<mutation> make_auth_version_mutation(api::timestamp_type ts, db::system_auth_keyspace::version_t version);
+    future<system_auth_keyspace::version_t> get_auth_version();
 
     future<> sstables_registry_create_entry(sstring location, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc);
     future<> sstables_registry_update_entry_status(sstring location, sstables::generation_type gen, sstring status);

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -926,7 +926,7 @@ private:
 
             _auth_service.start(perm_cache_config, std::ref(_qp), std::ref(group0_client), std::ref(_mnotifier), std::ref(_mm), auth_config, maintenance_socket_enabled::no).get();
             _auth_service.invoke_on_all([this] (auth::service& auth) {
-                return auth.start(_mm.local());
+                return auth.start(_mm.local(), _sys_ks.local());
             }).get();
 
             auto deinit_storage_service_server = defer([this] {


### PR DESCRIPTION
Before the patch selection of auth version depended
on consistent topology feature but during raft recovery
procedure this feature is disabled so we need to persist
the version somewhere to not switch back to v1 as this
is not supported.

During recovery auth works in read-only mode, writes
will fail.

Fixes https://github.com/scylladb/scylladb/issues/17736