### PR TITLE
lang: remove redundant std::move()

### DIFF
--- a/lang/lua.cc
+++ b/lang/lua.cc
@@ -794,7 +794,7 @@ struct from_lua_visitor {
         if (error_pos) {
             throw exceptions::invalid_request_exception(format("value is not valid utf8, invalid character at byte offset {}", *error_pos));
         }
-        return std::move(s);
+        return s;
     }
 
     data_value operator()(const ascii_type_impl& t) {


### PR DESCRIPTION
C++ standard enforces copy elision in this case. and copy elision is more performant than constructing the return value with a move constructor, so no need to use `std:move()` here.

and GCC-14 rightfully points this out:

```
/home/kefu/dev/scylladb/lang/lua.cc: In member function ‘data_value {anonymous}::from_lua_visitor::operator()(const utf8_type_impl&)’:
/var/ssd/scylladb/lang/lua.cc:797:25: error: redundant move in return statement [-Werror=redundant-move]
  797 |         return std::move(s);
      |                ~~~~~~~~~^~~
/home/kefu/dev/scylladb/lang/lua.cc:797:25: note: remove ‘std::move’ call
```

* it's more of a cleanup. and could improve the performance a little bit, but it's far from a fix. so no need to backport.