### PR TITLE
doc: add the tablets limitation to the nodetool describering command

### DIFF
--- a/docs/operating-scylla/nodetool-commands/describering.rst
+++ b/docs/operating-scylla/nodetool-commands/describering.rst
@@ -2,14 +2,28 @@ Nodetool describering
 =====================
 
 **describering** - :code:`<keyspace>`- Shows the partition ranges of a given keyspace.
-
 For example:
 
 .. code-block:: shell
 
    nodetool describering nba
 
-Example output (for three node cluster on AWS):
+If :doc:`tablets </architecture/tablets>` are enabled for your keyspace, you
+need to additionally specify the table name. The command will display the ring
+of the table.
+
+.. code:: shell
+
+   nodetool describering <keyspace> <table>
+
+For example:
+
+.. code-block:: shell
+
+   nodetool describering nba player_name
+
+
+Example output (for a three-node cluster on AWS with tablets disabled):
 
 .. code-block:: shell
 


### PR DESCRIPTION
This PR adds a note to the `nodetool describering` command that the command cannot be used with tablets.

Refs https://github.com/scylladb/scylladb/pull/17163

Backport to branch-6.0 required. This PR adds tablet-related information valid since 6.0.