### PR TITLE
Getting per-table snapshot size is racy wrt creating new snapshots

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -764,24 +764,6 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cf::get_true_snapshots_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
-        auto uuid = get_uuid(req->param["name"], ctx.db.local());
-        return ctx.db.local().find_column_family(uuid).get_snapshot_details().then([](
-                const std::unordered_map<sstring, replica::column_family::snapshot_details>& sd) {
-            int64_t res = 0;
-            for (auto i : sd) {
-                res += i.second.total;
-            }
-            return make_ready_future<json::json_return_type>(res);
-        });
-    });
-
-    cf::get_all_true_snapshots_size.set(r, [] (std::unique_ptr<http::request> req) {
-        //TBD
-        unimplemented();
-        return make_ready_future<json::json_return_type>(0);
-    });
-
     cf::get_row_cache_hit_out_of_range.set(r, [] (std::unique_ptr<http::request> req) {
         //TBD
         unimplemented();
@@ -1156,8 +1138,6 @@ void unset_column_family(http_context& ctx, routes& r) {
     cf::get_speculative_retries.unset(r);
     cf::get_all_speculative_retries.unset(r);
     cf::get_key_cache_hit_rate.unset(r);
-    cf::get_true_snapshots_size.unset(r);
-    cf::get_all_true_snapshots_size.unset(r);
     cf::get_row_cache_hit_out_of_range.unset(r);
     cf::get_all_row_cache_hit_out_of_range.unset(r);
     cf::get_row_cache_hit.unset(r);

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -64,6 +64,7 @@ namespace api {
 
 namespace ss = httpd::storage_service_json;
 namespace sp = httpd::storage_proxy_json;
+namespace cf = httpd::column_family_json;
 using namespace json;
 
 sstring validate_keyspace(const http_context& ctx, sstring ks_name) {
@@ -207,7 +208,6 @@ static auto wrap_ks_cf(http_context &ctx, ks_cf_func f) {
 }
 
 seastar::future<json::json_return_type> run_toppartitions_query(db::toppartitions_query& q, http_context &ctx, bool legacy_request) {
-    namespace cf = httpd::column_family_json;
     return q.scatter().then([&q, legacy_request] {
         return sleep(q.duration()).then([&q, legacy_request] {
             return q.gather(q.capacity()).then([&q, legacy_request] (auto topk_results) {
@@ -1837,6 +1837,25 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
 
         co_return json::json_return_type(static_cast<int>(scrub_status::successful));
     });
+
+    cf::get_true_snapshots_size.set(r, [&ctx] (std::unique_ptr<http::request> req) {
+        auto uuid = get_uuid(req->param["name"], ctx.db.local());
+        return ctx.db.local().find_column_family(uuid).get_snapshot_details().then([](
+                const std::unordered_map<sstring, replica::column_family::snapshot_details>& sd) {
+            int64_t res = 0;
+            for (auto i : sd) {
+                res += i.second.total;
+            }
+            return make_ready_future<json::json_return_type>(res);
+        });
+    });
+
+    cf::get_all_true_snapshots_size.set(r, [] (std::unique_ptr<http::request> req) {
+        //TBD
+        unimplemented();
+        return make_ready_future<json::json_return_type>(0);
+    });
+
 }
 
 void unset_snapshot(http_context& ctx, routes& r) {
@@ -1845,6 +1864,8 @@ void unset_snapshot(http_context& ctx, routes& r) {
     ss::del_snapshot.unset(r);
     ss::true_snapshots_size.unset(r);
     ss::scrub.unset(r);
+    cf::get_true_snapshots_size.unset(r);
+    cf::get_all_true_snapshots_size.unset(r);
 }
 
 }

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -126,4 +126,14 @@ future<int64_t> snapshot_ctl::true_snapshots_size() {
     }));
 }
 
+future<int64_t> snapshot_ctl::true_snapshots_size(sstring ks, sstring cf) {
+    co_return co_await run_snapshot_list_operation(coroutine::lambda([this, ks = std::move(ks), cf = std::move(cf)] () -> future<int64_t> {
+        int64_t total = 0;
+        for (auto& [name, details] : co_await _db.local().find_column_family(ks, cf).get_snapshot_details()) {
+            total += details.total;
+        }
+        co_return total;
+    }));
+}
+
 }

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -93,6 +93,7 @@ public:
     future<std::unordered_map<sstring, db_snapshot_details>> get_snapshot_details();
 
     future<int64_t> true_snapshots_size();
+    future<int64_t> true_snapshots_size(sstring ks, sstring cf);
 private:
     sharded<replica::database>& _db;
     seastar::rwlock _lock;


### PR DESCRIPTION
The API endpoint in question calls table::get_snapshot_detail() which just walks table/snapshots/ directory. This can clash with creating a new snapshot. Database-wide walk is guarded with snapshot-ctl's locking, so should the per-table API do