### PR TITLE
sync_raft_topology_nodes: call real_mark_alive

### DIFF
--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -468,6 +468,8 @@ public:
      * @return the rpc address
      */
     sstring get_rpc_address(const inet_address& endpoint) const;
+
+    future<> real_mark_alive(inet_address addr);
 private:
     // FIXME: for now, allow modifying the endpoint_state's heartbeat_state in place
     // Gets or creates endpoint_state for this node
@@ -484,8 +486,6 @@ private:
     void update_timestamp_for_nodes(const std::map<inet_address, endpoint_state>& map);
 
     void mark_alive(inet_address addr);
-
-    future<> real_mark_alive(inet_address addr);
 
     // Must be called under lock_endpoint.
     future<> mark_dead(inet_address addr, endpoint_state_ptr local_state, permit_id);

--- a/test/topology_custom/test_replace.py
+++ b/test/topology_custom/test_replace.py
@@ -12,6 +12,9 @@ from test.pylib.manager_client import ManagerClient
 from test.topology.util import wait_for_token_ring_and_group0_consistency, wait_for_cql_and_get_hosts, wait_for
 import pytest
 import logging
+import asyncio
+from cassandra.query import SimpleStatement, ConsistencyLevel
+from test.pylib.random_tables import RandomTables, Column, TextType
 
 
 logger = logging.getLogger(__name__)
@@ -73,12 +76,50 @@ async def test_replace_different_ip_using_host_id(manager: ManagerClient) -> Non
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
 @pytest.mark.asyncio
-async def test_replace_reuse_ip(manager: ManagerClient) -> None:
+async def test_replace_reuse_ip(request, manager: ManagerClient) -> None:
     """Replace an existing node with new node using the same IP address"""
     servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': 2000})
-    await manager.server_stop(servers[0].server_id)
+    host2 = (await wait_for_cql_and_get_hosts(manager.get_cql(), [servers[2]], time.time() + 60))[0]
+
+    logger.info(f"creating test table")
+    random_tables = RandomTables(request.node.name, manager, "ks", 3)
+    await random_tables.add_table(name='test_table', pks=1, columns=[
+        Column(name="key", ctype=TextType),
+        Column(name="value", ctype=TextType)
+    ])
+
+    await manager.server_stop_gracefully(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = True, use_host_id = False)
-    await manager.server_add(replace_cfg)
+    replace_future = asyncio.create_task(manager.server_add(replace_cfg))
+    start_time = time.time()
+    next_id = 0
+    logger.info(f"running write requests in a loop while the replacing node is starting")
+    expected_data = []
+    while not replace_future.done():
+        i = next_id
+        next_id += 1
+        k = f'key_{i}'
+        v = f'value_{i}'
+        expected_data.append((k, v))
+        await manager.get_cql().run_async(SimpleStatement("insert into ks.test_table(key, value) values (%s, %s)",
+                                                          consistency_level=ConsistencyLevel.QUORUM),
+                                          parameters=[k, v],
+                                          host=host2)
+    finish_time = time.time()
+    await replace_future
+    logger.info(f"done, writes count {next_id}, took {finish_time - start_time} seconds")
+
+    # TODO: see #18111
+    # result_set = await manager.get_cql().run_async(SimpleStatement("select * from ks.test_table",
+    #                                                                consistency_level=ConsistencyLevel.QUORUM),
+    #                                                host=host2)
+    # read_data = [(row.key, row.value) for row in result_set]
+    # expected_data.sort()
+    # read_data.sort()
+    # logger.info(f"expected data:\n{expected_data}\nread_data:\n{read_data}")
+    # assert read_data == expected_data
+    # logger.info("the data is correct")
+
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
     await manager.server_sees_other_server(servers[1].ip_addr, servers[0].ip_addr)
     await manager.server_sees_other_server(servers[2].ip_addr, servers[0].ip_addr)


### PR DESCRIPTION
In replace-with-same-ip a new node calls gossiper.start_gossiping from join_token_ring with the 'advertise' parameter set to false. This means that this node will fail echo RPC-s from other nodes, making it appear as not alive to them. The node changes this only in storage_service::join_node_response_handler, when the topology coordinator notifies it that it's actually allowed to join the cluster. The node calls _gossiper.advertise_to_nodes({}), and only from this moment other nodes can see it as alive.

The problem is that topology coordinator sends this notification in topology::transition_state::join_group0 state. In this state nodes of the cluster already see the new node as pending, they react with calling tmpr->add_replacing_endpoint and update_topology_change_info when they process the corresponding raft notification in sync_raft_topology_nodes. When the new token_metadata is published, assure_sufficient_live_nodes sees the new node in pending_endpoints. All of this happen before the new node handled successful join notification, so it's not alive yet. Suppose we had a cluster with three nodes and we're replacing on them with a fourth node. For cl=qurum assure_sufficient_live_nodes throws if live < need + pending, which in our case becomes 2 < 2 + 1. The end effect is that during replace-with-same-ip data plane requests can fail with unavailable_exception, breaking availability.

As soon as a new node is moved to transitioning state and became pending in terms of token_metadata it should be atomically marked as alive. That's the essence of this commit. We can't rely on mark_alive, since a new node may not advertised itself yet.

fixes scylladb/scylladb#17421