### PR TITLE
tools: lua_sstable_consumer.cc: be compatible with Lua 5.3's lua_resu…

### DIFF
--- a/tools/lua_sstable_consumer.cc
+++ b/tools/lua_sstable_consumer.cc
@@ -24,6 +24,14 @@
 #include "types/tuple.hh"
 #include "dht/i_partitioner.hh"
 
+// Lua 5.4 added an extra parameter to lua_resume
+
+#if LUA_VERSION_NUM >= 504
+#    define LUA_504_PLUS(x...) x
+#else
+#    define LUA_504_PLUS(x...)
+#endif
+
 namespace {
 
 class gc_clock_time_point;
@@ -1289,7 +1297,7 @@ private:
         int ret = LUA_YIELD;
         int nresults = 0;
         while (ret == LUA_YIELD) {
-            ret = lua_resume(l, nullptr, nargs, &nresults);
+            ret = lua_resume(l, nullptr, nargs LUA_504_PLUS(, &nresults));
             if (ret == LUA_YIELD) {
                 if (nresults == 0) {
                     co_await coroutine::maybe_yield();


### PR DESCRIPTION
…me()

in Lua 5.3, lua_resume() only accepts three parameters, while in Lua 5.4, this function accepts four parameters. so in order to be compatible with Lua 5.3, we should not pass the 4th parameter to this function. a macro is defined to conditionally pass this parameter based on the Lua's version.

see https://www.lua.org/manual/5.3/manual.html#lua_resume

Refs 5b5b8b3264203d47c1b09e674ee65764651f6de4
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

- [x] ** Backport reason (please explain below if this patch should be backported or not) **

