### PR TITLE
Cleanup inactive reads on tablet migration

### DIFF
--- a/querier.cc
+++ b/querier.cc
@@ -13,6 +13,7 @@
 #include "reader_concurrency_semaphore.hh"
 #include "schema/schema.hh"
 #include "log.hh"
+#include "utils/error_injection.hh"
 
 #include <boost/range/adaptor/map.hpp>
 
@@ -289,6 +290,11 @@ void querier_cache::insert_querier(
         }
         --stats.population;
     };
+
+
+    if (const auto override_ttl = utils::get_local_injector().inject_parameter<uint64_t>("querier-cache-ttl-seconds"); override_ttl) {
+        ttl = std::chrono::seconds(*override_ttl);
+    }
 
     sem.set_notify_handler(irh, std::move(notify_handler), ttl);
     querier_utils::set_inactive_read_handle(*it->second, std::move(irh));

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -359,7 +359,12 @@ public:
     void clear_inactive_reads();
 
     /// Evict all inactive reads the belong to the table designated by the id.
-    future<> evict_inactive_reads_for_table(table_id id) noexcept;
+    /// If a range is provided, only inactive reads whose range overlaps with the
+    /// range are evicted.
+    /// The range of the inactive read is provided in register_inactive_read().
+    /// If the range for an inactive read was not provided, all reads for the
+    /// table are evicted.
+    future<> evict_inactive_reads_for_table(table_id id, const dht::partition_range* range = nullptr) noexcept;
 private:
     // The following two functions are extension points for
     // future inheriting classes that needs to run some stop

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -15,6 +15,7 @@
 #include <seastar/core/metrics_registration.hh>
 #include "reader_permit.hh"
 #include "utils/updateable_value.hh"
+#include "dht/i_partitioner_fwd.hh"
 
 namespace bi = boost::intrusive;
 
@@ -326,7 +327,7 @@ public:
     ///
     /// The semaphore takes ownership of the passed in reader for the duration
     /// of its inactivity and it may evict it to free up resources if necessary.
-    inactive_read_handle register_inactive_read(flat_mutation_reader_v2 ir) noexcept;
+    inactive_read_handle register_inactive_read(flat_mutation_reader_v2 ir, const dht::partition_range* range = nullptr) noexcept;
 
     /// Set the inactive read eviction notification handler and optionally eviction ttl.
     ///

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1551,6 +1551,8 @@ private:
     void drop_keyspace(const sstring& name);
     future<> update_keyspace(const keyspace_metadata& tmp_ksm);
     static future<> modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func, std::function<future<>(replica::database&)> notifier);
+
+    future<> foreach_reader_concurrency_semaphore(std::function<future<>(reader_concurrency_semaphore&)> func);
 public:
     static table_schema_version empty_version;
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1872,6 +1872,8 @@ public:
     db::timeout_semaphore& view_update_sem() {
         return _view_update_concurrency_sem;
     }
+
+    future<> clear_inactive_reads_for_tablet(table_id table, dht::token_range tablet_range);
 };
 
 } // namespace replica

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3420,6 +3420,8 @@ future<> table::cleanup_tablet(database& db, db::system_keyspace& sys_ks, locato
                                             tid, _schema->ks_name(), _schema->cf_name()));
         }
 
+        co_await db.clear_inactive_reads_for_tablet(_schema->id(), cg_ptr->token_range());
+
         // Synchronizes with in-flight writes if any, and also takes care of flushing if needed.
         // FIXME: to be able to stop group and provide guarantee above, we must first be able to reallocate a new group if tablet is migrated back.
         //co_await _cg.stop();


### PR DESCRIPTION
When a tablet is migrated away, any inactive read which might be reading from said tablet, has to be dropped. Otherwise these inactive reads can prevent sstables from being removed and these sstables can potentially survive until the tablet is migrated back and resurrect data.
This series introduces the fix as well as a reproducer test.

Fixes: https://github.com/scylladb/scylladb/issues/18110