### PR TITLE
perf-simple-query: add cpu_cycles / op metric

### DIFF
--- a/test/perf/perf.cc
+++ b/test/perf/perf.cc
@@ -56,8 +56,8 @@ auto fmt::formatter<scheduling_latency_measurer>::format(const scheduling_latenc
 
 auto fmt::formatter<perf_result>::format(const perf_result& result, fmt::format_context& ctx) const
         -> decltype(ctx.out()) {
-    return fmt::format_to(ctx.out(), "{:.2f} tps ({:5.1f} allocs/op, {:5.1f} logallocs/op, {:5.1f} tasks/op, {:7.0f} insns/op, {:8} errors)",
-            result.throughput, result.mallocs_per_op, result.logallocs_per_op, result.tasks_per_op, result.instructions_per_op, result.errors);
+    return fmt::format_to(ctx.out(), "{:.2f} tps ({:5.1f} allocs/op, {:5.1f} logallocs/op, {:5.1f} tasks/op, {:7.0f} insns/op, {:7.0f} cycles/op, {:8} errors)",
+            result.throughput, result.mallocs_per_op, result.logallocs_per_op, result.tasks_per_op, result.instructions_per_op, result.cpu_cycles_per_op, result.errors);
 }
 
 aggregated_perf_results::aggregated_perf_results(std::vector<perf_result>& results) {
@@ -94,8 +94,8 @@ void aio_writes_result_mixin::update(aio_writes_result_mixin& result, const exec
 
 auto fmt::formatter<perf_result_with_aio_writes>::format(const perf_result_with_aio_writes& result, fmt::format_context& ctx) const
         -> decltype(ctx.out()) {
-    return fmt::format_to(ctx.out(), "{:.2f} tps ({:5.1f} allocs/op, {:5.1f} logallocs/op, {:5.1f} tasks/op, {:7.0f} insns/op, {:8} errors, {:7.2f} bytes/op, {:5.1f} writes/op)",
-            result.throughput, result.mallocs_per_op, result.logallocs_per_op, result.tasks_per_op, result.instructions_per_op, result.errors, result.aio_write_bytes, result.aio_writes);
+    return fmt::format_to(ctx.out(), "{:.2f} tps ({:5.1f} allocs/op, {:5.1f} logallocs/op, {:5.1f} tasks/op, {:7.0f} insns/op, {:7.0f} cycles/op, {:8} errors, {:7.2f} bytes/op, {:5.1f} writes/op)",
+            result.throughput, result.mallocs_per_op, result.logallocs_per_op, result.tasks_per_op, result.instructions_per_op, result.cpu_cycles_per_op, result.errors, result.aio_write_bytes, result.aio_writes);
 }
 
 namespace perf {

--- a/test/perf/perf_commitlog.cc
+++ b/test/perf/perf_commitlog.cc
@@ -68,6 +68,7 @@ static void write_json_result(std::string result_file, const test_config& cfg, c
     stats["logallocs_per_op"] = median.logallocs_per_op;
     stats["tasks_per_op"] = median.tasks_per_op;
     stats["instructions_per_op"] = median.instructions_per_op;
+    stats["cpu_cycles_per_op"] = median.cpu_cycles_per_op;
     stats["aio_writes"] = median.aio_writes;
     stats["aio_write_bytes"] = median.aio_write_bytes;
     stats["mad tps"] = mad;

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -476,6 +476,7 @@ void write_json_result(std::string result_file, const test_config& cfg, const ag
     stats["logallocs_per_op"] = med.logallocs_per_op;
     stats["tasks_per_op"] = med.tasks_per_op;
     stats["instructions_per_op"] = med.instructions_per_op;
+    stats["cpu_cycles_per_op"] = med.cpu_cycles_per_op;
     stats["mad tps"] = agg.throughput.median_absolute_deviation;
     stats["max tps"] = agg.throughput.max;
     stats["min tps"] = agg.throughput.min;


### PR DESCRIPTION
Example output:
```
bhalevy@[] scylla$ build/release/scylla perf-simple-query --default-log-level=error -c 1 --duration 10
random-seed=4058714023
enable-cache=1
Running test with config: {partitions=10000, concurrency=100, mode=read, frontend=cql, query_single_key=no, counters=no}
Disabling auto compaction
Creating 10000 partitions...
86912.75 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42346 insns/op,   22811 cycles/op,        0 errors)
91348.29 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42306 insns/op,   22362 cycles/op,        0 errors)
87965.84 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42338 insns/op,   22966 cycles/op,        0 errors)
90793.67 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42351 insns/op,   22783 cycles/op,        0 errors)
90104.27 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42358 insns/op,   22875 cycles/op,        0 errors)
90397.13 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42355 insns/op,   22735 cycles/op,        0 errors)
89142.39 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42363 insns/op,   22996 cycles/op,        0 errors)
90410.40 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42363 insns/op,   22725 cycles/op,        0 errors)
88173.10 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42366 insns/op,   23160 cycles/op,        0 errors)
88416.51 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42379 insns/op,   23102 cycles/op,        0 errors)

median 90104.26849997675
median absolute deviation: 1244.02
maximum: 91348.29
minimum: 86912.75
```

- No backport required since it's an improvement to a benchmark tool