### PR TITLE
serializer_impl, sstables: fix build failure due to missing includes

### DIFF
--- a/serializer_impl.hh
+++ b/serializer_impl.hh
@@ -8,11 +8,13 @@
 
 #pragma once
 
+#include <list>
+#include <unordered_set>
+
 #include "serializer.hh"
 #include "enum_set.hh"
 #include "utils/chunked_vector.hh"
 #include "utils/input_stream.hh"
-#include <unordered_set>
 #include <seastar/util/bool_class.hh>
 #include "utils/small_vector.hh"
 #include <absl/container/btree_set.h>

--- a/sstables/compress.hh
+++ b/sstables/compress.hh
@@ -36,6 +36,7 @@
 #include <vector>
 #include <cstdint>
 #include <iterator>
+#include <deque>
 
 #include <seastar/core/file.hh>
 #include <seastar/core/seastar.hh>


### PR DESCRIPTION
When building scylla with cmake, it fails due to missing includes in serializer_impl.hh and sstables/compress.hh files. Fix that by adding the appropriate include files.

Fixes #18343