### PR TITLE
chunked_vector_test: include <optional> header

### DIFF
--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -10,6 +10,7 @@
 
 #include <stdexcept>
 #include <fmt/format.h>
+#include <optional>
 
 #include <boost/test/included/unit_test.hpp>
 #include <deque>

--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -8,7 +8,6 @@
 
 #define BOOST_TEST_MODULE core
 
-#include <stdexcept>
 #include <fmt/format.h>
 #include <optional>
 


### PR DESCRIPTION
The chunked_vector_test fails to compile with latest versions of boost(1.82 and above) due to missing include file. This patch fixes that by including the appropriate header file to the test.

Fixes #18746