### PR TITLE
install-dependencies.sh: set file mode creation mask to 0022

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -299,6 +299,8 @@ if $PRINT_NODE_EXPORTER; then
     exit 0
 fi
 
+umask 0022
+
 ./seastar/install-dependencies.sh
 ./tools/jmx/install-dependencies.sh
 ./tools/java/install-dependencies.sh


### PR DESCRIPTION
The docs [1] clearly say "install-dependencies.sh" should be run as "root"; however, the script silently assumes that the umask inherited from the calling environment is 0022. That's not necessarily the case, and there's an argument to be made for "root" setting umask 0077 by default. The script behaves unexpectedly under such circumstances; files and directories it creates under /opt and /usr/local are then not accessible to unprivileged users, leading to compilation failures later on.

Set the creation mask explicitly to 0022.

[1] https://github.com/scylladb/scylladb/blob/master/HACKING.md#dependencies

... I figure backporting this might make sense (it might improve the dev env in older branches too).