### PR TITLE
Fix undefined reference to utils::murmur_hash::hash32

### DIFF
--- a/utils/murmur_hash.hh
+++ b/utils/murmur_hash.hh
@@ -28,7 +28,7 @@ namespace utils {
 
 namespace murmur_hash {
 
-uint32_t hash32(bytes_view data, int32_t seed);
+uint32_t hash32(bytes_view data, uint32_t seed);
 uint64_t hash2_64(bytes_view key, uint64_t seed);
 
 template<typename InputIterator>


### PR DESCRIPTION
When using [utils::murmur_hash::hash32()](https://github.com/scylladb/scylladb/blob/master/utils/murmur_hash.hh#L31), compilation fails with an `undefined reference to utils::murmur_hash::hash32` due signature mismatch between declaration and definition.