### PR TITLE
dht: convert dht::partition_range_vector to chunked_vector

### DIFF
--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -169,7 +169,7 @@ future<std::vector<mutation>> batch_statement::get_mutations(query_processor& qp
         auto&& statement_options = options.for_statement(i);
         auto timestamp = _attrs->get_timestamp(now, statement_options);
         modification_statement::json_cache_opt json_cache = statement->maybe_prepare_json_cache(statement_options);
-        std::vector<dht::partition_range> keys = statement->build_partition_keys(statement_options, json_cache);
+        auto keys = statement->build_partition_keys(statement_options, json_cache);
         auto more = co_await statement->get_mutations(qp, statement_options, timeout, local, timestamp, query_state, json_cache, std::move(keys));
 
         for (auto&& m : more) {
@@ -349,7 +349,7 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::exe
         statement.inc_cql_stats(qs.get_client_state().is_internal());
         modification_statement::json_cache_opt json_cache = statement.maybe_prepare_json_cache(statement_options);
         // At most one key
-        std::vector<dht::partition_range> keys = statement.build_partition_keys(statement_options, json_cache);
+        auto keys = statement.build_partition_keys(statement_options, json_cache);
         if (keys.empty()) {
             continue;
         }

--- a/cql3/statements/cas_request.hh
+++ b/cql3/statements/cas_request.hh
@@ -52,8 +52,8 @@ public:
         assert(_key.size() == 1 && query::is_single_partition(_key.front()));
     }
 
-    dht::partition_range_vector key() const {
-        return dht::partition_range_vector(_key);
+    const dht::partition_range_vector& key() const {
+        return _key;
     }
 
     const update_parameters::prefetch_data& rows() const {

--- a/cql3/statements/cas_request.hh
+++ b/cql3/statements/cas_request.hh
@@ -40,11 +40,11 @@ private:
     schema_ptr _schema;
     // A single partition key. Represented as a vector of partition ranges
     // since this is the conventional format for storage_proxy.
-    std::vector<dht::partition_range> _key;
+    dht::partition_range_vector _key;
     update_parameters::prefetch_data _rows;
 
 public:
-    cas_request(schema_ptr schema_arg, std::vector<dht::partition_range> key_arg)
+    cas_request(schema_ptr schema_arg, dht::partition_range_vector key_arg)
           : _schema(schema_arg)
           , _key(std::move(key_arg))
           , _rows(schema_arg)

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -199,7 +199,7 @@ public:
     // of mutations, one per partition key, for statements which affect multiple partition keys,
     // e.g. DELETE FROM table WHERE pk  IN (1, 2, 3).
     std::vector<mutation> apply_updates(
-            const std::vector<dht::partition_range>& keys,
+            const dht::partition_range_vector& keys,
             const std::vector<query::clustering_range>& ranges,
             const update_parameters& params,
             const json_cache_opt& json_cache) const;
@@ -234,7 +234,7 @@ public:
 
 private:
     future<exceptions::coordinator_result<>>
-    execute_without_condition(query_processor& qp, service::query_state& qs, const query_options& options, json_cache_opt& json_cache, std::vector<dht::partition_range> keys) const;
+    execute_without_condition(query_processor& qp, service::query_state& qs, const query_options& options, json_cache_opt& json_cache, dht::partition_range_vector keys) const;
 
     future<::shared_ptr<cql_transport::messages::result_message>>
     execute_with_condition(query_processor& qp, service::query_state& qs, const query_options& options) const;
@@ -250,7 +250,7 @@ public:
      * @return vector of the mutations
      * @throws invalid_request_exception on invalid requests
      */
-    future<std::vector<mutation>> get_mutations(query_processor& qp, const query_options& options, db::timeout_clock::time_point timeout, bool local, int64_t now, service::query_state& qs, json_cache_opt& json_cache, std::vector<dht::partition_range> keys) const;
+    future<std::vector<mutation>> get_mutations(query_processor& qp, const query_options& options, db::timeout_clock::time_point timeout, bool local, int64_t now, service::query_state& qs, json_cache_opt& json_cache, dht::partition_range_vector keys) const;
 
     virtual json_cache_opt maybe_prepare_json_cache(const query_options& options) const;
 

--- a/dht/i_partitioner_fwd.hh
+++ b/dht/i_partitioner_fwd.hh
@@ -10,6 +10,7 @@
 #pragma once
 #include <vector>
 #include "interval.hh"
+#include "utils/chunked_vector.hh"
 
 namespace sstables {
 
@@ -28,7 +29,7 @@ class sharder;
 using partition_range = interval<ring_position>;
 using token_range = interval<token>;
 
-using partition_range_vector = std::vector<partition_range>;
+using partition_range_vector = utils::chunked_vector<partition_range>;
 using token_range_vector = std::vector<token_range>;
 
 class decorated_key;

--- a/query_ranges_to_vnodes.cc
+++ b/query_ranges_to_vnodes.cc
@@ -21,21 +21,25 @@ const dht::token& end_token(const dht::partition_range& r) {
 }
 
 query_ranges_to_vnodes_generator::query_ranges_to_vnodes_generator(std::unique_ptr<locator::token_range_splitter> splitter, schema_ptr s, dht::partition_range_vector ranges, bool local) :
-        _s(s), _ranges(std::move(ranges)), _i(_ranges.begin()), _local(local), _splitter(std::move(splitter)) {}
+        _s(s), _ranges(std::move(ranges)), _i(0), _local(local), _splitter(std::move(splitter)) {}
+
+query_ranges_to_vnodes_generator::query_ranges_to_vnodes_generator(query_ranges_to_vnodes_generator&& o)
+    : _s(std::move(o._s))
+    , _ranges(std::move(o._ranges))
+    , _i(std::exchange(o._i, 0))
+    , _local(std::exchange(o._local, false))
+    , _splitter(std::move(o._splitter))
+{}
 
 dht::partition_range_vector query_ranges_to_vnodes_generator::operator()(size_t n) {
     n = std::min(n, size_t(1024));
 
     dht::partition_range_vector result;
     result.reserve(n);
-    while (_i != _ranges.end() && result.size() != n) {
+    while (!empty() && result.size() != n) {
         process_one_range(n, result);
     }
     return result;
-}
-
-bool query_ranges_to_vnodes_generator::empty() const {
-    return _ranges.end() == _i;
 }
 
 /**
@@ -44,7 +48,7 @@ bool query_ranges_to_vnodes_generator::empty() const {
  */
 void query_ranges_to_vnodes_generator::process_one_range(size_t n, dht::partition_range_vector& ranges) {
     dht::ring_position_comparator cmp(*_s);
-    dht::partition_range& cr = *_i;
+    dht::partition_range& cr = _ranges[_i];
 
     auto get_remainder = [this, &cr] {
         _i++;

--- a/query_ranges_to_vnodes.hh
+++ b/query_ranges_to_vnodes.hh
@@ -14,18 +14,21 @@
 class query_ranges_to_vnodes_generator {
     schema_ptr _s;
     dht::partition_range_vector _ranges;
-    dht::partition_range_vector::iterator _i; // iterator to current range in _ranges
-    bool _local;
+    size_t _i = 0; // position of current range in _ranges
+    bool _local = false;
     std::unique_ptr<locator::token_range_splitter> _splitter;
     void process_one_range(size_t n, dht::partition_range_vector& ranges);
 public:
     query_ranges_to_vnodes_generator(std::unique_ptr<locator::token_range_splitter> splitter, schema_ptr s, dht::partition_range_vector ranges, bool local = false);
+    query_ranges_to_vnodes_generator() = default;
     query_ranges_to_vnodes_generator(const query_ranges_to_vnodes_generator&) = delete;
-    query_ranges_to_vnodes_generator(query_ranges_to_vnodes_generator&&) = default;
+    query_ranges_to_vnodes_generator(query_ranges_to_vnodes_generator&&);
     // generate next 'n' vnodes, may return less than requested number of ranges
     // which means either that there are no more ranges
     // (in which case empty() == true), or too many ranges
     // are requested
     dht::partition_range_vector operator()(size_t n);
-    bool empty() const;
+    bool empty() const {
+        return _ranges.size() == _i;
+    }
 };

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -125,33 +125,31 @@ future<result<service::storage_proxy::coordinator_query_result>> query_pager::do
 
             dht::partition_range_vector modified;
             modified.reserve(ranges.size());
-            auto i = ranges.begin();
-            while (i != ranges.end()) {
-                bool contains = i->contains(lo, cmp);
+            for (auto& i : ranges) {
+                bool contains = i.contains(lo, cmp);
 
                 if (contains) {
                     found = true;
                 }
 
                 bool remove = !found
-                        || (contains && !inclusive && (i->is_singular()
-                            || (reversed && i->start() && cmp(i->start()->value(), lo) == 0)
-                            || (!reversed && i->end() && cmp(i->end()->value(), lo) == 0)))
+                        || (contains && !inclusive && (i.is_singular()
+                            || (reversed && i.start() && cmp(i.start()->value(), lo) == 0)
+                            || (!reversed && i.end() && cmp(i.end()->value(), lo) == 0)))
                         ;
 
                 if (remove) {
-                    qlogger.trace("Remove range {}", *i);
+                    qlogger.trace("Remove range {}", i);
                 } else if (contains) {
-                    auto r = reversed && !i->is_singular()
-                            ? range_type(i->start(), bound_type{ lo, inclusive })
-                            : range_type( bound_type{ lo, inclusive }, i->end(), i->is_singular())
+                    auto r = reversed && !i.is_singular()
+                            ? range_type(i.start(), bound_type{ lo, inclusive })
+                            : range_type( bound_type{ lo, inclusive }, i.end(), i.is_singular())
                             ;
-                    qlogger.trace("Modify range {} -> {}", *i, r);
+                    qlogger.trace("Modify range {} -> {}", i, r);
                     modified.emplace_back(std::move(r));
                 } else {
-                    modified.emplace_back(std::move(*i));
+                    modified.emplace_back(std::move(i));
                 }
-                ++i;
             }
             ranges = std::move(modified);
             qlogger.trace("Result ranges {}", ranges);

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -931,7 +931,7 @@ SEASTAR_THREAD_TEST_CASE(read_max_size) {
             e.execute_prepared(id, {cql3_pk, cql3_ck, cql3_value}).get();
         }
 
-        const auto partition_ranges = std::vector<dht::partition_range>{query::full_partition_range};
+        const auto partition_ranges = dht::partition_range_vector{query::full_partition_range};
 
         const std::vector<std::pair<sstring, std::function<future<size_t>(schema_ptr, const query::read_command&)>>> query_methods{
                 {"query_mutations()", [&db, &partition_ranges] (schema_ptr s, const query::read_command& cmd) -> future<size_t> {
@@ -1021,7 +1021,7 @@ SEASTAR_THREAD_TEST_CASE(unpaged_mutation_read_global_limit) {
             e.execute_prepared(id, {cql3_pk, cql3_ck, cql3_value}).get();
         }
 
-        const auto partition_ranges = std::vector<dht::partition_range>{query::full_partition_range};
+        const auto partition_ranges = dht::partition_range_vector{query::full_partition_range};
 
         const std::vector<std::pair<sstring, std::function<future<size_t>(schema_ptr, const query::read_command&)>>> query_methods{
                 {"query_mutations()", [&db, &partition_ranges] (schema_ptr s, const query::read_command& cmd) -> future<size_t> {

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -453,7 +453,7 @@ do_test_split_range_to_single_shard(const schema& s, const dht::sharder& sharder
         auto sharder = dht::ring_position_range_sharder(sharder_, pr);
         auto x = sharder.next(s);
         auto cmp = dht::ring_position_comparator(s);
-        auto reference_ranges = std::vector<dht::partition_range>();
+        auto reference_ranges = dht::partition_range_vector();
         while (x) {
             if (x->shard == shard) {
                 reference_ranges.push_back(std::move(x->ring_range));

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1978,7 +1978,7 @@ SEASTAR_THREAD_TEST_CASE(test_tablet_range_splitter) {
     using bound = dht::partition_range::bound;
 
     std::vector<result> included_ranges;
-    std::vector<dht::partition_range> excluded_ranges;
+    dht::partition_range_vector excluded_ranges;
     for (auto tid = std::optional(tmap.first_tablet()); tid; tid = tmap.next_tablet(*tid)) {
         const auto& tablet_info = tmap.get_tablet_info(*tid);
         auto replica_it = std::ranges::find_if(tablet_info.replicas, [&] (auto&& r) { return r.host == h1; });

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -289,7 +289,7 @@ public:
         auto& qo = cql3::query_options::DEFAULT;
         auto timeout = db::timeout_clock::now() + qs->get_client_state().get_timeout_config().write_timeout;
         cql3::statements::modification_statement::json_cache_opt json_cache = modif_stmt->maybe_prepare_json_cache(qo);
-        std::vector<dht::partition_range> keys = modif_stmt->build_partition_keys(qo, json_cache);
+        auto keys = modif_stmt->build_partition_keys(qo, json_cache);
 
         return modif_stmt->get_mutations(local_qp(), qo, timeout, false, qo.get_timestamp(*qs), *qs, json_cache, keys)
             .finally([qs, modif_stmt = std::move(modif_stmt)] {});

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -57,12 +57,12 @@ namespace {
 
 // Helper class for testing mutation_reader::fast_forward_to(dht::partition_range).
 class partition_range_walker {
-    std::vector<dht::partition_range> _ranges;
+    dht::partition_range_vector _ranges;
     size_t _current_position = 0;
 private:
     const dht::partition_range& current_range() const { return _ranges[_current_position]; }
 public:
-    explicit partition_range_walker(std::vector<dht::partition_range> ranges) : _ranges(ranges) { }
+    explicit partition_range_walker(dht::partition_range_vector ranges) : _ranges(ranges) { }
     const dht::partition_range& initial_range() const { return _ranges[0]; }
     void fast_forward_if_needed(flat_reader_assertions_v2& mr, const mutation& expected, bool verify_eos = true) {
         while (!current_range().contains(expected.decorated_key(), dht::ring_position_comparator(*expected.schema()))) {
@@ -159,7 +159,7 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
 
     mutation_source ms = populate(s.schema(), mutations, gc_clock::now());
 
-    auto test_ckey = [&] (std::vector<dht::partition_range> pranges, std::vector<mutation> mutations, mutation_reader::forwarding fwd_mr) {
+    auto test_ckey = [&] (dht::partition_range_vector pranges, std::vector<mutation> mutations, mutation_reader::forwarding fwd_mr) {
         for (auto range_size = 1u; range_size <= ckey_count + 1; range_size++) {
             for (auto start = 0u; start <= ckey_count; start++) {
                 auto range = range_size == 1
@@ -332,7 +332,7 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
             }
 
             {
-                auto pranges = std::vector<dht::partition_range>();
+                auto pranges = dht::partition_range_vector();
                 for (auto current = pstart; current < pstart + prange_size; current++) {
                     pranges.emplace_back(dht::partition_range::make_singular(mutations[current].decorated_key()));
                 }
@@ -340,7 +340,7 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
             }
 
             if (prange_size > 1) {
-                auto pranges = std::vector<dht::partition_range>();
+                auto pranges = dht::partition_range_vector();
                 for (auto current = pstart; current < pstart + prange_size;) {
                     if (current + 1 < pstart + prange_size) {
                         pranges.emplace_back(dht::partition_range::make({mutations[current].decorated_key()}, {mutations[current + 1].decorated_key()}));

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -14,6 +14,7 @@
 #include "Cassandra.h"
 #include <seastar/core/distributed.hh>
 #include <seastar/core/coroutine.hh>
+#include "dht/i_partitioner_fwd.hh"
 #include "replica/database.hh" // for database::get_version()
 #include "data_dictionary/data_dictionary.hh"
 #include <seastar/core/sstring.hh>
@@ -459,8 +460,8 @@ public:
             if (columns == 0 || columns == column_limit || (slices.size() < cmd->partition_limit && columns < cmd->get_row_limit())) {
                 if (!output.empty() || !start_key) {
                     if (range.size() > 1 && columns < column_limit) {
-                        range.erase(range.begin());
-                        return do_get_paged_slice(proxy, std::move(schema), column_limit - columns, std::move(range), nullptr, consistency_level, timeout_config, output, qs, std::move(permit));
+                        auto new_range = dht::partition_range_vector(range.begin() + 1, range.end());
+                        return do_get_paged_slice(proxy, std::move(schema), column_limit - columns, std::move(new_range), nullptr, consistency_level, timeout_config, output, qs, std::move(permit));
                     }
                     return make_ready_future();
                 }

--- a/types/types.hh
+++ b/types/types.hh
@@ -31,7 +31,6 @@
 #include "utils/exceptions.hh"
 #include "utils/managed_bytes.hh"
 #include "utils/bit_cast.hh"
-#include "utils/chunked_vector.hh"
 #include "utils/lexicographical_compare.hh"
 #include "utils/overloaded_functor.hh"
 #include "tasks/types.hh"
@@ -964,14 +963,6 @@ void write_collection_value(bytes::iterator& out, bytes_view_opt val_bytes);
 void write_collection_value(managed_bytes_mutable_view&, bytes_view_opt val_bytes);
 void write_collection_value(managed_bytes_mutable_view&, const managed_bytes_view_opt& val_bytes);
 void write_int32(bytes::iterator& out, int32_t value);
-
-// Splits a serialized collection into a vector of elements, but does not recursively deserialize the elements.
-// Does not perform validation.
-template <FragmentedView View>
-utils::chunked_vector<managed_bytes_opt> partially_deserialize_listlike(View in);
-template <FragmentedView View>
-std::vector<std::pair<managed_bytes, managed_bytes>> partially_deserialize_map(View in);
-
 
 // Given a serialized tuple value, reads the nth element and returns it.
 // Returns std::nullopt when there's no element with such index.

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -105,6 +105,8 @@ public:
     chunked_vector(chunked_vector&& x) noexcept;
     template <typename Iterator>
     chunked_vector(Iterator begin, Iterator end);
+    chunked_vector(std::initializer_list<T> x);
+    chunked_vector(const T& v) : chunked_vector(1, v) {}
     explicit chunked_vector(size_t n, const T& value = T());
     ~chunked_vector();
     chunked_vector& operator=(const chunked_vector& x);
@@ -359,6 +361,13 @@ chunked_vector<T, max_contiguous_allocation>::chunked_vector(Iterator begin, Ite
     if (!is_random_access) {
         shrink_to_fit();
     }
+}
+
+template <typename T, size_t max_contiguous_allocation>
+chunked_vector<T, max_contiguous_allocation>::chunked_vector(std::initializer_list<T> x)
+        : chunked_vector() {
+    reserve(x.size());
+    std::move(std::move(x).begin(), std::move(x).end(), std::back_inserter(*this));
 }
 
 template <typename T, size_t max_contiguous_allocation>

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -224,10 +224,17 @@ public:
         pointer addr() const {
             return &_chunks[_i / max_chunk_capacity()][_i % max_chunk_capacity()];
         }
-        iterator_type(const chunk_ptr* chunks, size_t i) : _chunks(chunks), _i(i) {}
+        iterator_type(const chunk_ptr* chunks, size_t i) noexcept : _chunks(chunks), _i(i) {}
     public:
         iterator_type() = default;
-        iterator_type(const iterator_type<std::remove_const_t<ValueType>>& x) : _chunks(x._chunks), _i(x._i) {} // needed for iterator->const_iterator conversion
+        iterator_type(const iterator_type& x) = default;
+
+        iterator_type& operator=(const iterator_type& x) = default;
+
+        template <typename U>
+        requires std::same_as<U, iterator_type<std::remove_const_t<ValueType>>>
+        iterator_type(const U& x) noexcept : iterator_type(x._chunks, x._i) {} // needed for iterator->const_iterator conversion
+
         reference operator*() const {
             return *addr();
         }

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -101,12 +101,14 @@ public:
 public:
     chunked_vector() = default;
     chunked_vector(const chunked_vector& x);
+    // Moving a chunked_vector invalidates all iterators to it
     chunked_vector(chunked_vector&& x) noexcept;
     template <typename Iterator>
     chunked_vector(Iterator begin, Iterator end);
     explicit chunked_vector(size_t n, const T& value = T());
     ~chunked_vector();
     chunked_vector& operator=(const chunked_vector& x);
+    // Moving a chunked_vector invalidates all iterators to it
     chunked_vector& operator=(chunked_vector&& x) noexcept;
 
     bool empty() const {
@@ -208,8 +210,10 @@ public:
 public:
     template <class ValueType>
     class iterator_type {
-        const chunk_ptr* _chunks;
-        size_t _i;
+        // Note that _chunks points to the chunked_vector::_chunks data
+        // and therefore it is invalidated when the chunked_vector is moved
+        const chunk_ptr* _chunks = nullptr;
+        size_t _i = 0;
     public:
         using iterator_category = std::random_access_iterator_tag;
         using value_type = ValueType;

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -53,6 +53,10 @@
 #include <malloc.h>
 #include <fmt/ostream.h>
 
+namespace dht {
+class partition_ranges_view;
+}
+
 namespace utils {
 
 struct chunked_vector_free_deleter {
@@ -67,6 +71,11 @@ class chunked_vector {
     utils::small_vector<chunk_ptr, 1> _chunks;
     size_t _size = 0;
     size_t _capacity = 0;
+
+    utils::small_vector<chunk_ptr, 1>& chunks() noexcept { return _chunks; };
+    const utils::small_vector<chunk_ptr, 1>& chunks() const noexcept { return _chunks; };
+
+    friend class dht::partition_ranges_view;
 public:
     // Maximum number of T elements fitting in a single chunk.
     static constexpr size_t max_chunk_capacity() {

--- a/utils/managed_bytes.hh
+++ b/utils/managed_bytes.hh
@@ -13,6 +13,7 @@
 #include "bytes.hh"
 #include "utils/allocation_strategy.hh"
 #include "utils/fragment_range.hh"
+#include "utils/chunked_vector.hh"
 #include <seastar/util/alloc_failure_injector.hh>
 #include <type_traits>
 #include <utility>
@@ -627,3 +628,10 @@ template <> struct fmt::formatter<managed_bytes_opt> : fmt::formatter<string_vie
         return fmt::format_to(ctx.out(), "null");
     }
 };
+
+// Splits a serialized collection into a vector of elements, but does not recursively deserialize the elements.
+// Does not perform validation.
+template <FragmentedView View>
+utils::chunked_vector<managed_bytes_opt> partially_deserialize_listlike(View in);
+template <FragmentedView View>
+std::vector<std::pair<managed_bytes, managed_bytes>> partially_deserialize_map(View in);


### PR DESCRIPTION
Define dht::partition_range_vector using utils::chunked_vector
to prevent large memory allocations and consequently, possible
reactor stalls when allocating a very long vector of partition ranges.

This series requires some fixes and tweaks to support chunked_vector,
some are on the data path, so here are pre- and post- change perf-simple-query
results, showing no regression:
```
perf.before:median 97105.79 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42316 insns/op,        0 errors)
 perf.after:median 98877.77 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42728 insns/op,        0 errors)
```

Fixes scylladb/scylladb#18536

- [x] ** Backport reason (please explain below if this patch should be backported or not) **
This issue was hit in the field and should be backported in principle, however, it is rare and a bit risky since the change is quite intrusive, so even if we still consider it for backporting, it must soak for awhile in master to make sure it doesn't cause any regressions.


