### PR TITLE
main: reload service levels data accessor after join_cluster

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1793,13 +1793,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             db.local().enable_autocompaction_toggle();
 
             sl_controller.invoke_on_all([&qp, &group0_client] (qos::service_level_controller& controller) -> future<> {
-                return qos::get_service_level_distributed_data_accessor_for_current_version(
-                    sys_ks.local(),
-                    sys_dist_ks.local(),
-                    qp.local(), group0_client
-                    ).then([&controller] (auto data_accessor) {
-                        controller.set_distributed_data_accessor(std::move(data_accessor));
-                    });
+                return controller.reload_distributed_data_accessor(
+                        qp.local(), group0_client, sys_ks.local(), sys_dist_ks.local());
             }).get();
 
             group0_service.start().get();

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -88,6 +88,15 @@ void service_level_controller::set_distributed_data_accessor(service_level_distr
     }
 }
 
+future<> service_level_controller::reload_distributed_data_accessor(cql3::query_processor& qp, service::raft_group0_client& g0, db::system_keyspace& sys_ks, db::system_distributed_keyspace& sys_dist_ks) {
+    auto accesor = co_await qos::get_service_level_distributed_data_accessor_for_current_version(
+            sys_ks,
+            sys_dist_ks,
+            qp,
+            g0);
+    set_distributed_data_accessor(std::move(accesor));
+}
+
 future<> service_level_controller::drain() {
     if (this_shard_id() != global_controller) {
         co_return;

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -106,6 +106,12 @@ public:
     void set_distributed_data_accessor(service_level_distributed_data_accessor_ptr sl_data_accessor);
 
     /**
+     * Reloads data accessor, this is used to align it with service level version
+     * stored in scylla_local table.
+     */
+    future<> reload_distributed_data_accessor(cql3::query_processor&, service::raft_group0_client&, db::system_keyspace&, db::system_distributed_keyspace&);
+
+    /**
      *  Adds a service level configuration if it doesn't exists, and updates
      *  an the existing one if it does exist.
      *  Handles both, static and non static service level configurations.


### PR DESCRIPTION
Setting data accessor implicitly depends on node joining the cluster
with raft leader elected as only then service level mutation is put
into scylla_local table. Calling it after join_cluster avoids starting
new cluster with older version only to immediately migrate it to the
latest one in the background.
