### PR TITLE
utils/large_bitset: replace reserve_partial with utils::reserve_gently

### DIFF
--- a/test/boost/stall_free_test.cc
+++ b/test/boost/stall_free_test.cc
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <random>
+
 #include "test/lib/scylla_test_case.hh"
 #include "utils/stall_free.hh"
 #include "utils/small_vector.hh"
@@ -529,4 +531,16 @@ SEASTAR_THREAD_TEST_CASE(test_clear_gently_vector_of_optimized_optionals) {
 
     utils::clear_gently(v).get();
     BOOST_REQUIRE_EQUAL(cleared_gently, 1);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_reserve_gently_with_chunked_vector) {
+    auto rand = std::default_random_engine();
+    auto size_dist = std::uniform_int_distribution<unsigned>(1, 1 << 12);
+
+    for (int i = 0; i < 100; ++i) {
+        utils::chunked_vector<uint8_t, 512> v;
+        const auto size = size_dist(rand);
+        utils::reserve_gently(v, size).get();
+        BOOST_REQUIRE_EQUAL(v.capacity(), size);
+    }
 }

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -191,6 +191,10 @@ public:
     ///
     /// Here, `do_until()` takes care of yielding between iterations when
     /// necessary.
+    ///
+    /// The recommended way to use this method is by calling utils::reserve_gently() from stall_free.hh
+    /// instead of looping with this method directly. utils::reserve_gently() will repeatedly call this
+    /// method to reserve the required quantity, yielding between calls when necessary.
     void reserve_partial(size_t n) {
         if (n > _capacity) {
             make_room(n, true);

--- a/utils/lsa/chunked_managed_vector.hh
+++ b/utils/lsa/chunked_managed_vector.hh
@@ -155,6 +155,10 @@ public:
     ///
     /// Here, `do_until()` takes care of yielding between iterations when
     /// necessary.
+    ///
+    /// The recommended way to use this method is by calling utils::reserve_gently() from stall_free.hh
+    /// instead of looping with this method directly. utils::reserve_gently() will repeatedly call this
+    /// method to reserve the required quantity, yielding between calls when necessary.
     void reserve_partial(size_t n) {
         if (n > _capacity) {
             return make_room(n, true);


### PR DESCRIPTION
Replace the reserve_partial loop in large_bitset constructor with a new function - reserve_gently() that can reserve memory without stalling by repeatedly calling reserve_partial() method of the passed container.