### PR TITLE
Move some view updating methods from table to view_update_generator

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2503,8 +2503,8 @@ public:
             auto reader = make_flat_mutation_reader_from_fragments(_step.reader.schema(), _builder._permit, std::move(_fragments));
             auto close_reader = defer([&reader] { reader.close().get(); });
             reader.upgrade_schema(base_schema);
-            _step.base->populate_views(
-                    _gen,
+            _gen->populate_views(
+                    *_step.base,
                     std::move(views),
                     _step.current_token(),
                     std::move(reader),

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -17,6 +17,7 @@
 #include "readers/evictable.hh"
 #include "dht/partition_filter.hh"
 #include "utils/pretty_printers.hh"
+#include "readers/from_mutations_v2.hh"
 
 static logging::logger vug_logger("view_update_generator");
 
@@ -302,6 +303,134 @@ void view_update_generator::discover_staging_sstables() {
             }
         }
     });
+}
+
+static size_t memory_usage_of(const utils::chunked_vector<frozen_mutation_and_schema>& ms) {
+    return boost::accumulate(ms | boost::adaptors::transformed([] (const frozen_mutation_and_schema& m) {
+        return memory_usage_of(m);
+    }), 0);
+}
+
+/**
+ * Given some updates on the base table and assuming there are no pre-existing, overlapping updates,
+ * generates the mutations to be applied to the base table's views, and sends them to the paired
+ * view replicas. The future resolves when the updates have been acknowledged by the repicas, i.e.,
+ * propagating the view updates to the view replicas happens synchronously.
+ *
+ * @param views the affected views which need to be updated.
+ * @param base_token The token to use to match the base replica with the paired replicas.
+ * @param reader the base table updates being applied, which all correspond to the base token.
+ * @return a future that resolves when the updates have been acknowledged by the view replicas
+ */
+future<> view_update_generator::populate_views(const replica::table& table,
+        std::vector<view_and_base> views,
+        dht::token base_token,
+        flat_mutation_reader_v2&& reader,
+        gc_clock::time_point now) {
+    auto schema = reader.schema();
+    view_update_builder builder = make_view_update_builder(
+            get_db().as_data_dictionary(),
+            table,
+            schema,
+            std::move(views),
+            std::move(reader),
+            { },
+            now);
+
+    std::exception_ptr err;
+    while (true) {
+        try {
+            auto updates = co_await builder.build_some();
+            if (!updates) {
+                break;
+            }
+            size_t update_size = memory_usage_of(*updates);
+            size_t units_to_wait_for = std::min(table.get_config().view_update_concurrency_semaphore_limit, update_size);
+            auto units = co_await seastar::get_units(table.view_update_sem(), units_to_wait_for);
+            units.adopt(seastar::consume_units(table.view_update_sem(), update_size - units_to_wait_for));
+            co_await mutate_MV(schema, base_token, std::move(*updates), table.view_stats(), *table.cf_stats(),
+                    tracing::trace_state_ptr(), std::move(units), service::allow_hints::no, wait_for_all_updates::yes);
+        } catch (...) {
+            if (!err) {
+                err = std::current_exception();
+            }
+        }
+    }
+    co_await builder.close();
+    if (err) {
+        std::rethrow_exception(err);
+    }
+}
+
+/**
+ * Given some updates on the base table and the existing values for the rows affected by that update, generates the
+ * mutations to be applied to the base table's views, and sends them to the paired view replicas.
+ *
+ * @param base the base schema at a particular version.
+ * @param views the affected views which need to be updated.
+ * @param updates the base table updates being applied.
+ * @param existings the existing values for the rows affected by updates. This is used to decide if a view is
+ * obsoleted by the update and should be removed, gather the values for columns that may not be part of the update if
+ * a new view entry needs to be created, and compute the minimal updates to be applied if the view entry isn't changed
+ * but has simply some updated values.
+ * @return a future resolving to the mutations to apply to the views, which can be empty.
+ */
+future<> view_update_generator::generate_and_propagate_view_updates(const replica::table& table,
+        const schema_ptr& base,
+        reader_permit permit,
+        std::vector<view_and_base>&& views,
+        mutation&& m,
+        flat_mutation_reader_v2_opt existings,
+        tracing::trace_state_ptr tr_state,
+        gc_clock::time_point now) {
+    auto base_token = m.token();
+    auto m_schema = m.schema();
+    view_update_builder builder = make_view_update_builder(
+            get_db().as_data_dictionary(),
+            table,
+            base,
+            std::move(views),
+            make_flat_mutation_reader_from_mutations_v2(std::move(m_schema), std::move(permit), std::move(m)),
+            std::move(existings),
+            now);
+
+    std::exception_ptr err = nullptr;
+    while (true) {
+        std::optional<utils::chunked_vector<frozen_mutation_and_schema>> updates;
+        try {
+            updates = co_await builder.build_some();
+        } catch (...) {
+            err = std::current_exception();
+            break;
+        }
+        if (!updates) {
+            break;
+        }
+        tracing::trace(tr_state, "Generated {} view update mutations", updates->size());
+        auto units = seastar::consume_units(table.view_update_sem(), memory_usage_of(*updates));
+        if (table.view_update_sem().current() == 0) {
+            // We don't have resources to propagate view updates for this write. If we reached this point, we failed to
+            // throttle the client. The memory queue is already full, waiting on the semaphore would block view updates
+            // that we've already started applying, and generating hints would ultimately result in the disk queue being
+            // full. Instead, we drop the base write, which will create inconsistencies between base replicas, but we
+            // will fix them using repair.
+            err = std::make_exception_ptr(exceptions::overloaded_exception("Too many view updates started concurrently"));
+            break;
+        }
+        try {
+            co_await mutate_MV(base, base_token, std::move(*updates), table.view_stats(), *table.cf_stats(), tr_state,
+                std::move(units), service::allow_hints::yes, wait_for_all_updates::no);
+        } catch (...) {
+            // Ignore exceptions: any individual failure to propagate a view update will be reported
+            // by a separate mechanism in mutate_MV() function. Moreover, we should continue trying
+            // to generate updates even if some of them fail, in order to minimize the potential
+            // inconsistencies caused by not being able to propagate an update
+        }
+    }
+    co_await builder.close();
+    if (err) {
+        std::rethrow_exception(err);
+    }
 }
 
 }

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -83,6 +83,7 @@ public:
 
     replica::database& get_db() noexcept { return _db; }
 
