### PR TITLE
mv: reject user requests by coordinator when a replica is overloaded by MVs

### DIFF
--- a/db/view/node_view_update_backlog.hh
+++ b/db/view/node_view_update_backlog.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "db/view/view_update_backlog.hh"
+#include "utils/error_injection.hh"
 
 #include <seastar/core/cacheline.hh>
 #include <seastar/core/future.hh>
@@ -48,6 +49,10 @@ public:
             , _interval(interval)
             , _last_update(clock::now() - _interval)
             , _max(update_backlog::no_backlog()) {
+        if (utils::get_local_injector().enter("update_backlog_immediately")) {
+            _interval = std::chrono::milliseconds(0);
+            _last_update = clock::now();
+        }
     }
 
     update_backlog fetch();

--- a/exceptions/coordinator_result.hh
+++ b/exceptions/coordinator_result.hh
@@ -32,7 +32,8 @@ using coordinator_exception_container = utils::exception_container<
     mutation_write_timeout_exception,
     read_timeout_exception,
     read_failure_exception,
-    rate_limit_exception
+    rate_limit_exception,
+    overloaded_exception
 >;
 
 template<typename T = void>

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3207,14 +3207,14 @@ storage_proxy::create_write_response_handler_helper(schema_ptr s, const dht::tok
         // The idea is that if we have over maxHintsInProgress hints in flight, this is probably due to
         // a small number of nodes causing problems, so we should avoid shutting down writes completely to
         // healthy nodes.  Any node with no hintsInProgress is considered healthy.
-        throw overloaded_exception(_hints_manager.size_of_hints_in_progress());
+        return boost::outcome_v2::failure(overloaded_exception(_hints_manager.size_of_hints_in_progress()));
     }
 
     if (should_reject_due_to_view_backlog(all, s)) {
         // A base replica won't be able to send its view updates because there's too many of them.
         // To avoid any base or view inconsistencies, the request should be retried when the replica
         // isn't overloaded
-        throw overloaded_exception("View update backlog is too high on node containing the base replica");
+        return boost::outcome_v2::failure(overloaded_exception("View update backlog is too high on node containing the base replica"));
     }
     // filter live endpoints from dead ones
     inet_address_vector_replica_set live_endpoints;
@@ -3296,7 +3296,7 @@ storage_proxy::create_write_response_handler(const std::tuple<lw_shared_ptr<paxo
         // A base replica won't be able to send its view updates because there's too many of them.
         // To avoid any base or view inconsistencies, the request should be retried when the replica
         // isn't overloaded
-        throw overloaded_exception("View update backlog is too high on node containing the base replica");
+        return boost::outcome_v2::failure(overloaded_exception("View update backlog is too high on node containing the base replica"));
     }
     slogger.trace("creating write handler for paxos repair token: {} endpoint: {}", token, endpoints);
     tracing::trace(tr_state, "Creating write handler for paxos repair token: {} endpoint: {}", token, endpoints);

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -342,6 +342,8 @@ private:
     result<response_id_type> create_write_response_handler(const std::tuple<lw_shared_ptr<paxos::proposal>, schema_ptr, shared_ptr<paxos_response_handler>, dht::token, inet_address_vector_replica_set>& meta,
             db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit);
     void register_cdc_operation_result_tracker(const storage_proxy::unique_response_handler_vector& ids, lw_shared_ptr<cdc::operation_result_tracker> tracker);
