### PR TITLE
db: remove unused operator<<

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -2387,20 +2387,6 @@ future<> db::commitlog::segment_manager::do_pending_deletes() {
     deleting_done.set_value();
 }
 
-namespace db {
-
-std::ostream& operator<<(std::ostream& os, const commitlog::segment_manager::named_file& f) {
-    fmt::print(os, "{}", f);
-    return os;
-}
-
-std::ostream& operator<<(std::ostream& os, commitlog::segment_manager::dispose_mode mode) {
-    fmt::print(os, "{}", mode);
-    return os;
-}
-
-}
-
 future<> db::commitlog::segment_manager::orphan_all() {
     _segments.clear();
     return clear_reserve_segments();

--- a/db/hints/host_filter.cc
+++ b/db/hints/host_filter.cc
@@ -68,11 +68,6 @@ host_filter host_filter::parse_from_dc_list(sstring opt) {
     return host_filter(std::unordered_set<sstring>(dcs.begin(), dcs.end()));
 }
 
-std::ostream& operator<<(std::ostream& os, const host_filter& f) {
-    fmt::print(os, "{}", f);
-    return os;
-}
-
 std::istream& operator>>(std::istream& is, host_filter& f) {
     sstring tmp;
     is >> tmp;

--- a/db/hints/host_filter.hh
+++ b/db/hints/host_filter.hh
@@ -85,7 +85,6 @@ public:
     friend fmt::formatter<host_filter>;
 };
 
-std::ostream& operator<<(std::ostream& os, const host_filter& f);
 std::istream& operator>>(std::istream& is, host_filter& f);
 
 class hints_configuration_parse_error : public std::runtime_error {


### PR DESCRIPTION
since we've switched almost all callers of the operator<< to {fmt}, let's drop the unused operator<<:s.

---

it's a cleanup, hence no needs to backport.