+private:
     future<> mutate_MV(
             schema_ptr base,
             dht::token base_token,
@@ -94,6 +95,7 @@ public:
             service::allow_hints allow_hints,
             wait_for_all_updates wait_for_all);
 
+public:
     ssize_t available_register_units() const { return _registration_sem.available_units(); }
     size_t queued_batches_count() const { return _sstables_with_tables.size(); }
 

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -23,7 +23,10 @@
 using namespace seastar;
 
 struct frozen_mutation_and_schema;
+class mutation;
+class reader_permit;
 class flat_mutation_reader_v2;
+using flat_mutation_reader_v2_opt = optimized_optional<flat_mutation_reader_v2>;
 
 namespace dht {
 class token;
@@ -100,6 +103,15 @@ public:
             dht::token base_token,
             flat_mutation_reader_v2&&,
             gc_clock::time_point);
+
+    future<> generate_and_propagate_view_updates(const replica::table& table,
+            const schema_ptr& base,
+            reader_permit permit,
+            std::vector<view_and_base>&& views,
+            mutation&& m,
+            flat_mutation_reader_v2_opt existings,
+            tracing::trace_state_ptr tr_state,
+            gc_clock::time_point now);
 
 private:
     bool should_throttle() const;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1245,7 +1245,6 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.reversed_reads_auto_bypass_cache = db_config.reversed_reads_auto_bypass_cache;
     cfg.enable_optimized_reversed_reads = db_config.enable_optimized_reversed_reads;
     cfg.tombstone_warn_threshold = db_config.tombstone_warn_threshold();
