### PR TITLE
Update tools/java submodule

### DIFF
--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-38-20240321
+docker.io/scylladb/scylla-toolchain:fedora-38-20240521


### PR DESCRIPTION
* tools/java 4ee15fd9...88809606 (2):
  > Update Scylla Java driver to 3.11.5.3.
  > install-dependencies.sh: s/python/python3/

[botond: regenerate toolchain image]