### PR TITLE
main: do not reference moved variable

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -555,8 +555,9 @@ static locator::host_id initialize_local_info_thread(sharded<db::system_keyspace
     }
 
     linfo.listen_address = listen_address;
+    const auto host_id = linfo.host_id;
     sys_ks.local().save_local_info(std::move(linfo), snitch.local()->get_location(), broadcast_address, broadcast_rpc_address).get();
-    return linfo.host_id;
+    return host_id;
 }
 
 extern "C" void __attribute__((weak)) __llvm_profile_dump();


### PR DESCRIPTION
before this change, we dereference `linfo` after moving it away. and clang-tidy warns us like

```
[19/171] Building CXX object CMakeFiles/scylla.dir/main.cc.o
/home/kefu/dev/scylladb/main.cc:559:12: warning: 'linfo' used after it was moved [bugprone-use-after-move]
  559 |     return linfo.host_id;
      |            ^
/home/kefu/dev/scylladb/main.cc:558:36: note: move occurred here
  558 |     sys_ks.local().save_local_info(std::move(linfo), snitch.local()->get_location(), broadcast_address, broadcast_rpc_address).get();
      |                                    ^
```

the default-generated move constructor of `local_info` uses the default-generated move constructor of `locator::host_id`, which in turn use the default-generated move constructor of
`utils::tagged_uuid<struct host_id_tag>`, and then `utils::UUID` 's move constructor. since `UUID` does not contain any moveable resources, what it has is but two `int64_t` member variables. so this is a benign issue. but still, it is distracting.

in this change, we keep the value of `host_id` locally, and return it instead to silence this warning, and to improve the maintainability.