### PR TITLE
conf: scylla.yaml: update documentation for tablets

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -611,5 +611,16 @@ maintenance_socket: ignore
 #  - SimpleStrategy
 # replication_strategy_fail_list:
 
-# This enables tablets on newly created keyspaces
+# Enables the tablets feature.
+# When enabled, newly created keyspaces will have tablets enabled by default.
+# That can be explicitly disabled in the CREATE KEYSPACE query
+# by using the `tablets = {'enabled': false}` replication option.
+#
+# When the tablets feature is disabled, there is no way to enable tablets
+# per keyspace.
+#
+# Note that creating keyspaces with tablets enabled is irreversible.
+# Disabling the tablets feature may impact existing keyspaces that were created with tablets.
+# For example, the tablets map would remain "frozen" and will not respond to topology changes
+# like adding, removing, or replacing nodes, or to replication factor changes.
 enable_tablets: true

--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -276,7 +276,6 @@ batch_size_fail_threshold_in_kb: 1024
 #     - alternator-streams
 #     - broadcast-tables
 #     - keyspace-storage-options
-#     - tablets
 
 # The directory where hints files are stored if hinted handoff is enabled.
 # hints_directory: /var/lib/scylla/hints


### PR DESCRIPTION
Tablets are no longer in experimental_features since 83d491a, so remove them from the experimental_features section documentation.

Also, expand the documentation for the `enable_tablets` option.

Fixes #19456

Needs backport to 6.0
