### PR TITLE
Remove sstable_directory::_sstable_dir member

### DIFF
--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -109,7 +109,6 @@ sstable_directory::sstable_directory(sstables_manager& manager,
     , _storage_opts(std::move(storage_opts))
     , _table_dir(std::move(table_dir))
     , _state(state)
-    , _sstable_dir(make_path(_table_dir, _state))
     , _error_handler_gen(error_handler_gen)
     , _storage(make_storage(_manager, *_storage_opts, _table_dir, _state))
     , _lister(make_components_lister())

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -274,7 +274,6 @@ future<> sstable_directory::sstables_registry_components_lister::prepare(sstable
 }
 
 future<> sstable_directory::process_sstable_dir(process_flags flags) {
-    dirlog.debug("Start processing directory {} for SSTables (storage {})", _sstable_dir, _storage_opts->type_string());
     return _lister->process(*this, flags);
 }
 
@@ -285,6 +284,7 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
         }
     }
 
+    dirlog.debug("Start processing directory {} for SSTables", _directory);
     // It seems wasteful that each shard is repeating this scan, and to some extent it is.
     // However, we still want to open the files and especially call process_dir() in a distributed
     // fashion not to overload any shard. Also in the common case the SSTables will all be
@@ -374,6 +374,7 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
 }
 
 future<> sstable_directory::sstables_registry_components_lister::process(sstable_directory& directory, process_flags flags) {
+    dirlog.debug("Start processing registry entry {} (state {})", _location, directory._state);
     return _sstables_registry.sstables_registry_list(_location, [this, flags, &directory] (sstring status, sstable_state state, entry_descriptor desc) {
         if (state != directory._state) {
             return make_ready_future<>();

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -227,7 +227,7 @@ sstable_directory::sort_sstable(sstables::entry_descriptor desc, process_flags f
 }
 
 sstring sstable_directory::sstable_filename(const sstables::entry_descriptor& desc) const {
-    return sstable::filename(_sstable_dir.native(), _schema->ks_name(), _schema->cf_name(), desc.version, desc.generation, desc.format, component_type::Data);
+    return sstable::filename(make_path(_table_dir, _state).native(), _schema->ks_name(), _schema->cf_name(), desc.version, desc.generation, desc.format, component_type::Data);
 }
 
 generation_type

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -55,7 +55,7 @@ std::unique_ptr<sstable_directory::components_lister>
 sstable_directory::make_components_lister() {
     return std::visit(overloaded_functor {
         [this] (const data_dictionary::storage_options::local& loc) mutable -> std::unique_ptr<sstable_directory::components_lister> {
-            return std::make_unique<sstable_directory::filesystem_components_lister>(_sstable_dir);
+            return std::make_unique<sstable_directory::filesystem_components_lister>(make_path(_table_dir, _state));
         },
         [this] (const data_dictionary::storage_options::s3& os) mutable -> std::unique_ptr<sstable_directory::components_lister> {
             return std::make_unique<sstable_directory::sstables_registry_components_lister>(_manager.sstables_registry(), _table_dir);

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -144,7 +144,6 @@ private:
     lw_shared_ptr<const data_dictionary::storage_options> _storage_opts;
     sstring _table_dir;
     sstable_state _state;
-    std::filesystem::path _sstable_dir; // FIXME -- remove eventually
     io_error_handler_gen _error_handler_gen;
     std::unique_ptr<storage> _storage;
     std::unique_ptr<components_lister> _lister;


### PR DESCRIPTION
Different sstable storage backends use slightly different notion of what sstable location is. Filesystem storage knows it's `/var/lib/data/ks/cf-uuid/state` path, while s3 storage keeps only this path's part without state (and even that's not very accurate, because bucket prefix is missing as well as "/var/lib/data" prefix is not needed and eventually should be omitted). Nonetheless, the sstable_directory still keeps the filsystem-like path, while it's really only needed by the filesystem lister. This PR removes it.