### PR TITLE
streaming: Fix use after move in fire_stream_event

### DIFF
--- a/streaming/stream_result_future.cc
+++ b/streaming/stream_result_future.cc
@@ -77,7 +77,7 @@ template <typename Event>
 void stream_result_future::fire_stream_event(Event event) {
     // delegate to listener
     for (auto listener : _event_listeners) {
-        listener->handle_stream_event(std::move(event));
+        listener->handle_stream_event(event);
     }
 }
 


### PR DESCRIPTION
The event is used in a loop.

Found by clang-tidy:

```
streaming/stream_result_future.cc:80:49: warning: 'event' used after it was moved [bugprone-use-after-move]
        listener->handle_stream_event(std::move(event));
                                                ^
streaming/stream_result_future.cc:80:39: note: move occurred here
        listener->handle_stream_event(std::move(event));
                                      ^
streaming/stream_result_future.cc:80:49: note: the use happens in a later loop iteration than the move
        listener->handle_stream_event(std::move(event));
                                                ^
```

Fixes #18332