### PR TITLE
utils/to_string: include fmt/std.h if fmt >= v10

### DIFF
--- a/utils/to_string.hh
+++ b/utils/to_string.hh
@@ -8,9 +8,13 @@
 
 #pragma once
 
-#include <optional>
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#if FMT_VERSION >= 100000
+#include <fmt/std.h>
+#else
+#include <optional>
+#endif
 
 #if FMT_VERSION < 100000
 


### PR DESCRIPTION
in to_string.hh, we define the specialization of
`fmt::formatter<std::optional<T>>`, which is available in {fmt} v10 and up. to avoid conditionally including `utils/to_string.hh` and `fmt/std.h` in all source files formatting `std::optional<T>` using {fmt}, let's include `fmt/std.h` if {fmt}'s verison is greater or equal to 10. in future, we should drop the specialization and use `fmt/std.h` directly.

Refs #13245