### PR TITLE
Move some /storage_proxy API endpoints to config.cc

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -71,6 +71,8 @@ future<> set_server_init(http_context& ctx) {
         rb->register_function(r, "error_injection",
             "The error injection API");
         set_error_injection(ctx, r);
+        rb->register_function(r, "storage_proxy",
+                "The storage proxy API");
     });
 }
 
@@ -220,10 +222,7 @@ future<> unset_server_messaging_service(http_context& ctx) {
 }
 
 future<> set_server_storage_proxy(http_context& ctx, sharded<service::storage_proxy>& proxy) {
-    return register_api(ctx, "storage_proxy",
-                "The storage proxy API", [&proxy] (http_context& ctx, routes& r) {
-                    set_storage_proxy(ctx, r, proxy);
-                });
+    return ctx.http_server.set_routes([&ctx, &proxy] (routes& r) { set_storage_proxy(ctx, r, proxy); });
 }
 
 future<> unset_server_storage_proxy(http_context& ctx) {

--- a/api/api.cc
+++ b/api/api.cc
@@ -81,6 +81,10 @@ future<> set_server_config(http_context& ctx, const db::config& cfg) {
     });
 }
 
+future<> unset_server_config(http_context& ctx) {
+    return ctx.http_server.set_routes([&ctx] (routes& r) { unset_config(ctx, r); });
+}
+
 static future<> register_api(http_context& ctx, const sstring& api_name,
         const sstring api_desc,
         std::function<void(http_context& ctx, routes& r)> f) {

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -85,6 +85,7 @@ struct http_context {
 
 future<> set_server_init(http_context& ctx);
 future<> set_server_config(http_context& ctx, const db::config& cfg);
+future<> unset_server_config(http_context& ctx);
 future<> set_server_snitch(http_context& ctx, sharded<locator::snitch_ptr>& snitch);
 future<> unset_server_snitch(http_context& ctx);
 future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss, service::raft_group0_client&);

--- a/api/config.cc
+++ b/api/config.cc
@@ -6,8 +6,11 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "api/api.hh"
 #include "api/config.hh"
 #include "api/api-doc/config.json.hh"
+#include "api/api-doc/storage_proxy.json.hh"
+#include "replica/database.hh"
 #include "db/config.hh"
 #include <sstream>
 #include <boost/algorithm/string/replace.hpp>
@@ -15,6 +18,7 @@
 
 namespace api {
 using namespace seastar::httpd;
+namespace sp = httpd::storage_proxy_json;
 
 template<class T>
 json::json_return_type get_json_return_type(const T& val) {
@@ -101,10 +105,102 @@ void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx
         }
         throw bad_param_exception(sstring("No such config entry: ") + id);
     });
