### PR TITLE
gms: do not include unused headers

### DIFF
--- a/gms/endpoint_state.cc
+++ b/gms/endpoint_state.cc
@@ -10,7 +10,6 @@
 
 #include "gms/endpoint_state.hh"
 #include "gms/i_endpoint_state_change_subscriber.hh"
-#include <optional>
 #include <ostream>
 #include <boost/lexical_cast.hpp>
 

--- a/gms/endpoint_state.hh
+++ b/gms/endpoint_state.hh
@@ -14,8 +14,6 @@
 #include "gms/application_state.hh"
 #include "gms/versioned_value.hh"
 #include "locator/host_id.hh"
-#include <optional>
-#include <chrono>
 
 namespace gms {
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -14,9 +14,7 @@
 #include <seastar/core/sharded.hh>
 #include <unordered_map>
 #include <functional>
-#include <exception>
 #include <set>
-#include <any>
 #include "seastarx.hh"
 #include "db/schema_features.hh"
 #include "gms/feature.hh"

--- a/gms/gossip_digest_ack2.hh
+++ b/gms/gossip_digest_ack2.hh
@@ -12,7 +12,6 @@
 
 #include <fmt/core.h>
 #include "utils/serialization.hh"
-#include "gms/gossip_digest.hh"
 #include "gms/inet_address.hh"
 #include "gms/endpoint_state.hh"
 

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -17,7 +17,6 @@
 #include "gms/inet_address.hh"
 #include "dht/token.hh"
 #include "schema/schema_fwd.hh"
-#include "utils/to_string.hh"
 #include "version.hh"
 #include "cdc/generation_id.hh"
 #include <unordered_set>


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.