### PR TITLE
Use chunked partition_range vectors for indexed query and in forward_request

### DIFF
--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -10,10 +10,12 @@
 
 #pragma once
 
+#include <ranges>
 #include <vector>
 #include "bounds_slice.hh"
 #include "cql3/expr/expression.hh"
 #include "cql3/expr/restrictions.hh"
+#include "dht/i_partitioner_fwd.hh"
 #include "schema/schema_fwd.hh"
 #include "cql3/prepare_context.hh"
 #include "cql3/statements/statement_type.hh"
@@ -291,12 +293,13 @@ public:
     /**
      * Returns the specified range of the partition key.
      *
-     * @param b the boundary type
+     * @param ranges the partition_range vector output param
      * @param options the query options
-     * @return the specified bound of the partition key
      * @throws InvalidRequestException if the boundary cannot be retrieved
      */
-    dht::partition_range_vector get_partition_key_ranges(const query_options& options) const;
+    template <std::ranges::range Range = dht::partition_range_vector>
+    requires std::same_as<std::ranges::range_value_t<Range>, dht::partition_range>
+    Range get_partition_key_ranges(const query_options& options) const;
 
 
 public:
@@ -378,6 +381,9 @@ public:
     /// Checks that the primary key restrictions don't contain null values, throws invalid_request_exception otherwise.
     void validate_primary_key(const query_options& options) const;
 };
+
+extern template dht::partition_range_vector statement_restrictions::get_partition_key_ranges(const query_options& options) const;
+extern template dht::chunked_partition_range_vector statement_restrictions::get_partition_key_ranges(const query_options& options) const;
 
 }
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -18,6 +18,7 @@
 #include "cql3/statements/prune_materialized_view_statement.hh"
 #include "cql3/statements/strongly_consistent_select_statement.hh"
 
+#include "dht/i_partitioner_fwd.hh"
 #include "service/broadcast_tables/experimental/lang.hh"
 #include "transport/messages/result_message.hh"
 #include "cql3/functions/as_json_function.hh"
@@ -1642,7 +1643,7 @@ parallelized_select_statement::do_execute(
         query::is_first_page::no,
         options.get_timestamp(state)
     );
