### PR TITLE
keep compaction group alive for the duration of queries

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -237,6 +237,7 @@ protected:
     // The list entries are unlinked automatically when the storage group, they belong to, is removed.
     compaction_group_list _compaction_groups;
     storage_group_map _storage_groups;
+    std::forward_list<std::unique_ptr<storage_group>> _storage_groups_marked_for_remove;
     // Prevents _storage_groups from having its elements inserted or deleted while other layer iterates
     // over them (or over _compaction_groups).
     seastar::rwlock _lock;
@@ -256,7 +257,9 @@ public:
 
     future<> for_each_storage_group_gently(std::function<future<>(size_t, storage_group&)> f);
     void for_each_storage_group(std::function<void(size_t, storage_group&)> f) const;
-    void remove_storage_group(size_t id);
+    // Storage group will not be found by lookup but is only destroyed by the
+    // next `update_effective_replication_map()` call.
+    void mark_storage_group_for_remove(size_t id);
     // FIXME: Cannot return nullptr, signature can be changed to return storage_group&.
     storage_group* storage_group_for_id(const schema_ptr&, size_t i) const;
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2937,13 +2937,12 @@ table::query(schema_ptr s,
         co_return make_lw_shared<query::result>();
     }
 
-    _async_gate.enter();
+    const auto table_async_gate_holder = _async_gate.hold();
     utils::latency_counter lc;
     _stats.reads.set_latency(lc);
 
     auto finally = defer([&] () noexcept {
         _stats.reads.mark(lc);
-        _async_gate.leave();
     });
 
     const auto short_read_allowed = query::short_read(cmd.slice.options.contains<query::partition_slice::option::allow_short_read>());
@@ -3010,6 +3009,8 @@ table::mutation_query(schema_ptr s,
     if (cmd.get_row_limit() == 0 || cmd.slice.partition_row_limit() == 0 || cmd.partition_limit == 0) {
         co_return reconcilable_result();
     }
+
+    const auto table_async_gate_holder = _async_gate.hold();
 
     std::optional<query::querier> querier_opt;
     if (saved_querier) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -740,6 +740,9 @@ private:
             slogger.info("storage_proxy::handle_read injection done");
         });
 
+        // Pin the current ERM version, for the duration of the read.
+        const auto erm = s->table().get_effective_replication_map();
+
         auto pr2 = ::compat::unwrap(std::move(pr), *s);
         auto do_query = [&]() {
             if constexpr (verb == read_verb::read_data) {
@@ -747,7 +750,6 @@ private:
                     // this function assumes singular queries but doesn't validate
                     throw std::runtime_error("READ_DATA called with wrapping range");
                 }
-                auto erm = s->table().get_effective_replication_map();
                 p->get_stats().replica_data_reads++;
                 if (!oda) {
                     throw std::runtime_error("READ_DATA called without digest algorithm");
@@ -765,7 +767,6 @@ private:
                     // this function assumes singular queries but doesn't validate
                     throw std::runtime_error("READ_DIGEST called with wrapping range");
                 }
-                auto erm = s->table().get_effective_replication_map();
                 p->get_stats().replica_digest_reads++;
                 if (!oda) {
                     throw std::runtime_error("READ_DIGEST called without digest algorithm");


### PR DESCRIPTION
We have some mechanisms to keep the table+compaction-group alive for the duration of queries, but these are incomplete:
* handle_read() (in storage_proxy.cc) does obtain and keep an ERM but only for 2/3 of its code-paths
* mutation queries don't keep the table object alive
* cleanup_tablet() can be called before current ERM is drained, destroying the compaction group which is potentially still in use

This series fixes all of these points:
* handle_read() is fixed to cover all code-paths with its pinned ERM
* query_mutations() now holds the table's async gate
* cleanup_tablet() now doesn't destroy the compaction group, it is just marked for deletion and destroy is deferred to `update_effective_replication_map()`.

Fixes: #19079

Needs backport to 6.0, as it fixes a use-after-free introduced in 6.0