### PR TITLE
[Backport 5.2] : Reload reclaimed bloom filters when memory is available 

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -4118,7 +4118,7 @@ def find_sstables():
         system_sstables_manager = std_unique_ptr(db["_system_sstables_manager"]).get()
         for manager in (user_sstables_manager, system_sstables_manager):
             for sst_list_name in ("_active", "_undergoing_close"):
-                for sst in intrusive_list(manager[sst_list_name], link="_manager_link"):
+                for sst in intrusive_list(manager[sst_list_name], link="_manager_list_link"):
                     yield sst.address
     except gdb.error:
         # Scylla Enterprise 2020.1 compatibility

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1510,7 +1510,7 @@ size_t sstable::total_reclaimable_memory_size() const {
 }
 
 size_t sstable::reclaim_memory_from_components() {
-    size_t total_memory_reclaimed = 0;
+    size_t memory_reclaimed_this_iteration = 0;
 
     if (_components->filter) {
         auto filter_memory_size = _components->filter->memory_size();
@@ -1518,12 +1518,12 @@ size_t sstable::reclaim_memory_from_components() {
             // Discard it from memory by replacing it with an always present variant.
             // No need to remove it from _recognized_components as the filter is still in disk.
             _components->filter = std::make_unique<utils::filter::always_present_filter>();
-            total_memory_reclaimed += filter_memory_size;
+            memory_reclaimed_this_iteration += filter_memory_size;
         }
     }
 
     _total_reclaimable_memory.reset();
-    return total_memory_reclaimed;
+    return memory_reclaimed_this_iteration;
 }
 
 // This interface is only used during tests, snapshot loading and early initialization.

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -32,6 +32,7 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/coroutine/as_future.hh>
 
+#include "utils/error_injection.hh"
 #include "dht/sharder.hh"
 #include "types.hh"
 #include "writer.hh"
@@ -1536,6 +1537,8 @@ future<> sstable::reload_reclaimed_components(const io_priority_class& pc) {
         // nothing to reload
         co_return;
     }
+
+    co_await utils::get_local_injector().inject("reload_reclaimed_components/pause", std::chrono::seconds{3});
 
     co_await read_filter(pc);
     _total_reclaimable_memory.reset();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1531,6 +1531,18 @@ size_t sstable::total_memory_reclaimed() const {
     return _total_memory_reclaimed;
 }
 
+future<> sstable::reload_reclaimed_components(const io_priority_class& pc) {
+    if (_total_memory_reclaimed == 0) {
+        // nothing to reload
+        co_return;
+    }
+
+    co_await read_filter(pc);
+    _total_reclaimable_memory.reset();
+    _total_memory_reclaimed -= _components->filter->memory_size();
+    sstlog.info("Reloaded bloom filter of {}", get_filename());
+}
+
 // This interface is only used during tests, snapshot loading and early initialization.
 // No need to set tunable priorities for it.
 future<> sstable::load(const io_priority_class& pc, sstable_open_config cfg) noexcept {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1523,7 +1523,12 @@ size_t sstable::reclaim_memory_from_components() {
     }
 
     _total_reclaimable_memory.reset();
+    _total_memory_reclaimed += memory_reclaimed_this_iteration;
     return memory_reclaimed_this_iteration;
+}
+
+size_t sstable::total_memory_reclaimed() const {
+    return _total_memory_reclaimed;
 }
 
 // This interface is only used during tests, snapshot loading and early initialization.

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -590,6 +590,8 @@ private:
     // It is initialized to 0 to prevent the sstables manager from reclaiming memory
     // from the components before the SSTable has been fully loaded.
     mutable std::optional<size_t> _total_reclaimable_memory{0};
+    // Total memory reclaimed so far from this sstable
+    size_t _total_memory_reclaimed{0};
 public:
     const bool has_component(component_type f) const;
     sstables_manager& manager() { return _manager; }
@@ -673,6 +675,8 @@ private:
     // Reclaim memory from the components back to the system.
     // Note that only bloom filters are reclaimable.
     size_t reclaim_memory_from_components();
+    // Return memory reclaimed so far from this sstable
+    size_t total_memory_reclaimed() const;
 
 public:
     // Finds first position_in_partition in a given partition.

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -675,13 +675,15 @@ private:
 
     future<> create_data() noexcept;
 
+    // Note that only bloom filters are reclaimable by the following methods.
     // Return the total reclaimable memory in this SSTable
     size_t total_reclaimable_memory_size() const;
     // Reclaim memory from the components back to the system.
-    // Note that only bloom filters are reclaimable.
     size_t reclaim_memory_from_components();
     // Return memory reclaimed so far from this sstable
     size_t total_memory_reclaimed() const;
