### PR TITLE
test: revert 4c1b6f04

### DIFF
--- a/test/lib/test_utils.hh
+++ b/test/lib/test_utils.hh
@@ -113,16 +113,10 @@ extern std::mutex boost_logger_mutex;
 
 }
 
-namespace internal {
-
-template <typename T, typename Char = char>
-concept formattable = fmt::is_formattable<std::remove_reference_t<T>, Char>::value;
-
-}
-
 namespace std {
 
-template <::internal::formattable T>
+template <typename T>
+requires fmt::is_formattable<T>::value
 std::ostream& boost_test_print_type(std::ostream& os, const T& p) {
     fmt::print(os, "{}", p);
     return os;


### PR DESCRIPTION
in 4c1b6f04, we added a concept for fmt::is_formattable<>. but it was not ncessary. the fmt::is_formattable<> trait was enough. the reason 4c1b6f04 was actually a leftover of a bigger change which tried to add trait for the cases where fmt::is_formattable<> was not able to cover. but that was based on the wrong impression that fmt::is_formattable<> should be able to work with container types without including, for instance `fmt/ranges.h`. but in 222dbf2c, we include `fmt/ranges.h` in tests, where the range-alike formatter is used, that enables `fmt::is_formattable<>` to tell that container types are formattable.

in short, 4c1b6f04 was created based on a misunderstanding, and it was a reduced type trait, which is proved to be not necessary.

so, in this change, it is dropped. but the type constraints is preserved to make the build failure more explicit, if the fallback formatter does not match with the type to be formatted by Boost.test.

* this change is merely a cleanup. and there is no need to backport it.