### PR TITLE
test/cql-pytest: test_tombstone_limit.py: enable xfailing tests

### DIFF
--- a/test/cql-pytest/test_tombstone_limit.py
+++ b/test/cql-pytest/test_tombstone_limit.py
@@ -247,10 +247,7 @@ def check_pages_many_partitions(results, expected):
         assert p == expected_pages.get(i, [])
 
 
-# xfail with tablets due to https://github.com/scylladb/scylladb/issues/16486
-@pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16486")]), "vnodes"],
-                         indirect=True)
+@pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def test_partition_tombstone_prefix(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1):
     with new_test_table(cql, test_keyspace, 'pk int, ck int, v int, PRIMARY KEY (pk, ck)') as table:
         insert_row_id = cql.prepare(f"INSERT INTO {table} (pk, ck, v) VALUES (?, ?, ?)")
@@ -271,9 +268,7 @@ def test_partition_tombstone_prefix(cql, test_keyspace, lowered_tombstone_limit,
         check_pages_many_partitions(cql.execute(statement), {-1: all_pks[-1]})
 
 
-@pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16486")]), "vnodes"],
-                         indirect=True)
+@pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def test_partition_tombstone_span(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1):
     with new_test_table(cql, test_keyspace, 'pk int, ck int, v int, PRIMARY KEY (pk, ck)') as table:
         insert_row_id = cql.prepare(f"INSERT INTO {table} (pk, ck, v) VALUES (?, ?, ?)")
@@ -294,9 +289,7 @@ def test_partition_tombstone_span(cql, test_keyspace, lowered_tombstone_limit, d
         check_pages_many_partitions(cql.execute(statement), {0: all_pks[0], -1: all_pks[-1]})
 
 
-@pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16486")]), "vnodes"],
-                         indirect=True)
+@pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def test_static_row_tombstone_prefix(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1):
     with new_test_table(cql, test_keyspace, 'pk int, ck int, v int, s int static, PRIMARY KEY (pk, ck)') as table:
         upsert_row_id = cql.prepare(f"UPDATE {table} SET s = ? WHERE pk = ?")
@@ -317,9 +310,7 @@ def test_static_row_tombstone_prefix(cql, test_keyspace, lowered_tombstone_limit
         check_pages_many_partitions(cql.execute(statement), {-1: all_pks[-1]})
 
 
-@pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16486")]), "vnodes"],
-                         indirect=True)
+@pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def test_static_row_tombstone_span(cql, test_keyspace, lowered_tombstone_limit, driver_bug_1):
     with new_test_table(cql, test_keyspace, 'pk int, ck int, v int, s int static, PRIMARY KEY (pk, ck)') as table:
         upsert_row_id = cql.prepare(f"UPDATE {table} SET s = ? WHERE pk = ?")


### PR DESCRIPTION
These tests were marked as xfail because they use to fail with tablets. They don't anymore, so remove the xfail.

Fixes: #16486

- [x] Tablets are experimental pre 6.0, no backport needed.

