### PR TITLE
[branch-6.0] Update the tools/java submodule

### DIFF
--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-38-20240321
+docker.io/scylladb/scylla-toolchain:fedora-38-20240530


### PR DESCRIPTION
* tools/java 4ee15fd9...6dfc187a (1):
  > Update Scylla Java driver to 3.11.5.3.

[botond: regenerate frozen toolchain]