### PR TITLE
doc: replace 5.5 with 6.0 in SStable docs (me)

### DIFF
--- a/docs/architecture/sstable/index.rst
+++ b/docs/architecture/sstable/index.rst
@@ -9,7 +9,7 @@ ScyllaDB SSTable Format
 
 .. include:: _common/sstable_what_is.rst
 
-* In Scylla 5.5 and above, *me* format is enabled by default.
+* In Scylla 6.0 and above, *me* format is enabled by default.
 
 * In Scylla Enterprise 2021.1, Scylla 4.3 and above, *md* format is enabled by default.
   

--- a/docs/architecture/sstable/sstable3/index.rst
+++ b/docs/architecture/sstable/sstable3/index.rst
@@ -12,7 +12,7 @@ ScyllaDB SSTable - 3.x
 
 .. include:: ../_common/sstable_what_is.rst
 
-* In ScyllaDB 5.5 and above, the ``me`` format is mandatory, and ``md`` format is used only when upgrading from an existing cluster using ``md``. The ``sstable_format`` parameter is ignored if it is set to ``md``.
+* In ScyllaDB 6.0 and above, the ``me`` format is mandatory, and ``md`` format is used only when upgrading from an existing cluster using ``md``. The ``sstable_format`` parameter is ignored if it is set to ``md``.
 * In ScyllaDB 5.1 and above, the ``me`` format is enabled by default.
 * In ScyllaDB 4.3 to 5.0, the ``md`` format is enabled by default.
 * In ScyllaDB 3.1 to 4.2, the ``mc`` format is enabled by default. 


### PR DESCRIPTION
This PR replaces version number 5.5 with 6.0 because 5.5 has never been released.

This is a follow-up to https://github.com/scylladb/scylladb/pull/16716.

Refs https://github.com/scylladb/scylladb/issues/16551 Refs https://github.com/scylladb/scylladb/issues/18580

- No backport. This is a 6.0-related update.

