### PR TITLE
docs: add the latest image info to GCP and Azure pages

### DIFF
--- a/docs/getting-started/install-scylla/launch-on-azure.rst
+++ b/docs/getting-started/install-scylla/launch-on-azure.rst
@@ -38,11 +38,12 @@ Launching ScyllaDB on Azure
     
         az group create --name my-group --location eastus
 
-#. Go to `ScyllaDB for Azure <https://www.scylladb.com/download/?platform=azure#open-source>`_ in ScyllaDB's download center to obtain the image information:
+#. See the following table to obtain image information for the latest patch release. 
+   For earlier releases, see :doc:`Azure Images </reference/azure-images/>`
 
-   * gallery-image-definition
-   * gallery-image-version
-   * public-gallery-name
+   .. scylladb_azure_images_template::
+      :exclude: rc,dev
+      :only_latest:
 
 #. Get the ScyllaDB image ID using the information from the previous step:
 

--- a/docs/getting-started/install-scylla/launch-on-gcp.rst
+++ b/docs/getting-started/install-scylla/launch-on-gcp.rst
@@ -19,11 +19,12 @@ Launching ScyllaDB on GCP
 
    Other instance types will work, but with lesser performance. If you choose an instance type other than the recommended ones, make sure to run the :ref:`scylla_setup <system-configuration-scripts>` script.
 
-#. Go to `ScyllaDB for GCP <https://www.scylladb.com/download/?platform=gcp#open-source>`_ in ScyllaDB's download center to obtain the image information:
+#. See the following table to obtain image information for the latest patch release. 
+   For earlier releases, see :doc:`GCP Images </reference/gcp-images/>`
 
-   * image name
-   * image id
-   * project name
+   .. scylladb_gcp_images_template::
+      :exclude: rc,dev
+      :only_latest:
 
 #. Launch a ScyllaDB instance on GCP with ``gcloud`` using the information from the previous step. Use the following syntax:
 


### PR DESCRIPTION
This PR adds image information for the latest patch release to the GCP and Azure deployment page.
The information now replaces the reference to the Download Center so that the user doesn't have to jump to another website.

Fixes https://github.com/scylladb/scylladb/issues/18144