### PR TITLE
gitattributes: Mark swagger .js files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.cc diff=cpp
 *.hh diff=cpp
 *.svg binary
+docs/_static/api/js/* binary


### PR DESCRIPTION
The goal is the same as in 29768a2d02 (gitattributes: Mark *.svg as binary) -- prevent grep from searching patterns in those files.

Despite those files are, in fact, javascript code, the way they are formatted is not suitable for human reading, so it's unlikely that anyone would be interested in grep-ing patters in it. At the same time, those files consist of of very long lines, so if a grep finds a pattern in one of those, the output is spoiled.