### PR TITLE
auth/role_or_anonymous: drop operator<< for role_or_anonymous

### DIFF
--- a/auth/role_or_anonymous.cc
+++ b/auth/role_or_anonymous.cc
@@ -10,11 +10,6 @@
 
 namespace auth {
 
-std::ostream& operator<<(std::ostream& os, const role_or_anonymous& mr) {
-    os << mr.name.value_or("<anonymous>");
-    return os;
-}
-
 bool is_anonymous(const role_or_anonymous& mr) noexcept {
     return !mr.name.has_value();
 }


### PR DESCRIPTION
its declaration was removed in 84a9d2fa, which failed to remove the implementation from .cc file.

in this change, let's remove operator<< for role_or_anonymous completely.

* it's a cleanup. so no need to backport.