### PR TITLE
Downsize badly estimated large Bloom filters before sealing SSTables

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -467,6 +467,7 @@ scylla_tests = set([
     'test/boost/auth_test',
     'test/boost/batchlog_manager_test',
     'test/boost/big_decimal_test',
+    'test/boost/bloom_filter_test',
     'test/boost/broken_sstable_test',
     'test/boost/bytes_ostream_test',
     'test/boost/cache_algorithm_test',

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -11,12 +11,9 @@
 #include "encoding_stats.hh"
 #include "schema/schema.hh"
 #include "mutation/mutation_fragment.hh"
-#include "vint-serialization.hh"
 #include "sstables/types.hh"
 #include "sstables/mx/types.hh"
-#include "db/config.hh"
 #include "mutation/atomic_cell.hh"
-#include "utils/exceptions.hh"
 #include "db/large_data_handler.hh"
 
 #include <functional>

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1470,6 +1470,7 @@ void writer::consume_end_of_stream() {
         _sst._schema, _sst.get_first_decorated_key(), _sst.get_last_decorated_key(), _enc_stats);
     close_data_writer();
     _sst.write_summary();
+    utils::i_filter::maybe_fold_filter(_sst._components->filter, _num_partitions_consumed, _schema.bloom_filter_fp_chance());
     _sst.write_filter();
     _sst.write_statistics();
     _sst.write_compression();

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -544,6 +544,7 @@ private:
     std::optional<key> _first_key, _last_key;
     index_sampling_state _index_sampling_state;
     bytes_ostream _tmp_bufs;
+    uint64_t _num_partitions_consumed = 0;
 
     const sstable_schema _sst_schema;
 
@@ -924,6 +925,7 @@ void writer::consume_new_partition(const dht::decorated_key& dk) {
 
     _sst._components->filter->add(bytes_view(*_partition_key));
     _collector.add_key(bytes_view(*_partition_key));
+    _num_partitions_consumed++;
 
     auto p_key = disk_string_view<uint16_t>();
     p_key.value = bytes_view(*_partition_key);

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -19,6 +19,8 @@ add_scylla_test(batchlog_manager_test
 add_scylla_test(big_decimal_test
   KIND BOOST
   LIBRARIES utils)
+add_scylla_test(bloom_filter_test
+  KIND SEASTAR)
 add_scylla_test(bptree_test
   KIND BOOST
   LIBRARIES utils)

--- a/test/boost/bloom_filter_test.cc
+++ b/test/boost/bloom_filter_test.cc
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <seastar/testing/test_case.hh>
+
+#include "test/lib/eventually.hh"
+#include "test/lib/simple_schema.hh"
+#include "test/lib/sstable_test_env.hh"
+#include "test/lib/sstable_utils.hh"
+
+SEASTAR_TEST_CASE(test_sstable_reclaim_memory_from_components_and_reload_reclaimed_components) {
+    return test_env::do_with_async([] (test_env& env) {
+        simple_schema ss;
+        auto schema_ptr = ss.schema();
+        auto sst = env.make_sstable(schema_ptr);
+
+        // create a bloom filter
+        auto sst_test = sstables::test(sst);
+        sst_test.create_bloom_filter(100);
+        sst_test.write_filter();
+        auto total_reclaimable_memory = sst_test.total_reclaimable_memory_size();
+
+        // Test sstable::reclaim_memory_from_components() :
+        BOOST_REQUIRE_EQUAL(sst_test.reclaim_memory_from_components(), total_reclaimable_memory);
+        // No more memory to reclaim in the sstable
+        BOOST_REQUIRE_EQUAL(sst_test.total_reclaimable_memory_size(), 0);
+        BOOST_REQUIRE_EQUAL(sst->filter_memory_size(), 0);
+
+        // Test sstable::reload_reclaimed_components() :
+        // Reloading should load the bloom filter back into memory
+        sst_test.reload_reclaimed_components();
+        // SSTable should have reclaimable memory from the bloom filter
+        BOOST_REQUIRE_EQUAL(sst_test.total_reclaimable_memory_size(), total_reclaimable_memory);
+        BOOST_REQUIRE_EQUAL(sst->filter_memory_size(), total_reclaimable_memory);
+    });
+}
+
+std::pair<shared_sstable, size_t> create_sstable_with_bloom_filter(test_env& env, test_env_sstables_manager& sst_mgr, schema_ptr sptr, uint64_t estimated_partitions) {
+    auto sst = env.make_sstable(sptr);
+    sstables::test(sst).create_bloom_filter(estimated_partitions);
+    sstables::test(sst).write_filter();
+    auto sst_bf_memory = sst->filter_memory_size();
+    sst_mgr.increment_total_reclaimable_memory_and_maybe_reclaim(sst.get());
+    return {sst, sst_bf_memory};
+}
+
+SEASTAR_TEST_CASE(test_sstable_manager_auto_reclaim_and_reload_of_bloom_filter) {
+    return test_env::do_with_async([] (test_env& env) {
+        simple_schema ss;
+        auto schema_ptr = ss.schema();
+
+        auto& sst_mgr = env.manager();
+
+        // Verify nothing it reclaimed when under threshold
+        auto [sst1, sst1_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 70);
+        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), sst1_bf_memory);
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), 0);
+
+        auto [sst2, sst2_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 20);
+        // Confirm reclaim was still not triggered
+        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), sst1_bf_memory);
+        BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), 0);
+
+        // Verify manager reclaims from the largest sst when the total usage crosses thresold.
+        auto [sst3, sst3_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 50);
+        // sst1 has the most reclaimable memory
+        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), 0);
+        BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
+        BOOST_REQUIRE_EQUAL(sst3->filter_memory_size(), sst3_bf_memory);
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst1_bf_memory);
+
+        // Reclaim should also work on the latest sst being added
+        auto [sst4, sst4_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 100);
+        // sst4 should have been reclaimed
+        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), 0);
+        BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
+        BOOST_REQUIRE_EQUAL(sst3->filter_memory_size(), sst3_bf_memory);
+        BOOST_REQUIRE_EQUAL(sst4->filter_memory_size(), 0);
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst1_bf_memory + sst4_bf_memory);
+
+        // Test auto reload - disposing sst3 should trigger reload of the
+        // smallest filter in the reclaimed list, which is sst1's bloom filter.
+        shared_sstable::dispose(sst3.release().release());
+        REQUIRE_EVENTUALLY_EQUAL(sst1->filter_memory_size(), sst1_bf_memory);
+        // only sst4's bloom filter memory should be reported as reclaimed
+        REQUIRE_EVENTUALLY_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst4_bf_memory);
+        // sst2 and sst4 remain the same
+        BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
+        BOOST_REQUIRE_EQUAL(sst4->filter_memory_size(), 0);
+    }, {
+        // limit available memory to the sstables_manager to test reclaiming.
+        // this will set the reclaim threshold to 100 bytes.
+        .available_memory = 1000
+    });
+}
+
+// Reproducer for https://github.com/scylladb/scylladb/issues/18398.
+SEASTAR_TEST_CASE(test_reclaimed_bloom_filter_deletion_from_disk) {
+    return test_env::do_with_async([] (test_env& env) {
+        simple_schema ss;
+        auto s = ss.schema();
+        auto pks = ss.make_pkeys(1);
+
+        auto mut1 = mutation(s, pks[0]);
+        mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
+        auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)});
+        auto sst_test = sstables::test(sst);
+
+        const auto filter_path = (env.tempdir().path() / sst_test.filename(component_type::Filter)).native();
+        // confirm that the filter exists in disk
+        BOOST_REQUIRE(file_exists(filter_path).get());
+
+        // reclaim filter from memory and unlink the sst
+        sst_test.reclaim_memory_from_components();
+        sst->unlink().get();
+
+        // verify the filter doesn't exist in disk anymore
+        BOOST_REQUIRE(!file_exists(filter_path).get());
+    });
+}
+
+SEASTAR_TEST_CASE(test_bloom_filter_reclaim_during_reload) {
+    return test_env::do_with_async([](test_env& env) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+        fmt::print("Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n");
+        return;
+#endif
+        simple_schema ss;
+        auto schema_ptr = ss.schema();
+
+        auto& sst_mgr = env.manager();
+
+        auto [sst1, sst1_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 100);
+        // there is sufficient memory for sst1's filter
+        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), sst1_bf_memory);
+
+        auto [sst2, sst2_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 60);
+        // total memory used by the bloom filters has crossed the threshold, so sst1's
+        // filter, which occupies the most memory, will be discarded from memory.
+        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), 0);
+        BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst1_bf_memory);
+
+        // enable injector that delays reloading a filter
+        utils::get_local_injector().enable("reload_reclaimed_components/pause", true);
+
+        // dispose sst2 to trigger reload of sst1's bloom filter
+        shared_sstable::dispose(sst2.release().release());
+        // _total_reclaimable_memory will be updated when the reload begins; wait for it.
+        REQUIRE_EVENTUALLY_EQUAL(sst_mgr.get_total_reclaimable_memory(), sst1_bf_memory);
+
+        // now that the reload is midway and paused, create new sst to verify that its
+        // filter gets evicted immediately as the memory that became available is reserved
+        // for sst1's filter reload.
+        auto [sst3, sst3_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 80);
+        BOOST_REQUIRE_EQUAL(sst3->filter_memory_size(), 0);
+        // confirm sst1 is not reloaded yet
+        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), 0);
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst1_bf_memory + sst3_bf_memory);
+
+        // resume reloading sst1 filter
+        utils::get_local_injector().receive_message("reload_reclaimed_components/pause");
+        REQUIRE_EVENTUALLY_EQUAL(sst1->filter_memory_size(), sst1_bf_memory);
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_reclaimable_memory(), sst1_bf_memory);
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst3_bf_memory);
+
+        utils::get_local_injector().disable("reload_reclaimed_components/pause");
+    }, {
+        // limit available memory to the sstables_manager to test reclaiming.
+        // this will set the reclaim threshold to 100 bytes.
+        .available_memory = 1000
+    });
+}

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -17,7 +17,6 @@
 #include "sstables/sstables.hh"
 #include "sstables/compress.hh"
 #include "sstables/metadata_collector.hh"
