### PR TITLE
test: randomized_nemesis_test: define static variable

### DIFF
--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -2917,7 +2917,7 @@ private:
     size_t _end; // <= _seq.size()
     elem_t _digest; // sum of all elements modulo `magic`
 
-    static const elem_t magic = 54313;
+    static constexpr elem_t magic = 54313;
 
 public:
     append_seq(std::vector<elem_t> v) : _seq{make_lw_shared<std::vector<elem_t>>(std::move(v))}, _end{_seq->size()}, _digest{0} {


### PR DESCRIPTION
before this change, when linking randomized_nemesis_test with ld.lld:

```
[4/4] Linking CXX executable test/raft/RelWithDebInfo/randomized_nemesis_test
FAILED: test/raft/RelWithDebInfo/randomized_nemesis_test
: && /home/kefu/.local/bin/clang++ -ffunction-sections -fdata-sections -O3 -g -gz -Xlinker --build-id=sha1 --ld-path=ld.lld -dynamic-linker=/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////lib64/ld-linux-x86-64.so.2 -Xlinker --gc-sections test/raft/CMakeFiles/test-raft-helper.dir/RelWithDebInfo/helpers.cc.o test/raft/CMakeFiles/randomized_nemesis_test.dir/RelWithDebInfo/randomized_nemesis_test.cc.o -o test/raft/RelWithDebInfo/randomized_nemesis_test -L/home/kefu/dev/scylladb/idl/absl::headers -Wl,-rpath,/home/kefu/dev/scylladb/idl/absl::headers  test/lib/RelWithDebInfo/libtest-lib.a  seastar/RelWithDebInfo/libseastar.a  /usr/lib64/libxxhash.so  seastar/RelWithDebInfo/libseastar_testing.a  test/lib/RelWithDebInfo/libtest-lib.a  -Xlinker --push-state -Xlinker --whole-archive  auth/RelWithDebInfo/libscylla_auth.a  -Xlinker --pop-state  /usr/lib64/libcrypt.so  cdc/RelWithDebInfo/libcdc.a  compaction/RelWithDebInfo/libcompaction.a  mutation_writer/RelWithDebInfo/libmutation_writer.a  -Xlinker --push-state -Xlinker --whole-archive  dht/RelWithDebInfo/libscylla_dht.a  -Xlinker --pop-state  types/RelWithDebInfo/libtypes.a  index/RelWithDebInfo/libindex.a  -Xlinker --push-state -Xlinker --whole-archive  locator/RelWithDebInfo/libscylla_locator.a  -Xlinker --pop-state  message/RelWithDebInfo/libmessage.a  gms/RelWithDebInfo/libgms.a  sstables/RelWithDebInfo/libsstables.a  readers/RelWithDebInfo/libreaders.a  schema/RelWithDebInfo/libschema.a  -Xlinker --push-state -Xlinker --whole-archive  tracing/RelWithDebInfo/libscylla_tracing.a  -Xlinker --pop-state  RelWithDebInfo/libscylla-main.a  abseil/absl/strings/RelWithDebInfo/libabsl_cord.a  abseil/absl/strings/RelWithDebInfo/libabsl_cordz_info.a  abseil/absl/strings/RelWithDebInfo/libabsl_cord_internal.a  abseil/absl/strings/RelWithDebInfo/libabsl_cordz_functions.a  abseil/absl/strings/RelWithDebInfo/libabsl_cordz_handle.a  abseil/absl/crc/RelWithDebInfo/libabsl_crc_cord_state.a  abseil/absl/crc/RelWithDebInfo/libabsl_crc32c.a  abseil/absl/crc/RelWithDebInfo/libabsl_crc_internal.a  abseil/absl/crc/RelWithDebInfo/libabsl_crc_cpu_detect.a  abseil/absl/strings/RelWithDebInfo/libabsl_str_format_internal.a  /usr/lib64/libz.so  service/RelWithDebInfo/libservice.a  node_ops/RelWithDebInfo/libnode_ops.a  service/RelWithDebInfo/libservice.a  node_ops/RelWithDebInfo/libnode_ops.a  -lsystemd  raft/RelWithDebInfo/libraft.a  repair/RelWithDebInfo/librepair.a  streaming/RelWithDebInfo/libstreaming.a  replica/RelWithDebInfo/libreplica.a  db/RelWithDebInfo/libdb.a  mutation/RelWithDebInfo/libmutation.a  data_dictionary/RelWithDebInfo/libdata_dictionary.a  cql3/RelWithDebInfo/libcql3.a  transport/RelWithDebInfo/libtransport.a  cql3/RelWithDebInfo/libcql3.a  transport/RelWithDebInfo/libtransport.a  lang/RelWithDebInfo/liblang.a  /usr/lib64/liblua-5.4.so  -lm  /usr/lib64/libsnappy.so.1.1.10  abseil/absl/container/RelWithDebInfo/libabsl_raw_hash_set.a  abseil/absl/hash/RelWithDebInfo/libabsl_hash.a  abseil/absl/hash/RelWithDebInfo/libabsl_city.a  abseil/absl/types/RelWithDebInfo/libabsl_bad_variant_access.a  abseil/absl/hash/RelWithDebInfo/libabsl_low_level_hash.a  abseil/absl/types/RelWithDebInfo/libabsl_bad_optional_access.a  abseil/absl/container/RelWithDebInfo/libabsl_hashtablez_sampler.a  abseil/absl/profiling/RelWithDebInfo/libabsl_exponential_biased.a  abseil/absl/synchronization/RelWithDebInfo/libabsl_synchronization.a  abseil/absl/debugging/RelWithDebInfo/libabsl_stacktrace.a  abseil/absl/synchronization/RelWithDebInfo/libabsl_graphcycles_internal.a  abseil/absl/synchronization/RelWithDebInfo/libabsl_kernel_timeout_internal.a  abseil/absl/debugging/RelWithDebInfo/libabsl_symbolize.a  abseil/absl/debugging/RelWithDebInfo/libabsl_debugging_internal.a  abseil/absl/base/RelWithDebInfo/libabsl_malloc_internal.a  abseil/absl/debugging/RelWithDebInfo/libabsl_demangle_internal.a  abseil/absl/time/RelWithDebInfo/libabsl_time.a  abseil/absl/strings/RelWithDebInfo/libabsl_strings.a  abseil/absl/strings/RelWithDebInfo/libabsl_strings_internal.a  abseil/absl/strings/RelWithDebInfo/libabsl_string_view.a  abseil/absl/base/RelWithDebInfo/libabsl_throw_delegate.a  abseil/absl/numeric/RelWithDebInfo/libabsl_int128.a  abseil/absl/base/RelWithDebInfo/libabsl_base.a  abseil/absl/base/RelWithDebInfo/libabsl_raw_logging_internal.a  abseil/absl/base/RelWithDebInfo/libabsl_log_severity.a  abseil/absl/base/RelWithDebInfo/libabsl_spinlock_wait.a  -lrt  abseil/absl/time/RelWithDebInfo/libabsl_civil_time.a  abseil/absl/time/RelWithDebInfo/libabsl_time_zone.a  rust/RelWithDebInfo/libwasmtime_bindings.a  rust/librust_combined.a  /usr/lib64/libdeflate.so  utils/RelWithDebInfo/libutils.a  /usr/lib64/libxxhash.so  /usr/lib64/libcryptopp.so  /usr/lib64/libboost_regex.so.1.83.0  /usr/lib64/libicui18n.so  /usr/lib64/libicuuc.so  /usr/lib64/libboost_unit_test_framework.so.1.83.0  seastar/RelWithDebInfo/libseastar_testing.a  seastar/RelWithDebInfo/libseastar.a  /usr/lib64/libboost_program_options.so  /usr/lib64/libboost_thread.so  /usr/lib64/libboost_chrono.so  /usr/lib64/libboost_atomic.so  /usr/lib64/libcares.so  /usr/lib64/libfmt.so.10.2.1  /usr/lib64/liblz4.so  -ldl  /usr/lib64/libgnutls.so  -latomic  /usr/lib64/libsctp.so  /usr/lib64/libprotobuf.so  /usr/lib64/libyaml-cpp.so  /usr/lib64/libhwloc.so  //usr/lib64/liburing.so  /usr/lib64/libnuma.so  /usr/lib64/libboost_unit_test_framework.so && :
ld.lld: error: undefined symbol: append_seq::magic
>>> referenced by impl.hpp:92 (/usr/include/boost/test/tools/old/impl.hpp:92)
>>>               test/raft/CMakeFiles/randomized_nemesis_test.dir/RelWithDebInfo/randomized_nemesis_test.cc.o:(__cxx_global_var_init.38)
>>> referenced by impl.hpp:92 (/usr/include/boost/test/tools/old/impl.hpp:92)
>>>               test/raft/CMakeFiles/randomized_nemesis_test.dir/RelWithDebInfo/randomized_nemesis_test.cc.o:(__cxx_global_var_init.38)
>>> referenced by impl.hpp:92 (/usr/include/boost/test/tools/old/impl.hpp:92)
>>>               test/raft/CMakeFiles/randomized_nemesis_test.dir/RelWithDebInfo/randomized_nemesis_test.cc.o:(append_seq::append(int) const)
>>> referenced 5 more times
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

it turns out `append_seq::magic` is only declared, but never defined. please note, the non-inline static member variable in its class definition is not considered as a definition, see
[class.static.data](https://eel.is/c++draft/class.static.data#3)

> The declaration of a non-inline static data member in its class
> definition is not a definition and may be of an incomplete type
> other than cv void.

so, let's declare it as a `constexpr` instead. it implies `inline`.

* since this test compiles with our CI. there is no need to backport this change.