### PR TITLE
replica: Use flat_hash_map for tablet storage

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -591,6 +591,8 @@ private:
     // Select a compaction group from a given token.
     std::pair<size_t, locator::tablet_range_side> storage_group_of(dht::token token) const noexcept;
     storage_group* storage_group_for_token(dht::token token) const noexcept;
+    // FIXME: Cannot return nullptr, signature can be changed to return storage_group&.
+    storage_group* storage_group_for_id(size_t i) const;
 
     std::unique_ptr<storage_group_manager> make_storage_group_manager();
     // Return compaction group if table owns a single one. Otherwise, null is returned.
@@ -607,7 +609,7 @@ private:
     // Returns a list of all compaction groups.
     compaction_group_list& compaction_groups() const noexcept;
     // Returns a list of all storage groups.
-    const storage_group_vector& storage_groups() const noexcept;
+    const storage_group_map& storage_groups() const noexcept;
     // Safely iterate through compaction groups, while performing async operations on them.
     future<> parallel_foreach_compaction_group(std::function<future<>(compaction_group&)> action);
 


### PR DESCRIPTION
The reason that we want to switch to flat_hash_map is that only a small subset of tablets will be allocated on any given shard, therefore it's wasteful to use a sparse array, and iterations are slow. Also, the map gives greater development flexibility as one doesn't have to worry about empty entries.

perf result:

```
-- reads

scylla_with_chunked_vector-read-no-tablets.txt
median 3185.23 tps (143.9 allocs/op,  41.7 tasks/op, 1376280 insns/op,        0 errors)
median 3188.02 tps (143.9 allocs/op,  41.6 tasks/op, 1375281 insns/op,        0 errors)
median 3174.20 tps (143.9 allocs/op,  41.7 tasks/op, 1376079 insns/op,        0 errors)
median 3176.89 tps (143.9 allocs/op,  41.6 tasks/op, 1376365 insns/op,        0 errors)
median 3180.71 tps (144.0 allocs/op,  41.7 tasks/op, 1375830 insns/op,        0 errors)

scylla_with_hash_map-read-no-tablets.txt
median 3173.52 tps (143.9 allocs/op,  41.6 tasks/op, 1376780 insns/op,        0 errors)
median 3160.90 tps (144.0 allocs/op,  41.7 tasks/op, 1375791 insns/op,        0 errors)
median 3184.74 tps (143.9 allocs/op,  41.6 tasks/op, 1375739 insns/op,        0 errors)
median 3162.45 tps (143.9 allocs/op,  41.7 tasks/op, 1376766 insns/op,        0 errors)
median 3160.08 tps (143.9 allocs/op,  41.7 tasks/op, 1375774 insns/op,        0 errors)

scylla_with_chunked_vector-read-tablets-1.txt
median 3168.02 tps (143.9 allocs/op,  41.7 tasks/op, 1377753 insns/op,        0 errors)
median 3159.93 tps (143.9 allocs/op,  41.6 tasks/op, 1376816 insns/op,        0 errors)
median 3174.50 tps (143.9 allocs/op,  41.7 tasks/op, 1376928 insns/op,        0 errors)
median 3173.73 tps (143.9 allocs/op,  41.7 tasks/op, 1377247 insns/op,        0 errors)
median 3170.43 tps (143.9 allocs/op,  41.6 tasks/op, 1376206 insns/op,        0 errors)

scylla_with_hash_map-read-tablets-1.txt
median 3167.78 tps (143.9 allocs/op,  41.7 tasks/op, 1376271 insns/op,        0 errors)
median 3163.32 tps (143.9 allocs/op,  41.7 tasks/op, 1377433 insns/op,        0 errors)
median 3160.78 tps (143.9 allocs/op,  41.7 tasks/op, 1375723 insns/op,        0 errors)
median 3162.10 tps (143.9 allocs/op,  41.7 tasks/op, 1376536 insns/op,        0 errors)
median 3146.68 tps (143.9 allocs/op,  41.6 tasks/op, 1378097 insns/op,        0 errors)

scylla_with_chunked_vector-read-tablets-128.txt
median 13392.89 tps (143.7 allocs/op,  41.3 tasks/op,  264531 insns/op,        0 errors)
median 13360.79 tps (143.7 allocs/op,  41.3 tasks/op,  264401 insns/op,        0 errors)
median 13330.00 tps (143.7 allocs/op,  41.3 tasks/op,  264645 insns/op,        0 errors)
median 13330.75 tps (143.7 allocs/op,  41.3 tasks/op,  264510 insns/op,        0 errors)
median 13369.72 tps (143.7 allocs/op,  41.3 tasks/op,  264439 insns/op,        0 errors)

scylla_with_hash_map-read-tablets-128.txt
median 13336.14 tps (143.7 allocs/op,  41.3 tasks/op,  264527 insns/op,        0 errors)
median 13316.85 tps (143.7 allocs/op,  41.3 tasks/op,  264661 insns/op,        0 errors)
median 13299.45 tps (143.7 allocs/op,  41.3 tasks/op,  264236 insns/op,        0 errors)
median 13311.89 tps (143.7 allocs/op,  41.3 tasks/op,  264376 insns/op,        0 errors)
median 13330.37 tps (143.7 allocs/op,  41.3 tasks/op,  264541 insns/op,        0 errors)

[1] with 1 or 128 tablets, flat_hash_map provides similar perf as chunked_vector.
```

