### PR TITLE
sstable: large data handler needs to count range tombstones as rows

### DIFF
--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -35,14 +35,14 @@ large_data_handler::large_data_handler(uint64_t partition_threshold_bytes, uint6
         partition_threshold_bytes, row_threshold_bytes, cell_threshold_bytes, rows_count_threshold, _collection_elements_count_threshold);
 }
 
-future<large_data_handler::partition_above_threshold> large_data_handler::maybe_record_large_partitions(const sstables::sstable& sst, const sstables::key& key, uint64_t partition_size, uint64_t rows) {
+future<large_data_handler::partition_above_threshold> large_data_handler::maybe_record_large_partitions(const sstables::sstable& sst, const sstables::key& key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones) {
     assert(running());
     partition_above_threshold above_threshold{partition_size > _partition_threshold_bytes, rows > _rows_count_threshold};
     static_assert(std::is_same_v<decltype(above_threshold.size), bool>);
     _stats.partitions_bigger_than_threshold += above_threshold.size; // increment if true
     if (above_threshold.size || above_threshold.rows) [[unlikely]] {
-        return with_sem([&sst, &key, partition_size, rows, this] {
-            return record_large_partitions(sst, key, partition_size, rows);
+        return with_sem([&sst, &key, partition_size, rows, range_tombstones, this] {
+            return record_large_partitions(sst, key, partition_size, rows, range_tombstones);
         }).then([above_threshold] {
             return above_threshold;
         });
@@ -164,8 +164,8 @@ future<> cql_table_large_data_handler::try_record(std::string_view large_table, 
             .finally([ p = _sys_ks ] {});
 }
 
-future<> cql_table_large_data_handler::record_large_partitions(const sstables::sstable& sst, const sstables::key& key, uint64_t partition_size, uint64_t rows) const {
-    return try_record("partition", sst, key, int64_t(partition_size), "partition", "", {"rows"}, data_value((int64_t)rows));
+future<> cql_table_large_data_handler::record_large_partitions(const sstables::sstable& sst, const sstables::key& key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones) const {
+    return try_record("partition", sst, key, int64_t(partition_size), "partition", "", {"rows", "range_tombstones"}, data_value((int64_t)rows), data_value((int64_t)range_tombstones));
 }
 
 future<> cql_table_large_data_handler::record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -93,7 +93,8 @@ public:
         bool size = false;
         bool rows = false;
     };
-    future<partition_above_threshold> maybe_record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows);
+    future<partition_above_threshold> maybe_record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key,
+            uint64_t partition_size, uint64_t rows, uint64_t range_tombstones);
 
     future<bool> maybe_record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) {
@@ -138,7 +139,7 @@ protected:
             const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) const = 0;
     virtual future<> record_large_rows(const sstables::sstable& sst, const sstables::key& partition_key, const clustering_key_prefix* clustering_key, uint64_t row_size) const = 0;
     virtual future<> delete_large_data_entries(const schema& s, sstring sstable_name, std::string_view large_table_name) const = 0;
-    virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows) const = 0;
+    virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones) const = 0;
 };
 
 class cql_table_large_data_handler : public large_data_handler {
@@ -164,7 +165,7 @@ public:
             utils::updateable_value<uint32_t> collection_elements_count_threshold);
 
 protected:
-    virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows) const override;
+    virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones) const override;
     virtual future<> delete_large_data_entries(const schema& s, sstring sstable_name, std::string_view large_table_name) const override;
     virtual future<> record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) const override;
