### PR TITLE
alternator: support different timeout with different op

### DIFF
--- a/alternator/controller.cc
+++ b/alternator/controller.cc
@@ -77,6 +77,10 @@ future<> controller::start_server() {
 
         rmw_operation::set_default_write_isolation(_config.alternator_write_isolation());
         executor::set_default_timeout(std::chrono::milliseconds(_config.alternator_timeout_in_ms()));
+        executor::set_default_getitem_timeout(std::chrono::milliseconds(_config.alternator_getitem_timeout_in_ms()));
+        executor::set_default_putitem_nonlwt_timeout(std::chrono::milliseconds(_config.alternator_putitem_nonlwt_timeout_in_ms()));
+        executor::set_default_putitem_lwt_timeout(std::chrono::milliseconds(_config.alternator_putitem_lwt_timeout_in_ms()));
+        executor::set_default_query_timeout(std::chrono::milliseconds(_config.alternator_query_timeout_in_ms()));
 
         net::inet_address addr = utils::resolve(_config.alternator_address, family).get0();
 

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -202,10 +202,17 @@ public:
     future<> stop() { return make_ready_future<>(); }
 
     static sstring table_name(const schema&);
-    static db::timeout_clock::time_point default_timeout();
+    static db::timeout_clock::time_point default_timeout(db::timeout_clock::duration timeout = executor::s_default_timeout);
     static void set_default_timeout(db::timeout_clock::duration timeout);
-private:
+    static void set_default_getitem_timeout(db::timeout_clock::duration timeout);
+    static void set_default_putitem_nonlwt_timeout(db::timeout_clock::duration timeout);
+    static void set_default_putitem_lwt_timeout(db::timeout_clock::duration timeout);
+    static void set_default_query_timeout(db::timeout_clock::duration timeout);
     static db::timeout_clock::duration s_default_timeout;
+    static db::timeout_clock::duration default_getitem_timeout;
+    static db::timeout_clock::duration default_putitem_nonlwt_timeout;
+    static db::timeout_clock::duration default_putitem_lwt_timeout;
+    static db::timeout_clock::duration default_query_timeout;
 public:
     static schema_ptr find_table(service::storage_proxy&, const rjson::value& request);
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -889,6 +889,10 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , alternator_ttl_period_in_seconds(this, "alternator_ttl_period_in_seconds", value_status::Used,
         60*60*24,
         "The default period for Alternator's expiration scan. Alternator attempts to scan every table within that period.")
+    , alternator_getitem_timeout_in_ms(this, "alternator_getitem_timeout_in_ms", value_status::Used, 3000, "The server-side timeout for completing Alternator getitem API requests.")
+    , alternator_putitem_nonlwt_timeout_in_ms(this, "alternator_putitem_nonlwt_timeout_in_ms", value_status::Used, 2000, "The server-side timeout for completing Alternator normal write API requests.")
+    , alternator_putitem_lwt_timeout_in_ms(this, "alternator_putitem_lwt_timeout_in_ms", value_status::Used, 5000, "The server-side timeout for completing Alternator lwt write API requests.")
+    , alternator_query_timeout_in_ms(this, "alternator_query_timeout_in_ms", value_status::Used, 10000, "The server-side timeout for completing Alternator query API requests.")
     , abort_on_ebadf(this, "abort_on_ebadf", value_status::Used, true, "Abort the server on incorrect file descriptor access. Throws exception when disabled.")
     , redis_port(this, "redis_port", value_status::Used, 0, "Port on which the REDIS transport listens for clients.")
     , redis_ssl_port(this, "redis_ssl_port", value_status::Used, 0, "Port on which the REDIS TLS native transport listens for clients.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -367,6 +367,10 @@ public:
     named_value<uint32_t> alternator_streams_time_window_s;
     named_value<uint32_t> alternator_timeout_in_ms;
     named_value<double> alternator_ttl_period_in_seconds;
+    named_value<uint32_t> alternator_getitem_timeout_in_ms;
+    named_value<uint32_t> alternator_putitem_nonlwt_timeout_in_ms;
+    named_value<uint32_t> alternator_putitem_lwt_timeout_in_ms;
+    named_value<uint32_t> alternator_query_timeout_in_ms;
 
     named_value<bool> abort_on_ebadf;
 


### PR DESCRIPTION
The tail latency of different alternator operations varies greatly, especially the tail latency of lwt requests is significantly higher than that of ordinary read requests. This commit supports setting different timeouts for different kind of operations.
