### PR TITLE
auth: move fmt::formatter<auth::resource_kind> up

### DIFF
--- a/auth/resource.hh
+++ b/auth/resource.hh
@@ -41,6 +41,28 @@ enum class resource_kind {
     data, role, service_level, functions
 };
 
+}
+
+template <>
+struct fmt::formatter<auth::resource_kind> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const auth::resource_kind kind, FormatContext& ctx) const {
+        using enum auth::resource_kind;
+        switch (kind) {
+        case data:
+            return formatter<string_view>::format("data", ctx);
+        case role:
+            return formatter<string_view>::format("role", ctx);
+        case service_level:
+            return formatter<string_view>::format("service_level", ctx);
+        case functions:
+            return formatter<string_view>::format("functions", ctx);
+        }
+        std::abort();
+    }
+};
+
+namespace auth {
 ///
 /// Type tag for constructing data resources.
 ///
@@ -245,25 +267,6 @@ sstring encode_signature(std::string_view name, std::vector<data_type> args);
 std::pair<sstring, std::vector<data_type>> decode_signature(std::string_view encoded_signature);
 
 }
-
-template <>
-struct fmt::formatter<auth::resource_kind> : fmt::formatter<string_view> {
-    template <typename FormatContext>
-    auto format(const auth::resource_kind kind, FormatContext& ctx) const {
-        using enum auth::resource_kind;
-        switch (kind) {
-        case data:
-            return formatter<string_view>::format("data", ctx);
-        case role:
-            return formatter<string_view>::format("role", ctx);
-        case service_level:
-            return formatter<string_view>::format("service_level", ctx);
-        case functions:
-            return formatter<string_view>::format("functions", ctx);
-        }
-        std::abort();
-    }
-};
 
 namespace std {
 


### PR DESCRIPTION
before this change, `fmt::formatter<auth::resource_kind>` is located at line 250 in this file, but it is used at line 130. so, {fmt} is not able to find it:

```
/usr/include/fmt/core.h:2593:45: error: implicit instantiation of undefined template 'fmt::detail::type_is_unformattable_for<auth::resource_kind, char>'
 2593 |     type_is_unformattable_for<T, char_type> _;
      |                                             ^
/usr/include/fmt/core.h:2656:23: note: in instantiation of function template specialization 'fmt::detail::parse_format_specs<auth::resource_kind, fmt::detail::compile_parse_context<char>>' requested here
 2656 |         parse_funcs_{&parse_format_specs<Args, parse_context_type>...} {}
      |                       ^
/usr/include/fmt/core.h:2787:47: note: in instantiation of member function 'fmt::detail::format_string_checker<char, auth::resource_kind, auth::resource_kind>::format_string_checker' requested here
 2787 |       detail::parse_format_string<true>(str_, checker(s));
      |                                               ^
/home/kefu/dev/scylladb/auth/resource.hh:130:29: note: in instantiation of function template specialization 'fmt::basic_format_string<char, auth::resource_kind &, auth::resource_kind &>::basic_format_string<char[65], 0>' requested here
  130 |             seastar::format("This resource has kind '{}', but was expected to have kind '{}'.", actual, expected)) {
      |                             ^
/usr/include/fmt/core.h:1578:45: note: template is declared here
 1578 | template <typename T, typename Char> struct type_is_unformattable_for;
      |                                             ^
```

in this change, `fmt::formatter<auth::resource_kind>` is moved up to where `auth::resource_kind` is defined. so that it can be used by its caller.

Refs #13245