### PR TITLE
batchlog_manager, test: initialize delay configuration

### DIFF
--- a/db/batchlog_manager.hh
+++ b/db/batchlog_manager.hh
@@ -36,7 +36,7 @@ class system_keyspace;
 struct batchlog_manager_config {
     std::chrono::duration<double> write_request_timeout;
     uint64_t replay_rate = std::numeric_limits<uint64_t>::max();
-    std::chrono::milliseconds delay;
+    std::chrono::milliseconds delay = std::chrono::milliseconds(0);
 };
 
 class batchlog_manager : public peering_sharded_service<batchlog_manager> {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -935,6 +935,7 @@ private:
             db::batchlog_manager_config bmcfg;
             bmcfg.replay_rate = 100000000;
             bmcfg.write_request_timeout = 2s;
+            bmcfg.delay = 0ms;
             _batchlog_manager.start(std::ref(_qp), std::ref(_sys_ks), bmcfg).get();
             auto stop_bm = defer([this] {
                 _batchlog_manager.stop().get();


### PR DESCRIPTION
In b4e66ddf1df (4.0) we added a new batchlog_manager configuration named delay, but forgot to initialize it in cql_test_env. This somehow worked, but doesn't with clang 18.

Fix it by initializing to 0 (there isn't a good reason to delay it). Also provide a default to make it safer.

- [x] no need to backport; only happens with clang 18 which isn't in use today

