### PR TITLE
bytes: drop unused operator<<

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -233,11 +233,8 @@ struct shard_id {
 
     // dynamo specifies shardid as max 65 chars. 
     friend std::ostream& operator<<(std::ostream& os, const shard_id& id) {
-        boost::io::ios_flags_saver fs(os);
-        return os << marker << std::hex  
-            << id.time.time_since_epoch().count()
-            << ':' << id.id.to_bytes()
-            ;
+        fmt::print(os, "{} {:x}:{}", marker, id.time.time_since_epoch().count(), id.id.to_bytes());
+        return os;
     }
 };
 
@@ -787,10 +784,8 @@ struct event_id {
     {}
     
     friend std::ostream& operator<<(std::ostream& os, const event_id& id) {
-        boost::io::ios_flags_saver fs(os);
-        return os << marker << std::hex << id.stream.to_bytes()
-            << ':' << id.timestamp
-            ;
+        fmt::print(os, "{}{}:{}", marker, id.stream.to_bytes(), id.timestamp);
+        return os;
     }
 };
 }

--- a/bytes.cc
+++ b/bytes.cc
@@ -61,19 +61,6 @@ sstring to_hex(const bytes_opt& b) {
     return !b ? "null" : to_hex(*b);
 }
 
-std::ostream& operator<<(std::ostream& os, const bytes& b) {
-    fmt::print(os, "{}", b);
-    return os;
-}
-
-std::ostream& operator<<(std::ostream& os, const bytes_opt& b) {
-    if (b) {
-        fmt::print(os, "{}", *b);
-        return os;
-    }
-    return os << "null";
-}
-
 namespace std {
 
 std::ostream& operator<<(std::ostream& os, const bytes_view& b) {
@@ -81,9 +68,4 @@ std::ostream& operator<<(std::ostream& os, const bytes_view& b) {
     return os;
 }
 
-}
-
-std::ostream& operator<<(std::ostream& os, const fmt_hex& b) {
-    fmt::print(os, "{}", b);
-    return os;
 }

--- a/bytes.hh
+++ b/bytes.hh
@@ -42,15 +42,10 @@ struct fmt_hex {
     fmt_hex(const bytes_view& v) noexcept : v(v) {}
 };
 
-std::ostream& operator<<(std::ostream& os, const fmt_hex& hex);
-
 bytes from_hex(sstring_view s);
 sstring to_hex(bytes_view b);
 sstring to_hex(const bytes& b);
 sstring to_hex(const bytes_opt& b);
-
-std::ostream& operator<<(std::ostream& os, const bytes& b);
-std::ostream& operator<<(std::ostream& os, const bytes_opt& b);
 
 template <>
 struct fmt::formatter<fmt_hex> {

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -19,6 +19,7 @@
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
+#include "test/lib/test_utils.hh"
 
 #include <seastar/core/future-util.hh>
 #include "transport/messages/result_message.hh"


### PR DESCRIPTION
since we've switched almost all callers of the operator<< to {fmt}, let's drop the unused operator<<:s.

the callers in alternator/streams.cc is updated to use `fmt::print()` to format the `bytes` instances.

---

it's a cleanup, hence no need to backport.