### PR TITLE
mv: delete a partition in a single operation when applicable

### DIFF
--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -223,8 +223,13 @@ public:
     future<> move_to(utils::chunked_vector<frozen_mutation_and_schema>& mutations);
 
     void generate_update(data_dictionary::database db, const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing, gc_clock::time_point now);
+    void generate_partition_tombstone_update(data_dictionary::database db, const partition_key& base_key, tombstone partition_tomb);
 
     size_t op_count() const;
+
+    bool is_partition_key_permutation_of_base_partition_key() const;
+
+    std::optional<partition_key> construct_view_partition_key_from_base(const partition_key& base_pk);
 
 private:
     mutation_partition& partition_for(partition_key&& key);
@@ -233,7 +238,7 @@ private:
         deletable_row* _row;
         view_key_and_action::action _action;
     };
-    std::vector<view_row_entry> get_view_rows(const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing);
+    std::vector<view_row_entry> get_view_rows(const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing, row_tombstone update_tomb);
     bool can_skip_view_updates(const clustering_or_static_row& update, const clustering_or_static_row& existing) const;
     void create_entry(data_dictionary::database db, const partition_key& base_key, const clustering_or_static_row& update, gc_clock::time_point now);
     void delete_old_entry(data_dictionary::database db, const partition_key& base_key, const clustering_or_static_row& existing, const clustering_or_static_row& update, gc_clock::time_point now);

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -223,7 +223,7 @@ public:
     future<> move_to(utils::chunked_vector<frozen_mutation_and_schema>& mutations);
 
     void generate_update(data_dictionary::database db, const partition_key& base_key, const clustering_or_static_row& update, const std::optional<clustering_or_static_row>& existing, gc_clock::time_point now);
-    void generate_partition_tombstone_update(data_dictionary::database db, const partition_key& base_key, tombstone partition_tomb);
+    bool generate_partition_tombstone_update(data_dictionary::database db, const partition_key& base_key, tombstone partition_tomb);
 
     size_t op_count() const;
 
@@ -262,6 +262,7 @@ class view_update_builder {
     mutation_fragment_v2_opt _existing;
     gc_clock::time_point _now;
     partition_key _key = partition_key::make_empty();
+    bool _skip_row_updates = false;
 public:
 
     view_update_builder(data_dictionary::database db, const replica::table& base, schema_ptr s,

--- a/test/cql-pytest/util.py
+++ b/test/cql-pytest/util.py
@@ -11,6 +11,7 @@ import random
 import time
 import socket
 import os
+import requests
 import collections
 import ssl
 from contextlib import contextmanager
@@ -336,3 +337,35 @@ class config_value_context:
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self._cql.execute(self._update, (self._original_value, self._key))
+
+class ScyllaMetrics:
+    def __init__(self, lines):
+        self._lines = lines
+    @staticmethod
+    def query(cql):
+        url = f'http://{cql.cluster.contact_points[0]}:9180/metrics'
+        return ScyllaMetrics(requests.get(url).text.split('\n'))
+    def get(self, name, labels = None, shard='total'):
+        result = None
+        for l in self._lines:
+            if not l.startswith(name):
+                continue
+            labels_start = l.find('{')
+            labels_finish = l.find('}')
+            if labels_start == -1 or labels_finish == -1:
+                raise ValueError(f'invalid metric format [{l}]')
+            def match_kv(kv):
+                key, val = kv.split('=')
+                val = val.strip('"')
+                return shard == 'total' or val == shard if key == 'shard' \
+                    else labels is None or labels.get(key, None) == val
+            match = all(match_kv(kv) for kv in l[labels_start + 1:labels_finish].split(','))
+            if match:
+                value = float(l[labels_finish + 2:])
+                if result is None:
+                    result = value
+                else:
+                    result += value
+                if shard != 'total':
+                    break
+        return result

--- a/view_info.hh
+++ b/view_info.hh
@@ -24,6 +24,10 @@ class view_info final {
     mutable std::optional<query::partition_slice> _partition_slice;
     db::view::base_info_ptr _base_info;
     mutable bool _has_computed_column_depending_on_base_non_primary_key;
+
+    // True if the partition key columns of the view are the same as the
+    // partition key columns of the base, maybe in a different order.
+    mutable bool _is_partition_key_permutation_of_base_partition_key;
 public:
     view_info(const schema& schema, const raw_view_info& raw_view_info);
 
@@ -54,6 +58,10 @@ public:
     bool has_base_non_pk_columns_in_view_pk() const;
     bool has_computed_column_depending_on_base_non_primary_key() const {
         return _has_computed_column_depending_on_base_non_primary_key;
+    }
+
+    bool is_partition_key_permutation_of_base_partition_key() const {
+        return _is_partition_key_permutation_of_base_partition_key;
     }
 
     /// Returns a pointer to the base_dependent_view_info which matches the current


### PR DESCRIPTION
Currently when a partition is deleted from the base table, we generate a
row tombstone update for each one of the view rows in the partition.

When the partition key in the view is the same as the base, maybe in a
different order, this can be done more efficiently - The whole corresponding
view partition can be deleted with one partition tombstone update.

With this commit, when generating view updates, if the update mutation has a
partition tombstone then for the views which have the same partition key
we will generate a partition tombstone update, and skip the individual
row tombstone updates.

Fixes #8199 