### PR TITLE
test: remove unused operator<<

### DIFF
--- a/test/lib/expr_test_utils.hh
+++ b/test/lib/expr_test_utils.hh
@@ -158,14 +158,3 @@ template <> struct fmt::formatter<cql3::expr::test_utils::mutation_column_value>
 
     }
 };
-
-namespace cql3::expr::test_utils {
-
-inline
-std::ostream&
-operator<<(std::ostream& os, const mutation_column_value& mcv) {
-    fmt::print(os, "{}", mcv);
-    return os;
-}
-
-}


### PR DESCRIPTION
since we've switched almost all callers of the operator<< to {fmt}, let's drop the unused operator<<:s.

---

it is a cleanup, hence no need to backport.
