### PR TITLE
repair: Support repair_history migration after topology change

### DIFF
--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -142,6 +142,8 @@ public:
     // This feature MUST NOT be advertised in release mode!
     gms::feature test_only_feature { *this, "TEST_ONLY_FEATURE"sv };
 
+    gms::feature repair_history_over_raft { *this, "REPAIR_HISTORY_OVER_RAFT"sv };
+
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/idl/group0_state_machine.idl.hh
+++ b/idl/group0_state_machine.idl.hh
@@ -12,6 +12,8 @@
 #include "idl/frozen_schema.idl.hh"
 #include "idl/uuid.idl.hh"
 #include "idl/raft_storage.idl.hh"
+#include "idl/range.idl.hh"
+#include "idl/token.idl.hh"
 
 namespace service {
 
@@ -31,8 +33,15 @@ struct write_mutations {
     std::vector<canonical_mutation> mutations;
 };
 
+struct repair_history_update {
+    std::vector<canonical_mutation> mutations;
+    table_id table_uuid;
+    dht::token_range range;
+    gc_clock::time_point repair_time;
+};
+
 struct group0_command {
-    std::variant<service::schema_change, service::broadcast_table_query, service::topology_change, service::write_mutations> change;
+    std::variant<service::schema_change, service::broadcast_table_query, service::topology_change, service::write_mutations, service::repair_history_update> change;
     canonical_mutation history_append;
 
     std::optional<utils::UUID> prev_state_id;

--- a/main.cc
+++ b/main.cc
@@ -1606,7 +1606,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // both)
             supervisor::notify("starting repair service");
             auto max_memory_repair = memory::stats().total_memory() * 0.1;
-            repair.start(std::ref(gossiper), std::ref(messaging), std::ref(db), std::ref(proxy), std::ref(raft_address_map), std::ref(bm), std::ref(sys_dist_ks), std::ref(sys_ks), std::ref(view_update_generator), std::ref(task_manager), std::ref(mm), max_memory_repair).get();
+            repair.start(std::ref(gossiper), std::ref(messaging), std::ref(db), std::ref(proxy), std::ref(raft_address_map), std::ref(bm), std::ref(sys_dist_ks), std::ref(sys_ks), std::ref(view_update_generator), std::ref(task_manager), std::ref(mm), std::ref(group0_client), std::ref(qp.local()), std::ref(feature_service.local()), max_memory_repair).get();
             auto stop_repair_service = defer_verbose_shutdown("repair service", [&repair] {
                 repair.stop().get();
             });

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -171,6 +171,10 @@ future<> group0_state_machine::merge_and_apply(group0_state_machine_merger& merg
     },
     [&] (write_mutations& muts) -> future<> {
         return write_mutations_to_database(_sp, cmd.creator_addr, std::move(muts.mutations));
+    },
+    [&] (repair_history_update& update) -> future<> {
+        co_await write_mutations_to_database(_sp, cmd.creator_addr, std::move(update.mutations));
+        co_await _ss.update_repair_history(update.table_uuid, update.range, update.repair_time);
     }
     ), cmd.change);
 

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -17,6 +17,8 @@
 #include "mutation/canonical_mutation.hh"
 #include "service/raft/raft_state_machine.hh"
 #include "gms/feature.hh"
