### PR TITLE
 [Backport 5.4] schema: Make "describe" use extensions to string #19358 

### DIFF
--- a/db/paxos_grace_seconds_extension.hh
+++ b/db/paxos_grace_seconds_extension.hh
@@ -55,6 +55,10 @@ public:
         return ser::serialize_to_buffer<bytes>(_paxos_gc_sec);
     }
 
+    std::string options_to_string() const override {
+        return std::to_string(_paxos_gc_sec);
+    }
+
     static int32_t deserialize(const bytes_view& buffer) {
         return ser::deserialize_from_buffer(buffer, boost::type<int32_t>());
     }

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -932,23 +932,19 @@ std::ostream& schema::describe(replica::database& db, std::ostream& os, bool wit
     os << "}";
 
     os << "\n    AND crc_check_chance = " << crc_check_chance();
-    os << "\n    AND dclocal_read_repair_chance = " << dc_local_read_repair_chance();
+    os << "\n    AND dclocal_read_repair_chance = " << dc_local_read_repair_chance();    
     os << "\n    AND default_time_to_live = " << default_time_to_live().count();
     os << "\n    AND gc_grace_seconds = " << gc_grace_seconds().count();
     os << "\n    AND max_index_interval = " << max_index_interval();
     os << "\n    AND memtable_flush_period_in_ms = " << memtable_flush_period();
     os << "\n    AND min_index_interval = " << min_index_interval();
-    os << "\n    AND read_repair_chance = " << read_repair_chance();
+    os << "\n    AND read_repair_chance = " << read_repair_chance(); 
     os << "\n    AND speculative_retry = '" << speculative_retry().to_sstring() << "'";
-    os << "\n    AND paxos_grace_seconds = " << paxos_grace_seconds().count();
-
-    auto tombstone_gc_str = tombstone_gc_options().to_sstring();
-    std::replace(tombstone_gc_str.begin(), tombstone_gc_str.end(), '"', '\'');
-    os << "\n    AND tombstone_gc = " << tombstone_gc_str;
     
-    if (cdc_options().enabled()) {
-        os << "\n    AND cdc = " << cdc_options().to_sstring();
+    for (auto& [type, ext] : extensions()) {
+        os << "\n    AND " << type << " = " << ext->options_to_string();
     }
+
     if (is_view() && !is_index(db, view_info()->base_id(), *this)) {
         auto is_sync_update = db::find_tag(*this, db::SYNCHRONOUS_VIEW_UPDATES_TAG_KEY);
         if (is_sync_update.has_value()) {

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -768,6 +768,16 @@ static std::ostream& map_as_cql_param(std::ostream& os, const std::map<sstring, 
     return os;
 }
 
+// default impl assumes options are in a map.
+// implementations should override if not
+std::string schema_extension::options_to_string() const {
+    std::ostringstream ss;
+    ss << '{';
+    map_as_cql_param(ss, ser::deserialize_from_buffer(serialize(), boost::type<default_map_type>(), 0));
+    ss << '}';
+    return ss.str();
+}
+
 static std::ostream& column_definition_as_cql_key(std::ostream& os, const column_definition & cd) {
     os << cd.name_as_cql_string();
     os << " " << cd.type->cql3_type_name();

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -551,6 +551,10 @@ public:
     virtual bool is_placeholder() const {
         return false;
     }
+    using default_map_type = std::map<sstring, sstring>;
+    // default impl assumes options are in a map.
+    // implementations should override if not
+    virtual std::string options_to_string() const;
 };
 
 struct schema_static_props {

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -4125,7 +4125,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    AND read_repair_chance = 0\n"
                 "    AND speculative_retry = '99.0PERCENTILE'\n"
                 "    AND paxos_grace_seconds = 43200\n"
-                "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'};\n"
+                "    AND tombstone_gc = {'mode': 'timeout','propagation_delay_in_seconds': '3600'};\n"
             },
             {"cf1", "CREATE TABLE ks.cf1 (\n"
                 "    pk blob,\n"
@@ -4149,7 +4149,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    AND read_repair_chance = 0\n"
                 "    AND speculative_retry = '99.0PERCENTILE'\n"
                 "    AND paxos_grace_seconds = 43200\n"
-                "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'};\n"
+                "    AND tombstone_gc = {'mode': 'timeout','propagation_delay_in_seconds': '3600'};\n"
             },
             {"CF2", "CREATE TABLE ks.\"CF2\" (\n"
                 "    pk blob,\n"
@@ -4173,7 +4173,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    AND read_repair_chance = 0\n"
                 "    AND speculative_retry = '99.0PERCENTILE'\n"
                 "    AND paxos_grace_seconds = 43200\n"
-                "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'};\n"
+                "    AND tombstone_gc = {'mode': 'timeout','propagation_delay_in_seconds': '3600'};\n"
             },
             {"Cf3", "CREATE TABLE ks.\"Cf3\" (\n"
                 "    pk blob,\n"
@@ -4198,7 +4198,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    AND read_repair_chance = 0\n"
                 "    AND speculative_retry = '99.0PERCENTILE'\n"
                 "    AND paxos_grace_seconds = 43200\n"
-                "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'};\n"
+                "    AND tombstone_gc = {'mode': 'timeout','propagation_delay_in_seconds': '3600'};\n"
             },
             {"cf4", "CREATE TABLE ks.cf4 (\n"
                 "    pk blob,\n"
@@ -4222,7 +4222,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
                 "    AND read_repair_chance = 0\n"
                 "    AND speculative_retry = '99.0PERCENTILE'\n"
                 "    AND paxos_grace_seconds = 43200\n"
-                "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'};\n"
+                "    AND tombstone_gc = {'mode': 'timeout','propagation_delay_in_seconds': '3600'};\n"
             }
 
         };
@@ -4267,7 +4267,7 @@ SEASTAR_TEST_CASE(test_describe_view_schema) {
                 "    AND read_repair_chance = 0\n"
                 "    AND speculative_retry = '99.0PERCENTILE'\n"
                 "    AND paxos_grace_seconds = 43200\n"
-                "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'};\n";
+                "    AND tombstone_gc = {'mode': 'timeout','propagation_delay_in_seconds': '3600'};\n";
 
         std::unordered_map<std::string, std::string> cql_create_tables {
           {"cf_view", "CREATE MATERIALIZED VIEW \"KS\".cf_view AS\n"
@@ -4291,7 +4291,7 @@ SEASTAR_TEST_CASE(test_describe_view_schema) {
               "    AND read_repair_chance = 0\n"
               "    AND speculative_retry = '99.0PERCENTILE'\n"
               "    AND paxos_grace_seconds = 43200\n"
-              "    AND tombstone_gc = {'mode':'timeout','propagation_delay_in_seconds':'3600'};\n"},
+              "    AND tombstone_gc = {'mode': 'timeout','propagation_delay_in_seconds': '3600'};\n"},
           {"cf_index_index", "CREATE INDEX cf_index ON \"KS\".\"cF\"(col2);"},
           {"cf_index1_index", "CREATE INDEX cf_index1 ON \"KS\".\"cF\"(pk);"},
           {"cf_index2_index", "CREATE INDEX cf_index2 ON \"KS\".\"cF\"(pk1);"},


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/19334

Current impl uses hardcoded printing of a few extensions.
Instead, use extension options to string and print all.

Note: required to make enterprise CI happy again.

(cherry picked from commit https://github.com/scylladb/scylladb/commit/d27620e1462597e4c3cbbeb5df524e4528c85cf5)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/73abc56d79dcc02f9874cae086f50ac208aa2bcf)

Refs https://github.com/scylladb/scylladb/pull/19337'

(Manually re-done from mergify fail #19358)