### PR TITLE
topology_experimental_raft/test_tablets: restore usage of check_with_down

### DIFF
--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -455,7 +455,7 @@ async def test_tablet_missing_data_repair(manager: ManagerClient):
         for r in rows:
             assert r.c == r.pk
 
-    cql = await safe_rolling_restart(manager, servers, with_down=insert_with_down)
+    cql = await safe_rolling_restart(manager, servers, with_down=check_with_down)
 
 
 @pytest.mark.repair


### PR DESCRIPTION
e7246751b64 incorrectly dropped its usage in test_tablet_missing_data_repair.

