### PR TITLE
auth: do not include unused headers

### DIFF
--- a/auth/authenticator.hh
+++ b/auth/authenticator.hh
@@ -22,9 +22,10 @@
 #include <seastar/core/shared_ptr.hh>
 
 #include "auth/authentication_options.hh"
-#include "auth/common.hh"
 #include "auth/resource.hh"
 #include "auth/sasl_challenge.hh"
+
+#include "service/raft/raft_group0_client.hh"
 
 namespace db {
     class config;

--- a/auth/common.cc
+++ b/auth/common.cc
@@ -23,7 +23,6 @@
 #include "service/migration_manager.hh"
 #include "service/raft/group0_state_machine.hh"
 #include "timeout_config.hh"
-#include "db/config.hh"
 #include "utils/error_injection.hh"
 
 namespace auth {

--- a/auth/role_manager.hh
+++ b/auth/role_manager.hh
@@ -20,7 +20,6 @@
 #include "auth/resource.hh"
 #include "seastarx.hh"
 #include "exceptions/exceptions.hh"
-#include "auth/common.hh"
 #include "service/raft/raft_group0_client.hh"
 
 namespace auth {

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -27,7 +27,6 @@
 #include "service/raft/raft_group0_client.hh"
 #include "utils/observable.hh"
 #include "utils/serialized_action.hh"
-#include "db/config.hh"
 #include "service/maintenance_mode.hh"
 
 namespace cql3 {

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -8,6 +8,7 @@
 #include "service/raft/raft_sys_table_storage.hh"
 
 #include "cql3/untyped_result_set.hh"
+#include "db/config.hh"
 #include "db/system_keyspace.hh"
 #include "utils/UUID.hh"
 #include "utils/error_injection.hh"

--- a/test/boost/cache_algorithm_test.cc
+++ b/test/boost/cache_algorithm_test.cc
@@ -9,6 +9,7 @@
 #include <fmt/ranges.h>
 #include <seastar/testing/test_case.hh>
 #include "test/lib/cql_test_env.hh"
+#include "db/config.hh"
 
 // These tests are slow, and tuned to a particular amount of memory
 // (and --memory is ignored in debug mode).

--- a/test/boost/commitlog_cleanup_test.cc
+++ b/test/boost/commitlog_cleanup_test.cc
@@ -11,6 +11,7 @@
 #include "test/lib/cql_test_env.hh"
 #include "db/commitlog/commitlog_replayer.hh"
 #include "db/commitlog/commitlog.hh"
+#include "db/config.hh"
 
 // Test that `canonical_token_range(tr)` contains the same tokens as `tr`.
 SEASTAR_TEST_CASE(test_canonical_token_range) {


### PR DESCRIPTION
also add `auth` to iwyu's CLEANER_DIR

----

it's a cleanup, hence no need to backport.