### PR TITLE
test/nodetool: accept -1 returncode also when --help is invoked

### DIFF
--- a/test/nodetool/test_help.py
+++ b/test/nodetool/test_help.py
@@ -52,9 +52,9 @@ def test_help_command_too_many_args(nodetool, scylla_only):
 def test_help_consistent(nodetool, scylla_only):
     for command in ("version", "compact", "settraceprobability"):
         res1 = nodetool("help", command)
-        # seastar returns 1 when --help is invoked
-        with pytest.raises(subprocess.CalledProcessError) as e:
-            nodetool(command, "--help")
-        assert e.value.returncode == 1
-        out2 = e.value.stdout
-        assert res1.stdout == out2
+        res2 = nodetool(command, "--help", check_return_code=False)
+        # TODO: older seastar returns 1 when --help is invoked
+        #       remove the check_return_code parameter above after
+        #       updating the seastar submodule
+        assert res2.returncode in (1, 0)
+        assert res1.stdout == res2.stdout


### PR DESCRIPTION
in newer seastar, 0 is returned as the returncode of the application when handling `--help`. to prepare for this behavior, let's accept it before updating the seastar submodule.

- [x]  this PR prepares for a change in seasetar, and is not a fix, so no need to backport

