### PR TITLE
hinted handoff: migrate sync point to host ID

### DIFF
--- a/db/hints/sync_point.cc
+++ b/db/hints/sync_point.cc
@@ -26,20 +26,20 @@ namespace hints {
 //
 // Format V1 (encoded in base64):
 //   uint8_t 0x01 - version of format
-//   sync_point_v1 - encoded using IDL
+//   sync_point_v1_or_v2 - encoded using IDL
 //
 // Format V2 (encoded in base64):
 //   uint8_t 0x02 - version of format
-//   sync_point_v1 - encoded using IDL
+//   sync_point_v1_or_v2 - encoded using IDL
 //   uint64_t - checksum computed using the xxHash algorithm
 //
-// sync_point_v1:
+// sync_point_v1_or_v2:
 //   UUID host_id - ID of the host which created the sync point
 //   uint16_t shard_count - the number of shards in this sync point
-//   per_manager_sync_point_v1 regular_sp - replay positions for regular mutation hint queues
-//   per_manager_sync_point_v1 mv_sp - replay positions for materialized view hint queues
+//   per_manager_sync_point_v1_or_v2 regular_sp - replay positions for regular mutation hint queues
+//   per_manager_sync_point_v1_or_v2 mv_sp - replay positions for materialized view hint queues
 //
-// per_manager_sync_point_v1:
+// per_manager_sync_point_v1_or_v2:
 //   std::vector<gms::inet_address> addresses - addresses for which this sync point defines replay positions
 //   std::vector<db::replay_position> flattened_rps:
 //       A flattened collection of replay positions for all addresses and shards.
@@ -52,18 +52,18 @@ namespace hints {
 static constexpr size_t version_size = sizeof(uint8_t);
 static constexpr size_t checksum_size = sizeof(uint64_t);
 
-static std::vector<sync_point::shard_rps> decode_one_type_v1(uint16_t shard_count, const per_manager_sync_point_v1& v1) {
+static std::vector<sync_point::shard_rps> decode_one_type(uint16_t shard_count, const per_manager_sync_point_v1_or_v2& v) {
     std::vector<sync_point::shard_rps> ret;
 
-    if (size_t(shard_count) * v1.addresses.size() != v1.flattened_rps.size()) {
+    if (size_t(shard_count) * v.addresses.size() != v.flattened_rps.size()) {
         throw std::runtime_error(format("Could not decode the sync point - there should be {} rps in flattened_rps, but there are only {}",
-                size_t(shard_count) * v1.addresses.size(), v1.flattened_rps.size()));
+                size_t(shard_count) * v.addresses.size(), v.flattened_rps.size()));
     }
 
     ret.resize(std::max(unsigned(shard_count), smp::count));
 
-    auto rps_it = v1.flattened_rps.begin();
-    for (const auto addr : v1.addresses) {
+    auto rps_it = v.flattened_rps.begin();
+    for (const auto addr : v.addresses) {
         uint16_t shard;
         for (shard = 0; shard < shard_count; shard++) {
             ret[shard].emplace(addr, *rps_it++);
@@ -109,17 +109,17 @@ sync_point sync_point::decode(sstring_view s) {
         throw std::runtime_error(format("Unsupported sync point format version: {}", int(version)));
     }
 
-    sync_point_v1 v1 = ser::serializer<sync_point_v1>::read(in);
+    sync_point_v1_or_v2 v = ser::serializer<sync_point_v1_or_v2>::read(in);
 
     return sync_point{
-        v1.host_id,
-        decode_one_type_v1(v1.shard_count, v1.regular_sp),
-        decode_one_type_v1(v1.shard_count, v1.mv_sp),
+        v.host_id,
+        decode_one_type(v.shard_count, v.regular_sp),
+        decode_one_type(v.shard_count, v.mv_sp),
     };
 }
 
-static per_manager_sync_point_v1 encode_one_type_v1(unsigned shards, const std::vector<sync_point::shard_rps>& rps) {
-    per_manager_sync_point_v1 ret;
+static per_manager_sync_point_v1_or_v2 encode_one_type_v2(unsigned shards, const std::vector<sync_point::shard_rps>& rps) {
+    per_manager_sync_point_v1_or_v2 ret;
 
     // Gather all addresses, from all shards
     std::unordered_set<gms::inet_address> all_addrs;
@@ -131,7 +131,7 @@ static per_manager_sync_point_v1 encode_one_type_v1(unsigned shards, const std::
 
     ret.flattened_rps.reserve(size_t(shards) * all_addrs.size());
 
-    // Encode into v1 struct
+    // Encode into v2 struct
     // For each address, we encode a replay position for all shards.
     // If there is no replay position for a shard, we use a zero replay position.
     for (const auto addr : all_addrs) {
@@ -154,16 +154,16 @@ static per_manager_sync_point_v1 encode_one_type_v1(unsigned shards, const std::
 }
 
 sstring sync_point::encode() const {
-    // Encode as v1 structure
-    sync_point_v1 v1;
-    v1.host_id = this->host_id;
-    v1.shard_count = std::max(this->regular_per_shard_rps.size(), this->mv_per_shard_rps.size());
-    v1.regular_sp = encode_one_type_v1(v1.shard_count, this->regular_per_shard_rps);
-    v1.mv_sp = encode_one_type_v1(v1.shard_count, this->mv_per_shard_rps);
+    // Encode as v2 structure
+    sync_point_v1_or_v2 v2;
+    v2.host_id = this->host_id;
+    v2.shard_count = std::max(this->regular_per_shard_rps.size(), this->mv_per_shard_rps.size());
+    v2.regular_sp = encode_one_type_v2(v2.shard_count, this->regular_per_shard_rps);
+    v2.mv_sp = encode_one_type_v2(v2.shard_count, this->mv_per_shard_rps);
 
     // Measure how much space we need
     seastar::measuring_output_stream measure;
-    ser::serializer<sync_point_v1>::write(measure, v1);
+    ser::serializer<sync_point_v1_or_v2>::write(measure, v2);
 
     // Reserve version_size bytes for the version and checksum_size bytes for the checksum
     bytes serialized{bytes::initialized_later{}, version_size + measure.size() + checksum_size};
@@ -171,7 +171,7 @@ sstring sync_point::encode() const {
     // Encode using V2 format
     seastar::simple_memory_output_stream out{reinterpret_cast<char*>(serialized.data()), serialized.size()};
     ser::serializer<uint8_t>::write(out, 2);
-    ser::serializer<sync_point_v1>::write(out, v1);
+    ser::serializer<sync_point_v1_or_v2>::write(out, v2);
     sstring_view serialized_s(reinterpret_cast<const char*>(serialized.data()), version_size + measure.size());
     uint64_t checksum = calculate_checksum(serialized_s);
     ser::serializer<uint64_t>::write(out, checksum);

--- a/db/hints/sync_point.cc
+++ b/db/hints/sync_point.cc
@@ -33,6 +33,11 @@ namespace hints {
 //   sync_point_v1_or_v2 - encoded using IDL
 //   uint64_t - checksum computed using the xxHash algorithm
 //
+// Format V3 (encoded in base64):
+//   uint8_t 0x03 - version of format
+//   sync_point_v3 - encoded using IDL
+//   uint64_t - checksum computed using the xxHash algorithm
+//
 // sync_point_v1_or_v2:
 //   UUID host_id - ID of the host which created the sync point
 //   uint16_t shard_count - the number of shards in this sync point
@@ -40,38 +45,44 @@ namespace hints {
 //   per_manager_sync_point_v1_or_v2 mv_sp - replay positions for materialized view hint queues
 //
 // per_manager_sync_point_v1_or_v2:
-//   std::vector<gms::inet_address> addresses - addresses for which this sync point defines replay positions
+//   std::vector<gms::inet_address> endpoints - addresses for which this sync point defines replay positions
 //   std::vector<db::replay_position> flattened_rps:
-//       A flattened collection of replay positions for all addresses and shards.
+//       A flattened collection of replay positions for all endpoints and shards.
 //       Replay positions are grouped by address, in the same order as in
-//       the `addresses` field, and there is one replay position for each of
+//       the `endpoints` field, and there is one replay position for each of
 //       the shards (shard count is defined by the `shard_count`) field.
 //       Flattened representation was chosen in order to save space on
 //       vector lengths etc.
+//
+// sync_point_v3:
+//   similar to sync_point_v1_or_v2 except it uses per_manager_sync_point_v3 instead
+//   of per_manager_sync_point_v1_or_v2, which has locator::host_id instead of
+//   gms::inet_address.
 
 static constexpr size_t version_size = sizeof(uint8_t);
 static constexpr size_t checksum_size = sizeof(uint64_t);
 
-static std::vector<sync_point::shard_rps> decode_one_type(uint16_t shard_count, const per_manager_sync_point_v1_or_v2& v) {
+template <typename PerManagerType>
+static std::vector<sync_point::shard_rps> decode_one_type(uint16_t shard_count, const PerManagerType& v) {
     std::vector<sync_point::shard_rps> ret;
 
-    if (size_t(shard_count) * v.addresses.size() != v.flattened_rps.size()) {
+    if (size_t(shard_count) * v.endpoints.size() != v.flattened_rps.size()) {
         throw std::runtime_error(format("Could not decode the sync point - there should be {} rps in flattened_rps, but there are only {}",
-                size_t(shard_count) * v.addresses.size(), v.flattened_rps.size()));
+                size_t(shard_count) * v.endpoints.size(), v.flattened_rps.size()));
     }
 
     ret.resize(std::max(unsigned(shard_count), smp::count));
 
     auto rps_it = v.flattened_rps.begin();
-    for (const auto addr : v.addresses) {
+    for (const auto ep : v.endpoints) {
         uint16_t shard;
         for (shard = 0; shard < shard_count; shard++) {
-            ret[shard].emplace(addr, *rps_it++);
+            ret[shard].emplace(ep, *rps_it++);
         }
         // Fill missing shards with zero replay positions so that segments
         // which were moved across shards will be correctly waited on
         for (; shard < smp::count; shard++) {
-            ret[shard].emplace(addr, db::replay_position());
+            ret[shard].emplace(ep, db::replay_position());
         }
     }
 
@@ -94,50 +105,62 @@ sync_point sync_point::decode(sstring_view s) {
     seastar::simple_memory_input_stream in{raw_s.data(), raw_s.size()};
 
     uint8_t version = ser::serializer<uint8_t>::read(in);
-    if (version == 2) {
+    if (version == 2 || version == 3) {
         if (raw_s.size() < version_size + checksum_size) {
-            throw std::runtime_error("Could not decode the sync point encoded in the V2 format - serialized blob is too short");
+            throw std::runtime_error("Could not decode the sync point encoded in the V2/V3 format - serialized blob is too short");
         }
 
         seastar::simple_memory_input_stream in_checksum{raw_s.end() - checksum_size, checksum_size};
         uint64_t checksum = ser::serializer<uint64_t>::read(in_checksum);
         if (checksum != calculate_checksum(raw_s.substr(0, raw_s.size() - checksum_size))) {
-            throw std::runtime_error("Could not decode the sync point encoded in the V2 format - wrong checksum");
+            throw std::runtime_error("Could not decode the sync point encoded in the V2/V3 format - wrong checksum");
         }
     }
     else if (version != 1) {
         throw std::runtime_error(format("Unsupported sync point format version: {}", int(version)));
     }
 
-    sync_point_v1_or_v2 v = ser::serializer<sync_point_v1_or_v2>::read(in);
+    if (version == 1 || version == 2) {
+        sync_point_v1_or_v2 v = ser::serializer<sync_point_v1_or_v2>::read(in);
+
+        return sync_point{
+            v.host_id,
+            decode_one_type(v.shard_count, v.regular_sp),
+            decode_one_type(v.shard_count, v.mv_sp),
+        };
+    }
+
+    // version == 3
+    sync_point_v3 v3 = ser::serializer<sync_point_v3>::read(in);
 
     return sync_point{
-        v.host_id,
-        decode_one_type(v.shard_count, v.regular_sp),
-        decode_one_type(v.shard_count, v.mv_sp),
+        v3.host_id,
+        decode_one_type(v3.shard_count, v3.regular_sp),
+        decode_one_type(v3.shard_count, v3.mv_sp),
     };
 }
 
-static per_manager_sync_point_v1_or_v2 encode_one_type_v2(unsigned shards, const std::vector<sync_point::shard_rps>& rps) {
-    per_manager_sync_point_v1_or_v2 ret;
+static per_manager_sync_point_v3 encode_one_type_v3(unsigned shards, const std::vector<sync_point::shard_rps>& rps) {
+    per_manager_sync_point_v3 ret;
 
-    // Gather all addresses, from all shards
-    std::unordered_set<gms::inet_address> all_addrs;
+    // Gather all endpoints, from all shards
+    std::unordered_set<locator::host_id> all_eps;
     for (const auto& shard_rps : rps) {
         for (const auto& p : shard_rps) {
-            all_addrs.insert(p.first);
+            // New sync points are created with host_id only
+            all_eps.insert(std::get<locator::host_id>(p.first));
         }
     }
 
-    ret.flattened_rps.reserve(size_t(shards) * all_addrs.size());
+    ret.flattened_rps.reserve(size_t(shards) * all_eps.size());
 
-    // Encode into v2 struct
-    // For each address, we encode a replay position for all shards.
+    // Encode into v3 struct
+    // For each endpoint, we encode a replay position for all shards.
     // If there is no replay position for a shard, we use a zero replay position.
-    for (const auto addr : all_addrs) {
-        ret.addresses.push_back(addr);
+    for (const auto ep : all_eps) {
+        ret.endpoints.push_back(ep);
         for (const auto& shard_rps : rps) {
-            auto it = shard_rps.find(addr);
+            auto it = shard_rps.find(ep);
             if (it != shard_rps.end()) {
                 ret.flattened_rps.push_back(it->second);
             } else {
@@ -154,24 +177,24 @@ static per_manager_sync_point_v1_or_v2 encode_one_type_v2(unsigned shards, const
 }
 
 sstring sync_point::encode() const {
-    // Encode as v2 structure
-    sync_point_v1_or_v2 v2;
-    v2.host_id = this->host_id;
-    v2.shard_count = std::max(this->regular_per_shard_rps.size(), this->mv_per_shard_rps.size());
-    v2.regular_sp = encode_one_type_v2(v2.shard_count, this->regular_per_shard_rps);
-    v2.mv_sp = encode_one_type_v2(v2.shard_count, this->mv_per_shard_rps);
+    // Encode as v3 structure
+    sync_point_v3 v3;
+    v3.host_id = this->host_id;
+    v3.shard_count = std::max(this->regular_per_shard_rps.size(), this->mv_per_shard_rps.size());
+    v3.regular_sp = encode_one_type_v3(v3.shard_count, this->regular_per_shard_rps);
+    v3.mv_sp = encode_one_type_v3(v3.shard_count, this->mv_per_shard_rps);
 
     // Measure how much space we need
     seastar::measuring_output_stream measure;
-    ser::serializer<sync_point_v1_or_v2>::write(measure, v2);
+    ser::serializer<sync_point_v3>::write(measure, v3);
 
     // Reserve version_size bytes for the version and checksum_size bytes for the checksum
     bytes serialized{bytes::initialized_later{}, version_size + measure.size() + checksum_size};
 
-    // Encode using V2 format
+    // Encode using V3 format
     seastar::simple_memory_output_stream out{reinterpret_cast<char*>(serialized.data()), serialized.size()};
-    ser::serializer<uint8_t>::write(out, 2);
-    ser::serializer<sync_point_v1_or_v2>::write(out, v2);
+    ser::serializer<uint8_t>::write(out, 3);
+    ser::serializer<sync_point_v3>::write(out, v3);
     sstring_view serialized_s(reinterpret_cast<const char*>(serialized.data()), version_size + measure.size());
     uint64_t checksum = calculate_checksum(serialized_s);
     ser::serializer<uint64_t>::write(out, checksum);

--- a/db/hints/sync_point.hh
+++ b/db/hints/sync_point.hh
@@ -22,7 +22,8 @@ namespace hints {
 // A sync point is a collection of positions in hint queues which can be waited on.
 // The sync point encompasses one type of hints manager only.
 struct sync_point {
-    using shard_rps = std::unordered_map<gms::inet_address, db::replay_position>;
+    using host_id_or_addr = std::variant<locator::host_id, gms::inet_address>;
+    using shard_rps = std::unordered_map<host_id_or_addr, db::replay_position>;
     // ID of the host which created this sync point
     locator::host_id host_id;
     std::vector<shard_rps> regular_per_shard_rps;
@@ -41,7 +42,7 @@ struct sync_point {
 // Contains per-endpoint and per-shard information about replay positions
 // for a particular type of hint queues (regular mutation hints or MV update hints)
 struct per_manager_sync_point_v1_or_v2 {
-    std::vector<gms::inet_address> addresses;
+    std::vector<gms::inet_address> endpoints;
     std::vector<db::replay_position> flattened_rps;
 };
 
@@ -55,6 +56,26 @@ struct sync_point_v1_or_v2 {
 
     // Sync point information for materialized view hints
     db::hints::per_manager_sync_point_v1_or_v2 mv_sp;
+};
+
+// IDL type
+// same as per_manager_sync_point_v1_or_v2 except that it stores the
+// endpoints as host_id instead of address
+struct per_manager_sync_point_v3 {
+    std::vector<locator::host_id> endpoints;
+    std::vector<db::replay_position> flattened_rps;
+};
+
+// IDL type
+struct sync_point_v3 {
+    locator::host_id host_id;
+    uint16_t shard_count;
+
+    // Sync point information for regular mutation hints
+    db::hints::per_manager_sync_point_v3 regular_sp;
+
+    // Sync point information for materialized view hints
+    db::hints::per_manager_sync_point_v3 mv_sp;
 };
 
 }

--- a/db/hints/sync_point.hh
+++ b/db/hints/sync_point.hh
@@ -40,21 +40,21 @@ struct sync_point {
 // IDL type
 // Contains per-endpoint and per-shard information about replay positions
 // for a particular type of hint queues (regular mutation hints or MV update hints)
-struct per_manager_sync_point_v1 {
+struct per_manager_sync_point_v1_or_v2 {
     std::vector<gms::inet_address> addresses;
     std::vector<db::replay_position> flattened_rps;
 };
 
 // IDL type
-struct sync_point_v1 {
+struct sync_point_v1_or_v2 {
     locator::host_id host_id;
     uint16_t shard_count;
 
     // Sync point information for regular mutation hints
-    db::hints::per_manager_sync_point_v1 regular_sp;
+    db::hints::per_manager_sync_point_v1_or_v2 regular_sp;
 
     // Sync point information for materialized view hints
-    db::hints::per_manager_sync_point_v1 mv_sp;
+    db::hints::per_manager_sync_point_v1_or_v2 mv_sp;
 };
 
 }

--- a/idl/hinted_handoff.idl.hh
+++ b/idl/hinted_handoff.idl.hh
@@ -18,20 +18,20 @@ namespace hints {
 
 // Contains per-endpoint and per-shard information about replay positions
 // for a particular type of hint queues (regular mutation hints or MV update hints)
-struct per_manager_sync_point_v1 {
+struct per_manager_sync_point_v1_or_v2 {
     std::vector<gms::inet_address> addresses;
     std::vector<db::replay_position> flattened_rps;
 };
 
-struct sync_point_v1 {
+struct sync_point_v1_or_v2 {
     locator::host_id host_id;
     uint16_t shard_count;
 
     // Sync point information for regular mutation hints
-    db::hints::per_manager_sync_point_v1 regular_sp;
+    db::hints::per_manager_sync_point_v1_or_v2 regular_sp;
 
     // Sync point information for materialized view hints
-    db::hints::per_manager_sync_point_v1 mv_sp;
+    db::hints::per_manager_sync_point_v1_or_v2 mv_sp;
 };
 
 }

--- a/idl/hinted_handoff.idl.hh
+++ b/idl/hinted_handoff.idl.hh
@@ -19,7 +19,7 @@ namespace hints {
 // Contains per-endpoint and per-shard information about replay positions
 // for a particular type of hint queues (regular mutation hints or MV update hints)
 struct per_manager_sync_point_v1_or_v2 {
-    std::vector<gms::inet_address> addresses;
+    std::vector<gms::inet_address> endpoints;
     std::vector<db::replay_position> flattened_rps;
 };
 
@@ -32,6 +32,22 @@ struct sync_point_v1_or_v2 {
 
     // Sync point information for materialized view hints
     db::hints::per_manager_sync_point_v1_or_v2 mv_sp;
+};
+
+struct per_manager_sync_point_v3 {
+    std::vector<locator::host_id> endpoints;
+    std::vector<db::replay_position> flattened_rps;
+};
+
+struct sync_point_v3 {
+    locator::host_id host_id;
+    uint16_t shard_count;
+
+    // Sync point information for regular mutation hints
+    db::hints::per_manager_sync_point_v3 regular_sp;
+
+    // Sync point information for materialized view hints
+    db::hints::per_manager_sync_point_v3 mv_sp;
 };
 
 }

--- a/test/boost/hint_test.cc
+++ b/test/boost/hint_test.cc
@@ -10,8 +10,19 @@
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/core/smp.hh>
 #include <fmt/ranges.h>
+#include <unordered_set>
+#include <seastar/core/simple-stream.hh>
+#include "utils/base64.hh"
+#include "utils/xx_hasher.hh"
+#include "idl/hinted_handoff.dist.hh"
+#include "idl/hinted_handoff.dist.impl.hh"
 
 #include "db/hints/sync_point.hh"
+
+enum class encode_version {
+    v1,
+    v2,
+};
 
 namespace db {
 std::ostream& operator<<(std::ostream& out, const replay_position& p) {
@@ -20,19 +31,108 @@ std::ostream& operator<<(std::ostream& out, const replay_position& p) {
 }
 }
 
+template <>
+struct fmt::formatter<db::hints::sync_point::host_id_or_addr> {
+    constexpr static auto format(const db::hints::sync_point::host_id_or_addr& value, fmt::format_context& ctx) {
+        return std::visit([&ctx](const auto& v) {
+            return fmt::format_to(ctx.out(), "{}", v);
+        }, value);
+    }
+};
+
 namespace db::hints {
 std::ostream& operator<<(std::ostream& out, const sync_point& sp) {
     fmt::print(out, "{{regular_per_shard_rps: {}, mv_per_shard_rps: {}}}",
                sp.regular_per_shard_rps, sp.mv_per_shard_rps);
     return out;
 }
+
+// the code for v1 and v2 encoding is here for testing of decode only and it is
+// based on the encoding code of sync_point, except that in v2 we have
+// gms::inet_address instead of locator::host_id, and for v1 additionally we
+// don't encode a checksum
+
+static constexpr size_t version_size = sizeof(uint8_t);
+static constexpr size_t checksum_size = sizeof(uint64_t);
+
+static uint64_t calculate_checksum(const sstring_view s) {
+    xx_hasher h;
+    h.update(s.data(), s.size());
+    return h.finalize_uint64();
+}
+
+static per_manager_sync_point_v1_or_v2 encode_one_type_v2(unsigned shards, const std::vector<sync_point::shard_rps>& rps) {
+    per_manager_sync_point_v1_or_v2 ret;
+
+    // Gather all addresses, from all shards
+    std::unordered_set<gms::inet_address> all_eps;
+    for (const auto& shard_rps : rps) {
+        for (const auto& p : shard_rps) {
+            all_eps.insert(std::get<gms::inet_address>(p.first));
+        }
+    }
+
+    ret.flattened_rps.reserve(size_t(shards) * all_eps.size());
+
+    // Encode into v3 struct
+    // For each address, we encode a replay position for all shards.
+    // If there is no replay position for a shard, we use a zero replay position.
+    for (const auto addr : all_eps) {
+        ret.endpoints.push_back(addr);
+        for (const auto& shard_rps : rps) {
+            auto it = shard_rps.find(addr);
+            if (it != shard_rps.end()) {
+                ret.flattened_rps.push_back(it->second);
+            } else {
+                ret.flattened_rps.push_back(db::replay_position());
+            }
+        }
+        // Fill with zeros for remaining shards
+        for (unsigned i = rps.size(); i < shards; i++) {
+            ret.flattened_rps.push_back(db::replay_position());
+        }
+    }
+
+    return ret;
+}
+
+sstring encode_v1_or_v2(const sync_point& sp, encode_version v) {
+    // Encode as v2 structure
+    sync_point_v1_or_v2 v2;
+    v2.host_id = sp.host_id;
+    v2.shard_count = std::max(sp.regular_per_shard_rps.size(), sp.mv_per_shard_rps.size());
+    v2.regular_sp = encode_one_type_v2(v2.shard_count, sp.regular_per_shard_rps);
+    v2.mv_sp = encode_one_type_v2(v2.shard_count, sp.mv_per_shard_rps);
+
+    // Measure how much space we need
+    seastar::measuring_output_stream measure;
+    ser::serializer<sync_point_v1_or_v2>::write(measure, v2);
+
+    // Reserve version_size bytes for the version and checksum_size bytes for the checksum
+    bytes serialized{bytes::initialized_later{}, version_size + measure.size()
+        + (v == encode_version::v2 ? checksum_size : 0)};
+
+    // Encode using V2 format
+    seastar::simple_memory_output_stream out{reinterpret_cast<char*>(serialized.data()), serialized.size()};
+    ser::serializer<uint8_t>::write(out, v == encode_version::v1 ? 1 : 2);
+    ser::serializer<sync_point_v1_or_v2>::write(out, v2);
+
+    if (v == encode_version::v2) {
+        sstring_view serialized_s(reinterpret_cast<const char*>(serialized.data()), version_size + measure.size());
+        uint64_t checksum = calculate_checksum(serialized_s);
+        ser::serializer<uint64_t>::write(out, checksum);
+    }
+
+    return base64_encode(serialized);
+}
+
 }
 
 SEASTAR_TEST_CASE(test_hint_sync_point_faithful_reserialization) {
     const unsigned encoded_shard_count = 2;
 
-    const gms::inet_address addr1{"172.16.0.1"};
-    const gms::inet_address addr2{"172.16.0.2"};
+    const locator::host_id addr1 {utils::UUID(0, 1)};
+    const locator::host_id addr2 {utils::UUID(0, 2)};
 
     const db::replay_position s0_rp1{0, 10, 100};
     const db::replay_position s0_rp2{0, 20, 200};
@@ -81,3 +181,66 @@ SEASTAR_TEST_CASE(test_hint_sync_point_faithful_reserialization) {
 
     return make_ready_future<>();
 }
+
+static future<> test_decode_v1_or_v2(encode_version v)
+{
+    const unsigned encoded_shard_count = 2;
+
+    const gms::inet_address addr1{"172.16.0.1"};
+    const gms::inet_address addr2{"172.16.0.2"};
+
+    const db::replay_position s0_rp1{0, 10, 100};
+    const db::replay_position s0_rp2{0, 20, 200};
+    const db::replay_position s1_rp1{1, 10, 100};
+    const db::replay_position s1_rp2{1, 20, 200};
+
+    db::hints::sync_point spoint;
+
+    spoint.regular_per_shard_rps.resize(encoded_shard_count);
+    spoint.regular_per_shard_rps[0][addr1] = s0_rp1;
+    spoint.regular_per_shard_rps[0][addr2] = s0_rp2;
+    spoint.regular_per_shard_rps[1][addr1] = s1_rp1;
+
+    spoint.mv_per_shard_rps.resize(encoded_shard_count);
+    spoint.mv_per_shard_rps[0][addr1] = s0_rp1;
+    spoint.mv_per_shard_rps[1][addr1] = s1_rp1;
+    spoint.mv_per_shard_rps[1][addr2] = s1_rp2;
+
+    const sstring encoded = encode_v1_or_v2(spoint, v);
+    const db::hints::sync_point decoded_spoint = db::hints::sync_point::decode(encoded);
+
+    // If some shard is missing a replay position for a given address
+    // then it will have a 0 position written there. Fill missing positions
+    // with zeros in the original sync point.
+    spoint.regular_per_shard_rps[1][addr2] = db::replay_position();
+    spoint.mv_per_shard_rps[0][addr2] = db::replay_position();
+
+    // If the sync point contains information about less shards than smp::count,
+    // the missing shards are filled with zero. Do it here manually so that
+    // we can compare spoint with decoded_spoint.
+    const unsigned adjusted_count = std::max(encoded_shard_count, smp::count);
+    spoint.regular_per_shard_rps.resize(adjusted_count);
+    spoint.mv_per_shard_rps.resize(adjusted_count);
+    for (unsigned s = encoded_shard_count; s < smp::count; s++) {
+        spoint.regular_per_shard_rps[s][addr1] = db::replay_position();
+        spoint.regular_per_shard_rps[s][addr2] = db::replay_position();
+        spoint.mv_per_shard_rps[s][addr1] = db::replay_position();
+        spoint.mv_per_shard_rps[s][addr2] = db::replay_position();
+    }
+
+    std::cout << "spoint:  " << spoint << std::endl;
+    std::cout << "encoded: " << encoded << std::endl;
+    std::cout << "decoded: " << decoded_spoint << std::endl;
+
+    BOOST_REQUIRE_EQUAL(spoint, decoded_spoint);
+
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_hint_sync_point_faithful_reserialization_v2) {
+    return test_decode_v1_or_v2(encode_version::v2);
+};
+
+SEASTAR_TEST_CASE(test_hint_sync_point_faithful_reserialization_v1) {
+    return test_decode_v1_or_v2(encode_version::v1);
+};


### PR DESCRIPTION
Change the format of sync points to use host ID instead of IPs, to be consistent with the use of host IDs in hinted handoff module.
Introduce sync point v3 format which is the same as v2 except it stores host IDs instead of IPs.
The decoding supports both formats with host IDs and IPs, so a sync point contains now a variant of either types, and in the case of new type the translation is avoided.

Fixes #18653 