### PR TITLE
doc: separate Entrprise- from OSS-only content

### DIFF
--- a/docs/reference/_common/enterprise-vs-oss-matrix-link.rst
+++ b/docs/reference/_common/enterprise-vs-oss-matrix-link.rst
@@ -1,0 +1,1 @@
+`ScyllaDB Enterprise vs. Open Source Matrix <https://enterprise.docs.scylladb.com/stable/reference/versions-matrix-enterprise-oss.html>`_

--- a/docs/reference/_common/reference-toc.rst
+++ b/docs/reference/_common/reference-toc.rst
@@ -1,0 +1,11 @@
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   AWS Images </reference/aws-images>
+   Azure Images </reference/azure-images>
+   GCP Images </reference/gcp-images>
+   Configuration Parameters </reference/configuration-parameters>
+   Glossary </reference/glossary>
+   API Reference (BETA) </reference/api-reference>
+   Metrics (BETA) </reference/metrics>

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -2,17 +2,7 @@
 Reference 
 ===============
 
-.. toctree::
-   :maxdepth: 2
-   :hidden:
-
-   AWS Images </reference/aws-images>
-   Azure Images </reference/azure-images>
-   GCP Images </reference/gcp-images>
-   Configuration Parameters </reference/configuration-parameters>
-   Glossary </reference/glossary>
-   API Reference (BETA) </reference/api-reference>
-   Metrics (BETA) </reference/metrics>
+.. scylladb_include_flag:: reference-toc.rst
 
 
 * ScyllaDB images for AWS, Azure, and GCP.
@@ -24,3 +14,4 @@ Reference
 * :doc:`Glossary </reference/glossary>` - ScyllaDB-related terms and definitions.
 * :doc:`API Reference (BETA) </reference/api-reference>`
 * :doc:`Metrics (BETA) </reference/metrics>`
+* .. scylladb_include_flag:: enterprise-vs-oss-matrix-link.rst


### PR DESCRIPTION
This PR adds files that contain Open Source-specific information and includes these files with the `.. scylladb_include_flag::` directive. The files include a) a link and b) Table of Contents.

The purpose of this update is to enable adding Open Source/Enterprise-specific information in the Reference section.

(Files with the same names but Enterprise-specific content have to be added in the Enterprise repository).

Refs https://github.com/scylladb/scylla-enterprise/issues/4300 


- This PR must be backported to branch 6.0, as it includes a fix to version 6.0 and the corresponding Enterprise version.