### PR TITLE
utils/rjson: include tasklocal backtrace in rapidjson assert error message

### DIFF
--- a/utils/rjson.hh
+++ b/utils/rjson.hh
@@ -55,7 +55,7 @@ public:
 // 2. assert() crashes a program
 // Fortunately, the default policy can be overridden, and so rapidjson errors will
 // throw an rjson::error exception instead.
-#define RAPIDJSON_ASSERT(x) do { if (!(x)) throw rjson::error(std::string("JSON error: condition not met: ") + #x); } while (0)
+#define RAPIDJSON_ASSERT(x) do { if (!(x)) throw rjson::error(fmt::format("JSON assert failed on condition '{}', at: {}", #x, current_backtrace_tasklocal())); } while (0)
 // This macro is used for functions which are called for every json char making it
 // quite costly if not inlined, by default rapidjson only enables it if NDEBUG
 // is defined which isn't the case for us.


### PR DESCRIPTION
Currently, the error message on a failed RAPIDJSON_ASSERT() is this:

    rjson::error (JSON error: condition not met: false)

This is printed e.g. when the code processing a json expects an object but the JSON has a different type. Or if a JSON object is missing an expected member. This message however is completely inadequate for determinig what went wrong. Change this to include a task-local backtrace, like a real assert failure would. The new error looks like this:

    rjson::error (JSON assertion failed on condition '{}' at: libseastar.so+0x56dede 0x2bde95e 0x2cc18f3 0x2cf092d 0x2d2316b libseastar.so+0x46b623)