### PR TITLE
Add API for read barrier

### DIFF
--- a/api/api-doc/raft.json
+++ b/api/api-doc/raft.json
@@ -62,6 +62,38 @@
                ]
             }
          ]
+      },
+      {
+         "path": "/raft/read_barrier",
+         "operations": [
+            {
+               "method": "POST",
+               "summary": "Triggers read barrier for the given Raft group to wait for previously committed commands in this group to be applied locally. For example, can be used on group 0 to wait for the node to obtain latest schema changes.",
+               "type": "string",
+               "nickname": "read_barrier",
+               "produces": [
+                  "application/json"
+               ],
+               "parameters": [
+                  {
+                     "name": "group_id",
+                     "description": "The ID of the group. When absent, group0 is used.",
+                     "required": false,
+                     "allowMultiple": false,
+                     "type": "string",
+                     "paramType": "query"
+                  },
+                  {
+                     "name": "timeout",
+                     "description": "Timeout in seconds after which the endpoint returns a failure. If not provided, 60s is used.",
+                     "required": false,
+                     "allowMultiple": false,
+                     "type": "long",
+                     "paramType": "query"
+                  }
+               ]
+            }
+         ]
       }
    ]
 }

--- a/api/raft.cc
+++ b/api/raft.cc
@@ -23,31 +23,40 @@ struct http_context;
 namespace r = httpd::raft_json;
 using namespace json;
 
