### PR TITLE
table: cleanup_tablet: delay destroy of storage_group till update_effective_replication_map

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -237,6 +237,7 @@ protected:
     // The list entries are unlinked automatically when the storage group, they belong to, is removed.
     compaction_group_list _compaction_groups;
     storage_group_map _storage_groups;
+    storage_group_map _storage_groups_pending_deletion;
     // Prevents _storage_groups from having its elements inserted or deleted while other layer iterates
     // over them (or over _compaction_groups).
     seastar::rwlock _lock;


### PR DESCRIPTION
There could be readers of sstables in cleaned tablet that did not enter the respective compaction_group's gate and that might still hold on to the current effective_replication_map. Let them continue to read from the existing sstable and destroy the storage_group (and its compaction groups, memtables, and sstables) only later, on update_effective_replication_map when we're sure the e_r_m is drained.

**Please replace this line with justification for the backport/\* labels added to this PR**