### PR TITLE
exceptions: make view update timeouts inherit from timed_out_error

### DIFF
--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -7,7 +7,7 @@
  */
 
 #include "db/view/view_update_backlog.hh"
-#include "exceptions/exceptions.hh"
+#include <seastar/core/timed_out_error.hh>
 #include "gms/inet_address.hh"
 #include <seastar/util/defer.hh>
 #include <boost/range/adaptor/map.hpp>
@@ -370,6 +370,17 @@ future<> view_update_generator::populate_views(const replica::table& table,
     }
 }
 
+
+// Generating view updates for a single client request can take a long time and might not finish before the timeout is
+// reached. In such case this exception is thrown.
+// "Generating a view update" means creating a view update and scheduling it to be sent later.
+// This exception isn't thrown if the sending timeouts, it's only concrened with generating.
+struct view_update_generation_timeout_exception : public seastar::timed_out_error {
+    const char* what() const noexcept override {
+        return "Request timed out - couldn't prepare materialized view updates in time";
+    }
+};
+
 /**
  * Given some updates on the base table and the existing values for the rows affected by that update, generates the
  * mutations to be applied to the base table's views, and sends them to the paired view replicas.
@@ -446,7 +457,7 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
             }
 
             if (db::timeout_clock::now() > timeout) {
-                err = std::make_exception_ptr(exceptions::view_update_generation_timeout_exception());
+                err = std::make_exception_ptr(view_update_generation_timeout_exception());
                 break;
             }
         }

--- a/exceptions/exceptions.cc
+++ b/exceptions/exceptions.cc
@@ -65,10 +65,6 @@ read_write_timeout_exception::read_write_timeout_exception(exception_code code, 
     , block_for{block_for}
     { }
 
-view_update_generation_timeout_exception::view_update_generation_timeout_exception()
-    : request_timeout_exception{
-          exception_code::WRITE_TIMEOUT, "Request timed out - couldn't prepare materialized view updates in time"} {}
-
 request_failure_exception::request_failure_exception(exception_code code, const sstring& ks, const sstring& cf, db::consistency_level consistency_, int32_t received_, int32_t failures_, int32_t block_for_) noexcept
     : cassandra_exception{code, prepare_message("Operation failed for {}.{} - received {} responses and {} failures from {} CL={}.", ks, cf, received_, failures_, block_for_, consistency_)}
     , consistency{consistency_}

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -154,14 +154,6 @@ struct mutation_write_timeout_exception : public read_write_timeout_exception {
     { }
 };
 
-// Generating view updates for a single client request can take a long time and might not finish before the timeout is
-// reached. In such case this exception is thrown.
-// "Generating a view update" means creating a view update and scheduling it to be sent later.
-// This exception isn't thrown if the sending timeouts, it's only concrened with generating.
-struct view_update_generation_timeout_exception : public request_timeout_exception {
-    view_update_generation_timeout_exception();
-};
-
 class request_failure_exception : public cassandra_exception {
 public:
     db::consistency_level consistency;


### PR DESCRIPTION
Currently, when generating and propagating view updates, if we notice
that we've already exceeded the time limit, we throw an exception
inheriting from `request_timeout_exception`, to later catch and
log it when finishing request handling. However, when catching, we
only check timeouts by matching the `timed_out_error` exception,
so the exception thrown in the view update code is not registered
as a timeout exception, but an unknown one. This can cause tests
which were based on the log output to start failing, as in the past
we were noticing the timeout at the end of the request handling
and using the `timed_out_error` to keep processing it and now, even
though we do notice the timeout even earlier, due to it's type we
log an error to the log, instead of treating it as a regular timeout.
In this patch we make the error thrown on timeout during view updates
inherit from `timed_out_error` instead of the `request_timeout_exception`
(it is also moved from the "exceptions" directory, where we define
exceptions returned to the user).
Aside from helping with the issue described above, we also improve our
metrics, as the `request_timeout_exception` is also not checked for
in the `is_timeout_exception` method, and because we're using it to
check whether we should update write timeout metrics, they will only
start getting updated after this patch.