### PR TITLE
Update Driver root page: from  AWS DynamoDB  to Amazon DynamoDB

### DIFF
--- a/docs/using-scylla/drivers/index.rst
+++ b/docs/using-scylla/drivers/index.rst
@@ -14,7 +14,7 @@ Scylla Drivers
 You can use Scylla with:
 
 * :doc:`Apache Cassandra CQL Compatible Drivers <cql-drivers/index>`
-* :doc:`AWS DynamoDB Compatible API Drivers <dynamo-drivers/index>`
+* :doc:`Amazon DynamoDB Compatible API Drivers <dynamo-drivers/index>`
 
 Additional drivers coming soon!
 


### PR DESCRIPTION
The right term is Amazon DynamoDB not AWS DynamoDB 
See https://aws.amazon.com/dynamodb/