```
-- writes

scylla_with_chunked_vector-write-no-tablets.txt
median 68635.17 tps ( 58.4 allocs/op,  13.3 tasks/op,   52709 insns/op,        0 errors)
median 68716.36 tps ( 58.4 allocs/op,  13.3 tasks/op,   52691 insns/op,        0 errors)
median 68512.76 tps ( 58.4 allocs/op,  13.3 tasks/op,   52721 insns/op,        0 errors)
median 68606.14 tps ( 58.4 allocs/op,  13.3 tasks/op,   52696 insns/op,        0 errors)
median 68619.25 tps ( 58.4 allocs/op,  13.3 tasks/op,   52697 insns/op,        0 errors)

scylla_with_hash_map-write-no-tablets.txt
median 67678.10 tps ( 58.4 allocs/op,  13.3 tasks/op,   52723 insns/op,        0 errors)
median 67966.06 tps ( 58.4 allocs/op,  13.3 tasks/op,   52736 insns/op,        0 errors)
median 67881.47 tps ( 58.4 allocs/op,  13.3 tasks/op,   52743 insns/op,        0 errors)
median 67856.81 tps ( 58.4 allocs/op,  13.3 tasks/op,   52730 insns/op,        0 errors)
median 67812.58 tps ( 58.4 allocs/op,  13.3 tasks/op,   52740 insns/op,        0 errors)


scylla_with_chunked_vector-write-tablets-1.txt
median 67741.83 tps ( 58.4 allocs/op,  13.3 tasks/op,   53425 insns/op,        0 errors)
median 68014.20 tps ( 58.4 allocs/op,  13.3 tasks/op,   53455 insns/op,        0 errors)
median 68228.48 tps ( 58.4 allocs/op,  13.3 tasks/op,   53447 insns/op,        0 errors)
median 67950.96 tps ( 58.4 allocs/op,  13.3 tasks/op,   53443 insns/op,        0 errors)
median 67832.69 tps ( 58.4 allocs/op,  13.3 tasks/op,   53462 insns/op,        0 errors)

scylla_with_hash_map-write-tablets-1.txt
median 66873.70 tps ( 58.4 allocs/op,  13.3 tasks/op,   53548 insns/op,        0 errors)
median 67568.23 tps ( 58.4 allocs/op,  13.3 tasks/op,   53547 insns/op,        0 errors)
median 67653.70 tps ( 58.4 allocs/op,  13.3 tasks/op,   53525 insns/op,        0 errors)
median 67389.21 tps ( 58.4 allocs/op,  13.3 tasks/op,   53536 insns/op,        0 errors)
median 67437.91 tps ( 58.4 allocs/op,  13.3 tasks/op,   53537 insns/op,        0 errors)


scylla_with_chunked_vector-write-tablets-128.txt
median 67115.41 tps ( 58.3 allocs/op,  13.3 tasks/op,   53341 insns/op,        0 errors)
median 66836.07 tps ( 58.3 allocs/op,  13.3 tasks/op,   53342 insns/op,        0 errors)
median 67214.07 tps ( 58.3 allocs/op,  13.3 tasks/op,   53303 insns/op,        0 errors)
median 67198.25 tps ( 58.3 allocs/op,  13.3 tasks/op,   53347 insns/op,        0 errors)
median 67368.78 tps ( 58.3 allocs/op,  13.3 tasks/op,   53374 insns/op,        0 errors)

scylla_with_hash_map-write-tablets-128.txt
median 66273.50 tps ( 58.3 allocs/op,  13.3 tasks/op,   53400 insns/op,        0 errors)
median 66564.89 tps ( 58.3 allocs/op,  13.3 tasks/op,   53432 insns/op,        0 errors)
median 66568.52 tps ( 58.3 allocs/op,  13.3 tasks/op,   53408 insns/op,        0 errors)
median 66368.00 tps ( 58.3 allocs/op,  13.3 tasks/op,   53441 insns/op,        0 errors)
median 66293.55 tps ( 58.3 allocs/op,  13.3 tasks/op,   53408 insns/op,        0 errors)
```

Fixes #18010.