### PR TITLE
everywhere: include seastar headers using angle brackets

### DIFF
--- a/auth/maintenance_socket_role_manager.hh
+++ b/auth/maintenance_socket_role_manager.hh
@@ -10,7 +10,7 @@
 
 #include "auth/resource.hh"
 #include "auth/role_manager.hh"
-#include "seastar/core/future.hh"
+#include <seastar/core/future.hh>
 
 namespace cql3 {
 class query_processor;

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -31,7 +31,7 @@
 #include "db/system_auth_keyspace.hh"
 #include "log.hh"
 #include "schema/schema_fwd.hh"
-#include "seastar/core/future.hh"
+#include <seastar/core/future.hh>
 #include "service/migration_manager.hh"
 #include "timestamp.hh"
 #include "utils/class_registrator.hh"

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -13,7 +13,7 @@
 #include <chrono>
 #include <fmt/ranges.h>
 #include <seastar/core/shared_ptr.hh>
-#include "seastar/core/on_internal_error.hh"
+#include <seastar/core/on_internal_error.hh>
 #include "sstables/shared_sstable.hh"
 #include "sstables/sstables.hh"
 #include "compaction_strategy.hh"

--- a/db/hints/internal/hint_storage.cc
+++ b/db/hints/internal/hint_storage.cc
@@ -24,7 +24,7 @@
 
 // Scylla includes.
 #include "db/hints/internal/hint_logger.hh"
-#include "seastar/core/future.hh"
+#include <seastar/core/future.hh>
 #include "utils/disk-error-handler.hh"
 #include "utils/lister.hh"
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -15,7 +15,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
-#include "seastar/core/on_internal_error.hh"
+#include <seastar/core/on_internal_error.hh>
 #include "system_keyspace.hh"
 #include "cql3/untyped_result_set.hh"
 #include "db/system_auth_keyspace.hh"

--- a/db/tags/utils.cc
+++ b/db/tags/utils.cc
@@ -11,7 +11,7 @@
 #include "db/tags/extension.hh"
 #include "schema/schema_builder.hh"
 #include "schema/schema_registry.hh"
-#include "seastar/core/on_internal_error.hh"
+#include <seastar/core/on_internal_error.hh>
 #include "service/storage_proxy.hh"
 #include "data_dictionary/data_dictionary.hh"
 

--- a/main.cc
+++ b/main.cc
@@ -16,8 +16,8 @@
 #include "auth/allow_all_authenticator.hh"
 #include "auth/allow_all_authorizer.hh"
 #include "auth/maintenance_socket_role_manager.hh"
-#include "seastar/core/future.hh"
-#include "seastar/core/timer.hh"
+#include <seastar/core/future.hh>
+#include <seastar/core/timer.hh>
 #include "service/qos/raft_service_level_distributed_data_accessor.hh"
 #include "tasks/task_manager.hh"
 #include "utils/build_id.hh"

--- a/mutation/mutation_partition_serializer.cc
+++ b/mutation/mutation_partition_serializer.cc
@@ -14,7 +14,7 @@
 #include "idl/mutation.dist.hh"
 #include "idl/mutation.dist.impl.hh"
 #include "frozen_mutation.hh"
-#include "seastar/coroutine/maybe_yield.hh"
+#include <seastar/coroutine/maybe_yield.hh>
 
 using namespace db;
 

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -13,7 +13,7 @@
 #include "repair/repair.hh"
 #include "message/messaging_service.hh"
 #include "repair/task_manager_module.hh"
-#include "seastar/coroutine/exception.hh"
+#include <seastar/coroutine/exception.hh>
 #include "sstables/sstables.hh"
 #include "sstables/sstables_manager.hh"
 #include "mutation/mutation_fragment.hh"

--- a/service/qos/raft_service_level_distributed_data_accessor.cc
+++ b/service/qos/raft_service_level_distributed_data_accessor.cc
@@ -9,7 +9,7 @@
 #include "raft_service_level_distributed_data_accessor.hh"
 #include "cql3/query_processor.hh"
 #include "db/consistency_level_type.hh"
-#include "seastar/core/abort_source.hh"
+#include <seastar/core/abort_source.hh>
 #include "service/raft/raft_group0_client.hh"
 #include "db/system_keyspace.hh"
 #include "types/types.hh"

--- a/service/qos/raft_service_level_distributed_data_accessor.hh
+++ b/service/qos/raft_service_level_distributed_data_accessor.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "seastar/core/abort_source.hh"
+#include <seastar/core/abort_source.hh>
 #include "seastarx.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "service_level_controller.hh"

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -15,8 +15,8 @@
 #include "cql3/untyped_result_set.hh"
 #include "db/consistency_level_type.hh"
 #include "db/system_keyspace.hh"
-#include "seastar/core/on_internal_error.hh"
-#include "seastar/core/timer.hh"
+#include <seastar/core/on_internal_error.hh>
+#include <seastar/core/timer.hh>
 #include "service/qos/raft_service_level_distributed_data_accessor.hh"
 #include "service/qos/standard_service_level_distributed_data_accessor.hh"
 #include "service_level_controller.hh"

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "seastar/core/timer.hh"
+#include <seastar/core/timer.hh>
 #include "seastarx.hh"
 #include "auth/role_manager.hh"
 #include <seastar/core/sstring.hh>

--- a/service/qos/standard_service_level_distributed_data_accessor.hh
+++ b/service/qos/standard_service_level_distributed_data_accessor.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "seastar/core/abort_source.hh"
+#include <seastar/core/abort_source.hh>
 #include "seastarx.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "service_level_controller.hh"

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -14,9 +14,9 @@
 #include "message/messaging_service.hh"
 #include "mutation/canonical_mutation.hh"
 #include "mutation/async_utils.hh"
-#include "seastar/core/abort_source.hh"
-#include "seastar/core/on_internal_error.hh"
-#include "seastar/coroutine/parallel_for_each.hh"
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/on_internal_error.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 #include "service/broadcast_tables/experimental/query_result.hh"
 #include "schema_mutations.hh"
 #include "frozen_schema.hh"

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -10,7 +10,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/abort_source.hh>
 
-#include "seastar/core/abort_source.hh"
+#include <seastar/core/abort_source.hh>
 #include "service/broadcast_tables/experimental/lang.hh"
 #include "raft/raft.hh"
 #include "utils/UUID_gen.hh"

--- a/service/raft/raft_rpc.hh
+++ b/service/raft/raft_rpc.hh
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <seastar/core/gate.hh>
-#include "seastar/util/std-compat.hh"
+#include <seastar/util/std-compat.hh>
 #include "raft/raft.hh"
 #include "message/messaging_service_fwd.hh"
 #include "utils/UUID.hh"

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -32,7 +32,7 @@
 #include "db/system_keyspace.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "db/consistency_level.hh"
-#include "seastar/core/when_all.hh"
+#include <seastar/core/when_all.hh>
 #include "service/tablet_allocator.hh"
 #include "locator/types.hh"
 #include "locator/tablets.hh"
@@ -41,7 +41,7 @@
 #include <seastar/core/smp.hh>
 #include "mutation/canonical_mutation.hh"
 #include "mutation/async_utils.hh"
-#include "seastar/core/on_internal_error.hh"
+#include <seastar/core/on_internal_error.hh>
 #include "service/raft/group0_state_machine.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "service/topology_state_machine.hh"

--- a/utils/composite_abort_source.hh
+++ b/utils/composite_abort_source.hh
@@ -1,4 +1,4 @@
-#include "seastar/core/abort_source.hh"
+#include <seastar/core/abort_source.hh>
 #include "utils/small_vector.hh"
 #include "seastarx.hh"
 


### PR DESCRIPTION
seastar is an external library therefore it should use the system-include syntax.

- [x] ** Backport reason (please explain below if this patch should be backported or not) **
-No backport required as this just cleans up include directives.

