### PR TITLE
build: cmake: add commitlog_cleanup_test

### DIFF
--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -60,6 +60,8 @@ add_scylla_test(column_mapping_test
   KIND SEASTAR)
 add_scylla_test(commitlog_test
   KIND SEASTAR)
+add_scylla_test(commitlog_cleanup_test
+  KIND SEASTAR)
 add_scylla_test(compaction_group_test
   KIND SEASTAR)
 add_scylla_test(compound_test


### PR DESCRIPTION
in 94cdfcaa94, we added commitlog_cleanup_test to `configure.py`, but didn't add it to the CMake building system.

in this change, let's add it to the CMake building system.

---

cmake related change, hence no need to backport.