### PR TITLE
Improve modularity of some per-table API endpoints

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -1154,6 +1154,9 @@ void unset_column_family(http_context& ctx, routes& r) {
     cf::get_auto_compaction.unset(r);
     cf::enable_auto_compaction.unset(r);
     cf::disable_auto_compaction.unset(r);
+    cf::get_tombstone_gc.unset(r);
+    cf::enable_tombstone_gc.unset(r);
+    cf::disable_tombstone_gc.unset(r);
     cf::get_built_indexes.unset(r);
     cf::get_compression_metadata_off_heap_memory_used.unset(r);
     cf::get_compression_parameters.unset(r);

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -82,8 +82,46 @@ future<json::json_return_type>  get_cf_stats(http_context& ctx,
     }, std::plus<int64_t>());
 }
 
-future<json::json_return_type> set_tables_autocompaction(http_context& ctx, const sstring &keyspace, std::vector<sstring> tables, bool enabled);
-future<json::json_return_type> set_tables_tombstone_gc(http_context& ctx, const sstring &keyspace, std::vector<sstring> tables, bool enabled);
+static future<json::json_return_type> set_tables(http_context& ctx, const sstring& keyspace, std::vector<sstring> tables, std::function<future<>(replica::table&)> set) {
+    if (tables.empty()) {
+        tables = map_keys(ctx.db.local().find_keyspace(keyspace).metadata().get()->cf_meta_data());
+    }
+
+    return do_with(keyspace, std::move(tables), [&ctx, set] (const sstring& keyspace, const std::vector<sstring>& tables) {
+        return ctx.db.invoke_on_all([&keyspace, &tables, set] (replica::database& db) {
+            return parallel_for_each(tables, [&db, &keyspace, set] (const sstring& table) {
+                replica::table& t = db.find_column_family(keyspace, table);
+                return set(t);
+            });
+        });
+    }).then([] {
+        return make_ready_future<json::json_return_type>(json_void());
+    });
+}
+
+static future<json::json_return_type> set_tables_autocompaction(http_context& ctx, const sstring &keyspace, std::vector<sstring> tables, bool enabled) {
+    apilog.info("set_tables_autocompaction: enabled={} keyspace={} tables={}", enabled, keyspace, tables);
+
+    return ctx.db.invoke_on(0, [&ctx, keyspace, tables = std::move(tables), enabled] (replica::database& db) {
+        auto g = replica::database::autocompaction_toggle_guard(db);
+        return set_tables(ctx, keyspace, tables, [enabled] (replica::table& cf) {
+            if (enabled) {
+                cf.enable_auto_compaction();
+            } else {
+                return cf.disable_auto_compaction();
+            }
+            return make_ready_future<>();
+        }).finally([g = std::move(g)] {});
+    });
+}
+
+static future<json::json_return_type> set_tables_tombstone_gc(http_context& ctx, const sstring &keyspace, std::vector<sstring> tables, bool enabled) {
+    apilog.info("set_tables_tombstone_gc: enabled={} keyspace={} tables={}", enabled, keyspace, tables);
+    return set_tables(ctx, keyspace, std::move(tables), [enabled] (replica::table& t) {
+        t.set_tombstone_gc_enabled(enabled);
+        return make_ready_future<>();
+    });
+}
 
 static future<json::json_return_type>  get_cf_stats_count(http_context& ctx, const sstring& name,
         utils::timed_rate_moving_average_summary_and_histogram replica::column_family_stats::*f) {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1281,38 +1281,6 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         }
     });
 
