### PR TITLE
sstables: add dead row count when issuing warning to system.large_partitions

### DIFF
--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -35,14 +35,14 @@ large_data_handler::large_data_handler(uint64_t partition_threshold_bytes, uint6
         partition_threshold_bytes, row_threshold_bytes, cell_threshold_bytes, rows_count_threshold, _collection_elements_count_threshold);
 }
 
-future<large_data_handler::partition_above_threshold> large_data_handler::maybe_record_large_partitions(const sstables::sstable& sst, const sstables::key& key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones) {
+future<large_data_handler::partition_above_threshold> large_data_handler::maybe_record_large_partitions(const sstables::sstable& sst, const sstables::key& key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones, uint64_t dead_rows) {
     assert(running());
     partition_above_threshold above_threshold{partition_size > _partition_threshold_bytes, rows > _rows_count_threshold};
     static_assert(std::is_same_v<decltype(above_threshold.size), bool>);
     _stats.partitions_bigger_than_threshold += above_threshold.size; // increment if true
     if (above_threshold.size || above_threshold.rows) [[unlikely]] {
-        return with_sem([&sst, &key, partition_size, rows, range_tombstones, this] {
-            return record_large_partitions(sst, key, partition_size, rows, range_tombstones);
+        return with_sem([&sst, &key, partition_size, rows, range_tombstones, dead_rows, this] {
+            return record_large_partitions(sst, key, partition_size, rows, range_tombstones, dead_rows);
         }).then([above_threshold] {
             return above_threshold;
         });
@@ -164,8 +164,8 @@ future<> cql_table_large_data_handler::try_record(std::string_view large_table, 
             .finally([ p = _sys_ks ] {});
 }
 
-future<> cql_table_large_data_handler::record_large_partitions(const sstables::sstable& sst, const sstables::key& key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones) const {
-    return try_record("partition", sst, key, int64_t(partition_size), "partition", "", {"rows", "range_tombstones"}, data_value((int64_t)rows), data_value((int64_t)range_tombstones));
+future<> cql_table_large_data_handler::record_large_partitions(const sstables::sstable& sst, const sstables::key& key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones, uint64_t dead_rows) const {
+    return try_record("partition", sst, key, int64_t(partition_size), "partition", "", {"rows", "range_tombstones", "dead_rows"}, data_value((int64_t)rows), data_value((int64_t)range_tombstones), data_value((int64_t)dead_rows));
 }
 
 future<> cql_table_large_data_handler::record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -120,10 +120,19 @@ cql_table_large_data_handler::cql_table_large_data_handler(gms::feature_service&
     , _record_large_cells([this] (const sstables::sstable& sst, const sstables::key& pk, const clustering_key_prefix* ck, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) {
         return internal_record_large_cells(sst, pk, ck, cdef, cell_size, collection_elements);
     })
-    , _feat_listener(_feat.large_collection_detection.when_enabled([this] {
+    , _record_large_partitions([this] (const sstables::sstable& sst, const sstables::key& pk, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones, uint64_t dead_rows) {
+        return internal_record_large_partitions(sst, pk, partition_size, rows);
+    })
+    , _large_collection_detection_listener(_feat.large_collection_detection.when_enabled([this] {
         large_data_logger.debug("Enabled large_collection detection");
         _record_large_cells = [this] (const sstables::sstable& sst, const sstables::key& pk, const clustering_key_prefix* ck, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) {
             return internal_record_large_cells_and_collections(sst, pk, ck, cdef, cell_size, collection_elements);
+        };
+    }))
+    , _range_tombstone_and_dead_rows_detection_listener(_feat.range_tombstone_and_dead_rows_detection.when_enabled([this] {
+        large_data_logger.debug("Enabled detection or range tombstones and dead rows");
+        _record_large_partitions = [this] (const sstables::sstable& sst, const sstables::key& pk, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones, uint64_t dead_rows) {
+            return internal_record_large_partitions_all_data(sst, pk, partition_size, rows, range_tombstones, dead_rows);
         };
     }))
     , _partition_threshold_mb_updater(_partition_threshold_bytes, std::move(partition_threshold_mb), [] (uint32_t threshold_mb) { return uint64_t(threshold_mb) * MB; })
@@ -164,8 +173,20 @@ future<> cql_table_large_data_handler::try_record(std::string_view large_table, 
             .finally([ p = _sys_ks ] {});
 }
 
-future<> cql_table_large_data_handler::record_large_partitions(const sstables::sstable& sst, const sstables::key& key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones, uint64_t dead_rows) const {
-    return try_record("partition", sst, key, int64_t(partition_size), "partition", "", {"rows", "range_tombstones", "dead_rows"}, data_value((int64_t)rows), data_value((int64_t)range_tombstones), data_value((int64_t)dead_rows));
+future<> cql_table_large_data_handler::record_large_partitions(const sstables::sstable& sst, const sstables::key& key,
+        uint64_t partition_size, uint64_t rows, uint64_t range_tombstones, uint64_t dead_rows) const {
+    return _record_large_partitions(sst, key, partition_size, rows, range_tombstones, dead_rows);
+}
+
+future<> cql_table_large_data_handler::internal_record_large_partitions(const sstables::sstable& sst, const sstables::key& key,
+        uint64_t partition_size, uint64_t rows) const {
+    return try_record("partition", sst, key, int64_t(partition_size), "partition", "", {"rows"}, data_value((int64_t)rows));
+}
+
+future<> cql_table_large_data_handler::internal_record_large_partitions_all_data(const sstables::sstable& sst, const sstables::key& key,
+        uint64_t partition_size, uint64_t rows, uint64_t range_tombstones, uint64_t dead_rows) const {
+    return try_record("partition", sst, key, int64_t(partition_size), "partition", "", {"rows", "range_tombstones", "dead_rows"},
+                data_value((int64_t)rows), data_value((int64_t)range_tombstones), data_value((int64_t)dead_rows));
 }
 
 future<> cql_table_large_data_handler::record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -94,7 +94,7 @@ public:
         bool rows = false;
     };
     future<partition_above_threshold> maybe_record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key,
-            uint64_t partition_size, uint64_t rows, uint64_t range_tombstones);
+            uint64_t partition_size, uint64_t rows, uint64_t range_tombstones, uint64_t dead_rows);
 
     future<bool> maybe_record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) {
@@ -139,7 +139,7 @@ protected:
             const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) const = 0;
     virtual future<> record_large_rows(const sstables::sstable& sst, const sstables::key& partition_key, const clustering_key_prefix* clustering_key, uint64_t row_size) const = 0;
     virtual future<> delete_large_data_entries(const schema& s, sstring sstable_name, std::string_view large_table_name) const = 0;
-    virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones) const = 0;
+    virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones, uint64_t dead_rows) const = 0;
 };
 
 class cql_table_large_data_handler : public large_data_handler {
@@ -165,7 +165,7 @@ public:
             utils::updateable_value<uint32_t> collection_elements_count_threshold);
 
 protected:
-    virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones) const override;
+    virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones, uint64_t dead_rows) const override;
     virtual future<> delete_large_data_entries(const schema& s, sstring sstable_name, std::string_view large_table_name) const override;
     virtual future<> record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) const override;
@@ -186,7 +186,7 @@ private:
 class nop_large_data_handler : public large_data_handler {
 public:
     nop_large_data_handler();
-    virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones) const override {
+    virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones, uint64_t dead_rows) const override {
         return make_ready_future<>();
     }
 

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -146,7 +146,10 @@ class cql_table_large_data_handler : public large_data_handler {
     gms::feature_service& _feat;
     std::function<future<> (const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements)> _record_large_cells;
-    std::optional<std::any> _feat_listener;
+    std::function<future<> (const sstables::sstable& sst, const sstables::key& partition_key,
+            uint64_t partition_size, uint64_t rows, uint64_t range_tombstones, uint64_t dead_rows)> _record_large_partitions;
+    std::optional<std::any> _large_collection_detection_listener;
+    std::optional<std::any> _range_tombstone_and_dead_rows_detection_listener;
 
     static constexpr uint64_t MB = 1024 * 1024;
 
@@ -176,6 +179,9 @@ private:
             const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) const;
     future<> internal_record_large_cells_and_collections(const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) const;
+    future<> internal_record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows) const;
+    future<> internal_record_large_partitions_all_data(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows,
+            uint64_t dead_rows, uint64_t range_tombstones) const;
 
 private:
     template <typename... Args>

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -668,7 +668,8 @@ schema_ptr system_keyspace::size_estimates() {
         {
             {"rows", long_type},
             {"compaction_time", timestamp_type},
-            {"range_tombstones", long_type}
+            {"range_tombstones", long_type},
+            {"dead_rows", long_type}
         },
         // static columns
         {},

--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -33,6 +33,7 @@ CREATE TABLE system.large_partitions (
     partition_size bigint,
     partition_key text,
     range_tombstones bigint,
+    dead_rows bigint,
     rows bigint,
     compaction_time timestamp,
     PRIMARY KEY ((keyspace_name, table_name), sstable_name, partition_size, partition_key)

--- a/docs/troubleshooting/large-partition-table.rst
+++ b/docs/troubleshooting/large-partition-table.rst
@@ -31,10 +31,10 @@ Example output:
 
 .. code-block:: console
 
-   keyspace_name | table_name | sstable_name     | partition_size | partition_key                                       | range_tombstones | rows   | compaction_time     
-   --------------+------------+------------------+----------------+-----------------------------------------------------+------------------+--------+---------------------
-          demodb |       tmcr | md-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} |                0 |    100 | 2018-07-23 08:10:34 
-          testdb |       tmcr | md-7-big-Data.db |        1234567 | {key: pk{000400000001}, token:-3169959284402457813} |                0 | 100101 | 2018-07-23 08:10:34 
+   keyspace_name | table_name | sstable_name     | partition_size | partition_key                                       | compaction_time     | dead_rows | range_tombstones | rows
+   --------------+------------+------------------+----------------+-----------------------------------------------------+---------------------+-----------+------------------+--------
+          demodb |       tmcr | md-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} | 2018-07-23 08:10:34 |         0 |                0 |    100
+          testdb |       tmcr | md-7-big-Data.db |        1234567 | {key: pk{000400000001}, token:-3169959284402457813} | 2018-07-23 08:10:34 |         0 |                0 | 100101
   
 ================================================  =================================================================================
 Parameter                                         Description
