### PR TITLE
api: do not include unused headers

### DIFF
--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -10,7 +10,7 @@ env:
   BUILD_TYPE: RelWithDebInfo
   BUILD_DIR: build
   CLEANER_OUTPUT_PATH: build/clang-include-cleaner.log
-  CLEANER_DIRS: test/unit exceptions alternator
+  CLEANER_DIRS: test/unit exceptions alternator api
 
 permissions: {}
 

--- a/api/authorization_cache.hh
+++ b/api/authorization_cache.hh
@@ -8,11 +8,20 @@
 
 #pragma once
 
-#include "api.hh"
+#include <seastar/core/sharded.hh>
+
+namespace seastar::httpd {
+class routes;
+}
+
+namespace auth {
+class service;
+}
 
 namespace api {
 
-void set_authorization_cache(http_context& ctx, httpd::routes& r, sharded<auth::service> &auth_service);
-void unset_authorization_cache(http_context& ctx, httpd::routes& r);
+struct http_context;
+void set_authorization_cache(http_context& ctx, seastar::httpd::routes& r, seastar::sharded<auth::service> &auth_service);
+void unset_authorization_cache(http_context& ctx, seastar::httpd::routes& r);
 
 }

--- a/api/cache_service.cc
+++ b/api/cache_service.cc
@@ -7,6 +7,7 @@
  */
 
 #include "cache_service.hh"
+#include "api/api.hh"
 #include "api/api-doc/cache_service.json.hh"
 #include "column_family.hh"
 

--- a/api/cache_service.hh
+++ b/api/cache_service.hh
@@ -8,10 +8,13 @@
 
 #pragma once
 
-#include "api.hh"
+namespace seastar::httpd {
+class routes;
+}
 
 namespace api {
 
-void set_cache_service(http_context& ctx, httpd::routes& r);
+struct http_context;
+void set_cache_service(http_context& ctx, seastar::httpd::routes& r);
 
 }

--- a/api/column_family.hh
+++ b/api/column_family.hh
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "replica/database.hh"
-#include <seastar/core/future-util.hh>
 #include <seastar/json/json_elements.hh>
 #include <any>
 #include "api/api_init.hh"

--- a/api/error_injection.cc
+++ b/api/error_injection.cc
@@ -7,10 +7,8 @@
  */
 
 #include "api/api-doc/error_injection.json.hh"
-#include "api/api.hh"
-
+#include "api/api_init.hh"
 #include <seastar/http/exception.hh>
-#include "log.hh"
 #include "utils/error_injection.hh"
 #include "utils/rjson.hh"
 #include <seastar/core/future-util.hh>

--- a/api/raft.cc
+++ b/api/raft.cc
@@ -8,10 +8,10 @@
 
 #include <seastar/core/coroutine.hh>
 
-#include "api/api.hh"
 #include "api/api-doc/raft.json.hh"
 
 #include "service/raft/raft_group_registry.hh"
+#include "log.hh"
 
 using namespace seastar::httpd;
 
@@ -19,6 +19,7 @@ extern logging::logger apilog;
 
 namespace api {
 
+struct http_context;
 namespace r = httpd::raft_json;
 using namespace json;
 

--- a/api/system.hh
+++ b/api/system.hh
@@ -8,10 +8,13 @@
 
 #pragma once
 
-#include "api.hh"
+namespace seastar::httpd {
+class routes;
+}
 
 namespace api {
 
-void set_system(http_context& ctx, httpd::routes& r);
+struct http_context;
+void set_system(http_context& ctx, seastar::httpd::routes& r);
 
 }

--- a/api/task_manager_test.hh
+++ b/api/task_manager_test.hh
@@ -11,16 +11,19 @@
 #pragma once
 
 #include <seastar/core/sharded.hh>
-#include "api.hh"
 
 namespace tasks {
 class task_manager;
 }
 
-namespace api {
+namespace seastar::httpd {
+class routes;
+}
 
-void set_task_manager_test(http_context& ctx, httpd::routes& r, sharded<tasks::task_manager>& tm);
-void unset_task_manager_test(http_context& ctx, httpd::routes& r);
+namespace api {
+struct http_context;
+void set_task_manager_test(http_context& ctx, seastar::httpd::routes& r, seastar::sharded<tasks::task_manager>& tm);
+void unset_task_manager_test(http_context& ctx, seastar::httpd::routes& r);
 
 }
 

--- a/api/tasks.hh
+++ b/api/tasks.hh
@@ -8,11 +8,20 @@
 
 #pragma once
 
-#include "api.hh"
-#include "db/config.hh"
+#include <seastar/core/sharded.hh>
+#include "db/snapshot-ctl.hh"
+
+namespace seastar::httpd {
+class routes;
+}
+
+namespace service {
+class storage_service;
+}
 
 namespace api {
 
+struct http_context;
 void set_tasks_compaction_module(http_context& ctx, httpd::routes& r, sharded<service::storage_service>& ss, sharded<db::snapshot_ctl>& snap_ctl);
 void unset_tasks_compaction_module(http_context& ctx, httpd::routes& r);
 

--- a/api/token_metadata.hh
+++ b/api/token_metadata.hh
@@ -9,13 +9,16 @@
 #pragma once
 
 #include <seastar/core/sharded.hh>
-#include "api/api_init.hh"
+
+namespace seastar::httpd {
+class routes;
+}
 
 namespace locator { class shared_token_metadata; }
 
 namespace api {
-
-void set_token_metadata(http_context& ctx, httpd::routes& r, sharded<locator::shared_token_metadata>& tm);
-void unset_token_metadata(http_context& ctx, httpd::routes& r);
+struct http_context;
+void set_token_metadata(http_context& ctx, seastar::httpd::routes& r, seastar::sharded<locator::shared_token_metadata>& tm);
+void unset_token_metadata(http_context& ctx, seastar::httpd::routes& r);
 
 }


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.

also, add api to iwyu github workflow's CLEANER_DIR, to prevent future violations.

---

it's a cleanup, hence no need to backport.