### PR TITLE
tools/scylla-sstable: Use shorter check is unordered_set contains a key

### DIFF
--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -765,7 +765,7 @@ stop_iteration consume_reader(flat_mutation_reader_v2 rd, sstable_consumer& cons
     consumer_wrapper::filter_type filter;
     if (!partitions.empty()) {
         filter = [&] (const dht::decorated_key& key) {
-            const auto pass = partitions.count(key) != 0;
+            const auto pass = partitions.contains(key);
             sst_log.trace("filter({})={}", key, pass);
             skip_partition = !pass;
             return pass;


### PR DESCRIPTION
Currentl code counts the number of keys in it just to see if this number is non-zero. Using .contains() method is better fit here