### PR TITLE
test: nodetool: match with vector printed by {fmt}

### DIFF
--- a/test/nodetool/test_compactionhistory.py
+++ b/test/nodetool/test_compactionhistory.py
@@ -136,4 +136,5 @@ def test_invalid_format(nodetool):
             ("compactionhistory", "-F", "foo"),
             {},
             ["error processing arguments: invalid format foo, valid formats are: {text, json, yaml}",
+             "error processing arguments: invalid format foo, valid formats are: [\"text\", \"json\", \"yaml\"]",
              "nodetool: arguments for -F are json,yaml only."])


### PR DESCRIPTION
our homebrew formatter for std::vector<string> formats like

```
{hello, world}
```

while {fmt}'s formatter for sequence-like container formats like

```
["hello", "world"]
```

since we are moving to {fmt} formatters. and in this context, quoting the verbatim text makes more sense to user. let's support the format used by {fmt} as well.