### PR TITLE
Do not export statement scheduling group from database

### DIFF
--- a/alternator/controller.cc
+++ b/alternator/controller.cc
@@ -32,7 +32,8 @@ controller::controller(
         sharded<service::memory_limiter>& memory_limiter,
         sharded<auth::service>& auth_service,
         sharded<qos::service_level_controller>& sl_controller,
-        const db::config& config)
+        const db::config& config,
+        seastar::scheduling_group sg)
     : _gossiper(gossiper)
     , _proxy(proxy)
     , _mm(mm)

--- a/alternator/controller.cc
+++ b/alternator/controller.cc
@@ -160,7 +160,9 @@ future<> controller::stop_server() {
 }
 
 future<> controller::request_stop_server() {
-    return stop_server();
+    return with_scheduling_group(_sched_group, [this] {
+        return stop_server();
+    });
 }
 
 }

--- a/alternator/controller.cc
+++ b/alternator/controller.cc
@@ -34,7 +34,8 @@ controller::controller(
         sharded<qos::service_level_controller>& sl_controller,
         const db::config& config,
         seastar::scheduling_group sg)
-    : _gossiper(gossiper)
+    : protocol_server(sg)
+    , _gossiper(gossiper)
     , _proxy(proxy)
     , _mm(mm)
     , _sys_dist_ks(sys_dist_ks)

