### PR TITLE
cql3: remove unused operator<<

### DIFF
--- a/cql3/assignment_testable.hh
+++ b/cql3/assignment_testable.hh
@@ -58,12 +58,6 @@ inline bool is_exact_match(assignment_testable::test_result tr) {
     return assignment_testable::is_exact_match(tr);
 }
 
-inline
-std::ostream&
-operator<<(std::ostream& os, const assignment_testable& at) {
-    return os << at.assignment_testable_source_context();
-}
-
 }
 
 template <>

--- a/cql3/column_identifier.hh
+++ b/cql3/column_identifier.hh
@@ -130,12 +130,3 @@ template <> struct fmt::formatter<cql3::column_identifier_raw> : fmt::formatter<
         return fmt::format_to(ctx.out(), "{}", id.text());
     }
 };
-
-namespace cql3 {
-
-static inline std::ostream& operator<<(std::ostream& out, const column_identifier& i) {
-    fmt::print(out, "{}", i);
-    return out;
-}
-
-}

--- a/cql3/cql3_type.cc
+++ b/cql3/cql3_type.cc
@@ -420,11 +420,6 @@ cql3_type::values() {
     return v;
 }
 
-std::ostream&
-operator<<(std::ostream& os, const cql3_type::raw& r) {
-    return os << r.to_string();
-}
-
 namespace util {
 
 sstring maybe_quote(const sstring& identifier) {

--- a/cql3/cql3_type.hh
+++ b/cql3/cql3_type.hh
@@ -64,7 +64,6 @@ public:
         static shared_ptr<raw> set(shared_ptr<raw> t);
         static shared_ptr<raw> tuple(std::vector<shared_ptr<raw>> ts);
         static shared_ptr<raw> frozen(shared_ptr<raw> t);
-        friend std::ostream& operator<<(std::ostream& os, const raw& r);
         friend sstring format_as(const raw& r) {
             return r.to_string();
         }
@@ -78,9 +77,6 @@ private:
     class raw_tuple;
     friend std::string_view format_as(const cql3_type& t) {
         return t.to_string();
-    }
-    friend std::ostream& operator<<(std::ostream& os, const cql3_type& t) {
-        return os << t.to_string();
     }
 
 public:

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1021,16 +1021,6 @@ std::ostream& operator<<(std::ostream& os, const column_value& cv) {
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const expression& expr) {
-    expression::printer pr {
-        .expr_to_print = expr,
-        .debug_mode = false
-    };
-
-    fmt::print(os, "{}", pr);
-    return os;
-}
-
 }
 }
 
@@ -1506,11 +1496,6 @@ expression search_and_replace(const expression& e,
                 },
             }, e);
     }
-}
-
-std::ostream& operator<<(std::ostream& s, oper_t op) {
-    fmt::print(s, "{}", op);
-    return s;
 }
 
 std::vector<expression> extract_single_column_restrictions_for_column(const expression& expr,

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -504,13 +504,9 @@ E* as_if(expression* e) {
 /// directly into the resulting conjunction's children, flattening the expression tree.
 extern expression make_conjunction(expression a, expression b);
 
-extern std::ostream& operator<<(std::ostream&, oper_t);
-
 extern sstring to_string(const expression&);
 
 extern std::ostream& operator<<(std::ostream&, const column_value&);
-
-extern std::ostream& operator<<(std::ostream&, const expression&);
 
 data_type type_of(const expression& e);
 

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -302,14 +302,3 @@ template <> struct fmt::formatter<cql3::raw_value> : fmt::formatter<string_view>
         return fmt::format_to(ctx.out(), "{}", value.view());
     }
 };
-
-namespace cql3 {
-static inline std::ostream& operator<<(std::ostream& os, const raw_value_view& value) {
-    fmt::print(os, "{}", value);
-    return os;
-}
-static inline std::ostream& operator<<(std::ostream& os, const raw_value& value) {
-    fmt::print(os, "{}", value);
-    return os;
-}
-}


### PR DESCRIPTION
as these operators are not used anymore.

* this change is a cleanup, hence no need to backport.