@@ -48,6 +48,8 @@ sstable_name                                      The name of SSTable containing
 partition_size                                    The size of the partition in this sstable
 ------------------------------------------------  ---------------------------------------------------------------------------------
 partition_key                                     The value of a partition key that identifies the large partition
+------------------------------------------------  ---------------------------------------------------------------------------------
+dead_rows                                         The number of dead rows in the partition in this sstable
 ------------------------------------------------  ---------------------------------------------------------------------------------
 range_tombstones                                  The number of range tombstones in the partition in this sstable
 ------------------------------------------------  ---------------------------------------------------------------------------------
@@ -73,9 +75,9 @@ Example output:
 
 .. code-block:: console
 
-   keyspace_name | table_name | sstable_name     | partition_size | partition_key                                       | range_tombstones | rows | compaction_time
-   --------------+------------+------------------+----------------+-----------------------------------------------------+------------------+------+---------------------
-          demodb |       tmcr | md-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} |                0 | 1942 | 2018-07-23 08:10:34
+   keyspace_name | table_name | sstable_name     | partition_size | partition_key                                       | compaction_time     | dead_rows | range_tombstones | rows
+   --------------+------------+------------------+----------------+-----------------------------------------------------+---------------------+-----------+------------------+------
+          demodb |       tmcr | md-6-big-Data.db |     1188716932 | {key: pk{000400000001}, token:-4069959284402364209} | 2018-07-23 08:10:34 |         0 |                0 | 1942
 
 
 .. _large-partition-table-configure:
