### PR TITLE
replica: Refresh mutation source when allocating tablet replicas

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -262,7 +262,11 @@ public:
 
     // Caller must keep the current effective_replication_map_ptr valid
     // until the storage_group_manager finishes update_effective_replication_map
-    virtual future<> update_effective_replication_map(const locator::effective_replication_map& erm) = 0;
+    //
+    // refresh_mutation_source must be called when there are changes to data source
+    // structures but logical state of data is not changed (e.g. when state for a
+    // new tablet replica is allocated).
+    virtual future<> update_effective_replication_map(const locator::effective_replication_map& erm, noncopyable_function<void()> refresh_mutation_source) = 0;
 
     virtual compaction_group& compaction_group_for_token(dht::token token) const noexcept = 0;
     virtual utils::chunked_vector<compaction_group*> compaction_groups_for_token_range(dht::token_range tr) const = 0;

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -305,6 +305,10 @@ class ScyllaRESTAPIClient():
         primary_replica_value = 'true' if primary_replica else 'false'
         await self.client.post(f"/storage_service/sstables/{keyspace}?cf={table}&primary_replica_only={primary_replica_value}", host=node_ip)
 
+    async def drop_sstable_caches(self, node_ip: str) -> None:
+        """Drop sstable caches"""
+        await self.client.post(f"/system/drop_sstable_caches", host=node_ip)
+
     async def keyspace_flush(self, node_ip: str, keyspace: str, table: Optional[str] = None) -> None:
         """Flush the specified or all tables in the keyspace"""
         url = f"/storage_service/keyspace_flush/{keyspace}"


### PR DESCRIPTION
Consider the following:

1) table A has N tablets and views
2) migration starts for a tablet of A from node 1 to 2.
3) migration is at write_both_read_old stage
4) coordinator will push writes to both nodes (pending and leaving)
5) A has view, so writes to it will also result in reads (table::push_view_replica_updates())
6) tablet's update_effective_replication_map() is not refreshing tablet sstable set (for new tablet migrating in)
7) so read on step 5 is not being able to find sstable set for tablet migrating in

Causes the following error:
"tablets - SSTable set wasn't found for tablet 21 of table mview.users"

which means loss of write on pending replica.

The fix will refresh the table's sstable set (tablet_sstable_set) and cache's snapshot. It's not a problem to refresh the cache snapshot as long as the logical state of the data hasn't changed, which is true when allocating new tablet replicas. That's also done in the context of compactions for example.

Fixes #19052.
Fixes #19033.

**Please replace this line with justification for the backport/\* labels added to this PR**
Must be backported to 6.0