### PR TITLE
repair: drop timeout from table_sync_and_check

### DIFF
--- a/repair/table_check.cc
+++ b/repair/table_check.cc
@@ -14,16 +14,8 @@ namespace repair {
 
 future<table_dropped> table_sync_and_check(replica::database& db, service::migration_manager& mm, const table_id& uuid) {
     if (mm.use_raft()) {
-        abort_on_expiry aoe(lowres_clock::now() + std::chrono::seconds{10});
-        auto& as = aoe.abort_source();
-        auto sub = mm.get_abort_source().subscribe([&as] () noexcept {
-            if (!as.abort_requested()) {
-                as.request_abort();
-            }
-        });
-
         // Trigger read barrier to synchronize schema.
-        co_await mm.get_group0_barrier().trigger(as);
+        co_await mm.get_group0_barrier().trigger(mm.get_abort_source());
     }
 
     co_return !db.column_family_exists(uuid);


### PR DESCRIPTION
Delete 10s timeout from read barrier in table_sync_and_check, so that the function always considers all previous group0 changes.

Fixes: #18490.

- [x] ** Backport reason (please explain below if this patch should be backported or not) **
Should be backported to 5.2 and 5.4 as they use timeout
