### PR TITLE
.github: use the latest dbuild image

### DIFF
--- a/.github/workflows/build-scylla.yaml
+++ b/.github/workflows/build-scylla.yaml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # be consistent with tools/toolchain/image
-    container: scylladb/scylla-toolchain:fedora-38-20240521
+    container: scylladb/scylla-toolchain:fedora-40-20240621
     outputs:
       md5sum: ${{ steps.checksum.outputs.md5sum }}
     steps:

--- a/.github/workflows/seastar.yaml
+++ b/.github/workflows/seastar.yaml
@@ -18,7 +18,7 @@ jobs:
   build-with-the-latest-seastar:
     runs-on: ubuntu-latest
     # be consistent with tools/toolchain/image
-    container: scylladb/scylla-toolchain:fedora-38-20240521
+    container: scylladb/scylla-toolchain:fedora-40-20240621
     strategy:
       matrix:
         build_type:


### PR DESCRIPTION
scylla does not build using scylla-toolchain:fedora-38-20240521, like:

```
FAILED: repair/CMakeFiles/repair.dir/repair.cc.o
/usr/bin/clang++ -DBOOST_NO_CXX98_FUNCTION_BASE -DDEVEL -DFMT_SHARED -DSCYLLA_BUILD_MODE=dev -DSCYLLA_ENABLE_ERROR_INJECTION -DSEASTAR_API_LEVEL=7 -DSEASTAR_ENABLE_ALLOC_FAILURE_INJECTION -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SSTRING -DSEASTAR_TYPE_ERASE_MORE -DXXH_PRIVATE_API -I/__w/scylladb/scylladb -I/__w/scylladb/scylladb/build/gen -I/__w/scylladb/scylladb/seastar/include -I/__w/scylladb/scylladb/build/seastar/gen/include -I/__w/scylladb/scylladb/build/seastar/gen/src -isystem /__w/scylladb/scylladb/abseil -O2 -std=gnu++2b -fvisibility=hidden -Wall -Werror -Wextra -Wno-error=deprecated-declarations -Wimplicit-fallthrough -Wno-c++11-narrowing -Wno-deprecated-copy -Wno-mismatched-tags -Wno-missing-field-initializers -Wno-overloaded-virtual -Wno-unsupported-friend -Wno-enum-constexpr-conversion -Wno-unused-parameter -ffile-prefix-map=/__w/scylladb/scylladb=. -march=westmere -U_FORTIFY_SOURCE -Werror=unused-result -fstack-clash-protection -MD -MT repair/CMakeFiles/repair.dir/repair.cc.o -MF repair/CMakeFiles/repair.dir/repair.cc.o.d -o repair/CMakeFiles/repair.dir/repair.cc.o -c /__w/scylladb/scylladb/repair/repair.cc
In file included from /__w/scylladb/scylladb/repair/repair.cc:10:
In file included from /__w/scylladb/scylladb/repair/row_level.hh:14:
In file included from /__w/scylladb/scylladb/repair/task_manager_module.hh:14:
In file included from /__w/scylladb/scylladb/tasks/task_manager.hh:20:
In file included from /__w/scylladb/scylladb/seastar/include/seastar/coroutine/parallel_for_each.hh:24:
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/ranges:6161:14: error: requires clause differs in template redeclaration
    requires forward_range<_Vp>
             ^
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/ranges:5860:14: note: previous template declaration is here
    requires input_range<_Vp>
             ^
```


---


the C++23 change is not included by any LTS branches, so no need to backport.