+
+    sp::get_rpc_timeout.set(r, [&ctx](const_req req)  {
+        return ctx.db.local().get_config().request_timeout_in_ms()/1000.0;
+    });
+
+    sp::set_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
+        //TBD
+        unimplemented();
+        auto enable = req->get_query_param("timeout");
+        return make_ready_future<json::json_return_type>(seastar::json::json_void());
+    });
+
+    sp::get_read_rpc_timeout.set(r, [&ctx](const_req req)  {
+        return ctx.db.local().get_config().read_request_timeout_in_ms()/1000.0;
+    });
+
+    sp::set_read_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
+        //TBD
+        unimplemented();
+        auto enable = req->get_query_param("timeout");
+        return make_ready_future<json::json_return_type>(seastar::json::json_void());
+    });
+
+    sp::get_write_rpc_timeout.set(r, [&ctx](const_req req)  {
+        return ctx.db.local().get_config().write_request_timeout_in_ms()/1000.0;
+    });
+
+    sp::set_write_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
+        //TBD
+        unimplemented();
+        auto enable = req->get_query_param("timeout");
+        return make_ready_future<json::json_return_type>(seastar::json::json_void());
+    });
+
+    sp::get_counter_write_rpc_timeout.set(r, [&ctx](const_req req)  {
+        return ctx.db.local().get_config().counter_write_request_timeout_in_ms()/1000.0;
+    });
+
+    sp::set_counter_write_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
+        //TBD
+        unimplemented();
+        auto enable = req->get_query_param("timeout");
+        return make_ready_future<json::json_return_type>(seastar::json::json_void());
+    });
+
+    sp::get_cas_contention_timeout.set(r, [&ctx](const_req req)  {
+        return ctx.db.local().get_config().cas_contention_timeout_in_ms()/1000.0;
+    });
+
+    sp::set_cas_contention_timeout.set(r, [](std::unique_ptr<http::request> req)  {
+        //TBD
+        unimplemented();
+        auto enable = req->get_query_param("timeout");
+        return make_ready_future<json::json_return_type>(seastar::json::json_void());
+    });
+
+    sp::get_range_rpc_timeout.set(r, [&ctx](const_req req)  {
+        return ctx.db.local().get_config().range_request_timeout_in_ms()/1000.0;
+    });
+
+    sp::set_range_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
+        //TBD
+        unimplemented();
+        auto enable = req->get_query_param("timeout");
+        return make_ready_future<json::json_return_type>(seastar::json::json_void());
+    });
+
+    sp::get_truncate_rpc_timeout.set(r, [&ctx](const_req req)  {
+        return ctx.db.local().get_config().truncate_request_timeout_in_ms()/1000.0;
+    });
+
+    sp::set_truncate_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
+        //TBD
+        unimplemented();
+        auto enable = req->get_query_param("timeout");
+        return make_ready_future<json::json_return_type>(seastar::json::json_void());
+    });
+
 }
 
 void unset_config(http_context& ctx, routes& r) {
     cs::find_config_id.unset(r);
+    sp::get_rpc_timeout.unset(r);
+    sp::set_rpc_timeout.unset(r);
+    sp::get_read_rpc_timeout.unset(r);
+    sp::set_read_rpc_timeout.unset(r);
+    sp::get_write_rpc_timeout.unset(r);
+    sp::set_write_rpc_timeout.unset(r);
+    sp::get_counter_write_rpc_timeout.unset(r);
+    sp::set_counter_write_rpc_timeout.unset(r);
+    sp::get_cas_contention_timeout.unset(r);
+    sp::set_cas_contention_timeout.unset(r);
+    sp::get_range_rpc_timeout.unset(r);
+    sp::set_range_rpc_timeout.unset(r);
+    sp::get_truncate_rpc_timeout.unset(r);
+    sp::set_truncate_rpc_timeout.unset(r);
 }
 
 }

--- a/api/config.cc
+++ b/api/config.cc
@@ -106,8 +106,8 @@ void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx
         throw bad_param_exception(sstring("No such config entry: ") + id);
     });
 
-    sp::get_rpc_timeout.set(r, [&ctx](const_req req)  {
-        return ctx.db.local().get_config().request_timeout_in_ms()/1000.0;
+    sp::get_rpc_timeout.set(r, [&cfg](const_req req)  {
+        return cfg.request_timeout_in_ms()/1000.0;
     });
 
     sp::set_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
@@ -117,8 +117,8 @@ void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx
         return make_ready_future<json::json_return_type>(seastar::json::json_void());
     });
 
-    sp::get_read_rpc_timeout.set(r, [&ctx](const_req req)  {
-        return ctx.db.local().get_config().read_request_timeout_in_ms()/1000.0;
+    sp::get_read_rpc_timeout.set(r, [&cfg](const_req req)  {
+        return cfg.read_request_timeout_in_ms()/1000.0;
     });
 
     sp::set_read_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
@@ -128,8 +128,8 @@ void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx
         return make_ready_future<json::json_return_type>(seastar::json::json_void());
     });
 
-    sp::get_write_rpc_timeout.set(r, [&ctx](const_req req)  {
-        return ctx.db.local().get_config().write_request_timeout_in_ms()/1000.0;
+    sp::get_write_rpc_timeout.set(r, [&cfg](const_req req)  {
+        return cfg.write_request_timeout_in_ms()/1000.0;
     });
 
     sp::set_write_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
@@ -139,8 +139,8 @@ void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx
         return make_ready_future<json::json_return_type>(seastar::json::json_void());
     });
 
