### PR TITLE
atomic_delete: allow deletion of sstables from several prefixes

### DIFF
--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -301,6 +301,9 @@ public:
     future<> start() {
         SCYLLA_ASSERT(this_shard_id() == 0);
 
+        // The table base directory (with sstable_state::normal) must be
+        // loaded and processed first as it now may contain the shared
+        // pending_delete_dir, possibly referring to sstables in sub-directories.
         for (auto state : { sstables::sstable_state::normal, sstables::sstable_state::staging, sstables::sstable_state::quarantine }) {
             co_await start_subdir(state);
         }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -577,7 +577,7 @@ future<std::unordered_map<sstring, sstring>> sstable_directory::create_pending_d
         sstring pending_delete_dir = prefix + "/" + sstables::pending_delete_dir;
         sstring pending_delete_log = format("{}/sstables-{}-{}.log", pending_delete_dir, gen_tracker.min(), gen_tracker.max());
         sstring tmp_pending_delete_log = pending_delete_log + ".tmp";
-        sstlog.trace("Writing {}", tmp_pending_delete_log);
+        dirlog.trace("Writing {}", tmp_pending_delete_log);
         try {
             touch_directory(pending_delete_dir).get();
             auto oflags = open_flags::wo | open_flags::create | open_flags::exclusive;
@@ -604,10 +604,10 @@ future<std::unordered_map<sstring, sstring>> sstable_directory::create_pending_d
             // Guarantee that the changes above reached the disk.
             dir_f.flush().get();
             close_dir.close_now();
-            sstlog.debug("{} written successfully.", pending_delete_log);
+            dirlog.debug("{} written successfully.", pending_delete_log);
             res.emplace(std::move(pending_delete_dir), std::move(pending_delete_log));
         } catch (...) {
-            sstlog.warn("Error while writing {}: {}. Ignoring.", pending_delete_log, std::current_exception());
+            dirlog.warn("Error while writing {}: {}. Ignoring.", pending_delete_log, std::current_exception());
         }
       }
 
@@ -618,7 +618,7 @@ future<std::unordered_map<sstring, sstring>> sstable_directory::create_pending_d
 // FIXME: Go through maybe_delete_large_partitions_entry on recovery since
 // this is an indication we crashed in the middle of atomic deletion
 future<> sstable_directory::filesystem_components_lister::replay_pending_delete_log(fs::path pending_delete_log) {
-    sstlog.debug("Reading pending_deletes log file {}", pending_delete_log);
+    dirlog.debug("Reading pending_deletes log file {}", pending_delete_log);
     fs::path pending_delete_dir = pending_delete_log.parent_path();
     try {
         sstring sstdir = pending_delete_dir.parent_path().native();
@@ -632,10 +632,10 @@ future<> sstable_directory::filesystem_components_lister::replay_pending_delete_
             // Only move TOC to TOC.tmp, the rest will be finished by regular process
             return make_toc_temporary(sstdir + "/" + name).discard_result();
         });
-        sstlog.debug("Replayed {}, removing", pending_delete_log);
+        dirlog.debug("Replayed {}, removing", pending_delete_log);
         co_await remove_file(pending_delete_log.native());
     } catch (...) {
-        sstlog.warn("Error replaying {}: {}. Ignoring.", pending_delete_log, std::current_exception());
+        dirlog.warn("Error replaying {}: {}. Ignoring.", pending_delete_log, std::current_exception());
     }
 }
 
@@ -655,7 +655,7 @@ future<> sstable_directory::filesystem_components_lister::cleanup_column_family_
             // reading the next entry in the directory.
             fs::path dirpath = _directory / de->name;
             if (dirpath.extension().string() == tempdir_extension) {
-                sstlog.info("Found temporary sstable directory: {}, removing", dirpath);
+                dirlog.info("Found temporary sstable directory: {}, removing", dirpath);
                 futures.push_back(io_check([dirpath = std::move(dirpath)] () { return lister::rmdir(dirpath); }));
             }
         }
