### PR TITLE
Improve handling of outdated --experimental-features

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1343,6 +1343,7 @@ std::map<sstring, db::experimental_features_t::feature> db::experimental_feature
         {"consistent-topology-changes", feature::UNUSED},
         {"broadcast-tables", feature::BROADCAST_TABLES},
         {"keyspace-storage-options", feature::KEYSPACE_STORAGE_OPTIONS},
+        {"tablets", feature::UNUSED},
     };
 }
 

--- a/main.cc
+++ b/main.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <functional>
 #include <yaml-cpp/yaml.h>
+#include <fmt/ranges.h>
 
 #include <seastar/util/closeable.hh>
 #include <seastar/core/abort_source.hh>
@@ -780,6 +781,13 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                             "  Contact scylladb-users@googlegroups.com if you are using it in production", cfg->partitioner());
                     throw bad_configuration_error();
                 }
+            }
+
+            auto unused_features = cfg->experimental_features() | boost::adaptors::filtered([] (auto& f) {
+                return f == db::experimental_features_t::feature::UNUSED;
+            });
+            if (!unused_features.empty()) {
+                startlog.warn("Ignoring unused features found in config: {}", unused_features);
             }
 
             gms::feature_config fcfg = gms::feature_config_from_db_config(*cfg);

--- a/utils/enum_option.hh
+++ b/utils/enum_option.hh
@@ -63,13 +63,12 @@ requires HasMapInterface<decltype(Mapper::map())>
 class enum_option {
     using map_t = typename std::remove_reference<decltype(Mapper::map())>::type;
     typename map_t::mapped_type _value;
-    map_t _map;
   public:
     // For smooth conversion from enum values:
-    enum_option(const typename map_t::mapped_type& v) : _value(v), _map(Mapper::map()) {}
+    enum_option(const typename map_t::mapped_type& v) : _value(v) {}
 
     // So values can be default-constructed before streaming into them:
-    enum_option() : _map(Mapper::map()) {}
+    enum_option() {}
 
     bool operator==(const enum_option<Mapper>& that) const {
         return _value == that._value;
@@ -87,8 +86,9 @@ class enum_option {
     friend std::istream& operator>>(std::istream& s, enum_option<Mapper>& opt) {
         typename map_t::key_type key;
         s >> key;
-        const auto found = opt._map.find(key);
-        if (found == opt._map.end()) {
+        auto map = Mapper::map();
+        const auto found = map.find(key);
+        if (found == map.end()) {
             std::string text;
             if (s.rdstate() & s.failbit) {
                 // key wasn't read successfully.
@@ -113,11 +113,12 @@ template <typename Mapper>
 struct fmt::formatter<enum_option<Mapper>> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     auto format(const enum_option<Mapper>& opt, fmt::format_context& ctx) const {
-        auto found = find_if(opt._map.cbegin(), opt._map.cend(),
+        auto map = Mapper::map();
+        auto found = find_if(map.cbegin(), map.cend(),
                              [&opt](const auto& e) {
                                  return e.second == opt._value;
                              });
-        if (found == opt._map.cend()) {
+        if (found == map.cend()) {
             return fmt::format_to(ctx.out(), "?unknown");
         } else {
             return fmt::format_to(ctx.out(), "{}", found->first);


### PR DESCRIPTION
Some time ago it turned out that if unrecognized feature name is met in scylla.yaml, the whole experimental features list is ignored, but scylla continues to boot. There's UNUSED feature which is the proper way to deprecate a feature, and this PR improves its handling in several ways.

1. The recently removed "tablets" feature is partially brought back, but marked as UNUSED
2. Any UNUSED features met while parsing are printed into logs
3. The enum_option<> helper is enlightened along the way

refs: #18968 