### PR TITLE
expression: Shorten making raw_value from FragmetedView

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1723,11 +1723,7 @@ cql3::raw_value do_evaluate(const field_selection& field_select, const evaluatio
             // std::optional<FragmentedView> read_field
             auto read_field = read_nth_user_type_field(udt_serialized_bytes, field_select.field_idx);
 
-            if (read_field.has_value()) {
-                return cql3::raw_value::make_value(managed_bytes(*read_field));
-            } else {
-                return cql3::raw_value::make_null();
-            }
+            return cql3::raw_value::make_value(managed_bytes_opt(read_field));
     });
 
     return field_value;


### PR DESCRIPTION
The read_field is std::optional<View>. The raw_value::make_value() accepts managed_bytes_opt which is std::optional<manager_bytes>. Finally, there's std::optional<T>::optional(std::optional<U>&&) move constructor (and its copy-constructor peer).