### PR TITLE
Sanitize gossiper API endpoints management

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -192,11 +192,16 @@ future<> set_server_gossip(http_context& ctx, sharded<gms::gossiper>& g) {
                 "The gossiper API", [&g] (http_context& ctx, routes& r) {
                     set_gossiper(ctx, r, g.local());
                 });
+    co_await register_api(ctx, "failure_detector",
+                "The failure detector API", [&g] (http_context& ctx, routes& r) {
+                    set_failure_detector(ctx, r, g.local());
+                });
 }
 
 future<> unset_server_gossip(http_context& ctx) {
     return ctx.http_server.set_routes([&ctx] (routes& r) {
         unset_gossiper(ctx, r);
+        unset_failure_detector(ctx, r);
     });
 }
 
@@ -260,13 +265,7 @@ future<> unset_hinted_handoff(http_context& ctx) {
 }
 
 future<> set_server_gossip_settle(http_context& ctx, sharded<gms::gossiper>& g) {
-    auto rb = std::make_shared < api_registry_builder > (ctx.api_doc);
-
-    return ctx.http_server.set_routes([rb, &ctx, &g](routes& r) {
-        rb->register_function(r, "failure_detector",
-                "The failure detector API");
-        set_failure_detector(ctx, r, g.local());
-    });
+    return make_ready_future<>();
 }
 
 future<> set_server_compaction_manager(http_context& ctx) {

--- a/api/api.cc
+++ b/api/api.cc
@@ -264,10 +264,6 @@ future<> unset_hinted_handoff(http_context& ctx) {
     return ctx.http_server.set_routes([&ctx] (routes& r) { unset_hinted_handoff(ctx, r); });
 }
 
-future<> set_server_gossip_settle(http_context& ctx, sharded<gms::gossiper>& g) {
-    return make_ready_future<>();
-}
-
 future<> set_server_compaction_manager(http_context& ctx) {
     auto rb = std::make_shared < api_registry_builder > (ctx.api_doc);
 

--- a/api/api.cc
+++ b/api/api.cc
@@ -188,7 +188,7 @@ future<> unset_server_snitch(http_context& ctx) {
 }
 
 future<> set_server_gossip(http_context& ctx, sharded<gms::gossiper>& g) {
-    return register_api(ctx, "gossiper",
+    co_await register_api(ctx, "gossiper",
                 "The gossiper API", [&g] (http_context& ctx, routes& r) {
                     set_gossiper(ctx, r, g.local());
                 });

--- a/api/api.cc
+++ b/api/api.cc
@@ -194,6 +194,12 @@ future<> set_server_gossip(http_context& ctx, sharded<gms::gossiper>& g) {
                 });
 }
 
+future<> unset_server_gossip(http_context& ctx) {
+    return ctx.http_server.set_routes([&ctx] (routes& r) {
+        unset_gossiper(ctx, r);
+    });
+}
+
 future<> set_server_column_family(http_context& ctx, sharded<db::system_keyspace>& sys_ks) {
     return register_api(ctx, "column_family",
                 "The column family API", [&sys_ks] (http_context& ctx, routes& r) {

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -117,7 +117,6 @@ future<> set_server_stream_manager(http_context& ctx, sharded<streaming::stream_
 future<> unset_server_stream_manager(http_context& ctx);
 future<> set_hinted_handoff(http_context& ctx, sharded<service::storage_proxy>& p);
 future<> unset_hinted_handoff(http_context& ctx);
-future<> set_server_gossip_settle(http_context& ctx, sharded<gms::gossiper>& g);
 future<> set_server_cache(http_context& ctx);
 future<> set_server_compaction_manager(http_context& ctx);
 future<> set_server_done(http_context& ctx);

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -106,6 +106,7 @@ future<> unset_server_snapshot(http_context& ctx);
 future<> set_server_token_metadata(http_context& ctx, sharded<locator::shared_token_metadata>& tm);
 future<> unset_server_token_metadata(http_context& ctx);
 future<> set_server_gossip(http_context& ctx, sharded<gms::gossiper>& g);
+future<> unset_server_gossip(http_context& ctx);
 future<> set_server_column_family(http_context& ctx, sharded<db::system_keyspace>& sys_ks);
 future<> unset_server_column_family(http_context& ctx);
 future<> set_server_messaging_service(http_context& ctx, sharded<netw::messaging_service>& ms);

--- a/api/failure_detector.cc
+++ b/api/failure_detector.cc
@@ -99,5 +99,16 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
     });
 }
 
+void unset_failure_detector(http_context& ctx, routes& r) {
+    fd::get_all_endpoint_states.unset(r);
+    fd::get_up_endpoint_count.unset(r);
+    fd::get_down_endpoint_count.unset(r);
+    fd::get_phi_convict_threshold.unset(r);
+    fd::get_simple_states.unset(r);
+    fd::set_phi_convict_threshold.unset(r);
+    fd::get_endpoint_state.unset(r);
+    fd::get_endpoint_phi_values.unset(r);
+}
+
 }
 

--- a/api/failure_detector.hh
+++ b/api/failure_detector.hh
@@ -19,5 +19,6 @@ class gossiper;
 namespace api {
 
 void set_failure_detector(http_context& ctx, httpd::routes& r, gms::gossiper& g);
+void unset_failure_detector(http_context& ctx, httpd::routes& r);
 
 }

--- a/api/gossiper.cc
+++ b/api/gossiper.cc
@@ -71,4 +71,14 @@ void set_gossiper(http_context& ctx, routes& r, gms::gossiper& g) {
     });
 }
 
