### PR TITLE
Allow specifying TLS options with internode_encryption=none + add "transitional" mode

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1400,9 +1400,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             debug::the_messaging_service = &messaging;
 
             std::shared_ptr<seastar::tls::credentials_builder> creds;
-            if (mscfg.encrypt != netw::messaging_service::encrypt_what::none) {
+            if (mscfg.encrypt != netw::messaging_service::encrypt_what::none 
+                || (cfg->ssl_storage_port() != 0 && seo.contains("certificate"))
+            ) {
                 creds = std::make_shared<seastar::tls::credentials_builder>();
-                utils::configure_tls_creds_builder(*creds, cfg->server_encryption_options()).get();
+                utils::configure_tls_creds_builder(*creds, seo).get();
             }
 
             // Delay listening messaging_service until gossip message handlers are registered

--- a/main.cc
+++ b/main.cc
@@ -1381,6 +1381,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 mscfg.encrypt = netw::messaging_service::encrypt_what::dc;
             } else if (encrypt == "rack") {
                 mscfg.encrypt = netw::messaging_service::encrypt_what::rack;
+            } else if (encrypt == "transitional") {
+                mscfg.encrypt = netw::messaging_service::encrypt_what::transitional;
             }
 
             if (!cfg->inter_dc_tcp_nodelay()) {

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -384,7 +384,7 @@ void messaging_service::do_start_listen() {
             so.streaming_domain = sdomain;
             return std::unique_ptr<rpc_protocol_server_wrapper>(
                     [this, &so, &a, limits] () -> std::unique_ptr<rpc_protocol_server_wrapper>{
-                if (_cfg.encrypt == encrypt_what::none) {
+                if (_cfg.encrypt == encrypt_what::none && !_credentials) {
                     return nullptr;
                 }
                 if (!_credentials) {

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -354,6 +354,7 @@ void messaging_service::do_start_listen() {
             switch (_cfg.encrypt) {
                 default:
                 case encrypt_what::none:
+                case encrypt_what::transitional:
                     break;
                 case encrypt_what::dc:
                     so.filter_connection = [this](const seastar::socket_address& caddr) {
@@ -384,7 +385,9 @@ void messaging_service::do_start_listen() {
             so.streaming_domain = sdomain;
             return std::unique_ptr<rpc_protocol_server_wrapper>(
                     [this, &so, &a, limits] () -> std::unique_ptr<rpc_protocol_server_wrapper>{
-                if (_cfg.encrypt == encrypt_what::none && !_credentials) {
+                // TODO: the condition to skip this if cfg.port == 0 is mainly to appease dtest.
+                // remove once we've adjusted those tests.
+                if (_cfg.encrypt == encrypt_what::none && (!_credentials || _cfg.port == 0)) {
                     return nullptr;
                 }
                 if (!_credentials) {
@@ -862,7 +865,7 @@ shared_ptr<messaging_service::rpc_protocol_client_wrapper> messaging_service::ge
         }
 
         // See comment above `TOPOLOGY_INDEPENDENT_IDX`.
-        if (_cfg.encrypt == encrypt_what::all || idx == TOPOLOGY_INDEPENDENT_IDX) {
+        if (_cfg.encrypt == encrypt_what::all || _cfg.encrypt == encrypt_what::transitional || idx == TOPOLOGY_INDEPENDENT_IDX) {
             return true;
         }
 

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -268,6 +268,7 @@ public:
         rack,
         dc,
         all,
+        transitional, // encrypt all outgoing, but do not enforce incoming.
     };
 
     enum class compress_what {

--- a/test/topology/test_tls.py
+++ b/test/topology/test_tls.py
@@ -1,0 +1,102 @@
+#
+# Copyright (C) 2022-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from test.pylib.manager_client import ManagerClient
+from cassandra.connection import ConnectionShutdown
+
+import asyncio
+import logging
+import pytest
+
+logger = logging.getLogger(__name__)
+
+@pytest.mark.asyncio
+async def test_upgrade_to_ssl(manager: ManagerClient) -> None:
+    """Tests rolling upgrade/downgrade from non-SSL to SSL and back
+    """
+
+    mode2ports = {
+        "none": [7000],
+        "transitional": [7000, 7001],
+        "all": [7001],
+    }
+
+    ks = 'ks'
+    cf = 'cf'
+
+    servers = await manager.running_servers()
+    cql = manager.get_cql()
+    await cql.run_async(f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}}")
+    await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY) WITH tombstone_gc = {{'mode': 'immediate'}}")
+
+    async def update_config_and_restart(mode):
+        for srv in servers:
+            # get the log and current pos
+            log = await manager.server_open_log(srv.server_id)
+            mark = await log.mark()
+            # stop one server
+            await manager.server_stop_gracefully(srv.server_id)
+            # change internode encryption
+            seo = (await manager.server_get_config(srv.server_id))['server_encryption_options']
+            seo['internode_encryption'] = mode
+            await manager.server_update_config(srv.server_id, "server_encryption_options", seo)
+            # restart
+            await manager.server_start(srv.server_id)
+            # now check we get the expected messaging server listening lines in log
+            expected_ports = mode2ports[mode]
+            pattern = "|".join(["port " + str(port) for port in expected_ports])
+            res = await log.grep(pattern, from_mark=mark)
+            assert len(res) == len(expected_ports), \
+                f"The listened ports are not same as expected! " \
+                f"Expected ports: {expected_ports}\nReal listened ports: {res}"
+
+    async def reconnect():
+        manager.driver_close()
+        await manager.driver_connect()
+        return manager.get_cql()
+
+    async def run_retry_async(stmt : str):
+        lcql = cql
+        while True:
+            try:
+                await lcql.run_async(stmt)
+                return
+            except ConnectionShutdown:
+                lcql = await reconnect();
+
+    # iterate from none to all and back
+    for mode in ["none", "transitional", "all", "transitional", "none"]:
+        # run a bunch of inserts in background. TODO: have something akin to cassandra-stress
+        # we can run in separate thread/process to really guarantee parallelism.
+        go_on = True
+
+        async def write_in_background():
+            count = 0;
+            while go_on:
+                await run_retry_async(f"INSERT INTO {ks}.{cf} (pk) VALUES ({count});")
+                count = count + 1
+            return count
+
+#        f = asyncio.gather(
+#            *[run_retry_async(f"INSERT INTO {ks}.{cf} (pk) VALUES ({k});") for k in range(count)]
+#            )
+        f = write_in_background()
+
+        # do a rolling restart, updating the internode_encryption mode
+        await update_config_and_restart(mode)
+        go_on = False
+        # wait for the writes to finish
+        count = await f
+        cql = await reconnect()
+        # check writes completed even though we are so very rolling
+        await cql.run_async(f"SELECT COUNT(*) FROM {ks}.{cf}")
+        assert count == (await cql.run_async(f"SELECT COUNT(*) FROM {ks}.{cf}"))[0].count
+        # and drop data
+        await cql.run_async(f"TRUNCATE {ks}.{cf}")
+
+    await cql.run_async(f"DROP TABLE {ks}.{cf};")
+    await cql.run_async(f"DROP KEYSPACE {ks};")
+


### PR DESCRIPTION
Fixes #18903
    
Adds a "transitional" internode encryption mode, under which all _outgoing_ RPC connections will use TLS, but we will still accept any incoming non-tls connection.

This allows an operator to perform a move to TLS RPC without cluster downtime:

1. For each server, add certificate etc options to server_encryption_options + internode_encryption=none + set ssl_storage_port + restart (rolling)

2. For each server, set internode_encryption=transitional + RR
3. For each server, set internode_encryption=all + RR