### PR TITLE
test mv: remove injection delaying shutdown of a node

### DIFF
--- a/test/topology_custom/test_mv_topology_change.py
+++ b/test/topology_custom/test_mv_topology_change.py
@@ -62,7 +62,7 @@ async def test_mv_topology_change(manager: ManagerClient):
     # replication maps for base and view will change after the writes start but before they finish
     tasks = [asyncio.create_task(do_writes(i, repeat=False)) for i in range(concurrency)]
 
-    server = await manager.server_add(config=cfg)
+    server = await manager.server_add()
 
     await asyncio.gather(*tasks)
 


### PR DESCRIPTION
In the test_mv_topology_change case, we use an injection to delay the view updates application, so that the ERMs have a chance to change in the process. This injection was also enabled on a new node in the test, which was later decommissioned. During the shutdown, writes were still being performed, causing view update generation and delays due to the injection which in turn delayed the node shutdown, causing the test to timeout. This patch removes the injection for the node being shut down. At the same time, the force_gossip_topology_changes=True option is also removed from its config, but for that option it's enough to enable on the first node in the cluster and all nodes use it.

Fixes: https://github.com/scylladb/scylladb/issues/18941
