### PR TITLE
Remove comma that breaks  CQL DML on tablets.rst

### DIFF
--- a/docs/architecture/tablets.rst
+++ b/docs/architecture/tablets.rst
@@ -93,7 +93,7 @@ disabled with the ``tablets = {'enabled': false}`` option:
     CREATE KEYSPACE my_keyspace
     WITH replication = {
         'class': 'NetworkTopologyStrategy',
-        'replication_factor': 3,
+        'replication_factor': 3
     } AND tablets = {
         'enabled': false
     };


### PR DESCRIPTION
The current sample reads:

```cql
CREATE KEYSPACE my_keyspace
WITH replication = {
    'class': 'NetworkTopologyStrategy',
    'replication_factor': 3,
} AND tablets = {
    'enabled': false
};
```

The additional comma after `'replication_factor': 3` breaks the query execution.