### PR TITLE
[action] add github context info for better debugging

### DIFF
--- a/.github/workflows/add-label-when-promoted.yaml
+++ b/.github/workflows/add-label-when-promoted.yaml
@@ -12,6 +12,10 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -16,6 +16,10 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
It seems that we skipped the sync label process between PR and linked Issues

Adding those debug prints will allow us to understand why

**GitHub action debug improvement, no need for backport**