-    cfg.view_update_concurrency_semaphore = _config.view_update_concurrency_semaphore;
     cfg.view_update_concurrency_semaphore_limit = _config.view_update_concurrency_semaphore_limit;
     cfg.data_listeners = &db.data_listeners();
     cfg.enable_compacting_data_for_streaming_and_repair = db_config.enable_compacting_data_for_streaming_and_repair();
@@ -2131,7 +2130,6 @@ database::make_keyspace_config(const keyspace_metadata& ksm) {
     cfg.statement_scheduling_group = _dbcfg.statement_scheduling_group;
     cfg.enable_metrics_reporting = _cfg.enable_keyspace_column_family_metrics();
 
-    cfg.view_update_concurrency_semaphore = &_view_update_concurrency_sem;
     cfg.view_update_concurrency_semaphore_limit = max_memory_pending_view_updates();
     return cfg;
 }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1025,7 +1025,11 @@ public:
         return _view_stats;
     }
 
-    replica::cf_stats* cf_stats() {
+    db::view::stats& view_stats() const noexcept {
+        return _view_stats;
+    }
+
+    replica::cf_stats* cf_stats() const {
         return _config.cf_stats;
     }
 
@@ -1142,14 +1146,6 @@ public:
         return _sstables_manager;
     }
 
-    // Reader's schema must be the same as the base schema of each of the views.
-    future<> populate_views(
-            shared_ptr<db::view::view_update_generator> gen,
-            std::vector<db::view::view_and_base>,
-            dht::token base_token,
-            flat_mutation_reader_v2&&,
-            gc_clock::time_point);
-
     reader_concurrency_semaphore& streaming_read_concurrency_semaphore() {
         return *_config.streaming_read_concurrency_semaphore;
     }
@@ -1239,6 +1235,10 @@ public:
     future<utils::chunked_vector<sstables::sstable_files_snapshot>> take_storage_snapshot(dht::token_range tr);
 
     friend class compaction_group;
+
+    db::timeout_semaphore& view_update_sem() const { // FIXME -- temporary helper
+        return *_config.view_update_concurrency_semaphore;
+    }
 };
 
 lw_shared_ptr<sstables::sstable_set> make_tablet_sstable_set(schema_ptr, const storage_group_manager& sgm, const locator::tablet_map&);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -409,7 +409,6 @@ public:
         seastar::scheduling_group streaming_scheduling_group;
         bool enable_metrics_reporting = false;
         bool enable_node_aggregated_table_metrics = true;
-        db::timeout_semaphore* view_update_concurrency_semaphore;
         size_t view_update_concurrency_semaphore_limit;
         db::data_listeners* data_listeners = nullptr;
         // Not really table-specific (it's a global configuration parameter), but stored here
@@ -1259,7 +1258,6 @@ public:
         seastar::scheduling_group statement_scheduling_group;
         seastar::scheduling_group streaming_scheduling_group;
         bool enable_metrics_reporting = false;
-        db::timeout_semaphore* view_update_concurrency_semaphore = nullptr;
         size_t view_update_concurrency_semaphore_limit;
     };
 private:

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1228,10 +1228,6 @@ public:
     future<utils::chunked_vector<sstables::sstable_files_snapshot>> take_storage_snapshot(dht::token_range tr);
 
     friend class compaction_group;
-
-    db::timeout_semaphore& view_update_sem() const { // FIXME -- temporary helper
-        return *_config.view_update_concurrency_semaphore;
-    }
 };
 
 lw_shared_ptr<sstables::sstable_set> make_tablet_sstable_set(schema_ptr, const storage_group_manager& sgm, const locator::tablet_map&);
@@ -1871,6 +1867,10 @@ public:
 
     bool is_internal_query() const;
     bool is_user_semaphore(const reader_concurrency_semaphore& semaphore) const;
