### PR TITLE
db/hints: Initialize endpoint managers only for valid hint directories

### DIFF
--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -323,6 +323,10 @@ public:
 
     void update_backlog(size_t backlog, size_t max_backlog);
 
+    bool uses_host_id() const noexcept {
+        return _uses_host_id;
+    }
+
 private:
     bool stopping() const noexcept {
         return _state.contains(state::stopping);


### PR DESCRIPTION
Before these changes, it could happen that Scylla initialized endpoint managers for hint directories representing

* host IDs before migrating hinted handoff to using host IDs,
* IP addresses after the migration.

One scenario looked like this:

1. Start Scylla and upgrade the cluster to using host IDs.
2. Create, by hand, a hint directory representing an IP address.
3. Trigger changing the host filter in hinted handoff; it could be achieved by, for example, restricting the set of data centers Scylla is allowed to save hints for.

When changing the host filter, we browse the hint directories and create endpoint managers if we can send hints towards the node corresponding to a given hint directory. We only accepted hint directories representing IP addresses and host IDs. However, we didn't check whether the local node has already been upgraded to host-ID-based hinted handoff or not. As a result, endpoint managers were created for both IP addresses and host IDs, no matter whether we were before or after the migration.

These changes make sure that any time we browse the hint directories, we take that into account.

Fixes scylladb/scylladb#19172