### PR TITLE
[Backport 5.4] tasks: fix tasks abort

### DIFF
--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -180,7 +180,7 @@ void set_task_manager(http_context& ctx, routes& r, db::config& cfg) {
                 if (!task->is_abortable()) {
                     co_await coroutine::return_exception(std::runtime_error("Requested task cannot be aborted"));
                 }
-                co_await task->abort();
+                task->abort();
             });
         } catch (tasks::task_manager::task_not_found& e) {
             throw bad_param_exception(e.what());

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -472,7 +472,7 @@ void repair::task_manager_module::abort_all_repairs() {
         if (it != _tasks.end()) {
             auto& impl = dynamic_cast<repair::shard_repair_task_impl&>(*it->second->_impl);
             // If the task is aborted, its state will change to failed. One can wait for this with task_manager::task::done().
-            (void)impl.abort();
+            impl.abort();
         }
     }
     rlogger.info0("Started to abort repair jobs={}, nr_jobs={}", _aborted_pending_repairs, _aborted_pending_repairs.size());
@@ -656,7 +656,7 @@ future<> repair::shard_repair_task_impl::repair_range(const dht::token_range& ra
             rlogger.error("repair[{}]: Repair {} out of {} ranges, keyspace={}, table={}, range={}, peers={}, live_peers={}, status={}",
                     global_repair_id.uuid(), ranges_index, ranges_size(), _status.keyspace, table.name, range, neighbors, live_neighbors, status);
             // If the task is aborted, its state will change to failed. One can wait for this with task_manager::task::done().
-            (void)abort();
+            abort();
             co_await coroutine::return_exception(std::runtime_error(format("Repair mandatory neighbor={} is not alive, keyspace={}, mandatory_neighbors={}",
                 node, _status.keyspace, mandatory_neighbors)));
         }

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -83,7 +83,7 @@ public:
     {
         if (ops_info && ops_info->as) {
             _abort_subscription = ops_info->as->subscribe([this] () noexcept {
-                (void)abort();
+                abort();
             });
         }
     }

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -10,6 +10,7 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/util/defer.hh>
 
 #include "task_manager.hh"
 #include "test_module.hh"
@@ -35,7 +36,7 @@ task_manager::task::impl::impl(module_ptr module, task_id id, uint64_t sequence_
     // Child tasks do not need to subscribe to abort source because they will be aborted recursively by their parents.
     if (!parent_id) {
         _shutdown_subscription = module->abort_source().subscribe([this] () noexcept {
-            (void)abort();
+            abort();
         });
     }
 }
@@ -88,24 +89,28 @@ is_internal task_manager::task::impl::is_internal() const noexcept {
     return tasks::is_internal(bool(_parent_id));
 }
 
-future<> task_manager::task::impl::abort() noexcept {
+static future<> abort_children(task_manager::module_ptr module, task_id parent_id) noexcept {
+    auto entered = module->async_gate().try_enter();
+    if (!entered) {
+        return make_ready_future();
+    }
+    auto leave_gate = defer([&module] () {
+        module->async_gate().leave();
+    });
+    return module->get_task_manager().container().invoke_on_all([parent_id] (task_manager& tm) {
+        for (auto& task : tm.get_all_tasks()) {
+            if (task.second->get_parent_id() == parent_id) {
+                task.second->abort();
+            }
+        }
+    });
+}
+
+void task_manager::task::impl::abort() noexcept {
     if (!_as.abort_requested()) {
         _as.request_abort();
 
-        std::vector<task_info> children_info{_children.size()};
-        boost::transform(_children, children_info.begin(), [] (const auto& child) {
-            return task_info{child->id(), child.get_owner_shard()};
-        });
-
-        co_await coroutine::parallel_for_each(children_info, [this] (auto info) {
-            return smp::submit_to(info.shard, [info, &tm = _module->get_task_manager().container()] {
-                auto& tasks = tm.local().get_all_tasks();
-                if (auto it = tasks.find(info.id); it != tasks.end()) {
-                    return it->second->abort();
-                }
-                return make_ready_future<>();
-            });
-        });
+        (void)abort_children(_module, _status.id);
     }
 }
 
@@ -224,8 +229,8 @@ is_internal task_manager::task::is_internal() const noexcept {
     return _impl->is_internal();
 }
 
-future<> task_manager::task::abort() noexcept {
-    return _impl->abort();
+void task_manager::task::abort() noexcept {
+    _impl->abort();
 }
 
 bool task_manager::task::abort_requested() const noexcept {
@@ -328,7 +333,7 @@ future<task_manager::task_ptr> task_manager::module::make_task(task::task_impl_p
         });
     }
     if (abort) {
-        co_await task->abort();
+        task->abort();
     }
     co_return task;
 }

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -12,8 +12,12 @@
 #include <seastar/core/gate.hh>
 #include <seastar/util/defer.hh>
 
+#include "db/timeout_clock.hh"
 #include "task_manager.hh"
 #include "test_module.hh"
+#include "utils/error_injection.hh"
+
+using namespace std::chrono_literals;
 
 namespace tasks {
 
@@ -90,14 +94,17 @@ is_internal task_manager::task::impl::is_internal() const noexcept {
 }
 
 static future<> abort_children(task_manager::module_ptr module, task_id parent_id) noexcept {
+    co_await utils::get_local_injector().inject_with_handler("tasks_abort_children",
+            [] (auto& handler) { return handler.wait_for_message(db::timeout_clock::now() + 10s); });
+
     auto entered = module->async_gate().try_enter();
     if (!entered) {
-        return make_ready_future();
+        co_return;
     }
     auto leave_gate = defer([&module] () {
         module->async_gate().leave();
     });
-    return module->get_task_manager().container().invoke_on_all([parent_id] (task_manager& tm) {
+    co_await module->get_task_manager().container().invoke_on_all([parent_id] (task_manager& tm) {
         for (auto& task : tm.get_all_tasks()) {
             if (task.second->get_parent_id() == parent_id) {
                 task.second->abort();

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -125,7 +125,7 @@ public:
             virtual future<task_manager::task::progress> get_progress() const;
             virtual tasks::is_abortable is_abortable() const noexcept;
             virtual tasks::is_internal is_internal() const noexcept;
-            virtual future<> abort() noexcept;
+            virtual void abort() noexcept;
             bool is_complete() const noexcept;
             virtual void release_resources() noexcept {}
         protected:
@@ -161,7 +161,7 @@ public:
         future<progress> get_progress() const;
         tasks::is_abortable is_abortable() const noexcept;
         tasks::is_internal is_internal() const noexcept;
-        future<> abort() noexcept;
+        void abort() noexcept;
         bool abort_requested() const noexcept;
         future<> done() const noexcept;
         void register_task();


### PR DESCRIPTION
Currently if task_manager::task::impl::abort preempts before children are recursively aborted and then the task gets unregistered, we hit use after free since abort uses children vector which is no longer alive.

Modify abort method so that it goes over all tasks in task manager and aborts those with the given parent.

Fixes: https://github.com/scylladb/scylladb/issues/19304.

Requires backport to all versions containing task manager

(cherry picked from commit https://github.com/scylladb/scylladb/commit/3463f495b1c54f3ea0de96f1dcee807a86e49fe8)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/50cb797d9525274ce0a196e161ecf53bd02314e7)

Refs https://github.com/scylladb/scylladb/pull/19305