### PR TITLE
storage_proxy: update view update backlog on correct shard when writing

### DIFF
--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -252,7 +252,7 @@ future<> db::batchlog_manager::replay_all_failed_batches() {
             mutation m(schema, key);
             auto now = service::client_state(service::client_state::internal_tag()).get_timestamp();
             m.partition().apply_delete(*schema, clustering_key_prefix::make_empty(), tombstone(now, gc_clock::now()));
-            return _qp.proxy().mutate_locally(m, tracing::trace_state_ptr(), db::commitlog::force_sync::no);
+            return _qp.proxy().mutate_locally(m, tracing::trace_state_ptr(), db::commitlog::force_sync::no).discard_result();
         });
     };
 

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -557,7 +557,7 @@ public:
                 db::schema_tables::add_type_to_schema_mutation(t.metadata, t.timestamp.time_since_epoch().count(), mutations);
             }
         }
-        return _qp.proxy().mutate_locally(std::move(mutations), tracing::trace_state_ptr());
+        return _qp.proxy().mutate_locally(std::move(mutations), tracing::trace_state_ptr()).discard_result();
     }
 
     future<> flush_schemas() {

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -227,7 +227,7 @@ static future<> save_system_schema_to_keyspace(cql3::query_processor& qp, const 
     });
     {
         auto mvec  = make_create_keyspace_mutations(qp.db().features().cluster_schema_features(), ksm, system_keyspace::schema_creation_timestamp(), true);
-        co_await qp.proxy().mutate_locally(std::move(mvec), tracing::trace_state_ptr());
+        co_await qp.proxy().mutate_locally(std::move(mvec), tracing::trace_state_ptr()).discard_result();
     }
 }
 
@@ -1239,7 +1239,7 @@ future<> store_column_mapping(distributed<service::storage_proxy>& proxy, schema
         fill_column_info(*s, ckey, cdef, ts, ttl, m);
         muts.emplace_back(std::move(m));
     }
-    co_await proxy.local().mutate_locally(std::move(muts), tracing::trace_state_ptr());
+    co_await proxy.local().mutate_locally(std::move(muts), tracing::trace_state_ptr()).discard_result();
 }
 
 // Limit concurrency of user tables to prevent stalls.

--- a/db/view/node_view_update_backlog.hh
+++ b/db/view/node_view_update_backlog.hh
@@ -47,6 +47,7 @@ public:
     }
 
     update_backlog add_fetch(unsigned shard, update_backlog backlog);
