### PR TITLE
Native reverse pages over RPC

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -542,10 +542,6 @@ murmur3_partitioner_ignore_msb_bits: 12
 # Bypass in-memory data cache (the row cache) when performing reversed queries.
 # reversed_reads_auto_bypass_cache: false
 
-# Use a new optimized algorithm for performing reversed reads.
-# Set to `false` to fall-back to the old algorithm.
-# enable_optimized_reversed_reads: true
-
 # Use on a new, parallel algorithm for performing aggregate queries.
 # Set to `false` to fall-back to the old algorithm.
 # enable_parallelized_aggregation: true

--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -539,9 +539,6 @@ commitlog_total_space_in_mb: -1
 # Keep at 12 for new clusters.
 murmur3_partitioner_ignore_msb_bits: 12
 
-# Bypass in-memory data cache (the row cache) when performing reversed queries.
-# reversed_reads_auto_bypass_cache: false
-
 # Use on a new, parallel algorithm for performing aggregate queries.
 # Set to `false` to fall-back to the old algorithm.
 # enable_parallelized_aggregation: true

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -663,7 +663,7 @@ indexed_table_select_statement::do_execute_base_query(
                     auto base_ck = generate_base_key_from_index_pk<clustering_key>(old_paging_state->get_partition_key(),
                             old_paging_state->get_clustering_key(), *_schema, *_view_schema);
 
-                    query::trim_clustering_row_ranges_to(*_schema, row_ranges, base_ck, false);
+                    query::trim_clustering_row_ranges_to(*_schema, row_ranges, base_ck);
                     command->slice.set_range(*_schema, base_pk, row_ranges);
                 } else {
                     // There is no clustering key in old_paging_state and/or no clustering key in 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -61,6 +61,8 @@ namespace cql3 {
 
 namespace statements {
 
+static logging::logger logger("select_statement");
+
 template<typename C>
 struct result_to_error_message_wrapper {
     C c;
@@ -180,6 +182,7 @@ select_statement::select_statement(schema_ptr schema,
                                    std::unique_ptr<attributes> attrs)
     : cql_statement(select_timeout(*restrictions))
     , _schema(schema)
+    , _query_schema(is_reversed ? schema->get_reversed() : schema)
     , _bound_terms(bound_terms)
     , _parameters(std::move(parameters))
     , _selection(std::move(selection))
@@ -282,6 +285,9 @@ select_statement::make_partition_slice(const query_options& options) const
     }
     if (_is_reversed) {
         std::reverse(bounds.begin(), bounds.end());
+        for (auto& bound : bounds) {
+            bound = query::reverse(bound);
+        }
         ++_stats.reverse_queries;
     }
     return query::partition_slice(std::move(bounds),
@@ -376,8 +382,8 @@ select_statement::do_execute(query_processor& qp,
     auto slice = make_partition_slice(options);
     auto max_result_size = qp.proxy().get_max_result_size(slice);
     auto command = ::make_lw_shared<query::read_command>(
-            _schema->id(),
-            _schema->version(),
+            _query_schema->id(),
+            _query_schema->version(),
             std::move(slice),
             max_result_size,
             query::tombstone_limit(qp.proxy().get_tombstone_limit()),
@@ -389,6 +395,8 @@ select_statement::do_execute(query_processor& qp,
             query::is_first_page::no,
             options.get_timestamp(state));
     command->allow_limit = db::allow_per_partition_rate_limit::yes;
+    logger.trace("Executing read query (reversed {}): table schema {}, query schema {}",
+        slice.is_reversed(), _schema->version(), _query_schema->version());
 
     int32_t page_size = options.get_page_size();
 
@@ -435,7 +443,7 @@ select_statement::do_execute(query_processor& qp,
     auto f = make_ready_future<shared_ptr<cql_transport::messages::result_message>>();
 
     if (!aggregate && !_restrictions_need_filtering && (page_size <= 0
-            || !service::pager::query_pagers::may_need_paging(*_schema, page_size,
+            || !service::pager::query_pagers::may_need_paging(*_query_schema, page_size,
                     *command, key_ranges))) {
         f = execute_without_checking_exception_message_non_aggregate_unpaged(qp, command, std::move(key_ranges), state, options, now);
     } else {
@@ -459,7 +467,7 @@ select_statement::execute_without_checking_exception_message_aggregate_or_paged(
     command->slice.options.set<query::partition_slice::option::allow_short_read>();
     auto timeout_duration = get_timeout(state.get_client_state(), options);
     auto timeout = db::timeout_clock::now() + timeout_duration;
-    auto p = service::pager::query_pagers::pager(qp.proxy(), _schema, _selection,
+    auto p = service::pager::query_pagers::pager(qp.proxy(), _query_schema, _selection,
             state, options, command, std::move(key_ranges), _restrictions_need_filtering ? _restrictions : nullptr);
 
     if (aggregate || nonpaged_filtering) {
@@ -821,7 +829,7 @@ select_statement::execute_without_checking_exception_message_non_aggregate_unpag
             return utils::result_map_reduce(prs.begin(), prs.end(), [this, &qp, &state, &options, cmd, timeout] (auto& pr) {
                 dht::partition_range_vector prange { pr };
                 auto command = ::make_lw_shared<query::read_command>(*cmd);
-                return qp.proxy().query_result(_schema,
+                return qp.proxy().query_result(_query_schema,
                         command,
                         std::move(prange),
                         options.get_consistency(),
@@ -833,7 +841,7 @@ select_statement::execute_without_checking_exception_message_non_aggregate_unpag
             return this->process_results(std::move(result), cmd, options, now);
         }));
     } else {
-        return qp.proxy().query_result(_schema, cmd, std::move(partition_ranges), options.get_consistency(), {timeout, state.get_permit(), state.get_client_state(), state.get_trace_state()})
+        return qp.proxy().query_result(_query_schema, cmd, std::move(partition_ranges), options.get_consistency(), {timeout, state.get_permit(), state.get_client_state(), state.get_trace_state()})
             .then(wrap_result_to_error_message([this, &options, now, cmd] (service::storage_proxy::coordinator_query_result qr) {
                 return this->process_results(std::move(qr.query_result), cmd, options, now);
             }));
@@ -865,7 +873,7 @@ select_statement::process_results(foreign_ptr<lw_shared_ptr<query::result>> resu
     const bool fast_path = !needs_post_query_ordering() && _selection->is_trivial() && !_restrictions_need_filtering;
     if (fast_path) {
         return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(make_shared<cql_transport::messages::result_message::rows>(result(
-            result_generator(_schema, std::move(results), std::move(cmd), _selection, _stats),
+            result_generator(_query_schema, std::move(results), std::move(cmd), _selection, _stats),
             _selection->get_result_metadata())
         ));
     }
@@ -883,11 +891,11 @@ select_statement::process_results_complex(foreign_ptr<lw_shared_ptr<query::resul
             results->ensure_counts();
             _stats.filtered_rows_read_total += *results->row_count();
             query::result_view::consume(*results, cmd->slice,
-                    cql3::selection::result_set_builder::visitor(builder, *_schema,
-                            *_selection, cql3::selection::result_set_builder::restrictions_filter(_restrictions, options, cmd->get_row_limit(), _schema, cmd->slice.partition_row_limit())));
+                    cql3::selection::result_set_builder::visitor(builder, *_query_schema,
+                            *_selection, cql3::selection::result_set_builder::restrictions_filter(_restrictions, options, cmd->get_row_limit(), _query_schema, cmd->slice.partition_row_limit())));
         } else {
             query::result_view::consume(*results, cmd->slice,
-                    cql3::selection::result_set_builder::visitor(builder, *_schema,
+                    cql3::selection::result_set_builder::visitor(builder, *_query_schema,
                             *_selection));
         }
         auto rs = builder.build();

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -397,6 +397,7 @@ select_statement::do_execute(query_processor& qp,
     command->allow_limit = db::allow_per_partition_rate_limit::yes;
     logger.trace("Executing read query (reversed {}): table schema {}, query schema {}",
         slice.is_reversed(), _schema->version(), _query_schema->version());
+    tracing::trace(state.get_trace_state(), "Executing read query (reversed {})", slice.is_reversed());
 
     int32_t page_size = options.get_page_size();
 

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -58,6 +58,7 @@ public:
 protected:
     static thread_local const lw_shared_ptr<const parameters> _default_parameters;
     schema_ptr _schema;
+    schema_ptr _query_schema;
     uint32_t _bound_terms;
     lw_shared_ptr<const parameters> _parameters;
     ::shared_ptr<selection::selection> _selection;

--- a/db/config.cc
+++ b/db/config.cc
@@ -1068,8 +1068,6 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "to make sure that trying to create an invalid view causes an error.")
     , reversed_reads_auto_bypass_cache(this, "reversed_reads_auto_bypass_cache", liveness::LiveUpdate, value_status::Used, false,
             "Bypass in-memory data cache (the row cache) when performing reversed queries.")
-    , enable_optimized_reversed_reads(this, "enable_optimized_reversed_reads", liveness::LiveUpdate, value_status::Used, true,
-            "Use a new optimized algorithm for performing reversed reads.")
     , enable_cql_config_updates(this, "enable_cql_config_updates", liveness::LiveUpdate, value_status::Used, true,
             "Make the system.config table UPDATEable.")
     , enable_parallelized_aggregation(this, "enable_parallelized_aggregation", liveness::LiveUpdate, value_status::Used, true,

--- a/db/config.cc
+++ b/db/config.cc
@@ -1066,8 +1066,6 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "To preserve backwards compatibility on old clusters, Scylla's default setting is `warn`. "
         "New clusters have this option set to `true` by scylla.yaml (which overrides the default `warn`), "
         "to make sure that trying to create an invalid view causes an error.")
-    , reversed_reads_auto_bypass_cache(this, "reversed_reads_auto_bypass_cache", liveness::LiveUpdate, value_status::Used, false,
-            "Bypass in-memory data cache (the row cache) when performing reversed queries.")
     , enable_cql_config_updates(this, "enable_cql_config_updates", liveness::LiveUpdate, value_status::Used, true,
             "Make the system.config table UPDATEable.")
     , enable_parallelized_aggregation(this, "enable_parallelized_aggregation", liveness::LiveUpdate, value_status::Used, true,

--- a/db/config.hh
+++ b/db/config.hh
@@ -396,7 +396,6 @@ public:
     named_value<bool> cdc_dont_rewrite_streams;
     named_value<tri_mode_restriction> strict_allow_filtering;
     named_value<tri_mode_restriction> strict_is_not_null_in_views;
-    named_value<bool> reversed_reads_auto_bypass_cache;
     named_value<bool> enable_cql_config_updates;
     named_value<bool> enable_parallelized_aggregation;
 

--- a/db/config.hh
+++ b/db/config.hh
@@ -397,7 +397,6 @@ public:
     named_value<tri_mode_restriction> strict_allow_filtering;
     named_value<tri_mode_restriction> strict_is_not_null_in_views;
     named_value<bool> reversed_reads_auto_bypass_cache;
-    named_value<bool> enable_optimized_reversed_reads;
     named_value<bool> enable_cql_config_updates;
     named_value<bool> enable_parallelized_aggregation;
 

--- a/docs/dev/reverse-reads.md
+++ b/docs/dev/reverse-reads.md
@@ -23,62 +23,6 @@ A read is called reverse when it reads with reverse clustering order
 If the table's native clustering order is DESC, then a read with ASC
 order is considered reverse.
 
-## Legacy format
-
-The legacy format is how scylla handled reverse queries internally. We
-are in the process of migrating to the native reverse format.
-
-### Request
-
-The `query::partition_slice::options::reversed` flag is set.
-Clustering ranges in both `query::partition_slice::_row_ranges` and
-`query::specific_ranges::_ranges`
-(`query::partition_slice::_specific_ranges`) are half-reversed: they
-are ordered in reverse, but when they are compared to other
-mutation-fragments, their end bound is used as position, instead of the
-start bound as usual. When compared to other clustering ranges the end
-bound is used as the start bound and vice-versa.
-Example:
-
-For the clustering keys (ASC order): `ck1`, `ck2`, `ck3`, `ck4`, `ck5`,
-`ck6`.
-A `_row_ranges` field of a slice might contain this:
-
-    [ck1, ck2], [ck4, ck5]
-
-The legacy reversed version would look like this:
-
-    [ck4, ck5], [ck1, ck2]
-
-Note how the ranges themselves are the same (bounds not reversed), it is
-just the range vector itself that is reversed.
-
-### Result
-
-Results are ordered with the reversed clustering order with the caveat
-that range-tombstones are ordered by their end bound, using the native
-schema's comparators. For example given the following partition:
-
-    ps{pk1}, sr{}, cr{ck1}, rt{[ck2, ck4)}, cr{ck2}, cr{ck3}, cr{ck4}, ck{ck5}, pe{}
-
-The legacy reverse format equivalent of this looks like the following:
-
-    ps{pk1}, sr{}, cr{ck5}, rt{[ck2, ck4)}, cr{ck4}, cr{ck3}, cr{ck2}, ck{ck1}, pe{}
-
-Note:
-* Only clustering elements change;
-* Range tombstone's bounds are not reversed;
-* Range tombstones can be ordered off-by-one due to native schema
-  comparators used: `rt{[ck2, ck4)}` should be ordered *after*
-  `cr{ck4}`.
-
-Legend:
-* ps = partitions-tart
-* sr = static-row
-* cr = clustering-row
-* rt = range-tombstone
-* pe = partition-end
-
 ## Native format
 
 The native format uses ordering equivalent to that of a table with
@@ -90,13 +34,11 @@ process the reverse stream as normal.
 
 ### Request
 
-The `query::partition_slice::options::reversed` flag is set as in the
-legacy format. Clustering ranges in both
-`query::partition_slice::_row_ranges` and
+The `query::partition_slice::options::reversed` flag is set.
+Clustering ranges in both `query::partition_slice::_row_ranges` and
 `query::specific_ranges::_ranges`
-(`query::partition_slice::_specific_ranges`) are fully-reversed: they
-are ordered in reverse, their bound being swapped as well.
-Example:
+(`query::partition_slice::_specific_ranges`)
+are reversed: they are ordered in reverse. Example:
 
 For the clustering keys (ASC order): `ck1`, `ck2`, `ck3`, `ck4`, `ck5`,
 `ck6`.
@@ -104,7 +46,7 @@ A `_row_ranges` field of a slice might contain this:
 
     [ck1, ck2], [ck4, ck5]
 
-The native reversed version would look like this:
+The reversed version would look like this:
 
     [ck5, ck4], [ck2, ck1]
 
@@ -115,8 +57,20 @@ stack get a reversed schema to work with.
 ### Result
 
 Results are ordered with the reversed clustering order with
-the bounds of range-tombstones swapped. For example, given the same
-partition that was used in the legacy format example, the native reverse
-version would look like this:
+the bounds of range-tombstones swapped. For example given the following
+partition:
+
+    ps{pk1}, sr{}, cr{ck1}, rt{[ck2, ck4)}, cr{ck2}, cr{ck3}, cr{ck4}, ck{ck5}, pe{}
+
+The native reverse version would look like this:
 
     ps{pk1}, sr{}, cr{ck5}, cr{ck4}, rt{(ck4, ck2]}, cr{ck3}, cr{ck2}, ck{ck1}, pe{}
+
+
+Legend:
+* ps = partitions-tart
+* sr = static-row
+* cr = clustering-row
+* rt = range-tombstone
+* pe = partition-end
+

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -132,6 +132,7 @@ public:
     gms::feature supports_consistent_topology_changes { *this, "SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES"sv };
     gms::feature host_id_based_hinted_handoff { *this, "HOST_ID_BASED_HINTED_HANDOFF"sv };
     gms::feature topology_requests_type_column { *this, "TOPOLOGY_REQUESTS_TYPE_COLUMN"sv };
+    gms::feature native_reverse_queries { *this, "NATIVE_REVERSE_QUERIES"sv };
 
     // A feature just for use in tests. It must not be advertised unless
     // the "features_enable_test_feature" injection is enabled.

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -986,31 +986,27 @@ public:
 
 future<std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>> query_mutations_on_all_shards(
         distributed<replica::database>& db,
-        schema_ptr table_schema,
+        schema_ptr query_schema,
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
         db::timeout_clock::time_point timeout) {
-    schema_ptr query_schema = cmd.slice.is_reversed() ? table_schema->make_reversed() : table_schema;
-
     return do_query_on_all_shards<mutation_query_result_builder>(db, query_schema, cmd, ranges, std::move(trace_state), timeout,
-            [table_schema, &cmd] (query::result_memory_accounter&& accounter) {
-        return mutation_query_result_builder(*table_schema, cmd.slice, std::move(accounter));
+            [query_schema, &cmd] (query::result_memory_accounter&& accounter) {
+        return mutation_query_result_builder(*query_schema, cmd.slice, std::move(accounter));
     });
 }
 
 future<std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> query_data_on_all_shards(
         distributed<replica::database>& db,
-        schema_ptr table_schema,
+        schema_ptr query_schema,
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
         query::result_options opts,
         tracing::trace_state_ptr trace_state,
         db::timeout_clock::time_point timeout) {
-    schema_ptr query_schema = cmd.slice.is_reversed() ? table_schema->make_reversed() : table_schema;
-
     return do_query_on_all_shards<data_query_result_builder>(db, query_schema, cmd, ranges, std::move(trace_state), timeout,
-            [table_schema, &cmd, opts] (query::result_memory_accounter&& accounter) {
-        return data_query_result_builder(*table_schema, cmd.slice, opts, std::move(accounter), cmd.tombstone_limit);
+            [query_schema, &cmd, opts] (query::result_memory_accounter&& accounter) {
+        return data_query_result_builder(*query_schema, cmd.slice, opts, std::move(accounter), cmd.tombstone_limit);
     });
 }

--- a/mutation/frozen_mutation.cc
+++ b/mutation/frozen_mutation.cc
@@ -149,11 +149,7 @@ stop_iteration streamed_mutation_freezer::consume(static_row&& sr) {
 }
 
 stop_iteration streamed_mutation_freezer::consume(clustering_row&& cr) {
-    if (_reversed) {
-        _crs.emplace_front(std::move(cr));
-    } else {
-        _crs.emplace_back(std::move(cr));
-    }
+    _crs.emplace_back(std::move(cr));
     return stop_iteration::no;
 }
 

--- a/mutation/frozen_mutation.hh
+++ b/mutation/frozen_mutation.hh
@@ -240,19 +240,17 @@ struct frozen_mutation_and_schema {
     schema_ptr s;
 };
 
-// Can receive streamed_mutation in reversed order.
 class streamed_mutation_freezer {
     const schema& _schema;
     partition_key _key;
-    bool _reversed;
 
     tombstone _partition_tombstone;
     std::optional<static_row> _sr;
     std::deque<clustering_row> _crs;
     range_tombstone_list _rts;
 public:
-    streamed_mutation_freezer(const schema& s, const partition_key& key, bool reversed = false)
-        : _schema(s), _key(key), _reversed(reversed), _rts(s) { }
+    streamed_mutation_freezer(const schema& s, const partition_key& key)
+        : _schema(s), _key(key), _rts(s) { }
 
     stop_iteration consume(tombstone pt);
 

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1009,7 +1009,7 @@ auto fmt::formatter<mutation_partition::printer>::format(const mutation_partitio
             out = fmt::format_to(out, "{}{}'{}':{},\n",
                                  indent, indent, column_def.name_as_text(),
                                  atomic_cell_or_collection::printer(column_def, cell));
-        }); 
+        });
         out = fmt::format_to(out, "{}}},\n", indent);
     }
 
@@ -2165,7 +2165,7 @@ void reconcilable_result_builder::consume_new_partition(const dht::decorated_key
         !has_ck_selector(_slice.row_ranges(*_query_schema, dk.key()));
     _static_row_is_alive = false;
     _live_rows = 0;
-    _mutation_consumer.emplace(streamed_mutation_freezer(*_query_schema, dk.key(), false));
+    _mutation_consumer.emplace(streamed_mutation_freezer(*_query_schema, dk.key()));
     _used_at_entry = _memory_accounter.used_memory();
 }
 

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -1363,7 +1363,6 @@ private:
         gc_clock::time_point now,
         const std::vector<query::clustering_range>& row_ranges,
         bool always_return_static_content,
-        bool reverse,
         uint64_t row_limit,
         can_gc_fn&,
         bool drop_tombstones_unconditionally,
@@ -1372,9 +1371,8 @@ private:
     // Calls func for each row entry inside row_ranges until func returns stop_iteration::yes.
     // Removes all entries for which func didn't return stop_iteration::no or wasn't called at all.
     // Removes all entries that are empty, check rows_entry::empty().
-    // If reversed is true, func will be called on entries in reverse order. In that case row_ranges
-    // must be already in reverse order.
-    template<bool reversed, typename Func>
+    // For row_ranges in reverse order, a reversed schema shall be provided.
+    template<typename Func>
     requires std::is_invocable_r_v<stop_iteration, Func, rows_entry&>
     void trim_rows(const schema& s,
         const std::vector<query::clustering_range>& row_ranges,
@@ -1398,7 +1396,7 @@ public:
     //
     uint64_t compact_for_query(const schema& s, const dht::decorated_key& dk, gc_clock::time_point query_time,
         const std::vector<query::clustering_range>& row_ranges, bool always_return_static_content,
-        bool reversed, uint64_t row_limit);
+        uint64_t row_limit);
 
     // Performs the following:
     //   - expires cells based on compaction_time

--- a/mutation_query.cc
+++ b/mutation_query.cc
@@ -92,16 +92,3 @@ future<foreign_ptr<lw_shared_ptr<reconcilable_result>>> reversed(foreign_ptr<lw_
 
     co_return std::move(result);
 }
-
-future<reconcilable_result> reversed(reconcilable_result result)
-{
-    for (auto& partition : result.partitions())
-    {
-        auto& m = partition.mut();
-        auto schema = local_schema_registry().get(m.schema_version());
-        m = frozen_mutation(reverse(m.unfreeze(schema)));
-        co_await coroutine::maybe_yield();
-    }
-
-    co_return std::move(result);
-}

--- a/mutation_query.hh
+++ b/mutation_query.hh
@@ -121,6 +121,10 @@ public:
     printer pretty_printer(schema_ptr) const;
 };
 
+// Reverse reconcilable_result by reversing mutations for all partitions.
+future<foreign_ptr<lw_shared_ptr<reconcilable_result>>> reversed(foreign_ptr<lw_shared_ptr<reconcilable_result>> result);
+future<reconcilable_result> reversed(reconcilable_result result);
+
 template <>
 struct fmt::formatter<reconcilable_result::printer> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }

--- a/mutation_query.hh
+++ b/mutation_query.hh
@@ -123,7 +123,6 @@ public:
 
 // Reverse reconcilable_result by reversing mutations for all partitions.
 future<foreign_ptr<lw_shared_ptr<reconcilable_result>>> reversed(foreign_ptr<lw_shared_ptr<reconcilable_result>> result);
-future<reconcilable_result> reversed(reconcilable_result result);
 
 template <>
 struct fmt::formatter<reconcilable_result::printer> {
@@ -134,10 +133,8 @@ struct fmt::formatter<reconcilable_result::printer> {
 
 
 class reconcilable_result_builder {
-    const schema& _schema;
-    const query::partition_slice& _slice;
-    bool _reversed;
     schema_ptr _query_schema;
+    const query::partition_slice& _slice;
 
     bool _return_static_content_on_partition_with_no_rows{};
     bool _static_row_is_alive{};
@@ -156,11 +153,10 @@ private:
     stop_iteration consume(range_tombstone&& rt);
 
 public:
-    // Expects table schema (non-reversed) and half-reversed (legacy) slice when building results for reverse query.
-    reconcilable_result_builder(const schema& s, const query::partition_slice& slice,
+    // Expects query schema (reversed) and reversed slice when building results for reverse query.
+    reconcilable_result_builder(const schema& query_schema, const query::partition_slice& slice,
                                 query::result_memory_accounter&& accounter) noexcept
-        : _schema(s), _slice(slice), _reversed(_slice.is_reversed())
-        , _query_schema(_reversed ? _schema.make_reversed() : _schema.shared_from_this())
+        : _query_schema(query_schema.shared_from_this()), _slice(slice)
         , _memory_accounter(std::move(accounter))
     { }
 

--- a/mutation_query.hh
+++ b/mutation_query.hh
@@ -153,7 +153,7 @@ private:
     stop_iteration consume(range_tombstone&& rt);
 
 public:
-    // Expects query schema (reversed) and reversed slice when building results for reverse query.
+    // Expects reversed schema and reversed slice when building results for reverse query.
     reconcilable_result_builder(const schema& query_schema, const query::partition_slice& slice,
                                 query::result_memory_accounter&& accounter) noexcept
         : _query_schema(query_schema.shared_from_this()), _slice(slice)

--- a/query-request.hh
+++ b/query-request.hh
@@ -147,13 +147,6 @@ constexpr auto max_rows_if_set = std::numeric_limits<uint32_t>::max();
 // Specifies subset of rows, columns and cell attributes to be returned in a query.
 // Can be accessed across cores.
 // Schema-dependent.
-//
-// COMPATIBILITY NOTE: the partition-slice for reverse queries has two different
-// format:
-// * legacy format
-// * native format
-// The wire format uses the legacy format. See docs/dev/reverse-reads.md
-// for more details on the formats.
 class partition_slice {
     friend class ::partition_slice_builder;
 public:

--- a/query-request.hh
+++ b/query-request.hh
@@ -475,6 +475,12 @@ public:
     friend std::ostream& operator<<(std::ostream& out, const read_command& r);
 };
 
+// Reverse read_command by reversing the schema version and transforming the slice from
+// the legacy reversed format to native reversed format. Shall be called with reversed
+// queries only.
+lw_shared_ptr<query::read_command> reversed(lw_shared_ptr<query::read_command>&& cmd);
+query::read_command reversed(query::read_command&& cmd);
+
 struct mapreduce_request {
     enum class reduction_type {
         count,
@@ -484,7 +490,7 @@ struct mapreduce_request {
         db::functions::function_name name;
         std::vector<sstring> column_names;
     };
-    struct reductions_info { 
+    struct reductions_info {
         // Used by selector_factries to prepare reductions information
         std::vector<reduction_type> types;
         std::vector<aggregation_info> infos;

--- a/query-request.hh
+++ b/query-request.hh
@@ -274,9 +274,6 @@ partition_slice native_reverse_slice_to_legacy_reverse_slice(const schema& schem
 // Fully reverse slice (forward to native reverse or native reverse to forward).
 // Also toggles the reversed bit in `partition_slice::options`.
 partition_slice reverse_slice(const schema& schema, partition_slice slice);
-// Half reverse slice (forward to legacy reverse or legacy reverse to forward).
-// Also toggles the reversed bit in `partition_slice::options`.
-partition_slice half_reverse_slice(const schema&, partition_slice);
 
 constexpr auto max_partitions = std::numeric_limits<uint32_t>::max();
 constexpr auto max_tombstones = std::numeric_limits<uint64_t>::max();

--- a/query-request.hh
+++ b/query-request.hh
@@ -83,21 +83,20 @@ typedef std::vector<clustering_range> clustering_row_ranges;
 /// Trim the clustering ranges.
 ///
 /// Equivalent of intersecting each clustering range with [pos, +inf) position
-/// in partition range, or (-inf, pos] position in partition range if
-/// reversed == true. Ranges that do not intersect are dropped. Ranges that
+/// in partition range. Ranges that do not intersect are dropped. Ranges that
 /// partially overlap are trimmed.
-/// Result: each range will overlap fully with [pos, +inf), or (-int, pos] if
-/// reversed is true.
-void trim_clustering_row_ranges_to(const schema& s, clustering_row_ranges& ranges, position_in_partition pos, bool reversed = false);
+/// Result: each range will overlap fully with [pos, +inf).
+/// Works both with forward schema and ranges, and reversed schema and native reversed ranges
+void trim_clustering_row_ranges_to(const schema& s, clustering_row_ranges& ranges, position_in_partition pos);
 
 /// Trim the clustering ranges.
 ///
 /// Equivalent of intersecting each clustering range with (key, +inf) clustering
-/// range, or (-inf, key) clustering range if reversed == true. Ranges that do
-/// not intersect are dropped. Ranges that partially overlap are trimmed.
-/// Result: each range will overlap fully with (key, +inf), or (-int, key) if
-/// reversed is true.
-void trim_clustering_row_ranges_to(const schema& s, clustering_row_ranges& ranges, const clustering_key& key, bool reversed = false);
+/// range. Ranges that do not intersect are dropped. Ranges that partially overlap
+/// are trimmed.
+/// Result: each range will overlap fully with (key, +inf).
+/// Works both with forward schema and ranges, and reversed schema and native reversed ranges
+void trim_clustering_row_ranges_to(const schema& s, clustering_row_ranges& ranges, const clustering_key& key);
 
 class specific_ranges {
 public:

--- a/query-request.hh
+++ b/query-request.hh
@@ -479,7 +479,6 @@ public:
 // the legacy reversed format to native reversed format. Shall be called with reversed
 // queries only.
 lw_shared_ptr<query::read_command> reversed(lw_shared_ptr<query::read_command>&& cmd);
-query::read_command reversed(query::read_command&& cmd);
 
 struct mapreduce_request {
     enum class reduction_type {

--- a/query.cc
+++ b/query.cc
@@ -70,15 +70,6 @@ lw_shared_ptr<query::read_command> reversed(lw_shared_ptr<query::read_command>&&
     return std::move(cmd);
 }
 
-query::read_command reversed(query::read_command&& cmd)
-{
-    auto schema = local_schema_registry().get(cmd.schema_version)->get_reversed();
-    cmd.schema_version = schema->version();
-    cmd.slice = query::legacy_reverse_slice_to_native_reverse_slice(*schema, cmd.slice);
-
-    return std::move(cmd);
-}
-
 std::ostream& operator<<(std::ostream& out, const mapreduce_request::reduction_type& r) {
     out << "reduction_type{";
     switch (r) {

--- a/query.cc
+++ b/query.cc
@@ -61,6 +61,24 @@ std::ostream& operator<<(std::ostream& out, const read_command& r) {
     return out;
 }
 
+lw_shared_ptr<query::read_command> reversed(lw_shared_ptr<query::read_command>&& cmd)
+{
+    auto schema = local_schema_registry().get(cmd->schema_version)->get_reversed();
+    cmd->schema_version = schema->version();
+    cmd->slice = query::legacy_reverse_slice_to_native_reverse_slice(*schema, cmd->slice);
+
+    return std::move(cmd);
+}
+
+query::read_command reversed(query::read_command&& cmd)
+{
+    auto schema = local_schema_registry().get(cmd.schema_version)->get_reversed();
+    cmd.schema_version = schema->version();
+    cmd.slice = query::legacy_reverse_slice_to_native_reverse_slice(*schema, cmd.slice);
+
+    return std::move(cmd);
+}
+
 std::ostream& operator<<(std::ostream& out, const mapreduce_request::reduction_type& r) {
     out << "reduction_type{";
     switch (r) {

--- a/query.cc
+++ b/query.cc
@@ -182,19 +182,6 @@ partition_slice reverse_slice(const schema& schema, partition_slice slice) {
         .build();
 }
 
-partition_slice half_reverse_slice(const schema& schema, partition_slice slice) {
-    return partition_slice_builder(schema, std::move(slice))
-        .mutate_ranges([] (clustering_row_ranges& ranges) {
-            std::reverse(ranges.begin(), ranges.end());
-        })
-        .mutate_specific_ranges([] (specific_ranges& sranges) {
-            auto& ranges = sranges.ranges();
-            std::reverse(ranges.begin(), ranges.end());
-        })
-        .with_option_toggled<partition_slice::option::reversed>()
-        .build();
-}
-
 partition_slice::partition_slice(clustering_row_ranges row_ranges,
     query::column_id_vector static_columns,
     query::column_id_vector regular_columns,

--- a/read_context.hh
+++ b/read_context.hh
@@ -122,7 +122,6 @@ class read_context final : public enable_lw_shared_from_this<read_context> {
     reader_permit _permit;
     const dht::partition_range& _range;
     const query::partition_slice& _slice;
-    std::optional<query::partition_slice> _native_slice;
     tracing::trace_state_ptr _trace_state;
     mutation_reader::forwarding _fwd_mr;
     bool _range_query;
@@ -163,9 +162,6 @@ public:
         , _tombstone_gc_state(gc_state)
         , _underlying(_cache, *this)
     {
-        if (_slice.is_reversed()) {
-            _native_slice = query::legacy_reverse_slice_to_native_reverse_slice(*_schema, _slice);
-        }
         ++_cache._tracker._stats.reads;
         if (!_range_query) {
             _key = range.start()->value().as_decorated_key();
@@ -188,7 +184,7 @@ public:
     const query::partition_slice& slice() const { return _slice; }
     bool is_reversed() const { return _slice.is_reversed(); }
     // Returns a slice in the native format (for reversed reads, in native-reversed format).
-    const query::partition_slice& native_slice() const { return is_reversed() ? *_native_slice : _slice; }
+    const query::partition_slice& native_slice() const { return _slice; }
     tracing::trace_state_ptr trace_state() const { return _trace_state; }
     mutation_reader::forwarding fwd_mr() const { return _fwd_mr; }
     bool is_range_query() const { return _range_query; }

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -284,7 +284,7 @@ mutation_reader make_slicing_filtering_reader(mutation_reader rd, const dht::par
 }
 
 static mutation slice_mutation(schema_ptr schema, mutation&& m, const query::partition_slice& slice) {
-    auto ck_ranges = query::clustering_key_filter_ranges::get_native_ranges(*schema, slice, m.key());
+    auto ck_ranges = query::clustering_key_filter_ranges::get_ranges(*schema, slice, m.key());
     auto&& mp = mutation_partition(std::move(m.partition()), *m.schema(), std::move(ck_ranges));
     return mutation(schema, m.decorated_key(), std::move(mp));
 }

--- a/readers/mutation_source.hh
+++ b/readers/mutation_source.hh
@@ -36,7 +36,7 @@ partition_presence_checker make_default_partition_presence_checker() {
 // when invoking the source.
 //
 // When reading in reverse, a reverse schema has to be passed (compared to the
-// table's schema), and a half-reverse (legacy) slice.
+// table's schema), and a reverse (native) slice.
 // See docs/dev/reverse-reads.md for more details.
 // Partition-range forwarding is not yet supported in reverse mode.
 class mutation_source {

--- a/readers/reversing_v2.hh
+++ b/readers/reversing_v2.hh
@@ -42,6 +42,6 @@ namespace query {
 /// \param slice serves as a convenience slice storage for reads that have to
 ///     store an edited slice somewhere. This is common for reads that work
 ///     with a native-reversed slice and so have to convert the one used in the
-///     query -- which is in half-reversed format.
+///     query -- which is in reversed format.
 mutation_reader
 make_reversing_reader(mutation_reader original, query::max_result_size max_size, std::unique_ptr<query::partition_slice> slice = {});

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1258,7 +1258,6 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.enable_metrics_reporting = db_config.enable_keyspace_column_family_metrics();
     cfg.enable_node_aggregated_table_metrics = db_config.enable_node_aggregated_table_metrics();
     cfg.reversed_reads_auto_bypass_cache = db_config.reversed_reads_auto_bypass_cache;
-    cfg.enable_optimized_reversed_reads = db_config.enable_optimized_reversed_reads;
     cfg.tombstone_warn_threshold = db_config.tombstone_warn_threshold();
     cfg.view_update_concurrency_semaphore_limit = _config.view_update_concurrency_semaphore_limit;
     cfg.data_listeners = &db.data_listeners();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1257,7 +1257,6 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.statement_scheduling_group = _config.statement_scheduling_group;
     cfg.enable_metrics_reporting = db_config.enable_keyspace_column_family_metrics();
     cfg.enable_node_aggregated_table_metrics = db_config.enable_node_aggregated_table_metrics();
-    cfg.reversed_reads_auto_bypass_cache = db_config.reversed_reads_auto_bypass_cache;
     cfg.tombstone_warn_threshold = db_config.tombstone_warn_threshold();
     cfg.view_update_concurrency_semaphore_limit = _config.view_update_concurrency_semaphore_limit;
     cfg.data_listeners = &db.data_listeners();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1698,10 +1698,10 @@ public:
             db::per_partition_rate_limit::account_and_enforce account_and_enforce_info,
             db::operation_type op_type);
 
-    future<std::tuple<lw_shared_ptr<query::result>, cache_temperature>> query(schema_ptr, const query::read_command& cmd, query::result_options opts,
+    future<std::tuple<lw_shared_ptr<query::result>, cache_temperature>> query(schema_ptr query_schema, const query::read_command& cmd, query::result_options opts,
                                                                   const dht::partition_range_vector& ranges, tracing::trace_state_ptr trace_state,
                                                                   db::timeout_clock::time_point timeout, db::per_partition_rate_limit::info rate_limit_info = std::monostate{});
-    future<std::tuple<reconcilable_result, cache_temperature>> query_mutations(schema_ptr, const query::read_command& cmd, const dht::partition_range& range,
+    future<std::tuple<reconcilable_result, cache_temperature>> query_mutations(schema_ptr query_schema, const query::read_command& cmd, const dht::partition_range& range,
                                                 tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout);
     // Apply the mutation atomically.
     // Throws timed_out_error when timeout is reached.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -900,7 +900,7 @@ public:
     // completion it contains the to-be saved querier for the next page (if
     // there is one). Pass nullptr when queriers are not saved.
     future<reconcilable_result>
-    mutation_query(schema_ptr s,
+    mutation_query(schema_ptr query_schema,
             reader_permit permit,
             const query::read_command& cmd,
             const dht::partition_range& range,

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -419,7 +419,6 @@ public:
         // Not really table-specific (it's a global configuration parameter), but stored here
         // for easy access from `table` member functions:
         utils::updateable_value<bool> reversed_reads_auto_bypass_cache{false};
-        utils::updateable_value<bool> enable_optimized_reversed_reads{true};
         uint32_t tombstone_warn_threshold{0};
         unsigned x_log2_compaction_groups{0};
         utils::updateable_value<bool> enable_compacting_data_for_streaming_and_repair;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -416,9 +416,6 @@ public:
         bool enable_node_aggregated_table_metrics = true;
         size_t view_update_concurrency_semaphore_limit;
         db::data_listeners* data_listeners = nullptr;
-        // Not really table-specific (it's a global configuration parameter), but stored here
-        // for easy access from `table` member functions:
-        utils::updateable_value<bool> reversed_reads_auto_bypass_cache{false};
         uint32_t tombstone_warn_threshold{0};
         unsigned x_log2_compaction_groups{0};
         utils::updateable_value<bool> enable_compacting_data_for_streaming_and_repair;

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -477,7 +477,7 @@ public:
                     if (key_and_snp) {
                         update_last(key_and_snp->first);
 
-                        auto cr = query::clustering_key_filter_ranges::get_native_ranges(*schema(), _slice, key_and_snp->first.key());
+                        auto cr = query::clustering_key_filter_ranges::get_ranges(*schema(), _slice, key_and_snp->first.key());
                         bool digest_requested = _slice.options.contains<query::partition_slice::option::with_digest>();
                         bool is_reversed = _slice.is_reversed();
                         _delegate = make_partition_snapshot_flat_reader_from_snp_schema(is_reversed, _permit, std::move(key_and_snp->first), std::move(cr), std::move(key_and_snp->second), digest_requested, region(), read_section(), mtbl(), streamed_mutation::forwarding::no, *mtbl());
@@ -727,7 +727,7 @@ memtable::make_flat_reader_opt(schema_ptr query_schema,
             return {};
         }
         auto dk = pos.as_decorated_key();
-        auto cr = query::clustering_key_filter_ranges::get_native_ranges(*query_schema, slice, dk.key());
+        auto cr = query::clustering_key_filter_ranges::get_ranges(*query_schema, slice, dk.key());
         bool digest_requested = slice.options.contains<query::partition_slice::option::with_digest>();
         auto rd = make_partition_snapshot_flat_reader_from_snp_schema(is_reversed, std::move(permit), std::move(dk), std::move(cr), std::move(snp), digest_requested, *this, _table_shared_data.read_section, shared_from_this(), fwd, *this);
         rd.upgrade_schema(query_schema);

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -477,11 +477,7 @@ public:
                     if (key_and_snp) {
                         update_last(key_and_snp->first);
 
-                        const query::clustering_row_ranges& ranges = _slice.row_ranges(*schema(), key_and_snp->first.key());
-                        // TODO: when the slice passed from query finally changes format from half-reversed into native reversed, this line needs to change.
-                        auto cr = query::clustering_key_filter_ranges(ranges);
-
-                        auto snp_schema = key_and_snp->second->schema();
+                        auto cr = query::clustering_key_filter_ranges::get_native_ranges(*schema(), _slice, key_and_snp->first.key());
                         bool digest_requested = _slice.options.contains<query::partition_slice::option::with_digest>();
                         bool is_reversed = _slice.is_reversed();
                         _delegate = make_partition_snapshot_flat_reader_from_snp_schema(is_reversed, _permit, std::move(key_and_snp->first), std::move(cr), std::move(key_and_snp->second), digest_requested, region(), read_section(), mtbl(), streamed_mutation::forwarding::no, *mtbl());
@@ -708,7 +704,7 @@ partition_snapshot_ptr memtable_entry::snapshot(memtable& mtbl) {
 }
 
 mutation_reader_opt
-memtable::make_flat_reader_opt(schema_ptr s,
+memtable::make_flat_reader_opt(schema_ptr query_schema,
                       reader_permit permit,
                       const dht::partition_range& range,
                       const query::partition_slice& slice,
@@ -731,17 +727,13 @@ memtable::make_flat_reader_opt(schema_ptr s,
             return {};
         }
         auto dk = pos.as_decorated_key();
-
-        const query::clustering_row_ranges& ranges = slice.row_ranges(*s, dk.key());
-        // TODO: when the slice passed from query finally changes format from half-reversed into native reversed, this line needs to change.
-        auto cr = query::clustering_key_filter_ranges(ranges);
-
+        auto cr = query::clustering_key_filter_ranges::get_native_ranges(*query_schema, slice, dk.key());
         bool digest_requested = slice.options.contains<query::partition_slice::option::with_digest>();
         auto rd = make_partition_snapshot_flat_reader_from_snp_schema(is_reversed, std::move(permit), std::move(dk), std::move(cr), std::move(snp), digest_requested, *this, _table_shared_data.read_section, shared_from_this(), fwd, *this);
-        rd.upgrade_schema(s);
+        rd.upgrade_schema(query_schema);
         return rd;
     } else {
-        auto res = make_mutation_reader<scanning_reader>(std::move(s), shared_from_this(), std::move(permit), range, slice, fwd_mr);
+        auto res = make_mutation_reader<scanning_reader>(std::move(query_schema), shared_from_this(), std::move(permit), range, slice, fwd_mr);
         if (fwd == streamed_mutation::forwarding::yes) {
             return make_forwardable(std::move(res));
         } else {

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -252,7 +252,7 @@ public:
     }
     // Same as make_flat_reader, but returns an empty optional instead of a no-op reader when there is nothing to
     // read. This is an optimization.
-    mutation_reader_opt make_flat_reader_opt(schema_ptr,
+    mutation_reader_opt make_flat_reader_opt(schema_ptr query_schema,
                                           reader_permit permit,
                                           const dht::partition_range& range,
                                           const query::partition_slice& slice,

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -246,7 +246,7 @@ table::make_reader_v2(schema_ptr s,
     });
 
     const auto bypass_cache = slice.options.contains(query::partition_slice::option::bypass_cache);
-    if (cache_enabled() && !bypass_cache && !(slice.is_reversed() && _config.reversed_reads_auto_bypass_cache())) {
+    if (cache_enabled() && !bypass_cache) {
         if (auto reader_opt = _cache.make_reader_opt(s, permit, range, slice, &_compaction_manager.get_tombstone_gc_state(), std::move(trace_state), fwd, fwd_mr)) {
             readers.emplace_back(std::move(*reader_opt));
         }

--- a/row_cache.cc
+++ b/row_cache.cc
@@ -1397,7 +1397,7 @@ mutation_reader cache_entry::read(row_cache& rc, std::unique_ptr<read_context> u
 // Assumes reader is in the corresponding partition
 mutation_reader cache_entry::do_read(row_cache& rc, read_context& reader) {
     auto snp = _pe.read(rc._tracker.region(), rc._tracker.cleaner(), &rc._tracker, reader.phase());
-    auto ckr = query::clustering_key_filter_ranges::get_native_ranges(*schema(), reader.native_slice(), _key.key());
+    auto ckr = query::clustering_key_filter_ranges::get_ranges(*schema(), reader.native_slice(), _key.key());
     schema_ptr entry_schema = to_query_domain(reader.slice(), schema());
     auto r = make_cache_mutation_reader(entry_schema, _key, std::move(ckr), rc, reader, std::move(snp));
     r.upgrade_schema(to_query_domain(reader.slice(), rc.schema()));
@@ -1407,7 +1407,7 @@ mutation_reader cache_entry::do_read(row_cache& rc, read_context& reader) {
 
 mutation_reader cache_entry::do_read(row_cache& rc, std::unique_ptr<read_context> unique_ctx) {
     auto snp = _pe.read(rc._tracker.region(), rc._tracker.cleaner(), &rc._tracker, unique_ctx->phase());
-    auto ckr = query::clustering_key_filter_ranges::get_native_ranges(*schema(), unique_ctx->native_slice(), _key.key());
+    auto ckr = query::clustering_key_filter_ranges::get_ranges(*schema(), unique_ctx->native_slice(), _key.key());
     schema_ptr reader_schema = unique_ctx->schema();
     schema_ptr entry_schema = to_query_domain(unique_ctx->slice(), schema());
     auto rc_schema = to_query_domain(unique_ctx->slice(), rc.schema());

--- a/service/pager/query_pager.hh
+++ b/service/pager/query_pager.hh
@@ -87,7 +87,7 @@ protected:
     query_function _query_function;
 
 public:
-    query_pager(service::storage_proxy& p, schema_ptr s, shared_ptr<const cql3::selection::selection> selection,
+    query_pager(service::storage_proxy& p, schema_ptr query_schema, shared_ptr<const cql3::selection::selection> selection,
                 service::query_state& state,
                 const cql3::query_options& options,
                 lw_shared_ptr<query::read_command> cmd,

--- a/service/pager/query_pager.hh
+++ b/service/pager/query_pager.hh
@@ -73,7 +73,7 @@ protected:
     std::optional<query_id> _query_uuid;
 
     shared_ptr<service::storage_proxy> _proxy;
-    schema_ptr _schema;
+    schema_ptr _query_schema;
     shared_ptr<const cql3::selection::selection> _selection;
     service::query_state& _state;
     const cql3::query_options& _options;

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -52,7 +52,7 @@ query_pager::query_pager(service::storage_proxy& p, schema_ptr query_schema,
                 , _per_partition_limit(cmd->slice.partition_row_limit())
                 , _last_pos(position_in_partition::for_partition_start())
                 , _proxy(p.shared_from_this())
-                , _schema(std::move(query_schema))
+                , _query_schema(std::move(query_schema))
                 , _selection(selection)
                 , _state(state)
                 , _options(options)
@@ -103,7 +103,7 @@ future<result<service::storage_proxy::coordinator_query_result>> query_pager::do
     qlogger.trace("fetch_page query id {}", _cmd->query_uuid);
 
     if (_last_pkey) {
-        auto dpk = dht::decorate_key(*_schema, *_last_pkey);
+        auto dpk = dht::decorate_key(*_query_schema, *_last_pkey);
         dht::ring_position lo(dpk);
 
         qlogger.trace("PKey={}, Pos={}, reversed={}", dpk, _last_pos, _cmd->slice.is_reversed());
@@ -155,17 +155,17 @@ future<result<service::storage_proxy::coordinator_query_result>> query_pager::do
 
         // If we have no clustering keys, it should mean we only have one row
         // per PK. Thus we can just bypass the last one.
-        modify_ranges(_ranges, lo, has_ck, dht::ring_position_comparator(*_schema));
+        modify_ranges(_ranges, lo, has_ck, dht::ring_position_comparator(*_query_schema));
 
         if (has_ck) {
             query::clustering_row_ranges row_ranges = _cmd->slice.default_row_ranges();
             position_in_partition next_pos = _last_pos;
             if (_last_pos.has_key()) {
-                next_pos = position_in_partition::after_key(*_schema, _last_pos);
+                next_pos = position_in_partition::after_key(*_query_schema, _last_pos);
             }
-            query::trim_clustering_row_ranges_to(*_schema, row_ranges, next_pos, false);
+            query::trim_clustering_row_ranges_to(*_query_schema, row_ranges, next_pos, false);
 
-            _cmd->slice.set_range(*_schema, *_last_pkey, row_ranges);
+            _cmd->slice.set_range(*_query_schema, *_last_pkey, row_ranges);
         }
     }
 
@@ -189,7 +189,7 @@ future<result<service::storage_proxy::coordinator_query_result>> query_pager::do
     auto command = ::make_lw_shared<query::read_command>(*_cmd);
     return _query_function(
             *_proxy,
-            _schema,
+            _query_schema,
             std::move(command),
             std::move(ranges),
             _options.get_consistency(),
@@ -206,7 +206,7 @@ future<result<>> query_pager::fetch_page_result(cql3::selection::result_set_buil
         _last_replicas = std::move(qr.last_replicas);
         _query_read_repair_decision = qr.read_repair_decision;
         return builder.with_thread_if_needed([this, &builder, page_size, now, qr = std::move(qr)] () mutable -> result<> {
-            handle_result(cql3::selection::result_set_builder::visitor(builder, *_schema, *_selection),
+            handle_result(cql3::selection::result_set_builder::visitor(builder, *_query_schema, *_selection),
                           std::move(qr.query_result), page_size, now);
             return bo::success();
         });
@@ -242,7 +242,7 @@ future<result<cql3::result_generator>> query_pager::fetch_page_generator_result(
         _last_replicas = std::move(qr.last_replicas);
         _query_read_repair_decision = qr.read_repair_decision;
         handle_result(noop_visitor(), qr.query_result, page_size, now);
-        return make_ready_future<result<cql3::result_generator>>(cql3::result_generator(_schema, std::move(qr.query_result), _cmd, _selection, stats));
+        return make_ready_future<result<cql3::result_generator>>(cql3::result_generator(_query_schema, std::move(qr.query_result), _cmd, _selection, stats));
     }));
 }
 
@@ -268,8 +268,8 @@ public:
             qr.query_result->ensure_counts();
             _stats.rows_read_total += *qr.query_result->row_count();
             return builder.with_thread_if_needed([&builder, this, query_result = std::move(qr.query_result), page_size, now] () mutable -> result<> {
-                handle_result(cql3::selection::result_set_builder::visitor(builder, *_schema, *_selection,
-                            cql3::selection::result_set_builder::restrictions_filter(_filtering_restrictions, _options, _max, _schema, _per_partition_limit, _last_pkey, _rows_fetched_for_last_partition)),
+                handle_result(cql3::selection::result_set_builder::visitor(builder, *_query_schema, *_selection,
+                            cql3::selection::result_set_builder::restrictions_filter(_filtering_restrictions, _options, _max, _query_schema, _per_partition_limit, _last_pkey, _rows_fetched_for_last_partition)),
                             std::move(query_result), page_size, now);
                 return bo::success();
             });
@@ -316,7 +316,7 @@ public:
             _query_read_repair_decision = qr.read_repair_decision;
             qr.query_result->ensure_counts();
             return seastar::async([this, query_result = std::move(qr.query_result), page_size, now] () mutable -> result<> {
-                handle_result(db::view::delete_ghost_rows_visitor{_proxy, _state, view_ptr(_schema), _timeout_duration},
+                handle_result(db::view::delete_ghost_rows_visitor{_proxy, _state, view_ptr(_query_schema), _timeout_duration},
                         std::move(query_result), page_size, now);
                 return bo::success();
             });
@@ -377,7 +377,7 @@ void query_pager::handle_result(
         // a single extra range, we must clear out the old one
         // Even if it was not so of course, leaving junk in the slice
         // is bad.
-        _cmd->slice.clear_range(*_schema, last_pkey);
+        _cmd->slice.clear_range(*_query_schema, last_pkey);
     };
 
     auto view = query::result_view(*results);
@@ -397,7 +397,7 @@ void query_pager::handle_result(
         _exhausted = (v.total_rows < page_size && !results->is_short_read() && v.dropped_rows == 0) || _max == 0;
         // If per partition limit is defined, we need to accumulate rows fetched for last partition key if the key matches
         if (_cmd->slice.partition_row_limit() < query::max_rows_if_set) {
-            if (_last_pkey && v.last_pkey && _last_pkey->equal(*_schema, *v.last_pkey)) {
+            if (_last_pkey && v.last_pkey && _last_pkey->equal(*_query_schema, *v.last_pkey)) {
                 _rows_fetched_for_last_partition += v.last_partition_row_count;
             } else {
                 _rows_fetched_for_last_partition = v.last_partition_row_count;

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -163,7 +163,7 @@ future<result<service::storage_proxy::coordinator_query_result>> query_pager::do
             if (_last_pos.has_key()) {
                 next_pos = position_in_partition::after_key(*_query_schema, _last_pos);
             }
-            query::trim_clustering_row_ranges_to(*_query_schema, row_ranges, next_pos, false);
+            query::trim_clustering_row_ranges_to(*_query_schema, row_ranges, next_pos);
 
             _cmd->slice.set_range(*_query_schema, *_last_pkey, row_ranges);
         }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4644,7 +4644,7 @@ private:
         auto mp = mutation_partition(s, m.partition());
         auto&& ranges = cmd.slice.row_ranges(s, m.key());
         bool always_return_static_content = cmd.slice.options.contains<query::partition_slice::option::always_return_static_content>();
-        mp.compact_for_query(s, m.decorated_key(), cmd.timestamp, ranges, always_return_static_content, false, limit);
+        mp.compact_for_query(s, m.decorated_key(), cmd.timestamp, ranges, always_return_static_content, limit);
         return primary_key{m.decorated_key(), get_last_reconciled_row(s, mp, is_reversed)};
     }
 
@@ -4720,7 +4720,7 @@ private:
                     ranges.emplace_back(is_reversed ? query::clustering_range::make_starting_with(std::move(*shortest_read->clustering))
                                                     : query::clustering_range::make_ending_with(std::move(*shortest_read->clustering)));
                     it->live_row_count = it->mut.partition().compact_for_query(s, it->mut.decorated_key(), cmd.timestamp, ranges, always_return_static_content,
-                            false, query::partition_max_rows);
+                            query::partition_max_rows);
                 }
             }
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -754,7 +754,10 @@ private:
             // 2. versions are different -> schema version is equal to reversed table schema version -> native format
             format_reverse_required = cmd->schema_version == table_schema->version();
         }
-        (void)format_reverse_required;
+        if (format_reverse_required) {
+            cmd = reversed(std::move(cmd));
+            s = s->get_reversed();
+        }
 
         co_await utils::get_local_injector().inject("storage_proxy::handle_read", [s] (auto& handler) -> future<> {
             const auto cf_name = handler.get("cf_name");
@@ -786,7 +789,16 @@ private:
                 return p->query_result_local(erm, std::move(s), cmd, std::move(pr2.first), opts, trace_state_ptr, timeout, rate_limit_info);
             } else if constexpr (verb == read_verb::read_mutation_data) {
                 p->get_stats().replica_mutation_data_reads++;
-                return p->query_mutations_locally(std::move(s), std::move(cmd), pr2, timeout, trace_state_ptr);
+                auto f = p->query_mutations_locally(std::move(s), std::move(cmd), pr2, timeout, trace_state_ptr);
+                if (format_reverse_required) {
+                    f = f.then([](auto result_ht) {
+                        auto&& [result, hit_rate] = result_ht;
+                        return reversed(std::move(result)).then([hit_rate=std::move(hit_rate)](auto result) mutable {
+                            return rpc::tuple{std::move(result), std::move(hit_rate)};
+                        });
+                    });
+                }
+                return f;
             } else if constexpr (verb == read_verb::read_digest) {
                 if (pr2.second) {
                     // this function assumes singular queries but doesn't validate
@@ -4632,7 +4644,7 @@ private:
         auto mp = mutation_partition(s, m.partition());
         auto&& ranges = cmd.slice.row_ranges(s, m.key());
         bool always_return_static_content = cmd.slice.options.contains<query::partition_slice::option::always_return_static_content>();
-        mp.compact_for_query(s, m.decorated_key(), cmd.timestamp, ranges, always_return_static_content, is_reversed, limit);
+        mp.compact_for_query(s, m.decorated_key(), cmd.timestamp, ranges, always_return_static_content, false, limit);
         return primary_key{m.decorated_key(), get_last_reconciled_row(s, mp, is_reversed)};
     }
 
@@ -4708,7 +4720,7 @@ private:
                     ranges.emplace_back(is_reversed ? query::clustering_range::make_starting_with(std::move(*shortest_read->clustering))
                                                     : query::clustering_range::make_ending_with(std::move(*shortest_read->clustering)));
                     it->live_row_count = it->mut.partition().compact_for_query(s, it->mut.decorated_key(), cmd.timestamp, ranges, always_return_static_content,
-                            is_reversed, query::partition_max_rows);
+                            false, query::partition_max_rows);
                 }
             }
 
@@ -5008,6 +5020,8 @@ protected:
     db::per_partition_rate_limit::info _rate_limit_info;
 
 private:
+    const bool _native_reversed_queries_enabled;
+
     void on_read_resolved() noexcept {
         // We could have !_foreground if this is called on behalf of background reconciliation.
         _proxy->get_stats().foreground_reads -= int(_foreground);
@@ -5026,7 +5040,8 @@ public:
                            _schema(std::move(s)), _proxy(std::move(proxy))
                          , _effective_replication_map_ptr(std::move(ermp))
                          , _cmd(std::move(cmd)), _partition_range(std::move(pr)), _cl(cl), _block_for(block_for), _targets(std::move(targets)), _trace_state(std::move(trace_state)),
-                           _cf(std::move(cf)), _permit(std::move(permit)), _rate_limit_info(rate_limit_info) {
+                           _cf(std::move(cf)), _permit(std::move(permit)), _rate_limit_info(rate_limit_info),
+                           _native_reversed_queries_enabled(_proxy->features().native_reverse_queries) {
         _proxy->get_stats().reads++;
         _proxy->get_stats().foreground_reads++;
     }
@@ -5051,9 +5066,20 @@ protected:
             tracing::trace(_trace_state, "read_mutation_data: querying locally");
             return _proxy->apply_fence(_proxy->query_mutations_locally(_schema, cmd, _partition_range, timeout, _trace_state), fence, _proxy->my_address());
         } else {
-            return _proxy->remote().send_read_mutation_data(netw::messaging_service::msg_addr{ep, 0}, timeout,
-                _trace_state, *cmd, _partition_range,
-                fence);
+            const bool format_reverse_required = cmd->slice.is_reversed() && !_native_reversed_queries_enabled;
+            cmd = format_reverse_required ? reversed(::make_lw_shared(*cmd)) : cmd;
+
+            auto f = _proxy->remote().send_read_mutation_data(netw::messaging_service::msg_addr{ep, 0}, timeout,
+                _trace_state, *cmd, _partition_range, fence);
+            if (format_reverse_required) {
+                f = f.then([](auto r) {
+                    auto&& [result, hit_rate] = r;
+                    return reversed(std::move(result)).then([hit_rate=std::move(hit_rate)](auto result) mutable {
+                        return rpc::tuple{std::move(result), std::move(hit_rate)};
+                    });
+                });
+            }
+            return f;
         }
     }
     future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>> make_data_request(gms::inet_address ep, clock_type::time_point timeout, bool want_digest) {
@@ -5066,8 +5092,10 @@ protected:
             tracing::trace(_trace_state, "read_data: querying locally");
             return _proxy->apply_fence(_proxy->query_result_local(_effective_replication_map_ptr, _schema, _cmd, _partition_range, opts, _trace_state, timeout, adjust_rate_limit_for_local_operation(_rate_limit_info)), fence, _proxy->my_address());
         } else {
+            const bool format_reverse_required = _cmd->slice.is_reversed() && !_native_reversed_queries_enabled;
+            auto cmd = format_reverse_required ? reversed(::make_lw_shared(*_cmd)) : _cmd;
             return _proxy->remote().send_read_data(netw::messaging_service::msg_addr{ep, 0}, timeout,
-                _trace_state, *_cmd, _partition_range, opts.digest_algo, _rate_limit_info,
+                _trace_state, *cmd, _partition_range, opts.digest_algo, _rate_limit_info,
                 fence);
         }
     }
@@ -5080,8 +5108,10 @@ protected:
                         timeout, digest_algorithm(*_proxy), adjust_rate_limit_for_local_operation(_rate_limit_info)), fence, _proxy->my_address());
         } else {
             tracing::trace(_trace_state, "read_digest: sending a message to /{}", ep);
+            const bool format_reverse_required = _cmd->slice.is_reversed() && !_native_reversed_queries_enabled;
+            auto cmd = format_reverse_required ? reversed(::make_lw_shared(*_cmd)) : _cmd;
             return _proxy->remote().send_read_digest(netw::messaging_service::msg_addr{ep, 0}, timeout,
-                _trace_state, *_cmd, _partition_range, digest_algorithm(*_proxy), _rate_limit_info,
+                _trace_state, *cmd, _partition_range, digest_algorithm(*_proxy), _rate_limit_info,
                 fence);
         }
     }
@@ -5223,14 +5253,40 @@ protected:
                         && !data_resolver->any_partition_short_read()) {
                     tracing::trace(_trace_state, "Read stage is done for read-repair");
                     mlogger.trace("reconciled: {}", rr_opt->pretty_printer(_schema));
+
+                    const bool is_reversed = _cmd->slice.is_reversed();
+                    auto schema = is_reversed ? _schema->get_reversed() : _schema;
+                    auto cmd = is_reversed ? reversed(::make_lw_shared(*_cmd)) : _cmd;
+                    auto&& rr = std::move(*rr_opt);
+                    if (is_reversed) {
+                        rr = co_await reversed(std::move(rr));
+                    }
+
                     auto result = ::make_foreign(::make_lw_shared<query::result>(
-                            co_await to_data_query_result(std::move(*rr_opt), _schema, _cmd->slice, _cmd->get_row_limit(), cmd->partition_limit)));
+                            co_await to_data_query_result(std::move(rr), schema, cmd->slice, cmd->get_row_limit(), cmd->partition_limit)));
                     qlogger.trace("reconciled: {}", result->pretty_printer(_schema, _cmd->slice));
+
+                    // Un-reverse mutations for reversed queries. When a mutation comes from a node in mixed-node cluster
+                    // it is reversed in make_mutation_data_request(). So we always deal here with reversed mutations for
+                    // reversed queries. No matter what format. Forward mutations are sent to spare replicas from reversing
+                    // them in the write-path.
+                    auto diffs = data_resolver->get_diffs_for_repair();
+                    if (is_reversed) {
+                        for (auto&& [token, diff] : diffs) {
+                            for (auto&& [address, opt_mut] : diff) {
+                                if (opt_mut) {
+                                    opt_mut = reverse(std::move(opt_mut.value()));
+                                    co_await coroutine::maybe_yield();
+                                }
+                            }
+                        }
+                    }
+
                     // wait for write to complete before returning result to prevent multiple concurrent read requests to
                     // trigger repair multiple times and to prevent quorum read to return an old value, even after a quorum
                     // another read had returned a newer value (but the newer value had not yet been sent to the other replicas)
                     // Waited on indirectly.
-                    (void)_proxy->schedule_repair(_effective_replication_map_ptr, data_resolver->get_diffs_for_repair(), _cl, _trace_state, _permit).then(utils::result_wrap([this, result = std::move(result)] () mutable {
+                    (void)_proxy->schedule_repair(_effective_replication_map_ptr, std::move(diffs), _cl, _trace_state, _permit).then(utils::result_wrap([this, result = std::move(result)] () mutable {
                         _result_promise.set_value(std::move(result));
                         return make_ready_future<::result<>>(bo::success());
                     })).then_wrapped([this, exec] (future<::result<>>&& f) {
@@ -5584,21 +5640,25 @@ result<::shared_ptr<abstract_read_executor>> storage_proxy::get_read_executor(lw
 }
 
 future<rpc::tuple<query::result_digest, api::timestamp_type, cache_temperature, std::optional<full_position>>>
-storage_proxy::query_result_local_digest(locator::effective_replication_map_ptr erm, schema_ptr s, lw_shared_ptr<query::read_command> cmd, const dht::partition_range& pr, tracing::trace_state_ptr trace_state, storage_proxy::clock_type::time_point timeout, query::digest_algorithm da, db::per_partition_rate_limit::info rate_limit_info) {
-    return query_result_local(std::move(erm), std::move(s), std::move(cmd), pr, query::result_options::only_digest(da), std::move(trace_state), timeout, rate_limit_info).then([] (rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature> result_and_hit_rate) {
+storage_proxy::query_result_local_digest(locator::effective_replication_map_ptr erm, schema_ptr query_schema, lw_shared_ptr<query::read_command> cmd, const dht::partition_range& pr, tracing::trace_state_ptr trace_state, storage_proxy::clock_type::time_point timeout, query::digest_algorithm da, db::per_partition_rate_limit::info rate_limit_info) {
+    return query_result_local(std::move(erm), std::move(query_schema), std::move(cmd), pr, query::result_options::only_digest(da), std::move(trace_state), timeout, rate_limit_info).then([] (rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature> result_and_hit_rate) {
         auto&& [result, hit_rate] = result_and_hit_rate;
         return make_ready_future<rpc::tuple<query::result_digest, api::timestamp_type, cache_temperature, std::optional<full_position>>>(rpc::tuple(*result->digest(), result->last_modified(), hit_rate, result->last_position()));
     });
 }
 
 future<rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>>
-storage_proxy::query_result_local(locator::effective_replication_map_ptr erm, schema_ptr s, lw_shared_ptr<query::read_command> cmd, const dht::partition_range& pr, query::result_options opts,
+storage_proxy::query_result_local(locator::effective_replication_map_ptr erm, schema_ptr query_schema, lw_shared_ptr<query::read_command> cmd1, const dht::partition_range& pr, query::result_options opts,
                                   tracing::trace_state_ptr trace_state, storage_proxy::clock_type::time_point timeout, db::per_partition_rate_limit::info rate_limit_info) {
+    const bool is_reversed = cmd1->slice.is_reversed();
+    auto table_schema = is_reversed ? query_schema->get_reversed() : query_schema;
+    auto cmd = is_reversed ? reversed(::make_lw_shared(*cmd1)) : cmd1;
+
     cmd->slice.options.set_if<query::partition_slice::option::with_digest>(opts.request != query::result_request::only_result);
-    if (auto shard_opt = dht::is_single_shard(erm->get_sharder(*s), *s, pr)) {
+    if (auto shard_opt = dht::is_single_shard(erm->get_sharder(*table_schema), *table_schema, pr)) {
         auto shard = *shard_opt;
         get_stats().replica_cross_shard_ops += shard != this_shard_id();
-        return _db.invoke_on(shard, _read_smp_service_group, [gs = global_schema_ptr(s), prv = dht::partition_range_vector({pr}) /* FIXME: pr is copied */, cmd, opts, timeout, gt = tracing::global_trace_state_ptr(std::move(trace_state)), rate_limit_info] (replica::database& db) mutable {
+        return _db.invoke_on(shard, _read_smp_service_group, [gs = global_schema_ptr(table_schema), prv = dht::partition_range_vector({pr}) /* FIXME: pr is copied */, cmd, opts, timeout, gt = tracing::global_trace_state_ptr(std::move(trace_state)), rate_limit_info] (replica::database& db) mutable {
             auto trace_state = gt.get();
             tracing::trace(trace_state, "Start querying singular range {}", prv.front());
             return db.query(gs, *cmd, opts, prv, trace_state, timeout, rate_limit_info).then([trace_state](std::tuple<lw_shared_ptr<query::result>, cache_temperature>&& f_ht) {
@@ -5610,7 +5670,7 @@ storage_proxy::query_result_local(locator::effective_replication_map_ptr erm, sc
     } else {
         // FIXME: adjust multishard_mutation_query to accept an smp_service_group and propagate it there
         tracing::trace(trace_state, "Start querying token range {}", pr);
-        return query_nonsingular_data_locally(s, cmd, {pr}, opts, trace_state, timeout).then(
+        return query_nonsingular_data_locally(table_schema, cmd, {pr}, opts, trace_state, timeout).then(
                 [trace_state = std::move(trace_state)] (rpc::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>&& r_ht) {
             auto&& [r, ht] = r_ht;
             tracing::trace(trace_state, "Querying is done");
@@ -6063,21 +6123,17 @@ storage_proxy::query(schema_ptr s,
 
 future<result<storage_proxy::coordinator_query_result>>
 storage_proxy::query_result(schema_ptr query_schema,
-    lw_shared_ptr<query::read_command> cmd1,
+    lw_shared_ptr<query::read_command> cmd,
     dht::partition_range_vector&& partition_ranges,
     db::consistency_level cl,
     storage_proxy::coordinator_query_options query_options)
 {
-    const bool is_reversed = cmd1->slice.is_reversed();
-    auto cmd = is_reversed ? reversed(::make_lw_shared(*cmd1)) : cmd1;
-    auto table_schema =  is_reversed ? query_schema->get_reversed() : query_schema;
-
     if (slogger.is_enabled(logging::log_level::trace) || qlogger.is_enabled(logging::log_level::trace)) {
         static thread_local int next_id = 0;
         auto query_id = next_id++;
 
-        slogger.trace("query {}.{} cmd={}, ranges={}, id={}", table_schema->ks_name(), table_schema->cf_name(), *cmd, partition_ranges, query_id);
-        return do_query(table_schema, cmd, std::move(partition_ranges), cl, std::move(query_options)).then_wrapped([query_id, cmd, table_schema] (future<result<coordinator_query_result>> f) -> result<coordinator_query_result> {
+        slogger.trace("query {}.{} cmd={}, ranges={}, id={}", query_schema->ks_name(), query_schema->cf_name(), *cmd, partition_ranges, query_id);
+        return do_query(query_schema, cmd, std::move(partition_ranges), cl, std::move(query_options)).then_wrapped([query_id, cmd, query_schema] (future<result<coordinator_query_result>> f) -> result<coordinator_query_result> {
             auto rres = utils::result_try([&] {
                 return f.get();
             },  utils::result_catch_dots([&] (auto&& handle) {
@@ -6095,12 +6151,12 @@ storage_proxy::query_result(schema_ptr query_schema,
             } else {
                 slogger.trace("query_result id={}, size={}", query_id, res->buf().size());
             }
-            qlogger.trace("id={}, {}", query_id, res->pretty_printer(table_schema, cmd->slice));
+            qlogger.trace("id={}, {}", query_id, res->pretty_printer(query_schema, cmd->slice));
             return qr;
         });
     }
 
-    return do_query(table_schema, cmd, std::move(partition_ranges), cl, std::move(query_options));
+    return do_query(query_schema, cmd, std::move(partition_ranges), cl, std::move(query_options));
 }
 
 future<result<storage_proxy::coordinator_query_result>>
@@ -6513,33 +6569,62 @@ future<> storage_proxy::stop_remote() {
 }
 
 future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>
-storage_proxy::query_mutations_locally(schema_ptr s, lw_shared_ptr<query::read_command> cmd, const dht::partition_range& pr,
+storage_proxy::query_mutations_locally(schema_ptr query_schema, lw_shared_ptr<query::read_command> cmd1, const dht::partition_range& pr,
                                        storage_proxy::clock_type::time_point timeout,
                                        tracing::trace_state_ptr trace_state) {
-    auto& table = s->table();
+    const bool is_reversed = cmd1->slice.is_reversed();
+    auto table_schema = is_reversed ? query_schema->get_reversed() : query_schema;
+    auto cmd = is_reversed ? reversed(::make_lw_shared(*cmd1)) : cmd1;
+
+    auto& table = table_schema->table();
     auto erm = table.get_effective_replication_map();
-    if (auto shard_opt = dht::is_single_shard(erm->get_sharder(*s), *s, pr)) {
+    if (auto shard_opt = dht::is_single_shard(erm->get_sharder(*table_schema), *table_schema, pr)) {
         auto shard = *shard_opt;
         get_stats().replica_cross_shard_ops += shard != this_shard_id();
-        return _db.invoke_on(shard, _read_smp_service_group, [cmd, &pr, gs=global_schema_ptr(s), timeout, gt = tracing::global_trace_state_ptr(std::move(trace_state))] (replica::database& db) mutable {
-            return db.query_mutations(gs, *cmd, pr, gt, timeout).then([] (std::tuple<reconcilable_result, cache_temperature> result_ht) {
+        return _db.invoke_on(shard, _read_smp_service_group, [cmd, &pr, gs=global_schema_ptr(table_schema), timeout, gt = tracing::global_trace_state_ptr(std::move(trace_state))] (replica::database& db) mutable {
+            return db.query_mutations(gs, *cmd, pr, gt, timeout).then([is_reversed=cmd->slice.is_reversed()] (std::tuple<reconcilable_result, cache_temperature> result_ht) {
                 auto&& [result, ht] = result_ht;
-                return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>(rpc::tuple(make_foreign(make_lw_shared<reconcilable_result>(std::move(result))), ht));
+                if (is_reversed) {
+                    return reversed(std::move(result)).then([ht=std::move(ht)] (auto result) mutable {
+                        return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>(rpc::tuple(make_foreign(make_lw_shared<reconcilable_result>(std::move(result))), std::move(ht)));
+                    });
+                }
+                return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>(rpc::tuple(make_foreign(make_lw_shared<reconcilable_result>(std::move(result))), std::move(ht)));
             });
         });
     } else {
-        return query_nonsingular_mutations_locally(std::move(s), std::move(cmd), {pr}, std::move(trace_state), timeout);
+        bool is_reversed = cmd->slice.is_reversed();
+        return query_nonsingular_mutations_locally(std::move(table_schema), std::move(cmd), {pr}, std::move(trace_state), timeout).then([is_reversed] (auto result_ht) {
+            auto&& [result, ht] = result_ht;
+            if (is_reversed) {
+                return reversed(std::move(result)).then([ht=std::move(ht)] (auto result) mutable {
+                    return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>(rpc::tuple(std::move(result), std::move(ht)));
+                });
+            }
+            return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>(rpc::tuple(std::move(result), std::move(ht)));
+        });
     }
 }
 
 future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>
-storage_proxy::query_mutations_locally(schema_ptr s, lw_shared_ptr<query::read_command> cmd, const ::compat::one_or_two_partition_ranges& pr,
+storage_proxy::query_mutations_locally(schema_ptr query_schema, lw_shared_ptr<query::read_command> cmd, const ::compat::one_or_two_partition_ranges& pr,
                                        storage_proxy::clock_type::time_point timeout,
                                        tracing::trace_state_ptr trace_state) {
     if (!pr.second) {
-        return query_mutations_locally(std::move(s), std::move(cmd), pr.first, timeout, std::move(trace_state));
+        return query_mutations_locally(std::move(query_schema), std::move(cmd), pr.first, timeout, std::move(trace_state));
     } else {
-        return query_nonsingular_mutations_locally(std::move(s), std::move(cmd), pr, std::move(trace_state), timeout);
+        const bool is_reversed = cmd->slice.is_reversed();
+        auto table_schema = is_reversed ? query_schema->get_reversed() : query_schema;
+        auto cmd1 = is_reversed ? reversed(std::move(cmd)) : cmd;
+        return query_nonsingular_mutations_locally(std::move(table_schema), std::move(cmd1), pr, std::move(trace_state), timeout).then([is_reversed] (auto result_ht) {
+            auto&& [result, ht] = result_ht;
+            if (is_reversed) {
+                return reversed(std::move(result)).then([ht=std::move(ht)] (auto result) mutable {
+                    return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>(rpc::tuple(std::move(result), std::move(ht)));
+                });
+            }
+            return make_ready_future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>(rpc::tuple(std::move(result), std::move(ht)));
+        });
     }
 }
 

--- a/sstables/kl/reader.hh
+++ b/sstables/kl/reader.hh
@@ -26,6 +26,18 @@ mutation_reader make_reader(
         mutation_reader::forwarding fwd_mr,
         read_monitor& monitor);
 
+// Same as above but the slice is moved and stored inside the reader.
+mutation_reader make_reader(
+        shared_sstable sstable,
+        schema_ptr schema,
+        reader_permit permit,
+        const dht::partition_range& range,
+        query::partition_slice&& slice,
+        tracing::trace_state_ptr trace_state,
+        streamed_mutation::forwarding fwd,
+        mutation_reader::forwarding fwd_mr,
+        read_monitor& monitor);
+
 // A reader which doesn't use the index at all. It reads everything from the
 // sstable and it doesn't support skipping.
 mutation_reader make_crawling_reader(

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1704,18 +1704,6 @@ static mutation_reader make_reader(
         streamed_mutation::forwarding fwd,
         mutation_reader::forwarding fwd_mr,
         read_monitor& monitor) {
-    // If we're provided a reversed slice we must fix it since currently callers
-    // provide them in a 'half-reversed' format: the order of ranges in the slice is reversed,
-    // but the ranges themselves are not.
-    // FIXME: drop this workaround when callers are fixed to provide the slice
-    // in 'native-reversed' format (if ever).
-    if (slice.get().is_reversed()) {
-        return make_mutation_reader<mx_sstable_mutation_reader>(
-            std::move(sstable), schema, std::move(permit), range,
-            value_or_reference(legacy_reverse_slice_to_native_reverse_slice(*schema, slice.get())),
-            std::move(trace_state), fwd, fwd_mr, monitor);
-    }
-
     return make_mutation_reader<mx_sstable_mutation_reader>(
         std::move(sstable), std::move(schema), std::move(permit), range,
         std::move(slice), std::move(trace_state), fwd, fwd_mr, monitor);

--- a/sstables/mx/reader.hh
+++ b/sstables/mx/reader.hh
@@ -17,8 +17,6 @@ namespace mx {
 
 // Precondition: if the slice is reversed, the schema must be reversed as well
 // and the range must be singular (`range.is_singular()`).
-// Reversed slices must be provided in the 'half-reversed' format (the order of ranges
-// being reversed, but the ranges themselves are not).
 // Fast-forwarding is not supported in reversed queries (FIXME).
 mutation_reader make_reader(
         shared_sstable sstable,

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -274,7 +274,7 @@ public:
     // Reversed slices must be provided in the 'half-reversed' format (the order of ranges
     // being reversed, but the ranges themselves are not).
     mutation_reader make_reader(
-            schema_ptr schema,
+            schema_ptr query_schema,
             reader_permit permit,
             const dht::partition_range& range,
             const query::partition_slice& slice,

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -271,8 +271,6 @@ public:
     // Returns a mutation_reader for given range of partitions.
     //
     // Precondition: if the slice is reversed, the schema must be reversed as well.
-    // Reversed slices must be provided in the 'half-reversed' format (the order of ranges
-    // being reversed, but the ranges themselves are not).
     mutation_reader make_reader(
             schema_ptr query_schema,
             reader_permit permit,

--- a/test/boost/counter_test.cc
+++ b/test/boost/counter_test.cc
@@ -254,7 +254,7 @@ SEASTAR_TEST_CASE(test_counter_mutations) {
         m = m1;
         m.apply(m4);
         m.partition().compact_for_query(*s, m.decorated_key(), gc_clock::now(), { query::clustering_range::make_singular(ck) },
-                                        false, false, query::max_rows);
+                                        false, query::max_rows);
         BOOST_REQUIRE_EQUAL(m.partition().clustered_rows().calculate_size(), 0);
         BOOST_REQUIRE(m.partition().static_row().empty());
 

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -320,7 +320,7 @@ read_partitions_with_generic_paged_scan(distributed<replica::database>& db, sche
 
         if (res_builder.last_ckey()) {
             auto ckranges = cmd.slice.default_row_ranges();
-            query::trim_clustering_row_ranges_to(*s, ckranges, *res_builder.last_ckey(), false);
+            query::trim_clustering_row_ranges_to(*s, ckranges, *res_builder.last_ckey());
             cmd.slice.clear_range(*s, res_builder.last_pkey().key());
             cmd.slice.clear_ranges();
             cmd.slice.set_range(*s, res_builder.last_pkey().key(), std::move(ckranges));

--- a/test/boost/mutation_reader_another_test.cc
+++ b/test/boost/mutation_reader_another_test.cc
@@ -1132,16 +1132,14 @@ SEASTAR_THREAD_TEST_CASE(test_reverse_reader_v2_is_mutation_source) {
                 streamed_mutation::forwarding fwd_sm,
                 mutation_reader::forwarding fwd_mr) mutable {
             mutation_reader rd(nullptr);
-            std::unique_ptr<query::partition_slice> reversed_slice;
             std::vector<mutation>* selected_muts;
+            auto reversed_slice = std::make_unique<query::partition_slice>(query::reverse_slice(*schema, slice));
 
             schema = schema->make_reversed();
             const auto reversed = slice.is_reversed();
             if (reversed) {
-                reversed_slice = std::make_unique<query::partition_slice>(query::half_reverse_slice(*schema, slice));
                 selected_muts = &muts;
             } else {
-                reversed_slice = std::make_unique<query::partition_slice>(query::reverse_slice(*schema, slice));
                 // We don't want the memtable reader to read in reverse.
                 reversed_slice->options.remove(query::partition_slice::option::reversed);
                 selected_muts = &reverse_muts;

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1730,7 +1730,9 @@ static mutation_source make_mutation_source(populate_fn_ex populate, schema_ptr 
             tracing::trace_state_ptr tr,
             streamed_mutation::forwarding fwd,
             mutation_reader::forwarding mr_fwd) mutable {
-        reversed_slices.emplace_back(partition_slice_builder(*table_schema, query::native_reverse_slice_to_legacy_reverse_slice(*table_schema, slice))
+        // Note that the clustering ranges of the provided slice are already reversed in relation to the table_schema
+        // above. Thus toggling its reverse option is all that needs to be done here.
+        reversed_slices.emplace_back(partition_slice_builder(*table_schema, slice)
                 .with_option<query::partition_slice::option::reversed>()
                 .build());
         return ms.make_reader_v2(query_schema, std::move(permit), pr, reversed_slices.back(), tr, fwd, mr_fwd);

--- a/utils/value_or_reference.hh
+++ b/utils/value_or_reference.hh
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <optional>
+
+template <typename T>
+struct value_or_reference {
+    std::optional<T> _opt;
+    const T& _ref;
+
+    explicit value_or_reference(T&& v) : _opt(std::move(v)), _ref(*_opt) {}
+    explicit value_or_reference(const T& v) : _ref(v) {}
+
+    value_or_reference(value_or_reference&& o) : _opt(std::move(o._opt)), _ref(_opt ? *_opt : o._ref) {}
+    value_or_reference(const value_or_reference& o) : _opt(o._opt), _ref(_opt ? *_opt : o._ref) {}
+
+    const T& get() const {
+        return _ref;
+    }
+};


### PR DESCRIPTION
Drop half-reversed (legacy) format of query::partition_slice.

The select query builds a fully reversed (native) slice for reversed queries and use it together with a reversed
schema to construct query::read_command that is further propagated to the database.

A cluster feature is added to support nodes that still operate on half-reversed slices. When the feature is turned off:
- query::read_command is transformed (to have table schema and half-reversed slices) before sending to other nodes
- query::read_command is transformed (to have query schema (reversed) and reversed slices) after receiving it from other nodes
- Similarly, mutations are transformed. They are reversed before being sent to other nodes or after receiving them from other nodes.

Additional manual tests were performed to test a mixed-node cluster:

1. 3-node cluster with one node upgraded: reverse read queries performed on an old node
2. 3-node cluster with one node upgraded: reverse read queries performed on a new node
3. 3-node cluster with one node upgraded and all its sstable files deleted to trigger repair: reverse read queries performed on an old node
4. 3-node cluster with one node upgraded and all its sstable files deleted to trigger repair: reverse read queries performed on a new node

All reverse read queries above consists of:

- single-partition reverse reads with no clustering key restrictions, with single column restrictions and multi column restrictions both with and without paging turned on
- multi-partition reverse reads with range restrictions with optional partition limit and partial ordering

The exact same tests were also performed on a fully upgraded cluster.

Fixes https://github.com/scylladb/scylladb/issues/12557