### PR TITLE
storage_service: don't rely on optional<> formatting for removed node error

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1092,7 +1092,7 @@ std::unordered_set<raft::server_id> storage_service::find_raft_nodes_from_hoeps(
             }
         }
         if (!_topology_state_machine._topology.find(*id)) {
-            throw std::runtime_error(::format("Node {} is not found in the cluster", id));
+            throw std::runtime_error(::format("Node {} is not found in the cluster", *id));
         }
         ids.insert(*id);
     }


### PR DESCRIPTION
std::optional formatting changed while moving from the home-grown formatter to the fmt provided formatter; don't rely on it for user visible messages.

Here, the optional formatted is known to be engaged, so just print it.

- [x] no backport - older branches don't have the new formatter and won't get it

