### PR TITLE
Close output_stream in get_snapshot_details() API handler

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1662,37 +1662,37 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
     ss::get_snapshot_details.set(r, [&snap_ctl](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto result = co_await snap_ctl.local().get_snapshot_details();
         co_return std::function([res = std::move(result)] (output_stream<char>&& o) -> future<> {
-          std::exception_ptr ex;
-          output_stream<char> out = std::move(o);
-          try {
-            auto result = std::move(res);
-            bool first = true;
+            std::exception_ptr ex;
+            output_stream<char> out = std::move(o);
+            try {
+                auto result = std::move(res);
+                bool first = true;
 
-            co_await out.write("[");
-            for (auto& [name, details] : result) {
-                if (!first) {
-                    co_await out.write(", ");
+                co_await out.write("[");
+                for (auto& [name, details] : result) {
+                    if (!first) {
+                        co_await out.write(", ");
+                    }
+                    std::vector<ss::snapshot> snapshot;
+                    for (auto& cf : details) {
+                        ss::snapshot snp;
+                        snp.ks = cf.ks;
+                        snp.cf = cf.cf;
+                        snp.live = cf.details.live;
+                        snp.total = cf.details.total;
+                        snapshot.push_back(std::move(snp));
+                    }
+                    ss::snapshots all_snapshots;
+                    all_snapshots.key = name;
+                    all_snapshots.value = std::move(snapshot);
+                    co_await all_snapshots.write(out);
+                    first = false;
                 }
-                std::vector<ss::snapshot> snapshot;
-                for (auto& cf : details) {
-                    ss::snapshot snp;
-                    snp.ks = cf.ks;
-                    snp.cf = cf.cf;
-                    snp.live = cf.details.live;
-                    snp.total = cf.details.total;
-                    snapshot.push_back(std::move(snp));
-                }
-                ss::snapshots all_snapshots;
-                all_snapshots.key = name;
-                all_snapshots.value = std::move(snapshot);
-                co_await all_snapshots.write(out);
-                first = false;
+                co_await out.write("]");
+                co_await out.flush();
+            } catch (...) {
+              ex = std::current_exception();
             }
-            co_await out.write("]");
-            co_await out.flush();
-          } catch (...) {
-            ex = std::current_exception();
-          }
             co_await out.close();
             if (ex) {
                 co_await coroutine::return_exception_ptr(std::move(ex));

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1686,6 +1686,7 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
                 first = false;
             }
             co_await out.write("]");
+            co_await out.flush();
             co_await out.close();
         });
     });

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -36,6 +36,7 @@
 #include <seastar/http/exception.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
+#include <seastar/coroutine/exception.hh>
 #include "repair/row_level.hh"
 #include "locator/snitch_base.hh"
 #include "column_family.hh"
@@ -1661,8 +1662,10 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
     ss::get_snapshot_details.set(r, [&snap_ctl](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto result = co_await snap_ctl.local().get_snapshot_details();
         co_return std::function([res = std::move(result)] (output_stream<char>&& o) -> future<> {
+          std::exception_ptr ex;
+          output_stream<char> out = std::move(o);
+          try {
             auto result = std::move(res);
-            output_stream<char> out = std::move(o);
             bool first = true;
 
             co_await out.write("[");
@@ -1687,7 +1690,13 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
             }
             co_await out.write("]");
             co_await out.flush();
+          } catch (...) {
+            ex = std::current_exception();
+          }
             co_await out.close();
+            if (ex) {
+                co_await coroutine::return_exception_ptr(std::move(ex));
+            }
         });
     });
 


### PR DESCRIPTION
All streams used by httpd handlers are to be closed by the handler itself, caller doesn't take care of that.

fixes: #19494 