@@ -681,14 +681,14 @@ future<> sstable_directory::filesystem_components_lister::handle_sstables_pendin
             // reading the next entry in the directory.
             fs::path file_path = pending_delete_dir / de->name;
             if (file_path.extension() == ".tmp") {
-                sstlog.info("Found temporary pending_delete log file: {}, deleting", file_path);
+                dirlog.info("Found temporary pending_delete log file: {}, deleting", file_path);
                 futures.push_back(remove_file(file_path.string()));
             } else if (file_path.extension() == ".log") {
-                sstlog.info("Found pending_delete log file: {}, replaying", file_path);
+                dirlog.info("Found pending_delete log file: {}, replaying", file_path);
                 auto f = replay_pending_delete_log(std::move(file_path));
                 futures.push_back(std::move(f));
             } else {
-                sstlog.debug("Found unknown file in pending_delete directory: {}, ignoring", file_path);
+                dirlog.debug("Found unknown file in pending_delete directory: {}, ignoring", file_path);
             }
         }
         co_return futures;

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -563,22 +563,22 @@ bool sstable_directory::compare_sstable_storage_prefix(const sstring& prefix_a, 
     return size_a == size_b && sstring::traits_type::compare(prefix_a.begin(), prefix_b.begin(), size_a) == 0;
 }
 
