### PR TITLE
cql3: test: include get_mutations_internal log in test.py

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -923,7 +923,7 @@ future<std::vector<mutation>> query_processor::get_mutations_internal(
         service::query_state& query_state,
         api::timestamp_type timestamp,
         std::vector<data_value_or_unset> values) {
-    log.trace("get_mutations_internal: \"{}\" ({})", query_string, fmt::join(values, ", "));
+    log.debug("get_mutations_internal: \"{}\" ({})", query_string, fmt::join(values, ", "));
     auto stmt = prepare_internal(query_string);
     auto mod_stmt = dynamic_pointer_cast<cql3::statements::modification_statement>(stmt->statement);
     if (!mod_stmt) {

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -137,6 +137,7 @@ SCYLLA_CMDLINE_OPTIONS = [
     '--abort-on-internal-error', '1',
     '--abort-on-ebadf', '1',
     '--logger-log-level', 'raft_topology=debug',
+    '--logger-log-level', 'query_processor=debug',
 ]
 
 # [--smp, 1], [--smp, 2] -> [--smp, 2]


### PR DESCRIPTION
We have a concurrent modification conflict in tests and suspect duplicated requests but since we don't log successful requests we have no way to verify if that's the case. get_mutations_internal log will help to tell wchich nodes are trying to push auth or service levels mutations into raft.

Refs scylladb/scylladb#18319