### PR TITLE
pull_github_pr.sh: add notes to commit with reference to PR

### DIFF
--- a/scripts/pull_github_pr.sh
+++ b/scripts/pull_github_pr.sh
@@ -69,7 +69,7 @@ git fetch "$REMOTE" pull/$PR_NUM/head
 
 nr_commits=$(git log --pretty=oneline HEAD..FETCH_HEAD | wc -l)
 
-closes="${NL}${NL}Closes ${PROJECT}#${PR_NUM}${NL}"
+closes="${NL}${NL}From pull request: ${PROJECT}#${PR_NUM}${NL}"
 
 if [[ $nr_commits == 1 ]]; then
 	commit=$(git log --pretty=oneline HEAD..FETCH_HEAD | awk '{print $1}')
@@ -84,7 +84,7 @@ if [[ $nr_commits == 1 ]]; then
 			exit 1
 		fi
 	fi
-	git commit --amend -m "${message}${closes}"
+	git notes add -m "${message}${closes}"
 else
 	git merge --no-ff --log=1000 FETCH_HEAD -m "Merge '$PR_TITLE' from $USER_NAME" -m "${PR_DESCR}${closes}"
 fi


### PR DESCRIPTION
Today when we need to merge a PR with one commit, we add the `closes` prefix and then merge it using the `pull_github_pr.sh` script. This is causing a difference in commit sha between the one we see in the PR and the promoted commit. Causing our automation bot (Mergify) to backport wrong commit SHA.

This change will use `git notes` instead to update the reference to the PR.

Also instead of using `closes` which is GitHub closing keyword, let's use `From pull request:`