### PR TITLE
topology_coordinator: remove unused variable

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -13,6 +13,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/util/noncopyable_function.hh>
+#include <variant>
 
 #include "auth/service.hh"
 #include "cdc/generation.hh"
@@ -1963,7 +1964,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         }
                     }
 
-                    if (auto* reject = std::get_if<join_node_response_params::rejected>(&validation_result)) {
+                    if (std::holds_alternative<join_node_response_params::rejected>(validation_result)) {
                         // Transition to left
                         topology_mutation_builder builder(node.guard.write_timestamp());
                         topology_request_tracking_mutation_builder rtbuilder(node.rs->request_id);


### PR DESCRIPTION
when compiling the tree with clang-19, it complains:

```
/home/kefu/dev/scylladb/service/topology_coordinator.cc:1968:31: error: variable 'reject' set but not used [-Werror,-Wunused-but-set-variable]
 1968 |                     if (auto* reject = std::get_if<join_node_response_params::rejected>(&validation_result)) {
      |                               ^
1 error generated.
```
so, despite that we evaluate the assignment statement to see it evaluates to true or false, the compiler still believes that the variable is not used. probably, the value of the statement is not dependent on the value of the value being assigned. either way, let's use `std::holds_alternative<..>` instead of `std::get_if<..>`, to silence this warning, and the code is a little bit more compacted, in the sense of less tokens in the `if` statement.

in order to be self-contained, we take the opportunity to include `<variant>` in this source file, as a function declared in this header is used.