### PR TITLE
repair, transport: s/get0()/get()/

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1336,7 +1336,7 @@ future<> repair::user_requested_repair_task_impl::run() {
         } else {
             participants = get_hosts_participating_in_repair(germs->get(), keyspace, ranges, data_centers, hosts, ignore_nodes).get();
         }
-        bool hints_batchlog_flushed = flush_hints(rs, id, db, keyspace, cfs, ignore_nodes, participants).get0();
+        bool hints_batchlog_flushed = flush_hints(rs, id, db, keyspace, cfs, ignore_nodes, participants).get();
 
         std::vector<future<>> repair_results;
         repair_results.reserve(smp::count);

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -89,7 +89,7 @@ future<> controller::start_listening_on_tcp_sockets(sharded<cql_server>& cserver
     _listen_addresses.clear();
     std::vector<listen_cfg> configs;
 
-    const seastar::net::inet_address ip = utils::resolve(cfg.rpc_address, family, preferred).get0();
+    const seastar::net::inet_address ip = utils::resolve(cfg.rpc_address, family, preferred).get();
     int native_port_idx = -1, native_shard_aware_port_idx = -1;
 
     if (cfg.native_transport_port.is_set() ||


### PR DESCRIPTION
`future::get0()` was deprecated in favor of `future::get()`. so let's use the latter instead. this change silences a `-Wdeprecated` warning.