### PR TITLE
build: add sanitizer compiling options directly

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1753,15 +1753,11 @@ def configure_seastar(build_dir, mode, mode_config):
 
 
 def configure_abseil(build_dir, mode, mode_config):
-    # for sanitizer cflags
-    seastar_flags = query_seastar_flags(f'{outdir}/{mode}/seastar/seastar.pc',
-                                        mode_config['build_seastar_shared_libs'],
-                                        args.staticcxx)
-    seastar_cflags = seastar_flags['seastar_cflags']
+    abseil_cflags = mode_config['lib_cflags']
+    if '-DSANITIZE' in mode_config['cxxflags']:
+        abseil_cflags += ' -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr'
+    abseil_cflags = abseil_cflags.strip()
 
-    abseil_build_dir = os.path.join(build_dir, mode, 'abseil')
-
-    abseil_cflags = seastar_cflags + ' ' + modes[mode]['cxx_ld_flags']
     # We want to "undo" coverage for abseil if we have it enabled, as we are not
     # interested in the coverage of the abseil library. these flags were previously
     # added to cxx_ld_flags
@@ -1780,6 +1776,7 @@ def configure_abseil(build_dir, mode, mode_config):
         '-DABSL_PROPAGATE_CXX_STD=ON',
     ]
 
+    abseil_build_dir = os.path.join(build_dir, mode, 'abseil')
     abseil_cmd = ['cmake', '-G', 'Ninja', real_relpath('abseil', abseil_build_dir)] + abseil_cmake_args
 
     os.makedirs(abseil_build_dir, exist_ok=True)


### PR DESCRIPTION
before this change, in order to avoid repeating/hardwiring the compiling options set by Seastar, we just inherit the compiling options of Seastar for building Abseil, as the former exposes the options to enable sanitizers.

this works fine, despite that, strictly speaking, not all options are necessary for building abseil, as abseil is not a Seastar application -- it is just a C++ library.

but when we introduce dependencies which are only generated at build time, and these dependencies are passed to the compiler at build time, this breaks the build of Abseil. because these dependencies are exposed by the Seastar's .pc file, and consumed by Abseil. when building Abseil, apparently, the building process driven by ninja is not started yet, so we are not able to build Abseil with these settings due to missing dependencies.

so instead of inheriting the compiling options from Seastar, just set the sanitizer related compiling options directly, to avoid referencing these missing dependencies.

the upside is that we pass a much smaller set of compiling options to compiler when building Abseil, the downside is that we hardwire these options related to sanitizer manually, they are also detected by Seastar's building system. but fortunately, these options are relatively stable across the building environements we support.

* need to backport to 6.0, as the abseil submodule change was included by this branch.