### PR TITLE
Close output_stream in get_compaction_history() API handler

### DIFF
--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -178,6 +178,7 @@ void set_compaction_manager(http_context& ctx, routes& r) {
                         co_await formatter::write(s, h);
                     });
                 co_await s.write("]");
+                co_await s.flush();
             co_await s.close();
         };
         return make_ready_future<json::json_return_type>(std::move(f));

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -153,10 +153,11 @@ void set_compaction_manager(http_context& ctx, routes& r) {
     });
 
     cm::get_compaction_history.set(r, [&ctx] (std::unique_ptr<http::request> req) {
-        std::function<future<>(output_stream<char>&&)> f = [&ctx](output_stream<char>&& s) {
-            return do_with(output_stream<char>(std::move(s)), true, [&ctx] (output_stream<char>& s, bool& first){
-                return s.write("[").then([&ctx, &s, &first] {
-                    return ctx.db.local().get_compaction_manager().get_compaction_history([&s, &first](const db::compaction_history_entry& entry) mutable {
+        std::function<future<>(output_stream<char>&&)> f = [&ctx] (output_stream<char>&& out) -> future<> {
+            auto s = std::move(out);
+            bool first = true;
+                co_await s.write("[");
+                co_await ctx.db.local().get_compaction_manager().get_compaction_history([&s, &first](const db::compaction_history_entry& entry) mutable -> future<> {
                         cm::history h;
                         h.id = fmt::to_string(entry.id);
                         h.ks = std::move(entry.ks);
@@ -170,18 +171,14 @@ void set_compaction_manager(http_context& ctx, routes& r) {
                             e.value = it.second;
                             h.rows_merged.push(std::move(e));
                         }
-                        auto fut = first ? make_ready_future<>() : s.write(", ");
+                        if (!first) {
+                            co_await s.write(", ");
+                        }
                         first = false;
-                        return fut.then([&s, h = std::move(h)] {
-                            return formatter::write(s, h);
-                        });
-                    }).then([&s] {
-                        return s.write("]").then([&s] {
-                            return s.close();
-                        });
+                        co_await formatter::write(s, h);
                     });
-                });
-            });
+                co_await s.write("]");
+            co_await s.close();
         };
         return make_ready_future<json::json_return_type>(std::move(f));
     });

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -7,6 +7,7 @@
  */
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/exception.hh>
 
 #include "compaction_manager.hh"
 #include "compaction/compaction_manager.hh"
@@ -156,6 +157,8 @@ void set_compaction_manager(http_context& ctx, routes& r) {
         std::function<future<>(output_stream<char>&&)> f = [&ctx] (output_stream<char>&& out) -> future<> {
             auto s = std::move(out);
             bool first = true;
+            std::exception_ptr ex;
+            try {
                 co_await s.write("[");
                 co_await ctx.db.local().get_compaction_manager().get_compaction_history([&s, &first](const db::compaction_history_entry& entry) mutable -> future<> {
                         cm::history h;
@@ -179,7 +182,13 @@ void set_compaction_manager(http_context& ctx, routes& r) {
                     });
                 co_await s.write("]");
                 co_await s.flush();
+            } catch (...) {
+                ex = std::current_exception();
+            }
             co_await s.close();
+            if (ex) {
+                co_await coroutine::return_exception_ptr(std::move(ex));
+            }
         };
         return make_ready_future<json::json_return_type>(std::move(f));
     });


### PR DESCRIPTION
If an httpd body writer is called with output_stream<>, it mist close the stream on its own regardless of any exceptions it may generate while working, otherwise stream destructor may step on non-closed assertion. Stepped on with different handler, see #19541 