### PR TITLE
Register API endpoints next to corresponding services

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1660,6 +1660,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 repair.stop().get();
             });
             repair.invoke_on_all(&repair_service::start).get();
+            api::set_server_repair(ctx, repair).get();
+            auto stop_repair_api = defer_verbose_shutdown("repair API", [&ctx] {
+                api::unset_server_repair(ctx).get();
+            });
 
             supervisor::notify("starting CDC Generation Management service");
             /* This service uses the system distributed keyspace.
@@ -1698,10 +1702,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             api::set_server_messaging_service(ctx, messaging).get();
             auto stop_messaging_api = defer_verbose_shutdown("messaging service API", [&ctx] {
                 api::unset_server_messaging_service(ctx).get();
-            });
-            api::set_server_repair(ctx, repair).get();
-            auto stop_repair_api = defer_verbose_shutdown("repair API", [&ctx] {
-                api::unset_server_repair(ctx).get();
             });
 
             api::set_server_task_manager(ctx, task_manager, cfg).get();

--- a/main.cc
+++ b/main.cc
@@ -1013,6 +1013,17 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 task_manager.stop().get();
             });
 
+            api::set_server_task_manager(ctx, task_manager, cfg).get();
+            auto stop_tm_api = defer_verbose_shutdown("task manager API", [&ctx] {
+                api::unset_server_task_manager(ctx).get();
+            });
+#ifndef SCYLLA_BUILD_MODE_RELEASE
+            api::set_server_task_manager_test(ctx, task_manager).get();
+            auto stop_tm_test_api = defer_verbose_shutdown("task manager API", [&ctx] {
+                api::unset_server_task_manager_test(ctx).get();
+            });
+#endif
+
             // Note: changed from using a move here, because we want the config object intact.
             replica::database_config dbcfg;
             dbcfg.compaction_scheduling_group = make_sched_group("compaction", "comp", 1000);
@@ -1704,16 +1715,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             supervisor::notify("starting storage service", true);
 
-            api::set_server_task_manager(ctx, task_manager, cfg).get();
-            auto stop_tm_api = defer_verbose_shutdown("task manager API", [&ctx] {
-                api::unset_server_task_manager(ctx).get();
-            });
-#ifndef SCYLLA_BUILD_MODE_RELEASE
-            api::set_server_task_manager_test(ctx, task_manager).get();
-            auto stop_tm_test_api = defer_verbose_shutdown("task manager API", [&ctx] {
-                api::unset_server_task_manager_test(ctx).get();
-            });
-#endif
             gossiper.local().register_(ss.local().shared_from_this());
             auto stop_listening = defer_verbose_shutdown("storage service notifications", [&gossiper, &ss] {
                 gossiper.local().unregister_(ss.local().shared_from_this()).get();


### PR DESCRIPTION
The API endpoints are registered for particular services (with rare exceptions), and once the corresponding service is ready, its endpoints section can be registered too. Same but reversed is for shutdown, and it's automatic with deferred actions.

refs: #2737 