### PR TITLE
view-update-generator: Start in provided scheduling group

### DIFF
--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -109,9 +109,7 @@ view_update_generator::view_update_generator(replica::database& db, sharded<serv
 view_update_generator::~view_update_generator() {}
 
 future<> view_update_generator::start() {
-    thread_attributes attr;
-    attr.sched_group = _db.get_streaming_scheduling_group();
-    _started = seastar::async(std::move(attr), [this]() mutable {
+    _started = seastar::async([this]() mutable {
         auto drop_sstable_references = defer([&] () noexcept {
             // Clear sstable references so sstables_manager::stop() doesn't hang.
             vug_logger.info("leaving {} unstaged sstables unprocessed",

--- a/main.cc
+++ b/main.cc
@@ -1947,7 +1947,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             if (cfg->view_building()) {
                 supervisor::notify("Launching generate_mv_updates for non system tables");
-                view_update_generator.invoke_on_all(&db::view::view_update_generator::start).get();
+                with_scheduling_group(maintenance_scheduling_group, [] {
+                    return view_update_generator.invoke_on_all(&db::view::view_update_generator::start);
+                }).get();
             }
 
             if (cfg->view_building()) {


### PR DESCRIPTION
Currently it gets the streaming/maintenance one from database, but it can as well just assume that it's already running in the correct one, and the main code fulfils this assumption.

This removes one more place that uses database as sched groups provider.

**Please replace this line with justification for the backport/\* labels added to this PR**