### PR TITLE
[Backport 5.4] compaction: Check for key presence in memtable when calculating max purgeable timestamp

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -144,12 +144,21 @@ std::ostream& operator<<(std::ostream& os, compaction_type_options::scrub::quara
 }
 
 static api::timestamp_type get_max_purgeable_timestamp(const table_state& table_s, sstable_set::incremental_selector& selector,
-        const std::unordered_set<shared_sstable>& compacting_set, const dht::decorated_key& dk, uint64_t& bloom_filter_checks) {
+        const std::unordered_set<shared_sstable>& compacting_set, const dht::decorated_key& dk, uint64_t& bloom_filter_checks,
+        const api::timestamp_type compacting_max_timestamp) {
     if (!table_s.tombstone_gc_enabled()) [[unlikely]] {
         return api::min_timestamp;
     }
 
-    auto timestamp = table_s.min_memtable_timestamp();
+    auto timestamp = api::max_timestamp;
+    auto memtable_min_timestamp = table_s.min_memtable_timestamp();
+    // Use memtable timestamp if it contains data older than the sstables being compacted,
+    // and if the memtable also contains the key we're calculating max purgeable timestamp for.
+    // First condition helps to not penalize the common scenario where memtable only contains
+    // newer data.
+    if (memtable_min_timestamp <= compacting_max_timestamp && table_s.memtable_has_key(dk)) {
+        timestamp = memtable_min_timestamp;
+    }
     std::optional<utils::hashed_key> hk;
     for (auto&& sst : boost::range::join(selector.select(dk).sstables, table_s.compacted_undeleted_sstables())) {
         if (compacting_set.contains(sst)) {
@@ -441,6 +450,7 @@ protected:
     uint64_t _end_size = 0;
     // fully expired files, which are skipped, aren't taken into account.
     uint64_t _compacting_data_file_size = 0;
+    api::timestamp_type _compacting_max_timestamp = api::min_timestamp;
     uint64_t _estimated_partitions = 0;
     uint64_t _bloom_filter_checks = 0;
     db::replay_position _rp;
@@ -734,6 +744,7 @@ private:
             // sstable than just adding up the lengths of individual sstables.
             _estimated_partitions += sst->get_estimated_key_count();
             _compacting_data_file_size += sst->ondisk_data_size();
+
             // TODO:
             // Note that this is not fully correct. Since we might be merging sstables that originated on
             // another shard (#cpu changed), we might be comparing RP:s with differing shard ids,
@@ -742,6 +753,8 @@ private:
             // this is kind of ok, esp. since we will hopefully not be trying to recover based on
             // compacted sstables anyway (CL should be clean by then).
             _rp = std::max(_rp, sst_stats.position);
+
+            _compacting_max_timestamp = std::max(_compacting_max_timestamp, sst->get_stats_metadata().max_timestamp);
         }
         log_info("{} {}", report_start_desc(), formatted_msg);
         if (ssts->size() < _sstables.size()) {
@@ -862,7 +875,7 @@ private:
             };
         }
         return [this] (const dht::decorated_key& dk) {
-            return get_max_purgeable_timestamp(_table_s, *_selector, _compacting_for_max_purgeable_func, dk, _bloom_filter_checks);
+            return get_max_purgeable_timestamp(_table_s, *_selector, _compacting_for_max_purgeable_func, dk, _bloom_filter_checks, _compacting_max_timestamp);
         };
     }
 

--- a/compaction/table_state.hh
+++ b/compaction/table_state.hh
@@ -48,6 +48,7 @@ public:
     virtual sstables::shared_sstable make_sstable() const = 0;
     virtual sstables::sstable_writer_config configure_writer(sstring origin) const = 0;
     virtual api::timestamp_type min_memtable_timestamp() const = 0;
+    virtual bool memtable_has_key(const dht::decorated_key& key) const = 0;
     virtual future<> on_compaction_completion(sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy) = 0;
     virtual bool is_auto_compaction_disabled_by_user() const noexcept = 0;
     virtual bool tombstone_gc_enabled() const noexcept = 0;

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -101,6 +101,8 @@ public:
     size_t memtable_count() const noexcept;
     // Returns minimum timestamp from memtable list
     api::timestamp_type min_memtable_timestamp() const;
