### PR TITLE
mutation: add fmt::formatter for invalid_mutation_fragment_stream

### DIFF
--- a/mutation/mutation_fragment_stream_validator.hh
+++ b/mutation/mutation_fragment_stream_validator.hh
@@ -218,3 +218,13 @@ public:
     void on_end_of_stream();
     mutation_fragment_stream_validator& validator() { return _validator; }
 };
+
+#if FMT_VERSION < 100000
+// fmt v10 introduced formatter for std::exception
+template <>
+struct fmt::formatter<invalid_mutation_fragment_stream> : fmt::formatter<std::string_view> {
+    auto format(const invalid_mutation_fragment_stream& e, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", e.what());
+    }
+};
+#endif


### PR DESCRIPTION
before this change, we rely on the default-generated fmt::formatter created from operator<<. but this depends on the
`FMT_DEPRECATED_OSTREAM` macro which is not respected in {fmt} v10.

this change addresses the formatting with fmtlib < 10, and without `FMT_DEPRECATED_OSTREAM` defined. please note, in {fmt} v10 and up, it defines formatter for classes derived from `std::exception`, so our formatter is only added when compiled with {fmt} < 10.

in this change, `fmt::formatter<invalid_mutation_fragment_stream>` is added for backward compatibility with {fmt} < 10.

Refs scylladb#13245