### PR TITLE
treewide: remove unused operator<<

### DIFF
--- a/dht/decorated_key.hh
+++ b/dht/decorated_key.hh
@@ -84,8 +84,6 @@ public:
 
 using decorated_key_opt = std::optional<decorated_key>;
 
-std::ostream& operator<<(std::ostream& out, const decorated_key& t);
-
 } // namespace dht
 
 namespace std {

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -78,11 +78,6 @@ static_sharder::next_shard_for_reads(const token& t) const {
     return next_shard(t);
 }
 
-std::ostream& operator<<(std::ostream& out, const decorated_key& dk) {
-    fmt::print(out, "{}", dk);
-    return out;
-}
-
 std::unique_ptr<dht::i_partitioner> make_partitioner(sstring partitioner_name) {
     try {
         return create_object<i_partitioner>(partitioner_name);

--- a/gms/application_state.cc
+++ b/gms/application_state.cc
@@ -41,11 +41,6 @@ static const std::map<application_state, sstring> application_state_names = {
     {application_state::SNITCH_NAME,            "SNITCH_NAME"},
 };
 
-std::ostream& operator<<(std::ostream& os, const application_state& m) {
-    fmt::print(os, "{}", m);
-    return os;
-}
-
 }
 
 auto fmt::formatter<gms::application_state>::format(gms::application_state m,

--- a/gms/application_state.hh
+++ b/gms/application_state.hh
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include <iosfwd>
 #include <fmt/core.h>
 
 namespace gms {
@@ -40,8 +39,6 @@ enum class application_state {
     CDC_GENERATION_ID,
     SNITCH_NAME,
 };
-
-std::ostream& operator<<(std::ostream& os, const application_state& m);
 
 }
 

--- a/gms/endpoint_state.cc
+++ b/gms/endpoint_state.cc
@@ -36,11 +36,6 @@ const versioned_value* endpoint_state::get_application_state_ptr(application_sta
     }
 }
 
-std::ostream& operator<<(std::ostream& os, const endpoint_state& x) {
-    fmt::print(os, "{}", x);
-    return os;
-}
-
 bool endpoint_state::is_cql_ready() const noexcept {
     auto* app_state = get_application_state_ptr(application_state::RPC_READY);
     if (!app_state) {

--- a/gms/endpoint_state.hh
+++ b/gms/endpoint_state.hh
@@ -162,8 +162,6 @@ public:
     friend fmt::formatter<endpoint_state>;
 };
 
-std::ostream& operator<<(std::ostream& os, const endpoint_state& x);
-
 using endpoint_state_ptr = lw_shared_ptr<const endpoint_state>;
 
 inline endpoint_state_ptr make_endpoint_state_ptr(const endpoint_state& eps) {

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2721,11 +2721,6 @@ locator::token_metadata_ptr gossiper::get_token_metadata_ptr() const noexcept {
     return _shared_token_metadata.get();
 }
 
-std::ostream& operator<<(std::ostream& os, const loaded_endpoint_state& st) {
-    fmt::print(os, "{}", st);
-    return os;
-}
-
 } // namespace gms
 
 auto fmt::formatter<gms::loaded_endpoint_state>::format(const gms::loaded_endpoint_state& st, fmt::format_context& ctx) const -> decltype(ctx.out()) {

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -82,8 +82,6 @@ struct loaded_endpoint_state {
     std::optional<gms::versioned_value> opt_status;
 };
 
-std::ostream& operator<<(std::ostream& os, const loaded_endpoint_state& st);
-
 /**
  * This module is responsible for Gossiping information for the local endpoint. This abstraction
  * maintains the list of live and dead endpoints. Periodically i.e. every 1 second this module

--- a/gms/inet_address.cc
+++ b/gms/inet_address.cc
@@ -31,8 +31,3 @@ future<gms::inet_address> gms::inet_address::lookup(sstring name, opt_family fam
         return gms::inet_address(h.addr_list.front());
     });
 }
-
-std::ostream& gms::operator<<(std::ostream& os, const inet_address& x) {
-    fmt::print(os, "{}", x);
-    return os;
-}

--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -73,8 +73,6 @@ public:
     static future<inet_address> lookup(sstring, opt_family family = {}, opt_family preferred = {});
 };
 
-std::ostream& operator<<(std::ostream& os, const inet_address& x);
-
 }
 
 namespace std {

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -201,11 +201,4 @@ template <> struct fmt::formatter<gms::versioned_value> : fmt::formatter<string_
     auto format(const gms::versioned_value& v, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "Value({},{})", v.value(), v.version());
     }
- };
-
-namespace gms {
-inline std::ostream& operator<<(std::ostream& os, const versioned_value& v) {
-    fmt::print(os, "{}", v);
-    return os;
-}
-}
+};

--- a/lang/wasm_instance_cache.cc
+++ b/lang/wasm_instance_cache.cc
@@ -287,10 +287,6 @@ future<> instance_cache::stop() {
 
 namespace std {
 
-inline std::ostream& operator<<(std::ostream& out, const seastar::scheduling_group& sg) {
-    return out << sg.name();
-}
-
 template <>
 struct equal_to<seastar::scheduling_group> {
     bool operator()(seastar::scheduling_group& sg1, seastar::scheduling_group& sg2) const noexcept {

--- a/node_ops/node_ops_ctl.hh
+++ b/node_ops/node_ops_ctl.hh
@@ -116,8 +116,6 @@ struct node_ops_cmd_request {
     }
 };
 
-std::ostream& operator<<(std::ostream& out, const node_ops_cmd_request& req);
-
 struct node_ops_cmd_response {
     // Mandatory field, set by all cmds
     bool ok;

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -474,7 +474,7 @@ SEASTAR_THREAD_TEST_CASE(test_primary_key_logging) {
         auto actual_i = results.begin();
         auto actual_end = results.end();
         auto assert_row = [&] (int pk, int pk2, int ck = -1, int ck2 = -1, std::optional<int64_t> ttl = {}) {
-            std::cerr << "check " << pk << " " << pk2 << " " << ck << " " << ck2 << " " << ttl << std::endl;
+            fmt::print(std::cerr, "check {} {} {} {} {}\n", pk, pk2, ck, ck2, ttl);
             BOOST_REQUIRE(actual_i != actual_end);
             auto& actual_row = *actual_i;
             BOOST_REQUIRE_EQUAL(int32_type->decompose(pk), actual_row[1]);

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -52,7 +52,7 @@ void print_natural_endpoints(double point, const inet_address_vector_replica_set
     std::ostringstream strm(str);
 
     for (auto& addr : v) {
-        strm<<addr<<" ";
+        fmt::print(strm, "{} ", addr);
     }
 
     testlog.debug("{}", strm.str());

--- a/test/boost/serialization_test.cc
+++ b/test/boost/serialization_test.cc
@@ -7,6 +7,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#define BOOST_TEST_MODULE test-serialization
+#include <boost/test/unit_test.hpp>
+
 #include <iostream>
 #include <assert.h>
 #include <sstream>
@@ -16,10 +19,8 @@
 #include "types/types.hh"
 #include "gms/inet_address.hh"
 #include "gms/inet_address_serializer.hh"
+#include "test/lib/test_utils.hh"
 #include "serializer_impl.hh"
-
-#define BOOST_TEST_MODULE test-serialization
-#include <boost/test/unit_test.hpp>
 
 void show(std::stringstream &ss) {
 	char c;

--- a/test/boost/types_test.cc
+++ b/test/boost/types_test.cc
@@ -24,6 +24,7 @@
 #include "types/list.hh"
 #include "types/set.hh"
 #include "test/lib/exception_utils.hh"
+#include "test/lib/test_utils.hh"
 
 using namespace std::literals::chrono_literals;
 using namespace std::literals::string_view_literals;

--- a/types/types.cc
+++ b/types/types.cc
@@ -3724,11 +3724,6 @@ auto fmt::formatter<data_value>::format(const data_value& v,
     return fmt::format_to(ctx.out(), "{}", v.type()->to_string_impl(v));
 }
 
-std::ostream& operator<<(std::ostream& out, const data_value& v) {
-    fmt::print(out, "{}", v);
-    return out;
-}
-
 shared_ptr<const reversed_type_impl> reversed_type_impl::get_instance(data_type type) {
     return intern::get_instance(std::move(type));
 }

--- a/types/types.hh
+++ b/types/types.hh
@@ -1047,7 +1047,4 @@ template <> struct fmt::formatter<data_value> {
     auto format(const data_value&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-std::ostream& operator<<(std::ostream& out, const data_value& v);
-
 using data_value_list = std::initializer_list<data_value_or_unset>;
-


### PR DESCRIPTION
since we've switched almost all callers of the operator<< to {fmt}, let's drop the unused operator<<:s.
there are more occurrences of unused operator<< in the tree, but let's do the cleanup piecemeal.

---

this is a cleanup, so no need to backport