### PR TITLE
repair/streaming: enable toggling tombstone gc with a config item

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -948,6 +948,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , enable_repair_based_node_ops(this, "enable_repair_based_node_ops", liveness::LiveUpdate, value_status::Used, true, "Set true to use enable repair based node operations instead of streaming based.")
     , allowed_repair_based_node_ops(this, "allowed_repair_based_node_ops", liveness::LiveUpdate, value_status::Used, "replace,removenode,rebuild,bootstrap,decommission", "A comma separated list of node operations which are allowed to enable repair based node operations. The operations can be bootstrap, replace, removenode, decommission and rebuild.")
     , enable_compacting_data_for_streaming_and_repair(this, "enable_compacting_data_for_streaming_and_repair", liveness::LiveUpdate, value_status::Used, true, "Enable the compacting reader, which compacts the data for streaming and repair (load'n'stream included) before sending it to, or synchronizing it with peers. Can reduce the amount of data to be processed by removing dead data, but adds CPU overhead.")
+    , enable_tombstone_gc_for_streaming_and_repair(this, "enable_tombstone_gc_for_streaming_and_repair", liveness::LiveUpdate, value_status::Used, false,
+            "If the compacting reader is enabled for streaming and repair (see enable_compacting_data_for_streaming_and_repair), allow it to garbage-collect tombstones."
+            " This can reduce the amount of data repair has to process.")
     , repair_partition_count_estimation_ratio(this, "repair_partition_count_estimation_ratio", liveness::LiveUpdate, value_status::Used, 0.1,
         "Specify the fraction of partitions written by repair out of the total partitions. The value is currently only used for bloom filter estimation. Value is between 0 and 1.")
     , ring_delay_ms(this, "ring_delay_ms", value_status::Used, 30 * 1000, "Time a node waits to hear from other nodes before joining the ring in milliseconds. Same as -Dcassandra.ring_delay_ms in cassandra.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -337,6 +337,7 @@ public:
     named_value<bool> enable_repair_based_node_ops;
     named_value<sstring> allowed_repair_based_node_ops;
     named_value<bool> enable_compacting_data_for_streaming_and_repair;
+    named_value<bool> enable_tombstone_gc_for_streaming_and_repair;
     named_value<double> repair_partition_count_estimation_ratio;
     named_value<uint32_t> ring_delay_ms;
     named_value<uint32_t> shadow_round_ms;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1250,6 +1250,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.view_update_concurrency_semaphore_limit = _config.view_update_concurrency_semaphore_limit;
     cfg.data_listeners = &db.data_listeners();
     cfg.enable_compacting_data_for_streaming_and_repair = db_config.enable_compacting_data_for_streaming_and_repair;
+    cfg.enable_tombstone_gc_for_streaming_and_repair = db_config.enable_tombstone_gc_for_streaming_and_repair;
 
     return cfg;
 }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -419,6 +419,7 @@ public:
         uint32_t tombstone_warn_threshold{0};
         unsigned x_log2_compaction_groups{0};
         utils::updateable_value<bool> enable_compacting_data_for_streaming_and_repair;
