### PR TITLE
test: randomized_nemesis_test: remove fmt::formatter for seastar::tim…

### DIFF
--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -48,16 +48,6 @@ std::ostream& operator<<(std::ostream& os, const std::variant<T, Ts...>& v) {
 
 } // namespace std
 
-#if FMT_VERSION < 100000
-// fmt v10 introduced formatter for std::exception
-template <>
-struct fmt::formatter<seastar::timed_out_error> : fmt::formatter<std::string_view> {
-    auto format(const seastar::timed_out_error& e, fmt::format_context& ctx) const {
-        return fmt::format_to(ctx.out(), "{}", e.what());
-    }
-};
-#endif
-
 using namespace seastar;
 using namespace std::chrono_literals;
 


### PR DESCRIPTION
…ed_out_error

This reverts commit 97b203b1af2dae6e606f14a724b208c31044a7aa.

since Seastar provides the formatter, it's not necessary to vendor it in scylladb anymore.

Refs #13245