### PR TITLE
feat: add the parse commitlog tool

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1347,7 +1347,7 @@ scylla_tests_dependencies = scylla_core + alternator + idls + scylla_tests_gener
 
 scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc', 'utils/error_injection.cc', 'utils/exceptions.cc']
 
-scylla_tools = ['tools/scylla-types.cc', 'tools/scylla-sstable.cc', 'tools/scylla-nodetool.cc', 'tools/schema_loader.cc', 'tools/utils.cc', 'tools/lua_sstable_consumer.cc']
+scylla_tools = ['tools/scylla-types.cc', 'tools/scylla-sstable.cc', 'tools/scylla-nodetool.cc', 'tools/scylla_commitlog.cc', 'tools/schema_loader.cc', 'tools/utils.cc', 'tools/lua_sstable_consumer.cc']
 scylla_perfs = ['test/perf/perf_fast_forward.cc',
                 'test/perf/perf_row_cache_update.cc',
                 'test/perf/perf_simple_query.cc',

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -252,6 +252,8 @@ future<> db::commitlog_replayer::impl::process(stats* s, commitlog::buffer_and_r
             // will not do this.
             auto& cf = db.find_column_family(fm.column_family_id());
 
+            rlogger.info("mutation partition printer {}", fm.pretty_printer(cf.schema()));
+
             if (rlogger.is_enabled(logging::log_level::debug)) {
                 rlogger.debug("replaying at {} v={} {}:{} at {}", fm.column_family_id(), fm.schema_version(),
                         cf.schema()->ks_name(), cf.schema()->cf_name(), rp);

--- a/main.cc
+++ b/main.cc
@@ -2109,6 +2109,7 @@ int main(int ac, char** av) {
         {"types", tools::scylla_types_main, "a command-line tool to examine values belonging to scylla types"},
         {"sstable", tools::scylla_sstable_main, "a multifunctional command-line tool to examine the content of sstables"},
         {"nodetool", tools::scylla_nodetool_main, "a command-line tool to administer local or remote ScyllaDB nodes"},
+        {"commitlog", tools::scylla_commitlog_main, "a command-line tool to parse the commitlog file"},
         {"perf-fast-forward", perf::scylla_fast_forward_main, "run performance tests by fast forwarding the reader on this server"},
         {"perf-row-cache-update", perf::scylla_row_cache_update_main, "run performance tests by updating row cache on this server"},
         {"perf-tablets", perf::scylla_tablets_main, "run performance tests of tablet metadata management"},

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(tools
     scylla-types.cc
     scylla-sstable.cc
     scylla-nodetool.cc
+    scylla_commitlog.cc
     schema_loader.cc
     utils.cc
     lua_sstable_consumer.cc)

--- a/tools/entry_point.hh
+++ b/tools/entry_point.hh
@@ -11,5 +11,6 @@ namespace tools {
 int scylla_types_main(int argc, char** argv);
 int scylla_sstable_main(int argc, char** argv);
 int scylla_nodetool_main(int argc, char** argv);
+int scylla_commitlog_main(int argc, char** argv);
 
 } // namespace tools

--- a/tools/scylla-commitlog.cc
+++ b/tools/scylla-commitlog.cc
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2020-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <boost/algorithm/string/join.hpp>
+#include <boost/range/adaptors.hpp>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/distributed.hh>
+
+#include "db/commitlog/commitlog.hh"
+#include "db/commitlog/commitlog_replayer.hh"
+#include "compound.hh"
+#include "db/marshal/type_parser.hh"
+#include "log.hh"
+#include "schema/schema_builder.hh"
+#include "tools/utils.hh"
+#include "test/lib/cql_test_env.hh"
+
+using namespace seastar;
+using namespace tools::utils;
+
+namespace bpo = boost::program_options;
+
+namespace {
+
+const auto app_name = "commitlog";
+
+using operation_func = void(*)(const bpo::variables_map&);
+std::map<operation, operation_func> get_operations_with_func();
+
+distributed<replica::database> db;
+static sharded<db::system_keyspace> sys_ks;
+
+const std::vector<operation_option> global_options{
+    typed_option<sstring>("path", "the commitlog file absolute path)"),
+};
+
+void parse_commit_operation(const bpo::variables_map& vm) {
+    fmt::print(std::cout, "\nscylla commitlog op.\n\n");
+    // std::vector<sstring> paths = vm["path"].as<sstring>().split(',');
+    auto path = vm["path"].as<sstring>();
+    fmt::print(std::cout, "value {}\n\n", path);
+    // TODO: initializ db and sys_ks
+    auto rp = db::commitlog_replayer::create_replayer(db, sys_ks).get0();
+    rp.recover(std::move(path), db::commitlog::descriptor::FILENAME_PREFIX).get();
+    
+}
+
+std::map<operation, operation_func> get_operations_with_func() {
+
+    const static std::map<operation, operation_func> operations_with_func {
+        {
+            {
+                "parse",
+                "Triggers removal of data that the node no longer owns",
+                R"(commitlog parse)",
+            },  
+            parse_commit_operation
+        },
+    };
+
+    return operations_with_func;
+}
+}
+
+namespace tools {
+
+int scylla_commitlog_main(int argc, char** argv) {
+    auto description_template =
+R"(scylla-{} - a command-line tool to examine values belonging to scylla types.
+Usage: scylla {} {{action}} [--option1] [--option2] ... {{hex_value1}} [{{hex_value2}}] ...
+The supported actions are:
+{}
+$ scylla types {{action}} --help
+)";
+
+    const auto operations = boost::copy_range<std::vector<operation>>(get_operations_with_func() | boost::adaptors::map_keys);
+    tool_app_template::config app_cfg{
+        .name = app_name,
+        .description = format(description_template, app_name, app_name, boost::algorithm::join(operations | boost::adaptors::transformed(
+                [] (const operation& op) { return format("* {} - {}", op.name(), op.summary()); } ), "\n")),
+        .operations = std::move(operations),
+        .global_options = &global_options,
+    };
+    tool_app_template app(std::move(app_cfg));
+
+    return app.run_async(argc, argv, [] (const operation& operation, const boost::program_options::variables_map& app_config) {
+        try {
+            // go to the specific operation
+            get_operations_with_func().at(operation)(app_config);
+        } catch (std::invalid_argument& e) {
+            fmt::print(std::cerr, "error processing arguments: {}\n", e.what());
+            return 1;
+        } catch (...) {
+            fmt::print(std::cerr, "error running operation: {}\n", std::current_exception());
+            return 2;
+        }
+
+        return 0;
+    });
+}
+
+} // namespace tools


### PR DESCRIPTION
Use the `pretty_printer` function of `frozen_mutation` to print the content of commitlog, making it easy for humans to read. The Use it like:
`./build/dev/scylla commitlog parse --path ./tmp/commitlog/CommitLog-2-3106584672.log`