### PR TITLE
raft_group_registry: do not use moved variable

### DIFF
--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -536,7 +536,7 @@ future<> raft_server_with_timeouts::read_barrier(seastar::abort_source* as, std:
 }
 
 future<bool> direct_fd_pinger::ping(direct_failure_detector::pinger::endpoint_id id, abort_source& as) {
-    auto dst_id = raft::server_id{std::move(id)};
+    auto dst_id = raft::server_id{id};
     auto addr = _address_map.find(dst_id);
     if (!addr) {
         {


### PR DESCRIPTION
clang-tidy warns like:
```
[628/713] Building CXX object service/CMakeFiles/service.dir/raft/raft_group_registry.cc.o
Warning: /home/runner/work/scylladb/scylladb/service/raft/raft_group_registry.cc:543:66: warning: 'id' used after it was moved [bugprone-use-after-move]
  543 |             auto& rate_limit = _rate_limits.try_get_recent_entry(id, std::chrono::minutes(5));
      |                                                                  ^
/home/runner/work/scylladb/scylladb/service/raft/raft_group_registry.cc:539:19: note: move occurred here
  539 |     auto dst_id = raft::server_id{std::move(id)};
      |                   ^
```

this is a false alarm. as the type of `id` is actually `utils::UUID` which is a struct enclosing two `int64_t` variables. and we don't define a move constructor for `utils::UUID`. so the value of of `id` is intact after being moved away. but it is still confusing at the first glance, as we are indeed referencing a moved-away variable.

so in order to reduce the confusion and to silence the warning, let's just do not `std::move(id)`.

- [x] cleanup, no need to backport
