### PR TITLE
api: Qualify callback commitlog* argument with const

### DIFF
--- a/api/commitlog.cc
+++ b/api/commitlog.cc
@@ -17,7 +17,7 @@ namespace api {
 using namespace seastar::httpd;
 
 template<typename T>
-static auto acquire_cl_metric(http_context& ctx, std::function<T (db::commitlog*)> func) {
+static auto acquire_cl_metric(http_context& ctx, std::function<T (const db::commitlog*)> func) {
     typedef T ret_type;
 
     return ctx.db.map_reduce0([func = std::move(func)](replica::database& db) {


### PR DESCRIPTION
There's a helper map-reducer that accepts a function to call on commitlog. All callers accumulate statistics with it, so the commitlog argument is const pointer.