### PR TITLE
cql: forbid having counter columns in tablets tables

### DIFF
--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -109,11 +109,10 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector
             locator::replication_strategy_params(ksm->strategy_options(), ksm->initial_tablets()));
         if (rs->uses_tablets()) {
             warnings.push_back(
-                "Tables in this keyspace will be replicated using tablets, "
-                "and will not support the CDC feature (issue #16317) and LWT "
-                "may suffer from issue #5251 more often. If you want to use "
-                "CDC or LWT, please drop this keyspace and re-create it "
-                "without tablets, by adding AND TABLETS = {'enabled': false} "
+                "Tables in this keyspace will be replicated using Tablets "
+                "and will not support CDC, LWT and counters features. "
+                "To use CDC, LWT or counters, drop this keyspace and re-create it "
+                "without tablets by adding AND TABLETS = {'enabled': false} "
                 "to the CREATE KEYSPACE statement.");
         }
     } catch (const exceptions::already_exists_exception& e) {

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -201,6 +201,10 @@ std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepa
             throw exceptions::invalid_request_exception("Cannot set default_time_to_live on a table with counters");
         }
 
+        if (db.find_keyspace(keyspace()).get_replication_strategy().uses_tablets() && pt.is_counter()) {
+            throw exceptions::invalid_request_exception(format("Cannot use the 'counter' type for table {}.{}: Counters are not yet supported with tablets", keyspace(), cf_name));
+        }
+
         if (pt.get_type()->is_multi_cell()) {
             if (pt.get_type()->is_user_type()) {
                 // check for multi-cell types (non-frozen UDTs or collections) inside a non-frozen UDT

--- a/docs/alternator/alternator.md
+++ b/docs/alternator/alternator.md
@@ -201,6 +201,10 @@ want modify a non-top-level attribute directly (e.g., a.b[3].c) need RMW:
 Alternator implements such requests by reading the entire top-level
 attribute a, modifying only a.b[3].c, and then writing back a.
 
+Currently, Alternator doesn't use Tablets. That's because Alternator relies
+on LWT (lightweight transactions), and LWT is not supported in keyspaces
+with Tablets enabled.
+
 ```{eval-rst}
 .. toctree::
     :maxdepth: 2

--- a/docs/using-scylla/cdc/index.rst
+++ b/docs/using-scylla/cdc/index.rst
@@ -2,6 +2,8 @@
 Change Data Capture (CDC)
 =========================
 
+.. note:: CDC is not supported in keyspaces with :doc:`tablets</architecture/tablets>` enabled.
+
 .. toctree::
    :maxdepth: 2
    :hidden:

--- a/docs/using-scylla/counters.rst
+++ b/docs/using-scylla/counters.rst
@@ -3,7 +3,9 @@
 ScyllaDB Counters
 ==================
 
-Counters are useful for any application where you need to increment a count,  such as keeping track of:
+.. note:: Counters are not supported in keyspaces with :doc:`tablets</architecture/tablets>` enabled.
+
+Counters are useful for any application where you need to increment a count, such as keeping a track of:
 
 * The number of web page views on a website.
 * The number of apps/updates downloaded.

--- a/docs/using-scylla/lwt.rst
+++ b/docs/using-scylla/lwt.rst
@@ -2,6 +2,8 @@
 Lightweight Transactions
 ========================
 
+.. note:: The LWT feature is not supported in keyspaces with :doc:`tablets</architecture/tablets>` enabled.
+
 There are cases when it is necessary to modify data based on its current state: that is, to perform an update that is executed only if a row does not exist or contains a certain value.
 :abbr:`LWTs (lightweight transactions)` provide this functionality by only allowing changes to data to occur if the condition provided evaluates as true.
 The conditional statements provide linearizable semantics thus allowing data to remain consistent.

--- a/test/cql-pytest/cassandra_tests/batch_test.py
+++ b/test/cql-pytest/cassandra_tests/batch_test.py
@@ -44,21 +44,39 @@ def testNonCounterInCounterBatch(cql, test_keyspace):
     with pytest.raises(InvalidRequest):
         sendBatch(cql, test_keyspace, BatchType.COUNTER, False, True, False)
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testNonCounterInLoggedBatch(cql, test_keyspace):
     sendBatch(cql, test_keyspace, BatchType.LOGGED, False, True, False)
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testNonCounterInUnLoggedBatch(cql, test_keyspace):
     sendBatch(cql, test_keyspace, BatchType.UNLOGGED, False, True, False)
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testCounterInCounterBatch(cql, test_keyspace):
     sendBatch(cql, test_keyspace, BatchType.COUNTER, True, False, False)
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testCounterInUnLoggedBatch(cql, test_keyspace):
     sendBatch(cql, test_keyspace, BatchType.UNLOGGED, True, False, False)
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testTableWithClusteringInLoggedBatch(cql, test_keyspace):
     sendBatch(cql, test_keyspace, BatchType.LOGGED, False, False, True)
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testTableWithClusteringInUnLoggedBatch(cql, test_keyspace):
     sendBatch(cql, test_keyspace, BatchType.UNLOGGED, False, False, True)
 

--- a/test/cql-pytest/cassandra_tests/functions/cast_fcts_test.py
+++ b/test/cql-pytest/cassandra_tests/functions/cast_fcts_test.py
@@ -242,6 +242,9 @@ def testCastsWithReverseOrder(cql, test_keyspace):
         #           row("2.0"))
 
 # Reproduces #14501:
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testCounterCastsInSelectionClause(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int primary key, b counter)") as table:
         execute(cql, table, "UPDATE %s SET b = b + 2 WHERE a = 1")

--- a/test/cql-pytest/cassandra_tests/validation/entities/counters_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/counters_test.py
@@ -12,6 +12,9 @@ from cassandra.query import UNSET_VALUE
 
 # Test for the validation bug of CASSANDRA-4706,
 # migrated from cql_tests.py:TestCQL.validate_counter_regular_test()
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testRegularCounters(cql, test_keyspace):
     # The Cassandra and Scylla error messages are different: Cassandra says
     # "Cannot mix counter and non counter columns in the same table", Scylla
@@ -28,6 +31,9 @@ def testRegularCounters(cql, test_keyspace):
                                  "CREATE TABLE %s (id bigint PRIMARY KEY, count counter, things set<text>)")
 
 # Migrated from cql_tests.py:TestCQL.collection_counter_test()
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testCountersOnCollections(cql, test_keyspace):
     assert_invalid_throw(cql, test_keyspace + "." + unique_name(),
                          InvalidRequest,
@@ -41,6 +47,9 @@ def testCountersOnCollections(cql, test_keyspace):
                          InvalidRequest,
                          "CREATE TABLE %s (k int PRIMARY KEY, m map<text, counter>)")
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testCounterUpdatesWithUnset(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, c counter)") as table:
         # set up
@@ -58,6 +67,9 @@ def testCounterUpdatesWithUnset(cql, test_keyspace):
         assert_rows(execute(cql, table, "SELECT c FROM %s WHERE k = 10"), [1]) # no change to the counter value
 
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testCounterFiltering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, a counter)") as table:
         for i in range(10):
@@ -85,6 +97,9 @@ def testCounterFiltering(cql, test_keyspace):
         assert_rows_ignoring_order(execute(cql, table, "SELECT * FROM %s WHERE a = ? ALLOW FILTERING", 6),
                                 [6, 6], [10, 6])
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testCounterFilteringWithNull(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, a counter, b counter)") as table:
         execute(cql, table, "UPDATE %s SET a = a + ? WHERE k = ?", 1, 1)
@@ -105,6 +120,9 @@ def testCounterFilteringWithNull(cql, test_keyspace):
                              "SELECT * FROM %s WHERE b = null ALLOW FILTERING")
 
 # Test for the validation bug of CASSANDRA-9395.
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testProhibitReversedCounterAsPartOfPrimaryKey(cql, test_keyspace):
     # The Cassandra message and Scylla message differ slightly -
     # counter type is not supported for PRIMARY KEY column 'a'"
@@ -116,6 +134,9 @@ def testProhibitReversedCounterAsPartOfPrimaryKey(cql, test_keyspace):
                                  "CREATE TABLE %s (a counter, b int, PRIMARY KEY (b, a)) WITH CLUSTERING ORDER BY (a desc);")
 
 # Check that a counter batch works as intended
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testCounterBatch(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(userid int, url text, total counter, PRIMARY KEY (userid, url))") as table:
         # Ensure we handle updates to the same CQL row in the same partition properly

--- a/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/entities/secondary_index_test.py
@@ -282,6 +282,9 @@ def testIndexOnCompoundRowKey(cql, test_keyspace):
                        ["t", 1, 4, 3])
 
 # Migrated from cql_tests.py:TestCQL.secondary_index_counters()
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testIndexOnCountersInvalid(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, c counter)") as table:
         assert_invalid(cql, table, "CREATE INDEX ON %s(c)")

--- a/test/cql-pytest/cassandra_tests/validation/operations/compact_storage_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/compact_storage_test.py
@@ -122,6 +122,9 @@ def testCounters(cql, test_keyspace):
         assert_rows(execute(cql, table, "SELECT total FROM %s WHERE userid = 1 AND url = 'http://foo.com'"),
                    [1])
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testCounterFiltering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, a COUNTER) WITH COMPACT STORAGE") as table:
         for i in range(10):
@@ -164,6 +167,9 @@ def testCounterFiltering(cql, test_keyspace):
                                 [10, 6])
 
 # Test for the bug of CASSANDRA-11726.
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testCounterAndColumnSelection(cql, test_keyspace):
     for compactStorageClause in ["", " WITH COMPACT STORAGE"]:
         with create_table(cql, test_keyspace, "(k int PRIMARY KEY, c counter) " + compactStorageClause) as table:
@@ -178,6 +184,9 @@ def testCounterAndColumnSelection(cql, test_keyspace):
             assert_rows(execute(cql, table, "SELECT k FROM %s"), [0])
 
 # Check that a counter batch works as intended
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testCounterBatch(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(userid int, url text, total counter, PRIMARY KEY (userid, url)) WITH COMPACT STORAGE") as table:
         # Ensure we handle updates to the same CQL row in the same partition properly

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
@@ -1651,6 +1651,9 @@ def executeFilteringOnly(cql, table, statement):
     assert_invalid(cql, table, statement)
     return execute_without_paging(cql, table, statement + " ALLOW FILTERING")
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testAllowFilteringOnPartitionKeyWithCounters(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, cnt counter, PRIMARY KEY ((a, b), c))") as table:
         execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 14, 11, 12, 13)
@@ -1974,6 +1977,9 @@ def testCustomIndexWithFiltering(cql, test_keyspace):
             assert_rows(executeFilteringOnly(cql, table, "SELECT * FROM %s WHERE c = 'b' AND d = 4"),
                        ["c", 3, "b", 4])
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def testFilteringWithCounters(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, cnt counter, PRIMARY KEY (a, b, c))") as table:
         execute(cql, table, "UPDATE %s SET cnt = cnt + ? WHERE a = ? AND b = ? AND c = ?", 14, 11, 12, 13)

--- a/test/cql-pytest/test_cast_data.py
+++ b/test/cql-pytest/test_cast_data.py
@@ -119,6 +119,9 @@ def test_ignore_cast_to_the_same_type(cql, table1):
     assert cql.execute(f"SELECT CAST(p as int) FROM {table1} WHERE p={p}").one()._fields[0] == "p"
 
 # Test casting a counter to various other types. Reproduces #14501.
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def test_cast_from_counter(cql, table2):
     p = unique_key_int()
     # Set the counter to 1000 in two increments, to make it less trivial to
@@ -153,6 +156,9 @@ def test_cast_from_counter(cql, table2):
 # "text" type. Since "varchar" is just an alias for "text", casting
 # to varchar should work too, but in Cassandra it doesn't so this test
 # is marked a Cassandra bug.
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def test_cast_from_counter_to_varchar(cql, table2, cassandra_bug):
     p = unique_key_int()
     cql.execute(f'UPDATE {table2} SET c = c + 1000 WHERE p = {p}')

--- a/test/cql-pytest/test_counter.py
+++ b/test/cql-pytest/test_counter.py
@@ -24,6 +24,9 @@ def table2(cql, test_keyspace):
 # Test that the function counterasblob() exists and works as expected -
 # same as bigintasblob on the same number (a counter is a 64-bit number).
 # Reproduces #14742
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def test_counter_to_blob(cql, table1, table2):
     p = unique_key_int()
     cql.execute(f'UPDATE {table1} SET i = 1000 WHERE p = {p}')

--- a/test/cql-pytest/test_describe.py
+++ b/test/cql-pytest/test_describe.py
@@ -140,7 +140,10 @@ def test_desc_scylla_keyspace(scylla_only, cql, random_seed):
 
 # Test that `DESC TABLE {tbl}` contains appropriate create statement for table
 # This test compares the content of `system_schema.tables` and `system_schema.columns` tables.
-def test_desc_table(cql, test_keyspace, random_seed):
+def test_desc_table(cql, test_keyspace, random_seed, has_tablets):
+    if has_tablets:  # issue #18180
+        global counter_table_chance
+        counter_table_chance = 0
     with new_random_table(cql, test_keyspace) as tbl:
         desc = cql.execute(f"DESC TABLE {tbl}")
         desc_stmt = desc.one().create_statement
@@ -191,7 +194,10 @@ def test_desc_table(cql, test_keyspace, random_seed):
 # Test that `DESC TABLE {tbl}` contains appropriate create statement for table
 # This test compares the content of `system_schema.scylla_tables` tables, thus the test
 # is `scylla_only`.
-def test_desc_scylla_table(scylla_only, cql, test_keyspace, random_seed):
+def test_desc_scylla_table(scylla_only, cql, test_keyspace, random_seed, has_tablets):
+    if has_tablets:  # issue #18180
+        global counter_table_chance
+        counter_table_chance = 0
     with new_random_table(cql, test_keyspace) as tbl:
         desc = cql.execute(f"DESC TABLE {tbl}")
         desc_stmt = desc.one().create_statement
@@ -345,7 +351,10 @@ def test_desc_table_internals(cql, test_keyspace):
         assert f"ALTER TABLE {tbl} ADD b int" in desc_internals
 
 # Test that `DESC KEYSPACE {ks}` contains not only keyspace create statement but also for its elements
-def test_desc_keyspace_elements(cql, random_seed):
+def test_desc_keyspace_elements(cql, random_seed, has_tablets):
+    if has_tablets:  # issue #18180
+        global counter_table_chance
+        counter_table_chance = 0
     with new_random_keyspace(cql) as ks:
         with new_random_type(cql, ks) as udt:
             with new_random_table(cql, ks, [udt]) as tbl:
@@ -365,7 +374,10 @@ def test_desc_keyspace_elements(cql, random_seed):
 
 # Test that `DESC SCHEMA` contains all information for user created keyspaces
 # and `DESC FULL SCHEMA` contains also information for system keyspaces
-def test_desc_schema(cql, test_keyspace, random_seed):
+def test_desc_schema(cql, test_keyspace, random_seed, has_tablets):
+    if has_tablets:  # issue #18180
+        global counter_table_chance
+        counter_table_chance = 0
     with new_random_keyspace(cql) as ks:
         with new_random_table(cql, test_keyspace) as tbl1, new_random_table(cql, ks) as tbl2:
             desc = cql.execute("DESC SCHEMA")
@@ -483,7 +495,10 @@ def test_index_desc_in_table_desc(cql, test_keyspace):
 # keyspace, table, view, index, UDT, UDF, UDA
 
 # Cassandra compatibility require us to be able generic describe: keyspace, table, view, index.
-def test_generic_desc(cql, random_seed):
+def test_generic_desc(cql, random_seed, has_tablets):
+    if has_tablets:  # issue #18180
+        global counter_table_chance
+        counter_table_chance = 0
     with new_random_keyspace(cql) as ks:
         with new_random_table(cql, ks) as t1, new_test_table(cql, ks, "a int primary key, b int, c int") as tbl:
             cql.execute(f"CREATE INDEX idx ON {tbl}(b)")

--- a/test/cql-pytest/test_tools.py
+++ b/test/cql-pytest/test_tools.py
@@ -187,6 +187,9 @@ def test_scylla_sstable_dump_component(cql, test_keyspace, scylla_path, scylla_d
 ])
 @pytest.mark.parametrize("merge", [True, False])
 @pytest.mark.parametrize("output_format", ["text", "json"])
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def test_scylla_sstable_dump_data(cql, test_keyspace, scylla_path, scylla_data_dir, table_factory, merge, output_format):
     with scylla_sstable(simple_clustering_table, cql, test_keyspace, scylla_data_dir) as (schema_file, sstables):
         args = [scylla_path, "sstable", "dump-data", "--schema-file", schema_file, "--output-format", output_format]
@@ -481,7 +484,9 @@ def test_scylla_sstable_script_slice(cql, test_keyspace, scylla_path, scylla_dat
         clustering_table_with_udt,
         table_with_counters,
 ])
-def test_scylla_sstable_script(cql, test_keyspace, scylla_path, scylla_data_dir, table_factory):
+def test_scylla_sstable_script(cql, test_keyspace, scylla_path, scylla_data_dir, table_factory, has_tablets):
+    if has_tablets and table_factory == table_with_counters: # issue #18180
+        return
     scripts_path = os.path.realpath(os.path.join(__file__, '../../../tools/scylla-sstable-scripts'))
     slice_script_path = os.path.join(scripts_path, 'slice.lua')
     dump_script_path = os.path.join(scripts_path, 'dump.lua')

--- a/test/cql-pytest/test_unset.py
+++ b/test/cql-pytest/test_unset.py
@@ -91,6 +91,9 @@ def test_update_unset_value_expr_arithmetic(cql, table1):
 # The rationale is that "c = c + ?" is not an expression - it doesn't actually
 # calculate c + ?, but rather it is a primitive increment operation, and
 # passing ?=UNSET_VALUE should be able to skip this primitive operation.
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def test_unset_counter_increment(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, c counter") as table:
         p = unique_key_int()

--- a/test/cql-pytest/test_wasm.py
+++ b/test/cql-pytest/test_wasm.py
@@ -635,6 +635,9 @@ def test_drop(cql, test_keyspace, table1, scylla_with_wasm_only, metrics):
         assert(get_metric(metrics, 'scylla_user_functions_cache_instace_count_any') == 0)
 
 # Test that we can use counters as the return type of a WASM UDF.
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #18180")]), "vnodes"],
+                         indirect=True)
 def test_counter(cql, test_keyspace, scylla_only):
     schema = "p int, c counter, PRIMARY KEY (p)"
     ri_counter_name = unique_name()

--- a/test/topology_experimental_raft/test_fencing.py
+++ b/test/topology_experimental_raft/test_fencing.py
@@ -59,14 +59,17 @@ def all_hints_metrics(metrics: ScyllaMetrics) -> list[str]:
 
 
 @pytest.mark.asyncio
-async def test_fence_writes(request, manager: ManagerClient):
+@pytest.mark.parametrize("tablets_enabled", [True, False])
+async def test_fence_writes(request, manager: ManagerClient, tablets_enabled: bool):
+    cfg = {'enable_tablets' : tablets_enabled}
+
     logger.info("Bootstrapping first two nodes")
-    servers = await manager.servers_add(2)
+    servers = await manager.servers_add(2, config=cfg)
 
     # The third node is started as the last one, so we can be sure that is has
     # the latest topology version
     logger.info("Bootstrapping the last node")
-    servers += [await manager.server_add()]
+    servers += [await manager.server_add(config=cfg)]
 
     # Disable load balancer as it might bump topology version, undoing the decrement below.
     # This should be done before adding the last two servers,
@@ -80,10 +83,11 @@ async def test_fence_writes(request, manager: ManagerClient):
         Column("pk", IntType),
         Column('int_c', IntType)
     ])
-    table2 = await random_tables.add_table(name='t2', pks=1, columns=[
-        Column("pk", IntType),
-        Column('counter_c', CounterType)
-    ])
+    if not tablets_enabled:  # issue #18180
+        table2 = await random_tables.add_table(name='t2', pks=1, columns=[
+            Column("pk", IntType),
+            Column('counter_c', CounterType)
+        ])
     cql = manager.get_cql()
     await cql.run_async(f"USE {random_tables.keyspace}")
 
@@ -107,9 +111,10 @@ async def test_fence_writes(request, manager: ManagerClient):
     with pytest.raises(WriteFailure, match="stale topology exception"):
         await cql.run_async("insert into t1(pk, int_c) values (1, 1)", host=host2)
 
-    logger.info(f"trying to write through host2 to counter column [{host2}]")
-    with pytest.raises(WriteFailure, match="stale topology exception"):
-        await cql.run_async("update t2 set counter_c=counter_c+1 where pk=1", host=host2)
+    if not tablets_enabled:  # issue #18180
+        logger.info(f"trying to write through host2 to counter column [{host2}]")
+        with pytest.raises(WriteFailure, match="stale topology exception"):
+            await cql.run_async("update t2 set counter_c=counter_c+1 where pk=1", host=host2)
 
     random_tables.drop_all()
 

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -40,6 +40,7 @@
 #include "data_dictionary/data_dictionary.hh"
 #include "gms/feature_service.hh"
 #include "locator/abstract_replication_strategy.hh"
+#include "locator/local_strategy.hh"
 #include "tools/schema_loader.hh"
 #include "view_info.hh"
 
@@ -159,7 +160,8 @@ private:
         return is_system_keyspace(unwrap(ks).metadata->name());
     }
     virtual const locator::abstract_replication_strategy& get_replication_strategy(data_dictionary::keyspace ks) const override {
-        throw std::bad_function_call();
+        static const locator::local_strategy strategy{locator::replication_strategy_params{locator::replication_strategy_config_options{}, 0}};
+        return strategy;
     }
     virtual const std::vector<view_ptr>& get_table_views(data_dictionary::table t) const override {
         static const std::vector<view_ptr> empty;


### PR DESCRIPTION
Counter updates break under tablet migration (#18180), and for this reason counters need to be disabled until the problem is fixed. It's enough to forbid creating a table with counters, as altering a table without counters already cannot result in the table having counters:
1) Adding a counter column to a table without counters:
```
cqlsh> ALTER TABLE temp.cf ADD (col_name counter);
ConfigurationException: Cannot add a counter column (col_name) in a non counter column family
```
2) Altering a column to be of the counter type:
```
cqlsh> ALTER TABLE temp.cf ALTER col_name TYPE counter;
ConfigurationException: Cannot change col_name from type int to type counter: types are incompatible.
```

Fixes: #19449
Fixes: https://github.com/scylladb/scylladb/issues/18876

Need to backport to 6.0, as this is broken there.