### PR TITLE
query_ranges_to_vnodes_generator: optimize comparisons

### DIFF
--- a/query_ranges_to_vnodes.cc
+++ b/query_ranges_to_vnodes.cc
@@ -102,7 +102,7 @@ void query_ranges_to_vnodes_generator::process_one_range(size_t n, dht::partitio
         cr = std::move(splits.second);
         if (ranges.size() == n) {
             // we have enough ranges
-            break;
+            return;
         }
     }
 

--- a/query_ranges_to_vnodes.cc
+++ b/query_ranges_to_vnodes.cc
@@ -24,11 +24,11 @@ query_ranges_to_vnodes_generator::query_ranges_to_vnodes_generator(std::unique_p
         _s(s), _ranges(std::move(ranges)), _i(_ranges.begin()), _local(local), _splitter(std::move(splitter)) {}
 
 dht::partition_range_vector query_ranges_to_vnodes_generator::operator()(size_t n) {
-    n = std::min(n, size_t(1024));
+    n = std::min({n, size_t(1024), size_t(_ranges.end() - _i)});
 
     dht::partition_range_vector result;
     result.reserve(n);
-    while (_i != _ranges.end() && result.size() != n) {
+    while (result.size() != n) {
         process_one_range(n, result);
     }
     return result;

--- a/query_ranges_to_vnodes.hh
+++ b/query_ranges_to_vnodes.hh
@@ -17,7 +17,7 @@ class query_ranges_to_vnodes_generator {
     dht::partition_range_vector::iterator _i; // iterator to current range in _ranges
     bool _local;
     std::unique_ptr<locator::token_range_splitter> _splitter;
-    void process_one_range(size_t n, dht::partition_range_vector& ranges);
+    stop_iteration process_one_range(size_t n, dht::partition_range_vector& ranges);
 public:
     query_ranges_to_vnodes_generator(std::unique_ptr<locator::token_range_splitter> splitter, schema_ptr s, dht::partition_range_vector ranges, bool local = false);
     query_ranges_to_vnodes_generator(const query_ranges_to_vnodes_generator&) = delete;


### PR DESCRIPTION
There is no need to test _it == _ranges.end()
every iteration, as this can be tested once to
reduce `n`, if needed.

Also, we already check for ranges.size() in
`process_one_range`, so that result can be
propagated back to the caller that can test it instead of checking the results vector size yet again.

Optimization, no backport required.