+    template<typename Range>
+    bool should_reject_due_to_view_backlog(const Range& targets, const schema_ptr& s) const;
     void send_to_live_endpoints(response_id_type response_id, clock_type::time_point timeout);
     template<typename Range>
     size_t hint_to_dead_endpoints(std::unique_ptr<mutation_holder>& mh, const Range& targets,

--- a/test/topology_custom/test_mv_admission_control.py
+++ b/test/topology_custom/test_mv_admission_control.py
@@ -1,0 +1,132 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from test.pylib.manager_client import ManagerClient
+
+import asyncio
+import pytest
+import time
+import logging
+
+from test.topology.conftest import skip_mode
+from test.pylib.util import wait_for_view
+from test.topology_experimental_raft.test_mv_tablets import pin_the_only_tablet, get_tablet_replicas
+
+from cassandra.cluster import ConsistencyLevel, EXEC_PROFILE_DEFAULT # type: ignore
+from cassandra.cqltypes import Int32Type # type: ignore
+from cassandra.policies import FallthroughRetryPolicy # type: ignore
+from cassandra.query import SimpleStatement, BoundStatement # type: ignore
+
+logger = logging.getLogger(__name__)
+
+# In the test, we create a table and perform a pair of writes to it. The
+# second write should fail due to admission control. We check that this
+# is indeed the error thrown.
+@pytest.mark.asyncio
+@skip_mode('release', "error injections aren't enabled in release mode")
+async def test_mv_admission_control_exception(manager: ManagerClient) -> None:
+    node_count = 2
+    config = {'error_injections_at_startup': ['view_update_limit', 'delay_before_remote_view_update', 'update_backlog_immediately'], 'enable_tablets': True}
+    servers = await manager.servers_add(node_count, config=config)
+    cql, hosts = await manager.get_ready_cql(servers)
+    await cql.run_async(f"CREATE KEYSPACE ks WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}"
+                        "AND tablets = {'initial': 1}")
+    await cql.run_async(f"CREATE TABLE ks.tab (key int, c int, v text, PRIMARY KEY (key, c))")
+    await cql.run_async(f"CREATE MATERIALIZED VIEW ks.mv_cf_view AS SELECT * FROM ks.tab "
+                    "WHERE c IS NOT NULL and key IS NOT NULL PRIMARY KEY (c, key) ")
+    await wait_for_view(cql, 'mv_cf_view', node_count)
+
+    # Only remote updates hold on to memory, so make the update remote by pinning base and view tablets to different nodes.
+    await pin_the_only_tablet(manager, "ks", "tab", servers[0])
+    await pin_the_only_tablet(manager, "ks", "mv_cf_view", servers[1])
+
+    # Prepare the statement so that the write goes to the same shard both
+    # times (the first write will cause only the shard on which it was
+    # performed to have the updated view update backlog).
+    stmt = cql.prepare(f"INSERT INTO ks.tab (key, c, v) VALUES (?, ?, ?)")
+    # To inspect the error message, we need to disable retries, which can't
+    # be done in `prepare()` or `run_async()`. Instead, we use `BoundStatement`.
+    bnd_stmt = BoundStatement(stmt, retry_policy=FallthroughRetryPolicy())
+    await cql.run_async(bnd_stmt.bind([0, 0, 240000*'a']), host=hosts[0])
+    with pytest.raises(Exception, match="View update backlog is too high"):
+        await cql.run_async(bnd_stmt.bind([0, 0, 'a']), host=hosts[0])
+
+    await cql.run_async(f"DROP KEYSPACE ks")
+
+# In this test we have a table with a materialized view and a replication factor of 3
+# and 4 nodes so that not all views get paired with replicas on the same nodes.
+# One of the nodes behaves as if it was slower than the rest - its view update backlog
+# quickly reaches its limit.
+# In the test we check that when the backlog increases on the node, following requests
+# are rejected by admission control and retried until they reach all replicas, instead
+# of succeeding just on the remaining replicas, reaching a quorum, but failing the
+# write on the slow node.
+@pytest.mark.asyncio
+@skip_mode('release', "error injections aren't enabled in release mode")
+async def test_mv_retried_writes_reach_all_replicas(manager: ManagerClient) -> None:
+    node_count = 4
+    servers = await manager.servers_add(node_count - 1, config={'error_injections_at_startup': ['update_backlog_immediately'], 'enable_tablets': True})
+    server = await manager.server_add(config={'error_injections_at_startup': ['view_update_limit', 'delay_before_remote_view_update', 'update_backlog_immediately'], 'enable_tablets': True})
+
+    cql, hosts = await manager.get_ready_cql(servers)
+    await cql.run_async(f"CREATE KEYSPACE ks WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}}"
+                        "AND tablets = {'initial': 1}")
+    await cql.run_async(f"CREATE TABLE ks.tab (key int, c int, v text, PRIMARY KEY (key, c))")
+    await cql.run_async(f"CREATE MATERIALIZED VIEW ks.mv_cf_view AS SELECT * FROM ks.tab "
+                    "WHERE c IS NOT NULL and key IS NOT NULL PRIMARY KEY (c, key) ")
+    await wait_for_view(cql, 'mv_cf_view', node_count)
+
+    # Disable tablet balancing so that the slow node doesn't get tablets moved away from it.
+    for s in servers:
+        await manager.api.disable_tablet_balancing(s.ip_addr)
+    await manager.api.disable_tablet_balancing(server.ip_addr)
+
+    # Make sure that the slow node has a base table tablet and no view tablets, so that the
+    # view updates from it are remote. (using shard 0 and token 0 when moving tablets as they don't make a difference here)
+    base_tablet_replicas = await get_tablet_replicas(manager, servers[0], "ks", "tab", 0)
+    base_tablet_hosts = [str(replica[0]) for replica in base_tablet_replicas]
+    slow_host_id = await manager.get_host_id(server.server_id)
+    if str(slow_host_id) not in base_tablet_hosts:
+        base_tablet_host_id, base_tablet_shard = base_tablet_replicas[0]
+        await manager.api.move_tablet(servers[0].ip_addr, "ks", "tab", base_tablet_host_id, base_tablet_shard, slow_host_id, 0, 0)
+    view_tablet_replicas = await get_tablet_replicas(manager, servers[0], "ks", "mv_cf_view", 0)
+    view_tablet_hosts = [str(replica[0]) for replica in view_tablet_replicas]
+    for replica_host, replica_shard in view_tablet_replicas:
+        if str(replica_host) != str(slow_host_id):
+            continue
+        slow_host_shard = replica_shard
+        # Move the view tablet to the node that doesn't have one
+        for s in servers:
+            fast_host_id = await manager.get_host_id(s.server_id)
+            if str(fast_host_id) not in view_tablet_hosts:
+                await manager.api.move_tablet(servers[0].ip_addr, "ks", "mv_cf_view", slow_host_id, slow_host_shard, fast_host_id, 0, 0)
+        break
+
+    # Prepare the statement so that the write goes to the same shard
+    # for all requests (the backlog increase caused by a write is only
+    # immediately noted on the shard that the write was performed on).
+    stmt = cql.prepare(f"INSERT INTO ks.tab (key, c, v) VALUES (?, ?, ?)")
+    for i in range(10):
+        # Perform a write that will increase the view update backlog on the slow node
+        # to a level causing admission control to reject the following writes.
+        await cql.run_async(stmt, [0, i, 240000*'a'], host=hosts[0])
+        # Based on whether the response from the slow node is received before the next write,
+        # the following small write can serve two purposes:
+        # 1. If the response is received before the next write, the write will be rejected by
+        #   admission control and retried until it reaches all replicas.
+        # 2. If the response is not received before the next write, the write will be sent to
+        #   the slow node without causing the view update backlog limit to be exceeded. Then,
+        #   due to cl=ALL, the coordinator will wait for the response from the slow node, which
+        #   will carry an up-to-date view update backlog for the next large write.
+        cl_all_execution_profile = cql.execution_profile_clone_update(EXEC_PROFILE_DEFAULT, consistency_level = ConsistencyLevel.ALL)
+        await cql.run_async(stmt, [0, 10 + i, 'a'], host=hosts[0], execution_profile=cl_all_execution_profile)
+
+    # Verify that all writes reached the slow node
+    await asyncio.gather(*(manager.server_stop_gracefully(s.server_id) for s in servers))
+    print(f"Connecting to {server.ip_addr}")
+    await manager.driver_connect(server=server)
+    cql = manager.get_cql()
+
+    assert len(await cql.run_async(SimpleStatement(f"SELECT * FROM ks.tab", consistency_level=ConsistencyLevel.ONE))) == 20

--- a/test/topology_custom/test_mv_backlog.py
+++ b/test/topology_custom/test_mv_backlog.py
@@ -46,3 +46,33 @@ async def test_view_backlog_increased_after_write(manager: ManagerClient) -> Non
         assert view_backlog > v
 
     await cql.run_async(f"DROP KEYSPACE ks")
+
+# This test reproduces issues #18461 and #18783
+# In the test, we create a table and perform a write to it that fills the view update backlog.
+# After a gossip round is performed, the following write should succeed.
+@pytest.mark.asyncio
+@skip_mode('release', "error injections aren't enabled in release mode")
+async def test_gossip_same_backlog(manager: ManagerClient) -> None:
+    node_count = 2
+    servers = await manager.servers_add(node_count, config={'error_injections_at_startup': ['view_update_limit', 'update_backlog_immediately'], 'enable_tablets': True})
+    cql, hosts = await manager.get_ready_cql(servers)
+    await cql.run_async(f"CREATE KEYSPACE ks WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}"
+                         "AND tablets = {'initial': 1}")
+    await cql.run_async(f"CREATE TABLE ks.tab (key int, c int, v text, PRIMARY KEY (key, c))")
+    await cql.run_async(f"CREATE MATERIALIZED VIEW ks.mv_cf_view AS SELECT * FROM ks.tab "
+                    "WHERE c IS NOT NULL and key IS NOT NULL PRIMARY KEY (c, key) ")
+    await wait_for_view(cql, 'mv_cf_view', node_count)
+
+    # Only remote updates hold on to memory, so make the update remote
+    await pin_the_only_tablet(manager, "ks", "tab", servers[0])
+    await pin_the_only_tablet(manager, "ks", "mv_cf_view", servers[1])
+
+    stmt = cql.prepare(f"INSERT INTO ks.tab (key, c, v) VALUES (?, ?, ?)")
+
+    await asyncio.gather(*(manager.api.enable_injection(s.ip_addr, "never_finish_remote_view_updates", one_shot=False) for s in servers))
+    await cql.run_async(stmt, [0, 0, 240000*'a'], host=hosts[0])
+    await asyncio.gather(*(manager.api.disable_injection(s.ip_addr, "never_finish_remote_view_updates") for s in servers))
+    # The next write should be admitted eventually, after a gossip round (1s) is performed
+    await cql.run_async(stmt, [0, 0, 'a'], host=hosts[0])
+
+    await cql.run_async(f"DROP KEYSPACE ks")


### PR DESCRIPTION
Currently, when a view update backlog of one replica is full, the write is still sent by the coordinator to all replicas. Because of the backlog, the write fails on the replica, causing inconsistency that needs to be fixed by repair. To avoid these inconsistencies, this patch adds a check on the coordinator for overloaded replicas. As a result, a write may be rejected before being sent to any replicas and later retried by the user, when the replica is no longer overloaded.

This patch does not remove the replica write failures, because we still may reach a full backlog when more view updates are generated after the coordinator check is performed and before the write reaches the replica.

Fixes https://github.com/scylladb/scylladb/issues/17426
