### PR TITLE
mutation: silence false alarm from clang-tidy

### DIFF
--- a/mutation/async_utils.cc
+++ b/mutation/async_utils.cc
@@ -27,6 +27,8 @@ future<> apply_gently(mutation_partition& target, const schema& s, mutation_part
         p2.upgrade(p_schema, s);
     }
     apply_resume res;
+    // we only move from p2.static_row() in the first iteration when target.static_row() is empty
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     while (target.apply_monotonically(s, std::move(p2), no_cache_tracker, app_stats, is_preemptible::yes, res) == stop_iteration::no) {
         co_await yield();
     }
@@ -39,6 +41,8 @@ future<> apply_gently(mutation_partition& target, const schema& s, const mutatio
         p2.upgrade(p_schema, s);
     }
     apply_resume res;
+    // we only move from p2.static_row() in the first iteration when target.static_row() is empty
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     while (target.apply_monotonically(s, std::move(p2), no_cache_tracker, app_stats, is_preemptible::yes, res) == stop_iteration::no) {
         co_await yield();
     }
@@ -46,6 +50,8 @@ future<> apply_gently(mutation_partition& target, const schema& s, const mutatio
 
 future<> apply_gently(mutation_partition& target, const schema& s, mutation_partition&& p, mutation_application_stats& app_stats) {
     apply_resume res;
+    // we only move from p2.static_row() in the first iteration when target.static_row() is empty
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     while (target.apply_monotonically(s, std::move(p), no_cache_tracker, app_stats, is_preemptible::yes, res) == stop_iteration::no) {
         co_await yield();
     }


### PR DESCRIPTION
before this change, because it seems that we move away from `p2` in each iteration, so the succeeding iterations are moving from an empty `p2`, clang-tidy warns at seeing this.

but we only move from `p2._static_row` in the first iteration when the dest `mutation_partition` instance's static row is empty. and in the succeeding iterations, the dest `mutation_partition` instance's static row is not empty anymore if it is set. so, this is a false alarm.

in this change, we silence this warning. another option is to extract the single-shot mutation out of the loop, and pass the `std::move(p2)` only for the single-shot mutation, but that'd be a much more intrusive change. we can revisit this later.

---

no need to backport. it is a cleanup silencing warnings from a lint tool.