@@ -111,9 +113,10 @@ Large partitions are stored in a system table with the following schema:
        sstable_name text,
        partition_size bigint,
        partition_key text,
-       rows bigint,
-       range_tombstones bigint,
        compaction_time timestamp,
+       dead_rows bigint,
+       range_tombstones bigint,
+       rows bigint,
        PRIMARY KEY ((keyspace_name, table_name), sstable_name, partition_size, partition_key)
    ) WITH CLUSTERING ORDER BY (sstable_name ASC, partition_size DESC, partition_key ASC)
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -124,6 +124,7 @@ public:
     gms::feature aggregate_storage_options { *this, "AGGREGATE_STORAGE_OPTIONS"sv };
     gms::feature collection_indexing { *this, "COLLECTION_INDEXING"sv };
     gms::feature large_collection_detection { *this, "LARGE_COLLECTION_DETECTION"sv };
+    gms::feature range_tombstone_and_dead_rows_detection { *this, "RANGE_TOMBSTONE_AND_DEAD_ROWS_DETECTION"sv };
     gms::feature secondary_indexes_on_static_columns { *this, "SECONDARY_INDEXES_ON_STATIC_COLUMNS"sv };
     gms::feature tablets { *this, "TABLETS"sv };
     gms::feature uuid_sstable_identifiers { *this, "UUID_SSTABLE_IDENTIFIERS"sv };

