### PR TITLE
treewide: include <fmt/ostream.h>

### DIFF
--- a/gms/application_state.cc
+++ b/gms/application_state.cc
@@ -11,6 +11,7 @@
 #include <seastar/core/sstring.hh>
 #include <ostream>
 #include <map>
+#include <fmt/ostream.h>
 #include "seastarx.hh"
 
 namespace gms {

--- a/utils/to_string.hh
+++ b/utils/to_string.hh
@@ -21,6 +21,7 @@
 #include <deque>
 
 #include <fmt/format.h>
+#include <fmt/ostream.h>
 
 #include "seastarx.hh"
 


### PR DESCRIPTION
this header was previously brought in by seastar's sstring.hh. but since sstring.hh does not include <fmt/ostream.h> anymore, `gms/application_state.cc` does not have access to this header. also, `gms/application_state.cc` should `#include` the used header by itself.

so, in this change, let's include  <fmt/ostream.h> in `gms/application_state.cc`. this change addresses the FTBFS with the latest seastar.