### PR TITLE
test: auth: remove if not exists from auth cql statement

### DIFF
--- a/test/auth_cluster/test_auth_no_quorum.py
+++ b/test/auth_cluster/test_auth_no_quorum.py
@@ -35,8 +35,7 @@ async def test_auth_no_quorum(manager: ManagerClient) -> None:
     # otherwise it could happen that all users are luckily placed on a single node
     roles = ["r" + unique_name() for _ in range(10)]
     for role in roles:
-        # if not exists due to https://github.com/scylladb/python-driver/issues/296
-        await cql.run_async(f"CREATE ROLE IF NOT EXISTS {role} WITH PASSWORD = '{role}' AND LOGIN = true")
+        await cql.run_async(f"CREATE ROLE {role} WITH PASSWORD = '{role}' AND LOGIN = true")
 
     # auth reads are eventually consistent so we need to sync all nodes
     await asyncio.gather(*(read_barrier(cql, host) for host in hosts))
@@ -71,8 +70,7 @@ async def test_auth_raft_snapshot_transfer(manager: ManagerClient) -> None:
 
     roles = ["ro" + unique_name() for _ in range(10)]
     for role in roles:
-        # if not exists due to https://github.com/scylladb/python-driver/issues/296
-        await cql.run_async(f"CREATE ROLE IF NOT EXISTS {role}")
+        await cql.run_async(f"CREATE ROLE {role}")
 
     await trigger_snapshot(manager, servers[0])
 

--- a/test/auth_cluster/test_auth_raft_command_split.py
+++ b/test/auth_cluster/test_auth_raft_command_split.py
@@ -22,12 +22,11 @@ async def test_auth_raft_command_split(manager: ManagerClient) -> None:
     initial_perms = await cql.run_async("SELECT * FROM system_auth_v2.role_permissions")
 
     shared_role = "shared_role_" + unique_name()
-    await cql.run_async(f"CREATE ROLE IF NOT EXISTS {shared_role}")
+    await cql.run_async(f"CREATE ROLE {shared_role}")
 
     users = ["user_" + unique_name() for _ in range(30)]
     for user in users:
-        # if not exists due to https://github.com/scylladb/python-driver/issues/296
-        await cql.run_async(f"CREATE ROLE IF NOT EXISTS {user}")
+        await cql.run_async(f"CREATE ROLE {user}")
         await cql.run_async(f"GRANT ALL ON ROLE {shared_role} TO {user}")
 
     # this will trigger cascade of deletes which should be packed

--- a/test/auth_cluster/test_auth_v2_migration.py
+++ b/test/auth_cluster/test_auth_v2_migration.py
@@ -117,7 +117,7 @@ async def check_auth_v2_works(manager: ManagerClient, hosts):
     assert len(user1_roles) == 2
     assert set([user1_roles[0].role, user1_roles[1].role]) == set(["users",  "user 1"])
 
-    await cql.run_async("CREATE ROLE IF NOT EXISTS user_after_migration")
+    await cql.run_async("CREATE ROLE user_after_migration")
     await asyncio.gather(*(read_barrier(cql, host) for host in hosts))
     # see warmup_v1_static_values for background about checks below
     # check if it was added to a new table


### PR DESCRIPTION
They were added due to https://github.com/scylladb/python-driver/issues/296 but looks like it no longer reproduces.

Change was tested with ./test.py -vv --repeat=100 test_auth to minimize chance of introducing flakiness.