### PR TITLE
alternator: do not use tablets on new Alternator tables

### DIFF
--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -684,3 +684,11 @@ def test_delete_table_description_with_si(dynamodb):
     for i in ['KeySchema', 'AttributeDefinitions', 'GlobalSecondaryIndexes', 'LocalSecondaryIndexes']:
         assert i in got_describe
         assert not i in got_delete
+
+# Currently, because of incomplete LWT support, Alternator tables do not use
+# tablets by default - even if the tablets experimental feature is enabled.
+# This test enshrines this fact - that an Alternator table doesn't use tablets.
+# This is a temporary test: When we reverse this decision and tablets go back
+# to being used by default on Alternator tables, this test should be deleted.
+def test_alternator_doesnt_use_tablets(dynamodb, has_tablets):
+    assert not has_tablets


### PR DESCRIPTION
A few months ago, in merge d3c1be910767cacf4f2c4ac35cd0d3c21abc0e2d, we decided that if Scylla has the experimental "tablets" feature enabled, new Alternator tables should use this feature by default - exactly like this is the default for new CQL tables.

Sadly, it was now decided to reverse this decision: We do not yet trust enough LWT on tablets, and since Alternator often (if not always) relies on LWT, we want Alternator tables to continue to use vnodes - not tablets.

The fix is trivial - just changing the default. No test needed to change because anyway, all Alternator tests work correctly on Scylla with the tablets experimental feature disabled. I added a new test to enshrine the fact that Alternator does not use tablets.

An unfortunate result of this patch will be that Alternator tables created on versions with this patch (e.g., Scylla 6.0) will not use tablets and will continue to not use tablets even if Scylla is upgraded (currently, the use of tablets is decided at table creation time, and there is no way to "upgrade" a vnode-based table to be tablet based).

This patch should be reverted as soon as LWT support matures on tablets.