### PR TITLE
[test.py] Fix several issues in log gathering

### DIFF
--- a/test.py
+++ b/test.py
@@ -1037,10 +1037,11 @@ class TopologyTest(PythonTest):
         test_path = os.path.join(self.suite.options.tmpdir, self.mode)
         async with get_cluster_manager(self.mode + '/' + self.uname, self.suite.clusters, test_path) as manager:
             self.args.insert(0, "--run_id={}".format(self.id))
-            self.args.insert(0, "--artifacts_dir_url={}".format(options.artifacts_dir_url))
             self.args.insert(0, "--tmpdir={}".format(options.tmpdir))
             self.args.insert(0, "--mode={}".format(self.mode))
             self.args.insert(0, "--manager-api={}".format(manager.sock_path))
+            if options.artifacts_dir_url:
+                self.args.insert(0, "--artifacts_dir_url={}".format(options.artifacts_dir_url))
 
             try:
                 # Note: start manager here so cluster (and its logs) is available in case of failure

--- a/test/object_store/conftest.py
+++ b/test/object_store/conftest.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import os
 
 # use minio_server
 from test.pylib.minio_server import MinioServer

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -151,6 +151,7 @@ class ManagerClient():
         self.test_finished_event.set()
         _client = self.client_for_asyncio_loop.get(asyncio.get_running_loop())
         logging.getLogger().removeHandler(self.test_log_fh)
+        pathlib.Path(self.test_log_fh.baseFilename).unlink()
         logger.debug("after_test for %s (success: %s)", test_case_name, success)
         cluster_str = await _client.put_json(f"/cluster/after-test/{success}",
                                                  response_type = "json")

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -917,10 +917,11 @@ class ScyllaCluster:
                 self.leased_ips.remove(ip_addr)
                 await self.host_registry.release_host(Host(ip_addr))
             raise
-        if start and not expected_error:
-            self.running[server.server_id] = server
-        else:
-            self.stopped[server.server_id] = server
+        finally:
+            if start and not expected_error:
+                self.running[server.server_id] = server
+            else:
+                self.stopped[server.server_id] = server
         self.logger.info("Cluster %s added %s", self, server)
         return ServerInfo(server.server_id, server.ip_addr, server.rpc_address)
 

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1386,6 +1386,7 @@ class ScyllaClusterManager:
             self.cluster.after_test(self.current_test_case_full_name, success)
         finally:
             logging.getLogger().removeHandler(self.test_case_log_fh)
+            pathlib.Path(self.test_case_log_fh.baseFilename).unlink()
             self.current_test_case_full_name = ''
         self.is_after_test_ok = True
         cluster_str = str(self.cluster)

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -219,7 +219,6 @@ async def manager(request, manager_internal, record_property, mode):
             full_url = f"<a href={request.config.getoption('artifacts_dir_url')}/{dir_path_relative}>failed_test_logs</a>"
             record_property("TEST_LOGS", full_url)
 
-    test_log.unlink()
     await manager_internal.after_test(test_case_name, not failed)
     await manager_internal.stop()  # Stop client session and close driver after each test
 

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -5,7 +5,6 @@
 #
 # This file configures pytest for all tests in this directory, and also
 # defines common test fixtures for all of them to use
-import os
 import pathlib
 import ssl
 import platform

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -205,7 +205,7 @@ async def manager(request, manager_internal, record_property, mode):
         # Save scylladb logs for failed tests in a separate directory and copy XML report to the same directory to have
         # all related logs in one dir.
         # Then add property to the XML report with the path to the directory, so it can be visible in Jenkins
-        failed_test_dir_path = tmp_dir / mode / "failed_test" / f"{test_case_name}.{mode}.{run_id}"
+        failed_test_dir_path = tmp_dir / mode / "failed_test" / f"{test_case_name}"
         failed_test_dir_path.mkdir(parents=True, exist_ok=True)
         await manager_internal.gather_related_logs(
             failed_test_dir_path,
@@ -273,3 +273,9 @@ def skip_mode_fixture(request, mode):
 
 def pytest_configure(config):
     config.pluginmanager.register(ReportPlugin())
+
+
+def pytest_collection_modifyitems(items, config):
+    run_id = config.getoption('run_id')
+    for item in items:
+        item.name = f"{item.name}.{run_id}"


### PR DESCRIPTION
Related: https://github.com/scylladb/scylladb/issues/17851

Fix the issue that test logs were not deleted
Fix the issue that the URL to the failed test directory was incorrectly shown even when artifacts_dir_url option was not provided
Fix the issue that there were no node logs when it failed to join the cluster

