### PR TITLE
compaction: not include unused headers

### DIFF
--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -10,7 +10,7 @@ env:
   BUILD_TYPE: RelWithDebInfo
   BUILD_DIR: build
   CLEANER_OUTPUT_PATH: build/clang-include-cleaner.log
-  CLEANER_DIRS: test/unit exceptions alternator api auth cdc
+  CLEANER_DIRS: test/unit exceptions alternator api auth cdc compaction
 
 permissions: {}
 

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -47,6 +47,7 @@
 #include "mutation/mutation_source_metadata.hh"
 #include "mutation/mutation_fragment_stream_validator.hh"
 #include "utils/error_injection.hh"
+#include "utils/pretty_printers.hh"
 #include "readers/multi_range.hh"
 #include "readers/compacting.hh"
 #include "tombstone_gc.hh"

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -12,11 +12,8 @@
 #include "sstables/shared_sstable.hh"
 #include "compaction/compaction_descriptor.hh"
 #include "gc_clock.hh"
-#include "compaction_weight_registration.hh"
 #include "utils/UUID.hh"
-#include "utils/pretty_printers.hh"
 #include "table_state.hh"
-#include <seastar/core/thread.hh>
 #include <seastar/core/abort_source.hh>
 
 using namespace compaction;

--- a/compaction/compaction_backlog_manager.hh
+++ b/compaction/compaction_backlog_manager.hh
@@ -10,7 +10,6 @@
 
 #include <unordered_set>
 #include <memory>
-#include <seastar/core/shared_ptr.hh>
 #include "sstables/shared_sstable.hh"
 #include "timestamp.hh"
 

--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -12,8 +12,6 @@
 #include <functional>
 #include <optional>
 #include <variant>
-#include <seastar/core/smp.hh>
-#include <seastar/core/file.hh>
 #include "sstables/types_fwd.hh"
 #include "sstables/sstable_set.hh"
 #include "compaction_fwd.hh"

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <boost/icl/interval.hpp>
 #include <boost/icl/interval_map.hpp>
 
 #include <seastar/core/semaphore.hh>
@@ -16,9 +15,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/shared_future.hh>
-#include <seastar/core/rwlock.hh>
 #include <seastar/core/metrics_registration.hh>
-#include <seastar/core/scheduling.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/condition-variable.hh>
 #include "sstables/shared_sstable.hh"

--- a/compaction/compaction_strategy.hh
+++ b/compaction/compaction_strategy.hh
@@ -8,10 +8,6 @@
 
 #pragma once
 
-#include <seastar/core/future.hh>
-#include <seastar/util/noncopyable_function.hh>
-#include <seastar/core/file.hh>
-
 #include "schema/schema_fwd.hh"
 #include "sstables/shared_sstable.hh"
 #include "exceptions/exceptions.hh"

--- a/compaction/size_tiered_compaction_strategy.hh
+++ b/compaction/size_tiered_compaction_strategy.hh
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "compaction_strategy_impl.hh"
-#include "compaction.hh"
 #include "sstables/shared_sstable.hh"
 #include <boost/algorithm/cxx11/any_of.hpp>
 

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <fmt/format.h>
-
 #include "compaction/compaction.hh"
 #include "replica/database_fwd.hh"
 #include "schema/schema_fwd.hh"

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -22,6 +22,8 @@
 
 #pragma once
 
+class compaction_manager;
+
 namespace locator {
 class effective_replication_map;
 }

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -69,6 +69,7 @@
 #include "readers/from_mutations_v2.hh"
 #include "readers/from_fragments_v2.hh"
 #include "readers/combined.hh"
+#include "utils/pretty_printers.hh"
 
 namespace fs = std::filesystem;
 


### PR DESCRIPTION
these unused includes were identified by clangd. see
https://clangd.llvm.org/guides/include-cleaner#unused-include-warning
for more details on the "Unused include" warning.

---

it's a cleanup, hence no need to backport.