### PR TITLE
test: unbreak test/{cql-pytest,alternator}/run

### DIFF
--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -14,7 +14,6 @@ import boto3
 import requests
 import re
 
-from test.pylib.report_plugin import ReportPlugin
 from test.alternator.util import create_test_table, is_aws, scylla_log
 from urllib.parse import urlparse
 from functools import cache
@@ -50,13 +49,8 @@ def pytest_addoption(parser):
         help='Omit scylla\'s output from the test output')
     parser.addoption('--host', action='store', default='localhost',
         help='Scylla server host to connect to')
-    parser.addoption('--mode', action='store', required=True,
-                     help='Scylla build mode. Tests can use it to adjust their behavior.')
-    parser.addoption('--run_id', action='store', default=1,
-                     help='Run id for the test run')
 def pytest_configure(config):
     config.addinivalue_line("markers", "veryslow: mark test as very slow to run")
-    config.pluginmanager.register(ReportPlugin())
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--runveryslow"):

--- a/test/cql-pytest/conftest.py
+++ b/test/cql-pytest/conftest.py
@@ -21,9 +21,6 @@ import tempfile
 import time
 import random
 
-import sys
-sys.path.insert(1, sys.path[0] + '/../..')
-from test.pylib.report_plugin import ReportPlugin
 from util import unique_name, new_test_keyspace, keyspace_has_tablets, cql_session, local_process_id, is_scylla
 
 
@@ -45,10 +42,6 @@ def pytest_addoption(parser):
     # presence.
     parser.addoption('--omit-scylla-output', action='store_true',
         help='Omit scylla\'s output from the test output')
-    parser.addoption('--mode', action='store', required=True,
-                     help='Scylla build mode. Tests can use it to adjust their behavior.')
-    parser.addoption('--run_id', action='store', default=1,
-                     help='Run id for the test run')
 
 # "cql" fixture: set up client object for communicating with the CQL API.
 # The host/port combination of the server are determined by the --host and
@@ -269,7 +262,3 @@ def has_tablets(cql):
 def skip_without_tablets(scylla_only, has_tablets):
     if not has_tablets:
         pytest.skip("Test needs tablets experimental feature on")
-
-
-def pytest_configure(config):
-    config.pluginmanager.register(ReportPlugin())


### PR DESCRIPTION
Commit 8d1d206aff1 introduced changes which broke test/cql-pytest/run and test/alternator/run (these scripts no longer run), and are very foreign to those test frameworks:

That patch introduced new mandatory options like "--mode", and introduced some sort of registration into some test.py machinary. Remember that these tests DO NOT need to run against Scylla at all - they can be run against AWS DynamoDB or Cassandra or some other CQL/DynamoDB clone - and the concept of "build mode" is completely unrelated to what they do.

So this patch basically reverts what these patches did to the test/{cql-pytest,alternator}/conftest.py.

I did not revert changes to any other test directories (which I care less about being broken).
