### PR TITLE
test/lib: do not include unused headers

### DIFF
--- a/test/boost/filtering_test.cc
+++ b/test/boost/filtering_test.cc
@@ -15,6 +15,7 @@
 
 #include <seastar/net/inet_address.hh>
 
+#include "test/lib/eventually.hh"
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"

--- a/test/boost/index_with_paging_test.cc
+++ b/test/boost/index_with_paging_test.cc
@@ -9,6 +9,7 @@
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
+#include "test/lib/eventually.hh"
 #include "cql3/untyped_result_set.hh"
 #include "cql3/query_processor.hh"
 #include "transport/messages/result_message.hh"

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -22,6 +22,7 @@
 #include "sstables/generation_type.hh"
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
+#include "test/lib/eventually.hh"
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/flat_mutation_reader_assertions.hh"
 #include "test/lib/sstable_utils.hh"

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -7,17 +7,18 @@
  */
 
 #include <seastar/core/coroutine.hh>
-#include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
+#include "test/lib/eventually.hh"
+#include "test/lib/exception_utils.hh"
+#include "test/lib/scylla_test_case.hh"
+#include "test/lib/select_statement_utils.hh"
 #include "transport/messages/result_message.hh"
 #include "service/pager/paging_state.hh"
 #include "types/map.hh"
 #include "types/list.hh"
 #include "types/set.hh"
-#include "test/lib/exception_utils.hh"
 #include "cql3/statements/select_statement.hh"
-#include "test/lib/select_statement_utils.hh"
 #include "utils/error_injection.hh"
 
 using namespace std::chrono_literals;

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -23,6 +23,7 @@
 
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
+#include "test/lib/eventually.hh"
 #include "test/lib/sstable_utils.hh"
 #include "schema/schema_builder.hh"
 #include "test/lib/data_model.hh"

--- a/test/boost/view_complex_test.cc
+++ b/test/boost/view_complex_test.cc
@@ -17,6 +17,7 @@
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
+#include "test/lib/eventually.hh"
 
 #include "db/config.hh"
 

--- a/test/boost/view_schema_ckey_test.cc
+++ b/test/boost/view_schema_ckey_test.cc
@@ -14,6 +14,7 @@
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
+#include "test/lib/eventually.hh"
 
 using namespace std::literals::chrono_literals;
 

--- a/test/boost/view_schema_pkey_test.cc
+++ b/test/boost/view_schema_pkey_test.cc
@@ -12,6 +12,7 @@
 
 #include "db/view/view_builder.hh"
 
+#include "test/lib/eventually.hh"
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"

--- a/test/boost/view_schema_test.cc
+++ b/test/boost/view_schema_test.cc
@@ -20,6 +20,7 @@
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
+#include "test/lib/eventually.hh"
 #include "exceptions/unrecognized_entity_exception.hh"
 #include "db/config.hh"
 #include "types/set.hh"

--- a/test/lib/cql_assertions.cc
+++ b/test/lib/cql_assertions.cc
@@ -11,6 +11,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <fmt/ranges.h>
 #include "test/lib/cql_assertions.hh"
+#include "test/lib/eventually.hh"
 #include "transport/messages/result_message.hh"
 #include "utils/to_string.hh"
 #include "bytes.hh"

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -12,8 +12,6 @@
 #include <seastar/core/thread.hh>
 #include <seastar/util/defer.hh>
 #include "replica/database_fwd.hh"
-#include "sstables/sstables.hh"
-#include <seastar/core/do_with.hh>
 #include "test/lib/cql_test_env.hh"
 #include "cdc/generation_service.hh"
 #include "cql3/functions/functions.hh"
@@ -29,7 +27,6 @@
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/coroutine.hh>
-#include "utils/UUID_gen.hh"
 #include "service/migration_manager.hh"
 #include "service/tablet_allocator.hh"
 #include "compaction/compaction_manager.hh"
@@ -46,7 +43,6 @@
 #include "db/batchlog_manager.hh"
 #include "schema/schema_builder.hh"
 #include "test/lib/tmpdir.hh"
-#include "test/lib/test_services.hh"
 #include "test/lib/log.hh"
 #include "unit_test_service_levels_accessor.hh"
 #include "db/view/view_builder.hh"

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -25,7 +25,6 @@
 #include "bytes.hh"
 #include "schema/schema.hh"
 #include "service/tablet_allocator.hh"
-#include "test/lib/eventually.hh"
 
 namespace replica {
 class database;

--- a/test/lib/key_utils.cc
+++ b/test/lib/key_utils.cc
@@ -9,7 +9,6 @@
 #include "test/lib/key_utils.hh"
 #include "test/lib/random_schema.hh"
 #include "test/lib/random_utils.hh"
-#include "test/lib/test_utils.hh"
 #include "dht/i_partitioner.hh"
 
 namespace tests {

--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -12,9 +12,9 @@
 
 #include "cql3/cql3_type.hh"
 #include "mutation/mutation.hh"
-#include "mutation/mutation_fragment.hh"
 #include "schema/schema_builder.hh"
 #include "test/lib/cql_test_env.hh"
+#include "test/lib/eventually.hh"
 #include "test/lib/random_schema.hh"
 #include "test/lib/random_utils.hh"
 #include "types/list.hh"

--- a/test/lib/tmpdir.cc
+++ b/test/lib/tmpdir.cc
@@ -7,6 +7,7 @@
  */
 
 #include "test/lib/tmpdir.hh"
+#include "utils/UUID.hh"
 
 #include <seastar/util/alloc_failure_injector.hh>
 

--- a/test/lib/tmpdir.hh
+++ b/test/lib/tmpdir.hh
@@ -12,8 +12,6 @@
 
 #include <seastar/util/std-compat.hh>
 
-#include "utils/UUID.hh"
-
 namespace fs = std::filesystem;
 
 // Creates a new empty directory with arbitrary name, which will be removed


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.

- [x] cleanup, no need to backport

