### PR TITLE
utils: UUID_gen: include <atomic>

### DIFF
--- a/utils/UUID_gen.cc
+++ b/utils/UUID_gen.cc
@@ -15,6 +15,7 @@
 #include <net/if_arp.h>
 #endif // __linux__
 
+#include <atomic>
 #include <stdlib.h>
 #include "utils/hashers.hh"
 


### PR DESCRIPTION
in UUID_gen.cc, we are using `std::atomic<int64_t>` in `make_thread_local_node()`, but this template is not defined by any of the included headers. but  we should include used headers to be self-contained.

when compiling on ubuntu:jammy with libstdc++-13, we have following error:
```
/usr/local/bin/cmake -E __run_co_compile --tidy="clang-tidy-18;--checks=-*,bugprone-use-after-move;--extra-arg-before=--driver-mode=g++" --source=/home/runner/work/scylladb/scylladb/utils/UUID_gen.cc -- /usr/bin/clang++-18 -DBOOST_ALL_NO_LIB -DBOOST_NO_CXX98_FUNCTION_BASE -DBOOST_REGEX_DYN_LINK -DSCYLLA_BUILD_MODE=release -DSEASTAR_API_LEVEL=7 -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SSTRING -DXXH_PRIVATE_API -I/home/runner/work/scylladb/scylladb -I/home/runner/work/scylladb/scylladb/seastar/include -I/home/runner/work/scylladb/scylladb/build/seastar/gen/include -I/home/runner/work/scylladb/scylladb/build/seastar/gen/src -isystem /home/runner/work/scylladb/scylladb/cooking/include -ffunction-sections -fdata-sections -O3 -g -gz -std=gnu++20 -fvisibility=hidden -Wall -Werror -Wextra -Wno-error=deprecated-declarations -Wimplicit-fallthrough -Wno-c++11-narrowing -Wno-deprecated-copy -Wno-mismatched-tags -Wno-missing-field-initializers -Wno-overl
Error: /home/runner/work/scylladb/scylladb/utils/UUID_gen.cc:29:33: error: implicit instantiation of undefined template 'std::atomic<long>' [clang-diagnostic-error]
   29 |     static std::atomic<int64_t> thread_id_counter;
      |                                 ^
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/shared_ptr_atomic.h:361:11: note: template is declared here
  361 |     class atomic;
      |           ^
```
so, in this change, we include `<atomic>` to address this build failure.