### PR TITLE
test/py/minio_server.py: do not reference non-existent old_env

### DIFF
--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -208,8 +208,8 @@ class MinioServer:
 
     def _unset_environ(self):
         for env in self._get_environs():
-            if self.old_env[env] is not None:
-                os.environ[env] = self.old_env[env]
+            if value := self.old_env.get(env):
+                os.environ[env] = value
             else:
                 del os.environ[env]
 


### PR DESCRIPTION
in 51c53d8db6, we check `self.old_env[env]` for None, but there are chances `self.old_env` does not contain a value with `env`. in that case, we'd have following failure:

```
Traceback (most recent call last):
  File "/home/kefu/dev/scylladb/test/pylib/minio_server.py", line 307, in <module>
    asyncio.run(main())
  File "/usr/lib64/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/kefu/dev/scylladb/test/pylib/minio_server.py", line 304, in main
    await server.stop()
  File "/home/kefu/dev/scylladb/test/pylib/minio_server.py", line 274, in stop
    self._unset_environ()
  File "/home/kefu/dev/scylladb/test/pylib/minio_server.py", line 211, in _unset_environ
    if self.old_env[env] is not None:
       ~~~~~~~~~~~~^^^^^
KeyError: 'S3_CONFFILE_FOR_TEST'
```

this happens if we run `pylib/minio_server.py` as a standalone application.

in this change, instead of getting the value with index, we use `dict.get()`, so that it does not throw when the dict does not have the given key.

**Please replace this line with justification for the backport/\* labels added to this PR**