### PR TITLE
migration_manager: Pull all of group0 state on repair

### DIFF
--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -1262,6 +1262,13 @@ future<> migration_manager::sync_schema(const replica::database& db, const std::
             schema_map[remote_version].emplace_back(node);
         }
     });
+    if (schema_map.empty()) {
+        co_return;
+    }
+    if (!_enable_schema_pulls) {
+        co_await _group0_barrier.trigger(_as);
+        co_return;
+    }
     co_await coroutine::parallel_for_each(schema_map, [this] (auto& x) -> future<> {
         auto& [schema, hosts] = x;
         const auto& src = hosts.front();


### PR DESCRIPTION
Current code uses non-raft path to pull the schema, which violates group0 linearizability because the node will have latest schema but miss group0 updates of other system tables. In particular, system.tablets. This manifests as repair errors due to missing tablet_map for a given table when trying to access it. Tablet map is always created together with the table in the same group0 command.

When a node is bootstrapping, repair calls sync_schema() to make sure local schema is up to date. This races with group0 catch up, and if sync_schema() wins, repair may fail on misssing tablet map.

Fix by making sync_schema() do a group0 read barrier when in raft mode.

Fixes #18002