### PR TITLE
docs: correct the link pointing to Scylla U

### DIFF
--- a/docs/using-scylla/cdc/cdc-intro.rst
+++ b/docs/using-scylla/cdc/cdc-intro.rst
@@ -85,7 +85,7 @@ The following libraries are available:
 More information
 ----------------
 
-`Scylla University: Change Data Capture (CDC) lesson <https://university.scylladb.com/courses/scylla-operations/lessons/change-data-capture-cdc/>`_ -  Learn how to use CDC. Some of the topics covered are:
+`Scylla University: Change Data Capture (CDC) lesson <https://university.scylladb.com/courses/data-modeling/lessons/change-data-capture-cdc/>`_ -  Learn how to use CDC. Some of the topics covered are:
 
 * An overview of Change Data Capture,  what exactly is it, what are some common use cases, what does it do, and an overview of how it works
 * How can that data be consumed? Different options for consuming the data changes including normal CQL, a layered approach, and integrators


### PR DESCRIPTION
before this change it points to
https://university.scylladb.com/courses/scylla-operations/lessons/change-data-capture-cdc/ which then redirects the browser to
https://university.scylladb.com/courses/scylla-operations/, but it should have pointed to
https://university.scylladb.com/courses/data-modeling/lessons/change-data-capture-cdc/

in this change, the hyperlink is corrected.

Fixes #19163
Refs 6e97b83b6028326f00b823c4f8f2da4fa5c50d3c
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

* the change (6e97b83b6028326f00b823c4f8f2da4fa5c50d3c) involving this link was included since 5.1, so this fix should be backported to all maintained branches after 5.1