### PR TITLE
topology_coordinator: compute cluster size correctly during upgrade

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2446,10 +2446,12 @@ future<> topology_coordinator::build_coordinator_state(group0_guard guard) {
                 [this] (abort_source*) { return start_operation();}, _as);
     }
 
+    auto tmptr = get_token_metadata_ptr();
+
     auto sl_version = co_await _sys_ks.get_service_levels_version();
     if (!sl_version || *sl_version < 2) {
         rtlogger.info("migrating service levels data");
-        co_await qos::service_level_controller::migrate_to_v2(_gossiper.num_endpoints(), _sys_ks, _sys_ks.query_processor(), _group0.client(), _as);
+        co_await qos::service_level_controller::migrate_to_v2(tmptr->get_all_endpoints().size(), _sys_ks, _sys_ks.query_processor(), _group0.client(), _as);
     }
 
     rtlogger.info("building initial raft topology state and CDC generation");
@@ -2466,7 +2468,6 @@ future<> topology_coordinator::build_coordinator_state(group0_guard guard) {
     };
 
     // Create a new CDC generation
-    auto tmptr = get_token_metadata_ptr();
     auto get_sharding_info_for_host_id = [&] (locator::host_id host_id) -> std::pair<size_t, uint8_t> {
         const auto ep = tmptr->get_endpoint_for_host_id_if_known(host_id);
         if (!ep) {

--- a/test/topology_experimental_raft/test_topology_upgrade_not_stuck_after_recent_removal.py
+++ b/test/topology_experimental_raft/test_topology_upgrade_not_stuck_after_recent_removal.py
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import asyncio
+import logging
+import pytest
+import time
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.rest_client import inject_error
+from test.pylib.util import wait_for_cql_and_get_hosts
+from test.topology.conftest import skip_mode
+from test.topology.util import wait_until_topology_upgrade_finishes, \
+        wait_for_cdc_generations_publishing, \
+        check_system_topology_and_cdc_generations_v3_consistency
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_topology_upgrade_not_stuck_after_recent_removal(request, manager: ManagerClient):
+    """
+    Regression test for https://github.com/scylladb/scylladb/issues/18198.
+    1. Create a two node cluster in legacy mode
+    2. Remove one of the nodes
+    3. Upgrade the cluster to raft topology.
+    4. Verify that the upgrade went OK and it did not get stuck.
+    """
+    # First, force the nodes to start in legacy mode due to the error injection
+    cfg = {'force_gossip_topology_changes': True}
+
+    logging.info("Creating a two node cluster")
+    servers = [await manager.server_add(config=cfg) for _ in range(2)]
+    cql = manager.cql
+    assert(cql)
+
+    srv1, srv2 = servers
+
+    logging.info("Removing the second node in the cluster")
+    await manager.decommission_node(srv2.server_id)
+
+    logging.info("Waiting until driver connects to the only server")
+    host1 = (await wait_for_cql_and_get_hosts(cql, [srv1], time.time() + 60))[0]
+
+    logging.info("Checking the upgrade state")
+    status = await manager.api.raft_topology_upgrade_status(host1.address)
+    assert status == "not_upgraded"
+    
+    logging.info("Triggering upgrade to raft topology")
+    await manager.api.upgrade_to_raft_topology(host1.address)
+
+    logging.info("Waiting until upgrade finishes")
+    await wait_until_topology_upgrade_finishes(manager, host1.address, time.time() + 60)
+
+    logging.info("Waiting for CDC generations publishing")
+    await wait_for_cdc_generations_publishing(cql, [host1], time.time() + 60)
+
+    logging.info("Checking consistency of data in system.topology and system.cdc_generations_v3")
+    await check_system_topology_and_cdc_generations_v3_consistency(manager, [host1])


### PR DESCRIPTION
During upgrade to raft topology, information about service levels is copied from the legacy tables in system_distributed to the raft-managed tables of group 0. system_distributed has RF=3, so if the cluster has only one or two nodes we should use lower consistency level than ALL - and the current procedure does exactly that, it selects QUORUM in case of two nodes and ONE in case of only one node. The cluster size is determined based on the call to _gossiper.num_endpoints().
    
Despite its name, gossiper::num_endpoints() does not necessarily return the number of nodes in the cluster but rather the number of endpoint states in gossiper (this behavior is documented in a comment near the declaration of this function). In some cases, e.g. after gossiper-based nodetool remove, the state might be kept for some time after removal (3 days in this case).

The consequence of this is that gossiper::num_endpoints() might return more than the current number of nodes during upgrade, and that in turn might cause migration of data from one table to another to fail - causing the upgrade procedure to get stuck if there is only 1 or two nodes in the cluster.

In order to fix this, use token_metadata::get_all_endpoints() as a measure of the cluster size.

Fixes: scylladb/scylladb#18198