### PR TITLE
service levels: update connections parameters automatically

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -7,6 +7,7 @@ set(swagger_files
   api-doc/commitlog.json
   api-doc/compaction_manager.json
   api-doc/config.json
+  api-doc/cql_server_test.json
   api-doc/endpoint_snitch_info.json
   api-doc/error_injection.json
   api-doc/failure_detector.json
@@ -46,6 +47,7 @@ target_sources(api
     commitlog.cc
     compaction_manager.cc
     config.cc
+    cql_server_test.cc
     endpoint_snitch.cc
     error_injection.cc
     authorization_cache.cc

--- a/api/api-doc/cql_server_test.json
+++ b/api/api-doc/cql_server_test.json
@@ -1,0 +1,26 @@
+{
+    "apiVersion":"0.0.1",
+    "swaggerVersion":"1.2",
+    "basePath":"{{Protocol}}://{{Host}}",
+    "resourcePath":"/cql_server_test",
+    "produces":[
+        "application/json"
+    ],
+    "apis":[
+        {
+            "path":"/cql_server_test/connections_params",
+            "operations":[
+                {
+                    "method":"GET",
+                    "summary":"Get service level params of each CQL connection",
+                    "type":"connections_service_level_params",
+                    "nickname":"connections_params",
+                    "produces":[
+                        "application/json"
+                    ],
+                    "parameters":[]
+                }
+            ]
+        }
+    ]
+}

--- a/api/api.cc
+++ b/api/api.cc
@@ -10,6 +10,7 @@
 #include <seastar/http/file_handler.hh>
 #include <seastar/http/transformers.hh>
 #include <seastar/http/api_docs.hh>
+#include "cql_server_test.hh"
 #include "storage_service.hh"
 #include "token_metadata.hh"
 #include "commitlog.hh"
@@ -327,6 +328,16 @@ future<> set_server_task_manager_test(http_context& ctx, sharded<tasks::task_man
 
 future<> unset_server_task_manager_test(http_context& ctx) {
     return ctx.http_server.set_routes([&ctx] (routes& r) { unset_task_manager_test(ctx, r); });
+}
+
+future<> set_server_cql_server_test(http_context& ctx, cql_transport::controller& ctl) {
+    return register_api(ctx, "cql_server_test", "The CQL server test API", [&ctl] (http_context& ctx, routes& r) {
+        set_cql_server_test(ctx, r, ctl);
+    });
+}
+
+future<> unset_server_cql_server_test(http_context& ctx) {
+    return ctx.http_server.set_routes([&ctx] (routes& r) { unset_cql_server_test(ctx, r); });
 }
 
 #endif

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -132,5 +132,7 @@ future<> set_server_raft(http_context&, sharded<service::raft_group_registry>&);
 future<> unset_server_raft(http_context&);
 future<> set_load_meter(http_context& ctx, service::load_meter& lm);
 future<> unset_load_meter(http_context& ctx);
+future<> set_server_cql_server_test(http_context& ctx, cql_transport::controller& ctl);
+future<> unset_server_cql_server_test(http_context& ctx);
 
 }

--- a/api/cql_server_test.cc
+++ b/api/cql_server_test.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef SCYLLA_BUILD_MODE_RELEASE
+
+#include <seastar/core/coroutine.hh>
+#include <boost/range/algorithm/transform.hpp>
+
+#include "api/api-doc/cql_server_test.json.hh"
+#include "cql_server_test.hh"
+#include "transport/controller.hh"
+#include "transport/server.hh"
+#include "service/qos/qos_common.hh"
+
+namespace api {
+
+namespace cst = httpd::cql_server_test_json;
+using namespace json;
+using namespace seastar::httpd;
+
+struct connection_sl_params : public json::json_base {
+    json::json_element<sstring> _role_name;
+    json::json_element<sstring> _workload_type;
+    json::json_element<sstring> _timeout;
+
+    connection_sl_params(const sstring& role_name, const sstring& workload_type, const sstring& timeout) {
+        _role_name = role_name;
+        _workload_type = workload_type;
+        _timeout = timeout;
+        register_params();
+    }
+
+    connection_sl_params(const connection_sl_params& params)
+        : connection_sl_params(params._role_name(), params._workload_type(), params._timeout()) {}
+
+    void register_params() {
+        add(&_role_name, "role_name");
+        add(&_workload_type, "workload_type");
+        add(&_timeout, "timeout");
+    }    
+};
+
+void set_cql_server_test(http_context& ctx, seastar::httpd::routes& r, cql_transport::controller& ctl) {
+    cst::connections_params.set(r, [&ctl] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        auto sl_params = co_await ctl.get_connections_service_level_params();
+
+        std::vector<connection_sl_params> result;
+        boost::transform(std::move(sl_params), std::back_inserter(result), [] (const cql_transport::connection_service_level_params& params) {
+            auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(params.timeout_config.read_timeout).count();
+            return connection_sl_params(
+                    std::move(params.role_name), 
+                    sstring(qos::service_level_options::to_string(params.workload_type)), 
+                    to_string(cql_duration(months_counter{0}, days_counter{0}, nanoseconds_counter{nanos})));
+        });
+        co_return result;
+    });
+}
+
+void unset_cql_server_test(http_context& ctx, seastar::httpd::routes& r) {
+    cst::connections_params.unset(r);
+}
+
+}
+
+#endif

--- a/api/cql_server_test.hh
+++ b/api/cql_server_test.hh
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef SCYLLA_BUILD_MODE_RELEASE
+
+#pragma once
+
+namespace cql_transport {
+class controller;
+}
+
+namespace seastar::httpd {
+class routes;
+}
+
+namespace api {
+struct http_context;
+
+void set_cql_server_test(http_context& ctx, seastar::httpd::routes& r, cql_transport::controller& ctl);
+void unset_cql_server_test(http_context& ctx, seastar::httpd::routes& r);
+
+}
+
+#endif

--- a/auth/maintenance_socket_role_manager.cc
+++ b/auth/maintenance_socket_role_manager.cc
@@ -73,6 +73,10 @@ future<role_set> maintenance_socket_role_manager::query_granted(std::string_view
     return operation_not_supported_exception<role_set>("QUERY GRANTED");
 }
 
+future<role_to_directly_granted_map> maintenance_socket_role_manager::query_all_directly_granted() {
+    return operation_not_supported_exception<role_to_directly_granted_map>("QUERY ALL DIRECTLY GRANTED");
+}
+
 future<role_set> maintenance_socket_role_manager::query_all() {
     return operation_not_supported_exception<role_set>("QUERY ALL");
 }

--- a/auth/maintenance_socket_role_manager.hh
+++ b/auth/maintenance_socket_role_manager.hh
@@ -51,6 +51,8 @@ public:
 
     virtual future<role_set> query_granted(std::string_view grantee_name, recursive_role_query) override;
 
+    virtual future<role_to_directly_granted_map> query_all_directly_granted() override;
+
     virtual future<role_set> query_all() override;
 
     virtual future<bool> exists(std::string_view role_name) override;

--- a/auth/role_manager.hh
+++ b/auth/role_manager.hh
@@ -76,6 +76,7 @@ public:
 };
 
 using role_set = std::unordered_set<sstring>;
