### PR TITLE
cql: reject ALTER tablets KS with repl opts

### DIFF
--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -50,6 +50,10 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
         }
         try {
             auto ks = qp.db().find_keyspace(_name);
+            // TODO: the full tablets support will be implemented in https://github.com/scylladb/scylladb/issues/16129
+            if (ks.get_replication_strategy().uses_tablets() && !_attrs->get_replication_options().empty()) {
+                throw exceptions::invalid_request_exception("Changing replication options via ALTER KEYSPACE statement is not yet supported for keyspaces with tablets.");
+            }
             data_dictionary::storage_options current_options = ks.metadata()->get_storage_options();
             data_dictionary::storage_options new_options = _attrs->get_storage_options();
             if (!qp.proxy().features().keyspace_storage_options && !new_options.is_local_type()) {

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -293,6 +293,17 @@ For instance::
 
 The supported options are the same as :ref:`creating a keyspace <create-keyspace-statement>`.
 
+ALTER KEYSPACE with Tablets :label-caution:`Experimental`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Modifying a keyspace with tablets enabled is not yet fully supported and all ``ALTER KEYSPACE`` statements specifying any replication option issued on a keyspace with tablets enabled are going to be rejected:
+
+.. code-block:: cql
+
+   cqlsh> CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': 4} and tablets = {'initial': 8};
+   cqlsh> ALTER KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': 3};
+   InvalidRequest: Error from server: code=2200 [Invalid query] message="Changing replication options via ALTER KEYSPACE statement is not yet supported for keyspaces with tablets."
+
 .. _drop-keyspace-statement:
 
 DROP KEYSPACE

--- a/test/cql-pytest/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/alter_test.py
@@ -222,6 +222,7 @@ def testAlterKeyspaceWithNoOptionThrowsConfigurationException(cql, test_keyspace
 
 # Test {@link ConfigurationException} thrown when altering a keyspace to
 # invalid DC option in replication configuration.
+@pytest.mark.xfail(reason="Issue #16129; ALTER tablets KS doesn't support replication options")
 def testAlterKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, test_keyspace, this_dc):
     # Create a keyspace with expected DC name.
     with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 }") as ks:
@@ -231,6 +232,7 @@ def testAlterKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, test_keysp
         # Mix valid and invalid, should throw an exception
         assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy for keyspace " + ks, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 , 'INVALID_DC': 1}")
 
+@pytest.mark.xfail(reason="Issue #16129; ALTER tablets KS doesn't support replication options")
 def testAlterKeyspaceWithMultipleInstancesOfSameDCThrowsSyntaxException(cql, test_keyspace, this_dc):
     # Create a keyspace
     with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 }") as ks:

--- a/test/cql-pytest/test_keyspace.py
+++ b/test/cql-pytest/test_keyspace.py
@@ -97,11 +97,17 @@ def test_drop_keyspace_nonexistent(cql):
         cql.execute('DROP KEYSPACE nonexistent_keyspace')
 
 # Test trying to ALTER a keyspace.
+@pytest.mark.xfail(reason="Issue #16129; ALTER tablets KS doesn't support replication options")
 def test_alter_keyspace(cql, this_dc):
     with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as keyspace:
         cql.execute(f"ALTER KEYSPACE {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 3 }} AND DURABLE_WRITES = false")
 
+def test_alter_keyspace_without_providing_replication_options(cql, this_dc):
+    with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as keyspace:
+        cql.execute(f"ALTER KEYSPACE {keyspace} WITH DURABLE_WRITES = false")
+
 # Test trying to ALTER a keyspace with invalid options.
+@pytest.mark.xfail(reason="Issue #16129; ALTER tablets KS doesn't support replication options")
 def test_alter_keyspace_invalid(cql, this_dc):
     with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as keyspace:
         with pytest.raises(ConfigurationException):
@@ -130,6 +136,7 @@ def test_alter_keyspace_missing_rf(cql, this_dc, scylla_only, has_tablets):
 
 # Test trying to ALTER a keyspace with invalid options.
 # Reproduces #7595.
+@pytest.mark.xfail(reason="Issue #16129; ALTER tablets KS doesn't support replication options")
 def test_alter_keyspace_nonexistent_dc(cql, this_dc):
     with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as keyspace:
         with pytest.raises(ConfigurationException):

--- a/test/cql-pytest/test_tablets.py
+++ b/test/cql-pytest/test_tablets.py
@@ -92,6 +92,7 @@ def test_tablets_can_be_explicitly_disabled(cql, skip_without_tablets):
         assert len(list(res)) == 0, "tablets replication strategy turned on"
 
 
+@pytest.mark.xfail(reason="Issue #16129; ALTER tablets KS doesn't support replication options")
 def test_alter_changes_initial_tablets(cql, skip_without_tablets):
     ksdef = "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};"
     with new_test_keyspace(cql, ksdef) as keyspace:

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="Issue #16129; ALTER tablets KS doesn't support replication options")
 async def test_tablet_replication_factor_enough_nodes(manager: ManagerClient):
     cfg = {'enable_user_defined_functions': False,
            'experimental_features': ['tablets']}


### PR DESCRIPTION
The full support for ALTERing a tablets-enabled KEYSPACE is not yet
implemented, and we don't want to only change the schema without changing
any tablets, so the statement has to be explicitly rejected for cases
that won't work, so every time any replication option is provided.

Fixes: #18795
References: #16129