+void unset_gossiper(http_context& ctx, routes& r) {
+    httpd::gossiper_json::get_down_endpoint.unset(r);
+    httpd::gossiper_json::get_live_endpoint.unset(r);
+    httpd::gossiper_json::get_endpoint_downtime.unset(r);
+    httpd::gossiper_json::get_current_generation_number.unset(r);
+    httpd::gossiper_json::get_current_heart_beat_version.unset(r);
+    httpd::gossiper_json::assassinate_endpoint.unset(r);
+    httpd::gossiper_json::force_remove_endpoint.unset(r);
+}
+
 }

--- a/api/gossiper.hh
+++ b/api/gossiper.hh
@@ -19,5 +19,6 @@ class gossiper;
 namespace api {
 
 void set_gossiper(http_context& ctx, httpd::routes& r, gms::gossiper& g);
+void unset_gossiper(http_context& ctx, httpd::routes& r);
 
 }

--- a/main.cc
+++ b/main.cc
@@ -1424,6 +1424,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
             gossiper.invoke_on_all(&gms::gossiper::start).get();
 
+            api::set_server_gossip(ctx, gossiper).get();
+            auto stop_gossip_api = defer_verbose_shutdown("gossiper API", [&ctx] {
+                api::unset_server_gossip(ctx).get();
+            });
+
             static sharded<service::raft_address_map> raft_address_map;
             supervisor::notify("starting Raft address map");
             raft_address_map.start().get();
@@ -1649,10 +1654,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 });
             }).get();
 
-            api::set_server_gossip(ctx, gossiper).get();
-            auto stop_gossip_api = defer_verbose_shutdown("gossiper API", [&ctx] {
-                api::unset_server_gossip(ctx).get();
-            });
             api::set_server_snitch(ctx, snitch).get();
             auto stop_snitch_api = defer_verbose_shutdown("snitch API", [&ctx] {
                 api::unset_server_snitch(ctx).get();

--- a/main.cc
+++ b/main.cc
@@ -1650,6 +1650,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }).get();
 
             api::set_server_gossip(ctx, gossiper).get();
+            auto stop_gossip_api = defer_verbose_shutdown("gossiper API", [&ctx] {
+                api::unset_server_gossip(ctx).get();
+            });
             api::set_server_snitch(ctx, snitch).get();
             auto stop_snitch_api = defer_verbose_shutdown("snitch API", [&ctx] {
                 api::unset_server_snitch(ctx).get();

--- a/main.cc
+++ b/main.cc
@@ -1999,7 +1999,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 startlog.info("Waiting for gossip to settle before accepting client requests...");
                 gossiper.local().wait_for_gossip_to_settle().get();
             }
-            api::set_server_gossip_settle(ctx, gossiper).get();
 
             supervisor::notify("allow replaying hints");
             proxy.invoke_on_all(&service::storage_proxy::allow_replaying_hints).get();


### PR DESCRIPTION
Gossiper has two blocs of endpoints, both are registered in legacy/random place in main. This PR moves them next to gossiper start and adds unregistration for both.

refs: #2737 