### PR TITLE
functions: Do not crash when schema is missing

### DIFF
--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -332,6 +332,9 @@ functions::get(data_dictionary::database db,
         if (!receiver_cf.has_value()) {
             throw exceptions::invalid_request_exception("functions::get for token doesn't have a known column family");
         }
+        if (schema == nullptr) {
+            throw exceptions::invalid_request_exception(format("functions::get for token cannot find {} table", *receiver_cf));
+        }
         auto fun = ::make_shared<token_fct>(schema);
         validate_types(db, keyspace, schema.get(), fun, provided_args, receiver_ks, receiver_cf);
         return fun;


### PR DESCRIPTION
Getting token() function first tries to find a schema for underlying table and continues with nullptr if there's no one. Later, when creating token_fct, the schema is passed as is and referenced. If it's null crash happens.

It used to throw before 5983e9e7b2 (cql3: test_assignment: pass optional schema everywhere) on missing schema, but this commit changed the way schema is looked up, so nullptr is now possible.

fixes: #18637