-    auto key_ranges = _restrictions->get_partition_key_ranges(options);
+    auto key_ranges = _restrictions->get_partition_key_ranges<dht::chunked_partition_range_vector>(options);
 
     if (db::is_serial_consistency(options.get_consistency())) {
         throw exceptions::invalid_request_exception(

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -642,10 +642,10 @@ indexed_table_select_statement::do_execute_base_query(
 
     struct base_query_state {
         query::result_merger merger;
-        query_ranges_to_vnodes_generator ranges_to_vnodes;
+        query_ranges_to_vnodes_generator<dht::partition_range_vector> ranges_to_vnodes;
         size_t concurrency = 1;
         size_t previous_result_size = 0;
-        base_query_state(uint64_t row_limit, query_ranges_to_vnodes_generator&& ranges_to_vnodes_)
+        base_query_state(uint64_t row_limit, query_ranges_to_vnodes_generator<dht::partition_range_vector>&& ranges_to_vnodes_)
                 : merger(row_limit, query::max_partitions)
                 , ranges_to_vnodes(std::move(ranges_to_vnodes_))
                 {}

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -225,7 +225,7 @@ private:
     lw_shared_ptr<const service::pager::paging_state> generate_view_paging_state_from_base_query_results(lw_shared_ptr<const service::pager::paging_state> paging_state,
             const foreign_ptr<lw_shared_ptr<query::result>>& results, service::query_state& state, const query_options& options) const;
 
-    future<coordinator_result<std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>>> find_index_partition_ranges(query_processor& qp,
+    future<coordinator_result<std::tuple<dht::chunked_partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>>> find_index_partition_ranges(query_processor& qp,
                                                                     service::query_state& state,
                                                                     const query_options& options) const;
 
@@ -249,7 +249,7 @@ private:
     future<coordinator_result<std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>>>>
     do_execute_base_query(
             query_processor& qp,
-            dht::partition_range_vector&& partition_ranges,
+            dht::chunked_partition_range_vector&& partition_ranges,
             service::query_state& state,
             const query_options& options,
             gc_clock::time_point now,
@@ -257,7 +257,7 @@ private:
     future<shared_ptr<cql_transport::messages::result_message>>
     execute_base_query(
             query_processor& qp,
-            dht::partition_range_vector&& partition_ranges,
+            dht::chunked_partition_range_vector&& partition_ranges,
             service::query_state& state,
             const query_options& options,
             gc_clock::time_point now,

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -227,7 +227,7 @@ ring_position_range_vector_sharder::next(const schema& s) {
     return ret;
 }
 
-future<utils::chunked_vector<partition_range>>
+future<chunked_partition_range_vector>
 split_range_to_single_shard(const schema& s, const static_sharder& sharder, const partition_range& pr, shard_id shard) {
     auto start_token = pr.start() ? pr.start()->value().token() : minimum_token();
     auto start_shard = sharder.shard_of(start_token);
@@ -236,7 +236,7 @@ split_range_to_single_shard(const schema& s, const static_sharder& sharder, cons
     return repeat_until_value([&sharder,
             &pr,
             cmp = ring_position_comparator(s),
-            ret = utils::chunked_vector<partition_range>(),
+            ret = chunked_partition_range_vector(),
             start_token,
             start_boundary,
             shard] () mutable {
@@ -253,7 +253,7 @@ split_range_to_single_shard(const schema& s, const static_sharder& sharder, cons
                 ret.push_back(std::move(*intersection));
             }
             if (!s_a_t) {
-                return make_ready_future<std::optional<utils::chunked_vector<partition_range>>>(std::move(ret));
+                return make_ready_future<std::optional<chunked_partition_range_vector>>(std::move(ret));
             }
             if (s_a_t->shard == shard) {
                 start_token = end_token;
@@ -261,9 +261,9 @@ split_range_to_single_shard(const schema& s, const static_sharder& sharder, cons
                 start_token = sharder.token_for_next_shard(end_token, shard);
             }
             start_boundary = interval_bound<ring_position>(ring_position::starting_at(start_token));
-            return make_ready_future<std::optional<utils::chunked_vector<partition_range>>>();
+            return make_ready_future<std::optional<chunked_partition_range_vector>>();
         }
-        return make_ready_future<std::optional<utils::chunked_vector<partition_range>>>(std::move(ret));
+        return make_ready_future<std::optional<chunked_partition_range_vector>>(std::move(ret));
     });
 }
 

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -101,7 +101,7 @@ std::map<unsigned, dht::partition_range_vector>
 split_range_to_shards(dht::partition_range pr, const schema& s, const sharder& sharder);
 
 // Intersect a partition_range with a shard and return the resulting sub-ranges, in sorted order
-future<utils::chunked_vector<partition_range>> split_range_to_single_shard(const schema& s,
+future<chunked_partition_range_vector> split_range_to_single_shard(const schema& s,
     const static_sharder& sharder, const dht::partition_range& pr, shard_id shard);
 
 std::unique_ptr<dht::i_partitioner> make_partitioner(sstring name);

--- a/dht/i_partitioner_fwd.hh
+++ b/dht/i_partitioner_fwd.hh
@@ -10,6 +10,7 @@
 #pragma once
 #include <vector>
 #include "interval.hh"
+#include "utils/chunked_vector.hh"
 
 namespace sstables {
 
@@ -29,6 +30,7 @@ using partition_range = interval<ring_position>;
 using token_range = interval<token>;
 
 using partition_range_vector = std::vector<partition_range>;
+using chunked_partition_range_vector = utils::chunked_vector<partition_range>;
 using token_range_vector = std::vector<token_range>;
 
 class decorated_key;

--- a/idl/mapreduce_request.idl.hh
+++ b/idl/mapreduce_request.idl.hh
@@ -33,7 +33,7 @@ struct mapreduce_request {
     std::vector<query::mapreduce_request::reduction_type> reduction_types;
 
     query::read_command cmd;
-    dht::partition_range_vector pr;
+    dht::chunked_partition_range_vector pr;
 
     db::consistency_level cl;
     lowres_system_clock::time_point timeout;

--- a/query-request.hh
+++ b/query-request.hh
@@ -487,7 +487,7 @@ struct mapreduce_request {
     std::vector<reduction_type> reduction_types;
 
     query::read_command cmd;
-    dht::partition_range_vector pr;
+    dht::chunked_partition_range_vector pr;
 
     db::consistency_level cl;
     lowres_system_clock::time_point timeout;

--- a/query_ranges_to_vnodes.hh
+++ b/query_ranges_to_vnodes.hh
@@ -8,18 +8,23 @@
 
 #pragma once
 
+#include <concepts>
+#include <ranges>
+
 #include "dht/i_partitioner_fwd.hh"
 #include "locator/token_range_splitter.hh"
 
+template <std::ranges::range Range>
+requires std::same_as<std::ranges::range_value_t<Range>, dht::partition_range>
 class query_ranges_to_vnodes_generator {
     schema_ptr _s;
-    dht::partition_range_vector _ranges;
+    Range _ranges;
     size_t _i; // index to current range in _ranges
     bool _local;
     std::unique_ptr<locator::token_range_splitter> _splitter;
     void process_one_range(size_t n, dht::partition_range_vector& ranges);
 public:
-    query_ranges_to_vnodes_generator(std::unique_ptr<locator::token_range_splitter> splitter, schema_ptr s, dht::partition_range_vector ranges, bool local = false);
+    query_ranges_to_vnodes_generator(std::unique_ptr<locator::token_range_splitter> splitter, schema_ptr s, Range ranges, bool local = false);
     query_ranges_to_vnodes_generator(const query_ranges_to_vnodes_generator&) = delete;
     query_ranges_to_vnodes_generator(query_ranges_to_vnodes_generator&&) = default;
     // generate next 'n' vnodes, may return less than requested number of ranges
@@ -31,3 +36,6 @@ public:
         return _i >= _ranges.size();
     }
 };
+
+extern template class query_ranges_to_vnodes_generator<dht::partition_range_vector>;
+extern template class query_ranges_to_vnodes_generator<dht::chunked_partition_range_vector>;

--- a/query_ranges_to_vnodes.hh
+++ b/query_ranges_to_vnodes.hh
@@ -14,7 +14,7 @@
 class query_ranges_to_vnodes_generator {
     schema_ptr _s;
     dht::partition_range_vector _ranges;
-    dht::partition_range_vector::iterator _i; // iterator to current range in _ranges
+    size_t _i; // index to current range in _ranges
     bool _local;
     std::unique_ptr<locator::token_range_splitter> _splitter;
     void process_one_range(size_t n, dht::partition_range_vector& ranges);
@@ -27,5 +27,7 @@ public:
     // (in which case empty() == true), or too many ranges
     // are requested
     dht::partition_range_vector operator()(size_t n);
-    bool empty() const;
+    bool empty() const noexcept {
+        return _i >= _ranges.size();
+    }
 };

--- a/service/mapreduce_service.cc
+++ b/service/mapreduce_service.cc
@@ -207,14 +207,14 @@ class partition_ranges_owned_by_this_shard {
     // _partition_ranges will contain a list of partition ranges that are known
     // to be owned by this node. We'll further need to split each such range to
     // the pieces owned by the current shard, using _intersecter.
-    const dht::partition_range_vector _partition_ranges;
+    const dht::chunked_partition_range_vector _partition_ranges;
     size_t _range_idx;
     std::optional<dht::ring_position_range_sharder> _intersecter;
     locator::effective_replication_map_ptr _erm;
 public:
-    partition_ranges_owned_by_this_shard(schema_ptr s, dht::partition_range_vector v)
+    partition_ranges_owned_by_this_shard(schema_ptr s, dht::chunked_partition_range_vector v)
         :  _s(s)
-        , _partition_ranges(v)
+        , _partition_ranges(std::move(v))
         , _range_idx(0)
         , _erm(_s->table().get_effective_replication_map())
     {}
@@ -549,7 +549,7 @@ future<query::mapreduce_result> mapreduce_service::dispatch(query::mapreduce_req
     };
 
     // Group vnodes by assigned endpoint.
-    std::map<netw::messaging_service::msg_addr, dht::partition_range_vector> vnodes_per_addr;
+    std::map<netw::messaging_service::msg_addr, dht::chunked_partition_range_vector> vnodes_per_addr;
     const auto& topo = get_token_metadata_ptr()->get_topology();
     while (std::optional<dht::partition_range> vnode = next_vnode()) {
         inet_address_vector_replica_set live_endpoints = _proxy.get_live_endpoints(*erm, end_token(*vnode));
@@ -575,7 +575,7 @@ future<query::mapreduce_result> mapreduce_service::dispatch(query::mapreduce_req
     query::mapreduce_result result;
 
     co_await coroutine::parallel_for_each(vnodes_per_addr.begin(), vnodes_per_addr.end(),
-            [&] (std::pair<const netw::messaging_service::msg_addr, dht::partition_range_vector>& vnodes_with_addr) -> future<> {
+            [&] (std::pair<const netw::messaging_service::msg_addr, dht::chunked_partition_range_vector>& vnodes_with_addr) -> future<> {
         netw::messaging_service::msg_addr addr = vnodes_with_addr.first;
         query::mapreduce_result& result_ = result;
         tracing::trace_state_ptr& tr_state_ = tr_state;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5829,7 +5829,7 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
         locator::effective_replication_map_ptr erm,
         lw_shared_ptr<query::read_command> cmd,
         db::consistency_level cl,
-        query_ranges_to_vnodes_generator ranges_to_vnodes,
+        query_ranges_to_vnodes_generator<dht::partition_range_vector> ranges_to_vnodes,
         int concurrency_factor,
         tracing::trace_state_ptr trace_state,
         uint64_t remaining_row_count,

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -37,12 +37,12 @@
 #include "replica/exceptions.hh"
 #include "locator/host_id.hh"
 #include "dht/token_range_endpoints.hh"
+#include "query_ranges_to_vnodes.hh"
 
 class reconcilable_result;
 class frozen_mutation_and_schema;
 class frozen_mutation;
 class cache_temperature;
-class query_ranges_to_vnodes_generator;
 
 namespace seastar::rpc {
 
@@ -393,7 +393,7 @@ private:
             locator::effective_replication_map_ptr erm,
             lw_shared_ptr<query::read_command> cmd,
             db::consistency_level cl,
-            query_ranges_to_vnodes_generator ranges_to_vnodes,
+            query_ranges_to_vnodes_generator<dht::partition_range_vector> ranges_to_vnodes,
             int concurrency_factor,
             tracing::trace_state_ptr trace_state,
             uint64_t remaining_row_count,

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1709,7 +1709,7 @@ populate_statistics_offsets(sstable_version_types v, statistics& s) {
 
 static
 sharding_metadata
-create_sharding_metadata(utils::chunked_vector<dht::partition_range> ranges) {
+create_sharding_metadata(dht::chunked_partition_range_vector ranges) {
     auto sm = sharding_metadata();
     sm.token_ranges.elements.reserve(ranges.size());
     for (auto&& range : std::move(ranges)) {
@@ -1749,7 +1749,7 @@ create_sharding_metadata(schema_ptr schema, const dht::decorated_key& first_key,
     if (sharder_opt) {
         return create_sharding_metadata(std::move(schema), *sharder_opt, first_key, last_key, shard);
     }
-    utils::chunked_vector<dht::partition_range> r;
+    dht::chunked_partition_range_vector r;
     r.push_back(dht::partition_range::make(dht::ring_position(first_key), dht::ring_position(last_key)));
     return create_sharding_metadata(std::move(r));
 }

--- a/test/boost/storage_proxy_test.cc
+++ b/test/boost/storage_proxy_test.cc
@@ -15,6 +15,7 @@
 #include "service/storage_proxy.hh"
 #include "query_ranges_to_vnodes.hh"
 #include "schema/schema_builder.hh"
+#include "dht/i_partitioner_fwd.hh"
 
 // Returns random keys sorted in ring order.
 // The schema must have a single bytes_type partition key column.
@@ -39,7 +40,7 @@ SEASTAR_TEST_CASE(test_get_restricted_ranges) {
 
         auto check = [&s](locator::token_metadata_ptr tmptr, dht::partition_range input,
                           dht::partition_range_vector expected) {
-            query_ranges_to_vnodes_generator ranges_to_vnodes(locator::make_splitter(tmptr), s, {input});
+            query_ranges_to_vnodes_generator ranges_to_vnodes(locator::make_splitter(tmptr), s, dht::partition_range_vector({input}));
             auto actual = ranges_to_vnodes(1000);
             if (!std::equal(actual.begin(), actual.end(), expected.begin(), [&s](auto&& r1, auto&& r2) {
                 return r1.equal(r2, dht::ring_position_comparator(*s));


### PR DESCRIPTION
This series uses `utils::chunked_vector<dht::partition_range>` in two places we know could be prone
to large allocations / reactor stalls where we need to allocate a long partition_range vector.

The first case is in `indexed_table_select_statement::find_index_partition_ranges`
where stalls of over 100 ms were seen in the field.

The other case is from `parallelized_select_statement::do_execute` where a cartesian product
of the the query range with lots of vnodes or tablets can result in a long
partition_range vector as well.

perf-simple-query results, using `perf-simple-query -c 1 --duration 10 --random-seed 20240623 --tablets --default-log-level=error`:
```
pre:  98373.34 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42658 insns/op,   21909 cycles/op,        0 errors)
post: 98854.32 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42606 insns/op,   21783 cycles/op,        0 errors)
```

Fixes https://github.com/scylladb/scylladb/issues/18536

Backport to 6.x since the stalls seen in the field were long: over 100ms.
