### PR TITLE
storage_proxy: update view update backlog on correct shard when writing

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1681,6 +1681,9 @@ static future<> apply_to_remote_endpoints(service::storage_proxy& proxy, locator
             std::move(tr_state),
             allow_hints,
             service::is_cancellable::yes);
+    while (utils::get_local_injector().enter("never_finish_remote_view_updates")) {
+        co_await seastar::sleep(100ms);
+    }
 }
 
 static bool should_update_synchronously(const schema& s) {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2646,7 +2646,7 @@ update_backlog node_update_backlog::fetch() {
         _max.store(new_max, std::memory_order_relaxed);
         return new_max;
     }
-    return std::max(fetch_shard(this_shard_id()), _max.load(std::memory_order_relaxed));
+    return _max.load(std::memory_order_relaxed);
 }
 
 future<std::optional<update_backlog>> node_update_backlog::fetch_if_changed() {

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -462,6 +462,7 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
         }
     }
     co_await builder.close();
+    _proxy.local().update_view_update_backlog();
     if (err) {
         std::rethrow_exception(err);
     }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2943,7 +2943,10 @@ storage_proxy::storage_proxy(distributed<replica::database>& db, storage_proxy::
         sm::make_queue_length("current_throttled_writes", [this] { return _throttled_writes.size(); },
                        sm::description("number of currently throttled write requests")),
     });
-
+    _metrics.add_group(storage_proxy_stats::REPLICA_STATS_CATEGORY, {
+        sm::make_current_bytes("view_update_backlog", [this] { return _max_view_update_backlog.fetch_shard(this_shard_id()).current; },
+                       sm::description("View update backlog size used for slowing down writes when it grows too large")),
+    });
     slogger.trace("hinted DCs: {}", cfg.hinted_handoff_enabled.to_configuration_string());
     _hints_manager.register_metrics("hints_manager");
     _hints_for_views_manager.register_metrics("hints_for_views_manager");

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -542,7 +542,6 @@ private:
                         //
                         // Usually we will return immediately, since this work only involves appending data to the connection
                         // send buffer.
-                        p->update_view_update_backlog();
                         auto f = co_await coroutine::as_future(send_mutation_done(netw::messaging_service::msg_addr{reply_to, shard}, trace_state_ptr,
                                 shard, response_id, p->get_view_update_backlog()));
                         f.ignore_ready_future();
