### PR TITLE
partition_version: do not rereference moved variable

### DIFF
--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -507,9 +507,11 @@ utils::coroutine partition_entry::apply_to_incomplete(const schema& s,
     // of allocating sections, so we return here to get out of the current allocating section and
     // give the caller a chance to store the coroutine object. The code inside coroutine below
     // runs outside allocating section.
+    auto& src_snp_ref = *src_snp;
+    auto& dst_snp_ref = *dst_snp;
     return utils::coroutine([&tracker, &s, &alloc, &reg, &acc, can_move, preemptible, &preempt_src,
-            cur = partition_snapshot_row_cursor(s, *dst_snp),
-            src_cur = partition_snapshot_row_cursor(s, *src_snp, can_move),
+            cur = partition_snapshot_row_cursor(s, dst_snp_ref),
+            src_cur = partition_snapshot_row_cursor(s, src_snp_ref, can_move),
             dst_snp = std::move(dst_snp),
             prev_snp = std::move(prev_snp),
             src_snp = std::move(src_snp),


### PR DESCRIPTION
in `partition_entry::apply_to_incomplete()`, we pass `*dst_snp` and `std::move(dst_snp)` to build the capture variable list of a lambda, but the order of evaluation of these variables are unspecified. fortunately, we haven't run into any issues at this moment. but this is not future-proof. so, let's avoid this by storing a reference of the dereferenced smart pointer, and use it later on.

this issue is identified by clang-tidy:

```
/home/kefu/dev/scylladb/mutation/partition_version.cc:500:53: warning: 'dst_snp' used after it was moved [bugprone-use-after-move]
  500 |             cur = partition_snapshot_row_cursor(s, *dst_snp),
      |                                                     ^
/home/kefu/dev/scylladb/mutation/partition_version.cc:502:23: note: move occurred here
  502 |             dst_snp = std::move(dst_snp),
      |                       ^
/home/kefu/dev/scylladb/mutation/partition_version.cc:500:53: note: the use and move are unsequenced, i.e. there is no guarantee about the order in which they are evaluated
  500 |             cur = partition_snapshot_row_cursor(s, *dst_snp),
      |                                                     ^
/home/kefu/dev/scylladb/mutation/partition_version.cc:501:57: warning: 'src_snp' used after it was moved [bugprone-use-after-move]
  501 |             src_cur = partition_snapshot_row_cursor(s, *src_snp, can_move),
      |                                                         ^
/home/kefu/dev/scylladb/mutation/partition_version.cc:504:23: note: move occurred here
  504 |             src_snp = std::move(src_snp),
      |                       ^
/home/kefu/dev/scylladb/mutation/partition_version.cc:501:57: note: the use and move are unsequenced, i.e. there is no guarantee about the order in which they are evaluated
  501 |             src_cur = partition_snapshot_row_cursor(s, *src_snp, can_move),
      |                                                         ^
```

Fixes #18360
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>