-#include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "schema/schema.hh"
 #include "schema/schema_builder.hh"
@@ -54,7 +53,6 @@
 #include "readers/from_fragments_v2.hh"
 #include "test/lib/random_schema.hh"
 #include "test/lib/exception_utils.hh"
-#include "test/lib/eventually.hh"
 
 namespace fs = std::filesystem;
 
@@ -3177,170 +3175,5 @@ SEASTAR_TEST_CASE(test_sstable_set_predicate) {
             testlog.info("inclusive_pred: range query");
             verify_reader_result(make_full_scan_reader(inclusive_pred), false);
         }
-    });
-}
-
-SEASTAR_TEST_CASE(test_sstable_reclaim_memory_from_components_and_reload_reclaimed_components) {
-    return test_env::do_with_async([] (test_env& env) {
-        simple_schema ss;
-        auto schema_ptr = ss.schema();
-        auto sst = env.make_sstable(schema_ptr);
-
-        // create a bloom filter
-        auto sst_test = sstables::test(sst);
-        sst_test.create_bloom_filter(100);
-        sst_test.write_filter();
-        auto total_reclaimable_memory = sst_test.total_reclaimable_memory_size();
-
-        // Test sstable::reclaim_memory_from_components() :
-        BOOST_REQUIRE_EQUAL(sst_test.reclaim_memory_from_components(), total_reclaimable_memory);
-        // No more memory to reclaim in the sstable
-        BOOST_REQUIRE_EQUAL(sst_test.total_reclaimable_memory_size(), 0);
-        BOOST_REQUIRE_EQUAL(sst->filter_memory_size(), 0);
-
-        // Test sstable::reload_reclaimed_components() :
-        // Reloading should load the bloom filter back into memory
-        sst_test.reload_reclaimed_components();
-        // SSTable should have reclaimable memory from the bloom filter
-        BOOST_REQUIRE_EQUAL(sst_test.total_reclaimable_memory_size(), total_reclaimable_memory);
-        BOOST_REQUIRE_EQUAL(sst->filter_memory_size(), total_reclaimable_memory);
-    });
-}
-
-std::pair<shared_sstable, size_t> create_sstable_with_bloom_filter(test_env& env, test_env_sstables_manager& sst_mgr, schema_ptr sptr, uint64_t estimated_partitions) {
-    auto sst = env.make_sstable(sptr);
-    sstables::test(sst).create_bloom_filter(estimated_partitions);
-    sstables::test(sst).write_filter();
-    auto sst_bf_memory = sst->filter_memory_size();
-    sst_mgr.increment_total_reclaimable_memory_and_maybe_reclaim(sst.get());
-    return {sst, sst_bf_memory};
-}
-
-SEASTAR_TEST_CASE(test_sstable_manager_auto_reclaim_and_reload_of_bloom_filter) {
-    return test_env::do_with_async([] (test_env& env) {
-        simple_schema ss;
-        auto schema_ptr = ss.schema();
-
-        auto& sst_mgr = env.manager();
-
-        // Verify nothing it reclaimed when under threshold
-        auto [sst1, sst1_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 70);
-        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), sst1_bf_memory);
-        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), 0);
-
-        auto [sst2, sst2_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 20);
-        // Confirm reclaim was still not triggered
-        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), sst1_bf_memory);
-        BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
-        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), 0);
-
-        // Verify manager reclaims from the largest sst when the total usage crosses thresold.
-        auto [sst3, sst3_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 50);
-        // sst1 has the most reclaimable memory
-        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), 0);
-        BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
-        BOOST_REQUIRE_EQUAL(sst3->filter_memory_size(), sst3_bf_memory);
-        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst1_bf_memory);
-
-        // Reclaim should also work on the latest sst being added
-        auto [sst4, sst4_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 100);
-        // sst4 should have been reclaimed
-        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), 0);
-        BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
-        BOOST_REQUIRE_EQUAL(sst3->filter_memory_size(), sst3_bf_memory);
-        BOOST_REQUIRE_EQUAL(sst4->filter_memory_size(), 0);
-        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst1_bf_memory + sst4_bf_memory);
-
-        // Test auto reload - disposing sst3 should trigger reload of the
-        // smallest filter in the reclaimed list, which is sst1's bloom filter.
-        shared_sstable::dispose(sst3.release().release());
-        REQUIRE_EVENTUALLY_EQUAL(sst1->filter_memory_size(), sst1_bf_memory);
-        // only sst4's bloom filter memory should be reported as reclaimed
-        REQUIRE_EVENTUALLY_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst4_bf_memory);
-        // sst2 and sst4 remain the same
-        BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
-        BOOST_REQUIRE_EQUAL(sst4->filter_memory_size(), 0);
-    }, {
-        // limit available memory to the sstables_manager to test reclaiming.
-        // this will set the reclaim threshold to 100 bytes.
-        .available_memory = 1000
-    });
-}
-
-// Reproducer for https://github.com/scylladb/scylladb/issues/18398.
-SEASTAR_TEST_CASE(test_reclaimed_bloom_filter_deletion_from_disk) {
-    return test_env::do_with_async([] (test_env& env) {
-        simple_schema ss;
-        auto s = ss.schema();
-        auto pks = ss.make_pkeys(1);
-
-        auto mut1 = mutation(s, pks[0]);
-        mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
-        auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)});
-        auto sst_test = sstables::test(sst);
-
-        const auto filter_path = (env.tempdir().path() / sst_test.filename(component_type::Filter)).native();
-        // confirm that the filter exists in disk
-        BOOST_REQUIRE(file_exists(filter_path).get());
-
-        // reclaim filter from memory and unlink the sst
-        sst_test.reclaim_memory_from_components();
-        sst->unlink().get();
-
-        // verify the filter doesn't exist in disk anymore
-        BOOST_REQUIRE(!file_exists(filter_path).get());
-    });
-}
-
-SEASTAR_TEST_CASE(test_bloom_filter_reclaim_during_reload) {
-    return test_env::do_with_async([](test_env& env) {
-#ifndef SCYLLA_ENABLE_ERROR_INJECTION
-        fmt::print("Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n");
-        return;
-#endif
-        simple_schema ss;
-        auto schema_ptr = ss.schema();
-
-        auto& sst_mgr = env.manager();
-
-        auto [sst1, sst1_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 100);
-        // there is sufficient memory for sst1's filter
-        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), sst1_bf_memory);
-
-        auto [sst2, sst2_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 60);
-        // total memory used by the bloom filters has crossed the threshold, so sst1's
-        // filter, which occupies the most memory, will be discarded from memory.
-        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), 0);
-        BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
-        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst1_bf_memory);
-
-        // enable injector that delays reloading a filter
-        utils::get_local_injector().enable("reload_reclaimed_components/pause", true);
-
-        // dispose sst2 to trigger reload of sst1's bloom filter
-        shared_sstable::dispose(sst2.release().release());
-        // _total_reclaimable_memory will be updated when the reload begins; wait for it.
-        REQUIRE_EVENTUALLY_EQUAL(sst_mgr.get_total_reclaimable_memory(), sst1_bf_memory);
-
-        // now that the reload is midway and paused, create new sst to verify that its
-        // filter gets evicted immediately as the memory that became available is reserved
-        // for sst1's filter reload.
-        auto [sst3, sst3_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 80);
-        BOOST_REQUIRE_EQUAL(sst3->filter_memory_size(), 0);
-        // confirm sst1 is not reloaded yet
-        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), 0);
-        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst1_bf_memory + sst3_bf_memory);
-
-        // resume reloading sst1 filter
-        utils::get_local_injector().receive_message("reload_reclaimed_components/pause");
-        REQUIRE_EVENTUALLY_EQUAL(sst1->filter_memory_size(), sst1_bf_memory);
-        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_reclaimable_memory(), sst1_bf_memory);
-        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst3_bf_memory);
-
-        utils::get_local_injector().disable("reload_reclaimed_components/pause");
-    }, {
-        // limit available memory to the sstables_manager to test reclaiming.
-        // this will set the reclaim threshold to 100 bytes.
-        .available_memory = 1000
     });
 }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -217,6 +217,10 @@ public:
         _sst->_total_reclaimable_memory.reset();
     }
 
