### PR TITLE
alternator: define static variable

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -779,7 +779,7 @@ struct event_id {
     cdc::stream_id stream;
     utils::UUID timestamp;
 
-    static const auto marker = 'E';
+    static constexpr auto marker = 'E';
 
     event_id(cdc::stream_id s, utils::UUID ts)
         : stream(s)


### PR DESCRIPTION
before this change, when linking an executable referencing `marker`, we could have following error:
```
13:58:02  ld.lld: error: undefined symbol: alternator::event_id::marker
13:58:02  >>> referenced by streams.cc
13:58:02  >>>               build/dev/alternator/streams.o:(from_string_helper<rapidjson::GenericValue<rapidjson::UTF8<char>, rjson::internal::throwing_allocator>, alternator::event_id>::Set(rapidjson::GenericValue<rapidjson::UTF8<char>, rjson::internal::throwing_allocator>&, alternator::event_id, rjson::internal::throwing_allocator&))
13:58:02  clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
```
it turns out `event_id::marker` is only declared, but never defined. please note, the non-inline static member variable in its class definition is not considered as a definition, see
[class.static.data](https://eel.is/c++draft/class.static.data#3)

> The declaration of a non-inline static data member in its class
> definition is not a definition and may be of an incomplete type
> other than cv void.

so, let's declare it as a `constexpr` instead. it implies `inline`.

---
it's a cleanup, hence no need to backport.