### PR TITLE
[backport 5.4] cql: don't crash when creating a view during a truncate

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2007,9 +2007,18 @@ future<> table::clear() {
 // NOTE: does not need to be futurized, but might eventually, depending on
 // if we implement notifications, whatnot.
 future<db::replay_position> table::discard_sstables(db_clock::time_point truncated_at) {
-    assert(std::ranges::all_of(compaction_groups(), [this] (const compaction_group_ptr& cg) {
-        return _compaction_manager.compaction_disabled(cg->as_table_state());
-    }));
+    // truncate_table_on_all_shards() disables compaction for the truncated
+    // tables and views, so we normally expect compaction to be disabled on
+    // this table. But as shown in issue #17543, it is possible that a new
+    // materialized view was created right after truncation started, and it
+    // would not have compaction disabled when this function is called on it.
+    if (!schema()->is_view()) {
+        if (!std::ranges::all_of(compaction_groups(), [this] (const compaction_group_ptr& cg) {
+                return _compaction_manager.compaction_disabled(cg->as_table_state()); })) {
+            utils::on_internal_error(fmt::format("compaction not disabled on table {}.{} during TRUNCATE",
+                schema()->ks_name(), schema()->cf_name()));
+        }
+    }
 
     struct pruner {
         column_family& cf;


### PR DESCRIPTION
The test dtest materialized_views_test.py::TestMaterializedViews:: test_mv_populating_from_existing_data_during_truncate reproduces an assertion failure, and crash, while doing a CREATE MATERIALIZED VIEW during a TRUNCATE operation.

This patch fixes the crash by removing the assert() call for a view (replacing it by a warning message) - we'll explain below why this is fine. Also for base tables change we change the assertion to an on_internal_error (Refs #7871).
This makes the test stop crashing Scylla, but it still fails due to issue #17635.

Let's explain the crash, and the fix:

The test starts TRUNCATE on table that doesn't yet have a view. truncate_table_on_all_shards() begins by disabling compaction on the table and all its views (of which there are none, at this point). At this point, the test creates a new view is on this table. The new view has, by default, compaction enabled. Later, TRUNCATE calls discard_sstables() on this new view, asserts that it has compaction disabled - and this assertion fails.

The fix in this patch is to not do the assert() for views. In other words, we acknowledge that in this use case, the view *will* have compactions enabled while being truncated. I claim that this is "good enough", if we remember *why* we disable compaction in the first place: It's important to disable compaction while truncating because truncating during compaction can lead us to data resurection when the old sstable is deleted during truncation but the result of the compaction is written back. True, this can now happen in a new view (a view created *DURING* the truncation). But I claim that worse things can happen for this new view: Notably, we may truncate a view and then the ongoing view building (which happens in a new view) might copy data from the base to the view and only then truncate the base - ending up with an empty base and non-empty view. This problem - issue #17635 - is more likely, and more serious, than the compaction problem, so will need to be solved in a separate patch.

Fixes #17543.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>

Closes scylladb/scylladb#17634

(cherry picked from commit 8df2ea3f95622a0c4f7f54f85dd794c96e9db0e3)