### PR TITLE
storage_proxy: use host_id replica sets

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1693,7 +1693,7 @@ mutation_fragments_select_statement::do_query(
     auto res = co_await replica::mutation_dump::dump_mutations(sp.get_db(), schema, _underlying_schema, partition_ranges, *cmd, optional_params.timeout(sp));
     service::replicas_per_token_range last_replicas;
     if (this_node) {
-        last_replicas.emplace(dht::token_range::make_open_ended_both_sides(), std::vector<locator::host_id>{this_node});
+        last_replicas.emplace(dht::token_range::make_open_ended_both_sides(), host_id_vector_replica_set({this_node}));
     }
     co_return service::storage_proxy_coordinator_query_result{std::move(res), std::move(last_replicas), {}};
 }

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -232,15 +232,16 @@ void assure_sufficient_live_nodes(
 
 template void assure_sufficient_live_nodes(consistency_level, const locator::effective_replication_map&, const inet_address_vector_replica_set&, const std::array<gms::inet_address, 0>&);
 template void assure_sufficient_live_nodes(db::consistency_level, const locator::effective_replication_map&, const inet_address_vector_replica_set&, const utils::small_vector<gms::inet_address, 1ul>&);
+template void assure_sufficient_live_nodes(consistency_level, const locator::effective_replication_map&, const host_id_vector_replica_set&, const std::array<gms::inet_address, 0>&);
 
-inet_address_vector_replica_set
+host_id_vector_replica_set
 filter_for_query(consistency_level cl,
                  const locator::effective_replication_map& erm,
-                 inet_address_vector_replica_set live_endpoints,
-                 const inet_address_vector_replica_set& preferred_endpoints,
+                 host_id_vector_replica_set live_endpoints,
+                 const host_id_vector_replica_set& preferred_endpoints,
                  read_repair_decision read_repair,
                  const gms::gossiper& g,
-                 std::optional<gms::inet_address>* extra,
+                 std::optional<locator::host_id>* extra,
                  replica::column_family* cf) {
     size_t local_count;
 
@@ -267,13 +268,13 @@ filter_for_query(consistency_level cl,
         return live_endpoints;
     }
 
-    inet_address_vector_replica_set selected_endpoints;
+    host_id_vector_replica_set selected_endpoints;
 
     // Pre-select endpoints based on client preference. If the endpoints
     // selected this way aren't enough to satisfy CL requirements select the
     // remaining ones according to the load-balancing strategy as before.
     if (!preferred_endpoints.empty()) {
-        const auto it = boost::stable_partition(live_endpoints, [&preferred_endpoints] (const gms::inet_address& a) {
+        const auto it = boost::stable_partition(live_endpoints, [&preferred_endpoints] (const locator::host_id& a) {
             return std::find(preferred_endpoints.cbegin(), preferred_endpoints.cend(), a) == preferred_endpoints.end();
         });
         const size_t selected = std::distance(it, live_endpoints.end());
@@ -281,7 +282,7 @@ filter_for_query(consistency_level cl,
              if (extra) {
                  *extra = selected == bf ? live_endpoints.front() : *(it + bf);
              }
-             return inet_address_vector_replica_set(it, it + bf);
+             return host_id_vector_replica_set(it, it + bf);
         } else if (selected) {
              selected_endpoints.reserve(bf);
              std::move(it, live_endpoints.end(), std::back_inserter(selected_endpoints));
@@ -323,8 +324,9 @@ filter_for_query(consistency_level cl,
         float ht_min = 1;
         bool old_node = false;
 
-        auto epi = boost::copy_range<std::vector<std::pair<gms::inet_address, float>>>(live_endpoints | boost::adaptors::transformed([&] (gms::inet_address ep) {
-            auto ht = get_hit_rate(ep);
+        const auto& topo = erm.get_topology();
+        auto epi = boost::copy_range<std::vector<std::pair<locator::host_id, float>>>(live_endpoints | boost::adaptors::transformed([&] (const auto& ep) {
+            auto ht = get_hit_rate(topo.get_node(ep).endpoint());
             old_node = old_node || ht < 0;
             ht_max = std::max(ht_max, ht);
             ht_min = std::min(ht_min, ht);
@@ -334,7 +336,7 @@ filter_for_query(consistency_level cl,
         if (!old_node && ht_max - ht_min > 0.01) { // if there is old node or hit rates are close skip calculations
             // local node is always first if present (see storage_proxy::get_endpoints_for_reading)
             unsigned local_idx = erm.get_topology().is_me(epi[0].first) ? 0 : epi.size() + 1;
-            live_endpoints = boost::copy_range<inet_address_vector_replica_set>(miss_equalizing_combination(epi, local_idx, remaining_bf, bool(extra)));
+            live_endpoints = boost::copy_range<host_id_vector_replica_set>(miss_equalizing_combination(epi, local_idx, remaining_bf, bool(extra)));
         }
     }
 
@@ -347,10 +349,48 @@ filter_for_query(consistency_level cl,
     return selected_endpoints;
 }
 
+/*
 bool
 is_sufficient_live_nodes(consistency_level cl,
                          const locator::effective_replication_map& erm,
                          const inet_address_vector_replica_set& live_endpoints) {
+    using namespace locator;
+    const auto& topo = erm.get_topology();
+
+    switch (cl) {
+    case consistency_level::ANY:
+        // local hint is acceptable, and local node is always live
+        return true;
+    case consistency_level::LOCAL_ONE:
+        return topo.count_local_endpoints(live_endpoints) >= 1;
+    case consistency_level::LOCAL_QUORUM:
+        return topo.count_local_endpoints(live_endpoints) >= block_for(erm, cl);
+    case consistency_level::EACH_QUORUM:
+    {
+        auto& rs = erm.get_replication_strategy();
+
+        if (rs.get_type() == replication_strategy_type::network_topology) {
+            for (auto& entry : count_per_dc_endpoints(erm, live_endpoints)) {
+                if (entry.second.live < local_quorum_for(erm, entry.first)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+        [[fallthrough]];
+        // Fallthrough on purpose for SimpleStrategy
+    default:
+        return live_endpoints.size() >= block_for(erm, cl);
+    }
+}
+*/
+
+bool
+is_sufficient_live_nodes(consistency_level cl,
+                         const locator::effective_replication_map& erm,
+                         const host_id_vector_replica_set& live_endpoints) {
     using namespace locator;
     const auto& topo = erm.get_topology();
 

--- a/db/consistency_level.hh
+++ b/db/consistency_level.hh
@@ -46,14 +46,14 @@ size_t block_for(const locator::effective_replication_map& erm, consistency_leve
 
 bool is_datacenter_local(consistency_level l);
 
-inet_address_vector_replica_set
+host_id_vector_replica_set
 filter_for_query(consistency_level cl,
                  const locator::effective_replication_map& erm,
-                 inet_address_vector_replica_set live_endpoints,
-                 const inet_address_vector_replica_set& preferred_endpoints,
+                 host_id_vector_replica_set live_endpoints,
+                 const host_id_vector_replica_set& preferred_endpoints,
                  read_repair_decision read_repair,
                  const gms::gossiper& g,
-                 std::optional<gms::inet_address>* extra,
+                 std::optional<locator::host_id>* extra,
                  replica::column_family* cf);
 
 struct dc_node_count {
@@ -64,7 +64,7 @@ struct dc_node_count {
 bool
 is_sufficient_live_nodes(consistency_level cl,
                          const locator::effective_replication_map& erm,
-                         const inet_address_vector_replica_set& live_endpoints);
+                         const host_id_vector_replica_set& live_endpoints);
 
 template<typename Range, typename PendingRange = std::array<gms::inet_address, 0>>
 void assure_sufficient_live_nodes(
@@ -75,5 +75,6 @@ void assure_sufficient_live_nodes(
 
 extern template void assure_sufficient_live_nodes(consistency_level, const locator::effective_replication_map&, const inet_address_vector_replica_set&, const std::array<gms::inet_address, 0>&);
 extern template void assure_sufficient_live_nodes(db::consistency_level, const locator::effective_replication_map&, const inet_address_vector_replica_set&, const utils::small_vector<gms::inet_address, 1ul>&);
+extern template void assure_sufficient_live_nodes(consistency_level, const locator::effective_replication_map&, const host_id_vector_replica_set&, const std::array<gms::inet_address, 0>&);
 
 }

--- a/db/hints/internal/hint_sender.cc
+++ b/db/hints/internal/hint_sender.cc
@@ -76,15 +76,16 @@ future<timespec> hint_sender::get_last_file_modification(const sstring& fname) {
     });
 }
 
-future<> hint_sender::do_send_one_mutation(frozen_mutation_and_schema m, locator::effective_replication_map_ptr ermp, const inet_address_vector_replica_set& natural_endpoints) {
+future<> hint_sender::do_send_one_mutation(frozen_mutation_and_schema m, locator::effective_replication_map_ptr ermp, const host_id_vector_replica_set& natural_endpoints) {
     return futurize_invoke([this, m = std::move(m), ermp = std::move(ermp), &natural_endpoints] () mutable -> future<> {
         // The fact that we send with CL::ALL in both cases below ensures that new hints are not going
         // to be generated as a result of hints sending.
         const auto& tm = ermp->get_token_metadata();
-        const auto maybe_addr = tm.get_endpoint_for_host_id_if_known(end_point_key());
+        auto ep = end_point_key();
+        const auto maybe_addr = tm.get_endpoint_for_host_id_if_known(ep);
 
-        if (maybe_addr && boost::range::find(natural_endpoints, *maybe_addr) != natural_endpoints.end()) {
-            manager_logger.trace("Sending directly to {}", end_point_key());
+        if (maybe_addr && boost::range::find(natural_endpoints, ep) != natural_endpoints.end()) {
+            manager_logger.trace("Sending directly to {}/{}", end_point_key(), *maybe_addr);
             return _proxy.send_hint_to_endpoint(std::move(m), std::move(ermp), *maybe_addr);
         } else {
             manager_logger.trace("Endpoints set has changed and {} is no longer a replica. Mutating from scratch...", end_point_key());
@@ -276,7 +277,7 @@ void hint_sender::start() {
 future<> hint_sender::send_one_mutation(frozen_mutation_and_schema m) {
     auto erm = _db.find_column_family(m.s).get_effective_replication_map();
     auto token = dht::get_token(*m.s, m.fm.key());
-    inet_address_vector_replica_set natural_endpoints = erm->get_natural_endpoints(std::move(token));
+    auto natural_endpoints = erm->get_replicas(std::move(token));
 
     return do_send_one_mutation(std::move(m), std::move(erm), std::move(natural_endpoints));
 }

--- a/db/hints/internal/hint_sender.hh
+++ b/db/hints/internal/hint_sender.hh
@@ -22,7 +22,6 @@
 #include "db/commitlog/replay_position.hh"
 #include "db/hints/internal/common.hh"
 #include "db/hints/internal/hint_storage.hh"
-#include "gms/inet_address.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "mutation/frozen_mutation.hh"
 #include "schema/schema.hh"
@@ -242,7 +241,7 @@ private:
     /// \param ermp points to the effective_replication_map used to obtain \c natural_endpoints
     /// \param natural_endpoints current replicas for the given mutation
     /// \return future that resolves when the operation is complete
-    future<> do_send_one_mutation(frozen_mutation_and_schema m, locator::effective_replication_map_ptr ermp, const inet_address_vector_replica_set& natural_endpoints);
+    future<> do_send_one_mutation(frozen_mutation_and_schema m, locator::effective_replication_map_ptr ermp, const host_id_vector_replica_set& natural_endpoints);
 
     /// \brief Send one mutation out.
     ///

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -175,7 +175,7 @@ public:
     void register_metrics(const sstring& group_name);
     future<> start(shared_ptr<gms::gossiper> gossiper_ptr);
     future<> stop();
-    bool store_hint(endpoint_id host_id, gms::inet_address ip, schema_ptr s, lw_shared_ptr<const frozen_mutation> fm,
+    bool store_hint(endpoint_id host_id, std::optional<gms::inet_address> ip, schema_ptr s, lw_shared_ptr<const frozen_mutation> fm,
             tracing::trace_state_ptr tr_state) noexcept;
 
     /// \brief Changes the host_filter currently used, stopping and starting endpoint_managers relevant to the new host_filter.

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1424,7 +1424,7 @@ future<std::set<sstring>> merge_keyspaces(distributed<service::storage_proxy>& p
     for (auto&& val : created) {
         auto scylla_specific_rs = co_await extract_scylla_specific_keyspace_info(proxy, val);
         auto ksm = create_keyspace_from_schema_partition(val, std::move(scylla_specific_rs));
-        co_await replica::database::create_keyspace_on_all_shards(sharded_db, proxy, *ksm);
+        co_await replica::database::create_keyspace_on_all_shards(sharded_db, *ksm);
     }
     for (auto& name : altered) {
         auto v = co_await db::schema_tables::read_schema_partition_for_keyspace(proxy, db::schema_tables::KEYSPACES, name);

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2285,11 +2285,9 @@ static bool maybe_write_in_user_memory(schema_ptr s) {
             || s == system_keyspace::v3::scylla_views_builds_in_progress();
 }
 
-future<> system_keyspace::make(
-        locator::effective_replication_map_factory& erm_factory,
-        replica::database& db) {
+future<> system_keyspace::make(replica::database& db) {
     for (auto&& table : system_keyspace::all_tables(db.get_config())) {
-        co_await db.create_local_system_table(table, maybe_write_in_user_memory(table), erm_factory);
+        co_await db.create_local_system_table(table, maybe_write_in_user_memory(table));
         co_await db.find_column_family(table).init_storage();
     }
 }

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -67,7 +67,6 @@ namespace gms {
 }
 
 namespace locator {
-    class effective_replication_map_factory;
     class endpoint_dc_rack;
 } // namespace locator
 
@@ -324,9 +323,7 @@ public:
     static std::vector<schema_ptr> auth_tables();
     static std::vector<schema_ptr> all_tables(const db::config& cfg);
 
-    future<> make(
-            locator::effective_replication_map_factory&,
-            replica::database&);
+    future<> make(replica::database&);
 
     void mark_writable();
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1650,7 +1650,9 @@ get_view_natural_endpoint(
         }
     }
 
-    assert(base_endpoints.size() == view_endpoints.size());
+    if (base_endpoints.size() != view_endpoints.size()) {
+        on_internal_error(vlogger, format("base and view endpoints are not the same size. base_endpoints={} view_endpoints={}", base_endpoints, view_endpoints));
+    }
     auto base_it = std::find(base_endpoints.begin(), base_endpoints.end(), me);
     if (base_it == base_endpoints.end()) {
         // This node is not a base replica of this key, so we return empty

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -1027,7 +1027,7 @@ future<> initialize_virtual_tables(
     auto add_table = [&] (std::unique_ptr<virtual_table>&& tbl) -> future<> {
         auto schema = tbl->schema();
         virtual_tables[schema->id()] = std::move(tbl);
-        co_await db.create_local_system_table(schema, false, ss.get_erm_factory());
+        co_await db.create_local_system_table(schema, false);
         auto& cf = db.find_column_family(schema);
         cf.mark_ready_for_writes(nullptr);
         auto& vt = virtual_tables[schema->id()];

--- a/idl/paging_state.idl.hh
+++ b/idl/paging_state.idl.hh
@@ -7,6 +7,7 @@
  */
 
 #include "dht/i_partitioner_fwd.hh"
+#include "inet_address_vectors.hh"
 #include "service/pager/paging_state.hh"
 
 #include "idl/range.idl.hh"
@@ -42,7 +43,7 @@ class paging_state {
     std::optional<clustering_key> get_clustering_key();
     uint32_t get_remaining_low_bits();
     query_id get_query_uuid() [[version 2.2]] = query_id::create_null_id();
-    std::unordered_map<dht::token_range, std::vector<locator::host_id>> get_last_replicas() [[version 2.2]] = std::unordered_map<dht::token_range, std::vector<locator::host_id>>();
+    std::unordered_map<dht::token_range, host_id_vector_replica_set> get_last_replicas() [[version 2.2]] = std::unordered_map<dht::token_range, host_id_vector_replica_set>();
     std::optional<db::read_repair_decision> get_query_read_repair_decision() [[version 2.3]] = std::nullopt;
     uint32_t get_rows_fetched_for_last_partition_low_bits() [[version 3.1]] = 0;
     uint32_t get_remaining_high_bits() [[version 4.3]] = 0;

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -486,7 +486,7 @@ auto vnode_effective_replication_map::clone_data_gently() const -> future<std::u
     co_return std::move(result);
 }
 
-host_id_vector_replica_set vnode_effective_replication_map::do_get_replicas(const token& tok,
+const host_id_vector_replica_set& vnode_effective_replication_map::do_get_replicas(const token& tok,
     bool is_vnode) const
 {
     const token& key_token = _rs->natural_endpoints_depend_on_token()

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -424,7 +424,7 @@ public:
 private:
     dht::token_range_vector do_get_ranges(noncopyable_function<stop_iteration(bool& add_range, const inet_address& natural_endpoint)> consider_range_for_endpoint) const;
     inet_address_vector_replica_set do_get_natural_endpoints(const token& tok, bool is_vnode) const;
-    host_id_vector_replica_set do_get_replicas(const token& tok, bool is_vnode) const;
+    const host_id_vector_replica_set& do_get_replicas(const token& tok, bool is_vnode) const;
     stop_iteration for_each_natural_endpoint_until(const token& vnode_tok, const noncopyable_function<stop_iteration(const inet_address&)>& func) const;
 
 public:

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -240,18 +240,23 @@ public:
     /// new replica.
     ///
     /// The returned addresses are present in the topology object associated with this instance.
-    virtual inet_address_vector_replica_set get_natural_endpoints(const token& search_token) const = 0;
+    inet_address_vector_replica_set get_natural_endpoints(const token& search_token) const;
 
     /// Returns a subset of replicas returned by get_natural_endpoints() without the pending replica.
-    virtual inet_address_vector_replica_set get_natural_endpoints_without_node_being_replaced(const token& search_token) const = 0;
+    virtual host_id_vector_replica_set get_natural_hosts_without_node_being_replaced(const token& search_token) const = 0;
+    inet_address_vector_replica_set get_natural_endpoints_without_node_being_replaced(const token& search_token) const {
+        return resolve_endpoints<inet_address_vector_replica_set>(get_natural_hosts_without_node_being_replaced(search_token));
+    }
 
     /// Returns the set of pending replicas for a given token.
     /// Pending replica is a replica which gains ownership of data.
     /// Non-empty only during topology change.
-    virtual inet_address_vector_topology_change get_pending_endpoints(const token& search_token) const = 0;
+    virtual host_id_vector_topology_change get_pending_hosts(const token& search_token) const  = 0;
+    inet_address_vector_topology_change get_pending_endpoints(const token& search_token) const;
 
     /// Returns a list of nodes to which a read request should be directed.
-    virtual inet_address_vector_replica_set get_endpoints_for_reading(const token& search_token) const = 0;
+    virtual host_id_vector_replica_set get_hosts_for_reading(const token& search_token) const = 0;
+    inet_address_vector_replica_set get_endpoints_for_reading(const token& search_token) const;
 
     /// Returns replicas for a given token.
     /// During topology change returns replicas which should be targets for writes, excluding the pending replica.
@@ -355,10 +360,9 @@ private:
     friend class abstract_replication_strategy;
     friend class effective_replication_map_factory;
 public: // effective_replication_map
-    inet_address_vector_replica_set get_natural_endpoints(const token& search_token) const override;
-    inet_address_vector_replica_set get_natural_endpoints_without_node_being_replaced(const token& search_token) const override;
-    inet_address_vector_topology_change get_pending_endpoints(const token& search_token) const override;
-    inet_address_vector_replica_set get_endpoints_for_reading(const token& search_token) const override;
+    host_id_vector_replica_set get_natural_hosts_without_node_being_replaced(const token& search_token) const override;
+    host_id_vector_topology_change get_pending_hosts(const token& search_token) const override;
+    host_id_vector_replica_set get_hosts_for_reading(const token& search_token) const override;
     host_id_vector_replica_set get_replicas(const token& search_token) const override;
     std::optional<tablet_routing_info> check_locality(const token& token) const override;
     bool has_pending_ranges(locator::host_id endpoint) const override;
@@ -566,6 +570,6 @@ private:
 
 void maybe_remove_node_being_replaced(const token_metadata&,
                                       const abstract_replication_strategy&,
-                                      inet_address_vector_replica_set& natural_endpoints);
+                                      host_id_vector_replica_set& natural_endpoints);
 
 }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -559,13 +559,18 @@ private:
         result.reserve(replicas.size());
         auto& topo = _tmptr->get_topology();
         for (auto&& replica : replicas) {
+            auto& host = replica.host;
+            if (!host || topo.is_me(host)) {
+                result.emplace_back(topo.my_host_id());
+                continue;
+            }
             if (filter_out_left_nodes) {
-                auto* node = topo.find_node(replica.host);
+                auto* node = topo.find_node(host);
                 if (!node || node->left()) {
                     continue;
                 }
             }
-            result.emplace_back(replica.host);
+            result.emplace_back(host);
         }
         return result;
     }

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -425,6 +425,8 @@ public:
         return _lock_func();
     }
 
+    future<std::tuple<token_metadata_lock, mutable_token_metadata_ptr>> get_mutable_token_metadata_ptr();
+
     // mutate_token_metadata_on_all_shards acquires the shared_token_metadata lock,
     // clones the token_metadata (using clone_async)
     // and calls an asynchronous functor on

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -298,7 +298,7 @@ public:
     // Get dc/rack location of a node identified by host_id
     // The specified node must exist.
     const endpoint_dc_rack& get_location(host_id id) const {
-        return find_node(id)->dc_rack();
+        return id ? find_node(id)->dc_rack() : get_location();
     }
     // Get dc/rack location of a node identified by endpoint
     // The specified node must exist.
@@ -350,6 +350,7 @@ public:
      * address.
      */
     void sort_by_proximity(inet_address address, inet_address_vector_replica_set& addresses) const;
+    void sort_by_proximity(const host_id& hid, host_id_vector_replica_set& hosts) const;
 
     void for_each_node(std::function<void(const node*)> func) const;
 

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -382,7 +382,7 @@ private:
 
     void index_node(const node* node);
     void unindex_node(const node* node);
-    node_holder pop_node(const node* node);
+    void pop_node(const node* node);
 
     static node* make_mutable(const node* nptr) {
         return const_cast<node*>(nptr);

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -397,7 +397,7 @@ private:
      * 2. Nodes in the same RACK as the reference node
      * 3. Nodes in the same DC as the reference node
      */
-    std::weak_ordering compare_endpoints(const inet_address& address, const inet_address& a1, const inet_address& a2) const;
+    std::weak_ordering compare_nodes_proximity(const node* address, const node* a1, const node* a2) const;
 
     unsigned _shard;
     config _cfg;

--- a/main.cc
+++ b/main.cc
@@ -573,6 +573,8 @@ static locator::host_id initialize_local_info_thread(sharded<db::system_keyspace
     if (!linfo.host_id) {
         linfo.host_id = locator::host_id::create_random_id();
         startlog.info("Setting local host id to {}", linfo.host_id);
+    } else {
+        startlog.info("Loaded local host id is {}", linfo.host_id);
     }
 
     linfo.listen_address = listen_address;
@@ -1285,14 +1287,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             const auto listen_address = utils::resolve(cfg->listen_address, family).get();
             const auto host_id = initialize_local_info_thread(sys_ks, snitch, listen_address, *cfg, broadcast_addr, broadcast_rpc_addr);
 
-          shared_token_metadata::mutate_on_all_shards(token_metadata, [host_id, endpoint = broadcast_addr] (locator::token_metadata& tm) {
-              // Makes local host id available in topology cfg as soon as possible.
-              // Raft topology discard the endpoint-to-id map, so the local id can
-              // still be found in the config.
-              tm.get_topology().set_host_id_cfg(host_id);
-              tm.get_topology().add_or_update_endpoint(host_id, endpoint);
-              return make_ready_future<>();
-          }).get();
+            // Makes local host id available in topology cfg as soon as possible.
+            // Raft topology discard the endpoint-to-id map, so the local id can
+            // still be found in the config.
+            replica::database::set_this_node(db, host_id, broadcast_addr).get();
 
             netw::messaging_service::config mscfg;
 

--- a/main.cc
+++ b/main.cc
@@ -1100,7 +1100,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             supervisor::notify("starting database");
             debug::the_database = &db;
-            db.start(std::ref(*cfg), dbcfg, std::ref(mm_notifier), std::ref(feature_service), std::ref(token_metadata),
+            db.start(std::ref(*cfg), dbcfg, std::ref(mm_notifier), std::ref(feature_service), std::ref(token_metadata), std::ref(erm_factory),
                     std::ref(cm), std::ref(sstm), std::ref(langman), std::ref(sst_dir_semaphore), utils::cross_shard_barrier()).get();
             auto stop_database_and_sstables = defer_verbose_shutdown("database", [&db] {
                 // #293 - do not stop anything - not even db (for real)

--- a/main.cc
+++ b/main.cc
@@ -1155,7 +1155,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             };
             proxy.start(std::ref(db), spcfg, std::ref(node_backlog),
                     scheduling_group_key_create(storage_proxy_stats_cfg).get(),
-                    std::ref(feature_service), std::ref(token_metadata), std::ref(erm_factory)).get();
+                    std::ref(feature_service), std::ref(token_metadata)).get();
 
             // #293 - do not stop anything
             // engine().at_exit([&proxy] { return proxy.stop(); });
@@ -1238,7 +1238,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // done only by shard 0, so we'll no longer face race conditions as
             // described here: https://github.com/scylladb/scylla/issues/1014
             supervisor::notify("loading system sstables");
-            replica::distributed_loader::init_system_keyspace(sys_ks, erm_factory, db).get();
+            replica::distributed_loader::init_system_keyspace(sys_ks, db).get();
 
             // 1. Here we notify dependent services that system tables have been loaded,
             //    and they in turn can load the necessary data from them;
@@ -1485,7 +1485,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             debug::the_storage_service = &ss;
             ss.start(std::ref(stop_signal.as_sharded_abort_source()),
                 std::ref(db), std::ref(gossiper), std::ref(sys_ks), std::ref(sys_dist_ks),
-                std::ref(feature_service), std::ref(mm), std::ref(token_metadata), std::ref(erm_factory),
+                std::ref(feature_service), std::ref(mm), std::ref(token_metadata),
                 std::ref(messaging), std::ref(repair),
                 std::ref(stream_manager), std::ref(lifecycle_notifier), std::ref(bm), std::ref(snitch),
                 std::ref(tablet_allocator), std::ref(cdc_generation_service), std::ref(view_builder), std::ref(qp), std::ref(sl_controller),

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -312,7 +312,7 @@ public:
     }
 };
 
-database::database(const db::config& cfg, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
+database::database(const db::config& cfg, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory,
         compaction_manager& cm, sstables::storage_manager& sstm, lang::manager& langm, sstables::directory_semaphore& sst_dir_sem, utils::cross_shard_barrier barrier)
     : _stats(make_lw_shared<db_stats>())
     , _user_types(std::make_shared<db_user_types_storage>(*this))
@@ -380,6 +380,7 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
     , _mnotifier(mn)
     , _feat(feat)
     , _shared_token_metadata(stm)
+    , _erm_factory(erm_factory)
     , _lang_manager(langm)
     , _stop_barrier(std::move(barrier))
     , _update_memtable_flush_static_shares_action([this, &cfg] { return _memtable_controller.update_static_shares(cfg.memtable_flush_static_shares()); })

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1633,6 +1633,8 @@ public:
     locator::effective_replication_map_factory& get_erm_factory() noexcept { return _erm_factory; }
     const locator::effective_replication_map_factory& get_erm_factory() const noexcept { return _erm_factory; }
 
+    static future<> mutate_token_metadata(sharded<database>& db, std::function<future<>(locator::token_metadata&)> func);
+
     lang::manager& lang() noexcept { return _lang_manager; }
     const lang::manager& lang() const noexcept { return _lang_manager; }
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1515,6 +1515,7 @@ private:
     gms::feature_service& _feat;
     std::vector<std::any> _listeners;
     const locator::shared_token_metadata& _shared_token_metadata;
+    locator::effective_replication_map_factory& _erm_factory;
     lang::manager& _lang_manager;
 
     utils::cross_shard_barrier _stop_barrier;
@@ -1624,6 +1625,8 @@ public:
 
     const locator::shared_token_metadata& get_shared_token_metadata() const { return _shared_token_metadata; }
     const locator::token_metadata& get_token_metadata() const { return *_shared_token_metadata.get(); }
+    locator::effective_replication_map_factory& get_erm_factory() noexcept { return _erm_factory; }
+    const locator::effective_replication_map_factory& get_erm_factory() const noexcept { return _erm_factory; }
 
     lang::manager& lang() noexcept { return _lang_manager; }
     const lang::manager& lang() const noexcept { return _lang_manager; }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1514,7 +1514,7 @@ private:
     service::migration_notifier& _mnotifier;
     gms::feature_service& _feat;
     std::vector<std::any> _listeners;
-    const locator::shared_token_metadata& _shared_token_metadata;
+    locator::shared_token_metadata& _shared_token_metadata;
     locator::effective_replication_map_factory& _erm_factory;
     lang::manager& _lang_manager;
 
@@ -1575,6 +1575,11 @@ private:
     static future<> modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func, std::function<future<>(replica::database&)> notifier);
 
     future<> foreach_reader_concurrency_semaphore(std::function<future<>(reader_concurrency_semaphore&)> func);
+
+    static future<> replicate_to_all_cores(sharded<database>& sharded_db, locator::mutable_token_metadata_ptr tmptr,
+            std::function<future<>(const database&)> per_shard_cb = [] (auto&) { return make_ready_future(); }) noexcept;
+
+    friend class service::storage_service;
 public:
     static table_schema_version empty_version;
 
@@ -1591,7 +1596,7 @@ public:
     // (keyspace/table definitions, column mappings etc.)
     future<> parse_system_tables(distributed<service::storage_proxy>&, sharded<db::system_keyspace>&);
 
-    database(const db::config&, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory,
+    database(const db::config&, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory,
             compaction_manager& cm, sstables::storage_manager& sstm, lang::manager& langm, sstables::directory_semaphore& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
     database(database&&) = delete;
     ~database();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1634,6 +1634,10 @@ public:
     const locator::effective_replication_map_factory& get_erm_factory() const noexcept { return _erm_factory; }
 
     static future<> mutate_token_metadata(sharded<database>& db, std::function<future<>(locator::token_metadata&)> func);
+    static future<> set_this_node(sharded<database>& db, const locator::host_id& host_id, const gms::inet_address& endpoint,
+            std::optional<locator::endpoint_dc_rack> opt_dr = std::nullopt,
+            std::optional<locator::node::state> opt_st = std::nullopt,
+            std::optional<shard_id> opt_shard_count = std::nullopt);
 
     lang::manager& lang() noexcept { return _lang_manager; }
     const lang::manager& lang() const noexcept { return _lang_manager; }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1554,7 +1554,7 @@ private:
     future<> flush_system_column_families();
 
     using system_keyspace = bool_class<struct system_keyspace_tag>;
-    future<> create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
+    future<> create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, system_keyspace system);
     void setup_metrics();
     void setup_scylla_memory_diagnostics_producer();
 
@@ -1568,7 +1568,7 @@ private:
     template<typename Future>
     Future update_write_metrics(Future&& f);
     void update_write_metrics_for_timed_out_write();
-    future<> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
+    future<> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, system_keyspace system);
     future<> remove(table&) noexcept;
     void drop_keyspace(const sstring& name);
     future<> update_keyspace(const keyspace_metadata& tmp_ksm);
@@ -1591,7 +1591,7 @@ public:
     // (keyspace/table definitions, column mappings etc.)
     future<> parse_system_tables(distributed<service::storage_proxy>&, sharded<db::system_keyspace>&);
 
-    database(const db::config&, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
+    database(const db::config&, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory,
             compaction_manager& cm, sstables::storage_manager& sstm, lang::manager& langm, sstables::directory_semaphore& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
     database(database&&) = delete;
     ~database();
@@ -1639,8 +1639,7 @@ public:
     //
     // Note: 'system table' does not necessarily mean it sits in `system` keyspace, it could also be `system_schema`;
     // in general we mean local tables created by the system (not the user).
-    future<> create_local_system_table(
-            schema_ptr table, bool write_in_user_memory, locator::effective_replication_map_factory&);
+    future<> create_local_system_table(schema_ptr table, bool write_in_user_memory);
 
     void init_schema_commitlog();
     using is_new_cf = bool_class<struct is_new_cf_tag>;
@@ -1655,7 +1654,7 @@ public:
      *
      * @return ready future when the operation is complete
      */
-    static future<> create_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ksm);
+    static future<> create_keyspace_on_all_shards(sharded<database>& sharded_db, const keyspace_metadata& ksm);
     /* below, find_keyspace throws no_such_<type> on fail */
     keyspace& find_keyspace(std::string_view name);
     const keyspace& find_keyspace(std::string_view name) const;

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -484,12 +484,12 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
     }
 }
 
-future<> distributed_loader::init_system_keyspace(sharded<db::system_keyspace>& sys_ks, distributed<locator::effective_replication_map_factory>& erm_factory, distributed<replica::database>& db) {
+future<> distributed_loader::init_system_keyspace(sharded<db::system_keyspace>& sys_ks, distributed<replica::database>& db) {
     population_started = true;
 
-    return seastar::async([&sys_ks, &erm_factory, &db] {
-        sys_ks.invoke_on_all([&erm_factory, &db] (auto& sys_ks) {
-            return sys_ks.make(erm_factory.local(), db.local());
+    return seastar::async([&sys_ks, &db] {
+        sys_ks.invoke_on_all([&db] (auto& sys_ks) {
+            return sys_ks.make(db.local());
         }).get();
 
         for (auto ksname : system_keyspaces) {

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -49,10 +49,6 @@ class storage_proxy;
 
 }
 
-namespace locator {
-class effective_replication_map_factory;
-}
-
 class distributed_loader_for_tests;
 
 namespace replica {
@@ -75,7 +71,7 @@ class distributed_loader {
     static future<> populate_keyspace(distributed<replica::database>& db, sharded<db::system_keyspace>& sys_ks, keyspace& ks, sstring ks_name);
 
 public:
-    static future<> init_system_keyspace(sharded<db::system_keyspace>&, distributed<locator::effective_replication_map_factory>&, distributed<replica::database>&);
+    static future<> init_system_keyspace(sharded<db::system_keyspace>&, distributed<replica::database>&);
     static future<> init_non_system_keyspaces(distributed<replica::database>& db, distributed<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks);
 
     /**

--- a/service/pager/paging_state.hh
+++ b/service/pager/paging_state.hh
@@ -17,7 +17,7 @@
 #include "query-request.hh"
 #include "db/read_repair_decision.hh"
 #include "mutation/position_in_partition.hh"
-#include "locator/host_id.hh"
+#include "inet_address_vectors.hh"
 
 namespace service {
 
@@ -25,7 +25,7 @@ namespace pager {
 
 class paging_state final {
 public:
-    using replicas_per_token_range = std::unordered_map<dht::token_range, std::vector<locator::host_id>>;
+    using replicas_per_token_range = std::unordered_map<dht::token_range, host_id_vector_replica_set>;
 
 private:
     partition_key _partition_key;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -154,11 +154,23 @@ gms::inet_address storage_proxy::my_address() const noexcept {
     return _shared_token_metadata.get()->get_topology().my_address();
 }
 
+locator::host_id storage_proxy::my_host_id() const noexcept {
+    return _shared_token_metadata.get()->get_topology().my_host_id();
+}
+
 bool storage_proxy::is_me(gms::inet_address addr) const noexcept {
     return local_db().get_token_metadata().get_topology().is_me(addr);
 }
 
+bool storage_proxy::is_me(locator::host_id hid) const noexcept {
+    return local_db().get_token_metadata().get_topology().is_me(hid);
+}
+
 bool storage_proxy::only_me(const inet_address_vector_replica_set& replicas) const noexcept {
+    return replicas.size() == 1 && is_me(replicas[0]);
+}
+
+bool storage_proxy::only_me(const host_id_vector_replica_set& replicas) const noexcept {
     return replicas.size() == 1 && is_me(replicas[0]);
 }
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2906,10 +2906,9 @@ storage_proxy::~storage_proxy() {
 }
 
 storage_proxy::storage_proxy(distributed<replica::database>& db, storage_proxy::config cfg, db::view::node_update_backlog& max_view_update_backlog,
-        scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory)
+        scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm)
     : _db(db)
     , _shared_token_metadata(stm)
-    , _erm_factory(erm_factory)
     , _read_smp_service_group(cfg.read_smp_service_group)
     , _write_smp_service_group(cfg.write_smp_service_group)
     , _write_mv_smp_service_group(cfg.write_mv_smp_service_group)

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -216,14 +216,6 @@ public:
     gms::feature_service& features() noexcept { return _features; }
     const gms::feature_service& features() const { return _features; }
 
-    locator::effective_replication_map_factory& get_erm_factory() noexcept {
-        return _erm_factory;
-    }
-
-    const locator::effective_replication_map_factory& get_erm_factory() const noexcept {
-        return _erm_factory;
-    }
-
     locator::token_metadata_ptr get_token_metadata_ptr() const noexcept;
 
     query::max_result_size get_max_result_size(const query::partition_slice& slice) const;
@@ -247,7 +239,6 @@ public:
 private:
     distributed<replica::database>& _db;
     const locator::shared_token_metadata& _shared_token_metadata;
-    locator::effective_replication_map_factory& _erm_factory;
     smp_service_group _read_smp_service_group;
     smp_service_group _write_smp_service_group;
     smp_service_group _write_mv_smp_service_group;
@@ -471,7 +462,7 @@ private:
 
 public:
     storage_proxy(distributed<replica::database>& db, config cfg, db::view::node_update_backlog& max_view_update_backlog,
-            scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm, locator::effective_replication_map_factory& erm_factory);
+            scheduling_group_key stats_key, gms::feature_service& feat, const locator::shared_token_metadata& stm);
     ~storage_proxy();
 
     const distributed<replica::database>& get_db() const {

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -501,11 +501,14 @@ public:
     future<> stop_remote();
 
     gms::inet_address my_address() const noexcept;
+    locator::host_id my_host_id() const noexcept;
 
     bool is_me(gms::inet_address addr) const noexcept;
+    bool is_me(locator::host_id hid) const noexcept;
 
 private:
     bool only_me(const inet_address_vector_replica_set& replicas) const noexcept;
+    bool only_me(const host_id_vector_replica_set& replicas) const noexcept;
 
     // Throws an error if remote is not initialized.
     const struct remote& remote() const;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -200,7 +200,6 @@ public:
         gms::feature_service& feature_service,
         sharded<service::migration_manager>& mm,
         locator::shared_token_metadata& stm,
-        locator::effective_replication_map_factory& erm_factory,
         sharded<netw::messaging_service>& ms,
         sharded<repair_service>& repair,
         sharded<streaming::stream_manager>& stream_manager,
@@ -276,14 +275,6 @@ public:
         return _gossiper;
     };
 
-    locator::effective_replication_map_factory& get_erm_factory() noexcept {
-        return _erm_factory;
-    }
-
-    const locator::effective_replication_map_factory& get_erm_factory() const noexcept {
-        return _erm_factory;
-    }
-
     token_metadata_ptr get_token_metadata_ptr() const noexcept {
         return _shared_token_metadata.get();
     }
@@ -308,7 +299,6 @@ private:
 
     /* This abstraction maintains the token/endpoint metadata information */
     shared_token_metadata& _shared_token_metadata;
-    locator::effective_replication_map_factory& _erm_factory;
 
 public:
     std::chrono::milliseconds get_ring_delay();

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1224,6 +1224,7 @@ public:
         };
 
         topo.for_each_node([&] (const locator::node* node_ptr) {
+            lblogger.info("Examining node {} in dc={} state={}", *node_ptr, node_ptr->dc_rack().dc, node_ptr->get_state());
             if (node_ptr->dc_rack().dc != dc) {
                 return;
             }

--- a/test/boost/locator_topology_test.cc
+++ b/test/boost/locator_topology_test.cc
@@ -36,6 +36,7 @@ SEASTAR_THREAD_TEST_CASE(test_add_node) {
 
     topology::config cfg = {
         .this_endpoint = ep1,
+        .this_host_id = id1,
         .local_dc_rack = endpoint_dc_rack::default_location,
     };
 
@@ -48,9 +49,9 @@ SEASTAR_THREAD_TEST_CASE(test_add_node) {
 
     std::unordered_set<const locator::node*> nodes;
 
+    nodes.insert(topo.this_node());
     nodes.insert(topo.add_node(id2, ep2, endpoint_dc_rack::default_location, node::state::normal));
-    nodes.insert(topo.add_node(id1, ep1, endpoint_dc_rack::default_location, node::state::normal));
-
+    BOOST_REQUIRE_THROW(topo.add_node(id1, ep1, endpoint_dc_rack::default_location, node::state::normal), std::runtime_error);
     BOOST_REQUIRE_THROW(topo.add_node(id1, ep2, endpoint_dc_rack::default_location, node::state::normal), std::runtime_error);
     BOOST_REQUIRE_THROW(topo.add_node(id2, ep1, endpoint_dc_rack::default_location, node::state::normal), std::runtime_error);
     BOOST_REQUIRE_THROW(topo.add_node(id2, ep2, endpoint_dc_rack::default_location, node::state::normal), std::runtime_error);
@@ -73,12 +74,11 @@ SEASTAR_THREAD_TEST_CASE(test_moving) {
 
     topology::config cfg = {
         .this_endpoint = ep1,
+        .this_host_id = id1,
         .local_dc_rack = endpoint_dc_rack::default_location,
     };
 
     auto topo = topology(cfg);
-
-    topo.add_node(id1, ep1, endpoint_dc_rack::default_location, node::state::normal);
 
     BOOST_REQUIRE(topo.this_node()->topology() == &topo);
 
@@ -227,12 +227,12 @@ SEASTAR_THREAD_TEST_CASE(test_remove_endpoint) {
 
     topology::config cfg = {
         .this_endpoint = ep1,
+        .this_host_id = id1,
         .local_dc_rack = dc_rack1
     };
 
     auto topo = topology(cfg);
 
-    topo.add_node(id1, ep1, dc_rack1, node::state::normal);
     topo.add_node(id2, ep2, dc_rack2, node::state::normal);
 
     BOOST_REQUIRE_EQUAL(topo.get_datacenter_endpoints(), (dc_endpoints_t{{"dc1", {ep1, ep2}}}));
@@ -383,6 +383,7 @@ SEASTAR_THREAD_TEST_CASE(test_left_node_is_kept_outside_dc) {
 
     topology::config cfg = {
         .this_endpoint = ep1,
+        .this_host_id = id1,
         .local_dc_rack = dc_rack1
     };
 

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -980,7 +980,10 @@ void topology::test_compare_endpoints(const inet_address& address, const inet_ad
             }
         }
     }
-    auto res = compare_endpoints(address, a1, a2);
+    auto n = find_node(address);
+    auto n1 = find_node(a1);
+    auto n2 = find_node(a2);
+    auto res = compare_nodes_proximity(n, n1, n2);
     testlog.debug("compare_endpoint: address={} [{}/{}] a1={} [{}/{}] a2={} [{}/{}]: res={} expected={} expected_value={}",
             address, loc.dc, loc.rack,
             a1, loc1.dc, loc1.rack,
@@ -1017,7 +1020,6 @@ SEASTAR_THREAD_TEST_CASE(test_topology_compare_endpoints) {
     std::generate_n(std::back_inserter(nodes), NODES, [&, i = 0u]() mutable {
         return make_address(++i);
     });
-    auto bogus_address = inet_address((127u << 24) | static_cast<int>(NODES + 1));
 
     semaphore sem(1);
     shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, tm_cfg);
@@ -1035,11 +1037,6 @@ SEASTAR_THREAD_TEST_CASE(test_topology_compare_endpoints) {
         topo.test_compare_endpoints(address, a1, a1);
         topo.test_compare_endpoints(address, a1, a2);
         topo.test_compare_endpoints(address, a2, a1);
-
-        topo.test_compare_endpoints(bogus_address, bogus_address, bogus_address);
-        topo.test_compare_endpoints(address, bogus_address, bogus_address);
-        topo.test_compare_endpoints(address, a1, bogus_address);
-        topo.test_compare_endpoints(address, bogus_address, a2);
         return make_ready_future<>();
     }).get();
 }

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -866,15 +866,17 @@ void generate_topology(topology& topo, const std::unordered_map<sstring, size_t>
         out = std::fill_n(out, rf, std::cref(dc));
     }
 
-    if (auto this_node = topo.this_node()) {
-        topo.remove_node(this_node->host_id());
-    }
     unsigned i = 0;
     for (auto& node : nodes) {
         const sstring& dc = dcs[udist(0, dcs.size() - 1)(e1)];
         auto rc = racks_per_dc.at(dc);
         auto r = udist(0, rc)(e1);
-        topo.add_node(node, inet_address((127u << 24) | ++i), {dc, to_sstring(r)}, locator::node::state::normal);
+        auto ep = inet_address((127u << 24) | ++i);
+        if (node != topo.my_host_id()) {
+            topo.add_node(node, ep, {dc, to_sstring(r)}, locator::node::state::normal);
+        } else {
+            topo.update_node(const_cast<locator::node*>(topo.this_node()), node, ep, std::make_optional<endpoint_dc_rack>(dc, to_sstring(r)), locator::node::state::normal);
+        }
     }
 }
 

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -337,6 +337,7 @@ SEASTAR_TEST_CASE(test_get_shard) {
         shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
                 locator::topology::config{
                         .this_endpoint = ip1,
+                        .this_host_id = h1,
                         .local_dc_rack = locator::endpoint_dc_rack::default_location
                 }
         });
@@ -348,9 +349,9 @@ SEASTAR_TEST_CASE(test_get_shard) {
             tm.update_host_id(h1, ip1);
             tm.update_host_id(h2, ip2);
             tm.update_host_id(h3, ip3);
-            tm.update_topology(h1, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
-            tm.update_topology(h2, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
-            tm.update_topology(h3, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+            tm.update_topology(h1, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
+            tm.update_topology(h2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
+            tm.update_topology(h3, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
 
             tablet_metadata tmeta;
             tablet_map tmap(2);
@@ -1053,6 +1054,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_empty_node) {
     shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
         locator::topology::config{
             .this_endpoint = ip1,
+            .this_host_id = host1,
             .local_dc_rack = locator::endpoint_dc_rack::default_location
         }
     });
@@ -1061,9 +1063,9 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_empty_node) {
         tm.update_host_id(host1, ip1);
         tm.update_host_id(host2, ip2);
         tm.update_host_id(host3, ip3);
-        tm.update_topology(host1, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
-        tm.update_topology(host2, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
-        tm.update_topology(host3, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+        tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
+        tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
+        tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
 
         tablet_map tmap(4);
         auto tid = tmap.first_tablet();
@@ -1150,6 +1152,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_skiplist) {
     shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
         locator::topology::config{
             .this_endpoint = ip1,
+            .this_host_id = host1,
             .local_dc_rack = locator::endpoint_dc_rack::default_location
         }
     });
@@ -1158,9 +1161,9 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_skiplist) {
         tm.update_host_id(host1, ip1);
         tm.update_host_id(host2, ip2);
         tm.update_host_id(host3, ip3);
-        tm.update_topology(host1, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
-        tm.update_topology(host2, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
-        tm.update_topology(host3, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+        tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
+        tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
+        tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
 
         tablet_map tmap(4);
         auto tid = tmap.first_tablet();
@@ -1238,6 +1241,7 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_met) {
         shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
                 locator::topology::config {
                         .this_endpoint = ip1,
+                        .this_host_id = host1,
                         .local_dc_rack = locator::endpoint_dc_rack::default_location
                 }
         });
@@ -1248,8 +1252,8 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_met) {
             tm.update_host_id(host1, ip1);
             tm.update_host_id(host2, ip2);
             tm.update_host_id(host3, ip3);
-            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
-            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
+            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
             tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::being_decommissioned,
                                shard_count);
 
@@ -1340,6 +1344,7 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_two_racks) {
         shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
                 locator::topology::config {
                         .this_endpoint = ip1,
+                        .this_host_id = host1,
                         .local_dc_rack = racks[0]
                 }
         });
@@ -1351,9 +1356,9 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_two_racks) {
             tm.update_host_id(host2, ip2);
             tm.update_host_id(host3, ip3);
             tm.update_host_id(host4, ip4);
-            tm.update_topology(host1, racks[0], std::nullopt, shard_count);
-            tm.update_topology(host2, racks[1], std::nullopt, shard_count);
-            tm.update_topology(host3, racks[0], std::nullopt, shard_count);
+            tm.update_topology(host1, racks[0], node::state::normal, shard_count);
+            tm.update_topology(host2, racks[1], node::state::normal, shard_count);
+            tm.update_topology(host3, racks[0], node::state::normal, shard_count);
             tm.update_topology(host4, racks[1], node::state::being_decommissioned,
                                shard_count);
 
@@ -1442,6 +1447,7 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rack_load_failure) {
         shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
                 locator::topology::config {
                         .this_endpoint = ip1,
+                        .this_host_id = host1,
                         .local_dc_rack = racks[0]
                 }
         });
@@ -1453,9 +1459,9 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rack_load_failure) {
             tm.update_host_id(host2, ip2);
             tm.update_host_id(host3, ip3);
             tm.update_host_id(host4, ip4);
-            tm.update_topology(host1, racks[0], std::nullopt, shard_count);
-            tm.update_topology(host2, racks[0], std::nullopt, shard_count);
-            tm.update_topology(host3, racks[0], std::nullopt, shard_count);
+            tm.update_topology(host1, racks[0], node::state::normal, shard_count);
+            tm.update_topology(host2, racks[0], node::state::normal, shard_count);
+            tm.update_topology(host3, racks[0], node::state::normal, shard_count);
             tm.update_topology(host4, racks[1], node::state::being_decommissioned,
                                shard_count);
 
@@ -1516,6 +1522,7 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_not_met) {
         shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
                 locator::topology::config {
                         .this_endpoint = ip1,
+                        .this_host_id = host1,
                         .local_dc_rack = locator::endpoint_dc_rack::default_location
                 }
         });
@@ -1526,8 +1533,8 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_not_met) {
             tm.update_host_id(host1, ip1);
             tm.update_host_id(host2, ip2);
             tm.update_host_id(host3, ip3);
-            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
-            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
+            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
             tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::being_decommissioned,
                                shard_count);
 
@@ -1573,6 +1580,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_works_with_in_progress_transitions)
     shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
         locator::topology::config{
             .this_endpoint = ip1,
+            .this_host_id = host1,
             .local_dc_rack = locator::endpoint_dc_rack::default_location
         }
     });
@@ -1581,9 +1589,9 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_works_with_in_progress_transitions)
         tm.update_host_id(host1, ip1);
         tm.update_host_id(host2, ip2);
         tm.update_host_id(host3, ip3);
-        tm.update_topology(host1, locator::endpoint_dc_rack::default_location, std::nullopt, 1);
-        tm.update_topology(host2, locator::endpoint_dc_rack::default_location, std::nullopt, 1);
-        tm.update_topology(host3, locator::endpoint_dc_rack::default_location, std::nullopt, 2);
+        tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, 1);
+        tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, 1);
+        tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::normal, 2);
 
         tablet_map tmap(4);
         std::optional<tablet_id> tid = tmap.first_tablet();
@@ -1643,6 +1651,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_shuffle_mode) {
     shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
         locator::topology::config{
             .this_endpoint = ip1,
+            .this_host_id = host1,
             .local_dc_rack = locator::endpoint_dc_rack::default_location
         }
     });
@@ -1651,9 +1660,9 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_shuffle_mode) {
         tm.update_host_id(host1, ip1);
         tm.update_host_id(host2, ip2);
         tm.update_host_id(host3, ip3);
-        tm.update_topology(host1, locator::endpoint_dc_rack::default_location, std::nullopt, 1);
-        tm.update_topology(host2, locator::endpoint_dc_rack::default_location, std::nullopt, 1);
-        tm.update_topology(host3, locator::endpoint_dc_rack::default_location, std::nullopt, 2);
+        tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, 1);
+        tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, 1);
+        tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::normal, 2);
 
         tablet_map tmap(4);
         std::optional<tablet_id> tid = tmap.first_tablet();
@@ -1706,6 +1715,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_two_empty_nodes) {
     shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
         locator::topology::config{
             .this_endpoint = ip1,
+            .this_host_id = host1,
             .local_dc_rack = locator::endpoint_dc_rack::default_location
         }
     });
@@ -1715,10 +1725,10 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_two_empty_nodes) {
         tm.update_host_id(host2, ip2);
         tm.update_host_id(host3, ip3);
         tm.update_host_id(host4, ip4);
-        tm.update_topology(host1, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
-        tm.update_topology(host2, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
-        tm.update_topology(host3, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
-        tm.update_topology(host4, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+        tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
+        tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
+        tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
+        tm.update_topology(host4, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
 
         tablet_map tmap(16);
         for (auto tid : tmap.tablet_ids()) {
@@ -1766,6 +1776,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_disabling) {
         shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
             locator::topology::config{
                 .this_endpoint = ip1,
+                .this_host_id = host1,
                 .local_dc_rack = locator::endpoint_dc_rack::default_location
             }
         });
@@ -1775,8 +1786,8 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_disabling) {
         stm.mutate_token_metadata([&] (auto& tm) {
             tm.update_host_id(host1, ip1);
             tm.update_host_id(host2, ip2);
-            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
-            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
+            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
 
             tablet_map tmap(16);
             for (auto tid : tmap.tablet_ids()) {
@@ -1865,7 +1876,7 @@ SEASTAR_THREAD_TEST_CASE(test_drained_node_is_not_balanced_internally) {
             tm.update_host_id(host1, ip1);
             tm.update_host_id(host2, ip2);
             tm.update_topology(host1, locator::endpoint_dc_rack::default_location, locator::node::state::being_removed, shard_count);
-            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
 
             tablet_map tmap(16);
             for (auto tid : tmap.tablet_ids()) {
@@ -1939,7 +1950,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
                 auto shard_count = 2;
                 tm.update_host_id(h, ip);
                 auto rack = racks[i % racks.size()];
-                tm.update_topology(h, rack, std::nullopt, shard_count);
+                tm.update_topology(h, rack, node::state::normal, shard_count);
                 if (h != hosts[0]) {
                     // Leave the first host empty by making it invisible to allocation algorithm.
                     hosts_by_rack[rack.rack].push_back(h);
@@ -2105,8 +2116,8 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
         stm.mutate_token_metadata([&] (token_metadata& tm) {
             tm.update_host_id(host1, ip1);
             tm.update_host_id(host2, ip2);
-            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
-            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, std::nullopt, shard_count);
+            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
+            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
 
             tablet_map tmap(2);
             for (auto tid : tmap.tablet_ids()) {
@@ -2386,7 +2397,7 @@ static void execute_tablet_for_new_rf_test(calculate_tablet_replicas_for_new_rf_
         for (const auto& [ring_point, endpoint, id] : test_config.ring_points) {
             std::unordered_set<token> tokens;
             tokens.insert({dht::token::kind::key, tests::d2t(ring_point / test_config.ring_points.size())});
-            topo.add_node(id, endpoint, make_endpoint_dc_rack(endpoint), locator::node::state::normal, 1);
+            topo.add_or_update_endpoint(id, endpoint, make_endpoint_dc_rack(endpoint), locator::node::state::normal, 1);
             tm.update_host_id(id, endpoint);
             co_await tm.update_normal_tokens(std::move(tokens), id);
         }
@@ -2409,7 +2420,7 @@ static void execute_tablet_for_new_rf_test(calculate_tablet_replicas_for_new_rf_
         for (size_t i = 0; i < test_config.ring_points.size(); ++i) {
             auto& [ring_point, endpoint, id] = test_config.ring_points[i];
             tm.update_host_id(id, endpoint);
-            tm.update_topology(id, make_endpoint_dc_rack(endpoint), std::nullopt, nodes_shard_count[i]);
+            tm.update_topology(id, make_endpoint_dc_rack(endpoint), node::state::normal, nodes_shard_count[i]);
         }
         return make_ready_future<>();
     }).get();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -607,7 +607,7 @@ private:
             db::view::node_update_backlog b(smp::count, 10ms);
             scheduling_group_key_config sg_conf =
                     make_scheduling_group_key_config<service::storage_proxy_stats::stats>();
-            _proxy.start(std::ref(_db), spcfg, std::ref(b), scheduling_group_key_create(sg_conf).get(), std::ref(_feature_service), std::ref(_token_metadata), std::ref(_erm_factory)).get();
+            _proxy.start(std::ref(_db), spcfg, std::ref(b), scheduling_group_key_create(sg_conf).get(), std::ref(_feature_service), std::ref(_token_metadata)).get();
             auto stop_proxy = defer([this] { _proxy.stop().get(); });
 
             _cql_config.start(cql3::cql_config::default_tag{}).get();
@@ -642,7 +642,7 @@ private:
             _sys_ks.start(std::ref(_qp), std::ref(_db)).get();
             auto stop_sys_kd = defer([this] { _sys_ks.stop().get(); });
 
-            replica::distributed_loader::init_system_keyspace(_sys_ks, _erm_factory, _db).get();
+            replica::distributed_loader::init_system_keyspace(_sys_ks, _db).get();
             _db.local().init_schema_commitlog();
             _sys_ks.invoke_on_all(&db::system_keyspace::mark_writable).get();
 
@@ -778,7 +778,7 @@ private:
                 std::ref(_sys_ks),
                 std::ref(_sys_dist_ks),
                 std::ref(_feature_service), std::ref(_mm),
-                std::ref(_token_metadata), std::ref(_erm_factory), std::ref(_ms),
+                std::ref(_token_metadata), std::ref(_ms),
                 std::ref(_repair),
                 std::ref(_stream_manager),
                 std::ref(_elc_notif),

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -589,7 +589,7 @@ private:
             _lang_manager.invoke_on_all(&lang::manager::start).get();
 
 
-            _db.start(std::ref(*cfg), dbcfg, std::ref(_mnotifier), std::ref(_feature_service), std::ref(_token_metadata), std::ref(_cm), std::ref(_sstm), std::ref(_lang_manager), std::ref(_sst_dir_semaphore), utils::cross_shard_barrier()).get();
+            _db.start(std::ref(*cfg), dbcfg, std::ref(_mnotifier), std::ref(_feature_service), std::ref(_token_metadata), std::ref(_erm_factory), std::ref(_cm), std::ref(_sstm), std::ref(_lang_manager), std::ref(_sst_dir_semaphore), utils::cross_shard_barrier()).get();
             auto stop_db = defer([this] {
                 _db.stop().get();
             });

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -657,16 +657,9 @@ private:
                 host_id = linfo.host_id;
                 _sys_ks.local().save_local_info(std::move(linfo), _snitch.local()->get_location(), my_address, my_address).get();
             }
-            locator::shared_token_metadata::mutate_on_all_shards(_token_metadata, [hostid = host_id, &cfg_in] (locator::token_metadata& tm) {
-                auto& topo = tm.get_topology();
-                topo.set_host_id_cfg(hostid);
-                topo.add_or_update_endpoint(hostid,
-                                            cfg_in.broadcast_address,
-                                            std::nullopt,
-                                            locator::node::state::normal,
-                                            smp::count);
-                return make_ready_future<>();
-            }).get();
+
+            replica::database::set_this_node(_db, host_id, cfg_in.broadcast_address,
+                    std::nullopt, locator::node::state::normal, smp::count).get();
 
             uint16_t port = 7000;
             if (cfg_in.ms_listen) {


### PR DESCRIPTION
This series augments the interface of effective_replication_map to return host_id-based replica sets
and uses it both on the write path, in create_write_response_handler_helper and mutation_holder::store_hint
to prevent cases where we cannot map an inet_address back to its host_id, and for the read path, by using host_id replica sets rather than inet_address-based replica sets.

perf-simple-query results:
```
pre:  98593.70 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42688 insns/op,        0 errors)
post: 97411.54 tps ( 62.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42486 insns/op,        0 errors)
```
perf-simple-query --write results:
```
pre:  79118.71 tps ( 59.3 allocs/op,  16.0 logallocs/op,  14.3 tasks/op,   54122 insns/op,        0 errors)
post: 78273.52 tps ( 59.3 allocs/op,  16.0 logallocs/op,  14.3 tasks/op,   54151 insns/op,        0 errors)
```

Refs https://github.com/scylladb/scylladb/issues/12280

- [x] This change is too intrusive to backport