### PR TITLE
test: paritioner_test: print using fmt::print()

### DIFF
--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -523,14 +523,16 @@ do_test_selective_token_range_sharder(const dht::sharder& input_sharder, const s
             if (range_shard->start() && range_shard->start()->is_inclusive()) {
                 auto start_shard = input_sharder.shard_of(range_shard->start()->value());
                 if (debug) {
-                    std::cout << " start_shard " << start_shard << " shard " << shard << " range " << range_shard << "\n";
+                    fmt::print(" start_shard {} shard {} range {}\n",
+                               start_shard, shard, range_shard);
                 }
                 BOOST_REQUIRE(start_shard == shard);
             }
             if (range_shard->end() && range_shard->end()->is_inclusive()) {
                 auto end_shard = input_sharder.shard_of(range_shard->end()->value());
                 if (debug) {
-                    std::cout << " end_shard " << end_shard << " shard " << shard << " range " << range_shard << "\n";
+                    fmt::print(" end_shard {} shard range {}\n",
+                               end_shard, shard, range_shard);
                 }
                 BOOST_REQUIRE(end_shard == shard);
             }
@@ -539,7 +541,8 @@ do_test_selective_token_range_sharder(const dht::sharder& input_sharder, const s
                     range_shard->end() ? range_shard->end()->value() : dht::minimum_token());
             auto mid_shard = input_sharder.shard_of(midpoint);
             if (debug) {
-                std::cout << " mid " << mid_shard << " shard " << shard << " range " << range_shard << "\n";
+                fmt::print(" mid {} shard {} range {}\n",
+                           mid_shard, shard, range_shard);
             }
             BOOST_REQUIRE(mid_shard == shard);
 


### PR DESCRIPTION
instead of using `operator<<`, use `fmt::print()` to format and print, so we can ditch the `operator<<`-based formatters.

Refs #13245