### PR TITLE
sstables: Fix use-after-move in an error path of FS-based sstable writer

### DIFF
--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -151,7 +151,7 @@ void filesystem_storage::open(sstable& sst) {
         // TOC will exist at this point if write_components() was called with
         // the generation of a sstable that exists.
         w.close();
-        remove_file(file_path).get();
+        remove_file(sst.filename(component_type::TemporaryTOC)).get();
         throw std::runtime_error(format("SSTable write failed due to existence of TOC file for generation {} of {}.{}", sst._generation, sst._schema->ks_name(), sst._schema->cf_name()));
     }
 


### PR DESCRIPTION
```
sstables/storage.cc:152:21: warning: 'file_path' used after it was moved [bugprone-use-after-move]
        remove_file(file_path).get();
                    ^
sstables/storage.cc:145:64: note: move occurred here
    auto w = file_writer(output_stream<char>(std::move(sink)), std::move(file_path));

```

It's a regression when TOC is found for a new sstable, and we try to delete temporary TOC.

courtesy of clang-tidy.

Fixes #18323.