### PR TITLE
build: cmake: mark wasm "ALL"

### DIFF
--- a/test/resource/wasm/CMakeLists.txt
+++ b/test/resource/wasm/CMakeLists.txt
@@ -14,7 +14,7 @@ function(wasm2wat input)
   set(${parsed_args_WAT} ${output} PARENT_SCOPE)
 endfunction()
 
-add_custom_target(wasm)
+add_custom_target(wasm ALL)
 add_dependencies(tests wasm)
 add_subdirectory(c)
 add_subdirectory(rust)


### PR DESCRIPTION
so that "wasm" target is built. "wasm" generates the text format of wasm code. and these wasm applications are used by the test_wasm tests.

the rules generated by `configure.py` adds these .wat files as a dependency of `{mode}-build`, which is in turn a dependency of `{mode}`.

in this change, let's mirror this behavior by making `wasm` ALL, so it is built by the default target.

---

cmake related change, hence no need to backport.