### PR TITLE
thrift: avoid use-after-move in `make_non_overlapping_ranges()`

### DIFF
--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -1868,11 +1868,13 @@ private:
             bool reversed) {
         std::vector<interval<RangeType>> ranges;
         std::transform(column_slices.begin(), column_slices.end(), std::back_inserter(ranges), [&](auto&& cslice) {
+            const std::string cslice_start = cslice.start;
+            const std::string cslice_finish = cslice.finish;
             auto range = mapper(std::move(cslice));
             if (!reversed && is_wrap_around(range)) {
-                throw make_exception<InvalidRequestException>("Column slice had start {} greater than finish {}", cslice.start, cslice.finish);
+                throw make_exception<InvalidRequestException>("Column slice had start {} greater than finish {}", cslice_start, cslice_finish);
             } else if (reversed && !is_wrap_around(range)) {
-                throw make_exception<InvalidRequestException>("Reversed column slice had start {} less than finish {}", cslice.start, cslice.finish);
+                throw make_exception<InvalidRequestException>("Reversed column slice had start {} less than finish {}", cslice_start, cslice_finish);
             } else if (reversed) {
                 range.reverse();
                 if (is_wrap_around(range)) {


### PR DESCRIPTION
in handler.cc, `make_non_overlapping_ranges()` references a moved instance of `ColumnSlice` when something unexpected happens to format the error message in an exception, the move constructor of `ColumnSlice` is default-generated, so the members' move constructors are used to construct the new instance in the move constructor. this could lead to undefined behavior when dereferencing the move instance.

in this change, in order to avoid use-after free, let's keep a copy of the referenced member variables and reference them when formatting error message in the exception.

this use-after-move issue was introduced in 822a315dfa, which implemented `get_multi_slice` verb and this piece in the first place. since both 5.2 and 5.4 include this commit, we should backport this change to them.

Refs 822a315dfa122811aa3a4d6bbce981cb3db4db4c
Fixes #18356
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>