-    sp::get_counter_write_rpc_timeout.set(r, [&ctx](const_req req)  {
-        return ctx.db.local().get_config().counter_write_request_timeout_in_ms()/1000.0;
+    sp::get_counter_write_rpc_timeout.set(r, [&cfg](const_req req)  {
+        return cfg.counter_write_request_timeout_in_ms()/1000.0;
     });
 
     sp::set_counter_write_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
@@ -150,8 +150,8 @@ void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx
         return make_ready_future<json::json_return_type>(seastar::json::json_void());
     });
 
-    sp::get_cas_contention_timeout.set(r, [&ctx](const_req req)  {
-        return ctx.db.local().get_config().cas_contention_timeout_in_ms()/1000.0;
+    sp::get_cas_contention_timeout.set(r, [&cfg](const_req req)  {
+        return cfg.cas_contention_timeout_in_ms()/1000.0;
     });
 
     sp::set_cas_contention_timeout.set(r, [](std::unique_ptr<http::request> req)  {
@@ -161,8 +161,8 @@ void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx
         return make_ready_future<json::json_return_type>(seastar::json::json_void());
     });
 
-    sp::get_range_rpc_timeout.set(r, [&ctx](const_req req)  {
-        return ctx.db.local().get_config().range_request_timeout_in_ms()/1000.0;
+    sp::get_range_rpc_timeout.set(r, [&cfg](const_req req)  {
+        return cfg.range_request_timeout_in_ms()/1000.0;
     });
 
     sp::set_range_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
@@ -172,8 +172,8 @@ void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx
         return make_ready_future<json::json_return_type>(seastar::json::json_void());
     });
 
-    sp::get_truncate_rpc_timeout.set(r, [&ctx](const_req req)  {
-        return ctx.db.local().get_config().truncate_request_timeout_in_ms()/1000.0;
+    sp::get_truncate_rpc_timeout.set(r, [&cfg](const_req req)  {
+        return cfg.truncate_request_timeout_in_ms()/1000.0;
     });
 
     sp::set_truncate_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {

--- a/api/config.cc
+++ b/api/config.cc
@@ -103,5 +103,9 @@ void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx
     });
 }
 
+void unset_config(http_context& ctx, routes& r) {
+    cs::find_config_id.unset(r);
+}
+
 }
 

--- a/api/config.hh
+++ b/api/config.hh
@@ -14,4 +14,5 @@
 namespace api {
 
 void set_config(std::shared_ptr<httpd::api_registry_builder20> rb, http_context& ctx, httpd::routes& r, const db::config& cfg, bool first = false);
+void unset_config(http_context& ctx, httpd::routes& r);
 }

--- a/api/storage_proxy.cc
+++ b/api/storage_proxy.cc
@@ -13,7 +13,6 @@
 #include "api/api-doc/utils.json.hh"
 #include "db/config.hh"
 #include "utils/histogram.hh"
-#include "replica/database.hh"
 #include <seastar/core/scheduling_specific.hh>
 
 namespace api {
@@ -259,83 +258,6 @@ void set_storage_proxy(http_context& ctx, routes& r, sharded<service::storage_pr
         return make_ready_future<json::json_return_type>(0);
     });
 
-    sp::get_rpc_timeout.set(r, [&ctx](const_req req)  {
-        return ctx.db.local().get_config().request_timeout_in_ms()/1000.0;
-    });
-
-    sp::set_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
-        //TBD
-        unimplemented();
-        auto enable = req->get_query_param("timeout");
-        return make_ready_future<json::json_return_type>(json_void());
-    });
-
-    sp::get_read_rpc_timeout.set(r, [&ctx](const_req req)  {
-        return ctx.db.local().get_config().read_request_timeout_in_ms()/1000.0;
-    });
-
-    sp::set_read_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
-        //TBD
-        unimplemented();
-        auto enable = req->get_query_param("timeout");
-        return make_ready_future<json::json_return_type>(json_void());
-    });
-
-    sp::get_write_rpc_timeout.set(r, [&ctx](const_req req)  {
-        return ctx.db.local().get_config().write_request_timeout_in_ms()/1000.0;
-    });
-
-    sp::set_write_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
-        //TBD
-        unimplemented();
-        auto enable = req->get_query_param("timeout");
-        return make_ready_future<json::json_return_type>(json_void());
-    });
-
-    sp::get_counter_write_rpc_timeout.set(r, [&ctx](const_req req)  {
-        return ctx.db.local().get_config().counter_write_request_timeout_in_ms()/1000.0;
-    });
-
-    sp::set_counter_write_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
-        //TBD
-        unimplemented();
-        auto enable = req->get_query_param("timeout");
-        return make_ready_future<json::json_return_type>(json_void());
-    });
-
-    sp::get_cas_contention_timeout.set(r, [&ctx](const_req req)  {
-        return ctx.db.local().get_config().cas_contention_timeout_in_ms()/1000.0;
-    });
-
-    sp::set_cas_contention_timeout.set(r, [](std::unique_ptr<http::request> req)  {
-        //TBD
-        unimplemented();
-        auto enable = req->get_query_param("timeout");
-        return make_ready_future<json::json_return_type>(json_void());
-    });
-
-    sp::get_range_rpc_timeout.set(r, [&ctx](const_req req)  {
-        return ctx.db.local().get_config().range_request_timeout_in_ms()/1000.0;
-    });
-
-    sp::set_range_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
-        //TBD
-        unimplemented();
-        auto enable = req->get_query_param("timeout");
-        return make_ready_future<json::json_return_type>(json_void());
-    });
-
-    sp::get_truncate_rpc_timeout.set(r, [&ctx](const_req req)  {
-        return ctx.db.local().get_config().truncate_request_timeout_in_ms()/1000.0;
-    });
-
-    sp::set_truncate_rpc_timeout.set(r, [](std::unique_ptr<http::request> req)  {
-        //TBD
-        unimplemented();
-        auto enable = req->get_query_param("timeout");
-        return make_ready_future<json::json_return_type>(json_void());
-    });
-
     sp::reload_trigger_classes.set(r, [](std::unique_ptr<http::request> req)  {
         //TBD
         unimplemented();
@@ -516,20 +438,6 @@ void unset_storage_proxy(http_context& ctx, routes& r) {
     sp::get_max_hints_in_progress.unset(r);
     sp::set_max_hints_in_progress.unset(r);
     sp::get_hints_in_progress.unset(r);
-    sp::get_rpc_timeout.unset(r);
-    sp::set_rpc_timeout.unset(r);
-    sp::get_read_rpc_timeout.unset(r);
-    sp::set_read_rpc_timeout.unset(r);
-    sp::get_write_rpc_timeout.unset(r);
-    sp::set_write_rpc_timeout.unset(r);
-    sp::get_counter_write_rpc_timeout.unset(r);
-    sp::set_counter_write_rpc_timeout.unset(r);
-    sp::get_cas_contention_timeout.unset(r);
-    sp::set_cas_contention_timeout.unset(r);
-    sp::get_range_rpc_timeout.unset(r);
-    sp::set_range_rpc_timeout.unset(r);
-    sp::get_truncate_rpc_timeout.unset(r);
-    sp::set_truncate_rpc_timeout.unset(r);
     sp::reload_trigger_classes.unset(r);
     sp::get_read_repair_attempted.unset(r);
     sp::get_read_repair_repaired_blocking.unset(r);

--- a/main.cc
+++ b/main.cc
@@ -1217,6 +1217,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             startlog.info("Scylla API server listening on {}:{} ...", api_addr, cfg->api_port());
 
             api::set_server_config(ctx, *cfg).get();
+            auto stop_config_api = defer_verbose_shutdown("config API", [&ctx] {
+                api::unset_server_config(ctx).get();
+            });
 
             static sharded<auth::service> auth_service;
             static sharded<auth::service> maintenance_auth_service;


### PR DESCRIPTION
API endpoints that need a particular service to get data from are registered next to this service (#2737). In /storage_proxy function there live some endpoints that work with config, so this PR moves them to the existing config.cc with config-related endpoints. The path these endpoints are registered with remains intact, so some tweak in proxy API registration is also here.