### PR TITLE
doc: document the system_auth_v2 feature

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -117,9 +117,15 @@ request. Alternator can then validate the authenticity and authorization of
 each request using a known list of authorized key pairs.
 
 In the current implementation, the user stores the list of allowed key pairs
-in the `system_auth.roles` table: The access key ID is the `role` column, and
+in the `system_auth_v2.roles` table: The access key ID is the `role` column, and
 the secret key is the `salted_hash`, i.e., the secret key can be found by
-`SELECT salted_hash from system_auth.roles WHERE role = ID;`.
+`SELECT salted_hash from system_auth_v2.roles WHERE role = ID;`.
+
+<!--- REMOVE IN FUTURE VERSIONS - Remove the note below in version 6.1 -->
+
+(Note: If you upgraded from version 5.4 to version 6.0 without 
+[enabling consistent topology updates](../upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology.rst), 
+the table name is `system_auth.roles`.)
 
 By default, authorization is not enforced at all. It can be turned on
 by providing an entry in Scylla configuration:

--- a/docs/dev/docker-hub.md
+++ b/docs/dev/docker-hub.md
@@ -341,7 +341,7 @@ The `--authenticator` command lines option allows to provide the authenticator c
 
 #### `--authorizer AUTHORIZER`
 
-The `--authorizer` command lines option allows to provide the authorizer class ScyllaDB will use. By default ScyllaDB uses the `AllowAllAuthorizer` which allows any action to any user. The second option is using the `CassandraAuthorizer` parameter, which stores permissions in `system_auth.permissions` table.
+The `--authorizer` command lines option allows to provide the authorizer class ScyllaDB will use. By default ScyllaDB uses the `AllowAllAuthorizer` which allows any action to any user. The second option is using the `CassandraAuthorizer` parameter, which stores permissions in `system_auth_v2.permissions` table.
 
 **Since: 2.3**
 

--- a/docs/dev/service_levels.md
+++ b/docs/dev/service_levels.md
@@ -6,7 +6,7 @@ There are two system tables that are used to facilitate the service level featur
 ### Service Level Attachment Table
 
 ```
-    CREATE TABLE system_auth.role_attributes (
+    CREATE TABLE system_auth_v2.role_attributes (
     role text,
     attribute_name text,
     attribute_value text,
@@ -23,7 +23,7 @@ So for example in order to find out which `service_level` is attached to role `r
 one can run the following query:
 
 ```
-SELECT * FROM  system_auth.role_attributes WHERE role='r' and attribute_name='service_level'
+SELECT * FROM  system_auth_v2.role_attributes WHERE role='r' and attribute_name='service_level'
 
 ```
 

--- a/docs/operating-scylla/procedures/cluster-management/_common/prereq.rst
+++ b/docs/operating-scylla/procedures/cluster-management/_common/prereq.rst
@@ -3,13 +3,3 @@
 * endpoint_snitch - ``grep endpoint_snitch /etc/scylla/scylla.yaml``
 * Scylla version - ``scylla --version``
 * Authenticator - ``grep authenticator /etc/scylla/scylla.yaml``
-
-.. Note:: 
-
-   If ``authenticator`` is set to ``PasswordAuthenticator`` - increase the replication factor of the ``system_auth`` keyspace.
-
-   For example:
-
-   ``ALTER KEYSPACE system_auth WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'dc1' : <new_replication_factor>};``
-
-   It is recommended to set ``system_auth`` replication factor to the number of nodes in each DC.

--- a/docs/operating-scylla/procedures/cluster-management/_common/system-auth-alter-info.rst
+++ b/docs/operating-scylla/procedures/cluster-management/_common/system-auth-alter-info.rst
@@ -1,0 +1,3 @@
+(Note: If you upgraded from version 5.4 without 
+:doc:`enabling consistent topology updates </upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology>`, 
+you must additionally alter the ``system_auth`` keyspace.)

--- a/docs/operating-scylla/procedures/cluster-management/_common/upgrade-warning-add-new-node-or-dc.rst
+++ b/docs/operating-scylla/procedures/cluster-management/_common/upgrade-warning-add-new-node-or-dc.rst
@@ -17,3 +17,8 @@ limitations while applying the procedure:
   retry, or the node refuses to boot on subsequent attempts, consult the 
   :doc:`Handling Membership Change Failures </operating-scylla/procedures/cluster-management/handling-membership-change-failures>`
   document. 
