### PR TITLE
test/pylib: random_tables: use IF NOT EXISTS when creating keyspace

### DIFF
--- a/test/pylib/random_tables.py
+++ b/test/pylib/random_tables.py
@@ -258,7 +258,7 @@ class RandomTables():
 
     def __init__(self, test_name: str, manager: ManagerClient, keyspace: str,
                  replication_factor: int, dc_replication_factor: dict[str, int] = None):
-        keyspace_query = f"CREATE KEYSPACE {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : {replication_factor}}}"
+        keyspace_query = f"CREATE KEYSPACE IF NOT EXISTS {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : {replication_factor}}}"
         self.test_name = test_name
         self.manager = manager
         self.keyspace = keyspace


### PR DESCRIPTION
Due to Python driver's unexpected behavior, "CREATE KEYSPACE" statement may sometimes get executed twice (scylladb/python-driver#317), leading to "Keyspace ... already exists" error in our tests (scylladb/scylladb#17654). Work around this by using "IF NOT EXISTS".

Fixes: scylladb/scylladb#17654