### PR TITLE
build: remove aarch64 workarounds

### DIFF
--- a/cmake/mode.Debug.cmake
+++ b/cmake/mode.Debug.cmake
@@ -1,9 +1,4 @@
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-  # -fasan -Og breaks some coroutines on aarch64, use -O0 instead
-  set(OptimizationLevel "0")
-else()
-  set(OptimizationLevel "g")
-endif()
+set(OptimizationLevel "g")
 
 update_cxx_flags(CMAKE_CXX_FLAGS_DEBUG
   WITH_DEBUG_INFO

--- a/cmake/mode.RelWithDebInfo.cmake
+++ b/cmake/mode.RelWithDebInfo.cmake
@@ -16,11 +16,7 @@ set(scylla_build_mode_RelWithDebInfo "release")
 add_compile_definitions(
     $<$<CONFIG:RelWithDebInfo>:SCYLLA_BUILD_MODE=${scylla_build_mode_RelWithDebInfo}>)
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
-  set(clang_inline_threshold 300)
-else()
-  set(clang_inline_threshold 2500)
-endif()
+set(clang_inline_threshold 2500)
 add_compile_options(
   "$<$<AND:$<CONFIG:RelWithDebInfo>,$<CXX_COMPILER_ID:GNU>>:--param;inline-unit-growth=300>"
   "$<$<AND:$<CONFIG:RelWithDebInfo>,$<CXX_COMPILER_ID:Clang>>:-mllvm;-inline-threshold=${clang_inline_threshold}>")

--- a/configure.py
+++ b/configure.py
@@ -371,8 +371,7 @@ modes = {
         'cxxflags': '-DDEBUG -DSANITIZE -DDEBUG_LSA_SANITIZER -DSCYLLA_ENABLE_ERROR_INJECTION',
         'cxx_ld_flags': '',
         'stack-usage-threshold': 1024*40,
-        # -fasan -Og breaks some coroutines on aarch64, use -O0 instead
-        'optimization-level': ('0' if platform.machine() == 'aarch64' else 'g'),
+        'optimization-level': 'g',
         'per_src_extra_cxxflags': {},
         'cmake_build_type': 'Debug',
         'can_have_debug_info': True,
@@ -1543,10 +1542,6 @@ def get_warning_options(cxx):
 def get_clang_inline_threshold():
     if args.clang_inline_threshold != -1:
         return args.clang_inline_threshold
-    elif platform.machine() == 'aarch64':
-        # we see miscompiles with 1200 and above with format("{}", uuid)
-        # also coroutine miscompiles with 600
-        return 300
     else:
         return 2500
 


### PR DESCRIPTION
In 90a6c3bd7ae21 ("build: reduce release mode inline tuning on aarch64") we reduced inlining on aarch64, due to miscompiles.

In 224a2877b9dcf ("build: disable -Og in debug mode to avoid coroutine asan breakage") we disabled optimization in debug mode, due to miscompiles.

With clang 18.1, it appears the miscompiles are gone, and we can remove the two workarounds.

Performance only, no backport required.