### PR TITLE
scylla-housekeeping: fix exception on parsing version string

### DIFF
--- a/dist/common/scripts/scylla-housekeeping
+++ b/dist/common/scripts/scylla-housekeeping
@@ -96,9 +96,11 @@ def sanitize_version(version):
     false negative version_compare() checks.
     """
     if version and '-' in version:
-        return version.split('-', 1)[0]
-    else:
-        return version
+        version = version.split('-', 1)[0]
+    # Newer setuptools does not accept ~dev in version strings, need to
+    # replace it to .dev0
+    if version and version.endswith('~dev'):
+        version = version.replace('~dev', '.dev0')
 
 
 def get_repo_file(dir):


### PR DESCRIPTION
Since Python 3.12, version parsing becomes strict, parse_version() does not accept the version string like '6.1.0\~dev'.
To fix this, we need to replace version string from '6.1.0\~dev' to '6.1.0.dev0', which is allowed on Python version scheme.

reference: https://packaging.python.org/en/latest/specifications/version-specifiers/

Fixes #19564