### PR TITLE
Mark prepare_statement as immutable

### DIFF
--- a/cql3/statements/prepared_statement.hh
+++ b/cql3/statements/prepared_statement.hh
@@ -38,8 +38,8 @@ public:
 public:
     const seastar::shared_ptr<cql_statement> statement;
     const std::vector<seastar::lw_shared_ptr<column_specification>> bound_names;
-    std::vector<uint16_t> partition_key_bind_indices;
-    std::vector<sstring> warnings;
+    const std::vector<uint16_t> partition_key_bind_indices;
+    const std::vector<sstring> warnings;
 
     prepared_statement(seastar::shared_ptr<cql_statement> statement_, std::vector<seastar::lw_shared_ptr<column_specification>> bound_names_,
                        std::vector<uint16_t> partition_key_bind_indices, std::vector<sstring> warnings = {});

--- a/cql3/statements/prepared_statement.hh
+++ b/cql3/statements/prepared_statement.hh
@@ -33,7 +33,7 @@ struct invalidated_prepared_usage_attempt {
 
 class prepared_statement : public seastar::weakly_referencable<prepared_statement> {
 public:
-    typedef seastar::checked_ptr<seastar::weak_ptr<prepared_statement>> checked_weak_ptr;
+    typedef seastar::checked_ptr<seastar::weak_ptr<const prepared_statement>> checked_weak_ptr;
 
 public:
     const seastar::shared_ptr<cql_statement> statement;
@@ -51,7 +51,7 @@ public:
 
     prepared_statement(seastar::shared_ptr<cql_statement>&& statement_);
 
-    checked_weak_ptr checked_weak_from_this() {
+    checked_weak_ptr checked_weak_from_this() const {
         return checked_weak_ptr(this->weak_from_this());
     }
 };

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -35,7 +35,7 @@ namespace tracing {
 
 extern logging::logger trace_state_logger;
 
-using prepared_checked_weak_ptr = seastar::checked_ptr<seastar::weak_ptr<cql3::statements::prepared_statement>>;
+using prepared_checked_weak_ptr = seastar::checked_ptr<seastar::weak_ptr<const cql3::statements::prepared_statement>>;
 
 class trace_state final {
 public:


### PR DESCRIPTION
Users of prepared statement reference it with the help of "smart" pointers. None of the users are supposed to modify the object they point to, so mark the respective pointer type as `pointer<const prepared_statement>`. Also mark the fields of prepared statement itself with const's (some of them already are)