### PR TITLE
Do not expire local addres in raft address map since the local node cannot disappear

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2831,8 +2831,10 @@ future<> storage_service::init_address_map(raft_address_map& address_map, gms::g
         address_map.add_or_update_entry(raft::server_id(host.uuid()), ip);
     }
     const auto& topology = get_token_metadata().get_topology();
-    address_map.add_or_update_entry(raft::server_id{topology.my_host_id().uuid()},
-        topology.my_address(), new_generation);
+    raft::server_id myid{topology.my_host_id().uuid()};
+    address_map.add_or_update_entry(myid,topology.my_address(), new_generation);
+    // Make my entry non expiring
+    address_map.set_nonexpiring(myid);
     _raft_ip_address_updater = make_shared<raft_ip_address_updater>(address_map, *this);
     _gossiper.register_(_raft_ip_address_updater);
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1224,6 +1224,10 @@ public:
                 rtlogger.info("join: request to join placed, waiting"
                              " for the response from the topology coordinator");
 
+                if (utils::get_local_injector().enter("pre_server_start_drop_expiring")) {
+                    _ss._group0->modifiable_address_map().force_drop_expiring_entries();
+                }
+
                 _ss._join_node_request_done.set_value();
             },
             [] (const join_node_request_result::rejected& rej) {

--- a/test/topology_custom/test_long_join.py
+++ b/test/topology_custom/test_long_join.py
@@ -25,3 +25,18 @@ async def test_long_join(manager: ManagerClient) -> None:
     await manager.api.enable_injection(s1.ip_addr, "handle_node_transition_drop_expiring", one_shot=True)
     await manager.api.message_injection(s1.ip_addr, inj)
     await asyncio.gather(task)
+
+@pytest.mark.asyncio
+async def test_long_join_drop_wntries_on_bootstrapping(manager: ManagerClient) -> None:
+    """The test checks that join works even if expiring entries are dropped
+       on the joining node between placement of the join request and its processing"""
+    s1 = await manager.server_add()
+    inj = 'topology_coordinator_pause_before_processing_backlog'
+    await manager.api.enable_injection(s1.ip_addr, inj, one_shot=True)
+    s2 = await manager.server_add(start=False,  config={
+        'error_injections_at_startup': ['pre_server_start_drop_expiring']
+    })
+    task = asyncio.create_task(manager.server_start(s2.server_id))
+    await manager.server_sees_other_server(s1.ip_addr, s2.ip_addr, interval=300)
+    await manager.api.message_injection(s1.ip_addr, inj)
+    await asyncio.gather(task)


### PR DESCRIPTION
A node may wait in the topology coordinator queue for awhile before been joined. Since the local address is added as expiring entry to the raft address map it may expire meanwhile and the bootstrap will fail. The series makes the entry non expiring.

Fixes  scylladb/scylladb#19523

Needs to be back ported to 6.0 since the bug may cause bootstrap to fail.