+
+    db::timeout_semaphore& view_update_sem() {
+        return _view_update_concurrency_sem;
+    }
 };
 
 } // namespace replica

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1160,13 +1160,6 @@ private:
     future<row_locker::lock_holder> do_push_view_replica_updates(shared_ptr<db::view::view_update_generator> gen, schema_ptr s, mutation m, db::timeout_clock::time_point timeout, mutation_source source,
             tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem, query::partition_slice::option_set custom_opts) const;
     std::vector<view_ptr> affected_views(shared_ptr<db::view::view_update_generator> gen, const schema_ptr& base, const mutation& update) const;
-    future<> generate_and_propagate_view_updates(shared_ptr<db::view::view_update_generator> gen, const schema_ptr& base,
-            reader_permit permit,
-            std::vector<db::view::view_and_base>&& views,
-            mutation&& m,
-            flat_mutation_reader_v2_opt existings,
-            tracing::trace_state_ptr tr_state,
-            gc_clock::time_point now) const;
 
     mutable row_locker _row_locker;
     future<row_locker::lock_holder> local_base_lock(

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -55,7 +55,6 @@
 #include <boost/range/algorithm.hpp>
 #include "utils/error_injection.hh"
 #include "readers/reversing_v2.hh"
-#include "readers/from_mutations_v2.hh"
 #include "readers/empty_v2.hh"
 #include "readers/multi_range.hh"
 #include "readers/combined.hh"
@@ -2612,87 +2611,6 @@ std::vector<view_ptr> table::affected_views(shared_ptr<db::view::view_update_gen
     }));
 }
 
