### PR TITLE
.github: annotate the report from clang-include-cleaner

### DIFF
--- a/.github/clang-include-cleaner.json
+++ b/.github/clang-include-cleaner.json
@@ -1,0 +1,20 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "clang-include-cleaner",
+            "severity": "warning",
+            "pattern": [
+                {
+                    "regexp": "^([^\\-\\+].*)$",
+                    "file": 1
+                },
+                {
+                    "regexp": "^(-\\s+[^\\s]+)\\s+@Line:(\\d+)$",
+                    "line": 2,
+                    "message": 1,
+                    "loop": true
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -42,6 +42,22 @@ jobs:
             -G Ninja                                    \
             -B $BUILD_DIR                               \
             -S .
+      - name: Build headers
+        run: |
+          swagger_targets=''
+          for f in api/api-doc/*.json; do
+            if test "${f#*.}" = json; then
+              name=$(basename "$f" .json)
+              if test $name != swagger20_header; then
+                swagger_targets+=" scylla_swagger_gen_$name"
+              fi
+            fi
+          done
+          cmake                                         \
+            --build build                               \
+             --target seastar_http_request_parser       \
+             --target idl-sources                       \
+             --target $swagger_targets
       - name: clang-include-cleaner
         run: |
           for d in $CLEANER_DIRS; do

--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -58,16 +58,21 @@ jobs:
              --target seastar_http_request_parser       \
              --target idl-sources                       \
              --target $swagger_targets
+      - run: |
+          echo "::add-matcher::.github/clang-include-cleaner.json"
       - name: clang-include-cleaner
         run: |
           for d in $CLEANER_DIRS; do
             find $d -name '*.cc' -o -name '*.hh'          \
               -exec echo {} \;                            \
               -exec clang-include-cleaner-$CLANG_VERSION  \
+                --ignore-headers=seastarx.hh              \
                 --print=changes                           \
                 -p $BUILD_DIR                             \
                 {} \; | tee --append $CLEANER_OUTPUT_PATH
           done
+      - run: |
+          echo "::remove-matcher owner=clang-include-cleaner::"
       - uses: actions/upload-artifact@v4
         with:
           name: Logs (clang-include-cleaner)

--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -10,7 +10,7 @@ env:
   BUILD_TYPE: RelWithDebInfo
   BUILD_DIR: build
   CLEANER_OUTPUT_PATH: build/clang-include-cleaner.log
-  CLEANER_DIRS: test/unit
+  CLEANER_DIRS: test/unit exceptions
 
 permissions: {}
 


### PR DESCRIPTION
this series

* add annotation to the github pull request when extraneous `#include` processor macros are identified
* add `exceptions` subdirectory to `CLEANER_DIRS` to demonstrate the annotation. we will fix the identified issue in a follow-up change.
 
* it's an improvement in our CI workflow. no need to backport.