### PR TITLE
tools/scylla-nodetool: add formatter for char*

### DIFF
--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -3722,6 +3722,11 @@ std::vector<char*> massage_argv(int argc, char** argv) {
 
 } // anonymous namespace
 
+#if FMT_VERSION == 100000
+template <>
+struct fmt::formatter<char*> : fmt::formatter<const char*> {};
+#endif
+
 namespace tools {
 
 int scylla_nodetool_main(int argc, char** argv) {


### PR DESCRIPTION
in {fmt} version 10.0.0, it has a regression, which dropped the formatter for `char *`, even it does format `const char*`, as the latter is convertible to `fmt::stirng_view`.

and this issue was addressed in 10.1.0 using 616a4937, which adds the formatter for `Char *`, where `Char` is a template parameter.

but we do need to print `vector<char*>`, so, to address the build failure with {fmt} version 10.0.0, which is shipped along with fedora 39. let's backport this formatter.

Fixes #18503
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

- [x] no need to backport. as our CI always uses older {fmt}, which does not suffer from this regression.

