### PR TITLE
Simplify access to topology::my_address()

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1179,7 +1179,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             //starting service level controller
             qos::service_level_options default_service_level_configuration;
-            sl_controller.start(std::ref(auth_service), default_service_level_configuration).get();
+            sl_controller.start(std::ref(auth_service), std::ref(token_metadata), default_service_level_configuration).get();
             sl_controller.invoke_on_all(&qos::service_level_controller::start).get();
             auto stop_sl_controller = defer_verbose_shutdown("service level controller", [] {
                 sl_controller.stop().get();

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -31,9 +31,10 @@ sstring service_level_controller::default_service_level_name = "default";
 
 
 
-service_level_controller::service_level_controller(sharded<auth::service>& auth_service, service_level_options default_service_level_config):
+service_level_controller::service_level_controller(sharded<auth::service>& auth_service, locator::shared_token_metadata& tm, service_level_options default_service_level_config):
         _sl_data_accessor(nullptr),
         _auth_service(auth_service),
+        _token_metadata(tm),
         _last_successful_config_update(seastar::lowres_clock::now()),
         _logged_intervals(0)
 

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -22,7 +22,6 @@
 #include "service_level_controller.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "cql3/query_processor.hh"
-#include "service/storage_proxy.hh"
 
 namespace qos {
 static logging::logger sl_logger("service_level_controller");
@@ -559,8 +558,7 @@ future<> service_level_controller::do_remove_service_level(sstring name, bool re
 void service_level_controller::on_join_cluster(const gms::inet_address& endpoint) { }
 
 void service_level_controller::on_leave_cluster(const gms::inet_address& endpoint, const locator::host_id& hid) {
-    auto my_address = _auth_service.local().query_processor().proxy().local_db().get_token_metadata().get_topology().my_address();
-    if (this_shard_id() == global_controller && endpoint == my_address) {
+    if (this_shard_id() == global_controller && _token_metadata.get()->get_topology().is_me(endpoint)) {
         _global_controller_db->dist_data_update_aborter.request_abort();
         _global_controller_db->group0_aborter.request_abort();
     }

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -90,11 +90,12 @@ private:
     service_level _default_service_level;
     service_level_distributed_data_accessor_ptr _sl_data_accessor;
     sharded<auth::service>& _auth_service;
+    locator::shared_token_metadata& _token_metadata;
     std::chrono::time_point<seastar::lowres_clock> _last_successful_config_update;
     unsigned _logged_intervals;
     atomic_vector<qos_configuration_change_subscriber*> _subscribers;
 public:
-    service_level_controller(sharded<auth::service>& auth_service, service_level_options default_service_level_config);
+    service_level_controller(sharded<auth::service>& auth_service, locator::shared_token_metadata& tm, service_level_options default_service_level_config);
 
     /**
      * this function must be called *once* from any shard before any other functions are called.

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -151,7 +151,7 @@ static future<ResultTuple> add_replica_exception_to_query_result(gms::feature_se
 }
 
 gms::inet_address storage_proxy::my_address() const noexcept {
-    return local_db().get_token_metadata().get_topology().my_address();
+    return _shared_token_metadata.get()->get_topology().my_address();
 }
 
 bool storage_proxy::is_me(gms::inet_address addr) const noexcept {

--- a/test/boost/service_level_controller_test.cc
+++ b/test/boost/service_level_controller_test.cc
@@ -17,6 +17,7 @@
 #include <seastar/core/future-util.hh>
 #include "service/qos/service_level_controller.hh"
 #include "service/qos/qos_configuration_change_subscriber.hh"
+#include "locator/token_metadata.hh"
 #include "auth/service.hh"
 #include "utils/overloaded_functor.hh"
 
@@ -86,7 +87,8 @@ std::ostream& operator<<(std::ostream& os, const service_level_op& op) {
 SEASTAR_THREAD_TEST_CASE(subscriber_simple) {
     sharded<service_level_controller> sl_controller;
     sharded<auth::service> auth_service;
-    sl_controller.start(std::ref(auth_service), service_level_options{}).get();
+    locator::shared_token_metadata tm({}, {});
+    sl_controller.start(std::ref(auth_service), std::ref(tm), service_level_options{}).get();
     qos_configuration_change_suscriber_simple ccss;
     sl_controller.local().register_subscriber(&ccss);
     sl_controller.local().add_service_level("sl1", service_level_options{}).get();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -618,7 +618,7 @@ private:
 
             set_abort_on_internal_error(true);
             const gms::inet_address listen("127.0.0.1");
-            _sl_controller.start(std::ref(_auth_service), qos::service_level_options{}).get();
+            _sl_controller.start(std::ref(_auth_service), std::ref(_token_metadata), qos::service_level_options{}).get();
             auto stop_sl_controller = defer([this] { _sl_controller.stop().get(); });
             _sl_controller.invoke_on_all(&qos::service_level_controller::start).get();
 

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -215,7 +215,7 @@ future<> trace_keyspace_helper::start(cql3::query_processor& qp, service::migrat
 }
 
 gms::inet_address trace_keyspace_helper::my_address() const noexcept {
-    return _qp_anchor->proxy().local_db().get_token_metadata().get_topology().my_address();
+    return _qp_anchor->proxy().my_address();
 }
 
 void trace_keyspace_helper::write_one_session_records(lw_shared_ptr<one_session_records> records) {


### PR DESCRIPTION
Recent commit 12f160045b (Get rid of fb_utilities) replaced the usage of global fb_utilities and made all services use topology::my_address() in order to get local node broadcast address. Some places resulted in long dependency chains dereferences. to get to topology This PR fixes some of them.