### PR TITLE
querier: include cell stats in page stats

### DIFF
--- a/collection_mutation.hh
+++ b/collection_mutation.hh
@@ -12,6 +12,7 @@
 #include "schema/schema_fwd.hh"
 #include "gc_clock.hh"
 #include "mutation/atomic_cell.hh"
+#include "mutation/compact_and_expire_result.hh"
 #include <iosfwd>
 #include <forward_list>
 
@@ -34,7 +35,7 @@ struct collection_mutation_description {
 
     // Expires cells based on query_time. Expires tombstones based on max_purgeable and gc_before.
     // Removes cells covered by tomb or this->tomb.
-    bool compact_and_expire(column_id id, row_tombstone tomb, gc_clock::time_point query_time,
+    compact_and_expire_result compact_and_expire(column_id id, row_tombstone tomb, gc_clock::time_point query_time,
         can_gc_fn&, gc_clock::time_point gc_before, compaction_garbage_collector* collector = nullptr);
 
     // Packs the data to a serialized blob.

--- a/mutation/compact_and_expire_result.hh
+++ b/mutation/compact_and_expire_result.hh
@@ -20,10 +20,6 @@ struct compact_and_expire_result {
         return live_cells;
     }
 
-    operator bool () const noexcept {
-        return is_live();
-    }
-
     bool operator==(const compact_and_expire_result&) const = default;
 
     compact_and_expire_result& operator+=(const compact_and_expire_result& o) {

--- a/mutation/compact_and_expire_result.hh
+++ b/mutation/compact_and_expire_result.hh
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <fmt/core.h>
+
+struct compact_and_expire_result {
+    uint64_t live_cells = 0;
+    uint64_t dead_cells = 0;
+    uint32_t collection_tombstones = 0;
+
+    bool is_live() const noexcept {
+        return live_cells;
+    }
+
+    operator bool () const noexcept {
+        return is_live();
+    }
+
+    bool operator==(const compact_and_expire_result&) const = default;
+
+    compact_and_expire_result& operator+=(const compact_and_expire_result& o) {
+        live_cells += o.live_cells;
+        dead_cells += o.dead_cells;
+        collection_tombstones += o.collection_tombstones;
+        return *this;
+    }
+};
+
+template <> struct fmt::formatter<compact_and_expire_result> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const compact_and_expire_result& r, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{{live_cells: {}, dead_cells: {}, collection_tombstones: {}}}", r.live_cells, r.dead_cells,
+                r.collection_tombstones);
+    }
+};

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1788,7 +1788,7 @@ bool lazy_row::compact_and_expire(
     if (!_row) {
         return false;
     }
-    return _row->compact_and_expire(s, kind, tomb, query_time, can_gc, gc_before, marker, collector);
+    return _row->compact_and_expire(s, kind, tomb, query_time, can_gc, gc_before, marker, collector).is_live();
 }
 
 bool lazy_row::compact_and_expire(
@@ -1802,7 +1802,7 @@ bool lazy_row::compact_and_expire(
     if (!_row) {
         return false;
     }
-    return _row->compact_and_expire(s, kind, tomb, query_time, can_gc, gc_before, collector);
+    return _row->compact_and_expire(s, kind, tomb, query_time, can_gc, gc_before, collector).is_live();
 }
 
 std::ostream& operator<<(std::ostream& os, const lazy_row::printer& p) {
@@ -1822,7 +1822,7 @@ bool deletable_row::compact_and_expire(const schema& s,
 
     apply(tomb);
     bool is_live = marker().compact_and_expire(deleted_at().tomb(), query_time, can_gc, gc_before);
-    is_live |= cells().compact_and_expire(s, column_kind::regular_column, deleted_at(), query_time, can_gc, gc_before, marker(), collector);
+    is_live |= cells().compact_and_expire(s, column_kind::regular_column, deleted_at(), query_time, can_gc, gc_before, marker(), collector).is_live();
 
     if (deleted_at().tomb() <= tomb || should_purge_row_tombstone(deleted_at())) {
         remove_tombstone();

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1702,7 +1702,7 @@ static bool dead_marker_shadows_row(const schema& s, column_kind kind, const row
             && kind == column_kind::regular_column; // not applicable to static rows
 }
 
-bool row::compact_and_expire(
+compact_and_expire_result row::compact_and_expire(
         const schema& s,
         column_kind kind,
         row_tombstone tomb,
@@ -1715,7 +1715,7 @@ bool row::compact_and_expire(
     if (dead_marker_shadows_row(s, kind, marker)) {
         tomb.apply(shadowable_tombstone(api::max_timestamp, gc_clock::time_point::max()), row_marker());
     }
-    bool any_live = false;
+    compact_and_expire_result res{};
     remove_if([&] (column_id id, atomic_cell_or_collection& c) {
         bool erase = false;
         const column_definition& def = s.column_at(kind, id);
@@ -1727,8 +1727,10 @@ bool row::compact_and_expire(
 
             if (cell.is_covered_by(tomb.regular(), def.is_counter())) {
                 erase = true;
+                res.dead_cells++;
             } else if (cell.is_covered_by(tomb.shadowable().tomb(), def.is_counter())) {
                 erase = true;
+                res.dead_cells++;
             } else if (cell.has_expired(query_time)) {
                 erase = can_erase_cell();
                 if (!erase) {
@@ -1736,18 +1738,20 @@ bool row::compact_and_expire(
                 } else if (collector) {
                     collector->collect(id, atomic_cell::make_dead(cell.timestamp(), cell.deletion_time()));
                 }
+                res.dead_cells++;
             } else if (!cell.is_live()) {
                 erase = can_erase_cell();
                 if (erase && collector) {
                     collector->collect(id, atomic_cell::make_dead(cell.timestamp(), cell.deletion_time()));
                 }
+                res.dead_cells++;
             } else {
-                any_live = true;
+                res.live_cells++;
             }
         } else {
             c.as_collection_mutation().with_deserialized(*def.type, [&] (collection_mutation_view_description m_view) {
                 auto m = m_view.materialize(*def.type);
-                any_live |= m.compact_and_expire(id, tomb, query_time, can_gc, gc_before, collector);
+                res += m.compact_and_expire(id, tomb, query_time, can_gc, gc_before, collector);
                 if (m.cells.empty() && m.tomb <= tomb.tomb()) {
                     erase = true;
                 } else {
@@ -1757,10 +1761,10 @@ bool row::compact_and_expire(
         }
         return erase;
     });
-    return any_live;
+    return res;
 }
 
-bool row::compact_and_expire(
+compact_and_expire_result row::compact_and_expire(
         const schema& s,
         column_kind kind,
         row_tombstone tomb,

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -32,6 +32,7 @@
 #include "utils/compact-radix-tree.hh"
 #include "utils/immutable-collection.hh"
 #include "tombstone_gc.hh"
+#include "mutation/compact_and_expire_result.hh"
 
 class mutation_fragment;
 class mutation_partition_view;
@@ -191,7 +192,7 @@ public:
     // Expires cells based on query_time. Expires tombstones based on gc_before
     // and max_purgeable. Removes cells covered by tomb.
     // Returns true iff there are any live cells left.
-    bool compact_and_expire(
+    compact_and_expire_result compact_and_expire(
             const schema& s,
             column_kind kind,
             row_tombstone tomb,
@@ -201,7 +202,7 @@ public:
             const row_marker& marker,
             compaction_garbage_collector* collector = nullptr);
 
-    bool compact_and_expire(
+    compact_and_expire_result compact_and_expire(
             const schema& s,
             column_kind kind,
             row_tombstone tomb,

--- a/querier.cc
+++ b/querier.cc
@@ -443,6 +443,19 @@ future<> querier_base::close() noexcept {
     return std::visit(variant_closer{*this}, _reader);
 }
 
+void querier::maybe_log_tombstone_warning(std::string_view what, uint64_t live, uint64_t dead) {
+    if (!_qr_config.tombstone_warn_threshold || dead < _qr_config.tombstone_warn_threshold) {
+        return;
+    }
+    if (_range->is_singular()) {
+        qrlogger.warn("Read {} live {} and {} dead {}/tombstones for {}.{} partition key \"{}\" {} (see tombstone_warn_threshold)",
+                      live, what, dead, what, _schema->ks_name(), _schema->cf_name(), _range->start()->value().key()->with_schema(*_schema), (*_range));
+    } else {
+        qrlogger.warn("Read {} live {} and {} dead {}/tombstones for {}.{} <partition-range-scan> {} (see tombstone_warn_threshold)",
+                      live, what, dead, what, _schema->ks_name(), _schema->cf_name(), (*_range));
+    }
+}
+
 void querier_cache::set_entry_ttl(std::chrono::seconds entry_ttl) {
     _entry_ttl = entry_ttl;
 }

--- a/querier.hh
+++ b/querier.hh
@@ -176,7 +176,7 @@ public:
         return ::query::consume_page(std::get<mutation_reader>(_reader), _compaction_state, *_slice, std::move(consumer), row_limit,
                 partition_limit, query_time).then_wrapped([this, trace_ptr = std::move(trace_ptr)] (auto&& fut) {
             const auto& cstats = _compaction_state->stats();
-            tracing::trace(trace_ptr, "Page stats: {} partition(s), {} static row(s) ({} live, {} dead), {} clustering row(s) ({} live, {} dead) and {} range tombstone(s)",
+            tracing::trace(trace_ptr, "Page stats: {} partition(s), {} static row(s) ({} live, {} dead), {} clustering row(s) ({} live, {} dead), {} range tombstone(s) and {} cell(s) ({} live, {} dead)",
                     cstats.partitions,
                     cstats.static_rows.total(),
                     cstats.static_rows.live,
@@ -184,7 +184,10 @@ public:
                     cstats.clustering_rows.total(),
                     cstats.clustering_rows.live,
                     cstats.clustering_rows.dead,
-                    cstats.range_tombstones);
+                    cstats.range_tombstones,
+                    cstats.live_cells() + cstats.dead_cells(),
+                    cstats.live_cells(),
+                    cstats.dead_cells());
             maybe_log_tombstone_warning(
                     "rows",
                     cstats.static_rows.live + cstats.clustering_rows.live,

--- a/querier.hh
+++ b/querier.hh
@@ -189,6 +189,7 @@ public:
                     "rows",
                     cstats.static_rows.live + cstats.clustering_rows.live,
                     cstats.static_rows.dead + cstats.clustering_rows.dead + cstats.range_tombstones);
+            maybe_log_tombstone_warning("cells", cstats.live_cells(), cstats.dead_cells());
             return std::move(fut);
         });
     }

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -3803,3 +3803,130 @@ SEASTAR_TEST_CASE(test_tracing_format) {
     BOOST_CHECK_EQUAL(formatted, "{key: pk{0103}, token: 42}");
     return make_ready_future();
  }
+
+void do_make_collection(collection_mutation_description& desc, std::pair<bytes, atomic_cell>&& cell) {
+    desc.cells.push_back(std::move(cell));
+};
+
+template <typename... Cell>
+void do_make_collection(collection_mutation_description& desc, std::pair<bytes, atomic_cell>&& cell, Cell&& ...cells) {
+    desc.cells.push_back(std::move(cell));
+    do_make_collection(desc, std::forward<Cell>(cells)...);
+};
+
+SEASTAR_TEST_CASE(test_compact_and_expire_cell_stats) {
+    const auto collection_type = map_type_impl::get_instance(int32_type, int32_type, true);
+
+    auto schema = schema_builder("test", "test_compact_and_expire_cell_stats")
+        .with_column("pk", int32_type, column_kind::partition_key)
+        .with_column("ck", int32_type, column_kind::clustering_key)
+        .with_column("static_atomic", int32_type, column_kind::static_column)
+        .with_column("static_collection", collection_type, column_kind::static_column)
+        .with_column("regular_atomic", int32_type, column_kind::regular_column)
+        .with_column("regular_collection", collection_type, column_kind::regular_column)
+        .build();
+    auto& s = *schema;
+
+    api::timestamp_type live_ts = 10;
+    api::timestamp_type tomb_ts = 5;
+    api::timestamp_type dead_ts = 0;
+
+    const auto now = gc_clock::now();
+
+    const auto value = data_value(10).serialize_nonnull();
+    const auto value1 = data_value(11).serialize_nonnull();
+
+    struct row_content {
+        std::optional<atomic_cell> atomic_column;
+        std::optional<collection_mutation> collection_column;
+    };
+
+    const auto make_collection = [&] (tombstone tomb, auto&&... cells) {
+        collection_mutation_description desc;
+        desc.tomb = tomb;
+        do_make_collection(desc, std::forward<decltype(cells)>(cells)...);
+        return desc.serialize(*collection_type);
+    };
+
+    const auto check = [&] (row_content rc, row_tombstone rt, compact_and_expire_result expected_res, std::source_location sl = std::source_location::current()) {
+        testlog.info("check() @ {}:{}", sl.file_name(), sl.line());
+        const static std::unordered_map<column_kind, std::array<bytes, 2>> column_names = {
+            {column_kind::static_column, {"static_atomic", "static_collection"}},
+            {column_kind::regular_column, {"regular_atomic", "regular_collection"}},
+        };
+        for (const auto col_kind : {column_kind::static_column, column_kind::regular_column}) {
+            row r;
+            if (rc.atomic_column) {
+                const auto cdef = *s.get_column_definition(column_names.at(col_kind)[0]);
+                r.apply(cdef, atomic_cell_or_collection(atomic_cell(*int32_type, *rc.atomic_column)));
+            }
+            if (rc.collection_column) {
+                const auto cdef = *s.get_column_definition(column_names.at(col_kind)[1]);
+                r.apply(cdef, atomic_cell_or_collection(collection_mutation(*collection_type, *rc.collection_column)));
+            }
+            auto res = r.compact_and_expire(s, col_kind, rt, now, always_gc, now);
+            BOOST_REQUIRE_EQUAL(res, expected_res);
+        }
+    };
+
+    check(row_content{}, row_tombstone{}, {});
+
+    check(row_content{.atomic_column = atomic_cell::make_live(*int32_type, live_ts, value)}, row_tombstone{}, {.live_cells = 1});
+    check(row_content{.atomic_column = atomic_cell::make_live(*int32_type, live_ts, value)}, row_tombstone{tombstone(tomb_ts, now)}, {.live_cells = 1});
+
+    check(row_content{.atomic_column = atomic_cell::make_dead(dead_ts, now)}, row_tombstone{}, {.dead_cells = 1});
+    check(row_content{.atomic_column = atomic_cell::make_live(*int32_type, dead_ts, value)}, row_tombstone{tombstone(tomb_ts, now)}, {.dead_cells = 1});
+
+    check(row_content{
+                .collection_column = make_collection({}, std::pair(value, atomic_cell::make_live(*int32_type, live_ts, value)))
+            }, row_tombstone{}, {.live_cells = 1});
+
+    check(row_content{
+                .collection_column = make_collection({}, std::pair(value, atomic_cell::make_live(*int32_type, live_ts, value)),
+                         std::pair(value1, atomic_cell::make_live(*int32_type, live_ts, value1)))
+            }, row_tombstone{}, {.live_cells = 2});
+
+    check(row_content{
+                .atomic_column = atomic_cell::make_dead(dead_ts, now),
+                .collection_column = make_collection({}, std::pair(value, atomic_cell::make_live(*int32_type, live_ts, value)),
+                         std::pair(value1, atomic_cell::make_live(*int32_type, live_ts, value1)))
+            }, row_tombstone{}, {.live_cells = 2, .dead_cells = 1});
+
+    check(row_content{
+                .atomic_column = atomic_cell::make_live(*int32_type, live_ts, value),
+                .collection_column = make_collection({}, std::pair(value, atomic_cell::make_live(*int32_type, live_ts, value)),
+                         std::pair(value1, atomic_cell::make_live(*int32_type, live_ts, value1)))
+            }, row_tombstone{}, {.live_cells = 3});
+
+    check(row_content{
+                .atomic_column = atomic_cell::make_live(*int32_type, live_ts, value),
+                .collection_column = make_collection({}, std::pair(value, atomic_cell::make_dead(dead_ts, now)),
+                         std::pair(value1, atomic_cell::make_live(*int32_type, live_ts, value1)))
+            }, row_tombstone{}, {.live_cells = 2, .dead_cells = 1});
+
+    check(row_content{
+                .atomic_column = atomic_cell::make_live(*int32_type, live_ts, value),
+                .collection_column = make_collection(tombstone(tomb_ts, now), std::pair(value, atomic_cell::make_dead(dead_ts, now)),
+                         std::pair(value1, atomic_cell::make_live(*int32_type, live_ts, value1)))
+            }, row_tombstone{}, {.live_cells = 2, .dead_cells = 1, .collection_tombstones = 1});
+
+    check(row_content{
+                .atomic_column = atomic_cell::make_live(*int32_type, live_ts, value),
+                .collection_column = make_collection(tombstone(tomb_ts, now), std::pair(value, atomic_cell::make_live(*int32_type, dead_ts, value)),
+                         std::pair(value1, atomic_cell::make_live(*int32_type, live_ts, value1)))
+            }, row_tombstone{}, {.live_cells = 2, .dead_cells = 1, .collection_tombstones = 1});
+
+    check(row_content{
+                .atomic_column = atomic_cell::make_live(*int32_type, dead_ts, value),
+                .collection_column = make_collection({}, std::pair(value, atomic_cell::make_dead(dead_ts, now)),
+                         std::pair(value1, atomic_cell::make_live(*int32_type, live_ts, value1)))
+            }, row_tombstone(tombstone(tomb_ts, now)), {.live_cells = 1, .dead_cells = 2});
+
+    check(row_content{
+                .atomic_column = atomic_cell::make_live(*int32_type, dead_ts, value),
+                .collection_column = make_collection(tombstone(dead_ts, now), std::pair(value, atomic_cell::make_dead(dead_ts, now)),
+                         std::pair(value1, atomic_cell::make_live(*int32_type, live_ts, value1)))
+            }, row_tombstone(tombstone(tomb_ts, now)), {.live_cells = 1, .dead_cells = 2, .collection_tombstones = 1});
+
+    return make_ready_future();
+}

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2665,24 +2665,24 @@ SEASTAR_THREAD_TEST_CASE(test_collection_compaction) {
     // No collection tombstone, row tombstone covers all cells
     auto cmut = make_collection_mutation({}, key, make_collection_member(bytes_type, value));
     auto row_tomb = row_tombstone(tombstone { 1, gc_clock::time_point() });
-    auto any_live = cmut.compact_and_expire(0, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point());
-    BOOST_CHECK(!any_live);
+    auto res = cmut.compact_and_expire(0, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point());
+    BOOST_CHECK(!res.is_live());
     BOOST_CHECK(!cmut.tomb);
     BOOST_CHECK(cmut.cells.empty());
 
     // No collection tombstone, row tombstone doesn't cover anything
     cmut = make_collection_mutation({}, key, make_collection_member(bytes_type, value));
     row_tomb = row_tombstone(tombstone { -1, gc_clock::time_point() });
-    any_live = cmut.compact_and_expire(0, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point());
-    BOOST_CHECK(any_live);
+    res = cmut.compact_and_expire(0, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point());
+    BOOST_CHECK(res.is_live());
     BOOST_CHECK(!cmut.tomb);
     BOOST_CHECK_EQUAL(cmut.cells.size(), 1);
 
     // Collection tombstone covers everything
     cmut = make_collection_mutation(tombstone { 2, gc_clock::time_point() }, key, make_collection_member(bytes_type, value));
     row_tomb = row_tombstone(tombstone { 1, gc_clock::time_point() });
-    any_live = cmut.compact_and_expire(0, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point());
-    BOOST_CHECK(!any_live);
+    res = cmut.compact_and_expire(0, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point());
+    BOOST_CHECK(!res.is_live());
     BOOST_CHECK(cmut.tomb);
     BOOST_CHECK_EQUAL(cmut.tomb.timestamp, 2);
     BOOST_CHECK(cmut.cells.empty());
@@ -2690,8 +2690,8 @@ SEASTAR_THREAD_TEST_CASE(test_collection_compaction) {
     // Collection tombstone covered by row tombstone
     cmut = make_collection_mutation(tombstone { 2, gc_clock::time_point() }, key, make_collection_member(bytes_type, value));
     row_tomb = row_tombstone(tombstone { 3, gc_clock::time_point() });
-    any_live = cmut.compact_and_expire(0, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point());
-    BOOST_CHECK(!any_live);
+    res = cmut.compact_and_expire(0, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point());
+    BOOST_CHECK(!res.is_live());
     BOOST_CHECK(!cmut.tomb);
     BOOST_CHECK(cmut.cells.empty());
 }


### PR DESCRIPTION
We have two mechanism to give visibility into reads having to process many tombstones:
* a warning in the logs, triggered if a read processed more the `tombstone_warn_threshold` dead rows/tombstones
* a trace message, which includes stats of the amount of rows in the page, including the amount of live and dead rows as well as tombstones

This series extends this to also include information on cells, so we have visibility into the case where a read has to process an excessive amount of cell tombstones (mainly because of collections).
A log line is now also logged if the amount of dead cells/tombstones in the page exceeds `tombstone_warn_threshold`. The trace message is also extended to contain cell stats.

The `tombstone_warn_threshold` log lines now receive a 10s rate-limit to avoid excessive log spamming. The rate-limit is separate for the row and cell logs.

Example of the new log line (`tombstone_warn_threshold=10` ):
```
WARN  2024-05-30 07:56:44,979 [shard 0:stmt] querier - Read 98 live cells and 126 dead cells/tombstones for system_schema.scylla_tables <partition-range-scan> (-inf, +inf) (see tombstone_warn_threshold) 
```

Example of the new tracing message:
```
Page stats: 1 partition(s), 0 static row(s) (0 live, 0 dead), 1 clustering row(s) (1 live, 0 dead), 0 range tombstone(s) and 13 cell(s) (1 live, 12 dead) [shard 0] | 2024-05-30 08:13:19.690803 | 127.0.0.1 |           6114 | 127.0.0.1
```

Fixes: https://github.com/scylladb/scylladb/issues/18996

Improvement, not a backport candidate.