### PR TITLE
lang: Return context as future, not via reference argument

### DIFF
--- a/cql3/statements/create_function_statement.cc
+++ b/cql3/statements/create_function_statement.cc
@@ -36,8 +36,7 @@ seastar::future<shared_ptr<functions::function>> create_function_statement::crea
         arg_names.push_back(arg_name->to_string());
     }
 
-    lang::manager::context ctx;
-    co_await qp.lang().create(_language, ctx, _name.name, arg_names, _body);
+    auto ctx = co_await qp.lang().create(_language, _name.name, arg_names, _body);
     if (!ctx) {
         co_return nullptr;
     }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1953,8 +1953,7 @@ static seastar::future<shared_ptr<cql3::functions::user_function>> create_func(r
     auto arg_names = get_list<sstring>(row, "argument_names");
     auto body = row.get_nonnull<sstring>("body");
     auto language = row.get_nonnull<sstring>("language");
-    lang::manager::context ctx;
-    co_await db.lang().create(language, ctx, name.name, arg_names, body);
+    auto ctx = co_await db.lang().create(language, name.name, arg_names, body);
     if (!ctx) {
         throw std::runtime_error(format("Unsupported language for UDF: {}", language));
     }

--- a/lang/manager.cc
+++ b/lang/manager.cc
@@ -44,7 +44,8 @@ future<> manager::stop() {
     }
 }
 
-future<> manager::create(sstring language, context& ctx, sstring name, const std::vector<sstring>& arg_names, std::string script) {
+future<manager::context> manager::create(sstring language, sstring name, const std::vector<sstring>& arg_names, std::string script) {
+    manager::context ctx;
     if (language == "lua") {
         utils::updateable_value<unsigned> max_bytes(lua_max_bytes);
         utils::updateable_value<unsigned> max_contiguous(lua_max_contiguous);
@@ -66,6 +67,7 @@ future<> manager::create(sstring language, context& ctx, sstring name, const std
        }
        ctx.emplace(std::move(wasm_ctx));
     }
+    co_return ctx;
 }
 
 } // lang namespace

--- a/lang/manager.hh
+++ b/lang/manager.hh
@@ -59,7 +59,7 @@ public:
     }
 
     using context = std::optional<cql3::functions::user_function::context>;
-    future<> create(sstring language, context& ctx, sstring name, const std::vector<sstring>& arg_names, std::string script);
+    future<context> create(sstring language, sstring name, const std::vector<sstring>& arg_names, std::string script);
 };
 
 } // lang namespace


### PR DESCRIPTION
Commit 882b2f4e9f (cql3, schema_tables: Generalize function creation) erroneously says that optional<context> is not suitable for future<> type, but in fact it is.