+        utils::updateable_value<bool> enable_tombstone_gc_for_streaming_and_repair;
     };
 
     using snapshot_details = db::snapshot_ctl::table_snapshot_details;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -296,7 +296,7 @@ static mutation_reader maybe_compact_for_streaming(mutation_reader underlying, c
     return make_compacting_reader(
             std::move(underlying),
             compaction_time,
-            [] (const dht::decorated_key&) { return api::min_timestamp; }, // disable tombstone purging
+            [compaction_can_gc] (const dht::decorated_key&) { return compaction_can_gc ? api::max_timestamp : api::min_timestamp; },
             cm.get_tombstone_gc_state(),
             streamed_mutation::forwarding::no);
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -290,6 +290,7 @@ sstables::shared_sstable table::make_streaming_staging_sstable() {
 static mutation_reader maybe_compact_for_streaming(mutation_reader underlying, const compaction_manager& cm,
         gc_clock::time_point compaction_time, bool compaction_enabled, bool compaction_can_gc) {
     utils::get_local_injector().set_parameter("maybe_compact_for_streaming", "compaction_enabled", fmt::to_string(compaction_enabled));
+    utils::get_local_injector().set_parameter("maybe_compact_for_streaming", "compaction_can_gc", fmt::to_string(compaction_can_gc));
     if (!compaction_enabled) {
         return underlying;
     }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -287,7 +287,8 @@ sstables::shared_sstable table::make_streaming_staging_sstable() {
     return newtab;
 }
 
-static mutation_reader maybe_compact_for_streaming(mutation_reader underlying, const compaction_manager& cm, gc_clock::time_point compaction_time, bool compaction_enabled) {
+static mutation_reader maybe_compact_for_streaming(mutation_reader underlying, const compaction_manager& cm,
+        gc_clock::time_point compaction_time, bool compaction_enabled, bool compaction_can_gc) {
     utils::get_local_injector().set_parameter("maybe_compact_for_streaming", "compaction_enabled", fmt::to_string(compaction_enabled));
     if (!compaction_enabled) {
         return underlying;
@@ -320,7 +321,8 @@ table::make_streaming_reader(schema_ptr s, reader_permit permit,
             make_flat_multi_range_reader(s, std::move(permit), std::move(source), ranges, slice, nullptr, mutation_reader::forwarding::no),
             get_compaction_manager(),
             compaction_time,
-            _config.enable_compacting_data_for_streaming_and_repair());
+            _config.enable_compacting_data_for_streaming_and_repair(),
+            _config.enable_tombstone_gc_for_streaming_and_repair());
 }
 
 mutation_reader table::make_streaming_reader(schema_ptr schema, reader_permit permit, const dht::partition_range& range,
@@ -337,7 +339,8 @@ mutation_reader table::make_streaming_reader(schema_ptr schema, reader_permit pe
             make_combined_reader(std::move(schema), std::move(permit), std::move(readers), fwd, fwd_mr),
             get_compaction_manager(),
             compaction_time,
-            _config.enable_compacting_data_for_streaming_and_repair());
+            _config.enable_compacting_data_for_streaming_and_repair(),
+            _config.enable_tombstone_gc_for_streaming_and_repair());
 }
 
 mutation_reader table::make_streaming_reader(schema_ptr schema, reader_permit permit, const dht::partition_range& range,
@@ -351,7 +354,8 @@ mutation_reader table::make_streaming_reader(schema_ptr schema, reader_permit pe
                     std::move(trace_state), fwd, fwd_mr),
             get_compaction_manager(),
             compaction_time,
-            _config.enable_compacting_data_for_streaming_and_repair());
+            _config.enable_compacting_data_for_streaming_and_repair(),
+            _config.enable_tombstone_gc_for_streaming_and_repair());
 }
 
 mutation_reader table::make_nonpopulating_cache_reader(schema_ptr schema, reader_permit permit, const dht::partition_range& range,

--- a/test/topology_custom/test_repair.py
+++ b/test/topology_custom/test_repair.py
@@ -8,6 +8,9 @@ import logging
 import pytest
 import time
 
+from cassandra.cluster import ConsistencyLevel
+from cassandra.query import SimpleStatement
+
 from test.pylib.util import wait_for_cql_and_get_hosts
 from test.topology.conftest import skip_mode
 
@@ -67,3 +70,77 @@ async def test_enable_compacting_data_for_streaming_and_repair_live_update(manag
     # After the update to the config above, the next repair should pick up the updated value.
     await manager.api.repair(node1.ip_addr, "ks", "tbl")
     assert (await get_injection_params(manager, node1.ip_addr, "maybe_compact_for_streaming"))["compaction_enabled"] == "true"
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_tombstone_gc_for_streaming_and_repair(manager):
+    """
+    Check that:
+    * enable_tombstone_gc_for_streaming_and_repair=1 works as expected
+    * enable_tombstone_gc_for_streaming_and_repair=0 works as expected
+    * enable_tombstone_gc_for_streaming_and_repair is live-update
+    """
+    cmdline = [
+            "--enable-compacting-data-for-streaming-and-repair", "1",
+            "--enable-tombstone-gc-for-streaming-and-repair", "1",
+            "--enable-cache", "0",
+            "--hinted-handoff-enabled", "0",
+            "--smp", "1",
+            "--logger-log-level", "api=trace:database=trace"]
+    node1 = await manager.server_add(cmdline=cmdline)
+    node2 = await manager.server_add(cmdline=cmdline)
+
+    cql = manager.get_cql()
+
+    cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
+    cql.execute("CREATE TABLE ks.tbl (pk int, ck int, PRIMARY KEY (pk, ck)) WITH compaction = {'class': 'NullCompactionStrategy'}")
+
+    await manager.server_stop_gracefully(node2.server_id)
+
+    stmt = SimpleStatement("DELETE FROM ks.tbl WHERE pk = 0 AND ck = 0", consistency_level=ConsistencyLevel.ONE)
+    cql.execute(stmt)
+
+    await manager.server_start(node2.server_id, wait_others=1)
+
+    # Flush memtables and remove commitlog, so we can freely GC tombstones.
+    await manager.server_restart(node1.server_id, wait_others=1)
+
+    host1, host2 = await wait_for_cql_and_get_hosts(cql, [node1, node2], time.time() + 30)
+
+    config_item = "enable_tombstone_gc_for_streaming_and_repair"
+
+    def check_nodes_have_data(node1_has_data, node2_has_data):
+        for (host, host_has_data) in ((host1, node1_has_data), (host2, node2_has_data)):
+            res = list(cql.execute("SELECT * FROM MUTATION_FRAGMENTS(ks.tbl) WHERE pk = 0", host=host))
+            print(res)
+            if host_has_data:
+                assert len(res) == 3
+            else:
+                assert len(res) < 3
+
+    # Initial start-condition check
+    check_nodes_have_data(True, False)
+
+    await manager.api.enable_injection(node1.ip_addr, "maybe_compact_for_streaming", False, {})
+
+    # Make the tombstone purgeable
+    cql.execute("ALTER TABLE ks.tbl WITH tombstone_gc = {'mode': 'immediate'}")
+
+    # With enable_tombstone_gc_for_streaming_and_repair=1, repair
+    # should not find any differences and thus not replicate the GCable
+    # tombstone.
+    await manager.api.repair(node1.ip_addr, "ks", "tbl")
+    assert (await get_injection_params(manager, node1.ip_addr, "maybe_compact_for_streaming")) == {
+            "compaction_enabled": "true", "compaction_can_gc": "true"}
+    check_nodes_have_data(True, False)
+
+    for host in (host1, host2):
+        cql.execute(f"UPDATE system.config SET value = '0' WHERE name = '{config_item}'", host=host)
+
+    # With enable_tombstone_gc_for_streaming_and_repair=0, repair
+    # should find the differences and replicate the GCable tombstone.
+    await manager.api.repair(node1.ip_addr, "ks", "tbl")
+    assert (await get_injection_params(manager, node1.ip_addr, "maybe_compact_for_streaming")) == {
+            "compaction_enabled": "true", "compaction_can_gc": "false"}
+    check_nodes_have_data(True, True)


### PR DESCRIPTION
We currently disable tombstone GC for compaction done on the read path of streaming and repair, because those expired tombstones can still prevent data resurrection. With time-based tombstone GC, missing a repair for long enough can cause data resurrection because a tombstone is potentially GC'd before it could be spread to every node by repair. So repair disseminating these expired tombstones helps clusters which missed repair for long enough. It is not a guarantee because compaction could have done the GC itself, but it is better than nothing.
This last resort is getting less important with repair-based tombstone GC. Furthermore, we have seen this cause huge repair amplification in a cluster, where expired tombstones triggered repair replicating otherwise identical rows.

This series makes tombstone GC on the streaming/repair compaction path configurable with a config item. This new config item defaults to `false` (current behaviour), setting it to `true`, will enable tombstone GC.

Fixes: https://github.com/scylladb/scylladb/issues/19015

Not a regression, no backport needed