### PR TITLE
treewide: include used headers

### DIFF
--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <filesystem>
 
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>

--- a/test/lib/tmpdir.hh
+++ b/test/lib/tmpdir.hh
@@ -8,9 +8,8 @@
 
 #pragma once
 
+#include <filesystem>
 #include <fmt/format.h>
-
-#include <seastar/util/std-compat.hh>
 
 namespace fs = std::filesystem;
 

--- a/utils/hashing.hh
+++ b/utils/hashing.hh
@@ -10,6 +10,7 @@
 
 #include <concepts>
 #include <map>
+#include <optional>
 #include <seastar/core/byteorder.hh>
 #include <seastar/core/sstring.hh>
 #include "seastarx.hh"


### PR DESCRIPTION
before this change, we rely on `seastar/util/std-compat.hh` to
include the used headers provided by stdandard library. this was
necessary before we move to a C++20 compliant standard library
implementation. but since Seastar has dropped C++17 support. its
`seastar/util/std-compat.hh` is not responsible for providing these
headers anymore.

so, in this change, we include the used headers directly instead
of relying on `seastar/util/std-compat.hh`.