### PR TITLE
compaction: compaction_strategy validation: don't rely on optional<> …

### DIFF
--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -150,7 +150,7 @@ static bool validate_unchecked_tombstone_compaction(const std::map<sstring, sstr
     auto tmp_value = compaction_strategy_impl::get_value(options, compaction_strategy_impl::UNCHECKED_TOMBSTONE_COMPACTION_OPTION);
     if (tmp_value.has_value()) {
         if (tmp_value != "true" && tmp_value != "false") {
-            throw exceptions::configuration_exception(fmt::format("{} value ({}) must be \"true\" or \"false\"", compaction_strategy_impl::UNCHECKED_TOMBSTONE_COMPACTION_OPTION, tmp_value));
+            throw exceptions::configuration_exception(fmt::format("{} value ({}) must be \"true\" or \"false\"", compaction_strategy_impl::UNCHECKED_TOMBSTONE_COMPACTION_OPTION, *tmp_value));
         }
         unchecked_tombstone_compaction = tmp_value == "true";
     }


### PR DESCRIPTION
std::optional formatting changed while moving from the home-grown formatter to the fmt provided formatter; don't rely on it for user visible messages.

Here, the optional formatted is known to be engaged, so just print it.

- [x] no backport - older branches don't have the new formatter and won't get it

