### PR TITLE
build: update C++ standard to C++23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
 include(limit_jobs)
 # Configure Seastar compile options to align with Scylla
-set(CMAKE_CXX_STANDARD "20" CACHE INTERNAL "")
+set(CMAKE_CXX_STANDARD "23" CACHE INTERNAL "")
 set(CMAKE_CXX_EXTENSIONS ON CACHE INTERNAL "")
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF CACHE INTERNAL "")
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)

--- a/configure.py
+++ b/configure.py
@@ -1689,10 +1689,10 @@ def configure_seastar(build_dir, mode, mode_config):
         '-DCMAKE_C_COMPILER={}'.format(args.cc),
         '-DCMAKE_CXX_COMPILER={}'.format(args.cxx),
         '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON',
-        '-DCMAKE_CXX_STANDARD=20',
+        '-DCMAKE_CXX_STANDARD=23',
         '-DSeastar_CXX_FLAGS=SHELL:{}'.format(mode_config['lib_cflags']),
         '-DSeastar_LD_FLAGS={}'.format(semicolon_separated(mode_config['lib_ldflags'], seastar_cxx_ld_flags)),
-        '-DSeastar_CXX_DIALECT=gnu++20',
+        '-DSeastar_CXX_DIALECT=gnu++23',
         '-DSeastar_API_LEVEL=7',
         '-DSeastar_DEPRECATED_OSTREAM_FORMATTERS=OFF',
         '-DSeastar_UNUSED_RESULT_ERROR=ON',
@@ -1755,7 +1755,7 @@ def configure_abseil(build_dir, mode, mode_config):
         '-DCMAKE_CXX_COMPILER={}'.format(args.cxx),
         '-DCMAKE_CXX_FLAGS_{}={}'.format(cmake_mode.upper(), cxx_flags),
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
-        '-DCMAKE_CXX_STANDARD=20',
+        '-DCMAKE_CXX_STANDARD=23',
         '-DABSL_PROPAGATE_CXX_STD=ON',
     ]
 
@@ -1890,7 +1890,7 @@ def write_build_file(f,
         configure_args = {configure_args}
         builddir = {outdir}
         cxx = {cxx}
-        cxxflags = -std=gnu++20 {user_cflags} {warnings} {defines}
+        cxxflags = -std=gnu++23 {user_cflags} {warnings} {defines}
         ldflags = {linker_flags} {user_ldflags}
         ldflags_build = {linker_flags}
         libs = {libs}

--- a/main.cc
+++ b/main.cc
@@ -648,7 +648,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
     init("list-tools", bpo::bool_switch(), "list included tools and exit");
 
     bpo::options_description deprecated_options("Deprecated options - ignored");
-    cfg->add_deprecated_options(deprecated_options.add_options());
+    auto deprecated_options_easy_init = deprecated_options.add_options();
+    cfg->add_deprecated_options(deprecated_options_easy_init);
     app.get_options_description().add(deprecated_options);
 
     // TODO : default, always read?

--- a/readers/reversing_v2.hh
+++ b/readers/reversing_v2.hh
@@ -8,12 +8,12 @@
 
 #pragma once
 #include <memory>
+#include "query-request.hh"
 
 class mutation_reader;
 
 namespace query {
     struct max_result_size;
-    class partition_slice;
 }
 
 

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -85,6 +85,7 @@ public:
         boost::intrusive::constant_time_size<false>>;
 
     compaction_group(table& t, size_t gid, dht::token_range token_range);
+    ~compaction_group();
 
     void update_id_and_range(size_t id, dht::token_range token_range) {
         _group_id = id;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2005,6 +2005,8 @@ compaction_group::compaction_group(table& t, size_t group_id, dht::token_range t
     _t._compaction_manager.add(as_table_state());
 }
 
+compaction_group::~compaction_group() = default;
+
 future<> compaction_group::stop() noexcept {
     if (_async_gate.is_closed()) {
         co_return;

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -26,17 +26,6 @@
 static const sstring some_keyspace("ks");
 static const sstring some_column_family("cf");
 
-table_for_tests::data::data()
-{ }
-
-table_for_tests::data::~data() {}
-
-schema_ptr table_for_tests::make_default_schema() {
-    return schema_builder(some_keyspace, some_column_family)
-        .with_column(utf8_type->decompose("p1"), utf8_type, column_kind::partition_key)
-        .build();
-}
-
 class table_for_tests::table_state : public compaction::table_state {
     table_for_tests::data& _data;
     sstables::sstables_manager& _sstables_manager;
@@ -126,6 +115,17 @@ public:
         return _staging_condition;
     }
 };
+
+table_for_tests::data::data()
+{ }
+
+table_for_tests::data::~data() {}
+
+schema_ptr table_for_tests::make_default_schema() {
+    return schema_builder(some_keyspace, some_column_family)
+        .with_column(utf8_type->decompose("p1"), utf8_type, column_kind::partition_key)
+        .build();
+}
 
 table_for_tests::table_for_tests(sstables::sstables_manager& sstables_manager, compaction_manager& cm, schema_ptr s, replica::table::config cfg, data_dictionary::storage_options storage)
     : _data(make_lw_shared<data>())

--- a/utils/config_file.cc
+++ b/utils/config_file.cc
@@ -270,7 +270,7 @@ utils::config_file::add_options(bpo::options_description_easy_init& init) {
 
 
 bpo::options_description_easy_init&
-utils::config_file::add_deprecated_options(bpo::options_description_easy_init&& init) {
+utils::config_file::add_deprecated_options(bpo::options_description_easy_init& init) {
     for (config_src& src : _cfgs) {
         if (src.status() == value_status::Deprecated) {
             src.add_command_line_option(init);

--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -281,7 +281,7 @@ public:
     boost::program_options::options_description_easy_init&
     add_options(boost::program_options::options_description_easy_init&);
     boost::program_options::options_description_easy_init&
-    add_deprecated_options(boost::program_options::options_description_easy_init&&);
+    add_deprecated_options(boost::program_options::options_description_easy_init&);
 
     /**
      * Default behaviour for yaml parser is to throw on


### PR DESCRIPTION
Switch the C++ standard from C++20 to C++23. This is straightforward, but there are a few
fallouts (mostly due to std::unique_ptr that became constexpr) that need to be fixed first.

Internal enhancement - no backport required 