### PR TITLE
main: drop sstables_format_listener from main()

### DIFF
--- a/db/sstables-format-selector.cc
+++ b/db/sstables-format-selector.cc
@@ -85,6 +85,10 @@ future<> sstables_format_listener::start() {
     assert(this_shard_id() == 0);
     // The listener may fire immediately, create a thread for that case.
     co_await seastar::async([this] {
+        // NOTE: when introducing a new format, please
+        // 1. plant a sstable_format_listener in main()
+        // 2. so it checks for the corresponding cluster feature
+        // 3. and bumping up the sstable format if this feature is set
         _me_feature_listener.on_enabled();
     });
 }

--- a/main.cc
+++ b/main.cc
@@ -1540,13 +1540,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // engine().at_exit([&qp] { return qp.stop(); });
             sstables::init_metrics().get();
 
-            db::sstables_format_listener sst_format_listener(gossiper.local(), feature_service, sst_format_selector);
-
-            sst_format_listener.start().get();
-            auto stop_format_listener = defer_verbose_shutdown("sstables format listener", [&sst_format_listener] {
-                sst_format_listener.stop().get();
-            });
-
             supervisor::notify("starting Raft Group Registry service");
             raft_gr.invoke_on_all(&service::raft_group_registry::start).get();
 


### PR DESCRIPTION
in c429a8d8ae, we make the default sstable format "me". but the sole purpose of `sstables_format_listener` is to bump up the sstable format to the specified format by updating system table and sstable managers for system and user sstables.

but now that "me" at the time of writing is already the highest sstable supported by scylla, there is no need to listen agreement on cluster features for updating the sstable format.

so, in this change, `sstables_format_listener` is removed from main().

Refs #18995
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

it's a cleanup, hence no need to backport.