### PR TITLE
test_tablets: add test_tablet_storage_freeing

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -277,6 +277,10 @@ class ManagerClient():
         logger.debug("ManagerClient wiping sstables on %s, keyspace=%s, table=%s", server_id, keyspace, table)
         await self.client.put_json(f"/cluster/server/{server_id}/wipe_sstables", {"keyspace": keyspace, "table": table})
 
+    async def server_get_sstables_disk_usage(self, server_id: ServerNum, keyspace: str, table: str) -> int:
+        """Get the total size of all sstable files for the given table"""
+        return await self.client.get_json(f"/cluster/server/{server_id}/sstables_disk_usage", params={"keyspace": keyspace, "table": table})
+
     def _create_server_add_data(self, replace_cfg: Optional[ReplaceConfig],
                                 cmdline: Optional[List[str]],
                                 config: Optional[dict[str, Any]],

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -35,6 +35,8 @@ import aiohttp.web
 import yaml
 import signal
 import glob
+import errno
+import re
 
 from cassandra import InvalidRequest                    # type: ignore
 from cassandra import OperationTimedOut                 # type: ignore
@@ -323,6 +325,31 @@ class ScyllaServer:
         for f in glob.iglob(f"./{keyspace}/{table}-????????????????????????????????/**/*", root_dir=root_dir, recursive=True):
             if ((root_dir/f).is_file()):
                 (root_dir/f).unlink()
+
+    def get_sstables_disk_usage(self, keyspace: str, table: str) -> int:
+        size = 0
+
+        if self.cmd is not None:
+            deleted_sstable_re = f"^.*/{keyspace}/{table}-[0-9a-f]{{32}}/.* \(deleted\)$"
+            deleted_sstable_re = re.compile(deleted_sstable_re)
+            for f in pathlib.Path(f"/proc/{self.cmd.pid}/fd/").iterdir():
+                try:
+                    link = f.readlink()
+                    if deleted_sstable_re.match(str(link)) is not None:
+                        size += f.stat().st_size
+                except OSError as e:
+                    if e.errno != errno.ENOENT:
+                        raise
+
+        table_dir = self.workdir/"data"
+        for f in table_dir.glob(f"{keyspace}/{table}-????????????????????????????????/**/*"):
+            try:
+                size += f.stat().st_size
+            except OSError as e:
+                if e.errno != errno.ENOENT:
+                    raise
+
+        return size
 
     async def install_and_start(self, api: ScyllaRESTAPIClient, expected_error: Optional[str] = None) -> None:
         """Setup and start this server"""
@@ -1119,6 +1146,12 @@ class ScyllaCluster:
         self.is_dirty = True
         server.wipe_sstables(keyspace, table)
 
+    def get_sstables_disk_usage(self, server_id: ServerNum, keyspace: str, table: str) -> int:
+        """Measure the disk usage of sstables for the given <node, keyspace, table>."""
+        assert server_id in self.servers, f"Server {server_id} unknown"
+        server = self.servers[server_id]
+        return server.get_sstables_disk_usage(keyspace, table)
+
 class ScyllaClusterManager:
     """Manages a Scylla cluster for running test cases
        Provides an async API for tests to request changes in the Cluster.
@@ -1280,6 +1313,7 @@ class ScyllaClusterManager:
         add_get('/cluster/server/{server_id}/maintenance_socket_path', self._server_get_maintenance_socket_path)
         add_get('/cluster/server/{server_id}/exe', self._server_get_exe)
         add_put('/cluster/server/{server_id}/wipe_sstables', self._cluster_server_wipe_sstables)
+        add_get('/cluster/server/{server_id}/sstables_disk_usage', self._server_get_sstables_disk_usage)
 
     async def _manager_up(self, _request) -> bool:
         return self.is_running
@@ -1596,6 +1630,11 @@ class ScyllaClusterManager:
         data = await request.json()
         server_id = ServerNum(int(request.match_info["server_id"]))
         return self.cluster.wipe_sstables(server_id, data["keyspace"], data["table"])
+
+    async def _server_get_sstables_disk_usage(self, request: aiohttp.web.Request) -> int:
+        data = request.query
+        server_id = ServerNum(int(request.match_info["server_id"]))
+        return self.cluster.get_sstables_disk_usage(server_id, data["keyspace"], data["table"])
 
 @asynccontextmanager
 async def get_cluster_manager(test_uname: str, clusters: Pool[ScyllaCluster], test_path: str) \

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -1017,3 +1017,41 @@ async def test_storage_service_api_uneven_ownership_keyspace_and_table_params_us
         assert actual_ownership == pytest.approx(expected_ownerships[i], abs=delta)
 
         already_verified.add(actual_ip)
+
+@pytest.mark.asyncio
+async def test_tablet_storage_freeing(manager: ManagerClient):
+    logger.info("Start first node")
+    servers = [await manager.server_add()]
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+    cql = manager.get_cql()
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logger.info("Create a table with two tablets and populate it with a moderate amount of data.")
+    n_tablets = 2
+    n_partitions = 1000
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': {}}};".format(n_tablets))
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, v text) WITH compression = {'sstable_compression': ''};")
+    insert_stmt = cql.prepare("INSERT INTO test.test (pk, v) VALUES (?, ?);")
+    payload = "a"*10000
+    await asyncio.gather(*[cql.run_async(insert_stmt, [k, payload]) for k in range(n_partitions)])
+    await manager.api.keyspace_flush(servers[0].ip_addr, "test")
+
+    logger.info("Start second node.")
+    servers.append(await manager.server_add())
+    s1_host_id = await manager.get_host_id(servers[1].server_id)
+
+    logger.info("Check the table's disk usage on first node.")
+    size_before = await manager.server_get_sstables_disk_usage(servers[0].server_id, "test", "test")
+    assert size_before > n_partitions * len(payload)
+
+    logger.info("Read system.tablets.")
+    tablet_replicas = await get_all_tablet_replicas(manager, servers[0], 'test', 'test')
+    assert len(tablet_replicas) == n_tablets
+
+    logger.info("Migrate one of the two tablets from the first node to the second node.")
+    t = tablet_replicas[0]
+    await manager.api.move_tablet(servers[0].ip_addr, "test", "test", *t.replicas[0], *(s1_host_id, 0), t.last_token)
+
+    logger.info("Verify that the table's disk usage on first node shrunk by about half.")
+    size_after = await manager.server_get_sstables_disk_usage(servers[0].server_id, "test", "test")
+    assert size_before * 0.33 < size_after < size_before * 0.66


### PR DESCRIPTION
Before work on tablets was completed, it was noticed that — due to some missing pieces of implementation — Scylla doesn't properly close sstables for migrated-away tablets. Because of this, disk space wasn't being reclaimed properly.

Since the missing pieces of implementation were added, the problem should be gone now. This patch adds a test which was used to reproduce the problem earlier. It's expected to pass now, validating that the issue was fixed.

Should be backported to branch-6.0, because the tested problem was also affecting that branch.

Fixes #16946