### PR TITLE
mutation_fragment_stream_validating_filter: respect validating_level::none

### DIFF
--- a/mutation/mutation_fragment_stream_validator.cc
+++ b/mutation/mutation_fragment_stream_validator.cc
@@ -316,7 +316,9 @@ bool mutation_fragment_stream_validating_filter::operator()(mutation_fragment_v2
 
     validator_log.debug("[validator {}] {}:{} new_current_tombstone: {}", static_cast<void*>(this), kind, pos, new_current_tombstone);
 
-    if (_validation_level >= mutation_fragment_stream_validation_level::clustering_key) {
+    if (_validation_level == mutation_fragment_stream_validation_level::none) {
+        return true;
+    } else if (_validation_level >= mutation_fragment_stream_validation_level::clustering_key) {
         res = _validator(kind, pos, new_current_tombstone);
     } else {
         res = _validator(kind, new_current_tombstone);

--- a/mutation/mutation_fragment_stream_validator.cc
+++ b/mutation/mutation_fragment_stream_validator.cc
@@ -229,7 +229,11 @@ void mutation_fragment_stream_validator::reset(const mutation_fragment& mf) {
 
 namespace {
 
-[[noreturn]] void on_validation_error(seastar::logger& l, const mutation_fragment_stream_validating_filter& zis, mutation_fragment_stream_validator::validation_result res) {
+bool on_validation_error(seastar::logger& l, const mutation_fragment_stream_validating_filter& zis, mutation_fragment_stream_validator::validation_result res) {
+    if (!zis.raise_errors()) {
+        l.error("[validator {} for {}] {}", fmt::ptr(&zis), zis.full_name(), res.what());
+        return false;
+    }
     try {
         on_internal_error(l, format("[validator {} for {}] {}", fmt::ptr(&zis), zis.full_name(), res.what()));
     } catch (std::runtime_error& e) {
@@ -245,12 +249,12 @@ bool mutation_fragment_stream_validating_filter::operator()(const dht::decorated
     }
     if (_validation_level == mutation_fragment_stream_validation_level::token) {
         if (auto res = _validator(dk.token()); !res) {
-            on_validation_error(validator_log, *this, res);
+            return on_validation_error(validator_log, *this, res);
         }
         return true;
     } else {
         if (auto res = _validator(dk); !res) {
-            on_validation_error(validator_log, *this, res);
+            return on_validation_error(validator_log, *this, res);
         }
         return true;
     }
@@ -262,10 +266,11 @@ sstring mutation_fragment_stream_validating_filter::full_name() const {
 }
 
 mutation_fragment_stream_validating_filter::mutation_fragment_stream_validating_filter(const char* name_literal, sstring name_value, const schema& s,
-        mutation_fragment_stream_validation_level level)
+        mutation_fragment_stream_validation_level level, bool raise_errors)
     : _validator(s)
     , _name_storage(std::move(name_value))
     , _validation_level(level)
+    , _raise_errors(raise_errors)
 {
     if (name_literal) {
         _name_view = name_literal;
@@ -296,13 +301,13 @@ mutation_fragment_stream_validating_filter::mutation_fragment_stream_validating_
 }
 
 mutation_fragment_stream_validating_filter::mutation_fragment_stream_validating_filter(sstring name, const schema& s,
-        mutation_fragment_stream_validation_level level)
-    : mutation_fragment_stream_validating_filter(nullptr, std::move(name), s, level)
+        mutation_fragment_stream_validation_level level, bool raise_errors)
+    : mutation_fragment_stream_validating_filter(nullptr, std::move(name), s, level, raise_errors)
 { }
 
 mutation_fragment_stream_validating_filter::mutation_fragment_stream_validating_filter(const char* name, const schema& s,
-        mutation_fragment_stream_validation_level level)
-    : mutation_fragment_stream_validating_filter(name, {}, s, level)
+        mutation_fragment_stream_validation_level level, bool raise_errors)
+    : mutation_fragment_stream_validating_filter(name, {}, s, level, raise_errors)
 { }
 
 bool mutation_fragment_stream_validating_filter::operator()(mutation_fragment_v2::kind kind, position_in_partition_view pos,
@@ -318,7 +323,7 @@ bool mutation_fragment_stream_validating_filter::operator()(mutation_fragment_v2
     }
 
     if (__builtin_expect(!res->is_valid(), false)) {
-        on_validation_error(validator_log, *this, *res);
+        return on_validation_error(validator_log, *this, *res);
     }
 
     return true;
@@ -360,13 +365,14 @@ bool mutation_fragment_stream_validating_filter::on_end_of_partition() {
     return (*this)(mutation_fragment::kind::partition_end, position_in_partition_view(position_in_partition_view::end_of_partition_tag_t()));
 }
 
-void mutation_fragment_stream_validating_filter::on_end_of_stream() {
+bool mutation_fragment_stream_validating_filter::on_end_of_stream() {
     if (_validation_level < mutation_fragment_stream_validation_level::partition_region) {
-        return;
+        return true;
     }
     validator_log.debug("[validator {}] EOS", static_cast<const void*>(this));
     if (auto res = _validator.on_end_of_stream(); !res) {
-        on_validation_error(validator_log, *this, res);
+        return on_validation_error(validator_log, *this, res);
     }
+    return true;
 }
 

--- a/mutation/mutation_fragment_stream_validator.hh
+++ b/mutation/mutation_fragment_stream_validator.hh
@@ -185,9 +185,11 @@ class mutation_fragment_stream_validating_filter {
     sstring _name_storage;
     std::string_view _name_view; // always valid
     mutation_fragment_stream_validation_level _validation_level;
+    bool _raise_errors;
 
 private:
-    mutation_fragment_stream_validating_filter(const char* name_literal, sstring name_value, const schema& s, mutation_fragment_stream_validation_level level);
+    mutation_fragment_stream_validating_filter(const char* name_literal, sstring name_value, const schema& s,
+            mutation_fragment_stream_validation_level level, bool raise_errors);
 
 public:
     /// Constructor.
@@ -195,13 +197,15 @@ public:
     /// \arg name is used in log messages to identify the validator, the
     ///     schema identity is added automatically
     /// \arg compare_keys enable validating clustering key monotonicity
-    mutation_fragment_stream_validating_filter(sstring name, const schema& s, mutation_fragment_stream_validation_level level);
-    mutation_fragment_stream_validating_filter(const char* name, const schema& s, mutation_fragment_stream_validation_level level);
+    mutation_fragment_stream_validating_filter(sstring name, const schema& s, mutation_fragment_stream_validation_level level, bool raise_errors = true);
+    mutation_fragment_stream_validating_filter(const char* name, const schema& s, mutation_fragment_stream_validation_level level, bool raise_errors = true);
 
     mutation_fragment_stream_validating_filter(mutation_fragment_stream_validating_filter&&) = delete;
     mutation_fragment_stream_validating_filter(const mutation_fragment_stream_validating_filter&) = delete;
 
     sstring full_name() const;
+
+    bool raise_errors() const { return _raise_errors; }
 
     const mutation_fragment_stream_validator& validator() const { return  _validator; }
 
@@ -215,7 +219,7 @@ public:
     void reset(const mutation_fragment_v2& mf);
     /// Equivalent to `operator()(partition_end{})`
     bool on_end_of_partition();
-    void on_end_of_stream();
+    bool on_end_of_stream();
     mutation_fragment_stream_validator& validator() { return _validator; }
 };
 


### PR DESCRIPTION
Even when configured to not do any validation at all, the validator still did some. This small series fixes this, and adds a test to check that validation levels in general are respected, and the validator doesn't validate more than it is asked to.

Fixes: #18662