### PR TITLE
test: correct some misspellings

### DIFF
--- a/test/cql-pytest/README.md
+++ b/test/cql-pytest/README.md
@@ -264,7 +264,7 @@ PATH=$JAVA_HOME:$JRE_HOME/bin:$PATH CASSANDRA_USE_JDK11=true \
 ant -Duse.jdk11=true
 ```
 This will take a few minutes, and may begin by downloading dozens of JAR
-dependecies into your maven cache (`$HOME/.m2`), if this hasn't happened
+dependencies into your maven cache (`$HOME/.m2`), if this hasn't happened
 last time you built Cassandra.
 
 That's it! In the Cassandra source directory, you now have bin/cassandra,

--- a/test/cql-pytest/test_aggregate.py
+++ b/test/cql-pytest/test_aggregate.py
@@ -254,7 +254,7 @@ def test_sum_in_partition(cql, table1):
     assert [(15,)] == list(cql.execute(f"select sum(v) from {table1} where p = {p}"))
 
 # Check that you *can't* do "sum(*)" expecting (perhaps) sums of all the
-# columns. It's a synax error: The grammar allows "count(*)" because it has
+# columns. It's a syntax error: The grammar allows "count(*)" because it has
 # a separate rule for # "count", but other functions and aggregators (like
 # "sum") don't allow "*" and expect a real column name as a parameter.
 def test_sum_star(cql, table1):

--- a/test/cql-pytest/test_materialized_view.py
+++ b/test/cql-pytest/test_materialized_view.py
@@ -926,7 +926,7 @@ def test_many_range_tombstone_base_update_2(cql, test_keyspace):
             print("Only in view: ", sorted(list(set(list_view)-set(list_base))))
             assert list_base == list_view
 
-# Test that deleting a base partion works fine, even if it produces a
+# Test that deleting a base partition works fine, even if it produces a
 # large batch of individual view updates. After issue #8852 was fixed,
 # this large batch is no longer done together, but rather split to smaller
 # batches, and this split can be done wrongly (e.g., see issue #17117)

--- a/test/nodetool/test_viewbuildstatus.py
+++ b/test/nodetool/test_viewbuildstatus.py
@@ -30,13 +30,13 @@ def format_status(host, info):
 
 def format_output(keyspace, view, view_status):
     table = format_status("Host", "Info")
-    succceed = True
+    succeed = True
     for host, status in view_status.items():
         if status != 'SUCCESS':
-            succceed = False
+            succeed = False
         table += format_status(host, status)
     output = ''
-    if succceed:
+    if succeed:
         output += f"{keyspace}.{view} has finished building\n"
     else:
         output += f"{keyspace}.{view} has not finished building; node status is below.\n"

--- a/test/perf/perf_alternator.cc
+++ b/test/perf/perf_alternator.cc
@@ -294,7 +294,7 @@ static future<> update_item_rmw(const test_config& _, http::experimental::client
                     "S": "{}"
                 }}
             }},)", seq, seq);
-    // making condtional write is one way of making sure scylla will do read before write (rmw)
+    // making conditional write is one way of making sure scylla will do read before write (rmw)
     // for our static data this condition is always true to simplify things
     auto condition_exp = R"(
          "ConditionExpression": "((NOT attribute_exists(C2)) OR size(C6) <= :val1) AND (C8 <> :val2 OR C6 IN (:val1)) ",
@@ -440,7 +440,7 @@ std::function<int(int, char**)> alternator(std::function<int(int, char**)> scyll
             ("concurrency", bpo::value<unsigned>()->default_value(100), "workers per core")
             ("flush", bpo::value<bool>()->default_value(true), "flush memtables before test")
             ("remote-host", bpo::value<std::string>()->default_value(""), "address of remote alternator service, use localhost by default")
-            ("scan-total-segments", bpo::value<unsigned>()->default_value(10), "single scan operation will retreive 1/scan-total-segments portion of a table")
+            ("scan-total-segments", bpo::value<unsigned>()->default_value(10), "single scan operation will retrieve 1/scan-total-segments portion of a table")
             ("continue-after-error", bpo::value<bool>()->default_value(false), "continue test after failed request")
         ;
         bpo::variables_map opts;

--- a/test/pylib/coverage_utils.py
+++ b/test/pylib/coverage_utils.py
@@ -478,7 +478,7 @@ async def get_profiled_binary_ids(
 
 # The best way to merge profiles is by the file build id that they map, somewhen in the future,
 # it might also be desirable to merge profiles from different binaries, but lcov format does it better
-# as it is source dependant so for now we will stick to it.
+# as it is source dependent so for now we will stick to it.
 # if more than one id is contained in one of the files, it is going to be merged only with files that contains
 # the same composition of ids.
 MergeProfilesResult = namedtuple(
@@ -686,7 +686,7 @@ async def lcov_combine_traces(
     Args:
         lcovs (Iterable[PathLike]): A list of source lcov trace files to merge
         output_lcov (PathLike): the final output lcov file
-        branch_coverage (bool, optional): Wether to include branch coverage data or not (if exists). Defaults to True.
+        branch_coverage (bool, optional): Whether to include branch coverage data or not (if exists). Defaults to True.
         files_per_chunk (Union[int, None], optional): How many files to combine per parallel task. Defaults to None.
         concurrency (ConcurrencyParam, optional): A concurrency limiting parameter for the execution. Defaults to None.
         logger (LoggerType, optional): A logger to which log information. Defaults to COVERAGE_TOOLS_LOGGER.
@@ -1159,7 +1159,7 @@ async def main():
         "--clear-on-success",
         action = "store_true",
         default = False,
-        help = "Wether to clear the raw profiles on success",
+        help = "Whether to clear the raw profiles on success",
     )
     raw_to_indexed_parser.set_defaults(func = merge_profiles_cmd)
 
@@ -1182,7 +1182,7 @@ async def main():
         "--clear-on-success",
         action = "store_true",
         default = False,
-        help = "Wether to clear the indexed profiles on success",
+        help = "Whether to clear the indexed profiles on success",
     )
     prof_to_lcov_parser.add_argument(
         "--exclude",
@@ -1439,7 +1439,7 @@ async def main():
     patch_coverage_parser.add_argument(
         "--dirty",
         action = "store_true",
-        help = "Wether to include a final meta patch which is the uncommitted changes to the environment,"
+        help = "Whether to include a final meta patch which is the uncommitted changes to the environment,"
         "if this parameter is not given and there are uncommitted changes in the repo, the command will fail. (not including untracked files)",
     )
     patch_coverage_parser.add_argument(

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -77,7 +77,7 @@ class ManagerClient():
         """Close driver"""
         self.driver_close()
         # TODO: good candidate for safe_gather  https://github.com/scylladb/scylladb/pull/17781
-        #  to make sure tha all connections is closed
+        #  to make sure that all connections is closed
         await asyncio.gather(*[client.shutdown() for client in self.client_for_asyncio_loop.values()])
 
     async def driver_connect(self, server: Optional[ServerInfo] = None, auth_provider: Optional[AuthProvider] = None) -> None:

--- a/test/topology/test_global_ignore_nodes.py
+++ b/test/topology/test_global_ignore_nodes.py
@@ -31,7 +31,7 @@ async def test_global_ignored_nodes_list(manager: ManagerClient, random_tables) 
     s3_id = await manager.get_host_id(servers[3].server_id)
     await manager.remove_node(servers[1].server_id, servers[4].server_id, [s3_id])
     # down one more node and try to replace it without providing server 3 as ignored
-    # this has to succeed since it was ignored previously and is non voter now so teh quorum
+    # this has to succeed since it was ignored previously and is non voter now so the quorum
     # is 2
     await manager.server_stop_gracefully(servers[2].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[2].server_id, reuse_ip_addr = False, use_host_id = True)

--- a/test/topology_custom/test_snitch_change.py
+++ b/test/topology_custom/test_snitch_change.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.asyncio
 async def test_snitch_change(manager: ManagerClient) -> None:
     """ The test changes snitch from simple to GossipingPropertyFileSnitch one and checks
-        that DC adn rack names change accordingly"""
+        that DC and rack names change accordingly"""
     s1 = await manager.server_add(property_file = {'dc': 'DC1', 'rack' : 'R1'})
     s2 = await manager.server_add(property_file = {'dc': 'DC1', 'rack' : 'R1'})
     cql = manager.get_cql()

--- a/test/topology_custom/test_tablets_migration.py
+++ b/test/topology_custom/test_tablets_migration.py
@@ -212,7 +212,7 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
 
         async def stop(self, via=0):
             if self.stage == "cleanup_target":
-                await self.cleanup_fail.stop(via=3) # removenode of source is happending via node0 already
+                await self.cleanup_fail.stop(via=3) # removenode of source is happening via node0 already
                 await self.stream_stop_task
                 return
             if self.stage == "revert_migration":

--- a/test/topology_custom/test_writes_to_previous_cdc_generations.py
+++ b/test/topology_custom/test_writes_to_previous_cdc_generations.py
@@ -70,7 +70,7 @@ async def test_writes_to_recent_previous_cdc_generations(request, manager: Manag
 
     gen_timestamps = await wait_for_publishing_generations(cql, servers)
 
-    logger.info("Ceating a test table")
+    logger.info("Creating a test table")
     await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int) WITH cdc = {'enabled': true}")
 
@@ -120,7 +120,7 @@ async def test_writes_to_old_previous_cdc_generation(request, manager: ManagerCl
 
     gen_timestamps = await wait_for_publishing_generations(cql, servers)
 
-    logger.info("Ceating a test table")
+    logger.info("Creating a test table")
     await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int) WITH cdc = {'enabled': true}")
 

--- a/test/topology_experimental_raft/test_alternator.py
+++ b/test/topology_experimental_raft/test_alternator.py
@@ -84,7 +84,7 @@ unique_table_name.last_ms = 0
 async def test_alternator_ttl_scheduling_group(alternator3):
     """A reproducer for issue #18719: The expiration scans and deletions
        initiated by the Alternator TTL feature are supposed to run entirely in
-       the "streaming" scheduling group. But because of a bug in inheritence
+       the "streaming" scheduling group. But because of a bug in inheritance
        of scheduling groups through RPC, some of the work ended up being done
        on the "statement" scheduling group.
        This test verifies that Alternator TTL work is done on the right


### PR DESCRIPTION
fix a typo in source code. this typo was identified by codespell.

---

no need to backport fixes for typos in non-user facing areas.