### PR TITLE
treewide: replace formatter<std::string_view> with formatter<string_v…

### DIFF
--- a/alternator/expressions_types.hh
+++ b/alternator/expressions_types.hh
@@ -256,6 +256,6 @@ public:
 } // namespace parsed
 } // namespace alternator
 
-template <> struct fmt::formatter<alternator::parsed::path> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<alternator::parsed::path> : fmt::formatter<string_view> {
     auto format(const alternator::parsed::path&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/auth/authenticated_user.hh
+++ b/auth/authenticated_user.hh
@@ -50,7 +50,7 @@ inline bool is_anonymous(const authenticated_user& u) noexcept {
 /// The user name, or "anonymous".
 ///
 template <>
-struct fmt::formatter<auth::authenticated_user> : fmt::formatter<std::string_view> {
+struct fmt::formatter<auth::authenticated_user> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const auth::authenticated_user& u, FormatContext& ctx) const {
         if (u.name) {

--- a/auth/authentication_options.hh
+++ b/auth/authentication_options.hh
@@ -48,15 +48,15 @@ public:
 }
 
 template <>
-struct fmt::formatter<auth::authentication_option> : fmt::formatter<std::string_view> {
+struct fmt::formatter<auth::authentication_option> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const auth::authentication_option a, FormatContext& ctx) const {
         using enum auth::authentication_option;
         switch (a) {
         case password:
-            return formatter<std::string_view>::format("PASSWORD", ctx);
+            return formatter<string_view>::format("PASSWORD", ctx);
         case options:
-            return formatter<std::string_view>::format("OPTIONS", ctx);
+            return formatter<string_view>::format("OPTIONS", ctx);
         }
         std::abort();
     }

--- a/auth/resource.hh
+++ b/auth/resource.hh
@@ -247,19 +247,19 @@ std::pair<sstring, std::vector<data_type>> decode_signature(std::string_view enc
 }
 
 template <>
-struct fmt::formatter<auth::resource_kind> : fmt::formatter<std::string_view> {
+struct fmt::formatter<auth::resource_kind> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const auth::resource_kind kind, FormatContext& ctx) const {
         using enum auth::resource_kind;
         switch (kind) {
         case data:
-            return formatter<std::string_view>::format("data", ctx);
+            return formatter<string_view>::format("data", ctx);
         case role:
-            return formatter<std::string_view>::format("role", ctx);
+            return formatter<string_view>::format("role", ctx);
         case service_level:
-            return formatter<std::string_view>::format("service_level", ctx);
+            return formatter<string_view>::format("service_level", ctx);
         case functions:
-            return formatter<std::string_view>::format("functions", ctx);
+            return formatter<string_view>::format("functions", ctx);
         }
         std::abort();
     }

--- a/cdc/cdc_options.hh
+++ b/cdc/cdc_options.hh
@@ -66,10 +66,10 @@ public:
 
 } // namespace cdc
 
-template <> struct fmt::formatter<cdc::image_mode> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<cdc::image_mode> : fmt::formatter<string_view> {
     auto format(cdc::image_mode, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<cdc::delta_mode> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<cdc::delta_mode> : fmt::formatter<string_view> {
     auto format(cdc::delta_mode, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -189,7 +189,7 @@ future<utils::chunked_vector<mutation>> get_cdc_generation_mutations_v3(
 #if FMT_VERSION < 100000
 // fmt v10 introduced formatter for std::exception
 template <>
-struct fmt::formatter<cdc::no_generation_data_exception> : fmt::formatter<std::string_view> {
+struct fmt::formatter<cdc::no_generation_data_exception> : fmt::formatter<string_view> {
     auto format(const cdc::no_generation_data_exception& e, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", e.what());
     }

--- a/clustering_bounds_comparator.hh
+++ b/clustering_bounds_comparator.hh
@@ -155,10 +155,10 @@ public:
     friend fmt::formatter<bound_view>;
 };
 
-template <> struct fmt::formatter<bound_kind> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<bound_kind> : fmt::formatter<string_view> {
     auto format(bound_kind, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
-template <> struct fmt::formatter<bound_view> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<bound_view> : fmt::formatter<string_view> {
     auto format(const bound_view& b, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{{bound: prefix={},kind={}}}", b._prefix.get(), b._kind);
     }

--- a/clustering_interval_set.hh
+++ b/clustering_interval_set.hh
@@ -124,7 +124,7 @@ public:
     position_range_iterator end() const { return {_set.end()}; }
 };
 
-template <> struct fmt::formatter<clustering_interval_set> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<clustering_interval_set> : fmt::formatter<string_view> {
     auto format(const clustering_interval_set& set, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{{{}}}", fmt::join(set, ",\n  "));
     }

--- a/collection_mutation.hh
+++ b/collection_mutation.hh
@@ -132,7 +132,7 @@ collection_mutation difference(const abstract_type&, collection_mutation_view, c
 bytes_ostream serialize_for_cql(const abstract_type&, collection_mutation_view);
 
 template <>
-struct fmt::formatter<collection_mutation_view::printer> : fmt::formatter<std::string_view> {
+struct fmt::formatter<collection_mutation_view::printer> : fmt::formatter<string_view> {
     auto format(const collection_mutation_view::printer&, fmt::format_context& ctx) const
       -> decltype(ctx.out());
 };

--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -213,14 +213,14 @@ struct compaction_descriptor {
 }
 
 template <>
-struct fmt::formatter<sstables::compaction_type> : fmt::formatter<std::string_view> {
+struct fmt::formatter<sstables::compaction_type> : fmt::formatter<string_view> {
     auto format(sstables::compaction_type, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 template <>
-struct fmt::formatter<sstables::compaction_type_options::scrub::mode> : fmt::formatter<std::string_view> {
+struct fmt::formatter<sstables::compaction_type_options::scrub::mode> : fmt::formatter<string_view> {
     auto format(sstables::compaction_type_options::scrub::mode, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 template <>
-struct fmt::formatter<sstables::compaction_type_options::scrub::quarantine_mode> : fmt::formatter<std::string_view> {
+struct fmt::formatter<sstables::compaction_type_options::scrub::quarantine_mode> : fmt::formatter<string_view> {
     auto format(sstables::compaction_type_options::scrub::quarantine_mode, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/compaction/table_state.hh
+++ b/compaction/table_state.hh
@@ -63,7 +63,7 @@ public:
 namespace fmt {
 
 template <>
-struct formatter<compaction::table_state> : formatter<std::string_view> {
+struct formatter<compaction::table_state> : formatter<string_view> {
     template <typename FormatContext>
     auto format(const compaction::table_state& t, FormatContext& ctx) const {
         auto s = t.schema();

--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -524,7 +524,7 @@ public:
 };
 
 template <typename Component>
-struct fmt::formatter<std::pair<Component, composite::eoc>> : fmt::formatter<std::string_view> {
+struct fmt::formatter<std::pair<Component, composite::eoc>> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const std::pair<Component, composite::eoc>& c, FormatContext& ctx) const {
         if constexpr (std::same_as<Component, bytes_view>) {
@@ -636,7 +636,7 @@ public:
 };
 
 template <>
-struct fmt::formatter<composite_view> : fmt::formatter<std::string_view> {
+struct fmt::formatter<composite_view> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const composite_view& v, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{{{}, compound={}, static={}}}",
@@ -650,7 +650,7 @@ composite::composite(const composite_view& v)
 { }
 
 template <>
-struct fmt::formatter<composite> : fmt::formatter<std::string_view> {
+struct fmt::formatter<composite> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const composite& v, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", composite_view(v));

--- a/counters.hh
+++ b/counters.hh
@@ -89,7 +89,7 @@ public:
 using counter_shard_view = basic_counter_shard_view<mutable_view::no>;
 
 template <>
-struct fmt::formatter<counter_shard_view> : fmt::formatter<std::string_view> {
+struct fmt::formatter<counter_shard_view> : fmt::formatter<string_view> {
     auto format(const counter_shard_view&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
@@ -352,7 +352,7 @@ struct counter_cell_view : basic_counter_cell_view<mutable_view::no> {
 };
 
 template <>
-struct fmt::formatter<counter_cell_view> : fmt::formatter<std::string_view> {
+struct fmt::formatter<counter_cell_view> : fmt::formatter<string_view> {
     auto format(const counter_cell_view&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 

--- a/cql3/column_identifier.hh
+++ b/cql3/column_identifier.hh
@@ -119,13 +119,13 @@ struct hash<cql3::column_identifier_raw> {
 
 }
 
-template <> struct fmt::formatter<cql3::column_identifier> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<cql3::column_identifier> : fmt::formatter<string_view> {
     auto format(const cql3::column_identifier& i, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", i.text());
     }
 };
 
-template <> struct fmt::formatter<cql3::column_identifier_raw> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<cql3::column_identifier_raw> : fmt::formatter<string_view> {
     auto format(const cql3::column_identifier_raw& id, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", id.text());
     }

--- a/cql3/cql3_type.hh
+++ b/cql3/cql3_type.hh
@@ -365,9 +365,9 @@ inline bool operator==(const cql3_type& a, const cql3_type& b) {
 }
 
 template <>
-struct fmt::formatter<cql3::cql3_type>: fmt::formatter<std::string_view> {
+struct fmt::formatter<cql3::cql3_type>: fmt::formatter<string_view> {
     auto format(const cql3::cql3_type& t, fmt::format_context& ctx) const {
-        return formatter<std::string_view>::format(format_as(t), ctx);
+        return formatter<string_view>::format(format_as(t), ctx);
     }
 };
 

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -574,7 +574,7 @@ struct fmt::formatter<E> : public fmt::formatter<cql3::expr::expression> {
 };
 
 template <>
-struct fmt::formatter<cql3::expr::column_mutation_attribute::attribute_kind> : fmt::formatter<std::string_view> {
+struct fmt::formatter<cql3::expr::column_mutation_attribute::attribute_kind> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(cql3::expr::column_mutation_attribute::attribute_kind k, FormatContext& ctx) const {
         switch (k) {

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -578,7 +578,7 @@ tuple_constructor_prepare_nontuple(const tuple_constructor& tc, data_dictionary:
 
 }
 
-template <> struct fmt::formatter<cql3::expr::untyped_constant::type_class> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<cql3::expr::untyped_constant::type_class> : fmt::formatter<string_view> {
     auto format(cql3::expr::untyped_constant::type_class t, fmt::format_context& ctx) const {
         using enum cql3::expr::untyped_constant::type_class;
         std::string_view name;

--- a/cql3/functions/abstract_function.hh
+++ b/cql3/functions/abstract_function.hh
@@ -19,7 +19,7 @@
 #include <fmt/core.h>
 
 
-template <> struct fmt::formatter<std::vector<data_type>> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<std::vector<data_type>> : fmt::formatter<string_view> {
     auto format(const std::vector<data_type>& arg_types, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -36,7 +36,7 @@ struct maybe_column_definition {
 }
 
 template<>
-struct fmt::formatter<maybe_column_definition> : fmt::formatter<std::string_view> {
+struct fmt::formatter<maybe_column_definition> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const maybe_column_definition& cd, FormatContext& ctx) const {
         if (cd.value != nullptr) {

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -293,11 +293,11 @@ inline bytes_opt to_bytes_opt(const cql3::raw_value& value) {
     return to_bytes_opt(value.view());
 }
 
-template <> struct fmt::formatter<cql3::raw_value_view> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<cql3::raw_value_view> : fmt::formatter<string_view> {
     auto format(const cql3::raw_value_view& value, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<cql3::raw_value> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<cql3::raw_value> : fmt::formatter<string_view> {
     auto format(const cql3::raw_value& value, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", value.view());
     }

--- a/data_dictionary/data_dictionary.hh
+++ b/data_dictionary/data_dictionary.hh
@@ -132,14 +132,14 @@ public:
 #if FMT_VERSION < 100000
 // fmt v10 introduced formatter for std::exception
 template <>
-struct fmt::formatter<data_dictionary::no_such_keyspace> : fmt::formatter<std::string_view> {
+struct fmt::formatter<data_dictionary::no_such_keyspace> : fmt::formatter<string_view> {
     auto format(const data_dictionary::no_such_keyspace& e, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", e.what());
     }
 };
 
 template <>
-struct fmt::formatter<data_dictionary::no_such_column_family> : fmt::formatter<std::string_view> {
+struct fmt::formatter<data_dictionary::no_such_column_family> : fmt::formatter<string_view> {
     auto format(const data_dictionary::no_such_column_family& e, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", e.what());
     }

--- a/db/functions/function_name.hh
+++ b/db/functions/function_name.hh
@@ -51,7 +51,7 @@ public:
 }
 
 template <>
-struct fmt::formatter<db::functions::function_name> : fmt::formatter<std::string_view> {
+struct fmt::formatter<db::functions::function_name> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const db::functions::function_name& fn, FormatContext& ctx) const {
         auto out = ctx.out();

--- a/db/hints/host_filter.hh
+++ b/db/hints/host_filter.hh
@@ -94,6 +94,6 @@ public:
 }
 
 template <>
-struct fmt::formatter<db::hints::host_filter> : fmt::formatter<std::string_view> {
+struct fmt::formatter<db::hints::host_filter> : fmt::formatter<string_view> {
     auto format(const db::hints::host_filter&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/db_clock.hh
+++ b/db_clock.hh
@@ -56,7 +56,7 @@ gc_clock::time_point to_gc_clock(db_clock::time_point tp) noexcept {
 
 /* For debugging and log messages. */
 template <>
-struct fmt::formatter<db_clock::time_point> : fmt::formatter<std::string_view> {
+struct fmt::formatter<db_clock::time_point> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const db_clock::time_point& tp, FormatContext& ctx) const {
         auto t = db_clock::to_time_t(tp);

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -119,7 +119,7 @@ std::optional<shard_id> is_single_shard(const dht::sharder&, const schema&, cons
 
 } // dht
 
-template <> struct fmt::formatter<dht::i_partitioner> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<dht::i_partitioner> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const dht::i_partitioner& p, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{{partitioner name = {}}}", p.name());

--- a/dht/ring_position.hh
+++ b/dht/ring_position.hh
@@ -508,7 +508,7 @@ struct fmt::formatter<dht::ring_position> {
     auto format(const dht::ring_position& pos, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<dht::partition_ranges_view> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<dht::partition_ranges_view> : fmt::formatter<string_view> {
     auto format(const dht::partition_ranges_view&, fmt::format_context& ctx) const
       -> decltype(ctx.out());
 };

--- a/dht/token.hh
+++ b/dht/token.hh
@@ -247,7 +247,7 @@ struct token_comparator {
 } // namespace dht
 
 template <>
-struct fmt::formatter<dht::token> : fmt::formatter<std::string_view> {
+struct fmt::formatter<dht::token> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const dht::token& t, FormatContext& ctx) const {
         if (t.is_maximum()) {

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -317,7 +317,7 @@ public:
 #if FMT_VERSION < 100000
 // fmt v10 introduced formatter for std::exception
 template <std::derived_from<exceptions::cassandra_exception> T>
-struct fmt::formatter<T> : fmt::formatter<std::string_view> {
+struct fmt::formatter<T> : fmt::formatter<string_view> {
     auto format(const T& e, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", e.what());
     }

--- a/gms/gossip_digest.hh
+++ b/gms/gossip_digest.hh
@@ -61,7 +61,7 @@ public:
 
 } // namespace gms
 
-template <> struct fmt::formatter<gms::gossip_digest> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<gms::gossip_digest> : fmt::formatter<string_view> {
     auto format(const gms::gossip_digest& d, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}:{}:{}", d._endpoint, d._generation, d._max_version);
     }

--- a/gms/gossip_digest_ack.hh
+++ b/gms/gossip_digest_ack.hh
@@ -54,6 +54,6 @@ public:
 
 }
 
-template <> struct fmt::formatter<gms::gossip_digest_ack> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<gms::gossip_digest_ack> : fmt::formatter<string_view> {
     auto format(const gms::gossip_digest_ack&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/gms/gossip_digest_syn.hh
+++ b/gms/gossip_digest_syn.hh
@@ -73,6 +73,6 @@ public:
 
 }
 
-template <> struct fmt::formatter<gms::gossip_digest_syn> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<gms::gossip_digest_syn> : fmt::formatter<string_view> {
     auto format(const gms::gossip_digest_syn&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -86,7 +86,7 @@ struct hash<gms::inet_address> {
 }
 
 template <>
-struct fmt::formatter<gms::inet_address> : fmt::formatter<std::string_view> {
+struct fmt::formatter<gms::inet_address> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const ::gms::inet_address& x, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", x.addr());

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -197,7 +197,7 @@ public:
 
 } // namespace gms
 
-template <> struct fmt::formatter<gms::versioned_value> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<gms::versioned_value> : fmt::formatter<string_view> {
     auto format(const gms::versioned_value& v, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "Value({},{})", v.value(), v.version());
     }

--- a/interval.hh
+++ b/interval.hh
@@ -431,7 +431,7 @@ private:
 };
 
 template<typename U>
-struct fmt::formatter<wrapping_interval<U>> : fmt::formatter<std::string_view> {
+struct fmt::formatter<wrapping_interval<U>> : fmt::formatter<string_view> {
     auto format(const wrapping_interval<U>& r, fmt::format_context& ctx) const {
         auto out = ctx.out();
         if (r.is_singular()) {
@@ -737,7 +737,7 @@ public:
 };
 
 template<typename U>
-struct fmt::formatter<interval<U>> : fmt::formatter<std::string_view> {
+struct fmt::formatter<interval<U>> : fmt::formatter<string_view> {
     auto format(const interval<U>& r, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", r._interval);
     }

--- a/keys.hh
+++ b/keys.hh
@@ -674,7 +674,7 @@ public:
 };
 
 template <>
-struct fmt::formatter<partition_key_view> : fmt::formatter<std::string_view> {
+struct fmt::formatter<partition_key_view> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const partition_key_view& pk, FormatContext& ctx) const {
         return with_linearized(pk.representation(), [&] (bytes_view v) {
@@ -758,7 +758,7 @@ public:
 };
 
 template <>
-struct fmt::formatter<partition_key> : fmt::formatter<std::string_view> {
+struct fmt::formatter<partition_key> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const partition_key& pk, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "pk{{{}}}", managed_bytes_view(pk.representation()));
@@ -790,7 +790,7 @@ auto format_pk(const WithSchemaWrapper& pk, FormatContext& ctx) {
 } // namespace detail
 
 template <>
-struct fmt::formatter<partition_key::with_schema_wrapper> : fmt::formatter<std::string_view> {
+struct fmt::formatter<partition_key::with_schema_wrapper> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const partition_key::with_schema_wrapper& pk, FormatContext& ctx) const {
         return ::detail::format_pk(pk, ctx);
@@ -908,7 +908,7 @@ public:
 };
 
 template <>
-struct fmt::formatter<clustering_key_prefix> : fmt::formatter<std::string_view> {
+struct fmt::formatter<clustering_key_prefix> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const clustering_key_prefix& ckp, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "ckp{{{}}}", managed_bytes_view(ckp.representation()));
@@ -916,7 +916,7 @@ struct fmt::formatter<clustering_key_prefix> : fmt::formatter<std::string_view> 
 };
 
 template <>
-struct fmt::formatter<clustering_key_prefix::with_schema_wrapper> : fmt::formatter<std::string_view> {
+struct fmt::formatter<clustering_key_prefix::with_schema_wrapper> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const clustering_key_prefix::with_schema_wrapper& pk, FormatContext& ctx) const {
         return ::detail::format_pk(pk, ctx);

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -514,40 +514,40 @@ public:
 }
 
 template <>
-struct fmt::formatter<locator::tablet_transition_stage> : fmt::formatter<std::string_view> {
+struct fmt::formatter<locator::tablet_transition_stage> : fmt::formatter<string_view> {
     auto format(const locator::tablet_transition_stage&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
 template <>
-struct fmt::formatter<locator::tablet_transition_kind> : fmt::formatter<std::string_view> {
+struct fmt::formatter<locator::tablet_transition_kind> : fmt::formatter<string_view> {
     auto format(const locator::tablet_transition_kind&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
 template <>
-struct fmt::formatter<locator::global_tablet_id> : fmt::formatter<std::string_view> {
+struct fmt::formatter<locator::global_tablet_id> : fmt::formatter<string_view> {
     auto format(const locator::global_tablet_id&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
 template <>
-struct fmt::formatter<locator::tablet_id> : fmt::formatter<std::string_view> {
+struct fmt::formatter<locator::tablet_id> : fmt::formatter<string_view> {
     auto format(locator::tablet_id  id, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", id.value());
     }
 };
 
 template <>
-struct fmt::formatter<locator::tablet_replica> : fmt::formatter<std::string_view> {
+struct fmt::formatter<locator::tablet_replica> : fmt::formatter<string_view> {
     auto format(const locator::tablet_replica& r, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}:{}", r.host, r.shard);
     }
 };
 
 template <>
-struct fmt::formatter<locator::tablet_map> : fmt::formatter<std::string_view> {
+struct fmt::formatter<locator::tablet_map> : fmt::formatter<string_view> {
     auto format(const locator::tablet_map&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
 template <>
-struct fmt::formatter<locator::tablet_metadata> : fmt::formatter<std::string_view> {
+struct fmt::formatter<locator::tablet_metadata> : fmt::formatter<string_view> {
     auto format(const locator::tablet_metadata&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -444,7 +444,7 @@ std::ostream& operator<<(std::ostream& out, const locator::node::state& state);
 
 // Accepts :v format option for verbose printing
 template <>
-struct fmt::formatter<locator::node> : fmt::formatter<std::string_view> {
+struct fmt::formatter<locator::node> : fmt::formatter<string_view> {
     bool verbose = false;
     constexpr auto parse(fmt::format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
@@ -478,7 +478,7 @@ struct fmt::formatter<locator::node> : fmt::formatter<std::string_view> {
 };
 
 template <>
-struct fmt::formatter<locator::node::state> : fmt::formatter<std::string_view> {
+struct fmt::formatter<locator::node::state> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const locator::node::state& state, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", locator::node::to_string(state));

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -289,7 +289,7 @@ public:
     future<> stop();
 };
 
-template <> struct fmt::formatter<read_context::dismantle_buffer_stats> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<read_context::dismantle_buffer_stats> : fmt::formatter<string_view> {
     auto format(const read_context::dismantle_buffer_stats& s, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(),
                               "kept {} partitions/{} fragments/{} bytes, discarded {} partitions/{} fragments/{} bytes",

--- a/mutation/atomic_cell.hh
+++ b/mutation/atomic_cell.hh
@@ -402,12 +402,12 @@ void merge_column(const abstract_type& def,
         const atomic_cell_or_collection& neww);
 
 template <>
-struct fmt::formatter<atomic_cell_view> : fmt::formatter<std::string_view> {
+struct fmt::formatter<atomic_cell_view> : fmt::formatter<string_view> {
     auto format(const atomic_cell_view&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
 template <>
-struct fmt::formatter<atomic_cell> : fmt::formatter<std::string_view> {
+struct fmt::formatter<atomic_cell> : fmt::formatter<string_view> {
     auto format(const atomic_cell& ac, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", atomic_cell_view(ac));
     }

--- a/mutation/atomic_cell_or_collection.hh
+++ b/mutation/atomic_cell_or_collection.hh
@@ -60,6 +60,6 @@ public:
 };
 
 template <>
-struct fmt::formatter<atomic_cell_or_collection::printer> : fmt::formatter<std::string_view> {
+struct fmt::formatter<atomic_cell_or_collection::printer> : fmt::formatter<string_view> {
     auto format(const atomic_cell_or_collection::printer&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/mutation/canonical_mutation.hh
+++ b/mutation/canonical_mutation.hh
@@ -41,7 +41,7 @@ public:
     friend fmt::formatter<canonical_mutation>;
 };
 
-template <> struct fmt::formatter<canonical_mutation> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<canonical_mutation> : fmt::formatter<string_view> {
     auto format(const canonical_mutation&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 

--- a/mutation/frozen_mutation.hh
+++ b/mutation/frozen_mutation.hh
@@ -327,7 +327,7 @@ auto frozen_mutation::consume_gently(schema_ptr s, Consumer& consumer) const -> 
     co_return co_await consume_gently(s, adaptor);
 }
 
-template <> struct fmt::formatter<frozen_mutation::printer> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<frozen_mutation::printer> : fmt::formatter<string_view> {
     auto format(const frozen_mutation::printer& pr, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", pr.self.unfreeze(pr.schema));
     }

--- a/mutation/mutation.hh
+++ b/mutation/mutation.hh
@@ -462,7 +462,7 @@ boost::iterator_range<std::vector<mutation>::const_iterator> slice(
 // clustering order. The resulting mutation will contain a reverse schema too.
 mutation reverse(mutation mut);
 
-template <> struct fmt::formatter<mutation> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<mutation> : fmt::formatter<string_view> {
     auto format(const mutation&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 

--- a/mutation/mutation_fragment.hh
+++ b/mutation/mutation_fragment.hh
@@ -586,38 +586,38 @@ struct appending_hash<mutation_fragment> {
     void operator()(Hasher& h, const mutation_fragment& mf, const schema& s) const;
 };
 
-template <> struct fmt::formatter<clustering_row::printer> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<clustering_row::printer> : fmt::formatter<string_view> {
     auto format(const clustering_row::printer& p, fmt::format_context& ctx) const {
         auto& row = p._clustering_row;
         return fmt::format_to(ctx.out(), "{{clustering_row: ck {} dr {}}}",
                               row._ck, deletable_row::printer(p._schema, row._row));
     }
 };
-template <> struct fmt::formatter<static_row::printer> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<static_row::printer> : fmt::formatter<string_view> {
     auto format(const static_row::printer& p, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{{static_row: {}}}",
                               row::printer(p._schema, column_kind::static_column, p._static_row._cells));
     }
 };
-template <> struct fmt::formatter<partition_start> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<partition_start> : fmt::formatter<string_view> {
     auto format(const partition_start& ph, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{{partition_start: pk {} partition_tombstone {}}}",
                               ph._key, ph._partition_tombstone);
     }
 };
-template <> struct fmt::formatter<partition_end> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<partition_end> : fmt::formatter<string_view> {
     auto format(const partition_end&, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{{partition_end}}");
     }
 };
-template <> struct fmt::formatter<mutation_fragment::printer> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<mutation_fragment::printer> : fmt::formatter<string_view> {
     auto format(const mutation_fragment::printer&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<mutation_fragment::kind> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<mutation_fragment::kind> : fmt::formatter<string_view> {
     auto format(mutation_fragment::kind, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
-template <> struct fmt::formatter<range_tombstone_stream> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<range_tombstone_stream> : fmt::formatter<string_view> {
     auto format(const range_tombstone_stream& rtl, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", rtl._list);
     }

--- a/mutation/mutation_fragment_stream_validator.hh
+++ b/mutation/mutation_fragment_stream_validator.hh
@@ -222,7 +222,7 @@ public:
 #if FMT_VERSION < 100000
 // fmt v10 introduced formatter for std::exception
 template <>
-struct fmt::formatter<invalid_mutation_fragment_stream> : fmt::formatter<std::string_view> {
+struct fmt::formatter<invalid_mutation_fragment_stream> : fmt::formatter<string_view> {
     auto format(const invalid_mutation_fragment_stream& e, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", e.what());
     }

--- a/mutation/mutation_fragment_v2.hh
+++ b/mutation/mutation_fragment_v2.hh
@@ -76,7 +76,7 @@ public:
 };
 
 template<>
-struct fmt::formatter<range_tombstone_change> : fmt::formatter<std::string_view> {
+struct fmt::formatter<range_tombstone_change> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const range_tombstone_change& rt, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{{range_tombstone_change: pos={}, {}}}", rt.position(), rt.tombstone());
@@ -368,13 +368,13 @@ private:
     }
 };
 
-template <> struct fmt::formatter<mutation_fragment_v2::printer> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<mutation_fragment_v2::printer> : fmt::formatter<string_view> {
     auto format(const mutation_fragment_v2::printer&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
 std::ostream& operator<<(std::ostream&, mutation_fragment_v2::kind);
 
-template <> struct fmt::formatter<mutation_fragment_v2::kind> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<mutation_fragment_v2::kind> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(mutation_fragment_v2::kind k, FormatContext& ctx) const {
         string_view name = "UNEXPECTED";

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -700,7 +700,7 @@ public:
 };
 
 template <>
-struct fmt::formatter<shadowable_tombstone> : fmt::formatter<std::string_view> {
+struct fmt::formatter<shadowable_tombstone> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const shadowable_tombstone& t, FormatContext& ctx) const {
         if (t) {

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -98,7 +98,7 @@ void mutation_partition_v2::ensure_last_dummy(const schema& s) {
 }
 
 template <>
-struct fmt::formatter<apply_resume> : fmt::formatter<std::string_view> {
+struct fmt::formatter<apply_resume> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const apply_resume& res, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{{{}, {}}}", int(res._stage), res._pos);

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -282,6 +282,6 @@ mutation_partition_v2& mutation_partition_v2::container_of(rows_type& rows) {
 // meaning that they can be removed without affecting the set of writes represented by the mutation.
 bool has_redundant_dummies(const mutation_partition_v2&);
 
-template <> struct fmt::formatter<mutation_partition_v2::printer> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<mutation_partition_v2::printer> : fmt::formatter<string_view> {
     auto format(const mutation_partition_v2::printer&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -730,6 +730,6 @@ inline const partition_version_ref& partition_snapshot::version() const
     }
 }
 
-template <> struct fmt::formatter<partition_entry::printer> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<partition_entry::printer> : fmt::formatter<string_view> {
     auto format(const partition_entry::printer&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/mutation/position_in_partition.hh
+++ b/mutation/position_in_partition.hh
@@ -83,18 +83,18 @@ enum class partition_region : uint8_t {
 struct view_and_holder;
 
 template <>
-struct fmt::formatter<partition_region> : fmt::formatter<std::string_view> {
+struct fmt::formatter<partition_region> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const ::partition_region& r, FormatContext& ctx) const {
         switch (r) {
             case partition_region::partition_start:
-                return formatter<std::string_view>::format("partition_start", ctx);
+                return formatter<string_view>::format("partition_start", ctx);
             case partition_region::static_row:
-                return formatter<std::string_view>::format("static_row", ctx);
+                return formatter<string_view>::format("static_row", ctx);
             case partition_region::clustered:
-                return formatter<std::string_view>::format("clustered", ctx);
+                return formatter<string_view>::format("clustered", ctx);
             case partition_region::partition_end:
-                return formatter<std::string_view>::format("partition_end", ctx);
+                return formatter<string_view>::format("partition_end", ctx);
         }
         std::abort(); // compiler will error before we reach here
     }
@@ -266,7 +266,7 @@ public:
 };
 
 template <>
-struct fmt::formatter<position_in_partition_view> : fmt::formatter<std::string_view> {
+struct fmt::formatter<position_in_partition_view> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const ::position_in_partition_view& pos, FormatContext& ctx) const {
         fmt::format_to(ctx.out(), "{{position: {}, ", pos._type);
@@ -280,7 +280,7 @@ struct fmt::formatter<position_in_partition_view> : fmt::formatter<std::string_v
 };
 
 template <>
-struct fmt::formatter<position_in_partition_view::printer> : fmt::formatter<std::string_view> {
+struct fmt::formatter<position_in_partition_view::printer> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const ::position_in_partition_view::printer& p, FormatContext& ctx) const {
         auto& pos = p._pipv;
@@ -647,7 +647,7 @@ public:
 };
 
 template <>
-struct fmt::formatter<position_in_partition> : fmt::formatter<std::string_view> {
+struct fmt::formatter<position_in_partition> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const ::position_in_partition& pos, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", position_in_partition_view(pos));
@@ -816,7 +816,7 @@ bool position_range::is_all_clustered_rows(const schema& s) const {
 // If `r` does not contain any keys, returns nullopt.
 std::optional<query::clustering_range> position_range_to_clustering_range(const position_range& r, const schema&);
 
-template <> struct fmt::formatter<position_range> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<position_range> : fmt::formatter<string_view> {
     auto format(const position_range& range, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{{{}, {}}}", range.start(), range.end());
     }

--- a/mutation/range_tombstone.hh
+++ b/mutation/range_tombstone.hh
@@ -287,7 +287,7 @@ public:
 };
 
 template<>
-struct fmt::formatter<range_tombstone> : fmt::formatter<std::string_view> {
+struct fmt::formatter<range_tombstone> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const range_tombstone& rt, FormatContext& ctx) const {
         if (rt) {

--- a/mutation/range_tombstone_list.hh
+++ b/mutation/range_tombstone_list.hh
@@ -78,7 +78,7 @@ private:
 };
 
 template <>
-struct fmt::formatter<range_tombstone_entry> : fmt::formatter<std::string_view> {
+struct fmt::formatter<range_tombstone_entry> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const range_tombstone_entry& rt, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", rt.tombstone());
@@ -300,7 +300,7 @@ private:
 };
 
 template <>
-struct fmt::formatter<range_tombstone_list> : fmt::formatter<std::string_view> {
+struct fmt::formatter<range_tombstone_list> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const range_tombstone_list& list, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{{{}}}", fmt::join(list, ", "));

--- a/mutation/tombstone.hh
+++ b/mutation/tombstone.hh
@@ -64,7 +64,7 @@ struct tombstone final {
 };
 
 template <>
-struct fmt::formatter<tombstone> : fmt::formatter<std::string_view> {
+struct fmt::formatter<tombstone> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const tombstone& t, FormatContext& ctx) const {
         if (t) {

--- a/node_ops/node_ops_ctl.hh
+++ b/node_ops/node_ops_ctl.hh
@@ -78,7 +78,7 @@ enum class node_ops_cmd_category {
 node_ops_cmd_category categorize_node_ops_cmd(node_ops_cmd cmd) noexcept;
 
 template <>
-struct fmt::formatter<node_ops_cmd> : fmt::formatter<std::string_view> {
+struct fmt::formatter<node_ops_cmd> : fmt::formatter<string_view> {
     auto format(node_ops_cmd, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
@@ -167,6 +167,6 @@ public:
 };
 
 template <>
-struct fmt::formatter<node_ops_cmd_request> : fmt::formatter<std::string_view> {
+struct fmt::formatter<node_ops_cmd_request> : fmt::formatter<string_view> {
     auto format(const node_ops_cmd_request&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/partition_snapshot_row_cursor.hh
+++ b/partition_snapshot_row_cursor.hh
@@ -756,7 +756,7 @@ public:
     friend fmt::formatter<partition_snapshot_row_cursor>;
 };
 
-template <> struct fmt::formatter<partition_snapshot_row_cursor> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<partition_snapshot_row_cursor> : fmt::formatter<string_view> {
     auto format(const  partition_snapshot_row_cursor& cur, fmt::format_context& ctx) const {
         auto out = ctx.out();
         out = fmt::format_to(out, "{{cursor: position={}, cont={}, rt={}}}",

--- a/raft/log.hh
+++ b/raft/log.hh
@@ -216,6 +216,6 @@ public:
 
 }
 
-template <> struct fmt::formatter<raft::log> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<raft::log> : fmt::formatter<string_view> {
     auto format(const raft::log&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -818,7 +818,7 @@ public:
 #if FMT_VERSION < 100000
 // fmt v10 introduced formatter for std::exception
 template <std::derived_from<raft::error> T>
-struct fmt::formatter<T> : fmt::formatter<std::string_view> {
+struct fmt::formatter<T> : fmt::formatter<string_view> {
     auto format(const T& e, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", e.what());
     }
@@ -826,16 +826,16 @@ struct fmt::formatter<T> : fmt::formatter<std::string_view> {
 #endif
 
 template <>
-struct fmt::formatter<raft::server_address> : fmt::formatter<std::string_view> {
+struct fmt::formatter<raft::server_address> : fmt::formatter<string_view> {
     auto format(const raft::server_address&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
 template <>
-struct fmt::formatter<raft::config_member> : fmt::formatter<std::string_view> {
+struct fmt::formatter<raft::config_member> : fmt::formatter<string_view> {
     auto format(const raft::config_member&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
 template <>
-struct fmt::formatter<raft::configuration> : fmt::formatter<std::string_view> {
+struct fmt::formatter<raft::configuration> : fmt::formatter<string_view> {
     auto format(const raft::configuration&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/raft/tracker.cc
+++ b/raft/tracker.cc
@@ -289,5 +289,5 @@ auto fmt::formatter<raft::vote_result>::format(const raft::vote_result& v, fmt::
         name = "LOST";
         break;
     }
-    return formatter<std::string_view>::format(name, ctx);
+    return formatter<string_view>::format(name, ctx);
 }

--- a/raft/tracker.hh
+++ b/raft/tracker.hh
@@ -206,14 +206,14 @@ public:
 
 } // namespace raft
 
-template <> struct fmt::formatter<raft::election_tracker> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<raft::election_tracker> : fmt::formatter<string_view> {
     auto format(const raft::election_tracker& v, fmt::format_context& ctx) const  -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<raft::votes> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<raft::votes> : fmt::formatter<string_view> {
     auto format(const raft::votes& v, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<raft::vote_result> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<raft::vote_result> : fmt::formatter<string_view> {
     auto format(const raft::vote_result& v, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -55,7 +55,7 @@ struct reader_concurrency_semaphore::inactive_read {
 };
 
 template <>
-struct fmt::formatter<reader_concurrency_semaphore::evict_reason> : fmt::formatter<std::string_view> {
+struct fmt::formatter<reader_concurrency_semaphore::evict_reason> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const reader_concurrency_semaphore::evict_reason& reason, FormatContext& ctx) const {
         static const char* value_table[] = {"permit", "time", "manual"};
@@ -681,7 +681,7 @@ auto fmt::formatter<reader_permit::state>::format(reader_permit::state s, fmt::f
             name = "evicted";
             break;
     }
-    return formatter<std::string_view>::format(name, ctx);
+    return formatter<string_view>::format(name, ctx);
 }
 
 namespace {

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -322,9 +322,9 @@ bool operator==(const tracking_allocator<T>& a, const tracking_allocator<T>& b) 
     return a._semaphore == b._semaphore;
 }
 
-template <> struct fmt::formatter<reader_permit::state> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<reader_permit::state> : fmt::formatter<string_view> {
     auto format(reader_permit::state, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
-template <> struct fmt::formatter<reader_resources> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<reader_resources> : fmt::formatter<string_view> {
     auto format(const reader_resources&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/repair/hash.hh
+++ b/repair/hash.hh
@@ -41,7 +41,7 @@ public:
     repair_hash do_hash_for_mf(const decorated_key_with_hash& dk_with_hash, const mutation_fragment& mf);
 };
 
-template <> struct fmt::formatter<repair_hash>  : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<repair_hash>  : fmt::formatter<string_view> {
     auto format(const repair_hash& x, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", x.hash);
     }

--- a/repair/reader.hh
+++ b/repair/reader.hh
@@ -77,7 +77,7 @@ public:
     void pause();
 };
 
-template <> struct fmt::formatter<repair_reader::read_strategy>  : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<repair_reader::read_strategy>  : fmt::formatter<string_view> {
     auto format(repair_reader::read_strategy s, fmt::format_context& ctx) const {
         using enum repair_reader::read_strategy;
         std::string_view name = "unknown";
@@ -92,6 +92,6 @@ template <> struct fmt::formatter<repair_reader::read_strategy>  : fmt::formatte
                 name = "multishard_filter";
                 break;
         };
-        return formatter<std::string_view>::format(name, ctx);
+        return formatter<string_view>::format(name, ctx);
     }
 };

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -286,8 +286,8 @@ struct hash<node_repair_meta_id> {
 
 }
 
-template <> struct fmt::formatter<row_level_diff_detect_algorithm> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<row_level_diff_detect_algorithm> : fmt::formatter<string_view> {
     auto format(row_level_diff_detect_algorithm algo, fmt::format_context& ctx) const {
-        return formatter<std::string_view>::format(format_as(algo), ctx);
+        return formatter<string_view>::format(format_as(algo), ctx);
     }
 };

--- a/row_cache.hh
+++ b/row_cache.hh
@@ -522,6 +522,6 @@ public:
 
 }
 
-template <> struct fmt::formatter<cache_entry> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<cache_entry> : fmt::formatter<string_view> {
     auto format(const cache_entry&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -1038,29 +1038,29 @@ inline void check_schema_version(table_schema_version expected, const schema& ac
     }
 }
 
-template <> struct fmt::formatter<ordinal_column_id> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<ordinal_column_id> : fmt::formatter<string_view> {
     auto format(ordinal_column_id id, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", static_cast<column_count_type>(id));
     }
 };
 
-template <> struct fmt::formatter<column_definition> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<column_definition> : fmt::formatter<string_view> {
     auto format(const column_definition&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<column_mapping> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<column_mapping> : fmt::formatter<string_view> {
     auto format(const column_mapping&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<raw_view_info> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<raw_view_info> : fmt::formatter<string_view> {
     auto format(const raw_view_info&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<schema> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<schema> : fmt::formatter<string_view> {
     auto format(const schema&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 std::ostream& operator<<(std::ostream& os, const schema& s);
 
-template <> struct fmt::formatter<view_ptr> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<view_ptr> : fmt::formatter<string_view> {
     auto format(const view_ptr& view, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/schema/schema_fwd.hh
+++ b/schema/schema_fwd.hh
@@ -37,7 +37,7 @@ std::ostream& operator<<(std::ostream& os, const table_info& ti);
 } // namespace std
 
 template <>
-struct fmt::formatter<table_info> : fmt::formatter<std::string_view> {
+struct fmt::formatter<table_info> : fmt::formatter<string_view> {
     auto format(const table_info&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 

--- a/schema_mutations.hh
+++ b/schema_mutations.hh
@@ -137,6 +137,6 @@ public:
     friend std::ostream& operator<<(std::ostream&, const schema_mutations&);
 };
 
-template <> struct fmt::formatter<schema_mutations> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<schema_mutations> : fmt::formatter<string_view> {
     auto format(const schema_mutations&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/service/paxos/prepare_response.hh
+++ b/service/paxos/prepare_response.hh
@@ -73,6 +73,6 @@ using prepare_response = std::variant<utils::UUID, promise>;
 
 } // end of namespace "service"
 
-template <> struct fmt::formatter<service::paxos::promise> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<service::paxos::promise> : fmt::formatter<string_view> {
     auto format(const service::paxos::promise&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/service/paxos/proposal.hh
+++ b/service/paxos/proposal.hh
@@ -50,7 +50,7 @@ inline bool operator>(const proposal& lhs, const proposal& rhs) {
 } // end of namespace "service"
 
 // Used for logging and debugging.
-template <> struct fmt::formatter<service::paxos::proposal> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<service::paxos::proposal> : fmt::formatter<string_view> {
     auto format(const service::paxos::proposal&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 

--- a/service/qos/qos_common.hh
+++ b/service/qos/qos_common.hh
@@ -100,8 +100,8 @@ future<service_levels_info> get_service_level(cql3::query_processor& qp, std::st
 
 }
 
-template <> struct fmt::formatter<qos::service_level_options::workload_type> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<qos::service_level_options::workload_type> : fmt::formatter<string_view> {
     auto format(qos::service_level_options::workload_type wt, fmt::format_context& ctx) const {
-        return formatter<std::string_view>::format(qos::service_level_options::to_string(wt), ctx);
+        return formatter<string_view>::format(qos::service_level_options::to_string(wt), ctx);
     }
 };

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -167,7 +167,7 @@ enum class storage_proxy_remote_read_verb {
 
 }
 
-template <> struct fmt::formatter<service::storage_proxy_remote_read_verb> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<service::storage_proxy_remote_read_verb> : fmt::formatter<string_view> {
     auto format(service::storage_proxy_remote_read_verb verb, fmt::format_context& ctx) const {
         std::string_view name;
         using enum service::storage_proxy_remote_read_verb;
@@ -182,7 +182,7 @@ template <> struct fmt::formatter<service::storage_proxy_remote_read_verb> : fmt
             name = "read_digest";
             break;
         }
-        return formatter<std::string_view>::format(name, ctx);
+        return formatter<string_view>::format(name, ctx);
     }
 };
 
@@ -2223,7 +2223,7 @@ future<bool> paxos_response_handler::accept_proposal(lw_shared_ptr<paxos::propos
 
 // debug output in mutate_internal needs this
 template <>
-struct fmt::formatter<service::paxos_response_handler> : fmt::formatter<std::string_view> {
+struct fmt::formatter<service::paxos_response_handler> : fmt::formatter<string_view> {
     auto format(const service::paxos_response_handler& h, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "paxos_response_handler{{{}}}", h.id());
     }
@@ -2854,14 +2854,14 @@ struct read_repair_mutation {
 
 }
 
-template <> struct fmt::formatter<service::hint_wrapper> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<service::hint_wrapper> : fmt::formatter<string_view> {
     auto format(const service::hint_wrapper& h, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "hint_wrapper{{{}}}", h.mut);
     }
 };
 
 template <>
-struct fmt::formatter<service::read_repair_mutation> : fmt::formatter<std::string_view> {
+struct fmt::formatter<service::read_repair_mutation> : fmt::formatter<string_view> {
     auto format(const service::read_repair_mutation& m, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", m.value);
     }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -912,7 +912,7 @@ private:
 }
 
 template <>
-struct fmt::formatter<service::storage_service::mode> : fmt::formatter<std::string_view> {
+struct fmt::formatter<service::storage_service::mode> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(service::storage_service::mode mode, FormatContext& ctx) const {
         std::string_view name;

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -127,6 +127,6 @@ public:
 }
 
 template <>
-struct fmt::formatter<service::tablet_migration_info> : fmt::formatter<std::string_view> {
+struct fmt::formatter<service::tablet_migration_info> : fmt::formatter<string_view> {
     auto format(const service::tablet_migration_info&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/service/topology_coordinator.hh
+++ b/service/topology_coordinator.hh
@@ -79,7 +79,7 @@ future<> run_topology_coordinator(
 #if FMT_VERSION < 100000
 // fmt v10 introduced formatter for std::exception
 template <>
-struct fmt::formatter<service::wait_for_ip_timeout> : fmt::formatter<std::string_view> {
+struct fmt::formatter<service::wait_for_ip_timeout> : fmt::formatter<string_view> {
     auto format(const service::wait_for_ip_timeout& e, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", e.what());
     }

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -251,7 +251,7 @@ auto fmt::formatter<service::topology::transition_state>::format(service::topolo
     if (it == service::transition_state_to_name_map.end()) {
         on_internal_error(service::tsmlogger, "cannot print transition_state");
     }
-    return formatter<std::string_view>::format(it->second, ctx);
+    return formatter<string_view>::format(std::string_view(it->second), ctx);
 }
 
 auto fmt::formatter<service::node_state>::format(service::node_state s,
@@ -260,13 +260,13 @@ auto fmt::formatter<service::node_state>::format(service::node_state s,
     if (it == service::node_state_to_name_map.end()) {
         on_internal_error(service::tsmlogger, "cannot print node_state");
     }
-    return formatter<std::string_view>::format(it->second, ctx);
+    return formatter<string_view>::format(std::string_view(it->second), ctx);
 }
 
 
 auto fmt::formatter<service::topology_request>::format(service::topology_request req,
                                                        fmt::format_context& ctx) const -> decltype(ctx.out()) {
-    return formatter<std::string_view>::format(service::topology_request_to_name_map[req], ctx);
+    return formatter<string_view>::format(std::string_view(service::topology_request_to_name_map[req]), ctx);
 }
 
 auto fmt::formatter<service::global_topology_request>::format(service::global_topology_request req,
@@ -275,7 +275,7 @@ auto fmt::formatter<service::global_topology_request>::format(service::global_to
     if (it == service::global_topology_request_to_name_map.end()) {
         on_internal_error(service::tsmlogger, fmt::format("cannot print global topology request {}", static_cast<uint8_t>(req)));
     }
-    return formatter<std::string_view>::format(it->second, ctx);
+    return formatter<string_view>::format(std::string_view(it->second), ctx);
 }
 
 
@@ -297,5 +297,5 @@ auto fmt::formatter<service::raft_topology_cmd::command>::format(service::raft_t
             name = "wait_for_ip";
             break;
     }
-    return formatter<std::string_view>::format(name, ctx);
+    return formatter<string_view>::format(name, ctx);
 }

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -287,28 +287,28 @@ template <> struct fmt::formatter<service::topology::upgrade_state_type> {
     auto format(service::topology::upgrade_state_type status, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<service::fencing_token> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<service::fencing_token> : fmt::formatter<string_view> {
     auto format(const service::fencing_token& fencing_token, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{{{}}}", fencing_token.topology_version);
     }
 };
 
-template <> struct fmt::formatter<service::topology::transition_state> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<service::topology::transition_state> : fmt::formatter<string_view> {
     auto format(service::topology::transition_state, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<service::node_state> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<service::node_state> : fmt::formatter<string_view> {
     auto format(service::node_state, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<service::topology_request> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<service::topology_request> : fmt::formatter<string_view> {
     auto format(service::topology_request, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<service::global_topology_request> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<service::global_topology_request> : fmt::formatter<string_view> {
     auto format(service::global_topology_request, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<service::raft_topology_cmd::command> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<service::raft_topology_cmd::command> : fmt::formatter<string_view> {
     auto format(service::raft_topology_cmd::command, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/sstables/component_type.hh
+++ b/sstables/component_type.hh
@@ -34,37 +34,37 @@ enum class component_type {
 using component_type = ::sstables::component_type;
 
 template <>
-struct fmt::formatter<sstables::component_type> : fmt::formatter<std::string_view> {
+struct fmt::formatter<sstables::component_type> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const sstables::component_type& comp_type, FormatContext& ctx) const {
         using enum sstables::component_type;
         switch (comp_type) {
         case Index:
-            return formatter<std::string_view>::format("Index", ctx);
+            return formatter<string_view>::format("Index", ctx);
         case CompressionInfo:
-            return formatter<std::string_view>::format("CompressionInfo", ctx);
+            return formatter<string_view>::format("CompressionInfo", ctx);
         case Data:
-            return formatter<std::string_view>::format("Data", ctx);
+            return formatter<string_view>::format("Data", ctx);
         case TOC:
-            return formatter<std::string_view>::format("TOC", ctx);
+            return formatter<string_view>::format("TOC", ctx);
         case Summary:
-            return formatter<std::string_view>::format("Summary", ctx);
+            return formatter<string_view>::format("Summary", ctx);
         case Digest:
-            return formatter<std::string_view>::format("Digest", ctx);
+            return formatter<string_view>::format("Digest", ctx);
         case CRC:
-            return formatter<std::string_view>::format("CRC", ctx);
+            return formatter<string_view>::format("CRC", ctx);
         case Filter:
-            return formatter<std::string_view>::format("Filter", ctx);
+            return formatter<string_view>::format("Filter", ctx);
         case Statistics:
-            return formatter<std::string_view>::format("Statistics", ctx);
+            return formatter<string_view>::format("Statistics", ctx);
         case TemporaryTOC:
-            return formatter<std::string_view>::format("TemporaryTOC", ctx);
+            return formatter<string_view>::format("TemporaryTOC", ctx);
         case TemporaryStatistics:
-            return formatter<std::string_view>::format("TemporaryStatistics", ctx);
+            return formatter<string_view>::format("TemporaryStatistics", ctx);
         case Scylla:
-            return formatter<std::string_view>::format("Scylla", ctx);
+            return formatter<string_view>::format("Scylla", ctx);
         case Unknown:
-            return formatter<std::string_view>::format("Unknown", ctx);
+            return formatter<string_view>::format("Unknown", ctx);
         }
     }
 };

--- a/sstables/exceptions.hh
+++ b/sstables/exceptions.hh
@@ -63,7 +63,7 @@ public:
 #if FMT_VERSION < 100000
  // fmt v10 introduced formatter for std::exception
  template <std::derived_from<sstables::malformed_sstable_exception> T>
- struct fmt::formatter<T> : fmt::formatter<std::string_view> {
+ struct fmt::formatter<T> : fmt::formatter<string_view> {
      auto format(const T& e, fmt::format_context& ctx) const {
          return fmt::format_to(ctx.out(), "{}", e.what());
      }

--- a/sstables/generation_type.hh
+++ b/sstables/generation_type.hh
@@ -218,7 +218,7 @@ struct numeric_limits<sstables::generation_type> : public numeric_limits<sstable
 } //namespace std
 
 template <>
-struct fmt::formatter<sstables::generation_type> : fmt::formatter<std::string_view> {
+struct fmt::formatter<sstables::generation_type> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const sstables::generation_type& generation, FormatContext& ctx) const {
         if (!generation) {

--- a/sstables/mx/types.hh
+++ b/sstables/mx/types.hh
@@ -84,6 +84,6 @@ inline bound_kind boundary_to_end_bound(bound_kind_m kind) {
 
 }
 
-template <> struct fmt::formatter<sstables::bound_kind_m> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<sstables::bound_kind_m> : fmt::formatter<string_view> {
     auto format(sstables::bound_kind_m, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/sstables/shared_sstable.hh
+++ b/sstables/shared_sstable.hh
@@ -43,7 +43,7 @@ std::string to_string(const shared_sstable& sst, bool include_origin = true);
 } // namespace sstables
 
 template <>
-struct fmt::formatter<sstables::shared_sstable> : fmt::formatter<std::string_view> {
+struct fmt::formatter<sstables::shared_sstable> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const sstables::shared_sstable& sst, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", sstables::to_string(sst));

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -1043,7 +1043,7 @@ struct sstable_files_snapshot {
 
 } // namespace sstables
 
-template <> struct fmt::formatter<sstables::sstable_state> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<sstables::sstable_state> : fmt::formatter<string_view> {
     auto format(sstables::sstable_state state, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", state_to_dir(state));
     }

--- a/sstables/version.hh
+++ b/sstables/version.hh
@@ -73,7 +73,7 @@ inline int operator<=>(sstable_version_types a, sstable_version_types b) {
 }
 
 template <>
-struct fmt::formatter<sstables::sstable_version_types> : fmt::formatter<std::string_view> {
+struct fmt::formatter<sstables::sstable_version_types> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const sstables::sstable_version_types& version, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", sstables::version_string.at(version));
@@ -81,7 +81,7 @@ struct fmt::formatter<sstables::sstable_version_types> : fmt::formatter<std::str
 };
 
 template <>
-struct fmt::formatter<sstables::sstable_format_types> : fmt::formatter<std::string_view> {
+struct fmt::formatter<sstables::sstable_format_types> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const sstables::sstable_format_types& format, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", sstables::format_string.at(format));

--- a/streaming/stream_reason.hh
+++ b/streaming/stream_reason.hh
@@ -29,29 +29,29 @@ enum class stream_reason : uint8_t {
 }
 
 template <>
-struct fmt::formatter<streaming::stream_reason> : fmt::formatter<std::string_view> {
+struct fmt::formatter<streaming::stream_reason> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const streaming::stream_reason& r, FormatContext& ctx) const {
         using enum streaming::stream_reason;
         switch (r) {
         case unspecified:
-            return formatter<std::string_view>::format("unspecified", ctx);
+            return formatter<string_view>::format("unspecified", ctx);
         case bootstrap:
-            return formatter<std::string_view>::format("bootstrap", ctx);
+            return formatter<string_view>::format("bootstrap", ctx);
         case decommission:
-            return formatter<std::string_view>::format("decommission", ctx);
+            return formatter<string_view>::format("decommission", ctx);
         case removenode:
-            return formatter<std::string_view>::format("removenode", ctx);
+            return formatter<string_view>::format("removenode", ctx);
         case rebuild:
-            return formatter<std::string_view>::format("rebuild", ctx);
+            return formatter<string_view>::format("rebuild", ctx);
         case repair:
-            return formatter<std::string_view>::format("repair", ctx);
+            return formatter<string_view>::format("repair", ctx);
         case replace:
-            return formatter<std::string_view>::format("replace", ctx);
+            return formatter<string_view>::format("replace", ctx);
         case tablet_migration:
-            return formatter<std::string_view>::format("tablet migration", ctx);
+            return formatter<string_view>::format("tablet migration", ctx);
         case tablet_rebuild:
-            return formatter<std::string_view>::format("tablet rebuild", ctx);
+            return formatter<string_view>::format("tablet rebuild", ctx);
         }
         std::abort();
     }

--- a/streaming/stream_request.hh
+++ b/streaming/stream_request.hh
@@ -40,6 +40,6 @@ public:
 
 } // namespace streaming
 
-template <> struct fmt::formatter<streaming::stream_request> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<streaming::stream_request> : fmt::formatter<string_view> {
     auto format(const streaming::stream_request&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/streaming/stream_session_state.hh
+++ b/streaming/stream_session_state.hh
@@ -25,6 +25,6 @@ enum class stream_session_state {
 
 } // namespace
 
-template <> struct fmt::formatter<streaming::stream_session_state> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<streaming::stream_session_state> : fmt::formatter<string_view> {
     auto format(streaming::stream_session_state, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/streaming/stream_summary.hh
+++ b/streaming/stream_summary.hh
@@ -38,6 +38,6 @@ public:
 
 } // namespace streaming
 
-template <> struct fmt::formatter<streaming::stream_summary> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<streaming::stream_summary> : fmt::formatter<string_view> {
     auto format(const streaming::stream_summary&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/test/boost/cache_flat_mutation_reader_test.cc
+++ b/test/boost/cache_flat_mutation_reader_test.cc
@@ -133,7 +133,7 @@ struct expected_row {
     }
 };
 
-template <> struct fmt::formatter<expected_row> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<expected_row> : fmt::formatter<string_view> {
     auto format(const expected_row& e, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{{pos={}, cont={}, dummy={}}}", e.key(), bool(e.continuous), bool(e.dummy));
     }

--- a/test/boost/enum_set_test.cc
+++ b/test/boost/enum_set_test.cc
@@ -20,7 +20,7 @@
 
 enum class fruit { apple = 3, pear = 7, banana = 8 };
 
-template <> struct fmt::formatter<fruit> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<fruit> : fmt::formatter<string_view> {
     auto format(fruit f, fmt::format_context& ctx) const {
         std::string_view name;
         using enum fruit;

--- a/test/lib/expr_test_utils.hh
+++ b/test/lib/expr_test_utils.hh
@@ -152,7 +152,7 @@ raw_value evaluate_with_bind_variables(const expression& e, std::vector<raw_valu
 }  // namespace expr
 }  // namespace cql3
 
-template <> struct fmt::formatter<cql3::expr::test_utils::mutation_column_value> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<cql3::expr::test_utils::mutation_column_value> : fmt::formatter<string_view> {
     auto format(const cql3::expr::test_utils::mutation_column_value& mcv, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{{{}/ts={}/ttl={}}}", mcv.value, mcv.timestamp, mcv.ttl);
 

--- a/test/perf/perf.hh
+++ b/test/perf/perf.hh
@@ -170,7 +170,7 @@ struct aio_writes_result_mixin {
 
 struct perf_result_with_aio_writes : public perf_result, public aio_writes_result_mixin {};
 
-template <> struct fmt::formatter<perf_result_with_aio_writes> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<perf_result_with_aio_writes> : fmt::formatter<string_view> {
     auto format(const perf_result_with_aio_writes&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
@@ -283,10 +283,10 @@ public:
 
 } // namespace perf
 
-template <> struct fmt::formatter<scheduling_latency_measurer> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<scheduling_latency_measurer> : fmt::formatter<string_view> {
     auto format(const scheduling_latency_measurer&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<perf_result> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<perf_result> : fmt::formatter<string_view> {
     auto format(const perf_result&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/test/raft/generator.hh
+++ b/test/raft/generator.hh
@@ -826,14 +826,14 @@ stagger_gen<G> stagger(
 } // namespace generator
 
 template <operation::Executable... Ops>
-struct fmt::formatter<operation::either_of<Ops...>> : fmt::formatter<std::string_view> {
+struct fmt::formatter<operation::either_of<Ops...>> : fmt::formatter<string_view> {
     auto format(operation::either_of<Ops...>& e, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", e.op);
     }
 };
 
 template <typename Op>
-struct fmt::formatter<operation::exceptional_result<Op>> : fmt::formatter<std::string_view> {
+struct fmt::formatter<operation::exceptional_result<Op>> : fmt::formatter<string_view> {
     auto format(const operation::exceptional_result<Op>& r, fmt::format_context& ctx) const {
         try {
             std::rethrow_exception(r.eptr);
@@ -844,14 +844,14 @@ struct fmt::formatter<operation::exceptional_result<Op>> : fmt::formatter<std::s
 };
 
 template <operation::Executable Op>
-struct fmt::formatter<operation::completion<Op>> : fmt::formatter<std::string_view> {
+struct fmt::formatter<operation::completion<Op>> : fmt::formatter<string_view> {
     auto format(const operation::completion<Op>& c, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "c{{r:{}, t:{}, tid:{}}}", c.result, c.time, c.thread);
     }
 };
 
 template <operation::Executable Op>
-struct fmt::formatter<operation::invocable<Op>> : fmt::formatter<std::string_view> {
+struct fmt::formatter<operation::invocable<Op>> : fmt::formatter<string_view> {
     auto format(const operation::invocable<Op>& op, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", static_cast<Op>(op));
     }

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -2592,7 +2592,7 @@ struct raft_call {
 };
 
 template <PureStateMachine M>
-struct fmt::formatter<raft_call<M>> : fmt::formatter<std::string_view> {
+struct fmt::formatter<raft_call<M>> : fmt::formatter<string_view> {
     auto format(const raft_call<M>& r, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "raft_call{{input:{}, timeout:{}}}", r.input, r.timeout);
     }
@@ -2630,7 +2630,7 @@ struct raft_read {
 };
 
 template <PureStateMachine M>
-struct fmt::formatter<raft_read<M>> : fmt::formatter<std::string_view> {
+struct fmt::formatter<raft_read<M>> : fmt::formatter<string_view> {
     auto format(const raft_read<M>& r, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "raft_read{{id:{}, timeout:{}}}", r.read_id, r.timeout);
     }
@@ -2706,7 +2706,7 @@ public:
 };
 
 template <PureStateMachine M>
-struct fmt::formatter<network_majority_grudge<M>> : fmt::formatter<std::string_view> {
+struct fmt::formatter<network_majority_grudge<M>> : fmt::formatter<string_view> {
     auto format(const network_majority_grudge<M>& p, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "network_majority_grudge{{duration:{}}}", p._duration);
     }
@@ -2836,7 +2836,7 @@ struct reconfiguration {
 };
 
 template <PureStateMachine M>
-struct fmt::formatter<reconfiguration<M>>: fmt::formatter<std::string_view> {
+struct fmt::formatter<reconfiguration<M>>: fmt::formatter<string_view> {
     auto format(const reconfiguration<M>& r, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "reconfiguration{{timeout:{}}}", r.timeout);
     }
@@ -2847,7 +2847,7 @@ struct fmt::formatter<reconfiguration<M>>: fmt::formatter<std::string_view> {
 struct stop_crash_result {};
 
 template <>
-struct fmt::formatter<stop_crash_result>: fmt::formatter<std::string_view> {
+struct fmt::formatter<stop_crash_result>: fmt::formatter<string_view> {
     auto format(stop_crash_result, fmt::format_context& ctx) const {
         return ctx.out();
     }
@@ -2890,13 +2890,13 @@ struct stop_crash {
 };
 
 template <PureStateMachine M>
-struct fmt::formatter<stop_crash<M>>: fmt::formatter<std::string_view> {
+struct fmt::formatter<stop_crash<M>>: fmt::formatter<string_view> {
     auto format(const stop_crash<M>& c, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "stop_crash{{delay:{}}}", c.restart_delay);
     }
 };
 
-template <> struct fmt::formatter<operation::thread_id>: fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<operation::thread_id>: fmt::formatter<string_view> {
     auto format(const operation::thread_id& tid, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "thread_id{{{}}}", tid.id);
     }
@@ -3005,7 +3005,7 @@ struct AppendReg {
     static thread_local const state_t init;
 };
 
-template <> struct fmt::formatter<append_seq> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<append_seq> : fmt::formatter<string_view> {
     auto format(const append_seq& s, fmt::format_context& ctx) const {
         // TODO: don't copy the elements
         std::vector<append_seq::elem_t> v{s._seq->begin(), s._seq->begin() + s._end};
@@ -3204,13 +3204,13 @@ private:
     }
 };
 
-template <> struct fmt::formatter<AppendReg::append> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<AppendReg::append> : fmt::formatter<string_view> {
     auto format(const AppendReg::append& a, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "append{{{}}}", a.x);
     }
 };
 
-template <> struct fmt::formatter<AppendReg::ret> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<AppendReg::ret> : fmt::formatter<string_view> {
     auto format(const AppendReg::ret& r, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "ret{{{}, {}}}", r.x, r.prev);
     }

--- a/test/unit/bptree_stress_test.cc
+++ b/test/unit/bptree_stress_test.cc
@@ -33,7 +33,7 @@ public:
     bool match_key(const test_key& k) const { return _value == (int)k + 10; }
 };
 
-template <> struct fmt::formatter<test_data> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<test_data> : fmt::formatter<string_view> {
     auto format(test_data d, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", static_cast<unsigned long>(d));
     }

--- a/test/unit/radix_tree_compaction_test.cc
+++ b/test/unit/radix_tree_compaction_test.cc
@@ -41,7 +41,7 @@ public:
     }
 };
 
-template <> struct fmt::formatter<test_data> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<test_data> : fmt::formatter<string_view> {
     auto format(const test_data& d, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", d.value());
     }

--- a/test/unit/radix_tree_stress_test.cc
+++ b/test/unit/radix_tree_stress_test.cc
@@ -41,7 +41,7 @@ public:
     }
 };
 
-template <> struct fmt::formatter<test_data> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<test_data> : fmt::formatter<string_view> {
     auto format(const test_data& d, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", d.value());
     }

--- a/test/unit/row_cache_stress_test.cc
+++ b/test/unit/row_cache_stress_test.cc
@@ -187,7 +187,7 @@ struct reader_id {
 } // namespace row_cache_stress_test
 
 // TODO: use format_as() after {fmt} v10
-template <> struct fmt::formatter<row_cache_stress_test::reader_id> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<row_cache_stress_test::reader_id> : fmt::formatter<string_view> {
     auto format(const row_cache_stress_test::reader_id& id, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", id.name);
     }

--- a/tombstone_gc_options.cc
+++ b/tombstone_gc_options.cc
@@ -65,5 +65,5 @@ auto fmt::formatter<tombstone_gc_mode>::format(tombstone_gc_mode mode, fmt::form
     case tombstone_gc_mode::immediate:   name = "immediate"; break;
     case tombstone_gc_mode::repair:      name = "repair"; break;
     }
-    return formatter<std::string_view>::format(name, ctx);
+    return formatter<string_view>::format(name, ctx);
 }

--- a/tombstone_gc_options.hh
+++ b/tombstone_gc_options.hh
@@ -31,6 +31,6 @@ public:
     bool operator==(const tombstone_gc_options&) const = default;
 };
 
-template <> struct fmt::formatter<tombstone_gc_mode> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<tombstone_gc_mode> : fmt::formatter<string_view> {
     auto format(tombstone_gc_mode mode, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -76,7 +76,7 @@ struct file_size_printer {
 };
 
 template <>
-struct fmt::formatter<file_size_printer> : fmt::formatter<std::string_view> {
+struct fmt::formatter<file_size_printer> : fmt::formatter<string_view> {
     auto format(file_size_printer size, auto& ctx) const {
         if (!size.human_readable) {
             return fmt::format_to(ctx.out(), "{}", size.value);

--- a/types/types.hh
+++ b/types/types.hh
@@ -1022,7 +1022,7 @@ struct unset_value {
 using data_value_or_unset = std::variant<data_value, unset_value>;
 
 template <>
-struct fmt::formatter<unset_value> : fmt::formatter<std::string_view> {
+struct fmt::formatter<unset_value> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const unset_value& u, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "unset");
@@ -1030,7 +1030,7 @@ struct fmt::formatter<unset_value> : fmt::formatter<std::string_view> {
 };
 
 template <>
-struct fmt::formatter<data_value_or_unset> : fmt::formatter<std::string_view> {
+struct fmt::formatter<data_value_or_unset> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const data_value_or_unset& var, FormatContext& ctx) const {
         return std::visit(overloaded_functor {

--- a/utils/UUID.hh
+++ b/utils/UUID.hh
@@ -265,7 +265,7 @@ std::ostream& operator<<(std::ostream& os, const utils::tagged_uuid<Tag>& id) {
 } // namespace std
 
 template <>
-struct fmt::formatter<utils::UUID> : fmt::formatter<std::string_view> {
+struct fmt::formatter<utils::UUID> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const utils::UUID& id, FormatContext& ctx) const {
         // This matches Java's UUID.toString() actual implementation. Note that
@@ -281,7 +281,7 @@ struct fmt::formatter<utils::UUID> : fmt::formatter<std::string_view> {
 };
 
 template <typename Tag>
-struct fmt::formatter<utils::tagged_uuid<Tag>> : fmt::formatter<std::string_view> {
+struct fmt::formatter<utils::tagged_uuid<Tag>> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const utils::tagged_uuid<Tag>& id, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", id.id);

--- a/utils/big_decimal.hh
+++ b/utils/big_decimal.hh
@@ -47,7 +47,7 @@ public:
 };
 
 template <>
-struct fmt::formatter<big_decimal> : fmt::formatter<std::string_view> {
+struct fmt::formatter<big_decimal> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const big_decimal& v, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", v.to_string());

--- a/utils/exception_container.hh
+++ b/utils/exception_container.hh
@@ -155,14 +155,14 @@ concept ExceptionContainer = is_exception_container<T>::value;
 #if FMT_VERSION < 100000
 // fmt v10 introduced formatter for std::exception
 template <>
-struct fmt::formatter<utils::bad_exception_container_access> : fmt::formatter<std::string_view> {
+struct fmt::formatter<utils::bad_exception_container_access> : fmt::formatter<string_view> {
     auto format(const utils::bad_exception_container_access& e, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", e.what());
     }
 };
 #endif
 
-template <typename... Exs> struct fmt::formatter<utils::exception_container<Exs...>> : fmt::formatter<std::string_view> {
+template <typename... Exs> struct fmt::formatter<utils::exception_container<Exs...>> : fmt::formatter<string_view> {
     auto format(const auto& ec, fmt::format_context& ctx) const {
         auto out = ctx.out();
         ec.accept([&out] (const auto& ex) { out = fmt::format_to(out, "{}", ex); });

--- a/utils/fragment_range.hh
+++ b/utils/fragment_range.hh
@@ -413,7 +413,7 @@ void write_native(Out& out, std::type_identity_t<T> v) {
 }
 
 template <FragmentedView View>
-struct fmt::formatter<View> : fmt::formatter<std::string_view> {
+struct fmt::formatter<View> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const View& b, FormatContext& ctx) const {
         auto out = ctx.out();

--- a/utils/human_readable.hh
+++ b/utils/human_readable.hh
@@ -37,6 +37,6 @@ human_readable_value to_hr_size(uint64_t size);
 
 } // namespace utils
 
-template <> struct fmt::formatter<utils::human_readable_value> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<utils::human_readable_value> : fmt::formatter<string_view> {
     auto format(const utils::human_readable_value&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -539,7 +539,7 @@ future<> use_standard_allocator_segment_pool_backend(size_t available_memory);
 
 }
 
-template <> struct fmt::formatter<logalloc::occupancy_stats> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<logalloc::occupancy_stats> : fmt::formatter<string_view> {
     auto format(const logalloc::occupancy_stats& stats, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{:.2f}%, {:d} / {:d} [B]",
                               stats.used_fraction() * 100, stats.used_space(), stats.total_space());

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -592,7 +592,7 @@ sstring to_hex(const managed_bytes& b);
 sstring to_hex(const managed_bytes_opt& b);
 
 // The formatters below are used only by tests.
-template <> struct fmt::formatter<managed_bytes_view> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<managed_bytes_view> : fmt::formatter<string_view> {
     auto format(const managed_bytes_view& v, fmt::format_context& ctx) const {
         auto out = ctx.out();
         for (bytes_view frag : fragment_range(v)) {
@@ -606,7 +606,7 @@ inline std::ostream& operator<<(std::ostream& os, const managed_bytes_view& v) {
     return os;
 }
 
-template <> struct fmt::formatter<managed_bytes> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<managed_bytes> : fmt::formatter<string_view> {
     auto format(const managed_bytes& b, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", managed_bytes_view(b));
     }
@@ -616,7 +616,7 @@ inline std::ostream& operator<<(std::ostream& os, const managed_bytes& b) {
     return os;
 }
 
-template <> struct fmt::formatter<managed_bytes_opt> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<managed_bytes_opt> : fmt::formatter<string_view> {
     auto format(const managed_bytes_opt& opt, fmt::format_context& ctx) const {
         if (opt) {
             return fmt::format_to(ctx.out(), "{}", *opt);

--- a/utils/to_string.hh
+++ b/utils/to_string.hh
@@ -122,7 +122,7 @@ std::ostream& operator<<(std::ostream& os, const std::optional<T>& opt) {
 } // namespace std
 
 template<typename T>
-struct fmt::formatter<std::optional<T>> : fmt::formatter<std::string_view> {
+struct fmt::formatter<std::optional<T>> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const std::optional<T>& opt, FormatContext& ctx) const {
         if (opt) {
@@ -133,14 +133,14 @@ struct fmt::formatter<std::optional<T>> : fmt::formatter<std::string_view> {
      }
 };
 
-template <> struct fmt::formatter<std::strong_ordering> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<std::strong_ordering> : fmt::formatter<string_view> {
     auto format(std::strong_ordering, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<std::weak_ordering> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<std::weak_ordering> : fmt::formatter<string_view> {
     auto format(std::weak_ordering, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<std::partial_ordering> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<std::partial_ordering> : fmt::formatter<string_view> {
     auto format(std::partial_ordering, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/view_info.hh
+++ b/view_info.hh
@@ -77,7 +77,7 @@ public:
     friend fmt::formatter<view_info>;
 };
 
-template <> struct fmt::formatter<view_info> : fmt::formatter<std::string_view> {
+template <> struct fmt::formatter<view_info> : fmt::formatter<string_view> {
     auto format(const view_info& view, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}", view._raw);
     }


### PR DESCRIPTION
…iew>

in in {fmt} before v10, it provides the specialization of `fmt::formatter<..>` for `std::string_view` as well as the specialization of `fmt::formatter<..>` for `fmt::string_view` which is an implementation builtin in {fmt} for compatibility of pre-C++17. and this type is used even if the code is compiled with C++ stadandard greater or equal to C++17. also, before v10, the `fmt::formatter<std::string_view>::format()` is defined so it accepts `std::string_view`. after v10, `fmt::formatter<std::string_view>` still exists, but it is now defined using `format_as()` machinery, so it's `format()` method does not actually accept `std::string_view`, it accepts `fmt::string_view`, as the former can be converted to `fmt::string_view`.

this is why we can inherit from `fmt::formatter<std::string_view>` and use `formatter<std::string_view>::format(foo, ctx);` to implement the `format()` method with {fmt} v9, but we cannot do this with {fmt} v10, and we would have following compilation failure:

```
FAILED: service/CMakeFiles/service.dir/RelWithDebInfo/topology_state_machine.cc.o
/home/kefu/.local/bin/clang++ -DFMT_DEPRECATED_OSTREAM -DFMT_SHARED -DSCYLLA_BUILD_MODE=release -DSEASTAR_API_LEVEL=7 -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SSTRING -DXXH_PRIVATE_API -DCMAKE_INTDIR=\"RelWithDebInfo\" -I/home/kefu/dev/scylladb -I/home/kefu/dev/scylladb/build/gen -I/home/kefu/dev/scylladb/seastar/include -I/home/kefu/dev/scylladb/build/seastar/gen/include -I/home/kefu/dev/scylladb/build/seastar/gen/src -ffunction-sections -fdata-sections -O3 -g -gz -std=gnu++20 -fvisibility=hidden -Wall -Werror -Wextra -Wno-error=deprecated-declarations -Wimplicit-fallthrough -Wno-c++11-narrowing -Wno-deprecated-copy -Wno-mismatched-tags -Wno-missing-field-initializers -Wno-overloaded-virtual -Wno-unsupported-friend -Wno-enum-constexpr-conversion -Wno-unused-parameter -ffile-prefix-map=/home/kefu/dev/scylladb=. -march=westmere -mllvm -inline-threshold=2500 -fno-slp-vectorize -U_FORTIFY_SOURCE -Werror=unused-result -MD -MT service/CMakeFiles/service.dir/RelWithDebInfo/topology_state_machine.cc.o -MF service/CMakeFiles/service.dir/RelWithDebInfo/topology_state_machine.cc.o.d -o service/CMakeFiles/service.dir/RelWithDebInfo/topology_state_machine.cc.o -c /home/kefu/dev/scylladb/service/topology_state_machine.cc
/home/kefu/dev/scylladb/service/topology_state_machine.cc:254:41: error: no matching member function for call to 'format'
  254 |     return formatter<std::string_view>::format(it->second, ctx);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/usr/include/fmt/core.h:2759:22: note: candidate function template not viable: no known conversion from 'seastar::basic_sstring<char, unsigned int, 15>' to 'const fmt::basic_string_view<char>' for 1st argument
 2759 |   FMT_CONSTEXPR auto format(const T& val, FormatContext& ctx) const
      |                      ^      ~~~~~~~~~~~~
```

because the inherited `format()` method actually comes from `fmt::formatter<fmt::string_view>`. to reduce the confusion, in this change, we just inherit from `fmt::format<string_view>`, where `string_view` is actually `fmt::string_view`. this follows the document at
https://fmt.dev/latest/api.html#formatting-user-defined-types, and since there is less indirection under the hood -- we do not use the specialization created by `FMT_FORMAT_AS` which inherit from `formatter<fmt::string_view>`, hopefully this can improve the compilation speed a little bit. also, this change addresses the build failure with {fmt} v10.