### PR TITLE
docs: fix typos in dev documents

### DIFF
--- a/docs/dev/maintainer.md
+++ b/docs/dev/maintainer.md
@@ -178,7 +178,7 @@ latest submodules.
     commit log editor for every submodule to show that commits are being
     updated.
  3. Edit the submodule update commits with any necessary additional
-    imformation. For example, amend the message with `Fixes` tags.
+    information. For example, amend the message with `Fixes` tags.
  4. Use `git push` to publish your work.
 
 By default refresh-submodules.sh will refresh all submodules from their

--- a/docs/dev/redis.md
+++ b/docs/dev/redis.md
@@ -323,7 +323,7 @@ For the same reason as RMW command, the transaction is not supported
 currently.
 
 > In fact, some commands (e.g. MSET of STRINGs) are also not supported,
-> which also need the transcation mechanism.
+> which also need the transaction mechanism.
 
 ### 5.4 Time to Live (TTL)
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -298,7 +298,7 @@ Jenkins in event of test failure.
 ## Stability
 
 Testing is hard. Testing ScyllaDB is even harder, but we strive to ensure our testing
-suite is as solid as possible. The first step is contribuing a stable (read: non-flaky) test.
+suite is as solid as possible. The first step is contributing a stable (read: non-flaky) test.
 To do so, when developing tests, please run them (1) in debug mode and (2) 100 times in a row (using `--repeat 100`),
 and see that they pass successfully.
 


### PR DESCRIPTION
these typos were identified by codespell.

* no need to backport. as the target audience of these documents are developers, and the meaning does not change even with these typos, so we can live with them in the older document.