--- a/alternator/controller.cc
+++ b/alternator/controller.cc
@@ -64,7 +64,9 @@ std::vector<socket_address> controller::listen_addresses() const {
 }
 
 future<> controller::start_server() {
-    return seastar::async([this] {
+    seastar::thread_attributes attr;
+    attr.sched_group = _sched_group;
+    return seastar::async(std::move(attr), [this] {
         _listen_addresses.clear();
 
         auto preferred = _config.listen_interface_prefer_ipv6() ? std::make_optional(net::inet_address::family::INET6) : std::nullopt;

--- a/alternator/controller.hh
+++ b/alternator/controller.hh
@@ -80,7 +80,8 @@ public:
         sharded<service::memory_limiter>& memory_limiter,
         sharded<auth::service>& auth_service,
         sharded<qos::service_level_controller>& sl_controller,
-        const db::config& config);
+        const db::config& config,
+        seastar::scheduling_group sg);
 
     virtual sstring name() const override;
     virtual sstring protocol() const override;

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -306,21 +306,17 @@ future<scrub_info> parse_scrub_options(const http_context& ctx, sharded<db::snap
 }
 
 void set_transport_controller(http_context& ctx, routes& r, cql_transport::controller& ctl) {
-    ss::start_native_transport.set(r, [&ctx, &ctl](std::unique_ptr<http::request> req) {
+    ss::start_native_transport.set(r, [&ctl](std::unique_ptr<http::request> req) {
         return smp::submit_to(0, [&] {
-            return with_scheduling_group(ctx.db.local().get_statement_scheduling_group(), [&ctl] {
-                return ctl.start_server();
-            });
+            return ctl.start_server();
         }).then([] {
             return make_ready_future<json::json_return_type>(json_void());
         });
     });
 
-    ss::stop_native_transport.set(r, [&ctx, &ctl](std::unique_ptr<http::request> req) {
+    ss::stop_native_transport.set(r, [&ctl](std::unique_ptr<http::request> req) {
         return smp::submit_to(0, [&] {
-            return with_scheduling_group(ctx.db.local().get_statement_scheduling_group(), [&ctl] {
-                return ctl.request_stop_server();
-            });
+            return ctl.request_stop_server();
         }).then([] {
             return make_ready_future<json::json_return_type>(json_void());
         });
@@ -342,21 +338,17 @@ void unset_transport_controller(http_context& ctx, routes& r) {
 }
 
 void set_rpc_controller(http_context& ctx, routes& r, thrift_controller& ctl) {
-    ss::stop_rpc_server.set(r, [&ctx, &ctl](std::unique_ptr<http::request> req) {
+    ss::stop_rpc_server.set(r, [&ctl](std::unique_ptr<http::request> req) {
         return smp::submit_to(0, [&] {
-            return with_scheduling_group(ctx.db.local().get_statement_scheduling_group(), [&ctl] {
-                return ctl.request_stop_server();
-            });
+            return ctl.request_stop_server();
         }).then([] {
             return make_ready_future<json::json_return_type>(json_void());
         });
     });
 
-    ss::start_rpc_server.set(r, [&ctx, &ctl](std::unique_ptr<http::request> req) {
+    ss::start_rpc_server.set(r, [&ctl](std::unique_ptr<http::request> req) {
         return smp::submit_to(0, [&] {
-            return with_scheduling_group(ctx.db.local().get_statement_scheduling_group(), [&ctl] {
-                return ctl.start_server();
-            });
+            return ctl.start_server();
         }).then([] {
             return make_ready_future<json::json_return_type>(json_void());
         });

--- a/protocol_server.hh
+++ b/protocol_server.hh
@@ -19,6 +19,8 @@ struct client_data;
 
 // Abstraction for a server serving some kind of user-facing protocol.
 class protocol_server {
+protected:
+    seastar::scheduling_group _sched_group;
 public:
     virtual ~protocol_server() = default;
     /// Name of the server, can be different or the same as than the protocol it serves.
@@ -44,4 +46,6 @@ public:
     virtual future<utils::chunked_vector<client_data>> get_client_data() {
         return make_ready_future<utils::chunked_vector<client_data>>(utils::chunked_vector<client_data>());
     }
+
+    protocol_server(seastar::scheduling_group sg) noexcept : _sched_group(std::move(sg)) {}
 };

--- a/redis/controller.cc
+++ b/redis/controller.cc
@@ -20,7 +20,8 @@ static logging::logger slogger("controller");
 namespace redis {
 
 controller::controller(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<auth::service>& auth_service,
-        seastar::sharded<service::migration_manager>& mm, db::config& cfg, seastar::sharded<gms::gossiper>& gossiper)
+        seastar::sharded<service::migration_manager>& mm, db::config& cfg, seastar::sharded<gms::gossiper>& gossiper,
+        seastar::scheduling_group sg)
     : _proxy(proxy)
     , _db(proxy.local().data_dictionary())
     , _auth_service(auth_service)

--- a/redis/controller.cc
+++ b/redis/controller.cc
@@ -22,7 +22,8 @@ namespace redis {
 controller::controller(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<auth::service>& auth_service,
         seastar::sharded<service::migration_manager>& mm, db::config& cfg, seastar::sharded<gms::gossiper>& gossiper,
         seastar::scheduling_group sg)
-    : _proxy(proxy)
+    : protocol_server(sg)
+    , _proxy(proxy)
     , _db(proxy.local().data_dictionary())
     , _auth_service(auth_service)
     , _mm(mm)

--- a/redis/controller.cc
+++ b/redis/controller.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <seastar/coroutine/switch_to.hh>
 #include "timeout_config.hh"
 #include "redis/controller.hh"
 #include "redis/keyspace_utils.hh"
@@ -120,6 +121,7 @@ std::vector<socket_address> controller::listen_addresses() const {
 
 future<> controller::start_server()
 {
+    co_await coroutine::switch_to(_sched_group);
     // 1. Create keyspace/tables used by redis API if not exists.
     // 2. Initialize the redis query processor.
     // 3. Listen on the redis transport port.

--- a/redis/controller.cc
+++ b/redis/controller.cc
@@ -148,7 +148,9 @@ future<> controller::stop_server()
 }
 
 future<> controller::request_stop_server() {
-    return stop_server();
+    return with_scheduling_group(_sched_group, [this] {
+        return stop_server();
+    });
 }
 
 }

--- a/redis/controller.hh
+++ b/redis/controller.hh
@@ -64,7 +64,8 @@ private:
     seastar::future<> listen(seastar::sharded<auth::service>& auth_service, db::config& cfg);
 public:
     controller(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<auth::service>& auth_service,
-            seastar::sharded<service::migration_manager>& mm, db::config& cfg, seastar::sharded<gms::gossiper>& gossiper);
+            seastar::sharded<service::migration_manager>& mm, db::config& cfg, seastar::sharded<gms::gossiper>& gossiper,
+            seastar::scheduling_group sg);
     ~controller();
     virtual sstring name() const override;
     virtual sstring protocol() const override;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1607,7 +1607,6 @@ public:
         return &_cf_stats;
     }
 
-    seastar::scheduling_group get_statement_scheduling_group() const { return _dbcfg.statement_scheduling_group; }
     seastar::scheduling_group get_streaming_scheduling_group() const { return _dbcfg.streaming_scheduling_group; }
 
     compaction_manager& get_compaction_manager() {

--- a/test/manual/sstable_scan_footprint_test.cc
+++ b/test/manual/sstable_scan_footprint_test.cc
@@ -317,8 +317,10 @@ int main(int argc, char** argv) {
         db_cfg.sstable_format(app.configuration()["sstable-format"].as<std::string>());
 
         do_with_cql_env([] (cql_test_env& env) {
-            return with_scheduling_group(env.local_db().get_statement_scheduling_group(), [&] {
-                return seastar::async([&] {
+            return get_scheduling_groups().then([&env] (auto groups) {
+                seastar::thread_attributes attr;
+                attr.sched_group = groups.statement_scheduling_group;
+                return seastar::async(std::move(attr), [&] {
                     test_main_thread(env);
                 });
             });

--- a/thrift/controller.cc
+++ b/thrift/controller.cc
@@ -113,7 +113,9 @@ future<> thrift_controller::request_stop_server() {
         throw std::runtime_error(format("Thrift server is starting, try again later"));
     }
 
-    return do_stop_server().finally([this] { _ops_sem.signal(); });
+    return with_scheduling_group(_sched_group, [this] {
+        return do_stop_server();
+    }).finally([this] { _ops_sem.signal(); });
 }
 
 future<> thrift_controller::do_stop_server() {

--- a/thrift/controller.cc
+++ b/thrift/controller.cc
@@ -60,7 +60,10 @@ future<> thrift_controller::do_start_server() {
     if (_server) {
         return make_ready_future<>();
     }
-    return seastar::async([this] {
+
+    seastar::thread_attributes attr;
+    attr.sched_group = _sched_group;
+    return seastar::async(std::move(attr), [this] {
         auto tserver = std::make_unique<distributed<thrift_server>>();
         _addr.reset();
 

--- a/thrift/controller.cc
+++ b/thrift/controller.cc
@@ -19,7 +19,8 @@ thrift_controller::thrift_controller(distributed<replica::database>& db, sharded
         sharded<cql3::query_processor>& qp, sharded<service::memory_limiter>& ml,
         sharded<service::storage_service>& ss, sharded<service::storage_proxy>& proxy,
         seastar::scheduling_group sg)
-    : _ops_sem(1)
+    : protocol_server(sg)
+    , _ops_sem(1)
     , _db(db)
     , _auth_service(auth)
     , _qp(qp)

--- a/thrift/controller.cc
+++ b/thrift/controller.cc
@@ -17,7 +17,8 @@ static logging::logger clogger("thrift_controller");
 
 thrift_controller::thrift_controller(distributed<replica::database>& db, sharded<auth::service>& auth,
         sharded<cql3::query_processor>& qp, sharded<service::memory_limiter>& ml,
-        sharded<service::storage_service>& ss, sharded<service::storage_proxy>& proxy)
+        sharded<service::storage_service>& ss, sharded<service::storage_proxy>& proxy,
+        seastar::scheduling_group sg)
     : _ops_sem(1)
     , _db(db)
     , _auth_service(auth)

--- a/thrift/controller.hh
+++ b/thrift/controller.hh
@@ -46,7 +46,7 @@ class thrift_controller : public protocol_server {
     future<> do_stop_server();
 
 public:
-    thrift_controller(distributed<replica::database>&, sharded<auth::service>&, sharded<cql3::query_processor>&, sharded<service::memory_limiter>&, sharded<service::storage_service>& ss, sharded<service::storage_proxy>& proxy);
+    thrift_controller(distributed<replica::database>&, sharded<auth::service>&, sharded<cql3::query_processor>&, sharded<service::memory_limiter>&, sharded<service::storage_service>& ss, sharded<service::storage_proxy>& proxy, seastar::scheduling_group sg);
     virtual sstring name() const override;
     virtual sstring protocol() const override;
     virtual sstring protocol_version() const override;

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -214,7 +214,9 @@ future<> controller::do_start_server() {
         return make_ready_future<>();
     }
 
-    return seastar::async([this] {
+    seastar::thread_attributes attr;
+    attr.sched_group = _sched_group;
+    return seastar::async(std::move(attr), [this] {
         auto cserver = std::make_unique<sharded<cql_server>>();
 
         auto& cfg = _config;

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -30,7 +30,8 @@ controller::controller(sharded<auth::service>& auth, sharded<service::migration_
         sharded<qos::service_level_controller>& sl_controller, sharded<service::endpoint_lifecycle_notifier>& elc_notif,
         const db::config& cfg, scheduling_group_key cql_opcode_stats_key, maintenance_socket_enabled used_by_maintenance_socket,
         seastar::scheduling_group sg)
-    : _ops_sem(1)
+    : protocol_server(sg)
+    , _ops_sem(1)
     , _auth_service(auth)
     , _mnotifier(mn)
     , _lifecycle_notifier(elc_notif)

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -28,7 +28,8 @@ static logging::logger logger("cql_server_controller");
 controller::controller(sharded<auth::service>& auth, sharded<service::migration_notifier>& mn,
         sharded<gms::gossiper>& gossiper, sharded<cql3::query_processor>& qp, sharded<service::memory_limiter>& ml,
         sharded<qos::service_level_controller>& sl_controller, sharded<service::endpoint_lifecycle_notifier>& elc_notif,
-        const db::config& cfg, scheduling_group_key cql_opcode_stats_key, maintenance_socket_enabled used_by_maintenance_socket)
+        const db::config& cfg, scheduling_group_key cql_opcode_stats_key, maintenance_socket_enabled used_by_maintenance_socket,
+        seastar::scheduling_group sg)
     : _ops_sem(1)
     , _auth_service(auth)
     , _mnotifier(mn)

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -289,7 +289,9 @@ future<> controller::request_stop_server() {
         throw std::runtime_error(format("CQL server is starting, try again later"));
     }
 
-    return do_stop_server().finally([this] { _ops_sem.signal(); });
+    return with_scheduling_group(_sched_group, [this] {
+        return do_stop_server();
+    }).finally([this] { _ops_sem.signal(); });
 }
 
 future<> controller::do_stop_server() {

--- a/transport/controller.hh
+++ b/transport/controller.hh
@@ -68,7 +68,8 @@ public:
     controller(sharded<auth::service>&, sharded<service::migration_notifier>&, sharded<gms::gossiper>&,
             sharded<cql3::query_processor>&, sharded<service::memory_limiter>&,
             sharded<qos::service_level_controller>&, sharded<service::endpoint_lifecycle_notifier>&,
-            const db::config& cfg, scheduling_group_key cql_opcode_stats_key, maintenance_socket_enabled used_by_maintenance_socket);
+            const db::config& cfg, scheduling_group_key cql_opcode_stats_key, maintenance_socket_enabled used_by_maintenance_socket,
+            seastar::scheduling_group sg);
     virtual sstring name() const override;
     virtual sstring protocol() const override;
     virtual sstring protocol_version() const override;


### PR DESCRIPTION
Database used to be (and still is in many ways) an object used to get configuration from. Part of the configuration is the set of pre-configured scheduling groups. That's not nice, services should use each other for some real need, not as proxies to configuration. This patch patches the places that explicitly switch to statement group _not_ to use database to get the group itself.

fixes: #17643 