+    // Reload components from which memory was previously reclaimed
+    future<> reload_reclaimed_components(const io_priority_class& pc);
 
 public:
     // Finds first position_in_partition in a given partition.

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -146,7 +146,7 @@ class sstable : public enable_lw_shared_from_this<sstable> {
 public:
     using version_types = sstable_version_types;
     using format_types = sstable_format_types;
-    using manager_link_type = bi::list_member_hook<bi::link_mode<bi::auto_unlink>>;
+    using manager_list_link_type = bi::list_member_hook<bi::link_mode<bi::auto_unlink>>;
 public:
     sstable(schema_ptr schema,
             sstring dir,
@@ -576,7 +576,8 @@ private:
     sstables_manager& _manager;
 
     sstables_stats _stats;
-    manager_link_type _manager_link;
+    // link used by the _active list of sstables manager
+    manager_list_link_type _manager_list_link;
 
     // The _large_data_stats map stores e.g. largest partitions, rows, cells sizes,
     // and max number of rows in a partition.

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -92,6 +92,11 @@ void sstables_manager::increment_total_reclaimable_memory_and_maybe_reclaim(ssta
     smlogger.info("Reclaimed {} bytes of memory from SSTable components. Total memory reclaimed so far is {} bytes", memory_reclaimed, _total_memory_reclaimed);
 }
 
+size_t sstables_manager::get_memory_available_for_reclaimable_components() {
+    size_t memory_reclaim_threshold = _available_memory * _db_config.components_memory_reclaim_threshold();
+    return memory_reclaim_threshold - _total_reclaimable_memory;
+}
+
 future<> sstables_manager::components_reloader_fiber() {
     sstlog.trace("components_reloader_fiber start");
     while (true) {
@@ -99,6 +104,39 @@ future<> sstables_manager::components_reloader_fiber() {
 
         if (_closing) {
             co_return;
+        }
+
+        // Reload bloom filters from the smallest to largest so as to maximize
+        // the number of bloom filters being reloaded.
+        auto memory_available = get_memory_available_for_reclaimable_components();
+        while (!_reclaimed.empty() && memory_available > 0) {
+            auto sstable_to_reload = _reclaimed.begin();
+            const size_t reclaimed_memory = sstable_to_reload->total_memory_reclaimed();
+            if (reclaimed_memory > memory_available) {
+                // cannot reload anymore sstables
+                break;
+            }
+
+            // Increment the total memory before reloading to prevent any parallel
+            // fibers from loading new bloom filters into memory.
+            _total_reclaimable_memory += reclaimed_memory;
+            _reclaimed.erase(sstable_to_reload);
+            // Use a lw_shared_ptr to prevent the sstable from getting deleted when
+            // the components are being reloaded.
+            auto sstable_ptr = sstable_to_reload->shared_from_this();
+            try {
+                co_await sstable_ptr->reload_reclaimed_components(default_priority_class());
+            } catch (...) {
+                // reload failed due to some reason
+                sstlog.warn("Failed to reload reclaimed SSTable components : {}", std::current_exception());
+                // revert back changes made before the reload
+                _total_reclaimable_memory -= reclaimed_memory;
+                _reclaimed.insert(*sstable_to_reload);
+                break;
+            }
+
+            _total_memory_reclaimed -= reclaimed_memory;
+            memory_available = get_memory_available_for_reclaimable_components();
         }
     }
 }

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -87,6 +87,7 @@ void sstables_manager::increment_total_reclaimable_memory_and_maybe_reclaim(ssta
     auto memory_reclaimed = sst_with_max_memory->reclaim_memory_from_components();
     _total_memory_reclaimed += memory_reclaimed;
     _total_reclaimable_memory -= memory_reclaimed;
+    _reclaimed.insert(*sst_with_max_memory);
     smlogger.info("Reclaimed {} bytes of memory from SSTable components. Total memory reclaimed so far is {} bytes", memory_reclaimed, _total_memory_reclaimed);
 }
 
@@ -98,6 +99,7 @@ void sstables_manager::deactivate(sstable* sst) {
     // Remove SSTable from the reclaimable memory tracking
     _total_reclaimable_memory -= sst->total_reclaimable_memory_size();
     _total_memory_reclaimed -= sst->total_memory_reclaimed();
+    _reclaimed.erase(*sst);
 
     // At this point, sst has a reference count of zero, since we got here from
     // lw_shared_ptr_deleter<sstables::sstable>::dispose().

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -97,6 +97,7 @@ void sstables_manager::add(sstable* sst) {
 void sstables_manager::deactivate(sstable* sst) {
     // Remove SSTable from the reclaimable memory tracking
     _total_reclaimable_memory -= sst->total_reclaimable_memory_size();
+    _total_memory_reclaimed -= sst->total_memory_reclaimed();
 
     // At this point, sst has a reference count of zero, since we got here from
     // lw_shared_ptr_deleter<sstables::sstable>::dispose().

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -45,7 +45,7 @@ static constexpr size_t default_sstable_buffer_size = 128 * 1024;
 
 class sstables_manager {
     using list_type = boost::intrusive::list<sstable,
-            boost::intrusive::member_hook<sstable, sstable::manager_link_type, &sstable::_manager_link>,
+            boost::intrusive::member_hook<sstable, sstable::manager_list_link_type, &sstable::_manager_list_link>,
             boost::intrusive::constant_time_size<false>>;
 private:
     size_t _available_memory;

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -76,6 +76,9 @@ private:
     size_t _total_memory_reclaimed{0};
     // Set of sstables from which memory has been reclaimed
     set_type _reclaimed;
+    // Condition variable that gets notified when an sstable is deleted
+    seastar::condition_variable _sstable_deleted_event;
+    future<> _components_reloader_status = make_ready_future<>();
 
     bool _closing = false;
     promise<> _done;
@@ -137,6 +140,8 @@ private:
     // memory and if the total memory usage exceeds the pre-defined threshold,
     // reclaim it from the SSTable that has the most reclaimable memory.
     void increment_total_reclaimable_memory_and_maybe_reclaim(sstable* sst);
+    // Fiber to reload reclaimed components back into memory when memory becomes available.
+    future<> components_reloader_fiber();
 private:
     db::large_data_handler& get_large_data_handler() const {
         return _large_data_handler;

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -142,6 +142,7 @@ private:
     void increment_total_reclaimable_memory_and_maybe_reclaim(sstable* sst);
     // Fiber to reload reclaimed components back into memory when memory becomes available.
     future<> components_reloader_fiber();
+    size_t get_memory_available_for_reclaimable_components();
 private:
     db::large_data_handler& get_large_data_handler() const {
         return _large_data_handler;

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -47,6 +47,10 @@ class sstables_manager {
     using list_type = boost::intrusive::list<sstable,
             boost::intrusive::member_hook<sstable, sstable::manager_list_link_type, &sstable::_manager_list_link>,
             boost::intrusive::constant_time_size<false>>;
+    using set_type = boost::intrusive::set<sstable,
+            boost::intrusive::member_hook<sstable, sstable::manager_set_link_type, &sstable::_manager_set_link>,
+            boost::intrusive::constant_time_size<false>,
+            boost::intrusive::compare<sstable::lesser_reclaimed_memory>>;
 private:
     size_t _available_memory;
     db::large_data_handler& _large_data_handler;
@@ -70,6 +74,8 @@ private:
     size_t _total_reclaimable_memory{0};
     // Total memory reclaimed so far across all sstables
     size_t _total_memory_reclaimed{0};
+    // Set of sstables from which memory has been reclaimed
+    set_type _reclaimed;
 
     bool _closing = false;
     promise<> _done;

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -3494,12 +3494,21 @@ SEASTAR_TEST_CASE(test_sstable_reclaim_memory_from_components) {
             // create a bloom filter
             auto sst_test = sstables::test(sst);
             sst_test.create_bloom_filter(100);
+            sst_test.write_filter();
             auto total_reclaimable_memory = sst_test.total_reclaimable_memory_size();
 
             // Test sstable::reclaim_memory_from_components() :
             BOOST_REQUIRE_EQUAL(sst_test.reclaim_memory_from_components(), total_reclaimable_memory);
+            // No more memory to reclaim in the sstable
             BOOST_REQUIRE_EQUAL(sst_test.total_reclaimable_memory_size(), 0);
             BOOST_REQUIRE_EQUAL(sst->filter_memory_size(), 0);
+
+            // Test sstable::reload_reclaimed_components() :
+            // Reloading should load the bloom filter back into memory
+            sst_test.reload_reclaimed_components();
+            // SSTable should have reclaimable memory from the bloom filter
+            BOOST_REQUIRE_EQUAL(sst_test.total_reclaimable_memory_size(), total_reclaimable_memory);
+            BOOST_REQUIRE_EQUAL(sst->filter_memory_size(), total_reclaimable_memory);
         });
     });
 }

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -64,6 +64,7 @@
 #include "readers/from_fragments_v2.hh"
 #include "test/lib/random_schema.hh"
 #include "test/lib/exception_utils.hh"
+#include "test/lib/eventually.hh"
 
 namespace fs = std::filesystem;
 
@@ -3513,15 +3514,16 @@ SEASTAR_TEST_CASE(test_sstable_reclaim_memory_from_components) {
     });
 }
 
-std::pair<shared_sstable, size_t> create_sstable_with_bloom_filter(test_env& env, test_env_sstables_manager& sst_mgr, schema_ptr sptr, uint64_t estimated_partitions, sstring tmpdir_path) {
-    auto sst = env.make_sstable(sptr, tmpdir_path, 0);
+std::pair<shared_sstable, size_t> create_sstable_with_bloom_filter(test_env& env, test_env_sstables_manager& sst_mgr, schema_ptr sptr, uint64_t estimated_partitions, sstring tmpdir_path, int64_t generation) {
+    auto sst = env.make_sstable(sptr, tmpdir_path, generation);
     sstables::test(sst).create_bloom_filter(estimated_partitions);
+    sstables::test(sst).write_filter();
     auto sst_bf_memory = sst->filter_memory_size();
     sst_mgr.increment_total_reclaimable_memory_and_maybe_reclaim(sst.get());
     return {sst, sst_bf_memory};
 }
 
-SEASTAR_TEST_CASE(test_sstable_manager_auto_reclaim_under_pressure) {
+SEASTAR_TEST_CASE(test_sstable_manager_auto_reclaim_and_reload_of_bloom_filter) {
     return test_setup::do_with_tmp_directory([] (test_env& env, sstring tmpdir_path) {
         return async([&env, tmpdir_path] {
             simple_schema ss;
@@ -3530,18 +3532,18 @@ SEASTAR_TEST_CASE(test_sstable_manager_auto_reclaim_under_pressure) {
             auto& sst_mgr = env.manager();
 
             // Verify nothing it reclaimed when under threshold
-            auto [sst1, sst1_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 70, tmpdir_path);
+            auto [sst1, sst1_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 70, tmpdir_path, 0);
             BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), sst1_bf_memory);
             BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), 0);
 
-            auto [sst2, sst2_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 20, tmpdir_path);
+            auto [sst2, sst2_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 20, tmpdir_path, 1);
             // Confirm reclaim was still not triggered
             BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), sst1_bf_memory);
             BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
             BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), 0);
 
             // Verify manager reclaims from the largest sst when the total usage crosses thresold.
-            auto [sst3, sst3_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 50, tmpdir_path);
+            auto [sst3, sst3_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 50, tmpdir_path, 2);
             // sst1 has the most reclaimable memory
             BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), 0);
             BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
@@ -3549,13 +3551,24 @@ SEASTAR_TEST_CASE(test_sstable_manager_auto_reclaim_under_pressure) {
             BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst1_bf_memory);
 
             // Reclaim should also work on the latest sst being added
-            auto [sst4, sst4_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 100, tmpdir_path);
+            auto [sst4, sst4_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 100, tmpdir_path, 3);
             // sst4 should have been reclaimed
             BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), 0);
             BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
             BOOST_REQUIRE_EQUAL(sst3->filter_memory_size(), sst3_bf_memory);
             BOOST_REQUIRE_EQUAL(sst4->filter_memory_size(), 0);
             BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst1_bf_memory + sst4_bf_memory);
