### PR TITLE
make enable_compacting_data_for_streaming_and_repair truly live-update

### DIFF
--- a/api/api-doc/error_injection.json
+++ b/api/api-doc/error_injection.json
@@ -63,6 +63,28 @@
                      "paramType":"path"
                   }
                ]
+            },
+            {
+               "method":"GET",
+               "summary":"Read the state of an injection from all shards",
+               "type":"array",
+               "items":{
+                  "type":"error_injection_info"
+               },
+               "nickname":"read_injection",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"injection",
+                     "description":"injection name",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  }
+               ]
             }
          ]
       },
@@ -151,6 +173,40 @@
                "type": "string"
             }
          }
+      }
+   },
+   "models":{
+      "mapper":{
+         "id":"mapper",
+         "description":"A key value mapping",
+         "properties":{
+            "key":{
+               "type":"string",
+               "description":"The key"
+            },
+            "value":{
+               "type":"string",
+               "description":"The value"
+            }
+         }
+      },
+       "error_injection_info":{
+         "id":"error_injection_info",
+         "description":"Information about an error injection",
+         "properties":{
+            "enabled":{
+               "type":"boolean",
+               "description":"Is the error injection enabled"
+            },
+            "parameters":{
+               "type":"array",
+               "items":{
+                  "type":"mapper"
+               },
+               "description":"The parameter values"
+            }
+         },
+         "required":["enabled"]
       }
    }
 }

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1249,7 +1249,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.tombstone_warn_threshold = db_config.tombstone_warn_threshold();
     cfg.view_update_concurrency_semaphore_limit = _config.view_update_concurrency_semaphore_limit;
     cfg.data_listeners = &db.data_listeners();
-    cfg.enable_compacting_data_for_streaming_and_repair = db_config.enable_compacting_data_for_streaming_and_repair();
+    cfg.enable_compacting_data_for_streaming_and_repair = db_config.enable_compacting_data_for_streaming_and_repair;
 
     return cfg;
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -289,6 +289,7 @@ sstables::shared_sstable table::make_streaming_staging_sstable() {
 }
 
 static flat_mutation_reader_v2 maybe_compact_for_streaming(flat_mutation_reader_v2 underlying, const compaction_manager& cm, gc_clock::time_point compaction_time, bool compaction_enabled) {
+    utils::get_local_injector().set_parameter("maybe_compact_for_streaming", "compaction_enabled", fmt::to_string(compaction_enabled));
     if (!compaction_enabled) {
         return underlying;
     }

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -230,6 +230,14 @@ class ScyllaRESTAPIClient():
         await self.client.post(f"/v2/error_injection/injection/{injection}",
                                host=node_ip, params={"one_shot": str(one_shot)}, json={ key: str(value) for key, value in parameters.items() })
 
+    async def get_injection(self, node_ip: str, injection: str) -> list[dict[str, Any]]:
+        """Read the state of the error injection named `injection` on `node_ip`.
+           The returned information includes whether the error injections is
+           active, as well as any parameters it might have.
+           Note: this only has an effect in specific build modes: debug,dev,sanitize.
+        """
+        return await self.client.get_json(f"/v2/error_injection/injection/{injection}", host=node_ip)
+
     async def move_tablet(self, node_ip: str, ks: str, table: str, src_host: HostID, src_shard: int, dst_host: HostID, dst_shard: int, token: int) -> None:
         await self.client.post(f"/storage_service/tablets/move", host=node_ip, params={
             "ks": ks,

--- a/test/topology_custom/test_repair.py
+++ b/test/topology_custom/test_repair.py
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import logging
+import pytest
+import time
+
+from test.pylib.util import wait_for_cql_and_get_hosts
+from test.topology.conftest import skip_mode
+
+
+logger = logging.getLogger(__name__)
+
+
+async def get_injection_params(manager, node_ip, injection):
+    res = await manager.api.get_injection(node_ip, injection)
+    logger.debug(f"get_injection_params({injection}): {res}")
+    assert len(res) == 1
+    shard_res = res[0]
+    assert shard_res["enabled"]
+    if "parameters" in shard_res:
+        return {item["key"]: item["value"] for item in shard_res["parameters"]}
+    else:
+        return {}
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_enable_compacting_data_for_streaming_and_repair_live_update(manager):
+    """
+    Check that enable_compacting_data_for_streaming_and_repair is live_update.
+    This config item has a non-trivial path of propagation and live-update was
+    silently broken in the past.
+    """
+    cmdline = ["--enable-compacting-data-for-streaming-and-repair", "0", "--smp", "1", "--logger-log-level", "api=trace"]
+    node1 = await manager.server_add(cmdline=cmdline)
+    node2 = await manager.server_add(cmdline=cmdline)
+
+    cql = manager.get_cql()
+
+    cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
+    cql.execute("CREATE TABLE ks.tbl (pk int PRIMARY KEY)")
+
+    config_item = "enable_compacting_data_for_streaming_and_repair"
+
+    host1, host2 = await wait_for_cql_and_get_hosts(cql, [node1, node2], time.time() + 30)
+
+    for host in (host1, host2):
+        res = list(cql.execute(f"SELECT value FROM system.config WHERE name = '{config_item}'", host=host))
+        assert res[0].value == "false"
+
+    await manager.api.enable_injection(node1.ip_addr, "maybe_compact_for_streaming", False, {})
+
+    # Before the first repair, there should be no parameters present
+    assert (await get_injection_params(manager, node1.ip_addr, "maybe_compact_for_streaming")) == {}
+
+    # After the initial repair, we should see the config item value matching the value set via the command-line.
+    await manager.api.repair(node1.ip_addr, "ks", "tbl")
+    assert (await get_injection_params(manager, node1.ip_addr, "maybe_compact_for_streaming"))["compaction_enabled"] == "false"
+
+    for host in (host1, host2):
+        cql.execute(f"UPDATE system.config SET value = '1' WHERE name = '{config_item}'", host=host)
+
+    # After the update to the config above, the next repair should pick up the updated value.
+    await manager.api.repair(node1.ip_addr, "ks", "tbl")
+    assert (await get_injection_params(manager, node1.ip_addr, "maybe_compact_for_streaming"))["compaction_enabled"] == "true"


### PR DESCRIPTION
This config item is propagated to the table object via table::config. Although the field in `table::config`, used to propagate the value, was `utils::updateable_value<T>`, it was assigned a constant and so the live-update chain was broken.
This series fixes this and adds a test which fails before the patch and passes after. The test needed new test infrastructure, around the failure injection api, namely the ability to exfiltrate the value of internal variable. This infrastructure is also added in this series.

Fixes: https://github.com/scylladb/scylladb/issues/18674

- [x] This patch has to be backported because it fixes broken functionality

