### PR TITLE
cql/describe: hide cdc log tables

### DIFF
--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -1002,6 +1002,24 @@ std::ostream& schema::schema_properties(replica::database& db, std::ostream& os)
     return os;
 }
 
+std::ostream& schema::describe_alter_with_properties(replica::database& db, std::ostream& os) const {
+    os << "ALTER "; 
+    if (is_view()) {
+        if (is_index(db, view_info()->base_id(), *this)) {
+            on_internal_error(dblog, "ALTER statement is not supported for index");
+        }
+        
+        os << "MATERIALIZED VIEW ";
+    } else {
+        os << "TABLE ";
+    }
+    os << cql3::util::maybe_quote(ks_name()) << "." << cql3::util::maybe_quote(cf_name()) << " WITH ";
+    schema_properties(db, os);
+    os << ";\n";
+
+    return os;
+}
+
 const sstring&
 column_definition::name_as_text() const {
     return column_specification->name->text();

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -934,6 +934,9 @@ public:
      * (and `ALTER ADD` if the column has been re-added) to the description.
      */
     virtual std::ostream& describe(replica::database& db, std::ostream& os, bool with_internals) const override;
+    // Generate ALTER TABLE/MATERIALIZED VIEW statement containing all properties with current values.
+    // The method cannot be used on index, as indexes don't support alter statement.
+    std::ostream& describe_alter_with_properties(replica::database& db, std::ostream& os) const;
     friend bool operator==(const schema&, const schema&);
     const column_mapping& get_column_mapping() const;
     friend class schema_registry_entry;

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -948,6 +948,9 @@ public:
     bool wait_for_sync_to_commitlog() const {
         return _static_props.wait_for_sync_to_commitlog;
     }
+private:
+    // Print all schema properties in CQL syntax
+    std::ostream& schema_properties(replica::database& db, std::ostream& os) const;
 public:
     const v3_columns& v3() const {
         return _v3_columns;


### PR DESCRIPTION
Currently all tables are printed in statements like `DESC TABLES`, `DESC KEYSPACE ks` or `DESC SCHEMA`.
But when we create a table with cdc enabled, additional table with `_scylla_cdc_log` suffix is created.
Those tables shouldn't be recreated manually but created automatically when the base table is created.

This patch hides tables with `_scylla_cdc_log` suffix in all describe statements.
To preserve properties values of those tables, `ALTER TABLE` statement with all properties and their current values for log cdc table is added to description of the base table.

Fixes #18459