### PR TITLE
[Backport 5.4] Close output stream in task manager's API get_tasks handler

### DIFF
--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -141,23 +141,23 @@ void set_task_manager(http_context& ctx, routes& r, db::config& cfg) {
         std::function<future<>(output_stream<char>&&)> f = [r = std::move(res)] (output_stream<char>&& os) -> future<> {
             auto s = std::move(os);
             std::exception_ptr ex;
-          try {
-            auto res = std::move(r);
-            co_await s.write("[");
-            std::string delim = "";
-            for (auto& v: res) {
-                for (auto& stats: v) {
-                    co_await s.write(std::exchange(delim, ", "));
-                    tm::task_stats ts;
-                    ts = stats;
-                    co_await formatter::write(s, ts);
+            try {
+                auto res = std::move(r);
+                co_await s.write("[");
+                std::string delim = "";
+                for (auto& v: res) {
+                    for (auto& stats: v) {
+                        co_await s.write(std::exchange(delim, ", "));
+                        tm::task_stats ts;
+                        ts = stats;
+                        co_await formatter::write(s, ts);
+                    }
                 }
+                co_await s.write("]");
+                co_await s.flush();
+            } catch (...) {
+                ex = std::current_exception();
             }
-            co_await s.write("]");
-            co_await s.flush();
-          } catch (...) {
-              ex = std::current_exception();
-          }
             co_await s.close();
             if (ex) {
                 co_await coroutine::return_exception_ptr(std::move(ex));

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -151,6 +151,7 @@ void set_task_manager(http_context& ctx, routes& r, db::config& cfg) {
                 }
             }
             co_await s.write("]");
+            co_await s.flush();
             co_await s.close();
         };
         co_return std::move(f);


### PR DESCRIPTION
If client stops reading response early, the server-side stream throws but must be closed anyway. Seen in another endpoint and fixed by https://github.com/scylladb/scylladb/pull/19541

Original commit is 0ce00ebfbd845d9f3f71ade3c5e726815635e265
Had simple conflict with ffb5ad494fcb5779a22ace8af694a91c8598b5a5

closes: #19560 