### PR TITLE
sstables/index_reader: abort reading during shutdown

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -544,6 +544,7 @@ scylla_tests = set([
     'test/boost/schema_registry_test',
     'test/boost/secondary_index_test',
     'test/boost/tracing_test',
+    'test/boost/index_reader_test',
     'test/boost/index_with_paging_test',
     'test/boost/serialization_test',
     'test/boost/serialized_action_test',

--- a/main.cc
+++ b/main.cc
@@ -1120,7 +1120,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             supervisor::notify("starting database");
             debug::the_database = &db;
             db.start(std::ref(*cfg), dbcfg, std::ref(mm_notifier), std::ref(feature_service), std::ref(token_metadata),
-                    std::ref(cm), std::ref(sstm), std::ref(langman), std::ref(sst_dir_semaphore), utils::cross_shard_barrier()).get();
+                    std::ref(cm), std::ref(sstm), std::ref(langman), std::ref(sst_dir_semaphore), std::ref(stop_signal.as_sharded_abort_source()), utils::cross_shard_barrier()).get();
             auto stop_database_and_sstables = defer_verbose_shutdown("database", [&db] {
                 // #293 - do not stop anything - not even db (for real)
                 //return db.stop();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -313,7 +313,7 @@ public:
 };
 
 database::database(const db::config& cfg, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
-        compaction_manager& cm, sstables::storage_manager& sstm, lang::manager& langm, sstables::directory_semaphore& sst_dir_sem, utils::cross_shard_barrier barrier)
+        compaction_manager& cm, sstables::storage_manager& sstm, lang::manager& langm, sstables::directory_semaphore& sst_dir_sem, const abort_source& abort, utils::cross_shard_barrier barrier)
     : _stats(make_lw_shared<db_stats>())
     , _user_types(std::make_shared<db_user_types_storage>(*this))
     , _cl_stats(std::make_unique<cell_locker_stats>())

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -376,8 +376,8 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
               _cfg.compaction_rows_count_warning_threshold,
               _cfg.compaction_collection_elements_count_warning_threshold))
     , _nop_large_data_handler(std::make_unique<db::nop_large_data_handler>())
-    , _user_sstables_manager(std::make_unique<sstables::sstables_manager>("user", *_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem, [&stm]{ return stm.get()->get_my_id(); }, dbcfg.streaming_scheduling_group, &sstm))
-    , _system_sstables_manager(std::make_unique<sstables::sstables_manager>("system", *_nop_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem, [&stm]{ return stm.get()->get_my_id(); }, dbcfg.streaming_scheduling_group))
+    , _user_sstables_manager(std::make_unique<sstables::sstables_manager>("user", *_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem, [&stm]{ return stm.get()->get_my_id(); }, abort, dbcfg.streaming_scheduling_group, &sstm))
+    , _system_sstables_manager(std::make_unique<sstables::sstables_manager>("system", *_nop_large_data_handler, _cfg, feat, _row_cache_tracker, dbcfg.available_memory, sst_dir_sem, [&stm]{ return stm.get()->get_my_id(); }, abort, dbcfg.streaming_scheduling_group))
     , _result_memory_limiter(dbcfg.available_memory / 10)
     , _data_listeners(std::make_unique<db::data_listeners>())
     , _mnotifier(mn)

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1590,7 +1590,8 @@ public:
     future<> parse_system_tables(distributed<service::storage_proxy>&, sharded<db::system_keyspace>&);
 
     database(const db::config&, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, const locator::shared_token_metadata& stm,
-            compaction_manager& cm, sstables::storage_manager& sstm, lang::manager& langm, sstables::directory_semaphore& sst_dir_sem, utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
+            compaction_manager& cm, sstables::storage_manager& sstm, lang::manager& langm, sstables::directory_semaphore& sst_dir_sem, const abort_source& abort,
+            utils::cross_shard_barrier barrier = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}) /* for single-shard usage */);
     database(database&&) = delete;
     ~database();
 

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -186,6 +186,8 @@ public:
     }
 
     processing_result process_state(temporary_buffer<char>& data) {
+        _abort.check();
+
         auto current_pos = [&] { return this->position() - data.size(); };
         auto read_vint_or_uint64 = [this] (temporary_buffer<char>& data) {
             return is_mc_format() ? this->read_unsigned_vint(data) : this->read_64(data);

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -167,6 +167,7 @@ private:
     trust_promoted_index _trust_pi;
     std::optional<column_values_fixed_lengths> _ck_values_fixed_lengths;
     tracing::trace_state_ptr _trace_state;
+    const abort_source& _abort;
 
     inline bool is_mc_format() const { return static_cast<bool>(_ck_values_fixed_lengths); }
 
@@ -318,11 +319,13 @@ public:
 
     index_consume_entry_context(const sstable& sst, reader_permit permit, IndexConsumer& consumer, trust_promoted_index trust_pi,
             input_stream<char>&& input, uint64_t start, uint64_t maxlen,
-            std::optional<column_values_fixed_lengths> ck_values_fixed_lengths, tracing::trace_state_ptr trace_state = {})
+            std::optional<column_values_fixed_lengths> ck_values_fixed_lengths,
+            const abort_source& abort, tracing::trace_state_ptr trace_state = {})
         : continuous_data_consumer(std::move(permit), std::move(input), start, maxlen)
         , _sst(sst), _consumer(consumer), _entry_offset(start), _trust_pi(trust_pi)
         , _ck_values_fixed_lengths(std::move(ck_values_fixed_lengths))
         , _trace_state(std::move(trace_state))
+        , _abort(abort)
     {}
 };
 