+    // Returns true if memtable(s) contains key.
+    bool memtable_has_key(const dht::decorated_key& key) const;
     // Add sstable to main set
     void add_sstable(sstables::shared_sstable sstable);
     // Add sstable to maintenance set

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -239,6 +239,11 @@ memtable::find_or_create_partition(const dht::decorated_key& key) {
     return i->partition();
 }
 
+bool
+memtable::contains_partition(const dht::decorated_key& key) const {
+    return partitions.find(key, dht::ring_position_comparator(*_schema)) != partitions.end();
+}
+
 boost::iterator_range<memtable::partitions_type::const_iterator>
 memtable::slice(const dht::partition_range& range) const {
     if (query::is_single_partition(range)) {

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -216,6 +216,8 @@ public:
     mutation_cleaner& cleaner() noexcept {
         return _cleaner;
     }
+
+    bool contains_partition(const dht::decorated_key& key) const;
 public:
     memtable_list* get_memtable_list() noexcept {
         return _memtable_list;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -384,6 +384,14 @@ api::timestamp_type compaction_group::min_memtable_timestamp() const {
     );
 }
 
+bool compaction_group::memtable_has_key(const dht::decorated_key& key) const {
+    if (_memtables->empty()) {
+        return false;
+    }
+    return std::ranges::any_of(*_memtables,
+        std::bind(&memtable::contains_partition, std::placeholders::_1, std::ref(key)));
+}
+
 api::timestamp_type table::min_memtable_timestamp() const {
     return *boost::range::min_element(compaction_groups() | boost::adaptors::transformed(std::mem_fn(&compaction_group::min_memtable_timestamp)));
 }
@@ -2940,6 +2948,9 @@ public:
     }
     api::timestamp_type min_memtable_timestamp() const override {
         return _cg.min_memtable_timestamp();
+    }
+    bool memtable_has_key(const dht::decorated_key& key) const override {
+        return _cg.memtable_has_key(key);
     }
     future<> on_compaction_completion(sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy) override {
         if (offstrategy) {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -110,6 +110,7 @@ public:
     api::timestamp_type min_memtable_timestamp() const override {
         return table().min_memtable_timestamp();
     }
+    bool memtable_has_key(const dht::decorated_key& key) const override { return false; }
     future<> on_compaction_completion(sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy) override {
         return table().as_table_state().on_compaction_completion(std::move(desc), offstrategy);
     }

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -892,6 +892,7 @@ public:
     virtual sstables::shared_sstable make_sstable() const override { return do_make_sstable(); }
     virtual sstables::sstable_writer_config configure_writer(sstring origin) const override { return do_configure_writer(std::move(origin)); }
     virtual api::timestamp_type min_memtable_timestamp() const override { return api::min_timestamp; }
+    virtual bool memtable_has_key(const dht::decorated_key& key) const override { return false; }
     virtual future<> on_compaction_completion(sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy) override { return make_ready_future<>(); }
     virtual bool is_auto_compaction_disabled_by_user() const noexcept override { return false; }
     virtual bool tombstone_gc_enabled() const noexcept override { return false; }


### PR DESCRIPTION
It was observed that some use cases might append old data constantly to memtable, blocking GC of expired tombstones.

That's because timestamp of memtable is unconditionally used for calculating max purgeable, even when the memtable doesn't contain the key of the tombstone we're trying to GC.

The idea is to treat memtable as we treat L0 sstables, i.e. it will only prevent GC if it contains data that is possibly shadowed by the expired tombstone (after checking for key presence and timestamp).

Memtable will usually have a small subset of keys in largest tier, so after this change, a large fraction of keys containing expired tombstones can be GCed when memtable contains old data.

Fixes https://github.com/scylladb/scylladb/issues/17599.

(cherry picked from commit https://github.com/scylladb/scylladb/commit/38699f6c3d10144322b6f2a7d740bc9e5690c02f)