### PR TITLE
build: cmake: do not add "absl::headers" to include dirs

### DIFF
--- a/repair/CMakeLists.txt
+++ b/repair/CMakeLists.txt
@@ -6,7 +6,6 @@ target_sources(repair
     table_check.cc)
 target_include_directories(repair
   PUBLIC
-    absl::headers
     ${CMAKE_SOURCE_DIR})
 target_link_libraries(repair
   PUBLIC


### PR DESCRIPTION
`absl::headers` is a library, not the path to its headers.

before this change, the command lines of genereated build rule look like:

```
-I/home/kefu/dev/scylladb/repair/absl::headers
```

this does not hurt, as the `repair` target already links against `absl::headers`, but this is just wrong.

so let's remove it. 

---

cmake related change, so no need to backport.