### PR TITLE
Run sstables loader in scheduling group

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1792,7 +1792,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             supervisor::notify("starting sstables loader");
-            sst_loader.start(std::ref(db), std::ref(messaging), std::ref(view_builder)).get();
+            sst_loader.start(std::ref(db), std::ref(messaging), std::ref(view_builder), maintenance_scheduling_group).get();
             auto stop_sst_loader = defer_verbose_shutdown("sstables loader", [&sst_loader] {
                 sst_loader.stop().get();
             });

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -172,15 +172,12 @@ distributed_loader::make_sstables_available(sstables::sstable_directory& dir, sh
 
 future<>
 distributed_loader::process_upload_dir(distributed<replica::database>& db, sharded<db::view::view_builder>& vb, sstring ks, sstring cf) {
-    seastar::thread_attributes attr;
-    attr.sched_group = db.local().get_streaming_scheduling_group();
-
     const auto& rs = db.local().find_keyspace(ks).get_replication_strategy();
     if (rs.is_per_table()) {
         on_internal_error(dblog, "process_upload_dir is not supported with tablets");
     }
 
-    return seastar::async(std::move(attr), [&db, &vb, ks = std::move(ks), cf = std::move(cf)] {
+    return seastar::async([&db, &vb, ks = std::move(ks), cf = std::move(cf)] {
         auto global_table = get_table_on_all_shards(db, ks, cf).get();
 
         sharded<sstables::sstable_directory> directory;

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -8,6 +8,7 @@
 
 #include <fmt/ranges.h>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/switch_to.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/rpc/rpc.hh>
 #include "sstables_loader.hh"
@@ -406,6 +407,8 @@ future<> sstables_loader::load_new_sstables(sstring ks_name, sstring cf_name,
     } else {
         _loading_new_sstables = true;
     }
+
+    co_await coroutine::switch_to(_sched_group);
 
     sstring load_and_stream_desc = fmt::format("{}", load_and_stream);
     const auto& rs = _db.local().find_keyspace(ks_name).get_replication_strategy();

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -33,6 +33,7 @@ class sstables_loader : public seastar::peering_sharded_service<sstables_loader>
     sharded<replica::database>& _db;
     netw::messaging_service& _messaging;
     sharded<db::view::view_builder>& _view_builder;
+    seastar::scheduling_group _sched_group;
 
     // Note that this is obviously only valid for the current shard. Users of
     // this facility should elect a shard to be the coordinator based on any
@@ -49,10 +50,12 @@ class sstables_loader : public seastar::peering_sharded_service<sstables_loader>
 public:
     sstables_loader(sharded<replica::database>& db,
             netw::messaging_service& messaging,
-            sharded<db::view::view_builder>& vb)
+            sharded<db::view::view_builder>& vb,
+            seastar::scheduling_group sg)
         : _db(db)
         , _messaging(messaging)
         , _view_builder(vb)
+        , _sched_group(std::move(sg))
     {
     }
 


### PR DESCRIPTION
Currently the loader is called via API, which inherits the maintenance scheduling group from API http server. The loader then can either do load_and_stream() or call (legacy) distributed_loader::upload_new_sstables(). The latter first switches into streaming scheduling group, but the former doesn't and continues running in the maintenance one.

All this is not really a problem, because streaming sched group and maintenance sched group is one group under two different variable names. However, it's messy and worth delegating the sched group switch (even if it's a no-op) to the sstables-loader. As a nice side effect, this patch removes one place that uses database as proxy object to get configuration parameters.