### PR TITLE
test: {auth,topology}: use manager.rolling_restart

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -191,10 +191,8 @@ class ManagerClient():
     async def server_restart(self, server_id: ServerNum, wait_others: int = 0,
                              wait_interval: float = 45) -> None:
         """Restart specified server and optionally wait for it to learn of other servers"""
-        logger.debug("ManagerClient restarting %s", server_id)
-        await self.client.put_json(f"/cluster/server/{server_id}/restart")
-        await self.server_sees_others(server_id, wait_others, interval = wait_interval)
-        self._driver_update()
+        await self.server_stop_gracefully(server_id)
+        await self.server_start(server_id=server_id, wait_others=wait_others, wait_interval=wait_interval)
 
     async def rolling_restart(self, servers: List[ServerInfo], with_down: Optional[Callable[[ServerInfo], Awaitable[Any]]] = None):
         for idx, s in enumerate(servers):

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -978,12 +978,6 @@ class ScyllaCluster:
             self.running.pop(server_id)
             self.stopped[server_id] = server
 
-    async def server_restart(self, server_id: ServerNum) -> None:
-        """Restart a running server"""
-        self.logger.info("Cluster %s restarting server %s", self, server_id)
-        await self.server_stop(server_id, gracefully=True)
-        await self.server_start(server_id)
-
     def server_pause(self, server_id: ServerNum) -> None:
         """Pause a running server process."""
         self.logger.info("Cluster %s pausing server %s", self.name, server_id)
@@ -1186,7 +1180,6 @@ class ScyllaClusterManager:
         add_put('/cluster/server/{server_id}/stop', self._cluster_server_stop)
         add_put('/cluster/server/{server_id}/stop_gracefully', self._cluster_server_stop_gracefully)
         add_put('/cluster/server/{server_id}/start', self._cluster_server_start)
-        add_put('/cluster/server/{server_id}/restart', self._cluster_server_restart)
         add_put('/cluster/server/{server_id}/pause', self._cluster_server_pause)
         add_put('/cluster/server/{server_id}/unpause', self._cluster_server_unpause)
         add_put('/cluster/addserver', self._cluster_server_add)
@@ -1282,12 +1275,6 @@ class ScyllaClusterManager:
         data = await request.json()
         expected_error = data["expected_error"]
         await self.cluster.server_start(server_id, expected_error)
-
-    async def _cluster_server_restart(self, request) -> None:
-        """Restart a specified server (must be already started)"""
-        assert self.cluster
-        server_id = ServerNum(int(request.match_info["server_id"]))
-        await self.cluster.server_restart(server_id)
 
     async def _cluster_server_pause(self, request) -> None:
         """Pause the specified server."""

