### PR TITLE
toolchain: change optimized clang install method to standard one

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -111,7 +111,6 @@ fedora_packages=(
     wabt
     binaryen
     lcov
-    llvm-bolt
 )
 
 # lld is not available on s390x, see

--- a/tools/toolchain/optimized_clang.sh
+++ b/tools/toolchain/optimized_clang.sh
@@ -47,59 +47,103 @@ CLANG_SUFFIX=18
 
 CLANG_ARCHIVE=$(cd "${SCYLLA_DIR}" && realpath -m "${CLANG_ARCHIVE}")
 
-CLANG_OPTS=(-DCMAKE_C_COMPILER="/usr/bin/clang" -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DLLVM_USE_LINKER="/usr/bin/ld.lld" -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="${LLVM_TARGET_ARCH};WebAssembly" -DLLVM_TARGET_ARCH="${LLVM_TARGET_ARCH}" -G Ninja -DLLVM_INCLUDE_BENCHMARKS=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_ENABLE_BINDINGS=OFF -DLLVM_ENABLE_PROJECTS="clang;lld" -DLLVM_ENABLE_RUNTIMES="compiler-rt" -DLLVM_ENABLE_LTO=Thin -DCLANG_DEFAULT_PIE_ON_LINUX=OFF -DLLVM_BUILD_TOOLS=OFF -DLLVM_VP_COUNTERS_PER_SITE=6)
-SCYLLA_OPTS=(--date-stamp "$(date "+%Y%m%d")" --debuginfo 1 --tests-debuginfo 1 --c-compiler="${CLANG_BUILD_DIR}/build/bin/clang" --compiler="${CLANG_BUILD_DIR}/build/bin/clang++" --build-dir="${SCYLLA_BUILD_DIR}" --out="${SCYLLA_NINJA_FILE}")
+CLANG_OPTS=(
+    -G Ninja
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_C_COMPILER="/usr/bin/clang"
+    -DCMAKE_CXX_COMPILER="/usr/bin/clang++"
+    -DLLVM_USE_LINKER="/usr/bin/ld.lld"
+    -DLLVM_TARGETS_TO_BUILD="${LLVM_TARGET_ARCH};WebAssembly"
+    -DLLVM_TARGET_ARCH="${LLVM_TARGET_ARCH}"
+    -DLLVM_INCLUDE_BENCHMARKS=OFF
+    -DLLVM_INCLUDE_EXAMPLES=OFF
+    -DLLVM_INCLUDE_TESTS=OFF
+    -DLLVM_ENABLE_BINDINGS=OFF
+    -DLLVM_ENABLE_PROJECTS="clang"
+    -DLLVM_ENABLE_RUNTIMES="compiler-rt"
+    -DLLVM_ENABLE_LTO=Thin
+    -DCLANG_DEFAULT_PIE_ON_LINUX=OFF
+    -DLLVM_BUILD_TOOLS=OFF
+    -DLLVM_VP_COUNTERS_PER_SITE=6
+    -DLLVM_BUILD_LLVM_DYLIB=ON
+    -DLLVM_LINK_LLVM_DYLIB=ON
+    -DCMAKE_INSTALL_PREFIX="/usr/local"
+    -DLLVM_LIBDIR_SUFFIX=64
+    -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON
+)
+SCYLLA_OPTS=(
+    --date-stamp "$(date "+%Y%m%d")"
+    --debuginfo 1
+    --tests-debuginfo 1
+    --c-compiler="${CLANG_BUILD_DIR}/build/bin/clang"
+    --compiler="${CLANG_BUILD_DIR}/build/bin/clang++"
+    --build-dir="${SCYLLA_BUILD_DIR}"
+    --out="${SCYLLA_NINJA_FILE}"
+)
+
+# Utilizing LLVM_DISTRIBUTION_COMPONENTS to avoid
+# installing static libraries; inspired by Gentoo
+_get_distribution_components() {
+    local target
+    ninja -t targets | grep -Po 'install-\K.*(?=-stripped:)' | while read -r target; do
+        case $target in
+            clang-libraries|distribution)
+                continue
+                ;;
+            clang-tidy-headers)
+                continue
+                ;;
+            clang|clangd|clang-*)
+                ;;
+            clang*|findAllSymbols)
+                continue
+                ;;
+        esac
+        echo $target
+    done
+}
 
 if [[ "${CLANG_BUILD}" = "INSTALL" ]]; then
-    # Build a PGO-optimized compiler using the boostrapped compiler.
     rm -rf "${CLANG_BUILD_DIR}"
     git clone https://github.com/llvm/llvm-project --branch llvmorg-"${LLVM_CLANG_TAG}" --depth=1 "${CLANG_BUILD_DIR}"
+
+    echo "[clang-stage1] build the compiler for collecting PGO profile"
     cd "${CLANG_BUILD_DIR}"
+    rm -rf build
+    cmake -B build -S llvm "${CLANG_OPTS[@]}" -DLLVM_BUILD_INSTRUMENTED=IR
+    DISTRIBUTION_COMPONENTS=$(cd build && _get_distribution_components | paste -sd\;)
+    test -n "${DISTRIBUTION_COMPONENTS}"
+    CLANG_OPTS+=(-DLLVM_DISTRIBUTION_COMPONENTS="${DISTRIBUTION_COMPONENTS}")
     cmake -B build -S llvm "${CLANG_OPTS[@]}" -DLLVM_BUILD_INSTRUMENTED=IR
     ninja -C build
 
+    echo "[scylla-stage1] gather a clang profile for PGO"
     rm -rf "${SCYLLA_BUILD_DIR_FULLPATH}" "${SCYLLA_NINJA_FILE_FULLPATH}"
     cd "${SCYLLA_DIR}"
     ./configure.py "${SCYLLA_OPTS[@]}"
     LLVM_PROFILE_FILE="${CLANG_BUILD_DIR}"/build/profiles/default_%p-%m.profraw ninja -f "${SCYLLA_NINJA_FILE}" compiler-training
 
