### PR TITLE
fix test teardown race with ongoing test operation(client side fix)

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -53,9 +53,12 @@ class ManagerClient():
         self.api = ScyllaRESTAPIClient()
         self.metrics = ScyllaMetricsClient()
         self.thread_pool = ThreadPoolExecutor()
+        self.test_finished_event = asyncio.Event()
 
     @property
     def client(self):
+        if self.test_finished_event.is_set():
+            raise Exception("ManagerClient.after_test method was called, client object is not accessible anymore")
         _client = self.client_for_asyncio_loop.get(asyncio.get_running_loop(), None)
         if _client is None:
             _client = UnixRESTClient(self.sock_path)
@@ -129,8 +132,10 @@ class ManagerClient():
 
     async def after_test(self, test_case_name: str, success: bool) -> None:
         """Tell harness this test finished"""
+        self.test_finished_event.set()
+        _client = self.client_for_asyncio_loop.get(asyncio.get_running_loop())
         logger.debug("after_test for %s (success: %s)", test_case_name, success)
-        cluster_str = await self.client.put_json(f"/cluster/after-test/{success}",
+        cluster_str = await _client.put_json(f"/cluster/after-test/{success}",
                                                  response_type = "json")
         logger.info("Cluster after test %s: %s", test_case_name, cluster_str)
 


### PR DESCRIPTION
this commit is a client-side solution to fix 
fixes: https://github.com/scylladb/scylladb/issues/16472
fixes: https://github.com/scylladb/scylladb/issues/16651

In the case of having a runaway asyncio task which waits for a long time and then sends some requests.

server-side solution: https://github.com/scylladb/scylladb/pull/18236


