### PR TITLE
install.sh: use the native nodetool directly

### DIFF
--- a/bin/nodetool
+++ b/bin/nodetool
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+SCRIPT_PATH=$(dirname $(realpath "$0"))
+
+INSTALLED_SCYLLA_PATH="${SCRIPT_PATH}/scylla"
+
+# Allow plugging scylla path for local testing
+exec ${SCYLLA:-${INSTALLED_SCYLLA_PATH}} nodetool $@

--- a/dist/common/nodetool-completion
+++ b/dist/common/nodetool-completion
@@ -1,0 +1,269 @@
+# Apache Cassandra
+# Copyright 2009- The Apache Software Foundation
+#
+# This product includes software developed by The Apache Software
+# Foundation (http://www.apache.org/).
+#
+# Modified by ScyllaDB
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+have nodetool && have cqlsh &&
+{
+
+    show_keyspaces()
+    {
+        local ks=$(get_keyspaces)
+        COMPREPLY=( $(compgen -W "$ks" -- "$1") )
+    }
+
+    get_keyspaces()
+    {
+        [ -z "$keyspaces" ] && keyspaces=$(echo "DESCRIBE KEYSPACES" | cqlsh | grep -E -v '^$')
+        echo $keyspaces
+    }
+
+    show_datacenters()
+    {
+        cur=$1
+        set|grep -q ^dcs || dcs=$(echo "select data_center from system.peers;"|cqlsh |tail -n +4|sort|uniq|awk '{if(length($1)>1) print $1}'|xargs)
+        COMPREPLY=( $(compgen -W "$dcs" -- "$cur") )
+    }
+
+    show_cfs()
+    {
+        local cur prev cfs
+        prev=$1
+        cur=$2
+        cfs=$(get_cfs $1 $2)
+        COMPREPLY=( $(compgen -W "$cfs" -- "$cur") )
+    }
+
+    get_cfs()
+    {
+        local prev
+        prev=$1
+        [ -z "${cf[$prev]}" ] && cf[$prev]=$(echo "DESCRIBE COLUMNFAMILIES" | cqlsh -k ${prev} | grep -E -v '^$')
+        echo ${cf[$prev]}
+    }
+
+    show_last_cfs()
+    {
+        local cur cfs re
+        cur=$1
+        re=$(echo ${COMP_WORDS[@]:3:$(($COMP_CWORD - 3))} | sed -e 's/ /\\|/g')
+        cfs=$(get_cfs ${COMP_WORDS[2]} | sed -e "s/$re//g")
+        COMPREPLY=( $(compgen -W "$cfs" -- "${cur}") )
+    }
+
+    _nodetool()
+    {
+        local cur prev ks
+        COMPREPLY=()
+        _get_comp_words_by_ref cur prev
+
+        local shopt='
+            bootstrap
+            compactionhistory
+            compactionstats
+            decommission
+            describecluster
+            disablebackup
+            disablebinary
+            disablegossip
+            disablehandoff
+            disablehintsfordc
+            disablethrift
+            drain
+            enablebackup
+            enablebinary
+            enablegossip
+            enablehandoff
+            enablethrift
+            enablehintsfordc
+            failuredetector
+            gcstats
+            getcompactionthroughput
+            getconcurrentcompactors
+            getinterdcstreamthroughput
+            getlogginglevels
+            getstreamthroughput
+            gettimeout
+            gettraceprobability
+            gossipinfo
+            help
+            invalidatecountercache
+            invalidatekeycache
+            invalidaterowcache
+            join
+            listsnapshots
+            pausehandoff
+            proxyhistograms
+            rangekeysample
+            refreshsizeestimates
+            reloadlocalschema
+            reloadtriggers
+            replaybatchlog
+            resetlocalschema
+            resumehandoff
+            ring
+            setconcurrentcompactors
+            sethintedhandoffthrottlekb
+            setinterdcstreamthroughput
+            setlogginglevel
+            settimeout
+            status
+            statusbackup
+            statusbinary
+            statusthrift
+            statusgossip
+            statushandoff
+            stopdaemon
+            tablestats
+            tpstats
+            version
+            '
+
+        local lngopt='
+            assassinate
+            cleanup
+            clearsnapshot
+            compact
+            describering
+            disableautocompaction
+            enableautocompaction
+            flush
+            garbagecollect
+            getcompactionthreshold
+            getendpoints
+            getsstables
+            info
+            move
+            netstats
+            rebuild
+            rebuild_index
+            refresh
+            relocatesstables
+            removenode
+            repair
+            scrub
+            setcachecapacity
+            setcachekeystosave
+            setcompactionthreshold
+            setcompactionthroughput
+            setstreamthroughput
+            settraceprobability
+            snapshot
+            stop
+            tablehistograms
+            toppartitions
+            truncatehints
+            upgradesstables
+            verify
+            viewbuildstatus
+	    '
+
+        local optwks='
+            cleanup
+            clearsnapshot
+            compact
+            describering
+            flush
+            garbagecollect
+            getcompactionthreshold
+            getendpoints
+            getsstables
+            rebuild_index
+            refresh
+            relocatesstables
+            repair
+            scrub
+            setcompactionthreshold
+            snapshot
+            tablehistograms
+            toppartitions
+            verify
+            viewbuildstatus
+            '
+
+        local optwcfs='
+            cleanup
+            compact
+            disableautocompaction
+            enableautocompaction
+            flush
+            garbagecollect
+            relocatesstables
+            repair
+            scrub
+            toppartitions
+            upgradesstables
+            verify
+            '
+
+        if [[ $COMP_CWORD -eq 1 ]] ; then
+            COMPREPLY=( $(compgen -W "${lngopt} ${shopt}" -- "${cur}") )
+        elif [[ $(echo "${lngopt}"|grep -E -c "\b${prev}\b") -gt 0 ]] ; then
+            if echo $optwks|grep -q "\b$prev\b" ; then
+                show_keyspaces "${cur}"
+            else
+                case "${prev}" in
+                    removenode)
+                        # we don't want to lose time using nodetool status a 2nd time
+                        # in case of force or status
+                        if [[ "${cur}" =~ ^(f|s) ]] ; then
+                            COMPREPLY=( $(compgen -W "status force" -- "${cur}") )
+                        else
+                            [ -z "$IDS" ] && IDS=$(nodetool status|grep %|awk '{print $7}'|xargs)
+                            COMPREPLY=( $(compgen -W "status force $IDS" -- "${cur}") )
+                        fi
+                        return 0
+                        ;;
+                    stop)
+                        COMPREPLY=( $(compgen -W "COMPACTION VALIDATION CLEANUP SCRUB VERIFY INDEX_BUILD" -- "${cur}") )
+                        return 0
+                        ;;
+                    info)
+                        COMPREPLY=( $(compgen -W "-T --tokens" -- "${cur}") )
+                        return 0
+                        ;;
+                    rebuild|disablehintsfordc|enablehintsfordc)
+                        show_datacenters "${cur}"
+                        return 0
+                        ;;
+                    upgradesstables)
+                        ks=$(get_keyspaces)
+                        COMPREPLY=( $(compgen -W "-a --include-all-sstables $ks" -- "${cur}") )
+                        return 0
+                        ;;
+                esac
+            fi
+        elif [[ $COMP_CWORD -eq 3 ]] ; then
+            case "${COMP_WORDS[1]}" in
+                cleanup|compact|flush|garbagecollect|getcompactionthreshold|getendpoints|getsstables|rebuild_index|refresh|relocatesstables|repair|scrub|setcompactionthreshold|tablehistograms|toppartitions|verify)
+                    show_cfs ${prev} ${cur}
+                    return 0
+                    ;;
+                upgradesstables)
+                    if [[ ! ${prev} == -* ]]; then
+                        show_cfs ${prev} ${cur}
+                    fi
+                    return 0
+                    ;;
+                snapshot)
+                    COMPREPLY=( $(compgen -W "-cf" -- "${cur}") )
+                    return 0
+                    ;;
+            esac
+        elif [[ "${optwcfs}" == *${COMP_WORDS[1]}* ]] ; then
+            show_last_cfs ${cur}
+        elif [[ $COMP_CWORD -eq 4 && ${COMP_WORDS[1]} == "snapshot" ]] ; then
+            show_cfs ${COMP_WORDS[2]} ${cur}
+        elif [[ $COMP_CWORD -eq 5 && ${COMP_WORDS[1]} == "snapshot" ]] ; then
+            COMPREPLY=( $(compgen -W "-t" -- "${cur}") )
+        fi
+    }
+    complete -F _nodetool nodetool
+}

