### PR TITLE
cql-pytest/test_sstable: do not import unused modules

### DIFF
--- a/test/cql-pytest/test_sstable.py
+++ b/test/cql-pytest/test_sstable.py
@@ -11,8 +11,7 @@
 # the disk.
 #############################################################################
 
-import pytest
-from util import unique_name, new_test_table
+from util import new_test_table
 import nodetool
 import random
 


### PR DESCRIPTION
this is a cleanup, hence no need to backport.