### PR TITLE
test: test_topology_ops: run correctly without tablets

### DIFF
--- a/test/topology_experimental_raft/test_topology_ops.py
+++ b/test/topology_experimental_raft/test_topology_ops.py
@@ -21,10 +21,10 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("tablets_enabled", ["true", "false"])
+@pytest.mark.parametrize("tablets_enabled", [True, False])
 async def test_topology_ops(request, manager: ManagerClient, tablets_enabled: bool):
     """Test basic topology operations using the topology coordinator."""
-    cfg = {'experimental_features' : ['tablets']} if tablets_enabled else {}
+    cfg = {'experimental_features': ['tablets'] if tablets_enabled else []}
 
     logger.info("Bootstrapping first node")
     servers = [await manager.server_add(config=cfg)]


### PR DESCRIPTION
This patch fixes two bugs in `test_topology_ops`:
1. The values of `tablets_enabled` were nonempty strings, so they
always evaluated to `True` in the if statement responsible for
enabling writing workers only if tablets are disabled. Hence, the
writing workers were always disabled.
2. The `topology_experimental_raft suite` uses tablets by default,
so we need a config with empty `experimental_features` to disable
them.

Ensuring this test works with and without tablets is considered
a part of 6.0, so we should backport this patch.