### PR TITLE
storage_proxy: remove response handler if no targets

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1505,6 +1505,17 @@ public:
             timeout_cb();
         }
     }
+    void no_targets() {
+        // We don't have any live targets and we should complete the handler now.
+        // Either we already stored sufficient hints to achieve CL and the handler
+        // is completed successfully (see hint_to_dead_endpoints), or we don't achieve
+        // CL because we didn't store sufficient hints and we don't have live targets,
+        // so the handler is completed with error.
+        if (!_cl_achieved) {
+            _error = error::FAILURE;
+        }
+        _proxy->remove_response_handler(_id);
+    }
     void expire_at(storage_proxy::clock_type::time_point timeout) {
         _expire_timer.arm(timeout);
     }
@@ -4086,6 +4097,16 @@ void storage_proxy::send_to_live_endpoints(storage_proxy::response_id_type respo
     auto& stats = handler_ptr->stats();
     auto& handler = *handler_ptr;
     auto& global_stats = handler._proxy->_global_stats;
+
+    if (handler.get_targets().size() == 0) {
+        // Usually we remove the response handler when receiving responses from all targets.
+        // Here we don't have any live targets to get responses from, so we should complete
+        // the write response handler immediately. Otherwise, it will remain active
+        // until it timeouts.
+        handler.no_targets();
+        return;
+    }
+
     if (handler.get_targets().size() != 1 || !is_me(handler.get_targets()[0])) {
         auto& topology = handler_ptr->_effective_replication_map_ptr->get_topology();
         auto local_dc = topology.get_datacenter();

--- a/test/topology_custom/test_hints.py
+++ b/test/topology_custom/test_hints.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import asyncio
+import pytest
+import time
+import logging
+import requests
+import re
+
+from cassandra.cluster import ConnectionException, NoHostAvailable  # type: ignore
+from cassandra.query import SimpleStatement, ConsistencyLevel
+
+from test.pylib.manager_client import ManagerClient
+
+
+logger = logging.getLogger(__name__)
+
+# Write with RF=1 and CL=ANY to a dead node should write hints and succeed
+@pytest.mark.asyncio
+async def test_write_cl_any_to_dead_node_generates_hints(manager: ManagerClient):
+    node_count = 2
+    servers = await manager.servers_add(node_count)
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
+    await cql.run_async("CREATE TABLE ks.t (pk int primary key, v int)")
+
+    await manager.server_stop_gracefully(servers[1].server_id)
+
+    def get_hints_written_count(server):
+        c = 0
+        metrics = requests.get(f"http://{server.ip_addr}:9180/metrics").text
+        pattern = re.compile("^scylla_hints_manager_written")
+        for metric in metrics.split('\n'):
+            if pattern.match(metric) is not None:
+                c += int(float(metric.split()[1]))
+        return c
+
+    hints_before = get_hints_written_count(servers[0])
+
+    # Some of the inserts will be targeted to the dead node.
+    # The coordinator doesn't have live targets to send the write to, but it should write a hint.
+    for i in range(100):
+        await cql.run_async(SimpleStatement(f"INSERT INTO ks.t (pk, v) VALUES ({i}, {i+1})", consistency_level=ConsistencyLevel.ANY))
+
+    # Verify hints are written
+    hints_after = get_hints_written_count(servers[0])
+    assert hints_after > hints_before

--- a/test/topology_custom/test_mv_topology_change.py
+++ b/test/topology_custom/test_mv_topology_change.py
@@ -164,3 +164,32 @@ async def test_mv_update_on_pending_replica(manager: ManagerClient, intranode):
     assert [1] == [x.c for x in res]
     res = await cql.run_async(f"SELECT c FROM test.mv1 WHERE pk={key} ALLOW FILTERING")
     assert [1] == [x.c for x in res]
+
+# Reproduces issue #19529
+# Write to a table with MV while one node is stopped, and verify
+# it doesn't cause MV write timeouts or preventing topology changes.
+# The writes that are targeted to the stopped node are with CL=ANY so
+# they should store a hint and then complete successfuly.
+# If the MV write handler is not completed after storing the hint, as in
+# issue #19529, it remains active until it timeouts, preventing topology changes
+# during this time.
+@pytest.mark.asyncio
+async def test_mv_write_to_dead_node(manager: ManagerClient):
+    servers = await manager.servers_add(4)
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}")
+    await cql.run_async("CREATE TABLE ks.t (pk int primary key, v int)")
+    await cql.run_async("CREATE materialized view ks.t_view AS select pk, v from ks.t where v is not null primary key (v, pk)")
+
+    await manager.server_stop_gracefully(servers[-1].server_id)
+
+    # Do inserts. some should generate MV writes to the stopped node
+    for i in range(100):
+        await cql.run_async(f"insert into ks.t (pk, v) values ({i}, {i+1})")
+
+    # Remove the node to trigger a topology change.
+    # If the MV write is not completed, as in issue #19529, the topology change
+    # will be held for long time until the write timeouts.
+    # Otherwise, it is expected to complete in short time.
+    await manager.remove_node(servers[0].server_id, servers[-1].server_id, timeout=30)


### PR DESCRIPTION
When writing a mutation, it might happen that there are no live targets to send the mutation to, yet the request can be satisfied. For example, when writing with CL=ANY to a dead node, the request is completed by storing a local hint.

Currently, in that case, a write response handler is created for the request and it remains active until it timeouts because it is not removed anywhere, even though the write is completed successfuly after storing the hint. The response handler should be removed usually when receiving responses from all targets, but in this case there are no targets to trigger the removal.

In this commit we check if we don't have live targets to send the mutation to. If so, we remove the response handler immediately.

Fixes scylladb/scylladb#19529