### PR TITLE
replica: Only consume memtable of the tablet intersecting with range read

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -198,9 +198,11 @@ table::add_memtables_to_reader_list(std::vector<flat_mutation_reader_v2>& reader
         return;
     }
     reserve_fn(boost::accumulate(compaction_groups() | boost::adaptors::transformed(std::mem_fn(&compaction_group::memtable_count)), uint64_t(0)));
-    // TODO: implement a incremental reader selector for memtable, using existing reader_selector interface for combined_reader.
+    auto token_range = range.transform(std::mem_fn(&dht::ring_position::token));
     for (compaction_group& cg : compaction_groups()) {
-        add_memtables_from_cg(cg);
+        if (cg.token_range().overlaps(token_range, dht::token_comparator())) {
+            add_memtables_from_cg(cg);
+        }
     }
 }
 


### PR DESCRIPTION
storage_proxy is responsible for intersecting the range of the read with tablets, and calling replica with a single tablet range, therefore it makes sense to avoid touching memtables of tablets that don't intersect with a particular range.

Note this is a performance issue, not correctness one, as memtable readers that don't intersect with current range won't produce any data, but cpu is wasted until that's realized (they're added to list of readers in mutation_reader_merger, more allocations, more data sources to peek into, etc).

That's also important for streaming e.g. after decommission, that will consume one tablet at a time through a reader, so we don't want memtables of streamed tablets (that weren't cleaned up yet) to be consumed.

Refs #18904.
