### PR TITLE
repair: Add missing db/config.hh

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -44,6 +44,7 @@
 #include "streaming/consumer.hh"
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/all.hh>
+#include "db/config.hh"
 #include "db/system_keyspace.hh"
 #include "service/storage_proxy.hh"
 #include "service/raft/raft_address_map.hh"


### PR DESCRIPTION
Since commit 952dfc615742b6e96f6ad621fe4d932ccfb7d6a6 "repair: Introduce repair_partition_count_estimation_ratio config option", get_config() is used. We need to include db/config.hh for that.

Spotted when backporting to 5.4 branch.

Refs #18615

backport 5.4