### PR TITLE
github: sync-labels: run only in scylladb oss repo

### DIFF
--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   label-sync:
+    if: ${{ github.repository == 'scylladb/scylladb' }}
     name:  Synchronize labels between PR and the issue(s) fixed by it
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
We currently support the sync-label only in OSS. Since Scylla-enterprise get all the commits from OSS repo, the sync-label is running and failing during checkout (since it's a private repo and should have different configuration)

For now, let's limit the workflows for oss repo