### PR TITLE
api/api-doc/utils: fix a typo in description

### DIFF
--- a/api/api-doc/utils.json
+++ b/api/api-doc/utils.json
@@ -75,7 +75,7 @@
                "items":{
                   "type":"double"
                },
-               "description":"One, five and fifteen mintues rates"
+               "description":"One, five and fifteen minutes rates"
             },
             "mean_rate": {
                "type":"double",


### PR DESCRIPTION
s/mintues/minutes/

* no need to backport. it's but a description in API doc. the doc is supposed to be consumed by human developers.