### PR TITLE
group0, topology coordinator: run group0 and the topology coordinator…

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1398,7 +1398,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             service::raft_group0 group0_service{
                     stop_signal.as_local_abort_source(), raft_gr.local(), messaging,
-                    gossiper.local(), feature_service.local(), sys_ks.local(), group0_client};
+                    gossiper.local(), feature_service.local(), sys_ks.local(), group0_client, dbcfg.gossip_scheduling_group};
 
             service::tablet_allocator::config tacfg;
             tacfg.initial_tablets_scale = cfg->tablets_initial_scale_factor();

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -101,6 +101,7 @@ class raft_group0 {
     gms::feature_service& _feat;
     db::system_keyspace& _sys_ks;
     raft_group0_client& _client;
+    seastar::scheduling_group _sg;
 
     // Status of leader discovery. Initially there is no group 0,
     // and the variant contains no state. During initial cluster
@@ -140,7 +141,8 @@ public:
         gms::gossiper& gs,
         gms::feature_service& feat,
         db::system_keyspace& sys_ks,
-        raft_group0_client& client);
+        raft_group0_client& client,
+        seastar::scheduling_group sg);
 
     // Initialises RPC verbs on all shards.
     // Call after construction but before using the object.
@@ -294,6 +296,11 @@ public:
 
     const raft_address_map& address_map() const;
     raft_address_map& modifiable_address_map();
+
+    // Returns scheduling group group0 is configured to run with
+    seastar::scheduling_group get_scheduling_group() {
+        return _sg;
+    }
 private:
     static void init_rpc_verbs(raft_group0& shard0_this);
     static future<> uninit_rpc_verbs(netw::messaging_service& ms);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2934,7 +2934,9 @@ future<> run_topology_coordinator(
         rtlogger.info("start topology coordinator fiber");
         const bool upgrade_done = co_await coordinator.maybe_run_upgrade();
         if (upgrade_done) {
-            co_await coordinator.run();
+            co_await with_scheduling_group(group0.get_scheduling_group(), [&] {
+                return coordinator.run();
+            });
         }
     } catch (...) {
         ex = std::current_exception();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -753,7 +753,7 @@ private:
 
             service::raft_group0 group0_service{
                     abort_sources.local(), _group0_registry.local(), _ms,
-                    _gossiper.local(), _feature_service.local(), _sys_ks.local(), group0_client};
+                    _gossiper.local(), _feature_service.local(), _sys_ks.local(), group0_client, scheduling_groups.gossip_scheduling_group};
 
             _ss.start(std::ref(abort_sources), std::ref(_db),
                 std::ref(_gossiper),


### PR DESCRIPTION
… in gossiper scheduling group

Currently they both run in streaming group and it may become busy during repair/mv building and affect group0 functionality. Move it to the gossiper group where it should have more time to run.

Fixes #18863

Backport to 6.0 since it affects group0 performance under load.