### PR TITLE
perf-simple-query: change stats metric to instructions/op

### DIFF
--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -542,7 +542,7 @@ int scylla_simple_query_main(int argc, char** argv) {
         ("stop-on-error", bpo::value<bool>()->default_value(true), "stop after encountering the first error")
         ("timeout", bpo::value<std::string>()->default_value(""), "use timeout")
         ("bypass-cache", "use bypass cache when querying")
-        ("stats-metric", bpo::value<std::string>()->default_value("throughput"), "field to sort by for determining the median result and stats (options are: \"throughput\"|\"allocs\"|\"tasks\"|\"instructions\")")
+        ("stats-metric", bpo::value<std::string>()->default_value("instructions"), "field to sort by for determining the median result and stats (options are: \"throughput\"|\"allocs\"|\"tasks\"|\"instructions\")")
         ;
 
     set_abort_on_internal_error(true);


### PR DESCRIPTION
The "throughput" metric is noisy, as it affected by the environment,
like cpu-frequency scaling due to thermal considerations, other
processes that run on the system and may affect memory caching,
for example, and so on. Therefore it is invonvinient for comparing
run-to-run results both on the same test machine, and in particular,
on different test machines.

In contrast, instructions/op are a more reliable metric
for detecting regressions or improvements in different versions
of scylla.

- [ ] No need to backport as this just improves a microbenchmark tool


