### PR TITLE
mutation/mutation_rebuilder: remove redundant std::move()

### DIFF
--- a/mutation/mutation_rebuilder.hh
+++ b/mutation/mutation_rebuilder.hh
@@ -21,7 +21,7 @@ public:
     // Returned reference is valid until consume_end_of_stream() or flush() is called.
     const mutation& consume_new_partition(const dht::decorated_key& dk) {
         assert(!_m);
-        _m = mutation(_s, std::move(dk));
+        _m = mutation(_s, dk);
         return *_m;
     }
 


### PR DESCRIPTION
GCC-14 rightfully points out:

```
/var/ssd/scylladb/mutation/mutation_rebuilder.hh: In member function ‘const mutation& mutation_rebuilder::consume_new_partition(const dht::decorated_key&)’:
/var/ssd/scylladb/mutation/mutation_rebuilder.hh:24:36: error: redundant move in initialization [-Werror=redundant-move]
   24 |         _m = mutation(_s, std::move(dk));                                                                                                                                                                           |                           ~~~~~~~~~^~~~
/var/ssd/scylladb/mutation/mutation_rebuilder.hh:24:36: note: remove ‘std::move’ call
```

as `dk` is passed with a const reference, `std::move()` does not help the callee to consume from it. so drop the `std::move()` here.

* it's a cleanup, so no need to backport.