### PR TITLE
test/lib: do not use variable which could be moved away

### DIFF
--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -394,7 +394,7 @@ test_env::reusable_sst(schema_ptr schema, shared_sstable sst) {
 
 future<shared_sstable>
 test_env::reusable_sst(shared_sstable sst) {
-    return reusable_sst(sst->get_schema(), std::move(sst));
+    return reusable_sst(sst->get_schema(), sst);
 }
 
 future<shared_sstable>


### PR DESCRIPTION
C++ standard does not define the order in which the parameters passed to a function are evaluated. so in theory, in
```c++
reusable_sst(sst->get_schema(), std::move(sst));
```
`std::move(sst)` could be evaluated before `sst->get_schema`. but please note, `std::move(sst)` does not move `sst` away, it merely cast `sst` to a rvalue reference, it is `reusable_sst()` which *could* move `sst` away by
consuming it. so following call is much more dangerous than the above one:
```c++
reusable_sst(sst->get_schema(), modify_sst(std::move(sst)))
```
nevertheless, this usage is still confusing. so instead of passing a copy of `sst` to `reusable_sst`.

this change is inspired by clang-tidy, it warns like:

```
Warning: /home/runner/work/scylladb/scylladb/test/lib/test_services.cc:397:25: warning: 'sst' used after it was moved [bugprone-use-after-move]
  397 |     return reusable_sst(sst->get_schema(), std::move(sst));
      |                         ^
/home/runner/work/scylladb/scylladb/test/lib/test_services.cc:397:44: note: move occurred here
  397 |     return reusable_sst(sst->get_schema(), std::move(sst));
      |                                            ^
/home/runner/work/scylladb/scylladb/test/lib/test_services.cc:397:25: note: the use and move are unsequenced, i.e. there is no guarantee about the order in which they are evaluated
  397 |     return reusable_sst(sst->get_schema(), std::move(sst));
      |
```

per the analysis above, this is a false alarm.

- [x] no need to backport. it's a cleanup in test

