### PR TITLE
Drain view_builder in generic drain (again)

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1954,6 +1954,7 @@ future<> view_builder::drain() {
     _as.request_abort();
     co_await std::move(_started);
     co_await _mnotifier.unregister_listener(this);
+    co_await _vug.drain();
     co_await _sem.wait();
     _sem.broken();
     co_await _build_step.join();

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2566,6 +2566,20 @@ void view_builder::execute(build_step& step, exponential_backoff_retry r) {
     }).get();
 }
 
+future<> view_builder::mark_as_built(view_ptr view) {
+    return seastar::when_all_succeed(
+            _sys_ks.mark_view_as_built(view->ks_name(), view->cf_name()),
+            _sys_dist_ks.finish_view_build(view->ks_name(), view->cf_name())).discard_result();
+}
+
+future<> view_builder::mark_existing_views_as_built() {
+    assert(this_shard_id() == 0);
+    auto views = _db.get_views();
+    co_await coroutine::parallel_for_each(views, [this] (view_ptr& view) {
+        return mark_as_built(view);
+    });
+}
+
 future<> view_builder::maybe_mark_view_as_built(view_ptr view, dht::token next_token) {
     _built_views.emplace(view->id());
     vlogger.debug("Shard finished building view {}.{}", view->ks_name(), view->cf_name());
@@ -2585,9 +2599,7 @@ future<> view_builder::maybe_mark_view_as_built(view_ptr view, dht::token next_t
                 }
                 auto view = builder._db.find_schema(view_id);
                 vlogger.info("Finished building view {}.{}", view->ks_name(), view->cf_name());
-                return seastar::when_all_succeed(
-                        builder._sys_ks.mark_view_as_built(view->ks_name(), view->cf_name()),
-                        builder._sys_dist_ks.finish_view_build(view->ks_name(), view->cf_name())).then_unpack([&builder, view] {
+                return builder.mark_as_built(view_ptr(view)).then([&builder, view] {
                     // The view is built, so shard 0 can remove the entry in the build progress system table on
                     // behalf of all shards. It is guaranteed to have a higher timestamp than the per-shard entries.
                     return builder._sys_ks.remove_view_build_progress_across_all_shards(view->ks_name(), view->cf_name());

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -219,6 +219,9 @@ public:
 
     future<std::unordered_map<sstring, sstring>> view_build_statuses(sstring keyspace, sstring view_name) const;
 
+    // Can only be called on shard-0
+    future<> mark_existing_views_as_built();
+
 private:
     build_step& get_or_create_build_step(table_id);
     future<> initialize_reader_at_current_token(build_step&);
@@ -230,6 +233,7 @@ private:
     future<> do_build_step();
     void execute(build_step&, exponential_backoff_retry);
     future<> maybe_mark_view_as_built(view_ptr, dht::token);
+    future<> mark_as_built(view_ptr);
     void setup_metrics();
 
     struct consumer;

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -18,6 +18,7 @@
 #include "dht/partition_filter.hh"
 #include "utils/pretty_printers.hh"
 #include "readers/from_mutations_v2.hh"
+#include "service/storage_proxy.hh"
 
 static logging::logger vug_logger("view_update_generator");
 
@@ -238,6 +239,10 @@ void view_update_generator::do_abort() noexcept {
     vug_logger.info("Terminating background fiber");
     _as.request_abort();
     _pending_sstables.signal();
+}
+
+future<> view_update_generator::drain() {
+    return _proxy.local().abort_view_writes();
 }
 
 future<> view_update_generator::stop() {

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -78,6 +78,7 @@ public:
     ~view_update_generator();
 
     future<> start();
+    future<> drain();
     future<> stop();
     future<> register_staging_sstable(sstables::shared_sstable sst, lw_shared_ptr<replica::table> table);
 

--- a/main.cc
+++ b/main.cc
@@ -1178,6 +1178,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             static sharded<db::system_distributed_keyspace> sys_dist_ks;
             static sharded<db::system_keyspace> sys_ks;
             static sharded<db::view::view_update_generator> view_update_generator;
+            static sharded<db::view::view_builder> view_builder;
             static sharded<cdc::generation_service> cdc_generation_service;
 
             db::sstables_format_selector sst_format_selector(db);
@@ -1431,7 +1432,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 std::ref(feature_service), std::ref(mm), std::ref(token_metadata), std::ref(erm_factory),
                 std::ref(messaging), std::ref(repair),
                 std::ref(stream_manager), std::ref(lifecycle_notifier), std::ref(bm), std::ref(snitch),
-                std::ref(tablet_allocator), std::ref(cdc_generation_service), std::ref(qp), std::ref(sl_controller)).get();
+                std::ref(tablet_allocator), std::ref(cdc_generation_service), std::ref(view_builder), std::ref(qp), std::ref(sl_controller)).get();
 
             auto stop_storage_service = defer_verbose_shutdown("storage_service", [&] {
                 ss.stop().get();
@@ -1783,6 +1784,12 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 mm_notifier.local().unregister_listener(&ss.local()).get();
             });
 
+            supervisor::notify("starting the view builder");
+            view_builder.start(std::ref(db), std::ref(sys_ks), std::ref(sys_dist_ks), std::ref(mm_notifier), std::ref(view_update_generator)).get();
+            auto stop_view_builder = defer_verbose_shutdown("view builder", [cfg] {
+                view_builder.stop().get();
+            });
+
             /*
              * FIXME. In bb07678346 commit the API toggle for autocompaction was
              * (partially) delayed until system prepared to join the ring. Probably
@@ -1926,17 +1933,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 view_update_generator.invoke_on_all(&db::view::view_update_generator::start).get();
             }
 
-            static sharded<db::view::view_builder> view_builder;
             if (cfg->view_building()) {
-                supervisor::notify("starting the view builder");
-                view_builder.start(std::ref(db), std::ref(sys_ks), std::ref(sys_dist_ks), std::ref(mm_notifier), std::ref(view_update_generator)).get();
                 view_builder.invoke_on_all(&db::view::view_builder::start, std::ref(mm)).get();
             }
-            auto stop_view_builder = defer_verbose_shutdown("view builder", [cfg] {
-                if (cfg->view_building()) {
-                    view_builder.stop().get();
-                }
-            });
 
             api::set_server_view_builder(ctx, view_builder).get();
             auto stop_vb_api = defer_verbose_shutdown("view builder API", [&ctx] {
@@ -2031,12 +2030,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             auto do_drain = defer_verbose_shutdown("local storage", [&ss] {
                 ss.local().drain_on_shutdown().get();
-            });
-
-            auto drain_view_builder = defer_verbose_shutdown("view builder ops", [cfg] {
-                if (cfg->view_building()) {
-                    view_builder.invoke_on_all(&db::view::view_builder::drain).get();
-                }
             });
 
             startlog.info("Scylla version {} initialization completed.", scylla_version());

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1402,6 +1402,10 @@ public:
         return _type == db::write_type::COUNTER;
     }
 
+    bool is_view() const noexcept {
+        return _type == db::write_type::VIEW;
+    }
+
     void set_cdc_operation_result_tracker(lw_shared_ptr<cdc::operation_result_tracker> tracker) {
         _cdc_operation_result_tracker = std::move(tracker);
     }
@@ -6590,6 +6594,12 @@ future<> storage_proxy::drain_on_shutdown() {
     return async([this] {
         cancel_write_handlers([] (const abstract_write_response_handler&) { return true; });
         _hints_resource_manager.stop().get();
+    });
+}
+
+future<> storage_proxy::abort_view_writes() {
+    return async([this] {
+        cancel_write_handlers([] (const abstract_write_response_handler& handler) { return handler.is_view(); });
     });
 }
 

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -684,6 +684,7 @@ public:
     future<> start_hints_manager(shared_ptr<gms::gossiper>);
     void allow_replaying_hints() noexcept;
     future<> drain_on_shutdown();
+    future<> abort_view_writes();
 
     future<> change_hints_host_filter(db::hints::host_filter new_filter);
     const db::hints::host_filter& get_hints_host_filter() const;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -70,6 +70,9 @@ namespace db {
 class system_distributed_keyspace;
 class system_keyspace;
 class batchlog_manager;
+namespace view {
+class view_builder;
+}
 }
 
 namespace netw {
@@ -203,6 +206,7 @@ public:
         sharded<locator::snitch_ptr>& snitch,
         sharded<service::tablet_allocator>& tablet_allocator,
         sharded<cdc::generation_service>& cdc_gs,
+        sharded<db::view::view_builder>& view_builder,
         cql3::query_processor& qp,
         sharded<qos::service_level_controller>& sl_controller);
 
@@ -391,8 +395,6 @@ public:
 
 private:
     void set_mode(mode m);
-    // Can only be called on shard-0
-    future<> mark_existing_views_as_built();
 
     // Stream data for which we become a new replica.
     // Before that, if we're not replacing another node, inform other nodes about our chosen tokens
@@ -513,6 +515,7 @@ private:
     locator::snitch_signal_slot_t _snitch_reconfigure;
     sharded<service::tablet_allocator>& _tablet_allocator;
     sharded<cdc::generation_service>& _cdc_gens;
+    sharded<db::view::view_builder>& _view_builder;
 private:
     /**
      * Handle node bootstrap

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -774,6 +774,7 @@ private:
                 std::ref(_snitch),
                 std::ref(_tablet_allocator),
                 std::ref(_cdc_generation_service),
+                std::ref(_view_builder),
                 std::ref(_qp),
                 std::ref(_sl_controller)).get();
             auto stop_storage_service = defer([this] { _ss.stop().get(); });
@@ -845,6 +846,11 @@ private:
             });
 
             _sys_dist_ks.start(std::ref(_qp), std::ref(_mm), std::ref(_proxy)).get();
+
+            _view_builder.start(std::ref(_db), std::ref(_sys_ks), std::ref(_sys_dist_ks), std::ref(_mnotifier), std::ref(_view_update_generator)).get();
+            auto stop_view_builder = defer([this] {
+                _view_builder.stop().get();
+            });
 
             if (cfg_in.need_remote_proxy) {
                 _proxy.invoke_on_all(&service::storage_proxy::start_remote, std::ref(_ms), std::ref(_gossiper), std::ref(_mm), std::ref(_sys_ks)).get();
@@ -944,13 +950,9 @@ private:
                 _batchlog_manager.stop().get();
             });
 
-            _view_builder.start(std::ref(_db), std::ref(_sys_ks), std::ref(_sys_dist_ks), std::ref(_mnotifier), std::ref(_view_update_generator)).get();
             _view_builder.invoke_on_all([this] (db::view::view_builder& vb) {
                 return vb.start(_mm.local());
             }).get();
-            auto stop_view_builder = defer([this] {
-                _view_builder.stop().get();
-            });
 
             // Create the testing user.
             try {


### PR DESCRIPTION
Some time ago #16558 was merged that moved view builder drain into generic drain. After this merge dtests started to fail from time to time, so the PR was reverted (see #18278). In #18295 the hang was found. View builder drain was moved from "before stopping messaging service to "after" it, and view update write handlers in proxy hanged for hard-coded timeout of 5 minutes without being aborted. Tests don't wait for 5 minutes and kill scylla, then complain about it and fail.

This PR brings back the original PR as well as the necessary fix that cancels view update write handlers on stop.