### PR TITLE
locator/topology: update_node: format also shard_count in debug log message

### DIFF
--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -206,7 +206,7 @@ const node* topology::add_node(node_holder nptr) {
 }
 
 const node* topology::update_node(node* node, std::optional<host_id> opt_id, std::optional<inet_address> opt_ep, std::optional<endpoint_dc_rack> opt_dr, std::optional<node::state> opt_st, std::optional<shard_id> opt_shard_count) {
-    tlogger.debug("topology[{}]: update_node: {}: to: host_id={} endpoint={} dc={} rack={} state={}, at {}", fmt::ptr(this), node_printer(node),
+    tlogger.debug("topology[{}]: update_node: {}: to: host_id={} endpoint={} dc={} rack={} state={} shard_count={}, at {}", fmt::ptr(this), node_printer(node),
         opt_id ? format("{}", *opt_id) : "unchanged",
         opt_ep ? format("{}", *opt_ep) : "unchanged",
         opt_dr ? format("{}", opt_dr->dc) : "unchanged",


### PR DESCRIPTION
The format string is missing `shard_count={}`

* Backport not required as this just fixes a debug log message, which does not crash in previous branches, just prints wrong value for the `at {}` backtrace.