### PR TITLE
scylla_kernel_check: fix block device size error on latest mkfs.xfs

### DIFF
--- a/dist/common/scripts/scylla_kernel_check
+++ b/dist/common/scripts/scylla_kernel_check
@@ -22,7 +22,7 @@ if __name__ == '__main__':
         pkg_install('xfsprogs')
 
     os.makedirs('/var/tmp/mnt', exist_ok=True)
-    run('dd if=/dev/zero of=/var/tmp/kernel-check.img bs=1M count=128', shell=True, check=True, stdout=DEVNULL, stderr=DEVNULL)
+    run('dd if=/dev/zero of=/var/tmp/kernel-check.img bs=1M count=300', shell=True, check=True, stdout=DEVNULL, stderr=DEVNULL)
     run('mkfs.xfs /var/tmp/kernel-check.img', shell=True, check=True, stdout=DEVNULL, stderr=DEVNULL)
     run('mount /var/tmp/kernel-check.img /var/tmp/mnt -o loop', shell=True, check=True, stdout=DEVNULL, stderr=DEVNULL)
     ret = run('iotune --fs-check --evaluation-directory /var/tmp/mnt --default-log-level error', shell=True).returncode


### PR DESCRIPTION
On latest mkfs.xfs, it does not allow to format a block device which is smaller than 300MB.
There are options to ignore this validation but it is unsupported feature, so it is better to increase the loopback image size to "supported size" == 300MB.

reference: https://lore.kernel.org/all/164738662491.3191861.15611882856331908607.stgit@magnolia/

Fixes #18568

- [x] ** Backport reason (please explain below if this patch should be backported or not) **
Without the patch scylla_setup will cause Traceback, if we want to support Ubuntu 24.04LTS we must backport the patch.
