### PR TITLE
 feat: listen_backlog param added

### DIFF
--- a/alternator/controller.cc
+++ b/alternator/controller.cc
@@ -124,11 +124,12 @@ future<> controller::start_server() {
             }
         }
         bool alternator_enforce_authorization = _config.alternator_enforce_authorization();
+        int listen_backlogs = _config.alternator_listen_backlog();
         _server.invoke_on_all(
-                [this, addr, alternator_port, alternator_https_port, creds = std::move(creds), alternator_enforce_authorization] (server& server) mutable {
+                [this, addr, alternator_port, alternator_https_port, creds = std::move(creds), alternator_enforce_authorization, listen_backlogs] (server& server) mutable {
             return server.init(addr, alternator_port, alternator_https_port, creds, alternator_enforce_authorization,
                     &_memory_limiter.local().get_semaphore(),
-                    _config.max_concurrent_requests_per_shard);
+                    _config.max_concurrent_requests_per_shard, listen_backlogs);
         }).handle_exception([this, addr, alternator_port, alternator_https_port] (std::exception_ptr ep) {
             logger.error("Failed to set up Alternator HTTP server on {} port {}, TLS port {}: {}",
                     addr, alternator_port ? std::to_string(*alternator_port) : "OFF", alternator_https_port ? std::to_string(*alternator_https_port) : "OFF", ep);

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -538,7 +538,7 @@ server::server(executor& exec, service::storage_proxy& proxy, gms::gossiper& gos
 }
 
 future<> server::init(net::inet_address addr, std::optional<uint16_t> port, std::optional<uint16_t> https_port, std::optional<tls::credentials_builder> creds,
-        bool enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests) {
+        bool enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests, int listen_backlogs) {
     _memory_limiter = memory_limiter;
     _enforce_authorization = enforce_authorization;
     _max_concurrent_requests = std::move(max_concurrent_requests);
@@ -546,14 +546,18 @@ future<> server::init(net::inet_address addr, std::optional<uint16_t> port, std:
         return make_exception_future<>(std::runtime_error("Either regular port or TLS port"
                 " must be specified in order to init an alternator HTTP server instance"));
     }
-    return seastar::async([this, addr, port, https_port, creds] {
+    return seastar::async([this, addr, port, https_port, creds, listen_backlogs] {
         _executor.start().get();
 
         if (port) {
             set_routes(_http_server._routes);
             _http_server.set_content_length_limit(server::content_length_limit);
             _http_server.set_content_streaming(true);
-            _http_server.listen(socket_address{addr, *port}).get();
+            listen_options lo {
+                .reuse_address = true,
+                .listen_backlog = listen_backlogs,
+            };
+            _http_server.listen(socket_address{addr, *port}, std::move(lo)).get();
             _enabled_servers.push_back(std::ref(_http_server));
         }
         if (https_port) {

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -71,7 +71,7 @@ public:
     server(executor& executor, service::storage_proxy& proxy, gms::gossiper& gossiper, auth::service& service, qos::service_level_controller& sl_controller);
 
     future<> init(net::inet_address addr, std::optional<uint16_t> port, std::optional<uint16_t> https_port, std::optional<tls::credentials_builder> creds,
-            bool enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests);
+            bool enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests, int listen_backlogs);
     future<> stop();
 private:
     void set_routes(seastar::httpd::routes& r);

--- a/db/config.cc
+++ b/db/config.cc
@@ -889,6 +889,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , alternator_ttl_period_in_seconds(this, "alternator_ttl_period_in_seconds", value_status::Used,
         60*60*24,
         "The default period for Alternator's expiration scan. Alternator attempts to scan every table within that period.")
+    , alternator_listen_backlog(this, "alternator_listen_backlog", value_status::Used, 100, "The listen_backlog of Alternator http server, increase this parameter value in scenarios where there are a large number of connections.")
     , abort_on_ebadf(this, "abort_on_ebadf", value_status::Used, true, "Abort the server on incorrect file descriptor access. Throws exception when disabled.")
     , redis_port(this, "redis_port", value_status::Used, 0, "Port on which the REDIS transport listens for clients.")
     , redis_ssl_port(this, "redis_ssl_port", value_status::Used, 0, "Port on which the REDIS TLS native transport listens for clients.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -367,6 +367,7 @@ public:
     named_value<uint32_t> alternator_streams_time_window_s;
     named_value<uint32_t> alternator_timeout_in_ms;
     named_value<double> alternator_ttl_period_in_seconds;
+    named_value<int> alternator_listen_backlog;
 
     named_value<bool> abort_on_ebadf;
 


### PR DESCRIPTION
add listen_backlog param to increase the maximum length of the queue of connection-waiting to solve the problem of connection-timeout.
