### PR TITLE
build: cmake: use path to be compatible with CI

### DIFF
--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -9,7 +9,7 @@ add_custom_command(
       --debian-dir ${CMAKE_BINARY_DIR}/debian
       ${unstripped_dist_pkg}
   DEPENDS
-    scylla
+    ${CMAKE_BINARY_DIR}/$<CONFIG>/scylla
     ${CMAKE_BINARY_DIR}/$<CONFIG>/iotune
     ${CMAKE_BINARY_DIR}/node_exporter/node_exporter
     ${CMAKE_BINARY_DIR}/debian

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -1,12 +1,13 @@
 set(unstripped_dist_pkg
-  ${CMAKE_CURRENT_BINARY_DIR}/${Scylla_PRODUCT}-unstripped-${Scylla_VERSION}-${Scylla_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.tar.gz)
+  ${CMAKE_BINARY_DIR}/$<CONFIG>/dist/tar/${Scylla_PRODUCT}-unstripped-${Scylla_VERSION}-${Scylla_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.tar.gz)
 add_custom_command(
   OUTPUT ${unstripped_dist_pkg}
-  COMMAND scripts/create-relocatable-package.py
-    --build-dir ${CMAKE_BINARY_DIR}/$<CONFIG>
-    --node-exporter-dir ${CMAKE_BINARY_DIR}/node_exporter
-    --debian-dir ${CMAKE_BINARY_DIR}/debian
-    ${unstripped_dist_pkg}
+  COMMAND
+    scripts/create-relocatable-package.py
+      --build-dir ${CMAKE_BINARY_DIR}/$<CONFIG>
+      --node-exporter-dir ${CMAKE_BINARY_DIR}/node_exporter
+      --debian-dir ${CMAKE_BINARY_DIR}/debian
+      ${unstripped_dist_pkg}
   DEPENDS
     scylla
     ${CMAKE_BINARY_DIR}/$<CONFIG>/iotune
@@ -80,7 +81,7 @@ add_custom_command(
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 set(stripped_dist_pkg
-  "${CMAKE_BINARY_DIR}/$<CONFIG>/${Scylla_PRODUCT}-${Scylla_VERSION}-${Scylla_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.tar.gz")
+  "${CMAKE_BINARY_DIR}/$<CONFIG>/dist/tar/${Scylla_PRODUCT}-${Scylla_VERSION}-${Scylla_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.tar.gz")
 add_custom_command(
   OUTPUT
     ${stripped_dist_pkg}


### PR DESCRIPTION
this change is created in the same spirit of 1186ddef16, which updated the rule for generating the stripped dist pkg, but it failed to update the one for generating the unstripped dist pkg. what's why we have build failure when the workflow is looking for the unstripped tar.gz:

```
08:02:47  ++ ls /jenkins/workspace/scylla-master/scylla-ci/scylla/build/RelWithDebInfo/dist/tar/scylla-unstripped-6.1.0~dev-0.20240613.d5bdddaeb40b.x86_64.tar.gz
08:02:47  ls: cannot access '/jenkins/workspace/scylla-master/scylla-ci/scylla/build/RelWithDebInfo/dist/tar/scylla-unstripped-6.1.0~dev-0.20240613.d5bdddaeb40b.x86_64.tar.gz': No such file or directory`
```

so, in this change, we fix the path.

Refs #2717

---

* cmake related change, hence no need to backport.