### PR TITLE
raft: raft_group_registry: start_server_for_group: catch and rethrow abort_requested_exception

### DIFF
--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -382,6 +382,8 @@ future<> raft_group_registry::start_server_for_group(raft_server_for_group new_g
         // By the time the tick() is executed the server should already be initialized.
         co_await new_grp.server->start();
         new_grp.server->register_metrics();
+    } catch (abort_requested_exception&) {
+        throw;
     } catch (...) {
         on_internal_error(rslog, format("Failed to start a Raft group {}: {}", gid,
                 std::current_exception()));


### PR DESCRIPTION
If we initiate the shutdown while starting the group 0 server,
we could catch `abort_requested_exception` in `start_server_for_group`
and call `on_internal_error`. Then, Scylla aborts with a coredump.
It causes problems in tests that shut down bootstrapping nodes.

The `abort_requested_exception` can be thrown from
`gossiper::lock_endpoint` called in
`storage_service::topology_state_load`. So, the issue is new and
applies only to the raft-based topology. Hence, there is no need
to backport the patch.

Fixes scylladb/scylladb#17794
Fixes scylladb/scylladb#18197