### PR TITLE
[Backport 5.2] : Track and limit memory used by bloom filters

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -817,6 +817,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , unspooled_dirty_soft_limit(this, "unspooled_dirty_soft_limit", value_status::Used, 0.6, "Soft limit of unspooled dirty memory expressed as a portion of the hard limit")
     , sstable_summary_ratio(this, "sstable_summary_ratio", value_status::Used, 0.0005, "Enforces that 1 byte of summary is written for every N (2000 by default) "
         "bytes written to data file. Value must be between 0 and 1.")
+    , components_memory_reclaim_threshold(this, "components_memory_reclaim_threshold", liveness::LiveUpdate, value_status::Used, .1, "Ratio of available memory for all in-memory components of SSTables in a shard beyond which the memory will be reclaimed from components until it falls back under the threshold. Currently, this limit is only enforced for bloom filters.")
     , large_memory_allocation_warning_threshold(this, "large_memory_allocation_warning_threshold", value_status::Used, size_t(1) << 20, "Warn about memory allocations above this size; set to zero to disable")
     , enable_deprecated_partitioners(this, "enable_deprecated_partitioners", value_status::Used, false, "Enable the byteordered and random partitioners. These partitioners are deprecated and will be removed in a future version.")
     , enable_keyspace_column_family_metrics(this, "enable_keyspace_column_family_metrics", value_status::Used, false, "Enable per keyspace and per column family metrics reporting")

--- a/db/config.hh
+++ b/db/config.hh
@@ -322,6 +322,7 @@ public:
     named_value<unsigned> murmur3_partitioner_ignore_msb_bits;
     named_value<double> unspooled_dirty_soft_limit;
     named_value<double> sstable_summary_ratio;
+    named_value<double> components_memory_reclaim_threshold;
     named_value<size_t> large_memory_allocation_warning_threshold;
     named_value<bool> enable_deprecated_partitioners;
     named_value<bool> enable_keyspace_column_family_metrics;

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1397,7 +1397,7 @@ future<> sstable::open_data(sstable_open_config cfg) noexcept {
     _stats.on_open_for_reading();
 
     _total_reclaimable_memory.reset();
-    _manager.increment_total_reclaimable_memory(this);
+    _manager.increment_total_reclaimable_memory_and_maybe_reclaim(this);
 }
 
 future<> sstable::update_info_for_opened_data(sstable_open_config cfg) {
@@ -1558,7 +1558,7 @@ future<> sstable::load(sstables::foreign_sstable_open_info info) noexcept {
         validate_partitioner();
         return update_info_for_opened_data().then([this]() {
             _total_reclaimable_memory.reset();
-            _manager.increment_total_reclaimable_memory(this);
+            _manager.increment_total_reclaimable_memory_and_maybe_reclaim(this);
         });
     });
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1397,6 +1397,7 @@ future<> sstable::open_data(sstable_open_config cfg) noexcept {
     _stats.on_open_for_reading();
 
     _total_reclaimable_memory.reset();
+    _manager.increment_total_reclaimable_memory(this);
 }
 
 future<> sstable::update_info_for_opened_data(sstable_open_config cfg) {
@@ -1557,6 +1558,7 @@ future<> sstable::load(sstables::foreign_sstable_open_info info) noexcept {
         validate_partitioner();
         return update_info_for_opened_data().then([this]() {
             _total_reclaimable_memory.reset();
+            _manager.increment_total_reclaimable_memory(this);
         });
     });
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1395,6 +1395,8 @@ future<> sstable::open_data(sstable_open_config cfg) noexcept {
     }
     _open_mode.emplace(open_flags::ro);
     _stats.on_open_for_reading();
