### PR TITLE
treewide: include seastar headers with brackets

### DIFF
--- a/auth/allow_all_authorizer.hh
+++ b/auth/allow_all_authorizer.hh
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "auth/authorizer.hh"
-#include "seastar/core/future.hh"
+#include <seastar/core/future.hh>
 
 namespace cql3 {
 class query_processor;

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -32,7 +32,7 @@
 #include "log.hh"
 #include "schema/schema_fwd.hh"
 #include <seastar/core/future.hh>
-#include "seastar/coroutine/parallel_for_each.hh"
+#include <seastar/coroutine/parallel_for_each.hh>
 #include "service/migration_manager.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "timestamp.hh"

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -14,6 +14,7 @@
 
 #include <boost/algorithm/string/join.hpp>
 #include <seastar/core/future-util.hh>
+#include <seastar/core/on_internal_error.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/sstring.hh>
@@ -26,7 +27,6 @@
 #include "db/consistency_level_type.hh"
 #include "exceptions/exceptions.hh"
 #include "log.hh"
-#include "seastar/core/on_internal_error.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "utils/class_registrator.hh"
 #include "service/migration_manager.hh"

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -11,9 +11,9 @@
 #include "cql3/query_processor.hh"
 
 #include <seastar/core/metrics.hh>
+#include <seastar/core/shared_ptr.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 
-#include "seastar/core/shared_ptr.hh"
 #include "service/storage_proxy.hh"
 #include "service/topology_mutation.hh"
 #include "service/migration_manager.hh"

--- a/db/cql_type_parser.cc
+++ b/db/cql_type_parser.cc
@@ -9,12 +9,12 @@
 #include <unordered_map>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/sliced.hpp>
+#include <seastar/coroutine/maybe_yield.hh>
 
 #include "replica/database.hh"
 #include "cql3/CqlParser.hpp"
 #include "cql3/util.hh"
 #include "cql_type_parser.hh"
-#include "seastar/coroutine/maybe_yield.hh"
 #include "types/types.hh"
 #include "data_dictionary/user_types_metadata.hh"
 #include "utils/sorting.hh"

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -9,12 +9,12 @@
 #pragma once
 
 #include <seastar/core/timer.hh>
-#include "seastar/core/future.hh"
-#include "seastarx.hh"
-#include "auth/role_manager.hh"
+#include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/distributed.hh>
 #include <seastar/core/abort_source.hh>
+#include "seastarx.hh"
+#include "auth/role_manager.hh"
 #include "auth/service.hh"
 #include <map>
 #include "qos_common.hh"

--- a/service/qos/standard_service_level_distributed_data_accessor.hh
+++ b/service/qos/standard_service_level_distributed_data_accessor.hh
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <seastar/core/abort_source.hh>
-#include "seastar/core/future.hh"
+#include <seastar/core/future.hh>
 #include "seastarx.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "service_level_controller.hh"

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -14,12 +14,12 @@
 #include <boost/range/join.hpp>
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/rwlock.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include "db_clock.hh"
 #include "log.hh"
-#include "seastar/core/rwlock.hh"
 #include "tasks/types.hh"
 #include "utils/serialized_action.hh"
 #include "utils/updateable_value.hh"

--- a/test/boost/auth_test.cc
+++ b/test/boost/auth_test.cc
@@ -14,11 +14,11 @@
 #include <stdint.h>
 #include <fmt/ranges.h>
 
+#include <seastar/core/future.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/thread.hh>
 
-#include "seastar/core/future.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/cql_test_env.hh"

--- a/test/lib/unit_test_service_levels_accessor.hh
+++ b/test/lib/unit_test_service_levels_accessor.hh
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include "seastar/core/future.hh"
+#include <seastar/core/future.hh>
 #include "service/qos/service_level_controller.hh"
 #include "service/qos/qos_common.hh"
 #include "db/system_distributed_keyspace.hh"

--- a/test/perf/perf_alternator.cc
+++ b/test/perf/perf_alternator.cc
@@ -9,6 +9,7 @@
 #include <functional>
 #include <memory>
 #include <signal.h>
+#include <seastar/core/future.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/http/client.hh>
@@ -20,7 +21,6 @@
 #include <boost/program_options.hpp>
 
 #include "db/config.hh"
-#include "seastar/core/future.hh"
 #include "test/perf/perf.hh"
 #include "test/lib/random_utils.hh"
 

--- a/types/types.cc
+++ b/types/types.cc
@@ -17,8 +17,8 @@
 #include <exception>
 #include <iterator>
 #include <seastar/core/print.hh>
+#include <seastar/core/shared_ptr.hh>
 #include "types/types.hh"
-#include "seastar/core/shared_ptr.hh"
 #include "utils/serialization.hh"
 #include "vint-serialization.hh"
 #include <cmath>

--- a/utils/sorting.hh
+++ b/utils/sorting.hh
@@ -10,7 +10,7 @@
 #include <vector>
 #include <map>
 #include <seastar/core/future.hh>
-#include "seastar/coroutine/maybe_yield.hh"
+#include <seastar/coroutine/maybe_yield.hh>
 #include "utils/stall_free.hh"
 
 namespace utils {


### PR DESCRIPTION
this change was created in the same spirit of ebff5f5d.

despite that we include Seastar as a submodule, Seastar is not a part of scylla project. so we'd better include its headers using brackets.

ebff5f5d addressed this cosmetic issue a while back. but probably clangd's header-insertion helped some of contributor to insert the missing headers with `"`. so this style of `include` returned to the tree with these new changes.

unfortunately, clangd does not allow us to configure the style of `include` at the time of writing.


---

it's a cleanup, hence no need to backport