### PR TITLE
[test.py] add --extra-scylla-cmdline-options argument for test.py

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -160,7 +160,8 @@ SCYLLA_CMDLINE_OPTIONS = [
 # [--overprovisioned, --smp=1, --abort-on-ebadf], [--smp=2] -> [--overprovisioned, --smp=2, --abort-on-ebadf]
 # [], [--experimental-features, raft, --experimental-features, broadcast-tables] ->
 # [--experimental-features, raft, --experimental-features, broadcast-tables]
-def merge_cmdline_options(base: List[str], override: List[str]) -> List[str]:
+def merge_cmdline_options(
+        base: List[str], override: List[str], appending_options: List[str] = ["--logger-log-level"]) -> List[str]:
     if len(override) == 0:
         return base
 
@@ -191,7 +192,8 @@ def merge_cmdline_options(base: List[str], override: List[str]) -> List[str]:
                 if v != '__remove__':
                     if merged_values is None:
                         merged_values = merged.setdefault(name, [])
-                        merged_values.clear()
+                        if name not in appending_options:
+                            merged_values.clear()
                     merged_values.append(v if v != '__missing__' else None)
                 elif name in merged:
                     del merged[name]


### PR DESCRIPTION
this PR has 2 commits
- [test: pass Scylla extra CMD args from test.py args](https://github.com/scylladb/scylladb/commit/6b367a04b5c7a6afcba284b65cc40cffda33a790)
- [test: adjust scylla_cluster.merge_cmdline_options behavior](https://github.com/scylladb/scylladb/commit/c60b36090a9400e011e951587000bd49448d2db8)

the main goal is to solve [test.py: provide an easy-to-remember, univeral way to run scylla with trace level logging](https://github.com/scylladb/scylladb/issues/14960) issue

but also can be used to easily apply additional arguments for all UnitTests and PythonTests on the fly from the test.py CMD