### PR TITLE
[actions] fix sync label from PR to linked issue

### DIFF
--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -37,7 +37,7 @@ jobs:
         run: python .github/scripts/sync_labels.py --repo ${{ github.repository }} --number ${{ github.event.number }} --action ${{ github.event.action }}
 
       - name: Pull request labeled or unlabeled event
-        if: github.event_name == 'pull_request' && startsWith(github.event.label.name, 'backport/')
+        if: github.event_name == 'pull_request_target' && startsWith(github.event.label.name, 'backport/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python .github/scripts/sync_labels.py --repo ${{ github.repository }} --number ${{ github.event.number }} --action ${{ github.event.action }} --label ${{ github.event.label.name }}


### PR DESCRIPTION
in
https://github.com/scylladb/scylladb/commit/b8c705bc54ae8ffff6d48d60e9c91b8d4f050260 I modified the event name to `pull_request_target`,

This caused a skipping sync process when the PR label was added/removed

Fixing it

**sync label fix, no need to backport**