### PR TITLE
build: remove coverage compiling options from the cxx_flags

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1765,7 +1765,7 @@ def configure_abseil(build_dir, mode, mode_config):
     # added to cxx_ld_flags
     if args.coverage:
         for flag in COVERAGE_INST_FLAGS:
-            abseil_cflags = abseil_cflags.replace(f' {flag}', '')
+            cxx_flags = cxx_flags.replace(f' {flag}', '')
 
     cxx_flags += ' ' + abseil_cflags.strip()
     cmake_mode = mode_config['cmake_build_type']


### PR DESCRIPTION
in 44e85c7d, we remove coverage compiling options from the cflags when building abseil. but in 535f2b21, these options were brought back as parts of cxx_flags.

so we need to remove them again from cxx_flags.
Fixes #19219
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

* 535f2b21 is backported to 6.0. and the regression was introduced by 535f2b21. so we need to backport this change to 6.0