### PR TITLE
doc: replace Scylla with ScyllaDB in Glossary

### DIFF
--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -11,13 +11,13 @@ Glossary
       When a new node is added to a cluster, the bootstrap process ensures that the data in the cluster is automatically redistributed to the new node. A new node in this case is an empty node without system tables or data. See :ref:`bootstrap <temporary-fallback-to-stcs>`.
 
     Anti-entropy
-      A state where data is in order and organized. Scylla has processes in place to make sure that data is antientropic where all replicas contain the most recent data and that data is consistent between replicas. See :doc:`Scylla Anti-Entropy </architecture/anti-entropy/index>`.
+      A state where data is in order and organized. ScyllaDB has processes in place to make sure that data is antientropic where all replicas contain the most recent data and that data is consistent between replicas. See :doc:`ScyllaDB Anti-Entropy </architecture/anti-entropy/index>`.
     
     CAP Theorem
-      The CAP Theorem is the notion that **C** (Consistency), **A** (Availability) and **P** (Partition Tolerance) of data are mutually dependent in a distributed system. Increasing any 2 of these factors will reduce the third. Scylla chooses availability and partition tolerance over consistency. See :doc:`Fault Tolerance </architecture/architecture-fault-tolerance>`.
+      The CAP Theorem is the notion that **C** (Consistency), **A** (Availability) and **P** (Partition Tolerance) of data are mutually dependent in a distributed system. Increasing any 2 of these factors will reduce the third. ScyllaDB chooses availability and partition tolerance over consistency. See :doc:`Fault Tolerance </architecture/architecture-fault-tolerance>`.
  
     Cluster 
-      One or multiple Scylla nodes, acting in concert, which own a single contiguous token range. State is communicated between nodes in the cluster via the Gossip protocol. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
+      One or multiple ScyllaDB nodes, acting in concert, which own a single contiguous token range. State is communicated between nodes in the cluster via the Gossip protocol. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
 
     Clustering Key
       A single or multi-column clustering key determines a row’s uniqueness and sort order on disk within a partition. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
@@ -38,19 +38,19 @@ Glossary
       Quorum is a *global* consistency level setting across the entire cluster including all data centers. See :doc:`Consistency Levels </cql/consistency>`.
 
     Entropy
-      A state where data is not consistent. This is the result when replicas are not synced and data is random. Scylla has measures in place to be antientropic. See :doc:`Scylla Anti-Entropy </architecture/anti-entropy/index>`.
+      A state where data is not consistent. This is the result when replicas are not synced and data is random. ScyllaDB has measures in place to be antientropic. See :doc:`ScyllaDB Anti-Entropy </architecture/anti-entropy/index>`.
 
     Eventual Consistency
-      In Scylla, when considering the :term:`CAP Theorem <CAP Theorem>`, availability and partition tolerance are considered a higher priority than consistency.
+      In ScyllaDB, when considering the :term:`CAP Theorem <CAP Theorem>`, availability and partition tolerance are considered a higher priority than consistency.
 
     Hint
       A short record of a write request that is held by the co-ordinator until the unresponsive node becomes responsive again, at which point the write request data in the hint is written to the replica node. See :doc:`Hinted Handoff </architecture/anti-entropy/hinted-handoff>`. 
 
     Hinted Handoff
-      Reduces data inconsistency which can occur when a node is down or there is network congestion. In Scylla, when data is written and there is an unresponsive replica, the coordinator writes itself a hint. When the node recovers, the coordinator sends the node the pending hints to ensure that it has the data it should have received. See :doc:`Hinted Handoff </architecture/anti-entropy/hinted-handoff>`. 
+      Reduces data inconsistency which can occur when a node is down or there is network congestion. In ScyllaDB, when data is written and there is an unresponsive replica, the coordinator writes itself a hint. When the node recovers, the coordinator sends the node the pending hints to ensure that it has the data it should have received. See :doc:`Hinted Handoff </architecture/anti-entropy/hinted-handoff>`. 
     
     Idempotent   
