### PR TITLE
db: use format_as() in favor of fmt::streamed()

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -749,9 +749,10 @@ class db::commitlog::segment : public enable_shared_from_this<segment>, public c
 
     std::unordered_set<table_schema_version> _known_schema_versions;
 
-    // TODO: remove all explicit fmt::streamed(*this) calls with *this when using {fmt} v10,
-    //   as v10 can fallback to use format_as()
-    friend sstring format_as(const segment&);
+    friend sstring format_as(const segment& s) {
+        return s._desc.filename();
+    }
+
     friend std::ostream& operator<<(std::ostream&, const segment&);
     friend class segment_manager;
 
@@ -813,20 +814,20 @@ public:
         _sync_time(clock_type::now()), _pending_ops(true) // want exception propagation
     {
         ++_segment_manager->totals.segments_created;
-        clogger.debug("Created new segment {}", fmt::streamed(*this));
+        clogger.debug("Created new segment {}", *this);
     }
     ~segment() {
         dispose_mode mode = dispose_mode::Keep;
 
         if (is_clean()) {
-            clogger.debug("Segment {} is no longer active and will submitted for delete now", fmt::streamed(*this));
+            clogger.debug("Segment {} is no longer active and will submitted for delete now", *this);
             ++_segment_manager->totals.segments_destroyed;
             _segment_manager->totals.active_size_on_disk -= file_position();
             _segment_manager->totals.bytes_released += file_position();
             _segment_manager->totals.wasted_size_on_disk -= _waste;
             mode = dispose_mode::Delete;
         } else if (_segment_manager->cfg.warn_about_segments_left_on_disk_after_shutdown) {
-            clogger.warn("Segment {} is dirty and is left on disk.", fmt::streamed(*this));
+            clogger.warn("Segment {} is dirty and is left on disk.", *this);
         }
 
         _segment_manager->totals.buffer_list_bytes -= _buffer.size_bytes();
@@ -865,7 +866,7 @@ public:
         auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                 now - _sync_time).count();
         if ((_segment_manager->cfg.commitlog_sync_period_in_ms * 2) < uint64_t(ms)) {
-            clogger.debug("{} needs sync. {} ms elapsed", fmt::streamed(*this), ms);
+            clogger.debug("{} needs sync. {} ms elapsed", *this, ms);
             return true;
         }
         return false;
@@ -924,7 +925,7 @@ public:
         assert(me.use_count() > 1);
         uint64_t pos = _file_pos;
 
-        clogger.trace("Syncing {} {} -> {}", fmt::streamed(*this), _flush_pos, pos);
+        clogger.trace("Syncing {} {} -> {}", *this, _flush_pos, pos);
 
         // Only run the flush when all write ops at lower rp:s
         // have completed.
@@ -945,7 +946,7 @@ public:
             // we should only get here when all actual data is 
             // already flushed (see below, close()).
             if (file_position() < _segment_manager->max_size) {
-                clogger.trace("{} is closed but not terminated.", fmt::streamed(*this));
+                clogger.trace("{} is closed but not terminated.", *this);
                 if (_buffer.empty()) {
                     new_buffer(0);
                 }
@@ -972,7 +973,7 @@ public:
         });
 
         if (pos <= _flush_pos) {
-            clogger.trace("{} already synced! ({} < {})", fmt::streamed(*this), pos, _flush_pos);
+            clogger.trace("{} already synced! ({} < {})", *this, pos, _flush_pos);
             co_return me;
         }
 
@@ -982,7 +983,7 @@ public:
             // we fast-fail the whole commit.
             _flush_pos = std::max(pos, _flush_pos);
             ++_segment_manager->totals.flush_count;
-            clogger.trace("{} synced to {}", fmt::streamed(*this), _flush_pos);
+            clogger.trace("{} synced to {}", *this, _flush_pos);
         } catch (...) {
             clogger.error("Failed to flush commits to disk: {}", std::current_exception());
             throw;
@@ -1095,7 +1096,7 @@ public:
         } else {
             assert(num == 0);
             assert(_closed);
-            clogger.trace("Terminating {} at pos {}", fmt::streamed(*this), _file_pos);
+            clogger.trace("Terminating {} at pos {}", *this, _file_pos);
             write(out, uint64_t(0));
         }
 
