### PR TITLE
github: sync-labels: fix typo in pull request permissions

### DIFF
--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -26,17 +26,17 @@ jobs:
       - name: Pull request opened event
         if: github.event.action == 'opened'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
         run: python .github/scripts/sync_labels.py --repo ${{ github.repository }} --number ${{ github.event.number }} --action ${{ github.event.action }}
 
       - name: Pull request labeled or unlabeled event
         if: github.event_name == 'pull_request' && startsWith(github.event.label.name, 'backport/')
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
         run: python .github/scripts/sync_labels.py --repo ${{ github.repository }} --number ${{ github.event.number }} --action ${{ github.event.action }} --label ${{ github.event.label.name }}
 
       - name: Issue labeled or unlabeled event
         if: github.event_name == 'issues' && startsWith(github.event.label.name, 'backport/')
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
         run: python .github/scripts/sync_labels.py --repo ${{ github.repository }} --number ${{ github.event.issue.number }} --action ${{ github.event.action }} --is_issue --label ${{ github.event.label.name }}


### PR DESCRIPTION
Reported by @tzach
There was a typo in pull request permissions which caused an  error:
```
Traceback (most recent call last):
  File "/home/runner/work/scylladb/scylladb/.github/scripts/sync_labels.py", line 93, in <module>
    main()
  File "/home/runner/work/scylladb/scylladb/.github/scripts/sync_labels.py", line 89, in main
    sync_labels(repo, args.number, args.label, args.action, args.is_issue)
  File "/home/runner/work/scylladb/scylladb/.github/scripts/sync_labels.py", line 74, in sync_labels
    target.add_to_labels(label)
  File "/usr/lib/python3/dist-packages/github/Issue.py", line 321, in add_to_labels
    headers, data = self._requester.requestJsonAndCheck(
  File "/usr/lib/python3/dist-packages/github/Requester.py", line 353, in requestJsonAndCheck
    return self.__check(
  File "/usr/lib/python3/dist-packages/github/Requester.py", line 378, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.GithubException: 403 {"message": "Resource not accessible by integration", "documentation_url": "https://docs.github.com/rest/issues/labels#add-labels-to-an-issue"}
```

Fixing it