+    future<> read_filter() noexcept {
+        return _sst->read_filter();
+    }
+
     void write_filter() {
         _sst->_recognized_components.insert(component_type::Filter);
         _sst->write_filter();
@@ -232,6 +236,10 @@ public:
 
     void reload_reclaimed_components() {
         _sst->reload_reclaimed_components().get();
+    }
+
+    utils::filter_ptr& get_filter() {
+        return _sst->_components->filter;
     }
 };
 

--- a/utils/bloom_filter.cc
+++ b/utils/bloom_filter.cc
@@ -108,15 +108,18 @@ void bloom_filter::fold(const size_t new_num_bits) {
     _bitset.shrink(new_num_bits);
 }
 
+size_t get_bitset_size(int64_t num_elements, int buckets_per) {
+    int64_t num_bits = (num_elements * buckets_per) + bloom_calculations::EXCESS;
+    num_bits = align_up<int64_t>(num_bits, 64);  // Seems to be implied in origin
+    return num_bits;
+}
+
 filter_ptr create_filter(int hash, large_bitset&& bitset, filter_format format) {
     return std::make_unique<murmur3_bloom_filter>(hash, std::move(bitset), format);
 }
 
 filter_ptr create_filter(int hash, int64_t num_elements, int buckets_per, filter_format format) {
-    int64_t num_bits = (num_elements * buckets_per) + bloom_calculations::EXCESS;
-    num_bits = align_up<int64_t>(num_bits, 64);  // Seems to be implied in origin
-    large_bitset bitset(num_bits);
-    return std::make_unique<murmur3_bloom_filter>(hash, std::move(bitset), format);
+    return std::make_unique<murmur3_bloom_filter>(hash, large_bitset(get_bitset_size(num_elements, buckets_per)), format);
 }
 }
 }

