### PR TITLE
treewide: include used headers

### DIFF
--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <filesystem>
 
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>

--- a/test/boost/snitch_reset_test.cc
+++ b/test/boost/snitch_reset_test.cc
@@ -7,9 +7,9 @@
  */
 
 
+#include <filesystem>
 #include <string>
 #include <boost/test/unit_test.hpp>
-#include <seastar/util/std-compat.hh>
 #include "locator/snitch_base.hh"
 #include "gms/inet_address.hh"
 #include "test/lib/scylla_test_case.hh"

--- a/test/boost/top_k_test.cc
+++ b/test/boost/top_k_test.cc
@@ -14,6 +14,7 @@
 #include <fmt/ranges.h>
 #include <vector>
 #include <algorithm>
+#include <optional>
 
 //---------------------------------------------------------------------------------------------
 

--- a/test/lib/tmpdir.hh
+++ b/test/lib/tmpdir.hh
@@ -8,9 +8,8 @@
 
 #pragma once
 
+#include <filesystem>
 #include <fmt/format.h>
-
-#include <seastar/util/std-compat.hh>
 
 namespace fs = std::filesystem;
 

--- a/test/manual/ec2_snitch_test.cc
+++ b/test/manual/ec2_snitch_test.cc
@@ -7,12 +7,12 @@
  */
 
 
+#include <filesystem>
 #include <string>
 #include <boost/test/unit_test.hpp>
 #include <seastar/http/response_parser.hh>
 #include <seastar/net/api.hh>
 #include <seastar/testing/test_case.hh>
-#include <seastar/util/std-compat.hh>
 #include "locator/snitch_base.hh"
 
 namespace fs = std::filesystem;

--- a/utils/hashing.hh
+++ b/utils/hashing.hh
@@ -10,6 +10,7 @@
 
 #include <concepts>
 #include <map>
+#include <optional>
 #include <seastar/core/byteorder.hh>
 #include <seastar/core/sstring.hh>
 #include "seastarx.hh"

--- a/utils/top_k.hh
+++ b/utils/top_k.hh
@@ -45,6 +45,7 @@
 
 #include <cstdio>
 #include <list>
+#include <optional>
 #include <unordered_map>
 #include <tuple>
 #include <assert.h>


### PR DESCRIPTION
before this change, we rely on `seastar/util/std-compat.hh` to include the used headers provided by stdandard library. this was necessary before we moved to a C++20 compliant standard library implementation. but since Seastar has dropped C++17 support. its `seastar/util/std-compat.hh` is not responsible for providing these headers anymore.

 so, in this change, we include the used headers directly instead of relying on `seastar/util/std-compat.hh`. please note, this change is a prerequisite of bumping up the seastar submodule.

* no need to backport, as it is just a cleanup.