### PR TITLE
zstd: include external header with brackets

### DIFF
--- a/zstd.cc
+++ b/zstd.cc
@@ -11,7 +11,7 @@
 // We need to use experimental features of the zstd library (to allocate compression/decompression context),
 // which are available only when the library is linked statically.
 #define ZSTD_STATIC_LINKING_ONLY
-#include "zstd.h"
+#include <zstd.h>
 
 #include "compress.hh"
 #include "exceptions/exceptions.hh"


### PR DESCRIPTION
zstd.h is a header provided by libzstd, so let's include it with brackets, more consistent this way.

---

it's a cleanup, hence no need to backport.