### PR TITLE
.github: add workflow to build with clang nightly

### DIFF
--- a/.github/clang-matcher.json
+++ b/.github/clang-matcher.json
@@ -1,7 +1,7 @@
 {
     "problemMatcher": [
         {
-            "owner": "clang-tidy",
+            "owner": "clang",
             "pattern": [
                 {
                     "regexp": "^([^:]+):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*?)\\s+\\[(.*?)\\]$",

--- a/.github/workflows/clang-nightly.yaml
+++ b/.github/workflows/clang-nightly.yaml
@@ -1,0 +1,65 @@
+name: clang-nightly
+
+on:
+  schedule:
+    # only at 5AM Saturday
+    - cron: '0 5 * * SAT'
+
+env:
+  # use the development branch explicitly
+  CLANG_VERSION: 19
+  BUILD_DIR: build
+
+permissions: {}
+
+# cancel the in-progress run upon a repush
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clang-dev:
+    name: Build with clang nightly
+    runs-on: ubuntu-latest
+    container: fedora:40
+    strategy:
+      matrix:
+        build_type:
+          - Debug
+          - RelWithDebInfo
+          - Dev
+    steps:
+      - run: |
+          sudo dnf -y install git
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install build dependencies
+        run: |
+          # use the copr repo for llvm snapshot builds, see
+          # https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots/
+          sudo dnf -y install 'dnf-command(copr)'
+          sudo dnf copr enable -y @fedora-llvm-team/llvm-snapshots
+          # do not install java dependencies, which is not only not used here
+          sed -i.orig \
+            -e '/tools\/.*\/install-dependencies.sh/d' \
+            -e 's/(minio_download_jobs)/(true)/' \
+            ./install-dependencies.sh
+          sudo ./install-dependencies.sh
+          sudo dnf -y install lld
+      - name: Generate the building system
+        run: |
+          cmake                                         \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCMAKE_C_COMPILER=clang-$CLANG_VERSION     \
+            -DCMAKE_CXX_COMPILER=clang++-$CLANG_VERSION \
+            -G Ninja                                    \
+            -B $BUILD_DIR                               \
+            -S .
+      # see https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md
+      - run: |
+          echo "::add-matcher::.github/clang-matcher.json"
+      - run: |
+          cmake --build $BUILD_DIR --target scylla
+      - run: |
+          echo "::remove-matcher owner=clang::"

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -55,9 +55,9 @@ jobs:
             -S .
       # see https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md
       - run: |
-          echo "::add-matcher::.github/clang-tidy-matcher.json"
+          echo "::add-matcher::.github/clang-matcher.json"
       - name: Build with clang-tidy enabled
         run: |
           cmake --build $BUILD_DIR --target scylla
       - run: |
-          echo "::remove-matcher owner=clang-tidy::"
+          echo "::remove-matcher owner=clang::"


### PR DESCRIPTION
to be prepared for changes from clang, and enjoy the new warnings/errors from this compiler.


* it is an improvement in our CI, no need to backport.