### PR TITLE
cdc: do not include unused headers

### DIFF
--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -10,7 +10,7 @@ env:
   BUILD_TYPE: RelWithDebInfo
   BUILD_DIR: build
   CLEANER_OUTPUT_PATH: build/clang-include-cleaner.log
-  CLEANER_DIRS: test/unit exceptions alternator api
+  CLEANER_DIRS: test/unit exceptions alternator api auth cdc
 
 permissions: {}
 

--- a/cdc/cdc_extension.hh
+++ b/cdc/cdc_extension.hh
@@ -12,7 +12,6 @@
 #include <seastar/core/sstring.hh>
 
 #include "bytes.hh"
-#include "serializer.hh"
 #include "cdc/cdc_options.hh"
 #include "schema/schema.hh"
 #include "serializer_impl.hh"

--- a/cdc/metadata.cc
+++ b/cdc/metadata.cc
@@ -7,7 +7,6 @@
  */
 
 #include "dht/token-sharding.hh"
-#include "utils/exceptions.hh"
 #include "exceptions/exceptions.hh"
 
 #include "cdc/generation.hh"

--- a/cdc/stats.hh
+++ b/cdc/stats.hh
@@ -10,11 +10,8 @@
 
 #include <array>
 #include <cstdint>
-#include <string>
 #include <seastar/core/metrics_registration.hh>
 #include "enum_set.hh"
-#include "utils/histogram.hh"
-#include "utils/estimated_histogram.hh"
 
 namespace cdc {
 


### PR DESCRIPTION
also add `auth` and `cdc` to iwyu's `CLEANER_DIR` setting.

---

it's a cleanup, hence no need to backport.