### PR TITLE
doc: Snitch switch is not supported with tablets

### DIFF
--- a/docs/operating-scylla/procedures/config-change/switch-snitch.rst
+++ b/docs/operating-scylla/procedures/config-change/switch-snitch.rst
@@ -1,6 +1,15 @@
 
 How to Switch Snitches
 **********************
+.. REMOVE IN FUTURE VERSIONS - when the limitation in the note is no longer valid
+
+.. note::
+
+    Switching from one type of snitch to another is NOT supported for clusters 
+    where one or more keyspaces have tablets enabled. 
+    
+    NOTE: If you :ref:`create a new keyspace <create-keyspace-statement>`, 
+    it has tablets enabled by default.
 
 This procedure describes the steps that need to be done when switching from one type of snitch to another.
 Such a scenario can be when increasing the cluster and adding more data-centers in different locations. 


### PR DESCRIPTION
This PR adds the tablets-related limitation: if you use tablets, then changing snitch is not supported

Refs: https://github.com/scylladb/scylladb/issues/17513 
See: https://github.com/scylladb/scylladb/issues/17513#issuecomment-2022552677

- No backport. This update is tablets-related, and the feature is added in version 6.0.