--- a/utils/bloom_filter.cc
+++ b/utils/bloom_filter.cc
@@ -18,9 +18,11 @@
 #include <cstdlib>
 #include "utils/bloom_calculations.hh"
 #include "bloom_filter.hh"
+#include "log.hh"
 
 namespace utils {
 namespace filter {
+static logging::logger filterlog("bloom_filter");
 
 thread_local bloom_filter::stats bloom_filter::_shard_stats;
 

--- a/utils/bloom_filter.hh
+++ b/utils/bloom_filter.hh
@@ -13,6 +13,7 @@
 #pragma once
 #include "i_filter.hh"
 #include "utils/large_bitset.hh"
+#include <cstddef>
 
 namespace utils {
 namespace filter {
@@ -53,6 +54,10 @@ public:
     virtual size_t memory_size() override {
         return sizeof(_hash_count) + _bitset.memory_size();
     }
+
+    // Downsize the existing bloom filter's bitmap by folding it into new_num_bits.
+    // The folding is done in-place and should be called only on unsealed sstable filters.
+    virtual void fold(const size_t new_num_bits);
 
     static const stats& get_shard_stats() noexcept {
         return _shard_stats;

--- a/utils/bloom_filter.hh
+++ b/utils/bloom_filter.hh
@@ -92,6 +92,9 @@ struct always_present_filter: public i_filter {
     }
 };
 
+// Get the size of the bitset (in bits, not bytes) for the specific parameters.
+size_t get_bitset_size(int64_t num_elements, int buckets_per);
+
 filter_ptr create_filter(int hash, large_bitset&& bitset, filter_format format);
 filter_ptr create_filter(int hash, int64_t num_elements, int buckets_per, filter_format format);
 }

--- a/utils/bloom_filter.hh
+++ b/utils/bloom_filter.hh
@@ -97,5 +97,9 @@ size_t get_bitset_size(int64_t num_elements, int buckets_per);
 
 filter_ptr create_filter(int hash, large_bitset&& bitset, filter_format format);
 filter_ptr create_filter(int hash, int64_t num_elements, int buckets_per, filter_format format);
+
+// Fold the filter if the size of the filter that was based on the estimated
+// parameters differs largely from the size computed from the actual parameters.
+void maybe_fold_filter(filter_ptr& filter, int64_t num_elements, int buckets_per);
 }
 }

--- a/utils/i_filter.cc
+++ b/utils/i_filter.cc
@@ -30,6 +30,17 @@ filter_ptr i_filter::get_filter(int64_t num_elements, double max_false_pos_proba
     return filter::create_filter(spec.K, num_elements, spec.buckets_per_element, fformat);
 }
 
+size_t i_filter::get_filter_size(int64_t num_elements, double max_false_pos_probability) {
+    if (max_false_pos_probability >= 1.0) {
+        return 0;
+    }
+
+    int buckets_per_element = bloom_calculations::max_buckets_per_element(num_elements);
+    auto spec = bloom_calculations::compute_bloom_spec(buckets_per_element, max_false_pos_probability);
+
+    return filter::get_bitset_size(num_elements, spec.buckets_per_element) / 8;
+}
+
 hashed_key make_hashed_key(bytes_view b) {
     std::array<uint64_t, 2> h;
     utils::murmur_hash::hash3_x64_128(b, 0, h);

--- a/utils/i_filter.cc
+++ b/utils/i_filter.cc
@@ -41,6 +41,16 @@ size_t i_filter::get_filter_size(int64_t num_elements, double max_false_pos_prob
     return filter::get_bitset_size(num_elements, spec.buckets_per_element) / 8;
 }
 
+void i_filter::maybe_fold_filter(filter_ptr& filter, int64_t num_elements, double max_false_pos_probability) {
+    if (max_false_pos_probability == 1.0) {
+        return;
+    }
+
+    int buckets_per_element = bloom_calculations::max_buckets_per_element(num_elements);
+    auto spec = bloom_calculations::compute_bloom_spec(buckets_per_element, max_false_pos_probability);
+    filter::maybe_fold_filter(filter, num_elements, spec.buckets_per_element);
+}
+
 hashed_key make_hashed_key(bytes_view b) {
     std::array<uint64_t, 2> h;
     utils::murmur_hash::hash3_x64_128(b, 0, h);

--- a/utils/i_filter.cc
+++ b/utils/i_filter.cc
@@ -7,14 +7,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include "log.hh"
 #include "bloom_filter.hh"
 #include "bloom_calculations.hh"
 #include "utils/murmur_hash.hh"
 #include <seastar/core/thread.hh>
 
 namespace utils {
-static logging::logger filterlog("bloom_filter");
 
 filter_ptr i_filter::get_filter(int64_t num_elements, double max_false_pos_probability, filter_format fformat) {
     assert(seastar::thread::running_in_thread());

--- a/utils/i_filter.hh
+++ b/utils/i_filter.hh
@@ -52,5 +52,10 @@ struct i_filter {
      *         filter.
      */
     static filter_ptr get_filter(int64_t num_elements, double max_false_pos_prob, filter_format format);
+
+    /**
+     * @return the size of the smallest filter (in bytes), according to the conditions described at get_filter()
+     */
+    static size_t get_filter_size(int64_t num_elements, double max_false_pos_prob);
 };
 }

--- a/utils/i_filter.hh
+++ b/utils/i_filter.hh
@@ -57,5 +57,10 @@ struct i_filter {
      * @return the size of the smallest filter (in bytes), according to the conditions described at get_filter()
      */
     static size_t get_filter_size(int64_t num_elements, double max_false_pos_prob);
+
+    /**
+     * Fold the given filter if it is too large for the given num_elements and FP rate.
+     */
+    static void maybe_fold_filter(filter_ptr& filter, int64_t num_elements, double max_false_pos_probability);
 };
 }

--- a/utils/large_bitset.cc
+++ b/utils/large_bitset.cc
@@ -45,3 +45,30 @@ large_bitset::clear() {
         }
     }
 }
+
+void large_bitset::shrink(size_t new_nr_bits) {
+    assert(thread::running_in_thread());
+
+    if (_nr_bits <= new_nr_bits) {
+        // can only shrink
+        return;
+    }
+
+    const size_t new_nr_ints = align_up(new_nr_bits, bits_per_int()) / bits_per_int();
+    while (_storage.size() > new_nr_ints) {
+        _storage.pop_back();
+        if (need_preempt()) {
+            thread::yield();
+        }
+    }
+
+    // clear any bits beyond new_nr_bits in the last int
+    auto num_of_bits_to_clear = (new_nr_ints * bits_per_int()) - new_nr_bits;
+    if (num_of_bits_to_clear > 0) {
+        auto &last_int = _storage.back();
+        last_int = ((last_int << num_of_bits_to_clear) >> num_of_bits_to_clear);
+    }
+
+    _storage.shrink_to_fit();
+    _nr_bits = new_nr_bits;
+}

--- a/utils/large_bitset.cc
+++ b/utils/large_bitset.cc
@@ -7,10 +7,8 @@
  */
 
 #include "large_bitset.hh"
-#include <algorithm>
 #include <seastar/core/align.hh>
 #include <seastar/core/thread.hh>
-#include "seastarx.hh"
 
 using namespace seastar;
 

--- a/utils/large_bitset.hh
+++ b/utils/large_bitset.hh
@@ -61,4 +61,6 @@ public:
     const utils::chunked_vector<int_type>& get_storage() const {
         return _storage;
     }
+
+    void shrink(size_t new_nr_bits);
 };