+    echo "[clang-stage2] build the compiler applied PGO profile and for collecting CSPGO profile"
     cd "${CLANG_BUILD_DIR}"
     llvm-profdata merge "${CLANG_BUILD_DIR}"/build/profiles/default_*.profraw -output=ir.prof
     rm -rf build
     cmake -B build -S llvm "${CLANG_OPTS[@]}" -DLLVM_BUILD_INSTRUMENTED=CSIR -DLLVM_PROFDATA_FILE="$(realpath ir.prof)"
     ninja -C build
 
-    # 2nd compilation: gathering a clang profile for CSPGO
+    echo "[scylla-stage2] gathering a clang profile for CSPGO"
     rm -rf "${SCYLLA_BUILD_DIR_FULLPATH}" "${SCYLLA_NINJA_FILE_FULLPATH}"
     cd "${SCYLLA_DIR}"
     ./configure.py "${SCYLLA_OPTS[@]}"
     LLVM_PROFILE_FILE="${CLANG_BUILD_DIR}"/build/profiles/csir-%p-%m.profraw ninja -f "${SCYLLA_NINJA_FILE}" compiler-training
 
+    echo "[clang-stage3] build the compiler applied CSPGO profile"
     cd "${CLANG_BUILD_DIR}"
     llvm-profdata merge build/csprofiles/default_*.profraw -output=csir.prof
     llvm-profdata merge ir.prof csir.prof -output=combined.prof
     rm -rf build
-    # -DLLVM_LIBDIR_SUFFIX=64 for Fedora compatibility
-    cmake -B build -S llvm "${CLANG_OPTS[@]}" -DLLVM_PROFDATA_FILE="$(realpath combined.prof)" -DCMAKE_EXE_LINKER_FLAGS="-Wl,--emit-relocs" -DCMAKE_INSTALL_PREFIX=/usr/local -DLLVM_LIBDIR_SUFFIX=64
+    # linker flags are needed for BOLT
+    cmake -B build -S llvm "${CLANG_OPTS[@]}" -DLLVM_PROFDATA_FILE="$(realpath combined.prof)" -DCMAKE_EXE_LINKER_FLAGS="-Wl,--emit-relocs"
     ninja -C build
-
-    #TODO: skipping BOLT for aarch64 for now, since it causes segfault
-    if [[ "${ARCH}" != "aarch64" ]]; then
-        # BOLT phase
-        mv build/bin/clang-"${CLANG_SUFFIX}" build/bin/clang-"${CLANG_SUFFIX}".prebolt
-        mkdir -p build/profiles
-        llvm-bolt build/bin/clang-"${CLANG_SUFFIX}".prebolt -o build/bin/clang-"${CLANG_SUFFIX}" --instrument --instrumentation-file="${CLANG_BUILD_DIR}"/build/profiles/prof --instrumentation-file-append-pid --conservative-instrumentation
-
-        # 3rd ScyllaDB compilation: gathering a clang profile for BOLT
-        rm -rf "${SCYLLA_BUILD_DIR_FULLPATH}" "${SCYLLA_NINJA_FILE_FULLPATH}"
-        cd "${SCYLLA_DIR}"
-        ./configure.py "${SCYLLA_OPTS[@]}"
-        ninja -f "${SCYLLA_NINJA_FILE}" compiler-training
-
-        cd "${CLANG_BUILD_DIR}"
-        merge-fdata build/profiles/*.fdata > prof.fdata
-        llvm-bolt build/bin/clang-"${CLANG_SUFFIX}".prebolt -o build/bin/clang-"${CLANG_SUFFIX}" --data=prof.fdata --reorder-functions=hfsort --reorder-blocks=ext-tsp --split-functions --split-all-cold --split-eh --dyno-stats
-    fi
 
     cd "${CLANG_ROOT_DIR}"
     rm -rf "${CLANG_BUILD_DIR}"/{build/profiles,*.prof,prof.fdata}
@@ -110,10 +154,5 @@ elif [[ "${CLANG_BUILD}" = "INSTALL_FROM" ]]; then
 fi
 
 cd "${CLANG_BUILD_DIR}"
-mv /usr/bin/clang-"${CLANG_SUFFIX}" /usr/bin/clang-"${CLANG_SUFFIX}".orig
-mv /usr/bin/lld /usr/bin/lld.orig
-mv /usr/lib64/libLTO.so."${CLANG_SUFFIX}" /usr/lib64/libLTO.so."${CLANG_SUFFIX}".orig
-install -Z -m755 "${CLANG_BUILD_DIR}"/build/bin/clang-"${CLANG_SUFFIX}" /usr/bin/clang-"${CLANG_SUFFIX}"
-install -Z -m755 "${CLANG_BUILD_DIR}"/build/bin/lld /usr/bin/lld
-install -Z -m755 "${CLANG_BUILD_DIR}"/build/lib64/libLTO.so."${CLANG_SUFFIX}" /usr/lib64/libLTO.so."${CLANG_SUFFIX}"
-rm -rf "${CLANG_BUILD_DIR}" "${SCYLLA_BUILD_DIR_FULLPATH}" "${SCYLLA_NINJA_FILE_FULLPATH}"
+ninja -C build install-distribution-stripped
+dnf remove -y clang clang-libs


### PR DESCRIPTION
Previously optimized clang installation was not used standard build script, it overwrites preinstalled Fedora's clang binaries instead. However this breaks on clang-18.1.8, since libLTO versioning convention. To avoid such problem, let's switch to standard installation method and swith install prefix to /usr/local.

Fixes #19203