### PR TITLE
row_cache_test: avoid a throw in external_updater

### DIFF
--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -2531,6 +2531,7 @@ SEASTAR_TEST_CASE(test_exception_safety_of_update_from_memtable) {
             snap->fill_buffer().get();
 
             cache.update(row_cache::external_updater([&] {
+                memory::scoped_critical_alloc_section dfg;
                 auto mt2 = make_memtable(cache.schema(), muts2);
                 underlying.apply(std::move(mt2));
             }), *mt).get();


### PR DESCRIPTION
In test_exception_safety_of_update_from_memtable, we have a potential throw from external_updater.

external_updater is supposed to be infallible.
Scylla currently aborts when an external_updater throws, so a throw from there just fails the test.

This isn't intended. We aren't testing external_updater in this test.

Fixes #18163