### PR TITLE
build: cmake build dist-unified by default and put tarballs under per-config paths

### DIFF
--- a/cmake/build_submodule.cmake
+++ b/cmake/build_submodule.cmake
@@ -41,7 +41,7 @@ macro(dist_submodule name dir pkgs)
   endif()
   set(pkg_name "${Scylla_PRODUCT}-${name}-${Scylla_VERSION}-${Scylla_RELEASE}.${arch}.tar.gz")
   set(reloc_pkg "${CMAKE_SOURCE_DIR}/tools/${dir}/build/${pkg_name}")
-  set(dist_pkg "${CMAKE_CURRENT_BINARY_DIR}/${pkg_name}")
+  set(dist_pkg "${CMAKE_BINARY_DIR}/$<CONFIG>/dist/tar/${pkg_name}")
   add_custom_command(
     OUTPUT ${dist_pkg}
     COMMAND ${CMAKE_COMMAND} -E copy ${reloc_pkg} ${dist_pkg}

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -127,7 +127,7 @@ add_custom_command(
     ${dist_pkgs}
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   VERBATIM)
-add_custom_target(dist-unified
+add_custom_target(dist-unified ALL
   DEPENDS ${unified_dist_pkg})
 
 add_subdirectory(debuginfo)

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -80,7 +80,7 @@ add_custom_command(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 set(stripped_dist_pkg
-  "${CMAKE_CURRENT_BINARY_DIR}/${Scylla_PRODUCT}-${Scylla_VERSION}-${Scylla_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.tar.gz")
+  "${CMAKE_BINARY_DIR}/$<CONFIG>/${Scylla_PRODUCT}-${Scylla_VERSION}-${Scylla_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.tar.gz")
 add_custom_command(
   OUTPUT
     ${stripped_dist_pkg}
@@ -100,7 +100,7 @@ add_custom_command(
 add_custom_target(dist-server-tar
   DEPENDS ${stripped_dist_pkg})
 add_custom_target(package
-  ${CMAKE_COMMAND} -E copy ${stripped_dist_pkg} ${Scylla_PRODUCT}-package.tar.gz
+  ${CMAKE_COMMAND} -E copy ${stripped_dist_pkg} ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${Scylla_PRODUCT}-package.tar.gz
   DEPENDS ${stripped_dist_pkg})
 
 
@@ -114,7 +114,7 @@ dist_submodule(jmx jmx dist_pkgs
   NOARCH)
 dist_submodule(python3 python3 dist_pkgs)
 set(unified_dist_pkg
-  "${CMAKE_CURRENT_BINARY_DIR}/${Scylla_PRODUCT}-unified-${Scylla_VERSION}-${Scylla_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.tar.gz")
+  "${CMAKE_BINARY_DIR}/$<CONFIG>/dist/tar/${Scylla_PRODUCT}-unified-${Scylla_VERSION}-${Scylla_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.tar.gz")
 add_custom_command(
   OUTPUT
     "${unified_dist_pkg}"


### PR DESCRIPTION
in the same spirit of d57a82c156, this change adds `dist-unified` as one of the default targets. so that it is built by default. the unified package is required to when redistributing the precompiled packages -- we publish the rpm, deb and tar balls to S3.

- [x] cmake related change, no need to backport

