### PR TITLE
doc: (fix) include OSS-specific info as separate files

### DIFF
--- a/docs/architecture/_common/note-enabling-consistent-topology-changes.rst
+++ b/docs/architecture/_common/note-enabling-consistent-topology-changes.rst
@@ -1,0 +1,3 @@
+.. note::
+    After the procedure described in this section finishes, you must perform manual action in order to enable consistent topology changes.
+    See :doc:`the guide for enabling consistent topology changes</upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology>` for more details.

--- a/docs/architecture/raft.rst
+++ b/docs/architecture/raft.rst
@@ -54,9 +54,7 @@ When all the nodes in the cluster are upgraded to ScyllaDB Open Source 5.5 or Sc
 Verifying that the Raft upgrade procedure finished successfully
 ========================================================================
 
-.. note::
-    After the procedure described in this section finishes, you must perform manual action in order to enable consistent topology changes.
-    See :doc:`the guide for enabling consistent topology changes</upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology>` for more details.
+.. scylladb_include_flag:: note-enabling-consistent-topology-changes.rst
 
 The Raft upgrade procedure requires **full cluster availability** to correctly setup the Raft algorithm; after the setup finishes, Raft can proceed with only a majority of nodes, but this initial setup is an exception.
 An unlucky event, such as a hardware failure, may cause one of your nodes to fail. If this happens before the Raft upgrade procedure finishes, the procedure will get stuck and your intervention will be required.

--- a/docs/troubleshooting/_common/enable-consistent-topology.rst
+++ b/docs/troubleshooting/_common/enable-consistent-topology.rst
@@ -1,0 +1,1 @@
+Perform :doc:`the procedure for enabling consistent topology changes </upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology>`.

--- a/docs/troubleshooting/_common/enabling-consistent-topology-failure.rst
+++ b/docs/troubleshooting/_common/enabling-consistent-topology-failure.rst
@@ -1,0 +1,3 @@
+:ref:`The Raft upgrade procedure <verify-raft-procedure>`
+or :doc:`the procedure for enabling consistent topology changes</upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology>`
+got stuck because one of the nodes failed in the middle of the procedure and is irrecoverable.

--- a/docs/troubleshooting/handling-node-failures.rst
+++ b/docs/troubleshooting/handling-node-failures.rst
@@ -70,9 +70,7 @@ Manual Recovery Procedure
 You can follow the manual recovery procedure when:
 
 * The majority of nodes (for example, 2 out of 3) failed and are irrecoverable.
-* :ref:`The Raft upgrade procedure <verify-raft-procedure>`
-  or :doc:`the procedure for enabling consistent topology changes</upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology>`
-  got stuck because one of the nodes failed in the middle of the procedure and is irrecoverable.
+* .. scylladb_include_flag:: enabling-consistent-topology-failure.rst
 
 .. warning::
 
@@ -148,4 +146,4 @@ in the past and then had Raft enabled, and to clusters that were bootstrapped us
 
 #. The Raft upgrade procedure will start anew. :ref:`Verify <verify-raft-procedure>` that it finishes successfully.
 
-#. Perform :doc:`the procedure for enabling consistent topology changes </upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology>`.
+#. .. scylladb_include_flag:: enable-consistent-topology.rst


### PR DESCRIPTION
This commit excludes OSS-specific links and content added in https://github.com/scylladb/scylladb/pull/17624 to separate files and adds the include directive .. scylladb_include_flag:: to include these files in the doc source files.

Reason: Adding the link to the Open Source upgrade guide (/upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology) breaks the Enterprise documentation because the Enterprise docs don't contain that upgrade guide. We must add separate files for OSS and Enterprise to prevent failing the Enterprise build and breaking the links.

Refs: https://github.com/scylladb/scylladb/pull/17624 