### PR TITLE
transport: Use sharded<>::invoke_on_others()

### DIFF
--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1058,16 +1058,8 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_pr
     tracing::add_query(trace_state, query);
     tracing::begin(trace_state, "Preparing CQL3 query", client_state.get_client_address());
 
-    auto cpu_id = this_shard_id();
-    auto cpus = boost::irange(0u, smp::count);
-    return parallel_for_each(cpus.begin(), cpus.end(), [this, query, cpu_id, &client_state] (unsigned int c) mutable {
-        if (c != cpu_id) {
-            return smp::submit_to(c, [this, query, &client_state] () mutable {
-                return _server._query_processor.local().prepare(std::move(query), client_state).discard_result();
-            });
-        } else {
-            return make_ready_future<>();
-        }
+    return _server._query_processor.invoke_on_others([query, &client_state] (auto& qp) mutable {
+            return qp.prepare(std::move(query), client_state).discard_result();
     }).then([this, query, stream, &client_state, trace_state] () mutable {
         tracing::trace(trace_state, "Done preparing on remote shards");
         return _server._query_processor.local().prepare(std::move(query), client_state).then([this, stream, trace_state] (auto msg) {


### PR DESCRIPTION
When preparing statement, the server code first does it on non-local shards, then on local one. The former call is done the hard way, while there's a short sugar sharded<> class method doing it.
