### PR TITLE
sstables: change const_iterator::value_type to uint64_t

### DIFF
--- a/sstables/compress.hh
+++ b/sstables/compress.hh
@@ -148,7 +148,7 @@ struct compression {
         class const_iterator {
         public:
             using iterator_category = std::random_access_iterator_tag;
-            using value_type = const uint64_t;
+            using value_type = uint64_t;
             using difference_type = std::ptrdiff_t;
             using pointer = const uint64_t*;
             using reference = const uint64_t&;


### PR DESCRIPTION
in general, the value_type of a `const_iterator` is `T` instead of `const T`, what has the const specifier is `reference`. because, when dereferencing an iterator, the value type does not matter any more, as it always a copy.

and GCC-14 points this out:

```
/home/kefu/dev/scylladb/sstables/compress.hh:224:13: error: type qualifiers ignored on function return type [-Werror=ignored-qualifiers]
  224 |             value_type operator*() const {
      |             ^~~~~~~~~~
/home/kefu/dev/scylladb/sstables/compress.hh:228:13: error: type qualifiers ignored on function return type [-Werror=ignored-qualifiers]
  228 |             value_type operator[](ssize_t i) const {
      |             ^~~~~~~~~~
```

so, in this change, let's change the value_type to `uint64_t`. please note, it's not typical to return `value_type` from `operator*` or `operator[]` of an iterator. but due to the design of segmented_offsets, we cannot return a reference, so let's keep it this way.

* it's a cleanup. so no need to backport.