### PR TITLE
Add allure pytest adaptor to the toolchain

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -143,6 +143,7 @@ declare -A pip_packages=(
     [traceback-with-variables]=
     [scylla-api-client]=
     [treelib]=
+    [allure-pytest]=
 )
 
 pip_symlinks=(

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-38-20240521
+docker.io/scylladb/scylla-toolchain:fedora-38-20240526


### PR DESCRIPTION
Add allure-pytest pip dependency to be able to use it for generating the allure report later. Main benefits of the allure report:
1. Group test failures
2. Possibility to attach log files to she test itself
3. Timeline of test run
4. Test description on the report
5. Search by test name or tag