### PR TITLE
replica/mutation_dump: create_underlying_mutation_sources(): remove false move

### DIFF
--- a/replica/mutation_dump.cc
+++ b/replica/mutation_dump.cc
@@ -184,7 +184,7 @@ private:
                 auto& e = prepared_mutation_sources[ms_it->first];
                 e.ms = ms_it->second;
                 maybe_push(e.region_intervals, region_int, std::compare_three_way{});
-                maybe_push(e.underlying_crs, std::move(transformed_cr), clustering_key_view::tri_compare(*_underlying_schema));
+                maybe_push(e.underlying_crs, transformed_cr, clustering_key_view::tri_compare(*_underlying_schema));
                 ++ms_it;
             }
         }


### PR DESCRIPTION
transformed_cr is moved in a loop, in each iteration. This is harmless because the variable is const and the move has no effect, yet it is confusing to readers and triggers false positives in clang-tidy (moved-from object reused). Remove it.

Fixes: #18322