### PR TITLE
mv: fix value of the gossiped view update backlog

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2658,7 +2658,7 @@ future<std::optional<update_backlog>> node_update_backlog::fetch_if_changed() {
                     return std::make_pair(std::exchange(_backlogs[shard].need_publishing, need_publishing::no), fetch_shard(shard));
                 });
             },
-            std::make_pair(need_publishing::no, db::view::update_backlog()),
+            std::make_pair(need_publishing::no, db::view::update_backlog::no_backlog()),
             [] (std::pair<need_publishing, db::view::update_backlog> a, std::pair<need_publishing, db::view::update_backlog> b) {
                 return std::make_pair(a.first || b.first, std::max(a.second, b.second));
             });

--- a/db/view/view_update_backlog.hh
+++ b/db/view/view_update_backlog.hh
@@ -23,12 +23,32 @@ namespace db::view {
  * backlog - how much view hints are consuming. The size of a backlog is relative
  * to its maximum size.
  */
-struct update_backlog {
-    size_t current;
-    size_t max;
+class update_backlog {
+    size_t _current;
+    size_t _max;
+
+public:
+    update_backlog(size_t current, size_t max)
+            : _current(current), _max(max) {
+        if (max == 0) {
+            // We might have received an invalid backlog in a message from an old node,
+            // where we didn't check the max. In this case, fall back to the empty backlog.
+            _current = 0;
+            _max = std::numeric_limits<size_t>::max();
+        }
+    }
+    update_backlog() = delete;
 
     float relative_size() const {
-        return float(current) / float(max);
+        return float(_current) / float(_max);
+    }
+
+    const size_t& get_current_bytes() const {
+        return _current;
+    }
+
+    const size_t& get_max_bytes() const {
+        return _max;
     }
 
     std::partial_ordering operator<=>(const update_backlog &rhs) const {

--- a/idl/view.idl.hh
+++ b/idl/view.idl.hh
@@ -9,8 +9,8 @@
 namespace db {
 namespace view {
 class update_backlog {
-    size_t current;
-    size_t max;
+    size_t get_current_bytes();
+    size_t get_max_bytes();
 };
 }
 }

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -551,7 +551,7 @@ database::setup_metrics() {
         sm::make_counter("total_reads_rate_limited", _stats->total_reads_rate_limited,
                        sm::description("Counts read operations which were rejected on the replica side because the per-partition limit was reached.")),
 
-        sm::make_current_bytes("view_update_backlog", [this] { return get_view_update_backlog().current; },
+        sm::make_current_bytes("view_update_backlog", [this] { return get_view_update_backlog().get_current_bytes(); },
                        sm::description("Holds the current size in bytes of the pending view updates for all tables")),
 
         sm::make_counter("querier_cache_lookups", _querier_cache.get_stats().lookups,

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -251,7 +251,7 @@ future<> view_update_backlog_broker::start() {
                 //FIXME: discarded future.
                 (void)_gossiper.add_local_application_state(
                         gms::application_state::VIEW_BACKLOG,
-                        gms::versioned_value(seastar::format("{}:{}:{}", backlog->current, backlog->max, now)));
+                        gms::versioned_value(seastar::format("{}:{}:{}", backlog->get_current_bytes(), backlog->get_max_bytes(), now)));
                 sleep_abortable(gms::gossiper::INTERVAL, _as).get();
             }
         }).handle_exception_type([] (const seastar::sleep_aborted& ignored) { });


### PR DESCRIPTION
Currently, when calculating the view update backlog for gossip,
we start with `db::view::update_backlog()` and compare it to backlogs
from all shards. However, this backlog can't be compared to other
backlogs - it has size 0 and we compare the fraction current/size
when comparing backlogs, causing us to compare with `NaN`.
This patch fixes it by starting the comparisons with an empty backlog.

The patch introducing this issue (f70f774e404719ee6884c2c84d5def6e0690c7e7) wasn't backported, so this one doesn't need to be either