### PR TITLE
scylla_setup: Remove jmx and tools packages from being verified

### DIFF
--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -336,8 +336,6 @@ if __name__ == '__main__':
         verify_package = interactive_ask_service('Do you want to verify the ScyllaDB packages are installed?', 'Yes - runs a script to confirm that ScyllaDB is installed. No - skips the installation check.', verify_package)
         args.no_verify_package = not verify_package
         if verify_package:
-            do_verify_package_and_exit(f'{PRODUCT}-jmx')
-            do_verify_package_and_exit(f'{PRODUCT}-tools')
             do_verify_package_and_exit(f'{PRODUCT}-node-exporter')
 
     enable_service = interactive_ask_service('Do you want the Scylla server service to automatically start when the Scylla node boots?', 'Yes - Scylla server service automatically starts on Scylla node boot. No - skips this step. Note you will have to start the Scylla Server service manually.', enable_service)


### PR DESCRIPTION
Following https://github.com/scylladb/scylladb/commit/b8634fb244ab08c2ffa66700745b06e21ee57f30 machine image started to fail with the following error:
```
10:44:59  ␛[0;32m    googlecompute.gce: scylla-jmx package is not installed.␛[0m
10:44:59  ␛[1;31m==> googlecompute.gce: Traceback (most recent call last):␛[0m
10:44:59  ␛[1;31m==> googlecompute.gce:   File "/home/ubuntu/scylla_install_image", line 135, in <module>␛[0m
10:44:59  ␛[1;31m==> googlecompute.gce:     run('/opt/scylladb/scripts/scylla_setup --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-ec2-check --no-swap-setup --no-cpuscaling-setup --no-ntp-setup', shell=True, check=True)␛[0m
10:44:59  ␛[1;31m==> googlecompute.gce:   File "/usr/lib/python3.10/subprocess.py", line 526, in run␛[0m
10:44:59  ␛[1;31m==> googlecompute.gce:     raise CalledProcessError(retcode, process.args,␛[0m
10:44:59  ␛[1;31m==> googlecompute.gce: subprocess.CalledProcessError: Command '/opt/scylladb/scripts/scylla_setup --no-coredump-setup --no-sysconfig-setup --no-raid-setup --no-io-setup --no-ec2-check --no-swap-setup --no-cpuscaling-setup --no-ntp-setup' returned non-zero exit status 1.␛[0m
```

It seems we no longer need to verify that jmx and tools-java packages are installed.

- [x] ** Backport reason (please explain below if this patch should be backported or not) **
This is a new change relevant to 6.0 and above, no need for backport

