### PR TITLE
test: boost: chunked_vector_test: include <optional>

### DIFF
--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -9,6 +9,7 @@
 #define BOOST_TEST_MODULE core
 
 #include <stdexcept>
+#include <optional>
 #include <fmt/format.h>
 
 #include <boost/test/included/unit_test.hpp>


### PR DESCRIPTION
std::optional is used but not imported. This fails on libstdc++-14.

- [x] ** Backport reason (please explain below if this patch should be backported or not) **
No need to backport, only fails on newer toolchains

