### PR TITLE
perf-simple-query: add mean and standard deviation stats

### DIFF
--- a/test/perf/perf.hh
+++ b/test/perf/perf.hh
@@ -174,16 +174,21 @@ struct perf_result {
 
 
 struct aggregated_perf_results {
-    struct throughput_t {
+    struct stats_t {
         double median;
         double median_absolute_deviation;
         double min;
         double max;
+        double mean;
+        double stdev;
     };
-    throughput_t throughput;
+    std::unordered_map<std::string, stats_t> stats;
     perf_result median_by_throughput; // Simplification, median element is considered based on throughput value
 
     aggregated_perf_results(std::vector<perf_result>& results);
+
+private:
+    stats_t calculate_stats(std::vector<perf_result>&, std::function<double(const perf_result&)> get_stat) const;
 };
 
 std::ostream& operator<<(std::ostream& os, const aggregated_perf_results& result);

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -477,9 +477,10 @@ void write_json_result(std::string result_file, const test_config& cfg, const ag
     stats["tasks_per_op"] = med.tasks_per_op;
     stats["instructions_per_op"] = med.instructions_per_op;
     stats["cpu_cycles_per_op"] = med.cpu_cycles_per_op;
-    stats["mad tps"] = agg.throughput.median_absolute_deviation;
-    stats["max tps"] = agg.throughput.max;
-    stats["min tps"] = agg.throughput.min;
+    const auto& tps = agg.stats.at("throughput");
+    stats["mad tps"] = tps.median_absolute_deviation;
+    stats["max tps"] = tps.max;
+    stats["min tps"] = tps.min;
     results["stats"] = std::move(stats);
 
     std::string test_type;


### PR DESCRIPTION
Currently, perf-simple-query summarizes the statistics only for the throughput, printing the median,
median absolute deviation, minimum, and maximum.
But the throughput put is typically highly variable and its median is noisy.

This patch calculates also the mean and standard deviation and does that also for instructions_per_op and cpu_cycles_per_op to present a fuller picture of the performance metrics.

Output example:
```
random-seed=3383668492
enable-cache=1
Running test with config: {partitions=10000, concurrency=100, mode=read, frontend=cql, query_single_key=no, counters=no}
Disabling auto compaction
Creating 10000 partitions...
95613.97 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42456 insns/op,   22117 cycles/op,        0 errors)
97538.45 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42454 insns/op,   22094 cycles/op,        0 errors)
95883.37 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42438 insns/op,   22268 cycles/op,        0 errors)
96791.45 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42433 insns/op,   22256 cycles/op,        0 errors)
97894.71 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   42420 insns/op,   22010 cycles/op,        0 errors)

         throughput: mean=96744.39 standard-deviation=996.89 median=96791.45 median-absolute-deviation=861.02 maximum=97894.71 minimum=95613.97
instructions_per_op: mean=42440.08 standard-deviation=14.99 median=42437.59 median-absolute-deviation=13.58 maximum=42456.15 minimum=42420.10
  cpu_cycles_per_op: mean=22148.98 standard-deviation=110.43 median=22117.04 median-absolute-deviation=106.89 maximum=22267.70 minimum=22010.42
```

no backport required as this just improves the presentation of data of a perf testing tool.