### PR TITLE
test: string_format_test: disable test if {fmt} >= 10.0.0

### DIFF
--- a/test/boost/string_format_test.cc
+++ b/test/boost/string_format_test.cc
@@ -32,7 +32,19 @@ void verify_parenthesis(std::string_view sv) {
     BOOST_REQUIRE_EQUAL(close, it->second);
 }
 
-BOOST_AUTO_TEST_CASE(test_optional_string_format) {
+boost::test_tools::assertion_result use_homebrew_formatter_for_optional(boost::unit_test::test_unit_id) {
+    return FMT_VERSION < 100000;
+}
+
+// {fmt} >= 10.0.0 provides formatter for optional, and its
+// representation is different from our homebrew one:
+//            {fmt}      homebrew
+// nullopt    none       {}
+// "hello"    hello      hello
+//
+// so ignore this test for {fmt} >= 10.0.0
+BOOST_AUTO_TEST_CASE(test_optional_string_format,
+                     *boost::unit_test::precondition(use_homebrew_formatter_for_optional)) {
     std::optional<std::string> sopt;
 
     auto s = fmt::format("{}", sopt);


### PR DESCRIPTION
{fmt} v10.0.0 introduces formatter for `std::optional`, so there is no need to test it. furthermore the behavior of this formatter is different from our homebrew one. so let's skip this test if {fmt} v10.0.0 or up is used.

Refs #18508

- [x] we use fmt < 10.0.0 in our CI, so no need to backport.

