### PR TITLE
dbuild: update toolchain to get latest scylla-api-client

### DIFF
--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-38-20240521
+docker.io/scylladb/scylla-toolchain:fedora-38-20240616


### PR DESCRIPTION
a new Scylla-API-client was released to get proper license information in our SBOM report,

Refs: https://github.com/scylladb/scylla-jmx/issues/237

**This change is needed for 2024.1 SBOM report (and maybe also for 2023.1) , since it's a toolchain update, we should probably do it directly on the branch**