### PR TITLE
docker: drop jmx and tools-java from installation

### DIFF
--- a/dist/docker/debian/build_docker.sh
+++ b/dist/docker/debian/build_docker.sh
@@ -69,9 +69,6 @@ packages=(
     "build/dist/$config/debian/$product-conf_$version-$release-1_$arch.deb"
     "build/dist/$config/debian/$product-kernel-conf_$version-$release-1_$arch.deb"
     "build/dist/$config/debian/$product-node-exporter_$version-$release-1_$arch.deb"
-    "tools/java/build/debian/$product-tools_$version-$release-1_all.deb"
-    "tools/java/build/debian/$product-tools-core_$version-$release-1_all.deb"
-    "tools/jmx/build/debian/$product-jmx_$version-$release-1_all.deb"
     "tools/cqlsh/build/debian/$product-cqlsh_$version-$release-1_all.deb"
     "tools/python3/build/debian/$product-python3_$version-$release-1_$arch.deb"
 )
@@ -98,7 +95,7 @@ run apt-get -y upgrade
 run apt-get -y --no-install-suggests install dialog apt-utils
 run bash -ec "echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections"
 run bash -ec "rm -rf /etc/rsyslog.conf"
-run apt-get -y --no-install-suggests install hostname supervisor openjdk-11-jre-headless python2 python3 python3-yaml curl rsyslog sudo
+run apt-get -y --no-install-suggests install hostname supervisor python3 python3-yaml curl rsyslog sudo
 run bash -ec "echo LANG=C.UTF-8 > /etc/default/locale"
 run bash -ec "dpkg -i packages/*.deb"
 run apt-get -y clean all
@@ -111,7 +108,6 @@ run sed -i -e 's/^SCYLLA_ARGS=".*"$/SCYLLA_ARGS="--log-to-syslog 0 --log-to-stdo
 run mkdir -p /opt/scylladb/supervisor
 run touch /opt/scylladb/SCYLLA-CONTAINER-FILE
 bcp dist/common/supervisor/scylla-server.sh /opt/scylladb/supervisor/scylla-server.sh
-bcp dist/common/supervisor/scylla-jmx.sh /opt/scylladb/supervisor/scylla-jmx.sh
 bcp dist/common/supervisor/scylla-node-exporter.sh /opt/scylladb/supervisor/scylla-node-exporter.sh
 bcp dist/common/supervisor/scylla_util.sh /opt/scylladb/supervisor/scylla_util.sh
 

--- a/dist/docker/etc/supervisord.conf.d/scylla-jmx.conf
+++ b/dist/docker/etc/supervisord.conf.d/scylla-jmx.conf
@@ -1,6 +1,0 @@
-[program:scylla-jmx]
-command=/opt/scylladb/supervisor/scylla-jmx.sh
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0


### PR DESCRIPTION
Following the work done in dd0779675fa8b56de173ca7aa9c59a1727028761, removing the Scylla-jmx and Scylla-tools-java from our docker image

- [x] **for 6.0 and above, no need for backport**

