### PR TITLE
docs: install in non-package node

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -3,6 +3,7 @@ name = "scylla"
 description = "Scylla Documentation"
 version = "4.3.0"
 authors = ["ScyllaDB Contributors"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.9"
@@ -19,5 +20,5 @@ sphinx-scylladb-markdown = "^0.1.2"
 sphinx_collapse ="^0.1.3"
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=1.8"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
when running `make setup`, we could have following failure:
```
Installing the current project: scylla (4.3.0)
The current project could not be installed: No file/folder found for package scylla
If you do not want to install the current project use --no-root
```

because docs is not a proper python project named "scylla",
and do not have a directory structure expected by poetry. what we
expect from poetry, is to manage the dependencies for building
the document.

so, in this change, we install in the `non-package` mode when running
`poetry install`, this skips the root package, which does not exist.
as an alternative, we could put an empty `scylla.py` under `docs`
directory, but that'd be overkill. or we could pass `--no-root`
to `poetry install`, but would be ideal if we can keep the settings
in a single place.

see also https://python-poetry.org/docs/basic-usage/#operating-modes,
and https://python-poetry.org/docs/cli/#options-2, for more
details on the settings and command line options of poetry.

please note this setting was added to poetry 1.8, so the required
poetry version is updated. we might need to upgrade poetry in existing
installation.

---

this change addresses the build failure when preparing the building environment of document, so no need to backport.