### PR TITLE
view-builder: Print correct exception in built ste exception handler

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2341,7 +2341,7 @@ future<> view_builder::do_build_step() {
             }
         }
     }).handle_exception([] (std::exception_ptr ex) {
-        vlogger.warn("Unexcepted error executing build step: {}. Ignored.", std::current_exception());
+        vlogger.warn("Unexcepted error executing build step: {}. Ignored.", ex);
     });
 }
 


### PR DESCRIPTION
Inside .handle_exception() continuation std::current_exception() doesn't work, there's std::exception ex argument to handler's lambda instead

fixes #18423