### PR TITLE
[Backport 6.0] tasks: introduce task manager's task folding

### DIFF
--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -196,7 +196,6 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         try {
             task = co_await tasks::task_manager::invoke_on_task(tm, id, std::function([] (tasks::task_manager::task_ptr task) {
                 return task->done().then_wrapped([task] (auto f) {
-                    task->unregister_task();
                     // done() is called only because we want the task to be complete before getting its status.
                     // The future should be ignored here as the result does not matter.
                     f.ignore_ready_future();

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -23,6 +23,8 @@ namespace tm = httpd::task_manager_json;
 using namespace json;
 using namespace seastar::httpd;
 
+using task_variant = std::variant<tasks::task_manager::foreign_task_ptr, tasks::task_manager::task::task_essentials>;
+
 inline bool filter_tasks(tasks::task_manager::task_ptr task, std::unordered_map<sstring, sstring>& query_params) {
     return (!query_params.contains("keyspace") || query_params["keyspace"] == task->get_status().keyspace) &&
         (!query_params.contains("table") || query_params["table"] == task->get_status().table);
@@ -102,14 +104,14 @@ future<full_task_status> retrieve_status(const tasks::task_manager::foreign_task
     s.module = task->get_module_name();
     s.progress.completed = progress.completed;
     s.progress.total = progress.total;
-    std::vector<std::string> ct{task->get_children().size()};
-    boost::transform(task->get_children(), ct.begin(), [] (const auto& child_entry) {
-        const auto& [child_id, child] = child_entry;
+    std::vector<std::string> ct = co_await task->get_children().map_each_task<std::string>([] (const tasks::task_manager::foreign_task_ptr& child) {
         return child->id().to_sstring();
+    }, [] (const tasks::task_manager::task::task_essentials& child) {
+        return child.task_status.id.to_sstring();
     });
     s.children_ids = std::move(ct);
     co_return s;
-}
+};
 
 void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>& tm, db::config& cfg) {
     tm::get_modules.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
@@ -211,7 +213,7 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
     tm::get_task_status_recursively.set(r, [&_tm = tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto& tm = _tm;
         auto id = tasks::task_id{utils::UUID{req->get_path_param("task_id")}};
-        std::queue<tasks::task_manager::foreign_task_ptr> q;
+        std::queue<task_variant> q;
         utils::chunked_vector<full_task_status> res;
 
         tasks::task_manager::foreign_task_ptr task;
@@ -231,10 +233,33 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         q.push(co_await task.copy());   // Task cannot be moved since we need it to be alive during whole loop execution.
         while (!q.empty()) {
             auto& current = q.front();
-            res.push_back(co_await retrieve_status(current));
-            for (const auto& [_, child] : current->get_children()) {
-                q.push(co_await child.copy());
-            }
+            co_await std::visit(overloaded_functor {
+                [&] (const tasks::task_manager::foreign_task_ptr& task) -> future<> {
+                    res.push_back(co_await retrieve_status(task));
+                    co_await task->get_children().for_each_task([&q] (const tasks::task_manager::foreign_task_ptr& child) -> future<> {
+                        q.push(co_await child.copy());
+                    }, [&] (const tasks::task_manager::task::task_essentials& child) {
+                        q.push(child);
+                        return make_ready_future();
+                    });
+                },
+                [&] (const tasks::task_manager::task::task_essentials& task) -> future<> {
+                    res.push_back(full_task_status{
+                        .task_status = task.task_status,
+                        .type = task.type,
+                        .progress = task.task_progress,
+                        .parent_id = task.parent_id,
+                        .abortable = task.abortable,
+                        .children_ids = boost::copy_range<std::vector<std::string>>(task.failed_children | boost::adaptors::transformed([] (auto& child) {
+                            return child.task_status.id.to_sstring();
+                        }))
+                    });
+                    for (auto& child: task.failed_children) {
+                        q.push(child);
+                    }
+                    return make_ready_future();
+                }
+            }, current);
             q.pop();
         }
 

--- a/api/task_manager_test.cc
+++ b/api/task_manager_test.cc
@@ -89,14 +89,13 @@ void set_task_manager_test(http_context& ctx, routes& r, sharded<tasks::task_man
         std::string error = fail ? it->second : "";
 
         try {
-            co_await tasks::task_manager::invoke_on_task(tm, id, [fail, error = std::move(error)] (tasks::task_manager::task_ptr task) {
+            co_await tasks::task_manager::invoke_on_task(tm, id, [fail, error = std::move(error)] (tasks::task_manager::task_ptr task) -> future<> {
                 tasks::test_task test_task{task};
                 if (fail) {
-                    test_task.finish_failed(std::make_exception_ptr(std::runtime_error(error)));
+                    co_await test_task.finish_failed(std::make_exception_ptr(std::runtime_error(error)));
                 } else {
-                    test_task.finish();
+                    co_await test_task.finish();
                 }
-                return make_ready_future<>();
             });
         } catch (tasks::task_manager::task_not_found& e) {
             throw bad_param_exception(e.what());

--- a/docs/dev/task_manager.md
+++ b/docs/dev/task_manager.md
@@ -1,0 +1,63 @@
+Task manager is a tool for tracking long-running background
+operations.
+
+# Structure overview
+
+Task manager is divided into modules, e.g. repair or compaction
+module, which keep track of operations of similar nature. Operations
+are tracked with tasks.
+
+Each task covers a logical part of the operation, e.g repair
+of a keyspace or a table. Each operation is covered by a tree
+of tasks, e.g. global repair task is a parent of tasks covering
+a single keyspace, which are parents of table tasks.
+
+# Time to live of a task
+
+Root tasks are kept in task manager for `task_ttl` time after they are
+finished. `task_ttl` value can be set in node configuration with
+`--task-ttl-in-seconds` option or changed with task manager API
+(`/task_manager/ttl`).
+
+A task which isn't a root is unregistered immediately after it is
+finished and its status is folded into its parent. When a task
+is being folded into its parent, info about each of its children is
+lost unless the child or any child's descendant failed.
+
+# Internal
+
+Tasks can be marked as `internal`, which means they are not listed
+by default. A task should be marked as internal if it has a parent
+or if it's supposed to be unregistered immediately after it's finished.
+
+# Abortable
+
+A flag which determines if a task can be aborted through API.
+
+# Type vs scope
+
+`type` of a task describes what operation is covered by a task,
+e.g. "major compaction".
+
+`scope` of a task describes for which part of the operation
+the task is responsible, e.g. "shard".
+
+# API
+
+Documentation for task manager API is available under `api/api-doc/task_manager.json`.
+Briefly:
+- `/task_manager/list_modules` -
+        lists module supported by task manager;
+- `/task_manager/list_module_tasks/{module}` -
+        lists (by default non-internal) tasks in the module;
+- `/task_manager/task_status/{task_id}` -
+        gets the task's status, unregisters the task if it's finished;
+- `/task_manager/abort_task/{task_id}` -
+        aborts the task if it's abortable;
+- `/task_manager/wait_task/{task_id}` -
+        waits for the task and gets its status;
+- `/task_manager/task_status_recursive/{task_id}` -
+        gets statuses of the task and all its descendants in BFS
+        order, unregisters the task;
+- `/task_manager/ttl` -
+        sets new ttl, returns old value.

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -283,7 +283,7 @@ void task_manager::task::start() {
         // Background fiber does not capture task ptr, so the task can be unregistered and destroyed independently in the foreground.
         // After the ttl expires, the task id will be used to unregister the task if that didn't happen in any other way.
         auto module = _impl->_module;
-        bool drop_after_complete = is_internal() && !get_parent_id();
+        bool drop_after_complete = get_parent_id() || is_internal();
         (void)done().finally([module, drop_after_complete] {
             if (drop_after_complete) {
                 return make_ready_future<>();

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -17,6 +17,62 @@ namespace tasks {
 
 logging::logger tmlogger("task_manager");
 
+bool task_manager::task::children::all_finished() const noexcept {
+    return _children.empty();
+}
+
+size_t task_manager::task::children::size() const noexcept {
+    return _children.size() + _finished_children.size();
+}
+
+future<> task_manager::task::children::add_child(foreign_task_ptr task) {
+    rwlock::holder exclusive_holder = co_await _lock.hold_write_lock();
+
+    auto id = task->id();
+    auto inserted = _children.emplace(id, std::move(task)).second;
+    assert(inserted);
+}
+
+future<> task_manager::task::children::mark_as_finished(task_id id, task_essentials essentials) const {
+    rwlock::holder exclusive_holder = co_await _lock.hold_write_lock();
+
+    auto it = _children.find(id);
+    _finished_children.push_back(essentials);
+    [&] () noexcept {   // erase is expected to not throw
+        _children.erase(it);
+    }();
+}
+
+future<task_manager::task::progress> task_manager::task::children::get_progress(const std::string& progress_units) const {
+    rwlock::holder shared_holder = co_await _lock.hold_read_lock();
+
+    tasks::task_manager::task::progress progress{};
+    co_await coroutine::parallel_for_each(_children, [&] (const auto& child_entry) -> future<> {
+        const auto& child = child_entry.second;
+        auto local_progress = co_await smp::submit_to(child.get_owner_shard(), [&child, &progress_units] {
+            assert(child->get_status().progress_units == progress_units);
+            return child->get_progress();
+        });
+        progress += local_progress;
+    });
+    for (const auto& child: _finished_children) {
+        progress += child.task_progress;
+    }
+    co_return progress;
+}
+
+future<> task_manager::task::children::for_each_task(std::function<future<>(const foreign_task_ptr&)> f_children,
+        std::function<future<>(const task_essentials&)> f_finished_children) const {
+    rwlock::holder shared_holder = co_await _lock.hold_read_lock();
+
+    for (const auto& [_, child]: _children) {
+        co_await f_children(child);
+    }
+    for (const auto& child: _finished_children) {
+        co_await f_finished_children(child);
+    }
+}
+
 task_manager::task::impl::impl(module_ptr module, task_id id, uint64_t sequence_number, std::string scope, std::string keyspace, std::string table, std::string entity, task_id parent_id) noexcept
     : _status({
         .id = id,
@@ -69,12 +125,7 @@ future<task_manager::task::progress> task_manager::task::impl::get_progress() co
         co_return get_binary_progress();
     }
 
-    tasks::task_manager::task::progress progress{};
-    for (auto& [id, child]: _children) {
-        progress += co_await smp::submit_to(child.get_owner_shard(), [&child = child] {
-            return child->get_progress();
-        });
-    }
+    auto progress = co_await _children.get_progress(_status.progress_units);
     progress.total = expected_workload.value_or(progress.total);
     co_return progress;
 }
@@ -91,10 +142,10 @@ future<> task_manager::task::impl::abort() noexcept {
     if (!_as.abort_requested()) {
         _as.request_abort();
 
-        std::vector<task_info> children_info{_children.size()};
-        boost::transform(_children, children_info.begin(), [] (const auto& child_entry) {
-            const auto& [child_id, child] = child_entry;
-            return task_info{child_id, child.get_owner_shard()};
+        std::vector<task_info> children_info = co_await _children.map_each_task<task_info>([] (const foreign_task_ptr& child) {
+            return task_info{child->id(), child.get_owner_shard()};
+        }, [] (const task_essentials& child) {
+            return std::nullopt;
         });
 
         co_await coroutine::parallel_for_each(children_info, [this] (auto info) {
@@ -117,48 +168,77 @@ bool task_manager::task::impl::is_done() const noexcept {
     return _status.state == tasks::task_manager::task_state::done;
 }
 
-void task_manager::task::impl::run_to_completion() {
-    (void)run().then_wrapped([this] (auto f) {
-        if (f.failed()) {
-            finish_failed(f.get_exception());
-        } else {
-            try {
-                _as.check();
-                finish();
-            } catch (...) {
-                finish_failed(std::current_exception());
+future<std::vector<task_manager::task::task_essentials>> task_manager::task::impl::get_failed_children() const {
+    return _children.map_each_task<task_essentials>([] (const foreign_task_ptr&) { return std::nullopt; },
+        [] (const task_essentials& child) -> std::optional<task_essentials> {
+            if (child.task_status.state == task_state::failed || !child.failed_children.empty()) {
+                return child;
             }
+            return std::nullopt;
         }
+    );
+}
+
+void task_manager::task::impl::run_to_completion() {
+    (void)run().then([this] {
+        _as.check();
+        return finish();
+    }).handle_exception([this] (std::exception_ptr ex) {
+        return finish_failed(std::move(ex));
     });
 }
 
-void task_manager::task::impl::finish() noexcept {
+future<> task_manager::task::impl::maybe_fold_into_parent() const noexcept {
+    try {
+        if (is_internal() && _parent_id && _children.all_finished()) {
+            auto parent = co_await _module->get_task_manager().lookup_task_on_all_shards(_module->get_task_manager().container(), _parent_id);
+            task_essentials child{
+                .task_status = _status,
+                .task_progress = co_await get_progress(),
+                .parent_id = _parent_id,
+                .type = type(),
+                .abortable = is_abortable(),
+                .failed_children = co_await get_failed_children(),
+            };
+            co_await smp::submit_to(parent.get_owner_shard(), [&parent, id = _status.id, child = std::move(child)] () {
+                return parent->get_children().mark_as_finished(id, std::move(child));
+            });
+        }
+    } catch (...) {
+        // If folding fails, leave the subtree unfolded.
+        tasks::tmlogger.warn("Folding of task with id={} failed due to {}. Ignored", _status.id, std::current_exception());
+    }
+}
+
+future<> task_manager::task::impl::finish() noexcept {
     if (!_done.available()) {
         _status.end_time = db_clock::now();
         _status.state = task_manager::task_state::done;
+        co_await maybe_fold_into_parent();
         _done.set_value();
         release_resources();
     }
 }
 
-void task_manager::task::impl::finish_failed(std::exception_ptr ex, std::string error) noexcept {
+future<> task_manager::task::impl::finish_failed(std::exception_ptr ex, std::string error) noexcept {
     if (!_done.available()) {
         _status.end_time = db_clock::now();
         _status.state = task_manager::task_state::failed;
         _status.error = std::move(error);
+        co_await maybe_fold_into_parent();
         _done.set_exception(ex);
         release_resources();
     }
 }
 
-void task_manager::task::impl::finish_failed(std::exception_ptr ex) noexcept {
+future<> task_manager::task::impl::finish_failed(std::exception_ptr ex) noexcept {
     std::string error;
     try {
         error = fmt::format("{}", ex);
     } catch (...) {
         error = "Failed to get error message";
     }
-    finish_failed(ex, std::move(error));
+    return finish_failed(ex, std::move(error));
 }
 
 task_manager::task::task(task_impl_ptr&& impl, gate::holder gh) noexcept : _impl(std::move(impl)), _gate_holder(std::move(gh)) {
@@ -189,9 +269,8 @@ void task_manager::task::change_state(task_state state) noexcept {
     _impl->_status.state = state;
 }
 
-void task_manager::task::add_child(foreign_task_ptr&& child) {
-    auto inserted = _impl->_children.emplace(child->id(), std::move(child)).second;
-    assert(inserted);
+future<> task_manager::task::add_child(foreign_task_ptr&& child) {
+    return _impl->_children.add_child(std::move(child));
 }
 
 void task_manager::task::start() {
@@ -218,7 +297,7 @@ void task_manager::task::start() {
         _impl->_status.state = task_manager::task_state::running;
         _impl->run_to_completion();
     } catch (...) {
-        _impl->finish_failed(std::current_exception());
+        (void)_impl->finish_failed(std::current_exception()).then([impl = _impl] {});
     }
 }
 
@@ -262,12 +341,16 @@ void task_manager::task::unregister_task() noexcept {
     _impl->_module->unregister_task(id());
 }
 
-const task_manager::foreign_task_map& task_manager::task::get_children() const noexcept {
+const task_manager::task::children& task_manager::task::get_children() const noexcept {
     return _impl->_children;
 }
 
 bool task_manager::task::is_complete() const noexcept {
     return _impl->is_complete();
+}
+
+future<std::vector<task_manager::task::task_essentials>> task_manager::task::get_failed_children() const {
+    return _impl->get_failed_children();
 }
 
 task_manager::module::module(task_manager& tm, std::string name) noexcept : _tm(tm), _name(std::move(name)) {
@@ -330,16 +413,16 @@ future<task_manager::task_ptr> task_manager::module::make_task(task::task_impl_p
     auto task = make_lw_shared<task_manager::task>(std::move(task_impl_ptr), async_gate().hold());
     bool abort = false;
     if (parent_d) {
-        task->get_status().sequence_number = co_await _tm.container().invoke_on(parent_d.shard, [id = parent_d.id, task = make_foreign(task), &abort] (task_manager& tm) mutable {
+        task->get_status().sequence_number = co_await _tm.container().invoke_on(parent_d.shard, coroutine::lambda([id = parent_d.id, task = make_foreign(task), &abort] (task_manager& tm) mutable -> future<uint64_t> {
             const auto& all_tasks = tm.get_all_tasks();
             if (auto it = all_tasks.find(id); it != all_tasks.end()) {
-                it->second->add_child(std::move(task));
+                co_await it->second->add_child(std::move(task));
                 abort = it->second->abort_requested();
-                return it->second->get_sequence_number();
+                co_return it->second->get_sequence_number();
             } else {
                 throw task_manager::task_not_found(id);
             }
-        });
+        }));
     }
     if (abort) {
         co_await task->abort();

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -151,8 +151,14 @@ void task_manager::task::impl::finish_failed(std::exception_ptr ex, std::string 
     }
 }
 
-void task_manager::task::impl::finish_failed(std::exception_ptr ex) {
-    finish_failed(ex, fmt::format("{}", ex));
+void task_manager::task::impl::finish_failed(std::exception_ptr ex) noexcept {
+    std::string error;
+    try {
+        error = fmt::format("{}", ex);
+    } catch (...) {
+        error = "Failed to get error message";
+    }
+    finish_failed(ex, std::move(error));
 }
 
 task_manager::task::task(task_impl_ptr&& impl, gate::holder gh) noexcept : _impl(std::move(impl)), _gate_holder(std::move(gh)) {

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -134,7 +134,7 @@ public:
             void run_to_completion();
             void finish() noexcept;
             void finish_failed(std::exception_ptr ex, std::string error) noexcept;
-            void finish_failed(std::exception_ptr ex);
+            void finish_failed(std::exception_ptr ex) noexcept;
             virtual future<std::optional<double>> expected_total_workload() const;
             virtual std::optional<double> expected_children_number() const;
             task_manager::task::progress get_binary_progress() const;

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -42,7 +42,7 @@ public:
     using task_ptr = lw_shared_ptr<task_manager::task>;
     using task_map = std::unordered_map<task_id, task_ptr>;
     using foreign_task_ptr = foreign_ptr<task_ptr>;
-    using foreign_task_list = std::list<foreign_task_ptr>;
+    using foreign_task_map = std::unordered_map<task_id, foreign_task_ptr>;
     using module_ptr = shared_ptr<module>;
     using modules = std::unordered_map<std::string, module_ptr>;
 private:
@@ -109,7 +109,7 @@ public:
         protected:
             status _status;
             task_id _parent_id;
-            foreign_task_list _children;
+            foreign_task_map _children;
             shared_promise<> _done;
             module_ptr _module;
             seastar::abort_source _as;
@@ -167,7 +167,7 @@ public:
         future<> done() const noexcept;
         void register_task();
         void unregister_task() noexcept;
-        const foreign_task_list& get_children() const noexcept;
+        const foreign_task_map& get_children() const noexcept;
         bool is_complete() const noexcept;
 
         friend class test_task;

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -9,7 +9,9 @@
 #pragma once
 
 #include <list>
+#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm/transform.hpp>
+#include <boost/range/join.hpp>
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
@@ -17,6 +19,7 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 #include "db_clock.hh"
 #include "log.hh"
+#include "seastar/core/rwlock.hh"
 #include "tasks/types.hh"
 #include "utils/serialized_action.hh"
 #include "utils/updateable_value.hh"
@@ -105,11 +108,50 @@ public:
             std::string progress_units;     // A description of the units progress.
         };
 
+        struct task_essentials {
+            status task_status;
+            progress task_progress;
+            task_id parent_id;
+            std::string type;
+            is_abortable abortable;
+            std::vector<task_essentials> failed_children;
+        };
+
+        class children {
+            mutable foreign_task_map _children;
+            mutable std::vector<task_essentials> _finished_children;
+            mutable rwlock _lock;
+        public:
+            bool all_finished() const noexcept;
+            size_t size() const noexcept;
+            future<> add_child(foreign_task_ptr task);
+            future<> mark_as_finished(task_id id, task_essentials essentials) const;
+            future<progress> get_progress(const std::string& progress_units) const;
+            future<> for_each_task(std::function<future<>(const foreign_task_ptr&)> f_children,
+                    std::function<future<>(const task_essentials&)> f_finished_children) const;
+
+            template<typename Res>
+            future<std::vector<Res>> map_each_task(std::function<std::optional<Res>(const foreign_task_ptr&)> map_children,
+                    std::function<std::optional<Res>(const task_essentials&)> map_finished_children) const {
+                auto shared_holder = co_await _lock.hold_read_lock();
+
+                co_return boost::copy_range<std::vector<Res>>(
+                    boost::adaptors::filter(
+                        boost::join(
+                            _children | boost::adaptors::map_values | boost::adaptors::transformed(map_children),
+                            _finished_children | boost::adaptors::transformed(map_finished_children)
+                        ),
+                        [] (const auto& task) { return bool(task); }
+                    ) | boost::adaptors::transformed([] (const auto& res) { return res.value(); })
+                );
+            }
+        };
+
         class impl {
         protected:
             status _status;
             task_id _parent_id;
-            foreign_task_map _children;
+            children _children;
             shared_promise<> _done;
             module_ptr _module;
             seastar::abort_source _as;
@@ -129,12 +171,14 @@ public:
             bool is_complete() const noexcept;
             bool is_done() const noexcept;
             virtual void release_resources() noexcept {}
+            future<std::vector<task_essentials>> get_failed_children() const;
         protected:
             virtual future<> run() = 0;
             void run_to_completion();
-            void finish() noexcept;
-            void finish_failed(std::exception_ptr ex, std::string error) noexcept;
-            void finish_failed(std::exception_ptr ex) noexcept;
+            future<> maybe_fold_into_parent() const noexcept;
+            future<> finish() noexcept;
+            future<> finish_failed(std::exception_ptr ex, std::string error) noexcept;
+            future<> finish_failed(std::exception_ptr ex) noexcept;
             virtual future<std::optional<double>> expected_total_workload() const;
             virtual std::optional<double> expected_children_number() const;
             task_manager::task::progress get_binary_progress() const;
@@ -155,7 +199,7 @@ public:
         uint64_t get_sequence_number() const noexcept;
         task_id get_parent_id() const noexcept;
         void change_state(task_state state) noexcept;
-        void add_child(foreign_task_ptr&& child);
+        future<> add_child(foreign_task_ptr&& child);
         void start();
         std::string get_module_name() const noexcept;
         module_ptr get_module() const noexcept;
@@ -167,8 +211,9 @@ public:
         future<> done() const noexcept;
         void register_task();
         void unregister_task() noexcept;
-        const foreign_task_map& get_children() const noexcept;
+        const children& get_children() const noexcept;
         bool is_complete() const noexcept;
+        future<std::vector<task_essentials>> get_failed_children() const;
 
         friend class test_task;
         friend class ::repair::task_manager_module;

--- a/test/rest_api/rest_util.py
+++ b/test/rest_api/rest_util.py
@@ -52,13 +52,17 @@ def scylla_inject_error(rest_api, err, one_shot=False):
 
 @contextmanager
 def new_test_module(rest_api):
-    name = "test_module"
-    resp = rest_api.send("POST", f"task_manager_test/{name}")
+    resp = rest_api.send("POST", f"task_manager_test/test_module")
     resp.raise_for_status()
     try:
         yield
     finally:
-        resp = rest_api.send("DELETE", f"task_manager_test/{name}")
+        resp = rest_api.send("GET", f"task_manager/list_module_tasks/test", { "internal": "true" })
+        resp.raise_for_status()
+        for task in resp.json():
+            rest_api.send("DELETE", "task_manager_test/test_task", { "task_id": task["task_id"] })
+
+        resp = rest_api.send("DELETE", f"task_manager_test/test_module")
         resp.raise_for_status()
 
 @contextmanager

--- a/test/rest_api/task_manager_utils.py
+++ b/test/rest_api/task_manager_utils.py
@@ -55,15 +55,17 @@ def assert_task_does_not_exist(rest_api, task_id):
     resp = rest_api.send("GET", f"task_manager/task_status/{task_id}")
     assert resp.status_code == requests.codes.bad_request, f"Task {task_id} is kept in memory"
 
-def check_child_parent_relationship(rest_api, parent, tree_depth, allow_no_children, depth=0):
+def get_children(status_tree, parent_id):
+    return [s for s in status_tree if s["parent_id"] == parent_id]
+
+def check_child_parent_relationship(rest_api, status_tree, parent, allow_no_children):
     assert allow_no_children or parent.get("children_ids", []), f"Child tasks were not created for {parent}"
 
-    for child_id in parent.get("children_ids", []):
-        child = wait_for_task(rest_api, child_id)
+    for child in get_children(status_tree, parent["id"]):
+        child_id = child["id"]
         assert parent["sequence_number"] == child["sequence_number"], f"Child task with id {child_id} did not inherit parent's sequence number"
         assert child["parent_id"] == parent["id"], f"Parent id of task with id {child_id} is not set"
-        if depth + 1 < tree_depth:
-            check_child_parent_relationship(rest_api, child, tree_depth, allow_no_children, depth + 1)
+        check_child_parent_relationship(rest_api, status_tree, child, True)
 
 def drain_module_tasks(rest_api, module_name):
     tasks = [task for task in list_tasks(rest_api, module_name, True)]


### PR DESCRIPTION
Task manager's tasks stay in memory after they are finished.
Moreover, even if a child task is unregistered from task manager,
it is still alive since its parent keeps a foreign pointer to it. Also,
when a task has finished successfully there is no point in keeping
all of its descendants in memory.

The patch introduces folding of task manager's tasks. Whenever
a task which has a parent is finished it is unregistered from task
manager and foreign_ptr to it (kept in its parent) is replaced
with its status. Children's statuses of the task are dropped unless
they or one of their descendants failed. So for each operation we
keep a tree of tasks which contains:
- a root task and its direct children (status if they are finished, a task 
  otherwise);
- running tasks and their direct children (same as above);
- a statuses path from root to failed tasks.

/task_manager/wait_task/ does not unregister tasks anymore.

Refs: https://github.com/scylladb/scylladb/issues/16694.

- [ ] ** Backport reason (please explain below if this patch should be backported or not) **
Requires backport to 6.0 as task number exploded with tablets.

(cherry picked from commit https://github.com/scylladb/scylladb/commit/6add9edf8a760c12cccb488ae0bf1380f8fac199)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/319e799089abd8e30ad94d3fac954e2e53d00f1f)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/e6c50ad2d0973a3718c69fb35754e3f72380629a)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/a82a2f062472aa65aaa2383160f1fd42a8a1f6d3)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/c1b2b8cb2c35ec28a35d59619f6d56b895e9b2e3)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/30f97ea133ee65baf23bf2a54d4f715572281c00)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/fc0796f684a08aabe8e0e1fcf56117bc7d0a21b8)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/d7e80a6520ca4c0c33d8802b434f9a72b9597542)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/beef77a778e1b5fa182e710102969ed9a0d5d592)

Refs https://github.com/scylladb/scylladb/pull/18735