### PR TITLE
test/alternator: do not write to auth tables

### DIFF
--- a/test/alternator/README.md
+++ b/test/alternator/README.md
@@ -98,17 +98,8 @@ configuration parameter:
 ```yaml
   alternator_enforce_authorization: true
 ```
-The implementation is currently coupled with Scylla's system\_auth.roles table,
-which means that an additional step needs to be performed when setting up Scylla
-as the test environment. Tests will use the following credentials:
-Username: `alternator`
-Secret key: `secret_pass`
-
-With CQLSH, it can be achieved by executing this snipped:
-
-```bash
-cqlsh -x "INSERT INTO system_auth.roles (role, salted_hash) VALUES ('alternator', 'secret_pass')"
-```
+The test implementation is currently coupled with Scylla's default account
+"cassandra" with password "cassandra".
 
 Most tests expect the authorization to succeed, so they will pass even with `alternator_enforce_authorization`
 turned off. However, test cases from `test_authorization.py` may require this option to be turned on,

--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -15,6 +15,7 @@ import requests
 import re
 from util import create_test_table, is_aws, scylla_log
 from urllib.parse import urlparse
+from functools import cache
 
 # Test that the Boto libraries are new enough. These tests want to test a
 # large variety of DynamoDB API features, and to do this we need a new-enough
@@ -59,6 +60,39 @@ def pytest_collection_modifyitems(config, items):
         if "veryslow" in item.keywords:
             item.add_marker(skip_veryslow)
 
+# When testing Alternator running with --alternator-enforce-authorization=1,
+# we need to find a valid username and secret key to use in the connection.
+# Alternator allows any CQL role as the username any CQL role, and the key
+# is that role's password's salted hash. We can read a valid role/hash
+# from the appropriate system table, but can't do it with Alternator (because
+# we don't know yet the secret key!), so we need to do it with CQL.
+@cache
+def get_valid_alternator_role(url):
+    from cassandra.cluster import Cluster
+    from cassandra.auth import PlainTextAuthProvider
+    auth_provider = PlainTextAuthProvider(
+        username='cassandra', password='cassandra')
+    with (
+        Cluster([urlparse(url).hostname], auth_provider=auth_provider,
+            connect_timeout = 60, control_connection_timeout = 60) as cluster,
+        cluster.connect() as session
+    ):
+        # Newer Scylla places the "roles" table in the "system" keyspace, but
+        # older versions used "system_auth_v2" or "system_auth"
+        for ks in ['system', 'system_auth_v2', 'system_auth']:
+            try:
+                # We could have looked for any role/salted_hash pair, but we
+                # already know a role "cassandra" exists (we just used it to
+                # connect to CQL!), so let's just use that role.
+                role = 'cassandra'
+                salted_hash = list(session.execute(f"SELECT salted_hash FROM {ks}.roles WHERE role = '{role}'"))[0].salted_hash
+                return (role, salted_hash)
+            except:
+                pass
+    # If we couldn't find a valid role, let's hope that
+    # alternator-enforce-authorization is not enabled so anything will work
+    return ('unknown_user', 'unknown_secret')
+
 # "dynamodb" fixture: set up client object for communicating with the DynamoDB
 # API. Currently this chooses either Amazon's DynamoDB in the default region
 # or a local Alternator installation on http://localhost:8080 - depending on the
@@ -87,8 +121,9 @@ def dynamodb(request):
             local_url = 'https://localhost:8043' if request.config.getoption('https') else 'http://localhost:8000'
         # Disable verifying in order to be able to use self-signed TLS certificates
         verify = not request.config.getoption('https')
+        user, secret = get_valid_alternator_role(local_url)
         return boto3.resource('dynamodb', endpoint_url=local_url, verify=verify,
-            region_name='us-east-1', aws_access_key_id='alternator', aws_secret_access_key='secret_pass',
+            region_name='us-east-1', aws_access_key_id=user, aws_secret_access_key=secret,
             config=boto_config.merge(botocore.client.Config(retries={"max_attempts": 0}, read_timeout=300)))
 
 def new_dynamodb_session(request, dynamodb):
@@ -99,8 +134,9 @@ def new_dynamodb_session(request, dynamodb):
         return boto3.resource('dynamodb', config=conf)
     if host.hostname == 'localhost':
         conf = conf.merge(botocore.client.Config(retries={"max_attempts": 0}, read_timeout=300))
+    user, secret = get_valid_alternator_role(dynamodb.meta.client._endpoint.host)
     return ses.resource('dynamodb', endpoint_url=dynamodb.meta.client._endpoint.host, verify=host.scheme != 'http',
-        region_name='us-east-1', aws_access_key_id='alternator', aws_secret_access_key='secret_pass',
+        region_name='us-east-1', aws_access_key_id=user, aws_secret_access_key=secret,
         config=conf)
 
 @pytest.fixture(scope="session")
@@ -125,8 +161,9 @@ def dynamodbstreams(request):
             local_url = 'https://localhost:8043' if request.config.getoption('https') else 'http://localhost:8000'
         # Disable verifying in order to be able to use self-signed TLS certificates
         verify = not request.config.getoption('https')
+        user, secret = get_valid_alternator_role(local_url)
         return boto3.client('dynamodbstreams', endpoint_url=local_url, verify=verify,
-            region_name='us-east-1', aws_access_key_id='alternator', aws_secret_access_key='secret_pass',
+            region_name='us-east-1', aws_access_key_id=user, aws_secret_access_key=secret,
             config=boto_config.merge(botocore.client.Config(retries={"max_attempts": 0}, read_timeout=300)))
 
 # A function-scoped autouse=True fixture allows us to test after every test

