### PR TITLE
db: config: move consistent-topology-changes out of experimental and make it the default for new clusters

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -473,12 +473,11 @@ static std::optional<cdc::generation_id> get_generation_id_for(const gms::inet_a
 
 static future<std::optional<cdc::topology_description>> retrieve_generation_data_v2(
         cdc::generation_id_v2 id,
-        bool raft_experimental_topology,
         db::system_keyspace& sys_ks,
         db::system_distributed_keyspace& sys_dist_ks) {
     auto cdc_gen = co_await sys_dist_ks.read_cdc_generation(id.id);
 
-    if (raft_experimental_topology && !cdc_gen) {
+    if (!cdc_gen) {
         // If we entered legacy mode due to recovery, we (or some other node)
         // might gossip about a generation that was previously propagated
         // through raft. If that's the case, it will sit in
@@ -491,7 +490,6 @@ static future<std::optional<cdc::topology_description>> retrieve_generation_data
 
 static future<std::optional<cdc::topology_description>> retrieve_generation_data(
         cdc::generation_id gen_id,
-        bool raft_experimental_topology,
         db::system_keyspace& sys_ks,
         db::system_distributed_keyspace& sys_dist_ks,
         db::system_distributed_keyspace::context ctx) {
@@ -500,14 +498,13 @@ static future<std::optional<cdc::topology_description>> retrieve_generation_data
         return sys_dist_ks.read_cdc_topology_description(id, ctx);
     },
     [&] (const cdc::generation_id_v2& id) {
-        return retrieve_generation_data_v2(id, raft_experimental_topology, sys_ks, sys_dist_ks);
+        return retrieve_generation_data_v2(id, sys_ks, sys_dist_ks);
     }
     ), gen_id);
 }
 
 static future<> do_update_streams_description(
         cdc::generation_id gen_id,
-        bool raft_experimental_topology,
         db::system_keyspace& sys_ks,
         db::system_distributed_keyspace& sys_dist_ks,
         db::system_distributed_keyspace::context ctx) {
@@ -518,7 +515,7 @@ static future<> do_update_streams_description(
 
     // We might race with another node also inserting the description, but that's ok. It's an idempotent operation.
 
-    auto topo = co_await retrieve_generation_data(gen_id, raft_experimental_topology, sys_ks, sys_dist_ks, ctx);
+    auto topo = co_await retrieve_generation_data(gen_id, sys_ks, sys_dist_ks, ctx);
     if (!topo) {
         throw no_generation_data_exception(gen_id);
     }
@@ -537,13 +534,12 @@ static future<> do_update_streams_description(
  */
 static future<> update_streams_description(
         cdc::generation_id gen_id,
-        bool raft_experimental_topology,
         db::system_keyspace& sys_ks,
         shared_ptr<db::system_distributed_keyspace> sys_dist_ks,
         noncopyable_function<unsigned()> get_num_token_owners,
         abort_source& abort_src) {
     try {
-        co_await do_update_streams_description(gen_id, raft_experimental_topology, sys_ks, *sys_dist_ks, { get_num_token_owners() });
+        co_await do_update_streams_description(gen_id, sys_ks, *sys_dist_ks, { get_num_token_owners() });
     } catch (...) {
         cdc_log.warn(
             "Could not update CDC description table with generation {}: {}. Will retry in the background.",
@@ -551,7 +547,6 @@ static future<> update_streams_description(
 
         // It is safe to discard this future: we keep system distributed keyspace alive.
         (void)(([] (cdc::generation_id gen_id,
-                    bool raft_experimental_topology,
                     db::system_keyspace& sys_ks,
                     shared_ptr<db::system_distributed_keyspace> sys_dist_ks,
                     noncopyable_function<unsigned()> get_num_token_owners,
@@ -564,7 +559,7 @@ static future<> update_streams_description(
                     co_return;
                 }
                 try {
-                    co_await do_update_streams_description(gen_id, raft_experimental_topology, sys_ks, *sys_dist_ks, { get_num_token_owners() });
+                    co_await do_update_streams_description(gen_id, sys_ks, *sys_dist_ks, { get_num_token_owners() });
                     co_return;
                 } catch (...) {
                     cdc_log.warn(
@@ -572,7 +567,7 @@ static future<> update_streams_description(
                         gen_id, std::current_exception());
                 }
             }
-        })(gen_id, raft_experimental_topology, sys_ks, std::move(sys_dist_ks), std::move(get_num_token_owners), abort_src));
+        })(gen_id, sys_ks, std::move(sys_dist_ks), std::move(get_num_token_owners), abort_src));
     }
 }
 
@@ -610,7 +605,6 @@ struct time_and_ttl {
  */
 static future<std::optional<cdc::generation_id_v1>> rewrite_streams_descriptions(
         std::vector<time_and_ttl> times_and_ttls,
-        bool raft_experimental_topology,
         db::system_keyspace& sys_ks,
         shared_ptr<db::system_distributed_keyspace> sys_dist_ks,
         noncopyable_function<unsigned()> get_num_token_owners,
@@ -655,7 +649,7 @@ static future<std::optional<cdc::generation_id_v1>> rewrite_streams_descriptions
     co_await max_concurrent_for_each(first, tss.end(), 10, [&] (db_clock::time_point ts) -> future<> {
         while (true) {
             try {
-                co_return co_await do_update_streams_description(cdc::generation_id_v1{ts}, raft_experimental_topology, sys_ks, *sys_dist_ks, { get_num_token_owners() });
+                co_return co_await do_update_streams_description(cdc::generation_id_v1{ts}, sys_ks, *sys_dist_ks, { get_num_token_owners() });
             } catch (const no_generation_data_exception& e) {
                 cdc_log.error("Failed to rewrite streams for generation {}: {}. Giving up.", ts, e);
                 each_success = false;
@@ -731,7 +725,6 @@ future<> generation_service::maybe_rewrite_streams_descriptions() {
     cdc_log.info("Rewriting stream tables in the background...");
     auto last_rewritten = co_await rewrite_streams_descriptions(
             std::move(times_and_ttls),
-            _cfg.raft_experimental_topology,
             _sys_ks.local(),
             _sys_dist_ks.local_shared(),
             std::move(get_num_token_owners),
@@ -907,7 +900,7 @@ future<> generation_service::check_and_repair_cdc_streams() {
 
         std::optional<topology_description> gen;
         try {
-            gen = co_await retrieve_generation_data(*latest, _cfg.raft_experimental_topology, _sys_ks.local(), *sys_dist_ks, { tmptr->count_normal_token_owners() });
+            gen = co_await retrieve_generation_data(*latest, _sys_ks.local(), *sys_dist_ks, { tmptr->count_normal_token_owners() });
         } catch (exceptions::request_timeout_exception& e) {
             cdc_log.error("{}: \"{}\". {}.", timeout_msg, e.what(), exception_translating_msg);
             throw exceptions::request_execution_exception(exceptions::exception_code::READ_TIMEOUT,
@@ -1023,7 +1016,7 @@ future<> generation_service::legacy_handle_cdc_generation(std::optional<cdc::gen
 
     if (using_this_gen) {
         cdc_log.info("Starting to use generation {}", *gen_id);
-        co_await update_streams_description(*gen_id, _cfg.raft_experimental_topology, _sys_ks.local(), get_sys_dist_ks(),
+        co_await update_streams_description(*gen_id, _sys_ks.local(), get_sys_dist_ks(),
                 [tmptr = _token_metadata.get()] { return tmptr->count_normal_token_owners(); },
                 _abort_src);
     }
@@ -1040,7 +1033,7 @@ void generation_service::legacy_async_handle_cdc_generation(cdc::generation_id g
                 bool using_this_gen = co_await svc->legacy_do_handle_cdc_generation_intercept_nonfatal_errors(gen_id);
                 if (using_this_gen) {
                     cdc_log.info("Starting to use generation {}", gen_id);
-                    co_await update_streams_description(gen_id, svc->_cfg.raft_experimental_topology, svc->_sys_ks.local(), svc->get_sys_dist_ks(),
+                    co_await update_streams_description(gen_id, svc->_sys_ks.local(), svc->get_sys_dist_ks(),
                             [tmptr = svc->_token_metadata.get()] { return tmptr->count_normal_token_owners(); },
                             svc->_abort_src);
                 }
@@ -1109,7 +1102,7 @@ future<bool> generation_service::legacy_do_handle_cdc_generation(cdc::generation
     assert_shard_zero(__PRETTY_FUNCTION__);
 
     auto sys_dist_ks = get_sys_dist_ks();
-    auto gen = co_await retrieve_generation_data(gen_id, _cfg.raft_experimental_topology, _sys_ks.local(), *sys_dist_ks, { _token_metadata.get()->count_normal_token_owners() });
+    auto gen = co_await retrieve_generation_data(gen_id, _sys_ks.local(), *sys_dist_ks, { _token_metadata.get()->count_normal_token_owners() });
     if (!gen) {
         throw std::runtime_error(format(
             "Could not find CDC generation {} in distributed system tables (current time: {}),"

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -41,7 +41,6 @@ public:
         unsigned ignore_msb_bits;
         std::chrono::milliseconds ring_delay;
         bool dont_rewrite_streams = false;
-        bool raft_experimental_topology = false;
     };
 
 private:

--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -278,7 +278,6 @@ batch_size_fail_threshold_in_kb: 1024
 # experimental_features:
 #     - udf
 #     - alternator-streams
-#     - consistent-topology-changes
 #     - broadcast-tables
 #     - keyspace-storage-options
 #     - tablets

--- a/db/config.cc
+++ b/db/config.cc
@@ -1339,7 +1339,7 @@ std::map<sstring, db::experimental_features_t::feature> db::experimental_feature
         {"cdc", feature::UNUSED},
         {"alternator-streams", feature::ALTERNATOR_STREAMS},
         {"alternator-ttl", feature::UNUSED },
-        {"consistent-topology-changes", feature::CONSISTENT_TOPOLOGY_CHANGES},
+        {"consistent-topology-changes", feature::UNUSED},
         {"broadcast-tables", feature::BROADCAST_TABLES},
         {"keyspace-storage-options", feature::KEYSPACE_STORAGE_OPTIONS},
         {"tablets", feature::TABLETS},

--- a/db/config.hh
+++ b/db/config.hh
@@ -110,7 +110,6 @@ struct experimental_features_t {
         UNUSED,
         UDF,
         ALTERNATOR_STREAMS,
-        CONSISTENT_TOPOLOGY_CHANGES,
         BROADCAST_TABLES,
         KEYSPACE_STORAGE_OPTIONS,
         TABLETS,

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -234,7 +234,7 @@ future<> save_system_schema(cql3::query_processor& qp) {
     co_await save_system_schema_to_keyspace(qp, schema_tables::NAME);
     // #2514 - make sure "system" is written to system_schema.keyspaces.
     co_await save_system_schema_to_keyspace(qp, system_keyspace::NAME);
-        co_await save_system_schema_to_keyspace(qp, system_auth_keyspace::NAME);
+    co_await save_system_schema_to_keyspace(qp, system_auth_keyspace::NAME);
 }
 
 namespace v3 {

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -234,10 +234,7 @@ future<> save_system_schema(cql3::query_processor& qp) {
     co_await save_system_schema_to_keyspace(qp, schema_tables::NAME);
     // #2514 - make sure "system" is written to system_schema.keyspaces.
     co_await save_system_schema_to_keyspace(qp, system_keyspace::NAME);
-    if (qp.db().get_config().check_experimental(
-        db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES)) {
         co_await save_system_schema_to_keyspace(qp, system_auth_keyspace::NAME);
-    }
 }
 
 namespace v3 {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2149,8 +2149,8 @@ std::vector<schema_ptr> system_keyspace::all_tables(const db::config& cfg) {
                     topology(), cdc_generations_v3(), topology_requests(), service_levels_v2(),
     });
 
-        auto auth_tables = db::system_auth_keyspace::all_tables();
-        std::copy(auth_tables.begin(), auth_tables.end(), std::back_inserter(r));
+    auto auth_tables = db::system_auth_keyspace::all_tables();
+    std::copy(auth_tables.begin(), auth_tables.end(), std::back_inserter(r));
 
     if (cfg.check_experimental(db::experimental_features_t::feature::BROADCAST_TABLES)) {
         r.insert(r.end(), {broadcast_kv_store()});

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2145,18 +2145,12 @@ std::vector<schema_ptr> system_keyspace::all_tables(const db::config& cfg) {
                     v3::truncated(),
                     v3::commitlog_cleanups(),
                     v3::cdc_local(),
+                    raft(), raft_snapshots(), raft_snapshot_config(), group0_history(), discovery(),
+                    topology(), cdc_generations_v3(), topology_requests(), service_levels_v2(),
     });
 
-    r.insert(r.end(), {raft(), raft_snapshots(), raft_snapshot_config(), group0_history(), discovery()});
-
-    if (cfg.check_experimental(db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES)) {
-        r.insert(r.end(), {topology(), cdc_generations_v3(), topology_requests(), service_levels_v2()});
-    }
-
-    if (cfg.check_experimental(db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES)) {
         auto auth_tables = db::system_auth_keyspace::all_tables();
         std::copy(auth_tables.begin(), auth_tables.end(), std::back_inserter(r));
-    }
 
     if (cfg.check_experimental(db::experimental_features_t::feature::BROADCAST_TABLES)) {
         r.insert(r.end(), {broadcast_kv_store()});

--- a/docs/architecture/raft.rst
+++ b/docs/architecture/raft.rst
@@ -237,7 +237,7 @@ In summary, Raft makes schema changes safe, but it requires that a quorum of nod
 
 .. only:: opensource
 
-    Consistent Topology with Raft :label-caution:`Experimental`
+    Consistent Topology with Raft
     -----------------------------------------------------------------
 
     ScyllaDB can use Raft to manage cluster topology. With Raft-managed topology 
@@ -250,19 +250,11 @@ In summary, Raft makes schema changes safe, but it requires that a quorum of nod
     be bootstrapped concurrently, which couldn't be done with the old 
     gossip-based topology.
 
-    Support for Raft-managed topology is experimental and must be explicitly 
-    enabled in the ``scylla.yaml`` configuration file by specifying 
-    the ``consistent-topology-changes`` option:
-
-    .. code:: 
-    
-        experimental_features:
-        - consistent-topology-changes
-
-    As with other experimental features in ScyllaDB, you should not enable this 
-    feature in production clusters due to insufficient stability. The feature 
-    is undergoing backward-incompatible changes that may prevent upgrading 
-    the cluster. 
+    Raft-managed topology is enabled by default in new cluster installations
+    starting from 6.0. After upgrading from 5.4 to 6.0, the cluster will
+    continue using the old gossip-based topology. You must perform manual action
+    to enable the Raft-based topology. See :doc:`the guide for enabling consistent topology changes</upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology>`
+    for more details.
 
 .. _raft-handling-failures:
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -254,11 +254,11 @@ future<> feature_service::enable_features_on_startup(db::system_keyspace& sys_ks
     std::set<sstring> persisted_features;
     std::set<sstring> persisted_unsafe_to_disable_features;
 
-        auto topo_features = co_await sys_ks.load_topology_features_state();
-        if (topo_features) {
-            persisted_unsafe_to_disable_features = topo_features->calculate_not_yet_enabled_features();
-            persisted_features = std::move(topo_features->enabled_features);
-        } else {
+    auto topo_features = co_await sys_ks.load_topology_features_state();
+    if (topo_features) {
+        persisted_unsafe_to_disable_features = topo_features->calculate_not_yet_enabled_features();
+        persisted_features = std::move(topo_features->enabled_features);
+    } else {
         persisted_features = co_await sys_ks.load_local_enabled_features();
     }
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -78,9 +78,6 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
     if (!cfg.check_experimental(db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS)) {
         fcfg._disabled_features.insert("KEYSPACE_STORAGE_OPTIONS"s);
     }
-    if (!cfg.check_experimental(db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES)) {
-        fcfg._disabled_features.insert("SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES"s);
-    }
     if (!cfg.check_experimental(db::experimental_features_t::feature::TABLETS)) {
         fcfg._disabled_features.insert("TABLETS"s);
     }
@@ -257,16 +254,11 @@ future<> feature_service::enable_features_on_startup(db::system_keyspace& sys_ks
     std::set<sstring> persisted_features;
     std::set<sstring> persisted_unsafe_to_disable_features;
 
-    bool fall_back_to_legacy = true;
-    if (_config.use_raft_cluster_features) {
         auto topo_features = co_await sys_ks.load_topology_features_state();
         if (topo_features) {
             persisted_unsafe_to_disable_features = topo_features->calculate_not_yet_enabled_features();
             persisted_features = std::move(topo_features->enabled_features);
-            fall_back_to_legacy = false;
-        }
-    }
-    if (fall_back_to_legacy) {
+        } else {
         persisted_features = co_await sys_ks.load_local_enabled_features();
     }
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -32,7 +32,6 @@ class feature_service;
 class i_endpoint_state_change_subscriber;
 
 struct feature_config {
-    bool use_raft_cluster_features = false;
 private:
     std::set<sstring> _disabled_features;
     feature_config();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1768,7 +1768,7 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
             throw std::runtime_error(err);
         }
 
-        co_await _group0->finish_setup_after_join(*this, _qp, _migration_manager.local(), _raft_experimental_topology);
+        co_await _group0->finish_setup_after_join(*this, _qp, _migration_manager.local(), true);
 
         // Initializes monitor only after updating local topology.
         start_tablet_split_monitor();
@@ -1933,7 +1933,7 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
     }
 
     assert(_group0);
-    co_await _group0->finish_setup_after_join(*this, _qp, _migration_manager.local(), _raft_experimental_topology);
+    co_await _group0->finish_setup_after_join(*this, _qp, _migration_manager.local(), false);
     co_await _cdc_gens.local().after_join(std::move(cdc_gen_id));
 
     if (_raft_experimental_topology) {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -208,7 +208,7 @@ public:
 
     // Needed by distributed<>
     future<> stop();
-    void init_messaging_service(bool raft_topology_change_enabled);
+    void init_messaging_service();
     future<> uninit_messaging_service();
 
     future<> load_tablet_metadata();
@@ -358,7 +358,7 @@ public:
     future<> join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy,
             sharded<gms::gossiper>& gossiper_ptr, start_hint_manager start_hm, gms::generation_type new_generation);
 
-    void set_group0(service::raft_group0&, bool raft_experimental_topology);
+    void set_group0(service::raft_group0&);
 
     future<> init_address_map(raft_address_map& address_map, gms::generation_type new_generation);
 
@@ -750,7 +750,6 @@ private:
 
     friend class group0_state_machine;
 
-    bool _raft_experimental_topology = false;
     enum class topology_change_kind {
         // The node is still starting and didn't determine yet which ops kind to use
         unknown,

--- a/test/auth_cluster/suite.yaml
+++ b/test/auth_cluster/suite.yaml
@@ -6,4 +6,3 @@ extra_scylla_config_options:
   authenticator: PasswordAuthenticator
   authorizer: CassandraAuthorizer
   enable_user_defined_functions: False
-  experimental_features: ['consistent-topology-changes']

--- a/test/auth_cluster/suite.yaml
+++ b/test/auth_cluster/suite.yaml
@@ -2,9 +2,6 @@ type: Topology
 pool_size: 2
 cluster:
   initial_size: 0
-skip_in_release:
-  - test_auth_v2_migration
-  - test_service_levels_upgrade
 extra_scylla_config_options:
   authenticator: PasswordAuthenticator
   authorizer: CassandraAuthorizer

--- a/test/auth_cluster/test_auth_v2_migration.py
+++ b/test/auth_cluster/test_auth_v2_migration.py
@@ -129,13 +129,13 @@ async def check_auth_v2_works(manager: ManagerClient, hosts):
 
 @pytest.mark.asyncio
 async def test_auth_v2_migration(request, manager: ManagerClient):
-    # First, force the first node to start in legacy mode due to the error injection
-    cfg = {'error_injections_at_startup': ['force_gossip_based_join']}
+    # First, force the first node to start in legacy mode
+    cfg = {'force_gossip_topology_changes': True}
 
     servers = [await manager.server_add(config=cfg)]
-    # Disable injections for the subsequent nodes - they should fall back to
+    # Enable raft-based node operations for subsequent nodes - they should fall back to
     # using gossiper-based node operations
-    del cfg['error_injections_at_startup']
+    del cfg['force_gossip_topology_changes']
 
     servers += [await manager.server_add(config=cfg) for _ in range(2)]
     cql = manager.cql

--- a/test/auth_cluster/test_raft_service_levels.py
+++ b/test/auth_cluster/test_raft_service_levels.py
@@ -57,15 +57,14 @@ async def test_service_levels_snapshot(manager: ManagerClient):
     assert set([sl.service_level for sl in result]) == set([sl.service_level for sl in new_result])
 
 @pytest.mark.asyncio
-@skip_mode('release', 'error injections are not supported in release mode')
 async def test_service_levels_upgrade(request, manager: ManagerClient):
-    # First, force the first node to start in legacy mode due to the error injection
-    cfg = {'error_injections_at_startup': ['force_gossip_based_join']}
+    # First, force the first node to start in legacy mode
+    cfg = {'force_gossip_topology_changes': True}
 
     servers = [await manager.server_add(config=cfg)]
-    # Disable injections for the subsequent nodes - they should fall back to
+    # Enable raft-based node operations for subsequent nodes - they should fall back to
     # using gossiper-based node operations
-    del cfg['error_injections_at_startup']
+    del cfg['force_gossip_topology_changes']
 
     servers += [await manager.server_add(config=cfg) for _ in range(2)]
     cql = manager.get_cql()

--- a/test/boost/auth_test.cc
+++ b/test/boost/auth_test.cc
@@ -39,9 +39,6 @@ cql_test_config auth_on(bool with_authorizer = true) {
         cfg.db_config->authorizer("CassandraAuthorizer");
     }
     cfg.db_config->authenticator("PasswordAuthenticator");
-    cfg.db_config->experimental_features({
-        db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES,
-    });
     return cfg;
 }
 

--- a/test/boost/config_test.cc
+++ b/test/boost/config_test.cc
@@ -921,7 +921,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_cdc) {
     BOOST_CHECK(cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
     BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
-    BOOST_CHECK(!cfg.check_experimental(ef::CONSISTENT_TOPOLOGY_CHANGES));
     BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
@@ -934,7 +933,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_unused) {
     BOOST_CHECK(cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
     BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
-    BOOST_CHECK(!cfg.check_experimental(ef::CONSISTENT_TOPOLOGY_CHANGES));
     BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
@@ -947,7 +945,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_udf) {
     BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(cfg.check_experimental(ef::UDF));
     BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
-    BOOST_CHECK(!cfg.check_experimental(ef::CONSISTENT_TOPOLOGY_CHANGES));
     BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
@@ -960,21 +957,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_alternator_streams) {
     BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
     BOOST_CHECK(cfg.check_experimental(ef::ALTERNATOR_STREAMS));
-    BOOST_CHECK(!cfg.check_experimental(ef::CONSISTENT_TOPOLOGY_CHANGES));
-    BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
-    return make_ready_future();
-}
-
-SEASTAR_TEST_CASE(test_parse_experimental_features_consistent_topology_changes) {
-    auto cfg_ptr = std::make_unique<config>();
-    config& cfg = *cfg_ptr;
-    cfg.read_from_yaml("experimental_features:\n    - consistent-topology-changes\n", throw_on_error);
-    BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::CONSISTENT_TOPOLOGY_CHANGES});
-    BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
-    BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
-    BOOST_CHECK(cfg.check_experimental(ef::CONSISTENT_TOPOLOGY_CHANGES));
-    BOOST_CHECK(!cfg.check_experimental(ef::BROADCAST_TABLES));
     BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
@@ -987,7 +969,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_broadcast_tables) {
     BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
     BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
-    BOOST_CHECK(!cfg.check_experimental(ef::CONSISTENT_TOPOLOGY_CHANGES));
     BOOST_CHECK(cfg.check_experimental(ef::BROADCAST_TABLES));
     BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
@@ -1001,7 +982,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_keyspace_storage_options) {
     BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
     BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
-    BOOST_CHECK(!cfg.check_experimental(ef::CONSISTENT_TOPOLOGY_CHANGES));
     BOOST_CHECK(cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -5712,7 +5712,6 @@ cql_test_config tablet_cql_test_config() {
     cql_test_config c;
     c.db_config->experimental_features({
             db::experimental_features_t::feature::TABLETS,
-            db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES,
         }, db::config::config_source::CommandLine);
     return c;
 }

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -267,6 +267,10 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
 }
 
 SEASTAR_TEST_CASE(test_read_required_hosts) {
+    // FIXME: the test fails without using force_gossip_topology_changes.
+    // Fix the test and remove force_gossip_topology_changes from config.
+    auto cfg = tablet_cql_test_config();
+    cfg.db_config->force_gossip_topology_changes(true);
     return do_with_cql_env_thread([] (cql_test_env& e) {
         auto h1 = host_id(utils::UUID_gen::get_time_UUID());
         auto h2 = host_id(utils::UUID_gen::get_time_UUID());
@@ -328,7 +332,7 @@ SEASTAR_TEST_CASE(test_read_required_hosts) {
         verify_tablet_metadata_persistence(e, tm, ts);
         BOOST_REQUIRE_EQUAL(std::unordered_set<locator::host_id>({h1, h2, h3}),
                             read_required_hosts(e.local_qp()).get());
-    }, tablet_cql_test_config());
+    }, cfg);
 }
 
 SEASTAR_TEST_CASE(test_get_shard) {

--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -312,7 +312,6 @@ def run_scylla_cmd(pid, dir):
         # test/alternator/run.
         '--experimental-features=udf',
         '--experimental-features=keyspace-storage-options',
-        '--experimental-features=consistent-topology-changes',
         '--experimental-features=tablets',
         '--enable-user-defined-functions', '1',
         # Set up authentication in order to allow testing this module

--- a/test/cql-pytest/suite.yaml
+++ b/test/cql-pytest/suite.yaml
@@ -4,6 +4,5 @@ dirties_cluster:
   - test_native_transport
 extra_scylla_cmdline_options:
   - '--experimental-features=udf'
-  - '--experimental-features=consistent-topology-changes'
   - '--experimental-features=keyspace-storage-options'
   - '--experimental-features=tablets'

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -632,6 +632,8 @@ private:
             _db.local().init_schema_commitlog();
             _sys_ks.invoke_on_all(&db::system_keyspace::mark_writable).get();
 
+            _sys_ks.local().build_bootstrap_info().get();
+
             auto host_id = cfg_in.host_id;
             if (!host_id) {
                 auto linfo = _sys_ks.local().load_local_info().get();
@@ -901,6 +903,8 @@ private:
             auto stop_group0_usage_in_storage_service = defer([this] {
                 _ss.local().wait_for_group0_stop().get();
             });
+
+            group0_service.setup_group0_if_exist(_sys_ks.local(), _ss.local(), _qp.local(), _mm.local()).get();
 
             try {
                 _ss.local().join_cluster(_sys_dist_ks, _proxy, _gossiper, service::start_hint_manager::no, generation_number).get();

--- a/test/perf/perf_tablets.cc
+++ b/test/perf/perf_tablets.cc
@@ -38,7 +38,6 @@ cql_test_config tablet_cql_test_config() {
     cql_test_config c;
     c.db_config->experimental_features({
                db::experimental_features_t::feature::TABLETS,
-               db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES
        }, db::config::config_source::CommandLine);
     return c;
 }

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -86,7 +86,6 @@ def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addr
         'enable_user_defined_functions': True,
         'experimental_features': ['udf',
                                   'alternator-streams',
-                                  'consistent-topology-changes',
                                   'broadcast-tables',
                                   'keyspace-storage-options'],
 

--- a/test/rest_api/suite.yaml
+++ b/test/rest_api/suite.yaml
@@ -7,5 +7,4 @@ skip_in_release:
 
 extra_scylla_cmdline_options:
   - '--experimental-features=udf'
-  - '--experimental-features=consistent-topology-changes'
   - '--experimental-features=tablets'

--- a/test/topology_custom/test_boot_after_ip_change.py
+++ b/test/topology_custom/test_boot_after_ip_change.py
@@ -22,7 +22,7 @@ async def test_boot_after_ip_change(manager: ManagerClient) -> None:
        Regression test for #14468. Does not apply to Raft-topology mode.
     """
     cfg = {'enable_user_defined_functions': False,
-           'experimental_features': list[str]()}
+           'force_gossip_topology_changes': True}
     logger.info(f"Booting initial cluster")
     servers = [await manager.server_add(config=cfg) for _ in range(2)]
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)

--- a/test/topology_custom/test_different_group0_ids.py
+++ b/test/topology_custom/test_different_group0_ids.py
@@ -28,12 +28,8 @@ async def test_different_group0_ids(manager: ManagerClient):
     """
 
     # Consistent topology changes are disabled to use repair based node operations.
-    scylla_a = await manager.server_add(config={
-        'experimental_features': ["udf"] # disable consistent topology changes
-    })
-    scylla_b = await manager.server_add(start=False, config={
-        'experimental_features': ["udf"] # disable consistent topology changes
-    })
+    scylla_a = await manager.server_add(config={'force_gossip_topology_changes': True})
+    scylla_b = await manager.server_add(start=False, config={'force_gossip_topology_changes': True})
     await manager.server_update_config(scylla_b.server_id, key='seed_provider', value=[{
             'class_name': 'org.apache.cassandra.locator.SimpleSeedProvider',
             'parameters': [{

--- a/test/topology_custom/test_gossip_boot.py
+++ b/test/topology_custom/test_gossip_boot.py
@@ -11,7 +11,8 @@ async def test_gossip_boot(manager: ManagerClient):
     Regression test for scylladb/scylladb#17493.
     """
 
-    cfg = {'error_injections_at_startup': ['force_gossip_based_join', 'gossiper_replicate_sleep']}
+    cfg = {'error_injections_at_startup': ['gossiper_replicate_sleep'],
+           'force_gossip_topology_changes': True}
 
     servers = [await manager.server_add(config=cfg, timeout=60) for _ in range(3)]
     logs = [await manager.server_open_log(s.server_id) for s in servers]

--- a/test/topology_custom/test_group0_schema_versioning.py
+++ b/test/topology_custom/test_group0_schema_versioning.py
@@ -124,7 +124,7 @@ async def test_schema_versioning_with_recovery(manager: ManagerClient):
     Verify that schema versions are in sync after each schema change.
     """
     cfg = {'enable_user_defined_functions': False,
-           'experimental_features': list[str]()}
+           'force_gossip_topology_changes': True}
     logger.info("Booting cluster")
     servers = [await manager.server_add(config=cfg) for _ in range(3)]
     cql = manager.get_cql()
@@ -292,7 +292,7 @@ async def test_upgrade(manager: ManagerClient):
     # So we do the same here: start a cluster in Raft mode, then enter recovery
     # to simulate a non-Raft cluster.
     cfg = {'enable_user_defined_functions': False,
-           'experimental_features': list[str]()}
+           'force_gossip_topology_changes': True}
     logger.info("Booting cluster")
     servers = [await manager.server_add(config=cfg) for _ in range(2)]
     cql = manager.get_cql()

--- a/test/topology_custom/test_raft_fix_broken_snapshot.py
+++ b/test/topology_custom/test_raft_fix_broken_snapshot.py
@@ -33,7 +33,7 @@ async def test_raft_fix_broken_snapshot(manager: ManagerClient):
     """
 
     cfg = {'enable_user_defined_functions': False,
-           'experimental_features': list[str](),
+           'force_gossip_topology_changes': True,
            'error_injections_at_startup': ['raft_sys_table_storage::bootstrap/init_index_0']}
     srv = await manager.server_add(config=cfg)
     cql = manager.get_cql()

--- a/test/topology_custom/test_raft_recovery_basic.py
+++ b/test/topology_custom/test_raft_recovery_basic.py
@@ -20,7 +20,7 @@ from test.topology.util import reconnect_driver, restart, enter_recovery_state, 
 @log_run_time
 async def test_raft_recovery_basic(request, manager: ManagerClient):
     cfg = {'enable_user_defined_functions': False,
-           'experimental_features': list[str]()}
+           'force_gossip_topology_changes': True}
     servers = [await manager.server_add(config=cfg) for _ in range(3)]
     cql = manager.cql
     assert(cql)

--- a/test/topology_custom/test_raft_recovery_majority_loss.py
+++ b/test/topology_custom/test_raft_recovery_majority_loss.py
@@ -29,7 +29,7 @@ async def test_recovery_after_majority_loss(request, manager: ManagerClient):
     about the schema changes.
     """
     cfg = {'enable_user_defined_functions': False,
-           'experimental_features': list[str]()}
+           'force_gossip_topology_changes': True}
     servers = [await manager.server_add(config=cfg) for _ in range(3)]
 
     logging.info("Waiting until driver connects to every server")

--- a/test/topology_custom/test_raft_recovery_stuck.py
+++ b/test/topology_custom/test_raft_recovery_stuck.py
@@ -30,7 +30,7 @@ async def test_recover_stuck_raft_recovery(request, manager: ManagerClient):
     remaining nodes will restart the procedure, establish a new group 0 and finish upgrade.
     """
     cfg = {'enable_user_defined_functions': False,
-           'experimental_features': list[str]()}
+           'force_gossip_topology_changes': True}
     servers = [await manager.server_add(config=cfg) for _ in range(3)]
     srv1, *others = servers
 

--- a/test/topology_custom/test_replace_ignore_nodes.py
+++ b/test/topology_custom/test_replace_ignore_nodes.py
@@ -26,7 +26,7 @@ async def test_replace_ignore_nodes(manager: ManagerClient) -> None:
        Preferably run it only in one mode e.g. dev.
     """
     cfg = {'enable_user_defined_functions': False,
-           'experimental_features': list[str]()}
+           'force_gossip_topology_changes': True}
     logger.info(f"Booting initial cluster")
     servers = [await manager.server_add(config=cfg) for _ in range(7)]
     s2_id = await manager.get_host_id(servers[2].server_id)

--- a/test/topology_custom/test_table_drop.py
+++ b/test/topology_custom/test_table_drop.py
@@ -7,5 +7,5 @@ async def test_drop_table_during_streaming_receiver_side(manager: ManagerClient)
         'error_injections_at_startup': ['stream_mutation_fragments_table_dropped'],
         'enable_repair_based_node_ops': False,
         'enable_user_defined_functions': False,
-        'experimental_features': []
+        'force_gossip_topology_changes': True
     }) for _ in range(2)]

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.asyncio
 async def test_tablet_replication_factor_enough_nodes(manager: ManagerClient):
     cfg = {'enable_user_defined_functions': False,
-           'experimental_features': ['tablets', 'consistent-topology-changes']}
+           'experimental_features': ['tablets']}
     servers = await manager.servers_add(2, config=cfg)
 
     cql = manager.get_cql()
@@ -36,7 +36,7 @@ async def test_tablet_replication_factor_enough_nodes(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_tablet_cannot_decommision_below_replication_factor(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
-    cfg = {'enable_user_defined_functions': False, 'experimental_features': ['tablets', 'consistent-topology-changes']}
+    cfg = {'enable_user_defined_functions': False, 'experimental_features': ['tablets']}
     servers = await manager.servers_add(4, config=cfg)
 
     logger.info("Creating table")
@@ -65,7 +65,7 @@ async def test_tablet_cannot_decommision_below_replication_factor(manager: Manag
 
 async def test_reshape_with_tablets(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
-    cfg = {'enable_user_defined_functions': False, 'experimental_features': ['tablets', 'consistent-topology-changes']}
+    cfg = {'enable_user_defined_functions': False, 'experimental_features': ['tablets']}
     server = (await manager.servers_add(1, config=cfg, cmdline=['--smp', '1']))[0]
 
     logger.info("Creating table")
@@ -103,7 +103,7 @@ async def test_reshape_with_tablets(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_tablet_rf_change(manager: ManagerClient, direction):
     cfg = {'enable_user_defined_functions': False,
-           'experimental_features': ['tablets', 'consistent-topology-changes']}
+           'experimental_features': ['tablets']}
     servers = await manager.servers_add(3, config=cfg)
 
     cql = manager.get_cql()

--- a/test/topology_custom/test_tablets_migration.py
+++ b/test/topology_custom/test_tablets_migration.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.asyncio
 async def test_tablet_transition_sanity(manager: ManagerClient, action):
     logger.info("Bootstrapping cluster")
-    cfg = {'enable_user_defined_functions': False, 'experimental_features': ['tablets', 'consistent-topology-changes']}
+    cfg = {'enable_user_defined_functions': False, 'experimental_features': ['tablets']}
     host_ids = []
     servers = []
 
@@ -104,7 +104,7 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
         pytest.skip('Failing source during target cleanup is pointless')
 
     logger.info("Bootstrapping cluster")
-    cfg = {'enable_user_defined_functions': False, 'experimental_features': ['tablets', 'consistent-topology-changes']}
+    cfg = {'enable_user_defined_functions': False, 'experimental_features': ['tablets']}
     host_ids = []
     servers = []
 

--- a/test/topology_custom/test_topology_failure_recovery.py
+++ b/test/topology_custom/test_topology_failure_recovery.py
@@ -21,7 +21,7 @@ async def inject_error_on(manager, error_name, servers):
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_tablet_drain_failure_during_decommission(manager: ManagerClient):
     cfg = {'enable_user_defined_functions': False,
-           'experimental_features': ['tablets', 'consistent-topology-changes']}
+           'experimental_features': ['tablets']}
     servers = [await manager.server_add(config=cfg) for _ in range(3)]
 
     logs = [await manager.server_open_log(srv.server_id) for srv in servers]

--- a/test/topology_custom/test_topology_remove_garbage_group0.py
+++ b/test/topology_custom/test_topology_remove_garbage_group0.py
@@ -27,7 +27,7 @@ async def test_remove_garbage_group0_members(manager: ManagerClient):
     """
     # 4 servers, one dead
     cfg = {'enable_user_defined_functions': False,
-           'experimental_features': list[str]()}
+           'force_gossip_topology_changes': True}
     servers = [await manager.server_add(config=cfg) for _ in range(4)]
 
     # Make sure that the driver has connected to all nodes, and they see each other as NORMAL

--- a/test/topology_experimental_raft/suite.yaml
+++ b/test/topology_experimental_raft/suite.yaml
@@ -6,7 +6,7 @@ extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer
     enable_user_defined_functions: False
-    experimental_features: ['consistent-topology-changes', 'tablets']
+    experimental_features: ['tablets']
 run_first:
   - test_raft_cluster_features
   - test_raft_ignore_nodes

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -584,7 +584,7 @@ async def test_tablet_cleanup(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_tablet_resharding(manager: ManagerClient):
     cmdline = ['--smp=3']
-    config = {'experimental_features': ['consistent-topology-changes', 'tablets']}
+    config = {'experimental_features': ['tablets']}
     servers = await manager.servers_add(1, cmdline=cmdline)
     server = servers[0]
 

--- a/test/topology_experimental_raft/test_topology_ops.py
+++ b/test/topology_experimental_raft/test_topology_ops.py
@@ -24,9 +24,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize("tablets_enabled", ["true", "false"])
 async def test_topology_ops(request, manager: ManagerClient, tablets_enabled: bool):
     """Test basic topology operations using the topology coordinator."""
-    cfg = {'experimental_features': ['consistent-topology-changes']}
-    if tablets_enabled:
-        cfg['experimental_features'].append('tablets')
+    cfg = {'experimental_features' : ['tablets']} if tablets_enabled else {}
 
     logger.info("Bootstrapping first node")
     servers = [await manager.server_add(config=cfg)]

--- a/test/topology_experimental_raft/test_topology_upgrade.py
+++ b/test/topology_experimental_raft/test_topology_upgrade.py
@@ -19,19 +19,18 @@ from test.topology.util import log_run_time, wait_until_last_generation_is_in_us
 
 
 @pytest.mark.asyncio
-@skip_mode('release', 'error injections are not supported in release mode')
 @log_run_time
 async def test_topology_upgrade_basic(request, mode: str, manager: ManagerClient):
-    # First, force the first node to start in legacy mode due to the error injection
+    # First, force the first node to start in legacy mode
     cfg = {
-        'error_injections_at_startup': ['force_gossip_based_join'],
+        'force_gossip_topology_changes': True,
         'ring_delay_ms': 15000 if mode == 'debug' else 5000,
     }
 
     servers = [await manager.server_add(config=cfg)]
-    # Disable injections for the subsequent nodes - they should fall back to
+    # Enable raft-based node operations for subsequent nodes - they should fall back to
     # using gossiper-based node operations
-    del cfg['error_injections_at_startup']
+    del cfg['force_gossip_topology_changes']
 
     servers += [await manager.server_add(config=cfg) for _ in range(2)]
     cql = manager.cql

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -682,7 +682,7 @@ schema_ptr load_system_schema(const db::config& cfg, std::string_view keyspace, 
         {db::system_distributed_keyspace::NAME, db::system_distributed_keyspace::all_distributed_tables()},
         {db::system_distributed_keyspace::NAME_EVERYWHERE, db::system_distributed_keyspace::all_everywhere_tables()},
     };
-        schemas[db::system_auth_keyspace::NAME] = db::system_auth_keyspace::all_tables();
+    schemas[db::system_auth_keyspace::NAME] = db::system_auth_keyspace::all_tables();
     auto ks_it = schemas.find(keyspace);
     if (ks_it == schemas.end()) {
         throw std::invalid_argument(fmt::format("unknown system keyspace: {}", keyspace));

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -682,9 +682,7 @@ schema_ptr load_system_schema(const db::config& cfg, std::string_view keyspace, 
         {db::system_distributed_keyspace::NAME, db::system_distributed_keyspace::all_distributed_tables()},
         {db::system_distributed_keyspace::NAME_EVERYWHERE, db::system_distributed_keyspace::all_everywhere_tables()},
     };
-    if (cfg.check_experimental(db::experimental_features_t::feature::CONSISTENT_TOPOLOGY_CHANGES)) {
         schemas[db::system_auth_keyspace::NAME] = db::system_auth_keyspace::all_tables();
-    }
     auto ks_it = schemas.find(keyspace);
     if (ks_it == schemas.end()) {
         throw std::invalid_argument(fmt::format("unknown system keyspace: {}", keyspace));


### PR DESCRIPTION
We move consistent cluster management out of experimental and
make it the default for new clusters in 6.0. In code, we make the 
`consistent-topology-changes` flag unused and assumed to be true.

In 6.0, the topology upgrade procedure will be manual and
voluntary, so some clusters will still be using the gossip-based
topology even though they support the raft-based topology.
Therefore, we need to continue testing the gossip-based topology.
This is possible by using the `force-gossip-topology-changes` flag
introduced in scylladb/scylladb#18284.

Ref scylladb/scylladb#17802