-      Denoting an element of a set which is unchanged in value when multiplied or otherwise operated on by itself. :doc:`Scylla Counters </using-scylla/counters>` are not indepotent because in the case of a write failure, the client cannot safely retry the request.
+      Denoting an element of a set which is unchanged in value when multiplied or otherwise operated on by itself. :doc:`ScyllaDB Counters </using-scylla/counters>` are not indepotent because in the case of a write failure, the client cannot safely retry the request.
     
     JBOD
       JBOD or Just another Bunch Of Disks is a non-raid storage system using a server with multiple disks in order to instantiate a separate file system per disk. The benefit is that if a single disk fails, only it needs to be replaced and not the whole disk array. The disadvantage is that free space and load may not be evenly distributed. See the :ref:`FAQ <faq-raid0-required>`.
@@ -78,10 +78,10 @@ Glossary
      A change to data such as column or columns to insert, or a deletion. See :doc:`Hinted Handoff </architecture/anti-entropy/hinted-handoff>`. 
 
     Node
-     A single installed instance of Scylla. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
+     A single installed instance of ScyllaDB. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
 
     Nodetool
-     A simple command-line interface for administering a Scylla node. A nodetool command can display a given node’s exposed operations and attributes. Scylla’s nodetool contains a subset of these operations. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
+     A simple command-line interface for administering a ScyllaDB node. A nodetool command can display a given node’s exposed operations and attributes. ScyllaDB’s nodetool contains a subset of these operations. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
 
     Primary Key
      In a CQL table definition, the primary key clause specifies the partition key and optional clustering key. These keys uniquely identify each partition and row within a partition. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
@@ -93,7 +93,7 @@ Glossary
      The unique identifier for a partition, a partition key may be hashed from the first column in the primary key. A partition key may also be hashed from a set of columns, often referred to as a compound primary key. A partition key determines which virtual node gets the first partition replica. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
 
     Partitioner
-     A hash function for computing which data is stored on which node in the cluster. The partitioner takes a partition key as an input, and returns a ring token as an output. By default Scylla uses the 64 bit :term:`MurmurHash3` function and this hash range is numerically represented as a signed 64bit integer, see :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
+     A hash function for computing which data is stored on which node in the cluster. The partitioner takes a partition key as an input, and returns a ring token as an output. By default ScyllaDB uses the 64 bit :term:`MurmurHash3` function and this hash range is numerically represented as a signed 64bit integer, see :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
 
     Read Amplification
      Excessive read requests which require many SSTables. RA is calculated by the number of disk reads per query. High RA occurs when there are many pages to read in order to answer a query.  See :doc:`Compaction Strategies</architecture/compaction/compaction-strategies/>`.
@@ -102,13 +102,13 @@ Glossary
       A  read operation occurs when an application gets information from an SSTable and does not change that information in any way. See :doc:`Fault Tolerance </architecture/architecture-fault-tolerance>`.
 
     Read Repair
-      An anti-entropy mechanism for read operations ensuring that replicas are updated with most recently updated data. These repairs run automatically, asynchronously, and in the background. See :doc:`Scylla Read Repair </architecture/anti-entropy/read-repair>`.
+      An anti-entropy mechanism for read operations ensuring that replicas are updated with most recently updated data. These repairs run automatically, asynchronously, and in the background. See :doc:`ScyllaDB Read Repair </architecture/anti-entropy/read-repair>`.
 
     Reconciliation
-      A verification phase during a data migration where the target data is compared against original source data to ensure that the migration architecture has transferred the data correctly. See :doc:`Scylla Read Repair </architecture/anti-entropy/read-repair>`.
+      A verification phase during a data migration where the target data is compared against original source data to ensure that the migration architecture has transferred the data correctly. See :doc:`ScyllaDB Read Repair </architecture/anti-entropy/read-repair>`.
 
     Repair