-future<std::unordered_map<sstring, sstring>> sstable_directory::create_pending_deletion_log(const std::vector<shared_sstable>& ssts) {
-    return seastar::async([&ssts] {
-        std::unordered_map<sstring, min_max_tracker<generation_type>> gen_trackers;
-        std::unordered_map<sstring, sstring> res;
+future<sstable_directory::pending_delete_result> sstable_directory::create_pending_deletion_log(opened_directory& base_dir, const std::vector<shared_sstable>& ssts) {
+    return seastar::async([&] {
+        min_max_tracker<generation_type> gen_tracker;
+        pending_delete_result res;
 
         for (const auto& sst : ssts) {
             auto prefix = sst->_storage->prefix();
-            gen_trackers[prefix].update(sst->generation());
+            res.prefixes.insert(prefix);
+            gen_tracker.update(sst->generation());
         }
 
-      for (const auto& [prefix, gen_tracker] : gen_trackers) {
-        sstring pending_delete_dir = prefix + "/" + sstables::pending_delete_dir;
-        sstring pending_delete_log = format("{}/sstables-{}-{}.log", pending_delete_dir, gen_tracker.min(), gen_tracker.max());
-        sstring tmp_pending_delete_log = pending_delete_log + ".tmp";
+        sstring pending_delete_dir = (base_dir.path() / sstables::pending_delete_dir).native();
+        res.pending_delete_log = format("{}/sstables-{}-{}.log", pending_delete_dir, gen_tracker.min(), gen_tracker.max());
+        sstring tmp_pending_delete_log = res.pending_delete_log + ".tmp";
         dirlog.trace("Writing {}", tmp_pending_delete_log);
-        try {
+
             touch_directory(pending_delete_dir).get();
             auto oflags = open_flags::wo | open_flags::create | open_flags::exclusive;
             // Create temporary pending_delete log file.
@@ -587,29 +587,34 @@ future<std::unordered_map<sstring, sstring>> sstable_directory::create_pending_d
             auto out = make_file_output_stream(std::move(f), 4096).get();
             auto close_out = deferred_close(out);
 
+        try {
+            auto trim_size = base_dir.native().size() + 1; // Account for the '/' delimiter
             for (const auto& sst : ssts) {
+                auto prefix = sst->_storage->prefix();
+                if (prefix.size() > trim_size) {
+                    out.write(prefix.begin() + trim_size, prefix.size() - trim_size).get();
+                    out.write("/").get();
+                }
                 auto toc = sst->component_basename(component_type::TOC);
                 out.write(toc).get();
                 out.write("\n").get();
+                dirlog.trace("Wrote '{}{}' to {}",
+                    prefix.size() > trim_size ? sstring(prefix.begin() + trim_size, prefix.size() - trim_size) + "/" : "",
+                    sst->component_basename(component_type::TOC), tmp_pending_delete_log);
             }
 
             out.flush().get();
             close_out.close_now();
+        } catch (...) {
+            dirlog.warn("Error while writing {}: {}. Ignoring.", tmp_pending_delete_log, std::current_exception());
+        }
 
-            auto dir_f = open_directory(pending_delete_dir).get();
-            auto close_dir = deferred_close(dir_f);
             // Once flushed and closed, the temporary log file can be renamed.
-            rename_file(tmp_pending_delete_log, pending_delete_log).get();
+            io_check(rename_file, tmp_pending_delete_log, res.pending_delete_log).get();
 
             // Guarantee that the changes above reached the disk.
-            dir_f.flush().get();
-            close_dir.close_now();
-            dirlog.debug("{} written successfully.", pending_delete_log);
-            res.emplace(std::move(pending_delete_dir), std::move(pending_delete_log));
-        } catch (...) {
-            dirlog.warn("Error while writing {}: {}. Ignoring.", pending_delete_log, std::current_exception());
-        }
-      }
+            base_dir.sync(general_disk_error_handler).get();
+            dirlog.debug("{} written successfully.", res.pending_delete_log);
 
       return res;
     });
@@ -628,6 +633,7 @@ future<> sstable_directory::filesystem_components_lister::replay_pending_delete_
         std::vector<sstring> basenames;
         boost::split(basenames, all, boost::is_any_of("\n"), boost::token_compress_on);
         auto tocs = boost::copy_range<std::vector<sstring>>(basenames | boost::adaptors::filtered([] (auto&& basename) { return !basename.empty(); }));
+        dirlog.debug("TOCs to remove: {}", tocs);
         co_await parallel_for_each(tocs, [&sstdir] (const sstring& name) {
             // Only move TOC to TOC.tmp, the rest will be finished by regular process
             return make_toc_temporary(sstdir + "/" + name).discard_result();

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -34,6 +34,7 @@ namespace sstables {
 enum class sstable_state;
 class storage;
 class sstables_manager;
+class opened_directory;
 bool manifest_json_filter(const std::filesystem::path&, const directory_entry& entry);
 
 class directory_semaphore {
@@ -267,6 +268,11 @@ public:
     using can_be_remote = bool_class<struct can_be_remote_tag>;
     future<> collect_output_unshared_sstables(std::vector<sstables::shared_sstable> resharded_sstables, can_be_remote);
 
+    struct pending_delete_result {
+        sstring pending_delete_log;
+        std::unordered_set<sstring> prefixes;
+    };
+
     // When we compact sstables, we have to atomically instantiate the new
     // sstable and delete the old ones.  Otherwise, if we compact A+B into C,
     // and if A contained some data that was tombstoned by B, and if B was
@@ -280,11 +286,10 @@ public:
     //
     // This function only solves the second problem for now.
 
-    // Creates the deletion log for atomic deletion of sstables (helper for the
+    // Creates the deletion log for atomic deletion of sstables at `base_dir` (helper for the
     // above function that's also used by tests)
-    // Returns an unordered_map of <directory with sstables, logfile_name> for every sstable prefix.
-    // Currently, atomicity is guaranteed only within each unique prefix and not across prefixes (See #18862)
-    static future<std::unordered_map<sstring, sstring>> create_pending_deletion_log(const std::vector<shared_sstable>& ssts);
+    // Returns the name of the pending_delete_log and an unordered_set of sstable prefixes.
+    static future<pending_delete_result> create_pending_deletion_log(opened_directory& base_dir, const std::vector<shared_sstable>& ssts);
 
     static bool compare_sstable_storage_prefix(const sstring& a, const sstring& b) noexcept;
 };

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -68,7 +68,8 @@ private:
 
 public:
     explicit filesystem_storage(sstring dir, sstable_state state)
-        : _dir(make_path(dir, state))
+        : storage(dir)
+        , _dir(make_path(dir, state))
     {}
 
     virtual future<> seal(const sstable& sst) override;
@@ -505,7 +506,6 @@ future<> filesystem_storage::remove_by_registry_entry(entry_descriptor desc) {
 class s3_storage : public sstables::storage {
     shared_ptr<s3::client> _client;
     sstring _bucket;
-    sstring _location;
 
     static constexpr auto status_creating = "creating";
     static constexpr auto status_sealed = "sealed";
@@ -515,9 +515,9 @@ class s3_storage : public sstables::storage {
 
 public:
     s3_storage(shared_ptr<s3::client> client, sstring bucket, sstring dir)
-        : _client(std::move(client))
+        : storage(std::move(dir))
+        , _client(std::move(client))
         , _bucket(std::move(bucket))
-        , _location(std::move(dir))
     {
     }
 
@@ -541,7 +541,7 @@ public:
         return make_ready_future<uint64_t>(std::numeric_limits<uint64_t>::max());
     }
 
-    virtual sstring prefix() const override { return _location; }
+    virtual sstring prefix() const override { return base_dir().native(); }
 };
 
 sstring s3_storage::make_s3_object_name(const sstable& sst, component_type type) const {
@@ -556,7 +556,7 @@ sstring s3_storage::make_s3_object_name(const sstable& sst, component_type type)
 
 void s3_storage::open(sstable& sst) {
     entry_descriptor desc(sst._generation, sst._version, sst._format, component_type::TOC);
-    sst.manager().sstables_registry().create_entry(_location, status_creating, sst._state, std::move(desc)).get();
+    sst.manager().sstables_registry().create_entry(prefix(), status_creating, sst._state, std::move(desc)).get();
 
     memory_data_sink_buffers bufs;
     sst.write_toc(
@@ -586,7 +586,7 @@ future<data_sink> s3_storage::make_component_sink(sstable& sst, component_type t
 }
 
 future<> s3_storage::seal(const sstable& sst) {
-    co_await sst.manager().sstables_registry().update_entry_status(_location, sst.generation(), status_sealed);
+    co_await sst.manager().sstables_registry().update_entry_status(prefix(), sst.generation(), status_sealed);
 }
 
 future<> s3_storage::change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) {
@@ -596,19 +596,19 @@ future<> s3_storage::change_state(const sstable& sst, sstable_state state, gener
         // is moved from upload directory and this is another issue for S3 (#13018)
         co_await coroutine::return_exception(std::runtime_error("Cannot change state and generation of an S3 object"));
     }
-    co_await sst.manager().sstables_registry().update_entry_state(_location, sst.generation(), state);
+    co_await sst.manager().sstables_registry().update_entry_state(prefix(), sst.generation(), state);
 }
 
 future<> s3_storage::wipe(const sstable& sst, sync_dir) noexcept {
     auto& sstables_registry = sst.manager().sstables_registry();
 
-    co_await sstables_registry.update_entry_status(_location, sst.generation(), status_removing);
+    co_await sstables_registry.update_entry_status(prefix(), sst.generation(), status_removing);
 
     co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (auto type) -> future<> {
         co_await _client->delete_object(make_s3_object_name(sst, type));
     });
 
-    co_await sstables_registry.delete_entry(_location, sst.generation());
+    co_await sstables_registry.delete_entry(prefix(), sst.generation());
 }
 
 future<atomic_delete_context> s3_storage::atomic_delete_prepare(const std::vector<shared_sstable>&) const {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -38,39 +38,6 @@
 
 namespace sstables {
 
-class opened_directory final {
-    std::filesystem::path _pathname;
-    file _file;
-
-public:
-    explicit opened_directory(std::filesystem::path pathname) : _pathname(std::move(pathname)) {};
-    explicit opened_directory(const sstring &dir) : _pathname(std::string_view(dir)) {};
-    opened_directory(const opened_directory&) = delete;
-    opened_directory& operator=(const opened_directory&) = delete;
-    opened_directory(opened_directory&&) = default;
-    opened_directory& operator=(opened_directory&&) = default;
-    ~opened_directory() = default;
-
-    const std::filesystem::path::string_type& native() const noexcept {
-        return _pathname.native();
-    }
-
-    const std::filesystem::path& path() const noexcept {
-        return _pathname;
-    }
-
-    future<> sync(io_error_handler error_handler) {
-        if (!_file) {
-            _file = co_await do_io_check(error_handler, open_directory, _pathname.native());
-        }
-        co_await do_io_check(error_handler, std::mem_fn(&file::flush), _file);
-    };
-
-    future<> close() {
-        return _file ? _file.close() : make_ready_future<>();
-    }
-};
-
 // cannot define these classes in an anonymous namespace, as we need to
 // declare these storage classes as "friend" of class sstable
 class filesystem_storage final : public sstables::storage {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -477,26 +477,24 @@ future<> filesystem_storage::wipe(const sstable& sst, sync_dir sync) noexcept {
 }
 
 future<atomic_delete_context> filesystem_storage::atomic_delete_prepare(const std::vector<shared_sstable>& ssts) const {
-    return sstable_directory::create_pending_deletion_log(ssts);
+    co_return co_await sstable_directory::create_pending_deletion_log(base_dir(), ssts);
 }
 
 future<> filesystem_storage::atomic_delete_complete(atomic_delete_context ctx) const {
-    co_await coroutine::parallel_for_each(ctx, [] (const auto& x) -> future<> {
-        const auto& dir = x.first;
-        const auto& log = x.second;
-
+    co_await coroutine::parallel_for_each(ctx.prefixes, [] (const auto& dir) -> future<> {
         co_await sync_directory(dir);
+    });
 
         // Once all sstables are deleted, the log file can be removed.
         // Note: the log file will be removed also if unlink failed to remove
         // any sstable and ignored the error.
+        const auto& log = ctx.pending_delete_log;
         try {
             co_await remove_file(log);
             sstlog.debug("{} removed.", log);
         } catch (...) {
             sstlog.warn("Error removing {}: {}. Ignoring.", log, std::current_exception());
         }
-    });
 }
 
 future<> filesystem_storage::remove_by_registry_entry(entry_descriptor desc) {

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -15,12 +15,14 @@
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/reactor.hh>
 
 #include "data_dictionary/storage_options.hh"
 #include "seastarx.hh"
 #include "sstables/shared_sstable.hh"
 #include "sstables/component_type.hh"
 #include "sstables/generation_type.hh"
+#include "utils/disk-error-handler.hh"
 
 namespace data_dictionary {
 class storage_options;
@@ -35,6 +37,39 @@ class sstables_manager;
 class entry_descriptor;
 
 using atomic_delete_context = std::unordered_map<sstring, sstring>;
+
+class opened_directory final {
+    std::filesystem::path _pathname;
+    file _file;
+
+public:
+    explicit opened_directory(std::filesystem::path pathname) : _pathname(std::move(pathname)) {};
+    explicit opened_directory(const sstring &dir) : _pathname(std::string_view(dir)) {};
+    opened_directory(const opened_directory&) = delete;
+    opened_directory& operator=(const opened_directory&) = delete;
+    opened_directory(opened_directory&&) = default;
+    opened_directory& operator=(opened_directory&&) = default;
+    ~opened_directory() = default;
+
+    const std::filesystem::path::string_type& native() const noexcept {
+        return _pathname.native();
+    }
+
+    const std::filesystem::path& path() const noexcept {
+        return _pathname;
+    }
+
+    future<> sync(io_error_handler error_handler) {
+        if (!_file) {
+            _file = co_await do_io_check(error_handler, open_directory, _pathname.native());
+        }
+        co_await do_io_check(error_handler, std::mem_fn(&file::flush), _file);
+    };
+
+    future<> close() {
+        return _file ? _file.close() : make_ready_future<>();
+    }
+};
 
 class storage {
     friend class test;

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -74,6 +74,8 @@ public:
 class storage {
     friend class test;
 
+    std::filesystem::path _base_dir;    // Local base directory (of table)
+
     // Internal, but can also be used by tests
     virtual future<> change_dir_for_test(sstring nd) {
         SCYLLA_ASSERT(false && "Changing directory not implemented");
@@ -86,10 +88,15 @@ class storage {
     }
 
 public:
+    explicit storage(std::string_view base_dir) : _base_dir(base_dir) {}
     virtual ~storage() {}
 
     using absolute_path = bool_class<class absolute_path_tag>; // FIXME -- should go away eventually
     using sync_dir = bool_class<struct sync_dir_tag>; // meaningful only to filesystem storage
+
+    const std::filesystem::path& base_dir() const {
+        return _base_dir;
+    }
 
     virtual future<> seal(const sstable& sst) = 0;
     virtual future<> snapshot(const sstable& sst, sstring dir, absolute_path abs, std::optional<generation_type> gen = {}) const = 0;

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -23,6 +23,7 @@
 #include "sstables/component_type.hh"
 #include "sstables/generation_type.hh"
 #include "utils/disk-error-handler.hh"
+#include "sstables/sstable_directory.hh"
 
 namespace data_dictionary {
 class storage_options;
@@ -36,7 +37,7 @@ class sstable;
 class sstables_manager;
 class entry_descriptor;
 
-using atomic_delete_context = std::unordered_map<sstring, sstring>;
+using atomic_delete_context = sstable_directory::pending_delete_result;
 
 class opened_directory final {
     std::filesystem::path _pathname;
@@ -74,7 +75,7 @@ public:
 class storage {
     friend class test;
 
-    std::filesystem::path _base_dir;    // Local base directory (of table)
+    mutable opened_directory _base_dir;    // Local base directory (of table)
 
     // Internal, but can also be used by tests
     virtual future<> change_dir_for_test(sstring nd) {
@@ -94,7 +95,7 @@ public:
     using absolute_path = bool_class<class absolute_path_tag>; // FIXME -- should go away eventually
     using sync_dir = bool_class<struct sync_dir_tag>; // meaningful only to filesystem storage
 
-    const std::filesystem::path& base_dir() const {
+    opened_directory& base_dir() const {
         return _base_dir;
     }
 

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -796,7 +796,8 @@ SEASTAR_TEST_CASE(test_pending_log_garbage_collection) {
         // Now start atomic deletion -- create the pending deletion log for all
         // three sstables, move TOC file for one of them into temporary-TOC, and 
         // partially delete another
-        sstable_directory::create_pending_deletion_log(ssts_to_remove).get();
+        auto base_opened_dir = opened_directory(base);
+        sstable_directory::create_pending_deletion_log(base_opened_dir, ssts_to_remove).get();
         rename_file(test(ssts_to_remove[1]).filename(sstables::component_type::TOC).native(), test(ssts_to_remove[1]).filename(sstables::component_type::TemporaryTOC).native()).get();
         rename_file(test(ssts_to_remove[2]).filename(sstables::component_type::TOC).native(), test(ssts_to_remove[2]).filename(sstables::component_type::TemporaryTOC).native()).get();
         remove_file(test(ssts_to_remove[2]).filename(sstables::component_type::Data).native()).get();


### PR DESCRIPTION
Allow create_pending_deletion_log to delete a bunch of sstables
potentially resides in different prefixes (e.g. in the base directory
and under staging/).

The motivation arises from table::cleanup_tablet that calls compaction_group::cleanup on all cg:s via cleanup_compaction_groups.  Cleanup, in turn, calls delete_sstables_atomically on all sstables in the compaction_group, in all states, including the normal state as well as staging - hence the requirement to support deleting sstables in different sub-directories.

Also, apparently truncate calls delete_atomically for all sstables too, via table::discard_sstables, so if it happened to be executed during view update generation, i.e. when there are sstables in staging, it should hit the assertion failure reported in https://github.com/scylladb/scylladb/issues/18862 as well (although I haven't seen it yet, but I see no reason why it would happen). So the issue was apparently present since the initial implementation of the pending_delete_log. It's just that with tablet migration it is more likely to be hit.

Fixes scylladb/scylladb#18862

Needs backport to 6.0 since tablets require this capability
