### PR TITLE
dist: s/SafeConfigParser/ConfigParser/

### DIFF
--- a/dist/common/scripts/scylla-housekeeping
+++ b/dist/common/scripts/scylla-housekeeping
@@ -180,7 +180,7 @@ if args.config != "":
     if not os.path.isfile(args.config):
         traceln("Config file ", args.config, " is missing, terminating")
         sys.exit(0)
-    config = configparser.SafeConfigParser()
+    config = configparser.ConfigParser()
     config.read(args.config)
 uid = None
 if args.uuid != "":


### PR DESCRIPTION
`SafeConfigParser` was renamed to `ConfigParser` in Python 3.2, and Python warns us:

> scylla-housekeeping:183: DeprecationWarning: The SafeConfigParser
> class has been renamed to ConfigParser in Python 3.2. This alias will
> be removed in Python 3.12. Use ConfigParser directly instead.

see https://docs.python.org/3.2/library/configparser.html#configparser.ConfigParser and https://docs.python.org/3.1/library/configparser.html#configparser.SafeConfigParser

Fixes #13046
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

* this is a cleanup. no need to backport.