+using role_to_directly_granted_map = std::multimap<sstring, sstring>;
 
 enum class recursive_role_query { yes, no };
 
@@ -143,6 +144,22 @@ public:
     /// \returns an exceptional future with \ref nonexistant_role if the role does not exist.
     ///
     virtual future<role_set> query_granted(std::string_view grantee, recursive_role_query) = 0;
+
+    /// \returns map of directly granted roles for all roles
+    ///
+    /// Example:
+    /// GRANT role2 TO role1
+    /// GRANT role3 TO role1
+    /// GRANT role3 TO role2
+    ///
+    /// Will return map:
+    /// {
+    ///   (role1, role2),
+    ///   (role1, role3),
+    ///   (role2, role3)
+    /// }
+    ///  
+    virtual future<role_to_directly_granted_map> query_all_directly_granted() = 0;
 
     virtual future<role_set> query_all() = 0;
 

--- a/auth/standard_role_manager.hh
+++ b/auth/standard_role_manager.hh
@@ -61,6 +61,8 @@ public:
 
     virtual future<role_set> query_granted(std::string_view grantee_name, recursive_role_query) override;
 
+    virtual future<role_to_directly_granted_map> query_all_directly_granted() override;
+
     virtual future<role_set> query_all() override;
 
     virtual future<bool> exists(std::string_view role_name) override;