--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -18,6 +18,8 @@ Conflicts: %{product}-server (<< 1.1)
 Package: %{product}-server
 Architecture: any
 Depends: ${misc:Depends}, %{product}-conf (= ${binary:Version}), %{product}-python3 (= ${binary:Version})
+Replaces: %{product}-tools (<<5.5)
+Breaks: %{product}-tools (<<5.5)
 Description: Scylla database server binaries 
  Scylla is a highly scalable, eventually consistent, distributed,
  partitioned row DB.

--- a/dist/debian/debian/scylla-server.install
+++ b/dist/debian/debian/scylla-server.install
@@ -1,6 +1,7 @@
 etc/default/scylla-server
 etc/default/scylla-housekeeping
 etc/scylla.d/*.conf
+etc/bash_completion.d/nodetool-completion
 opt/scylladb/share/doc/scylla/*
 opt/scylladb/share/doc/scylla/licenses/
 usr/lib/systemd/system/*.timer
@@ -8,6 +9,7 @@ usr/lib/systemd/system/*.slice
 usr/bin/scylla
 usr/bin/iotune
 usr/bin/scyllatop
+usr/bin/nodetool
 usr/sbin/scylla*
 usr/sbin/node_health_check
 usr/sbin/seastar-cpu-map.sh

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -74,6 +74,8 @@ Summary:        The Scylla database server
 Requires:       %{product}-conf = %{version}-%{release}
 Requires:       %{product}-python3 = %{version}-%{release}
 AutoReqProv:    no
+Provides:       %{product}-tools:%{_bindir}/nodetool
+Provides:       %{product}-tools:%{_sysconfigdir}/bash_completion.d/nodetool-completion
 
 %description server
 This package contains ScyllaDB server.
@@ -122,6 +124,7 @@ ln -sfT /etc/scylla /var/lib/scylla/conf
 %{_bindir}/scylla
 %{_bindir}/iotune
 %{_bindir}/scyllatop
+%{_bindir}/nodetool
 %{_sbindir}/scylla*
 %{_sbindir}/node_health_check
 %{_sbindir}/seastar-cpu-map.sh
@@ -148,6 +151,7 @@ ln -sfT /etc/scylla /var/lib/scylla/conf
 %ghost %config /etc/systemd/system/var-lib-systemd-coredump.mount
 %ghost /etc/systemd/system/scylla-cpupower.service
 %ghost %config /etc/systemd/system/var-lib-scylla.mount
+%{_sysconfdir}/bash_completion.d/nodetool-completion
 
 %package conf
 Group:          Applications/Databases

--- a/install.sh
+++ b/install.sh
@@ -450,6 +450,11 @@ if $supervisor; then
     install -m755 dist/common/supervisor/* -Dt "$rprefix"/supervisor
 fi
 
+# scylla tools
+install -d -m755 "$retc"/bash_completion.d
+install -m644 dist/common/nodetool-completion "$retc"/bash_completion.d
+install -m755 bin/nodetool "$rprefix/bin"
+
 SBINFILES=$(cd dist/common/scripts/; ls scylla_*setup node_health_check scylla_kernel_check)
 SBINFILES+=" $(cd seastar/scripts; ls seastar-cpu-map.sh)"
 
@@ -524,6 +529,7 @@ EOS
     ln -srf "$rprefix/bin/scylla" "$rusr/bin/scylla"
     ln -srf "$rprefix/bin/iotune" "$rusr/bin/iotune"
     ln -srf "$rprefix/bin/scyllatop" "$rusr/bin/scyllatop"
+    ln -srf "$rprefix/bin/nodetool" "$rusr/bin/nodetool"
     install -d "$rusr"/sbin
     for i in $SBINFILES; do
         ln -srf "$rprefix/scripts/$i" "$rusr/sbin/$i"

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -171,6 +171,7 @@ ar.reloc_add('swagger-ui')
 ar.reloc_add('api')
 ar.reloc_add('tools/scyllatop')
 ar.reloc_add('scylla-gdb.py')
+ar.reloc_add('bin/nodetool')
 ar.reloc_add(args.debian_dir, arcname='debian')
 node_exporter_dir = args.node_exporter_dir
 if args.stripped:


### PR DESCRIPTION
Add a bin/nodetool and install it to bin/ in install.sh. This script simply forwards to scylla nodetool and it is the replacement for the Java nodetool, which is dropped from the java-tools's install.sh, in the submodule update also included in this patch.
With this change, we now hardwire the usage of the native nodetool, as *the* nodetool, with the intermediary nodetool wrapper script removed from the picture.
Bash completion was copied from the java tools repository and it is now installed by the scylla package, together with nodetool.

Testing

I tested upgrades on a DEB and RPM distro: Ubuntu and Fedora.
First I installed scylla-5.4, then I installed the packages for this PR. On Ubuntu, I had to use `dpkg -i --auto-deconfigure`, otherwise, `dpkg` would refuse to install the new packages because they break the old ones. No extra flags were required on Fedora.
In both cases, `/usr/bin/nodetool` was changed from a thunk calling the Java nodetool (from 5.4) to the native launcher script from this PR.
`/opt/scylladb/share/cassandra/bin/nodetool` remained in place and still works after the upgrade.

I also verified that --nonroot installs also work. Nodetool works both
when called with an absolute path, or when ~/scylladb/bin is added to
$PATH.

Fixes: https://github.com/scylladb/scylladb/issues/18226
Fixes: https://github.com/scylladb/scylladb/issues/17412