### PR TITLE
cql: remove global_req_id from schema_altering_statement

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -1000,9 +1000,6 @@ query_processor::execute_schema_statement(const statements::schema_altering_stat
         on_internal_error(log, "DDL must be executed on shard 0");
     }
 
-    // TODO: remove this field, it should be injected directly as prepare_schema_mutations argument
-    stmt.global_req_id = mc.new_group0_state_id();
-
     auto [ce, warnings] = co_await stmt.prepare_schema_mutations(*this, state, options, mc);
     // We are creating something.
     if (!mc.empty()) {

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -118,8 +118,8 @@ bool cql3::statements::alter_keyspace_statement::changes_tablets(query_processor
     return ks.get_replication_strategy().uses_tablets() && !_attrs->get_replication_options().empty();
 }
 
-future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
-cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
+future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>>
+cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const {
     using namespace cql_transport;
     try {
         event::schema_change::target_type target_type = event::schema_change::target_type::KEYSPACE;
@@ -131,15 +131,16 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
         std::vector<mutation> muts;
         std::vector<sstring> warnings;
         auto ks_options = _attrs->get_all_options_flattened(feat);
+        auto ts = mc.write_timestamp();
 
         // we only want to run the tablets path if there are actually any tablets changes, not only schema changes
         if (changes_tablets(qp)) {
             if (!qp.topology_global_queue_empty()) {
-                return make_exception_future<std::tuple<::shared_ptr<::cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>(
+                return make_exception_future<std::tuple<::shared_ptr<::cql_transport::event::schema_change>, cql3::cql_warnings_vec>>(
                         exceptions::invalid_request_exception("Another global topology request is ongoing, please retry."));
             }
             if (_attrs->get_replication_options().contains(ks_prop_defs::REPLICATION_FACTOR_KEY)) {
-                return make_exception_future<std::tuple<::shared_ptr<::cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>(
+                return make_exception_future<std::tuple<::shared_ptr<::cql_transport::event::schema_change>, cql3::cql_warnings_vec>>(
                        exceptions::invalid_request_exception("'replication_factor' tag is not allowed when executing ALTER KEYSPACE with tablets, please list the DCs explicitly"));
             }
             qp.db().real_database().validate_keyspace_update(*ks_md_update);
@@ -173,10 +174,10 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
                 event::schema_change::change_type::UPDATED,
                 target_type,
                 keyspace());
-
-        return make_ready_future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>(std::make_tuple(std::move(ret), std::move(muts), warnings));
+        mc.add_mutations(std::move(muts), "CQL alter keyspace");
+        return make_ready_future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>>(std::make_tuple(std::move(ret), warnings));
     } catch (data_dictionary::no_such_keyspace& e) {
-        return make_exception_future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>(exceptions::invalid_request_exception("Unknown keyspace " + _name));
+        return make_exception_future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>>(exceptions::invalid_request_exception("Unknown keyspace " + _name));
     }
 }
 

--- a/cql3/statements/alter_keyspace_statement.hh
+++ b/cql3/statements/alter_keyspace_statement.hh
@@ -36,7 +36,7 @@ public:
 
     future<> check_access(query_processor& qp, const service::client_state& state) const override;
     void validate(query_processor& qp, const service::client_state& state) const override;
-    future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp,  const query_options& options, api::timestamp_type) const override;
+    virtual future<std::tuple<::shared_ptr<event_t>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const override;
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
     virtual future<::shared_ptr<messages::result_message>> execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
     bool changes_tablets(query_processor& qp) const;

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -65,8 +65,6 @@ public:
     using event_t = cql_transport::event::schema_change;
     virtual future<std::tuple<::shared_ptr<event_t>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const;
     virtual future<std::tuple<::shared_ptr<event_t>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const;
-
-    mutable utils::UUID global_req_id;
 };
 
 }


### PR DESCRIPTION
Such field is no longer needed as the information comes
directly from group0_batch.

Fixes scylladb/scylladb#19365

Backport: no, we don't backport code cleanups