### PR TITLE
test/boost/hint_test.cc: Add missing parse() callback

### DIFF
--- a/test/boost/hint_test.cc
+++ b/test/boost/hint_test.cc
@@ -33,6 +33,9 @@ std::ostream& operator<<(std::ostream& out, const replay_position& p) {
 
 template <>
 struct fmt::formatter<db::hints::sync_point::host_id_or_addr> {
+    constexpr static auto parse(format_parse_context& ctx) {
+        return ctx.begin();
+    }
     constexpr static auto format(const db::hints::sync_point::host_id_or_addr& value, fmt::format_context& ctx) {
         return std::visit([&ctx](const auto& v) {
             return fmt::format_to(ctx.out(), "{}", v);


### PR DESCRIPTION
Before these changes, compilation was failing with the following error:

In file included from test/boost/hint_test.cc:12:
/usr/include/fmt/ranges.h:298:7: error: no member named 'parse' in 'fmt::formatter<db::hints::sync_point::host_id_or_addr>'
  298 |     f.parse(ctx);
      |     ~ ^

We add the missing callback.