### PR TITLE
cql3: always return created event in create keyspace statement

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -1032,8 +1032,6 @@ query_processor::execute_schema_statement(const statements::schema_altering_stat
             co_await stmt.grant_permissions_to_creator(client_state, mc);
         }
     }
-    // If an IF [NOT] EXISTS clause was used, this may not result in an actual schema change.  To avoid doing
-    // extra work in the drivers to handle schema changes, we return an empty message in this case. (CASSANDRA-7600)
     ::shared_ptr<messages::result_message> result;
     if (!ce) {
         result = ::make_shared<messages::result_message::void_message>();

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -99,12 +99,7 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector
     try {
         auto ksm = _attrs->as_ks_metadata(_name, tm, feat);
         m = service::prepare_new_keyspace_announcement(qp.db().real_database(), ksm, ts);
-
-        ret = ::make_shared<event::schema_change>(
-                event::schema_change::change_type::CREATED,
-                event::schema_change::target_type::KEYSPACE,
-                keyspace());
-
+        ret = created_event();
         // If the new keyspace uses tablets, as long as there are features
         // which aren't supported by tablets we want to warn the user that
         // they will not be usable on the new keyspace - and suggest how a
@@ -281,6 +276,13 @@ create_keyspace_statement::execute(query_processor& qp, service::query_state& st
 lw_shared_ptr<data_dictionary::keyspace_metadata> create_keyspace_statement::get_keyspace_metadata(const locator::token_metadata& tm, const gms::feature_service& feat) {
     _attrs->validate();
     return _attrs->as_ks_metadata(_name, tm, feat);
+}
+
+::shared_ptr<schema_altering_statement::event_t> create_keyspace_statement::created_event() const {
+    return make_shared<event_t>(
+            event_t::change_type::CREATED,
+            event_t::target_type::KEYSPACE,
+            keyspace());
 }
 
 }

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -92,14 +92,12 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector
     using namespace cql_transport;
     const auto& tm = *qp.proxy().get_token_metadata_ptr();
     const auto& feat = qp.proxy().features();
-    ::shared_ptr<event::schema_change> ret;
     std::vector<mutation> m;
     std::vector<sstring> warnings;
 
     try {
         auto ksm = _attrs->as_ks_metadata(_name, tm, feat);
         m = service::prepare_new_keyspace_announcement(qp.db().real_database(), ksm, ts);
-        ret = created_event();
         // If the new keyspace uses tablets, as long as there are features
         // which aren't supported by tablets we want to warn the user that
         // they will not be usable on the new keyspace - and suggest how a
@@ -124,7 +122,15 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector
         }
     }
 
-    co_return std::make_tuple(std::move(ret), std::move(m), std::move(warnings));
+    // If an IF NOT EXISTS clause was used and resource was already created
+    // we shouldn't emit created event. However it interacts badly with
+    // concurrent clients creating resources. The client seeing no create event
+    // assumes resource already previously existed and proceeds with its logic
+    // which may depend on that resource. But it may send requests to nodes which
+    // are not yet aware of new schema or client's metadata may be outdated.
+    // To force synchronization always emit the event (see
+    // github.com/scylladb/scylladb/issues/16909).
+    co_return std::make_tuple(created_event(), std::move(m), std::move(warnings));
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>

--- a/cql3/statements/create_keyspace_statement.hh
+++ b/cql3/statements/create_keyspace_statement.hh
@@ -79,6 +79,9 @@ public:
     execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
 
     lw_shared_ptr<data_dictionary::keyspace_metadata> get_keyspace_metadata(const locator::token_metadata& tm, const gms::feature_service& feat);
+
+private:
+    ::shared_ptr<event_t> created_event() const;
 };
 
 std::vector<sstring> check_against_restricted_replication_strategies(

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -78,13 +78,7 @@ create_table_statement::prepare_schema_mutations(query_processor& qp, const quer
 
     try {
         m = co_await service::prepare_new_column_family_announcement(qp.proxy(), get_cf_meta_data(qp.db()), ts);
-
-        using namespace cql_transport;
-        ret = ::make_shared<event::schema_change>(
-            event::schema_change::change_type::CREATED,
-            event::schema_change::target_type::TABLE,
-            keyspace(),
-            column_family());
+        ret = created_event();
     } catch (const exceptions::already_exists_exception& e) {
         if (!_if_not_exists) {
             co_return coroutine::exception(std::current_exception());
@@ -493,6 +487,14 @@ std::optional<sstring> check_restricted_table_properties(
         }
    }
     return std::nullopt;
+}
+
+::shared_ptr<schema_altering_statement::event_t> create_table_statement::created_event() const {
+    return make_shared<event_t>(
+            event_t::change_type::CREATED,
+            event_t::target_type::TABLE,
+            keyspace(),
+            column_family());
 }
 
 }

--- a/cql3/statements/create_table_statement.hh
+++ b/cql3/statements/create_table_statement.hh
@@ -71,7 +71,6 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
-
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 
     virtual future<> grant_permissions_to_creator(const service::client_state&, service::group0_batch&) const override;
@@ -87,6 +86,8 @@ private:
     void apply_properties_to(schema_builder& builder, const data_dictionary::database) const;
 
     void add_column_metadata_from_aliases(schema_builder& builder, std::vector<bytes> aliases, const std::vector<data_type>& types, column_kind kind) const;
+
+    ::shared_ptr<event_t> created_event() const;
 };
 
 class create_table_statement::raw_statement : public raw::cf_statement {

--- a/cql3/statements/create_type_statement.hh
+++ b/cql3/statements/create_type_statement.hh
@@ -51,6 +51,8 @@ private:
     bool type_exists_in(data_dictionary::keyspace ks) const;
     std::optional<user_type> make_type(query_processor& qp) const;
 
+    ::shared_ptr<event_t> created_event() const;
+
 public:
     user_type create_type(data_dictionary::database db) const;
 };