+* The ``system_auth`` keyspace has not been upgraded to ``system_auth_v2``. 
+  As a result, if ``authenticator`` is set to ``PasswordAuthenticator``, you must 
+  increase the replication factor of the ``system_auth`` keyspace. It is 
+  recommended to set ``system_auth`` replication factor to the number of nodes 
+  in each DC.

--- a/docs/operating-scylla/procedures/cluster-management/add-dc-to-existing-dc.rst
+++ b/docs/operating-scylla/procedures/cluster-management/add-dc-to-existing-dc.rst
@@ -160,7 +160,9 @@ Add New DC
 #. When all nodes are up and running ``ALTER`` the following Keyspaces in the new nodes:
 
    * Keyspace created by the user (which needed to replicate to the new DC).
-   * System: ``system_auth``, ``system_distributed``, ``system_traces`` For example, replicate the data to three nodes in the new DC.
+   * System: ``system_distributed``, ``system_traces``, for example, replicate the data to three nodes in the new DC.
+
+   .. scylladb_include_flag:: system-auth-alter-info.rst
 
    For example:
 
@@ -177,7 +179,6 @@ Add New DC
    .. code-block:: cql
 
       ALTER KEYSPACE mykeyspace WITH replication = { 'class' : 'NetworkTopologyStrategy', '<exiting_dc>' : 3, <new_dc> : 3};
-      ALTER KEYSPACE system_auth WITH replication = { 'class' : 'NetworkTopologyStrategy', '<exiting_dc>' : 3, <new_dc> : 3};
       ALTER KEYSPACE system_distributed WITH replication = { 'class' : 'NetworkTopologyStrategy', '<exiting_dc>' : 3, <new_dc> : 3};
       ALTER KEYSPACE system_traces WITH replication = { 'class' : 'NetworkTopologyStrategy', '<exiting_dc>' : 3, <new_dc> : 3};
 