+
+    _total_reclaimable_memory.reset();
 }
 
 future<> sstable::update_info_for_opened_data(sstable_open_config cfg) {
@@ -1498,6 +1500,31 @@ void sstable::write_filter(const io_priority_class& pc) {
     write_simple<component_type::Filter>(filter_ref, pc);
 }
 
+size_t sstable::total_reclaimable_memory_size() const {
+    if (!_total_reclaimable_memory) {
+        _total_reclaimable_memory = _components->filter ? _components->filter->memory_size() : 0;
+    }
+
+    return _total_reclaimable_memory.value();
+}
+
+size_t sstable::reclaim_memory_from_components() {
+    size_t total_memory_reclaimed = 0;
+
+    if (_components->filter) {
+        auto filter_memory_size = _components->filter->memory_size();
+        if (filter_memory_size > 0) {
+            // discard it from memory by replacing it with an always present variant
+            _components->filter = std::make_unique<utils::filter::always_present_filter>();
+            _recognized_components.erase(component_type::Filter);
+            total_memory_reclaimed += filter_memory_size;
+        }
+    }
+
+    _total_reclaimable_memory.reset();
+    return total_memory_reclaimed;
+}
+
 // This interface is only used during tests, snapshot loading and early initialization.
 // No need to set tunable priorities for it.
 future<> sstable::load(const io_priority_class& pc, sstable_open_config cfg) noexcept {
@@ -1528,7 +1555,9 @@ future<> sstable::load(sstables::foreign_sstable_open_info info) noexcept {
         validate_min_max_metadata();
         validate_max_local_deletion_time();
         validate_partitioner();
-        return update_info_for_opened_data();
+        return update_info_for_opened_data().then([this]() {
+            _total_reclaimable_memory.reset();
+        });
     });
 }
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -585,6 +585,11 @@ private:
     // information in their scylla metadata.
     std::optional<scylla_metadata::large_data_stats> _large_data_stats;
     sstring _origin;
+
+    // Total reclaimable memory from all the components of the SSTable.
+    // It is initialized to 0 to prevent the sstables manager from reclaiming memory
+    // from the components before the SSTable has been fully loaded.
+    mutable std::optional<size_t> _total_reclaimable_memory{0};
 public:
     const bool has_component(component_type f) const;
     sstables_manager& manager() { return _manager; }
@@ -662,6 +667,12 @@ private:
     future<> load_first_and_last_position_in_partition();
 
     future<> create_data() noexcept;
+
+    // Return the total reclaimable memory in this SSTable
+    size_t total_reclaimable_memory_size() const;
+    // Reclaim memory from the components back to the system.
+    // Note that only bloom filters are reclaimable.
+    size_t reclaim_memory_from_components();
 
 public:
     // Finds first position_in_partition in a given partition.

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -20,7 +20,7 @@ logging::logger smlogger("sstables_manager");
 
 sstables_manager::sstables_manager(
     db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker& ct, size_t available_memory, directory_semaphore& dir_sem)
