### PR TITLE
.github: add reproducible-build workflow

### DIFF
--- a/.github/workflows/build-scylla.yaml
+++ b/.github/workflows/build-scylla.yaml
@@ -1,0 +1,35 @@
+name: Build Scylla
+
+on:
+  workflow_call:
+    inputs:
+      build_mode:
+        description: 'the build mode'
+        type: string
+        required: true
+    outputs:
+      md5sum:
+        description: 'the md5sum for scylla executable'
+        value: ${{ jobs.build.outputs.md5sum }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # be consistent with tools/toolchain/image
+    container: scylladb/scylla-toolchain:fedora-38-20240521
+    outputs:
+      md5sum: ${{ steps.checksum.outputs.md5sum }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Generate the building system
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          ./configure.py --mode ${{ inputs.build_mode }} --with scylla
+      - run: |
+          ninja build/${{ inputs.build_mode }}/scylla
+      - id: checksum
+        run: |
+          checksum=$(md5sum build/${{ inputs.build_mode }}/scylla | cut -c -32)
+          echo "md5sum=$checksum" >> $GITHUB_OUTPUT

--- a/.github/workflows/reproducible-build.yaml
+++ b/.github/workflows/reproducible-build.yaml
@@ -1,0 +1,34 @@
+name: Check Reproducible Build
+
+on:
+  schedule:
+    # 5AM every friday
+    - cron: '0 5 * * FRI'
+
+permissions: {}
+
+env:
+  BUILD_MODE: release
+jobs:
+  build-a:
+    uses: ./.github/workflows/build-scylla.yaml
+    with:
+      build_mode: release
+  build-b:
+    uses: ./.github/workflows/build-scylla.yaml
+    with:
+      build_mode: release
+  compare-checksum:
+    runs-on: ubuntu-latest
+    needs:
+      - build-a
+      - build-b
+    steps:
+      - env:
+          CHECKSUM_A: ${{needs.build-a.outputs.md5sum}}
+          CHECKSUM_B: ${{needs.build-b.outputs.md5sum}}
+        run: |
+          if [ $CHECKSUM_A != $CHECKSUM_B ]; then                             \
+            echo "::error::mismatched checksums: $CHECKSUM_A != $CHECKSUM_B"; \
+            exit 1;                                                           \
+          fi


### PR DESCRIPTION
to verify that scylla builds are reproducible.

the new workflow builds scylla twice with master HEAD, and compares
the md5sums of the built scylla executables. it fails if the md5sum:s
do not match.

this workflow is triggered at 5AM every Friday. its status can be
found at https://github.com/scylladb/scylladb/actions/workflows/reproducible-build.yaml
after it's built for the first time.

Refs #19225
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

no need to backport, as it's an addition to the workflow.