### PR TITLE
treewide: replace std::result_of_t with std::invoke_result_t

### DIFF
--- a/alternator/expressions.cc
+++ b/alternator/expressions.cc
@@ -28,7 +28,7 @@
 
 namespace alternator {
 
-template <typename Func, typename Result = std::result_of_t<Func(expressionsParser&)>>
+template <typename Func, typename Result = std::invoke_result_t<Func, expressionsParser&>>
 static Result do_with_parser(std::string_view input, Func&& f) {
     expressionsLexer::InputStreamType input_stream{
         reinterpret_cast<const ANTLR_UINT8*>(input.data()),
@@ -43,7 +43,7 @@ static Result do_with_parser(std::string_view input, Func&& f) {
     return result;
 }
 
-template <typename Func, typename Result = std::result_of_t<Func(expressionsParser&)>>
+template <typename Func, typename Result = std::invoke_result_t<Func, expressionsParser&>>
 static Result parse(const char* input_name, std::string_view input, Func&& f) {
     if (input.length() > 4096) {
         throw expressions_syntax_error(format("{} expression size {} exceeds allowed maximum 4096.",

--- a/cql3/util.hh
+++ b/cql3/util.hh
@@ -29,7 +29,7 @@ namespace util {
 
 void do_with_parser_impl(const sstring_view& cql, noncopyable_function<void (cql3_parser::CqlParser& p)> func);
 
-template <typename Func, typename Result = cql3_parser::unwrap_uninitialized_t<std::result_of_t<Func(cql3_parser::CqlParser&)>>>
+template <typename Func, typename Result = cql3_parser::unwrap_uninitialized_t<std::invoke_result_t<Func, cql3_parser::CqlParser&>>>
 Result do_with_parser(const sstring_view& cql, Func&& f) {
     std::optional<Result> ret;
     do_with_parser_impl(cql, [&] (cql3_parser::CqlParser& parser) {

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -36,7 +36,7 @@ future<> snapshot_ctl::check_snapshot_not_exist(sstring ks_name, sstring name, s
 }
 
 template <typename Func>
-std::result_of_t<Func()> snapshot_ctl::run_snapshot_modify_operation(Func&& f) {
+std::invoke_result_t<Func> snapshot_ctl::run_snapshot_modify_operation(Func&& f) {
     return with_gate(_ops, [f = std::move(f), this] () {
         return container().invoke_on(0, [f = std::move(f)] (snapshot_ctl& snap) mutable {
             return with_lock(snap._lock.for_write(), std::move(f));
@@ -45,7 +45,7 @@ std::result_of_t<Func()> snapshot_ctl::run_snapshot_modify_operation(Func&& f) {
 }
 
 template <typename Func>
-std::result_of_t<Func()> snapshot_ctl::run_snapshot_list_operation(Func&& f) {
+std::invoke_result_t<Func> snapshot_ctl::run_snapshot_list_operation(Func&& f) {
     return with_gate(_ops, [f = std::move(f), this] () {
         return container().invoke_on(0, [f = std::move(f)] (snapshot_ctl& snap) mutable {
             return with_lock(snap._lock.for_read(), std::move(f));

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -102,10 +102,10 @@ private:
     future<> check_snapshot_not_exist(sstring ks_name, sstring name, std::optional<std::vector<sstring>> filter = {});
 
     template <typename Func>
-    std::result_of_t<Func()> run_snapshot_modify_operation(Func&&);
+    std::invoke_result_t<Func> run_snapshot_modify_operation(Func&&);
 
     template <typename Func>
-    std::result_of_t<Func()> run_snapshot_list_operation(Func&&);
+    std::invoke_result_t<Func> run_snapshot_list_operation(Func&&);
 
     future<> do_take_snapshot(sstring tag, std::vector<sstring> keyspace_names, skip_flush sf = skip_flush::no);
     future<> do_take_column_family_snapshot(sstring ks_name, std::vector<sstring> tables, sstring tag, snap_views, skip_flush sf = skip_flush::no);

--- a/interval.hh
+++ b/interval.hh
@@ -76,7 +76,7 @@ public:
     using bound = interval_bound<T>;
 
     template <typename Transformer>
-    using transformed_type = typename std::remove_cv_t<std::remove_reference_t<std::result_of_t<Transformer(T)>>>;
+    using transformed_type = typename std::remove_cv_t<std::remove_reference_t<std::invoke_result_t<Transformer, T>>>;
 private:
     optional<bound> _start;
     optional<bound> _end;

--- a/message/rpc_protocol_impl.hh
+++ b/message/rpc_protocol_impl.hh
@@ -125,7 +125,7 @@ void register_handler(messaging_service *ms, messaging_verb verb, Func &&func) {
 template <typename MsgIn, typename... MsgOut>
 auto send_message(messaging_service* ms, messaging_verb verb, msg_addr id, MsgOut&&... msg) {
     auto rpc_handler = ms->rpc()->make_client<MsgIn(MsgOut...)>(verb);
-    using futurator = futurize<std::result_of_t<decltype(rpc_handler)(rpc_protocol::client&, MsgOut...)>>;
+    using futurator = futurize<std::invoke_result_t<decltype(rpc_handler), rpc_protocol::client&, MsgOut...>>;
     if (ms->is_shutting_down()) {
         return futurator::make_exception_future(rpc::closed_error());
     }
@@ -148,7 +148,7 @@ auto send_message(messaging_service* ms, messaging_verb verb, msg_addr id, MsgOu
 template <typename MsgIn, typename Timeout, typename... MsgOut>
 auto send_message_timeout(messaging_service* ms, messaging_verb verb, msg_addr id, Timeout timeout, MsgOut&&... msg) {
     auto rpc_handler = ms->rpc()->make_client<MsgIn(MsgOut...)>(verb);
-    using futurator = futurize<std::result_of_t<decltype(rpc_handler)(rpc_protocol::client&, MsgOut...)>>;
+    using futurator = futurize<std::invoke_result_t<decltype(rpc_handler), rpc_protocol::client&, MsgOut...>>;
     if (ms->is_shutting_down()) {
         return futurator::make_exception_future(rpc::closed_error());
     }
@@ -173,7 +173,7 @@ auto send_message_timeout(messaging_service* ms, messaging_verb verb, msg_addr i
 template <typename MsgIn, typename... MsgOut>
 auto send_message_cancellable(messaging_service* ms, messaging_verb verb, msg_addr id, abort_source& as, MsgOut&&... msg) {
     auto rpc_handler = ms->rpc()->make_client<MsgIn(MsgOut...)>(verb);
-    using futurator = futurize<std::result_of_t<decltype(rpc_handler)(rpc_protocol::client&, MsgOut...)>>;
+    using futurator = futurize<std::invoke_result_t<decltype(rpc_handler), rpc_protocol::client&, MsgOut...>>;
     if (ms->is_shutting_down()) {
         return futurator::make_exception_future(rpc::closed_error());
     }

--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -13,6 +13,7 @@
 #include "mutation_fragment_stream_validator.hh"
 #include "tombstone_gc.hh"
 #include "full_position.hh"
+#include <type_traits>
 
 static inline bool has_ck_selector(const query::clustering_row_ranges& ranges) {
     // Like PK range, an empty row range, should be considered an "exclude all" restriction
@@ -515,7 +516,7 @@ public:
             _last_dk = *_dk;
             _dk = &_last_dk;
         }
-        if constexpr (std::is_same_v<std::result_of_t<decltype(&GCConsumer::consume_end_of_stream)(GCConsumer&)>, void>) {
+        if constexpr (std::is_void_v<std::invoke_result_t<decltype(&GCConsumer::consume_end_of_stream), GCConsumer&>>) {
             gc_consumer.consume_end_of_stream();
             return consumer.consume_end_of_stream();
         } else {

--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -56,7 +56,7 @@ class foreign_reader : public flat_mutation_reader_v2::impl {
     // and move it to the background (save it's future but don't wait on it
     // now). If all works well read-aheads complete by the next operation and
     // we don't have to wait on the remote reader filling its buffer.
-    template <typename Operation, typename Result = futurize_t<std::result_of_t<Operation()>>>
+    template <typename Operation, typename Result = futurize_t<std::invoke_result_t<Operation>>>
     Result forward_operation(Operation op) {
         reader_permit::awaits_guard awaits_guard{_permit};
         return smp::submit_to(_reader.get_owner_shard(), [reader = _reader.get(),

--- a/replica/dirty_memory_manager.hh
+++ b/replica/dirty_memory_manager.hh
@@ -110,7 +110,7 @@ public:
 private:
     template <typename Func>
     struct concrete_allocating_function : public allocating_function {
-        using futurator = futurize<std::result_of_t<Func()>>;
+        using futurator = futurize<std::invoke_result_t<Func>>;
         typename futurator::promise_type pr;
         Func func;
     public:
@@ -311,7 +311,7 @@ public:
     // We disallow future-returning functions here, because otherwise memory may be available
     // when we start executing it, but no longer available in the middle of the execution.
     requires (!is_future<std::invoke_result_t<Func>>::value)
-    futurize_t<std::result_of_t<Func()>> run_when_memory_available(Func&& func, db::timeout_clock::time_point timeout);
+    futurize_t<std::invoke_result_t<Func>> run_when_memory_available(Func&& func, db::timeout_clock::time_point timeout);
 
     // returns a pointer to the largest region (in terms of memory usage) that sits below this
     // region group. This includes the regions owned by this region group as well as all of its
@@ -561,7 +561,7 @@ template <typename Func>
 // We disallow future-returning functions here, because otherwise memory may be available
 // when we start executing it, but no longer available in the middle of the execution.
 requires (!is_future<std::invoke_result_t<Func>>::value)
-futurize_t<std::result_of_t<Func()>>
+futurize_t<std::invoke_result_t<Func>>
 region_group::run_when_memory_available(Func&& func, db::timeout_clock::time_point timeout) {
     bool blocked = 
         !_blocked_requests.empty()

--- a/service/paxos/paxos_state.hh
+++ b/service/paxos/paxos_state.hh
@@ -46,7 +46,7 @@ private:
         // are no waiters.
         ///
         template<typename Func>
-        futurize_t<std::result_of_t<Func()>> with_locked_key(const dht::token& key, clock_type::time_point timeout, Func func) {
+        futurize_t<std::invoke_result_t<Func>> with_locked_key(const dht::token& key, clock_type::time_point timeout, Func func) {
             return with_semaphore(get_semaphore_for_key(key), 1, timeout - clock_type::now(), std::move(func)).finally([key, this] {
                 release_semaphore_for_key(key);
             });
@@ -68,7 +68,7 @@ private:
     // protects access to system.paxos
     template<typename Func>
     static
-    futurize_t<std::result_of_t<Func()>> with_locked_key(const dht::token& key, clock_type::time_point timeout, Func func) {
+    futurize_t<std::invoke_result_t<Func>> with_locked_key(const dht::token& key, clock_type::time_point timeout, Func func) {
         return _paxos_table_lock.with_locked_key(key, timeout, std::move(func));
     }
 

--- a/utils/disk-error-handler.hh
+++ b/utils/disk-error-handler.hh
@@ -59,26 +59,26 @@ requires std::invocable<Func, Args&&...>
 auto do_io_check(const io_error_handler& error_handler, Func&& func, Args&&... args) noexcept {
     return futurize_invoke(func, std::forward<Args>(args)...).handle_exception([&error_handler] (auto ep) {
         error_handler(ep);
-        return futurize<std::result_of_t<Func(Args&&...)>>::make_exception_future(ep);
+        return futurize<std::invoke_result_t<Func, Args&&...>>::make_exception_future(ep);
     });
 }
 
 template<typename Func, typename... Args>
-auto commit_io_check(Func&& func, Args&&... args) noexcept(is_future<std::result_of_t<Func(Args&&...)>>::value) {
+auto commit_io_check(Func&& func, Args&&... args) noexcept(is_future<std::invoke_result_t<Func, Args&&...>>::value) {
     return do_io_check(commit_error_handler, std::forward<Func>(func), std::forward<Args>(args)...);
 }
 
 template<typename Func, typename... Args>
-auto sstable_io_check(const io_error_handler& error_handler, Func&& func, Args&&... args) noexcept(is_future<std::result_of_t<Func(Args&&...)>>::value) {
+auto sstable_io_check(const io_error_handler& error_handler, Func&& func, Args&&... args) noexcept(is_future<std::invoke_result_t<Func, Args&&...>>::value) {
     return do_io_check(error_handler, std::forward<Func>(func), std::forward<Args>(args)...);
 }
 
 template<typename Func, typename... Args>
-auto io_check(const io_error_handler& error_handler, Func&& func, Args&&... args) noexcept(is_future<std::result_of_t<Func(Args&&...)>>::value) {
+auto io_check(const io_error_handler& error_handler, Func&& func, Args&&... args) noexcept(is_future<std::invoke_result_t<Func, Args&&...>>::value) {
     return do_io_check(error_handler, general_disk_error, std::forward<Func>(func), std::forward<Args>(args)...);
 }
 
 template<typename Func, typename... Args>
-auto io_check(Func&& func, Args&&... args) noexcept(is_future<std::result_of_t<Func(Args&&...)>>::value) {
+auto io_check(Func&& func, Args&&... args) noexcept(is_future<std::invoke_result_t<Func, Args&&...>>::value) {
     return do_io_check(general_disk_error_handler, std::forward<Func>(func), std::forward<Args>(args)...);
 }

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -403,7 +403,7 @@ public:
     // Avoid adding a sleep continuation in the chain for disabled error injection
     template <typename Clock, typename Duration, typename Func>
     [[gnu::always_inline]]
-    std::result_of_t<Func()> inject(const std::string_view& name, std::chrono::time_point<Clock, Duration> deadline,
+    std::invoke_result_t<Func> inject(const std::string_view& name, std::chrono::time_point<Clock, Duration> deadline,
                 Func&& func) {
         if (is_enabled(name)) {
             if (is_one_shot(name)) {
@@ -573,7 +573,7 @@ public:
     // Avoid adding a continuation in the chain for disabled error injections
     template <typename Clock, typename Duration, typename Func>
     [[gnu::always_inline]]
-    std::result_of_t<Func()> inject(const std::string_view& name, std::chrono::time_point<Clock, Duration> deadline,
+    std::invoke_result_t<Func> inject(const std::string_view& name, std::chrono::time_point<Clock, Duration> deadline,
                 Func&& func) {
         return func();
     }

--- a/utils/exponential_backoff_retry.hh
+++ b/utils/exponential_backoff_retry.hh
@@ -63,7 +63,7 @@ private:
 public:
     template<typename Func>
     static auto do_until_value(std::chrono::milliseconds base_sleep_time, std::chrono::milliseconds max_sleep_time, seastar::abort_source& as, Func f) {
-        using type_helper = retry_type_helper<std::result_of_t<Func()>>;
+        using type_helper = retry_type_helper<std::invoke_result_t<Func>>;
 
         auto r = exponential_backoff_retry(base_sleep_time, max_sleep_time);
         return seastar::do_with(std::move(r), [&as, f = std::move(f)] (exponential_backoff_retry& r) mutable {

--- a/utils/flush_queue.hh
+++ b/utils/flush_queue.hh
@@ -57,7 +57,7 @@ private:
 
     template<typename Func, typename Arg>
     static auto call_helper(Func&& func, future<Arg> f) {
-        using futurator = futurize<std::result_of_t<Func(Arg&&)>>;
+        using futurator = futurize<std::invoke_result_t<Func, Arg&&>>;
         try {
             return futurator::invoke(std::forward<Func>(func), f.get());
         } catch (...) {
@@ -67,7 +67,7 @@ private:
 
     template<typename Func, typename... Args>
     static auto call_helper(Func&& func, future<std::tuple<Args...>> f) {
-        using futurator = futurize<std::result_of_t<Func(std::tuple<Args&&...>)>>;
+        using futurator = futurize<std::invoke_result_t<Func, std::tuple<Args&&...>>>;
         try {
             return futurator::invoke(std::forward<Func>(func), f.get());
         } catch (...) {
@@ -116,7 +116,7 @@ public:
         _gate.enter();
         _map[rp].count++;
 
-        using futurator = futurize<std::result_of_t<Func()>>;
+        using futurator = futurize<std::invoke_result_t<Func>>;
 
         return futurator::invoke(std::forward<Func>(func)).then_wrapped([this, rp, post = std::forward<Post>(post)](typename futurator::type f) mutable {
             auto i = _map.find(rp);


### PR DESCRIPTION
in theory, std::result_of_t should have been removed in C++20. and std::invoke_result_t is available since C++17. thanks to libstdc++, the tree is compiling. but we should not rely on this.

so, in this change, we replace all `std::result_of_t` with `std::invoke_result_t`. actually, clang + libstdc++ is already warning us like:

```
In file included from /home/runner/work/scylladb/scylladb/multishard_mutation_query.cc:9:
In file included from /home/runner/work/scylladb/scylladb/schema/schema_registry.hh:11:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/unordered_map:38:
Warning: /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/type_traits:2624:5: warning: 'result_of<void (noop_compacted_fragments_consumer::*(noop_compacted_fragments_consumer &))()>' is deprecated: use 'std::invoke_result' instead [-Wdeprecated-declarations]
 2624 |     using result_of_t = typename result_of<_Tp>::type;
      |     ^
/home/runner/work/scylladb/scylladb/mutation/mutation_compactor.hh:518:43: note: in instantiation of template type alias 'result_of_t' requested here
  518 |         if constexpr (std::is_same_v<std::result_of_t<decltype(&GCConsumer::consume_end_of_stream)(GCConsumer&)>, void>) {
      |
```

* no need to backport, it's just a cleanup.