### PR TITLE
docs/dev/object_stroage.md: convert example AWS keys to be more innocent

### DIFF
--- a/docs/dev/object_storage.md
+++ b/docs/dev/object_storage.md
@@ -56,8 +56,8 @@ endpoints:
     port: 443
     https: true
     aws_region: us-east-2
-    aws_access_key_id: AKIAIOSFODNN7EXAMPLE
-    aws_secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    aws_access_key_id: EXAMPLE_ACCESS_KEY_ID
+    aws_secret_access_key: EXAMPLE_SECRET_ACCESS_KEY
 ```
 
 and when creating the keyspace:


### PR DESCRIPTION
Someone thought that they actually represent real keys (the 'EXAMPLE' in their name was not enough). Converted them to be as clear as can be, example data.

- [ X] Not materially important. We can skip backporting this.