+#include "dht/token.hh"
+#include "dht/i_partitioner_fwd.hh"
 
 namespace gms {
 class feature_service;
@@ -52,8 +54,15 @@ struct write_mutations {
     std::vector<canonical_mutation> mutations;
 };
 
+struct repair_history_update {
+    std::vector<canonical_mutation> mutations;
+    table_id table_uuid;
+    dht::token_range range;
+    gc_clock::time_point repair_time;
+};
+
 struct group0_command {
-    std::variant<schema_change, broadcast_table_query, topology_change, write_mutations> change;
+    std::variant<schema_change, broadcast_table_query, topology_change, write_mutations, repair_history_update> change;
 
     // Mutation of group0 history table, appending a new state ID and optionally a description.
     canonical_mutation history_append;

--- a/service/raft/group0_state_machine_merger.cc
+++ b/service/raft/group0_state_machine_merger.cc
@@ -34,7 +34,7 @@ size_t group0_state_machine_merger::cmd_size(group0_command& cmd) {
 bool group0_state_machine_merger::can_merge(group0_command& cmd, size_t s) const {
     if (!_cmd_to_merge.empty()) {
         // broadcast table commands or different type of commands cannot be merged
-        if (_cmd_to_merge[0].change.index() != cmd.change.index() || holds_alternative<broadcast_table_query>(cmd.change)) {
+        if (_cmd_to_merge[0].change.index() != cmd.change.index() || holds_alternative<broadcast_table_query>(cmd.change) || holds_alternative<repair_history_update>(cmd.change)) {
             return false;
         }
     }
@@ -79,6 +79,9 @@ std::vector<canonical_mutation>& group0_state_machine_merger::get_command_mutati
             return chng.mutations;
         },
         [] (write_mutations& muts) -> std::vector<canonical_mutation>& {
+            return muts.mutations;
+        },
+        [] (repair_history_update& muts) -> std::vector<canonical_mutation>& {
             return muts.mutations;
         }
     ), cmd.change);

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -297,7 +297,7 @@ future<group0_guard> raft_group0_client::start_operation(seastar::abort_source* 
 }
 
 template<typename Command>
-requires std::same_as<Command, schema_change> || std::same_as<Command, topology_change> || std::same_as<Command, write_mutations>
+requires std::same_as<Command, schema_change> || std::same_as<Command, topology_change> || std::same_as<Command, write_mutations> || std::same_as<Command, repair_history_update>
 group0_command raft_group0_client::prepare_command(Command change, group0_guard& guard, std::string_view description) {
     group0_command group0_cmd {
         .change{std::move(change)},
@@ -499,6 +499,7 @@ void raft_group0_client::set_query_result(utils::UUID query_id, service::broadca
 template group0_command raft_group0_client::prepare_command(schema_change change, group0_guard& guard, std::string_view description);
 template group0_command raft_group0_client::prepare_command(topology_change change, group0_guard& guard, std::string_view description);
 template group0_command raft_group0_client::prepare_command(write_mutations change, group0_guard& guard, std::string_view description);
+template group0_command raft_group0_client::prepare_command(repair_history_update change, group0_guard& guard, std::string_view description);
 template group0_command raft_group0_client::prepare_command(broadcast_table_query change, std::string_view description);
 template group0_command raft_group0_client::prepare_command(write_mutations change, std::string_view description);
 

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -137,7 +137,7 @@ public:
     requires std::same_as<Command, broadcast_table_query> || std::same_as<Command, write_mutations>
     group0_command prepare_command(Command change, std::string_view description);
     template<typename Command>
-    requires std::same_as<Command, schema_change> || std::same_as<Command, topology_change> || std::same_as<Command, write_mutations>
+    requires std::same_as<Command, schema_change> || std::same_as<Command, topology_change> || std::same_as<Command, write_mutations> || std::same_as<Command, repair_history_update>
     group0_command prepare_command(Command change, group0_guard& guard, std::string_view description);
     // Checks maximum allowed serialized command size, server rejects bigger commands with command_is_too_big_error exception
     size_t max_command_size() const;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -7071,6 +7071,14 @@ future<> storage_service::node_ops_abort_thread() {
     __builtin_unreachable();
 }
 
+future<> storage_service::update_repair_history(table_id table_uuid, dht::token_range range, gc_clock::time_point repair_time) {
+    return _db.invoke_on_all([table_uuid, range, repair_time] (replica::database& local_db) {
+        auto& gc_state = local_db.get_compaction_manager().get_tombstone_gc_state();
+        slogger.debug("Update repair history for table={} range={} time={}", table_uuid, range, repair_time);
+        return gc_state.update_repair_time(table_uuid, range, repair_time);
+    });
+}
+
 void storage_service::set_topology_change_kind(topology_change_kind kind) {
     _topology_change_kind_enabled = kind;
     _gossiper.set_topology_state_machine(kind == topology_change_kind::raft ? & _topology_state_machine : nullptr);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -871,6 +871,8 @@ public:
     // It is incompatible with the `join_cluster` method.
     future<> start_maintenance_mode();
 
+    future<> update_repair_history(table_id id, dht::token_range range, gc_clock::time_point repair_time);
+
 private:
     future<std::vector<canonical_mutation>> get_system_mutations(schema_ptr schema);
     future<std::vector<canonical_mutation>> get_system_mutations(const sstring& ks_name, const sstring& cf_name);


### PR DESCRIPTION
Currently, repiar history is written to repair participant nodes locally. When the range is migrated to a new node, the repair history is not migrated. This is not a big problem for vnode tables, since the range migration happens rarely only when a node is added or removed from the cluster. Token range migration happens much more frequently with tablet tables.

To solve the repair history migration problem, this patch changes system.repair_history to be replicated by the raft, like we do for other system tables, so that repair history will be available on all the nodes in the cluster no matter how token ranges are migrated.

This patch solves the migration problem for both vnode and tablet tables.

A new REPAIR_HISTORY_OVER_RAFT feature bit is added to turn on and use this feature only when all nodes support it.

Fixes #17507
Tests test_tablets.py::load_repair_history