### PR TITLE
sl_controller: fix a typo in comment

### DIFF
--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -144,7 +144,7 @@ public:
     /**
      * Check the distributed data for changes in a constant interval and updates
      * the service_levels configuration in accordance (adds, removes, or updates
-     * service levels as necessairy).
+     * service levels as necessary).
      * @param interval_f - lambda function which returns a interval in milliseconds.
                            The interval is time to check the distributed data.
      * @return a future that is resolved when the update loop stops.


### PR DESCRIPTION
s/necessairy/necessary/

* no need to backport. this change fixes a typo in comment.