### PR TITLE
sstables/compress.hh: remove unused forward declaration

### DIFF
--- a/sstables/compress.hh
+++ b/sstables/compress.hh
@@ -56,8 +56,6 @@ using compressor_ptr = shared_ptr<compressor>;
 
 namespace sstables {
 
-struct compression;
-
 struct compression {
     // To reduce the memory footpring of compression-info, n offsets are grouped
     // together into segments, where each segment stores a base absolute offset


### PR DESCRIPTION
struct compress if forward declared right before its definition. At some point in the past there was probably some code there using it, but now its gone so remove it.

Code cleanup, no backport needed.