### PR TITLE
compaction: Disconsider active tables in the hourly compaction reevaluation

### DIFF
--- a/compaction/compaction_state.hh
+++ b/compaction/compaction_state.hh
@@ -15,6 +15,7 @@
 
 #include "compaction/compaction_fwd.hh"
 #include "compaction/compaction_backlog_manager.hh"
+#include "gc_clock.hh"
 
 namespace compaction {
 
@@ -36,6 +37,8 @@ struct compaction_state {
 
     std::unordered_set<sstables::shared_sstable> sstables_requiring_cleanup;
     compaction::owned_ranges_ptr owned_ranges_ptr;
+
+    gc_clock::time_point last_regular_compaction;
 
     explicit compaction_state(table_state& t);
     compaction_state(compaction_state&&) = delete;


### PR DESCRIPTION
This hourly reevaluation is there to help tablets that have very low write activity, which can go a long time without flushing a memtable, and it's important to reevaluate compaction as data can get expired. Today it can happen that we reevaluate a table that is being compacted actively, which is waste of cpu as the reevaluation will happen anyway when there are changes to sstable set. This waste can be amplified with a significant tablet count in a given shard.
Eventually, we could make the revaluation time per table based on expiration histogram, but until we get there, let's avoid this waste by only reevaluating tables that are compaction idle for more than 1h.