### PR TITLE
test: use generic boost_test_print_type()

### DIFF
--- a/test/boost/auth_resource_test.cc
+++ b/test/boost/auth_resource_test.cc
@@ -9,28 +9,10 @@
 #define BOOST_TEST_MODULE core
 
 #include "auth/resource.hh"
+#include "test/lib/test_utils.hh"
 
 #include <boost/test/unit_test.hpp>
 #include <fmt/ranges.h>
-
-namespace auth {
-
-std::ostream& boost_test_print_type(std::ostream& os, const resource& r) {
-    fmt::print(os, "{}", r);
-    return os;
-}
-
-std::ostream& boost_test_print_type(std::ostream& os, const resource_kind& kind) {
-    fmt::print(os, "{}", kind);
-    return os;
-}
-
-std::ostream& boost_test_print_type(std::ostream& os, const resource_set& resources) {
-    fmt::print(os, "{}", resources);
-    return os;
-}
-
-}
 
 BOOST_AUTO_TEST_CASE(root_of) {
     //

--- a/test/boost/column_mapping_test.cc
+++ b/test/boost/column_mapping_test.cc
@@ -10,14 +10,10 @@
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
+#include "test/lib/test_utils.hh"
 
 #include "db/schema_tables.hh"
 #include "transport/messages/result_message.hh"
-
-std::ostream& boost_test_print_type(std::ostream& os, const column_mapping& cm) {
-    fmt::print(os, "{}", cm);
-    return os;
-}
 
 SEASTAR_TEST_CASE(test_column_mapping_persistence) {
     return do_with_cql_env_thread([] (cql_test_env& e) {

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -42,15 +42,9 @@
 #include "test/lib/sstable_utils.hh"
 #include "test/lib/mutation_source_test.hh"
 #include "test/lib/key_utils.hh"
+#include "test/lib/test_utils.hh"
 
 using namespace db;
-
-namespace db {
-std::ostream& boost_test_print_type(std::ostream& os, const replay_position& p) {
-    fmt::print(os, "{}", p);
-    return os;
-}
-}
 
 static future<> cl_test(commitlog::config cfg, noncopyable_function<future<> (commitlog&)> f) {
     // enable as needed.

--- a/test/boost/counter_test.cc
+++ b/test/boost/counter_test.cc
@@ -17,20 +17,11 @@
 #include <boost/range/algorithm/sort.hpp>
 
 #include "test/lib/scylla_test_case.hh"
+#include "test/lib/test_utils.hh"
 #include "schema/schema_builder.hh"
 #include "keys.hh"
 #include "mutation/mutation.hh"
 #include "mutation/frozen_mutation.hh"
-
-std::ostream& boost_test_print_type(std::ostream& os, const counter_shard_view& csv) {
-    fmt::print(os, "{}", csv);
-    return os;
-}
-
-std::ostream& boost_test_print_type(std::ostream& os, const counter_cell_view& ccv) {
-    fmt::print(os, "{}", ccv);
-    return os;
-}
 
 void verify_shard_order(counter_cell_view ccv) {
     if (ccv.shards().begin() == ccv.shards().end()) {

--- a/test/boost/cql_auth_query_test.cc
+++ b/test/boost/cql_auth_query_test.cc
@@ -13,8 +13,9 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>
-#include "test/lib/scylla_test_case.hh"
 #include <seastar/util/defer.hh>
+#include "test/lib/scylla_test_case.hh"
+#include "test/lib/test_utils.hh"
 
 #include "auth/authenticated_user.hh"
 #include "auth/permission.hh"
@@ -28,15 +29,6 @@
 
 static const auto alice = std::string_view("alice");
 static const auto bob = std::string_view("bob");
-
-namespace seastar {
-
-std::ostream& boost_test_print_type(std::ostream& os, const std::unordered_set<seastar::sstring>& strings) {
-    fmt::print(os, "{}", strings);
-    return os;
-}
-
-} // namespace seastar
 
 static shared_ptr<db::config> db_config_with_auth() {
     shared_ptr<db::config> config_ptr = make_shared<db::config>();

--- a/test/boost/error_injection_test.cc
+++ b/test/boost/error_injection_test.cc
@@ -14,6 +14,7 @@
 #include "utils/error_injection.hh"
 #include "db/timeout_clock.hh"
 #include "test/lib/cql_assertions.hh"
+#include "test/lib/test_utils.hh"
 #include "types/list.hh"
 #include "log.hh"
 #include <chrono>
@@ -27,14 +28,6 @@ using minutes = std::chrono::minutes;
 using steady_clock = std::chrono::steady_clock;
 
 constexpr milliseconds sleep_msec(10); // Injection time sleep 10 msec
-
-namespace std::chrono {
-template<class Clock, class Duration>
-std::ostream& boost_test_print_type(std::ostream& os, const std::chrono::time_point<Clock, Duration>& time_point) {
-    fmt::print(os, "{}", time_point);
-    return os;
-}
-}
 
 SEASTAR_TEST_CASE(test_inject_noop) {
     utils::error_injection<false> errinj;

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -28,22 +28,6 @@ using namespace cql3;
 using namespace cql3::expr;
 using namespace cql3::expr::test_utils;
 
-namespace cql3::expr {
-// required by BOOST_REQUIRE_EQUAL
-std::ostream& boost_test_print_type(std::ostream& os, const std::vector<cql3::expr::expression>& v) {
-    fmt::print(os, "{{{}}}", fmt::join(v, ", "));
-    return os;
-}
-}
-
-namespace cql3 {
-// required by BOOST_REQUIRE_EQUAL
-std::ostream& boost_test_print_type(std::ostream& os, const raw_value& value) {
-    fmt::print(os, "{}", value);
-    return os;
-}
-}
-
 bind_variable new_bind_variable(int bind_index, data_type type = int32_type) {
     return bind_variable {
         .bind_index = bind_index,

--- a/test/boost/flat_mutation_reader_test.cc
+++ b/test/boost/flat_mutation_reader_test.cc
@@ -22,6 +22,7 @@
 #include "replica/memtable.hh"
 #include "row_cache.hh"
 #include "mutation/mutation_rebuilder.hh"
+#include "utils/to_string.hh"
 
 #include "test/lib/simple_schema.hh"
 #include "test/lib/flat_mutation_reader_assertions.hh"

--- a/test/boost/gossiping_property_file_snitch_test.cc
+++ b/test/boost/gossiping_property_file_snitch_test.cc
@@ -8,7 +8,9 @@
 
 
 #include <boost/test/unit_test.hpp>
+#include <fmt/ranges.h>
 #include "test/lib/scylla_test_case.hh"
+#include "test/lib/test_utils.hh"
 #include <seastar/util/std-compat.hh>
 #include <seastar/core/reactor.hh>
 #include <string>
@@ -18,15 +20,6 @@
 #include "locator/production_snitch_base.hh"
 
 static std::filesystem::path test_files_subdir("test/resource/snitch_property_files");
-
-namespace std {
-
-std::ostream& boost_test_print_type(std::ostream& os, const std::pair<sstring, sstring>& p) {
-    fmt::print(os, "{}:{}", p.first, p.second);
-    return os;
-}
-
-}
 
 future<> one_test(const std::string& property_fname, bool exp_result) {
     using namespace locator;

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -18,6 +18,7 @@
 #include "test/lib/key_utils.hh"
 #include "test/lib/random_utils.hh"
 #include "test/lib/random_schema.hh"
+#include "test/lib/test_utils.hh"
 #include "test/lib/tmpdir.hh"
 
 #include <fmt/ranges.h>
@@ -30,16 +31,6 @@
 #include "readers/from_mutations_v2.hh"
 #include "replica/database.hh" // new_reader_base_cost is there :(
 #include "db/config.hh"
-
-std::ostream& boost_test_print_type(std::ostream& os, const reader_resources& r) {
-    fmt::print(os, "{}", r);
-    return os;
-}
-
-std::ostream& boost_test_print_type(std::ostream& os, reader_permit::state s) {
-    fmt::print(os, "{}", s);
-    return os;
-}
 
 SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_clear_inactive_reads) {
     simple_schema s;

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -65,6 +65,7 @@
 #include "test/lib/sstable_utils.hh"
 #include "test/lib/random_utils.hh"
 #include "test/lib/key_utils.hh"
+#include "test/lib/test_utils.hh"
 #include "readers/from_mutations_v2.hh"
 #include "readers/from_fragments_v2.hh"
 #include "readers/combined.hh"
@@ -85,12 +86,6 @@ atomic_cell make_atomic_cell(data_type dt, bytes_view value, uint32_t ttl = 0, u
     }
 }
 
-namespace sstables {
-std::ostream& boost_test_print_type(std::ostream& os, const generation_type& gen) {
-    fmt::print(os, "{}", gen);
-    return os;
-}
-}
 ////////////////////////////////  Test basic compaction support
 
 // open_sstables() opens several generations of the same sstable, returning,

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -33,23 +33,6 @@ using namespace locator;
 using namespace replica;
 using namespace service;
 
-namespace locator {
-static std::ostream& boost_test_print_type(std::ostream& out, tablet_id id) {
-    fmt::print(out, "{}", id);
-    return out;
-}
-
-static std::ostream& boost_test_print_type(std::ostream& out, const tablet_map& r) {
-    fmt::print(out, "{}", r);
-    return out;
-}
-
-static std::ostream& boost_test_print_type(std::ostream& out, const tablet_metadata& tm) {
-    fmt::print(out, "{}", tm);
-    return out;
-}
-}
-
 static api::timestamp_type current_timestamp(cql_test_env& e) {
     // Mutations in system.tablets got there via group0, so in order for new
     // mutations to take effect, their timestamp should be "later" than that

--- a/test/lib/test_utils.cc
+++ b/test/lib/test_utils.cc
@@ -102,22 +102,3 @@ future<> touch_file(std::string name) {
 std::mutex boost_logger_mutex;
 
 }
-
-namespace std {
-
-std::ostream& boost_test_print_type(std::ostream& os, const std::strong_ordering& order) {
-    fmt::print(os, "{}", order);
-    return os;
-}
-
-std::ostream& boost_test_print_type(std::ostream& os, const std::weak_ordering& order) {
-    fmt::print(os, "{}", order);
-    return os;
-}
-
-std::ostream& boost_test_print_type(std::ostream& os, const std::partial_ordering& order) {
-    fmt::print(os, "{}", order);
-    return os;
-}
-
-} // namespace std

--- a/test/lib/test_utils.hh
+++ b/test/lib/test_utils.hh
@@ -12,6 +12,7 @@
 #include <seastar/util/source_location-compat.hh>
 #include <string>
 #include <boost/test/unit_test.hpp>
+#include <fmt/core.h>
 #include <fmt/format.h>
 
 using namespace seastar;
@@ -113,10 +114,6 @@ extern std::mutex boost_logger_mutex;
 }
 
 namespace std {
-
-std::ostream& boost_test_print_type(std::ostream& os, const std::strong_ordering& order);
-std::ostream& boost_test_print_type(std::ostream& os, const std::weak_ordering& order);
-std::ostream& boost_test_print_type(std::ostream& os, const std::partial_ordering& order);
 
 template <typename T>
 requires fmt::is_formattable<T>::value

--- a/test/manual/hint_test.cc
+++ b/test/manual/hint_test.cc
@@ -20,18 +20,12 @@
 #include <seastar/core/file.hh>
 #include <seastar/core/seastar.hh>
 #include "utils/UUID_gen.hh"
+#include "test/lib/test_utils.hh"
 #include "test/lib/tmpdir.hh"
 #include "db/commitlog/commitlog.hh"
 #include "db/commitlog/rp_set.hh"
 
 using namespace db;
-
-namespace db {
-std::ostream& boost_test_print_type(std::ostream& os, const replay_position& p) {
-    fmt::print(os, "{}", p);
-    return os;
-}
-}
 
 static future<> cl_test(commitlog::config cfg, noncopyable_function<future<> (commitlog& log)> f) {
     tmpdir tmp;


### PR DESCRIPTION
in this change, we trade the `boost_test_print_type()` overloads
for the generic template of `boost_test_print_type()`, except for
those in the very small tests, which presumably want to keep
themselves relative self-contained.

- [x] cleanup of tests. no need to backport
