### PR TITLE
service/storage_proxy: add useful version of base write throttle metrics

### DIFF
--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -100,6 +100,7 @@ struct write_stats {
     uint64_t background_writes = 0; // client no longer waits for the write
     uint64_t throttled_writes = 0; // total number of writes ever delayed due to throttling
     uint64_t throttled_base_writes = 0; // current number of base writes delayed due to view update backlog
+    uint64_t total_throttled_base_writes = 0; // total number of base writes delayed due to view update backlog
     uint64_t background_writes_failed = 0;
     uint64_t writes_failed_due_to_too_many_in_flight_hints = 0;
 
@@ -115,6 +116,7 @@ struct write_stats {
     seastar::metrics::metric_groups _metrics;
 
     std::chrono::microseconds last_mv_flow_control_delay; // delay added for MV flow control in the last request
+    uint64_t mv_flow_control_delay = 0; // total delay added for MV flow control (in microseconds)
 public:
     write_stats();
     write_stats(const sstring& category, bool auto_register_stats);


### PR DESCRIPTION
There are two metrics to help observe base-write throttling:
* current_throttled_base_writes
* last_mv_flow_control_delay

Both show a snapshot of what is happening right at the time of querying these metrincs. This doesn't work well when one wants to investigate the role throttling is playing in occasional write timeouts.s Prometheus scrapes metrics in multi-second intervals, and the probability of that instant catching the throttling at play is very small (almost zero). Add two new metrics:
* throttled_base_writes_total
* mv_flow_control_delay_total

These accumulate all values, allowing graphana to derive the values and extract information about throttle events that happened in the past (but not necessarily at the instant of the scrape). Note that dividing the two values, will yield the average delay for a throttle, which is also useful.

Improvement, no backport needed.