### PR DESCRIPTION
Bloom filter sizes are computed based on partition estimates, which can lead to oversized filters if the estimates are inaccurate. This PR addresses this issue by attempting to downsize oversized Bloom filters based on the actual partition count available just before the SSTables are sealed. If the Bloom filter size is more than  1.5 * expected size, it will be downsized by folding the filter into a smaller size that is closer to the expected size and is a numerical factor of the original size. 

Fixes https://github.com/scylladb/scylladb/issues/19049

Note :
This downsizing is not guaranteed and depends on the existence of valid numerical factors of the original size.
Consider this example :
 - estimated partition count = 5000 => bitmap size (number of bits in the filter) = 25024
  - actual partition count = 1000 => bitmap size = 5056.

So, the bloom filter is almost 5 times more than the optimal size.

The valid factors of this original bitmap size (25024) that are also aligned to 64 (format requirement) are : 1472, 1088 and 64. So, the best possible folding size we have is 1472 which is a lot less than the ideal 5056. So, by folding we might lose information and end up increasing the FP rate. This PR actually chooses only valid factors that are >= ideal size for folding, so in this case folding doesn't happen. 

The problem here is the original bitmap size has large prime number factors - 17 and 23. In my experiment, a lot of bitmap sizes, computed by the code based on estimated count, had large prime factors, preventing folding from happening. I don't fully understand how they come in to play but they are related to the [probs](https://github.com/scylladb/scylladb/blob/a86fb293fe4a3fae1245e12dd6aaa86dfc344a13/utils/bloom_calculations.cc#L24) and [compute_bloom_spec](https://github.com/scylladb/scylladb/blob/a86fb293fe4a3fae1245e12dd6aaa86dfc344a13/utils/bloom_calculations.hh#L78).

@denesb suggested that we could probably try make the original bitmap size more nice. (i.e) once [compute_bloom_spec](https://github.com/scylladb/scylladb/blob/a86fb293fe4a3fae1245e12dd6aaa86dfc344a13/utils/bloom_calculations.hh#L78) gives us the spec, we could increment/decrement it a bit to make it have better factors that will make folding possible. I'm looking into that right now.

Refs #2024