### PR TITLE
Relax production_snitch_base's property file parsing

### DIFF
--- a/locator/production_snitch_base.cc
+++ b/locator/production_snitch_base.cc
@@ -69,15 +69,14 @@ future<> production_snitch_base::load_property_file() {
     auto f = co_await open_file_dma(_prop_file_name, open_flags::ro);
     auto s = co_await f.size();
     auto tb = co_await f.dma_read_exactly<char>(0, s);
-    _prop_file_contents = std::string(tb.get(), s);
-    parse_property_file();
+    parse_property_file(std::string(tb.get(), s));
 }
 
-void production_snitch_base::parse_property_file() {
+void production_snitch_base::parse_property_file(std::string contents) {
     using namespace boost::algorithm;
 
     std::string line;
-    std::istringstream istrm(_prop_file_contents);
+    std::istringstream istrm(contents);
     std::vector<std::string> split_line;
     _prop_values.clear();
 

--- a/locator/production_snitch_base.cc
+++ b/locator/production_snitch_base.cc
@@ -66,21 +66,12 @@ void production_snitch_base::set_prefer_local(bool prefer_local) {
 }
 
 future<> production_snitch_base::load_property_file() {
-    return open_file_dma(_prop_file_name, open_flags::ro)
-    .then([this] (file f) {
-        return do_with(std::move(f), [this] (file& f) {
-            return f.size().then([this, &f] (size_t s) {
-                _prop_file_size = s;
-
-                return f.dma_read_exactly<char>(0, s);
-            });
-        }).then([this] (temporary_buffer<char> tb) {
-            _prop_file_contents = std::string(tb.get(), _prop_file_size);
-            parse_property_file();
-
-            return make_ready_future<>();
-        });
-    });
+    auto f = co_await open_file_dma(_prop_file_name, open_flags::ro);
+    auto s = co_await f.size();
+    _prop_file_size = s;
+    auto tb = co_await f.dma_read_exactly<char>(0, s);
+    _prop_file_contents = std::string(tb.get(), _prop_file_size);
+    parse_property_file();
 }
 
 void production_snitch_base::parse_property_file() {

--- a/locator/production_snitch_base.cc
+++ b/locator/production_snitch_base.cc
@@ -68,9 +68,8 @@ void production_snitch_base::set_prefer_local(bool prefer_local) {
 future<> production_snitch_base::load_property_file() {
     auto f = co_await open_file_dma(_prop_file_name, open_flags::ro);
     auto s = co_await f.size();
-    _prop_file_size = s;
     auto tb = co_await f.dma_read_exactly<char>(0, s);
-    _prop_file_contents = std::string(tb.get(), _prop_file_size);
+    _prop_file_contents = std::string(tb.get(), s);
     parse_property_file();
 }
 

--- a/locator/production_snitch_base.hh
+++ b/locator/production_snitch_base.hh
@@ -45,7 +45,7 @@ public:
 private:
     virtual void set_my_dc_and_rack(const sstring& new_dc, const sstring& new_rack) override;
     virtual void set_prefer_local(bool prefer_local) override;
-    void parse_property_file();
+    void parse_property_file(std::string contents);
 
     virtual bool prefer_local() const noexcept override {
         return _prefer_local;
@@ -69,7 +69,6 @@ protected:
     void throw_incomplete_file() const;
 
 protected:
-    std::string _prop_file_contents;
     sstring _prop_file_name;
     std::unordered_map<sstring, sstring> _prop_values;
 

--- a/locator/production_snitch_base.hh
+++ b/locator/production_snitch_base.hh
@@ -89,7 +89,6 @@ protected:
     }
 
 private:
-    size_t _prop_file_size;
     snitch_ptr* _backreference = nullptr;
 protected:
     /*


### PR DESCRIPTION
It consists of reading method and parsing one and it uses class fields to carry data between those two. The former is additionally built with curly continuation chains, while it's naturally linear, so turn it into a coroutine while at it