### PR TITLE
chunked_vector enhancements

### DIFF
--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -10,6 +10,7 @@
 
 #include <stdexcept>
 #include <optional>
+#include <variant>
 #include <fmt/format.h>
 
 #include <boost/test/included/unit_test.hpp>
@@ -412,4 +413,17 @@ BOOST_AUTO_TEST_CASE(tests_copy_constructor_exception_safety) {
         src.clear();
         BOOST_REQUIRE_EQUAL(checker.live_objects(), 0);
     }
+}
+
+BOOST_AUTO_TEST_CASE(test_initializer_list_ctor) {
+    using value_t = std::variant<int, double, std::string>;
+    constexpr size_t chunk_size = 2;
+    auto vec = utils::chunked_vector<value_t, chunk_size>({1, "two", 3.0});
+    auto expected = std::vector<value_t>({1, "two", 3.0});
+    BOOST_REQUIRE_EQUAL(vec.size(), expected.size());
+    auto vit = vec.begin();
+    for (auto it = expected.begin(); it != expected.end(); ++it, ++vit) {
+        BOOST_REQUIRE(*it == *vit);
+    }
+    BOOST_REQUIRE(vit == vec.end());
 }

--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -427,3 +427,22 @@ BOOST_AUTO_TEST_CASE(test_initializer_list_ctor) {
     }
     BOOST_REQUIRE(vit == vec.end());
 }
+
+BOOST_AUTO_TEST_CASE(test_value_default_init_ctor) {
+    int n = 17;
+    auto vec = utils::chunked_vector<std::string, 8>(n);
+    BOOST_REQUIRE_EQUAL(vec.size(), n);
+    for (auto it = vec.begin(); it != vec.end(); ++it) {
+        BOOST_REQUIRE(it->empty());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_value_init_ctor) {
+    double v = 3.14;
+    int n = 17;
+    auto vec = utils::chunked_vector<double, 8>(n, v);
+    BOOST_REQUIRE_EQUAL(vec.size(), n);
+    for (auto it = vec.begin(); it != vec.end(); ++it) {
+        BOOST_REQUIRE_EQUAL(*it, v);
+    }
+}

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -105,6 +105,7 @@ public:
     chunked_vector(chunked_vector&& x) noexcept;
     template <typename Iterator>
     chunked_vector(Iterator begin, Iterator end);
+    chunked_vector(std::initializer_list<T> x);
     explicit chunked_vector(size_t n, const T& value = T());
     ~chunked_vector();
     chunked_vector& operator=(const chunked_vector& x);
@@ -362,6 +363,13 @@ chunked_vector<T, max_contiguous_allocation>::chunked_vector(Iterator begin, Ite
     if (!is_random_access) {
         shrink_to_fit();
     }
+}
+
+template <typename T, size_t max_contiguous_allocation>
+chunked_vector<T, max_contiguous_allocation>::chunked_vector(std::initializer_list<T> x)
+        : chunked_vector() {
+    reserve(x.size());
+    std::copy(x.begin(), x.end(), std::back_inserter(*this));
 }
 
 template <typename T, size_t max_contiguous_allocation>

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -101,12 +101,14 @@ public:
 public:
     chunked_vector() = default;
     chunked_vector(const chunked_vector& x);
+    // Moving a chunked_vector invalidates all iterators to it
     chunked_vector(chunked_vector&& x) noexcept;
     template <typename Iterator>
     chunked_vector(Iterator begin, Iterator end);
     explicit chunked_vector(size_t n, const T& value = T());
     ~chunked_vector();
     chunked_vector& operator=(const chunked_vector& x);
+    // Moving a chunked_vector invalidates all iterators to it
     chunked_vector& operator=(chunked_vector&& x) noexcept;
 
     bool empty() const {
@@ -209,8 +211,10 @@ public:
 public:
     template <class ValueType>
     class iterator_type {
-        const chunk_ptr* _chunks;
-        size_t _i;
+        // Note that _chunks points to the chunked_vector::_chunks data
+        // and therefore it is invalidated when the chunked_vector is moved
+        const chunk_ptr* _chunks = nullptr;
+        size_t _i = 0;
     public:
         using iterator_category = std::random_access_iterator_tag;
         using value_type = ValueType;


### PR DESCRIPTION
This short series enhances utils::chunked_vector so it could be used more easily to convert dht::partition_range_vector to chunked_vector, for example.

- utils: chunked_vector: document invalidation of iterators on move
- utils: chunked_vector: add ctor from std::initializer_list
- utils: chunked_vector: add ctor from a single value

No backport required