### PR TITLE
service/storage_proxy: Add metrics keeping track of incoming hints

### DIFF
--- a/db/hints/internal/common.hh
+++ b/db/hints/internal/common.hh
@@ -38,7 +38,8 @@ struct hint_stats {
     uint64_t written                    = 0;
     uint64_t errors                     = 0;
     uint64_t dropped                    = 0;
-    uint64_t sent                       = 0;
+    uint64_t sent_total                 = 0;
+    uint64_t sent_hints_bytes_total     = 0;
     uint64_t discarded                  = 0;
     uint64_t send_errors                = 0;
     uint64_t corrupted_files            = 0;

--- a/db/hints/internal/hint_sender.cc
+++ b/db/hints/internal/hint_sender.cc
@@ -303,8 +303,10 @@ future<> hint_sender::send_one_hint(lw_shared_ptr<send_one_file_ctx> ctx_ptr, fr
                     return make_ready_future<>();
                 }
 
-                return this->send_one_mutation(std::move(m)).then([this, ctx_ptr] {
-                    ++this->shard_stats().sent;
+                const auto mutation_size = m.fm.representation().size();
+                return this->send_one_mutation(std::move(m)).then([this, ctx_ptr, mutation_size] {
+                    ++this->shard_stats().sent_total;
+                    this->shard_stats().sent_hints_bytes_total += mutation_size;
                 }).handle_exception([this, ctx_ptr] (auto eptr) {
                     manager_logger.trace("send_one_hint(): failed to send to {}: {}", end_point_key(), eptr);
                     ++this->shard_stats().send_errors;

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -171,8 +171,11 @@ void manager::register_metrics(const sstring& group_name) {
         sm::make_counter("dropped", _stats.dropped,
                         sm::description("Number of dropped hints.")),
 
-        sm::make_counter("sent", _stats.sent,
+        sm::make_counter("sent_total", _stats.sent_total,
                         sm::description("Number of sent hints.")),
+
+        sm::make_counter("sent_bytes_total", _stats.sent_hints_bytes_total,
+                        sm::description("The total size of the sent hints (in bytes)")),
 
         sm::make_counter("discarded", _stats.discarded,
                         sm::description("Number of hints that were discarded during sending (too old, schema changed, etc.).")),

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -627,6 +627,9 @@ private:
             unsigned shard, storage_proxy::response_id_type response_id,
             rpc::optional<std::optional<tracing::trace_info>> trace_info,
             rpc::optional<fencing_token> fence) {
+        ++_sp.get_stats().received_hints_total;
+        _sp.get_stats().received_hints_bytes_total += in.representation().size();
+
         return receive_mutation_handler(_sp._hints_write_smp_service_group, cinfo, t, std::move(in),
             std::move(forward), std::move(reply_to), shard, response_id, std::move(trace_info),
             std::monostate(), fence);
@@ -2807,6 +2810,14 @@ void storage_proxy_stats::stats::register_stats() {
         sm::make_total_operations("cas_dropped_prune", cas_replica_dropped_prune,
                        sm::description("how many times a coordinator did not perform prune after cas"),
                        {storage_proxy_stats::current_scheduling_group_label()}).set_skip_when_empty(),
+
+        sm::make_counter("received_hints_total", received_hints_total,
+                        sm::description("number of hints and MV hints received by this node"),
+                        {storage_proxy_stats::current_scheduling_group_label()}).set_skip_when_empty(),
+
+        sm::make_counter("received_hints_bytes_total", received_hints_bytes_total,
+                        sm::description("total size of hints and MV hints received by this node"),
+                        {storage_proxy_stats::current_scheduling_group_label()}).set_skip_when_empty(),
     });
     _metrics = std::exchange(new_metrics, {});
 }

--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -191,6 +191,10 @@ struct stats : public write_stats {
     split_stats mutation_data_read_completed;
     split_stats mutation_data_read_errors;
 
+    // Received hints
+    uint64_t received_hints_total = 0;
+    uint64_t received_hints_bytes_total = 0;
+
 public:
     stats();
     void register_stats();

--- a/test/topology_experimental_raft/test_fencing.py
+++ b/test/topology_experimental_raft/test_fencing.py
@@ -50,8 +50,8 @@ def send_errors_metric(metrics: ScyllaMetrics):
     return metrics.get('scylla_hints_manager_send_errors')
 
 
-def sent_metric(metrics: ScyllaMetrics):
-    return metrics.get('scylla_hints_manager_sent')
+def sent_total_metric(metrics: ScyllaMetrics):
+    return metrics.get('scylla_hints_manager_sent_total')
 
 
 def all_hints_metrics(metrics: ScyllaMetrics) -> list[str]:
@@ -166,7 +166,7 @@ async def test_fence_hints(request, manager: ManagerClient):
     logger.info(f"Waiting for failed hints on {host0}")
     async def at_least_one_hint_failed():
         metrics_data = await manager.metrics.query(s0.ip_addr)
-        if sent_metric(metrics_data) > 0:
+        if sent_total_metric(metrics_data) > 0:
             pytest.fail(f"Unexpected successful hints; metrics on {s0}: {all_hints_metrics(metrics_data)}")
         if send_errors_metric(metrics_data) >= 1:
             return True
@@ -187,9 +187,9 @@ async def test_fence_hints(request, manager: ManagerClient):
     logger.info(f"Waiting for sent hints on {host0}")
     async def exactly_one_hint_sent():
         metrics_data = await manager.metrics.query(s0.ip_addr)
-        if sent_metric(metrics_data) > 1:
+        if sent_total_metric(metrics_data) > 1:
             pytest.fail(f"Unexpected more than 1 successful hints; metrics on {s0}: {all_hints_metrics(metrics_data)}")
-        if sent_metric(metrics_data) == 1:
+        if sent_total_metric(metrics_data) == 1:
             return True
         logger.info(f"Metrics on {s0}: {all_hints_metrics(metrics_data)}")
     await wait_for(exactly_one_hint_sent, time.time() + 60)


### PR DESCRIPTION
Although Scylla already exposes metrics keeping track of various information related to hinted handoff, all of them correspond to either storing or sending hints. However, when debugging, it's also crucial to be aware of how many hints are coming to a given node and what their size is. Unfortunately, the existing metrics are not enough to obtain that information.

This PR introduces the following new metrics:

* `sent_bytes_total` – the total size of the hints that have been sent from a given shard,
* `received_hints_total` – the total number of hints that a given shard has received,
* `received_hints_bytes_total` – the total size of the hints a given shard has received.

It also renames `hints_manager_sent` to `hints_manager_sent_total` to avoid conflicts of prefixes between that metric and `sent_bytes_total` in tests.

Fixes scylladb/scylladb#10987