-    : _large_data_handler(large_data_handler), _db_config(dbcfg), _features(feat), _cache_tracker(ct)
+    : _available_memory(available_memory), _large_data_handler(large_data_handler), _db_config(dbcfg), _features(feat), _cache_tracker(ct)
     , _sstable_metadata_concurrency_sem(
         max_count_sstable_metadata_concurrent_reads,
         max_memory_sstable_metadata_concurrent_reads(available_memory),

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -69,8 +69,25 @@ sstable_writer_config sstables_manager::configure_writer(sstring origin) const {
     return cfg;
 }
 
-void sstables_manager::increment_total_reclaimable_memory(sstable* sst) {
+void sstables_manager::increment_total_reclaimable_memory_and_maybe_reclaim(sstable* sst) {
     _total_reclaimable_memory += sst->total_reclaimable_memory_size();
+
+    size_t memory_reclaim_threshold = _available_memory * _db_config.components_memory_reclaim_threshold();
+    if (_total_reclaimable_memory <= memory_reclaim_threshold) {
+        // total memory used is within limit; no need to reclaim.
+        return;
+    }
+
+    // Memory consumption has crossed threshold. Reclaim from the SSTable that
+    // has the most reclaimable memory to get the total consumption under limit.
+    auto sst_with_max_memory = std::max_element(_active.begin(), _active.end(), [](const sstable& sst1, const sstable& sst2) {
+        return sst1.total_reclaimable_memory_size() < sst2.total_reclaimable_memory_size();
+    });
+
+    auto memory_reclaimed = sst_with_max_memory->reclaim_memory_from_components();
+    _total_memory_reclaimed += memory_reclaimed;
+    _total_reclaimable_memory -= memory_reclaimed;
+    smlogger.info("Reclaimed {} bytes of memory from SSTable components. Total memory reclaimed so far is {} bytes", memory_reclaimed, _total_memory_reclaimed);
 }
 
 void sstables_manager::add(sstable* sst) {

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -69,11 +69,18 @@ sstable_writer_config sstables_manager::configure_writer(sstring origin) const {
     return cfg;
 }
 
+void sstables_manager::increment_total_reclaimable_memory(sstable* sst) {
+    _total_reclaimable_memory += sst->total_reclaimable_memory_size();
+}
+
 void sstables_manager::add(sstable* sst) {
     _active.push_back(*sst);
 }
 
 void sstables_manager::deactivate(sstable* sst) {
+    // Remove SSTable from the reclaimable memory tracking
+    _total_reclaimable_memory -= sst->total_reclaimable_memory_size();
+
     // At this point, sst has a reference count of zero, since we got here from
     // lw_shared_ptr_deleter<sstables::sstable>::dispose().
     _active.erase(_active.iterator_to(*sst));

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -48,6 +48,7 @@ class sstables_manager {
             boost::intrusive::member_hook<sstable, sstable::manager_link_type, &sstable::_manager_link>,
             boost::intrusive::constant_time_size<false>>;
 private:
+    size_t _available_memory;
     db::large_data_handler& _large_data_handler;
     const db::config& _db_config;
     gms::feature_service& _features;

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -136,6 +136,9 @@ private:
         return _large_data_handler;
     }
     friend class sstable;
+
+    // Allow testing private methods/variables via test_env_sstables_manager
+    friend class test_env_sstables_manager;
 };
 
 }   // namespace sstables

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -68,6 +68,8 @@ private:
 
     // Total reclaimable memory used by components of sstables in _active list
     size_t _total_reclaimable_memory{0};
+    // Total memory reclaimed so far across all sstables
+    size_t _total_memory_reclaimed{0};
 
     bool _closing = false;
     promise<> _done;
@@ -125,7 +127,10 @@ private:
     // Allow at most 10% of memory to be filled with such reads.
     size_t max_memory_sstable_metadata_concurrent_reads(size_t available_memory) { return available_memory * 0.1; }
 
-    void increment_total_reclaimable_memory(sstable* sst);
+    // Increment the _total_reclaimable_memory with the new SSTable's reclaimable
+    // memory and if the total memory usage exceeds the pre-defined threshold,
+    // reclaim it from the SSTable that has the most reclaimable memory.
+    void increment_total_reclaimable_memory_and_maybe_reclaim(sstable* sst);
 private:
     db::large_data_handler& get_large_data_handler() const {
         return _large_data_handler;

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -65,6 +65,9 @@ private:
     list_type _active;
     list_type _undergoing_close;
 
+    // Total reclaimable memory used by components of sstables in _active list
+    size_t _total_reclaimable_memory{0};
+
     bool _closing = false;
     promise<> _done;
     cache_tracker& _cache_tracker;
@@ -120,6 +123,8 @@ private:
     static constexpr size_t max_count_sstable_metadata_concurrent_reads{10};
     // Allow at most 10% of memory to be filled with such reads.
     size_t max_memory_sstable_metadata_concurrent_reads(size_t available_memory) { return available_memory * 0.1; }
+
+    void increment_total_reclaimable_memory(sstable* sst);
 private:
     db::large_data_handler& get_large_data_handler() const {
         return _large_data_handler;

--- a/test/cql-pytest/test_bloom_filter.py
+++ b/test/cql-pytest/test_bloom_filter.py
@@ -5,14 +5,20 @@
 import pytest
 import rest_api
 import nodetool
-from util import new_test_table
+from util import new_test_table, config_value_context
 from cassandra.protocol import ConfigurationException
+
+# Disable component memory reclamation by setting the threshold to max value
+@pytest.fixture(scope="module")
+def disable_component_memory_reclaim(cql):
+    with config_value_context(cql, 'components_memory_reclaim_threshold', '1'):
+        yield
 
 # Test inserts `N` rows into table, flushes it 
 # and tries to read `M` non-existing keys.
 # Then bloom filter's false-positive ratio is checked.
 @pytest.mark.parametrize("N,M,fp_chance", [(500, 1000, 0.1)])
-def test_bloom_filter(scylla_only, cql, test_keyspace, N, M, fp_chance):
+def test_bloom_filter(scylla_only, cql, test_keyspace, disable_component_memory_reclaim, N, M, fp_chance):
     with new_test_table(cql, test_keyspace, "a int PRIMARY KEY", 
         f"WITH bloom_filter_fp_chance = {fp_chance}") as table:
         

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -43,6 +43,7 @@ public:
 
 struct test_env_config {
     db::large_data_handler* large_data_handler = nullptr;
+    size_t available_memory = memory::stats().total_memory();
 };
 
 class test_env {

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -39,6 +39,14 @@ public:
     void set_promoted_index_block_size(size_t promoted_index_block_size) {
         _promoted_index_block_size = promoted_index_block_size;
     }
+
+    void increment_total_reclaimable_memory_and_maybe_reclaim(sstable *sst) {
+        sstables_manager::increment_total_reclaimable_memory_and_maybe_reclaim(sst);
+    }
+
+    size_t get_total_memory_reclaimed() {
+        return _total_memory_reclaimed;
+    }
 };
 
 struct test_env_config {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -224,6 +224,19 @@ public:
     static fs::path filename(const sstable& sst, component_type c) {
         return fs::path(sst.filename(c));
     }
+
+    void create_bloom_filter(uint64_t estimated_partitions, double max_false_pos_prob = 0.1) {
+        _sst->_components->filter = utils::i_filter::get_filter(estimated_partitions, max_false_pos_prob, utils::filter_format::m_format);
+        _sst->_total_reclaimable_memory.reset();
+    }
+
+    size_t total_reclaimable_memory_size() const {
+        return _sst->total_reclaimable_memory_size();
+    }
+
+    size_t reclaim_memory_from_components() {
+        return _sst->reclaim_memory_from_components();
+    }
 };
 
 inline auto replacer_fn_no_op() {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -310,11 +310,11 @@ public:
         });
     }
 
-    static future<> do_with_tmp_directory(std::function<future<> (test_env&, sstring tmpdir_path)>&& fut) {
+    static future<> do_with_tmp_directory(std::function<future<> (test_env&, sstring tmpdir_path)>&& fut, test_env_config cfg = {}) {
         return test_env::do_with_async([fut = std::move(fut)] (test_env& env) {
             auto tmp = tmpdir();
             fut(env, tmp.path().string()).get();
-        });
+        }, cfg);
     }
 
     static future<> do_with_cloned_tmp_directory(sstring src, std::function<future<> (test_env&, sstring srcdir_path, sstring destdir_path)>&& fut) {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -151,7 +151,7 @@ namespace sstables {
 test_env::impl::impl(test_env_config cfg)
     : dir_sem(1)
     , feature_service(gms::feature_config_from_db_config(db_config))
-    , mgr(cfg.large_data_handler == nullptr ? nop_ld_handler : *cfg.large_data_handler, db_config, feature_service, cache_tracker, memory::stats().total_memory(), dir_sem)
+    , mgr(cfg.large_data_handler == nullptr ? nop_ld_handler : *cfg.large_data_handler, db_config, feature_service, cache_tracker, cfg.available_memory, dir_sem)
     , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env")
 { }
 


### PR DESCRIPTION
Added support to track and limit the memory usage by sstable components. A reclaimable component of an SSTable is one from which memory can be reclaimed. SSTables and their managers now track such reclaimable memory and limit the component memory usage accordingly. A new configuration variable defines the memory reclaim threshold. If the total memory of the reclaimable components exceeds this limit, memory will be reclaimed to keep the usage under the limit. This PR considers only the bloom filters as reclaimable and adds support to track and limit them as required.

The feature can be manually verified by doing the following :

1. run a single-node single-shard 1GB cluster
2. create a table with bloom-filter-false-positive-chance of 0.001 (to intentionally cause large bloom filter)
3. populate with tiny partitions
4. watch the bloom filter metrics get capped at 100MB

The default value of the `components_memory_reclaim_threshold` config variable which controls the reclamation process is `.1`. This can also be reduced further during manual tests to easily hit the threshold and verify the feature.

Fixes https://github.com/scylladb/scylladb/issues/17747

Backported from #17771 to 5.2.