### PR TITLE
utils: include "seastarx.hh" in composite_abort_source.hh

### DIFF
--- a/utils/composite_abort_source.hh
+++ b/utils/composite_abort_source.hh
@@ -1,5 +1,6 @@
 #include "seastar/core/abort_source.hh"
 #include "utils/small_vector.hh"
+#include "seastarx.hh"
 
 namespace utils {
 // A facility to combine several abort_source-s and expose them as a single abort_source.


### PR DESCRIPTION
there is chance that `utils/small_vector.hh` does not include `using namespace seastar`, and even if it does, we should not rely on it. but if it does not, checkhh would fail. so let's include "seastarx.hh" in this header, so it is self-contained.