### PR TITLE
build: bring abseil submodule back

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,6 +6,9 @@
 	path = swagger-ui
 	url = ../scylla-swagger-ui
 	ignore = dirty
+[submodule "abseil"]
+	path = abseil
+	url = ../abseil-cpp
 [submodule "scylla-jmx"]
 	path = tools/jmx
 	url = ../scylla-jmx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,33 @@ set(Seastar_EXCLUDE_APPS_FROM_ALL ON CACHE BOOL "" FORCE)
 set(Seastar_EXCLUDE_TESTS_FROM_ALL ON CACHE BOOL "" FORCE)
 set(Seastar_UNUSED_RESULT_ERROR ON CACHE BOOL "" FORCE)
 add_subdirectory(seastar)
+set(ABSL_PROPAGATE_CXX_STD ON CACHE BOOL "" FORCE)
+
+find_package(Sanitizers QUIET)
+set(sanitizer_cxx_flags
+    $<$<IN_LIST:$<CONFIG>,Debug;Sanitize>:$<TARGET_PROPERTY:Sanitizers::address,INTERFACE_COMPILE_OPTIONS>;$<TARGET_PROPERTY:Sanitizers::undefined_behavior,INTERFACE_COMPILE_OPTIONS>>)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(ABSL_GCC_FLAGS ${sanitizer_cxx_flags})
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(ABSL_LLVM_FLAGS ${sanitizer_cxx_flags})
+endif()
+set(ABSL_DEFAULT_LINKOPTS
+    $<$<IN_LIST:$<CONFIG>,Debug;Sanitize>:$<TARGET_PROPERTY:Sanitizers::address,INTERFACE_LINK_LIBRARIES>;$<TARGET_PROPERTY:Sanitizers::undefined_behavior,INTERFACE_LINK_LIBRARIES>>)
+add_subdirectory(abseil)
+add_library(absl-headers INTERFACE)
+target_include_directories(absl-headers INTERFACE
+    "${PROJECT_SOURCE_DIR}/abseil")
+add_library(absl::headers ALIAS absl-headers)
+
+# Exclude absl::strerror from the default "all" target since it's not
+# used in Scylla build and, moreover, makes use of deprecated glibc APIs,
+# such as sys_nerr, which are not exposed from "stdio.h" since glibc 2.32,
+# which happens to be the case for recent Fedora distribution versions.
+#
+# Need to use the internal "absl_strerror" target name instead of namespaced
+# variant because `set_target_properties` does not understand the latter form,
+# unfortunately.
+set_target_properties(absl_strerror PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
 # System libraries dependencies
 find_package(Boost REQUIRED
@@ -66,7 +93,6 @@ target_link_libraries(Boost::regex
 find_package(Lua REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(ICU COMPONENTS uc i18n REQUIRED)
-find_package(absl COMPONENTS hash raw_hash_set REQUIRED)
 find_package(fmt 9.0.0 REQUIRED)
 find_package(libdeflate REQUIRED)
 find_package(libxcrypt REQUIRED)
@@ -124,6 +150,8 @@ target_sources(scylla-main
 target_link_libraries(scylla-main
   PRIVATE
     db
+    absl::headers
+    absl::btree
     absl::hash
     absl::raw_hash_set
     Seastar::seastar
@@ -236,6 +264,7 @@ target_link_libraries(scylla PRIVATE
 
 target_link_libraries(scylla PRIVATE
     seastar
+    absl::headers
     Boost::program_options)
 
 target_include_directories(scylla PRIVATE

--- a/alternator/CMakeLists.txt
+++ b/alternator/CMakeLists.txt
@@ -27,7 +27,8 @@ target_link_libraries(alternator
   cql3
   idl
   Seastar::seastar
-  xxHash::xxhash)
+  xxHash::xxhash
+  absl::headers)
 
 check_headers(check-headers alternator
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -72,7 +72,8 @@ target_link_libraries(api
   idl
   wasmtime_bindings
   Seastar::seastar
-  xxHash::xxhash)
+  xxHash::xxhash
+  absl::headers)
 
 check_headers(check-headers api
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/auth/CMakeLists.txt
+++ b/auth/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(scylla_auth
     Seastar::seastar
     xxHash::xxhash
   PRIVATE
+    absl::headers
     cql3
     idl
     wasmtime_bindings

--- a/cdc/CMakeLists.txt
+++ b/cdc/CMakeLists.txt
@@ -11,6 +11,7 @@ target_include_directories(cdc
     ${CMAKE_SOURCE_DIR})
 target_link_libraries(cdc
   PUBLIC
+    absl::headers
     Seastar::seastar
     xxHash::xxhash
   PRIVATE

--- a/cql3/CMakeLists.txt
+++ b/cql3/CMakeLists.txt
@@ -131,6 +131,7 @@ target_link_libraries(cql3
     idl
     wasmtime_bindings
     Seastar::seastar
+    absl::headers
     xxHash::xxhash
     ANTLR3::antlr3
   PRIVATE

--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(db
     mutation
     Seastar::seastar
     xxHash::xxhash
+    absl::headers
   PRIVATE
     data_dictionary
     cql3)

--- a/gms/CMakeLists.txt
+++ b/gms/CMakeLists.txt
@@ -20,7 +20,8 @@ target_link_libraries(gms
     Seastar::seastar
     xxHash::xxhash
   PRIVATE
-    db)
+    db
+    absl::headers)
 
 check_headers(check-headers gms
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/idl/CMakeLists.txt
+++ b/idl/CMakeLists.txt
@@ -74,6 +74,9 @@ add_custom_target(idl-sources
   DEPENDS ${idl_sources})
 add_library(idl INTERFACE)
 add_dependencies(idl idl-sources)
+target_link_directories(idl
+  INTERFACE
+    absl::headers)
 target_include_directories(idl
   INTERFACE
     ${scylla_gen_build_dir})

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -48,7 +48,6 @@ debian_base_packages=(
     libunistring-dev
     libzstd-dev
     libdeflate-dev
-    libabsl-dev
     librapidxml-dev
     libcrypto++-dev
     libxxhash-dev
@@ -70,7 +69,6 @@ fedora_packages=(
     snappy-devel
     libdeflate-devel
     systemd-devel
-    abseil-cpp-devel
     cryptopp-devel
     git
     python

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(lang
     Seastar::seastar
     xxHash::xxhash
   PRIVATE
+    absl::headers
     ${LUA_LIBRARIES})
 
 check_headers(check-headers lang

--- a/message/CMakeLists.txt
+++ b/message/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(message
   PUBLIC
     gms
     Seastar::seastar
+    absl::headers
   PRIVATE
     idl)
 

--- a/mutation/CMakeLists.txt
+++ b/mutation/CMakeLists.txt
@@ -21,7 +21,9 @@ target_link_libraries(mutation
   PUBLIC
     idl
     Seastar::seastar
-    xxHash::xxhash)
+    xxHash::xxhash
+  PRIVATE
+    absl::headers)
 
 check_headers(check-headers mutation
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/raft/CMakeLists.txt
+++ b/raft/CMakeLists.txt
@@ -12,7 +12,9 @@ target_include_directories(raft
 target_link_libraries(raft
   PUBLIC
     Seastar::seastar
-    xxHash::xxhash)
+    xxHash::xxhash
+  PRIVATE
+    absl::headers)
 
 check_headers(check-headers raft
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/repair/CMakeLists.txt
+++ b/repair/CMakeLists.txt
@@ -6,10 +6,12 @@ target_sources(repair
     table_check.cc)
 target_include_directories(repair
   PUBLIC
+    absl::headers
     ${CMAKE_SOURCE_DIR})
 target_link_libraries(repair
   PUBLIC
     idl
+    absl::headers
     Seastar::seastar
     xxHash::xxhash)
 

--- a/replica/CMakeLists.txt
+++ b/replica/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(replica
 target_link_libraries(replica
   PUBLIC
     db
+    absl::headers
     wasmtime_bindings
     Seastar::seastar
     xxHash::xxhash

--- a/schema/CMakeLists.txt
+++ b/schema/CMakeLists.txt
@@ -12,7 +12,8 @@ target_link_libraries(schema
     cql3
     idl
     Seastar::seastar
-    xxHash::xxhash)
+    xxHash::xxhash
+    absl::headers)
 
 check_headers(check-headers schema
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -37,6 +37,7 @@ target_include_directories(service
 target_link_libraries(service
   PUBLIC
     db
+    absl::headers
     Seastar::seastar
     xxHash::xxhash
   PRIVATE

--- a/sstables/CMakeLists.txt
+++ b/sstables/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(sstables
   PRIVATE
     readers
     tracing
+    absl::headers
     libdeflate::libdeflate
     ZLIB::ZLIB)
 


### PR DESCRIPTION
because of https://bugzilla.redhat.com/show_bug.cgi?id=2278689, the prebuilt abseil package provided by fedora has different settings than the ones if the tree is built with the sanitizer enabled. this inconsistency leads to a crash.

to address this problem, we have to reinstate the abseil submodule, so we can build it with the same compiler options with which we build the tree.

in this change

* Revert "build: drop abseil submodule, replace with distribution abseil" (8635d24424dab59e4054209ec3f2616a246a9282)
* update CMake building system with abseil header include settings
* bump up the abseil submodule to the latest LTS branch of abseil: lts_2024_01_16
* update scylla-gdb.py to adapt to the new structure of flat_hash_map

- [x] this change prepares for migration to build with fedora 40, no need to backport

