### PR TITLE
mv: replicate the gossiped backlog to all shards

### DIFF
--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -290,11 +290,13 @@ future<> view_update_backlog_broker::on_change(gms::inet_address endpoint, const
             return make_ready_future();
         }
         auto backlog = view_update_backlog_timestamped{db::view::update_backlog{current, max}, ticks};
-        auto[it, inserted] = _sp.local()._view_update_backlogs.try_emplace(endpoint, std::move(backlog));
-        if (!inserted && it->second.ts < backlog.ts) {
-            it->second = std::move(backlog);
-        }
-        return make_ready_future();
+        return _sp.invoke_on_all([endpoint, backlog] (service::storage_proxy& sp) {
+            auto[it, inserted] = sp._view_update_backlogs.try_emplace(endpoint, backlog);
+            if (!inserted && it->second.ts < backlog.ts) {
+                it->second = backlog;
+            }
+            return make_ready_future();
+        });
     });
 }
 


### PR DESCRIPTION
On each shard of each node we store the view update backlogs of other nodes to, depending on their size, delay responses to incoming writes, lowering the load on these nodes and helping them get their backlog to normal if it were too high.

These backlogs are propagated between nodes in two ways: the first one is adding them to replica write responses. The seconds one is gossiping any changes to the node's backlog every 1s. The gossip becomes useful when writes stop to some node for some time and we stop getting the backlog using the first method, but we still want to be able to select a proper delay for new writes coming to this node. It will also be needed for the mv admission control.

Currently, the backlog is gossiped from shard 0, as expected. However, we also receive the backlog only on shard 0 and only update this shard's backlogs for the other node. Instead, we'd want to have the backlogs updated on all shards, allowing us to use proper delays also when requests are received on shards different than 0.

This patch changes the backlog update code, so that the backlogs on all shards are updated instead. This will only be performed up to once per second for each other node, and is done with a lower priority, so it won't severly impact other work.

Fixes: scylladb/scylladb#19232

This is a bug so I'm setting backport labels to 5.4 and 6.0