### PR TITLE
build: use default modes when no modes are selected

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2546,16 +2546,15 @@ def configure_using_cmake(args):
                    'dev': BuildType(True, 'Dev'),
                    'sanitize': BuildType(False, 'Sanitize'),
                    'coverage': BuildType(False, 'Coverage')}
-    selected_modes = list(build_modes[mode] for mode in
-                          args.selected_modes or build_modes.keys())
-    selected_configs = ';'.join(mode.cmake_build_type for mode in selected_modes)
-    default_configs = ';'.join(mode.cmake_build_type for mode in selected_modes
-                               if mode.build_by_default)
-
+    default_modes = list(name for name, mode in build_modes.items()
+                         if mode.build_by_default)
+    selected_modes = args.selected_modes or default_modes
+    selected_configs = ';'.join(build_modes[mode].cmake_build_type for mode
+                                in selected_modes)
     settings = {
         'CMAKE_CONFIGURATION_TYPES': selected_configs,
-        'CMAKE_CROSS_CONFIGS': default_configs,
-        'CMAKE_DEFAULT_CONFIGS': default_configs,
+        'CMAKE_CROSS_CONFIGS': selected_configs,
+        'CMAKE_DEFAULT_CONFIGS': selected_configs,
         'CMAKE_C_COMPILER': args.cc,
         'CMAKE_CXX_COMPILER': args.cxx,
         'CMAKE_CXX_FLAGS': args.user_cflags,


### PR DESCRIPTION
when `--use-cmake` option is passed to `configure.py`,

- before this change, all modes are selected if no `--mode` options are passed to `configure.py`.
- after this change, only the modes whose `build_by_default` is `True` are selected, if no `--mode` options are specfied.

the new behavior matches the existing behavior. otherwise, `ninja -C build mode_list` would list the mode which is not built by default.

* it's a cmake related change, hence no need to backport