### PR TITLE
service/paxos: drop operator<< for proposal

### DIFF
--- a/service/paxos/proposal.hh
+++ b/service/paxos/proposal.hh
@@ -53,12 +53,3 @@ inline bool operator>(const proposal& lhs, const proposal& rhs) {
 template <> struct fmt::formatter<service::paxos::proposal> : fmt::formatter<string_view> {
     auto format(const service::paxos::proposal&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
-
-namespace service::paxos {
-
-static inline std::ostream& operator<<(std::ostream& os, const proposal& proposal) {
-    fmt::print(os, "{}", proposal);
-    return os;
-}
-
-}


### PR DESCRIPTION
since we stopped using the generic container formatters which in turn use operator<< for formatting the elemements. we can drop more operator<< operators.

so, in this change, we drop operator<< for proposal.

* it's a cleanup. no need to backport.