### PR TITLE
[Backport 5.4] cache_flat_mutation_reader: only call get_iterator_in_latest() when pointing at a row

### DIFF
--- a/cache_flat_mutation_reader.hh
+++ b/cache_flat_mutation_reader.hh
@@ -453,7 +453,10 @@ future<> cache_flat_mutation_reader::read_from_underlying() {
                                 auto e = alloc_strategy_unique_ptr<rows_entry>(
                                     current_allocator().construct<rows_entry>(_ck_ranges_curr->start()->value()));
                                 // Use _next_row iterator only as a hint, because there could be insertions after _upper_bound.
-                                auto insert_result = rows.insert_before_hint(_next_row.get_iterator_in_latest_version(), std::move(e), cmp);
+                                auto insert_result = rows.insert_before_hint(
+                                        _next_row.at_a_row() ? _next_row.get_iterator_in_latest_version() : rows.begin(),
+                                        std::move(e),
+                                        cmp);
                                 if (insert_result.second) {
                                     auto it = insert_result.first;
                                     _snp->tracker()->insert(*it);
@@ -470,7 +473,10 @@ future<> cache_flat_mutation_reader::read_from_underlying() {
                                 auto e = alloc_strategy_unique_ptr<rows_entry>(
                                     current_allocator().construct<rows_entry>(table_s, to_table_domain(_upper_bound), is_dummy::yes, is_continuous::no));
                                 // Use _next_row iterator only as a hint, because there could be insertions after _upper_bound.
-                                auto insert_result = rows.insert_before_hint(_next_row.get_iterator_in_latest_version(), std::move(e), cmp);
+                                auto insert_result = rows.insert_before_hint(
+                                        _next_row.at_a_row() ? _next_row.get_iterator_in_latest_version() : rows.begin(),
+                                        std::move(e),
+                                        cmp);
                                 if (insert_result.second) {
                                     clogger.trace("csm {}: L{}: inserted dummy at {}", fmt::ptr(this), __LINE__, _upper_bound);
                                     _snp->tracker()->insert(*insert_result.first);
@@ -631,7 +637,7 @@ void cache_flat_mutation_reader::maybe_add_to_cache(const clustering_row& cr) {
             current_allocator().construct<rows_entry>(table_schema(), cr.key(), cr.as_deletable_row()));
         new_entry->set_continuous(false);
         new_entry->set_range_tombstone(_current_tombstone);
-        auto it = _next_row.iterators_valid() ? _next_row.get_iterator_in_latest_version()
+        auto it = _next_row.iterators_valid() && _next_row.at_a_row() ? _next_row.get_iterator_in_latest_version()
                                               : mp.clustered_rows().lower_bound(cr.key(), cmp);
         auto insert_result = mp.mutable_clustered_rows().insert_before_hint(it, std::move(new_entry), cmp);
         it = insert_result.first;
@@ -696,7 +702,7 @@ bool cache_flat_mutation_reader::maybe_add_to_cache(const range_tombstone_change
 
         auto new_entry = alloc_strategy_unique_ptr<rows_entry>(
                 current_allocator().construct<rows_entry>(table_schema(), to_table_domain(rtc.position()), is_dummy::yes, is_continuous::no));
-        auto it = _next_row.iterators_valid() ? _next_row.get_iterator_in_latest_version()
+        auto it = _next_row.iterators_valid() && _next_row.at_a_row() ? _next_row.get_iterator_in_latest_version()
                                               : mp.clustered_rows().lower_bound(to_table_domain(rtc.position()), cmp);
         auto insert_result = mp.mutable_clustered_rows().insert_before_hint(it, std::move(new_entry), cmp);
         it = insert_result.first;
@@ -899,7 +905,10 @@ void cache_flat_mutation_reader::move_to_range(query::clustering_row_ranges::con
                     auto& rows = _snp->version()->partition().mutable_clustered_rows();
                     auto new_entry = alloc_strategy_unique_ptr<rows_entry>(current_allocator().construct<rows_entry>(table_schema(),
                             to_table_domain(_lower_bound), is_dummy::yes, is_continuous::no));
-                    return rows.insert_before_hint(_next_row.get_iterator_in_latest_version(), std::move(new_entry), cmp);
+                    return rows.insert_before_hint(
+                            _next_row.at_a_row() ? _next_row.get_iterator_in_latest_version() : rows.begin(),
+                            std::move(new_entry),
+                            cmp);
                 });
                 auto it = insert_result.first;
                 if (insert_result.second) {

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -4737,3 +4737,66 @@ SEASTAR_THREAD_TEST_CASE(test_cache_reader_semaphore_oom_kill) {
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().total_reads_killed_due_to_kill_limit, ++kill_limit_before);
     }
 }
+
+// Reproducer for scylladb/scylladb#18045.
+SEASTAR_THREAD_TEST_CASE(test_reproduce_18045) {
+    auto s = schema_builder("ks", "cf")
+        .with_column("pk", int32_type, column_kind::partition_key)
+        .with_column("ck", int32_type, column_kind::clustering_key)
+        .with_column("v", int32_type)
+        .build();
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    auto make_ck = [&s] (int v) {
+        return clustering_key::from_deeply_exploded(*s, {data_value{v}});
+    };
+
+    auto pk = tests::generate_partition_key(s);
+    auto ck1 = make_ck(1);
+    auto ck2 = make_ck(2);
+    auto ck3 = make_ck(3);
+
+    // In the blocks below, we set up the following state:
+    // 1. Underlying row at ck1, live.
+    // 2. Cache entry at ck2, expired, discontinuous.
+    // 3. Cache entry at ck3, live, continuous.
+
+    auto dt_exp = gc_clock::now() - std::chrono::seconds(s->gc_grace_seconds().count() + 1);
+    mutation m(s, pk);
+    m.set_clustered_cell(ck1, "v", data_value(0), 1);
+    m.partition().apply_delete(*s, ck2, tombstone(1, dt_exp));
+    m.set_clustered_cell(ck3, "v", data_value(0), 1);
+
+    memtable_snapshot_source underlying(s);
+    underlying.apply(m);
+
+    cache_tracker tracker;
+    row_cache cache(s, snapshot_source([&] { return underlying(); }), tracker);
+    cache.populate(m);
+
+    with_allocator(tracker.allocator(), [&] {
+        auto& e = *cache.lookup(pk).partition().version()->partition().clustered_rows().begin();
+        tracker.get_lru().remove(e);
+        e.on_evicted(tracker);
+    });
+
+    // We have set up the desired state.
+    // Now we do a reverse query over the partition.
+    // This query will remove the expired entry at ck2, leaving cursor's _latest_it dangling.
+    // Then, it will populate the cache with ck3.
+    // Before the fix for issue #18045, this caused a (ASAN-triggering) use-after-free,
+    // because _latest_it was deferenced during the population.
+
+    tombstone_gc_state gc_state(nullptr);
+    auto slice = make_legacy_reversed(s, s->full_slice());
+    auto rd = cache.make_reader(
+        s->make_reversed(),
+        semaphore.make_permit(),
+        dht::partition_range::make_singular(pk),
+        slice,
+        nullptr,
+        streamed_mutation::forwarding::no,
+        mutation_reader::forwarding::no,
+        &gc_state);
+    auto close_rd = deferred_close(rd);
+    read_mutation_from_flat_mutation_reader(rd).get();
+}


### PR DESCRIPTION
Calling `_next_row.get_iterator_in_latest()` is illegal when `_next_row` is not pointing at a row. In particular, the iterator returned by such call might be dangling.

We have observed this to cause a use-after-free in the field, when a reverse read called `maybe_add_to_cache` after `_latest_it` was left dangling after a dead row removal in `copy_from_cache_to_buffer`.

To fix this, we should ensure that we only call `_next_row.get_iterator_in_latest` is pointing at a row.

Only the occurrences of this problem in `maybe_add_to_cache` are truly dangerous. As far as I can see, other occurrences can't break anything as of now. But we apply fixes to them anyway.

(cherry picked from commit [04db6d4](https://github.com/scylladb/scylladb/commit/04db6d4bb1af3994293093c8798b534a85fe0f00))

Refs #18046

