### PR TITLE
clustering_bounds_comparator: drop operator<< for bound_kind

### DIFF
--- a/clustering_bounds_comparator.hh
+++ b/clustering_bounds_comparator.hh
@@ -25,8 +25,6 @@ enum class bound_kind : uint8_t {
     excl_start = 7,
 };
 
-std::ostream& operator<<(std::ostream& out, const bound_kind k);
-
 // Swaps start <-> end && incl <-> excl
 bound_kind invert_kind(bound_kind k);
 // Swaps start <-> end

--- a/keys.cc
+++ b/keys.cc
@@ -52,11 +52,6 @@ partition_key partition_key::from_nodetool_style_string(const schema_ptr s, cons
     return partition_key::from_range(std::move(r));
 }
 
-std::ostream& operator<<(std::ostream& out, const bound_kind k) {
-    fmt::print(out, "{}", k);
-    return out;
-}
-
 auto fmt::formatter<bound_kind>::format(bound_kind k, fmt::format_context& ctx) const
         -> decltype(ctx.out()) {
     std::string_view name;


### PR DESCRIPTION
turns out operator<< for bound_kind is not used anymore, so let's drop it.

- [ ] ** Backport reason (please explain below if this patch should be backported or not) **

