### PR TITLE
utils/managed_bytes: add support for fmt::to_string() to bytes and fr…

### DIFF
--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -593,7 +593,8 @@ sstring to_hex(const managed_bytes_opt& b);
 
 // The formatters below are used only by tests.
 template <> struct fmt::formatter<managed_bytes_view> : fmt::formatter<string_view> {
-    auto format(const managed_bytes_view& v, fmt::format_context& ctx) const {
+    template <typename FormatContext>
+    auto format(const managed_bytes_view& v, FormatContext& ctx) const {
         auto out = ctx.out();
         for (bytes_view frag : fragment_range(v)) {
             out = fmt::format_to(out, "{}", fmt_hex(frag));
@@ -607,7 +608,8 @@ inline std::ostream& operator<<(std::ostream& os, const managed_bytes_view& v) {
 }
 
 template <> struct fmt::formatter<managed_bytes> : fmt::formatter<string_view> {
-    auto format(const managed_bytes& b, fmt::format_context& ctx) const {
+    template <typename FormatContext>
+    auto format(const managed_bytes& b, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{}", managed_bytes_view(b));
     }
 };
@@ -617,7 +619,8 @@ inline std::ostream& operator<<(std::ostream& os, const managed_bytes& b) {
 }
 
 template <> struct fmt::formatter<managed_bytes_opt> : fmt::formatter<string_view> {
-    auto format(const managed_bytes_opt& opt, fmt::format_context& ctx) const {
+    template <typename FormatContext>
+    auto format(const managed_bytes_opt& opt, FormatContext& ctx) const {
         if (opt) {
             return fmt::format_to(ctx.out(), "{}", *opt);
         }


### PR DESCRIPTION
…iends

in 3835ebfcdc, `fmt::formatter` were added to `bytes` and friend, but their `format()` methods were intentionally implemented as plain methods, which only acccept `fmt::format_context`. it was a design decision. the intention was to reduce the usage of templates, and to speed up the compilation at the expense of dropping the support of other appenders, notably the one used by `fmt::to_string()`, where the type of "format_context" is not a `fmt::format_context`, but a string appender. but it turns out we still have users in tests using `fmt::to_string()` to convert, for instance, `bytes` to `std::string`,

so, to make their lives easier, we add the templated `format()` to these types. an alternative is to change the callers to use something like `fmt::format("{}", v)`, which is less convenient though.

Refs #13245