@@ -185,7 +186,7 @@ private:
 class nop_large_data_handler : public large_data_handler {
 public:
     nop_large_data_handler();
-    virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows) const override {
+    virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones) const override {
         return make_ready_future<>();
     }
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -667,7 +667,8 @@ schema_ptr system_keyspace::size_estimates() {
         // regular columns
         {
             {"rows", long_type},
-            {"compaction_time", timestamp_type}
+            {"compaction_time", timestamp_type},
+            {"range_tombstones", long_type}
         },
         // static columns
         {},

--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -32,6 +32,7 @@ CREATE TABLE system.large_partitions (
     sstable_name text,
     partition_size bigint,
     partition_key text,
+    range_tombstones bigint,
     rows bigint,
     compaction_time timestamp,
     PRIMARY KEY ((keyspace_name, table_name), sstable_name, partition_size, partition_key)

--- a/docs/troubleshooting/large-partition-table.rst
+++ b/docs/troubleshooting/large-partition-table.rst
@@ -31,10 +31,10 @@ Example output:
 
 .. code-block:: console
 
-   keyspace_name | table_name | sstable_name     | partition_size | partition_key                                       | rows   | compaction_time
-   --------------+------------+------------------+----------------+-----------------------------------------------------+--------+--------------------------
-          demodb |       tmcr | md-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} |    100 | 2018-07-23 08:10:34
-          testdb |       tmcr | md-7-big-Data.db |        1234567 | {key: pk{000400000001}, token:-3169959284402457813} | 100101 | 2018-07-23 08:10:34
+   keyspace_name | table_name | sstable_name     | partition_size | partition_key                                       | range_tombstones | rows   | compaction_time     
+   --------------+------------+------------------+----------------+-----------------------------------------------------+------------------+--------+---------------------
+          demodb |       tmcr | md-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} |                0 |    100 | 2018-07-23 08:10:34 
+          testdb |       tmcr | md-7-big-Data.db |        1234567 | {key: pk{000400000001}, token:-3169959284402457813} |                0 | 100101 | 2018-07-23 08:10:34 
   
 ================================================  =================================================================================
 Parameter                                         Description
@@ -49,7 +49,9 @@ partition_size                                    The size of the partition in t
 ------------------------------------------------  ---------------------------------------------------------------------------------
 partition_key                                     The value of a partition key that identifies the large partition
 ------------------------------------------------  ---------------------------------------------------------------------------------
-rows                                              The number of rows in the partition in this sstable
+range_tombstones                                  The number of range tombstones in the partition in this sstable
+------------------------------------------------  ---------------------------------------------------------------------------------
+rows                                              The number of rows including range tombstones in the partition in this sstable
 ------------------------------------------------  ---------------------------------------------------------------------------------
 compaction_time                                   Time when compaction last occurred
 ================================================  =================================================================================
@@ -71,9 +73,9 @@ Example output:
 
 .. code-block:: console
 
-   keyspace_name | table_name | sstable_name     | partition_size | partition_key                                       | rows | compaction_time
-   --------------+------------+------------------+----------------+-----------------------------------------------------+------+--------------------------
-          demodb |       tmcr | md-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} | 1942 | 2018-07-23 08:10:34
+   keyspace_name | table_name | sstable_name     | partition_size | partition_key                                       | range_tombstones | rows | compaction_time
+   --------------+------------+------------------+----------------+-----------------------------------------------------+------------------+------+---------------------
+          demodb |       tmcr | md-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} |                0 | 1942 | 2018-07-23 08:10:34
 
 
 .. _large-partition-table-configure:
@@ -110,6 +112,7 @@ Large partitions are stored in a system table with the following schema:
        partition_size bigint,
        partition_key text,
        rows bigint,
+       range_tombstones bigint,
        compaction_time timestamp,
        PRIMARY KEY ((keyspace_name, table_name), sstable_name, partition_size, partition_key)
    ) WITH CLUSTERING ORDER BY (sstable_name ASC, partition_size DESC, partition_key ASC)

--- a/sstables/metadata_collector.hh
+++ b/sstables/metadata_collector.hh
@@ -31,8 +31,10 @@ struct column_stats {
     uint64_t cells_count;
     /** how many columns are there in the partition */
     uint64_t column_count;
-    /** how many rows are there in the partition */
+    /** how many rows (including range tombstone markers) are there in the partition */
     uint64_t rows_count;
+    /** how many range tombstones are there in the partition */
+    uint64_t range_tombstones_count;
 
     uint64_t start_offset;
     uint64_t partition_size;
@@ -51,6 +53,7 @@ struct column_stats {
         cells_count(0),
         column_count(0),
         rows_count(0),
+        range_tombstones_count(0),
         start_offset(0),
         partition_size(0),
         tombstone_histogram(TOMBSTONE_HISTOGRAM_BIN_SIZE),


### PR DESCRIPTION
When issuing warnings about partitions with the number of rows above a configured threshold, the  large partitions handler does not take into consideration the number of range tombstone markers in the total rows count. This fix adds the number of range tombstone markers to the total number of rows and saves this total in system.large_partitions.rows (if it is above the threshold). It also adds a new column range_tombstones to the system.large_partitions table which only contains the number of range tombstone markers for the given partition.

This PR fixes the first part of issue #13968
It does not cover distinguishing between live and dead rows. A subsequent PR will handle that.