### PR TITLE
join_token_ring, gossip topology: recalculate sync nodes in wait_alive

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2393,8 +2393,13 @@ bool gossiper::is_alive(inet_address ep) const {
 }
 
 future<> gossiper::wait_alive(std::vector<gms::inet_address> nodes, std::chrono::milliseconds timeout) {
+    return wait_alive([nodes = std::move(nodes)] { return nodes; }, timeout);
+}
+
+future<> gossiper::wait_alive(noncopyable_function<std::vector<gms::inet_address>()> get_nodes, std::chrono::milliseconds timeout) {
     auto start_time = std::chrono::steady_clock::now();
     for (;;) {
+        auto nodes = get_nodes();
         std::vector<gms::inet_address> live_nodes;
         for (const auto& node: nodes) {
             size_t nr_alive = co_await container().map_reduce0([node] (gossiper& g) -> size_t {

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -526,6 +526,7 @@ public:
     bool is_dead_state(const endpoint_state& eps) const;
     // Wait for nodes to be alive on all shards
     future<> wait_alive(std::vector<gms::inet_address> nodes, std::chrono::milliseconds timeout);
+    future<> wait_alive(noncopyable_function<std::vector<gms::inet_address>()> get_nodes, std::chrono::milliseconds timeout);
 
     // Wait for `n` live nodes to show up in gossip (including ourself).
     future<> wait_for_live_nodes_to_show_up(size_t n);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1676,10 +1676,8 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
         // NORMAL doesn't necessarily mean UP (#14042). Wait for these nodes to be UP as well
         // to reduce flakiness (we need them to be UP to perform CDC generation write and for repair/streaming).
         //
-        // This could be done in Raft topology mode as well, but the calculation of nodes to sync with
-        // has to be done based on topology state machine instead of gossiper as it is here;
-        // furthermore, the place in the code where we do this has to be different (it has to be coordinated
-        // by the topology coordinator after it joins the node to the cluster).
+        // We do it in Raft topology mode as well in join_node_response_handler. The calculation of nodes to
+        // sync with is done based on topology state machine instead of gossiper as it is here.
         //
         // We calculate nodes to wait for based on token_metadata. Previously we would use gossiper
         // directly for this, but gossiper may still contain obsolete entries from 1. replaced nodes

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1687,20 +1687,26 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
         // but here they may still be present if we're performing topology changes in quick succession.
         // `token_metadata` has all host ID / token collisions resolved so in particular it doesn't contain
         // these obsolete IPs. Refs: #14487, #14468
-        auto& tm = get_token_metadata();
-
+        //
+        // We recalculate nodes in every step of the loop in wait_alive. For example, if we booted a new node
+        // just after removing a different node, other nodes could still see the removed node as NORMAL. Then,
+        // the joining node would wait for it to be UP, and wait_alive would time out. Recalculation fixes
+        // this problem. Ref: #17526
+        auto get_sync_nodes = [&] {
         std::vector<gms::inet_address> sync_nodes;
-        tm.get_topology().for_each_node([&] (const locator::node* np) {
+        get_token_metadata().get_topology().for_each_node([&] (const locator::node* np) {
             auto ep = np->endpoint();
             const auto& host_id = np->host_id();
             if (!ri || (host_id != ri->host_id && !ri->ignore_nodes.contains(host_id))) {
                 sync_nodes.push_back(ep);
             }
         });
+            return sync_nodes;
+        };
 
-        slogger.info("Waiting for nodes {} to be alive", sync_nodes);
-        co_await _gossiper.wait_alive(sync_nodes, wait_for_live_nodes_timeout);
-        slogger.info("Nodes {} are alive", sync_nodes);
+        slogger.info("Waiting for other nodes to be alive. Current nodes: {}", get_sync_nodes());
+        co_await _gossiper.wait_alive(get_sync_nodes, wait_for_live_nodes_timeout);
+        slogger.info("Nodes {} are alive", get_sync_nodes());
     }
 
     assert(_group0);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1693,14 +1693,14 @@ future<> storage_service::join_token_ring(sharded<db::system_distributed_keyspac
         // the joining node would wait for it to be UP, and wait_alive would time out. Recalculation fixes
         // this problem. Ref: #17526
         auto get_sync_nodes = [&] {
-        std::vector<gms::inet_address> sync_nodes;
-        get_token_metadata().get_topology().for_each_node([&] (const locator::node* np) {
-            auto ep = np->endpoint();
-            const auto& host_id = np->host_id();
-            if (!ri || (host_id != ri->host_id && !ri->ignore_nodes.contains(host_id))) {
-                sync_nodes.push_back(ep);
-            }
-        });
+            std::vector<gms::inet_address> sync_nodes;
+            get_token_metadata().get_topology().for_each_node([&] (const locator::node* np) {
+                auto ep = np->endpoint();
+                const auto& host_id = np->host_id();
+                if (!ri || (host_id != ri->host_id && !ri->ignore_nodes.contains(host_id))) {
+                    sync_nodes.push_back(ep);
+                }
+            });
             return sync_nodes;
         };
 


### PR DESCRIPTION
The node booting in gossip topology waits until all NORMAL
nodes are UP. If we removed a different node just before,
the booting node could still see it as NORMAL and wait for
it to be UP, which would time out and fail the bootstrap.

This issue caused scylladb/scylladb#17526.

Fix it by recalculating the nodes to wait for in every step of the
of the `wait_alive` loop.

Although the issue fixed by this PR caused only test flakiness,
it could also manifest in real clusters. It's best to backport this
PR to 5.4 and 6.0.

Fixes scylladb/scylladb#17526