### PR TITLE
data_dictionary: include <variant>

### DIFF
--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <map>
+#include <variant>
 #include <seastar/core/sstring.hh>
 #include "seastarx.hh"
 


### PR DESCRIPTION
otherwise when compiling with the new seastar, which removed `#include <variant>` from `std-compat.hh`, the {mode}-headers target would fail to build, like:

```
 ./data_dictionary/storage_options.hh:34:29: error: no template named 'variant' in namespace 'std'
10:45:15      using value_type = std::variant<local, s3>;
10:45:15                         ~~~~~^
10:45:15  ./data_dictionary/storage_options.hh:35:5: error: unknown type name 'value_type'; did you mean 'std::_Bit_const_iterator::value_type'?
10:45:15      value_type value = local{};
10:45:15      ^~~~~~~~~~
10:45:15      std::_Bit_const_iterator::value_type
```

* this change prepares for the seastar submodule bump. no need to backport.