-static size_t memory_usage_of(const utils::chunked_vector<frozen_mutation_and_schema>& ms) {
-    return boost::accumulate(ms | boost::adaptors::transformed([] (const frozen_mutation_and_schema& m) {
-        return db::view::memory_usage_of(m);
-    }), 0);
-}
-
-} namespace db::view {
-
-/**
- * Given some updates on the base table and the existing values for the rows affected by that update, generates the
- * mutations to be applied to the base table's views, and sends them to the paired view replicas.
- *
- * @param base the base schema at a particular version.
- * @param views the affected views which need to be updated.
- * @param updates the base table updates being applied.
- * @param existings the existing values for the rows affected by updates. This is used to decide if a view is
- * obsoleted by the update and should be removed, gather the values for columns that may not be part of the update if
- * a new view entry needs to be created, and compute the minimal updates to be applied if the view entry isn't changed
- * but has simply some updated values.
- * @return a future resolving to the mutations to apply to the views, which can be empty.
- */
-future<> view_update_generator::generate_and_propagate_view_updates(const replica::table& table,
-        const schema_ptr& base,
-        reader_permit permit,
-        std::vector<db::view::view_and_base>&& views,
-        mutation&& m,
-        flat_mutation_reader_v2_opt existings,
-        tracing::trace_state_ptr tr_state,
-        gc_clock::time_point now) {
-    auto base_token = m.token();
-    auto m_schema = m.schema();
-    db::view::view_update_builder builder = db::view::make_view_update_builder(
-            get_db().as_data_dictionary(),
-            table,
-            base,
-            std::move(views),
-            make_flat_mutation_reader_from_mutations_v2(std::move(m_schema), std::move(permit), std::move(m)),
-            std::move(existings),
-            now);
-
-    std::exception_ptr err = nullptr;
-    while (true) {
-        std::optional<utils::chunked_vector<frozen_mutation_and_schema>> updates;
-        try {
-            updates = co_await builder.build_some();
-        } catch (...) {
-            err = std::current_exception();
-            break;
-        }
-        if (!updates) {
-            break;
-        }
-        tracing::trace(tr_state, "Generated {} view update mutations", updates->size());
-        auto units = seastar::consume_units(table.view_update_sem(), replica::memory_usage_of(*updates));
-        if (table.view_update_sem().current() == 0) {
-            // We don't have resources to propagate view updates for this write. If we reached this point, we failed to
-            // throttle the client. The memory queue is already full, waiting on the semaphore would block view updates
-            // that we've already started applying, and generating hints would ultimately result in the disk queue being
-            // full. Instead, we drop the base write, which will create inconsistencies between base replicas, but we
-            // will fix them using repair.
-            err = std::make_exception_ptr(exceptions::overloaded_exception("Too many view updates started concurrently"));
-            break;
-        }
-        try {
-            co_await mutate_MV(base, base_token, std::move(*updates), table.view_stats(), *table.cf_stats(), tr_state,
-                std::move(units), service::allow_hints::yes, db::view::wait_for_all_updates::no);
-        } catch (...) {
-            // Ignore exceptions: any individual failure to propagate a view update will be reported
-            // by a separate mechanism in mutate_MV() function. Moreover, we should continue trying
-            // to generate updates even if some of them fail, in order to minimize the potential
-            // inconsistencies caused by not being able to propagate an update
-        }
-    }
-    co_await builder.close();
-    if (err) {
-        std::rethrow_exception(err);
-    }
-}
-
-} /* db::view namespace */ namespace replica {
-
 /**
  * Shard-local locking of clustering rows or entire partitions of the base
  * table during a Materialized-View read-modify-update:
@@ -2773,61 +2691,6 @@ table::local_base_lock(
         return _row_locker.lock_pk(pk, true, timeout, _row_locker_stats);
     }
 }
-
-} namespace db::view {
-
-/**
- * Given some updates on the base table and assuming there are no pre-existing, overlapping updates,
- * generates the mutations to be applied to the base table's views, and sends them to the paired
- * view replicas. The future resolves when the updates have been acknowledged by the repicas, i.e.,
- * propagating the view updates to the view replicas happens synchronously.
- *
- * @param views the affected views which need to be updated.
- * @param base_token The token to use to match the base replica with the paired replicas.
- * @param reader the base table updates being applied, which all correspond to the base token.
- * @return a future that resolves when the updates have been acknowledged by the view replicas
- */
-future<> view_update_generator::populate_views(const replica::table& table,
-        std::vector<view_and_base> views,
-        dht::token base_token,
-        flat_mutation_reader_v2&& reader,
-        gc_clock::time_point now) {
-    auto schema = reader.schema();
-    db::view::view_update_builder builder = db::view::make_view_update_builder(
-            get_db().as_data_dictionary(),
-            table,
-            schema,
-            std::move(views),
-            std::move(reader),
-            { },
-            now);
-
-    std::exception_ptr err;
-    while (true) {
-        try {
-            auto updates = co_await builder.build_some();
-            if (!updates) {
-                break;
-            }
-            size_t update_size = replica::memory_usage_of(*updates);
-            size_t units_to_wait_for = std::min(table.get_config().view_update_concurrency_semaphore_limit, update_size);
-            auto units = co_await seastar::get_units(table.view_update_sem(), units_to_wait_for);
-            units.adopt(seastar::consume_units(table.view_update_sem(), update_size - units_to_wait_for));
-            co_await mutate_MV(schema, base_token, std::move(*updates), table.view_stats(), *table.cf_stats(),
-                    tracing::trace_state_ptr(), std::move(units), service::allow_hints::no, db::view::wait_for_all_updates::yes);
-        } catch (...) {
-            if (!err) {
-                err = std::current_exception();
-            }
-        }
-    }
-    co_await builder.close();
-    if (err) {
-        std::rethrow_exception(err);
-    }
-}
-
-} /* db::view namespace */ namespace replica {
 
 const ssize_t new_reader_base_cost{16 * 1024};
 


### PR DESCRIPTION
The populate_views() and generate_and_propagate_view_updates() both naturally belong to view_update_generator -- they don't need anything special from table itself, but rather depend on some internals of the v.u.generator itself.

Moving them there lets removing the view concurrency semaphore from keyspace and table, thus reducing the cross-components dependencies.