### PR TITLE
build: cmake: do not scan for C++20 modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ include(limit_jobs)
 # Configure Seastar compile options to align with Scylla
 set(CMAKE_CXX_STANDARD "20" CACHE INTERNAL "")
 set(CMAKE_CXX_EXTENSIONS ON CACHE INTERNAL "")
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF CACHE INTERNAL "")
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 set(Seastar_TESTING ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
when creating the build rules using CMake 3.28 and up, it generates the rules to scan for C++20 modules for C++20 projects by default. but this slows down the compilation, and introduces unnecessary dependencies for each of the targets when building .cc files. also, it prevents the static analysis tools from running from a repo which only have its building system generated, but not yet built. as, these tools would need to process the source files just like a compiler does, and if any of the included header files is missing, they just fail.

so, before we migrate to C++20 modules, let's disable this feature.

* cmake related changes, hence no need to backport.