### PR TITLE
[DONT-MERGE] test: test_topology_ops: use bool in parametrize

### DIFF
--- a/test/topology_experimental_raft/test_topology_ops.py
+++ b/test/topology_experimental_raft/test_topology_ops.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("tablets_enabled", ["true", "false"])
+@pytest.mark.parametrize("tablets_enabled", [True, False])
 async def test_topology_ops(request, manager: ManagerClient, tablets_enabled: bool):
     """Test basic topology operations using the topology coordinator."""
     cfg = {'experimental_features' : ['tablets']} if tablets_enabled else {}

--- a/test/topology_experimental_raft/test_topology_ops.py
+++ b/test/topology_experimental_raft/test_topology_ops.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("tablets_enabled", [True, False])
+@pytest.mark.parametrize("tablets_enabled", [False])
 async def test_topology_ops(request, manager: ManagerClient, tablets_enabled: bool):
     """Test basic topology operations using the topology coordinator."""
     cfg = {'experimental_features' : ['tablets']} if tablets_enabled else {}


### PR DESCRIPTION
in 90317c5c, we parameterize `test_topology_ops()` with
```py
@pytest.mark.parametrize("tablets_enabled", ["true", "false"])
```
and check it with
```py
if tablets_enabled:
```

since Python evaluate non-empty string as True, we always run this test with tablets enabled. so in order to correct it for better coverage, let's replace "true" and "false" with `True` and `False` respectively.

* no need to backport this change, as 90317c5c is contained by any LTS branches.