### PR TITLE
Querier: optimize moves of querier_opt, partition_range and partition_slice

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2925,7 +2925,7 @@ table::query(schema_ptr s,
 
         if (!querier_opt) {
             query::querier_base::querier_config conf(_config.tombstone_warn_threshold);
-            querier_opt = query::querier(as_mutation_source(), s, permit, range, qs.cmd.slice, trace_state, conf);
+            querier_opt.emplace(as_mutation_source(), s, permit, range, qs.cmd.slice, trace_state, conf);
         }
         auto& q = *querier_opt;
 
@@ -2979,7 +2979,7 @@ table::mutation_query(schema_ptr s,
     }
     if (!querier_opt) {
         query::querier_base::querier_config conf(_config.tombstone_warn_threshold);
-        querier_opt = query::querier(as_mutation_source(), s, permit, range, cmd.slice, trace_state, conf);
+        querier_opt.emplace(as_mutation_source(), s, permit, range, cmd.slice, trace_state, conf);
     }
     auto& q = *querier_opt;
 


### PR DESCRIPTION
This series contains a couple of optimizations for the querier interface
that optimize `optional<querier>` moves and packs the querier `dht::partition_range` and `query::partition_alice`
into a new `querier_reader_context` structure that uses a single allocation.

Total improvement as measured with perf-simple-query is of about 400 instructions/op (~1%) and 1 fewer allocs/op:
```
base: 94575.94 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42288 insns/op,        0 errors)
post: 96538.66 tps ( 62.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   41895 insns/op,        0 errors)
```

- [x] No backport required, this PR contains only optimizations
