### PR TITLE
treewide: fix typos in comment and error messages

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -862,7 +862,7 @@ future<> manager::perform_migration() {
     }
 
     manager_logger.info("Migration of hinted handoff to host ID is starting");
-    // Step 1. Prevent acceping incoming hints.
+    // Step 1. Prevent accepting incoming hints.
     _state.set(state::migrating);
 
     // Step 2. Make sure during the migration there is no draining process and we don't await any sync points.

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1557,7 +1557,7 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
     });
 
     // First drop views and *only then* the tables, if interleaved it can lead
-    // to a mv not finding its schema when snapshoting since the main table
+    // to a mv not finding its schema when snapshotting since the main table
     // was already dropped (see https://github.com/scylladb/scylla/issues/5614)
     auto& db = proxy.local().get_db();
     co_await max_concurrent_for_each(views_diff.dropped, max_concurrent, [&db, &sys_ks] (schema_diff::dropped_schema& dt) {

--- a/readers/foreign.hh
+++ b/readers/foreign.hh
@@ -23,7 +23,7 @@ class reader_permit;
 /// bufferful at a time.
 /// To maximize throughput read-ahead is used. After each fill_buffer() or
 /// fast_forward_to() a read-ahead (a fill_buffer() on the remote reader) is
-/// issued. This read-ahead runs in the background and is brough back to
+/// issued. This read-ahead runs in the background and is brought back to
 /// foreground on the next fill_buffer() or fast_forward_to() call.
 /// If the reader resides on this shard (the shard where make_foreign_reader()
 /// is called) there is no need to wrap it in foreign_reader, just return it as

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2001,7 +2001,7 @@ future<> storage_service::track_upgrade_progress_to_topology_coordinator(sharded
         } catch (const seastar::abort_requested_exception&) {
             throw;
         } catch (...) {
-            rtlogger.error("the fiber tracking readiness of upgrade to raft toplogy got an unexpected error: {}", std::current_exception());
+            rtlogger.error("the fiber tracking readiness of upgrade to raft topology got an unexpected error: {}", std::current_exception());
         }
 
         co_await sleep_abortable(std::chrono::seconds(1), _group0_as);
@@ -2030,7 +2030,7 @@ future<> storage_service::track_upgrade_progress_to_topology_coordinator(sharded
         } catch (const seastar::abort_requested_exception&) {
             throw;
         } catch (...) {
-            rtlogger.error("the fiber tracking progress of upgrade to raft toplogy got an unexpected error. "
+            rtlogger.error("the fiber tracking progress of upgrade to raft topology got an unexpected error. "
                     "Will not report in logs when upgrade has completed. Error: {}", std::current_exception());
         }
     }

--- a/utils/rjson.hh
+++ b/utils/rjson.hh
@@ -363,7 +363,7 @@ inline bytes base64_decode(const value& v) {
     return ::base64_decode(std::string_view(v.GetString(), v.GetStringLength()));
 }
 
-// A writer which allows writing json into an std::ostream in a streamin manner.
+// A writer which allows writing json into an std::ostream in a streaming manner.
 //
 // It is a wrapper around rapidjson::Writer, with a more convenient API.
 class streaming_writer {


### PR DESCRIPTION
these typos were identified by codespell

* fixes of the typos in the comment and error message. no need to backport.