### PR TITLE
alternator: yield while converting large responses to json text

### DIFF
--- a/utils/rjson.cc
+++ b/utils/rjson.cc
@@ -242,23 +242,15 @@ class output_stream_buffer {
 public:
     output_stream_buffer(seastar::output_stream<char>& os) : _os(os) {}
     using Ch = char; // Used by rjson internally
-    future<> f = make_ready_future<>();
 
     void Flush() {
-        if (f.failed()) {
-            f.get();
-        }
         if (_pos == 0) {
             return;
         }
         if (_pos < _buf_size) {
             _buf.trim(_pos);  // Last flush may be shorter
         }
-        // Either we call futures right away (if they are ready) or we start growing continuations
-        // chain as we don't have the ability to wait here because Flush() signature is set by rjson.
-        f = f.then([this, b = std::move(_buf)] () mutable {
-            return send(std::move(b));
-        });
+        send(std::move(_buf)).get();
         _pos = 0;
         _buf = temporary_buffer<char>(_buf_size);
     }
@@ -277,14 +269,14 @@ public:
 };
 
 future<> print(const rjson::value& value, seastar::output_stream<char>& os, size_t max_nested_level) {
+  // Use a thread so that we can yield while printing the JSON. This is only called for large values.
+  return async([&value, &os, max_nested_level] {
     output_stream_buffer buf{ os };
     using streamer = rapidjson::Writer<output_stream_buffer, encoding, encoding, allocator>;
-    guarded_yieldable_json_handler<streamer, false, output_stream_buffer> writer(buf, max_nested_level);
+    guarded_yieldable_json_handler<streamer, true, output_stream_buffer> writer(buf, max_nested_level);
     value.Accept(writer);
     buf.Flush();
-    // This function has to be a coroutine otherwise buf gets destroyed before all its
-    // continuations from buf.f finish leading to use-after-free.
-    co_return co_await std::move(buf.f);
+  });
 }
 
 rjson::malformed_value::malformed_value(std::string_view name, const rjson::value& value)


### PR DESCRIPTION
We have two paths for generating the json text representation, one for large items and one for small items, but the large item path is lacking:

 - it doesn't yield, so a response with many items will stall
 - it doesn't wait for network sends to be accepted by the network stack, so it will allocate a lot of memory

Fix by moving the generation to a thread. This allows us to wait for the network stack, which incidentally also fixes stalls.

The cost of the thread is amortized by the fact we're emitting a large response.

Fixes #18806

No backport required: not a regression.