+
+            // Test auto reload - disposing sst3 should trigger reload of the
+            // smallest filter in the reclaimed list, which is sst1's bloom filter.
+            shared_sstable::dispose(sst3.release().release());
+            BOOST_REQUIRE(eventually_true([&sst1 = sst1, sst1_bf_memory = sst1_bf_memory] { return sst1->filter_memory_size() == sst1_bf_memory; }));
+
+            // only sst4's bloom filter memory should be reported as reclaimed
+            BOOST_REQUIRE(eventually_true([&sst_mgr, sst4_bf_memory = sst4_bf_memory] { return sst_mgr.get_total_memory_reclaimed() == sst4_bf_memory; }));
+            // sst2 and sst4 remain the same
+            BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
+            BOOST_REQUIRE_EQUAL(sst4->filter_memory_size(), 0);
         });
     }, {
         // limit available memory to the sstables_manager to test reclaiming.

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -3603,3 +3603,57 @@ SEASTAR_TEST_CASE(test_reclaimed_bloom_filter_deletion_from_disk) {
         });
     });
 }
+
+SEASTAR_TEST_CASE(test_bloom_filter_reclaim_during_reload) {
+    return test_setup::do_with_tmp_directory([] (test_env& env, sstring tmpdir_path) {
+        return async([&env, tmpdir_path] {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+            fmt::print("Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n");
+            return;
+#endif
+            simple_schema ss;
+            auto schema_ptr = ss.schema();
+
+            auto& sst_mgr = env.manager();
+
+            auto [sst1, sst1_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 100, tmpdir_path, 0);
+            // there is sufficient memory for sst1's filter
+            BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), sst1_bf_memory);
+
+            auto [sst2, sst2_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 60, tmpdir_path, 1);
+            // total memory used by the bloom filters has crossed the threshold, so sst1's
+            // filter, which occupies the most memory, will be discarded from memory.
+            BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), 0);
+            BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
+            BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst1_bf_memory);
+
+            // enable injector that delays reloading a filter
+            utils::get_local_injector().enable("reload_reclaimed_components/pause", true);
+
+            // dispose sst2 to trigger reload of sst1's bloom filter
+            shared_sstable::dispose(sst2.release().release());
+            // _total_reclaimable_memory will be updated when the reload begins; wait for it.
+            BOOST_REQUIRE(eventually_true([&sst_mgr, sst1_bf_memory = sst1_bf_memory] { return sst_mgr.get_total_reclaimable_memory() == sst1_bf_memory; }));
+
+            // now that the reload is midway and paused, create new sst to verify that its
+            // filter gets evicted immediately as the memory that became available is reserved
+            // for sst1's filter reload.
+            auto [sst3, sst3_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 80, tmpdir_path, 2);
+            BOOST_REQUIRE_EQUAL(sst3->filter_memory_size(), 0);
+            // confirm sst1 is not reloaded yet
+            BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), 0);
+            BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst1_bf_memory + sst3_bf_memory);
+
+            // resume reloading sst1 filter
+            BOOST_REQUIRE(eventually_true([&sst1 = sst1, sst1_bf_memory = sst1_bf_memory] { return sst1->filter_memory_size() == sst1_bf_memory; }));
+            BOOST_REQUIRE_EQUAL(sst_mgr.get_total_reclaimable_memory(), sst1_bf_memory);
+            BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst3_bf_memory);
+
+            utils::get_local_injector().disable("reload_reclaimed_components/pause");
+        });
+    }, {
+        // limit available memory to the sstables_manager to test reclaiming.
+        // this will set the reclaim threshold to 100 bytes.
+        .available_memory = 1000
+    });
+}

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -179,7 +179,7 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_simple_empty_directory_scan) {
 SEASTAR_TEST_CASE(sstable_directory_test_table_scan_incomplete_sstables) {
   return sstables::test_env::do_with_async([] (test_env& env) {
     auto dir = tmpdir();
-    auto sst = make_sstable_for_this_shard(std::bind(new_sstable, std::ref(env), dir.path(), 1));
+    auto sst = make_sstable_for_this_shard(std::bind(new_sstable, std::ref(env), dir.path(), generation_type(this_shard_id()).value()));
 
     // Now there is one sstable to the upload directory, but it is incomplete and one component is missing.
     // We should fail validation and leave the directory untouched

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -47,6 +47,10 @@ public:
     size_t get_total_memory_reclaimed() {
         return _total_memory_reclaimed;
     }
+
+    size_t get_total_reclaimable_memory() {
+        return _total_reclaimable_memory;
+    }
 };
 
 struct test_env_config {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -230,12 +230,21 @@ public:
         _sst->_total_reclaimable_memory.reset();
     }
 
+    void write_filter() {
+        _sst->_recognized_components.insert(component_type::Filter);
+        _sst->write_filter(default_priority_class());
+    }
+
     size_t total_reclaimable_memory_size() const {
         return _sst->total_reclaimable_memory_size();
     }
 
     size_t reclaim_memory_from_components() {
         return _sst->reclaim_memory_from_components();
+    }
+
+    void reload_reclaimed_components() {
+        _sst->reload_reclaimed_components(default_priority_class()).get();
     }
 };
 


### PR DESCRIPTION
PR https://github.com/scylladb/scylladb/pull/17771 introduced a threshold for the total memory used by all bloom filters across SSTables. When the total usage surpasses the threshold, the largest bloom filter will be removed from memory, bringing the total usage back under the threshold. This PR adds support for reloading such reclaimed bloom filters back into memory when memory becomes available (i.e., within the 10% of available memory earmarked for the reclaimable components).

The SSTables manager now maintains a list of all SSTables whose bloom filter was removed from memory and attempts to reload them when an SSTable, whose bloom filter is still in memory, gets deleted. The manager reloads from the smallest to the largest bloom filter to maximize the number of filters being reloaded into memory.

Backported from https://github.com/scylladb/scylladb/pull/18186 to 5.2.