### PR TITLE
replica: Fix race of tablet snapshot with compaction

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -990,6 +990,14 @@ future<> table::parallel_foreach_compaction_group(std::function<future<>(compact
     });
 }
 
+future<> table::safe_foreach_sstable(const sstables::sstable_set& set, noncopyable_function<future<>(const sstables::shared_sstable&)> action) {
+    auto deletion_guard = co_await get_units(_sstable_deletion_sem, 1);
+
+    co_await set.for_each_sstable_gently([&] (const sstables::shared_sstable& sst) -> future<> {
+        return action(sst);
+    });
+}
+
 future<utils::chunked_vector<sstables::sstable_files_snapshot>> table::take_storage_snapshot(dht::token_range tr) {
     utils::chunked_vector<sstables::sstable_files_snapshot> ret;
 
@@ -1004,12 +1012,12 @@ future<utils::chunked_vector<sstables::sstable_files_snapshot>> table::take_stor
 
         auto set = cg->make_sstable_set();
 
-        for (auto all_sstables = set->all(); auto& sst : *all_sstables) {
+        co_await safe_foreach_sstable(*set, [&] (const sstables::shared_sstable& sst) -> future<> {
            ret.push_back({
                .sst = sst,
                .files = co_await sst->readable_file_for_all_components(),
            });
-        }
+        });
     }
 
     co_return std::move(ret);
@@ -1024,7 +1032,7 @@ table::clone_tablet_storage(locator::tablet_id tid) {
     auto* sg = storage_group_for_id(tid.value());
     co_await sg->flush();
     auto set = sg->make_sstable_set();
-    co_await set->for_each_sstable_gently([this, &ret] (const sstables::shared_sstable& sst) -> future<> {
+    co_await safe_foreach_sstable(*set, [&] (const sstables::shared_sstable& sst) -> future<> {
         ret.push_back(co_await sst->clone(calculate_generation_for_new_table()));
     });
     co_return ret;


### PR DESCRIPTION
tablet snapshot, used by migration, can race with compaction and can find files deleted. That won't cause data loss because the error is propagated back into the coordinator that decides to retry streaming stage. So the consequence is delayed migration, which might in turn reduce node operation throughput (e.g. when decommissioning a node). It should be rare though, so shouldn't have drastic consequences.

Fixes #18977.

**Please replace this line with justification for the backport/\* labels added to this PR**
should be backported because it's an error during migration, not a correctness issue, but can cause unnecessary retry.