### PR TITLE
storage_service: Fix use-after-move in storage_service::node_ops_cmd_handler

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4272,7 +4272,8 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
                 }
                 return make_ready_future<>();
             }).get();
-            node_ops_insert(ops_uuid, coordinator, std::move(req.ignore_nodes), [this, coordinator, coordinator_host_id, req = std::move(req)] () mutable {
+            auto ignore_nodes = std::move(req.ignore_nodes);
+            node_ops_insert(ops_uuid, coordinator, std::move(ignore_nodes), [this, coordinator, coordinator_host_id, req = std::move(req)] () mutable {
                 return mutate_token_metadata([this, coordinator, coordinator_host_id, req = std::move(req)] (mutable_token_metadata_ptr tmptr) mutable {
                     for (auto& x: req.replace_nodes) {
                         auto existing_node = x.first;


### PR DESCRIPTION
```
service/storage_service.cc:4288:62: warning: 'req' used after it was moved [bugprone-use-after-move]
            node_ops_insert(ops_uuid, coordinator, std::move(req.ignore_nodes), [this, coordinator, req = std::move(req)] () mutable {
                                                             ^
service/storage_service.cc:4288:107: note: move occurred here
            node_ops_insert(ops_uuid, coordinator, std::move(req.ignore_nodes), [this, coordinator, req = std::move(req)] () mutable {
                                                                                                          ^
service/storage_service.cc:4288:62: note: the use and move are unsequenced, i.e. there is no guarantee about the order in which they are evaluated
            node_ops_insert(ops_uuid, coordinator, std::move(req.ignore_nodes), [this, coordinator, req = std::move(req)] () mutable {
                                                             ^

```

if evaluation order is right-to-left (GCC), req is moved first, and req.ignore_nodes will be empty, so nodes that should be ignored will still be considered, potentially resulting in a failure during replace.

https://godbolt.org/z/jPcM6GEx1

courtesy of clang-tidy.

Fixes #18324.