### PR TITLE
cql3: castas_fcts: do not rely on boost casting large multiprecision integers to floats behavior

### DIFF
--- a/cql3/functions/castas_fcts.cc
+++ b/cql3/functions/castas_fcts.cc
@@ -69,6 +69,16 @@ using bytes_opt = std::optional<bytes>;
 template<typename ToType, typename FromType>
 static data_value castas_fctn_simple(data_value from) {
     auto val_from = value_cast<FromType>(from);
+    // Workaround for https://github.com/boostorg/multiprecision/issues/553 (the additional bug discovered post-closing)
+    if constexpr (std::is_floating_point_v<ToType> && std::is_same_v<FromType, utils::multiprecision_int>) {
+        static auto min = utils::multiprecision_int(std::numeric_limits<ToType>::lowest());
+        static auto max = utils::multiprecision_int(std::numeric_limits<ToType>::max());
+        if (val_from < min) {
+            return -std::numeric_limits<ToType>::infinity();
+        } else if (val_from > max) {
+            return std::numeric_limits<ToType>::infinity();
+        }
+    }
     return static_cast<ToType>(val_from);
 }
 

--- a/test/cql-pytest/test_cast_data.py
+++ b/test/cql-pytest/test_cast_data.py
@@ -55,8 +55,10 @@ def signed(number, bits):
 # numbers.
 def test_cast_from_large_varint(cql, table1):
     p = unique_key_int()
+    p_negative = unique_key_int()
     v = 32767456456456456456545678943512357658768763546575675
     cql.execute(f'INSERT INTO {table1} (p, cVarint) VALUES ({p}, {v})')
+    cql.execute(f'INSERT INTO {table1} (p, cVarint) VALUES ({p_negative}, {-v})')
     # We can read back the original number without a cast, or with a cast
     # to the same type. The "decimal" type can also hold a varint and return
     # the same number.
@@ -71,6 +73,7 @@ def test_cast_from_large_varint(cql, table1):
     # Casting to a 32-bit floating point, which only supports numbers up
     # to 1e38, results in infinity
     assert [(math.inf,)] == list(cql.execute(f"SELECT CAST(cVarint AS float) FROM {table1} WHERE p={p}"))
+    assert [(-math.inf,)] == list(cql.execute(f"SELECT CAST(cVarint AS float) FROM {table1} WHERE p={p_negative}"))
     # Casting to a 64-bit floating point, which supports the range of our
     # given number (though not its full precision!) is allowed, and some
     # precision is lost. Confusingly, Python's 64-bit floating point is


### PR DESCRIPTION
In [1] a bug casting large multiprecision integers to floats is documented (note that it
received two fixes, the most recent and relevant is [2]). Even with the fix, boost now
returns NaN instead of ±∞ as it did before [3].

Since we cannot rely on boost, detect the conditions that trigger the bug and return
the expected result.

The unit test is extended to cover large negative numbers.

Boost version behavior:
 - 1.78 - returns ±∞
 - 1.79 - terminates
 - 1.79 + fix - returns NaN

Fixes https://github.com/scylladb/scylladb/issues/18508

[1] https://github.com/boostorg/multiprecision/issues/553
[2] https://github.com/boostorg/multiprecision/commit/ea786494db78efdf178cbe36810f3326156e3347
[3] https://github.com/boostorg/math/issues/1132

- [x] no backport - bug only affects toolchains based on Fedora 40; no branches affected

