### PR TITLE
docs: change "create an issue" github label to "type/documentation"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,6 +146,7 @@ html_theme_options = {
     "hide_feedback_buttons": 'false',
     "github_issues_repository": "scylladb/scylladb",
     "github_repository": "scylladb/scylladb",
+    "github_label": "type/documentation",
     "versions_unstable": UNSTABLE_VERSIONS,
     "versions_deprecated": DEPRECATED_VERSIONS,
     'banner_button_text': 'Register for Free',


### PR DESCRIPTION
## Motivation

Related https://github.com/scylladb/sphinx-scylladb-theme/pull/1093

Change "create an issue" github label to "type/documentation" for this project.

## How to test

1. Clone the PR and build the docs.
2. Open an issue from the docs. The "type/documentation" label should be assigned to the issue.
