### PR TITLE
test/lib: do not include unused headers

### DIFF
--- a/test/unit/btree_compaction_test.cc
+++ b/test/unit/btree_compaction_test.cc
@@ -8,10 +8,7 @@
 
 #include <seastar/core/app-template.hh>
 #include <seastar/core/thread.hh>
-#include <map>
-#include <iostream>
 #include <fmt/core.h>
-#include "utils/logalloc.hh"
 
 constexpr int TEST_NODE_SIZE = 7;
 constexpr int TEST_LINEAR_THRESHOLD = 19;

--- a/test/unit/lsa_sync_eviction_test.cc
+++ b/test/unit/lsa_sync_eviction_test.cc
@@ -13,8 +13,6 @@
 
 #include "utils/managed_bytes.hh"
 #include "utils/logalloc.hh"
-#include "utils/managed_ref.hh"
-#include "test/perf/perf.hh"
 #include "log.hh"
 
 #include <random>

--- a/test/unit/radix_tree_compaction_test.cc
+++ b/test/unit/radix_tree_compaction_test.cc
@@ -8,13 +8,8 @@
 
 #include <seastar/core/app-template.hh>
 #include <seastar/core/thread.hh>
-#include <map>
-#include <vector>
-#include <random>
 #include <string>
-#include <iostream>
 #include <fmt/core.h>
-#include "utils/logalloc.hh"
 
 #include "utils/compact-radix-tree.hh"
 #include "radix_tree_printer.hh"

--- a/test/unit/radix_tree_stress_test.cc
+++ b/test/unit/radix_tree_stress_test.cc
@@ -9,10 +9,7 @@
 #include <seastar/core/app-template.hh>
 #include <seastar/core/thread.hh>
 #include <map>
-#include <vector>
-#include <random>
 #include <string>
-#include <iostream>
 #include <fmt/core.h>
 #include <fmt/ostream.h>
 #include <fmt/ranges.h>

--- a/test/unit/row_cache_alloc_stress_test.cc
+++ b/test/unit/row_cache_alloc_stress_test.cc
@@ -12,7 +12,6 @@
 #include <seastar/core/thread.hh>
 #include <seastar/util/closeable.hh>
 
-#include "utils/managed_bytes.hh"
 #include "utils/logalloc.hh"
 #include "row_cache.hh"
 #include "log.hh"

--- a/test/unit/tree_test_key.hh
+++ b/test/unit/tree_test_key.hh
@@ -10,7 +10,6 @@
 
 #include <fmt/core.h>
 #include <cassert>
-#include "utils/bptree.hh"
 
 /*
  * Helper class that helps to check that tree


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.

* no need to backport. as it is a cleanup.