@@ -459,6 +462,7 @@ class index_reader {
     logalloc::region& _region;
     use_caching _use_caching;
     bool _single_page_read;
+    abort_source _abort;
 
     std::unique_ptr<index_consume_entry_context<index_consumer>> make_context(uint64_t begin, uint64_t end, index_consumer& consumer) {
         auto index_file = make_tracked_index_file(*_sstable, _permit, _trace_state, _use_caching);
@@ -469,7 +473,7 @@ class index_reader {
                             ? std::make_optional(get_clustering_values_fixed_lengths(_sstable->get_serialization_header()))
                             : std::optional<column_values_fixed_lengths>{};
         return std::make_unique<index_consume_entry_context<index_consumer>>(*_sstable, _permit, consumer, trust_pi, std::move(input),
-                            begin, end - begin, ck_values_fixed_lengths, _trace_state);
+                            begin, end - begin, ck_values_fixed_lengths, _abort, _trace_state);
     }
 
     future<> advance_context(index_bound& bound, uint64_t begin, uint64_t end, int quantity) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1483,7 +1483,7 @@ void sstable::maybe_rebuild_filter_from_index(uint64_t num_partitions, sstring o
             make_file_input_stream(index_file, 0, index_file_size, {.buffer_size = sstable_buffer_size}), 0, index_file_size,
             (_version >= sstable_version_types::mc
                 ? std::make_optional(get_clustering_values_fixed_lengths(get_serialization_header()))
-                : std::optional<column_values_fixed_lengths>{}));
+                : std::optional<column_values_fixed_lengths>{}), _manager._abort);
     auto consumer_ctx_closer = deferred_close(consumer_ctx);
     try {
         consumer_ctx.consume_input().get();
@@ -2040,7 +2040,7 @@ future<> sstable::generate_summary() {
                     make_file_input_stream(index_file, 0, index_size, std::move(options)), 0, index_size,
                     (_version >= sstable_version_types::mc
                         ? std::make_optional(get_clustering_values_fixed_lengths(get_serialization_header()))
-                        : std::optional<column_values_fixed_lengths>{}));
+                        : std::optional<column_values_fixed_lengths>{}), _manager._abort);
 
         try {
             co_await ctx->consume_input();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1456,11 +1456,10 @@ void sstable::maybe_rebuild_filter_from_index(uint64_t num_partitions, sstring o
         }
     };
 
