### PR TITLE
.github: add clang-tidy workflow

### DIFF
--- a/.github/actions/setup-build/action.yaml
+++ b/.github/actions/setup-build/action.yaml
@@ -1,0 +1,84 @@
+name: setup-build-env
+description: Setup Building Environment
+inputs:
+  install_clang_tool:
+    description: 'install clang-tool'
+    required: false
+    default: false
+    type: boolean
+  install_clang_tidy:
+    description: 'install clang-tidy'
+    required: false
+    default: false
+    type: boolean
+
+# use the stable branch
+# should be the same as the one used by the compositing workflow
+env:
+  CLANG_VERSION: 18
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Add scylla-ppa repo
+      shell: bash
+      run: |
+        sudo add-apt-repository ppa:scylladb/ppa
+
+    - name: Add clang apt repo
+      if: ${{ inputs.install_clang_tool || inputs.install_clang_tidy }}
+      shell: bash
+      run: |
+        sudo apt-get install -y curl
+        curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc >/dev/null
+        repo_component=llvm-toolchain-jammy
+        # use the development branch if $CLANG_VERSION is empty
+        if [ -n "$CLANG_VERSION" ]; then
+            repo_component+=-$CLANG_VERSION
+        fi
+        echo "deb http://apt.llvm.org/jammy/ $repo_component main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+        sudo apt-get update
+
+    - name: Install clang-tools
+      if: ${{ inputs.install_clang_tools }}
+      shell: bash
+      run: |
+        sudo apt-get install -y clang-tools-$CLANG_VERSION
+
+    - name: Install clang-tidy
+      if: ${{ inputs.install_clang_tidy }}
+      shell: bash
+      run: |
+        sudo apt-get install -y clang-tidy-$CLANG_VERSION
+
+    - name: Install GCC-12
+      # ubuntu:jammy comes with GCC-11. and libstdc++-11 fails to compile
+      # scylla which defines value type of std::unordered_map in .cc
+      shell: bash
+      run: |
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/ppa
+        sudo apt-get install -y libstdc++-12-dev
+
+    - name: Install more build dependencies
+      shell: bash
+      run: |
+        # - do not install java dependencies, which is not only not necessary,
+        #   and they include "python", which is not EOL and not available.
+        # - replace "scylla-libthrift010" with "libthrift-dev". because
+        #   scylla-libthrift010 : Depends: libssl1.0.0 (>= 1.0.1) but it is not installable
+        # - we don't perform tests, so minio is not necessary.
+        sed -i.orig \
+          -e '/tools\/.*\/install-dependencies.sh/d' \
+          -e 's/scylla-libthrift010-dev/libthrift-dev/' \
+          -e 's/(minio_download_jobs)/(true)/' \
+          ./install-dependencies.sh
+        sudo ./install-dependencies.sh
+        mv ./install-dependencies.sh{.orig,}
+        # for ld.lld
+        sudo apt-get install -y lld-18
+
+    - name: Install {fmt} using cooking.sh
+      shell: bash
+      run: |
+        sudo apt-get remove -y libfmt-dev
+        seastar/cooking.sh -d build-fmt -p cooking -i fmt

--- a/.github/clang-tidy-matcher.json
+++ b/.github/clang-tidy-matcher.json
@@ -1,0 +1,18 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "clang-tidy",
+            "pattern": [
+                {
+                    "regexp": "^([^:]+):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*?)\\s+\\[(.*?)\\]$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5,
+                    "code": 6
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -1,0 +1,63 @@
+name: clang-tidy
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.rst'
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/**'
+  workflow_dispatch:
+  schedule:
+    # only at 5AM Saturday
+    - cron: '0 5 * * SAT'
+
+env:
+  # use the stable branch
+  CLANG_VERSION: 18
+  BUILD_TYPE: RelWithDebInfo
+  BUILD_DIR: build
+  CLANG_TIDY_CHECKS: '-*,bugprone-use-after-move'
+
+permissions: {}
+
+# cancel the in-progress run upon a repush
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clang-tidy:
+    name: Run clang-tidy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: ./.github/actions/setup-build
+        with:
+          install_clang_tidy: true
+      - name: Generate the building system
+        run: |
+          cmake                                         \
+            -DCMAKE_BUILD_TYPE=$BUILD_TYPE              \
+            -DCMAKE_C_COMPILER=clang-$CLANG_VERSION     \
+            -DScylla_USE_LINKER=ld.lld-$CLANG_VERSION   \
+            -DCMAKE_CXX_COMPILER=clang++-$CLANG_VERSION \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON          \
+            -DCMAKE_CXX_CLANG_TIDY="clang-tidy-$CLANG_VERSION;--checks=$CLANG_TIDY_CHECKS" \
+            -DCMAKE_CXX_FLAGS=-DFMT_HEADER_ONLY         \
+            -DCMAKE_PREFIX_PATH=$PWD/cooking            \
+            -G Ninja                                    \
+            -B $BUILD_DIR                               \
+            -S .
+      # see https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md
+      - run: |
+          echo "::add-matcher::.github/clang-tidy-matcher.json"
+      - name: Build with clang-tidy enabled
+        run: |
+          cmake --build $BUILD_DIR --target scylla
+      - run: |
+          echo "::remove-matcher owner=clang-tidy::"


### PR DESCRIPTION
This workflow is triggered when a pull request is created targetting the "master" branch. It uses the clang-tidy tool provided by clang-tidy package to analyze the source files when building the tree.

a composite action is added so that we can add more github workflows in future. they will be able to reuse this action. a workflow using clang-include-cleaner is planed.

clang-tidy-matcher.json is added to annotate the change, so that the warnings are more visible with github webpage.