### PR TITLE
hinted handoff: Prevent segmentation fault when initializing endpoint managers 

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -912,11 +912,11 @@ future<> manager::perform_migration() {
 
     // Step 6. Make resource manager scan the hint directory again.
     resource_manager_lock.return_all();
-    // Step 7. Once resource manager is working again, endpoint managers can be safely recreated.
+    // Step 7. Start accepting incoming hints again.
+    _state.remove(state::migrating);
+    // Step 8. Once resource manager is working again, endpoint managers can be safely recreated.
     //         We won't modify the contents of the hint directory anymore.
     co_await initialize_endpoint_managers();
-    // Step 8. Start accepting incoming hints again.
-    _state.remove(state::migrating);
     manager_logger.info("Migration of hinted handoff to host ID has finished successfully");
 }
 

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -14,7 +14,6 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sharded.hh>
-#include <seastar/core/shared_future.hh>
 #include <seastar/core/shared_mutex.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/util/noncopyable_function.hh>


### PR DESCRIPTION
We don't attempt to create an endpoint manager for a hint directory if there is no mapping host ID–IP corresponding to the directory's name, an IP address. That prevents a segmentation fault.

Fixes scylladb/scylladb#18649