### PR TITLE
Sanitize sl controller draining

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -2039,10 +2039,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             supervisor::notify("serving");
             // Register at_exit last, so that storage_service::drain_on_shutdown will be called first
 
-            auto drain_sl_controller = defer_verbose_shutdown("service level controller update loop", [] {
-                sl_controller.invoke_on_all(&qos::service_level_controller::drain).get();
-            });
-
             auto do_drain = defer_verbose_shutdown("local storage", [&ss] {
                 ss.local().drain_on_shutdown().get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1179,7 +1179,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             //starting service level controller
             qos::service_level_options default_service_level_configuration;
-            sl_controller.start(std::ref(auth_service), std::ref(token_metadata), default_service_level_configuration).get();
+            sl_controller.start(std::ref(auth_service), std::ref(token_metadata), std::ref(stop_signal.as_sharded_abort_source()), default_service_level_configuration).get();
             sl_controller.invoke_on_all(&qos::service_level_controller::start).get();
             auto stop_sl_controller = defer_verbose_shutdown("service level controller", [] {
                 sl_controller.stop().get();

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -113,7 +113,7 @@ void service_level_controller::do_abort() noexcept {
     _global_controller_db->notifications_serializer.broken();
 }
 
-future<> service_level_controller::drain() {
+future<> service_level_controller::stop() {
     if (this_shard_id() != global_controller) {
         co_return;
     }
@@ -130,10 +130,6 @@ future<> service_level_controller::drain() {
     } catch (const exceptions::unavailable_exception& ignored) {
     } catch (const exceptions::read_timeout_exception& ignored) {
     }
-}
-
-future<> service_level_controller::stop() {
-    return drain();
 }
 
 void service_level_controller::abort_group0_operations() {

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -94,8 +94,10 @@ private:
     std::chrono::time_point<seastar::lowres_clock> _last_successful_config_update;
     unsigned _logged_intervals;
     atomic_vector<qos_configuration_change_subscriber*> _subscribers;
+    optimized_optional<abort_source::subscription> _early_abort_subscription;
+    void do_abort() noexcept;
 public:
-    service_level_controller(sharded<auth::service>& auth_service, locator::shared_token_metadata& tm, service_level_options default_service_level_config);
+    service_level_controller(sharded<auth::service>& auth_service, locator::shared_token_metadata& tm, abort_source& as, service_level_options default_service_level_config);
 
     /**
      * this function must be called *once* from any shard before any other functions are called.

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -134,12 +134,6 @@ public:
     future<> remove_service_level(sstring name, bool remove_static);
 
     /**
-     * stops the distributed updater
-     * @return a future that is resolved when the updates stopped
-     */
-    future<> drain();
-
-    /**
      * stops all ongoing operations if exists
      * @return a future that is resolved when all operations has stopped
      */

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -618,7 +618,7 @@ private:
 
             set_abort_on_internal_error(true);
             const gms::inet_address listen("127.0.0.1");
-            _sl_controller.start(std::ref(_auth_service), std::ref(_token_metadata), qos::service_level_options{}).get();
+            _sl_controller.start(std::ref(_auth_service), std::ref(_token_metadata), std::ref(abort_sources), qos::service_level_options{}).get();
             auto stop_sl_controller = defer([this] { _sl_controller.stop().get(); });
             _sl_controller.invoke_on_all(&qos::service_level_controller::start).get();
 


### PR DESCRIPTION
The sl-controller is stopped in three steps. The first (and instantly the second) is unsubscribing from lifecycle notification and draining. The third is stop itself. First two steps are "out of order" as compared to the desired start-stop sequence of any service, this patch fixes these steps.

After this PR the drain_on_shutdown() (the call that drains the node upon stop) finally becomes clean and tidy and is no longer accompanied by ad-hoc fellow drains/stops/aborts/whatever.

refs: #2737 