-      A process which runs in the background and synchronizes the data between nodes, so that eventually, all the replicas hold the same data. See :doc:`Scylla Repair </operating-scylla/procedures/maintenance/repair>`.
+      A process which runs in the background and synchronizes the data between nodes, so that eventually, all the replicas hold the same data. See :doc:`ScyllaDB Repair </operating-scylla/procedures/maintenance/repair>`.
     
     Replication
       The process of replicating data across nodes in a cluster. See :doc:`Fault Tolerance </architecture/architecture-fault-tolerance>`.
@@ -125,24 +125,24 @@ Glossary
       See :doc:`Repair Based Node Operations </operating-scylla/procedures/cluster-management/repair-based-node-operation>` for details.
 
     Shard
-      Each Scylla node is internally split into *shards*, an independent thread bound to a dedicated core.
+      Each ScyllaDB node is internally split into *shards*, an independent thread bound to a dedicated core.
       Each shard of data is allotted CPU, RAM, persistent storage, and networking resources which it uses as efficiently as possible.
-      See `Scylla Shard per Core Architecture <https://www.scylladb.com/product/technology/shard-per-core-architecture/>`_ for more information.
+      See `ScyllaDB Shard per Core Architecture <https://www.scylladb.com/product/technology/shard-per-core-architecture/>`_ for more information.
 
     Size-tiered compaction strategy
       Triggers when the system has enough (four by default) similarly sized SSTables.  See :doc:`Compaction Strategies</architecture/compaction/compaction-strategies/>`.
 
     Snapshot
-      Snapshots in Scylla are an essential part of the backup and restore mechanism. Whereas in other databases a backup starts with creating a copy of a data file (cold backup, hot backup, shadow copy backup), in Scylla the process starts with creating a table or keyspace snapshot.  See :doc:`Scylla Snapshots </kb/snapshots>`.
+      Snapshots in ScyllaDB are an essential part of the backup and restore mechanism. Whereas in other databases a backup starts with creating a copy of a data file (cold backup, hot backup, shadow copy backup), in ScyllaDB the process starts with creating a table or keyspace snapshot.  See :doc:`ScyllaDB Snapshots </kb/snapshots>`.
 
     Snitch
-      The mapping from the IP addresses of nodes to physical and virtual locations, such as racks and data centers. There are several types of snitches. The type of snitch affects the request routing mechanism. See :doc:`Scylla Snitches </operating-scylla/system-configuration/snitch/>`.
+      The mapping from the IP addresses of nodes to physical and virtual locations, such as racks and data centers. There are several types of snitches. The type of snitch affects the request routing mechanism. See :doc:`ScyllaDB Snitches </operating-scylla/system-configuration/snitch/>`.
 
     Space amplification
       Excessive disk space usage which requires that the disk be larger than a perfectly-compacted representation of the data (i.e., all the data in one single SSTable). SA is calculated as the ratio of the size of database files on a disk to the actual data size. High SA occurs when there is more disk space being used than the size of the data.  See :doc:`Compaction Strategies</architecture/compaction/compaction-strategies/>`.
 
     SSTable
-      A concept borrowed from Google Big Table, SSTables or Sorted String Tables store a series of immutable rows where each row is identified by its row key.  See :doc:`Compaction Strategies</architecture/compaction/compaction-strategies/>`. The SSTable format is a persistent file format. See :doc:`Scylla SSTable Format</architecture/sstable/index>`.
+      A concept borrowed from Google Big Table, SSTables or Sorted String Tables store a series of immutable rows where each row is identified by its row key.  See :doc:`Compaction Strategies</architecture/compaction/compaction-strategies/>`. The SSTable format is a persistent file format. See :doc:`ScyllaDB SSTable Format</architecture/sstable/index>`.
 
     Table
       A collection of columns fetched by row. Columns are ordered by Clustering Key. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
@@ -151,10 +151,10 @@ Glossary
       TWCS is designed for time series data. See :doc:`Compaction Strategies</architecture/compaction/compaction-strategies/>`.
 
     Token
