### PR TITLE
[Backport 6.0] tasks: fix tasks abort

### DIFF
--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -182,7 +182,7 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
                 if (!task->is_abortable()) {
                     co_await coroutine::return_exception(std::runtime_error("Requested task cannot be aborted"));
                 }
-                co_await task->abort();
+                task->abort();
             });
         } catch (tasks::task_manager::task_not_found& e) {
             throw bad_param_exception(e.what());

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -489,7 +489,7 @@ public:
         return compaction_task_impl::get_progress(_compaction_data, _progress_monitor);
     }
 
-    virtual future<> abort() noexcept override {
+    virtual void abort() noexcept override {
         return compaction_task_executor::abort(_as);
     }
 protected:
@@ -514,7 +514,7 @@ public:
         return compaction_task_impl::get_progress(_compaction_data, _progress_monitor);
     }
 
-    virtual future<> abort() noexcept override {
+    virtual void abort() noexcept override {
         return compaction_task_executor::abort(_as);
     }
 protected:
@@ -629,7 +629,7 @@ public:
         return compaction_task_impl::get_progress(_compaction_data, _progress_monitor);
     }
 
-    virtual future<> abort() noexcept override {
+    virtual void abort() noexcept override {
         return compaction_task_executor::abort(_as);
     }
 protected:
@@ -855,12 +855,11 @@ void compaction_task_executor::finish_compaction(state finish_state) noexcept {
     _compaction_state.compaction_done.signal();
 }
 
-future<> compaction_task_executor::abort(abort_source& as) noexcept {
+void compaction_task_executor::abort(abort_source& as) noexcept {
     if (!as.abort_requested()) {
         as.request_abort();
         stop_compaction("user requested abort");
     }
-    return make_ready_future();
 }
 
 void compaction_task_executor::stop_compaction(sstring reason) noexcept {
@@ -1181,7 +1180,7 @@ public:
         , regular_compaction_task_impl(mgr._task_manager_module, tasks::task_id::create_random_id(), mgr._task_manager_module->new_sequence_number(), t.schema()->ks_name(), t.schema()->cf_name(), "", tasks::task_id::create_null_id())
     {}
 
-    virtual future<> abort() noexcept override {
+    virtual void abort() noexcept override {
         return compaction_task_executor::abort(_as);
     }
 protected:
@@ -1352,7 +1351,7 @@ public:
         return compaction_task_impl::get_progress(_compaction_data, _progress_monitor);
     }
 
-    virtual future<> abort() noexcept override {
+    virtual void abort() noexcept override {
         return compaction_task_executor::abort(_as);
     }
 protected:
@@ -1755,7 +1754,7 @@ public:
         return compaction_task_impl::get_progress(_compaction_data, _progress_monitor);
     }
 
-    virtual future<> abort() noexcept override {
+    virtual void abort() noexcept override {
         return compaction_task_executor::abort(_as);
     }
 protected:

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -594,7 +594,7 @@ public:
         return _compaction_data.abort.abort_requested();
     }
 
-    future<> abort(abort_source& as) noexcept;
+    void abort(abort_source& as) noexcept;
 
     void stop_compaction(sstring reason) noexcept;
 

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -548,7 +548,7 @@ void repair::task_manager_module::abort_all_repairs() {
         if (it != _tasks.end()) {
             auto& impl = dynamic_cast<repair::shard_repair_task_impl&>(*it->second->_impl);
             // If the task is aborted, its state will change to failed. One can wait for this with task_manager::task::done().
-            (void)impl.abort();
+            impl.abort();
         }
     }
     rlogger.info0("Started to abort repair jobs={}, nr_jobs={}", _aborted_pending_repairs, _aborted_pending_repairs.size());
@@ -706,7 +706,7 @@ future<> repair::shard_repair_task_impl::repair_range(const dht::token_range& ra
             rlogger.error("repair[{}]: Repair {} out of {} ranges, keyspace={}, table={}, range={}, peers={}, live_peers={}, status={}",
                     global_repair_id.uuid(), ranges_index, ranges_size(), _status.keyspace, table.name, range, neighbors, live_neighbors, status);
             // If the task is aborted, its state will change to failed. One can wait for this with task_manager::task::done().
-            (void)abort();
+            abort();
             co_await coroutine::return_exception(std::runtime_error(format("Repair mandatory neighbor={} is not alive, keyspace={}, mandatory_neighbors={}",
                 node, _status.keyspace, mandatory_neighbors)));
         }

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -86,7 +86,7 @@ public:
     {
         if (ops_info && ops_info->as) {
             _abort_subscription = ops_info->as->subscribe([this] () noexcept {
-                (void)abort();
+                abort();
             });
         }
     }

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -10,6 +10,7 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/util/defer.hh>
 
 #include "task_manager.hh"
 
@@ -90,7 +91,7 @@ task_manager::task::impl::impl(module_ptr module, task_id id, uint64_t sequence_
     // Child tasks do not need to subscribe to abort source because they will be aborted recursively by their parents.
     if (!parent_id) {
         _shutdown_subscription = module->abort_source().subscribe([this] () noexcept {
-            (void)abort();
+            abort();
         });
     }
 }
@@ -138,25 +139,28 @@ is_internal task_manager::task::impl::is_internal() const noexcept {
     return tasks::is_internal(bool(_parent_id));
 }
 
-future<> task_manager::task::impl::abort() noexcept {
+static future<> abort_children(task_manager::module_ptr module, task_id parent_id) noexcept {
+    auto entered = module->async_gate().try_enter();
+    if (!entered) {
+        return make_ready_future();
+    }
+    auto leave_gate = defer([&module] () {
+        module->async_gate().leave();
+    });
+    return module->get_task_manager().container().invoke_on_all([parent_id] (task_manager& tm) {
+        for (auto& task : tm.get_all_tasks()) {
+            if (task.second->get_parent_id() == parent_id) {
+                task.second->abort();
+            }
+        }
+    });
+}
+
+void task_manager::task::impl::abort() noexcept {
     if (!_as.abort_requested()) {
         _as.request_abort();
 
-        std::vector<task_info> children_info = co_await _children.map_each_task<task_info>([] (const foreign_task_ptr& child) {
-            return task_info{child->id(), child.get_owner_shard()};
-        }, [] (const task_essentials& child) {
-            return std::nullopt;
-        });
-
-        co_await coroutine::parallel_for_each(children_info, [this] (auto info) {
-            return smp::submit_to(info.shard, [info, &tm = _module->get_task_manager().container()] {
-                auto& tasks = tm.local().get_all_tasks();
-                if (auto it = tasks.find(info.id); it != tasks.end()) {
-                    return it->second->abort();
-                }
-                return make_ready_future<>();
-            });
-        });
+        (void)abort_children(_module, _status.id);
     }
 }
 
@@ -321,8 +325,8 @@ is_internal task_manager::task::is_internal() const noexcept {
     return _impl->is_internal();
 }
 
-future<> task_manager::task::abort() noexcept {
-    return _impl->abort();
+void task_manager::task::abort() noexcept {
+    _impl->abort();
 }
 
 bool task_manager::task::abort_requested() const noexcept {
@@ -425,7 +429,7 @@ future<task_manager::task_ptr> task_manager::module::make_task(task::task_impl_p
         }));
     }
     if (abort) {
-        co_await task->abort();
+        task->abort();
     }
     co_return task;
 }

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -12,7 +12,11 @@
 #include <seastar/core/gate.hh>
 #include <seastar/util/defer.hh>
 
+#include "db/timeout_clock.hh"
 #include "task_manager.hh"
+#include "utils/error_injection.hh"
+
+using namespace std::chrono_literals;
 
 namespace tasks {
 
@@ -140,14 +144,17 @@ is_internal task_manager::task::impl::is_internal() const noexcept {
 }
 
 static future<> abort_children(task_manager::module_ptr module, task_id parent_id) noexcept {
+    co_await utils::get_local_injector().inject("tasks_abort_children",
+            [] (auto& handler) { return handler.wait_for_message(db::timeout_clock::now() + 10s); });
+
     auto entered = module->async_gate().try_enter();
     if (!entered) {
-        return make_ready_future();
+        co_return;
     }
     auto leave_gate = defer([&module] () {
         module->async_gate().leave();
     });
-    return module->get_task_manager().container().invoke_on_all([parent_id] (task_manager& tm) {
+    co_await module->get_task_manager().container().invoke_on_all([parent_id] (task_manager& tm) {
         for (auto& task : tm.get_all_tasks()) {
             if (task.second->get_parent_id() == parent_id) {
                 task.second->abort();

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -167,7 +167,7 @@ public:
             virtual future<task_manager::task::progress> get_progress() const;
             virtual tasks::is_abortable is_abortable() const noexcept;
             virtual tasks::is_internal is_internal() const noexcept;
-            virtual future<> abort() noexcept;
+            virtual void abort() noexcept;
             bool is_complete() const noexcept;
             bool is_done() const noexcept;
             virtual void release_resources() noexcept {}
@@ -206,7 +206,7 @@ public:
         future<progress> get_progress() const;
         tasks::is_abortable is_abortable() const noexcept;
         tasks::is_internal is_internal() const noexcept;
-        future<> abort() noexcept;
+        void abort() noexcept;
         bool abort_requested() const noexcept;
         future<> done() const noexcept;
         void register_task();

--- a/test/rest_api/test_task_manager.py
+++ b/test/rest_api/test_task_manager.py
@@ -1,9 +1,13 @@
 from enum import Enum
 import requests
+import sys
 import time
 
-from rest_util import new_test_module, new_test_task, set_tmp_task_ttl, ThreadWrapper
-from task_manager_utils import check_field_correctness, check_status_correctness, assert_task_does_not_exist, list_modules, get_task_status, list_tasks, get_task_status_recursively, wait_for_task
+# Use the util.py library from ../cql-pytest:
+sys.path.insert(1, sys.path[0] + '/test/cql-pytest')
+from util import new_test_table, new_test_keyspace
+from rest_util import new_test_module, new_test_task, set_tmp_task_ttl, ThreadWrapper, scylla_inject_error
+from task_manager_utils import check_field_correctness, check_status_correctness, assert_task_does_not_exist, list_modules, get_task_status, list_tasks, get_task_status_recursively, wait_for_task, drain_module_tasks, abort_task
 
 long_time = 1000000000
 
@@ -359,3 +363,39 @@ def test_task_folding(rest_api):
             task_folding4(rest_api)
             task_folding5(rest_api)
             task_folding6(rest_api)
+
+def test_abort_on_unregistered_task(cql, this_dc, rest_api):
+    module_name = "compaction"
+    drain_module_tasks(rest_api, module_name)
+    with set_tmp_task_ttl(rest_api, long_time):
+        with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
+            schema = 'p int, v text, primary key (p)'
+            with new_test_table(cql, keyspace, schema) as t0:
+                stmt = cql.prepare(f"INSERT INTO {t0} (p, v) VALUES (?, ?)")
+                cql.execute(stmt, [0, 'hello'])
+                cql.execute(stmt, [1, 'world'])
+
+                compaction_injection = "compaction_major_keyspace_compaction_task_impl_run"
+                abort_injection = "tasks_abort_children"
+                with scylla_inject_error(rest_api, compaction_injection, True): # Stops running compaction.
+                    with scylla_inject_error(rest_api, abort_injection, True):  # Stops task abort.
+                        # Start compaction.
+                        resp = rest_api.send("POST", f"tasks/compaction/keyspace_compaction/{keyspace}")
+                        resp.raise_for_status()
+                        task_id = resp.json()
+
+                        # Abort compaction.
+                        abort_task(rest_api, task_id)
+
+                        # Resume compaction.
+                        resp = rest_api.send("POST", f"v2/error_injection/injection/{compaction_injection}/message")
+                        resp.raise_for_status()
+
+                        # Wait until compaction is done and unregister the task.
+                        wait_for_task(rest_api, task_id)
+                        get_task_status(rest_api, task_id)
+
+                        # Resume abort.
+                        resp = rest_api.send("POST", f"v2/error_injection/injection/{abort_injection}/message")
+                        resp.raise_for_status()
+    drain_module_tasks(rest_api, module_name)


### PR DESCRIPTION
Currently if task_manager::task::impl::abort preempts before children are recursively aborted and then the task gets unregistered, we hit use after free since abort uses children vector which is no longer alive.

Modify abort method so that it goes over all tasks in task manager and aborts those with the given parent.

Fixes: https://github.com/scylladb/scylladb/issues/19304.

Requires backport to all versions containing task manager

(cherry picked from commit https://github.com/scylladb/scylladb/commit/3463f495b1c54f3ea0de96f1dcee807a86e49fe8)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/50cb797d9525274ce0a196e161ecf53bd02314e7)

Refs https://github.com/scylladb/scylladb/pull/19305