### PR TITLE
utils: use fmt to print chunk_vector and small_vector

### DIFF
--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -52,8 +52,8 @@
 #include <algorithm>
 #include <stdexcept>
 #include <malloc.h>
-
-#include "utils/to_string.hh"
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
 
 namespace utils {
 
@@ -496,7 +496,8 @@ chunked_vector<T, max_contiguous_allocation>::clear() {
 
 template <typename T, size_t max_contiguous_allocation>
 std::ostream& operator<<(std::ostream& os, const chunked_vector<T, max_contiguous_allocation>& v) {
-    return utils::format_range(os, v);
+    fmt::print(os, v);
+    return os;
 }
 
 }

--- a/utils/small_vector.hh
+++ b/utils/small_vector.hh
@@ -20,8 +20,8 @@
 #include <stdexcept>
 #include <malloc.h>
 #include <iostream>
-
-#include "utils/to_string.hh"
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
 
 namespace utils {
 
@@ -466,7 +466,8 @@ public:
 
 template <typename T, size_t N>
 std::ostream& operator<<(std::ostream& os, const utils::small_vector<T, N>& v) {
-    return utils::format_range(os, v);
+    fmt::print(os, v);
+    return os;
 }
 
 }


### PR DESCRIPTION
this intends to reduce the dependency on `utils/to_string.hh` in the source tree, so that we can remove the range formatters implemented in it, and migrate the existing users of these formatters to {fmt}

Refs #13245