### PR TITLE
dbuild: pass --tty when running in interactive mode

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -224,7 +224,7 @@ if [[ -n "$interactive" || -n "$is_podman" ]]; then
 
     # We also avoid detached mode with podman, which doesn't need it
     # (it does not proxy SIGTERM) and doesn't work well with it.
-    $tool run --rm "${docker_common_args[@]}"
+    $tool run --tty --rm "${docker_common_args[@]}"
     ret=$?
     cleanup
     exit $ret


### PR DESCRIPTION
podman does not allocate a tty by default, so without `-t` or `--tty`, one cannot use a functional terminal when interacting with the container. that what one can expect when running `dbuild -i --`, and we are greeted with :

```
bash: cannot set terminal process group (-1): Inappropriate ioctl for device
bash: no job control in this shell
```

after this change, one can enjoy the good-old terminal as usual after being dropped to the container provided by `dbuild -i --`.

---

no need to backport, this change improves developers' experience.