### PR TITLE
Copy tablets

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1565,11 +1565,13 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         auto table_id = ctx.db.local().find_column_family(ks, table).schema()->id();
         auto force_str = req->get_query_param("force");
         auto force = service::loosen_constraints(force_str == "" ? false : validate_bool(force_str));
+        auto copy_str = req->get_query_param("copy");
+        auto copy = service::copy_tablet(copy_str == "" ? false : validate_bool(copy_str));
 
         co_await ss.local().move_tablet(table_id, token,
             locator::tablet_replica{src_host_id, src_shard_id},
             locator::tablet_replica{dst_host_id, dst_shard_id},
-            force);
+            force, copy);
 
         co_return json_void();
     });

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -117,10 +117,10 @@ tablet_migration_streaming_info get_migration_streaming_info(const locator::topo
     on_internal_error(tablet_logger, format("Invalid tablet transition kind: {}", static_cast<int>(trinfo.transition)));
 }
 
-tablet_replica get_leaving_replica(const tablet_info& tinfo, const tablet_transition_info& trinfo) {
+std::optional<tablet_replica> get_leaving_replica(const tablet_info& tinfo, const tablet_transition_info& trinfo) {
     auto leaving = substract_sets(tinfo.replicas, trinfo.next);
     if (leaving.empty()) {
-        throw std::runtime_error(format("No leaving replicas"));
+        return {};
     }
     if (leaving.size() > 1) {
         throw std::runtime_error(format("More than one leaving replica"));

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -217,7 +217,7 @@ struct tablet_transition_info {
 };
 
 // Returns the leaving replica for a given transition.
-tablet_replica get_leaving_replica(const tablet_info&, const tablet_transition_info&);
+std::optional<tablet_replica> get_leaving_replica(const tablet_info&, const tablet_transition_info&);
 
 /// Represents intention to move a single tablet replica from src to dst.
 struct tablet_migration_info {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5695,13 +5695,17 @@ static bool increases_replicas_per_rack(const locator::topology& topology, const
     return m[dst_rack] + 1 > max;
 }
 
-future<> storage_service::move_tablet(table_id table, dht::token token, locator::tablet_replica src, locator::tablet_replica dst, loosen_constraints force) {
+future<> storage_service::move_tablet(table_id table, dht::token token, locator::tablet_replica src, locator::tablet_replica dst, loosen_constraints force, copy_tablet copy) {
     auto holder = _async_gate.hold();
+
+    if (copy) {
+        throw std::runtime_error("Tablet copying not implemented" /* yet */);
+    }
 
     if (this_shard_id() != 0) {
         // group0 is only set on shard 0.
         co_return co_await container().invoke_on(0, [&] (auto& ss) {
-            return ss.move_tablet(table, token, src, dst, force);
+            return ss.move_tablet(table, token, src, dst, force, copy);
         });
     }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5768,8 +5768,10 @@ future<> storage_service::move_tablet(table_id table, dht::token token, locator:
             }
         }
 
+        auto new_replicas = locator::replace_replica(tinfo.replicas, src, dst);
+
         updates.push_back(canonical_mutation(replica::tablet_mutation_builder(guard.write_timestamp(), table)
-            .set_new_replicas(last_token, locator::replace_replica(tinfo.replicas, src, dst))
+            .set_new_replicas(last_token, new_replicas)
             .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
             .set_transition(last_token, locator::tablet_transition_kind::migration)
             .build()));

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5580,12 +5580,12 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
 
         auto& tinfo = tmap.get_tablet_info(tablet.tablet);
         auto range = tmap.get_token_range(tablet.tablet);
-        locator::tablet_replica leaving_replica = locator::get_leaving_replica(tinfo, *trinfo);
-        if (leaving_replica.host == tm->get_my_id()) {
+        std::optional<locator::tablet_replica> leaving_replica = locator::get_leaving_replica(tinfo, *trinfo);
+        if (leaving_replica && leaving_replica->host == tm->get_my_id()) {
             // The algorithm doesn't work with tablet migration within the same node because
             // it assumes there is only one tablet replica, picked by the sharder, on local node.
             throw std::runtime_error(fmt::format("Cannot stream within the same node, tablet: {}, shard {} -> {}",
-                                            tablet, leaving_replica.shard, trinfo->pending_replica.shard));
+                                            tablet, leaving_replica->shard, trinfo->pending_replica.shard));
         }
 
         locator::tablet_migration_streaming_info streaming_info = get_migration_streaming_info(tm->get_topology(), tinfo, *trinfo);
@@ -5661,8 +5661,11 @@ future<> storage_service::cleanup_tablet(locator::global_tablet_id tablet) {
 
             if (trinfo->stage == locator::tablet_transition_stage::cleanup) {
                 auto& tinfo = tmap.get_tablet_info(tablet.tablet);
-                locator::tablet_replica leaving_replica = locator::get_leaving_replica(tinfo, *trinfo);
-                if (leaving_replica.host != tm->get_my_id()) {
+                std::optional<locator::tablet_replica> leaving_replica = locator::get_leaving_replica(tinfo, *trinfo);
+                if (!leaving_replica) {
+                    throw std::runtime_error(fmt::format("Tablet {} has no leaving replica", tablet));
+                }
+                if (leaving_replica->host != tm->get_my_id()) {
                     throw std::runtime_error(fmt::format("Tablet {} has leaving replica different than this one", tablet));
                 }
             } else if (trinfo->stage == locator::tablet_transition_stage::cleanup_target) {
@@ -5697,10 +5700,6 @@ static bool increases_replicas_per_rack(const locator::topology& topology, const
 
 future<> storage_service::move_tablet(table_id table, dht::token token, locator::tablet_replica src, locator::tablet_replica dst, loosen_constraints force, copy_tablet copy) {
     auto holder = _async_gate.hold();
-
-    if (copy) {
-        throw std::runtime_error("Tablet copying not implemented" /* yet */);
-    }
 
     if (this_shard_id() != 0) {
         // group0 is only set on shard 0.
@@ -5772,7 +5771,15 @@ future<> storage_service::move_tablet(table_id table, dht::token token, locator:
             }
         }
 
-        auto new_replicas = locator::replace_replica(tinfo.replicas, src, dst);
+        auto new_replicas = [&] {
+            if (!copy) {
+                return locator::replace_replica(tinfo.replicas, src, dst);
+            }
+
+            locator::tablet_replica_set result(tinfo.replicas);
+            result.push_back(dst);
+            return result;
+        }();
 
         updates.push_back(canonical_mutation(replica::tablet_mutation_builder(guard.write_timestamp(), table)
             .set_new_replicas(last_token, new_replicas)

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -106,6 +106,7 @@ class node_ops_meta_data;
 
 using start_hint_manager = seastar::bool_class<class start_hint_manager_tag>;
 using loosen_constraints = seastar::bool_class<class loosen_constraints_tag>;
+using copy_tablet = seastar::bool_class<class copy_tablet_tag>;
 
 /**
  * This abstraction contains the token/identifier of this node
@@ -855,7 +856,7 @@ private:
     future<> track_upgrade_progress_to_topology_coordinator(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy);
 
 public:
-    future<> move_tablet(table_id, dht::token, locator::tablet_replica src, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
+    future<> move_tablet(table_id, dht::token, locator::tablet_replica src, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no, copy_tablet copy = copy_tablet::no);
     future<> set_tablet_balancing_enabled(bool);
 
     // In the maintenance mode, other nodes won't be available thus we disabled joining

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1139,7 +1139,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     break;
                 case locator::tablet_transition_stage::cleanup:
                     if (advance_in_background(gid, tablet_state.cleanup, "cleanup", [&] {
-                        locator::tablet_replica dst = locator::get_leaving_replica(tmap.get_tablet_info(gid.tablet), trinfo);
+                        auto maybe_dst = locator::get_leaving_replica(tmap.get_tablet_info(gid.tablet), trinfo);
+                        if (!maybe_dst) {
+                            rtlogger.info("Tablet cleanup of {} skipped because no replicas leaving", gid);
+                            return make_ready_future<>();
+                        }
+                        locator::tablet_replica& dst = *maybe_dst;
                         if (is_excluded(raft::server_id(dst.host.uuid()))) {
                             rtlogger.info("Tablet cleanup of {} on {} skipped because node is excluded", gid, dst);
                             return make_ready_future<>();

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -230,7 +230,7 @@ class ScyllaRESTAPIClient():
         await self.client.post(f"/v2/error_injection/injection/{injection}",
                                host=node_ip, params={"one_shot": str(one_shot)}, json={ key: str(value) for key, value in parameters.items() })
 
-    async def move_tablet(self, node_ip: str, ks: str, table: str, src_host: HostID, src_shard: int, dst_host: HostID, dst_shard: int, token: int) -> None:
+    async def move_tablet(self, node_ip: str, ks: str, table: str, src_host: HostID, src_shard: int, dst_host: HostID, dst_shard: int, token: int, copy: bool = False) -> None:
         await self.client.post(f"/storage_service/tablets/move", host=node_ip, params={
             "ks": ks,
             "table": table,
@@ -238,7 +238,8 @@ class ScyllaRESTAPIClient():
             "src_shard": str(src_shard),
             "dst_host": str(dst_host),
             "dst_shard": str(dst_shard),
-            "token": str(token)
+            "token": str(token),
+            "copy": str(copy).lower()
         })
 
     async def enable_tablet_balancing(self, node_ip: str) -> None:

--- a/test/topology_custom/test_tablets_migration.py
+++ b/test/topology_custom/test_tablets_migration.py
@@ -15,8 +15,9 @@ import asyncio
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.parametrize("do_copy", [True, False])
 @pytest.mark.asyncio
-async def test_tablet_migration_sanity(manager: ManagerClient):
+async def test_tablet_migration_sanity(manager: ManagerClient, do_copy):
     logger.info("Bootstrapping cluster")
     cfg = {'enable_user_defined_functions': False, 'experimental_features': ['tablets', 'consistent-topology-changes']}
     host_ids = []
@@ -50,13 +51,18 @@ async def test_tablet_migration_sanity(manager: ManagerClient):
     else:
         assert False, "Cannot find tablet on none of the servers"
 
-    logger.info(f"Copy tablet {old_replica[0]} -> {new_replica[0]}")
-    await manager.api.move_tablet(servers[0].ip_addr, "test", "test", old_replica[0], old_replica[1], new_replica[0], new_replica[1], 0)
+    logger.info(f"{'Copy' if do_copy else 'Move'} tablet {old_replica[0]} -> {new_replica[0]}")
+    await manager.api.move_tablet(servers[0].ip_addr, "test", "test", old_replica[0], old_replica[1], new_replica[0], new_replica[1], 0, copy = do_copy)
 
     replicas = await get_all_tablet_replicas(manager, servers[0], 'test', 'test')
     logger.info(f"Tablet is now on [{replicas}]")
-    assert len(replicas) == 1 and len(replicas[0].replicas) == 1
-    assert replicas[0].replicas[0] == new_replica
+    if do_copy:
+        assert len(replicas) == 1 and len(replicas[0].replicas) == 2
+        reps = [ r[0] for r in replicas[0].replicas ]
+        assert new_replica[0] in reps and old_replica[0] in reps
+    else:
+        assert len(replicas) == 1 and len(replicas[0].replicas) == 1
+        assert replicas[0].replicas[0] == new_replica
 
 
 @pytest.mark.parametrize("fail_replica", ["source", "destination"])

--- a/test/topology_custom/test_tablets_migration.py
+++ b/test/topology_custom/test_tablets_migration.py
@@ -15,6 +15,50 @@ import asyncio
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.asyncio
+async def test_tablet_migration_sanity(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    cfg = {'enable_user_defined_functions': False, 'experimental_features': ['tablets', 'consistent-topology-changes']}
+    host_ids = []
+    servers = []
+
+    async def make_server():
+        s = await manager.server_add(config=cfg)
+        servers.append(s)
+        host_ids.append(await manager.get_host_id(s.server_id))
+        await manager.api.disable_tablet_balancing(s.ip_addr)
+
+    await make_server()
+    await make_server()
+
+    cql = manager.get_cql()
+
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+    keys = range(256)
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+
+    replicas = await get_all_tablet_replicas(manager, servers[0], 'test', 'test')
+    logger.info(f"Tablet is on [{replicas}]")
+    assert len(replicas) == 1 and len(replicas[0].replicas) == 1
+
+    old_replica = replicas[0].replicas[0]
+    if old_replica[0] == host_ids[0]:
+        new_replica = (host_ids[1], 0)
+    elif old_replica[0] == host_ids[1]:
+        new_replica = (host_ids[0], 0)
+    else:
+        assert False, "Cannot find tablet on none of the servers"
+
+    logger.info(f"Copy tablet {old_replica[0]} -> {new_replica[0]}")
+    await manager.api.move_tablet(servers[0].ip_addr, "test", "test", old_replica[0], old_replica[1], new_replica[0], new_replica[1], 0)
+
+    replicas = await get_all_tablet_replicas(manager, servers[0], 'test', 'test')
+    logger.info(f"Tablet is now on [{replicas}]")
+    assert len(replicas) == 1 and len(replicas[0].replicas) == 1
+    assert replicas[0].replicas[0] == new_replica
+
+
 @pytest.mark.parametrize("fail_replica", ["source", "destination"])
 @pytest.mark.parametrize("fail_stage", ["streaming", "allow_write_both_read_old", "write_both_read_old", "write_both_read_new", "use_new", "cleanup", "cleanup_target", "end_migration", "revert_migration"])
 @pytest.mark.asyncio


### PR DESCRIPTION
When altering rf for a keyspace, all tablets in this ks will get more replicas. Part of this process is copying the tablets' data around. This PR extends the tablets transition code to support copying of tablet replica.

fixes: #18030