### PR TITLE
statement_restrictions: partition_ranges_from_singles: no need to default-initialize result

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1067,8 +1067,9 @@ dht::partition_range_vector partition_ranges_from_singles(
         }
     }
     cartesian_product cp(column_values);
-    dht::partition_range_vector ranges(product_size);
-    std::transform(cp.begin(), cp.end(), ranges.begin(), std::bind_front(range_from_bytes, std::ref(schema)));
+    dht::partition_range_vector ranges;
+    ranges.reserve(product_size);
+    std::transform(cp.begin(), cp.end(), std::back_inserter(ranges), std::bind_front(range_from_bytes, std::ref(schema)));
     return ranges;
 }
 


### PR DESCRIPTION
Currently, the returned `ranges` vector is first initialized to `product_size` and then the returned partition ranges are copied into it.

Instead, we can simply reserve the vector capacity, without initializing it, and then emplace all partition ranges onto it using std::back_inserter.

Optimization, no backport required