### PR TITLE
Extend tablet_transition_kind::rebuild to remove replicas

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2639,6 +2639,70 @@
          ]
       },
       {
+         "path":"/storage_service/tablets/del_replica",
+         "operations":[
+            {
+               "nickname":"del_tablet_replica",
+               "method":"POST",
+               "summary":"Deletes replica from tablet",
+               "type":"void",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"ks",
+                     "description":"Keyspace name",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"table",
+                     "description":"Table name",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"token",
+                     "description":"Token owned by the tablet to delete replica from",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"integer",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"host",
+                     "description":"Host id to remove replica from",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"shard",
+                     "description":"Shard number to remove replica from",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"integer",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"force",
+                     "description":"When set to true, replication strategy constraints can be broken (false by default)",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"boolean",
+                     "paramType":"query"
+                  }
+               ]
+            }
+         ]
+      },
+      {
          "path":"/storage_service/tablets/balancing",
          "operations":[
             {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1599,6 +1599,23 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         co_return json_void();
     });
 
+    ss::del_tablet_replica.set(r, [&ctx, &ss] (std::unique_ptr<http::request> req) -> future<json_return_type> {
+        auto dst_host_id = validate_host_id(req->get_query_param("host"));
+        shard_id dst_shard_id = validate_int(req->get_query_param("shard"));
+        auto token = dht::token::from_int64(validate_int(req->get_query_param("token")));
+        auto ks = req->get_query_param("ks");
+        auto table = req->get_query_param("table");
+        auto table_id = ctx.db.local().find_column_family(ks, table).schema()->id();
+        auto force_str = req->get_query_param("force");
+        auto force = service::loosen_constraints(force_str == "" ? false : validate_bool(force_str));
+
+        co_await ss.local().del_tablet_replica(table_id, token,
+            locator::tablet_replica{dst_host_id, dst_shard_id},
+            force);
+
+        co_return json_void();
+    });
+
     ss::tablet_balancing_enable.set(r, [&ss] (std::unique_ptr<http::request> req) -> future<json_return_type> {
         auto enabled = validate_bool(req->get_query_param("enabled"));
         co_await ss.local().set_tablet_balancing_enabled(enabled);
@@ -1706,6 +1723,7 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::raft_topology_upgrade_status.unset(r);
     ss::move_tablet.unset(r);
     ss::add_tablet_replica.unset(r);
+    ss::del_tablet_replica.unset(r);
     ss::tablet_balancing_enable.unset(r);
     sp::get_schema_versions.unset(r);
 }

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -202,7 +202,7 @@ struct tablet_transition_info {
     tablet_transition_stage stage;
     tablet_transition_kind transition;
     tablet_replica_set next;
-    tablet_replica pending_replica; // Optimization (next - tablet_info::replicas)
+    std::optional<tablet_replica> pending_replica; // Optimization (next - tablet_info::replicas)
     service::session_id session_id;
     write_replica_set_selector writes;
     read_replica_set_selector reads;
@@ -210,7 +210,7 @@ struct tablet_transition_info {
     tablet_transition_info(tablet_transition_stage stage,
                            tablet_transition_kind kind,
                            tablet_replica_set next,
-                           tablet_replica pending_replica,
+                           std::optional<tablet_replica> pending_replica,
                            service::session_id session_id = {});
 
     bool operator==(const tablet_transition_info&) const = default;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5886,6 +5886,87 @@ future<> storage_service::add_tablet_replica(table_id table, dht::token token, l
     });
 }
 
+future<> storage_service::del_tablet_replica(table_id table, dht::token token, locator::tablet_replica dst, loosen_constraints force) {
+    auto holder = _async_gate.hold();
+
+    if (this_shard_id() != 0) {
+        // group0 is only set on shard 0.
+        co_return co_await container().invoke_on(0, [&] (auto& ss) {
+            return ss.del_tablet_replica(table, token, dst, force);
+        });
+    }
+
+    while (true) {
+        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+
+        while (_topology_state_machine._topology.is_busy()) {
+            const auto tstate = *_topology_state_machine._topology.tstate;
+            if (tstate == topology::transition_state::tablet_draining ||
+                tstate == topology::transition_state::tablet_migration) {
+                break;
+            }
+            rtlogger.debug("del_tablet_replica(): topology state machine is busy: {}", tstate);
+            release_guard(std::move(guard));
+            co_await _topology_state_machine.event.wait();
+            guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+        }
+
+        std::vector<canonical_mutation> updates;
+        auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
+        auto tid = tmap.get_tablet_id(token);
+        auto& tinfo = tmap.get_tablet_info(tid);
+        auto last_token = tmap.get_last_token(tid);
+        auto gid = locator::global_tablet_id{table, tid};
+
+        if (tmap.get_tablet_transition_info(tid)) {
+            throw std::runtime_error(fmt::format("Tablet {} is in transition", gid));
+        }
+        auto* node = get_token_metadata().get_topology().find_node(dst.host);
+        if (!node) {
+            throw std::runtime_error(format("Unknown host: {}", dst.host));
+        }
+        if (dst.shard >= node->get_shard_count()) {
+            throw std::runtime_error(format("Host {} does not have shard {}", *node, dst.shard));
+        }
+
+        if (!locator::contains(tinfo.replicas, dst.host)) {
+            throw std::runtime_error(fmt::format("Tablet {} doesn't have replica on {}", gid, dst.host));
+        }
+
+        locator::tablet_replica_set new_replicas;
+        new_replicas.reserve(tinfo.replicas.size() - 1);
+        std::copy_if(tinfo.replicas.begin(), tinfo.replicas.end(), std::back_inserter(new_replicas), [&dst] (auto r) { return r != dst; });
+
+        updates.emplace_back(replica::tablet_mutation_builder(guard.write_timestamp(), table)
+            .set_new_replicas(last_token, new_replicas)
+            .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
+            .set_transition(last_token, locator::tablet_transition_kind::rebuild)
+            .build());
+        updates.emplace_back(topology_mutation_builder(guard.write_timestamp())
+            .set_transition_state(topology::transition_state::tablet_migration)
+            .set_version(_topology_state_machine._topology.version + 1)
+            .build());
+
+        sstring reason = format("Removing replica from tablet {}, node {}", gid, dst);
+        rtlogger.info("{}", reason);
+        rtlogger.trace("do update {} reason {}", updates, reason);
+        topology_change change{std::move(updates)};
+        group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, reason);
+        try {
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
+            break;
+        } catch (group0_concurrent_modification&) {
+            rtlogger.debug("del_tablet_replica(): concurrent modification, retrying");
+        }
+    }
+
+    // Wait for transition to finish.
+    co_await _topology_state_machine.event.wait([&] {
+        auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
+        return !tmap.get_tablet_transition_info(tmap.get_tablet_id(token));
+    });
+}
+
 future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables() {
     auto holder = _async_gate.hold();
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -857,6 +857,7 @@ private:
 public:
     future<> move_tablet(table_id, dht::token, locator::tablet_replica src, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> add_tablet_replica(table_id, dht::token, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
+    future<> del_tablet_replica(table_id, dht::token, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> set_tablet_balancing_enabled(bool);
 
     // In the maintenance mode, other nodes won't be available thus we disabled joining

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -250,6 +250,15 @@ class ScyllaRESTAPIClient():
             "token": str(token)
         })
 
+    async def del_tablet_replica(self, node_ip: str, ks: str, table: str, host: HostID, shard: int, token: int) -> None:
+        await self.client.post(f"/storage_service/tablets/del_replica", host=node_ip, params={
+            "ks": ks,
+            "table": table,
+            "host": str(host),
+            "shard": str(shard),
+            "token": str(token)
+        })
+
     async def enable_tablet_balancing(self, node_ip: str) -> None:
         await self.client.post(f"/storage_service/tablets/balancing", host=node_ip, params={"enabled": "true"})
 


### PR DESCRIPTION
When altering rf for a keyspace, all tablets in this ks may have less replicas. Part of this process is removing replicas from some node(s). This PR extends the tablets rebuild transition to handle this case by making pending_replica optional.

fixes: #18176

