### PR TITLE
table: Directly compare std::optional<shard_id> with shard_id

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2138,11 +2138,7 @@ int64_t table::calculate_tablet_count() const {
 
     for (auto tablet_id : tablet_map.tablet_ids()) {
         const std::optional<shard_id> shard_id = tablet_map.get_shard(tablet_id, this_host_id);
-        if (!shard_id.has_value()) {
-            continue;
-        }
-
-        if (*shard_id == this_shard_id()) {
+        if (shard_id == this_shard_id()) {
             ++new_tablet_count;
         }
     }


### PR DESCRIPTION
There's a loop that calculates the number of shard matches over a tablet map. The check of the given shard against optional<shard> can be made shorter.

