### PR TITLE
test: extract boost_test_print_type() into test_utils.hh

### DIFF
--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -812,22 +812,6 @@ BOOST_AUTO_TEST_CASE(test_empty_key_view_comparison) {
     BOOST_CHECK(lf.begin() == lf.end());
 }
 
-template <typename T> concept Formattable = fmt::is_formattable<T>::value;
-
-namespace sstables {
-
-template <Formattable T>
-std::ostream& boost_test_print_type(std::ostream& os, const T& v) {
-    fmt::print(os, "{}", v);
-    return os;
-}
-
-std::ostream& boost_test_print_type(std::ostream& os, sstable_format_types format_type) {
-    return os << static_cast<int>(format_type);
-}
-
-}
-
 // Test that sstables::parse_path is able to parse the paths of sstables
 BOOST_AUTO_TEST_CASE(test_parse_path_good) {
     struct sstable_case {

--- a/test/lib/test_utils.hh
+++ b/test/lib/test_utils.hh
@@ -118,4 +118,11 @@ std::ostream& boost_test_print_type(std::ostream& os, const std::strong_ordering
 std::ostream& boost_test_print_type(std::ostream& os, const std::weak_ordering& order);
 std::ostream& boost_test_print_type(std::ostream& os, const std::partial_ordering& order);
 
+template <typename T>
+requires fmt::is_formattable<T>::value
+std::ostream& boost_test_print_type(std::ostream& os, const T& p) {
+    fmt::print(os, "{}", p);
+    return os;
+}
+
 }


### PR DESCRIPTION
since Boost.Test relies on operator<< or `boost_test_print_type()` to print the value of variables being compared, instead of defining the fallback formatter of `boost_test_print_type()` for each individual test, let's define it in `test/lib/test_utils.hh`, so that it can be shared across tests.

Refs #13245