### PR TITLE
tasks: use default task_ttl in scylla.yaml

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -559,7 +559,7 @@ murmur3_partitioner_ignore_msb_bits: 12
 # enable_parallelized_aggregation: true
 
 # Time for which task manager task is kept in memory after it completes.
-task_ttl_in_seconds: 10
+# task_ttl_in_seconds: 0
 
 # In materialized views, restrictions are allowed only on the view's primary key columns.
 # In old versions Scylla mistakenly allowed IS NOT NULL restrictions on columns which were not part


### PR DESCRIPTION
Currently default task_ttl_in_seconds is 0, but scylla.yaml changes the value to 10.

Change task_ttl_in_seconds in scylla.yaml to 0, so that there are consistent defaults. Comment it out.

Fixes: #16714.

- [ ] ** Backport reason (please explain below if this patch should be backported or not) **

It should be backported to all version containing task manager (5.2 and 5.4)