### PR TITLE
test/alternator: be more forgiving on authorizer configuration

### DIFF
--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -86,6 +86,8 @@ def get_valid_alternator_role(url):
                 # connect to CQL!), so let's just use that role.
                 role = 'cassandra'
                 salted_hash = list(session.execute(f"SELECT salted_hash FROM {ks}.roles WHERE role = '{role}'"))[0].salted_hash
+                if salted_hash is None:
+                    break
                 return (role, salted_hash)
             except:
                 pass


### PR DESCRIPTION
The Alternator test suite usually runs on a specific configuration of Scylla set up by test.py or test/alternator/run. However, we do consider it an important design goal of this test suite that developers should be able to run these tests against any DynamoDB-API implementation, including any version Scylla manually run by the developer in *any way* he or she pleases.

The recent commit dc80b5dafe80af87ee0439f3de83d6108c9672f0 changed the way we retrieve the configured autentication key, which is needed if Scylla is run with --alternator-enforce-authorization. However, the new code assumed that Scylla was also run with
     --authenticator PasswordAuthenticator --authorizer CassandraAuthorizer
so that the default role of "cassandra" has a valid, non-null, password (namely, "cassandra"). If the developer ran Scylla manually without these options, the test initialization code broke, and all tests in the suite failed.

This patch fixes this breakage. You can now run the Alternator test suite against Scylla run manually without any of the aforementioned options, and everything will work except some tests in test_authorization.py will fail as expected.

This patch has no affect on the usual test.py or test/alternator/run runs, as they already run Scylla with all the aforementioned options and weren't exposed to the problem fixed here.

This is a test improvement, no backports needed.