### PR TITLE
configure.py: revert changing builddir as absolute path

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -784,7 +784,7 @@ args = arg_parser.parse_args()
 
 PROFILES_LIST_FILE_NAME = "coverage_sources.list"
 
-outdir = os.path.abspath(args.build_dir)
+outdir = args.build_dir
 tempfile.tempdir = f"{outdir}/tmp"
 
 if args.list_artifacts:
@@ -2294,7 +2294,7 @@ def write_build_file(f,
         build dist-server: phony dist-server-tar dist-server-debuginfo dist-server-rpm dist-server-deb
 
         rule build-submodule-reloc
-          command = cd $reloc_dir && ./reloc/build_reloc.sh --version $$(<$builddir/SCYLLA-PRODUCT-FILE)-$$(sed 's/-/~/' <$builddir/SCYLLA-VERSION-FILE)-$$(<$builddir/SCYLLA-RELEASE-FILE) --nodeps $args
+          command = cd $reloc_dir && ./reloc/build_reloc.sh --version $$(<../../$builddir/SCYLLA-PRODUCT-FILE)-$$(sed 's/-/~/' <../../$builddir/SCYLLA-VERSION-FILE)-$$(<../../$builddir/SCYLLA-RELEASE-FILE) --nodeps $args
         rule build-submodule-rpm
           command = cd $dir && ./reloc/build_rpm.sh --reloc-pkg $artifact
         rule build-submodule-deb

--- a/tools/toolchain/optimized_clang.sh
+++ b/tools/toolchain/optimized_clang.sh
@@ -36,8 +36,10 @@ CLANG_ROOT_DIR="${SCYLLA_DIR}"/clang_build
 CLANG_CHECKOUT_NAME=llvm-project
 CLANG_BUILD_DIR="${CLANG_ROOT_DIR}"/"${CLANG_CHECKOUT_NAME}"
 
-SCYLLA_BUILD_DIR="${SCYLLA_DIR}"/build_profile
-SCYLLA_NINJA_FILE="${SCYLLA_DIR}"/build_profile.ninja
+SCYLLA_BUILD_DIR=build_profile
+SCYLLA_NINJA_FILE=build_profile.ninja
+SCYLLA_BUILD_DIR_FULLPATH="${SCYLLA_DIR}"/"${SCYLLA_BUILD_DIR}"
+SCYLLA_NINJA_FILE_FULLPATH="${SCYLLA_DIR}"/"${SCYLLA_NINJA_FILE}"
 
 # Which LLVM release to build in order to compile Scylla
 LLVM_CLANG_TAG=16.0.6
@@ -56,7 +58,7 @@ if [[ "${CLANG_BUILD}" = "INSTALL" ]]; then
     cmake -B build -S llvm "${CLANG_OPTS[@]}" -DLLVM_BUILD_INSTRUMENTED=IR
     ninja -C build
 
-    rm -rf "${SCYLLA_BUILD_DIR}" "${SCYLLA_NINJA_FILE}"
+    rm -rf "${SCYLLA_BUILD_DIR_FULLPATH}" "${SCYLLA_NINJA_FILE_FULLPATH}"
     cd "${SCYLLA_DIR}"
     ./configure.py "${SCYLLA_OPTS[@]}"
     LLVM_PROFILE_FILE="${CLANG_BUILD_DIR}"/build/profiles/default_%p-%m.profraw ninja -f "${SCYLLA_NINJA_FILE}" compiler-training
@@ -68,7 +70,7 @@ if [[ "${CLANG_BUILD}" = "INSTALL" ]]; then
     ninja -C build
 
     # 2nd compilation: gathering a clang profile for CSPGO
-    rm -rf "${SCYLLA_BUILD_DIR}" "${SCYLLA_NINJA_FILE}"
+    rm -rf "${SCYLLA_BUILD_DIR_FULLPATH}" "${SCYLLA_NINJA_FILE_FULLPATH}"
     cd "${SCYLLA_DIR}"
     ./configure.py "${SCYLLA_OPTS[@]}"
     LLVM_PROFILE_FILE="${CLANG_BUILD_DIR}"/build/profiles/csir-%p-%m.profraw ninja -f "${SCYLLA_NINJA_FILE}" compiler-training
@@ -89,7 +91,7 @@ if [[ "${CLANG_BUILD}" = "INSTALL" ]]; then
         llvm-bolt build/bin/clang-"${CLANG_SUFFIX}".prebolt -o build/bin/clang-"${CLANG_SUFFIX}" --instrument --instrumentation-file="${CLANG_BUILD_DIR}"/build/profiles/prof --instrumentation-file-append-pid --conservative-instrumentation
 
         # 3rd ScyllaDB compilation: gathering a clang profile for BOLT
-        rm -rf "${SCYLLA_BUILD_DIR}" "${SCYLLA_NINJA_FILE}"
+        rm -rf "${SCYLLA_BUILD_DIR_FULLPATH}" "${SCYLLA_NINJA_FILE_FULLPATH}"
         cd "${SCYLLA_DIR}"
         ./configure.py "${SCYLLA_OPTS[@]}"
         ninja -f "${SCYLLA_NINJA_FILE}" compiler-training
@@ -114,4 +116,4 @@ mv /usr/lib64/libLTO.so."${CLANG_SUFFIX}" /usr/lib64/libLTO.so."${CLANG_SUFFIX}"
 install -Z -m755 "${CLANG_BUILD_DIR}"/build/bin/clang-"${CLANG_SUFFIX}" /usr/bin/clang-"${CLANG_SUFFIX}"
 install -Z -m755 "${CLANG_BUILD_DIR}"/build/bin/lld /usr/bin/lld
 install -Z -m755 "${CLANG_BUILD_DIR}"/build/lib64/libLTO.so."${CLANG_SUFFIX}" /usr/lib64/libLTO.so."${CLANG_SUFFIX}"
-rm -rf "${CLANG_BUILD_DIR}" "${SCYLLA_BUILD_DIR}" "${SCYLLA_NINJA_FILE}"
+rm -rf "${CLANG_BUILD_DIR}" "${SCYLLA_BUILD_DIR_FULLPATH}" "${SCYLLA_NINJA_FILE_FULLPATH}"


### PR DESCRIPTION
On be3776ec2ab11e0c13f191ec79e907b358a95612, we changed outdir to absolute path.
This causes "unknown target" error when we build Scylla using the relative path something like "ninja build/dev/scylla", since the target name become absolte path.
Revert the change to able to build with the relative path.

Fixes #18321