### PR TITLE
[github] add PR template and action to verify PR tasks was completed

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,2 @@
+- [ ] ** Backport reason (please explain below if this patch should be backported or not) **
+

--- a/.github/workflows/pr-check-completed-tests.yaml
+++ b/.github/workflows/pr-check-completed-tests.yaml
@@ -1,0 +1,12 @@
+name: 'PR Tasks Completed Check'
+on: 
+  pull_request_target:
+    types: [opened, edited]
+
+jobs:
+  task-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: chromaui/task-completed-checker-action@main
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Today with the backport automation, the developer added the relevant backport label, but without any explanation of why

Adding the PR template with a placeholder for the developer to add his decision about backport yes or no

The placeholder is marked as a task, so once the explanation is added, the task must be checked as completed

Also adding another check to the PR summary will make it clear to the maintainer/reviewer if the developer explained about backport