### PR TITLE
schema: Introduce build() && overload

### DIFF
--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -1343,9 +1343,16 @@ schema_builder& schema_builder::without_indexes() {
     return *this;
 }
 
-schema_ptr schema_builder::build() {
-    schema::raw_schema new_raw = _raw; // Copy so that build() remains idempotent.
+schema_ptr schema_builder::build() && {
+    return build(_raw);
+}
 
+schema_ptr schema_builder::build() & {
+    schema::raw_schema new_raw = _raw; // Copy so that build() remains idempotent.
+    return build(new_raw);
+}
+
+schema_ptr schema_builder::build(schema::raw_schema& new_raw) {
     schema_static_props static_props{};
     for (const auto& c: static_configurators()) {
         c(new_raw._ks_name, new_raw._cf_name, static_props);

--- a/schema/schema_builder.hh
+++ b/schema/schema_builder.hh
@@ -291,8 +291,10 @@ public:
     // Equivalent to with(cp).build()
     schema_ptr build(compact_storage cp);
 
-    schema_ptr build();
+    schema_ptr build() &;
+    schema_ptr build() &&;
 private:
+    schema_ptr build(schema::raw_schema& raw);
     friend class default_names;
     void prepare_dense_schema(schema::raw_schema& raw);
 


### PR DESCRIPTION
The schema_builder::build() method creates a copy of raw schema internaly in a hope that builder will be updated and be asked to build the resulting schema again (e.g. alternator uses this).

However, there are places that build schema using temporary object once in a `return schema_builder().with_...().build()` manner. For those invocations copying raw schema is just waste of cycles.