### PR TITLE
sstables: use "me" sstable format by default

### DIFF
--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -93,7 +93,7 @@ private:
     // that format. read_sstables_format() also overwrites _sstables_format
     // if an sstable format was chosen earlier (and this choice was persisted
     // in the system table).
-    sstable_version_types _format = sstable_version_types::md;
+    sstable_version_types _format = sstable_version_types::me;
 
     // _active and _undergoing_close are used in scylla-gdb.py to fetch all sstables
     // on current shard using "scylla sstables" command. If those fields are renamed,


### PR DESCRIPTION
in 7952200c, we changed the `selected_format` from `mc` to `me`, but to be backward compatible the cluster starts with "md", so when the nodes in cluster agree on the "ME_SSTABLE_FORMAT" feature, the format selector believes that the node is already using "ME", which is specified by `_selected_format`. even it is actually still using "md", which is specified by `sstable_manager::_format`, as changed by 54d49c04. as explained above, it's specified to "md" to be backward compatible when upgrading from an existign installation which might be still using "md".

in other words, 7952200c introduced a regression which changed the "default" sstable format from `me` to `md`.

to address this, we just change `sstable_manager::_format` to "me", so that all sstables are created using "me" format. regarding the "backward compatibility", we can always read sstables persisted with older formats, so this concern does not hold.

a test is added accordingly.

Fixes #18995
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

needs to backport to 6.0, as 7952200c is included by 6.0 branch. and this change addresses the regression introduced by it.