### PR TITLE
freeze mutations gently

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1001,7 +1001,7 @@ future<> merge_schema(sharded<db::system_keyspace>& sys_ks, distributed<service:
 {
     if (this_shard_id() != 0) {
         // mutations must be applied on the owning shard (0).
-        co_await smp::submit_to(0, coroutine::lambda([&, fmuts = freeze(mutations)] () mutable -> future<> {
+        co_await smp::submit_to(0, coroutine::lambda([&, fmuts = co_await freeze_gently(mutations)] () mutable -> future<> {
             co_await merge_schema(sys_ks, proxy, feat, co_await unfreeze_gently(fmuts), reload);
         }));
         co_return;

--- a/mutation/frozen_mutation.cc
+++ b/mutation/frozen_mutation.cc
@@ -75,21 +75,6 @@ frozen_mutation::frozen_mutation(bytes_ostream&& b, partition_key pk)
     _bytes.reduce_chunk_count();
 }
 
-frozen_mutation::frozen_mutation(const mutation& m)
-    : _pk(m.key())
-{
-    mutation_partition_serializer part_ser(*m.schema(), m.partition());
-
-    ser::writer_of_mutation<bytes_ostream> wom(_bytes);
-    std::move(wom).write_table_id(m.schema()->id())
-                  .write_schema_version(m.schema()->version())
-                  .write_key(m.key())
-                  .partition([&] (auto wr) {
-                      part_ser.write(std::move(wr));
-                  }).end_mutation();
-    _bytes.reduce_chunk_count();
-}
-
 mutation
 frozen_mutation::unfreeze(schema_ptr schema) const {
     check_schema_version(schema_version(), *schema);

--- a/mutation/frozen_mutation.hh
+++ b/mutation/frozen_mutation.hh
@@ -232,6 +232,11 @@ public:
 
 frozen_mutation freeze(const mutation& m);
 std::vector<frozen_mutation> freeze(const std::vector<mutation>&);
+// Caller is responsible for keeping the argument stable in memory
+// freeze_gently may yield only between mutations, threfore it's suitable for
+// a long vector of short mutations.
+future<std::vector<frozen_mutation>> freeze_gently(const std::vector<mutation>&);
+
 std::vector<mutation> unfreeze(const std::vector<frozen_mutation>&);
 // Caller is responsible for keeping the argument stable in memory
 future<std::vector<mutation>> unfreeze_gently(std::span<frozen_mutation>);

--- a/mutation/frozen_mutation.hh
+++ b/mutation/frozen_mutation.hh
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <seastar/core/thread.hh>
+
 #include "dht/i_partitioner.hh"
 #include "replica/database_fwd.hh"
 #include "mutation_fragment.hh"
@@ -230,8 +232,9 @@ public:
     printer pretty_printer(schema_ptr) const;
 };
 
-frozen_mutation freeze(const mutation& m);
-std::vector<frozen_mutation> freeze(const std::vector<mutation>&);
+// is_preemptible can be set when called in a seastar thread
+frozen_mutation freeze(const mutation& m, is_preemptible = is_preemptible(seastar::thread::running_in_thread()));
+std::vector<frozen_mutation> freeze(const std::vector<mutation>&, is_preemptible = is_preemptible(seastar::thread::running_in_thread()));
 // Caller is responsible for keeping the argument stable in memory
 // freeze_gently may yield only between mutations, threfore it's suitable for
 // a long vector of short mutations.

--- a/mutation/frozen_mutation.hh
+++ b/mutation/frozen_mutation.hh
@@ -167,7 +167,6 @@ private:
     partition_key deserialize_key() const;
     ser::mutation_view mutation_view() const;
 public:
-    explicit frozen_mutation(const mutation& m);
     explicit frozen_mutation(bytes_ostream&& b);
     frozen_mutation(bytes_ostream&& b, partition_key key);
     frozen_mutation(frozen_mutation&& m) = default;

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -19,6 +19,7 @@
 #include "replica/tablet_mutation_builder.hh"
 #include "sstables/sstable_set.hh"
 #include "dht/token.hh"
+#include "mutation/frozen_mutation.hh"
 
 namespace replica {
 
@@ -190,6 +191,7 @@ tablet_replica_set deserialize_replica_set(cql3::untyped_result_set_row::view_ty
 }
 
 future<> save_tablet_metadata(replica::database& db, const tablet_metadata& tm, api::timestamp_type ts) {
+  return async([&db, &tm, ts] {
     tablet_logger.trace("Saving tablet metadata: {}", tm);
     std::vector<mutation> muts;
     muts.reserve(tm.all_tables().size());
@@ -197,9 +199,10 @@ future<> save_tablet_metadata(replica::database& db, const tablet_metadata& tm, 
         // FIXME: Should we ignore missing tables? Currently doesn't matter because this is only used in tests.
         auto s = db.find_schema(id);
         muts.emplace_back(
-                co_await tablet_map_to_mutation(tablets, id, s->ks_name(), s->cf_name(), ts));
+                tablet_map_to_mutation(tablets, id, s->ks_name(), s->cf_name(), ts).get());
     }
-    co_await db.apply(freeze(muts), db::no_timeout);
+    db.apply(freeze(muts), db::no_timeout).get();
+  });
 }
 
 future<tablet_metadata> read_tablet_metadata(cql3::query_processor& qp) {

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -300,7 +300,7 @@ future<> group0_state_machine::transfer_snapshot(raft::server_id from_id, raft::
     _mm.merge_schema_from(addr, std::move(*cm)).get();
 
     if (topology_snp && !topology_snp->mutations.empty()) {
-        _ss.merge_topology_snapshot(std::move(*topology_snp)).get();
+        _ss.merge_topology_snapshot_in_thread(std::move(*topology_snp));
         // Flush so that current supported and enabled features are readable before commitlog replay
         _sp.get_db().local().flush(db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY).get();
     }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -782,13 +782,13 @@ void storage_service::merge_topology_snapshot_in_thread(raft_snapshot snp) {
 
     // Apply system.topology and system.topology_requests mutations atomically
     // to have a consistent state after restart
-    std::vector<mutation> muts;
+    std::vector<frozen_mutation> muts;
     muts.reserve(std::distance(snp.mutations.begin(), it));
     std::transform(snp.mutations.begin(), it, std::back_inserter(muts), [this] (const canonical_mutation& m) {
         auto s = _db.local().find_schema(m.column_family_id());
-        return m.to_mutation(s);
+        return freeze(m.to_mutation(s));
     });
-    _db.local().apply(freeze(muts), db::no_timeout).get();
+    _db.local().apply(muts, db::no_timeout).get();
 }
 
 // Moves the coroutine lambda onto the heap and extends its

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -878,7 +878,7 @@ private:
     future<> topology_state_load();
     // Applies received raft snapshot to local state machine persistent storage
     // raft_group0_client::_read_apply_mutex must be held
-    future<> merge_topology_snapshot(raft_snapshot snp);
+    void merge_topology_snapshot_in_thread(raft_snapshot snp);
 
     std::vector<canonical_mutation> build_mutation_from_join_params(const join_node_request_params& params, service::group0_guard& guard);
     std::unordered_set<raft::server_id> ignored_nodes_from_join_params(const join_node_request_params& params);

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -994,7 +994,7 @@ SEASTAR_TEST_CASE(test_commitlog_add_entry) {
 
                 for (auto i = 0; i < n; ++i) {
                     random_mutation_generator gen(random_mutation_generator::generate_counters(false));
-                    mutations.emplace_back(gen(1).front());
+                    mutations.emplace_back(freeze(gen(1).front()));
                     writers.emplace_back(gen.schema(), mutations.back(), fs);
                 }
 
@@ -1057,7 +1057,7 @@ SEASTAR_TEST_CASE(test_commitlog_add_entries) {
 
                 for (auto i = 0; i < n; ++i) {
                     random_mutation_generator gen(random_mutation_generator::generate_counters(false));
-                    mutations.emplace_back(gen(1).front());
+                    mutations.emplace_back(freeze(gen(1).front()));
                     writers.emplace_back(gen.schema(), mutations.back(), fs);
                 }
 

--- a/test/boost/frozen_mutation_test.cc
+++ b/test/boost/frozen_mutation_test.cc
@@ -217,7 +217,7 @@ SEASTAR_TEST_CASE(frozen_mutation_is_consumed_in_order) {
     random_mutation_generator gen{random_mutation_generator::generate_counters::no};
     mutation m = gen();
     auto& s = m.schema();
-    frozen_mutation fm{m};
+    auto fm = freeze(m);
 
     auto validate_consume = [] (schema_ptr s, const frozen_mutation& fm, const mutation& m) {
         testlog.info("Validating frozen_mutation::consume");

--- a/test/perf/perf_idl.cc
+++ b/test/perf/perf_idl.cc
@@ -26,7 +26,7 @@ public:
     frozen_mutation()
         : _semaphore(__FILE__)
         , _one_small_row(_schema.schema(), _schema.make_pkey(0))
-        , _frozen_one_small_row(_one_small_row)
+        , _frozen_one_small_row(freeze(_one_small_row))
     {
         _one_small_row.apply(_schema.make_row(_semaphore.make_permit(), _schema.make_ckey(0), "value"));
         _frozen_one_small_row = freeze(_one_small_row);


### PR DESCRIPTION
This series introduces a freeze_gently function that freezes a vector of mutations
and maybe yielding in between mutations.  This is useful for potentially long vectors of small mutations,
like in `merge_schema`.

In addition it adds a `is_preemptible` flag to `freeze` (for single mutation or vector of mutation), that allow yielding in between rows.  Those are suitable for large mutations, like the ones expected for tables with many tablets (order of up to 100,000).  The reason we need a thread here is a limitation of `ser::writer_of_mutation<bytes_ostream>` which has a synchronous interface.
Making it asynchronous might be possible but will require a bigger change, and based on the main use of `merge_topology_snapshot`, it can be safely and easily converted to use a seastar thread, as done in this series.

Unit tests in frozen_mutation_tests were extended to cover the new functionality.