### PR TITLE
README.md: add badges for cron jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ $ ./tools/toolchain/dbuild ./build/release/scylla --help
 
 ## Testing
 
+[![Build with the latest Seastar](https://github.com/scylladb/scylladb/actions/workflows/seastar.yaml/badge.svg)](https://github.com/scylladb/scylladb/actions/workflows/seastar.yaml) [![Check Reproducible Build](https://github.com/scylladb/scylladb/actions/workflows/reproducible-build.yaml/badge.svg)](https://github.com/scylladb/scylladb/actions/workflows/reproducible-build.yaml) [![clang-nightly](https://github.com/scylladb/scylladb/actions/workflows/clang-nightly.yaml/badge.svg)](https://github.com/scylladb/scylladb/actions/workflows/clang-nightly.yaml)
+
 See [test.py manual](docs/dev/testing.md).
 
 ## Scylla APIs and compatibility


### PR DESCRIPTION
these jobs are scheduled to verify the builds of scylla, like if it builds with the latest Seastar, if scylla can generated reproducible builds, and if it builds with the nightly build of clang. the failure of these workflow are not very visible without clicking into the corresponding workflow in
https://github.com/scylladb/scylladb/actions.

in this change, we add their badges in the testing section of README.md, so one can identify the test failures of them if any,

---

it's an improvement in developer experience, hence no need to backport.