### PR TITLE
test: auth: add random tag to resources in test_auth_v2_migration

### DIFF
--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -10,6 +10,8 @@ import logging
 import pathlib
 import os
 import pytest
+import random
+import string
 
 from typing import Callable, Awaitable, Optional, TypeVar, Any
 
@@ -29,11 +31,10 @@ class LogPrefixAdapter(logging.LoggerAdapter):
         return '[%s] %s' % (self.extra['prefix'], msg), kwargs
 
 
-unique_name_prefix = 'test_'
 T = TypeVar('T')
 
 
-def unique_name():
+def unique_name(unique_name_prefix = 'test_'):
     if not hasattr(unique_name, "last_ms"):
         unique_name.last_ms = 0
     current_ms = int(round(time.time() * 1000))
@@ -41,7 +42,7 @@ def unique_name():
     if unique_name.last_ms >= current_ms:
         current_ms = unique_name.last_ms + 1
     unique_name.last_ms = current_ms
-    return unique_name_prefix + str(current_ms)
+    return unique_name_prefix + str(current_ms) + '_' + ''.join(random.choice(string.ascii_lowercase) for _ in range(5))
 
 
 async def wait_for(


### PR DESCRIPTION
Those tests are sometimes failing on CI and we have two hypothesis:
1. Something wrong with consistency of statements
2. Interruption from another test run (e.g. same queries performed concurrently or data remained after previous run)

To exclude or confirm 2. we add random marker to avoid potential collision, in such case it will be clearly visible that wrong data comes from a different run.

Related scylladb/scylladb#18931
Related scylladb/scylladb#18319

backport: no, just a test fix