### PR TITLE
scylla-gdb.py: add $coro_frame()

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -90,6 +90,8 @@ if(target_arch)
   add_compile_options("-march=${target_arch}")
 endif()
 
+add_compile_options("SHELL:-Xclang -fexperimental-assignment-tracking=disabled")
+
 function(maybe_limit_stack_usage_in_KB stack_usage_threshold_in_KB config)
   math(EXPR _stack_usage_threshold_in_bytes "${stack_usage_threshold_in_KB} * 1024")
   set(_stack_usage_threshold_flag "-Wstack-usage=${_stack_usage_threshold_in_bytes}")

--- a/configure.py
+++ b/configure.py
@@ -1861,6 +1861,14 @@ def get_extra_cxxflags(mode, mode_config, cxx, debuginfo):
     if debuginfo and mode_config['can_have_debug_info']:
         cxxflags += ['-g', '-gz']
 
+    # Since AssignmentTracking was enabled by default in clang
+    # (llvm/llvm-project@de6da6ad55d3ca945195d1cb109cb8efdf40a52a)
+    # coroutine frame debugging info (`coro_frame_ty`) is broken.
+    # 
+    # It seems that we aren't losing much by disabling AssigmentTracking,
+    # so for now we choose to disable it to get `coro_frame_ty` back.
+    cxxflags.append('-Xclang -fexperimental-assignment-tracking=disabled')
+
     return cxxflags
 
 


### PR DESCRIPTION
Adds a convenience function for inspecting the coroutine frame of a given seastar task.

Short example of extracting a coroutine argument:

```
(gdb) p *$coro_frame(seastar::local_engine->_current_task)
$1 = {
  __resume_fn = 0x2485f80 <sstables::parse(schema const&, sstables::sstable_version_types, sstables::random_access_reader&, sstables::statistics&)>,
  ...
  PointerType_7 = 0x601008e67880,
  ...
  __coro_index = 0 '\000'
  ...
(gdb) p $downcast_vptr($->PointerType_7)
  $2 = (schema *) 0x601008e67880
```