+
+namespace {
+
+::service::raft_timeout get_request_timeout(const http::request& req) {
+    return std::invoke([timeout_str = req.get_query_param("timeout")] {
+        if (timeout_str.empty()) {
+            return ::service::raft_timeout{};
+        }
+        auto dur = std::stoll(timeout_str);
+        if (dur <= 0) {
+            throw bad_param_exception{"Timeout must be a positive number."};
+        }
+        return ::service::raft_timeout{.value = lowres_clock::now() + std::chrono::seconds{dur}};
+    });
+}
+
+}  // namespace
+
+
 void set_raft(http_context&, httpd::routes& r, sharded<service::raft_group_registry>& raft_gr) {
     r::trigger_snapshot.set(r, [&raft_gr] (std::unique_ptr<http::request> req) -> future<json_return_type> {
         raft::group_id gid{utils::UUID{req->get_path_param("group_id")}};
-        auto timeout_dur = std::invoke([timeout_str = req->get_query_param("timeout")] {
-            if (timeout_str.empty()) {
-                return std::chrono::seconds{60};
-            }
-            auto dur = std::stoll(timeout_str);
-            if (dur <= 0) {
-                throw bad_param_exception{"Timeout must be a positive number."};
-            }
-            return std::chrono::seconds{dur};
-        });
+        auto timeout = get_request_timeout(*req);
 
         std::atomic<bool> found_srv{false};
-        co_await raft_gr.invoke_on_all([gid, timeout_dur, &found_srv] (service::raft_group_registry& raft_gr) -> future<> {
-            auto* srv = raft_gr.find_server(gid);
-            if (!srv) {
+        co_await raft_gr.invoke_on_all([gid, timeout, &found_srv] (service::raft_group_registry& raft_gr) -> future<> {
+            if (!raft_gr.find_server(gid)) {
                 co_return;
             }
 
             found_srv = true;
-            abort_on_expiry aoe(lowres_clock::now() + timeout_dur);
             apilog.info("Triggering Raft group {} snapshot", gid);
-            auto result = co_await srv->trigger_snapshot(&aoe.abort_source());
+            auto srv = raft_gr.get_server_with_timeouts(gid);
+            auto result = co_await srv.trigger_snapshot(nullptr, timeout);
             if (result) {
                 apilog.info("New snapshot for Raft group {} created", gid);
             } else {

--- a/api/raft.cc
+++ b/api/raft.cc
@@ -32,7 +32,7 @@ void set_raft(http_context&, httpd::routes& r, sharded<service::raft_group_regis
             }
             auto dur = std::stoll(timeout_str);
             if (dur <= 0) {
-                throw std::runtime_error{"Timeout must be a positive number."};
+                throw bad_param_exception{"Timeout must be a positive number."};
             }
             return std::chrono::seconds{dur};
         });
@@ -56,7 +56,7 @@ void set_raft(http_context&, httpd::routes& r, sharded<service::raft_group_regis
         });
 
         if (!found_srv) {
-            throw std::runtime_error{fmt::format("Server for group ID {} not found", gid)};
+            throw bad_param_exception{fmt::format("Server for group ID {} not found", gid)};
         }
 
         co_return json_void{};

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -184,6 +184,8 @@ future<> group0_state_machine::merge_and_apply(group0_state_machine_merger& merg
 future<> group0_state_machine::apply(std::vector<raft::command_cref> command) {
     slogger.trace("apply() is called with {} commands", command.size());
 
+    co_await utils::get_local_injector().inject("group0_state_machine::delay_apply", 1s);
+
     auto read_apply_mutex_holder = co_await _client.hold_read_apply_mutex();
 
     // max_mutation_size = 1/2 of commitlog segment size, thus max_command_size is set 1/3 of commitlog segment size to leave space for metadata.

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -94,6 +94,7 @@ public:
     raft_server_with_timeouts(raft_server_for_group& group_server, raft_group_registry& registry);
     future<> add_entry(raft::command command, raft::wait_type type, seastar::abort_source* as, std::optional<raft_timeout> timeout);
     future<> modify_config(std::vector<raft::config_member> add, std::vector<raft::server_id> del, seastar::abort_source* as, std::optional<raft_timeout> timeout);
+    future<bool> trigger_snapshot(seastar::abort_source* as, std::optional<raft_timeout> timeout);
     future<> read_barrier(seastar::abort_source* as, std::optional<raft_timeout> timeout);
 };
 

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -487,3 +487,17 @@ async def inject_error_one_shot(api: ScyllaRESTAPIClient, node_ip: IPAddress, in
     if not enabled:
         pytest.skip("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
     return InjectionHandler(api, injection, node_ip)
+
+
+async def read_barrier(api: ScyllaRESTAPIClient, node_ip: IPAddress, group_id: Optional[str] = None) -> None:
+    """ Issue a read barrier on the specific host for the group_id.
+
+        :param api: the REST API client
+        :param node_ip: the node IP address for which the read barrier will be posted
+        :param group_id: the optional group id (default=group0)
+    """
+    params = {}
+    if group_id:
+        params["group_id"] = group_id
+
+    await api.client.post("/raft/read_barrier", host=node_ip, params=params)

--- a/test/topology_custom/test_table_desc_read_barrier.py
+++ b/test/topology_custom/test_table_desc_read_barrier.py
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import logging
+import pytest
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.rest_client import inject_error
+from test.topology.conftest import skip_mode
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(reason="issue #19213")
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_table_desc_read_barrier(manager: ManagerClient) -> None:
+    """
+    Regression test for #19213.
+
+    Test that the schema is always updated after read barrier.
+
+    Arrange:
+        - start 2 nodes
+        - create a table
+        - inject raft delay on the first node
+        - disable the schema agreement wait
+    Act:
+        - alter the table (change schema) on the second node
+        - trigger the read barrier
+    Assert:
+        - the schema retrieved on both hosts matches
+    """
+    servers = await manager.servers_add(2)
+
+    logging.info("Waiting until driver connects to every server")
+    cql, hosts = await manager.get_ready_cql(servers)
+
+    logger.info("Creating keyspace and table")
+    await cql.run_async("create keyspace ks with replication = "
+                        "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
+    await cql.run_async("create table ks.t (pk int primary key)")
+
+    logger.info("Disabling the schema agreement wait")
+    assert hasattr(cql.cluster, "max_schema_agreement_wait")
+    cql.cluster.max_schema_agreement_wait = 0
+
+    async with inject_error(manager.api, servers[0].ip_addr, 'group0_state_machine::delay_apply'):
+        logger.info("Altering table")
+        sec_host = next(h for h in hosts if h.address == servers[1].ip_addr)
+        await cql.run_async("alter table ks.t add s1 int", host=sec_host)
+
+        # TODO: trigger the read barrier once available
+
+        # verify that there is no schema difference after the read barrier
+        desc_schema = [await cql.run_async("DESC SCHEMA", host=h) for h in hosts]
+        assert desc_schema[0] == desc_schema[1]

--- a/test/topology_custom/test_table_desc_read_barrier.py
+++ b/test/topology_custom/test_table_desc_read_barrier.py
@@ -8,7 +8,7 @@ import logging
 import pytest
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.rest_client import inject_error
+from test.pylib.rest_client import inject_error, read_barrier
 from test.topology.conftest import skip_mode
 
 
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="issue #19213")
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_table_desc_read_barrier(manager: ManagerClient) -> None:
     """
@@ -54,7 +53,8 @@ async def test_table_desc_read_barrier(manager: ManagerClient) -> None:
         sec_host = next(h for h in hosts if h.address == servers[1].ip_addr)
         await cql.run_async("alter table ks.t add s1 int", host=sec_host)
 
-        # TODO: trigger the read barrier once available
+        # wait for the first node to see the latest state (after the delay ends)
+        await read_barrier(manager.api, servers[0].ip_addr)
 
         # verify that there is no schema difference after the read barrier
         desc_schema = [await cql.run_async("DESC SCHEMA", host=h) for h in hosts]


### PR DESCRIPTION
Introduce REST API for triggering a read barrier.

This is to make sure the database schema is up to date on the node where the read barrier is triggered. One of the use cases is the database backup via the Scylla Manager, which requires that the schema backed up is matching the data or newer (data can be migrated, but an older schema would cause issues).

Fixes #19213