### PR TITLE
docs: render default value with user-facing representation

### DIFF
--- a/docs/_ext/utils.py
+++ b/docs/_ext/utils.py
@@ -35,6 +35,26 @@ def readable_desc_rst(description):
     return ''.join(cleaned_lines)
 
 
+def readable_default(value, type_):
+    # default values of options are extracted from source file, but the
+    # representation in source code of a certain value does not necessarily
+    # identical to its representation in scylla.yaml, sometimes the default
+    # value is not even a literal. strictly speaking, it is an expression,
+    # so a function call is also valid. we have to translate them on a
+    # case-by-case basis
+    if type_ == 'tri_mode_restriction':
+        # see db/config.cc
+        #   db::tri_mode_restriction_t::map()
+        *_, v = value.rsplit('::', 1)
+        return v.lower()
+    if type_ == 'seastar::log_level':
+        # see seastar/src/util/log.cc
+        #   log_level_names
+        *_, v = value.rsplit('::', 1)
+        return v
+    return value
+
+
 def maybe_add_filters(builder):
     env = builder.templates.environment
     if 'readable_desc' not in env.filters:
@@ -42,3 +62,6 @@ def maybe_add_filters(builder):
 
     if 'readable_desc_rst' not in env.filters:
         env.filters['readable_desc_rst'] = readable_desc_rst
+
+    if 'readable_default' not in env.filters:
+        env.filters['readable_default'] = readable_default

--- a/docs/_templates/db_option.tmpl
+++ b/docs/_templates/db_option.tmpl
@@ -2,5 +2,5 @@
 {{ description | readable_desc_rst }}
 
    {% if type %}* **Type:** ``{{ type }}``{% endif %}
-   {% if default %}* **Default value:** ``{{ default }}``{% endif %}
+   {% if default %}* **Default value:** ``{{ default | readable_default(type) }}``{% endif %}
    {% if liveness %}* :term:`Liveness <Liveness>`: ``{{ liveness }}``{% endif %}


### PR DESCRIPTION
before this change, quite a few of the default values are represented in the form of their representations in source code, but this is not user-friendly.

after this change, some of them are updated so that the new representations match with what user finds in `scylla.yaml`. this change is not exhaustive, and there are still cases where the default values are either not readable or still in the form of the expression in C++ source code. but this change establishes a mechinary allowing us to customize the representation on a case-by-case basis.

---

non-critical document improvement, hence no need to backport