### PR TITLE
main: drop unused namespace alias

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -113,8 +113,6 @@
 
 #include <boost/algorithm/string/join.hpp>
 
-namespace fs = std::filesystem;
-
 seastar::metrics::metric_groups app_metrics;
 
 using namespace std::chrono_literals;


### PR DESCRIPTION
`fs` namespace alias was introduced in ff4d8b6e85, but we don't use it anymore. so let's drop it.