### PR TITLE
doc: add Run in Docker page to the documentation

### DIFF
--- a/docs/getting-started/install-scylla/index.rst
+++ b/docs/getting-started/install-scylla/index.rst
@@ -10,6 +10,7 @@ Install ScyllaDB
    /getting-started/install-scylla/launch-on-azure
    /getting-started/installation-common/scylla-web-installer
    /getting-started/install-scylla/install-on-linux
+   /getting-started/install-scylla/run-in-docker
    /getting-started/installation-common/unified-installer
    /getting-started/installation-common/air-gapped-install
    /getting-started/installation-common/disable-housekeeping
@@ -37,3 +38,10 @@ Keep your versions up-to-date. The two latest versions are supported. Also, alwa
   * :doc:`Install ScyllaDB Without root Privileges </getting-started/installation-common/unified-installer>`
   * :doc:`Air-gapped Server Installation </getting-started/installation-common/air-gapped-install>`
   * :doc:`ScyllaDB Developer Mode </getting-started/installation-common/dev-mod>`
+
+.. panel-box::
+  :title: Docker
+  :id: "getting-started"
+  :class: my-panel
+
+  * :doc:`Run ScyllaDB in Docker </getting-started/install-scylla/run-in-docker>`

--- a/docs/getting-started/install-scylla/run-in-docker.rst
+++ b/docs/getting-started/install-scylla/run-in-docker.rst
@@ -1,0 +1,71 @@
+=========================
+Run ScyllaDB in Docker
+=========================
+
+
+Each ScyllaDB version is available as a Docker image you can use to create
+a ScyllaDB container.
+
+Running ScyllaDB in Docker is the simplest way to experiment with ScyllaDB in
+non-production environments. In production environments, additional tuning is
+required to run a stateful container and maximize performance; follow
+:doc:`Best Practices for Running ScyllaDB on Docker </operating-scylla/procedures/tips/best-practices-scylla-on-docker>`.
+
+Prerequisites
+---------------
+
+#. Download and install Docker from the `Docker website <https://docs.docker.com/get-docker/>`_.
+#. Download the ScyllaDB image from `DockerHub <https://hub.docker.com/r/scylladb/scylla>`_
+   (the latest stable ScyllaDB version will be downloaded):
+   
+   .. code::
+    
+    docker pull scylladb/scylla
+
+Examples
+-----------
+
+To start a one-node ScyllaDB instance:
+
+.. code::
+    
+    docker run --name scylla -d scylladb/scylla
+
+To add more nodes:
+
+.. code::
+    
+    docker run --name scylla-node2 -d scylladb/scylla --seeds="$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' scylla)"
+
+.. code::
+    
+    docker run --name scylla-node3 -d scylladb/scylla --seeds="$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' scylla)"
+
+To verify that the cluster is up and running:
+
+.. code::
+    
+    docker exec -it scylla nodetool status
+
+To start cqlsh to interact with ScyllaDB:
+
+.. code::
+    
+    docker exec -it scylla cqlsh
+
+
+Useful Resources
+-------------------
+
+* `Documentation for the ScyllaDB Docker image <https://hub.docker.com/r/scylladb/scylla>`_ on DockerHub.
+* :doc:`Best Practices for Running ScyllaDB on Docker </operating-scylla/procedures/tips/best-practices-scylla-on-docker>`
+  in the ScyllaDB documentation.
+* `Quick Wins Lab <https://university.scylladb.com/courses/scylla-essentials-overview/lessons/quick-wins-install-and-run-scylla/topic/quick-wins-lab/>`_
+  using Docker on ScyllaDB University.
+* `ScyllaDB on Docker <https://www.scylladb.com/2016/11/09/scylla-on-docker/>`_ blog post.
+
+
+
+
+
+


### PR DESCRIPTION
The page was missing from the docs. I created the page based on the information in the [download center](https://www.scylladb.com/download/?platform=docker#open-source) (which will be closed down soon) and other ScyllaDB resources.