### PR TITLE
mv: gossip the same backlog if a different backlog was sent in a response

### DIFF
--- a/db/view/node_view_update_backlog.hh
+++ b/db/view/node_view_update_backlog.hh
@@ -11,7 +11,9 @@
 #include "db/view/view_update_backlog.hh"
 
 #include <seastar/core/cacheline.hh>
+#include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/util/bool_class.hh>
 
 #include <atomic>
 #include <chrono>
@@ -25,9 +27,11 @@ namespace db::view {
  */
 class node_update_backlog {
     using clock = seastar::lowres_clock;
+    using need_publishing = seastar::bool_class<class need_publishing_tag>;
     struct per_shard_backlog {
         // Multiply by 2 to defeat the prefetcher
         alignas(seastar::cache_line_size * 2) std::atomic<update_backlog> backlog = update_backlog::no_backlog();
+        need_publishing need_publishing = need_publishing::no;
 
         update_backlog load() const {
             return backlog.load(std::memory_order_relaxed);
@@ -49,6 +53,7 @@ public:
     update_backlog fetch();
     void add(update_backlog backlog);
     update_backlog fetch_shard(unsigned shard);
+    seastar::future<std::optional<update_backlog>> fetch_if_changed();
 
     // Exposed for testing only.
     update_backlog load() const {

--- a/db/view/node_view_update_backlog.hh
+++ b/db/view/node_view_update_backlog.hh
@@ -46,7 +46,9 @@ public:
             , _max(update_backlog::no_backlog()) {
     }
 
-    update_backlog add_fetch(unsigned shard, update_backlog backlog);
+    update_backlog fetch();
+    void add(update_backlog backlog);
+    update_backlog fetch_shard(unsigned shard);
 
     // Exposed for testing only.
     update_backlog load() const {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2630,6 +2630,7 @@ future<> view_builder::wait_until_built(const sstring& ks_name, const sstring& v
 
 void node_update_backlog::add(update_backlog backlog) {
     _backlogs[this_shard_id()].backlog.store(backlog, std::memory_order_relaxed);
+    _backlogs[this_shard_id()].need_publishing = need_publishing::yes;
 }
 
 update_backlog node_update_backlog::fetch() {
@@ -2646,6 +2647,23 @@ update_backlog node_update_backlog::fetch() {
         return new_max;
     }
     return std::max(fetch_shard(this_shard_id()), _max.load(std::memory_order_relaxed));
+}
+
+future<std::optional<update_backlog>> node_update_backlog::fetch_if_changed() {
+    _last_update.store(clock::now(), std::memory_order_relaxed);
+    auto [np, max] = co_await map_reduce(boost::irange(0u, smp::count),
+            [this] (shard_id shard) {
+                return smp::submit_to(shard, [this, shard] {
+                    // Even if the shard's backlog didn't change, we still need to take it into account when calculating the new max.
+                    return std::make_pair(std::exchange(_backlogs[shard].need_publishing, need_publishing::no), fetch_shard(shard));
+                });
+            },
+            std::make_pair(need_publishing::no, db::view::update_backlog()),
+            [] (std::pair<need_publishing, db::view::update_backlog> a, std::pair<need_publishing, db::view::update_backlog> b) {
+                return std::make_pair(a.first || b.first, std::max(a.second, b.second));
+            });
+    _max.store(max, std::memory_order_relaxed);
+    co_return np ? std::make_optional(max) : std::nullopt;
 }
 
 update_backlog node_update_backlog::fetch_shard(unsigned shard) {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1782,7 +1782,7 @@ future<> view_update_generator::mutate_MV(
                             sem_units, this] (future<>&& f) mutable {
                 --stats.writes;
                 sem_units = nullptr;
-                _proxy.local().get_view_update_backlog();
+                _proxy.local().update_view_update_backlog();
                 if (f.failed()) {
                     ++stats.view_updates_failed_local;
                     ++cf_stats.total_view_updates_failed_local;
@@ -1819,7 +1819,7 @@ future<> view_update_generator::mutate_MV(
                 [s = std::move(s), &stats, &cf_stats, tr_state, base_token, view_token, target_endpoint, updates_pushed_remote,
                  sem_units, apply_update_synchronously, this] (future<>&& f) mutable {
                 sem_units = nullptr;
-                _proxy.local().get_view_update_backlog();
+                _proxy.local().update_view_update_backlog();
                 if (f.failed()) {
                     stats.view_updates_failed_remote += updates_pushed_remote;
                     cf_stats.total_view_updates_failed_remote += updates_pushed_remote;
@@ -2628,8 +2628,11 @@ future<> view_builder::wait_until_built(const sstring& ks_name, const sstring& v
     });
 }
 
-update_backlog node_update_backlog::add_fetch(unsigned shard, update_backlog backlog) {
-    _backlogs[shard].backlog.store(backlog, std::memory_order_relaxed);
+void node_update_backlog::add(update_backlog backlog) {
+    _backlogs[this_shard_id()].backlog.store(backlog, std::memory_order_relaxed);
+}
+
+update_backlog node_update_backlog::fetch() {
     auto now = clock::now();
     if (now >= _last_update.load(std::memory_order_relaxed) + _interval) {
         _last_update.store(now, std::memory_order_relaxed);
@@ -2642,7 +2645,11 @@ update_backlog node_update_backlog::add_fetch(unsigned shard, update_backlog bac
         _max.store(new_max, std::memory_order_relaxed);
         return new_max;
     }
-    return std::max(backlog, _max.load(std::memory_order_relaxed));
+    return std::max(fetch_shard(this_shard_id()), _max.load(std::memory_order_relaxed));
+}
+
+update_backlog node_update_backlog::fetch_shard(unsigned shard) {
+    return _backlogs[shard].backlog.load(std::memory_order_relaxed);
 }
 
 future<bool> view_builder::check_view_build_ongoing(const locator::token_metadata& tm, const sstring& ks_name, const sstring& cf_name) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -542,6 +542,7 @@ private:
                         //
                         // Usually we will return immediately, since this work only involves appending data to the connection
                         // send buffer.
+                        p->update_view_update_backlog();
                         auto f = co_await coroutine::as_future(send_mutation_done(netw::messaging_service::msg_addr{reply_to, shard}, trace_state_ptr,
                                 shard, response_id, p->get_view_update_backlog()));
                         f.ignore_ready_future();
@@ -580,6 +581,7 @@ private:
         }
         // ignore results, since we'll be returning them via MUTATION_DONE/MUTATION_FAILURE verbs
         if (errors.count) {
+            p->update_view_update_backlog();
             auto f = co_await coroutine::as_future(send_mutation_failed(
                     netw::messaging_service::msg_addr{reply_to, shard},
                     trace_state_ptr,
@@ -2433,8 +2435,12 @@ void storage_proxy::maybe_update_view_backlog_of(gms::inet_address replica, std:
     }
 }
 
-db::view::update_backlog storage_proxy::get_view_update_backlog() const {
-    return _max_view_update_backlog.add_fetch(this_shard_id(), get_db().local().get_view_update_backlog());
+void storage_proxy::update_view_update_backlog() {
+    _max_view_update_backlog.add(get_db().local().get_view_update_backlog());
+}
+
+db::view::update_backlog storage_proxy::get_view_update_backlog() {
+    return _max_view_update_backlog.fetch();
 }
 
 db::view::update_backlog storage_proxy::get_backlog_of(gms::inet_address ep) const {
@@ -4081,6 +4087,7 @@ void storage_proxy::send_to_live_endpoints(storage_proxy::response_id_type respo
                 .then([response_id, this, my_address, h = std::move(handler_ptr), p = shared_from_this()] {
             // make mutation alive until it is processed locally, otherwise it
             // may disappear if write timeouts before this future is ready
+            update_view_update_backlog();
             got_response(response_id, my_address, get_view_update_backlog());
         });
     };

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2443,6 +2443,13 @@ db::view::update_backlog storage_proxy::get_view_update_backlog() {
     return _max_view_update_backlog.fetch();
 }
 
+future<std::optional<db::view::update_backlog>> storage_proxy::get_view_update_backlog_if_changed() {
+    if (this_shard_id() != 0) {
+        on_internal_error(slogger, format("getting view update backlog for gossip on a non-gossip shard {}", this_shard_id()));
+    }
+    return _max_view_update_backlog.fetch_if_changed();
+}
+
 db::view::update_backlog storage_proxy::get_backlog_of(gms::inet_address ep) const {
     auto it = _view_update_backlogs.find(ep);
     if (it == _view_update_backlogs.end()) {

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -235,6 +235,9 @@ public:
     // Get information about this node's view update backlog. It combines information from all local shards.
     db::view::update_backlog get_view_update_backlog();
 
+    // Used for gossiping view update backlog information. Must be called on shard 0.
+    future<std::optional<db::view::update_backlog>> get_view_update_backlog_if_changed();
+
     // Get information about a remote node's view update backlog. Information about remote backlogs is constantly updated
     // using gossip and by passing the information in each MUTATION_DONE rpc call response.
     db::view::update_backlog get_backlog_of(gms::inet_address) const;

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -230,8 +230,10 @@ public:
     query::tombstone_limit get_tombstone_limit() const;
     inet_address_vector_replica_set get_live_endpoints(const locator::effective_replication_map& erm, const dht::token& token) const;
 
+    void update_view_update_backlog();
+
     // Get information about this node's view update backlog. It combines information from all local shards.
-    db::view::update_backlog get_view_update_backlog() const;
+    db::view::update_backlog get_view_update_backlog();
 
     // Get information about a remote node's view update backlog. Information about remote backlogs is constantly updated
     // using gossip and by passing the information in each MUTATION_DONE rpc call response.


### PR DESCRIPTION
Currently, there are 2 ways of sharing a backlog with other nodes: through
a gossip mechanism, and with responses to replica writes. In gossip, we
check each second if the backlog changed, and if it did we update other
nodes with it. However if the backlog for this node changed on another
node with a write response, the gossiped backlog is currently not updated,
so if after the response the backlog goes back to the value from the previous
gossip round, it will not get sent and the other node will stay with an
outdated backlog - this can be observed in the following scenario:

1. Cluster starts, all nodes gossip their empty view update backlog to one another
2. On node N, `view_update_backlog_broker` (the backlog gossiper) performs an iteration of its backlog update loop, sees no change (backlog has been empty since the start), schedules the next iteration after 1s
3. Within the next 1s, coordinator (different than N) sends a write to N causing a remote view update (which we do not wait for). As a result, node N replies immediately with an increased view update backlog, which is then noted by the coordinator.
4. Still within the 1s, node N finishes the view update in the background, dropping its view update backlog to 0.
5. In the next and following iterations of `view_update_backlog_broker` on N, backlog is empty, as it was in step 2, so no change is seen and no update is sent due to the check
```
auto backlog = _sp.local().get_view_update_backlog(); 
if (backlog_published && *backlog_published == backlog) { 
    sleep_abortable(gms::gossiper::INTERVAL, _as).get(); 
    continue; 
} 
```

After this scenario happens, the coordinator keeps an information about an increased view update backlog on N even though it's actually already empty

This patch fixes the issue this by notifying the gossip that a different backlog
was sent in a response, causing it to send an unchanged backlog to other
nodes in the following gossip round.

Fixes: https://github.com/scylladb/scylladb/issues/18461

Similarly to https://github.com/scylladb/scylladb/pull/18646, without admission control (https://github.com/scylladb/scylladb/pull/18334), this patch doesn't affect much, so I'm marking it as backport/none

Tests: manual. Currently this patch only affects the length of MV flow control delay, which is not reliable to base a test on. A proper test will be added when MV admission control is added, so we'll be able to base the test on rejected requests