### PR TITLE
test/boost: s/boost::range::random_shuffle/std::ranges::shuffle/

### DIFF
--- a/test/boost/counter_test.cc
+++ b/test/boost/counter_test.cc
@@ -8,13 +8,13 @@
 
 #include "counters.hh"
 
+#include <algorithm>
 #include <random>
 
 #include <seastar/core/thread.hh>
 #include <seastar/testing/random.hh>
 
 #include <boost/range/algorithm/sort.hpp>
-#include <boost/range/algorithm/random_shuffle.hpp>
 
 #include "test/lib/scylla_test_case.hh"
 #include "schema/schema_builder.hh"
@@ -504,7 +504,7 @@ SEASTAR_TEST_CASE(test_sanitize_corrupted_cells) {
             auto c1 = atomic_cell_or_collection(b1.build(0));
 
             // Corrupt it by changing shard order and adding duplicates
-            boost::range::random_shuffle(shards);
+            std::ranges::shuffle(shards, gen);
 
             std::uniform_int_distribution<unsigned> duplicate_count_dist(1, shard_count / 2);
             auto duplicate_count = duplicate_count_dist(gen);
@@ -513,7 +513,7 @@ SEASTAR_TEST_CASE(test_sanitize_corrupted_cells) {
                 shards.emplace_back(cs);
             }
 
-            boost::range::random_shuffle(shards);
+            std::ranges::shuffle(shards, gen);
 
             // Sanitize
             counter_cell_builder b2;


### PR DESCRIPTION
`boost::range::random_shuffle()` uses the deprecated `std::random_shuffle()` under the hood, so let's use `std::ranges::shuffle()` which is available since C++20.

this change should address the warning like:

```
[312/753] CXX build/debug/test/boost/counter_test.o                                                                                                                                                                 In file included from test/boost/counter_test.cc:17:
/usr/include/boost/range/algorithm/random_shuffle.hpp:106:13: warning: 'random_shuffle<__gnu_cxx::__normal_iterator<counter_shard *, std::vector<counter_shard>>>' is deprecated: use 'std::shuffle' instead [-Wdepr
ecated-declarations]
  106 |     detail::random_shuffle(boost::begin(rng), boost::end(rng));
      |             ^
test/boost/counter_test.cc:507:27: note: in instantiation of function template specialization 'boost::range::random_shuffle<std::vector<counter_shard>>' requested here
  507 |             boost::range::random_shuffle(shards);
      |                           ^
/usr/lib/gcc/x86_64-redhat-linux/14/../../../../include/c++/14/bits/stl_algo.h:4489:5: note: 'random_shuffle<__gnu_cxx::__normal_iterator<counter_shard *, std::vector<counter_shard>>>' has been explicitly marked
deprecated here
 4489 |     _GLIBCXX14_DEPRECATED_SUGGEST("std::shuffle")
      |     ^
/usr/lib/gcc/x86_64-redhat-linux/14/../../../../include/c++/14/x86_64-redhat-linux/bits/c++config.h:1957:45: note: expanded from macro '_GLIBCXX14_DEPRECATED_SUGGEST'
 1957 | # define _GLIBCXX14_DEPRECATED_SUGGEST(ALT) _GLIBCXX_DEPRECATED_SUGGEST(ALT)
      |                                             ^
/usr/lib/gcc/x86_64-redhat-linux/14/../../../../include/c++/14/x86_64-redhat-linux/bits/c++config.h:1941:19: note: expanded from macro '_GLIBCXX_DEPRECATED_SUGGEST'
 1941 |   __attribute__ ((__deprecated__ ("use '" ALT "' instead")))
      |                   ^
```

- [x] cleanup in test, no need to backport

