### PR TITLE
test.py: add the pytest junit_suite_name parameter

### DIFF
--- a/test.py
+++ b/test.py
@@ -898,7 +898,11 @@ class RunTest(Test):
         super().__init__(test_no, shortname, suite)
         self.path = suite.suite_path / shortname
         self.xmlout = os.path.join(suite.options.tmpdir, self.mode, "xml", self.uname + ".xunit.xml")
-        self.args = ["--junit-xml={}".format(self.xmlout)]
+        self.args = [
+            "--junit-xml={}".format(self.xmlout),
+            "-o",
+            "junit_suite_name={}".format(self.suite.name)
+        ]
         RunTest._reset(self)
 
     def _reset(self):
@@ -934,6 +938,8 @@ class PythonTest(Test):
             "--log-level=DEBUG",   # Capture logs
             "-o",
             "junit_family=xunit2",
+            "-o",
+            "junit_suite_name={}".format(self.suite.name),
             "--junit-xml={}".format(self.xmlout),
             "-rs"]
         if options.markers:


### PR DESCRIPTION
By default the suitename in the junit files generated by pytest is named `pytest` for all suites instead of the suite, ex. `topology_experimental_raft` With this change, the junit files will use the real suitename

This change doesn't affect the Test Report in Jenkins, but it raised part of the other task of publishing the test results to elasticsearch https://github.com/scylladb/scylla-pkg/pull/3950 where we parse the XMLs and we need the correct suitename