--- a/sstables/metadata_collector.hh
+++ b/sstables/metadata_collector.hh
@@ -35,6 +35,8 @@ struct column_stats {
     uint64_t rows_count;
     /** how many range tombstones are there in the partition */
     uint64_t range_tombstones_count;
+    /** how many dead rows are there in the partition */
+    uint64_t dead_rows_count;
 
     uint64_t start_offset;
     uint64_t partition_size;
@@ -54,6 +56,7 @@ struct column_stats {
         column_count(0),
         rows_count(0),
         range_tombstones_count(0),
+        dead_rows_count(0),
         start_offset(0),
         partition_size(0),
         tombstone_histogram(TOMBSTONE_HISTOGRAM_BIN_SIZE),

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -688,7 +688,7 @@ private:
         std::optional<gc_clock::time_point> local_deletion_time;
     };
 
-    void maybe_record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones);
+    void maybe_record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones, uint64_t dead_rows);
     void maybe_record_large_rows(const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, const uint64_t row_size);
     void maybe_record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
@@ -969,12 +969,12 @@ void writer::consume(tombstone t) {
 }
 
 void writer::maybe_record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key,
-                                           uint64_t partition_size, uint64_t rows, uint64_t range_rombstones) {
+                                           uint64_t partition_size, uint64_t rows, uint64_t range_rombstones, uint64_t dead_rows) {
     auto& size_entry = _partition_size_entry;
     auto& row_count_entry = _rows_in_partition_entry;
     size_entry.max_value = std::max(size_entry.max_value, partition_size);
     row_count_entry.max_value = std::max(row_count_entry.max_value, rows);
-    auto ret = _sst.get_large_data_handler().maybe_record_large_partitions(sst, partition_key, partition_size, rows, range_rombstones).get();
+    auto ret = _sst.get_large_data_handler().maybe_record_large_partitions(sst, partition_key, partition_size, rows, range_rombstones, dead_rows).get();
     size_entry.above_threshold += unsigned(bool(ret.size));
     row_count_entry.above_threshold += unsigned(bool(ret.rows));
 }
