### PR TITLE
doc: update Raft information in 6.0

### DIFF
--- a/docs/architecture/_common/note-enabling-consistent-topology-changes.rst
+++ b/docs/architecture/_common/note-enabling-consistent-topology-changes.rst
@@ -1,3 +1,0 @@
-.. note::
-    After the procedure described in this section finishes, you must perform manual action in order to enable consistent topology changes.
-    See :doc:`the guide for enabling consistent topology changes</upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology>` for more details.


### PR DESCRIPTION
This commit updates the documentation about Raft in version 6.0.

- "Introduction": The outdated information about consistent topology updates not being supported is removed and replaced with the correct information.
- "Enabling Raft": The relevant information is moved to other sections. The irrelevant information is removed. The section no longer exists.
- "Verifying that the Raft upgrade procedure finished successfully" - moved under Schema (in the same document). I additionally removed the include saying that after you verify that schema on Raft is enabled, you MUST enable topology changes on Raft (it is not mandatory; also, it should be part of the upgrade guide, not the Raft document).
- Unnecessary or incorrect references to versions are removed.

Refs https://github.com/scylladb/scylladb/issues/18580

- No backport. This update is relevant in version 6.0.

