### PR TITLE
Update seastar submodule

### DIFF
--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <map>
+#include <variant>
 #include <seastar/core/sstring.hh>
 #include "seastarx.hh"
 


### PR DESCRIPTION
* seastar 914a4241...7cd0cabf (10):
  > github: s/clang++-18/clang++/
  > include: include used headers
  > include: include used headers
  > iotune: allow user to set buffer size for random IO
  > abort_source: add method to get exception pointer
  > github: cancel a job if it takes longer than 40 minutes
  > std-compat: remove #include:s which were added for pre C++17
  > perf_tests: measure and report also cpu cycles
  > linux_perf_events: add user_cpu_cycles_retired
  > linux_perf_event: user_instructions_retired: exclude_idle

* no need to backport. this submodule change is to prevent usages of including `seastar/util/std-compat.hh` for including `<optional>` and/or `<filesystem>` before we decide to bump up seastar submodule.