### PR TITLE
db,service: fix typos in comments

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -862,11 +862,11 @@ future<> manager::perform_migration() {
     const auto lock = co_await seastar::get_units(_drain_lock, 1);
 
     using lock_type = std::unique_lock<seastar::shared_mutex>;
-    // We're taking this lock because we're about to stop endpoint managers here, wheras
+    // We're taking this lock because we're about to stop endpoint managers here, whereas
     // `manager::wait_for_sync_point` browses them and awaits their corresponding sync points.
     // If we stop them during that process, that function will get exceptions.
     //
-    // Although in the current implemenation there is no danger of race conditions
+    // Although in the current implementation there is no danger of race conditions
     // (or at least race conditions that could be harmful in any way), it's better
     // to avoid them anyway. Hence this lock.
     const auto unique_lock = co_await std::invoke(coroutine::lambda([&] () -> future<lock_type> {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3134,7 +3134,7 @@ storage_proxy::create_write_response_handler_helper(schema_ptr s, const dht::tok
         }
         // We need this additional check because even after removing the mapping IP-host ID corresponding
         // to this node from `locator::token_metadata` while decommissioning, we still perform mutations
-        // targetting the local node.
+        // targeting the local node.
         if (tm.get_topology().is_me(ep)) {
             return tm.get_topology().my_host_id();
         }


### PR DESCRIPTION
- [x] typo in comments, no need to backport.