--- a/test/alternator/run
+++ b/test/alternator/run
@@ -97,13 +97,6 @@ run.wait_for_services(pid, [
     lambda: check_alternator(alternator_url),
 ])
 
-# Set up the the proper authentication credentials needed by the Alternator
-# test. Currently this can only be done through CQL, which is why above we
-# needed to make sure CQL is available.
-cluster = run.get_cql_cluster(ip)
-cluster.connect().execute("INSERT INTO system_auth_v2.roles (role, salted_hash) VALUES ('alternator', 'secret_pass')")
-cluster.shutdown()
-
 # Finally run pytest:
 success = run.run_pytest(sys.path[0], ['--url', alternator_url] + sys.argv[1:])
 

--- a/test/alternator/suite.yaml
+++ b/test/alternator/suite.yaml
@@ -1,6 +1,5 @@
 type: Python
 pool_size: 4
-prepare_cql: INSERT INTO system_auth_v2.roles (role, salted_hash) VALUES ('alternator', 'secret_pass')
 run_first:
     - test_streams
     - test_scan

--- a/test/alternator/test_authorization.py
+++ b/test/alternator/test_authorization.py
@@ -40,7 +40,7 @@ def test_expired_signature(dynamodb, test_table):
     headers = {'Content-Type': 'application/x-amz-json-1.0',
                'X-Amz-Date': '20170101T010101Z',
                'X-Amz-Target': 'DynamoDB_20120810.DescribeEndpoints',
-               'Authorization': 'AWS4-HMAC-SHA256 Credential=alternator/2/3/4/aws4_request SignedHeaders=x-amz-date;host Signature=123'
+               'Authorization': 'AWS4-HMAC-SHA256 Credential=cassandra/2/3/4/aws4_request SignedHeaders=x-amz-date;host Signature=123'
     }
     response = requests.post(url, headers=headers, verify=False)
     assert not response.ok
@@ -67,7 +67,7 @@ def test_signature_too_futuristic(dynamodb, test_table):
     headers = {'Content-Type': 'application/x-amz-json-1.0',
                'X-Amz-Date': '30200101T010101Z',
                'X-Amz-Target': 'DynamoDB_20120810.DescribeEndpoints',
-               'Authorization': 'AWS4-HMAC-SHA256 Credential=alternator/2/3/4/aws4_request SignedHeaders=x-amz-date;host Signature=123'
+               'Authorization': 'AWS4-HMAC-SHA256 Credential=cassandra/2/3/4/aws4_request SignedHeaders=x-amz-date;host Signature=123'
     }
     response = requests.post(url, headers=headers, verify=False)
     assert not response.ok

--- a/test/alternator/test_describe_endpoints.py
+++ b/test/alternator/test_describe_endpoints.py
@@ -31,6 +31,8 @@ def test_describe_endpoints(request, dynamodb):
             # requires us to specify dummy region and credential parameters,
             # otherwise the user is forced to properly configure ~/.aws even
             # for local runs.
-            boto3.client('dynamodb',endpoint_url=url, region_name='us-east-1', aws_access_key_id='alternator', aws_secret_access_key='secret_pass', verify=verify).describe_endpoints()
+            from conftest import get_valid_alternator_role
+            user, secret = get_valid_alternator_role(url)
+            boto3.client('dynamodb',endpoint_url=url, region_name='us-east-1', aws_access_key_id=user, aws_secret_access_key=secret, verify=verify).describe_endpoints()
         # Nothing to check here - if the above call failed with an exception,
         # the test would fail.

--- a/test/alternator/test_tracing.py
+++ b/test/alternator/test_tracing.py
@@ -240,9 +240,9 @@ def test_slow_query_log(with_slow_query_logging, test_table_s, dynamodb):
     while time.time() < start_time + 60:
         results = full_scan(slow_query_table, ConsistentRead=False)
         put_item_found = any("PutItem" in result['parameters'] and p in result['parameters']
-                and result['username'] == "alternator" for result in results)
+                and result['username'] == "cassandra" for result in results)
         delete_item_found = any("DeleteItem" in result['parameters'] and p in result['parameters']
-                and result['username'] == "alternator" for result in results)
+                and result['username'] == "cassandra" for result in results)
         if put_item_found and delete_item_found:
             return
         else:


### PR DESCRIPTION
As part of the Alternator test suite, we check Alternator's support for authentication. Alternator maps Scylla's existing CQL roles to AWS's authentication:
  * AWS's access_key_id:     the name of the CQL role
  * AWS's secret_access_key: the salted hash of the password of the CQL role.

Before this patch, the Alternator test suite created a new role with a preset salted hash (role "alternator", salted hash "secret_pass") and than used that in the tests. However, with the advent of Raft-based metadata it is wrong to write directly to the roles table, and starting with #17952 such writes will be outright forbidden.

But we don't actually need to create a new CQL role! We already have a perfectly good CQL role called "cassandra", and the tests already use it. So what this patch does is to have the tests (conftest.py) read from the roles system-table the salted hash of the "cassandra" role, and then use that - instead of the hard-coded pair alternator/secret_pass - in the tests.

A couple more tests assumed that the role name that was used was "alternator", but now it was changed to "cassasandra" so those tests needed minor fixes as well.

After this patch, the Alternator tests no longer *write* to the roles system table. Moreover, after this patch, test/alternator/run and test/alternator/suite.yaml (used when testing with test.py) no longer need to do extra ugly CQL setup before starting the Alternator tests.

Fixes #18744

This is a test-only patch so normally backports are not needed. We may want to later reconsider this decision if we decide to backport #17952 which will break the unpatched tests.