### PR TITLE
build: cmake: link thrift against absl::header

### DIFF
--- a/thrift/CMakeLists.txt
+++ b/thrift/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(thrift
     xxHash::xxhash
   PRIVATE
     interface
+    absl::headers
     Thrift::thrift)
 
 check_headers(check-headers thrift


### PR DESCRIPTION
this change is a leftover of 0b0e661a85.

- [x] cmake related change. no need to backport.

