### PR TITLE
main: introduce schema commitlog scheduling group

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1024,6 +1024,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             dbcfg.memtable_to_cache_scheduling_group = make_sched_group("memtable_to_cache", "mt2c", 200);
             dbcfg.gossip_scheduling_group = make_sched_group("gossip", "gms", 1000);
             dbcfg.commitlog_scheduling_group = make_sched_group("commitlog", "clog", 1000);
+            dbcfg.schema_commitlog_scheduling_group = make_sched_group("schema_commitlog", "sclg", 1000);
             dbcfg.available_memory = memory::stats().total_memory();
 
             // Make sure to initialize the scheduling group keys at a point where we are sure

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -819,6 +819,7 @@ void database::init_schema_commitlog() {
     assert(this_shard_id() == 0);
 
     db::commitlog::config c;
+    c.sched_group = _dbcfg.schema_commitlog_scheduling_group;
     c.commit_log_location = _cfg.schema_commitlog_directory();
     c.fname_prefix = db::schema_tables::COMMITLOG_FILENAME_PREFIX;
     c.metrics_category_name = "schema-commitlog";

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1340,6 +1340,7 @@ struct database_config {
     seastar::scheduling_group streaming_scheduling_group;
     seastar::scheduling_group gossip_scheduling_group;
     seastar::scheduling_group commitlog_scheduling_group;
+    seastar::scheduling_group schema_commitlog_scheduling_group;
     size_t available_memory;
     std::optional<sstables::sstable_version_types> sstables_format;
 };


### PR DESCRIPTION
Currently, we do not explicitly set a scheduling group for the schema commitlog which causes it to run in the default scheduling group (called "main"). However:

- It is important and significant enough that it should run in a scheduling group that is separate from the main one,
- It should not run in the existing "commitlog" group as user writes may sometimes need to wait for schema commitlog writes (e.g. read barrier done to learn the schema necessary to interpret the user write) and we want to avoid priority inversion issues.

Therefore, introduce a new scheduling group dedicated to the schema commitlog.

Fixes: scylladb/scylladb#15566

- [x] It's not a regression, so conservatively not marking for backport

