### PR TITLE
.github/workflow: close and replace label when backport promoted

### DIFF
--- a/.github/scripts/label_promoted_commits.py
+++ b/.github/scripts/label_promoted_commits.py
@@ -23,8 +23,16 @@ def parser():
                              'commit, exclusive).')
     parser.add_argument('--update_issue', type=bool, default=False, help='Set True to update issues when backport was '
                                                                          'done')
-    parser.add_argument('--label', type=str, required=True, help='Label to use')
+    parser.add_argument('--label', type=str, default='promoted-to-master', help='Label to use')
+    parser.add_argument('--ref', type=str, required=True, help='PR target branch')
     return parser.parse_args()
+
+
+def add_comment_and_close_pr(pr_number, repository, comment):
+    pr = repository.get_pull(pr_number)
+    if pr.state == open:
+        pr.create_issue_comment(comment)
+        pr.edit(state="closed")
 
 
 def main():
@@ -32,27 +40,53 @@ def main():
     pr_pattern = re.compile(r'Closes .*#([0-9]+)')
     g = Github(github_token)
     repo = g.get_repo(args.repository, lazy=False)
-
     commits = repo.compare(head=args.commit_after_merge, base=args.commit_before_merge)
+    processed_prs = set()
     # Print commit information
     for commit in commits.commits:
-        print(commit.sha)
         match = pr_pattern.search(commit.commit.message)
         if match:
-            pr_number = match.group(1)
-            url = f'https://api.github.com/repos/{args.repository}/issues/{pr_number}/labels'
-            data = {
-                "labels": [f'{args.label}']
+            search_url = f'https://api.github.com/search/issues'
+            query = f"repo:{args.repository} is:pr is:closed sha:{commit.sha}"
+            params = {
+                "q": query,
             }
             headers = {
                 "Authorization": f"token {github_token}",
                 "Accept": "application/vnd.github.v3+json"
             }
-            response = requests.post(url, headers=headers, json=data)
-            if response.ok:
-                print(f"Label added successfully to {url}")
-            else:
-                print(f"No label was added to {url}")
+            response = requests.get(search_url, headers=headers, params=params)
+            prs = response.json().get("items", [])
+            for pr in prs:
+                refs_match = re.findall(r'Refs (?:#|https.*?)(\d+)', pr["body"])
+                ref = re.search(r'branch-(\d+\.\d+)', args.ref)
+                if refs_match and ref:
+                    pr_number = int(refs_match[0])
+                    backport_pr_number = int(match.group(1))
+                    if pr_number in processed_prs:
+                        continue
+                    label_to_add = f'backport/{ref.group(1)}-done'
+                    label_to_remove = f'backport/{ref.group(1)}'
+                    pr = repo.get_pull(pr_number)
+                    current_labels = pr.get_labels()
+                    current_label_names = [label.name for label in current_labels]
+                    if label_to_remove in current_label_names:
+                        pr.remove_from_labels(label_to_remove)
+                    if label_to_add not in current_label_names:
+                        pr.add_to_labels(label_to_add)
+                    comment = f'Closed via {commit.sha}'
+                    add_comment_and_close_pr(backport_pr_number, repo, comment)
+                    processed_prs.add(pr_number)
+                else:
+                    assert re.match(r'/master', args.ref)
+                    pr_number = pr["number"]
+                    pr = repo.get_pull(pr_number)
+                    label_to_add = args.label
+                    current_labels = pr.get_labels()
+                    current_label_names = [label.name for label in current_labels]
+                    if label_to_add not in current_label_names:
+                        pr.add_to_labels(label_to_add)
+                processed_prs.add(pr_number)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/add-label-when-promoted.yaml
+++ b/.github/workflows/add-label-when-promoted.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+      - branch-*.*
+
+env:
+  DEFAULT_BRANCH: 'master'
 
 jobs:
   check-commit:
@@ -19,6 +23,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.repository }}
+          ref: ${{ env.DEFAULT_BRANCH }}
           fetch-depth: 0  # Fetch all history for all tags and branches
 
       - name: Install dependencies
@@ -27,4 +33,4 @@ jobs:
       - name: Run python script
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python .github/scripts/label_promoted_commits.py --commit_before_merge ${{ github.event.before }} --commit_after_merge ${{ github.event.after }} --repository ${{ github.repository }} --label promoted-to-master
+        run: python .github/scripts/label_promoted_commits.py --commit_before_merge ${{ github.event.before }} --commit_after_merge ${{ github.event.after }} --repository ${{ github.repository }} --ref ${{ github.ref }}


### PR DESCRIPTION
Today after Mergify opened a Backport PR, it will stay open until someone manually close the backport PR , also we can't track using labels which backport was done or not since there is no indication for that except digging into the PR and looking for a comment or a commit ref

The following changes were made in this PR:
* trigger add-label-when-promoted.yaml also when the push was made to `branch-x.y`
* Replace label `backport/x.y` with `backport/x.y-done` in the original PR (this will automatically update the original Issue as well)
* Add a comment on the backport PR and close it

Fixes: https://github.com/scylladb/scylladb/issues/19441

**Need to backport those changes to both 5.4 and 6.0 for the auto close to work**