### PR TITLE
[Backport-6.0] docs: nodetool status: document keyspace and table arguments

### DIFF
--- a/docs/operating-scylla/nodetool-commands/status.rst
+++ b/docs/operating-scylla/nodetool-commands/status.rst
@@ -2,11 +2,14 @@ Nodetool status
 ===============
 **status** - This command prints the cluster information for a single keyspace or all keyspaces.
 
+The keyspace argument is required to calculate effective ownership information (``Owns`` column).
+For tablet keyspaces, a table is also required for effective ownership.
+
 For example:
 
 ::
 
-    nodetool status
+    nodetool status my_keyspace
 
 Example output:
 


### PR DESCRIPTION
Also fix the example nodetool status invocation.

Fixes: #17840

Closes scylladb/scylladb#18037

(cherry picked from commit 6e3b997e0418ae16d870a21c8ada923baa237644)

Parent PR: #18037

---

the change in `nodetool status` document is specific to tablets, hence is critical for 6.0