### PR TITLE
Fix population of non-normal sstables from registry

### DIFF
--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -58,7 +58,7 @@ sstable_directory::make_components_lister() {
             return std::make_unique<sstable_directory::filesystem_components_lister>(_sstable_dir);
         },
         [this] (const data_dictionary::storage_options::s3& os) mutable -> std::unique_ptr<sstable_directory::components_lister> {
-            return std::make_unique<sstable_directory::sstables_registry_components_lister>(_manager.sstables_registry(), _sstable_dir.native());
+            return std::make_unique<sstable_directory::sstables_registry_components_lister>(_manager.sstables_registry(), _table_dir);
         }
     }, _storage_opts->value);
 }


### PR DESCRIPTION
On boot sstables are populated from normal location as well as from quarantine and staging. It turned out that sstables listed in registry (S3-backed ones) are not populated from non-normal states.