### PR TITLE
[Backport 5.4] Close output_stream in get_snapshot_details() API handler

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1546,8 +1546,10 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
                         });
                     }).then([&s] {
                         return s.write("]").then([&s] {
-                            return s.close();
+                            return s.flush();
                         });
+                    }).finally([&s] {
+                        return s.close();
                     });
                 });
             };


### PR DESCRIPTION
All streams used by httpd handlers are to be closed by the handler itself, caller doesn't take care of that.

On master this place is coroutinized, thus the original fix doesn't fit as is. Original commit is 0ce00ebfbd845d9f3f71ade3c5e726815635e265

refs: #19494
closes: #19561
