### PR TITLE
mv gossip: check errno instead of value returned by strtoull

### DIFF
--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -280,17 +280,19 @@ future<> view_update_backlog_broker::on_change(gms::inet_address endpoint, gms::
         const char* start_bound = value.value.data();
         char* end_bound;
         for (auto* ptr : {&current, &max}) {
+            errno = 0;
             *ptr = std::strtoull(start_bound, &end_bound, 10);
-            if (*ptr == ULLONG_MAX) {
-                return make_ready_future();;
+            if (errno == ERANGE) {
+                return make_ready_future();
             }
             start_bound = end_bound + 1;
         }
         if (max == 0) {
             return make_ready_future();
         }
+        errno = 0;
         ticks = std::strtoll(start_bound, &end_bound, 10);
-        if (ticks == 0 || ticks == LLONG_MAX || end_bound != value.value.data() + value.value.size()) {
+        if (ticks == 0 || errno == ERANGE || end_bound != value.value.data() + value.value.size()) {
             return make_ready_future();
         }
         auto backlog = view_update_backlog_timestamped{db::view::update_backlog{current, max}, ticks};


### PR DESCRIPTION
Currently, when a view update backlog is changed and sent using gossip, we check whether the strtoll/strtoull function used for reading the backlog returned
LLONG_MAX/ULLONG_MAX, signaling an error of a value exceeding the type's limit, and if so, we do not store it as the new value for the node.

However, the ULLONG_MAX value can also be used as the max backlog size when sending empty backlogs that were never updated. In theory, we could avoid sending the default backlog because each node has its real backlog (based on the node's memory, different than the ULLONG_MAX used in the default backlog). In practice, if the node's
backlog changed to 0, the backlog sent by it will be likely the default backlog, because when selecting the biggest backlog across node's shards, we use the operator<=>(), which treats the default backlog as equal to an empty backlog and we may get the default backlog during comparison if the backlog of some shard was never changed (also it's the initial max value we compare shard's backlogs against).

This patch removes the (U)LLONG_MAX check and replaces it with the errno check, which is also set to ERANGE during the strtoll error, and which won't prevent empty backlogs from being read

Fixes: #18462
(cherry picked from commit 5154429713134e9b01567a48acbd186e8c7f0052)
