### PR TITLE
service/storage_proxy: Move a comment to its relevant place

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3168,8 +3168,6 @@ storage_proxy::create_write_response_handler_helper(schema_ptr s, const dht::tok
         on_internal_error(slogger, seastar::format("No mapping for {} in the passed effective replication map", ep));
     });
 
-    // If the manager hasn't started yet, no mutation will be performed to another node.
-    // No hint will need to be stored.
     if (cannot_hint(all_hids, type)) {
         get_stats().writes_failed_due_to_too_many_in_flight_hints++;
         // avoid OOMing due to excess hints.  we need to do this check even for "live" nodes, since we can
@@ -3897,7 +3895,8 @@ template<typename Range>
 bool storage_proxy::cannot_hint(const Range& targets, db::write_type type) const {
     // if hints are disabled we "can always hint" since there's going to be no hint generated in this case
     return hints_enabled(type) &&
-            _hints_manager.started() &&
+            _hints_manager.started() && // If the manager hasn't started yet, no mutation will be performed to another node.
+                                        // No hint will need to be stored.
             boost::algorithm::any_of(targets, std::bind(&db::hints::manager::too_many_in_flight_hints_for, &_hints_manager, std::placeholders::_1));
 }
 


### PR DESCRIPTION
In b92fb35, we put a comment in the wrong place. These changes move it to the right one.