### PR TITLE
[Backport 6.0] storage_service: Fix race between tablet split and stats retrieval

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -273,7 +273,7 @@ public:
     virtual size_t log2_storage_groups() const = 0;
     virtual storage_group* storage_group_for_token(dht::token) const noexcept = 0;
 
-    virtual locator::resize_decision::seq_number_t split_ready_seq_number() const noexcept = 0;
+    virtual locator::table_load_stats table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept = 0;
     virtual bool all_storage_groups_split() = 0;
     virtual future<> split_all_storage_groups() = 0;
     virtual future<> maybe_split_compaction_group_of(size_t idx) = 0;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1023,7 +1023,7 @@ public:
 
     // The tablet filter is used to not double account migrating tablets, so it's important that
     // only one of pending or leaving replica is accounted based on current migration stage.
-    locator::table_load_stats table_load_stats(std::function<bool(locator::global_tablet_id)> tablet_filter) const noexcept;
+    locator::table_load_stats table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept;
 
     const db::view::stats& get_view_stats() const {
         return _view_stats;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6018,34 +6018,36 @@ future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables(
         });
     }
 
-    using table_erms_t = std::unordered_map<table_id, const locator::effective_replication_map_ptr>;
-    // Creates a snapshot of transitions, so different shards will find their tablet replicas in the
-    // same migration stage. Important for intra-node migration.
-    const auto erms = co_await std::invoke([this] () -> future<table_erms_t> {
-        table_erms_t erms;
+    using table_ids_t = std::unordered_set<table_id>;
+    const auto table_ids = co_await std::invoke([this] () -> future<table_ids_t> {
+        table_ids_t ids;
         co_await _db.local().get_tables_metadata().for_each_table_gently([&] (table_id id, lw_shared_ptr<replica::table> table) mutable {
             if (table->uses_tablets()) {
-                erms.emplace(id, table->get_effective_replication_map());
+                ids.insert(id);
             }
             return make_ready_future<>();
         });
-        co_return std::move(erms);
+        co_return std::move(ids);
     });
+
+    // Helps with intra-node migration by serializing with changes to token metadata, so shards
+    // participating in the migration will see migration in same stage, therefore preventing
+    // double accounting (anomaly) in the reported size.
+    auto tmlock = co_await get_token_metadata_lock();
 
     // Each node combines a per-table load map from all of its shards and returns it to the coordinator.
     // So if there are 1k nodes, there will be 1k RPCs in total.
-    auto load_stats = co_await _db.map_reduce0([&erms] (replica::database& db) -> future<locator::load_stats> {
+    auto load_stats = co_await _db.map_reduce0([&table_ids] (replica::database& db) -> future<locator::load_stats> {
         locator::load_stats load_stats{};
         auto& tables_metadata = db.get_tables_metadata();
 
-        for (const auto& [id, erm] : erms) {
+        for (const auto& id : table_ids) {
             auto table = tables_metadata.get_table_if_exists(id);
             if (!table) {
                 continue;
             }
-
+            auto erm = table->get_effective_replication_map();
             auto& token_metadata = erm->get_token_metadata();
-            auto& tmap = token_metadata.tablets().get_tablet_map(id);
             auto me = locator::tablet_replica { token_metadata.get_my_id(), this_shard_id() };
 
             // It's important to tackle the anomaly in reported size, since both leaving and
@@ -6053,7 +6055,7 @@ future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables(
             // If transition hasn't reached cleanup stage, then leaving replicas are accounted.
             // If transition is past cleanup stage, then pending replicas are accounted.
             // This helps to reduce the discrepancy window.
-            auto tablet_filter = [&tmap, &me] (locator::global_tablet_id id) {
+            auto tablet_filter = [&me] (const locator::tablet_map& tmap, locator::global_tablet_id id) {
                 auto transition = tmap.get_tablet_transition_info(id.tablet);
                 auto& info = tmap.get_tablet_info(id.tablet);
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6066,11 +6066,11 @@ future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables(
 
                 bool is_pending = transition->pending_replica == me;
                 bool is_leaving = locator::get_leaving_replica(info, *transition) == me;
-                auto s = transition->stage;
+                auto s = transition->reads; // read selector
 
                 return (!is_pending && !is_leaving)
-                       || (is_leaving && s < locator::tablet_transition_stage::cleanup)
-                       || (is_pending && s >= locator::tablet_transition_stage::cleanup);
+                       || (is_leaving && s == locator::read_replica_set_selector::previous)
+                       || (is_pending && s == locator::read_replica_set_selector::next);
             };
 
             load_stats.tables.emplace(id, table->table_load_stats(tablet_filter));

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2472,9 +2472,11 @@ future<> topology_coordinator::start_tablet_load_stats_refresher() {
         } catch (...) {
             rtlogger.warn("Found error while refreshing load stats for tablets: {}, retrying...", std::current_exception());
         }
+        auto refresh_interval = utils::get_local_injector().is_enabled("short_tablet_stats_refresh_interval") ?
+                std::chrono::seconds(1) : tablet_load_stats_refresh_interval;
         if (sleep && can_proceed()) {
             try {
-                co_await seastar::sleep_abortable(tablet_load_stats_refresh_interval, _as);
+                co_await seastar::sleep_abortable(refresh_interval, _as);
             } catch (...) {
                 rtlogger.debug("raft topology: Tablet load stats refresher: sleep failed: {}", std::current_exception());
             }

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -677,7 +677,9 @@ async def test_tablet_split(manager: ManagerClient):
         '--logger-log-level', 'table=debug',
         '--target-tablet-size-in-bytes', '1024',
     ]
-    servers = [await manager.server_add(cmdline=cmdline)]
+    servers = [await manager.server_add(config={
+        'error_injections_at_startup': ['short_tablet_stats_refresh_interval']
+    }, cmdline=cmdline)]
 
     await manager.api.disable_tablet_balancing(servers[0].ip_addr)
 

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -57,6 +57,22 @@ async def load_repair_history(cql, hosts):
         logging.info(f"Got repair_history_entry={row}")
     return all_rows
 
+async def safe_server_stop_gracefully(manager, server_id, timeout: float = 60, reconnect: bool = False):
+    # Explicitly close the driver to avoid reconnections if scylla fails to update gossiper state on shutdown.
+    # It's a problem until https://github.com/scylladb/scylladb/issues/15356 is fixed.
+    manager.driver_close()
+    await manager.server_stop_gracefully(server_id, timeout)
+    cql = None
+    if reconnect:
+        cql = await reconnect_driver(manager)
+    return cql
+
+async def safe_rolling_restart(manager, servers, with_down):
+    # https://github.com/scylladb/python-driver/issues/230 is not fixed yet, so for sake of CI stability,
+    # driver must be reconnected after rolling restart of servers.
+    await manager.rolling_restart(servers, with_down)
+    cql = await reconnect_driver(manager)
+    return cql
 
 @pytest.mark.asyncio
 async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(manager: ManagerClient):
@@ -79,9 +95,8 @@ async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(m
     not_s0 = servers[1:]
 
     # s0 should miss schema and tablet changes
-    await manager.server_stop_gracefully(s0)
+    cql = await safe_server_stop_gracefully(manager, s0, reconnect=True)
 
-    cql = manager.get_cql()
     await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 100};")
 
     # force s0 to catch up later from the snapshot and not the raft log
@@ -428,7 +443,7 @@ async def test_tablet_missing_data_repair(manager: ManagerClient):
         await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});")
                                for k in keys_for_server[down_server.server_id]])
 
-    await manager.rolling_restart(servers, with_down=insert_with_down)
+    cql = await safe_rolling_restart(manager, servers, with_down=insert_with_down)
 
     await repair_on_node(manager, servers[0], servers)
 
@@ -440,7 +455,7 @@ async def test_tablet_missing_data_repair(manager: ManagerClient):
         for r in rows:
             assert r.c == r.pk
 
-    await manager.rolling_restart(servers, with_down=check_with_down)
+    cql = await safe_rolling_restart(manager, servers, with_down=insert_with_down)
 
 
 @pytest.mark.repair
@@ -896,11 +911,7 @@ async def test_tablet_load_and_stream(manager: ManagerClient, primary_replica_on
 
     await create_table("test2", 16)
 
-    # Explicitly close the driver to avoid reconnections if scylla fails to update gossiper state on shutdown.
-    # It's a problem until https://github.com/scylladb/scylladb/issues/15356 is fixed.
-    manager.driver_close()
-    cql = None
-    await manager.server_stop_gracefully(servers[0].server_id)
+    cql = await safe_server_stop_gracefully(manager, servers[0].server_id)
 
     table_dir = glob.glob(os.path.join(node_workdir, "data", "test", "test-*"))[0]
     logger.info(f"Table dir: {table_dir}")

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -455,7 +455,7 @@ async def test_tablet_missing_data_repair(manager: ManagerClient):
         for r in rows:
             assert r.c == r.pk
 
-    cql = await safe_rolling_restart(manager, servers, with_down=insert_with_down)
+    cql = await safe_rolling_restart(manager, servers, with_down=check_with_down)
 
 
 @pytest.mark.repair


### PR DESCRIPTION
Retrieval of tablet stats must be serialized with mutation to token metadata, as the former requires tablet id stability.
If tablet split is finalized while retrieving stats, the saved erm, used by all shards, can have a lower tablet count than the one in a particular shard, causing an abort as tablet map requires that any id feeded into it is lower than its current tablet count.

Fixes https://github.com/scylladb/scylladb/issues/18085.

(cherry picked from commit https://github.com/scylladb/scylladb/commit/abcc68dbe771f1a05a73b0a1e1686f2b4e7fd57e)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/551bf9dd58483c57e25341cc0e9af984e175b42f)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/e7246751b649379b8188633ce92f02a64afcf465)

Refs https://github.com/scylladb/scylladb/pull/18287