### PR TITLE
test/nodetool: do not accept 1 return code when passing --help to nod…

### DIFF
--- a/test/nodetool/test_help.py
+++ b/test/nodetool/test_help.py
@@ -52,9 +52,5 @@ def test_help_command_too_many_args(nodetool, scylla_only):
 def test_help_consistent(nodetool, scylla_only):
     for command in ("version", "compact", "settraceprobability"):
         res1 = nodetool("help", command)
-        res2 = nodetool(command, "--help", check_return_code=False)
-        # TODO: older seastar returns 1 when --help is invoked
-        #       remove the check_return_code parameter above after
-        #       updating the seastar submodule
-        assert res2.returncode in (1, 0)
+        res2 = nodetool(command, "--help")
         assert res1.stdout == res2.stdout


### PR DESCRIPTION
…etool

in 906700d5, we accepted 0 as well as the return code of "nodetool <command> --help", because we needed to be prepared for the newer seastar submodule while be compatible with the older seastar versions. now that in 305f1bd3, we bumped up the seastar module, and this commit picked up the change to return 0 when handling "--help" command line option in seastar, we are able to drop the workaround.

so, in this change, we only use "0" as the expected return code.

- [x] addresses a workaround / todo introduced in master, no need to backport