-      A value in a range, used to identify both nodes and partitions. Each node in a Scylla cluster is given an (initial) token, which defines the end of the range a node handles. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
+      A value in a range, used to identify both nodes and partitions. Each node in a ScyllaDB cluster is given an (initial) token, which defines the end of the range a node handles. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
 
     Token Range
-      The total range of potential unique identifiers supported by the partitioner. By default, each Scylla node in the cluster handles 256 token ranges. Each token range corresponds to a Vnode. Each range of hashes in turn is a segment of the total range of a given hash function. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
+      The total range of potential unique identifiers supported by the partitioner. By default, each ScyllaDB node in the cluster handles 256 token ranges. Each token range corresponds to a Vnode. Each range of hashes in turn is a segment of the total range of a given hash function. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
 
     Tombstone
       A marker that indicates that data has been deleted. A large number of tombstones may impact read performance and disk usage, so an efficient tombstone garbage collection strategy should be employed. See :ref:`Tombstones GC options <ddl-tombstones-gc>`.
@@ -163,7 +163,7 @@ Glossary
       The possibility for unique, per-query, Consistency Level settings. These are incremental and override fixed database settings intended to enforce data consistency. Such settings may be set directly from a CQL statement when response speed for a given query or operation is more important. See :doc:`Fault Tolerance </architecture/architecture-fault-tolerance>`.
 
     Virtual node
-      A range of tokens owned by a single Scylla node. Scylla nodes are configurable and support a set of :abbr:`Vnodes (virtual nodes)`. In legacy token selection, a node owns one token (or token range) per node. With Vnodes, a node can own many tokens or token ranges; within a cluster, these may be selected randomly from a non-contiguous set. In a Vnode configuration, each token falls within a specific token range which in turn is represented as a Vnode. Each Vnode is then allocated to a physical node in the cluster. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
+      A range of tokens owned by a single ScyllaDB node. ScyllaDB nodes are configurable and support a set of :abbr:`Vnodes (virtual nodes)`. In legacy token selection, a node owns one token (or token range) per node. With Vnodes, a node can own many tokens or token ranges; within a cluster, these may be selected randomly from a non-contiguous set. In a Vnode configuration, each token falls within a specific token range which in turn is represented as a Vnode. Each Vnode is then allocated to a physical node in the cluster. See :doc:`Ring Architecture </architecture/ringarchitecture/index>`.
 
     Write Amplification
       Excessive compaction of the same data. :abbr:`WA (Write amplification)` is calculated by the ratio of bytes written to storage versus bytes written to the database. High WA occurs when there are more bytes/second written to storage than are actually written to the database. See :doc:`Compaction Strategies</architecture/compaction/compaction-strategies/>`.
@@ -181,7 +181,7 @@ Glossary
        Dropping requests to protect the system. This will occur if the request is too large or exceeds the max number of concurrent requests per shard.
 
     Dummy Rows
-       Cache dummy rows are entries in the row set, which have a clustering position, although they do not represent CQL rows written by users.  Scylla cache uses them to mark boundaries of population ranges, to represent the information that the whole range is complete, and there is no need to go to sstables to read the gaps between existing row entries when scanning.
+       Cache dummy rows are entries in the row set, which have a clustering position, although they do not represent CQL rows written by users.  ScyllaDB cache uses them to mark boundaries of population ranges, to represent the information that the whole range is complete, and there is no need to go to sstables to read the gaps between existing row entries when scanning.
       
     Workload
       A database category that allows you to manage different sources of database activities, such as requests or administrative activities. By defining workloads, you can specify how ScyllaDB will process those activities. For example, `ScyllaDB Enterprise <https://enterprise.docs.scylladb.com/>`_


### PR DESCRIPTION
This commit replaces "Scylla" with "ScyllaDB" on the Glossary page.

The product has been rebranded as "ScyllaDB".