### PR TITLE
Cleanup the way snapshot details are propagated via API

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1737,21 +1737,21 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
             bool first = true;
 
             co_await out.write("[");
-            for (auto&& map : result) {
+            for (auto& [name, details] : result) {
                 if (!first) {
                     co_await out.write(", ");
                 }
                 std::vector<ss::snapshot> snapshot;
-                for (auto& cf : std::get<1>(map)) {
+                for (auto& cf : details) {
                     ss::snapshot snp;
                     snp.ks = cf.ks;
                     snp.cf = cf.cf;
-                    snp.live = cf.live;
-                    snp.total = cf.total;
+                    snp.live = cf.details.live;
+                    snp.total = cf.details.total;
                     snapshot.push_back(std::move(snp));
                 }
                 ss::snapshots all_snapshots;
-                all_snapshots.key = std::get<0>(map);
+                all_snapshots.key = name;
                 all_snapshots.value = std::move(snapshot);
                 co_await all_snapshots.write(out);
                 first = false;

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -107,18 +107,12 @@ future<> snapshot_ctl::clear_snapshot(sstring tag, std::vector<sstring> keyspace
     });
 }
 
-future<std::unordered_map<sstring, std::vector<snapshot_ctl::snapshot_details>>>
+future<std::unordered_map<sstring, snapshot_ctl::db_snapshot_details>>
 snapshot_ctl::get_snapshot_details() {
-    using snapshot_map = std::unordered_map<sstring, std::vector<snapshot_ctl::snapshot_details>>;
+    using snapshot_map = std::unordered_map<sstring, db_snapshot_details>;
 
     co_return co_await run_snapshot_list_operation(coroutine::lambda([this] () -> future<snapshot_map> {
-        snapshot_map result;
-        for (auto& [name, details] : co_await _db.local().get_snapshot_details()) {
-          for (auto& r : details) {
-            result[name].emplace_back(r.details.live, r.details.total, std::move(r.cf), std::move(r.ks));
-          }
-        }
-        co_return result;
+        return _db.local().get_snapshot_details();
     }));
 }
 

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -113,8 +113,10 @@ snapshot_ctl::get_snapshot_details() {
 
     co_return co_await run_snapshot_list_operation(coroutine::lambda([this] () -> future<snapshot_map> {
         snapshot_map result;
-        for (auto& r : co_await _db.local().get_snapshot_details()) {
-            result[r.snapshot_name].emplace_back(std::move(r.details));
+        for (auto& [name, details] : co_await _db.local().get_snapshot_details()) {
+          for (auto& r : details) {
+            result[name].emplace_back(std::move(r.details));
+          }
         }
         co_return result;
     }));
@@ -123,8 +125,10 @@ snapshot_ctl::get_snapshot_details() {
 future<int64_t> snapshot_ctl::true_snapshots_size() {
     co_return co_await run_snapshot_list_operation(coroutine::lambda([this] () -> future<int64_t> {
         int64_t total = 0;
-        for (auto& r : co_await _db.local().get_snapshot_details()) {
+        for (auto& [name, details] : co_await _db.local().get_snapshot_details()) {
+          for (auto& r : details) {
             total += r.details.live;
+          }
         }
         co_return total;
     }));

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -115,7 +115,7 @@ snapshot_ctl::get_snapshot_details() {
         snapshot_map result;
         for (auto& [name, details] : co_await _db.local().get_snapshot_details()) {
           for (auto& r : details) {
-            result[name].emplace_back(std::move(r.details));
+            result[name].emplace_back(r.details.live, r.details.total, std::move(r.cf), std::move(r.ks));
           }
         }
         co_return result;

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -120,9 +120,7 @@ future<int64_t> snapshot_ctl::true_snapshots_size() {
     co_return co_await run_snapshot_list_operation(coroutine::lambda([this] () -> future<int64_t> {
         int64_t total = 0;
         for (auto& [name, details] : co_await _db.local().get_snapshot_details()) {
-          for (auto& r : details) {
-            total += r.details.live;
-          }
+            total += std::accumulate(details.begin(), details.end(), int64_t(0), [] (int64_t sum, const auto& d) { return sum + d.details.live; });
         }
         co_return total;
     }));

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -34,6 +34,14 @@ public:
         int64_t live;
     };
 
+    struct table_snapshot_details_ext {
+        sstring ks;
+        sstring cf;
+        table_snapshot_details details;
+    };
+
+    using db_snapshot_details = std::vector<table_snapshot_details_ext>;
+
     struct snapshot_details {
         int64_t live;
         int64_t total;

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -98,7 +98,7 @@ public:
      */
     future<> clear_snapshot(sstring tag, std::vector<sstring> keyspace_names, sstring cf_name);
 
-    future<std::unordered_map<sstring, std::vector<snapshot_details>>> get_snapshot_details();
+    future<std::unordered_map<sstring, db_snapshot_details>> get_snapshot_details();
 
     future<int64_t> true_snapshots_size();
 private:

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -42,14 +42,6 @@ public:
 
     using db_snapshot_details = std::vector<table_snapshot_details_ext>;
 
-    struct snapshot_details {
-        int64_t live;
-        int64_t total;
-        sstring cf;
-        sstring ks;
-
-        bool operator==(const snapshot_details&) const = default;
-    };
     explicit snapshot_ctl(sharded<replica::database>& db) : _db(db) {}
 
     future<> stop() {

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -29,6 +29,11 @@ public:
     using skip_flush = bool_class<class skip_flush_tag>;
     using snap_views = bool_class<class snap_views_tag>;
 
+    struct table_snapshot_details {
+        int64_t total;
+        int64_t live;
+    };
+
     struct snapshot_details {
         int64_t live;
         int64_t total;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -421,10 +421,7 @@ public:
         utils::updateable_value<bool> enable_compacting_data_for_streaming_and_repair;
     };
 
-    struct snapshot_details {
-        int64_t total;
-        int64_t live;
-    };
+    using snapshot_details = db::snapshot_ctl::table_snapshot_details;
     struct cache_hit_rate {
         cache_temperature rate;
         lowres_clock::time_point last_updated;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1745,12 +1745,7 @@ public:
      */
     future<> clear_snapshot(sstring tag, std::vector<sstring> keyspace_names, const sstring& table_name);
 
-    struct snapshot_details_result {
-        db::snapshot_ctl::snapshot_details details;
-        bool operator==(const snapshot_details_result&) const = default;
-    };
-    using snapshot_details = std::vector<snapshot_details_result>;
-
+    using snapshot_details = db::snapshot_ctl::db_snapshot_details;
     future<std::unordered_map<sstring, snapshot_details>> get_snapshot_details();
 
     friend std::ostream& operator<<(std::ostream& out, const database& db);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1746,12 +1746,12 @@ public:
     future<> clear_snapshot(sstring tag, std::vector<sstring> keyspace_names, const sstring& table_name);
 
     struct snapshot_details_result {
-        sstring snapshot_name;
         db::snapshot_ctl::snapshot_details details;
         bool operator==(const snapshot_details_result&) const = default;
     };
+    using snapshot_details = std::vector<snapshot_details_result>;
 
-    future<std::vector<snapshot_details_result>> get_snapshot_details();
+    future<std::unordered_map<sstring, snapshot_details>> get_snapshot_details();
 
     friend std::ostream& operator<<(std::ostream& out, const database& db);
     const flat_hash_map<sstring, keyspace>& get_keyspaces() const {

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -658,8 +658,9 @@ SEASTAR_TEST_CASE(snapshot_list_contains_dropped_tables) {
 
         auto details = e.local_db().get_snapshot_details().get();
         BOOST_REQUIRE_EQUAL(details.size(), 1);
+        BOOST_REQUIRE_EQUAL(details.begin()->second.size(), 1);
 
-        const auto& sd = details.front().details;
+        const auto& sd = details.begin()->second.front().details;
         BOOST_REQUIRE_GT(sd.live, 0);
         BOOST_REQUIRE_EQUAL(sd.total, sd.live);
 
@@ -674,10 +675,12 @@ SEASTAR_TEST_CASE(snapshot_list_contains_dropped_tables) {
         details = e.local_db().get_snapshot_details().get();
         BOOST_REQUIRE_EQUAL(details.size(), 4);
 
-        for (const auto& result : details) {
+        for (const auto& [name, r] : details) {
+            BOOST_REQUIRE_EQUAL(r.size(), 1);
+            const auto& result = r.front();
             const auto& sd = result.details;
 
-            if (result.snapshot_name == "test2" || result.snapshot_name == "test3") {
+            if (name == "test2" || name == "test3") {
                 BOOST_REQUIRE_EQUAL(sd.live, 0);
                 BOOST_REQUIRE_GT(sd.total, 0);
             } else {

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -828,8 +828,8 @@ SEASTAR_TEST_CASE(test_snapshot_ctl_details) {
         const auto &sc_sd = sc_sd_vec[0];
         BOOST_REQUIRE_EQUAL(sc_sd.ks, "ks");
         BOOST_REQUIRE_EQUAL(sc_sd.cf, "cf");
-        BOOST_REQUIRE_EQUAL(sc_sd.live, sd.live);
-        BOOST_REQUIRE_EQUAL(sc_sd.total, sd.total);
+        BOOST_REQUIRE_EQUAL(sc_sd.details.live, sd.live);
+        BOOST_REQUIRE_EQUAL(sc_sd.details.total, sd.total);
 
         lister::scan_dir(fs::path(cf.dir()), lister::dir_entry_types::of<directory_entry_type::regular>(), [] (fs::path parent_dir, directory_entry de) {
             fs::remove(parent_dir / de.name);
@@ -847,8 +847,8 @@ SEASTAR_TEST_CASE(test_snapshot_ctl_details) {
         const auto &sc_sd_post_deletion = sc_sd_post_deletion_vec[0];
         BOOST_REQUIRE_EQUAL(sc_sd_post_deletion.ks, "ks");
         BOOST_REQUIRE_EQUAL(sc_sd_post_deletion.cf, "cf");
-        BOOST_REQUIRE_EQUAL(sc_sd_post_deletion.live, sd_post_deletion.live);
-        BOOST_REQUIRE_EQUAL(sc_sd_post_deletion.total, sd_post_deletion.total);
+        BOOST_REQUIRE_EQUAL(sc_sd_post_deletion.details.live, sd_post_deletion.live);
+        BOOST_REQUIRE_EQUAL(sc_sd_post_deletion.details.total, sd_post_deletion.total);
 
         return make_ready_future<>();
     });


### PR DESCRIPTION
There's a database::get_snapshot_details() method that returns collection of all snapshots for all ks.cf out there and there are several *snapshot_details* aux structures around it. This PR keeps only one "details" and cleans up the way it propagates from database up to the respective API calls.