### PR TITLE
[Backport 6.0] doc: document "enable_tablets" option

### DIFF
--- a/docs/architecture/tablets.rst
+++ b/docs/architecture/tablets.rst
@@ -77,10 +77,13 @@ to a new node.
 Enabling Tablets
 -------------------
 
-Tablets are enabled or disabled on the keyspace level. When you create a new
-keyspace, tablets are enabled by default. 
-``NetworkTopologyStrategy``, recommended for all keyspaces,
-is *required* when creating a keyspace with tablets enabled. 
+ScyllaDB now uses tablets by default for data distribution. This functionality is
+controlled by the :confval:`enable_tablets` option. However, tablets only work if
+enabled on all nodes within the cluster.
+
+When creating a new keyspace with tablets enabled (the default), you can still disable
+them on a per-keyspace basis. The recommended ``NetworkTopologyStrategy`` for keyspaces
+remains *required* when using tablets.
 
 You can create a keyspace with tablets
 disabled with the ``tablets = {'enabled': false}`` option:


### PR DESCRIPTION
it sets the cluster feature of tablets, and is a prerequisite for using tablets.

Refs #18670
Fixes #19157
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>
(cherry picked from commit adba09a5d9fd3320cca2ed966dcb62b02ba16494)

**Please replace this line with justification for the backport/\* labels added to this PR**