### PR TITLE
alternator: drop unused friend declaration

### DIFF
--- a/alternator/expressions_types.hh
+++ b/alternator/expressions_types.hh
@@ -66,7 +66,6 @@ public:
     std::vector<std::variant<std::string, unsigned>>& operators() {
         return _operators;
     }
-    friend std::ostream& operator<<(std::ostream&, const path&);
 };
 
 // When an expression is first parsed, all constants are references, like


### PR DESCRIPTION
in 57c408ab, we dropped operator<< for `parsed::path`, but we forgot to drop the friend declaration for it along with the operator. so in this change, let's drop the friend declaration.

* it's a cleanup, so no need to backport it.