### PR TITLE
topology_coordinator: Fix synchronization of tablet split with other concurrent ops

### DIFF
--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -340,10 +340,15 @@ local state,  which is pulled periodically by the coordinator.
 
 When the coordinator realizes all tablet replicas have completed the splitting work, the load balancer
 emits a decision to finalize the split request. The finalization is serialized with migration, as
-doubling tablet count would interfere with the migration process. When the state machine leaves the
-migration track, then finalize can proceed and split each preexisting tablet into two in the topology
-metadata. The replicas  will react to that by remapping its compaction groups into a new set which size
-is equal to the new tablet count.
+doubling tablet count would interfere with the migration process.
+
+When the state machine leaves the migration track, and there are tablets waiting for tablet split to
+be finalized, the topology will transition into `tablet_split_finalization` state. At this moment, there will
+be no migration running in the system. A global token metadata barrier is executed to make sure that no
+process e.g. repair will be holding stale metadata when finalizing split. After that, the new tablet map,
+which is a result of splitting each preexisting tablet into two, is committed to group0.
+The replicas will react to that by remapping its compaction groups into a new set which is, at least,
+twice as large as the old one.
 
 # Topology guards
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -661,6 +661,8 @@ future<> storage_service::topology_state_load() {
                     [[fallthrough]];
                 case topology::transition_state::tablet_migration:
                     [[fallthrough]];
+                case topology::transition_state::tablet_split_finalization:
+                    [[fallthrough]];
                 case topology::transition_state::commit_cdc_generation:
                     [[fallthrough]];
                 case topology::transition_state::tablet_draining:

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -584,7 +584,6 @@ public:
             // If all replicas have completed split work for the current sequence number, it means that
             // load balancer can emit finalize decision, for split to be completed.
             if (table_stats->split_ready_seq_number == tmap.resize_decision().sequence_number) {
-                resize_plan.resize[table] = cluster_resize_load::revoke_resize_decision();
                 _stats.for_cluster().resizes_finalized++;
                 resize_plan.finalize_resize.insert(table);
                 lblogger.info("Finalizing resize decision for table {} as all replicas agree on sequence number {}",

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -137,6 +137,7 @@ static std::unordered_map<topology::transition_state, sstring> transition_state_
     {topology::transition_state::write_both_read_old, "write both read old"},
     {topology::transition_state::write_both_read_new, "write both read new"},
     {topology::transition_state::tablet_migration, "tablet migration"},
+    {topology::transition_state::tablet_split_finalization, "tablet split finalization"},
     {topology::transition_state::tablet_draining, "tablet draining"},
     {topology::transition_state::left_token_ring, "left token ring"},
     {topology::transition_state::rollback_to_normal, "rollback to normal"},

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -110,6 +110,7 @@ struct topology {
         write_both_read_old,
         write_both_read_new,
         tablet_migration,
+        tablet_split_finalization,
         left_token_ring,
         rollback_to_normal,
     };


### PR DESCRIPTION
Finalization of tablet split was only synchronizing with migrations, but that's not enough as we want to make sure that all processes like repair completes first as they might hold erm and therefore will be working with a "stale" version of token metadata.

For synchronization to work properly, handling of tablet split finalize will now take over the state machine, when possible, and execute a global token metadata barrier to guarantee that update in topology by split won't cause problems. Repair for example could be writing a sstable with stale metadata, and therefore, could generate a sstable that spans multiple tablets. We don't want that to happen, therefore we need the barrier.