### PR TITLE
reloc: create $BUILDDIR for getting its path

### DIFF
--- a/reloc/build_rpm.sh
+++ b/reloc/build_rpm.sh
@@ -45,8 +45,8 @@ if [ ! -e $RELOC_PKG ]; then
     exit 1
 fi
 RELOC_PKG=$(readlink -f $RELOC_PKG)
-RPMBUILD=$(readlink -f $BUILDDIR)
 mkdir -p $BUILDDIR/
+RPMBUILD=$(readlink -f $BUILDDIR)
 tar -C $BUILDDIR/ -xpf $RELOC_PKG scylla/SCYLLA-RELOCATABLE-FILE scylla/SCYLLA-RELEASE-FILE scylla/SCYLLA-VERSION-FILE scylla/SCYLLA-PRODUCT-FILE scylla/dist/redhat
 cd $BUILDDIR/scylla
 


### PR DESCRIPTION
when building with CMake, there is a use case where the $BUILDIR is not created yet, when `reloc/build_rpm.sh` is launched. in order to enable us to run this script without creating $BUILDIR first, let's create this directory first.

- [x] cmake related change, no need to backport

