### PR TITLE
Relax initialization of virtual tables

### DIFF
--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -1014,12 +1014,6 @@ private:
 
 }
 
-static void install_virtual_readers_and_writers(db::system_keyspace& sys_ks, replica::database& db) {
-    db.find_column_family(system_keyspace::size_estimates()).set_virtual_reader(mutation_source(db::size_estimates::virtual_reader(db, sys_ks)));
-    db.find_column_family(system_keyspace::v3::views_builds_in_progress()).set_virtual_reader(mutation_source(db::view::build_progress_virtual_reader(db)));
-    db.find_column_family(system_keyspace::built_indexes()).set_virtual_reader(mutation_source(db::index::built_indexes_virtual_reader(db)));
-}
-
 future<> initialize_virtual_tables(
         distributed<replica::database>& dist_db, distributed<service::storage_service>& dist_ss,
         sharded<gms::gossiper>& dist_gossiper, distributed<service::raft_group_registry>& dist_raft_gr,
@@ -1052,7 +1046,9 @@ future<> initialize_virtual_tables(
     co_await add_table(std::make_unique<clients_table>(ss));
     co_await add_table(std::make_unique<raft_state_table>(dist_raft_gr));
 
-    install_virtual_readers_and_writers(sys_ks.local(), db);
+    db.find_column_family(system_keyspace::size_estimates()).set_virtual_reader(mutation_source(db::size_estimates::virtual_reader(db, sys_ks.local())));
+    db.find_column_family(system_keyspace::v3::views_builds_in_progress()).set_virtual_reader(mutation_source(db::view::build_progress_virtual_reader(db)));
+    db.find_column_family(system_keyspace::built_indexes()).set_virtual_reader(mutation_source(db::index::built_indexes_virtual_reader(db)));
 }
 
 virtual_tables_registry::virtual_tables_registry() : unique_ptr(std::make_unique<virtual_tables_registry_impl>()) {

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -1014,26 +1014,6 @@ private:
 
 }
 
-static void register_virtual_tables(virtual_tables_registry_impl& virtual_tables, distributed<replica::database>& dist_db, distributed<service::storage_service>& dist_ss, sharded<gms::gossiper>& dist_gossiper, sharded<service::raft_group_registry>& dist_raft_gr, db::config& cfg) {
-    auto add_table = [&] (std::unique_ptr<virtual_table>&& tbl) {
-        virtual_tables[tbl->schema()->id()] = std::move(tbl);
-    };
-
-    auto& db = dist_db.local();
-    auto& ss = dist_ss.local();
-
-    // Add built-in virtual tables here.
-    add_table(std::make_unique<cluster_status_table>(dist_ss, dist_gossiper));
-    add_table(std::make_unique<token_ring_table>(db, ss));
-    add_table(std::make_unique<snapshots_table>(dist_db));
-    add_table(std::make_unique<protocol_servers_table>(ss));
-    add_table(std::make_unique<runtime_info_table>(dist_db, ss));
-    add_table(std::make_unique<versions_table>());
-    add_table(std::make_unique<db_config_table>(cfg));
-    add_table(std::make_unique<clients_table>(ss));
-    add_table(std::make_unique<raft_state_table>(dist_raft_gr));
-}
-
 static void install_virtual_readers_and_writers(db::system_keyspace& sys_ks, replica::database& db) {
     auto& virtual_tables = *sys_ks.get_virtual_tables_registry();
     db.find_column_family(system_keyspace::size_estimates()).set_virtual_reader(mutation_source(db::size_estimates::virtual_reader(db, sys_ks)));
@@ -1054,9 +1034,24 @@ future<> initialize_virtual_tables(
         db::config& cfg) {
     auto& virtual_tables_registry = sys_ks.local().get_virtual_tables_registry();
     auto& virtual_tables = *virtual_tables_registry;
-    register_virtual_tables(virtual_tables, dist_db, dist_ss, dist_gossiper, dist_raft_gr, cfg);
-
     auto& db = dist_db.local();
+    auto& ss = dist_ss.local();
+
+    auto add_table = [&] (std::unique_ptr<virtual_table>&& tbl) {
+        virtual_tables[tbl->schema()->id()] = std::move(tbl);
+    };
+
+    // Add built-in virtual tables here.
+    add_table(std::make_unique<cluster_status_table>(dist_ss, dist_gossiper));
+    add_table(std::make_unique<token_ring_table>(db, ss));
+    add_table(std::make_unique<snapshots_table>(dist_db));
+    add_table(std::make_unique<protocol_servers_table>(ss));
+    add_table(std::make_unique<runtime_info_table>(dist_db, ss));
+    add_table(std::make_unique<versions_table>());
+    add_table(std::make_unique<db_config_table>(cfg));
+    add_table(std::make_unique<clients_table>(ss));
+    add_table(std::make_unique<raft_state_table>(dist_raft_gr));
+
     for (auto&& [id, vt] : virtual_tables) {
         co_await db.create_local_system_table(vt->schema(), false, dist_ss.local().get_erm_factory());
         db.find_column_family(vt->schema()).mark_ready_for_writes(nullptr);


### PR DESCRIPTION
It now happens in initialize_virtual_tables(), but this function is split into sub-calls and iterates over virtual tables map several times to do its work. This PR squashes it into a straightforward code which is shorter and, hopefully, easier to read.