### PR TITLE
test.py: improve help message on tests selection

### DIFF
--- a/test.py
+++ b/test.py
@@ -1279,8 +1279,9 @@ def parse_cmd_line() -> argparse.Namespace:
                 suites. Each name is used as a substring to look for in the
                 path to test file, e.g. "mem" will run all tests that have
                 "mem" in their name in all suites, "boost/mem" will only enable
-                tests starting with "mem" in "boost" suite. Default: run all
-                tests in all suites.""",
+                tests starting with "mem" in "boost" suite, and
+                "boost/memtable_test::test_hash_is_cached" to narrow down to
+                a certain test case. Default: run all tests in all suites.""",
     )
     parser.add_argument(
         "--tmpdir",


### PR DESCRIPTION
Since 3afbd21f, we are able to selectively choose a single test in a boost test executable which represents a test suite, and to choose a single test in a pytest script with the syntax of "test_suite::test_case". it's very handy for manual testing.

so let's document in the command line help message as well.

---

no need to backport. as this change improves the developers' experience.