@@ -1156,7 +1157,7 @@ public:
                     _segment_manager->totals.active_size_on_disk += bytes;
                     ++_segment_manager->totals.cycle_count;
                     if (bytes == view.size_bytes()) {
-                        clogger.trace("Final write of {} to {}: {}/{} bytes at {}", bytes, fmt::streamed(*this), size, size, off);
+                        clogger.trace("Final write of {} to {}: {}/{} bytes at {}", bytes, *this, size, size, off);
                         break;
                     }
                     // gah, partial write. should always get here with dma chunk sized
@@ -1164,12 +1165,12 @@ public:
                     bytes = align_down(bytes, _alignment);
                     off += bytes;
                     view.remove_prefix(bytes);
-                    clogger.trace("Partial write of {} to {}: {}/{} bytes at at {}", bytes, fmt::streamed(*this), size - view.size_bytes(), size, off - bytes);
+                    clogger.trace("Partial write of {} to {}: {}/{} bytes at at {}", bytes, *this, size - view.size_bytes(), size, off - bytes);
                     continue;
                     // TODO: retry/ignore/fail/stop - optional behaviour in origin.
                     // we fast-fail the whole commit.
                 } catch (...) {
-                    clogger.error("Failed to persist commits to disk for {}: {}", fmt::streamed(*this), std::current_exception());
+                    clogger.error("Failed to persist commits to disk for {}: {}", *this, std::current_exception());
                     throw;
                 }
             }
@@ -2060,10 +2061,6 @@ future<> db::commitlog::segment_manager::wait_for_pending_deletes() noexcept {
 
 namespace db {
 
-sstring format_as(const db::commitlog::segment& s) {
-    return s._desc.filename();
-}
-
 std::ostream& operator<<(std::ostream& out, const db::commitlog::segment& s) {
     return out << format_as(s);
 }
@@ -2089,15 +2086,15 @@ void db::commitlog::segment_manager::discard_unused_segments() noexcept {
 
     std::erase_if(_segments, [=](sseg_ptr s) {
         if (s->can_delete()) {
-            clogger.debug("Segment {} is unused", fmt::streamed(*s));
+            clogger.debug("Segment {} is unused", *s);
             return true;
         }
         if (s->is_still_allocating()) {
-            clogger.debug("Not safe to delete segment {}; still allocating.", fmt::streamed(*s));
+            clogger.debug("Not safe to delete segment {}; still allocating.", *s);
         } else if (!s->is_clean()) {
-            clogger.debug("Not safe to delete segment {}; dirty is {}", fmt::streamed(*s), segment::cf_mark {*s});
+            clogger.debug("Not safe to delete segment {}; dirty is {}", *s, segment::cf_mark {*s});
         } else {
-            clogger.debug("Not safe to delete segment {}; disk ops pending", fmt::streamed(*s));
+            clogger.debug("Not safe to delete segment {}; disk ops pending", *s);
         }
         return false;
     });
@@ -2139,7 +2136,7 @@ future<> db::commitlog::segment_manager::sync_all_segments() {
     auto def_copy = _segments;
     co_await coroutine::parallel_for_each(def_copy, [] (sseg_ptr s) -> future<> {
         co_await s->sync();
-        clogger.debug("Synced segment {}", fmt::streamed(*s));
+        clogger.debug("Synced segment {}", *s);
     });
 }
 
@@ -2150,7 +2147,7 @@ future<> db::commitlog::segment_manager::shutdown_all_segments() {
     auto def_copy = _segments;
     co_await coroutine::parallel_for_each(def_copy, [] (sseg_ptr s) -> future<> {
         co_await s->shutdown();
-        clogger.debug("Shutdown segment {}", fmt::streamed(*s));
+        clogger.debug("Shutdown segment {}", *s);
     });
 }
 


### PR DESCRIPTION
since fedora 38 is EOL. and fedora 39 comes with fmt v10.0.0, also, we've switched to the build image based on fedora 40, which ships fmt-devel v10.2.1, there is no need to use fmt::streamed() when the corresponding format_as() is available.

simpler this way.
---

it's a cleanup, hence no need to backport.