### PR TITLE
storage_service: notify lifecycle subs only after token metadata update

### DIFF
--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -882,10 +882,20 @@ public:
 private:
     future<std::vector<canonical_mutation>> get_system_mutations(schema_ptr schema);
     future<std::vector<canonical_mutation>> get_system_mutations(const sstring& ks_name, const sstring& cf_name);
+
+    struct nodes_to_notify_after_sync {
+        std::vector<std::pair<gms::inet_address, locator::host_id>> left;
+        std::vector<gms::inet_address> joined;
+    };
+
     // Synchronizes the local node state (token_metadata, system.peers/system.local tables,
     // gossiper) to align it with the other raft topology nodes.
     // Optional target_node can be provided to restrict the synchronization to the specified node.
-    future<> sync_raft_topology_nodes(mutable_token_metadata_ptr tmptr, std::optional<locator::host_id> target_node, std::unordered_set<raft::server_id> prev_normal);
+    // Returns a structure that describes which notifications to trigger after token metadata is updated.
+    future<nodes_to_notify_after_sync> sync_raft_topology_nodes(mutable_token_metadata_ptr tmptr, std::optional<locator::host_id> target_node, std::unordered_set<raft::server_id> prev_normal);
+    // Triggers notifications (on_joined, on_left) based on the recent changes to token metadata, as described by the passed in structure.
+    // This function should be called on the result of `sync_raft_topology_nodes`, after the global token metadata is updated.
+    future<> notify_nodes_after_sync(nodes_to_notify_after_sync&& nodes_to_notify);
     // load topology state machine snapshot into memory
     // raft_group0_client::_read_apply_mutex must be held
     future<> topology_state_load();


### PR DESCRIPTION
Currently, in raft mode, when raft topology is reloaded from disk or a notification is received from gossip about an endpoint change, token metadata is updated accordingly. While updating token metadata we detect whether some nodes are joining or are leaving and we notify endpoint lifecycle subscribers if such an event occurs. These notifications are fired _before_ we finish updating token metadata and before the updated version is globally available.

This behavior, for "node leaving" notifications specifically, was not present in legacy topology mode. Hinted handoff depends on token metadata being updated before it is notified about a leaving node (we had a similar issue before: scylladb/scylladb#5087, and we fixed it by enforcing this property). Because this is not true right now for raft mode, this causes the hint draining logic not to work properly - when a node leaves the cluster, there should be an attempt to send out hints for that node, but instead hints are not sent out and are kept on disk.

In order to fix the issue with hints, postpone notifying endpoint lifecycle subscribers about joined and left nodes only after the final token metadata is computed and replicated to all shards.

Fixes: scylladb/scylladb#17023