### PR TITLE
loading_shared_values: Replace static-assert with concept

### DIFF
--- a/utils/loading_shared_values.hh
+++ b/utils/loading_shared_values.hh
@@ -212,8 +212,8 @@ public:
     ///
     /// The loader object does not survive deferring, so the caller must deal with its liveness.
     template<typename Loader>
+    requires std::same_as<typename futurize<std::invoke_result_t<Loader, const key_type&>>::type, future<value_type>>
     future<entry_ptr> get_or_load(const key_type& key, Loader&& loader) noexcept {
-        static_assert(std::is_same<future<value_type>, typename futurize<std::result_of_t<Loader(const key_type&)>>::type>::value, "Bad Loader signature");
         try {
             auto i = _set.find(key, Hash(), key_eq<key_type, EqualPred>());
             lw_shared_ptr<entry> e;


### PR DESCRIPTION
The templatized get_or_load() accepts Loader template parameter and static-asserts on its signature. Concept is more suitable here.
