### PR TITLE
test.py: Make it possible to avoid wildcard test names matching

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -38,9 +38,16 @@ If you want to run only a specific test:
 
     $ ./test.py suitename/testname
 
-If you want to run only a specific test-case from a test:
+This will select and run all tests having suitename/testname as substring,
+e.g. suitename/testname_ext and others.
+
+If you want to run only a specific test-case from a specific test:
 
     $ ./test.py suitename/testname::casename
+
+This will select only the test with the suitename/testname name, no
+substring search is performed in this case. If the casename is `*`, then
+all test-cases will be selected.
 
 Note that not all tests are divided into cases. Below sections will
 shed more light on this.

--- a/test.py
+++ b/test.py
@@ -279,7 +279,8 @@ class TestSuite(ABC):
                     if len(pn) == 1 and p in testname:
                         break
                     if len(pn) == 2 and pn[0] == testname:
-                        casename = pn[1]
+                        if pn[1] != "*":
+                            casename = pn[1]
                         break
                 else:
                     continue


### PR DESCRIPTION
There's a nasty scenario when this searching plays bad joke.

When CI picks up a new branch and notices, that a test had changed, it spawns a custom job with `test.py --repeat 100 $changed_test_name` in it. Next, when the test.py tries opt-in test name matching, it uses the wildcard search and can pick up extra unwanted tests into the run.

To solve this, the case-selection syntax is extended. Now if the caller specifies `suite/test::*` as test, the test file is selected by exact name match, but the specific test-case is not selected, the `*` makes it run all cases.

