### PR TITLE
test/pylib: use raw string to avoid using escape sequence

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -330,7 +330,7 @@ class ScyllaServer:
         size = 0
 
         if self.cmd is not None:
-            deleted_sstable_re = f"^.*/{keyspace}/{table}-[0-9a-f]{{32}}/.* \(deleted\)$"
+            deleted_sstable_re = rf"^.*/{keyspace}/{table}-[0-9a-f]{{32}}/.* \(deleted\)$"
             deleted_sstable_re = re.compile(deleted_sstable_re)
             for f in pathlib.Path(f"/proc/{self.cmd.pid}/fd/").iterdir():
                 try:


### PR DESCRIPTION
before this change, when running test like:
```console
./test.py --mode release topology_experimental_raft/test_tablets
/home/kefu/dev/scylladb/test/pylib/scylla_cluster.py:333: SyntaxWarning: invalid escape sequence '\('
  deleted_sstable_re = f"^.*/{keyspace}/{table}-[0-9a-f]{{32}}/.* \(deleted\)$"
```
we could have the warning above. because `\(` is not a valid escape sequence, but the Python interpreter accepts it as two separated characters of `\(` after complaining. but it's still annoying.

so, let's use a raw string here, as we want to match "(deleted)".

----

it's a cleanup, hence no need to backport.