### PR TITLE
test: servers_add: fix the expected_error parameter

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -222,10 +222,11 @@ class ManagerClient():
         data = {"expected_error": expected_error}
         await self.client.put_json(f"/cluster/server/{server_id}/start", data, timeout=timeout)
         await self.server_sees_others(server_id, wait_others, interval = wait_interval)
-        if self.cql:
-            self._driver_update()
-        else:
-            await self.driver_connect()
+        if expected_error is None:
+            if self.cql:
+                self._driver_update()
+            else:
+                await self.driver_connect()
 
     async def server_restart(self, server_id: ServerNum, wait_others: int = 0,
                              wait_interval: float = 45) -> None:
@@ -331,10 +332,11 @@ class ManagerClient():
         except Exception as exc:
             raise RuntimeError(f"server_add got invalid server data {server_info}") from exc
         logger.debug("ManagerClient added %s", s_info)
-        if self.cql:
-            self._driver_update()
-        elif start:
-            await self.driver_connect()
+        if expected_error is None:
+            if self.cql:
+                self._driver_update()
+            elif start:
+                await self.driver_connect()
         return s_info
 
     async def servers_add(self, servers_num: int = 1,
@@ -371,10 +373,11 @@ class ManagerClient():
                 raise RuntimeError(f"servers_add got invalid server data {server_info}") from exc
 
         logger.debug("ManagerClient added %s", s_infos)
-        if self.cql:
-            self._driver_update()
-        elif start:
-            await self.driver_connect()
+        if expected_error is None:
+            if self.cql:
+                self._driver_update()
+            elif start:
+                await self.driver_connect()
         return s_infos
 
     async def remove_node(self, initiator_id: ServerNum, server_id: ServerNum,

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -345,7 +345,7 @@ class ManagerClient():
                           property_file: Optional[dict[str, Any]] = None,
                           start: bool = True,
                           seeds: Optional[List[IPAddress]] = None,
-                          expected_error: Optional[str] = None) -> [ServerInfo]:
+                          expected_error: Optional[str] = None) -> List[ServerInfo]:
         """Add new servers concurrently.
         This function can be called only if the cluster uses consistent topology changes, which support
         concurrent bootstraps. If your test does not fulfill this condition and you want to add multiple

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -902,11 +902,12 @@ class ScyllaCluster:
                           config: Optional[dict[str, Any]] = None,
                           property_file: Optional[dict[str, Any]] = None,
                           start: bool = True,
+                          seeds: Optional[List[IPAddress]] = None,
                           expected_error: Optional[str] = None) -> [ServerInfo]:
         """Add multiple servers to the cluster concurrently"""
         assert servers_num > 0, f"add_servers: cannot add {servers_num} servers"
 
-        return await asyncio.gather(*(self.add_server(None, cmdline, config, property_file, start, expected_error)
+        return await asyncio.gather(*(self.add_server(None, cmdline, config, property_file, start, seeds, expected_error)
                                       for _ in range(servers_num)))
 
     def endpoint(self) -> str:
@@ -1418,7 +1419,7 @@ class ScyllaClusterManager:
         data = await request.json()
         s_infos = await self.cluster.add_servers(data.get('servers_num'), data.get('cmdline'), data.get('config'),
                                                  data.get('property_file'), data.get('start', True),
-                                                 data.get('expected_error', None))
+                                                 data.get('seeds', None), data.get('expected_error', None))
         return [
             {"server_id": s_info.server_id, "ip_addr": s_info.ip_addr, "rpc_address": s_info.rpc_address}
             for s_info in s_infos

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -903,7 +903,7 @@ class ScyllaCluster:
                           property_file: Optional[dict[str, Any]] = None,
                           start: bool = True,
                           seeds: Optional[List[IPAddress]] = None,
-                          expected_error: Optional[str] = None) -> [ServerInfo]:
+                          expected_error: Optional[str] = None) -> List[ServerInfo]:
         """Add multiple servers to the cluster concurrently"""
         assert servers_num > 0, f"add_servers: cannot add {servers_num} servers"
 


### PR DESCRIPTION
This PR fixes two problems with the `expected_error`
parameter in `server_add` and `servers_add`.
1. It didn't work in `server_add` if the cluster was empty
because of an incorrect attempt to connect the driver.
2. It didn't work in `servers_add` completely because the
`seeds` parameter was handled incorrectly.

This PR only adds improvements in the testing framework,
no need to backport it.