### PR TITLE
dist/common/scripts/scylla_coredump_setup: fix typo

### DIFF
--- a/dist/common/scripts/scylla_coredump_setup
+++ b/dist/common/scripts/scylla_coredump_setup
@@ -110,7 +110,7 @@ WantedBy=local-fs.target scylla-server.service
         try:
             coreinfo = run('coredumpctl --no-pager --no-legend info {}'.format(pid), shell=True, check=True, capture_output=True, encoding='utf-8').stdout.strip()
         except subprocess.CalledProcessError:
-            print('Does not able to detect coredump, failed to configure systemd-coredump.')
+            print('Unable to detect coredump, failed to configure systemd-coredump.')
             sys.exit(1)
 
         print(coreinfo)


### PR DESCRIPTION
Does not able -> Unable

**Tiny typo, no need to backport**