### PR TITLE
[Backport 5.4] auth: reuse roles select query during cache population

### DIFF
--- a/auth/service.cc
+++ b/auth/service.cc
@@ -30,6 +30,7 @@
 #include "db/functions/function_name.hh"
 #include "exceptions/exceptions.hh"
 #include "log.hh"
+#include "seastar/coroutine/parallel_for_each.hh"
 #include "service/migration_manager.hh"
 #include "utils/class_registrator.hh"
 #include "locator/abstract_replication_strategy.hh"
@@ -280,34 +281,21 @@ future<bool> service::has_existing_legacy_users() const {
 future<permission_set>
 service::get_uncached_permissions(const role_or_anonymous& maybe_role, const resource& r) const {
     if (is_anonymous(maybe_role)) {
-        return _authorizer->authorize(maybe_role, r);
+        co_return co_await _authorizer->authorize(maybe_role, r);
     }
-
     const std::string_view role_name = *maybe_role.name;
-
-    return has_superuser(role_name).then([this, role_name, &r](bool superuser) {
-        if (superuser) {
-            return make_ready_future<permission_set>(r.applicable_permissions());
-        }
-
-        //
-        // Aggregate the permissions from all granted roles.
-        //
-
-        return do_with(permission_set(), [this, role_name, &r](auto& all_perms) {
-            return get_roles(role_name).then([this, &r, &all_perms](role_set all_roles) {
-                return do_with(std::move(all_roles), [this, &r, &all_perms](const auto& all_roles) {
-                    return parallel_for_each(all_roles, [this, &r, &all_perms](std::string_view role_name) {
-                        return _authorizer->authorize(role_name, r).then([&all_perms](permission_set perms) {
-                            all_perms = permission_set::from_mask(all_perms.mask() | perms.mask());
-                        });
-                    });
-                });
-            }).then([&all_perms] {
-                return all_perms;
-            });
-        });
+    auto superuser = co_await has_superuser(role_name);
+    if (superuser) {
+        co_return r.applicable_permissions();
+    }
+    // Aggregate the permissions from all granted roles.
+    permission_set all_perms;
+    auto all_roles = co_await get_roles(role_name);
+    co_await coroutine::parallel_for_each(all_roles, [this, &r, &all_perms](std::string_view role_name) -> future<> {
+        auto perms = co_await _authorizer->authorize(role_name, r);
+        all_perms = permission_set::from_mask(all_perms.mask() | perms.mask());
     });
+    co_return std::move(all_perms);
 }
 
 future<permission_set> service::get_permissions(const role_or_anonymous& maybe_role, const resource& r) const {

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -284,13 +284,13 @@ service::get_uncached_permissions(const role_or_anonymous& maybe_role, const res
         co_return co_await _authorizer->authorize(maybe_role, r);
     }
     const std::string_view role_name = *maybe_role.name;
-    auto superuser = co_await has_superuser(role_name);
+    auto all_roles = co_await get_roles(role_name);
+    auto superuser = co_await has_superuser(role_name, all_roles);
     if (superuser) {
         co_return r.applicable_permissions();
     }
     // Aggregate the permissions from all granted roles.
     permission_set all_perms;
-    auto all_roles = co_await get_roles(role_name);
     co_await coroutine::parallel_for_each(all_roles, [this, &r, &all_perms](std::string_view role_name) -> future<> {
         auto perms = co_await _authorizer->authorize(role_name, r);
         all_perms = permission_set::from_mask(all_perms.mask() | perms.mask());
@@ -302,14 +302,18 @@ future<permission_set> service::get_permissions(const role_or_anonymous& maybe_r
     return _permissions_cache->get(maybe_role, r);
 }
 
-future<bool> service::has_superuser(std::string_view role_name) const {
-    auto roles = co_await get_roles(role_name);
+future<bool> service::has_superuser(std::string_view role_name, const role_set& roles) const {
     for (const auto& role : roles) {
         if (co_await _role_manager->is_superuser(role)) {
             co_return true;
         }
     }
     co_return false;
+}
+
+future<bool> service::has_superuser(std::string_view role_name) const {
+    auto roles = co_await get_roles(role_name);
+    co_return co_await has_superuser(role_name, roles);
 }
 
 future<role_set> service::get_roles(std::string_view role_name) const {

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -315,21 +315,13 @@ future<permission_set> service::get_permissions(const role_or_anonymous& maybe_r
 }
 
 future<bool> service::has_superuser(std::string_view role_name) const {
-    return this->get_roles(std::move(role_name)).then([this](role_set roles) {
-        return do_with(std::move(roles), [this](const role_set& roles) {
-            return do_with(false, roles.begin(), [this, &roles](bool& any_super, auto& iter) {
-                return do_until(
-                        [&roles, &any_super, &iter] { return any_super || (iter == roles.end()); },
-                        [this, &any_super, &iter] {
-                    return _role_manager->is_superuser(*iter++).then([&any_super](bool super) {
-                        any_super = super;
-                    });
-                }).then([&any_super] {
-                    return any_super;
-                });
-            });
-        });
-    });
+    auto roles = co_await get_roles(role_name);
+    for (const auto& role : roles) {
+        if (co_await _role_manager->is_superuser(role)) {
+            co_return true;
+        }
+    }
+    co_return false;
 }
 
 future<role_set> service::get_roles(std::string_view role_name) const {

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -163,7 +163,7 @@ public:
 
 private:
     future<bool> has_existing_legacy_users() const;
-
+    future<bool> has_superuser(std::string_view role_name, const role_set& roles) const;
     future<> create_keyspace_if_missing(::service::migration_manager& mm) const;
 };
 


### PR DESCRIPTION
With big number of shards in the cluster (e.g. 500+) due to cache
periodic refresh we experience high load on role_permissions table
(e.g. 1k op/s). The load on roles table is amplified because to populate
single entry in the cache we do several selects on roles table. Some
of this can't be avoided because roles are arranged in a tree-like
structure where permissions can be inherited.

This patch tries to reuse queries which are simply duplicated. It should
reduce the load on roles table by up to 50%.

Fixes https://github.com/scylladb/scylladb/issues/19299

(cherry picked from commit https://github.com/scylladb/scylladb/commit/00a24507cb895cce8c5135f0631e41b40aee2cfa)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/547eb6d59b2d36d6beaae2b6e3f37e5dedda1afd)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/95673907cae4efee14cc9383b8fbdc3c07e656d9)

Refs https://github.com/scylladb/scylladb/pull/19300