### PR TITLE
compress, auth: include used headers

### DIFF
--- a/auth/roles-metadata.hh
+++ b/auth/roles-metadata.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string_view>
 #include <functional>
 

--- a/compress.hh
+++ b/compress.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <map>
+#include <optional>
 #include <set>
 
 #include <seastar/core/future.hh>


### PR DESCRIPTION
before this change, we rely on `seastar/util/std-compat.hh` to include the used headers provided by stdandard library. this was necessary before we moved to a C++20 compliant standard library implementation. but since Seastar has dropped C++17 support. its `seastar/util/std-compat.hh` is not responsible for providing these headers anymore.

so, in this change, we include the used header directly instead of relying on `seastar/util/std-compat.hh`.

* this change prepares for bumping up seastar, so no need to backport.