### PR TITLE
repair: Introduce new primary replica selection algorithm for tablets

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -250,6 +250,14 @@ tablet_replica tablet_map::get_primary_replica(tablet_id id) const {
     return replicas.at(size_t(id) % replicas.size());
 }
 
+tablet_replica tablet_map::get_primary_replica_within_dc(tablet_id id, const topology& topo, sstring dc) const {
+    const auto replicas = boost::copy_range<tablet_replica_set>(get_tablet_info(id).replicas | boost::adaptors::filtered([&] (const auto& tr) {
+        const auto& node = topo.get_node(tr.host);
+        return node.dc_rack().dc == dc;
+    }));
+    return replicas.at(size_t(id) % replicas.size());
+}
+
 future<std::vector<token>> tablet_map::get_sorted_tokens() const {
     std::vector<token> tokens;
     tokens.reserve(tablet_count());

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -245,9 +245,9 @@ dht::token_range tablet_map::get_token_range(tablet_id id) const {
     }
 }
 
-host_id tablet_map::get_primary_replica(tablet_id id) const {
+tablet_replica tablet_map::get_primary_replica(tablet_id id) const {
     const auto info = get_tablet_info(id);
-    return info.replicas.at(size_t(id) % info.replicas.size()).host;
+    return info.replicas.at(size_t(id) % info.replicas.size());
 }
 
 future<std::vector<token>> tablet_map::get_sorted_tokens() const {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -246,8 +246,8 @@ dht::token_range tablet_map::get_token_range(tablet_id id) const {
 }
 
 tablet_replica tablet_map::get_primary_replica(tablet_id id) const {
-    const auto info = get_tablet_info(id);
-    return info.replicas.at(size_t(id) % info.replicas.size());
+    const auto& replicas = get_tablet_info(id).replicas;
+    return replicas.at(size_t(id) % replicas.size());
 }
 
 future<std::vector<token>> tablet_map::get_sorted_tokens() const {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -361,6 +361,7 @@ public:
 
     /// Returns the primary replica for the tablet
     tablet_replica get_primary_replica(tablet_id id) const;
+    tablet_replica get_primary_replica_within_dc(tablet_id id, const topology& topo, sstring dc) const;
 
     /// Returns a vector of sorted last tokens for tablets.
     future<std::vector<token>> get_sorted_tokens() const;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -360,7 +360,7 @@ public:
     dht::token_range get_token_range(tablet_id id) const;
 
     /// Returns the primary replica for the tablet
-    host_id get_primary_replica(tablet_id id) const;
+    tablet_replica get_primary_replica(tablet_id id) const;
 
     /// Returns a vector of sorted last tokens for tablets.
     future<std::vector<token>> get_sorted_tokens() const;

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -2122,6 +2122,7 @@ future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_nam
         auto mydc = erm->get_topology().get_datacenter();
         bool select_primary_ranges_within_dc = false;
         // If the user specified the ranges option, ignore the primary_replica_only option.
+        // Since the ranges are requested explicitly.
         if (!ranges_specified.empty()) {
             primary_replica_only = false;
         }
@@ -2158,11 +2159,7 @@ future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_nam
                     found = true;
                     break;
                 }
-                // If users use both the primary_replica_only and the ranges
-                // option to select which ranges to repair, prefer the more
-                // sophisticated ranges option, since the ranges the requested
-                // explicitly.
-                if (primary_replica_only && ranges_specified.empty()) {
+                if (primary_replica_only) {
                     break;
                 }
             }

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -2144,22 +2144,22 @@ future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_nam
         co_await tmap.for_each_tablet([&] (locator::tablet_id id, const locator::tablet_info& info) -> future<> {
             auto range = tmap.get_token_range(id);
             auto& replicas = info.replicas;
+
+            if (primary_replica_only) {
+                const auto pr = select_primary_ranges_within_dc ? tmap.get_primary_replica_within_dc(id, erm->get_topology(), mydc) : tmap.get_primary_replica(id);
+                if (pr.host == myhostid) {
+                    metas.push_back(repair_tablet_meta{id, range, myhostid, pr.shard, replicas});
+                }
+                return make_ready_future<>();
+            }
+
             bool found = false;
             shard_id master_shard_id;
             // Repair all tablets belong to this node
             for (auto& r : replicas) {
-                if (select_primary_ranges_within_dc) {
-                    auto dc = erm->get_topology().get_datacenter(r.host);
-                    if (dc != mydc) {
-                        continue;
-                    }
-                }
                 if (r.host == myhostid) {
                     master_shard_id = r.shard;
                     found = true;
-                    break;
-                }
-                if (primary_replica_only) {
                     break;
                 }
             }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5055,7 +5055,7 @@ future<std::map<token, inet_address>> storage_service::get_tablet_to_endpoint_ma
     const auto& tmap = tm.tablets().get_tablet_map(table);
     std::map<token, inet_address> result;
     for (std::optional<locator::tablet_id> tid = tmap.first_tablet(); tid; tid = tmap.next_tablet(*tid)) {
-        result.emplace(tmap.get_last_token(*tid), tm.get_endpoint_for_host_id(tmap.get_primary_replica(*tid)));
+        result.emplace(tmap.get_last_token(*tid), tm.get_endpoint_for_host_id(tmap.get_primary_replica(*tid).host));
         co_await coroutine::maybe_yield();
     }
     co_return result;


### PR DESCRIPTION
Tablet allocation does not guarantee fairness of
the first replica in the replicas set across dcs.
The lack of this fix cause the following dtest to fail:
repair_additional_test.py::TestRepairAdditional::test_repair_option_pr_multi_dc

Use the tablet_map get_primary_replica or get_primary_replica_within_dc,
respectively to see if this node is the primary replica for each tablet
or not.

Fixes https://github.com/scylladb/scylladb/issues/17752

No backport is required before 6.0 as tablets (and tablet repair) are introduced in 6.0