### PR TITLE
 [Backport 6.0] db/hints: Use host ID to IP mappings to choose the ep manager to drain when node is leaving

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -409,6 +409,12 @@ bool manager::have_ep_manager(const std::variant<locator::host_id, gms::inet_add
 bool manager::store_hint(endpoint_id host_id, gms::inet_address ip, schema_ptr s, lw_shared_ptr<const frozen_mutation> fm,
         tracing::trace_state_ptr tr_state) noexcept
 {
+    if (utils::get_local_injector().enter("reject_incoming_hints")) {
+        manager_logger.debug("Rejecting a hint to {} / {} due to an error injection", host_id, ip);
+        ++_stats.dropped;
+        return false;
+    }
+
     if (stopping() || draining_all() || !started() || !can_hint_for(host_id)) {
         manager_logger.trace("Can't store a hint to {}", host_id);
         ++_stats.dropped;

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -317,8 +317,9 @@ public:
     /// In both cases - removes the corresponding hints' directories after all hints have been drained and erases the
     /// corresponding hint_endpoint_manager objects.
     ///
-    /// \param endpoint node that left the cluster
-    future<> drain_for(endpoint_id endpoint) noexcept;
+    /// \param host_id host ID of the node that left the cluster
+    /// \param ip the IP of the node that left the cluster
+    future<> drain_for(endpoint_id host_id, gms::inet_address ip) noexcept;
 
     void update_backlog(size_t backlog, size_t max_backlog);
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6603,8 +6603,8 @@ void storage_proxy::on_join_cluster(const gms::inet_address& endpoint) {};
 
 void storage_proxy::on_leave_cluster(const gms::inet_address& endpoint, const locator::host_id& hid) {
     // Discarding these futures is safe. They're awaited by db::hints::manager::stop().
-    (void) _hints_manager.drain_for(hid);
-    (void) _hints_for_views_manager.drain_for(hid);
+    (void) _hints_manager.drain_for(hid, endpoint);
+    (void) _hints_for_views_manager.drain_for(hid, endpoint);
 }
 
 void storage_proxy::on_up(const gms::inet_address& endpoint) {};


### PR DESCRIPTION
In [d0f5873](https://github.com/scylladb/scylladb/commit/d0f58736c839b1d9c76672ccac38d301d1dc1be6), we introduced mappings IP–host ID between hint directories and the hint endpoint managers managing them. As a consequence, it may happen that one hint directory stores hints towards multiple nodes at the same time. If any of those nodes leaves the cluster, we should drain the hint directory. However, before these changes that doesn't happen – we only drain it when the node of the same host ID as the hint endpoint manager leaves the cluster.

This PR fixes that draining issue in the pre-host-ID-based hinted handoff. Now no matter which of the nodes corresponding to a hint directory leaves the cluster, the directory will be drained.

We also introduce error injections to be able to test that it indeed happens.

Fixes scylladb/scylladb#18761

(cherry picked from commit [745a9c6](https://github.com/scylladb/scylladb/commit/745a9c6ab83fdaaea803614e79a599441d274f06))

(cherry picked from commit [e855794](https://github.com/scylladb/scylladb/commit/e85579432768cf7b4f0eae4e9bf00f0e1bafca51))

Refs scylladb/scylladb#18764