### PR TITLE
build: cmake: let iotune depend on config specific file

### DIFF
--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -48,7 +48,7 @@ set(iotune_path "${CMAKE_BINARY_DIR}/$<CONFIG>/iotune")
 add_custom_command(
   OUTPUT "${iotune_path}"
   COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:app_iotune> "${iotune_path}"
-  DEPENDS app_iotune)
+  DEPENDS $<OUTPUT_CONFIG:$<TARGET_FILE:app_iotune>>)
 add_stripped("${iotune_path}")
 
 find_program(TAR_COMMAND tar


### PR DESCRIPTION
build: cmake: let iotune depends on config specific file

before this change, in order to build `${iotune_path}`, we use
the rule to build `app_iotune` but this target is built using
the default build type, see
https://cmake.org/cmake/help/latest/variable/CMAKE_DEFAULT_BUILD_TYPE.html#variable:CMAKE_DEFAULT_BUILD_TYPE
so, if we want to build `${iotune_path}` for the configuration
which is not listed as the first item in `CMAKE_CONFIGURATION_TYPES`,
we would end up with copying a nonexistent file.

to address this issue, we override the this behavior using
the `$<OUTPUT_CONFIG:...>` generator-expression. so that we
can depend on non-unique path. and the file-level dependency
between ${iotune_path} and $<CONFIG>/iotune can be established.

see also
https://cmake.org/cmake/help/latest/generator/Ninja%20Multi-Config.html#custom-commands

Refs #2717

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>
