### PR TITLE
Commitlog: Optionally support oversized entries using external file(s)

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1511,7 +1511,9 @@ db::commitlog::segment_manager::segment_manager(config c)
     clogger.trace("Commitlog {} maximum disk size: {} MB / cpu ({} cpus)",
             cfg.commit_log_location, max_disk_size / (1024 * 1024),
             smp::count);
-
+    if (!cfg.allow_going_over_size_limit && cfg.allow_oversized_allocation) {
+        throw std::invalid_argument("Oversized allocation requires allowing exceeding disk size limit");
+    }
     if (!cfg.metrics_category_name.empty()) {
         create_counters(cfg.metrics_category_name);
     }

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -110,6 +110,7 @@ public:
         bool use_o_dsync = false;
         bool warn_about_segments_left_on_disk_after_shutdown = true;
         bool allow_going_over_size_limit = true;
+        bool allow_oversized_allocation = false;
 
         // The base segment ID to use.
         // The segment IDs of newly allocated segments will be issued sequentially

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -828,6 +828,7 @@ void database::init_schema_commitlog() {
     c.extensions = &_cfg.extensions();
     c.use_o_dsync = _cfg.commitlog_use_o_dsync();
     c.allow_going_over_size_limit = true; // for lower latency
+    c.allow_oversized_allocation = true; // for humungous schema mutations
 
     _schema_commitlog = std::make_unique<db::commitlog>(db::commitlog::create_commitlog(std::move(c)).get());
     _schema_commitlog->add_flush_handler([this] (db::cf_id_type id, db::replay_position pos) {

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -1709,3 +1709,85 @@ SEASTAR_TEST_CASE(test_wait_for_delete) {
     co_await log.shutdown();
     co_await log.clear();
 }
+
+/**
+ * Test allocating oversized multi-entry
+*/
+SEASTAR_TEST_CASE(test_oversized_entry) {
+    commitlog::config cfg;
+
+    constexpr auto max_size_mb = 1;
+
+    cfg.commitlog_segment_size_in_mb = max_size_mb;
+    cfg.commitlog_total_space_in_mb = 8 * max_size_mb * smp::count;
+    cfg.allow_going_over_size_limit = true;
+    cfg.allow_oversized_allocation = true;
+    cfg.use_o_dsync = false; 
+
+    // not using cl_test, because we need to be able to abandon
+    // the log.
+    tmpdir tmp;
+    cfg.commit_log_location = tmp.path().string();
+    std::unordered_map<replay_position, frozen_mutation> rp2mut;
+    random_mutation_generator gen(random_mutation_generator::generate_counters(false));
+
+    {
+        auto log = co_await commitlog::create_commitlog(cfg);
+        auto size = log.max_record_size() * 2;
+
+        std::vector<commitlog_entry_writer> writers;
+        std::vector<frozen_mutation> mutations;
+
+        size_t tot = 0; 
+        // generate a bunch of mutation until we have more data than allowed.
+        while (tot <= size) {
+            mutations.emplace_back(gen(1).front());
+            tot += mutations.back().representation().size();
+        }
+        for (auto& fm : mutations) {
+            writers.emplace_back(gen.schema(), fm, commitlog::force_sync::no);
+        }
+
+        // this will create an oversized entry set.
+        auto res = co_await log.add_entries(writers, db::timeout_clock::now() + 60s);
+
+        auto i = mutations.begin();
+        for (auto& h : res) {
+            rp2mut.emplace(h.release(), *i++);
+        }
+        co_await log.sync_all_segments();
+        // as if we crashed -> segment left on disk
+        co_await log.release();
+        co_await log.shutdown();
+    }
+
+    // new log, for replay.
+    auto log = co_await commitlog::create_commitlog(cfg);
+    std::exception_ptr e;
+    size_t n = 0;
+
+    auto replay_set = co_await log.get_segments_to_replay();
+    // Now replay the old commitlog and ensure we match all data.
+    for (auto& f : replay_set) {
+        co_await commitlog::read_log_file(f, cfg.fname_prefix, [&](commitlog::buffer_and_replay_position buf_rp) -> future<> {
+            auto&& buf = buf_rp.buffer;
+            auto&& rp = buf_rp.position;
+
+            BOOST_CHECK(rp2mut.count(rp));
+            commitlog_entry_reader cer(buf);
+            auto& fm = cer.mutation();
+            auto m1 = fm.unfreeze(gen.schema());
+            auto m2 = rp2mut.at(rp).unfreeze(gen.schema());
+
+            BOOST_CHECK_EQUAL(m1, m2);
+            ++n;
+            co_return;
+        });
+    }
+
+    BOOST_CHECK_EQUAL(n, rp2mut.size());
+
+    co_await log.shutdown();
+    co_await log.clear();
+}
+


### PR DESCRIPTION
Fixes #18161

Note: potentially temporary solution. This cannot handle hard size limit. 

Technically, if we could add some sort of sync between writers
we could fairly easily either write an oversized entry across several 
segments (if size is devided into more than one entry), or just allow a segment
to grow larger than normally allowed. However, such sync would probably impact 
throughput in the common case, and it would also be sensitive to 
both way to large temp buffer requirements (if we don't break each entry into 
chunks like we do here), but more importantly: If we crash while writing we
end up with half the entries written and any number missing -> partial 
recovery. 

We really want to know that the data is on disk fully before commiting
something that can be replayed to "real" commitlog. Hence we instead
write data to an "external" segment (just a special allocated segment), which 
we place no size limit on. We write each entry as a separate chunk to minimize
memory usage, then we flush and close the file. 

Once we are sure the data is on disk, we then just write a metadata entry
to the normal commitlog segment, in which we reference the external segment
and provide some other metadata (off, size). Then we set up a reference from
the "metedata" segment to the external one, so that once the metadata entries
are released, we also release the external segment.

Since we use a special prefix for the external file, much like recycled segments,
it will be picked up on replay, but ignored by the first level replay. If a metadata
entry is encountered however, we will find the external file and, if avail, replay the
data in it, pretending it comes from the "original" segment. I.e. transparent to 
client. The external files will then be freed/reused the same way any other replayed
segment is.

Again: this only works for non-hard limit CL.