### PR TITLE
doc: add a page with ScyllaDB limits

### DIFF
--- a/docs/reference/_common/reference-toc.rst
+++ b/docs/reference/_common/reference-toc.rst
@@ -7,5 +7,6 @@
    GCP Images </reference/gcp-images>
    Configuration Parameters </reference/configuration-parameters>
    Glossary </reference/glossary>
+   Limits </reference/limits>
    API Reference (BETA) </reference/api-reference>
    Metrics (BETA) </reference/metrics>

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -12,6 +12,7 @@ Reference
   * :doc:`GCP Images </reference/gcp-images>`
 * :doc:`Configuration Parameters </reference/configuration-parameters>` - ScyllaDB properties configurable in the ``scylla.yaml`` configuration file.
 * :doc:`Glossary </reference/glossary>` - ScyllaDB-related terms and definitions.
+* :doc:`Limits </reference/limits>`
 * :doc:`API Reference (BETA) </reference/api-reference>`
 * :doc:`Metrics (BETA) </reference/metrics>`
 * .. scylladb_include_flag:: enterprise-vs-oss-matrix-link.rst

--- a/docs/reference/limits.rst
+++ b/docs/reference/limits.rst
@@ -1,0 +1,75 @@
+==============
+Limits
+==============
+
+This document provides hard and soft limits in ScyllaDB.
+
+Cluster and Node Limits
+-----------------------------
+
+.. list-table:: 
+   :widths: 50 50
+   :header-rows: 1
+
+   * - Component
+     - Limit 
+   * - Nodes per cluster
+     - Low hundreds
+   * - Node size
+     - 256 vcpu
+  
+See :ref:`Hardware Requirements <system-requirements-hardware>` for storage
+and memory requirements and limits.
+
+CQL Limits
+--------------
+
+.. list-table:: 
+   :widths: 50 50
+   :header-rows: 1
+
+   * - Component
+     - Limit
+   * - Keyspaces per cluster 
+     - Thousands (tested with 1000)
+   * - Tables per keyspace 
+     - Low thousands (tested with 5000)
+   * - Tables per cluster (including indexes)
+     - Thousands
+   * - Tables with CDC enabled
+     - No limit. CDC can be enabled for all tables in a cluster.
+   * - Materialized views and secondary indexes per table
+     - Low tens
+   * - Columns per table
+     - Hundreds
+   * - Columns per cluster
+     - Tens of thousands
+   * - Partition size
+     - Gigabytes
+   * - Rows per partition
+     - No limit
+   * - Row size
+     - Latency-related soft limit: 
+     
+       Hundreds of kilobytes (good latency) or megabytes (mediocre latency)
+   * - Key length
+     - 65533
+   * - Table / CF name length
+     - 48 characters
+   * - Keyspace name length
+     - 48 characters
+   * - Query parameters in a query
+     - 65535 (2^16-1)
+   * - Statements in a batch
+     - 65535 (2^16-1)
+   * - Fields in a tuple
+     - 32768 (2^15) (just a few fields, such as 2-10, are recommended)
+   * - Collection (List)
+     - ~2 billion (2^31)
+   * - Collection (Set)
+     - ~2 billion (2^31)
+   * - Collection (Map)
+     - Number of keys: 65535 (2^16-1)
+   * - Blob size
+     - 2 GB ( less than 1 MB is recommended)
+ 


### PR DESCRIPTION
This PR adds a page listing the ScyllDB limits we know today.
The page can and should be extended when other limits are confirmed.

Refs https://github.com/scylladb/scylladb/issues/18897