@@ -187,7 +188,6 @@ Add New DC
 
       DESCRIBE KEYSPACE mykeyspace;
       CREATE KEYSPACE mykeyspace WITH REPLICATION = {'class’: 'NetworkTopologyStrategy', <exiting_dc>:3, <new_dc>: 3};
-      CREATE KEYSPACE system_auth WITH replication = { 'class' : 'NetworkTopologyStrategy', '<exiting_dc>' : 3, <new_dc> : 3};
       CREATE KEYSPACE system_distributed WITH replication = { 'class' : 'NetworkTopologyStrategy', '<exiting_dc>' : 3, <new_dc> : 3};
       CREATE KEYSPACE system_traces WITH replication = { 'class' : 'NetworkTopologyStrategy', '<exiting_dc>' : 3, <new_dc> : 3};
 

--- a/docs/operating-scylla/procedures/cluster-management/update-topology-strategy-from-simple-to-network.rst
+++ b/docs/operating-scylla/procedures/cluster-management/update-topology-strategy-from-simple-to-network.rst
@@ -21,7 +21,9 @@ Alter each Keyspace replication to use ``class : NetworkTopologyStrategy``.
 Alter the following:
 
 * Keyspace created by the user.
-* System: ``system_auth``, ``system_distributed``, ``system_traces``.
+* System: ``system_distributed``, ``system_traces``.
+
+.. scylladb_include_flag:: system-auth-alter-info.rst
 
 For example:
 

--- a/docs/operating-scylla/security/_common/upgrade-note-authentication.rst
+++ b/docs/operating-scylla/security/_common/upgrade-note-authentication.rst
@@ -1,0 +1,3 @@
+.. note::
+
+   If you upgraded your cluster from version 5.4, see :ref:`After Upgrading from 5.4 <authentication-upgrade-info>`.

--- a/docs/operating-scylla/security/_common/upgrade-note-runtime-authentication.rst
+++ b/docs/operating-scylla/security/_common/upgrade-note-runtime-authentication.rst
@@ -1,0 +1,3 @@
+.. note::
+
+   If you upgraded your cluster from version 5.4, see :ref:`After Upgrading from 5.4 <runtime-authentication-upgrade-info>`.

--- a/docs/operating-scylla/security/_common/upgrade-warning-authentication.rst
+++ b/docs/operating-scylla/security/_common/upgrade-warning-authentication.rst
@@ -1,0 +1,20 @@
+
+After Upgrading from 5.4
+----------------------------
+
+The procedure described above applies to clusters where consistent topology updates 
+are enabled. The feature is automatically enabled in new clusters.
+
+If you've upgraded an existing cluster from version 5.4, ensure that you 
+:doc:`manually enabled consistent topology updates </upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology>`.
+Without consistent topology updates enabled, you must take additional steps
+to enable authentication: 
+    
+* Before you start the procedure, set the ``system_auth`` keyspace replication factor 
+  to the number of nodes in the datacenter via cqlsh. It allows you to ensure that
+  the user's information is kept highly available for the cluster. If ``system_auth`` 
+  is not equal to the number of nodes and a node fails, the user whose information 
+  is on that node will be denied access.
+* After you start cqlsh with the default superuser username and password, run 
+  a repair on the ``system_auth`` keyspace on all the nodes in the cluster, for example: 
+  ``nodetool repair -pr system_auth``

--- a/docs/operating-scylla/security/_common/upgrade-warning-runtime-authentication.rst
+++ b/docs/operating-scylla/security/_common/upgrade-warning-runtime-authentication.rst
@@ -1,0 +1,20 @@
+
+After Upgrading from 5.4
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The procedures described above apply to clusters where consistent topology updates 
+are enabled. The feature is automatically enabled in new clusters.
+
+If you've upgraded an existing cluster from version 5.4, ensure that you 
+:doc:`manually enabled consistent topology updates </upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology>`.
+Without consistent topology updates enabled, you must take additional steps
+to enable or disable authentication without downtime: 
+    
+* Before you enable authentication without downtime, set the ``system_auth`` 
+  keyspace replication factor to the number of nodes in the datacenter via cqlsh. 
+  It allows you to ensure that the user's information is kept highly available 
+  for the cluster. If ``system_auth`` is not equal to the number of nodes and 
+  a node fails, the user whose information is on that node will be denied access.
+* After you restart the nodes when you enable or disable authentication without
+  downtime, run repair on the ``system_auth`` keyspace, one node at a time on 
+  all the nodes in the cluster.

--- a/docs/operating-scylla/security/authentication.rst
+++ b/docs/operating-scylla/security/authentication.rst
@@ -1,6 +1,8 @@
 Enable Authentication
 =====================
 
+.. scylladb_include_flag:: upgrade-note-authentication.rst
+
 Authentication is the process where login accounts and their passwords are verified, and the user is allowed access to the database. Authentication is done internally within Scylla and is not done with a third party. Users and passwords are created with roles using a ``CREATE ROLE`` statement. Refer to :doc:`Grant Authorization CQL Reference </operating-scylla/security/authorization>` for details.  
 
 The procedure described below enables Authentication on the Scylla servers. It is intended to be used when you do **not** have applications running with Scylla/Cassandra drivers.
@@ -8,45 +10,6 @@ The procedure described below enables Authentication on the Scylla servers. It i
 .. warning:: Once you enable authentication, all clients (such as applications using Scylla/Apache Cassandra drivers) will **stop working** until they are updated or reconfigured to work with authentication.
 
 If this downtime is not an option, you can follow the instructions in :doc:`Enable and Disable Authentication Without Downtime </operating-scylla/security/runtime-authentication>`, which using a transient state, allows clients to work with or without Authentication at the same time. In this state, you can update the clients (application using Scylla/Apache Cassandra drivers) one at the time. Once all the clients are using Authentication, you can enforce Authentication on all Scylla nodes as well.
-
-Prerequisites
---------------
-Set the ``system_auth`` keyspace replication factor to the number of nodes in the datacenter via cqlsh. It allows you to ensure that 
-the user's information is kept highly available for the cluster. If ``system_auth`` is not equal to the number of nodes
-and a node fails, the user whose information is on that node will be denied access.
-
-For **production environments** use only ``NetworkTopologyStrategy``.
-
-* Single DC (SimpleStrategy)
-
-.. code-block:: cql
-
-   ALTER KEYSPACE system_auth WITH REPLICATION =
-     { 'class' : 'SimpleStrategy', 'replication_factor' : <new_rf> };
-
-For example:
-
-.. code-block:: cql
-
-   ALTER KEYSPACE system_auth WITH REPLICATION =
-     { 'class' : 'SimpleStrategy', 'replication_factor' : 3 };
-
-* Multi - DC (NetworkTopologyStrategy)
-
-.. code-block:: cql
-
-   ALTER KEYSPACE system_auth WITH REPLICATION =
-     {'class' : 'NetworkTopologyStrategy', '<name of DC 1>' : <new RF>, '<name of DC 2>' : <new RF>};
-
-For example:
-
-.. code-block:: cql
-
-   ALTER KEYSPACE system_auth WITH REPLICATION =
-     {'class' : 'NetworkTopologyStrategy', 'dc1' : 3, 'dc2' : 3};
-
-The names of the DCs must match the datacenter names specified in the rack & DC configuration file: ``/etc/scylla/cassandra-rackdc.properties``.
-
 
 Procedure
 ----------
@@ -74,16 +37,11 @@ Procedure
       to ensure security and prevent performance degradation.
       See :doc:`Creating a Custom Superuser </operating-scylla/security/create-superuser/>` for instructions.
 
-#. Run a repair on the ``system_auth`` keyspace on **all** the nodes in the cluster.
-	
-    For example:
-	
-    .. code-block:: none
-	
-       nodetool repair -pr system_auth
+#. If you want to create users and roles, continue to :doc:`Enable Authorization </operating-scylla/security/enable-authorization>`.
 
-6. If you want to create users and roles, continue to :doc:`Enable Authorization </operating-scylla/security/enable-authorization>`.
+.. _authentication-upgrade-info:
 
+.. scylladb_include_flag:: upgrade-warning-authentication.rst
 
 Additional Resources
 --------------------

--- a/docs/operating-scylla/security/runtime-authentication.rst
+++ b/docs/operating-scylla/security/runtime-authentication.rst
@@ -1,6 +1,7 @@
 Enable and Disable Authentication Without Downtime
 ==================================================
 
+.. scylladb_include_flag:: upgrade-note-runtime-authentication.rst
 
 Authentication is the process where login accounts and their passwords are verified, and the user is allowed access into the database. Authentication is done internally within Scylla and is not done with a third party. Users and passwords are created with :doc:`roles </operating-scylla/security/authorization>` using a ``CREATE ROLE`` statement. This procedure enables Authentication on the Scylla servers using a transit state, allowing clients to work with or without Authentication at the same time. In this state, you can update the clients (application using Scylla/Apache Cassandra drivers) one at the time. Once all the clients are using Authentication, you can enforce Authentication on all Scylla nodes as well. If you would rather perform a faster authentication procedure where all clients (application using Scylla/Apache Cassandra drivers) will stop working until they are updated to work with Authentication, refer to :doc:`Enable Authentication </operating-scylla/security/runtime-authentication>`.
 
@@ -10,29 +11,6 @@ Enable Authentication Without Downtime
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This procedure allows you to enable authentication on a live Scylla cluster without downtime.
-
-Prerequisites
--------------
-
-Set the ``system_auth`` keyspace replication factor to the number of nodes in the datacenter and set the class to ``NetworkTopologyStrategy`` (required in production environments):
-
-For example:
-
-* Single DC (NetworkTopologyStrategy)
-
-  .. code-block:: cql
-
-      ALTER KEYSPACE system_auth WITH REPLICATION =
-        { 'class' : 'NetworkTopologyStrategy', '<name of DC>' : <new RF> };
-
-* Multi - DC (NetworkTopologyStrategy)
-
-  .. code-block:: cql
-
-     ALTER KEYSPACE system_auth WITH REPLICATION =
-        {'class' : 'NetworkTopologyStrategy', '<name of DC 1>' : <new RF>, '<name of DC 2>' : <new RF>};
-
-The names of the DCs must match the datacenter names specified in the rack & DC configuration file: ``/etc/scylla/cassandra-rackdc.properties``.
 
 Procedure
 ---------
@@ -95,14 +73,6 @@ Procedure
 
    .. include:: /rst_include/scylla-commands-restart-index.rst
 
-#. Run repair on the ``system_auth`` keyspace, one node at a time on all the nodes in the cluster.
-
-   For example:
-
-   .. code-block:: cql
-
-      nodetool repair system_auth
-
 #. Verify that all the client applications are working correctly with authentication enabled.
                               
 
@@ -136,13 +106,8 @@ Procedure
 
    .. include:: /rst_include/scylla-commands-restart-index.rst
 
-#. Run repair on the ``system_auth`` keyspace, one node at a time on all the nodes in the cluster.
-
-   For example:
-
-   .. code-block:: cql
-
-      nodetool repair system_auth
-
 #. Verify that all the client applications are working correctly with authentication disabled.
 
+.. _runtime-authentication-upgrade-info:
+
+.. scylladb_include_flag:: upgrade-warning-runtime-authentication.rst

--- a/docs/troubleshooting/_common/system-auth-name-info.rst
+++ b/docs/troubleshooting/_common/system-auth-name-info.rst
@@ -1,0 +1,3 @@
+(Note: If you upgraded from version 5.4 without 
+:doc:`enabling consistent topology updates </upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology>`, 
+the keyspace name is ``system_auth``.)

--- a/docs/troubleshooting/password-reset.rst
+++ b/docs/troubleshooting/password-reset.rst
@@ -2,7 +2,9 @@ Reset Authenticator Password
 ============================
 
 This procedure describes what to do when a user loses his password and can not reset it with a superuser role. 
-The procedure requires cluster downtime and as a result, all of the system_auth data is deleted.
+The procedure requires cluster downtime and as a result, all of the ``system_auth_v2`` data is deleted.
+
+.. scylladb_include_flag:: system-auth-name-info.rst
 
 Procedure
 .........
@@ -13,11 +15,11 @@ Procedure
 
    sudo systemctl stop scylla-server
 
-| 2. Remove your tables under ``/var/lib/scylla/data/system_auth/``.
+| 2. Remove your tables under ``/var/lib/scylla/data/system_auth_v2/``.
 
 .. code-block:: shell  
 
-   rm -rf /var/lib/scylla/data/system_auth/
+   rm -rf /var/lib/scylla/data/ssystem_auth_v2/
 
 | 3. Start Scylla nodes.
 

--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology.rst
@@ -32,8 +32,8 @@ Prerequisites
 
     features - Feature SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES is enabled
 
-  Alternatively, this can be checked programmatically by checking whether ``value`` column under the key ``enabled_features`` contains the name of the feature in the ``system.scylla_local`` table.
-  For example, this can be done with the following bash command:
+  Alternatively, this can be verified programmatically by checking whether ``value`` column under the key ``enabled_features`` contains the name of the feature in the ``system.scylla_local`` table.
+  For example, this can be done with the following bash script:
 
   .. code-block:: bash
 
@@ -57,6 +57,9 @@ In particular, you must abstain from:
 * :doc:`Cluster management procedures </operating-scylla/procedures/cluster-management/index>` (adding, replacing, removing, decommissioning nodes etc.).
 * Running :doc:`nodetool repair </operating-scylla/nodetool-commands/repair>`.
 * Running :doc:`nodetool checkAndRepairCdcStreams </operating-scylla/nodetool-commands/checkandrepaircdcstreams>`.
+* Any modifications of :doc:`authentication </operating-scylla/security/authentication>` and :doc:`authorization </operating-scylla/security/enable-authorization>` settings.
+* Any change of authorization via :doc:`CQL API </operating-scylla/security/authorization>`.
+* Doing schema changes.
 
 Running the procedure
 =====================


### PR DESCRIPTION
This PR is V2 of https://github.com/scylladb/scylladb/pull/17951 
I've added the same updates, plus information on how to proceed if consistent topology updates with Raft were not enabled upon upgrade from 5.4.

This PR includes updates related to replacing system_auth with system_auth_v2.

- The keyspace name system_auth is renamed to system_auth_v2.
- The procedures are updated to account for system_auth_v2.
- No longer required system_auth RF changes are removed from procedures.
- The information is added that if the consistent topology updates feature was not enabled upon upgrade from 5.4, there are limitations or additional steps to do (depending on the procedure). The files with that kind of information are to be found in _common folders and included as needed.
- The upgrade guide has been updated to reflect system_auth_v2 and related impacts.

Fixes https://github.com/scylladb/scylladb/issues/17061
Fixes https://github.com/scylladb/scylladb/issues/17718