### PR TITLE
git: add build.ninja.new to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .settings
 build
 build.ninja
+build.ninja.new
 cscope.*
 /debian/
 dist/ami/files/*.rpm


### PR DESCRIPTION
Since some time executing our ninja build
targets generates also build.ninja.new file.
Adding it to .gitignore for convenience as we
won't commit this file.