### PR TITLE
.github: post a comment if "Fixes" policy is violated

### DIFF
--- a/.github/workflows/backport-pr-fixes-validation.yaml
+++ b/.github/workflows/backport-pr-fixes-validation.yaml
@@ -22,5 +22,12 @@ jobs:
             const regex = new RegExp(pattern);
             
             if (!regex.test(body)) {
-              core.setFailed("PR body does not contain a valid 'Fixes' reference.");
+              const error = "PR body does not contain a valid 'Fixes' reference.";
+              core.setFailed(error);
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `:warning: ${error}`
+              });
             }


### PR DESCRIPTION
it's more visible than an "Error" in the action's detail message.

---

no need to backport. it's an improvement in the CI workflow.