### PR TITLE
Enrich test results produced by test.py

### DIFF
--- a/test/object_store/conftest.py
+++ b/test/object_store/conftest.py
@@ -30,6 +30,13 @@ def pytest_addoption(parser):
                      help='Manager unix socket path')
     parser.addoption('--mode', action='store', required=True,
                      help='Scylla build mode. Tests can use it to adjust their behavior.')
+    parser.addoption('--run_id', action='store', default=None,
+                     help='Run id for the test run')
+    parser.addoption('--tmpdir', action='store', type=str, dest='tmpdir',
+                     help='Temporary directory where logs are stored')
+    parser.addoption("--artifacts_dir_url", action='store', type=str, default=None, dest="artifacts_dir_url",
+                     help="Provide the URL to artifacts directory to generate the link to failed tests directory "
+                          "with logs")
     parser.addoption('--auth_username', action='store', default=None,
                         help='username for authentication')
     parser.addoption('--auth_password', action='store', default=None,


### PR DESCRIPTION
Related to #17851

This PR resolves issue with double count of the test result for topology tests. It will not appear in the consolidated report anymore.
Another fix is to provide a better view which test failed by modifying the test case name in the report enriching it with mode and run id, so making them unique across the run.

The scope of this change is:
1. Modify the test name to have run id in name
2. Add handlers to get logs of test.py and pytest in one file that are related to test, rather than to the full suite
3. Remove topology tests from aggregating them on a suite level in Junit results
4. Add a link to the logs related to the failed tests in Junit results, so it will be easier to navigate to all logs related to test
5. Gather logs related to the failed test to one directory for better logs investigation