### PR TITLE
Remove outdated information regarding Scylla versions in CDC Stream Generations documentation

### DIFF
--- a/docs/using-scylla/cdc/cdc-stream-generations.rst
+++ b/docs/using-scylla/cdc/cdc-stream-generations.rst
@@ -25,8 +25,7 @@ A CDC generation consists of:
 This is the mapping used to decide on which stream IDs to use when making writes, as explained in the :doc:`./cdc-streams` document. It is a global property of the cluster: it doesn't depend on the table you're making writes to.
 
 .. caution::
-   The tables mentioned in the following sections: ``system_distributed.cdc_generation_timestamps`` and ``system_distributed.cdc_streams_descriptions_v2`` have been introduced in ScyllaDB 4.4. It is highly recommended to upgrade to 4.4 for efficient CDC usage. The last section explains how to run the below examples in ScyllaDB 4.3.
-
+   The tables mentioned in the following sections: ``system_distributed.cdc_generation_timestamps`` and ``system_distributed.cdc_streams_descriptions_v2`` are used for CDC in Scylla 4.4 and later versions.
 When CDC generations change
 ---------------------------
 


### PR DESCRIPTION
Removed the outdated recommendation to upgrade to Scylla 4.4.
Fixes #19569 