### PR TITLE
github: sync_labels: do not error out if PR's cover letter is empty

### DIFF
--- a/.github/scripts/sync_labels.py
+++ b/.github/scripts/sync_labels.py
@@ -51,8 +51,10 @@ def get_linked_issues_based_on_pr_body(repo, number):
     pr = repo.get_pull(number)
     repo_name = repo.full_name
     pattern = rf"(?:fix(?:|es|ed)|resolve(?:|d|s))\s*:?\s*(?:(?:(?:{repo_name})?#)|https://github\.com/{repo_name}/issues/)(\d+)"
-    matches = re.findall(pattern, pr.body, re.IGNORECASE)
     issue_number_from_pr_body = []
+    if pr.body is None:
+        return issue_number_from_pr_body
+    matches = re.findall(pattern, pr.body, re.IGNORECASE)
     if matches:
         for match in matches:
             issue_number_from_pr_body.append(match)


### PR DESCRIPTION
if a pull request's cover letter is empty, `pr.body` is None. in that case we should not try to pass it to `re.findall()` as the "string" parameter. otherwise, we'd get

```
TypeError: expected string or bytes-like object, got 'NoneType'
```
so, in this change, we just return an empty list if the PR in question has an empty cover letter.