### PR TITLE
api,locator: add API to disable tablet balancing for a given table 

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2709,6 +2709,22 @@
                ],
                "parameters":[
                   {
+                     "name":"ks",
+                     "description":"The keyspace",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"table",
+                     "description":"Table name",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
                      "name":"enabled",
                      "description":"When set to false, tablet load balancing is disabled",
                      "required":true,

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -296,6 +296,10 @@ void tablet_map::clear_transitions() {
     _transitions.clear();
 }
 
+void tablet_map::set_balancing_enabled(bool enabled) {
+    _balancing_enabled = enabled;
+}
+
 bool tablet_map::has_replica(tablet_id tid, tablet_replica r) const {
     auto& tinfo = get_tablet_info(tid);
     if (contains(tinfo.replicas, r)) {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -326,6 +326,7 @@ private:
     size_t _log2_tablets; // log_2(_tablets.size())
     std::unordered_map<tablet_id, tablet_transition_info> _transitions;
     resize_decision _resize_decision;
+    bool _balancing_enabled = true;
 public:
     /// Constructs a tablet map.
     ///
@@ -415,6 +416,10 @@ public:
         return _tablets.size();
     }
 
+    bool balancing_enabled() const {
+        return _balancing_enabled;
+    }
+
     /// Returns tablet_info associated with the tablet which owns a given token.
     const tablet_info& get_tablet_info(token t) const {
         return get_tablet_info(get_tablet_id(t));
@@ -432,6 +437,7 @@ public:
     void set_tablet_transition_info(tablet_id, tablet_transition_info);
     void set_resize_decision(locator::resize_decision);
     void clear_transitions();
+    void set_balancing_enabled(bool);
 
     // Destroys gently.
     // The tablet map is not usable after this call and should be destroyed.
@@ -466,6 +472,10 @@ private:
     // When false, tablet load balancer will not try to rebalance tablets.
     bool _balancing_enabled = true;
 public:
+    // we also have a per-table setting in tablet_map with the same name.
+    // balancing of a given table is enabled only if both settings are enabled:
+    // - tablet_metadata::balancing_enabled()
+    // - tablet_map::balancing_enabled()
     bool balancing_enabled() const { return _balancing_enabled; }
     const tablet_map& get_tablet_map(table_id id) const;
     const table_to_tablet_map& all_tables() const { return _tablets; }

--- a/replica/tablet_mutation_builder.hh
+++ b/replica/tablet_mutation_builder.hh
@@ -40,6 +40,7 @@ public:
     tablet_mutation_builder& del_session(dht::token last_token);
     tablet_mutation_builder& del_transition(dht::token last_token);
     tablet_mutation_builder& set_resize_decision(locator::resize_decision);
+    tablet_mutation_builder& set_balancing_enabled(bool enabled);
 
     mutation build() {
         return std::move(_m);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -889,6 +889,7 @@ public:
     future<> add_tablet_replica(table_id, dht::token, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> del_tablet_replica(table_id, dht::token, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> set_tablet_balancing_enabled(bool);
+    future<> set_tablet_balancing_enabled(table_id, bool);
     future<> await_topology_quiesced();
 
     // In the maintenance mode, other nodes won't be available thus we disabled joining

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -538,10 +538,13 @@ public:
         cluster_resize_load resize_load;
 
         for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
-            auto& tmap = tmap_;
-
             const auto* table_stats = load_stats_for_table(table);
             if (!table_stats) {
+                continue;
+            }
+
+            auto& tmap = tmap_;
+            if (!tmap.balancing_enabled()) {
                 continue;
             }
 
@@ -1364,7 +1367,7 @@ public:
                         node_load_info.shards_by_load.push_back(replica.shard);
                     }
                     shard_load_info.tablet_count += 1;
-                    if (!trinfo) { // migrating tablets are not candidates
+                    if (tmap.balancing_enabled() && !trinfo) { // migrating tablets are not candidates
                         add_candidate(shard_load_info, global_tablet_id {table, tid});
                     }
                 }

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -270,15 +270,22 @@ class ScyllaRESTAPIClient():
             "token": str(token)
         })
 
-    async def _set_tablet_balancing_enable(self, node_ip: str, enabled: bool) -> None:
+    async def _set_tablet_balancing_enable(self, node_ip: str,
+                                           enabled: bool,
+                                           keyspace: Optional[str],
+                                           table: Optional[str]) -> None:
         params = {"enabled": "true" if enabled else "false"}
+        if keyspace is not None:
+            params["ks"] = keyspace
+        if table is not None:
+            params["table"] = table
         await self.client.post("/storage_service/tablets/balancing", host=node_ip, params=params)
 
-    async def enable_tablet_balancing(self, node_ip: str) -> None:
-        await self._set_tablet_balancing_enable(node_ip, True)
+    async def enable_tablet_balancing(self, node_ip: str, keyspace: Optional[str] = None, table: Optional[str] = None) -> None:
+        await self._set_tablet_balancing_enable(node_ip, True, keyspace, table)
 
-    async def disable_tablet_balancing(self, node_ip: str) -> None:
-        await self._set_tablet_balancing_enable(node_ip, False)
+    async def disable_tablet_balancing(self, node_ip: str, keyspace: Optional[str] = None, table: Optional[str] = None) -> None:
+        await self._set_tablet_balancing_enable(node_ip, False, keyspace, table)
 
     async def disable_injection(self, node_ip: str, injection: str) -> None:
         await self.client.delete(f"/v2/error_injection/injection/{injection}", host=node_ip)

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -270,11 +270,15 @@ class ScyllaRESTAPIClient():
             "token": str(token)
         })
 
+    async def _set_tablet_balancing_enable(self, node_ip: str, enabled: bool) -> None:
+        params = {"enabled": "true" if enabled else "false"}
+        await self.client.post("/storage_service/tablets/balancing", host=node_ip, params=params)
+
     async def enable_tablet_balancing(self, node_ip: str) -> None:
-        await self.client.post(f"/storage_service/tablets/balancing", host=node_ip, params={"enabled": "true"})
+        await self._set_tablet_balancing_enable(node_ip, True)
 
     async def disable_tablet_balancing(self, node_ip: str) -> None:
-        await self.client.post(f"/storage_service/tablets/balancing", host=node_ip, params={"enabled": "false"})
+        await self._set_tablet_balancing_enable(node_ip, False)
 
     async def disable_injection(self, node_ip: str, injection: str) -> None:
         await self.client.delete(f"/v2/error_injection/injection/{injection}", host=node_ip)

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -431,13 +431,13 @@ async def test_tablet_repair(manager: ManagerClient):
         # Disable in the background so that repair is started with migrations in progress.
         # We need to disable balancing so that repair which blocks on migrations eventually gets unblocked.
         # Otherwise, shuffling would keep the topology busy forever.
-        disable_balancing_future = asyncio.create_task(manager.api.disable_tablet_balancing(servers[0].ip_addr))
+        disable_balancing_future = asyncio.create_task(manager.api.disable_tablet_balancing(servers[0].ip_addr, "test", "test"))
 
         await repair_on_node(manager, servers[0], servers)
 
         await inserts_future
         await disable_balancing_future
-        await manager.api.enable_tablet_balancing(servers[0].ip_addr)
+        await manager.api.enable_tablet_balancing(servers[0].ip_addr, "test", "test")
 
     key_count = len(keys)
     stmt = cql.prepare("SELECT * FROM test.test;")


### PR DESCRIPTION
in this change, we add optional arguments to existing RESTful API of `/storage_service/tablets/balancing`, so that we are allowed to enable/disable the tablets balancing of a certain table. now, there are two settings for controlling if the tablets of a table can be balanced.

- the global setting managed using `/storage_service/tablets/balancing`,  without specifing the keyspace and table
- the per-tablet setting managed using the same API entry of  `/storage_service/tablets/balancing`, but this setting is specified with the keyspace and table query parameters

the tablets of a table can be balanced only if both setting are enabled, by default the second setting is not set, so as long as the global setting is not disabled, all tables are considered when performing balancing. but if the per-table setting is disabled, the balancing of that table is disabled, unless both settings are enabled. this enables scylla-manager to selectively prevent the tablets migration of a given table when performing, for instance, repairing, on it, so that the
balancing of the other tables in the cluster are not blocked by the table being repaired.

Fixes https://github.com/scylladb/scylladb/issues/17435

---

this change should be a part of the 6.1 release, but not 6.0.