### PR TITLE
Alternator - add the ability to write, not just read, system tables

### DIFF
--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -212,6 +212,7 @@ public:
 private:
     static thread_local utils::updateable_value<uint32_t> s_default_timeout_in_ms;
 public:
+    static schema_ptr find_table(service::storage_proxy&, std::string_view table_name);
     static schema_ptr find_table(service::storage_proxy&, const rjson::value& request);
 
 private:

--- a/db/config.cc
+++ b/db/config.cc
@@ -1391,6 +1391,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     // alternator_max_items_in_batch_write matches DynamoDB behaviour of size limit, but with different value - for DynamoDB it's 25
     // (see DynamoDB's documentation for BatchWriteItem command)
     , alternator_max_items_in_batch_write(this, "alternator_max_items_in_batch_write", value_status::Used, 100, "Maximum amount of items in single BatchItemWrite call.")
+    , alternator_allow_system_table_write(this, "alternator_allow_system_table_write", liveness::LiveUpdate, value_status::Used,
+        false,
+        "Allow writing to system tables using the .scylla.alternator.system prefix")
     , vector_store_uri(this, "vector_store_uri", value_status::Used, "", "The URI of the vector store to use for vector search. If not set, vector search is disabled.")
     , abort_on_ebadf(this, "abort_on_ebadf", value_status::Used, true, "Abort the server on incorrect file descriptor access. Throws exception when disabled.")
     , redis_port(this, "redis_port", value_status::Used, 0, "Port on which the REDIS transport listens for clients.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -489,6 +489,7 @@ public:
     named_value<double> alternator_ttl_period_in_seconds;
     named_value<sstring> alternator_describe_endpoints;
     named_value<uint32_t> alternator_max_items_in_batch_write;
+    named_value<bool> alternator_allow_system_table_write;
 
     named_value<sstring> vector_store_uri;
 

--- a/docs/alternator/new-apis.md
+++ b/docs/alternator/new-apis.md
@@ -84,6 +84,12 @@ request.
 Note that currently only `Scan` and `Query` on system tables is supported -
 `GetItem` is not (so use `Query` even to read a single item).
 
+If the `alternator_allow_system_table_write` configuration option is set to
+true (by default, it is false), system tables can also be written to. This
+can be useful for, for example, modifying configuration options. Even when
+writing system tables is enabled, the role sending the command must be a
+superuser or the write will be denied.
+
 ### Listing ongoing requests
 One useful system table to read is `.scylla.alternator.system.clients`,
 which lists the currently active Alternator clients. Reading from this

--- a/test/alternator/run
+++ b/test/alternator/run
@@ -69,6 +69,7 @@ def run_alternator_cmd(pid, dir):
         '--alternator-streams-time-window-s', '0',
         '--alternator-timeout-in-ms', '30000',
         '--alternator-ttl-period-in-seconds', '0.5',
+        '--alternator-allow-system-table-write=1',
         # Allow testing experimental features. Following issue #9467, we need
         # to add here specific experimental features as they are introduced.
         # We only list here Alternator-specific experimental features - CQL
@@ -87,6 +88,19 @@ def run_alternator_cmd(pid, dir):
 
     for i in remove_scylla_options:
         cmd.remove(i)
+
+    # Unfortunately, earlier Scylla versions required different command line
+    # options to run, so for some old versions we need to drop some of the
+    # command line options added above, or add more options. In cqlpy/run.py's
+    # run_precompiled_scylla_cmd we already do this for most Scylla options,
+    # but here we just need to take care of the Alternator-specific options
+    # that we added here and were different in older versions.
+    if 'release' in globals():
+        version = release.split('~')[0].split('.')
+        major = [int(version[0]), int(version[1])]
+        print(major)
+        if major < [2025,4]:
+            cmd.remove('--alternator-allow-system-table-write=1')
 
     return (cmd, env)
 

--- a/test/alternator/test_scan.py
+++ b/test/alternator/test_scan.py
@@ -5,10 +5,11 @@
 # Tests for the Scan operation
 
 import pytest
+import time
 from boto3.dynamodb.conditions import Attr
 from botocore.exceptions import ClientError
 
-from test.alternator.util import random_bytes, full_scan, full_scan_and_count, multiset, new_test_table
+from test.alternator.util import random_string, random_bytes, full_scan, full_scan_and_count, multiset, new_test_table, scylla_config_read
 
 
 # Test that scanning works fine with/without pagination
@@ -293,12 +294,7 @@ def test_scan_paging_bytes(test_table_b):
 # against Scylla.
 @pytest.fixture(scope="module")
 def query_tombstone_page_limit(dynamodb, scylla_only):
-    config_table = dynamodb.Table('.scylla.alternator.system.config')
-    return int(config_table.query(
-            KeyConditionExpression='#key=:val',
-            ExpressionAttributeNames={'#key': 'name'},
-            ExpressionAttributeValues={':val': 'query_tombstone_page_limit'}
-        )['Items'][0]['value'])
+    return int(scylla_config_read(dynamodb, 'query_tombstone_page_limit'))
 
 # The following two tests reproduced issue #7933, where a scan encounters a
 # long string of row/partition tombstones, and because it is expected to

--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -14,7 +14,7 @@ from re import fullmatch
 import pytest
 from botocore.exceptions import ClientError
 
-from test.alternator.util import list_tables, unique_table_name, create_test_table, random_string, new_test_table, is_aws
+from test.alternator.util import list_tables, multiset, unique_table_name, create_test_table, random_string, new_test_table, is_aws, scylla_config_read
 
 
 # Utility function for create a table with a given name and some valid
@@ -461,15 +461,9 @@ def check_pre_consistent_cluster_management(dynamodb):
     # If not running on Scylla, return false.
     if is_aws(dynamodb):
         return False
-    # In Scylla, we check Raft mode by inspecting the configuration via a
-    # system table (which is also visible in Alternator)
-    config_table = dynamodb.Table('.scylla.alternator.system.config')
-    consistent = config_table.query(
-            KeyConditionExpression='#key=:val',
-            ExpressionAttributeNames={'#key': 'name'},
-            ExpressionAttributeValues={':val': 'consistent_cluster_management'}
-        )['Items']
-    return len(consistent) == 0 or consistent[0]['value'] == 'false'
+    consistent = scylla_config_read(dynamodb, 'consistent_cluster_management')
+    return consistent is None or consistent == 'false'
+
 @pytest.fixture(scope="function")
 def fails_without_consistent_cluster_management(request, check_pre_consistent_cluster_management):
     if check_pre_consistent_cluster_management:

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -296,3 +296,23 @@ def wait_for_gsi_gone(table, gsi_name):
                 continue
         return
     raise AssertionError("wait_for_gsi_gone did not complete")
+
+# Read a parameter from Scylla's configuration, stored in the system table
+# which is also visible to Alternator. This function will only work on Scylla,
+# and fail otherwise, so should only be used in Scylla-only tests.
+# If this is Scylla, but the specific parameter name is not present in the
+# configuration, this function returns None. If the parameter is present,
+# it is returned (as a string).
+def scylla_config_read(dynamodb, name):
+    config_table = dynamodb.Table('.scylla.alternator.system.config')
+    # We use query() here instead of the simpler get_item(), because
+    # commit 44a1daf only added support for system tables in Query and
+    # Scan, not in GetItem...
+    r = config_table.query(
+            KeyConditionExpression='#key=:val',
+            ExpressionAttributeNames={'#key': 'name'},
+            ExpressionAttributeValues={':val': name}
+        )
+    if not 'Items' in r:
+        return None
+    return r['Items'][0]['value']

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -316,3 +316,34 @@ def scylla_config_read(dynamodb, name):
     if not 'Items' in r:
         return None
     return r['Items'][0]['value']
+
+# Write a parameter in Scylla's configuration, using in the system table
+# which is also visible to Alternator. This function will only work on Scylla,
+# and fail otherwise, so should only be used in Scylla-only tests.
+# Also on Scylla, this function may fail with an exception if the
+# configuration parameter alternator_allow_system_table_write is not turned
+# on, so callers might want to catch such an exception and skip the test.
+def scylla_config_write(dynamodb, name, value):
+    config_table = dynamodb.Table('.scylla.alternator.system.config')
+    config_table.update_item(
+            Key={'name': name},
+            UpdateExpression='SET #val = :val',
+            ExpressionAttributeNames={'#val': 'value'},
+            ExpressionAttributeValues={':val': value}
+        )
+
+# A context manager that can be used in a "with" to temporarily set a
+# configuration parameter to a desired value, and restore its original
+# value when the context ends.
+# The configuration parameter has to be live-updatable.
+# Note that using this mechanism is only a good idea if you're sure that
+# no other workload or test is using the same Alternator cluster in parallel,
+# because the changed configuration will affect the other workload too.
+@contextmanager
+def scylla_config_temporary(dynamodb, name, value):
+    original_value = scylla_config_read(dynamodb, name)
+    scylla_config_write(dynamodb, name, value)
+    try:
+        yield
+    finally:
+        scylla_config_write(dynamodb, name, original_value)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -151,6 +151,7 @@ def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addr
 
         'rf_rack_valid_keyspaces': True,
 
+        'alternator_allow_system_table_write': True,
     }
 
 # Seastar options can not be passed through scylla.yaml, use command line


### PR DESCRIPTION
In commit 44a1daf we added the ability to read Scylla system tables with Alternator. This feature is useful, among other things, in tests that want to read Scylla's configuration through the system table system.config. But tests often want to modify system.config, e.g., to temporarily reduce some threshold to make tests shorter. Until now, this was not possible

This series add supports for writing to system tables through Alternator, and examples of tests using this capability (and utility functions to make it easy).

Because the ability to write to system tables may have non-obvious security consequences, it is turned off by default and needs to be enabled with a new configuration option "alternator_allow_system_table_write"

No backports are necessary - this feature is only intended for tests. We may later decide to backport if we want to backport new tests, but I think the probability we'll want to do this is low.

Fixes #12348