### PR TITLE
mutation: drop operator<< for mutation

### DIFF
--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -309,11 +309,6 @@ auto fmt::formatter<mutation>::format(const mutation& m, fmt::format_context& ct
     return fmt::format_to(out, "token: {}}}, {}\n}}", dk._token, mutation_partition::printer(s, m.partition()));
 }
 
-std::ostream& operator<<(std::ostream& os, const mutation& m) {
-    fmt::print(os, "{}", m);
-    return os;
-}
-
 namespace mutation_json {
 
 void mutation_partition_json_writer::write_each_collection_cell(const collection_mutation_view_description& mv, data_type type,

--- a/mutation/mutation.hh
+++ b/mutation/mutation.hh
@@ -466,8 +466,6 @@ template <> struct fmt::formatter<mutation> : fmt::formatter<string_view> {
     auto format(const mutation&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-std::ostream& operator<<(std::ostream& os, const mutation& m);
-
 // Splits the source mutation into multiple mutations so that their size
 // does not exceed the max_size limit.
 // The size of a mutation is calculated as the sum of the memory_usage()


### PR DESCRIPTION
since we've migrated away from the generic homebrew formatters for range-alike containers, there is no need to keep this operator<< around -- it was preserved in order to work with the container formatters which expect operator<< of the elements.

- [ ] ** Backport reason (please explain below if this patch should be backported or not) **