-    ss::enable_auto_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) {
-        auto keyspace = validate_keyspace(ctx, req);
-        auto tables = parse_tables(keyspace, ctx, req->query_parameters, "cf");
-
-        apilog.info("enable_auto_compaction: keyspace={} tables={}", keyspace, tables);
-        return set_tables_autocompaction(ctx, keyspace, tables, true);
-    });
-
-    ss::disable_auto_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) {
-        auto keyspace = validate_keyspace(ctx, req);
-        auto tables = parse_tables(keyspace, ctx, req->query_parameters, "cf");
-
-        apilog.info("disable_auto_compaction: keyspace={} tables={}", keyspace, tables);
-        return set_tables_autocompaction(ctx, keyspace, tables, false);
-    });
-
-    ss::enable_tombstone_gc.set(r, [&ctx](std::unique_ptr<http::request> req) {
-        auto keyspace = validate_keyspace(ctx, req);
-        auto tables = parse_tables(keyspace, ctx, req->query_parameters, "cf");
-
-        apilog.info("enable_tombstone_gc: keyspace={} tables={}", keyspace, tables);
-        return set_tables_tombstone_gc(ctx, keyspace, tables, true);
-    });
-
-    ss::disable_tombstone_gc.set(r, [&ctx](std::unique_ptr<http::request> req) {
-        auto keyspace = validate_keyspace(ctx, req);
-        auto tables = parse_tables(keyspace, ctx, req->query_parameters, "cf");
-
-        apilog.info("disable_tombstone_gc: keyspace={} tables={}", keyspace, tables);
-        return set_tables_tombstone_gc(ctx, keyspace, tables, false);
-    });
-
     ss::deliver_hints.set(r, [](std::unique_ptr<http::request> req) {
         //TBD
         unimplemented();
@@ -1721,10 +1689,6 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::get_trace_probability.unset(r);
     ss::get_slow_query_info.unset(r);
     ss::set_slow_query.unset(r);
-    ss::enable_auto_compaction.unset(r);
-    ss::disable_auto_compaction.unset(r);
-    ss::enable_tombstone_gc.unset(r);
-    ss::disable_tombstone_gc.unset(r);
     ss::deliver_hints.unset(r);
     ss::get_cluster_name.unset(r);
     ss::get_partitioner_name.unset(r);

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -82,7 +82,7 @@ sstring validate_keyspace(const http_context& ctx, const http::request& req) {
     return validate_keyspace(ctx, req.get_path_param("keyspace"));
 }
 
-static void validate_table(const http_context& ctx, sstring ks_name, sstring table_name) {
+void validate_table(const http_context& ctx, sstring ks_name, sstring table_name) {
     auto& db = ctx.db.local();
     try {
         db.find_column_family(ks_name, table_name);

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -42,6 +42,10 @@ sstring validate_keyspace(const http_context& ctx, sstring ks_name);
 // containing the description of the respective keyspace error.
 sstring validate_keyspace(const http_context& ctx, const std::unique_ptr<http::request>& req);
 
+// verify that the table parameter is found, otherwise a bad_param_exception exception is thrown
+// containing the description of the respective table error.
+void validate_table(const http_context& ctx, sstring ks_name, sstring table_name);
+
 // splits a request parameter assumed to hold a comma-separated list of table names
 // verify that the tables are found, otherwise a bad_param_exception exception is thrown
 // containing the description of the respective no_such_column_family error.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -118,6 +118,10 @@ namespace compaction {
 class shard_reshaping_compaction_task_impl;
 }
 
+namespace api {
+class autocompaction_toggle_guard;
+}
+
 namespace db {
 class commitlog;
 class config;
@@ -1566,23 +1570,7 @@ public:
     void set_enable_incremental_backups(bool val) { _enable_incremental_backups = val; }
 
     void enable_autocompaction_toggle() noexcept { _enable_autocompaction_toggle = true; }
-    class autocompaction_toggle_guard {
-        database& _db;
-    public:
-        autocompaction_toggle_guard(database& db) : _db(db) {
-            assert(this_shard_id() == 0);
-            if (!_db._enable_autocompaction_toggle) {
-                throw std::runtime_error("Autocompaction toggle is busy");
-            }
-            _db._enable_autocompaction_toggle = false;
-        }
-        autocompaction_toggle_guard(const autocompaction_toggle_guard&) = delete;
-        autocompaction_toggle_guard(autocompaction_toggle_guard&&) = default;
-        ~autocompaction_toggle_guard() {
-            assert(this_shard_id() == 0);
-            _db._enable_autocompaction_toggle = true;
-        }
-    };
+    friend class api::autocompaction_toggle_guard;
 
     // Load the schema definitions kept in schema tables from disk and initialize in-memory schema data structures
     // (keyspace/table definitions, column mappings etc.)


### PR DESCRIPTION
There's a set of API endpoints that toggle per-table auto-compaction and tombstone-gc booleans. They all live in two different .cc files under api/ directory and duplicate code of each other. This PR generalizes those handlers, places them next to each other, fixes leak on stop and, as a nice side effect, enlightens database.hh header.