### PR TITLE
cql: Reserve vector of column definitions in advance

### DIFF
--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -59,6 +59,7 @@ future<> create_table_statement::check_access(query_processor& qp, const service
 std::vector<column_definition> create_table_statement::get_columns() const
 {
     std::vector<column_definition> column_defs;
+    column_defs.reserve(_columns.size());
     for (auto&& col : _columns) {
         column_kind kind = column_kind::regular_column;
         if (_static_columns.contains(col.first)) {


### PR DESCRIPTION
The vector in question is populted from the content of another map, so its size is known in advance