### PR TITLE
.github: change severity to error in clang-include-cleaner 

### DIFF
--- a/.github/clang-include-cleaner.json
+++ b/.github/clang-include-cleaner.json
@@ -2,7 +2,7 @@
     "problemMatcher": [
         {
             "owner": "clang-include-cleaner",
-            "severity": "warning",
+            "severity": "error",
             "pattern": [
                 {
                     "regexp": "^([^\\-\\+].*)$",

--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -10,7 +10,7 @@ env:
   BUILD_TYPE: RelWithDebInfo
   BUILD_DIR: build
   CLEANER_OUTPUT_PATH: build/clang-include-cleaner.log
-  CLEANER_DIRS: test/unit exceptions
+  CLEANER_DIRS: test/unit exceptions alternator
 
 permissions: {}
 

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <seastar/core/future.hh>
-#include <seastar/http/httpd.hh>
 #include "seastarx.hh"
 #include <seastar/json/json_elements.hh>
 #include <seastar/core/sharded.hh>

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -11,7 +11,6 @@
 #include <cstdint>
 
 #include <seastar/core/metrics_registration.hh>
-#include "utils/estimated_histogram.hh"
 #include "utils/histogram.hh"
 #include "cql3/stats.hh"
 

--- a/exceptions/unrecognized_entity_exception.hh
+++ b/exceptions/unrecognized_entity_exception.hh
@@ -11,7 +11,6 @@
 #pragma once
 
 #include "exceptions.hh"
-#include <seastar/core/shared_ptr.hh>
 #include "cql3/column_identifier.hh"
 
 namespace exceptions {


### PR DESCRIPTION
in this changeset, we tighten the clang-include-cleaner workflow, and address the warnings in two more subdirectories in the source tree.

* it's a cleanup, no need to backport