### PR TITLE
db: config: drop operator<<() for error_injection_at_startup

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1240,11 +1240,6 @@ std::istream& operator>>(std::istream& is, db::seed_provider_type& s) {
     return is;
 }
 
-std::ostream& operator<<(std::ostream& os, const error_injection_at_startup& eias) {
-    fmt::print(os, "{}", eias);
-    return os;
-}
-
 std::istream& operator>>(std::istream& is, error_injection_at_startup& eias) {
     eias = error_injection_at_startup();
     is >> eias.name;

--- a/db/config.hh
+++ b/db/config.hh
@@ -81,7 +81,6 @@ struct error_injection_at_startup {
     }
 };
 
-std::ostream& operator<<(std::ostream& os, const error_injection_at_startup&);
 std::istream& operator>>(std::istream& is, error_injection_at_startup&);
 
 }


### PR DESCRIPTION
it is not used anymore, so let's drop it.

- [x] it's a cleanup. so no need to backport.

