### PR TITLE
repair: remove unused operator<<

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -120,10 +120,6 @@ static std::ostream& operator<<(std::ostream& os, const std::unordered_map<T1, T
     return os;
 }
 
-std::ostream& operator<<(std::ostream& out, row_level_diff_detect_algorithm algo) {
-    return out << format_as(algo);
-}
-
 std::string_view format_as(row_level_diff_detect_algorithm algo) {
     using enum row_level_diff_detect_algorithm;
     switch (algo) {

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -236,7 +236,6 @@ enum class row_level_diff_detect_algorithm : uint8_t {
     send_full_set_rpc_stream,
 };
 
-std::ostream& operator<<(std::ostream& out, row_level_diff_detect_algorithm algo);
 std::string_view format_as(row_level_diff_detect_algorithm);
 
 struct repair_update_system_table_request {

--- a/repair/sync_boundary.hh
+++ b/repair/sync_boundary.hh
@@ -37,8 +37,3 @@ template <> struct fmt::formatter<repair_sync_boundary> {
         return fmt::format_to(ctx.out(), "{{ {}, {} }}", boundary.pk, boundary.position);
     }
 };
-
-inline std::ostream& operator<<(std::ostream& os, const repair_sync_boundary& x) {
-    fmt::print(os, "{}", x);
-    return os;
-}


### PR DESCRIPTION
since we've switched almost all callers of the operator<< to {fmt}, let's drop the unused operator<<:s.

---

it's a cleanup, hence no need to backport.