### PR TITLE
Backport "migration manager: if raft is enables sync with group0 leader before pulling a schema which is not available locally" to 5.2.x

### DIFF
--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -42,7 +42,20 @@ static future<schema_ptr> get_schema_definition(table_schema_version v, netw::me
 
 migration_manager::migration_manager(migration_notifier& notifier, gms::feature_service& feat, netw::messaging_service& ms,
             service::storage_proxy& storage_proxy, gms::gossiper& gossiper, service::raft_group0_client& group0_client, sharded<db::system_keyspace>& sysks) :
-        _notifier(notifier), _feat(feat), _messaging(ms), _storage_proxy(storage_proxy), _gossiper(gossiper), _group0_client(group0_client)
+          _notifier(notifier)
+        , _group0_barrier(this_shard_id() == 0 ?
+            std::function<future<>()>([this] () -> future<> {
+                // This will run raft barrier and will sync schema with the leader
+                (void)co_await start_group0_operation();
+            }) :
+            std::function<future<>()>([this] () -> future<> {
+                co_await container().invoke_on(0, [] (migration_manager& mm) -> future<> {
+                    // batch group0 raft barriers
+                    co_await mm._group0_barrier.trigger();
+                });
+            })
+        )
+        , _feat(feat), _messaging(ms), _storage_proxy(storage_proxy), _gossiper(gossiper), _group0_client(group0_client)
         , _sys_ks(sysks)
         , _schema_push([this] { return passive_announce(); })
         , _concurrent_ddl_retries{10}
@@ -73,6 +86,7 @@ future<> migration_manager::drain()
     } catch (...) {
         mlogger.error("schema_pull failed: {}", std::current_exception());
     }
+    co_await _group0_barrier.join();
     co_await _background_tasks.close();
 }
 
@@ -1081,14 +1095,31 @@ future<schema_ptr> migration_manager::get_schema_for_read(table_schema_version v
 
 future<schema_ptr> migration_manager::get_schema_for_write(table_schema_version v, netw::messaging_service::msg_addr dst, netw::messaging_service& ms) {
     if (_as.abort_requested()) {
-        return make_exception_future<schema_ptr>(abort_requested_exception());
+        co_return coroutine::exception(std::make_exception_ptr(abort_requested_exception()));
     }
 
-    return get_schema_definition(v, dst, ms, _storage_proxy).then([this, dst] (schema_ptr s) {
-        return maybe_sync(s, dst).then([s] {
-            return s;
-        });
-    });
+    auto s = local_schema_registry().get_or_null(v);
+
+    if (s && s->is_synced()) {
+        co_return s;
+    }
+
+    if (_group0_client.using_raft()) {
+        // batch group0 raft barriers
+        co_await _group0_barrier.trigger();
+    }
+
+    s = co_await get_schema_definition(v, dst, ms, _storage_proxy);
+
+    if (_group0_client.using_raft()) {
+        // Mark entry as synced
+        co_await s->registry_entry()->maybe_sync([] { return make_ready_future<>(); });
+    } else {
+        // If raft is used the schema is synced already
+        co_await maybe_sync(s, dst);
+    }
+
+    co_return s;
 }
 
 future<> migration_manager::sync_schema(const replica::database& db, const std::vector<gms::inet_address>& nodes) {

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -60,6 +60,7 @@ private:
     migration_notifier& _notifier;
 
     std::unordered_map<netw::msg_addr, serialized_action, netw::msg_addr::hash> _schema_pulls;
+    serialized_action _group0_barrier;
     std::vector<gms::feature::listener_registration> _feature_listeners;
     seastar::gate _background_tasks;
     static const std::chrono::milliseconds migration_delay;

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -351,6 +351,12 @@ future<std::pair<rwlock::holder, group0_upgrade_state>> raft_group0_client::get_
     co_return std::pair{rwlock::holder{}, _upgrade_state};
 }
 
+bool raft_group0_client::using_raft() {
+    // No need to take upgrade log since after the state becomes use_post_raft_procedures
+    // it never goes back
+    return _upgrade_state == group0_upgrade_state::use_post_raft_procedures;
+}
+
 future<> raft_group0_client::set_group0_upgrade_state(group0_upgrade_state state) {
     // We could explicitly handle abort here but we assume that if someone holds the lock,
     // they will eventually finish (say, due to abort) and release it.

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -156,6 +156,11 @@ public:
     // the holder does not actually hold any lock.
     future<std::pair<rwlock::holder, group0_upgrade_state>> get_group0_upgrade_state();
 
+    // Returns true iff the upgrade state is `use_post_raft_procedures`
+    // The function does not take upgrade lock since after the state becomes
+    // `use_post_raft_procedures` it can never go back
+    bool using_raft();
+
     // Ensures that nobody holds any `rwlock::holder`s returned from `get_group0_upgrade_state()`
     // then changes the state to `s`.
     //


### PR DESCRIPTION
Schema pull may fail because the pull does not contain everything that is needed to instantiate a schema pointer. For instance it does not contain a keyspace. This patch changes the code to issue raft read barrier before the pull which will guaranty that the keyspace is created before the actual schema pull is performed.

Refs: #3760
Fixes: #13211
(cherry picked from commit 70189b60dee9d378f525d2db1a378b4709eb3576)