@@ -1436,7 +1436,7 @@ stop_iteration writer::consume_end_of_partition() {
     // compute size of the current row.
     _c_stats.partition_size = _data_writer->offset() - _c_stats.start_offset;
 
-    maybe_record_large_partitions(_sst, *_partition_key, _c_stats.partition_size, _c_stats.rows_count, _c_stats.range_tombstones_count);
+    maybe_record_large_partitions(_sst, *_partition_key, _c_stats.partition_size, _c_stats.rows_count, _c_stats.range_tombstones_count, _c_stats.dead_rows_count);
 
     // update is about merging column_stats with the data being stored by collector.
     _collector.update(std::move(_c_stats));

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5112,8 +5112,8 @@ struct large_row_handler : public db::large_data_handler {
         return make_ready_future<>();
     }
 
-    virtual future<> record_large_partitions(const sstables::sstable& sst,
-        const sstables::key& partition_key, uint64_t partition_size, uint64_t rows_count, uint64_t range_tombstones_count) const override {
+    virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key,
+            uint64_t partition_size, uint64_t rows_count, uint64_t range_tombstones_count, uint64_t dead_rows_count) const override {
         const schema_ptr s = sst.get_schema();
         callback(*s, partition_key, nullptr, rows_count, range_tombstones_count, nullptr, 0, 0);
         return make_ready_future<>();

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5087,7 +5087,7 @@ SEASTAR_TEST_CASE(test_sstable_reader_on_unknown_column) {
 namespace {
 struct large_row_handler : public db::large_data_handler {
     using callback_t = std::function<void(const schema& s, const sstables::key& partition_key,
-            const clustering_key_prefix* clustering_key, uint64_t row_size, uint64_t range_tombstones,
+            const clustering_key_prefix* clustering_key, uint64_t row_size, uint64_t range_tombstones, uint64_t dead_rows,
             const column_definition* cdef, uint64_t cell_size, uint64_t collection_elements)>;
     callback_t callback;
 
@@ -5101,21 +5101,21 @@ struct large_row_handler : public db::large_data_handler {
     virtual future<> record_large_rows(const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, uint64_t row_size) const override {
         const schema_ptr s = sst.get_schema();
-        callback(*s, partition_key, clustering_key, row_size, 0, nullptr, 0, 0);
+        callback(*s, partition_key, clustering_key, row_size, 0, 0, nullptr, 0, 0);
         return make_ready_future<>();
     }
 
     virtual future<> record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
         const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) const override {
         const schema_ptr s = sst.get_schema();
-        callback(*s, partition_key, clustering_key, 0, 0, &cdef, cell_size, collection_elements);
+        callback(*s, partition_key, clustering_key, 0, 0, 0, &cdef, cell_size, collection_elements);
         return make_ready_future<>();
     }
 
     virtual future<> record_large_partitions(const sstables::sstable& sst, const sstables::key& partition_key,
             uint64_t partition_size, uint64_t rows_count, uint64_t range_tombstones_count, uint64_t dead_rows_count) const override {
         const schema_ptr s = sst.get_schema();
-        callback(*s, partition_key, nullptr, rows_count, range_tombstones_count, nullptr, 0, 0);
+        callback(*s, partition_key, nullptr, rows_count, range_tombstones_count, dead_rows_count, nullptr, 0, 0);
         return make_ready_future<>();
     }
 
@@ -5129,11 +5129,13 @@ static void test_sstable_write_large_row_f(schema_ptr s, reader_permit permit, r
         std::vector<clustering_key*> expected, uint64_t threshold, sstables::sstable_version_types version) {
     unsigned i = 0;
     auto f = [&i, &expected, &pk, &threshold](const schema& s, const sstables::key& partition_key,
-                     const clustering_key_prefix* clustering_key, uint64_t row_size, uint64_t range_tombstones,
+                     const clustering_key_prefix* clustering_key, uint64_t row_size, uint64_t range_tombstones, uint64_t dead_rows,
                      const column_definition* cdef, uint64_t cell_size, uint64_t collection_elements) {
         BOOST_REQUIRE_EQUAL(pk.components(s), partition_key.to_partition_key(s).components(s));
         BOOST_REQUIRE_LT(i, expected.size());
         BOOST_REQUIRE_GT(row_size, threshold);
+        BOOST_REQUIRE_EQUAL(range_tombstones, 0);
+        BOOST_REQUIRE_EQUAL(dead_rows, 0);
 
         if (clustering_key) {
             BOOST_REQUIRE(expected[i]->equal(s, *clustering_key));
@@ -5180,12 +5182,14 @@ static void test_sstable_write_large_cell_f(schema_ptr s, reader_permit permit, 
         std::vector<clustering_key*> expected, uint64_t threshold, sstables::sstable_version_types version) {
     unsigned i = 0;
     auto f = [&i, &expected, &pk, &threshold](const schema& s, const sstables::key& partition_key,
-                     const clustering_key_prefix* clustering_key, uint64_t row_size, uint64_t range_tombstones,
+                     const clustering_key_prefix* clustering_key, uint64_t row_size, uint64_t range_tombstones, uint64_t dead_rows,
                      const column_definition* cdef, uint64_t cell_size, uint64_t collection_elements) {
         BOOST_TEST_MESSAGE(format("i={} ck={} cell_size={} threshold={}", i, clustering_key ? format("{}", *clustering_key) : "null", cell_size, threshold));
         BOOST_REQUIRE_EQUAL(pk.components(s), partition_key.to_partition_key(s).components(s));
         BOOST_REQUIRE_LT(i, expected.size());
         BOOST_REQUIRE_GT(cell_size, threshold);
+        BOOST_REQUIRE_EQUAL(range_tombstones, 0);
+        BOOST_REQUIRE_EQUAL(dead_rows, 0);
 
         if (clustering_key) {
             BOOST_REQUIRE(expected[i]->equal(s, *clustering_key));
@@ -5247,10 +5251,11 @@ static void test_sstable_log_too_many_rows_f(int rows, int range_tombstones, uin
 
     bool logged = false;
     auto f = [&logged, &pk, &threshold, &rows, &range_tombstones](const schema& sc, const sstables::key& partition_key,
-                     const clustering_key_prefix* clustering_key, uint64_t rows_count, uint64_t range_tombstones_count,
+                     const clustering_key_prefix* clustering_key, uint64_t rows_count, uint64_t range_tombstones_count, uint64_t dead_rows,
                      const column_definition* cdef, uint64_t cell_size, uint64_t collection_elements) {
         BOOST_REQUIRE_GT(rows_count, threshold);
         BOOST_REQUIRE_EQUAL(pk.components(sc), partition_key.to_partition_key(sc).components(sc));
+        BOOST_REQUIRE_EQUAL(dead_rows, 0);
 
         // Inserting one range tombstone creates two range tombstone marker rows
         BOOST_REQUIRE_EQUAL(rows_count, rows + range_tombstones * 2);
@@ -5289,6 +5294,115 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_log_too_many_rows) {
 }
 
 
+static void test_sstable_log_too_many_dead_rows_f(int rows, uint64_t threshold, bool expected, sstable_version_types version) {
+    simple_schema s;
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    mutation p = s.new_mutation("pv");
+    const partition_key& pk = p.key();
+    sstring sv;
+    int live_rows = 0;
+    int expected_dead_rows = 0;
+    int expected_expired_rows = 0;
+    int expected_rows_with_dead_cell = 0;
+    int expected_range_tombstones = 0;
+    while (live_rows + expected_dead_rows + expected_expired_rows + expected_rows_with_dead_cell + expected_range_tombstones < rows - 1) {
+        sv += "X";
+        auto ck = s.make_ckey(sv);
+        switch (tests::random::get_int(0, 4)) {
+        case 0:
+            // regular row
+            s.add_row(p, ck, sv);
+            ++live_rows;
+            testlog.debug("added live row: {}", ck);
+            break;
+        case 1: {
+            // dead (deleted) row
+            auto& row = p.partition().clustered_row(*s.schema(), ck);
+            row.apply(row_marker(s.new_tombstone()));
+            testlog.debug("added dead row: {}", ck);
+            ++expected_dead_rows;
+            break;
+        }
+        case 2: {
+            // dead (expired) row
+            auto& row = p.partition().clustered_row(*s.schema(), ck);
+            row.apply(row_marker(s.new_timestamp(), gc_clock::duration(1), gc_clock::now()));
+            testlog.debug("added expired row: {}", ck);
+            ++expected_expired_rows;
+            break;
+        }
+        case 3: {
+            // row with dead cell
+            s.add_row_with_dead_cell(p, ck);
+            ++expected_rows_with_dead_cell;
+            testlog.debug("added row with dead cell: {}", ck);
+            break;
+        }
+        case 4: {
+            // multi-row range tombstone
+            if (live_rows + expected_dead_rows + expected_rows_with_dead_cell + expected_expired_rows + expected_range_tombstones + 2 >= rows - 1) {
+                continue;
+            }
+            auto ck_start = ck;
+            auto rt_start = bound_view(ck_start, tests::random::get_bool() ? bound_kind::incl_start : bound_kind::excl_start);
+            auto sv_end = sv;
+            auto rt_size = tests::random::get_int(1, 10);
+            for (auto i = 0; i < rt_size; i++) {
+                sv += "X";
+            }
+            auto ck_end = s.make_ckey(sv);
+            auto rt_end = bound_view(ck_end, tests::random::get_bool() ? bound_kind::excl_end : bound_kind::incl_end);
+            auto rt = range_tombstone(rt_start, rt_end, s.new_tombstone());
+            testlog.debug("added range tombstone: {}", rt);
+            p.partition().apply_delete(*s.schema(), std::move(rt));
+            expected_range_tombstones += 2;
+            break;
+        }
+        }
+    }
+    schema_ptr sc = s.schema();
+    auto mt = make_lw_shared<replica::memtable>(sc);
+    mt->apply(p);
+
+    bool logged = false;
+    auto f = [&] (const schema& sc, const sstables::key& partition_key,
+                     const clustering_key_prefix* clustering_key, uint64_t rows_count, uint64_t range_tombstones, uint64_t dead_rows,
+                     const column_definition* cdef, uint64_t cell_size, uint64_t collection_elements) {
+        BOOST_REQUIRE_GT(rows_count, threshold);
+        BOOST_REQUIRE_EQUAL(rows_count, rows);
+        BOOST_REQUIRE_EQUAL(dead_rows, expected_dead_rows + expected_expired_rows + expected_rows_with_dead_cell);
+        BOOST_REQUIRE_EQUAL(range_tombstones, expected_range_tombstones);
+        BOOST_REQUIRE_EQUAL(pk.components(sc), partition_key.to_partition_key(sc).components(sc));
+        logged = true;
+    };
+
+    large_row_handler handler(std::numeric_limits<uint64_t>::max(), threshold, std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(), f);
+
+    sstables::test_env::do_with_async([&] (auto& env) {
+        auto sst = env.make_sstable(sc, version);
+        sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
+
+        BOOST_REQUIRE_EQUAL(logged, expected);
+    }, { &handler }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_sstable_log_too_many_dead_rows) {
+    // Generates a pseudo-random number from 1 to 100
+    uint64_t random = tests::random::get_int(1, 100);
+
+    // This test creates a sstable with a given number of rows and test it against a
+    // compaction_rows_count_warning_threshold. A warning is triggered when the number of rows
+    // exceeds the threshold.
+    for (auto version : test_sstable_versions) {
+        test_sstable_log_too_many_dead_rows_f(random, 0, true, version);
+        test_sstable_log_too_many_dead_rows_f(random, (random - 1), true, version);
+        test_sstable_log_too_many_dead_rows_f(random, random, false, version);
+        test_sstable_log_too_many_dead_rows_f(random, (random + 1), false, version);
+        test_sstable_log_too_many_dead_rows_f((random + 1), random, true, version);
+    }
+}
+
+
 static void test_sstable_too_many_collection_elements_f(int elements, uint64_t threshold, bool expected, sstable_version_types version) {
     simple_schema s(simple_schema::with_static::no, simple_schema::with_collection::yes);
     tests::reader_concurrency_semaphore_wrapper semaphore;
@@ -5304,10 +5418,12 @@ static void test_sstable_too_many_collection_elements_f(int elements, uint64_t t
 
     bool logged = false;
     auto f = [&logged, &pk, &threshold](const schema& sc, const sstables::key& partition_key,
-                     const clustering_key_prefix* clustering_key, uint64_t rows_count, uint64_t range_tombstones,
+                     const clustering_key_prefix* clustering_key, uint64_t rows_count, uint64_t range_tombstones, uint64_t dead_rows,
                      const column_definition* cdef, uint64_t cell_size, uint64_t collection_elements) {
         BOOST_REQUIRE_GT(collection_elements, threshold);
         BOOST_REQUIRE_EQUAL(pk.components(sc), partition_key.to_partition_key(sc).components(sc));
+        BOOST_REQUIRE_EQUAL(range_tombstones, 0);
+        BOOST_REQUIRE_EQUAL(dead_rows, 0);
         logged = true;
     };
 

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -134,6 +134,16 @@ public:
         return t;
     }
 
+    api::timestamp_type add_row_with_dead_cell(mutation& m, const clustering_key& key,
+            api::timestamp_type t = api::missing_timestamp, gc_clock::time_point deletion_time = gc_clock::now()) {
+        if (t == api::missing_timestamp) {
+            t = new_timestamp();
+        }
+        const column_definition& v_def = get_v_def(*_s);
+        m.set_clustered_cell(key, v_def, atomic_cell::make_dead(t, deletion_time));
+        return t;
+    }
+
     api::timestamp_type add_row_with_collection(mutation& m, const clustering_key& ck, const std::map<bytes, bytes>& kv_map, api::timestamp_type t = api::missing_timestamp) {
         if (t == api::missing_timestamp) {
             t = new_timestamp();


### PR DESCRIPTION
This is the second half of the fix for issue #13968. The first half is already merged with PR #18346

Scylla issues warnings for partitions containing more rows than a configured threshold. The warning is issued by inserting a row into the `system.large_partitions` table. This row contains the information about the partition for which the warning is issued: keyspace, table, sstable, partition key and size, compaction time and the number of rows in the partition. A previous PR #18346 also added range tombstone count to this row.

This change adds a new counter for dead rows to the large_partitions table.

This change also adds cluster feature protection for writing into these new counters. This is needed in case a cluster is in the process of being upgraded to this new version, after which an upgraded node writes data with the new schema into `system.large_partitions`, and finally a node is then rolled back to an old version. This node will then revert the schema to the old version, but the written sstables will still contain data with the new counters, causing any readers of this table to throw errors when they encounter these cells.

This is an enhancement, and backporting is not needed.

Fixes #13968