### PR TITLE
main,proxy: Drain proxy in its stop_remote

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1700,11 +1700,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 lifecycle_notifier.local().register_subscriber(&local_proxy);
             }).get();
 
-            auto drain_proxy = defer_verbose_shutdown("drain storage proxy", [&proxy, &lifecycle_notifier] {
+            auto unsubscribe_proxy = defer_verbose_shutdown("unsubscribe storage proxy", [&proxy, &lifecycle_notifier] {
                 proxy.invoke_on_all([&lifecycle_notifier] (service::storage_proxy& local_proxy) mutable {
-                    return lifecycle_notifier.local().unregister_subscriber(&local_proxy).finally([&local_proxy] {
-                        return local_proxy.drain_on_shutdown();
-                    });
+                    return lifecycle_notifier.local().unregister_subscriber(&local_proxy);
                 }).get();
             });
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6440,6 +6440,7 @@ void storage_proxy::start_remote(netw::messaging_service& ms, gms::gossiper& g, 
 }
 
 future<> storage_proxy::stop_remote() {
+    co_await drain_on_shutdown();
     co_await _remote->stop();
     _remote = nullptr;
 }

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -546,6 +546,7 @@ private:
     }
 
     mutation do_get_batchlog_mutation_for(schema_ptr schema, const std::vector<mutation>& mutations, const utils::UUID& id, int32_t version, db_clock::time_point now);
+    future<> drain_on_shutdown();
 public:
     // Applies mutation on this node.
     // Resolves with timed_out_error when timeout is reached.
@@ -695,7 +696,6 @@ public:
     future<> stop();
     future<> start_hints_manager(shared_ptr<gms::gossiper>);
     void allow_replaying_hints() noexcept;
-    future<> drain_on_shutdown();
     future<> abort_view_writes();
 
     future<> change_hints_host_filter(db::hints::host_filter new_filter);


### PR DESCRIPTION
Currently proxy initialization is pretty disperse, in particular it's stopped in several steps -- first drain_on_shutdown() then stop_remote(). In between there's nothing that needs proxy in any particular sate, so those two steps can be merged into one.

refs: #2737
