### PR TITLE
dist: scylla_util: sysconfig_parser: replace deprecated ConfigParser.readfp

### DIFF
--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -458,7 +458,7 @@ class sysconfig_parser:
         f = io.StringIO('[global]\n{}'.format(self._data))
         self._cfg = configparser.ConfigParser()
         self._cfg.optionxform = str
-        self._cfg.readfp(f)
+        self._cfg.read_file(f)
 
     def __escape(self, val):
         return re.sub(r'"', r'\"', val)


### PR DESCRIPTION
ConfigParser.readfp was deprecated in Python 3.2 and removed in Python 3.12.

Under Fedora 40, the container fails to launch because it cannot parse its configuration.

Fix by using the newer read_file().

No backport needed; since we bundle our Python the removal of readfp doesn't affect older versions.