### PR TITLE
partition_version: move the base class in move ctor

### DIFF
--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -32,7 +32,7 @@ static void remove_or_mark_as_unique_owner(partition_version* current, mutation_
 }
 
 partition_version::partition_version(partition_version&& pv) noexcept
-    : anchorless_list_base_hook(std::move(pv))
+    : anchorless_list_base_hook(std::move(static_cast<anchorless_list_base_hook&>(pv)))
     , _backref(pv._backref)
     , _schema(std::move(pv._schema))
     , _is_being_upgraded(pv._is_being_upgraded)


### PR DESCRIPTION
before this change, `partition_version` uses a hand-crafted move constructor. but it suffers from the warning from clang-tidy, which believe there is a use-after-move issue, as the inner instance of it's parent class is constructed using
`anchorless_list_base_hook(std::move(pv))`, and its other member variables are initialized like `_partition(std::move(pv._partition))`

`std::move(pv)` does not do anything, but *indicates* `pv` maybe moved from. and what is moved away is but the part belong to its parent class. so this issue is benign.

but, it's still annoying. as we need to tell the genuine issues reported by clang-tidy from the false alarms. so we have at least two options:

- stop using clang-tidy
- ignore this warning
- silence this warning using LINT direction in a comment
- use another way to implement the move constructor

in this change, we just cast the moved instance to its base class and move it instead, this should applease clang-tidy.

Fixes #18354
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>