### PR TITLE
tools/scylla-nodetool: implement the resetlocalschema command

### DIFF
--- a/test/nodetool/test_resetlocalschema.py
+++ b/test/nodetool/test_resetlocalschema.py
@@ -1,0 +1,12 @@
+#
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from rest_api_mock import expected_request
+
+
+def test_resetlocalschema(nodetool):
+    nodetool("resetlocalschema", expected_requests=[
+        expected_request("POST", "/storage_service/relocal_schema")])

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -655,6 +655,10 @@ void decommission_operation(scylla_rest_client& client, const bpo::variables_map
     client.post("/storage_service/decommission");
 }
 
+void resetlocalschema_operation(scylla_rest_client& client, const bpo::variables_map&) {
+    client.post("/storage_service/relocal_schema");
+}
+
 void describering_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     if (!vm.contains("keyspace")) {
         throw std::invalid_argument("keyspace must be specified");
@@ -3341,6 +3345,18 @@ For more information, see: https://opensource.docs.scylladb.com/stable/operating
                 },
             },
             repair_operation
+        },
+        {
+            {
+                "resetlocalschema",
+                "Reset node's local schema and resync",
+R"(
+For more information, see: https://opensource.docs.scylladb.com/stable/operating-scylla/nodetool-commands/resetlocalschema.html
+)",
+                { },
+                { },
+            },
+            resetlocalschema_operation
         },
         {
             {


### PR DESCRIPTION
Fixes #18468
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

- [x] nodetool is a new feature in 5.5, no need to backport
