### PR TITLE
test: pylib: Fetch all pages by default in run_async

### DIFF
--- a/test/pylib/async_cql.py
+++ b/test/pylib/async_cql.py
@@ -77,7 +77,7 @@ def _wrap_future(driver_response_future: ResponseFuture, all_pages: bool = False
 
 
 # TODO: paged result query handling (iterable?)
-def run_async(self, *args, all_pages = False, **kwargs) -> asyncio.Future:
+def run_async(self, *args, all_pages = True, **kwargs) -> asyncio.Future:
     """Execute a CQL query asynchronously by wrapping the driver's future"""
     # The default timeouts should have been more than enough, but in some
     # extreme cases with a very slow debug build running on a slow or very busy

--- a/test/topology/test_random_tables.py
+++ b/test/topology/test_random_tables.py
@@ -115,7 +115,7 @@ async def test_paged_result(manager, random_tables):
 
     # Check only 1 page
     stmt = SimpleStatement(f"SELECT * FROM {table} ALLOW FILTERING", fetch_size = fetch_size)
-    res = await cql.run_async(stmt)
+    res = await cql.run_async(stmt, all_pages=False)
     assert len(res) == fetch_size
 
     # Check all pages

--- a/test/topology/util.py
+++ b/test/topology/util.py
@@ -304,7 +304,8 @@ async def start_writes_to_cdc_table(cql: Session, concurrency: int = 3):
 
         stream_to_timestamp = { stream: gen.time for gen in generations for stream in gen.streams}
 
-        cdc_log = await cql.run_async(f"SELECT * FROM {ks_name}.tbl_scylla_cdc_log")
+        # FIXME: Doesn't work with all_pages=True (https://github.com/scylladb/scylladb/issues/19101)
+        cdc_log = await cql.run_async(f"SELECT * FROM {ks_name}.tbl_scylla_cdc_log", all_pages=False)
         for log_entry in cdc_log:
             assert log_entry.cdc_stream_id in stream_to_timestamp
             timestamp = stream_to_timestamp[log_entry.cdc_stream_id]


### PR DESCRIPTION
Fetching only the first page is not the intuitive behavior expected by users.

This causes flakiness in some tests which generate variable amount of keys depending on execution speed and verify later that all keys were written using a single SELECT statement. When the amount of keys becomes larger than page size, the test fails.

Fixes #18774
