### PR TITLE
[Backport 5.2] repair: fix memory counting in repair

### DIFF
--- a/repair/row.hh
+++ b/repair/row.hh
@@ -50,6 +50,9 @@ public:
         }
         return *_mf;
     }
+    void reset_mutation_fragment() {
+        _mf = nullptr;
+    }
     frozen_mutation_fragment& get_frozen_mutation() {
         if (!_fm) {
             throw std::runtime_error("empty frozen_mutation_fragment");
@@ -69,7 +72,14 @@ public:
         if (!_fm) {
             throw std::runtime_error("empty size due to empty frozen_mutation_fragment");
         }
-        return _fm->representation().size();
+        auto size = sizeof(repair_row) + _fm->representation().size();
+        if (_boundary) {
+            size += _boundary->pk.external_memory_usage() + _boundary->position.external_memory_usage();
+        }
+        if (_mf) {
+            size += _mf->memory_usage();
+        }
+        return size;
     }
     const repair_sync_boundary& boundary() const {
         if (!_boundary) {

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -133,3 +133,33 @@ SEASTAR_TEST_CASE(flush_repair_rows_on_wire_to_sstable) {
     });
 }
 
+SEASTAR_TEST_CASE(repair_rows_size_considers_external_memory) {
+    return seastar::async([&] {
+        tests::reader_concurrency_semaphore_wrapper semaphore;
+        reader_permit permit = semaphore.make_permit();
+        random_mutation_generator gen{random_mutation_generator::generate_counters::no};
+        schema_ptr s = gen.schema();
+        auto m = make_lw_shared<replica::memtable>(s);
+        auto r = *make_random_repair_rows_on_wire(gen, s, permit, m).begin();
+        uint64_t seed = tests::random::get_int<uint64_t>();
+
+        auto& frozen_mf = *r.get_mutation_fragments().begin();
+        auto mf = make_lw_shared<mutation_fragment>(frozen_mf.unfreeze(*s, permit));
+        auto dk_ptr = make_lw_shared<const decorated_key_with_hash>(*s, dht::decorate_key(*s, r.get_key()), seed);
+        position_in_partition pos(mf->position());
+        repair_sync_boundary boundary{dk_ptr->dk, pos};
+        auto fmf_size = frozen_mf.representation().size();
+
+        // Test that frozen mutation fragment memory is counted.
+        repair_row row{frozen_mf, std::nullopt, nullptr, std::nullopt, is_dirty_on_master::no, nullptr};
+        BOOST_REQUIRE_EQUAL(row.size(), fmf_size + sizeof(repair_row));
+
+        // Test that mutation fragment memory is counted.
+        repair_row row_with_mf{frozen_mf, std::nullopt, nullptr, std::nullopt, is_dirty_on_master::no, mf};
+        BOOST_REQUIRE_EQUAL(row_with_mf.size(), fmf_size + mf->memory_usage() + sizeof(repair_row));
+
+        // Test that boundary memory is counted.
+        repair_row row_with_boundary{frozen_mf, pos, dk_ptr, std::nullopt, is_dirty_on_master::no, nullptr};
+        BOOST_REQUIRE_EQUAL(row_with_boundary.size(), fmf_size + boundary.pk.external_memory_usage() + boundary.position.external_memory_usage() + sizeof(repair_row));
+    });
+}


### PR DESCRIPTION
Repair memory limit includes only the size of frozen mutation
fragments in repair row. The size of other members of repair
row may grow uncontrollably and cause out of memory.

Modify what's counted to repair memory limit.

Fixes: https://github.com/scylladb/scylladb/issues/16710.

(cherry picked from commit https://github.com/scylladb/scylladb/commit/a4dc6553ab8f1a30a7eab88a5b4170a1201aa22a)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/51c09a84cc421681f3f9f17c5b69e1976d7f5f8e)

Refs https://github.com/scylladb/scylladb/pull/17785