### PR TITLE
chunked_vector: fix use after free in emplace back

### DIFF
--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -43,7 +43,6 @@
 #include "utils/small_vector.hh"
 
 #include <boost/range/algorithm/equal.hpp>
-#include <boost/algorithm/clamp.hpp>
 #include <boost/version.hpp>
 #include <memory>
 #include <type_traits>
@@ -439,7 +438,7 @@ void
 chunked_vector<T, max_contiguous_allocation>::do_reserve_for_push_back() {
     if (_capacity == 0) {
         // allocate a bit of room in case utilization will be low
-        reserve(boost::algorithm::clamp(512 / sizeof(T), 1, max_chunk_capacity()));
+        reserve(std::clamp(512 / sizeof(T), size_t(1), max_chunk_capacity()));
     } else if (_capacity < max_chunk_capacity() / 2) {
         // exponential increase when only one chunk to reduce copying
         reserve(_capacity * 2);

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -73,6 +73,10 @@ public:
     static constexpr size_t max_chunk_capacity() {
         return std::max(max_contiguous_allocation / sizeof(T), size_t(1));
     }
+    // Minimum number of T elements allocated in the first chunk.
+    static constexpr size_t min_chunk_capacity() {
+        return std::clamp(512 / sizeof(T), size_t(1), max_chunk_capacity());
+    }
 private:
     void reserve_for_push_back() {
         if (_size == _capacity) {
@@ -438,7 +442,7 @@ void
 chunked_vector<T, max_contiguous_allocation>::do_reserve_for_push_back() {
     if (_capacity == 0) {
         // allocate a bit of room in case utilization will be low
-        reserve(std::clamp(512 / sizeof(T), size_t(1), max_chunk_capacity()));
+        reserve(min_chunk_capacity());
     } else if (_capacity < max_chunk_capacity() / 2) {
         // exponential increase when only one chunk to reduce copying
         reserve(_capacity * 2);

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -139,14 +139,10 @@ public:
     }
 
     void push_back(const T& x) {
-        reserve_for_push_back();
-        new (addr(_size)) T(x);
-        ++_size;
+        emplace_back(x);
     }
     void push_back(T&& x) {
-        reserve_for_push_back();
-        new (addr(_size)) T(std::move(x));
-        ++_size;
+        emplace_back(std::move(x));
     }
     template <typename... Args>
     T& emplace_back(Args&&... args) {

--- a/utils/lsa/chunked_managed_vector.hh
+++ b/utils/lsa/chunked_managed_vector.hh
@@ -17,7 +17,6 @@
 #include "utils/managed_vector.hh"
 
 #include <boost/range/algorithm/equal.hpp>
-#include <boost/algorithm/clamp.hpp>
 #include <boost/version.hpp>
 #include <type_traits>
 #include <iterator>
@@ -398,7 +397,7 @@ void
 chunked_managed_vector<T>::do_reserve_for_push_back() {
     if (_capacity == 0) {
         // allocate a bit of room in case utilization will be low
-        reserve(boost::algorithm::clamp(512 / sizeof(T), 1, max_chunk_capacity()));
+        reserve(std::clamp(512 / sizeof(T), size_t(1), max_chunk_capacity()));
     } else if (_capacity < max_chunk_capacity() / 2) {
         // exponential increase when only one chunk to reduce copying
         reserve(_capacity * 2);


### PR DESCRIPTION
Currently, push_back or emplace_back reallocate the last chunk
before constructing the new element.

If the arg passed to push_back/emplace_back is a reference to an
existing element in the vector, reallocating the last chunk will
invalidate the arg reference before it is used.

This patch changes the order when reallocating
the last chunk in reserve_for_emplace_back:
First, a new chunk_ptr is allocated.
Then, the back_element is emplaced in the
newly allocated array.
And only then, existing elements in the current
last chunk are migrated to the new chunk.
Eventually, the new chunk replaces the existing chunk.

If no reservation is requried, the back element
is emplaced "in place" in the current last chunk.

Fixes scylladb/scylladb#18072