### PR TITLE
Sanitize load_meter API handlers management

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -118,6 +118,14 @@ future<> unset_server_storage_service(http_context& ctx) {
     return ctx.http_server.set_routes([&ctx] (routes& r) { unset_storage_service(ctx, r); });
 }
 
+future<> set_load_meter(http_context& ctx, service::load_meter& lm) {
+    return ctx.http_server.set_routes([&ctx, &lm] (routes& r) { set_load_meter(ctx, r, lm); });
+}
+
+future<> unset_load_meter(http_context& ctx) {
+    return ctx.http_server.set_routes([&ctx] (routes& r) { unset_load_meter(ctx, r); });
+}
+
 future<> set_server_sstables_loader(http_context& ctx, sharded<sstables_loader>& sst_loader) {
     return ctx.http_server.set_routes([&ctx, &sst_loader] (routes& r) { set_sstables_loader(ctx, r, sst_loader); });
 }

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -76,11 +76,9 @@ struct http_context {
     sstring api_doc;
     httpd::http_server_control http_server;
     distributed<replica::database>& db;
-    service::load_meter& lmeter;
 
-    http_context(distributed<replica::database>& _db,
-            service::load_meter& _lm)
-            : db(_db), lmeter(_lm)
+    http_context(distributed<replica::database>& _db)
+            : db(_db)
     {
     }
 };

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -130,5 +130,7 @@ future<> set_server_tasks_compaction_module(http_context& ctx, sharded<service::
 future<> unset_server_tasks_compaction_module(http_context& ctx);
 future<> set_server_raft(http_context&, sharded<service::raft_group_registry>&);
 future<> unset_server_raft(http_context&);
+future<> set_load_meter(http_context& ctx, service::load_meter& lm);
+future<> unset_load_meter(http_context& ctx);
 
 }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1653,6 +1653,12 @@ void unset_storage_service(http_context& ctx, routes& r) {
     sp::get_schema_versions.unset(r);
 }
 
+void set_load_meter(http_context& ctx, routes& r, service::load_meter& lm) {
+}
+
+void unset_load_meter(http_context& ctx, routes& r) {
+}
+
 void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_ctl) {
     ss::get_snapshot_details.set(r, [&snap_ctl](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto result = co_await snap_ctl.local().get_snapshot_details();

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1640,8 +1640,8 @@ void unset_storage_service(http_context& ctx, routes& r) {
 }
 
 void set_load_meter(http_context& ctx, routes& r, service::load_meter& lm) {
-    ss::get_load_map.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        auto load_map = co_await ctx.lmeter.get_load_map();
+    ss::get_load_map.set(r, [&lm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        auto load_map = co_await lm.get_load_map();
         std::vector<ss::map_string_double> res;
         for (auto i : load_map) {
             ss::map_string_double val;

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1640,8 +1640,8 @@ void unset_storage_service(http_context& ctx, routes& r) {
 }
 
 void set_load_meter(http_context& ctx, routes& r, service::load_meter& lm) {
-    ss::get_load_map.set(r, [&ctx] (std::unique_ptr<http::request> req) {
-        return ctx.lmeter.get_load_map().then([] (auto&& load_map) {
+    ss::get_load_map.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        auto load_map = co_await ctx.lmeter.get_load_map();
             std::vector<ss::map_string_double> res;
             for (auto i : load_map) {
                 ss::map_string_double val;
@@ -1649,8 +1649,7 @@ void set_load_meter(http_context& ctx, routes& r, service::load_meter& lm) {
                 val.value = i.second;
                 res.push_back(val);
             }
-            return make_ready_future<json::json_return_type>(res);
-        });
+            co_return res;
     });
 }
 

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1642,14 +1642,14 @@ void unset_storage_service(http_context& ctx, routes& r) {
 void set_load_meter(http_context& ctx, routes& r, service::load_meter& lm) {
     ss::get_load_map.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto load_map = co_await ctx.lmeter.get_load_map();
-            std::vector<ss::map_string_double> res;
-            for (auto i : load_map) {
-                ss::map_string_double val;
-                val.key = i.first;
-                val.value = i.second;
-                res.push_back(val);
-            }
-            co_return res;
+        std::vector<ss::map_string_double> res;
+        for (auto i : load_map) {
+            ss::map_string_double val;
+            val.key = i.first;
+            val.value = i.second;
+            res.push_back(val);
+        }
+        co_return res;
     });
 }
 

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -83,6 +83,8 @@ void set_thrift_controller(http_context& ctx, httpd::routes& r);
 void unset_thrift_controller(http_context& ctx, httpd::routes& r);
 void set_snapshot(http_context& ctx, httpd::routes& r, sharded<db::snapshot_ctl>& snap_ctl);
 void unset_snapshot(http_context& ctx, httpd::routes& r);
+void set_load_meter(http_context& ctx, httpd::routes& r, service::load_meter& lm);
+void unset_load_meter(http_context& ctx, httpd::routes& r);
 seastar::future<json::json_return_type> run_toppartitions_query(db::toppartitions_query& q, http_context &ctx, bool legacy_request = false);
 
 } // namespace api

--- a/main.cc
+++ b/main.cc
@@ -677,7 +677,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
     sharded<service::storage_service> ss;
     sharded<service::migration_manager> mm;
     sharded<tasks::task_manager> task_manager;
-    api::http_context ctx(db, load_meter);
+    api::http_context ctx(db);
     httpd::http_server_control prometheus_server;
     std::optional<utils::directories> dirs = {};
     sharded<gms::feature_service> feature_service;

--- a/main.cc
+++ b/main.cc
@@ -1969,6 +1969,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 load_meter.exit().get();
             });
 
+            api::set_load_meter(ctx, load_meter).get();
+            auto stop_load_meter_api = defer_verbose_shutdown("load meter API", [&ctx] {
+                api::unset_load_meter(ctx).get();
+            });
+
             supervisor::notify("starting cf cache hit rate calculator");
             cf_cache_hitrate_calculator.start(std::ref(db), std::ref(gossiper)).get();
             auto stop_cache_hitrate_calculator = defer_verbose_shutdown("cf cache hit rate calculator",


### PR DESCRIPTION
The service in question is pretty small one, but it has its API endpoint that lives in /storage_service group. Currently when a service starts and has any endpoints that depend on it, the endpoint registration should follow it (#2737). Here's the PR that does it for load meter. Another goal of this change is that http context now has one less dependency onboard.