### PR TITLE
[test.py] Throw meaningful error when something wrong wit Scylla binary

### DIFF
--- a/test.py
+++ b/test.py
@@ -90,8 +90,14 @@ def path_to(mode, *components):
     build_dir = 'build'
     if os.path.exists(os.path.join(build_dir, 'build.ninja')):
         *dir_components, basename = components
-        return os.path.join(build_dir, *dir_components, all_modes[mode], basename)
-    return os.path.join(build_dir, mode, *components)
+        exe_path = os.path.join(build_dir, *dir_components, all_modes[mode], basename)
+    else:
+        exe_path = os.path.join(build_dir, mode, *components)
+    if not os.access(exe_path, os.F_OK):
+        raise FileNotFoundError(f"{exe_path} does not exist.")
+    elif not os.access(exe_path, os.X_OK):
+        raise PermissionError(f"{exe_path} is not executable.")
+    return exe_path
 
 
 def ninja(target):


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylladb/issues/19489

There is already a check that Scylla binary is executable, but it's done on later stage. So in logs for a specific test file there will be a message about something wrong with binary, but in console there will be now signs of that. Moreover, there will be an error that completely misleads what actually happened and why test run failed. With this check test will fail earlier providing the correct reason why it's failed

