### PR TITLE
test: unflake test test_alternator_ttl_scheduling_group

### DIFF
--- a/test/topology_experimental_raft/test_alternator.py
+++ b/test/topology_experimental_raft/test_alternator.py
@@ -173,10 +173,10 @@ async def test_alternator_ttl_scheduling_group(alternator3):
     # so "ratio" calculate below should be tiny, even exactly zero. Before
     # issue #18719 was fixed, it was not tiny at all - 0.58.
     # Just in case there are other unknown things happening, let's assert it
-    # is <0.01 instead of zero.
+    # is <0.1 instead of zero.
     ms_streaming = ms_streaming_after - ms_streaming_before
     ms_statement = ms_statement_after - ms_statement_before
     ratio = ms_statement / ms_streaming
-    assert ratio < 0.01
+    assert ratio < 0.1
 
     table.delete()


### PR DESCRIPTION
This test in topology_experimental_raft/test_alternator.py wants to check that during Alternator TTL's expiration scans, ALL of the CPU was used in the "streaming" scheduling group and not in the "statement" scheduling group. But to allow for some fluke requests (e.g., from the driver), the test actually allows work in the statement group to be up to 1% of the work.

Unfortunately, in one test run - a very slow debug+aarch64 run - we saw the work on the statement group reach 1.4%, failing the test. I don't know exactly where this work comes from, perhaps the driver, but before this bug was fixed we saw more than 58% of the work in the wrong scheduling group, so neither 1% or 1.4% is a sign that the bug came back. In fact, let's just change the threshold in the test to 10%, which is also much lower than the pre-fix value of 58%, so is still a valid regression test.

Fixes #19307

This fix can be backported to whichever branches that this test was backported to, which is 6.0 and 5.4 (note that in 5.4, the test was moved to a different directory).