--- a/test/topology/util.py
+++ b/test/topology/util.py
@@ -122,14 +122,6 @@ async def wait_for_token_ring_and_group0_consistency(manager: ManagerClient, dea
         await wait_for(token_ring_matches, deadline, period=.5)
 
 
-async def restart(manager: ManagerClient, server: ServerInfo) -> None:
-    logging.info(f"Stopping {server} gracefully")
-    await manager.server_stop_gracefully(server.server_id)
-    logging.info(f"Restarting {server}")
-    await manager.server_start(server.server_id)
-    logging.info(f"{server} restarted")
-
-
 async def wait_for_upgrade_state(state: str, cql: Session, host: Host, deadline: float) -> None:
     """Wait until group 0 upgrade state reaches `state` on `host`, using `cql` to query it.  Warning: if the
        upgrade procedure may progress beyond `state` this function may not notice when it entered `state` and

--- a/test/topology_custom/test_group0_schema_versioning.py
+++ b/test/topology_custom/test_group0_schema_versioning.py
@@ -17,7 +17,7 @@ from cassandra.pool import Host # type: ignore
 from test.pylib.manager_client import ManagerClient, ServerInfo
 from test.pylib.util import wait_for_cql_and_get_hosts
 from test.pylib.log_browsing import ScyllaLogFile
-from test.topology.util import reconnect_driver, restart, wait_until_upgrade_finishes, \
+from test.topology.util import reconnect_driver, wait_until_upgrade_finishes, \
         enter_recovery_state, delete_raft_data_and_upgrade_state
 
 
@@ -302,7 +302,7 @@ async def test_upgrade(manager: ManagerClient):
 
     logging.info(f"Setting recovery state on {hosts} and restarting")
     await asyncio.gather(*(enter_recovery_state(cql, h) for h in hosts))
-    await asyncio.gather(*(restart(manager, srv) for srv in servers))
+    await asyncio.gather(*(manager.server_restart(srv.server_id) for srv in servers))
     cql = await reconnect_driver(manager)
 
     logging.info("Waiting until driver connects to every server")
@@ -318,7 +318,7 @@ async def test_upgrade(manager: ManagerClient):
     await asyncio.gather(*(delete_raft_data_and_upgrade_state(cql, h) for h in hosts))
 
     logging.info(f"Restarting {servers}")
-    await asyncio.gather(*(restart(manager, srv) for srv in servers))
+    await asyncio.gather(*(manager.server_restart(srv.server_id) for srv in servers))
     cql = await reconnect_driver(manager)
 
     logger.info("Waiting for driver")

--- a/test/topology_custom/test_raft_fix_broken_snapshot.py
+++ b/test/topology_custom/test_raft_fix_broken_snapshot.py
@@ -10,7 +10,7 @@ import logging
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.topology.util import reconnect_driver, restart, enter_recovery_state, \
+from test.topology.util import reconnect_driver, enter_recovery_state, \
         delete_raft_data_and_upgrade_state, wait_until_upgrade_finishes, \
         wait_for_token_ring_and_group0_consistency
 from test.topology.conftest import skip_mode
@@ -43,7 +43,7 @@ async def test_raft_fix_broken_snapshot(manager: ManagerClient):
     # but with error injection that causes the snapshot to have index 0 (as in ScyllaDB 5.2).
     logger.info(f"Entering recovery state on {srv}")
     await enter_recovery_state(cql, h)
-    await restart(manager, srv)
+    await manager.server_restart(srv.server_id)
     cql = await reconnect_driver(manager)
     await wait_for_cql_and_get_hosts(cql, [srv], time.time() + 60)
 
@@ -67,7 +67,7 @@ async def test_raft_fix_broken_snapshot(manager: ManagerClient):
     await cql.run_async("create table ks.t2 (pk int primary key)")
 
     # Restarting the server should trigger snapshot creation.
-    await restart(manager, srv)
+    await manager.server_restart(srv.server_id)
     cql = await reconnect_driver(manager)
     await wait_for_cql_and_get_hosts(cql, [srv], time.time() + 60)
 

--- a/test/topology_custom/test_raft_recovery_basic.py
+++ b/test/topology_custom/test_raft_recovery_basic.py
@@ -12,7 +12,7 @@ import time
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
-from test.topology.util import reconnect_driver, restart, enter_recovery_state, \
+from test.topology.util import reconnect_driver, enter_recovery_state, \
         wait_until_upgrade_finishes, delete_raft_data_and_upgrade_state, log_run_time
 
 
@@ -30,7 +30,7 @@ async def test_raft_recovery_basic(request, manager: ManagerClient):
 
     logging.info(f"Setting recovery state on {hosts}")
     await asyncio.gather(*(enter_recovery_state(cql, h) for h in hosts))
-    await asyncio.gather(*(restart(manager, srv) for srv in servers))
+    await asyncio.gather(*(manager.server_restart(srv.server_id) for srv in servers))
     cql = await reconnect_driver(manager)
 
     logging.info("Cluster restarted, waiting until driver reconnects to every server")
@@ -41,7 +41,7 @@ async def test_raft_recovery_basic(request, manager: ManagerClient):
     await asyncio.gather(*(delete_raft_data_and_upgrade_state(cql, h) for h in hosts))
 
     logging.info(f"Restarting {servers}")
-    await asyncio.gather(*(restart(manager, srv) for srv in servers))
+    await asyncio.gather(*(manager.server_restart(srv.server_id) for srv in servers))
     cql = await reconnect_driver(manager)
 
     logging.info(f"Cluster restarted, waiting until driver reconnects to every server")

--- a/test/topology_custom/test_raft_recovery_majority_loss.py
+++ b/test/topology_custom/test_raft_recovery_majority_loss.py
@@ -11,7 +11,7 @@ import time
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
-from test.topology.util import reconnect_driver, restart, enter_recovery_state, \
+from test.topology.util import reconnect_driver, enter_recovery_state, \
         wait_until_upgrade_finishes, delete_raft_data_and_upgrade_state, log_run_time
 
 
@@ -48,7 +48,7 @@ async def test_recovery_after_majority_loss(request, manager: ManagerClient):
     logging.info(f"Entering recovery state on {srv1}")
     host1 = next(h for h in hosts if h.address == srv1.ip_addr)
     await enter_recovery_state(cql, host1)
-    await restart(manager, srv1)
+    await manager.server_restart(srv1.server_id)
     cql = await reconnect_driver(manager)
 
     logging.info("Node restarted, waiting until driver connects")
@@ -62,7 +62,7 @@ async def test_recovery_after_majority_loss(request, manager: ManagerClient):
 
     logging.info(f"Deleting old Raft data and upgrade state on {host1} and restarting")
     await delete_raft_data_and_upgrade_state(cql, host1)
-    await restart(manager, srv1)
+    await manager.server_restart(srv1.server_id)
     cql = await reconnect_driver(manager)
 
     logging.info("Node restarted, waiting until driver connects")

--- a/test/topology_custom/test_raft_recovery_stuck.py
+++ b/test/topology_custom/test_raft_recovery_stuck.py
@@ -12,7 +12,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables
 from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
 from test.topology.conftest import skip_mode
-from test.topology.util import reconnect_driver, restart, enter_recovery_state, wait_for_upgrade_state, \
+from test.topology.util import reconnect_driver, enter_recovery_state, wait_for_upgrade_state, \
         wait_until_upgrade_finishes, delete_raft_data_and_upgrade_state, log_run_time
 
 
@@ -40,7 +40,7 @@ async def test_recover_stuck_raft_recovery(request, manager: ManagerClient):
 
     logging.info(f"Setting recovery state on {hosts}")
     await asyncio.gather(*(enter_recovery_state(cql, h) for h in hosts))
-    await asyncio.gather(*(restart(manager, srv) for srv in servers))
+    await asyncio.gather(*(manager.server_restart(srv.server_id) for srv in servers))
     cql = await reconnect_driver(manager)
 
     logging.info(f"Cluster restarted, waiting until driver reconnects to {others}")
@@ -77,7 +77,7 @@ async def test_recover_stuck_raft_recovery(request, manager: ManagerClient):
     await asyncio.gather(*(enter_recovery_state(cql, h) for h in hosts))
 
     logging.info(f"Restarting {others}")
-    await asyncio.gather(*(restart(manager, srv) for srv in others))
+    await asyncio.gather(*(manager.server_restart(srv.server_id) for srv in others))
     cql = await reconnect_driver(manager)
 
     logging.info(f"{others} restarted, waiting until driver reconnects to them")
@@ -103,7 +103,7 @@ async def test_recover_stuck_raft_recovery(request, manager: ManagerClient):
     logging.info(f"Deleting Raft data and upgrade state on {hosts} and restarting")
     await asyncio.gather(*(delete_raft_data_and_upgrade_state(cql, h) for h in hosts))
 
-    await asyncio.gather(*(restart(manager, srv) for srv in others))
+    await asyncio.gather(*(manager.server_restart(srv.server_id) for srv in others))
     cql = await reconnect_driver(manager)
 
     logging.info(f"Cluster restarted, waiting until driver reconnects to {others}")

--- a/test/topology_experimental_raft/test_topology_recovery_basic.py
+++ b/test/topology_experimental_raft/test_topology_recovery_basic.py
@@ -11,7 +11,7 @@ import time
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.topology.util import reconnect_driver, restart, enter_recovery_state, \
+from test.topology.util import reconnect_driver, enter_recovery_state, \
         delete_raft_data_and_upgrade_state, log_run_time, wait_until_upgrade_finishes as wait_until_schema_upgrade_finishes, \
         wait_until_topology_upgrade_finishes, delete_raft_topology_state, wait_for_cdc_generations_publishing, \
         check_system_topology_and_cdc_generations_v3_consistency
@@ -31,8 +31,7 @@ async def test_topology_recovery_basic(request, manager: ManagerClient):
     await asyncio.gather(*(enter_recovery_state(cql, h) for h in hosts))
     # Restart sequentially, as it tests how nodes operating in legacy mode
     # react to raft topology mode nodes and vice versa
-    for srv in servers:
-        await restart(manager, srv)
+    await manager.rolling_restart(servers)
     cql = await reconnect_driver(manager)
 
     logging.info("Cluster restarted, waiting until driver reconnects to every server")
@@ -44,8 +43,7 @@ async def test_topology_recovery_basic(request, manager: ManagerClient):
     await asyncio.gather(*(delete_raft_data_and_upgrade_state(cql, h) for h in hosts))
 
     logging.info(f"Restarting hosts {hosts}")
-    for srv in servers:
-        await restart(manager, srv)
+    await manager.rolling_restart(servers)
     cql = await reconnect_driver(manager)
 
     logging.info("Cluster restarted, waiting until driver reconnects to every server")

--- a/test/topology_experimental_raft/test_topology_recovery_majority_loss.py
+++ b/test/topology_experimental_raft/test_topology_recovery_majority_loss.py
@@ -11,7 +11,7 @@ import time
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.topology.util import reconnect_driver, restart, enter_recovery_state, \
+from test.topology.util import reconnect_driver, enter_recovery_state, \
         delete_raft_data_and_upgrade_state, log_run_time, wait_until_upgrade_finishes as wait_until_schema_upgrade_finishes, \
         wait_until_topology_upgrade_finishes, delete_raft_topology_state, wait_for_cdc_generations_publishing, \
         check_system_topology_and_cdc_generations_v3_consistency
@@ -35,7 +35,7 @@ async def test_topology_recovery_after_majority_loss(request, manager: ManagerCl
     logging.info(f"Entering recovery state on {srv1}")
     host1 = next(h for h in hosts if h.address == srv1.ip_addr)
     await enter_recovery_state(cql, host1)
-    await restart(manager, srv1)
+    await manager.server_restart(srv1.server_id)
     cql = await reconnect_driver(manager)
 
     logging.info("Node restarted, waiting until driver connects")
@@ -50,7 +50,7 @@ async def test_topology_recovery_after_majority_loss(request, manager: ManagerCl
     logging.info(f"Deleting old Raft data and upgrade state on {host1} and restarting")
     await delete_raft_topology_state(cql, host1)
     await delete_raft_data_and_upgrade_state(cql, host1)
-    await restart(manager, srv1)
+    await manager.server_restart(srv1.server_id)
     cql = await reconnect_driver(manager)
 
     logging.info("Node restarted, waiting until driver connects")


### PR DESCRIPTION
Instead of performing a rolling restart by calling `restart` in a loop over every node in the cluster, use the dedicated
`manager.rolling_restart` function. This method waits until all other nodes see the currently processed node as up or down before proceeding to the next step. Not doing so may lead to surprising behavior.

In particular, in scylladb/scylladb#18369, a test failed shortly after restarting three nodes. Because nodes were restarted one after another too fast, when the third node was restarted it didn't send a notification to the second node because it still didn't know that the second node was alive. This led the second node to notice that the third node restarted by observing that it incremented its generation in gossip (it restarted too fast to be marked as down by the failure detector). In turn, this caused the second node to send "third node down" and "third node up" notifications to the driver in a quick succession, causing it to drop and reestablish all connections to that node. However, this happened _after_ rolling upgrade finished and _after_ the test logic confirmed that all nodes were alive. When the notifications were sent to the driver, the test was executing some statements necessary for the test to pass - as they broke, the test failed.

Fixes: scylladb/scylladb#18369