### PR TITLE
main: do not echo parsed options when calling scylla interactively

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -59,6 +59,7 @@
 #include "repair/row_level.hh"
 #include <cstdio>
 #include <seastar/core/file.hh>
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <sys/prctl.h>
@@ -638,8 +639,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
     // If --version is requested, print it out and exit immediately to avoid
     // Seastar-specific warnings that may occur when running the app
-    auto parsed_opts = bpo::command_line_parser(ac, av).options(app.get_options_description()).allow_unregistered().run();
-    print_starting_message(ac, av, parsed_opts);
+    if (!isatty(fileno(stdin))) {
+        auto parsed_opts = bpo::command_line_parser(ac, av).options(app.get_options_description()).allow_unregistered().run();
+        print_starting_message(ac, av, parsed_opts);
+    }
 
     sharded<locator::shared_token_metadata> token_metadata;
     sharded<locator::effective_replication_map_factory> erm_factory;


### PR DESCRIPTION
in 2f0f53ac, we added logging of parsed command line options so that we can see how scylla is launched in case it fails to boot. but when scylla is called interactively in console. this echo is a little bit annoying. see following console session
```console
$ scylla --help-loggers
Scylla version 5.5.0~dev-0.20240419.3c9651adf297 with build-id 7dd6a110e608535e5c259a03548eda6517ab4bde starting ...
command used: "./RelWithDebInfo/scylla --help-loggers"
pid: 996503
parsed command line options: [help-loggers]
Available loggers:
    BatchStatement
    LeveledManifest
    alter_keyspace
    alter_table
...
```

so in this change, we check if the stdin is associated with a terminal device, if that the case, we don't print the scylla version, parsed command line and pid. and the interactive session looks like:

```console
$ scylla --help-loggers
Available loggers:
    BatchStatement
    LeveledManifest
    alter_keyspace
    alter_table
```
no more distracting information printed. the original behavior can be tested like:

```console
$ : | ./RelWithDebInfo/scylla --help-loggers
```

assuming scylla is always launched with systemd, which connects stdin to /dev/null. see
https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#Logging%20and%20Standard%20Input/Output . so this behavior is preserved with this change.

Refs #4203