### PR TITLE
dht: remove unused operator<<

### DIFF
--- a/dht/token.cc
+++ b/dht/token.cc
@@ -54,11 +54,6 @@ std::strong_ordering token_comparator::operator()(const token& t1, const token& 
     return t1 <=> t2;
 }
 
-std::ostream& operator<<(std::ostream& out, const token& t) {
-    fmt::print(out, "{}", t);
-    return out;
-}
-
 sstring token::to_sstring() const {
     return seastar::to_sstring<sstring>(long_token(*this));
 }

--- a/dht/token.hh
+++ b/dht/token.hh
@@ -215,7 +215,6 @@ const token& minimum_token() noexcept;
 const token& maximum_token() noexcept;
 std::strong_ordering operator<=>(const token& t1, const token& t2);
 inline bool operator==(const token& t1, const token& t2) { return t1 <=> t2 == 0; }
-std::ostream& operator<<(std::ostream& out, const token& t);
 
 // Returns a successor for token t.
 // The caller must ensure there is a next token, otherwise


### PR DESCRIPTION
drop `operator<<(std::ostream& out, const token& t)`, as it is not used anymore.

* it's a cleanup, hence no need to backport.