### PR TITLE
bytes.hh: stop at '}' in fmt::formatter<fmt_hex>

### DIFF
--- a/bytes.hh
+++ b/bytes.hh
@@ -89,7 +89,7 @@ public:
         // get the delimiter if any
         auto it = ctx.begin();
         auto end = ctx.end();
-        if (it != end) {
+        if (it != end && *it != '}') {
             int group_size = *it++ - '0';
             if (group_size < 0 ||
                 static_cast<size_t>(group_size) > sizeof(uint64_t)) {


### PR DESCRIPTION
according to {fmt}'s document at
https://fmt.dev/latest/api.html#formatting-user-defined-types,

```
  // the range will contain "f} continued". The formatter should parse
  // specifiers until '}' or the end of the range. In this example the
  // formatter should parse the 'f' specifier and return an iterator
  // pointing to '}'.
```

so we should check for _both_ '}' and end of the range. when building scylla with {fmt} 10.2.1, it fails to build code like

```c++
fmt::format_to(out, "{}", fmt_hex(frag))
```

as {fmt}'s compile-time checker fails to parse this format string along with given argument, as at compile time,
```c++
throw format_error("invalid group_size")
```
is executed.

so, in this change, we check both '}' and the end of range.

the change which introduced this formatter was 2f9dfba800b81ef1837dc0ce8738522eebf7b196

Refs 2f9dfba800b81ef1837dc0ce8738522eebf7b196