### PR TITLE
auth: reuse roles select query during cache population

### DIFF
--- a/auth/service.cc
+++ b/auth/service.cc
@@ -32,6 +32,7 @@
 #include "log.hh"
 #include "schema/schema_fwd.hh"
 #include <seastar/core/future.hh>
+#include "seastar/coroutine/parallel_for_each.hh"
 #include "service/migration_manager.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "timestamp.hh"
@@ -276,34 +277,21 @@ void service::reset_authorization_cache() {
 future<permission_set>
 service::get_uncached_permissions(const role_or_anonymous& maybe_role, const resource& r) const {
     if (is_anonymous(maybe_role)) {
-        return _authorizer->authorize(maybe_role, r);
+        co_return co_await _authorizer->authorize(maybe_role, r);
     }
-
     const std::string_view role_name = *maybe_role.name;
-
-    return has_superuser(role_name).then([this, role_name, &r](bool superuser) {
-        if (superuser) {
-            return make_ready_future<permission_set>(r.applicable_permissions());
-        }
-
-        //
-        // Aggregate the permissions from all granted roles.
-        //
-
-        return do_with(permission_set(), [this, role_name, &r](auto& all_perms) {
-            return get_roles(role_name).then([this, &r, &all_perms](role_set all_roles) {
-                return do_with(std::move(all_roles), [this, &r, &all_perms](const auto& all_roles) {
-                    return parallel_for_each(all_roles, [this, &r, &all_perms](std::string_view role_name) {
-                        return _authorizer->authorize(role_name, r).then([&all_perms](permission_set perms) {
-                            all_perms = permission_set::from_mask(all_perms.mask() | perms.mask());
-                        });
-                    });
-                });
-            }).then([&all_perms] {
-                return all_perms;
-            });
-        });
+    auto superuser = co_await has_superuser(role_name);
+    if (superuser) {
+        co_return r.applicable_permissions();
+    }
+    // Aggregate the permissions from all granted roles.
+    permission_set all_perms;
+    auto all_roles = co_await get_roles(role_name);
+    co_await coroutine::parallel_for_each(all_roles, [this, &r, &all_perms](std::string_view role_name) -> future<> {
+        auto perms = co_await _authorizer->authorize(role_name, r);
+        all_perms = permission_set::from_mask(all_perms.mask() | perms.mask());
     });
+    co_return std::move(all_perms);
 }
 
 future<permission_set> service::get_permissions(const role_or_anonymous& maybe_role, const resource& r) const {

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -280,13 +280,13 @@ service::get_uncached_permissions(const role_or_anonymous& maybe_role, const res
         co_return co_await _authorizer->authorize(maybe_role, r);
     }
     const std::string_view role_name = *maybe_role.name;
-    auto superuser = co_await has_superuser(role_name);
+    auto all_roles = co_await get_roles(role_name);
+    auto superuser = co_await has_superuser(role_name, all_roles);
     if (superuser) {
         co_return r.applicable_permissions();
     }
     // Aggregate the permissions from all granted roles.
     permission_set all_perms;
-    auto all_roles = co_await get_roles(role_name);
     co_await coroutine::parallel_for_each(all_roles, [this, &r, &all_perms](std::string_view role_name) -> future<> {
         auto perms = co_await _authorizer->authorize(role_name, r);
         all_perms = permission_set::from_mask(all_perms.mask() | perms.mask());
@@ -298,14 +298,18 @@ future<permission_set> service::get_permissions(const role_or_anonymous& maybe_r
     return _permissions_cache->get(maybe_role, r);
 }
 
-future<bool> service::has_superuser(std::string_view role_name) const {
-    auto roles = co_await get_roles(role_name);
+future<bool> service::has_superuser(std::string_view role_name, const role_set& roles) const {
     for (const auto& role : roles) {
         if (co_await _role_manager->is_superuser(role)) {
             co_return true;
         }
     }
     co_return false;
+}
+
+future<bool> service::has_superuser(std::string_view role_name) const {
+    auto roles = co_await get_roles(role_name);
+    co_return co_await has_superuser(role_name, roles);
 }
 
 static void validate_authentication_options_are_supported(

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -197,6 +197,7 @@ public:
 
 private:
     future<> create_legacy_keyspace_if_missing(::service::migration_manager& mm) const;
+    future<bool> has_superuser(std::string_view role_name, const role_set& roles) const;
 };
 
 future<bool> has_superuser(const service&, const authenticated_user&);


### PR DESCRIPTION
With big number of shards in the cluster (e.g. 500+) due to cache
periodic refresh we experience high load on role_permissions table
(e.g. 1k op/s). The load on roles table is amplified because to populate
single entry in the cache we do several selects on roles table. Some
of this can't be avoided because roles are arranged in a tree-like
structure where permissions can be inherited.

This patch tries to reuse queries which are simply duplicated. It should
reduce the load on roles table by up to 50%.

Fixes scylladb/scylladb#19299