--- a/configure.py
+++ b/configure.py
@@ -1234,6 +1234,8 @@ api = ['api/api.cc',
        Json2Code('api/api-doc/authorization_cache.json'),
        'api/raft.cc',
        Json2Code('api/api-doc/raft.json'),
+       Json2Code('api/api-doc/cql_server_test.json'),
+       'api/cql_server_test.cc',
        ]
 
 alternator = [

--- a/cql3/statements/list_effective_service_level_statement.cc
+++ b/cql3/statements/list_effective_service_level_statement.cc
@@ -68,7 +68,7 @@ list_effective_service_level_statement::execute(query_processor& qp, service::qu
 
     auto role_set = co_await role_manager.query_granted(_role_name, auth::recursive_role_query::yes);
     auto& sl_controller = state.get_service_level_controller();
-    auto slo = co_await sl_controller.find_service_level(role_set, qos::include_effective_names::yes);
+    auto slo = co_await sl_controller.find_effective_service_level(role_set, qos::include_effective_names::yes);
 
     if (!slo) {
         throw exceptions::invalid_request_exception(format("Role {} doesn't have assigned any service level", _role_name));

--- a/cql3/statements/list_effective_service_level_statement.cc
+++ b/cql3/statements/list_effective_service_level_statement.cc
@@ -66,9 +66,8 @@ list_effective_service_level_statement::execute(query_processor& qp, service::qu
         throw auth::nonexistant_role(_role_name);
     }
 
-    auto role_set = co_await role_manager.query_granted(_role_name, auth::recursive_role_query::yes);
     auto& sl_controller = state.get_service_level_controller();
-    auto slo = co_await sl_controller.find_effective_service_level(role_set, qos::include_effective_names::yes);
+    auto slo = co_await sl_controller.find_effective_service_level(_role_name);
 
     if (!slo) {
         throw exceptions::invalid_request_exception(format("Role {} doesn't have assigned any service level", _role_name));

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -119,7 +119,7 @@ protected:
 
     virtual future<> unadvertise_connection(shared_ptr<connection> conn);
 
-    future<> for_each_gently(noncopyable_function<void(connection&)>);
+    future<> for_each_gently(noncopyable_function<future<>(connection&)>);
 
     void maybe_stop();
 };

--- a/main.cc
+++ b/main.cc
@@ -2089,6 +2089,13 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 api::unset_thrift_controller(ctx).get();
             });
 
+#ifndef SCYLLA_BUILD_MODE_RELEASE
+            api::set_server_cql_server_test(ctx, cql_server_ctl).get();
+            auto stop_cql_server_test_api = defer_verbose_shutdown("cql server API", [&ctx] {
+                api::unset_server_cql_server_test(ctx).get();
+            });
+#endif
+
             ss.local().register_protocol_server(alternator_ctl, cfg->alternator_port() || cfg->alternator_https_port()).get();
 
             ss.local().register_protocol_server(redis_ctl, cfg->redis_port() || cfg->redis_ssl_port()).get();

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -241,7 +241,7 @@ future<> service::client_state::maybe_update_per_service_level_params() {
     if (_sl_controller && _user && _user->name) {
         auto& role_manager = _auth_service->underlying_role_manager();
         auto role_set = co_await role_manager.query_granted(_user->name.value(), auth::recursive_role_query::yes);
-        auto slo_opt = co_await _sl_controller->find_service_level(role_set);
+        auto slo_opt = co_await _sl_controller->find_effective_service_level(role_set);
         if (!slo_opt) {
             co_return;
         }

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -239,9 +239,7 @@ future<> service::client_state::ensure_exists(const auth::resource& r) const {
 
 future<> service::client_state::maybe_update_per_service_level_params() {
     if (_sl_controller && _user && _user->name) {
-        auto& role_manager = _auth_service->underlying_role_manager();
-        auto role_set = co_await role_manager.query_granted(_user->name.value(), auth::recursive_role_query::yes);
-        auto slo_opt = co_await _sl_controller->find_effective_service_level(role_set);
+        auto slo_opt = co_await _sl_controller->find_effective_service_level(_user->name.value());
         if (!slo_opt) {
             co_return;
         }

--- a/service/qos/qos_common.cc
+++ b/service/qos/qos_common.cc
@@ -11,6 +11,7 @@
 #include "cql3/query_processor.hh"
 #include "cql3/result_set.hh"
 #include "cql3/untyped_result_set.hh"
+#include <string_view>
 
 namespace qos {
 
@@ -118,10 +119,10 @@ std::optional<service_level_options::workload_type> service_level_options::parse
     return std::nullopt;
 }
 
-void service_level_options::init_effective_names(sstring& service_level_name) {
+void service_level_options::init_effective_names(std::string_view service_level_name) {
     effective_names = service_level_options::slo_effective_names {
-        .timeout = service_level_name,
-        .workload = service_level_name
+        .timeout = sstring(service_level_name),
+        .workload = sstring(service_level_name)
     };
 }
 

--- a/service/qos/qos_common.hh
+++ b/service/qos/qos_common.hh
@@ -14,6 +14,7 @@
 #include <seastar/core/print.hh>
 #include <map>
 #include <stdexcept>
+#include <string_view>
 #include <variant>
 #include <seastar/core/lowres_clock.hh>
 
@@ -68,7 +69,7 @@ struct service_level_options {
     };
     std::optional<slo_effective_names> effective_names = std::nullopt;
 
-    void init_effective_names(sstring& service_level_name);
+    void init_effective_names(std::string_view service_level_name);
 };
 
 std::ostream& operator<<(std::ostream& os, const service_level_options::workload_type&);

--- a/service/qos/qos_configuration_change_subscriber.hh
+++ b/service/qos/qos_configuration_change_subscriber.hh
@@ -25,6 +25,8 @@ namespace qos {
         /** This callback is going to be called just before the service level is changed **/
         virtual future<> on_before_service_level_change(service_level_options slo_before, service_level_options slo_after, service_level_info sl_info) = 0;
 
+        virtual future<> on_effective_service_levels_cache_reloaded() = 0;
+
         virtual ~qos_configuration_change_subscriber() {};
     };
 }

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -143,12 +143,9 @@ void service_level_controller::abort_group0_operations() {
 }
 
 future<> service_level_controller::update_service_levels_cache() {
+    SCYLLA_ASSERT(this_shard_id() == global_controller);
 
     if (!_sl_data_accessor) {
-        return make_ready_future();
-    }
-
-    if (this_shard_id() != global_controller) {
         return make_ready_future();
     }
 

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -282,6 +282,14 @@ future<> service_level_controller::update_effective_service_levels_cache() {
     });
 }
 
+future<> service_level_controller::update_cache(update_both_cache_levels update_both_cache_levels) {
+    SCYLLA_ASSERT(this_shard_id() == global_controller);
+    if (update_both_cache_levels) {
+        co_await update_service_levels_cache();
+    }
+    co_await update_effective_service_levels_cache();
+}
+
 void service_level_controller::stop_legacy_update_from_distributed_data() {
     SCYLLA_ASSERT(this_shard_id() == global_controller);
 

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -300,40 +300,46 @@ void service_level_controller::stop_legacy_update_from_distributed_data() {
     _global_controller_db->dist_data_update_aborter.request_abort();
 }
 
-future<std::optional<service_level_options>> service_level_controller::find_effective_service_level(auth::role_set roles, include_effective_names include_names) {
-    auto& role_manager = _auth_service.local().underlying_role_manager();
+future<std::optional<service_level_options>> service_level_controller::find_effective_service_level(const sstring& role_name) {
+    if (_sl_data_accessor->is_v2()) {
+        auto effective_sl_it = _effective_service_levels_db.find(role_name);
+        co_return effective_sl_it != _effective_service_levels_db.end() 
+            ? std::optional<service_level_options>(effective_sl_it->second)
+            : std::nullopt;
+    } else {
+        auto& role_manager = _auth_service.local().underlying_role_manager();
+        auto roles = co_await role_manager.query_granted(role_name, auth::recursive_role_query::yes);
 
-    // converts a list of roles into the chosen service level.
-    return ::map_reduce(roles.begin(), roles.end(), [&role_manager, include_names, this] (const sstring& role) {
-        return role_manager.get_attribute(role, "service_level").then_wrapped([include_names, this, role] (future<std::optional<sstring>> sl_name_fut) -> std::optional<service_level_options> {
-            try {
-                std::optional<sstring> sl_name = sl_name_fut.get();
-                if (!sl_name) {
-                    return std::nullopt;
-                }
-                auto sl_it = _service_levels_db.find(*sl_name);
-                if ( sl_it == _service_levels_db.end()) {
-                    return std::nullopt;
-                }
+        // converts a list of roles into the chosen service level.
+        co_return co_await ::map_reduce(roles.begin(), roles.end(), [&role_manager, this] (const sstring& role) {
+            return role_manager.get_attribute(role, "service_level").then_wrapped([this, role] (future<std::optional<sstring>> sl_name_fut) -> std::optional<service_level_options> {
+                try {
+                    std::optional<sstring> sl_name = sl_name_fut.get();
+                    if (!sl_name) {
+                        return std::nullopt;
+                    }
+                    auto sl_it = _service_levels_db.find(*sl_name);
+                    if ( sl_it == _service_levels_db.end()) {
+                        return std::nullopt;
+                    }
 
-                if (include_names == include_effective_names::yes) {
                     sl_it->second.slo.init_effective_names(*sl_name);
+                    return sl_it->second.slo;
+                } catch (...) { // when we fail, we act as if the attribute does not exist so the node
+                            // will not be brought down.
+                    return std::nullopt;
                 }
-                return sl_it->second.slo;
-            } catch (...) { // when we fail, we act as if the attribute does not exist so the node
-                           // will not be brought down.
-                return std::nullopt;
+            });
+        }, std::optional<service_level_options>{}, [] (std::optional<service_level_options> first, std::optional<service_level_options> second) -> std::optional<service_level_options> {
+            if (!second) {
+                return first;
+            } else if (!first) {
+                return second;
+            } else {
+                return first->merge_with(*second);
             }
         });
-    }, std::optional<service_level_options>{}, [] (std::optional<service_level_options> first, std::optional<service_level_options> second) -> std::optional<service_level_options> {
-        if (!second) {
-            return first;
-        } else if (!first) {
-            return second;
-        } else {
-            return first->merge_with(*second);
-        }
-    });
+    }
 }
 
 future<>  service_level_controller::notify_service_level_added(sstring name, service_level sl_data) {

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -301,6 +301,7 @@ private:
     future<> notify_service_level_added(sstring name, service_level sl_data);
     future<> notify_service_level_updated(sstring name, service_level_options slo);
     future<> notify_service_level_removed(sstring name);
+    future<> notify_effective_service_levels_cache_reloaded();
 
     enum class  set_service_level_op_type {
         add_if_not_exists,

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -237,7 +237,7 @@ public:
      * @return the effective service level options - they may in particular be a combination
      *         of options from multiple service levels
      */
-    future<std::optional<service_level_options>> find_effective_service_level(auth::role_set roles, include_effective_names include_names = include_effective_names::no);
+    future<std::optional<service_level_options>> find_effective_service_level(const sstring& role_name);
 
     /**
      * Gets the service level data by name.

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -117,7 +117,10 @@ private:
 
     static constexpr shard_id global_controller = 0;
 
+    // service level name -> service_level object
     std::map<sstring, service_level> _service_levels_db;
+    // role name -> effective service_level_options 
+    std::map<sstring, service_level_options> _effective_service_levels_db;
     service_level _default_service_level;
     service_level_distributed_data_accessor_ptr _sl_data_accessor;
     sharded<auth::service>& _auth_service;
@@ -200,6 +203,14 @@ public:
      */
     future<> update_service_levels_cache();
 
+    /**
+     * Updates effective service levels cache.
+     * The method uses service levels cache (_service_levels_db)
+     * and data from auth tables.
+     * Must be executed on shard 0.
+     * @return a future that is resolved when the update is done
+     */
+    future<> update_effective_service_levels_cache();
 
     future<> add_distributed_service_level(sstring name, service_level_options slo, bool if_not_exsists, service::group0_batch& mc);
     future<> alter_distributed_service_level(sstring name, service_level_options slo, service::group0_batch& mc);

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -91,7 +91,6 @@ private:
     static constexpr shard_id global_controller = 0;
 
     std::map<sstring, service_level> _service_levels_db;
-    std::unordered_map<sstring, sstring> _role_to_service_level;
     service_level _default_service_level;
     service_level_distributed_data_accessor_ptr _sl_data_accessor;
     sharded<auth::service>& _auth_service;

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <seastar/core/timer.hh>
+#include "seastar/util/bool_class.hh"
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/distributed.hh>
@@ -44,6 +45,8 @@ struct service_level {
      bool marked_for_deletion;
      bool is_static;
 };
+
+using update_both_cache_levels = bool_class<class update_both_cache_levels_tag>;
 
 /**
  *  The service_level_controller class is an implementation of the service level
@@ -211,6 +214,15 @@ public:
      * @return a future that is resolved when the update is done
      */
     future<> update_effective_service_levels_cache();
+
+    /**
+     * Service levels cache consists of two levels: service levels cache and effective service levels cache
+     * The second one is dependent on the first one.
+     *
+     * update_both_cache_levels::yes - updates both levels of the cache
+     * update_both_cache_levels::no  - update only effective service levels cache
+     */
+    future<> update_cache(update_both_cache_levels update_both_cache_levels = update_both_cache_levels::yes);
 
     future<> add_distributed_service_level(sstring name, service_level_options slo, bool if_not_exsists, service::group0_batch& mc);
     future<> alter_distributed_service_level(sstring name, service_level_options slo, service::group0_batch& mc);

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -97,6 +97,7 @@ struct group0_command {
 class group0_state_machine : public raft_state_machine {
     struct modules_to_reload {
         bool service_levels_cache = false;
+        bool service_levels_effective_cache = false;
     };
 
     raft_group0_client& _client;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -685,7 +685,7 @@ future<> storage_service::topology_state_load() {
     co_await _sl_controller.invoke_on_all([this] (qos::service_level_controller& sl_controller) {
         sl_controller.upgrade_to_v2(_qp, _group0->client());
     });
-    co_await update_service_levels_cache();
+    co_await update_service_levels_cache(qos::update_both_cache_levels::yes);
 
     co_await _feature_service.container().invoke_on_all([&] (gms::feature_service& fs) {
         return fs.enable(boost::copy_range<std::set<std::string_view>>(_topology_state_machine._topology.enabled_features));
@@ -873,9 +873,9 @@ future<> storage_service::merge_topology_snapshot(raft_snapshot snp) {
     co_await _db.local().apply(freeze(muts), db::no_timeout);
 }
 
-future<> storage_service::update_service_levels_cache() {
+future<> storage_service::update_service_levels_cache(qos::update_both_cache_levels update_only_effective_cache) {
     SCYLLA_ASSERT(this_shard_id() == 0);
-    co_await _sl_controller.local().update_service_levels_cache();
+    co_await _sl_controller.local().update_cache(update_only_effective_cache);
 }
 
 // Moves the coroutine lambda onto the heap and extends its

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -875,7 +875,7 @@ future<> storage_service::merge_topology_snapshot(raft_snapshot snp) {
 
 future<> storage_service::update_service_levels_cache() {
     SCYLLA_ASSERT(this_shard_id() == 0);
-    co_await _sl_controller.local().update_service_levels_from_distributed_data();
+    co_await _sl_controller.local().update_service_levels_cache();
 }
 
 // Moves the coroutine lambda onto the heap and extends its

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -880,9 +880,14 @@ public:
     // Public for `reload_raft_topology_state` REST API.
     future<> topology_transition();
 
-    // Reload service levels in-memory configuration once.
+
+    // Service levels cache consists of two levels: service levels cache and effective service levels cache
+    // The second one is dependent on the first one.
     // Must be called on shard 0.
-    future<> update_service_levels_cache();
+    //    
+    // update_both_cache_levels::yes - updates both levels of the cache
+    // update_both_cache_levels::no  - update only effective service levels cache
+    future<> update_service_levels_cache(qos::update_both_cache_levels update_only_effective_cache = qos::update_both_cache_levels::yes);
 
     future<> do_cluster_cleanup();
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2604,19 +2604,19 @@ future<> topology_coordinator::build_coordinator_state(group0_guard guard) {
     release_guard(std::move(guard));
     co_await _group0.wait_for_all_nodes_to_finish_upgrade(_as);
 
-    auto auth_version = co_await _sys_ks.get_auth_version();
-    if (auth_version < db::system_keyspace::auth_version_t::v2) {
-        rtlogger.info("migrating system_auth keyspace data");
-        co_await auth::migrate_to_auth_v2(_sys_ks, _group0.client(),
-                [this] (abort_source&) { return start_operation();}, _as);
-    }
-
     auto tmptr = get_token_metadata_ptr();
 
     auto sl_version = co_await _sys_ks.get_service_levels_version();
     if (!sl_version || *sl_version < 2) {
         rtlogger.info("migrating service levels data");
         co_await qos::service_level_controller::migrate_to_v2(tmptr->get_all_endpoints().size(), _sys_ks, _sys_ks.query_processor(), _group0.client(), _as);
+    }
+
+    auto auth_version = co_await _sys_ks.get_auth_version();
+    if (auth_version < db::system_keyspace::auth_version_t::v2) {
+        rtlogger.info("migrating system_auth keyspace data");
+        co_await auth::migrate_to_auth_v2(_sys_ks, _group0.client(),
+                [this] (abort_source&) { return start_operation();}, _as);
     }
 
     rtlogger.info("building initial raft topology state and CDC generation");

--- a/test/auth_cluster/test_raft_service_levels.py
+++ b/test/auth_cluster/test_raft_service_levels.py
@@ -17,6 +17,7 @@ from test.topology.conftest import skip_mode
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
 from cassandra.protocol import InvalidRequest
+from cassandra.auth import PlainTextAuthProvider
 
 
 logger = logging.getLogger(__name__)
@@ -170,3 +171,138 @@ async def test_service_levels_work_during_recovery(manager: ManagerClient):
     sls_list = await cql.run_async("LIST ALL SERVICE LEVELS")
     assert sl_v1 not in [sl.service_level for sl in sls_list]
     assert set([sl.service_level for sl in sls_list]) == set(sls + [new_sl])
+
+def default_timeout(mode):
+    if mode == "dev":
+        return "30s"
+    elif mode == "debug":
+        return "3m"
+    else:
+        # this branch shouldn't be reached
+        assert False
+
+def create_roles_stmts():
+    return [
+        "CREATE ROLE r1 WITH password='r1' AND login=true",
+        "CREATE ROLE r2 WITH password='r2' AND login=true",
+        "CREATE ROLE r3 WITH password='r3' AND login=true",
+    ]
+
+def create_service_levels_stmts():
+    return [
+        "CREATE SERVICE LEVEL sl1 WITH timeout=30m AND workload_type='interactive'",
+        "CREATE SERVICE LEVEL sl2 WITH timeout=1h AND workload_type='batch'",
+        "CREATE SERVICE LEVEL sl3 WITH timeout=30s",
+    ]
+
+def attach_service_levels_stms():
+    return [
+        "ATTACH SERVICE LEVEL sl1 TO r1",
+        "ATTACH SERVICE LEVEL sl2 TO r2",
+        "ATTACH SERVICE LEVEL sl3 TO r3",
+    ]
+
+def grant_roles_stmts():
+    return [
+        "GRANT r2 TO r1",
+        "GRANT r3 TO r2",
+    ]
+
+async def get_roles_connections(manager: ManagerClient, servers):
+    roles = ["r1", "r2", "r3"]
+    cluster_connections = []
+    sessions = []
+
+    for role in roles:
+        cluster = manager.con_gen([s.ip_addr for s in servers], 
+            manager.port, manager.use_ssl, PlainTextAuthProvider(username=role, password=role))
+        connection = cluster.connect()
+        cluster_connections.append(cluster)
+        sessions.append(connection)
+    
+    return cluster_connections, sessions
+
+async def assert_connections_params(manager: ManagerClient, hosts, expect):
+    for host in hosts:
+        params = await manager.api.client.get_json("/cql_server_test/connections_params", host=host.address)
+        for param in params:
+            role = param["role_name"]
+            if not role in expect:
+                continue
+            assert param["workload_type"] == expect[role]["workload_type"]
+            assert param["timeout"] == expect[role]["timeout"]
+
+@pytest.mark.asyncio
+@skip_mode('release', 'cql server testing REST API is not supported in release mode')
+async def test_connections_parameters_auto_update(manager: ManagerClient, mode):
+    servers = await manager.servers_add(3)
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    logging.info("Creating user roles and their connections")
+    await asyncio.gather(*(
+        cql.run_async(stmt) for stmt in create_roles_stmts()))
+    cluster_connections, sessions = await get_roles_connections(manager, servers)
+
+    logging.info("Asserting all connections have default parameters")
+    await assert_connections_params(manager, hosts, {
+        "r1": {
+            "workload_type": "unspecified",
+            "timeout": default_timeout(mode),
+        },
+        "r2": {
+            "workload_type": "unspecified",
+            "timeout": default_timeout(mode),
+        },
+        "r3": {
+            "workload_type": "unspecified",
+            "timeout": default_timeout(mode),
+        },
+    })
+
+    logging.info("Creating service levels and attaching them to corresponding roles")
+    await asyncio.gather(*(
+        cql.run_async(stmt) for stmt in create_service_levels_stmts()))
+    await asyncio.gather(*(
+        cql.run_async(stmt) for stmt in attach_service_levels_stms()))
+    await asyncio.gather(*(read_barrier(manager.api, get_host_api_address(host)) for host in hosts))
+    
+    logging.info("Asserting all connections have parameters from their service levels")
+    await assert_connections_params(manager, hosts, {
+        "r1": {
+            "workload_type": "interactive",
+            "timeout": "30m",
+        },
+        "r2": {
+            "workload_type": "batch",
+            "timeout": "1h",
+        },
+        "r3": {
+            "workload_type": "unspecified",
+            "timeout": "30s",
+        },
+    })
+
+    logging.info("Granting roles and creating roles hierarchy")
+    await asyncio.gather(*(
+        cql.run_async(stmt) for stmt in grant_roles_stmts()))
+    await asyncio.gather(*(read_barrier(manager.api, get_host_api_address(host)) for host in hosts))
+
+    logging.info("Asserting all connections have correct parameters based on roles hierarchy")
+    await assert_connections_params(manager, hosts, {
+        "r1": {
+            "workload_type": "batch",
+            "timeout": "30s",
+        },
+        "r2": {
+            "workload_type": "batch",
+            "timeout": "30s",
+        },
+        "r3": {
+            "workload_type": "unspecified",
+            "timeout": "30s",
+        },
+    })
+
+    for cluster_conn in cluster_connections:
+        cluster_conn.shutdown()

--- a/test/boost/service_level_controller_test.cc
+++ b/test/boost/service_level_controller_test.cc
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <fmt/std.h>
 
+#include "seastar/core/future.hh"
 #include "seastarx.hh"
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/test_utils.hh"
@@ -62,6 +63,10 @@ struct qos_configuration_change_suscriber_simple : public qos_configuration_chan
 
     virtual future<> on_before_service_level_change(service_level_options slo_before, service_level_options slo_after, service_level_info sl_info) override {
         ops.push_back(change_op{sl_info.name, slo_before, slo_after});
+        return make_ready_future<>();
+    }
+
+    virtual future<> on_effective_service_levels_cache_reloaded() override {
         return make_ready_future<>();
     }
 };

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -358,4 +358,19 @@ future<utils::chunked_vector<client_data>> controller::get_client_data() {
     return _server ? _server->local().get_client_data() : protocol_server::get_client_data();
 }
 
+future<std::vector<connection_service_level_params>> controller::get_connections_service_level_params() {
+    if (!_server) {
+        co_return std::vector<connection_service_level_params>();
+    }
+
+    auto sl_params_vectors = co_await _server->map([] (cql_server& server) {
+        return server.get_connections_service_level_params();
+    });    
+    std::vector<connection_service_level_params> sl_params;
+    for (auto& vec: sl_params_vectors) {
+        sl_params.insert(sl_params.end(), std::make_move_iterator(vec.begin()), std::make_move_iterator(vec.end()));
+    }
+    co_return sl_params;
+}
+
 } // namespace cql_transport

--- a/transport/controller.hh
+++ b/transport/controller.hh
@@ -34,6 +34,7 @@ struct client_data;
 namespace cql_transport {
 
 class cql_server;
+struct connection_service_level_params;
 class controller : public protocol_server {
     std::vector<socket_address> _listen_addresses;
     std::unique_ptr<sharded<cql_server>> _server;
@@ -78,6 +79,8 @@ public:
     virtual future<> stop_server() override;
     virtual future<> request_stop_server() override;
     virtual future<utils::chunked_vector<client_data>> get_client_data() override;
+
+    future<std::vector<connection_service_level_params>> get_connections_service_level_params();
 };
 
 } // namespace cql_transport

--- a/transport/event_notifier.cc
+++ b/transport/event_notifier.cc
@@ -216,6 +216,22 @@ void cql_server::event_notifier::on_drop_aggregate(const sstring& ks_name, const
     elogger.warn("%s event ignored", __func__);
 }
 
+future<> cql_server::event_notifier::on_before_service_level_add(qos::service_level_options, qos::service_level_info sl_info) {
+    co_return;
+}
+
+future<> cql_server::event_notifier::on_after_service_level_remove(qos::service_level_info sl_info) {
+    co_return;
+}
+
+future<> cql_server::event_notifier::on_before_service_level_change(qos::service_level_options slo_before, qos::service_level_options slo_after, qos::service_level_info sl_info) {
+    co_return;
+}
+
+future<> cql_server::event_notifier::on_effective_service_levels_cache_reloaded() {
+    return _server.update_connections_service_level_params();
+}
+
 void cql_server::event_notifier::on_join_cluster(const gms::inet_address& endpoint)
 {
     if (!_server._gossiper.is_cql_ready(endpoint)) {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -2022,9 +2022,10 @@ void cql_server::response::write(const cql3::prepared_metadata& m, uint8_t versi
 
 future<utils::chunked_vector<client_data>> cql_server::get_client_data() {
     utils::chunked_vector<client_data> ret;
-    co_await for_each_gently([&ret] (const generic_server::connection& c) {
+    co_await for_each_gently([&ret] (const generic_server::connection& c) -> future<> {
         const connection& conn = dynamic_cast<const connection&>(c);
         ret.emplace_back(conn.make_client_data());
+        return make_ready_future<>();
     });
     co_return ret;
 }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -2030,4 +2030,11 @@ future<utils::chunked_vector<client_data>> cql_server::get_client_data() {
     co_return ret;
 }
 
+future<> cql_server::update_connections_service_level_params() {
+    return for_each_gently([] (generic_server::connection& conn) -> future<> {
+        connection& cql_conn = dynamic_cast<connection&>(conn);
+        return cql_conn.get_client_state().maybe_update_per_service_level_params();
+    });
+}
+
 }

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -184,6 +184,7 @@ public:
     }
 
     future<utils::chunked_vector<client_data>> get_client_data();
+    future<> update_connections_service_level_params();
 private:
     class fmt_visitor;
     friend class connection;
@@ -228,6 +229,7 @@ private:
         static std::pair<net::inet_address, int> make_client_key(const service::client_state& cli_state);
         client_data make_client_data() const;
         const service::client_state& get_client_state() const { return _client_state; }
+        service::client_state& get_client_state() { return _client_state; }
     private:
         friend class process_request_executor;
         future<foreign_ptr<std::unique_ptr<cql_server::response>>> process_request_one(fragmented_temporary_buffer::istream buf, uint8_t op, uint16_t stream, service::client_state& client_state, tracing_request_type tracing_request, service_permit permit);

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -133,6 +133,12 @@ private:
     std::vector<request_kind_stats> _cql_requests_stats;
 };
 
+struct connection_service_level_params {
+    sstring role_name;
+    timeout_config timeout_config;
+    qos::service_level_options::workload_type workload_type;
+};
+
 class cql_server : public seastar::peering_sharded_service<cql_server>, public generic_server::server {
 private:
     struct transport_stats {
@@ -187,6 +193,7 @@ public:
 
     future<utils::chunked_vector<client_data>> get_client_data();
     future<> update_connections_service_level_params();
+    future<std::vector<connection_service_level_params>> get_connections_service_level_params();
 private:
     class fmt_visitor;
     friend class connection;

--- a/utils/sorting.hh
+++ b/utils/sorting.hh
@@ -17,6 +17,14 @@
 
 namespace utils {
 
+template <typename Container, typename T>
+concept VerticiesContainer = requires(const Container& c) {
+    c.begin();
+    c.end();
+    c.size();
+    std::same_as<typename Container::value_type, T>;
+};
+
 /**
  * Topological sort a DAG using Kahn's algorithm.
  *
@@ -26,8 +34,9 @@ namespace utils {
         If there is an edge k->v, then vertex k will be before vertex v.
  * @throws std::runtime_error when a graph has any cycle.
  */
-template<typename T, typename Compare = std::less<T>>
-seastar::future<std::vector<T>> topological_sort(const std::vector<T>& vertices, const std::multimap<T, T, Compare>& adjacency_map) {
+template<typename T, typename Compare = std::less<T>, typename Container>
+requires VerticiesContainer<Container, T>
+seastar::future<std::vector<T>> topological_sort(const Container& vertices, const std::multimap<T, T, Compare>& adjacency_map) {
     std::map<T, size_t, Compare> ref_count_map; // Contains counters how many edges point (reference) to a vertex
     std::vector<T> sorted;
     sorted.reserve(vertices.size());


### PR DESCRIPTION
This patch makes all cql connections update theirs service level parameters automatically when:
- any service level is created or changed
- one role is granted to another
- any service level is attached to/detached from a role

First of all, the patch defines what a service level and an effective service level are https://github.com/scylladb/scylladb/commit/938aa10509fb499928eb0a35e4acc39abcd138b6. No new type of service levels are introduced, the commit only clarifies definitions and names what an effective service level is.
(Effective service level is created by merging all service levels which are attached to all roles granted to the user. It represents exact  values of connection's parameters.)

Previously, to find an effective service level of a user, it required O(n) internal queries: O(n) queries to recursively find all granted roles (`standard_role_manager::query_granted()`) and a query for each role to get its service level (`standard_role_manager::get_attribute()`, which sums to O(n) queries).

Because we want to reload SL parameters for all opened cql connections, we don't want to do O(n) queries for every connection, every time we create or change any service level/grant one role to another/attach or detach a service level to/from a role.

To speed it up, the patch adds another layer of service level controller cache, which stored `role_name -> effective_service_level` mapping. This way finding a effective service level for a role is only a lookup to a map.
Building the new cache requires only 2 queries: one to obtain all role hierarchy one to get all roles' service level.

Fixes scylladb/scylladb#12923