### PR TITLE
test: test_topology_ops: stop a write worker after the first error

### DIFF
--- a/test/topology_experimental_raft/test_topology_ops.py
+++ b/test/topology_experimental_raft/test_topology_ops.py
@@ -101,7 +101,6 @@ async def start_writes(cql: Session, concurrency: int = 3):
 
     async def do_writes(worker_id: int):
         write_count = 0
-        last_error = None
         while not stop_event.is_set():
             start_time = time.time()
             try:
@@ -109,10 +108,8 @@ async def start_writes(cql: Session, concurrency: int = 3):
                 write_count += 1
             except Exception as e:
                 logger.error(f"Write started {time.time() - start_time}s ago failed: {e}")
-                last_error = e
+                raise
         logger.info(f"Worker #{worker_id} did {write_count} successful writes")
-        if last_error is not None:
-            raise last_error
 
     tasks = [asyncio.create_task(do_writes(worker_id)) for worker_id in range(concurrency)]
 


### PR DESCRIPTION
`test_topology_ops` is flaky, which has been uncovered by gating
in scylladb/scylladb#18707. However, debugging it is harder than it
should be because write workers can flood the logs. They may send
a lot of failed writes before the test fails. Then, the log file
can become huge, even up to 20 GB.

Fix this issue by stopping a write worker after the first error.

This test is important for 6.0, so we can backport this change.