+    update_backlog fetch_shard(unsigned shard);
 
     // Exposed for testing only.
     update_backlog load() const {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1777,7 +1777,7 @@ future<> view_update_generator::mutate_MV(
                     mut.s->ks_name(), mut.s->cf_name(), base_token, view_token);
             local_view_update = _proxy.local().mutate_mv_locally(mut.s, *mut_ptr, tr_state, db::commitlog::force_sync::no).then_wrapped(
                     [s = mut.s, &stats, &cf_stats, tr_state, base_token, view_token, my_address, mut_ptr = std::move(mut_ptr),
-                            sem_units] (future<>&& f) {
+                            sem_units] (future<std::optional<db::view::update_backlog>>&& f) {
                 --stats.writes;
                 if (f.failed()) {
                     ++stats.view_updates_failed_local;

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -385,7 +385,7 @@ future<> view_update_generator::populate_views(const replica::table& table,
  * but has simply some updated values.
  * @return a future resolving to the mutations to apply to the views, which can be empty.
  */
-future<std::optional<update_backlog>> view_update_generator::generate_and_propagate_view_updates(const replica::table& table,
+future<update_backlog> view_update_generator::generate_and_propagate_view_updates(const replica::table& table,
         const schema_ptr& base,
         reader_permit permit,
         std::vector<view_and_base>&& views,
@@ -465,7 +465,7 @@ future<std::optional<update_backlog>> view_update_generator::generate_and_propag
     if (err) {
         std::rethrow_exception(err);
     }
-    co_return std::nullopt;
+    co_return _proxy.local().get_view_update_backlog();
 }
 
 }

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -385,7 +385,7 @@ future<> view_update_generator::populate_views(const replica::table& table,
  * but has simply some updated values.
  * @return a future resolving to the mutations to apply to the views, which can be empty.
  */
-future<> view_update_generator::generate_and_propagate_view_updates(const replica::table& table,
+future<std::optional<update_backlog>> view_update_generator::generate_and_propagate_view_updates(const replica::table& table,
         const schema_ptr& base,
         reader_permit permit,
         std::vector<view_and_base>&& views,
@@ -465,6 +465,7 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
     if (err) {
         std::rethrow_exception(err);
     }
+    co_return std::nullopt;
 }
 
 }

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -110,7 +110,7 @@ public:
             flat_mutation_reader_v2&&,
             gc_clock::time_point);
 
-    future<std::optional<update_backlog>> generate_and_propagate_view_updates(const replica::table& table,
+    future<update_backlog> generate_and_propagate_view_updates(const replica::table& table,
             const schema_ptr& base,
             reader_permit permit,
             std::vector<view_and_base>&& views,

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -51,6 +51,7 @@ using allow_hints = bool_class<allow_hints_tag>;
 namespace db::view {
 
 class stats;
+class update_backlog;
 struct view_and_base;
 struct wait_for_all_updates_tag {};
 using wait_for_all_updates = bool_class<wait_for_all_updates_tag>;
@@ -109,7 +110,7 @@ public:
             flat_mutation_reader_v2&&,
             gc_clock::time_point);
 
-    future<> generate_and_propagate_view_updates(const replica::table& table,
+    future<std::optional<update_backlog>> generate_and_propagate_view_updates(const replica::table& table,
             const schema_ptr& base,
             reader_permit permit,
             std::vector<view_and_base>&& views,

--- a/service/broadcast_tables/experimental/lang.cc
+++ b/service/broadcast_tables/experimental/lang.cc
@@ -116,7 +116,7 @@ future<query_result> execute_broadcast_table_query(
 
                 auto value = utf8_type->deserialize(q.new_value);
                 new_mutation.set_clustered_cell(clustering_key::make_empty(), "value", std::move(value), ts);
-                co_await proxy.mutate_locally(new_mutation, {}, {});
+                co_await proxy.mutate_locally(new_mutation, {}, {}).discard_result();
             }
 
             if (is_conditional) {

--- a/service/paxos/paxos_state.hh
+++ b/service/paxos/paxos_state.hh
@@ -20,6 +20,10 @@ class storage_proxy;
 }
 namespace db { class system_keyspace; }
 
+namespace db::view {
+class update_backlog;
+}
+
 namespace service::paxos {
 
 using clock_type = db::timeout_clock;
@@ -119,7 +123,7 @@ public:
     static future<bool> accept(storage_proxy& sp, db::system_keyspace& sys_ks, tracing::trace_state_ptr tr_state, schema_ptr schema, dht::token token, const proposal& proposal,
             clock_type::time_point timeout);
     // Replica RPC endpoint for Paxos "learn".
-    static future<> learn(storage_proxy& sp, db::system_keyspace& sys_ks, schema_ptr schema, proposal decision, clock_type::time_point timeout, tracing::trace_state_ptr tr_state);
+    static future<std::optional<db::view::update_backlog>> learn(storage_proxy& sp, db::system_keyspace& sys_ks, schema_ptr schema, proposal decision, clock_type::time_point timeout, tracing::trace_state_ptr tr_state);
     // Replica RPC endpoint for pruning Paxos table
     static future<> prune(db::system_keyspace& sys_ks, schema_ptr schema, const partition_key& key, utils::UUID ballot, clock_type::time_point timeout,
             tracing::trace_state_ptr tr_state);

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -298,7 +298,7 @@ static mutation make_discovery_mutation(discovery::peer_list peers) {
 }
 
 static future<> store_discovered_peers(cql3::query_processor& qp, discovery::peer_list peers) {
-    return qp.proxy().mutate_locally({make_discovery_mutation(std::move(peers))}, tracing::trace_state_ptr{});
+    return qp.proxy().mutate_locally({make_discovery_mutation(std::move(peers))}, tracing::trace_state_ptr{}).discard_result();
 }
 
 future<group0_info> persistent_discovery::run(

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2910,7 +2910,10 @@ storage_proxy::storage_proxy(distributed<replica::database>& db, storage_proxy::
         sm::make_queue_length("current_throttled_writes", [this] { return _throttled_writes.size(); },
                        sm::description("number of currently throttled write requests")),
     });
-
+    _metrics.add_group(storage_proxy_stats::REPLICA_STATS_CATEGORY, {
+        sm::make_current_bytes("view_update_backlog", [this] { return _max_view_update_backlog.fetch_shard(this_shard_id()).current; },
+                       sm::description("View update backlog size used for slowing down writes when it grows too large")),
+    });
     slogger.trace("hinted DCs: {}", cfg.hinted_handoff_enabled.to_configuration_string());
     _hints_manager.register_metrics("hints_manager");
     _hints_for_views_manager.register_metrics("hints_for_views_manager");

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -517,14 +517,14 @@ private:
 
     // Applies mutation on this node.
     // Resolves with timed_out_error when timeout is reached.
-    future<> mutate_locally(const mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout, smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info);
+    future<std::optional<db::view::update_backlog>> mutate_locally(const mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout, smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info);
     // Applies mutation on this node.
     // Resolves with timed_out_error when timeout is reached.
-    future<> mutate_locally(const schema_ptr&, const frozen_mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout,
+    future<std::optional<db::view::update_backlog>> mutate_locally(const schema_ptr&, const frozen_mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout,
             smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info);
     // Applies mutations on this node.
     // Resolves with timed_out_error when timeout is reached.
-    future<> mutate_locally(std::vector<mutation> mutation, tracing::trace_state_ptr tr_state, clock_type::time_point timeout, smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info);
+    future<std::optional<db::view::update_backlog>> mutate_locally(std::vector<mutation> mutation, tracing::trace_state_ptr tr_state, clock_type::time_point timeout, smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info);
     // Confirm whether the topology version from the token is greater than or equal
     // to the current fencing_version sourced from shared_token_metadata.
     // If it is not, the function will return an engaged optional.
@@ -544,27 +544,27 @@ private:
 public:
     // Applies mutation on this node.
     // Resolves with timed_out_error when timeout is reached.
-    future<> mutate_locally(const mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout = clock_type::time_point::max(), db::per_partition_rate_limit::info rate_limit_info = std::monostate()) {
+    future<std::optional<db::view::update_backlog>> mutate_locally(const mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout = clock_type::time_point::max(), db::per_partition_rate_limit::info rate_limit_info = std::monostate()) {
         return mutate_locally(m, tr_state, sync, timeout, _write_smp_service_group, rate_limit_info);
     }
     // Applies mutation on this node.
     // Resolves with timed_out_error when timeout is reached.
-    future<> mutate_locally(const schema_ptr& s, const frozen_mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout = clock_type::time_point::max(), db::per_partition_rate_limit::info rate_limit_info = std::monostate()) {
+    future<std::optional<db::view::update_backlog>> mutate_locally(const schema_ptr& s, const frozen_mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout = clock_type::time_point::max(), db::per_partition_rate_limit::info rate_limit_info = std::monostate()) {
         return mutate_locally(s, m, tr_state, sync, timeout, _write_smp_service_group, rate_limit_info);
     }
     // Applies materialized view mutation on this node.
     // Resolves with timed_out_error when timeout is reached.
-    future<> mutate_mv_locally(const schema_ptr& s, const frozen_mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout = clock_type::time_point::max(), db::per_partition_rate_limit::info rate_limit_info = std::monostate()) {
+    future<std::optional<db::view::update_backlog>> mutate_mv_locally(const schema_ptr& s, const frozen_mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout = clock_type::time_point::max(), db::per_partition_rate_limit::info rate_limit_info = std::monostate()) {
         return mutate_locally(s, m, tr_state, sync, timeout, _write_mv_smp_service_group, rate_limit_info);
     }
     // Applies mutations on this node.
     // Resolves with timed_out_error when timeout is reached.
-    future<> mutate_locally(std::vector<mutation> mutation, tracing::trace_state_ptr tr_state, clock_type::time_point timeout = clock_type::time_point::max(), db::per_partition_rate_limit::info rate_limit_info = std::monostate());
+    future<std::optional<db::view::update_backlog>> mutate_locally(std::vector<mutation> mutation, tracing::trace_state_ptr tr_state, clock_type::time_point timeout = clock_type::time_point::max(), db::per_partition_rate_limit::info rate_limit_info = std::monostate());
     // Applies a vector of frozen_mutation:s and their schemas on this node, in parallel.
     // Resolves with timed_out_error when timeout is reached.
-    future<> mutate_locally(std::vector<frozen_mutation_and_schema> mutations, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout = clock_type::time_point::max(), db::per_partition_rate_limit::info rate_limit_info = std::monostate());
+    future<std::optional<db::view::update_backlog>> mutate_locally(std::vector<frozen_mutation_and_schema> mutations, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout = clock_type::time_point::max(), db::per_partition_rate_limit::info rate_limit_info = std::monostate());
 
-    future<> mutate_hint(const schema_ptr&, const frozen_mutation& m, tracing::trace_state_ptr tr_state, clock_type::time_point timeout = clock_type::time_point::max());
+    future<std::optional<db::view::update_backlog>> mutate_hint(const schema_ptr&, const frozen_mutation& m, tracing::trace_state_ptr tr_state, clock_type::time_point timeout = clock_type::time_point::max());
 
     /**
     * Use this method to have these Mutations applied

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -826,7 +826,7 @@ future<> storage_service::merge_topology_snapshot(raft_snapshot snp) {
         // By applying the cdc_generations_v3 mutations before topology mutations
         // we ensure that the lack of atomicity isn't a problem here.
         co_await max_concurrent_for_each(frozen_muts_to_apply, 128, [&] (const frozen_mutation& m) -> future<> {
-            return _db.local().apply(s, m, {}, db::commitlog::force_sync::yes, db::no_timeout);
+            return _db.local().apply(s, m, {}, db::commitlog::force_sync::yes, db::no_timeout).discard_result();
         });
     }
 

--- a/test/boost/batchlog_manager_test.cc
+++ b/test/boost/batchlog_manager_test.cc
@@ -50,7 +50,7 @@ SEASTAR_TEST_CASE(test_execute_batch) {
             auto version = netw::messaging_service::current_version;
             auto bm = qp.proxy().get_batchlog_mutation_for({ m }, s->id().uuid(), version, db_clock::now() - db_clock::duration(3h));
 
-            return qp.proxy().mutate_locally(bm, tracing::trace_state_ptr(), db::commitlog::force_sync::no).then([&bp] () mutable {
+            return qp.proxy().mutate_locally(bm, tracing::trace_state_ptr(), db::commitlog::force_sync::no).then([&bp] (std::optional<db::view::update_backlog>) mutable {
                 return bp.count_all_batches().then([](auto n) {
                     BOOST_CHECK_EQUAL(n, 1);
                 }).then([&bp] () mutable {

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -70,7 +70,7 @@ static future<> apply_mutation(sharded<replica::database>& sharded_db, table_id 
     auto shard = t.shard_for_reads(m.token());
     return sharded_db.invoke_on(shard, [uuid, fm = freeze(m), do_flush, fs, timeout] (replica::database& db) {
         auto& t = db.find_column_family(uuid);
-        return db.apply(t.schema(), fm, tracing::trace_state_ptr(), fs, timeout).then([do_flush, &t] {
+        return db.apply(t.schema(), fm, tracing::trace_state_ptr(), fs, timeout).then([do_flush, &t] (std::optional<db::view::update_backlog>) {
             return do_flush ? t.flush() : make_ready_future<>();
         });
     });

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -164,7 +164,7 @@ SEASTAR_TEST_CASE(test_reader_with_different_strategies) {
                 max_token = std::max(max_token, t);
             }
             auto& storage_proxy = e.get_storage_proxy().local();
-            co_await storage_proxy.mutate_locally(std::move(mutations), tracing::trace_state_ptr());
+            co_await storage_proxy.mutate_locally(std::move(mutations), tracing::trace_state_ptr()).discard_result();
         }
 
         auto do_check = [&](const dht::static_sharder& remote_sharder,

--- a/test/topology_custom/test_mv_backlog.py
+++ b/test/topology_custom/test_mv_backlog.py
@@ -1,0 +1,105 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from test.pylib.manager_client import ManagerClient
+
+import asyncio
+import pytest
+import time
+import logging
+from test.topology.conftest import skip_mode
+from cassandra.cqltypes import Int32Type
+import requests
+import re
+
+logger = logging.getLogger(__name__)
+
+async def wait_for_views(cql, mvs_count, node_count):
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        done = await cql.run_async(f"SELECT COUNT(*) FROM system_distributed.view_build_status WHERE status = 'SUCCESS' ALLOW FILTERING")
+        logger.info(f"Views built: {done[0][0]}")
+        if done[0][0] == node_count * mvs_count:
+            return
+        else:
+            time.sleep(0.2)
+    raise Exception("Timeout waiting for views to build")
+
+
+def get_metrics(addr):
+    # The Prometheus API is on port 9180, and always http
+    addr = 'http://' + addr + ':9180/metrics'
+    resp = requests.get(addr)
+    if resp.status_code != 200:
+        pytest.skip('Metrics port 9180 is not available')
+    response = requests.get(addr)
+    assert response.status_code == 200
+    return response.text
+
+def get_metric(metrics, name, requested_labels=None):
+    the_metrics = get_metrics(metrics)
+    total = 0.0
+    lines = re.compile('^'+name+'{.*$', re.MULTILINE)
+    for match in re.findall(lines, the_metrics):
+        a = match.split()
+        metric = a[0]
+        val = float(a[1])
+        # Check if match also matches the requested labels
+        if requested_labels:
+            # we know metric begins with name{ and ends with } - the labels
+            # are what we have between those
+            got_labels = metric[len(name)+1:-1].split(',')
+            # Check that every one of the requested labels is in got_labels:
+            for k, v in requested_labels.items():
+                if not f'{k}="{v}"' in got_labels:
+                    # No match for requested label, skip this metric (python
+                    # doesn't have "continue 2" so let's just set val to 0...
+                    val = 0
+                    break
+        total += float(val)
+    return total
+
+def get_replicas(cql, key):
+    return cql.cluster.metadata.get_replicas("ks", Int32Type.serialize(key, cql.cluster.protocol_version))
+
+# This test reproduces issue #18542
+# In the test, we create a table and perform a write to it a couple of times
+# Each time, we check that a view update backlog on some shard increased
+# due to the write.
+@pytest.mark.asyncio
+@skip_mode('release', "error injections aren't enabled in release mode")
+async def test_view_backlog_increased_after_write(manager: ManagerClient) -> None:
+    node_count = 2
+    # Use a higher smp to make it more likely that the writes go to a different shard than the coordinator.
+    servers = await manager.servers_add(node_count, cmdline=['--smp', '5'])
+    cql = manager.get_cql()
+    await cql.run_async(f"CREATE KEYSPACE ks WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 1}}")
+    await cql.run_async(f"CREATE TABLE ks.tab (key int, c int, v text, PRIMARY KEY (key, c))")
+    await cql.run_async(f"CREATE MATERIALIZED VIEW ks.mv_cf_view AS SELECT * FROM ks.tab "
+                    "WHERE c IS NOT NULL and key IS NOT NULL PRIMARY KEY (c, key) ")
+    await wait_for_views(cql, 1, node_count)
+
+    key = int(time.time())
+    logger.info(f"Base table key: {key}")
+    local_node = get_replicas(cql, key)[0]
+    i = 0
+    for v in [1000, 4000, 16000, 64000, 256000]:
+        # Only remote updates hold on to memory, so make the update remote
+        while local_node == get_replicas(cql, i)[0]:
+            i = i + 1
+
+        # Make sure the view update backlog is still high (view udpate hasn't finished) when the replica returns
+        errs = [manager.api.enable_injection(s.ip_addr, "never_finish_remote_view_updates", False) for s in servers]
+        await asyncio.gather(*errs)
+
+        await cql.run_async(f"INSERT INTO ks.tab (key, c, v) VALUES ({key}, {i}, '{v*'a'}')")
+        # The view update backlog should increase on the node generating view updates
+        view_backlog = get_metric(local_node.address, 'scylla_storage_proxy_replica_view_update_backlog')
+        # The read view_backlog might still contain backlogs from the previous iterations, so we only assert that it large enough
+        assert view_backlog > v
+        errs = [manager.api.disable_injection(s.ip_addr, "never_finish_remote_view_updates") for s in servers]
+        await asyncio.gather(*errs)
+
+    await cql.run_async(f"DROP KEYSPACE ks")


### PR DESCRIPTION
When a replica applies a write on a table which has a materialized view
it generates view updates. These updates take memory which is tracked
by `database::_view_update_concurrency_sem`, separate on each shard.
The fraction of units taken from the semaphore to the semaphore limit
is the shard's `view update backlog`. Based on these backlogs, we want
to estimate how busy a node is with its view updates work. We do that
by taking the max backlog across all shards.
To avoid excessive cross-shard operations, the node's (max) backlog isn't
calculated each time we need it, but up to 1 time per 10ms (the `_interval`) with an optimization where the backlog of the calculating shard is immediately up-to-date (we don't need cross-shard operations for it):
```
 update_backlog node_update_backlog::add_fetch(unsigned shard, update_backlog backlog) { 
     _backlogs[shard].backlog.store(backlog, std::memory_order_relaxed); 
     auto now = clock::now(); 
     if (now >= _last_update.load(std::memory_order_relaxed) + _interval) { 
         _last_update.store(now, std::memory_order_relaxed); 
         auto new_max = boost::accumulate( 
                 _backlogs, 
                 update_backlog::no_backlog(), 
                 [] (const update_backlog& lhs, const per_shard_backlog& rhs) { 
                     return std::max(lhs, rhs.load()); 
                 }); 
         _max.store(new_max, std::memory_order_relaxed); 
         return new_max; 
     } 
     return std::max(backlog, _max.load(std::memory_order_relaxed)); 
 } 
```
For the same reason, even when we do calculate the new node's backlog,
we don't read from the `_view_update_concurrency_sem`. Instead, for
each shard we also store a `update_backlog` atomic which we use for
calculation:
```
 struct per_shard_backlog { 
     // Multiply by 2 to defeat the prefetcher 
     alignas(seastar::cache_line_size * 2) std::atomic<update_backlog> backlog = update_backlog::no_backlog(); 
  
     update_backlog load() const { 
         return backlog.load(std::memory_order_relaxed); 
     } 
 }; 
 std::vector<per_shard_backlog> _backlogs; 
```
Due to this distinction, the `update_backlog` atomic need to be updated
separately, when the `_view_update_concurrency_sem` changes.
This is done by calling `storage_proxy::get_view_update_backlog`, which reads the `_view_update_concurrency_sem` of the shard (in database::get_view_update_backlog) 
and then calls `node_update_backlog::add_fetch` where the read backlog
is stored in the atomic:
```
 db::view::update_backlog storage_proxy::get_view_update_backlog() const { 
     return _max_view_update_backlog.add_fetch(this_shard_id(), get_db().local().get_view_update_backlog()); 
 } 
```
```
 update_backlog node_update_backlog::add_fetch(unsigned shard, update_backlog backlog) { 
     _backlogs[shard].backlog.store(backlog, std::memory_order_relaxed); 

```
For this implementation of calculating the node's view update backlog to work,
we need the atomics to be updated correctly when the semaphores of corresponding
shards change.

The main event where the view update backlog changes is an incoming write
request. That's why when handling the request and preparing a response
we update the backlog calling `storage_proxy::get_view_update_backlog` (also
because we want to read the backlog and send it in the response):
backlog update after local view updates (`storage_proxy::send_to_live_endpoints` in `mutate_begin`)
```
 auto lmutate = [handler_ptr, response_id, this, my_address, timeout] () mutable { 
     return handler_ptr->apply_locally(timeout, handler_ptr->get_trace_state()) 
             .then([response_id, this, my_address, h = std::move(handler_ptr), p = shared_from_this()] { 
         // make mutation alive until it is processed locally, otherwise it 
         // may disappear if write timeouts before this future is ready 
         got_response(response_id, my_address, get_view_update_backlog()); 
     }); 
 }; 
```
backlog update after remote view updates (`storage_proxy::remote::handle_write`)
```
 auto f = co_await coroutine::as_future(send_mutation_done(netw::messaging_service::msg_addr{reply_to, shard}, trace_state_ptr, 
         shard, response_id, p->get_view_update_backlog())); 

```
Now assume that on a certain node we have a write request received on shard A,
which updates a row on shard B (A!=B). As a result, shard B will generate view
updates and consume units from its `_view_update_concurrency_sem`, but will
not update its atomic in `_backlogs` yet. Because both shards in the example
are on the same node, shard A will perform a local write calling `lmutate` shown
above. In the `lmutate` call, the `apply_locally` will initiate the actual write on
shard B and the `storage_proxy::get_view_update_backlog` will be called back
on shard A. In no place will the backlog atomic on shard B get updated even
though it increased in size due to the view updates generated there.
Currently, what we calculate there doesn't really matter - it's only used for the
MV flow control delays, so currently, in this scenario, we may only overload
a replica causing failed replica writes which will be later retried as hints. However,
when we add MV admission control, the calculated backlog will be the difference
between an accepted and a rejected request.

The fix for this correctness issue we need to _update_ the view update backlog
(call `storage_proxy::get_view_update_backlog`) on the shard whose semaphore
units have been consumed. We could still _read_ the backlog on the shard that
received the initial request (also using `storage_proxy::get_view_update_backlog`),
however, if we read the backlog on a different shard than the one which generated
the view updates, it will most likely be outdated (by 10ms), so we'll likely won't see
the backlog change caused by the write request. If we want to see that, we need
to get the return updated value from the shard that generated the view updates
and return it on the shard handling the request.

This patch ensures that when semaphore units are consumed on some shard, it's
atomic backlog is updated and that when a backlogs increases as a result of some
request, the increased backlog is returned in the response of this request. This
is achieved by calling `storage_proxy::get_view_update_backlog` on the shard
where the view update semaphore units are consumed and then returning the
received value through the call stack until the response is sent. The exact place
where the `get_view_update_backlog` call is added was chosen due to performance
considerations: we don't want to create a new task on the common write path
just for this, so it's been embedded deeply into `view_update_generator::generate_and_propagate_view_updates`, so that it's only
called when we actually generate view updates and it's performed as a part of a
larger coroutine, not a new continuation.

Perf simple query in write mode gives the following results:
Before:
median 506446.36 tps ( 59.3 allocs/op,  16.0 logallocs/op,  15.0 tasks/op,   52680 insns/op,        0 errors)
median absolute deviation: 5352.38
maximum: 521346.01
minimum: 500055.56
After:
median 523666.95 tps ( 59.3 allocs/op,  16.0 logallocs/op,  15.0 tasks/op,   52457 insns/op,        0 errors)
median absolute deviation: 7856.04
maximum: 547143.16
minimum: 451149.62

Fixes: https://github.com/scylladb/scylladb/issues/18542

Without admission control (https://github.com/scylladb/scylladb/pull/18334), this patch doesn't affect much, so I'm marking it as backport/none