### PR TITLE
auth: do not include unused headers

### DIFF
--- a/auth/common.hh
+++ b/auth/common.hh
@@ -13,7 +13,6 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/util/noncopyable_function.hh>
-#include <seastar/core/resource.hh>
 #include <seastar/core/sstring.hh>
 
 #include "types/types.hh"

--- a/cdc/split.hh
+++ b/cdc/split.hh
@@ -8,10 +8,9 @@
 
 #pragma once
 
-#include <boost/dynamic_bitset.hpp>
+#include <boost/dynamic_bitset.hpp>  // IWYU pragma: keep
 #include "replica/database_fwd.hh"
 #include "timestamp.hh"
-#include <seastar/util/noncopyable_function.hh>
 
 class mutation;
 


### PR DESCRIPTION
these unused includes were identified by clangd. see https://clangd.llvm.org/guides/include-cleaner#unused-include-warning for more details on the "Unused include" warning.

this change addresses the leftover of 850ee7e170a.

----

it's a cleanup, hence no need to backport.