### PR TITLE
dist: stop installing scylla-tools, scylla-jmx by default

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -51,9 +51,6 @@ Package: %{product}
 Section: metapackages
 Architecture: any
 Depends: %{product}-server (= ${binary:Version})
- , %{product}-jmx (= ${binary:Version})
- , %{product}-tools (= ${binary:Version})
- , %{product}-tools-core (= ${binary:Version})
  , %{product}-kernel-conf (= ${binary:Version})
  , %{product}-node-exporter (= ${binary:Version})
  , %{product}-cqlsh (= ${binary:Version})

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -11,9 +11,6 @@ Requires:       %{product}-server = %{version}-%{release}
 Requires:       %{product}-conf = %{version}-%{release}
 Requires:       %{product}-python3 = %{version}-%{release}
 Requires:       %{product}-kernel-conf = %{version}-%{release}
-Requires:       %{product}-jmx = %{version}-%{release}
-Requires:       %{product}-tools = %{version}-%{release}
-Requires:       %{product}-tools-core = %{version}-%{release}
 Requires:       %{product}-node-exporter = %{version}-%{release}
 Requires:       %{product}-cqlsh = %{version}-%{release}
 Obsoletes:      scylla-server < 1.1
@@ -36,7 +33,7 @@ Obsoletes:      scylla-server < 1.1
 Scylla is a highly scalable, eventually consistent, distributed,
 partitioned row DB.
 This package installs all required packages for ScyllaDB,  including
-%{product}-server, %{product}-jmx, %{product}-tools, %{product}-tools-core %{product}-node-exporter.
+%{product}-server, %{product}-node-exporter.
 
 # this is needed to prevent python compilation error on CentOS (#2235)
 %if 0%{?rhel}


### PR DESCRIPTION
Since we added native nodetool, we no longer need to install scylla-tools and scylla-jmx, drop them from scylla metapackage and make it optional package.

On unified package, since it does not have dependencies definition, just dropped scylla-tools and scylla-jmx instead.
Users who still want to install tools and jmx will need to use separated tar.gz packages.

Closes #18472

- [ ] ** Backport reason (please explain below if this patch should be backported or not) **

