### PR TITLE
build: cmake: pass -fprofile-list to compiler

### DIFF
--- a/cmake/mode.Coverage.cmake
+++ b/cmake/mode.Coverage.cmake
@@ -1,5 +1,5 @@
 set(CMAKE_CXX_FLAGS_COVERAGE
-  "-fprofile-instr-generate -fcoverage-mapping"
+  "-fprofile-instr-generate -fcoverage-mapping -fprofile-list=${CMAKE_SOURCE_DIR}/coverage_sources.list"
   CACHE
   INTERNAL
   "")


### PR DESCRIPTION
to mirror the behavior of the build.ninja generated by configure.py

- [x] cmake related change, no need to backport

