### PR TITLE
[Backport 5.4] dist/docker: revert dropping systemd package

### DIFF
--- a/dist/docker/debian/build_docker.sh
+++ b/dist/docker/debian/build_docker.sh
@@ -77,7 +77,7 @@ run apt-get -y upgrade
 run apt-get -y install dialog apt-utils
 run bash -ec "echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections"
 run bash -ec "rm -rf /etc/rsyslog.conf"
-run apt-get -y install hostname supervisor openjdk-11-jre-headless python2 python3 python3-yaml curl rsyslog sudo
+run apt-get -y install hostname supervisor openjdk-11-jre-headless python2 python3 python3-yaml curl rsyslog sudo systemd
 run bash -ec "echo LANG=C.UTF-8 > /etc/default/locale"
 run bash -ec "dpkg -i packages/*.deb"
 run apt-get -y clean all


### PR DESCRIPTION
On https://github.com/scylladb/scylladb/commit/7ce6962141dd4def9ce56837db691e2a8a983289 we dropped openssh-server, it also dropped systemd package and caused an error on Scylla Operator (https://github.com/scylladb/scylladb/issues/17787).

This reverts dropping systemd package and fix the issue.

Fix https://github.com/scylladb/scylladb/issues/17787

 ** Backport reason (please explain below if this patch should be backported or not) **
(cherry picked from commit https://github.com/scylladb/scylladb/commit/0c7aa9342d141ca85e71b2f07117d1de9b4ea52f)

Refs https://github.com/scylladb/scylladb/pull/18643