### PR TITLE
[Backport 5.4] mv: keep semaphore units alive until the end of a remote view update

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1698,7 +1698,7 @@ future<> view_update_generator::mutate_MV(
         bool network_topology = dynamic_cast<const locator::network_topology_strategy*>(&ks.get_replication_strategy());
         auto target_endpoint = get_view_natural_endpoint(ermp, network_topology, base_token, view_token);
         auto remote_endpoints = ermp->get_pending_endpoints(view_token);
-        auto sem_units = pending_view_updates.split(memory_usage_of(mut));
+        auto sem_units = seastar::make_lw_shared<db::timeout_semaphore_units>(pending_view_updates.split(memory_usage_of(mut)));
 
         const bool update_synchronously = should_update_synchronously(*mut.s);
         if (update_synchronously) {
@@ -1746,7 +1746,7 @@ future<> view_update_generator::mutate_MV(
                     mut.s->ks_name(), mut.s->cf_name(), base_token, view_token);
             local_view_update = _proxy.local().mutate_mv_locally(mut.s, *mut_ptr, tr_state, db::commitlog::force_sync::no).then_wrapped(
                     [s = mut.s, &stats, &cf_stats, tr_state, base_token, view_token, my_address, mut_ptr = std::move(mut_ptr),
-                            units = sem_units.split(sem_units.count())] (future<>&& f) {
+                            sem_units] (future<>&& f) {
                 --stats.writes;
                 if (f.failed()) {
                     ++stats.view_updates_failed_local;
@@ -1783,7 +1783,7 @@ future<> view_update_generator::mutate_MV(
             schema_ptr s = mut.s;
             future<> view_update = apply_to_remote_endpoints(_proxy.local(), std::move(ermp), *target_endpoint, std::move(remote_endpoints), std::move(mut), base_token, view_token, allow_hints, tr_state).then_wrapped(
                     [s = std::move(s), &stats, &cf_stats, tr_state, base_token, view_token, target_endpoint, updates_pushed_remote,
-                            units = sem_units.split(sem_units.count()), apply_update_synchronously] (future<>&& f) mutable {
+                            sem_units, apply_update_synchronously] (future<>&& f) mutable {
                 if (f.failed()) {
                     stats.view_updates_failed_remote += updates_pushed_remote;
                     cf_stats.total_view_updates_failed_remote += updates_pushed_remote;


### PR DESCRIPTION
When a view update has both a local and remote target endpoint, it extends the lifetime of its memory tracking semaphore units only until the end of the local update, while the resources are actually used until the remote update finishes.
This patch changes the semaphore transferring so that in case of both local and remote endpoints, the local update takes ownership of no semaphore units, and as a result, the remote update takes ownership of all correlated semaphore units.

Fixes https://github.com/scylladb/scylladb/issues/17890

(cherry picked from commit https://github.com/scylladb/scylladb/commit/9789a3dc7c0fde0d306d53d074a83a02a6bed880)

Refs https://github.com/scylladb/scylladb/pull/17891