### PR TITLE
reader: silence false-positive use-after-move warning

### DIFF
--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -76,12 +76,12 @@ class foreign_reader : public flat_mutation_reader_v2::impl {
                 return exec_op_and_read_ahead();
             }
         }).then([this] (auto fut_and_result) {
-            _read_ahead_future = std::get<0>(std::move(fut_and_result));
+            _read_ahead_future = std::get<0>(std::move(fut_and_result)); // NOLINT(bugprone-use-after-move)
             static_assert(std::tuple_size<decltype(fut_and_result)>::value <= 2);
             if constexpr (std::tuple_size<decltype(fut_and_result)>::value == 1) {
                 return make_ready_future<>();
             } else {
-                auto result = std::get<1>(std::move(fut_and_result));
+                auto result = std::get<1>(std::move(fut_and_result)); // NOLINT(bugprone-use-after-move)
                 return make_ready_future<decltype(result)>(std::move(result));
             }
         }).finally([awaits_guard = std::move(awaits_guard)] { });


### PR DESCRIPTION
when compiling with clang-tidy, it warngs:
```
[6/9] Building CXX object readers/CMakeFiles/readers.dir/multishard.cc.o
/home/kefu/dev/scylladb/readers/multishard.cc:84:53: warning: 'fut_and_result' used after it was moved [bugprone-use-after-move]
   84 |                 auto result = std::get<1>(std::move(fut_and_result));
      |                                                     ^
/home/kefu/dev/scylladb/readers/multishard.cc:79:34: note: move occurred here
   79 |             _read_ahead_future = std::get<0>(std::move(fut_and_result));
      |                                  ^
```

but this warning is but a false alarm, as we are not really moving away the *whole* tuple, we are just move away an element from it. but clang-tidy cannot tell which element we are actually moving. so, silence both places of `std::move()`.