### PR TITLE
auth: do not include unused headers

### DIFF
--- a/auth/authenticator.hh
+++ b/auth/authenticator.hh
@@ -16,10 +16,8 @@
 #include <optional>
 #include <functional>
 
-#include <seastar/core/enum.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/core/shared_ptr.hh>
 
 #include "auth/authentication_options.hh"
 #include "auth/resource.hh"

--- a/auth/authorizer.hh
+++ b/auth/authorizer.hh
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include <seastar/core/future.hh>
-#include <seastar/core/shared_ptr.hh>
 
 #include "auth/permission.hh"
 #include "auth/resource.hh"

--- a/auth/certificate_authenticator.hh
+++ b/auth/certificate_authenticator.hh
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <boost/regex.hpp>
 #include "auth/authenticator.hh"
 
 namespace cql3 {

--- a/auth/common.hh
+++ b/auth/common.hh
@@ -13,10 +13,8 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/util/noncopyable_function.hh>
-#include <seastar/core/seastar.hh>
 #include <seastar/core/resource.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/core/smp.hh>
 
 #include "types/types.hh"
 #include "service/raft/raft_group0_client.hh"

--- a/auth/permissions_cache.hh
+++ b/auth/permissions_cache.hh
@@ -13,8 +13,6 @@
 
 #include <fmt/core.h>
 #include <seastar/core/future.hh>
-#include <seastar/core/shared_ptr.hh>
-#include <seastar/core/sstring.hh>
 
 #include "auth/permission.hh"
 #include "auth/resource.hh"

--- a/auth/resource.hh
+++ b/auth/resource.hh
@@ -18,7 +18,6 @@
 #include <unordered_set>
 
 #include <fmt/core.h>
-#include <boost/range/adaptor/transformed.hpp>
 #include <seastar/core/print.hh>
 #include <seastar/core/sstring.hh>
 


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.

---

it's a cleanup, hence no need to backport.