### PR TITLE
repair: Don't get topology via database

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -899,7 +899,7 @@ public:
                 add_to_repair_meta_for_followers(*this);
             }
             assert(all_live_peer_shards.size() == all_live_peer_nodes.size());
-            _all_node_states.push_back(repair_node_state(_myip, this_shard_id()));
+            _all_node_states.push_back(repair_node_state(myip(), this_shard_id()));
             for (unsigned i = 0; i < all_live_peer_nodes.size(); i++) {
                 _all_node_states.push_back(repair_node_state(all_live_peer_nodes[i], all_live_peer_shards[i].value_or(repair_unspecified_shard)));
             }
@@ -1483,7 +1483,7 @@ public:
     // Return the hashes of the rows in _working_row_buf
     future<repair_hash_set>
     get_full_row_hashes(gms::inet_address remote_node, shard_id dst_cpu_id) {
-        if (remote_node == _myip) {
+        if (remote_node == myip()) {
             return get_full_row_hashes_handler();
         }
         return _messaging.send_repair_get_full_row_hashes(msg_addr(remote_node),
@@ -1538,7 +1538,7 @@ private:
 public:
     future<repair_hash_set>
     get_full_row_hashes_with_rpc_stream(gms::inet_address remote_node, unsigned node_idx, shard_id dst_cpu_id) {
-        if (remote_node == _myip) {
+        if (remote_node == myip()) {
             return get_full_row_hashes_handler();
         }
         auto current_hashes = make_lw_shared<repair_hash_set>();
@@ -1567,7 +1567,7 @@ public:
     // Return the combined hashes of the current working row buf
     future<get_combined_row_hash_response>
     get_combined_row_hash(std::optional<repair_sync_boundary> common_sync_boundary, gms::inet_address remote_node, shard_id dst_cpu_id) {
-        if (remote_node == _myip) {
+        if (remote_node == myip()) {
             return get_combined_row_hash_handler(common_sync_boundary);
         }
         return _messaging.send_repair_get_combined_row_hash(msg_addr(remote_node),
@@ -1595,7 +1595,7 @@ public:
     // RPC API
     future<>
     repair_row_level_start(gms::inet_address remote_node, sstring ks_name, sstring cf_name, dht::token_range range, table_schema_version schema_version, streaming::stream_reason reason, gc_clock::time_point compaction_time, shard_id dst_cpu_id) {
-        if (remote_node == _myip) {
+        if (remote_node == myip()) {
             return make_ready_future<>();
         }
         stats().rpc_call_nr++;
@@ -1634,7 +1634,7 @@ public:
 
     // RPC API
     future<> repair_row_level_stop(gms::inet_address remote_node, sstring ks_name, sstring cf_name, dht::token_range range, shard_id dst_cpu_id) {
-        if (remote_node == _myip) {
+        if (remote_node == myip()) {
             return stop();
         }
         stats().rpc_call_nr++;
@@ -1656,7 +1656,7 @@ public:
 
     // RPC API
     future<uint64_t> repair_get_estimated_partitions(gms::inet_address remote_node, shard_id dst_cpu_id) {
-        if (remote_node == _myip) {
+        if (remote_node == myip()) {
             return get_estimated_partitions();
         }
         stats().rpc_call_nr++;
@@ -1676,7 +1676,7 @@ public:
 
     // RPC API
     future<> repair_set_estimated_partitions(gms::inet_address remote_node, uint64_t estimated_partitions, shard_id dst_cpu_id) {
-        if (remote_node == _myip) {
+        if (remote_node == myip()) {
             return set_estimated_partitions(estimated_partitions);
         }
         stats().rpc_call_nr++;
@@ -1697,7 +1697,7 @@ public:
     // Return the largest sync point contained in the _row_buf , current _row_buf checksum, and the _row_buf size
     future<get_sync_boundary_response>
     get_sync_boundary(gms::inet_address remote_node, std::optional<repair_sync_boundary> skipped_sync_boundary, shard_id dst_cpu_id) {
-        if (remote_node == _myip) {
+        if (remote_node == myip()) {
             return get_sync_boundary_handler(skipped_sync_boundary);
         }
         stats().rpc_call_nr++;
@@ -1719,7 +1719,7 @@ public:
     // Must run inside a seastar thread
     void get_row_diff(repair_hash_set set_diff, needs_all_rows_t needs_all_rows, gms::inet_address remote_node, unsigned node_idx, shard_id dst_cpu_id) {
         if (needs_all_rows || !set_diff.empty()) {
-            if (remote_node == _myip) {
+            if (remote_node == myip()) {
                 return;
             }
             if (needs_all_rows) {
@@ -1739,7 +1739,7 @@ public:
 
     // Must run inside a seastar thread
     void get_row_diff_and_update_peer_row_hash_sets(gms::inet_address remote_node, unsigned node_idx, shard_id dst_cpu_id) {
-        if (remote_node == _myip) {
+        if (remote_node == myip()) {
             return;
         }
         stats().rpc_call_nr++;
@@ -1824,7 +1824,7 @@ public:
             unsigned node_idx,
             shard_id dst_cpu_id) {
         if (needs_all_rows || !set_diff.empty()) {
-            if (remote_node == _myip) {
+            if (remote_node == myip()) {
                 return;
             }
             if (needs_all_rows) {
@@ -1856,7 +1856,7 @@ public:
     // Send rows in the _working_row_buf with hash within the given sef_diff
     future<> put_row_diff(repair_hash_set set_diff, needs_all_rows_t needs_all_rows, gms::inet_address remote_node, shard_id dst_cpu_id) {
         if (!set_diff.empty()) {
-            if (remote_node == _myip) {
+            if (remote_node == myip()) {
                 return make_ready_future<>();
             }
             size_t sz = set_diff.size();
@@ -1938,7 +1938,7 @@ public:
         if (set_diff.empty()) {
             co_return;
         }
-        if (remote_node == _myip) {
+        if (remote_node == myip()) {
             co_return;
         }
         size_t sz = set_diff.size();

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3437,3 +3437,7 @@ future<uint32_t> repair_service::get_next_repair_meta_id() {
         return local_repair._next_repair_meta_id++;
     });
 }
+
+gms::inet_address repair_service::my_address() const noexcept {
+    return _sp.local().my_address();
+}

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2654,7 +2654,7 @@ private:
 
     inet_address_vector_replica_set sort_peer_nodes(const std::vector<gms::inet_address>& nodes) {
         inet_address_vector_replica_set sorted_nodes(nodes.begin(), nodes.end());
-        auto& topology = _shard_task.db.local().get_token_metadata().get_topology();
+        auto& topology = get_erm()->get_topology();
         topology.sort_by_proximity(topology.my_address(), sorted_nodes);
         return sorted_nodes;
     }

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -746,7 +746,6 @@ private:
     size_t _max_row_buf_size;
     uint64_t _seed = 0;
     repair_master _repair_master;
-    gms::inet_address _myip;
     uint32_t _repair_meta_id;
     streaming::stream_reason _reason;
     // Repair master's sharding configuration
@@ -811,7 +810,7 @@ public:
         return _stats;
     }
     gms::inet_address myip() const {
-        return _myip;
+        return _rs.my_address();
     }
     uint32_t repair_meta_id() const {
         return _repair_meta_id;
@@ -862,7 +861,6 @@ public:
             , _max_row_buf_size(max_row_buf_size)
             , _seed(seed)
             , _repair_master(master)
-            , _myip(_db.local().get_token_metadata().get_topology().my_address())
             , _repair_meta_id(repair_meta_id)
             , _reason(reason)
             , _master_node_shard_config(std::move(master_node_shard_config))

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -185,6 +185,8 @@ public:
     gms::gossiper& get_gossiper() noexcept { return _gossiper.local(); }
     size_t max_repair_memory() const { return _max_repair_memory; }
     seastar::semaphore& memory_sem() { return _memory_sem; }
+    gms::inet_address my_address() const noexcept;
+
     repair::task_manager_module& get_repair_module() noexcept {
         return *_repair_module;
     }


### PR DESCRIPTION
Database has token-metadata onboard and other services use it to get topology from. Repair code has simpler and cleaner ways to get access to topology.