### PR TITLE
rust: disable incremental build for release build

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,6 +34,7 @@ incremental = false
 [profile.rust-release]
 inherits = "release"
 debug = true
+incremental = false
 
 [profile.rust-coverage]
 inherits = "dev"


### PR DESCRIPTION
so that the release build is reproducible. a reproduciable helps developers to perform postmortem debugging.

Fixes #19225
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

no need to backport, as it improves the developer experience, instead of fixing a bug.