### PR TITLE
types: do not include unused headers

### DIFF
--- a/cql3/attributes.cc
+++ b/cql3/attributes.cc
@@ -12,6 +12,7 @@
 #include "cql3/column_identifier.hh"
 #include "cql3/expr/evaluate.hh"
 #include "cql3/expr/expr-utils.hh"
+#include "exceptions/exceptions.hh"
 #include <optional>
 
 namespace cql3 {

--- a/cql3/prepare_context.cc
+++ b/cql3/prepare_context.cc
@@ -11,6 +11,7 @@
 #include "cql3/prepare_context.hh"
 #include "cql3/column_identifier.hh"
 #include "cql3/column_specification.hh"
+#include "exceptions/exceptions.hh"
 
 namespace cql3 {
 

--- a/types/collection.hh
+++ b/types/collection.hh
@@ -10,14 +10,9 @@
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
-#include <vector>
 #include "types/types.hh"
 #include "collection_mutation.hh"
-#include "utils/chunked_vector.hh"
-#include "schema/schema_fwd.hh"
 #include "log.hh"
-
-#include "exceptions/exceptions.hh"
 
 namespace cql3 {
 

--- a/types/map.hh
+++ b/types/map.hh
@@ -13,6 +13,7 @@
 #include <vector>
 #include <utility>
 
+#include "exceptions/exceptions.hh"
 #include "types/types.hh"
 #include "types/collection.hh"
 

--- a/types/types.cc
+++ b/types/types.cc
@@ -8,7 +8,6 @@
 
 #include <boost/lexical_cast.hpp>
 #include <algorithm>
-#include <cinttypes>
 #include "cql3/cql3_type.hh"
 #include "cql3/lists.hh"
 #include "cql3/maps.hh"

--- a/types/types.hh
+++ b/types/types.hh
@@ -11,7 +11,6 @@
 #include <optional>
 #include <boost/functional/hash.hpp>
 #include <iosfwd>
-#include <sstream>
 #include <initializer_list>
 #include <unordered_set>
 


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.