### PR TITLE
[Backport 5.4] : Fix usage of utils/chunked_vector::reserve_partial

### DIFF
--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -180,13 +180,12 @@ BOOST_AUTO_TEST_CASE(tests_reserve_partial) {
     auto size_dist = std::uniform_int_distribution<unsigned>(1, 1 << 12);
 
     for (int i = 0; i < 100; ++i) {
-        utils::chunked_vector<uint8_t> v;
-        const auto orig_size = size_dist(rand);
-        auto size = orig_size;
-        while (size) {
-            size = v.reserve_partial(size);
+        utils::chunked_vector<uint8_t, 512> v;
+        const auto size = size_dist(rand);
+        while (v.capacity() != size) {
+            v.reserve_partial(size);
         }
-        BOOST_REQUIRE_EQUAL(v.capacity(), orig_size);
+        BOOST_REQUIRE_EQUAL(v.capacity(), size);
     }
 }
 

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -81,7 +81,7 @@ private:
         }
     }
     void do_reserve_for_push_back();
-    size_t make_room(size_t n, bool stop_after_one);
+    void make_room(size_t n, bool stop_after_one);
     chunk_ptr new_chunk(size_t n);
     T* addr(size_t i) const {
         return &_chunks[i / max_chunk_capacity()][i % max_chunk_capacity()];
@@ -177,22 +177,19 @@ public:
     ///
     /// Allows reserving the memory chunk-by-chunk, avoiding stalls when a lot of
     /// chunks are needed. To drive the reservation to completion, call this
-    /// repeatedly with the value returned from the previous call until it
-    /// returns 0, yielding between calls when necessary. Example usage:
+    /// repeatedly until the vector's capacity reaches the expected size, yielding
+    /// between calls when necessary. Example usage:
     ///
-    ///     return do_until([&size] { return !size; }, [&my_vector, &size] () mutable {
-    ///         size = my_vector.reserve_partial(size);
+    ///     return do_until([&my_vector, size] { return my_vector.capacity() == size; }, [&my_vector, size] () mutable {
+    ///         my_vector.reserve_partial(size);
     ///     });
     ///
     /// Here, `do_until()` takes care of yielding between iterations when
     /// necessary.
-    ///
-    /// \returns the memory that remains to be reserved
-    size_t reserve_partial(size_t n) {
+    void reserve_partial(size_t n) {
         if (n > _capacity) {
-            return make_room(n, true);
+            make_room(n, true);
         }
-        return 0;
     }
 
     size_t memory_size() const {
@@ -402,7 +399,7 @@ chunked_vector<T, max_contiguous_allocation>::migrate(T* begin, T* end, T* resul
 }
 
 template <typename T, size_t max_contiguous_allocation>
-size_t
+void
 chunked_vector<T, max_contiguous_allocation>::make_room(size_t n, bool stop_after_one) {
     // First, if the last chunk is below max_chunk_capacity(), enlarge it
 
@@ -434,7 +431,6 @@ chunked_vector<T, max_contiguous_allocation>::make_room(size_t n, bool stop_afte
         _capacity += now;
         stop = stop_after_one;
     }
-    return (n - _capacity);
 }
 
 template <typename T, size_t max_contiguous_allocation>

--- a/utils/large_bitset.cc
+++ b/utils/large_bitset.cc
@@ -7,31 +7,23 @@
  */
 
 #include "large_bitset.hh"
-#include <algorithm>
 #include <seastar/core/align.hh>
 #include <seastar/core/thread.hh>
-#include "seastarx.hh"
 
 using namespace seastar;
 
 large_bitset::large_bitset(size_t nr_bits) : _nr_bits(nr_bits) {
     assert(thread::running_in_thread());
 
-    const size_t orig_nr_ints = align_up(nr_bits, bits_per_int()) / bits_per_int();
-    auto nr_ints = orig_nr_ints;
-    while (nr_ints) {
-        nr_ints = _storage.reserve_partial(nr_ints);
-        if (need_preempt()) {
-            thread::yield();
-        }
+    size_t nr_ints = align_up(nr_bits, bits_per_int()) / bits_per_int();
+    while (_storage.capacity() != nr_ints) {
+        _storage.reserve_partial(nr_ints);
+        thread::maybe_yield();
     }
-    nr_ints = orig_nr_ints;
     while (nr_ints) {
         _storage.push_back(0);
         --nr_ints;
-        if (need_preempt()) {
-            thread::yield();
-        }
+        thread::maybe_yield();
     }
 }
 
@@ -40,8 +32,6 @@ large_bitset::clear() {
     assert(thread::running_in_thread());
     for (auto&& pos: _storage) {
         pos = 0;
-        if (need_preempt()) {
-            thread::yield();
-        }
+        thread::maybe_yield();
     }
 }

--- a/utils/lsa/chunked_managed_vector.hh
+++ b/utils/lsa/chunked_managed_vector.hh
@@ -48,7 +48,7 @@ private:
         }
     }
     void do_reserve_for_push_back();
-    size_t make_room(size_t n, bool stop_after_one);
+    void make_room(size_t n, bool stop_after_one);
     chunk_ptr new_chunk(size_t n);
     const T* addr(size_t i) const {
         return &_chunks[i / max_chunk_capacity()][i % max_chunk_capacity()];
@@ -148,22 +148,19 @@ public:
     ///
     /// Allows reserving the memory chunk-by-chunk, avoiding stalls when a lot of
     /// chunks are needed. To drive the reservation to completion, call this
-    /// repeatedly with the value returned from the previous call until it
-    /// returns 0, yielding between calls when necessary. Example usage:
+    /// repeatedly until the vector's capacity reaches the expected size, yielding
+    /// between calls when necessary. Example usage:
     ///
-    ///     return do_until([&size] { return !size; }, [&my_vector, &size] () mutable {
-    ///         size = my_vector.reserve_partial(size);
+    ///     return do_until([&my_vector, size] { return my_vector.capacity() == size; }, [&my_vector, size] () mutable {
+    ///         my_vector.reserve_partial(size);
     ///     });
     ///
     /// Here, `do_until()` takes care of yielding between iterations when
     /// necessary.
-    ///
-    /// \returns the memory that remains to be reserved
-    size_t reserve_partial(size_t n) {
+    void reserve_partial(size_t n) {
         if (n > _capacity) {
             return make_room(n, true);
         }
-        return 0;
     }
 
     size_t memory_size() const {
@@ -359,7 +356,7 @@ chunked_managed_vector<T>::migrate(T* begin, T* end, managed_vector<T>& result) 
 }
 
 template <typename T>
-size_t
+void
 chunked_managed_vector<T>::make_room(size_t n, bool stop_after_one) {
     // First, if the last chunk is below max_chunk_capacity(), enlarge it
 
@@ -391,7 +388,6 @@ chunked_managed_vector<T>::make_room(size_t n, bool stop_after_one) {
         _capacity += now;
         stop = stop_after_one;
     }
-    return (n - _capacity);
 }
 
 template <typename T>


### PR DESCRIPTION
The method reserve_partial(), when used as documented, quits before the intended capacity can be reserved fully. This can lead to overallocation of memory in the last chunk when data is inserted to the chunked vector. The method itself doesn't have any bug but the way it is being used by the callers needs to be updated to get the desired behaviour.

Instead of calling it repeatedly with the value returned from the previous call until it returns zero, it should be repeatedly called with the intended size until the vector's capacity reaches that size.

This PR updates the method comment and all the callers to use the right way.

Fixes #19254

Closes scylladb/scylladb#19279

* github.com:scylladb/scylladb:
  utils/large_bitset: remove unused includes identified by clangd
  utils/large_bitset: use thread::maybe_yield()
  test/boost/chunked_managed_vector_test: fix testcase tests_reserve_partial
  utils/lsa/chunked_managed_vector: fix reserve_partial()
  utils/chunked_vector: return void from reserve_partial and make_room
  test/boost/chunked_vector_test: fix testcase tests_reserve_partial
  utils/chunked_vector::reserve_partial: fix usage in callers

(cherry picked from commit b2ebc172d05dcfe817282a6859d08574e45d2194)

Backported from https://github.com/scylladb/scylladb/pull/19279 to 5.4