### PR TITLE
scylla-sstable: add method to load the schema from the sstable itself

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1455,9 +1455,7 @@ future<> sstable::reload_reclaimed_components() {
     sstlog.info("Reloaded bloom filter of {}", get_filename());
 }
 
-// This interface is only used during tests, snapshot loading and early initialization.
-// No need to set tunable priorities for it.
-future<> sstable::load(const dht::sharder& sharder, sstable_open_config cfg) noexcept {
+future<> sstable::load_metadata(sstable_open_config cfg, bool validate) noexcept {
     co_await read_toc();
     // read scylla-meta after toc. Might need it to parse
     // rest (hint extensions)
@@ -1469,9 +1467,17 @@ future<> sstable::load(const dht::sharder& sharder, sstable_open_config cfg) noe
             [&] { return read_compression(); },
             [&] { return read_filter(cfg); },
             [&] { return read_summary(); });
-    validate_min_max_metadata();
-    validate_max_local_deletion_time();
-    validate_partitioner();
+    if (validate) {
+        validate_min_max_metadata();
+        validate_max_local_deletion_time();
+        validate_partitioner();
+    }
+}
+
+// This interface is only used during tests, snapshot loading and early initialization.
+// No need to set tunable priorities for it.
+future<> sstable::load(const dht::sharder& sharder, sstable_open_config cfg) noexcept {
+    co_await load_metadata(cfg, true);
     if (_shards.empty()) {
         set_first_and_last_keys();
         _shards = cfg.current_shard_as_sstable_owner ?

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -236,6 +236,8 @@ public:
 
     // load sstable using components shared by a shard
     future<> load(foreign_sstable_open_info info) noexcept;
+    // Load metadata components from disk
+    future<> load_metadata(sstable_open_config cfg = {}, bool validate = true) noexcept;
     // load all components from disk
     // this variant will be useful for testing purposes and also when loading
     // a new sstable from scratch for sharing its components.

--- a/test/cql-pytest/test_tools.py
+++ b/test/cql-pytest/test_tools.py
@@ -744,13 +744,24 @@ class TestScyllaSsstableSchemaLoading(TestScyllaSsstableSchemaLoadingBase):
                 system_scylla_local_reference_dump,
                 env={"SCYLLA_HOME": scylla_home_dir})
 
-    def test_fail_schema_autodetect(self, scylla_path, system_scylla_local_sstable_prepared, temp_workdir):
+    def test_external_dir_autodetect_sstable_serialization_header_keyspace_table(self, scylla_path, system_scylla_local_sstable_prepared, system_scylla_local_reference_dump, temp_workdir):
         ext_sstable = self.copy_sstable_to_external_dir(system_scylla_local_sstable_prepared, temp_workdir)
         # It is important to use a controlled workdir, so scylla-sstable doesn't accidentally pick up a scylla.yaml.
-        self.check_fail(
+        self.check(
                 scylla_path,
                 ["--keyspace", self.keyspace, "--table", self.table],
                 ext_sstable,
+                system_scylla_local_reference_dump,
+                cwd=temp_workdir)
+
+    def test_external_dir_autodetect_sstable_serialization_header(self, scylla_path, system_scylla_local_sstable_prepared, system_scylla_local_reference_dump, temp_workdir):
+        ext_sstable = self.copy_sstable_to_external_dir(system_scylla_local_sstable_prepared, temp_workdir)
+        # It is important to use a controlled workdir, so scylla-sstable doesn't accidentally pick up a scylla.yaml.
+        self.check(
+                scylla_path,
+                [],
+                ext_sstable,
+                system_scylla_local_reference_dump,
                 cwd=temp_workdir)
 
     def test_fail_nonexistent_keyspace(self, scylla_path, system_scylla_local_sstable_prepared, temp_workdir, scylla_home_dir):

--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -179,7 +179,6 @@ public:
         , _static_column_count_dist(static_column_count_dist)
         , _type_generator(*this) {
         assert(_partition_column_count_dist.a() > 0);
-        assert(_regular_column_count_dist.a() > 0);
     }
     virtual sstring table_name(std::mt19937& engine) override {
         return format("table{}", generate_unique_id(engine, _used_table_ids));
@@ -826,7 +825,6 @@ schema_ptr build_random_schema(uint32_t seed, random_schema_specification& spec)
     }
 
     const auto regular_columns = spec.regular_columns(engine);
-    assert(!regular_columns.empty()); // Let's not pull in boost::test here
     for (size_t r = 0; r < regular_columns.size(); ++r) {
         builder.with_column(to_bytes(format("v{}", r)), std::move(regular_columns[r]), column_kind::regular_column);
     }

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -649,6 +649,89 @@ schema_ptr do_load_schema_from_schema_tables(const db::config& dbcfg, std::files
     }
 }
 
+schema_ptr do_load_schema_from_sstable(const db::config& dbcfg, std::filesystem::path sstable_path, sstring keyspace, sstring table) {
+    if (keyspace.empty()) {
+        keyspace = "my_keyspace";
+    }
+    if (table.empty()) {
+        table = "my_table";
+    }
+
+    db::nop_large_data_handler large_data_handler;
+    gms::feature_service feature_service(gms::feature_config_from_db_config(dbcfg));
+    cache_tracker tracker;
+    sstables::directory_semaphore dir_sem(1);
+    sstables::sstables_manager sst_man("tools::load_schema_from_sstable", large_data_handler, dbcfg, feature_service, tracker,
+        memory::stats().total_memory(), dir_sem,
+        [host_id = locator::host_id::create_random_id()] { return host_id; });
+    auto close_sst_man = deferred_close(sst_man);
+
+    schema_ptr bootstrap_schema = schema_builder(keyspace, table).with_column("pk", int32_type, column_kind::partition_key).build();
+
+    const auto ed = sstables::parse_path(sstable_path, keyspace, table);
+    const auto dir_path = sstable_path.parent_path();
+    data_dictionary::storage_options local;
+    auto bootstrap_sst = sst_man.make_sstable(bootstrap_schema, dir_path.c_str(), local, ed.generation, sstables::sstable_state::normal, ed.version, ed.format);
+
+    bootstrap_sst->load_metadata({}, false).get();
+
+    const auto& serialization_header = bootstrap_sst->get_serialization_header();
+    const auto& compression = bootstrap_sst->get_compression();
+
+    auto builder = schema_builder(keyspace, table);
+
+    const auto to_string_view = [] (bytes_view b) {
+        return std::string_view(reinterpret_cast<const char*>(b.data()), b.size());
+    };
+    const auto parse_type = [&to_string_view] (bytes_view type_name) {
+        return db::marshal::type_parser::parse(to_string_view(type_name));
+    };
+
+    // partition key
+    {
+        const auto pk_type_name = serialization_header.pk_type_name.value;
+
+        const bytes composite_prefix = "org.apache.cassandra.db.marshal.CompositeType(";
+
+        if (pk_type_name.starts_with(composite_prefix)) {
+            const auto composite_content = pk_type_name.substr(composite_prefix.size(), pk_type_name.size() - composite_prefix.size() - 1);
+
+            db::marshal::type_parser parser(to_string_view(composite_content));
+            unsigned i = 0;
+
+            while (!parser.is_eos()) {
+                builder.with_column(to_bytes(format("$pk{}", i++)), parser.parse(), column_kind::partition_key);
+                parser.skip_blank_and_comma();
+            }
+        } else {
+            builder.with_column("$pk", parse_type(pk_type_name), column_kind::partition_key);
+        }
+    }
+
+    // clustering key
+    {
+        unsigned i = 0;
+        for (const auto& type_name : serialization_header.clustering_key_types_names.elements) {
+            builder.with_column(to_bytes(format("$ck{}", i++)), parse_type(type_name.value), column_kind::clustering_key);
+        }
+    }
+
+    // static columns
+    for (const auto& col_desc : serialization_header.static_columns.elements) {
+        builder.with_column(col_desc.name.value, parse_type(col_desc.type_name.value), column_kind::static_column);
+    }
+
+    // regular columns
+    for (const auto& col_desc : serialization_header.regular_columns.elements) {
+        builder.with_column(col_desc.name.value, parse_type(col_desc.type_name.value), column_kind::regular_column);
+    }
+
+    // compression options
+    builder.set_compressor_params(sstables::get_sstable_compressor(compression));
+
+    return builder.build();
+}
+
 } // anonymous namespace
 
 namespace tools {
@@ -700,6 +783,12 @@ schema_ptr load_system_schema(const db::config& cfg, std::string_view keyspace, 
 future<schema_ptr> load_schema_from_schema_tables(const db::config& cfg, std::filesystem::path scylla_data_path, std::string_view keyspace, std::string_view table) {
     return async([=, &cfg] () mutable {
         return do_load_schema_from_schema_tables(cfg, scylla_data_path, keyspace, table);
+    });
+}
+
+future<schema_ptr> load_schema_from_sstable(const db::config& cfg, std::filesystem::path sstable_path, std::string_view keyspace, std::string_view table) {
+    return async([=, &cfg, sstable_path = std::move(sstable_path)] () mutable {
+        return do_load_schema_from_sstable(cfg, std::move(sstable_path), sstring(keyspace), sstring(table));
     });
 }
 

--- a/tools/schema_loader.hh
+++ b/tools/schema_loader.hh
@@ -62,4 +62,22 @@ schema_ptr load_system_schema(const db::config& dbcfg, std::string_view keyspace
 /// directory, which is usually /var/lib/scylla/data.
 future<schema_ptr> load_schema_from_schema_tables(const db::config& dbcfg, std::filesystem::path scylla_data_path, std::string_view keyspace, std::string_view table);
 
+/// Load the schema from the sstable's serialization header.
+///
+/// This schema is incomplete:
+/// * The names of the partition key and clustering key columns are not known
+///   and are given placeholder names when the schema is loaded.
+/// * Only the compression options are contained in the sstable, other options
+///   like compaction, etc. are missing and defaults are used instead in the
+///   returned schema object.
+/// * Encryption options are likewise not contained in the sstable, if the
+///   sstable is encrypted, the schema load will fail.
+///
+/// That said, this schema is enough to parse and display the sstable's content.
+///
+/// The keyspace and table parameters are optional. If known, provide them so
+/// the schema is created with the proper names, otherwise placeholder names
+/// will be used.
+future<schema_ptr> load_schema_from_sstable(const db::config& dbcfg, std::filesystem::path sstable_path, std::string_view keyspace = "", std::string_view table = "");
+
 } // namespace tools

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -3058,6 +3058,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
                     schema_with_source->source,
                     schema_with_source->path ? format(" ({})", schema_with_source->path->native()) : "",
                     schema_with_source->obtained_from);
+            sst_log.trace("Loaded schema: {}", schema);
         } else {
             return 1;
         }

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -281,6 +281,26 @@ std::optional<schema_with_source> try_load_schema_autodetect(const bpo::variable
         sst_log.debug("Trying to locate data dir failed: {}", std::current_exception());
     }
 
