### PR TITLE
test: topology: workaround probable Python 3.12 bug with list compreh…

### DIFF
--- a/test/topology/test_coordinator_queue_management.py
+++ b/test/topology/test_coordinator_queue_management.py
@@ -38,7 +38,10 @@ async def test_coordinator_queue_management(manager: ManagerClient):
              asyncio.create_task(manager.remove_node(servers[0].server_id, servers[3].server_id)),
              asyncio.create_task(manager.remove_node(servers[0].server_id, servers[4].server_id, [s3_id]))]
 
-    search = [asyncio.create_task(l.wait_for("received request to join from host_id", m) for l, m in zip(logs[:3], marks[:3]))]
+    # #18740 - list comprenhension with async calls fails mysteriously, so loop explicitly
+    search = []
+    for l, m in zip(logs[:3], marks[:3]):
+        search.append(asyncio.create_task(l.wait_for("received request to join from host_id", m)))
     done, pending = await asyncio.wait(search, return_when = asyncio.FIRST_COMPLETED)
     for t in pending: t.cancel()
 
@@ -60,7 +63,10 @@ async def test_coordinator_queue_management(manager: ManagerClient):
     tasks = [asyncio.create_task(manager.server_start(s.server_id, expected_error="request canceled because some required nodes are dead")),
              asyncio.create_task(manager.decommission_node(servers[1].server_id, expected_error="Decommission failed. See earlier errors"))]
 
-    search = [asyncio.create_task(l.wait_for("received request to join from host_id", m) for l, m in zip(logs[:3], marks[:3]))]
+    # #18740 - list comprenhension with async calls fails mysteriously, so loop explicitly
+    search = []
+    for l, m in zip(logs[:3], marks[:3]):
+        search.append(asyncio.create_task(l.wait_for("received request to join from host_id", m)))
     done, pending = await asyncio.wait(search, return_when = asyncio.FIRST_COMPLETED)
     for t in pending: t.cancel()
 


### PR DESCRIPTION
…ensions of coroutines

Python 3.12 complains when a list comprehension's element type is a coroutine. As far as I can tell this is a bug. Work around it be perfoming the iteration explicitly.

Fixes scylladb/scylladb#18740

- [x] ** Backport reason (please explain below if this patch should be backported or not) **
No backport needed, failures only seen with newer toolchain.

