### PR TITLE
raft: fsm: add details to on_internal_error_noexcept message

### DIFF
--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -637,7 +637,9 @@ void fsm::step(server_id from, Message&& msg) {
             _last_election_time = _clock.now();
 
             if (current_leader() != from) {
-                on_internal_error_noexcept(logger, "Got append request/install snapshot/read_quorum from an unexpected leader");
+                on_internal_error_noexcept(logger, format(
+                    "Got append request/install snapshot/read_quorum from an unexpected leader,"
+                    " expected leader: {}, message from: {}", current_leader(), from));
             }
         }
     }


### PR DESCRIPTION
If we receive a message in the same term but from a different leader than we expect, we print:
```
Got append request/install snapshot/read_quorum from an unexpected leader
```
For some reason the message did not include the details (who the leader was and who the sender was) which requires almost zero effort and might be useful for debugging. So let's include them.

Ref: scylladb/scylla-enterprise#4276