### PR TITLE
feat: support estimated row count metric

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -974,6 +974,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , enable_deprecated_partitioners(this, "enable_deprecated_partitioners", value_status::Used, false, "Enable the byteordered and random partitioners. These partitioners are deprecated and will be removed in a future version.")
     , enable_keyspace_column_family_metrics(this, "enable_keyspace_column_family_metrics", value_status::Used, false, "Enable per keyspace and per column family metrics reporting.")
     , enable_node_aggregated_table_metrics(this, "enable_node_aggregated_table_metrics", value_status::Used, true, "Enable aggregated per node, per keyspace and per table metrics reporting, applicable if enable_keyspace_column_family_metrics is false.")
+    , enable_keyspace_column_family_estimated_row_count(this, "enable_keyspace_column_family_estimated_row_count", value_status::Used, false, "Enable per keyspace and per column family estimated rows count(include tombstones) reporting.")
     , enable_sstable_data_integrity_check(this, "enable_sstable_data_integrity_check", value_status::Used, false, "Enable interposer which checks for integrity of every sstable write."
         " Performance is affected to some extent as a result. Useful to help debugging problems that may arise at another layers.")
     , enable_sstable_key_validation(this, "enable_sstable_key_validation", value_status::Used, ENABLE_SSTABLE_KEY_VALIDATION, "Enable validation of partition and clustering keys monotonicity"

--- a/db/config.hh
+++ b/db/config.hh
@@ -361,6 +361,7 @@ public:
     named_value<bool> enable_deprecated_partitioners;
     named_value<bool> enable_keyspace_column_family_metrics;
     named_value<bool> enable_node_aggregated_table_metrics;
+    named_value<bool> enable_keyspace_column_family_estimated_row_count;
     named_value<bool> enable_sstable_data_integrity_check;
     named_value<bool> enable_sstable_key_validation;
     named_value<bool> cpu_scheduler;

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -160,6 +160,7 @@ public:
     size_t live_sstable_count() const noexcept;
     uint64_t live_disk_space_used() const noexcept;
     uint64_t total_disk_space_used() const noexcept;
+    uint64_t estimated_row_count() const noexcept;
 
     compaction::table_state& as_table_state() const noexcept;
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1244,6 +1244,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.statement_scheduling_group = _config.statement_scheduling_group;
     cfg.enable_metrics_reporting = db_config.enable_keyspace_column_family_metrics();
     cfg.enable_node_aggregated_table_metrics = db_config.enable_node_aggregated_table_metrics();
+    cfg.enable_estimated_row_count_reporting = db_config.enable_keyspace_column_family_estimated_row_count();
     cfg.reversed_reads_auto_bypass_cache = db_config.reversed_reads_auto_bypass_cache;
     cfg.enable_optimized_reversed_reads = db_config.enable_optimized_reversed_reads;
     cfg.tombstone_warn_threshold = db_config.tombstone_warn_threshold();
@@ -2143,6 +2144,7 @@ database::make_keyspace_config(const keyspace_metadata& ksm) {
     cfg.streaming_scheduling_group = _dbcfg.streaming_scheduling_group;
     cfg.statement_scheduling_group = _dbcfg.statement_scheduling_group;
     cfg.enable_metrics_reporting = _cfg.enable_keyspace_column_family_metrics();
+    cfg.enable_estimated_row_count_reporting = _cfg.enable_keyspace_column_family_estimated_row_count();
 
     cfg.view_update_concurrency_semaphore_limit = max_memory_pending_view_updates();
     return cfg;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -339,6 +339,7 @@ struct table_stats {
     int64_t live_disk_space_used = 0;
     int64_t total_disk_space_used = 0;
     int64_t live_sstable_count = 0;
+    int64_t estimated_row_count = 0;
     /** Estimated number of compactions pending for this column family */
     int64_t pending_compactions = 0;
     int64_t memtable_partition_insertions = 0;
@@ -410,6 +411,7 @@ public:
         seastar::scheduling_group streaming_scheduling_group;
         bool enable_metrics_reporting = false;
         bool enable_node_aggregated_table_metrics = true;
+        bool enable_estimated_row_count_reporting = false;
         size_t view_update_concurrency_semaphore_limit;
         db::data_listeners* data_listeners = nullptr;
         // Not really table-specific (it's a global configuration parameter), but stored here
@@ -1267,6 +1269,7 @@ public:
         seastar::scheduling_group statement_scheduling_group;
         seastar::scheduling_group streaming_scheduling_group;
         bool enable_metrics_reporting = false;
+        bool enable_estimated_row_count_reporting = false;
         size_t view_update_concurrency_semaphore_limit;
     };
 private:


### PR DESCRIPTION
This commit adds a parameter
`enable_keyspace_column_family_estimated_row_count` to control whether to put the estimated number of rows per table into metrics. The numerical update occurs every time the sstables are updated, and the statistics of the entire sstables will be carried out. The expected performance impact is very small.