### PR TITLE
build: "undo" the coverage compiling options added to abseil

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1761,6 +1761,12 @@ def configure_abseil(build_dir, mode, mode_config):
     abseil_build_dir = os.path.join(build_dir, mode, 'abseil')
 
     abseil_cflags = seastar_cflags + ' ' + modes[mode]['cxx_ld_flags']
+    # We want to "undo" coverage for abseil if we have it enabled, as we are not
+    # interested in the coverage of the abseil library. these flags were previously
+    # added to cxx_ld_flags
+    if args.coverage:
+        for flag in COVERAGE_INST_FLAGS:
+            abseil_cflags = abseil_cflags.replace(f' {flag}', '')
     cmake_mode = mode_config['cmake_build_type']
     abseil_cmake_args = [
         '-DCMAKE_BUILD_TYPE={}'.format(cmake_mode),


### PR DESCRIPTION
we are not interseted in the code coverage of abseil library, so no need to apply the compiling options enabling the coverage instrumentation when building the abseil library.

moreover, since the path of the file passed to `-fprofile-list` is a relative path. when building with coverage enabled, the build fails when building abseil, like:

```
 /usr/lib64/ccache/clang++  -I/jenkins/workspace/scylla-master/scylla-ci/scylla/abseil -std=c++20 -I/jenkins/workspace/scylla-master/scylla-ci/scylla/seastar/include -I/jenkins/workspace/scylla-master/scylla-ci/scylla/build/debug/seastar/gen/include -U_FORTIFY_SOURCE -Werror=unused-result -fstack-clash-protection -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr -DSEASTAR_API_LEVEL=7 -DSEASTAR_BUILD_SHARED_LIBS -DSEASTAR_SSTRING -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_DEBUG -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEBUG_PROMISE -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_TYPE_ERASE_MORE -DBOOST_NO_CXX98_FUNCTION_BASE -DFMT_SHARED -I/usr/include/p11-kit-1 -fprofile-instr-generate -fcoverage-mapping -fprofile-list=./coverage_sources.list -std=gnu++20 -Wall -Wextra -Wcast-qual -Wconversion -Wfloat-overflow-conversion -Wfloat-zero-conversion -Wfor-loop-analysis -Wformat-security -Wgnu-redeclared-enum -Winfinite-recursion -Winvalid-constexpr -Wliteral-conversion -Wmissing-declarations -Woverlength-strings -Wpointer-arith -Wself-assign -Wshadow-all -Wshorten-64-to-32 -Wsign-conversion -Wstring-conversion -Wtautological-overlap-compare -Wtautological-unsigned-zero-compare -Wundef -Wuninitialized -Wunreachable-code -Wunused-comparison -Wunused-local-typedefs -Wunused-result -Wvla -Wwrite-strings -Wno-float-conversion -Wno-implicit-float-conversion -Wno-implicit-int-float-conversion -Wno-unknown-warning-option -DNOMINMAX -MD -MT absl/strings/CMakeFiles/strings.dir/str_cat.cc.o -MF absl/strings/CMakeFiles/strings.dir/str_cat.cc.o.d -o absl/strings/CMakeFiles/strings.dir/str_cat.cc.o -c /jenkins/workspace/scylla-master/scylla-ci/scylla/abseil/absl/strings/str_cat.cc
clang-16: error: no such file or directory: './coverage_sources.list'`
```

in this change, we just remove the compiling options enabling the coverage instrumentation from the cflags when building abseil.

Fixes #18686
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

- [x] no need to backport. as the abseil submodule was only introduced to master.
