### PR TITLE
version: bump version to 6.0.0-dev

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -78,7 +78,7 @@ fi
 
 # Default scylla product/version tags
 PRODUCT=scylla
-VERSION=5.5.0-dev
+VERSION=6.0.0-dev
 
 if test -f version
 then


### PR DESCRIPTION
The next release will be called 6.0, not 5.5, so bump the version to reflect that.

No backport needed - this is about the next version.