### PR TITLE
Migrate alternator tests to PythonTestSuite

### DIFF
--- a/test.py
+++ b/test.py
@@ -977,6 +977,9 @@ class PythonTest(Test):
         cluster = await self.suite.clusters.get(logger)
         try:
             cluster.before_test(self.uname)
+            prepare_cql = self.suite.cfg.get("prepare_cql", None)
+            if prepare_cql:
+                next(iter(cluster.running.values())).control_connection.execute(prepare_cql)
             logger.info("Leasing Scylla cluster %s for test %s", cluster, self.uname)
             self.args.insert(0, "--host={}".format(cluster.endpoint()))
             self.is_before_test_ok = True

--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -45,7 +45,8 @@ def pytest_addoption(parser):
     # presence.
     parser.addoption('--omit-scylla-output', action='store_true',
         help='Omit scylla\'s output from the test output')
-
+    parser.addoption('--host', action='store', default='localhost',
+        help='Scylla server host to connect to')
 def pytest_configure(config):
     config.addinivalue_line("markers", "veryslow: mark test as very slow to run")
 
@@ -79,6 +80,9 @@ def dynamodb(request):
         # for local runs.
         if request.config.getoption('url') != None:
             local_url = request.config.getoption('url')
+        elif request.config.getoption('host') is not None:
+            # this argument needed for compatibility with PythonTestSuite without modifying the previous behavior
+            local_url = f"http://{request.config.getoption('host')}:8000"
         else:
             local_url = 'https://localhost:8043' if request.config.getoption('https') else 'http://localhost:8000'
         # Disable verifying in order to be able to use self-signed TLS certificates
@@ -114,6 +118,9 @@ def dynamodbstreams(request):
         # for local runs.
         if request.config.getoption('url') != None:
             local_url = request.config.getoption('url')
+        elif request.config.getoption('host') is not None:
+            # this argument needed for compatibility with PythonTestSuite without modifying the previous behavior
+            local_url = f"http://{request.config.getoption('host')}:8000"
         else:
             local_url = 'https://localhost:8043' if request.config.getoption('https') else 'http://localhost:8000'
         # Disable verifying in order to be able to use self-signed TLS certificates

--- a/test/alternator/suite.yaml
+++ b/test/alternator/suite.yaml
@@ -1,1 +1,24 @@
-type: Run
+type: Python
+pool_size: 4
+prepare_cql: INSERT INTO system_auth_v2.roles (role, salted_hash) VALUES ('alternator', 'secret_pass')
+run_first:
+    - test_streams
+    - test_scan
+    - test_tracing
+    - test_ttl
+extra_scylla_config_options:
+  {
+    experimental_features: [
+                             udf,
+                             alternator-streams,
+                             keyspace-storage-options,
+                             tablets
+    ],
+    alternator_port: 8000,
+    query_tombstone_page_limit: 1000,
+    alternator_write_isolation: only_rmw_uses_lwt,
+    alternator_enforce_authorization: True,
+    alternator_timeout_in_ms: 30000,
+    alternator_ttl_period_in_seconds: 0.5,
+    alternator_streams_time_window_s: 0
+  }


### PR DESCRIPTION
- [x] ** Backport reason (please explain below if this patch should be backported or not) **

