### PR TITLE
cql-pytest: be more forgiving to ancient versions of Scylla

### DIFF
--- a/test/cql-pytest/util.py
+++ b/test/cql-pytest/util.py
@@ -87,9 +87,15 @@ def keyspace_has_tablets(cql, keyspace):
     if not is_scylla(cql):
         return False
 
-    # Need to use network strategy, otherwise tablets will not be enabled.
-    res = list(cql.execute(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name='{keyspace}'"))
-    # The row migh exist due to storage related options, but the tablets related fields are null.
+    try:
+        res = list(cql.execute(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name='{keyspace}'"))
+    except:
+        # Antique versions of Scylla are is_scylla() but did not have
+        # the scylla_keyspaces table. They didn't have tablets either, so
+        # we should just return False.
+        return False
+    # The row might exist due to storage related options, but the tablets
+    # related fields are null.
     # So we check that:
     # * the row exists
     # * `initial_tablets` has a value


### PR DESCRIPTION
We recently added to cql-pytest tests the ability to check if tablets are enabled or not (for some tablet-specific tests). When running tests against Cassandra or old pre-tablet versions of Scylla, this fact is detected and "False" is returned immediately. However, we still look at a system table which didn't exist on really ancient versions of Scylla, and tests couldn't run against such versions.

The fix is trivial: if that system table is missing, just ignore the error and return False (i.e., no tablets). There were no tablets on such ancient versions of Scylla.

No backports needed - the fix is about running the latest cql-pytest on old versions of Scylla, we don't need this fix in older versions of Scylla.