### PR TITLE
Close output stream in task manager's API get_tasks handler

### DIFF
--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -141,23 +141,23 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         std::function<future<>(output_stream<char>&&)> f = [r = std::move(res)] (output_stream<char>&& os) -> future<> {
             auto s = std::move(os);
             std::exception_ptr ex;
-          try {
-            auto res = std::move(r);
-            co_await s.write("[");
-            std::string delim = "";
-            for (auto& v: res) {
-                for (auto& stats: v) {
-                    co_await s.write(std::exchange(delim, ", "));
-                    tm::task_stats ts;
-                    ts = stats;
-                    co_await formatter::write(s, ts);
+            try {
+                auto res = std::move(r);
+                co_await s.write("[");
+                std::string delim = "";
+                for (auto& v: res) {
+                    for (auto& stats: v) {
+                        co_await s.write(std::exchange(delim, ", "));
+                        tm::task_stats ts;
+                        ts = stats;
+                        co_await formatter::write(s, ts);
+                    }
                 }
+                co_await s.write("]");
+                co_await s.flush();
+            } catch (...) {
+                ex = std::current_exception();
             }
-            co_await s.write("]");
-            co_await s.flush();
-          } catch (...) {
-              ex = std::current_exception();
-          }
             co_await s.close();
             if (ex) {
                 co_await coroutine::return_exception_ptr(std::move(ex));

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -7,6 +7,7 @@
  */
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/http/exception.hh>
 
 #include "task_manager.hh"
@@ -139,6 +140,8 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
 
         std::function<future<>(output_stream<char>&&)> f = [r = std::move(res)] (output_stream<char>&& os) -> future<> {
             auto s = std::move(os);
+            std::exception_ptr ex;
+          try {
             auto res = std::move(r);
             co_await s.write("[");
             std::string delim = "";
@@ -152,7 +155,13 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
             }
             co_await s.write("]");
             co_await s.flush();
+          } catch (...) {
+              ex = std::current_exception();
+          }
             co_await s.close();
+            if (ex) {
+                co_await coroutine::return_exception_ptr(std::move(ex));
+            }
         };
         co_return std::move(f);
     });

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -151,6 +151,7 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
                 }
             }
             co_await s.write("]");
+            co_await s.flush();
             co_await s.close();
         };
         co_return std::move(f);


### PR DESCRIPTION
If client stops reading response early, the server-side stream throws but must be closed anyway. Seen in another endpoint and fixed by #19541 