### PR TITLE
test/boost: specialize fmt::details::is_std_string_like<bytes>

### DIFF
--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -10,6 +10,7 @@
 #include "test/lib/scylla_test_case.hh"
 #include <string>
 #include <boost/range/adaptor/map.hpp>
+#include <fmt/ranges.h>
 
 #include "cdc/log.hh"
 #include "cdc/cdc_options.hh"
@@ -31,6 +32,20 @@
 #include "utils/UUID_gen.hh"
 
 using namespace std::string_literals;
+
+#if FMT_VERSION < 100000
+// {fmt} v9 considers basic_sstring<int8_t, uint32_t, 31, false>
+// as a string-like type, but it is not, as its char type is
+// int8_t, not char, so fix this by specializing the related type
+// trait, which is used when formatting when print a range whose
+// element type is "bytes"
+namespace fmt::detail {
+
+template <>
+struct is_std_string_like<seastar::basic_sstring<signed char, unsigned int, 31, false>> : std::false_type {};
+
+}
+#endif
 
 namespace cdc {
 api::timestamp_type find_timestamp(const mutation&);


### PR DESCRIPTION
due to a bug in {fmt} v9, {fmt} fails to format a range whose element type is `basic_sstring<uint8_t>`, as it considers it as a string-like type, but `basic_sstring<uint8_t>`'s char type is signed char, not char. this issue does not exist in {fmt} v10, so, in this change, we add a workaround to explicitly specialize the type trait to assure that {fmt} format this type using its `fmt::formatter` specialization instead of trying to format it as a string.

Refs #13245