### PR TITLE
query_processor: Coroutinize stop()

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -520,9 +520,9 @@ future<> query_processor::stop_remote() {
 }
 
 future<> query_processor::stop() {
-    return _mnotifier.unregister_listener(_migration_subscriber.get()).then([this] {
-        return _authorized_prepared_cache.stop().finally([this] { return _prepared_cache.stop(); });
-    });
+    co_await _mnotifier.unregister_listener(_migration_subscriber.get());
+    co_await _authorized_prepared_cache.stop();
+    co_await _prepared_cache.stop();
 }
 
 future<::shared_ptr<cql_transport::messages::result_message>> query_processor::execute_with_guard(


### PR DESCRIPTION
This effectively removes "finally" block so if
authorized_prepared_cache.stop() resolves with exception, the prepared_cache.stop() is skipped. But that's not a problem -- even if .stop() throws the shole scylla stop aborts so we don't really care if it was clean or not.

Also, authorized_prepared_cache.stop() closes the gate and cancels the timer. None of those can resolve with exception.

