### PR TITLE
tablet_allocator: Put more info into failed-to-drain exception

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -987,8 +987,8 @@ public:
                 auto end = nodes_by_load_dst.end();
                 while (true) {
                     if (nodes_by_load_dst.begin() == end) {
-                        throw std::runtime_error(format("Unable to find new replica for tablet {} on {} when draining {}",
-                                                        source_tablet, src, nodes_to_drain));
+                        throw std::runtime_error(format("Unable to find new replica for tablet {} on {} when draining {} (nodes {}, replicas {})",
+                                                        source_tablet, src, nodes_to_drain, nodes_by_load_dst, replicas));
                     }
 
                     pop_heap(nodes_by_load_dst.begin(), end, nodes_dst_cmp);


### PR DESCRIPTION
When balancer fails to find a node to balance drained tablets into, it throws an exception with tablet id and node id, but it's also good to know more details about the balancing state that lead to failure

refs: #19504