+    try {
+        sstring keyspace_name, table_name;
+        try {
+            std::tie(keyspace_name, table_name) = get_keyspace_and_table_options(app_config);
+        } catch (std::invalid_argument&) {
+            keyspace_name = "my_keyspace";
+            table_name = "my_table";
+        }
+        if (!app_config.count("sstables")) {
+            throw std::runtime_error("no sstables provided on the command-line");
+        }
+        const auto sst_path = app_config["sstables"].as<std::vector<sstring>>().front();
+        return schema_with_source{.schema = tools::load_schema_from_sstable(cfg, fs::path(sst_path),
+                keyspace_name, table_name).get(),
+            .source = "sstable's serialization header",
+            .obtained_from = sst_path};
+    } catch (...) {
+        sst_log.debug("Trying to load schema from the sstable itself failed: {}", std::current_exception());
+    }
+
     fmt::print(std::cerr, "Failed to autodetect and load schema, try again with --logger-log-level scylla-sstable=debug to learn more or provide the schema source manually\n");
     return {};
 }


### PR DESCRIPTION
As it turns out, each sstable carries its own schema in its serialization header (Statistics component). This schema is incomplete -- the names of the key columns are not stored, just their type. Static and regular columns do have names and types stored however. This bare-bones schema is enough to parse and display the content of the sstable. Another thing missing is schema options (the stuff after the `WITH` keyword, except the clustering order). The only options stored are the compression options (in the CompressionInfo component), this is actually needed to read the Data component.

This series adds a new method to `tools/schema_loader.cc` to extract the schema stored in the sstable itself. This new schema load method is used as the last fall-back for obtaining the schema, in case scylla-sstable is trying to autodetect the schema of the sstable. Although, right now this bare-bones schema is enough for everything scylla-sstable does, it is more future proof to stick to the "full" schema if possible, so this new method is the last resort for now.

Fixes: https://github.com/scylladb/scylladb/issues/17869
Fixes: https://github.com/scylladb/scylladb/issues/18809

New functionality, no backport needed.