### PR TITLE
schema: Make "describe" use extensions to string

### DIFF
--- a/db/paxos_grace_seconds_extension.hh
+++ b/db/paxos_grace_seconds_extension.hh
@@ -55,6 +55,10 @@ public:
         return ser::serialize_to_buffer<bytes>(_paxos_gc_sec);
     }
 
+    std::string options_to_string() const override {
+        return std::to_string(_paxos_gc_sec);
+    }
+
     static int32_t deserialize(const bytes_view& buffer) {
         return ser::deserialize_from_buffer(buffer, boost::type<int32_t>());
     }

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -801,6 +801,16 @@ std::ostream& operator<<(std::ostream& os, const schema& s) {
     return os;
 }
 
+// default impl assumes options are in a map.
+// implementations should override if not
+std::string schema_extension::options_to_string() const {
+    std::ostringstream ss;
+    ss << '{';
+    map_as_cql_param(ss, ser::deserialize_from_buffer(serialize(), boost::type<default_map_type>(), 0));
+    ss << '}';
+    return ss.str();
+}
+
 static std::ostream& column_definition_as_cql_key(std::ostream& os, const column_definition & cd) {
     os << cd.name_as_cql_string();
     os << " " << cd.type->cql3_type_name();

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -993,15 +993,9 @@ std::ostream& schema::schema_properties(replica::database& db, std::ostream& os)
     os << "\n    AND memtable_flush_period_in_ms = " << memtable_flush_period();
     os << "\n    AND min_index_interval = " << min_index_interval();
     os << "\n    AND speculative_retry = '" << speculative_retry().to_sstring() << "'";
-    os << "\n    AND paxos_grace_seconds = " << paxos_grace_seconds().count();
-    os << "\n    AND tombstone_gc = {";
-    map_as_cql_param(os, tombstone_gc_options().to_map());
-    os << "}";
     
-    if (cdc_options().enabled()) {
-        os << "\n    AND cdc = {";
-        map_as_cql_param(os, cdc_options().to_map());
-        os << "}";
+    for (auto& [type, ext] : extensions()) {
+        os << "\n    AND " << type << " = " << ext->options_to_string();
     }
     if (is_view() && !is_index(db, view_info()->base_id(), *this)) {
         auto is_sync_update = db::find_tag(*this, db::SYNCHRONOUS_VIEW_UPDATES_TAG_KEY);

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -534,6 +534,10 @@ public:
     virtual bool is_placeholder() const {
         return false;
     }
+    using default_map_type = std::map<sstring, sstring>;
+    // default impl assumes options are in a map.
+    // implementations should override if not
+    virtual std::string options_to_string() const;
 };
 
 struct schema_static_props {


### PR DESCRIPTION
Fixes #19334

Current impl uses hardcoded printing of a few extensions.
Instead, use extension options to string and print all.

Note: required to make enterprise CI happy again.