--- a/cql3/statements/create_view_statement.hh
+++ b/cql3/statements/create_view_statement.hh
@@ -61,6 +61,8 @@ public:
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 
     // FIXME: continue here. See create_table_statement.hh and CreateViewStatement.java
+private:
+    ::shared_ptr<event_t> created_event() const;
 };
 
 }

--- a/cql3/statements/schema_altering_statement.cc
+++ b/cql3/statements/schema_altering_statement.cc
@@ -86,13 +86,13 @@ schema_altering_statement::execute(query_processor& qp, service::query_state& st
     co_return std::move(result);
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> schema_altering_statement::prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const {
+future<std::tuple<::shared_ptr<schema_altering_statement::event_t>, std::vector<mutation>, cql3::cql_warnings_vec>> schema_altering_statement::prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const {
     // derived class must implement one of prepare_schema_mutations overloads
     on_internal_error(logger, "not implemented");
-    co_return std::make_tuple(::shared_ptr<cql_transport::event::schema_change>(nullptr), std::vector<mutation>{}, cql3::cql_warnings_vec{});
+    co_return std::make_tuple(::shared_ptr<event_t>(nullptr), std::vector<mutation>{}, cql3::cql_warnings_vec{});
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>> schema_altering_statement::prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const {
+future<std::tuple<::shared_ptr<schema_altering_statement::event_t>, cql3::cql_warnings_vec>> schema_altering_statement::prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const {
     auto [ret, muts, cql_warnings] = co_await prepare_schema_mutations(qp, options, mc.write_timestamp());
     mc.add_mutations(std::move(muts));
     co_return std::make_tuple(ret, cql_warnings);

--- a/cql3/statements/schema_altering_statement.cc
+++ b/cql3/statements/schema_altering_statement.cc
@@ -76,12 +76,6 @@ schema_altering_statement::execute(query_processor& qp, service::query_state& st
     }
     service::group0_batch mc{std::move(guard)};
     auto result = co_await qp.execute_schema_statement(*this, state, options, mc);
-    // We don't want to grant the permissions to the supposed creator even if the statement succeeded if it's an internal query
-    // or if the query did not actually create the item, i.e. the query is bounced to another shard or it's a IF NOT EXISTS
-    // query where the item already exists.
-    if (!internal && result->is_schema_change()) {
-        co_await grant_permissions_to_creator(state.get_client_state(), mc);
-    }
     co_await qp.announce_schema_statement(*this, mc);
     co_return std::move(result);
 }

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -44,14 +44,6 @@ protected:
     
     virtual bool needs_guard(query_processor& qp, service::query_state& state) const override;
 
-    /**
-     * When a new data_dictionary::database object (keyspace, table) is created, the creator needs to be granted all applicable
-     * permissions on it.
-     *
-     * By default, this function does nothing.
-     */
-    virtual future<> grant_permissions_to_creator(const service::client_state&, service::group0_batch&) const;
-
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 
     virtual uint32_t get_bound_terms() const override;
@@ -62,6 +54,14 @@ protected:
     execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
 
 public:
+    /**
+     * When a new data_dictionary::database object (keyspace, table) is created, the creator needs to be granted all applicable
+     * permissions on it.
+     *
+     * By default, this function does nothing.
+     */
+    virtual future<> grant_permissions_to_creator(const service::client_state&, service::group0_batch&) const;
+
     using event_t = cql_transport::event::schema_change;
     virtual future<std::tuple<::shared_ptr<event_t>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const;
     virtual future<std::tuple<::shared_ptr<event_t>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const;

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -62,9 +62,9 @@ protected:
     execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
 
 public:
-    virtual future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const;
-
-    virtual future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const;
+    using event_t = cql_transport::event::schema_change;
+    virtual future<std::tuple<::shared_ptr<event_t>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const;
+    virtual future<std::tuple<::shared_ptr<event_t>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const;
 
     mutable utils::UUID global_req_id;
 };

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -598,4 +598,9 @@ future<std::pair<std::vector<mutation>, ::service::group0_guard>> group0_batch::
     co_await materialize_mutations();
     co_return std::make_pair(std::move(_muts), std::move(*_guard));
 }
+
+bool group0_batch::empty() const {
+    return _muts.empty() && _generators.empty();
+}
+
 }

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -242,6 +242,10 @@ public:
     future<> commit(::service::raft_group0_client& group0_client, seastar::abort_source& as, std::optional<::service::raft_timeout> timeout) &&;
     // For rare cases where collector is used but announce logic is replaced with a custom one.
     future<std::pair<std::vector<mutation>, ::service::group0_guard>> extract() &&;
+
+    // Checks if any mutations or generators were added. Note that when generator is
+    // added it still can return no mutations.
+    bool empty() const;
 };
 
 }

--- a/transport/messages/result_message.hh
+++ b/transport/messages/result_message.hh
@@ -218,10 +218,6 @@ public:
         return _change;
     }
 
-    virtual bool is_schema_change() const override {
-        return true;
-    }
-
     virtual void accept(result_message::visitor& v) const override {
         v.visit(*this);
     }

--- a/transport/messages/result_message_base.hh
+++ b/transport/messages/result_message_base.hh
@@ -64,10 +64,6 @@ public:
         return std::nullopt;
     }
 
-    virtual bool is_schema_change() const {
-        return false;
-    }
-
     virtual bool is_exception() const {
         return false;
     }


### PR DESCRIPTION
cql3: always return created event in create ks/table/type/view statement

In case multiple clients issue concurrently CREATE KEYSPACE IF NOT EXISTS
and later USE KEYSPACE it can happen that schema in driver's session is
out of sync because it synces when it receives special message from
CREATE KEYSPACE response.

Similar situation occurs with other schema change statements.

In this patch we fix only create keyspace/table/type/view statements
by always sending created event. Behavior of any other schema altering
statements remains unchanged.

Fixes https://github.com/scylladb/scylladb/issues/16909

**backport: no, it's not a regression**