### PR TITLE
github: sync_labels: checkout a single file not the whole repo

### DIFF
--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -18,7 +18,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history for all tags and branches
+          sparse-checkout: |
+            .github/scripts/sync_labels.py
+          sparse-checkout-cone-mode: false
 
       - name: Install dependencies
         run: sudo apt-get install -y python3-github


### PR DESCRIPTION
what we need is but a script, so instead of checkout the whole repo, with all history for all tags and branches, let's just checkout a single file. faster this way.