### PR TITLE
cql: verify tuples length in multi-column IN restriction

### DIFF
--- a/cql3/expr/restrictions.cc
+++ b/cql3/expr/restrictions.cc
@@ -13,6 +13,7 @@
 #include "cql3/prepare_context.hh"
 #include "cql3/expr/expr-utils.hh"
 #include "types/list.hh"
+#include "types/tuple.hh"
 #include <iterator>
 #include <ranges>
 
@@ -116,6 +117,34 @@ void validate_token_relation(const std::vector<const column_definition*> column_
     }
 }
 
+void validate_tuples_size(const expression& rhs, size_t valid_size) {
+    auto coll = as_if<collection_constructor>(&rhs);
+    if (!coll) {
+        // Pre-prepare, the IN list arrives as a collection_constructor.
+        // After prepare it would be a constant of list type whose elements
+        // are serialized; arity validation has already happened earlier in
+        // that case, so nothing to do here.
+        return;
+    }
+    for (const auto& expr : coll->elements) {
+        size_t expr_size = 0;
+        if (auto tuple = as_if<tuple_constructor>(&expr)) {
+            expr_size = tuple->elements.size();
+        } else {
+            auto the_const = as_if<constant>(&expr);
+            if (the_const && the_const->type->without_reversed().is_tuple()) {
+                const tuple_type_impl* const_tuple = dynamic_cast<const tuple_type_impl*>(&the_const->type->without_reversed());
+                expr_size = const_tuple->size();
+            } else {
+                continue; // not a tuple; perhaps we need to set expr_size to 1 here when #12554 is fixed
+            }
+        }
+        if (expr_size != valid_size) {
+            throw exceptions::invalid_request_exception(format("Expected {} elements in value tuple, but got {}: {}", valid_size, expr_size, expr));
+        }
+    }
+}
+
 void preliminary_binop_vaidation_checks(const binary_operator& binop) {
     if (binop.op == oper_t::NEQ) {
         throw exceptions::invalid_request_exception(format("Unsupported \"!=\" relation: {:user}", binop));
@@ -140,6 +169,10 @@ void preliminary_binop_vaidation_checks(const binary_operator& binop) {
 
         if (binop.op == oper_t::LIKE) {
             throw exceptions::invalid_request_exception("LIKE cannot be used for Multi-column relations");
+        }
+
+        if (binop.op == oper_t::IN) {
+            validate_tuples_size(binop.rhs, lhs_tup->elements.size());
         }
 
         if (auto rhs_tup = as_if<tuple_constructor>(&binop.rhs)) {

--- a/test/cqlpy/cassandra_tests/validation/operations/select_multi_column_relation_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_multi_column_relation_test.py
@@ -28,9 +28,8 @@ def testSingleClusteringInvalidQueries(cql, test_keyspace):
         assertInvalidMessage(cql, table, "Multi-column relations can only be applied to clustering columns but was applied to: a",
                              "SELECT * FROM %s WHERE (a, b) = (?, ?)", 0, 0)
 
-# We need to skip this test because issue #13241 causes it to frequently
-# crash Scylla, and not just fail cleanly.
-@pytest.mark.skip_bug(reason="Issue #13241")
+# Issue #13241 used to crash Scylla on this test; it is now fixed.
+# The test is still expected to fail due to the unrelated issue #4244.
 @pytest.mark.xfail(reason="Issue #4244")
 def testMultiClusteringInvalidQueries(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, primary key (a, b, c, d))") as table:

--- a/test/cqlpy/test_filtering.py
+++ b/test/cqlpy/test_filtering.py
@@ -467,16 +467,14 @@ def test_multi_column_relation_tuples_null_check(cql, test_keyspace):
          with pytest.raises(InvalidRequest, match='Invalid null value in condition for column'): 
                 cql.execute(f'SELECT * FROM {table} WHERE a = 0 AND (b, c, d) IN ((1, 2, 3), (2, 1, null))')      
 
-#This test shows how Scylla handles invalid number of items in one of the tuples of multi-column relation.
-#If the number of items is lesser than required, Scylla throws "Expected {} elements in value tuple, but got {}"
-#But if the number of items is greater than required, Scylla throws different error: 
-#"Invalid list literal for IN((b,c,d)): value (1, 2, 3, 4) is not of type frozen<tuple<int, int, int>>"
+# This test shows how Scylla handles invalid number of items in one of the tuples of multi-column relation.
 # Reproduces #13217
+# Reproduces #13241
 def test_multi_column_relation_wrong_number_of_items_in_tuple(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'a int, b int, c int, d int, primary key (a, b, c, d)') as table:
-        with pytest.raises(InvalidRequest, match='elements in value tuple, but got'):
+        with pytest.raises(InvalidRequest, match='Expected 3 elements in value tuple, but got 2'):
             cql.execute(f'SELECT * FROM {table} WHERE a = 0 AND (b, c, d) IN ((1, 2), (2, 1, 4))')
-        with pytest.raises(InvalidRequest, match='Invalid list literal for IN'):
+        with pytest.raises(InvalidRequest, match='Expected 3 elements in value tuple, but got 5'):
             cql.execute(f'SELECT * FROM {table} WHERE a = 0 AND (b, c, d) IN ((1, 2, 3, 4, 5), (2, 1, 4))')
 
 # Test for a bug found while developing the fix for #10357. The bug was that if a regular column was selected

--- a/test/cqlpy/test_restrictions.py
+++ b/test/cqlpy/test_restrictions.py
@@ -130,7 +130,6 @@ def test_intersection_hang(cql, table4):
 # number of values on the right-hand-side of the restriction. Scylla should
 # cleanly report the error - and not silently ignore it or even crash as in
 # issue #13241.
-@pytest.mark.skip_bug(reason="Crashes due to issue #13241")
 def test_multi_column_restriction_in(cql, table3):
     p = unique_key_int()
     cql.execute(f'INSERT INTO {table3} (a, b, c, d) VALUES ({p}, 1, 2, 3)')


### PR DESCRIPTION
When a multi-column IN restriction contains tuples with a different
number of elements than the number of restricted columns (e.g.
`(b, c, d) IN ((1, 2), (2, 1, 4))`), Scylla would either produce an
inconsistent error message or, for over-sized tuples, an internal
type-mismatch error referencing the list literal representation.

Validate each tuple's arity against the number of restricted columns
while building the IN restriction and raise a clear
"Expected N elements in value tuple, but got M" error in both the
under- and over-sized cases.

Co-authored-by: Alexander Turetskiy <someone.tur@gmail.com>
This is a port of https://github.com/soft-stech/scylladb/commit/79c9ba76884d6a9630044ba3b5f5dfa68b9c500b

Fixes #13241