@@ -581,7 +580,6 @@ private:
         }
         // ignore results, since we'll be returning them via MUTATION_DONE/MUTATION_FAILURE verbs
         if (errors.count) {
-            p->update_view_update_backlog();
             auto f = co_await coroutine::as_future(send_mutation_failed(
                     netw::messaging_service::msg_addr{reply_to, shard},
                     trace_state_ptr,
@@ -4094,7 +4092,6 @@ void storage_proxy::send_to_live_endpoints(storage_proxy::response_id_type respo
                 .then([response_id, this, my_address, h = std::move(handler_ptr), p = shared_from_this()] {
             // make mutation alive until it is processed locally, otherwise it
             // may disappear if write timeouts before this future is ready
-            update_view_update_backlog();
             got_response(response_id, my_address, get_view_update_backlog());
         });
     };

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -238,6 +238,8 @@ public:
     // Used for gossiping view update backlog information. Must be called on shard 0.
     future<std::optional<db::view::update_backlog>> get_view_update_backlog_if_changed();
 
+    db::view::update_backlog get_view_update_backlog_for_shard(shard_id shard);
+
     // Get information about a remote node's view update backlog. Information about remote backlogs is constantly updated
     // using gossip and by passing the information in each MUTATION_DONE rpc call response.
     db::view::update_backlog get_backlog_of(gms::inet_address) const;

--- a/test/topology_custom/test_mv_backlog.py
+++ b/test/topology_custom/test_mv_backlog.py
@@ -1,0 +1,105 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from test.pylib.manager_client import ManagerClient
+
+import asyncio
+import pytest
+import time
+import logging
+from test.topology.conftest import skip_mode
+from cassandra.cqltypes import Int32Type
+import requests
+import re
+
+logger = logging.getLogger(__name__)
+
+async def wait_for_views(cql, mvs_count, node_count):
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        done = await cql.run_async(f"SELECT COUNT(*) FROM system_distributed.view_build_status WHERE status = 'SUCCESS' ALLOW FILTERING")
+        logger.info(f"Views built: {done[0][0]}")
+        if done[0][0] == node_count * mvs_count:
+            return
+        else:
+            time.sleep(0.2)
+    raise Exception("Timeout waiting for views to build")
+
+
+def get_metrics(addr):
+    # The Prometheus API is on port 9180, and always http
+    addr = 'http://' + addr + ':9180/metrics'
+    resp = requests.get(addr)
+    if resp.status_code != 200:
+        pytest.skip('Metrics port 9180 is not available')
+    response = requests.get(addr)
+    assert response.status_code == 200
+    return response.text
+
+def get_metric(metrics, name, requested_labels=None):
+    the_metrics = get_metrics(metrics)
+    total = 0.0
+    lines = re.compile('^'+name+'{.*$', re.MULTILINE)
+    for match in re.findall(lines, the_metrics):
+        a = match.split()
+        metric = a[0]
+        val = float(a[1])
+        # Check if match also matches the requested labels
+        if requested_labels:
+            # we know metric begins with name{ and ends with } - the labels
+            # are what we have between those
+            got_labels = metric[len(name)+1:-1].split(',')
+            # Check that every one of the requested labels is in got_labels:
+            for k, v in requested_labels.items():
+                if not f'{k}="{v}"' in got_labels:
+                    # No match for requested label, skip this metric (python
+                    # doesn't have "continue 2" so let's just set val to 0...
+                    val = 0
+                    break
+        total += float(val)
+    return total
+
+def get_replicas(cql, key):
+    return cql.cluster.metadata.get_replicas("ks", Int32Type.serialize(key, cql.cluster.protocol_version))
+
+# This test reproduces issue #18542
+# In the test, we create a table and perform a write to it a couple of times
+# Each time, we check that a view update backlog on some shard increased
+# due to the write.
+@pytest.mark.asyncio
+@skip_mode('release', "error injections aren't enabled in release mode")
+async def test_view_backlog_increased_after_write(manager: ManagerClient) -> None:
+    node_count = 2
+    # Use a higher smp to make it more likely that the writes go to a different shard than the coordinator.
+    servers = await manager.servers_add(node_count, cmdline=['--smp', '5'])
+    cql = manager.get_cql()
+    await cql.run_async(f"CREATE KEYSPACE ks WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 1}}")
+    await cql.run_async(f"CREATE TABLE ks.tab (key int, c int, v text, PRIMARY KEY (key, c))")
+    await cql.run_async(f"CREATE MATERIALIZED VIEW ks.mv_cf_view AS SELECT * FROM ks.tab "
+                    "WHERE c IS NOT NULL and key IS NOT NULL PRIMARY KEY (c, key) ")
+    await wait_for_views(cql, 1, node_count)
+
+    key = int(time.time())
+    logger.info(f"Base table key: {key}")
+    local_node = get_replicas(cql, key)[0]
+    i = 0
+    for v in [1000, 4000, 16000, 64000, 256000]:
+        # Only remote updates hold on to memory, so make the update remote
+        while local_node == get_replicas(cql, i)[0]:
+            i = i + 1
+
+        # Make sure the view update backlog is still high (view udpate hasn't finished) when the replica returns
+        errs = [manager.api.enable_injection(s.ip_addr, "never_finish_remote_view_updates", False) for s in servers]
+        await asyncio.gather(*errs)
+
+        await cql.run_async(f"INSERT INTO ks.tab (key, c, v) VALUES ({key}, {i}, '{v*'a'}')")
+        # The view update backlog should increase on the node generating view updates
+        view_backlog = get_metric(local_node.address, 'scylla_storage_proxy_replica_view_update_backlog')
+        # The read view_backlog might still contain backlogs from the previous iterations, so we only assert that it is large enough
+        assert view_backlog > v
+        errs = [manager.api.disable_injection(s.ip_addr, "never_finish_remote_view_updates") for s in servers]
+        await asyncio.gather(*errs)
+
+    await cql.run_async(f"DROP KEYSPACE ks")


### PR DESCRIPTION
This series is another approach of https://github.com/scylladb/scylladb/pull/18646. The main difference
between the two is that in the former series the updated backlog was propagated from the view updating
code to the write request handling using return values on a few different layers. This series performs
the atomic read of the view update backlog from the correct shard on the shard handling the replica
write request.
This series should be simpler thanks to the recent separation of backlog update and backlog retrieval,
however this can also benefit the original series after it's updated. It also modifies fewer layers, which
makes the series more concise.
The downside of this approach is the cross-shard read of an atomic holding the view update backlog of
another shard, which was performed inside the `invoke_on` in the original series, and the fact that
this read is now done regardless of whether the write actually generates view updates - we can only
discover this when we start processing the mutation. Additionally, the shard calculation also needed to
be duplicated - currently it's done in `storage_proxy::mutate_locally` where we can't add the view backlog
retrieval without adding an extra allocation to the common write path.
Due to this extra work, the instruction count per operation increased notably in the `perf-simple-query`
results, to an extend similar of adding the extra allocation to `storage_proxy::mutate_locally` - the results
are compared at the end of the cover message.

For now, this patch doesn't include getting the backlog atomic on failed requests - this would require
quite a few extra modifications only giving a small improvement for the uncommon patch - for now
it's left as a FIXME

The detailed description of the problem is mostly the same as in the original series, included below:

When a replica applies a write on a table which has a materialized view
it generates view updates. These updates take memory which is tracked
by `database::_view_update_concurrency_sem`, separate on each shard.
The fraction of units taken from the semaphore to the semaphore limit
is the shard's view update backlog. Based on these backlogs, we want
to estimate how busy a node is with its view updates work. We do that
by taking the max backlog across all shards.
To avoid excessive cross-shard operations, the node's (max) backlog isn't
calculated each time we need it, but up to 1 time per 10ms (the `_interval`) with an optimization where the backlog of the calculating shard is immediately up-to-date (we don't need cross-shard operations for it):
```
update_backlog node_update_backlog::fetch() {
    auto now = clock::now();
    if (now >= _last_update.load(std::memory_order_relaxed) + _interval) {
        _last_update.store(now, std::memory_order_relaxed);
        auto new_max = boost::accumulate(
                _backlogs,
                update_backlog::no_backlog(),
                [] (const update_backlog& lhs, const per_shard_backlog& rhs) {
                    return std::max(lhs, rhs.load());
                });
        _max.store(new_max, std::memory_order_relaxed);
        return new_max;
    }
    return std::max(fetch_shard(this_shard_id()), _max.load(std::memory_order_relaxed));
}
```
For the same reason, even when we do calculate the new node's backlog,
we don't read from the `_view_update_concurrency_sem`. Instead, for
each shard we also store a update_backlog atomic which we use for
calculation:
```
    struct per_shard_backlog {
        // Multiply by 2 to defeat the prefetcher
        alignas(seastar::cache_line_size * 2) std::atomic<update_backlog> backlog = update_backlog::no_backlog();
        need_publishing need_publishing = need_publishing::no;

        update_backlog load() const {
            return backlog.load(std::memory_order_relaxed);
        }
    };
 std::vector<per_shard_backlog> _backlogs; 
```
Due to this distinction, the update_backlog atomic need to be updated
separately, when the `_view_update_concurrency_sem` changes.
This is done by calling `storage_proxy::update_view_update_backlog`, which reads the `_view_update_concurrency_sem` of the shard (in `database::get_view_update_backlog`)
and then calls node`_update_backlog::add` where the read backlog
is stored in the atomic:
```
void storage_proxy::update_view_update_backlog() {
    _max_view_update_backlog.add(get_db().local().get_view_update_backlog());
}
void node_update_backlog::add(update_backlog backlog) {
    _backlogs[this_shard_id()].backlog.store(backlog, std::memory_order_relaxed);
    _backlogs[this_shard_id()].need_publishing = need_publishing::yes;
}
```
For this implementation of calculating the node's view update backlog to work,
we need the atomics to be updated correctly when the semaphores of corresponding
shards change.

The main event where the view update backlog changes is an incoming write
request. That's why when handling the request and preparing a response
we update the backlog calling `storage_proxy::get_view_update_backlog` (also
because we want to read the backlog and send it in the response):
backlog update after local view updates (`storage_proxy::send_to_live_endpoints` in `mutate_begin`)
```
 auto lmutate = [handler_ptr, response_id, this, my_address, timeout] () mutable { 
     return handler_ptr->apply_locally(timeout, handler_ptr->get_trace_state()) 
             .then([response_id, this, my_address, h = std::move(handler_ptr), p = shared_from_this()] { 
         // make mutation alive until it is processed locally, otherwise it 
         // may disappear if write timeouts before this future is ready 
         got_response(response_id, my_address, get_view_update_backlog()); 
     }); 
 }; 
backlog update after remote view updates (storage_proxy::remote::handle_write)

 auto f = co_await coroutine::as_future(send_mutation_done(netw::messaging_service::msg_addr{reply_to, shard}, trace_state_ptr, 
         shard, response_id, p->get_view_update_backlog())); 
```
Now assume that on a certain node we have a write request received on shard A,
which updates a row on shard B (A!=B). As a result, shard B will generate view
updates and consume units from its `_view_update_concurrency_sem`, but will
not update its atomic in `_backlogs` yet. Because both shards in the example
are on the same node, shard A will perform a local write calling `lmutate` shown
above. In the `lmutate` call, the `apply_locally` will initiate the actual write on
shard B and the `storage_proxy::update_view_update_backlog` will be called back
on shard A. In no place will the backlog atomic on shard B get updated even
though it increased in size due to the view updates generated there.
Currently, what we calculate there doesn't really matter - it's only used for the
MV flow control delays, so currently, in this scenario, we may only overload
a replica causing failed replica writes which will be later retried as hints. However,
when we add MV admission control, the calculated backlog will be the difference
between an accepted and a rejected request.

The fix for this correctness issue we need to update the view update backlog
on the shard whose semaphore units have been consumed. We could still read the
backlog on the shard that received the initial request, however, if we read the backlog
on a different shard than the one which generated the view updates, it will most likely
be outdated (by 10ms), so we'll likely won't see the backlog change caused by the write
request. If we want to see that, we need to get the return updated value from the shard
that generated the view updates and return it on the shard handling the request.

This patch ensures that when semaphore units are consumed on some shard, it's
atomic backlog is updated and that when a backlogs increases as a result of some
request, the increased backlog is returned in the response of this request. This
is achieved by reading the view update backlog atomic holding the backlog from
the shard where the mutation was applied when finishing the write request handling.
The exact place where we get the backlog was chosen due to performance considerations:
we don't want to create a new task on the common write path just for this, so it's inside the
`lmutate` and `handle_write` coroutines.

Perf simple query in write mode gives the following results:
Before:
median 337720.61 tps ( 59.3 allocs/op,  16.0 logallocs/op,  15.0 tasks/op,   52842 insns/op,        0 errors)
median absolute deviation: 1848.82
maximum: 342161.04
minimum: 299399.57
After:
median 333203.07 tps ( 59.3 allocs/op,  16.0 logallocs/op,  15.0 tasks/op,   53585 insns/op,        0 errors)
median absolute deviation: 5629.36
maximum: 339708.32
minimum: 309021.10

Fixes: https://github.com/scylladb/scylladb/issues/18542

The test added in this patch assures that the backlog is updated on the correct shard. The value
returned in responses isn't currently used for anything other than delaying responses, so it will
be tested when it start having an impact in https://github.com/scylladb/scylladb/pull/18334.

Without admission control (https://github.com/scylladb/scylladb/pull/18334), this patch doesn't affect much, so I'm marking it as backport/none