### PR TITLE
inet_address: Remove to_sstring() in favor of fmt::to_string

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -212,7 +212,7 @@ protected:
         std::unordered_set<gms::inet_address> local_dc_nodes = topology.get_datacenter_endpoints().at(local_dc);
         for (auto& ip : local_dc_nodes) {
             if (_gossiper.is_alive(ip)) {
-                rjson::push_back(results, rjson::from_string(ip.to_sstring()));
+                rjson::push_back(results, rjson::from_string(fmt::to_string(ip)));
             }
         }
         rep->set_status(reply::status_type::ok);

--- a/api/failure_detector.cc
+++ b/api/failure_detector.cc
@@ -66,7 +66,7 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
         return g.container().invoke_on(0, [] (gms::gossiper& g) {
             std::map<sstring, sstring> nodes_status;
             g.for_each_endpoint_state([&] (const gms::inet_address& node, const gms::endpoint_state&) {
-                nodes_status.emplace(node.to_sstring(), g.is_alive(node) ? "UP" : "DOWN");
+                nodes_status.emplace(fmt::to_string(node), g.is_alive(node) ? "UP" : "DOWN");
             });
             return make_ready_future<json::json_return_type>(map_to_key_value<fd::mapper>(nodes_status));
         });

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -718,7 +718,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
                 m.key.push("");
             }
             for (const gms::inet_address& address : entry.second) {
-                m.value.push(address.to_sstring());
+                m.value.push(fmt::to_string(address));
             }
             return m;
         });

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -380,7 +380,7 @@ hint_endpoint_manager& manager::get_ep_manager(const endpoint_id& host_id, const
             if (_uses_host_id) {
                 return hints_dir() / host_id.to_sstring();
             } else {
-                return hints_dir() / ip.to_sstring();
+                return hints_dir() / fmt::to_string(ip);
             }
         });
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2180,7 +2180,7 @@ view_builder::view_build_statuses(sstring keyspace, sstring view_name) const {
     topo.for_each_node([&] (const locator::node *node) {
         auto it = status.find(node->host_id());
         auto s = it != status.end() ? std::move(it->second) : "UNKNOWN";
-        status_map.emplace(node->endpoint().to_sstring(), std::move(s));
+        status_map.emplace(fmt::to_string(node->endpoint()), std::move(s));
     });
     co_return status_map;
 }

--- a/gms/inet_address.cc
+++ b/gms/inet_address.cc
@@ -36,7 +36,3 @@ std::ostream& gms::operator<<(std::ostream& os, const inet_address& x) {
     fmt::print(os, "{}", x);
     return os;
 }
-
-sstring gms::inet_address::to_sstring() const {
-    return format("{}", *this);
-}

--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -62,7 +62,6 @@ public:
     uint32_t raw_addr() const {
         return addr().as_ipv4_address().ip;
     }
-    sstring to_sstring() const;
     friend inline bool operator==(const inet_address& x, const inet_address& y) noexcept = default;
     friend inline bool operator<(const inet_address& x, const inet_address& y) noexcept {
         return x.bytes() < y.bytes();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3397,7 +3397,7 @@ future<std::unordered_map<sstring, std::vector<sstring>>> storage_service::descr
         });
     }, std::move(results), [] (auto results, auto host_and_version) {
         auto version = host_and_version.second ? host_and_version.second->to_sstring() : UNREACHABLE;
-        results.try_emplace(version).first->second.emplace_back(host_and_version.first.to_sstring());
+        results.try_emplace(version).first->second.emplace_back(fmt::to_string(host_and_version.first));
         return results;
     }).then([this] (auto results) {
         // we're done: the results map is ready to return to the client.  the rest is just debug logging:

--- a/thrift/handler.cc
+++ b/thrift/handler.cc
@@ -805,7 +805,7 @@ public:
             auto m = _ss.local().get_token_to_endpoint_map();
             std::map<std::string, std::string> ret;
             for (auto&& p : m) {
-                ret[format("{}", p.first)] = p.second.to_sstring();
+                ret[format("{}", p.first)] = fmt::to_string(p.second);
             }
             return ret;
         });


### PR DESCRIPTION
The existing inet_address::to_string() calls fmt::format("{}", *this) anyway. However, the to_string() method is declared in .cc file, while form formatter is in the header and is equipeed with constexprs so that converting an address to string is done as much as possible compile-time.

Also, though minor, fmt::to_string(foo) is believed to be even faster than fmt::format("{}", foo).