### PR TITLE
github: sync-labels: fix condition for adding labels

### DIFF
--- a/.github/scripts/sync_labels.py
+++ b/.github/scripts/sync_labels.py
@@ -49,8 +49,9 @@ def get_linked_pr_from_issue_number(repo, number):
 
 def get_linked_issues_based_on_pr_body(repo, number):
     pr = repo.get_pull(number)
-    pattern = fr'Fixes:? (?:#|{repo}#|https://github.com/{repo}/issues/)(\d+)'
-    matches = re.findall(pattern, pr.body)
+    repo_name = repo.full_name
+    pattern = rf"(?:fix(?:|es|ed)|resolve(?:|d|s))\s*:?\s*(?:(?:(?:{repo_name})?#)|https://github\.com/{repo_name}/issues/)(\d+)"
+    matches = re.findall(pattern, pr.body, re.IGNORECASE)
     if not matches:
         raise RuntimeError("No regex matches found in the body!")
     issue_number_from_pr_body = []

--- a/.github/scripts/sync_labels.py
+++ b/.github/scripts/sync_labels.py
@@ -49,14 +49,14 @@ def get_linked_pr_from_issue_number(repo, number):
 
 def get_linked_issues_based_on_pr_body(repo, number):
     pr = repo.get_pull(number)
-    repo_name = repo.full_name
-    pattern = rf"(?:fix(?:|es|ed)|resolve(?:|d|s))\s*:?\s*(?:(?:(?:{repo_name})?#)|https://github\.com/{repo_name}/issues/)(\d+)"
-    matches = re.findall(pattern, pr.body, re.IGNORECASE)
+    pattern = fr'Fixes:? (?:#|{repo}#|https://github.com/{repo}/issues/)(\d+)'
+    matches = re.findall(pattern, pr.body)
+    if not matches:
+        raise RuntimeError("No regex matches found in the body!")
     issue_number_from_pr_body = []
-    if matches:
-        for match in matches:
-            issue_number_from_pr_body.append(match)
-            print(f"Found issue number: {match}")
+    for match in matches:
+        issue_number_from_pr_body.append(match)
+        print(f"Found issue number: {match}")
     return issue_number_from_pr_body
 
 
@@ -70,6 +70,7 @@ def sync_labels(repo, number, label, action, is_issue=False):
             target = repo.get_issue(pr_or_issue_number)
         else:
             target = repo.get_issue(int(pr_or_issue_number))
+        print(pr_or_issue_number)
         if action == 'labeled':
             target.add_to_labels(label)
             print(f"Label '{label}' successfully added.")

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -26,17 +26,17 @@ jobs:
       - name: Pull request opened event
         if: github.event.action == 'opened'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BACKPORTS }}
         run: python .github/scripts/sync_labels.py --repo ${{ github.repository }} --number ${{ github.event.number }} --action ${{ github.event.action }}
 
       - name: Pull request labeled or unlabeled event
         if: github.event_name == 'pull_request' && startsWith(github.event.label.name, 'backport/')
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BACKPORTS }}
         run: python .github/scripts/sync_labels.py --repo ${{ github.repository }} --number ${{ github.event.number }} --action ${{ github.event.action }} --label ${{ github.event.label.name }}
 
       - name: Issue labeled or unlabeled event
         if: github.event_name == 'issues' && startsWith(github.event.label.name, 'backport/')
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BACKPORTS }}
         run: python .github/scripts/sync_labels.py --repo ${{ github.repository }} --number ${{ github.event.issue.number }} --action ${{ github.event.action }} --is_issue --label ${{ github.event.label.name }}


### PR DESCRIPTION
When a labeled/unlabeled action is taking place, we are searching for a `fix/resolve` pattern so we can also update an issue, in case we can't find this ref we skip it.
This condition is wrong, adding the option that incase we don't have any ref to an issue, we will just update the PR


Fixes: https://github.com/scylladb/scylladb/issues/18070