### PR TITLE
scylla-nodetool: add tablet support for ring command

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -90,7 +90,7 @@
          "operations":[
             {
                "method":"GET",
-               "summary":"Returns a list of the tokens endpoint mapping",
+               "summary":"Returns a list of the tokens endpoint mapping, provide keyspace and cf param to get tablet mapping",
                "type":"array",
                "items":{
                   "type":"mapper"
@@ -100,6 +100,22 @@
                   "application/json"
                ],
                "parameters":[
+                  {
+                     "name":"keyspace",
+                     "description":"The keyspace to provide the tablet mapping for",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"cf",
+                     "description":"The table to provide the tablet mapping for",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  }
                ]
             }
          ]

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -243,6 +243,11 @@ dht::token_range tablet_map::get_token_range(tablet_id id) const {
     }
 }
 
+host_id tablet_map::get_primary_replica(tablet_id id) const {
+    const auto info = get_tablet_info(id);
+    return info.replicas.at(size_t(id) % info.replicas.size()).host;
+}
+
 future<std::vector<token>> tablet_map::get_sorted_tokens() const {
     std::vector<token> tokens;
     tokens.reserve(tablet_count());

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -357,6 +357,9 @@ public:
     /// \throws std::logic_error If the given id does not belong to this instance.
     dht::token_range get_token_range(tablet_id id) const;
 
+    /// Returns the primary replica for the tablet
+    host_id get_primary_replica(tablet_id id) const;
+
     /// Returns a vector of sorted last tokens for tablets.
     future<std::vector<token>> get_sorted_tokens() const;
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5026,6 +5026,17 @@ std::map<token, inet_address> storage_service::get_token_to_endpoint_map() {
     return result;
 }
 
+future<std::map<token, inet_address>> storage_service::get_tablet_to_endpoint_map(table_id table) {
+    const auto& tm = get_token_metadata();
+    const auto& tmap = tm.tablets().get_tablet_map(table);
+    std::map<token, inet_address> result;
+    for (std::optional<locator::tablet_id> tid = tmap.first_tablet(); tid; tid = tmap.next_tablet(*tid)) {
+        result.emplace(tmap.get_last_token(*tid), tm.get_endpoint_for_host_id(tmap.get_primary_replica(*tid)));
+        co_await coroutine::maybe_yield();
+    }
+    co_return result;
+}
+
 std::chrono::milliseconds storage_service::get_ring_delay() {
     auto ring_delay = _db.local().get_config().ring_delay_ms();
     slogger.trace("Get RING_DELAY: {}ms", ring_delay);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -433,6 +433,15 @@ public:
     std::map<token, inet_address> get_token_to_endpoint_map();
 
     /**
+     * Retrieve a map of tablet tokens to endpoints.
+     *
+     * Tablet variant of get_token_to_endpoint_map().
+     *
+     * @return a map of tablet tokens to endpoints in ascending order
+     */
+    future<std::map<token, inet_address>> get_tablet_to_endpoint_map(table_id table);
+
+    /**
      * Construct the range to endpoint mapping based on the true view
      * of the world.
      * @param ranges

--- a/test/nodetool/test_status.py
+++ b/test/nodetool/test_status.py
@@ -45,7 +45,7 @@ null_ownership_error = ("Non-system keyspaces don't have the same replication se
                         "effective ownership information is meaningless")
 
 
-def validate_status_output(res, keyspace, nodes, ownership, resolve, effective_ownership_unknown):
+def validate_status_output(res, keyspace, nodes, ownership, resolve, effective_ownership_unknown, token_count_unknown):
     datacenters = sorted(list(set([node.datacenter for node in nodes.values()])))
     load_multiplier = {"bytes": 1, "KB": 1024, "MB": 1024**2, "GB": 1024**3, "TB": 1024**4}
 
@@ -106,7 +106,10 @@ def validate_status_output(res, keyspace, nodes, ownership, resolve, effective_o
             else:
                 assert load_unit is not None
                 assert load == "{:.2f}".format(int(node.load) / load_multiplier[load_unit])
-            assert int(tokens) == len(node.tokens)
+            if token_count_unknown:
+                tokens == "?"
+            else:
+                assert int(tokens) == len(node.tokens)
             if effective_ownership_unknown:
                 assert owns == "?"
             else:
@@ -198,6 +201,11 @@ def _do_test_status(request, nodetool, status_query_target, node_list, resolve=N
 
     host_id_map = [{"key": ep, "value": node.host_id} for ep, node in nodes.items() if node.host_id is not None]
 
+    tokens_endpoint_params = {}
+    if keyspace_uses_tablets and table:
+        tokens_endpoint_params["keyspace"] = keyspace
+        tokens_endpoint_params["cf"] = table
+
     tokens_endpoint = []
     for ep, node in nodes.items():
         for token in node.tokens:
@@ -212,7 +220,8 @@ def _do_test_status(request, nodetool, status_query_target, node_list, resolve=N
         expected_request("GET", "/storage_service/nodes/leaving", response=leaving),
         expected_request("GET", "/storage_service/nodes/moving", response=moving),
         expected_request("GET", "/storage_service/load_map", response=load_map),
-        expected_request("GET", "/storage_service/tokens_endpoint", response=tokens_endpoint),
+        expected_request("GET", "/storage_service/tokens_endpoint", params=tokens_endpoint_params,
+                         response=tokens_endpoint),
         expected_request("GET", "/gossiper/endpoint/live", response=live),
         expected_request("GET", "/gossiper/endpoint/down", response=down),
         expected_request("GET", "/storage_service/host_id", response=host_id_map),
@@ -227,18 +236,21 @@ def _do_test_status(request, nodetool, status_query_target, node_list, resolve=N
                                  response={"message": f"std::runtime_error({null_ownership_error})", "code": 500}),
                 expected_request("GET", "/storage_service/ownership", multiple=expected_request.ANY,
                                  response=ownership_response)]
-    elif table is None:
+    else:
         if not uses_cassandra_nodetool:
             keyspaces_using_tablets = [keyspace] if keyspace_uses_tablets else []
             expected_requests.append(
-                expected_request("GET", "/storage_service/keyspaces", params={"replication": "tablets"}, multiple=expected_request.ONE, response=keyspaces_using_tablets))
-
-        if not keyspace_uses_tablets:
+                expected_request("GET", "/storage_service/keyspaces", params={"replication": "tablets"},
+                                 multiple=expected_request.ONE, response=keyspaces_using_tablets))
+        if table is None:
+            if not keyspace_uses_tablets:
+                expected_requests.append(
+                    expected_request("GET", f"/storage_service/ownership/{keyspace}",
+                                     multiple=expected_request.ONE, response=ownership_response))
+        else:
             expected_requests.append(
-                expected_request("GET", f"/storage_service/ownership/{keyspace}", multiple=expected_request.ONE, response=ownership_response))
-    else:
-        expected_requests.append(
-                expected_request("GET", f"/storage_service/ownership/{keyspace}", params={"cf": table}, response=ownership_response))
+                    expected_request("GET", f"/storage_service/ownership/{keyspace}", params={"cf": table},
+                                     response=ownership_response))
 
     for ep, node in nodes.items():
         expected_requests += [
@@ -262,7 +274,9 @@ def _do_test_status(request, nodetool, status_query_target, node_list, resolve=N
     res = nodetool(*args, expected_requests=expected_requests)
 
     effective_ownership_unknown = keyspace is None or (table is None and keyspace_uses_tablets)
-    validate_status_output(res.stdout, keyspace, nodes, ownership, bool(resolve), effective_ownership_unknown)
+    token_count_unknown = keyspace_uses_tablets and not table
+    validate_status_output(res.stdout, keyspace, nodes, ownership, bool(resolve), effective_ownership_unknown,
+                           token_count_unknown)
 
 
 def test_status_no_keyspace_single_dc(request, nodetool):

--- a/test/nodetool/test_tablehistograms.py
+++ b/test/nodetool/test_tablehistograms.py
@@ -68,7 +68,9 @@ Max             7.00             17.00             95.00                 7      
 
 """
 
-def test_tablehistograms_empty_histogram(nodetool):
+# The java implementation explodes with null pointer exception.
+# It is not worth trying to fix, so just disable this test for the java nodetool.
+def test_tablehistograms_empty_histogram(scylla_only, nodetool):
     keyspace_name = "ks"
     table_name = "tbl"
     table_param = f"{keyspace_name}:{table_name}"

--- a/test/nodetool/test_toppartitions.py
+++ b/test/nodetool/test_toppartitions.py
@@ -163,9 +163,6 @@ def test_toppartitions_invalid_capacity(nodetool, request):
     for name, value in options.items():
         args.extend([name, str(value)])
     error = "TopK count (-k) option must be smaller than the summary capacity (-s)"
-    if request.config.getoption("nodetool") == "cassandra":
-        # cassandra nodetool's error message has a typo in it.
-        error = error.replace('than', 'then')
     check_nodetool_fails_with_error_contains(
         nodetool,
         tuple(args),


### PR DESCRIPTION
Currently, invoking `nodetool ring` on a tablet keyspace fails with an error, because it doesn't pass the required table parameter to `/storage_service/ownership/{keyspace}`. Further to this, the command will currently always output the vnode ring, regardless of the keyspace and table parameter. This series fixes this, adding tablet support to `/storage_service/tokens_endpoint`, which will now return the tablet ring (tablet token -> tablet primary replica mapping) if the new keyspace and table parameters are provided.
`nodetool status` also gets a touch-up, to provide the tablet ring's token count (the tablet count) when invoked with a tablet keyspace and table.

Fixes: #17889
Fixes: #18474
 
- [x] ** native-nodetool is new functionality, no backport is needed **
