### PR TITLE
commitlog: Handle oversized entries (partially)

### DIFF
--- a/db/commitlog/commitlog_entry.hh
+++ b/db/commitlog/commitlog_entry.hh
@@ -100,8 +100,9 @@ public:
     {}
 
     void set_with_schema(bool value) {
-        _with_schema = value;
-        compute_size();
+        if (std::exchange(_with_schema, value) != value || _size == std::numeric_limits<size_t>::max()) {
+            compute_size();
+        }
     }
     bool with_schema() const {
         return _with_schema;

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -1705,3 +1705,140 @@ SEASTAR_TEST_CASE(test_wait_for_delete) {
     co_await log.shutdown();
     co_await log.clear();
 }
+
+/**
+ * Test allocating oversized multi-entry
+*/
+static future<> do_test_oversized_entry(size_t max_size_mb) {
+    commitlog::config cfg;
+
+    cfg.commitlog_segment_size_in_mb = max_size_mb;
+    cfg.commitlog_total_space_in_mb = 8 * max_size_mb * smp::count;
+    cfg.allow_going_over_size_limit = false;
+    cfg.use_o_dsync = false; 
+
+    // not using cl_test, because we need to be able to abandon
+    // the log.
+    tmpdir tmp;
+    cfg.commit_log_location = tmp.path().string();
+    std::unordered_map<replay_position, frozen_mutation> rp2mut;
+    random_mutation_generator gen(random_mutation_generator::generate_counters(false));
+
+    {
+        auto log = co_await commitlog::create_commitlog(cfg);
+        auto size = log.max_record_size() * 2;
+
+        std::vector<commitlog_entry_writer> writers;
+        std::vector<frozen_mutation> mutations;
+
+        size_t tot = 0; 
+        // generate a bunch of mutation until we have more data than allowed.
+        while (tot <= size) {
+            mutations.emplace_back(gen(1).front());
+            tot += mutations.back().representation().size();
+        }
+        for (auto& fm : mutations) {
+            writers.emplace_back(gen.schema(), fm, commitlog::force_sync::no);
+        }
+
+        // this will create an oversized entry set.
+        auto res = co_await log.add_entries(writers, db::timeout_clock::now() + 60s);
+
+        auto i = mutations.begin();
+        for (auto& h : res) {
+            rp2mut.emplace(h.release(), *i++);
+        }
+        co_await log.sync_all_segments();
+        // as if we crashed -> segment left on disk
+        co_await log.release();
+        co_await log.shutdown();
+    }
+
+    // new log, for replay.
+    auto log = co_await commitlog::create_commitlog(cfg);
+    std::exception_ptr e;
+    size_t n = 0;
+
+    auto replay_set = co_await log.get_segments_to_replay();
+    // Now replay the old commitlog and ensure we match all data.
+    for (auto& f : replay_set) {
+        co_await commitlog::read_log_file(f, cfg.fname_prefix, [&](commitlog::buffer_and_replay_position buf_rp) -> future<> {
+            auto&& buf = buf_rp.buffer;
+            auto&& rp = buf_rp.position;
+
+            BOOST_CHECK(rp2mut.count(rp));
+            commitlog_entry_reader cer(buf);
+            auto& fm = cer.mutation();
+            auto m1 = fm.unfreeze(gen.schema());
+            auto m2 = rp2mut.at(rp).unfreeze(gen.schema());
+
+            BOOST_CHECK_EQUAL(m1, m2);
+            ++n;
+            co_return;
+        });
+    }
+
+    BOOST_CHECK_EQUAL(n, rp2mut.size());
+
+    co_await log.shutdown();
+    co_await log.clear();
+}
+
+SEASTAR_TEST_CASE(test_oversized_entry_small) {
+    co_await do_test_oversized_entry(1); // small segments
+}
+
+SEASTAR_TEST_CASE(test_oversized_entry_normal) {
+    co_await do_test_oversized_entry(32); // normal segments
+}
+
+SEASTAR_TEST_CASE(test_oversized_entry_large) {
+    co_await do_test_oversized_entry(32*3); // bigger segments
+}
+
+SEASTAR_TEST_CASE(test_oversized_entry_failure) {
+    commitlog::config cfg;
+
+    constexpr auto max_size_mb = 1;
+    cfg.commitlog_segment_size_in_mb = max_size_mb;
+    cfg.commitlog_total_space_in_mb = 8 * max_size_mb * smp::count;
+    cfg.allow_going_over_size_limit = false;
+    cfg.use_o_dsync = false; 
+
+    // not using cl_test, because we need to be able to abandon
+    // the log.
+    tmpdir tmp;
+    cfg.commit_log_location = tmp.path().string();
+    std::unordered_map<replay_position, frozen_mutation> rp2mut;
+    random_mutation_generator gen(random_mutation_generator::generate_counters(false));
+
+    auto log = co_await commitlog::create_commitlog(cfg);
+    auto size = log.max_record_size() * 2;
+
+    std::vector<commitlog_entry_writer> writers;
+    std::vector<frozen_mutation> mutations;
+
+    size_t tot = 0; 
+    // generate a bunch of mutation until we have more data than allowed.
+    while (tot <= size) {
+        mutations.emplace_back(gen(1).front());
+        tot += mutations.back().representation().size();
+    }
+    for (auto& fm : mutations) {
+        writers.emplace_back(gen.schema(), fm, commitlog::force_sync::no);
+    }
+
+    BOOST_REQUIRE_THROW(
+        for (;;) {
+            // this will create an oversized entry set.
+            auto res = co_await log.add_entries(writers, db::timeout_clock::now() + 2s);
+            for (auto& h : res) {
+                h.release(); // no freeing for you
+            }
+        }
+        , std::exception
+    );
+
+    co_await log.shutdown();
+    co_await log.clear();
+}


### PR DESCRIPTION
Refs #18161

Yet another approach to dealing with large commitlog submissions. This approach does not change any file format or file distribution. It only handles cases where the oversized write is actually a multi- write of N entries, where each sub-entry does in fact fit into a segment.

This does not change any rules on size limits.
However, oversized multi-allocs are automatically accepted if we can fit them using new tactics. This might break some dtest(?)

If an allocation is to large, we attempt a slow path, where we effectively lock out all other writers, and write each entry in turn, potentially to different chunks/segments.

To ensure "atomicity" we both force syncronization, and should the whole op fail, we restore segment state (rewinding), thus discarding data all we wrote.

Replaying will pick up entries in order, though, same as "normal" path, entries could be lost due to file corruption.


