### PR TITLE
test: tablets: Fix flakiness of test_removenode_with_ignored_node due to read timeout

### DIFF
--- a/test/topology_experimental_raft/test_tablets_removenode.py
+++ b/test/topology_experimental_raft/test_tablets_removenode.py
@@ -197,6 +197,8 @@ async def test_removenode_with_ignored_node(manager: ManagerClient):
     await manager.server_stop(servers[0].server_id) # removed
     await manager.server_stop(servers[1].server_id) # ignored
     await manager.remove_node(servers[2].server_id, servers[0].server_id, [servers[1].ip_addr])
+
+    await manager.others_not_see_server(servers[1].ip_addr)
     servers = servers[1:]
 
     await check()


### PR DESCRIPTION
The check query may be executed on a node which doesn't yet see that the downed server is down, as it is not shut down gracefully. The query coordinator can choose the down node as a CL=1 replica for read and time out.

To fix, wait for all nodes to notice the node is down before executing the checking query.

Fixes #17938

Backport to 6.0 because it's vulnerable to flakiness and there is no risk as this is a test change. 