### PR TITLE
table: Remove outdated FIXME about sstable spanning multiple tablets

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3462,7 +3462,6 @@ table::as_data_dictionary() const {
 }
 
 bool table::erase_sstable_cleanup_state(const sstables::shared_sstable& sst) {
-    // FIXME: it's possible that the sstable belongs to multiple compaction_groups
     auto& cg = compaction_group_for_sstable(sst);
     return get_compaction_manager().erase_sstable_cleanup_state(cg.as_table_state(), sst);
 }


### PR DESCRIPTION
The FIXME was added back then because we thought the interface of compaction_group_for_sstable might have to be adjusted if a sstable were allowed to temporarily span multiple tablets until it's split, but we have gone a different path.
If a sstable's key range incorrectly spans more than one tablet, that will be considered a bug and an exception is thrown.