### PR TITLE
cql: fix a crash lurking in `ks_prop_defs::get_initial_tablets`

### DIFF
--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -133,7 +133,7 @@ std::optional<unsigned> ks_prop_defs::get_initial_tablets(const sstring& strateg
             assert(!ret.has_value());
             return ret;
         } else {
-            throw exceptions::configuration_exception(sstring("Tablets enabled value must be true or false; found ") + it->second);
+            throw exceptions::configuration_exception(sstring("Tablets enabled value must be true or false; found: ") + enabled);
         }
     }
 


### PR DESCRIPTION
`tablets_options->erase(it);` invalidates `it`, but it's still referred to later in the code in the last `else`, and when that code is invoked, we get a `heap-use-after-free` crash.

Fixes: #18926

Backport is needed, because previous versions are prone to this error. Definitely 6.0, not sure about older versions, as this issue has been discovered when developing tablets and it may be that this code path is unreachable in older versions/this code doesn't exist in older versions.