### PR TITLE
s3/client: Always retry http requests

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -134,7 +134,7 @@ future<semaphore_units<>> client::claim_memory(size_t size) {
 }
 
 client::group_client::group_client(std::unique_ptr<http::experimental::connection_factory> f, unsigned max_conn)
-        : http(std::move(f), max_conn)
+        : http(std::move(f), max_conn, http::experimental::client::retry_requests::yes)
 {
 }
 


### PR DESCRIPTION
Real S3 server is known to actively close connections, thus breaking S3 storage backend at random places. The recent http client update is more robust against that, but the needed feature is OFF by default.

refs: scylladb/seastar#1883
