### PR TITLE
Sort user-defined types in describe statements

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -627,6 +627,7 @@ scylla_tests = set([
     'test/boost/string_format_test',
     'test/boost/tagged_integer_test',
     'test/boost/group0_cmd_merge_test',
+    'test/boost/sorting_test',
     'test/manual/ec2_snitch_test',
     'test/manual/enormous_table_scan_test',
     'test/manual/gce_snitch_test',

--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -110,13 +110,16 @@ struct description {
 future<std::vector<description>> generate_descriptions(
     replica::database& db, 
     std::vector<shared_ptr<const keyspace_element>> elements,
-    std::optional<bool> with_internals = std::nullopt) 
+    std::optional<bool> with_internals = std::nullopt,
+    bool sort_by_name = true) 
 {
     std::vector<description> descs;
     descs.reserve(elements.size());
-    boost::sort(elements, [] (const auto& a, const auto& b) {
-        return a->element_name() < b->element_name();
-    });
+    if (sort_by_name) {
+        boost::sort(elements, [] (const auto& a, const auto& b) {
+            return a->element_name() < b->element_name();
+        });
+    }
 
     for (auto& e: elements) {
         auto desc = (with_internals.has_value()) 

--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -44,6 +44,7 @@
 #include "utils/overloaded_functor.hh"
 #include "data_dictionary/keyspace_element.hh"
 #include "db/system_keyspace.hh"
+#include "utils/sorting.hh"
 
 static logging::logger dlogger("describe");
 
@@ -168,14 +169,31 @@ description type(replica::database& db, const lw_shared_ptr<keyspace_metadata>& 
     return description(db, *udt, true);
 }
 
-future<std::vector<description>> types(replica::database& db, const lw_shared_ptr<keyspace_metadata>& ks, bool with_stmt = false) {
-    auto user_types_map = ks->user_types().get_all_types();
-    auto user_types = boost::copy_range<std::vector<shared_ptr<const keyspace_element>>>(user_types_map | boost::adaptors::transformed([] (const auto& e) {
-        // return static_pointer_cast<const keyspace_element>(e.second);
-        return e.second;
-    }));
+// Because UDTs can depend on each other, we need to sort them topologically
+future<std::vector<shared_ptr<const keyspace_element>>> get_sorted_types(const lw_shared_ptr<keyspace_metadata>& ks) {
+    struct udts_comparator {
+        inline bool operator()(const user_type& a, const user_type& b) const {
+            return a->get_name_as_string() < b->get_name_as_string();
+        }
+    };
 
-    co_return co_await generate_descriptions(db, user_types, (with_stmt) ? std::optional(true) : std::nullopt);
+    std::vector<user_type> all_udts;
+    std::multimap<user_type, user_type, udts_comparator> adjacency;
+
+    for (auto& [_, udt]: ks->user_types().get_all_types()) {
+        all_udts.push_back(udt);
+        for (auto& ref_udt: udt->get_all_referenced_user_types()) {
+            adjacency.insert({ref_udt, udt});
+        }
+    }
+
+    auto sorted = co_await utils::topological_sort(all_udts, adjacency);
+    co_return boost::copy_range<std::vector<shared_ptr<const keyspace_element>>>(sorted);
+}
+
+future<std::vector<description>> types(replica::database& db, const lw_shared_ptr<keyspace_metadata>& ks, bool with_stmt = false) {
+    auto udts = co_await get_sorted_types(ks);
+    co_return co_await generate_descriptions(db, udts, (with_stmt) ? std::optional(true) : std::nullopt, false);
 }
     
 future<std::vector<description>> function(replica::database& db, const sstring& ks, const sstring& name) {

--- a/db/cql_type_parser.cc
+++ b/db/cql_type_parser.cc
@@ -14,8 +14,10 @@
 #include "cql3/CqlParser.hpp"
 #include "cql3/util.hh"
 #include "cql_type_parser.hh"
+#include "seastar/coroutine/maybe_yield.hh"
 #include "types/types.hh"
 #include "data_dictionary/user_types_metadata.hh"
+#include "utils/sorting.hh"
 
 static ::shared_ptr<cql3::cql3_type::raw> parse_raw(const sstring& str) {
     return cql3::util::do_with_parser(str,
@@ -86,6 +88,12 @@ public:
 
     // See cassandra Types.java
     future<std::vector<user_type>> build() {
+        struct entry_comparator {
+            inline bool operator()(const entry* a, const entry* b) const {
+                return a->name < b->name;
+            }
+        };
+
         if (_definitions.empty()) {
             co_return std::vector<user_type>();
         }
@@ -93,58 +101,32 @@ public:
         /*
          * build a DAG of UDT dependencies
          */
-        std::unordered_multimap<entry *, entry *> adjacency;
+        std::vector<entry *> all_definitions;
+        std::multimap<entry *, entry *, entry_comparator> adjacency;
         for (auto& e1 : _definitions) {
+            all_definitions.emplace_back(&e1);
             for (auto& e2 : _definitions) {
                 if (&e1 != &e2 && std::any_of(e1.field_types.begin(), e1.field_types.end(), [&e2](auto& t) { return t->references_user_type(e2.name); })) {
                     adjacency.emplace(&e2, &e1);
                 }
             }
-        }
-        /*
-         * resolve dependencies in topological order, using Kahn's algorithm
-         */
-        std::unordered_map<entry *, int32_t> vertices; // map values are numbers of referenced types
-        for (auto&p : adjacency) {
-            vertices[p.second]++;
-        }
-
-        std::deque<entry *> resolvable_types;
-        for (auto& e : _definitions) {
-            if (!vertices.contains(&e)) {
-                resolvable_types.emplace_back(&e);
-            }
+            co_await coroutine::maybe_yield();
         }
 
         // Create a copy of the existing types, so that we don't
         // modify the one in the keyspace. It is up to the caller to
         // do that.
         replica::user_types_metadata types = _ks.user_types();
-
         const auto &ks_name = _ks.name();
+
+        auto sorted = co_await utils::topological_sort(all_definitions, adjacency);
         std::vector<user_type> created;
+        created.reserve(sorted.size());
 
-        while (!resolvable_types.empty()) {
-            auto* e =  resolvable_types.front();
-            auto r = adjacency.equal_range(e);
-
-            while (r.first != r.second) {
-                auto* d = r.first->second;
-                if (--vertices[d] == 0) {
-                    resolvable_types.push_back(d);
-                }
-                ++r.first;
-            }
-
+        for (auto* e : sorted) {
             created.push_back(e->prepare(ks_name, types));
             types.add_type(created.back());
-            resolvable_types.pop_front();
         }
-
-        if (created.size() != _definitions.size()) {
-            throw exceptions::configuration_exception(format("Cannot resolve UDTs for keyspace {}: some types are missing", ks_name));
-        }
-
         co_return created;
     }
 private:

--- a/db/cql_type_parser.cc
+++ b/db/cql_type_parser.cc
@@ -85,9 +85,9 @@ public:
     }
 
     // See cassandra Types.java
-    std::vector<user_type> build() {
+    future<std::vector<user_type>> build() {
         if (_definitions.empty()) {
-            return {};
+            co_return std::vector<user_type>();
         }
 
         /*
@@ -145,7 +145,7 @@ public:
             throw exceptions::configuration_exception(format("Cannot resolve UDTs for keyspace {}: some types are missing", ks_name));
         }
 
-        return created;
+        co_return created;
     }
 private:
     data_dictionary::keyspace_metadata& _ks;
@@ -163,6 +163,6 @@ void db::cql_type_parser::raw_builder::add(sstring name, std::vector<sstring> fi
     _impl->add(std::move(name), std::move(field_names), std::move(field_types));
 }
 
-std::vector<user_type> db::cql_type_parser::raw_builder::build() {
+future<std::vector<user_type>> db::cql_type_parser::raw_builder::build() {
     return _impl->build();
 }

--- a/db/cql_type_parser.hh
+++ b/db/cql_type_parser.hh
@@ -37,7 +37,7 @@ public:
     ~raw_builder();
 
     void add(sstring name, std::vector<sstring> field_names, std::vector<sstring> field_types);
-    std::vector<user_type> build();
+    future<std::vector<user_type>> build();
 private:
     class impl;
     std::unique_ptr<impl>

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1790,7 +1790,7 @@ template<typename V>
 static std::vector<V> get_list(const query::result_set_row& row, const sstring& name);
 
 // Create types for a given keyspace. This takes care of topologically sorting user defined types.
-template <typename T> static std::vector<user_type> create_types(keyspace_metadata& ks, T&& range) {
+template <typename T> static future<std::vector<user_type>> create_types(keyspace_metadata& ks, T&& range) {
     cql_type_parser::raw_builder builder(ks);
     std::unordered_set<bytes> names;
     for (const query::result_set_row& row : range) {
@@ -1818,13 +1818,13 @@ template <typename T> static std::vector<user_type> create_types(keyspace_metada
             }
         }
     }
-    return builder.build();
+    co_return co_await builder.build();
 }
 
 // Given a set of rows that is sorted by keyspace, create types for each keyspace.
 // The topological sort in each keyspace is necessary when creating types, since we can only create a type when the
 // types it reference have already been created.
-static std::vector<user_type> create_types(replica::database& db, const std::vector<const query::result_set_row*>& rows) {
+static future<std::vector<user_type>> create_types(replica::database& db, const std::vector<const query::result_set_row*>& rows) {
     std::vector<user_type> ret;
     for (auto i = rows.begin(), e = rows.end(); i != e;) {
         const auto &row = *i;
@@ -1833,11 +1833,11 @@ static std::vector<user_type> create_types(replica::database& db, const std::vec
             return r->get_nonnull<sstring>("keyspace_name") != keyspace;
         });
         auto ks = db.find_keyspace(keyspace).metadata();
-        auto v = create_types(*ks, boost::make_iterator_range(i, next) | boost::adaptors::indirected);
+        auto v = co_await create_types(*ks, boost::make_iterator_range(i, next) | boost::adaptors::indirected);
         ret.insert(ret.end(), std::make_move_iterator(v.begin()), std::make_move_iterator(v.end()));
         i = next;
     }
-    return ret;
+    co_return ret;
 }
 
 // see the comments for merge_keyspaces()
@@ -1850,11 +1850,13 @@ static future<user_types_to_drop> merge_types(distributed<service::storage_proxy
     // some of these user types are dropped.
 
     co_await proxy.local().get_db().invoke_on_all([&] (replica::database& db) -> future<> {
-        for (auto&& user_type : create_types(db, diff.created)) {
+        auto created_types = co_await create_types(db, diff.created);
+        for (auto&& user_type : created_types) {
             db.find_keyspace(user_type->_keyspace).add_user_type(user_type);
             co_await db.get_notifier().create_user_type(user_type);
         }
-        for (auto&& user_type : create_types(db, diff.altered)) {
+        auto altered_types = co_await create_types(db, diff.altered);
+        for (auto&& user_type : altered_types) {
             db.find_keyspace(user_type->_keyspace).add_user_type(user_type);
             co_await db.get_notifier().update_user_type(user_type);
         }
@@ -1862,7 +1864,7 @@ static future<user_types_to_drop> merge_types(distributed<service::storage_proxy
 
     co_return user_types_to_drop{[&proxy, before = std::move(before), rows = std::move(diff.dropped)] () mutable -> future<> {
         co_await proxy.local().get_db().invoke_on_all([&] (replica::database& db) -> future<> {
-            auto dropped = create_types(db, rows);
+            auto dropped = co_await create_types(db, rows);
             for (auto& user_type : dropped) {
                 db.find_keyspace(user_type->_keyspace).remove_user_type(user_type);
                 co_await db.get_notifier().drop_user_type(user_type);
@@ -2261,9 +2263,9 @@ static std::vector<V> get_list(const query::result_set_row& row, const sstring& 
     return list;
 }
 
-std::vector<user_type> create_types_from_schema_partition(
+future<std::vector<user_type>> create_types_from_schema_partition(
         keyspace_metadata& ks, lw_shared_ptr<query::result_set> result) {
-    return create_types(ks, result->rows());
+    co_return co_await create_types(ks, result->rows());
 }
 
 seastar::future<std::vector<shared_ptr<cql3::functions::user_function>>> create_functions_from_schema_partition(

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -213,7 +213,7 @@ future<lw_shared_ptr<query::result_set>> extract_scylla_specific_keyspace_info(d
 
 std::vector<mutation> make_create_type_mutations(lw_shared_ptr<keyspace_metadata> keyspace, user_type type, api::timestamp_type timestamp);
 
-std::vector<user_type> create_types_from_schema_partition(keyspace_metadata& ks, lw_shared_ptr<query::result_set> result);
+future<std::vector<user_type>> create_types_from_schema_partition(keyspace_metadata& ks, lw_shared_ptr<query::result_set> result);
 
 seastar::future<std::vector<shared_ptr<cql3::functions::user_function>>> create_functions_from_schema_partition(replica::database& db, lw_shared_ptr<query::result_set> result);
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -684,7 +684,7 @@ future<> database::parse_system_tables(distributed<service::storage_proxy>& prox
     }));
     co_await do_parse_schema_tables(proxy, db::schema_tables::TYPES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
         auto& ks = this->find_keyspace(v.first);
-        auto&& user_types = create_types_from_schema_partition(*ks.metadata(), v.second);
+        auto&& user_types = co_await create_types_from_schema_partition(*ks.metadata(), v.second);
         for (auto&& type : user_types) {
             ks.add_user_type(type);
         }

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -360,6 +360,8 @@ add_scylla_test(wasm_test
   KIND SEASTAR)
 add_scylla_test(pretty_printers_test
   KIND BOOST)
+add_scylla_test(sorting_test
+  KIND SEASTAR)
 
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/suite.yaml")
   set(scylla_tests "${scylla_tests}" PARENT_SCOPE)

--- a/test/boost/sorting_test.cc
+++ b/test/boost/sorting_test.cc
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <seastar/testing/test_case.hh>
+#include "test/lib/log.hh"
+#include "utils/sorting.hh"
+
+struct sorting_test_data {
+    std::multimap<int, int> adjacent_map;
+    std::vector<int> expected_result;
+    bool expect_error = false;
+};
+
+SEASTAR_TEST_CASE(test_topological_sorting) {
+    return seastar::async([] {
+        std::vector<int> all_nodes = {1, 2, 3, 4, 5};
+        std::vector<sorting_test_data> tests = {
+            // valid directed acyclic graphs
+            {
+                {}, 
+                {1, 2, 3, 4, 5},
+            },
+            {
+                {{1, 2}, {2, 3}, {3, 4}, {4, 5}}, 
+                {1, 2, 3, 4, 5},
+            },
+            {
+                {{5, 4}, {4, 3}, {3, 2}, {2, 1}}, 
+                {5, 4, 3, 2, 1},
+            },
+            {
+                {{1, 2}, {1, 3}, {1, 4}, {1, 5}, {2, 3}, {2, 4}, {2, 5}, {3, 4}, {3, 5}, {4, 5}}, 
+                {1, 2, 3, 4, 5},
+            },
+            {
+                {{1, 2}, {2, 3}, {1, 4}, {4, 5}, {5, 2}}, 
+                {1, 4, 5, 2, 3},
+            },
+            {
+                {{1, 2}, {1, 4}, {2, 4}, {4, 3}, {4, 5}, {5, 3}}, 
+                {1, 2, 4, 5, 3},
+            },
+            {
+                {{2, 1}, {1, 4}, {3, 5}, {5, 4}}, 
+                {2, 3, 1, 5, 4},
+            },
+            {
+                {{4, 1}, {3, 2}}, 
+                {3, 4, 5, 2, 1}
+            },
+            // directed graphs with cycles
+            {
+                {{1, 2}, {2, 3}, {3, 1}}, 
+                {},
+                true
+            },
+            {
+                {{1, 2}, {2, 3}, {3, 4}, {4, 5}, {5, 1}}, 
+                {},
+                true
+            },
+            {
+                {{4, 1}, {3, 2}, {3, 4}, {1, 5}, {5, 3}}, 
+                {},
+                true
+            },
+            {
+                {{1, 2}, {1, 4}, {2, 4}, {4, 3}, {4, 5}, {5, 3}, {3, 1}}, 
+                {},
+                true
+            },
+        };
+
+        for (size_t i = 0; i < tests.size(); i++) {
+            testlog.info("Testing case index: {}", i);
+            if (tests[i].expect_error) {
+                BOOST_REQUIRE_THROW(utils::topological_sort(all_nodes, tests[i].adjacent_map).get(), std::runtime_error);
+            } else {
+                auto result = utils::topological_sort(all_nodes, tests[i].adjacent_map).get();
+                BOOST_REQUIRE_EQUAL_COLLECTIONS(result.begin(), result.end(), tests[i].expected_result.begin(), tests[i].expected_result.end());
+            }
+        }
+    });
+}

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -628,7 +628,8 @@ schema_ptr do_load_schema_from_schema_tables(const db::config& dbcfg, std::files
             ut_builder.add(name, field_names, field_types);
         }
 
-        for (auto&& ut : ut_builder.build()) {
+        auto user_types = ut_builder.build().get();
+        for (auto&& ut : user_types) {
             utm.add_type(std::move(ut));
         }
     }

--- a/types/user.hh
+++ b/types/user.hh
@@ -47,6 +47,18 @@ public:
     sstring get_name_as_string() const;
     sstring get_name_as_cql_string() const;
 
+    /* Returns set of user-defined types referenced by this UDT
+     * 
+     * Example:
+     * create type some_udt {
+     *   a frozen<udt_a>,
+     *   m frozen<map<udt_a, udt_b>,
+     *   t frozen<tuple<int, list<udt_c>>   
+     * }
+     * get_all_referenced_user_types() will return {udt_a, udt_b, udt_c}.
+     */
+    std::set<user_type> get_all_referenced_user_types() const;
+
     virtual sstring keypace_name() const override { return _keyspace; }
     virtual sstring element_name() const override { return get_name_as_string(); }
     virtual sstring element_type() const override { return "type"; }

--- a/utils/sorting.hh
+++ b/utils/sorting.hh
@@ -1,0 +1,67 @@
+    /*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <stdexcept>
+#include <vector>
+#include <map>
+#include <seastar/core/future.hh>
+#include "seastar/coroutine/maybe_yield.hh"
+#include "utils/stall_free.hh"
+
+namespace utils {
+
+/**
+ * Topological sort a DAG using Kahn's algorithm.
+ *
+ * @param vertices      Contains all vertices of the graph
+ * @param adjacency_map Entry {k, v} means there is an k->v edge in the graph
+ * @return a vector of topologically sorted vertices. 
+        If there is an edge k->v, then vertex k will be before vertex v.
+ * @throws std::runtime_error when a graph has any cycle.
+ */
+template<typename T, typename Compare = std::less<T>>
+seastar::future<std::vector<T>> topological_sort(const std::vector<T>& vertices, const std::multimap<T, T, Compare>& adjacency_map) {
+    std::map<T, size_t, Compare> ref_count_map; // Contains counters how many edges point (reference) to a vertex
+    std::vector<T> sorted;
+    sorted.reserve(vertices.size());
+
+    for (auto& edge: adjacency_map) {
+        ref_count_map[edge.second]++;
+    }
+
+    // Push to result vertices which reference counter == 0
+    for (auto& v: vertices) {
+        if (!ref_count_map.contains(v)) {
+            sorted.emplace_back(v);
+        }
+    }
+
+    // Iterate over already sorted vertices, 
+    // decrease counter of vertices to which sorted vertices points,
+    // push to the end of `sorted` vector vertices which counter == 0.
+    for (size_t i = 0; i < sorted.size(); i++) {
+        auto [it_begin, it_end] = adjacency_map.equal_range(sorted[i]);
+        
+        while (it_begin != it_end) {
+            auto d = it_begin->second;
+            if (--ref_count_map[d] == 0) {
+                sorted.push_back(d);
+            }
+            ++it_begin;
+        }
+        co_await seastar::coroutine::maybe_yield();
+    }
+    co_await utils::clear_gently(ref_count_map);
+
+    if (sorted.size() != vertices.size()) {
+        throw std::runtime_error("Detected cycle in the graph.");
+    }
+    co_return sorted;
+}
+
+}


### PR DESCRIPTION
User-defined types can depend on each other, creating directed acyclic graph.

In order to support restoring schema from `DESC SCHEMA`, UDTs should be
ordered topologically, not alphabetically as it was till now.

This patch changes the way UDTs are ordered in `DESC SCHEMA`/`DESC KEYSPACE <ks>` statements, so the output can be safely copy-pasted to restore the schema.

Fixes #18539