-    // Replace the existing filter with a new one that can optimally represent the given num_partitions.
-    // The rebuilding is done in-place as this method is only called before the sstable is sealed.
-    _components->filter = utils::i_filter::get_filter(num_partitions, _schema->bloom_filter_fp_chance(), get_filter_format(_version));
+    // Create a new filter that can optimally represent the given num_partitions.
+    auto optimal_filter = utils::i_filter::get_filter(num_partitions, _schema->bloom_filter_fp_chance(), get_filter_format(_version));
     sstlog.info("Rebuilding bloom filter {}: resizing bitset from {} bytes to {} bytes. sstable origin: {}", filename(component_type::Filter), curr_bitset_size,
-                downcast_ptr<utils::filter::bloom_filter>(_components->filter.get())->bits().memory_size(), origin);
+                downcast_ptr<utils::filter::bloom_filter>(optimal_filter.get())->bits().memory_size(), origin);
 
     auto index_file = open_file(component_type::Index, open_flags::ro).get();
     auto index_file_closer = deferred_action([&index_file] {
@@ -1478,7 +1477,7 @@ void sstable::maybe_rebuild_filter_from_index(uint64_t num_partitions, sstring o
     auto sem_stopper = deferred_stop(sem);
 
     // rebuild the filter using index_consume_entry_context
-    bloom_filter_builder bfb_consumer(_components->filter);
+    bloom_filter_builder bfb_consumer(optimal_filter);
     index_consume_entry_context<bloom_filter_builder> consumer_ctx(
             *this, sem.make_tracking_only_permit(_schema, "rebuild_filter_from_index", db::no_timeout, {}), bfb_consumer, trust_promoted_index::no,
             make_file_input_stream(index_file, 0, index_file_size, {.buffer_size = sstable_buffer_size}), 0, index_file_size,
@@ -1486,7 +1485,15 @@ void sstable::maybe_rebuild_filter_from_index(uint64_t num_partitions, sstring o
                 ? std::make_optional(get_clustering_values_fixed_lengths(get_serialization_header()))
                 : std::optional<column_values_fixed_lengths>{}));
     auto consumer_ctx_closer = deferred_close(consumer_ctx);
-    consumer_ctx.consume_input().get();
+    try {
+        consumer_ctx.consume_input().get();
+    } catch (...) {
+        sstlog.warn("Failed to rebuild bloom filter {} : {}. Existing bloom filter will be written to disk.", filename(component_type::Filter), std::current_exception());
+        return;
+    }
+
+    // Replace the existing filter with the new optimal filter.
+    _components->filter.swap(optimal_filter);
 }
 
 size_t sstable::total_reclaimable_memory_size() const {

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -24,7 +24,8 @@ namespace sstables {
 logging::logger smlogger("sstables_manager");
 
 sstables_manager::sstables_manager(
-    sstring name, db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker& ct, size_t available_memory, directory_semaphore& dir_sem, noncopyable_function<locator::host_id()>&& resolve_host_id, scheduling_group maintenance_sg, storage_manager* shared)
+    sstring name, db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker& ct, size_t available_memory, directory_semaphore& dir_sem,
+    noncopyable_function<locator::host_id()>&& resolve_host_id, const abort_source& abort, scheduling_group maintenance_sg, storage_manager* shared)
     : _storage(shared)
     , _available_memory(available_memory)
     , _large_data_handler(large_data_handler), _db_config(dbcfg), _features(feat), _cache_tracker(ct)
@@ -39,6 +40,7 @@ sstables_manager::sstables_manager(
     , _dir_semaphore(dir_sem)
     , _resolve_host_id(std::move(resolve_host_id))
     , _maintenance_sg(std::move(maintenance_sg))
+    , _abort(abort)
 {
     _components_reloader_status = components_reloader_fiber();
 }

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -125,8 +125,11 @@ private:
 
     scheduling_group _maintenance_sg;
 
+    const abort_source& _abort;
+
 public:
-    explicit sstables_manager(sstring name, db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker&, size_t available_memory, directory_semaphore& dir_sem, noncopyable_function<locator::host_id()>&& resolve_host_id, scheduling_group maintenance_sg = current_scheduling_group(), storage_manager* shared = nullptr);
+    explicit sstables_manager(sstring name, db::large_data_handler& large_data_handler, const db::config& dbcfg, gms::feature_service& feat, cache_tracker&, size_t available_memory, directory_semaphore& dir_sem,
+                              noncopyable_function<locator::host_id()>&& resolve_host_id, const abort_source& abort, scheduling_group maintenance_sg = current_scheduling_group(), storage_manager* shared = nullptr);
     virtual ~sstables_manager();
 
     shared_sstable make_sstable(schema_ptr schema, sstring table_dir,
@@ -187,6 +190,8 @@ public:
     future<> init_keyspace_storage(const data_dictionary::storage_options& so, sstring dir);
 
     void validate_new_keyspace_storage_options(const data_dictionary::storage_options&);
+
+    const abort_source& get_abort_source() const noexcept { return _abort; }
 
 private:
     void add(sstable* sst);

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -151,6 +151,8 @@ add_scylla_test(hint_test
 add_scylla_test(idl_test
   KIND BOOST
   LIBRARIES idl)
+add_scylla_test(index_reader_test
+  KIND SEASTAR)
 add_scylla_test(index_with_paging_test
   KIND SEASTAR)
 add_scylla_test(input_stream_test

--- a/test/boost/index_reader_test.cc
+++ b/test/boost/index_reader_test.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <seastar/testing/test_case.hh>
+
+#include "test/lib/simple_schema.hh"
+#include "test/lib/sstable_test_env.hh"
+#include "test/lib/sstable_utils.hh"
+
+#include "readers/from_mutations_v2.hh"
+
+using namespace sstables;
+
+SEASTAR_TEST_CASE(test_abort_during_index_read) {
+    return test_env::do_with_async([](test_env& env) {
+        simple_schema ss;
+        auto schema_ptr = ss.schema();
+        auto mut = mutation(schema_ptr, ss.make_pkey());
+        auto mut_reader = make_mutation_reader_from_mutations_v2(schema_ptr, env.make_reader_permit(), std::move(mut));
+        auto sst = make_sstable_easy(env, std::move(mut_reader), env.manager().configure_writer());
+
+        struct dummy_index_consumer {
+            dummy_index_consumer() {}
+            void consume_entry(parsed_partition_index_entry&& e) {
+                // should be aborted before reaching here
+                BOOST_ERROR("index_consume_entry_context was not aborted");
+            }
+        } consumer;
+
+        auto index_file = sst->index_file();
+        auto index_file_size = sst->index_size();
+        index_consume_entry_context<dummy_index_consumer> consumer_ctx(
+            *sst, env.make_reader_permit(), consumer, trust_promoted_index::no,
+            make_file_input_stream(index_file, 0, index_file_size), 0, index_file_size,
+            std::make_optional(get_clustering_values_fixed_lengths(sst->get_serialization_header())),
+            sst->manager().get_abort_source());
+
+        // request abort before starting to consume index, so that the consumer throws an exception as soon as it starts
+        env.request_abort();
+        BOOST_CHECK_THROW(consumer_ctx.consume_input().get(), seastar::abort_requested_exception);
+        consumer_ctx.close().get();
+    });
+}

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -589,7 +589,7 @@ private:
             _lang_manager.invoke_on_all(&lang::manager::start).get();
 
 
-            _db.start(std::ref(*cfg), dbcfg, std::ref(_mnotifier), std::ref(_feature_service), std::ref(_token_metadata), std::ref(_cm), std::ref(_sstm), std::ref(_lang_manager), std::ref(_sst_dir_semaphore), utils::cross_shard_barrier()).get();
+            _db.start(std::ref(*cfg), dbcfg, std::ref(_mnotifier), std::ref(_feature_service), std::ref(_token_metadata), std::ref(_cm), std::ref(_sstm), std::ref(_lang_manager), std::ref(_sst_dir_semaphore), std::ref(abort_sources), utils::cross_shard_barrier()).get();
             auto stop_db = defer([this] {
                 _db.stop().get();
             });

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -182,6 +182,8 @@ public:
     table_for_tests make_table_for_tests(schema_ptr s, sstring dir);
 
     table_for_tests make_table_for_tests(schema_ptr s = nullptr);
+
+    void request_abort();
 };
 
 }   // namespace sstables

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -476,6 +476,10 @@ test_env::make_table_for_tests(schema_ptr s) {
     return table_for_tests(manager(), _impl->cmgr->get_compaction_manager(), s, std::move(cfg), _impl->storage);
 }
 
+void test_env::request_abort() {
+    _impl->abort.request_abort();
+}
+
 data_dictionary::storage_options make_test_object_storage_options() {
     data_dictionary::storage_options ret;
     ret.value = data_dictionary::storage_options::s3 {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -196,6 +196,7 @@ struct test_env::impl {
     sstables::sstable_generation_generator gen{0};
     sstables::uuid_identifiers use_uuid;
     data_dictionary::storage_options storage;
+    abort_source abort;
 
     impl(test_env_config cfg, sstables::storage_manager* sstm);
     impl(impl&&) = delete;
@@ -213,7 +214,7 @@ test_env::impl::impl(test_env_config cfg, sstables::storage_manager* sstm)
     , feature_service(gms::feature_config_from_db_config(*db_config))
     , mgr("test_env", cfg.large_data_handler == nullptr ? nop_ld_handler : *cfg.large_data_handler, *db_config,
         feature_service, cache_tracker, cfg.available_memory, dir_sem,
-        [host_id = locator::host_id::create_random_id()]{ return host_id; }, current_scheduling_group(), sstm)
+        [host_id = locator::host_id::create_random_id()]{ return host_id; }, abort, current_scheduling_group(), sstm)
     , semaphore(reader_concurrency_semaphore::no_limits{}, "sstables::test_env", reader_concurrency_semaphore::register_metrics::no)
     , use_uuid(cfg.use_uuid)
     , storage(std::move(cfg.storage))

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -3064,9 +3064,10 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
         gms::feature_service feature_service(gms::feature_config_from_db_config(dbcfg));
         cache_tracker tracker;
         sstables::directory_semaphore dir_sem(1);
+        abort_source abort;
         sstables::sstables_manager sst_man("scylla_sstable", large_data_handler, dbcfg, feature_service, tracker,
             memory::stats().total_memory(), dir_sem,
-            [host_id = locator::host_id::create_random_id()] { return host_id; });
+            [host_id = locator::host_id::create_random_id()] { return host_id; }, abort);
         auto close_sst_man = deferred_close(sst_man);
 
         std::vector<sstables::shared_sstable> sstables;


### PR DESCRIPTION
This PR adds support for aborting index reads from within `index_consume_entry_context::consume_input` when the server is being stopped. The abort source is now propagated down to the `index_consume_entry_context`, making it available for `consume_input` to check if an abort has been requested. If an abort is detected, `consume_input` will throw an exception to stop the index read operation.