### PR TITLE
test: changes to prepare for dropping FMT_DEPRECATED_OSTREAM

### DIFF
--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -972,9 +972,9 @@ SEASTAR_THREAD_TEST_CASE(read_max_size) {
                         }
                     } catch (std::runtime_error& e) {
                         if (should_throw) {
-                            testlog.trace("Exception thrown, as expected: {}", e);
+                            testlog.trace("Exception thrown, as expected: {}", e.what());
                         } else {
-                            BOOST_FAIL(fmt::format("Expected no exception, but caught: {}", e));
+                            BOOST_FAIL(fmt::format("Expected no exception, but caught: {}", e.what()));
                         }
                     }
                 }
@@ -1044,7 +1044,7 @@ SEASTAR_THREAD_TEST_CASE(unpaged_mutation_read_global_limit) {
                 BOOST_REQUIRE(size != 0);
                 BOOST_FAIL("Expected exception, but none was thrown.");
             } catch (std::runtime_error& e) {
-                testlog.trace("Exception thrown, as expected: {}", e);
+                testlog.trace("Exception thrown, as expected: {}", e.what());
             }
         }
     }, std::move(cfg)).get();

--- a/test/lib/cql_assertions.cc
+++ b/test/lib/cql_assertions.cc
@@ -38,7 +38,7 @@ rows_assertions::is_empty() {
     auto row_count = rs.size();
     if (row_count != 0) {
         auto&& first_row = *rs.rows().begin();
-        fail(format("Expected no rows, but got {:d}. First row: {}", row_count, fmt::to_string(first_row)));
+        fail(format("Expected no rows, but got {:d}. First row: {}", row_count, first_row));
     }
     return {*this};
 }

--- a/test/unit/radix_tree_stress_test.cc
+++ b/test/unit/radix_tree_stress_test.cc
@@ -41,10 +41,11 @@ public:
     }
 };
 
-std::ostream& operator<<(std::ostream& out, const test_data& d) {
-    out << d.value();
-    return out;
-}
+template <> struct fmt::formatter<test_data> : fmt::formatter<std::string_view> {
+    auto format(const test_data& d, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", d.value());
+    }
+};
 
 using test_tree = tree<test_data>;
 


### PR DESCRIPTION
this series includes test related changes to enable us to drop `FMT_DEPRECATED_OSTREAM` deprecated in {fmt} v10.

Refs #13245
