### PR TITLE
Add copy on write to functions schema code

### DIFF
--- a/auth/service.cc
+++ b/auth/service.cc
@@ -410,7 +410,7 @@ future<bool> service::exists(const resource& r) const {
                 return make_ready_future<bool>(db.has_keyspace(sstring(*keyspace)));
             }
             auto [name, function_args] = auth::decode_signature(*function_signature);
-            return make_ready_future<bool>(cql3::functions::functions::find(db::functions::function_name{sstring(*keyspace), name}, function_args));
+            return make_ready_future<bool>(cql3::functions::instance().find(db::functions::function_name{sstring(*keyspace), name}, function_args));
         }
     }
 

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -969,7 +969,7 @@ prepare_function_call(const expr::function_call& fc, data_dictionary::database d
             return func;
         },
         [&] (const functions::function_name& name) {
-            auto fun = functions::functions::get(db, keyspace, name, partially_prepared_args, keyspace, cf_name, receiver.get());
+            auto fun = functions::instance().get(db, keyspace, name, partially_prepared_args, keyspace, cf_name, receiver.get());
             if (!fun) {
                 throw exceptions::invalid_request_exception(format("Unknown function {} called", name));
             }
@@ -995,7 +995,7 @@ prepare_function_call(const expr::function_call& fc, data_dictionary::database d
     bool all_terminal = true;
     for (size_t i = 0; i < partially_prepared_args.size(); ++i) {
         expr::expression e = prepare_expression(fc.args[i], db, keyspace, schema_opt,
-                                                functions::functions::make_arg_spec(keyspace, cf_name, *fun, i));
+                                                functions::instance().make_arg_spec(keyspace, cf_name, *fun, i));
         if (!expr::is<expr::constant>(e)) {
             all_terminal = false;
         }
@@ -1026,7 +1026,7 @@ test_assignment_function_call(const cql3::expr::function_call& fc, data_dictiona
         auto&& fun = std::visit(overloaded_functor{
             [&] (const functions::function_name& name) {
                 auto args = prepare_function_args_for_type_inference(fc.args, db, keyspace, schema_opt);
-                return functions::functions::get(db, keyspace, name, args, receiver.ks_name, receiver.cf_name, &receiver);
+                return functions::instance().get(db, keyspace, name, args, receiver.ks_name, receiver.cf_name, &receiver);
             },
             [] (const shared_ptr<functions::function>& func) {
                 return func;

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -54,10 +54,8 @@ static bool same_signature(const shared_ptr<function>& f1, const shared_ptr<func
     return f1->name() == f2->name() && f1->arg_types() == f2->arg_types();
 }
 
-thread_local std::unordered_multimap<function_name, shared_ptr<function>> functions::_declared = init();
-
 void functions::clear_functions() noexcept {
-    functions::_declared = init();
+    _declared = init();
 }
 
 std::unordered_multimap<function_name, shared_ptr<function>>
@@ -160,7 +158,7 @@ void functions::replace_function(shared_ptr<function> func) {
 }
 
 void functions::remove_function(const function_name& name, const std::vector<data_type>& arg_types) {
-    with_udf_iter(name, arg_types, [] (functions::declared_t::iterator i) { _declared.erase(i); });
+    with_udf_iter(name, arg_types, [this] (functions::declared_t::iterator i) { _declared.erase(i); });
 }
 
 std::optional<function_name> functions::used_by_user_aggregate(shared_ptr<user_function> func) {
@@ -567,6 +565,11 @@ functions::match_arguments(data_dictionary::database db, const sstring& keyspace
 bool
 functions::type_equals(const std::vector<data_type>& t1, const std::vector<data_type>& t2) {
     return t1 == t2;
+}
+
+functions& instance() {
+    static thread_local functions f;
+    return f;
 }
 
 }

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -54,10 +54,6 @@ static bool same_signature(const shared_ptr<function>& f1, const shared_ptr<func
     return f1->name() == f2->name() && f1->arg_types() == f2->arg_types();
 }
 
-void functions::clear_functions() noexcept {
-    _declared = init();
-}
-
 std::unordered_multimap<function_name, shared_ptr<function>>
 functions::init() noexcept {
     // It is possible that this function will fail with a
@@ -126,17 +122,19 @@ void functions::add_function(shared_ptr<function> func) {
 
 template <typename F>
 void functions::with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, F&& f) {
-    auto i = find_iter(name, arg_types);
-    if (i == _declared.end() || i->second->is_native()) {
+    auto cit = find_iter(name, arg_types);
+    if (cit == _declared.end() || cit->second->is_native()) {
         log.error("attempted to remove or alter non existent user defined function {}({})", name, arg_types);
         return;
     }
-    f(i);
+    // erase here is only to convert from const_iterator to iterator
+    auto it = _declared.erase(cit, cit);
+    f(it);
 }
 
 void functions::replace_function(shared_ptr<function> func) {
-    with_udf_iter(func->name(), func->arg_types(), [func] (functions::declared_t::iterator i) {
-        i->second = std::move(func);
+    with_udf_iter(func->name(), func->arg_types(), [func] (auto it) {
+        it->second = std::move(func);
     });
     auto scalar_func = dynamic_pointer_cast<scalar_function>(func);
     if (!scalar_func) {
@@ -158,10 +156,10 @@ void functions::replace_function(shared_ptr<function> func) {
 }
 
 void functions::remove_function(const function_name& name, const std::vector<data_type>& arg_types) {
-    with_udf_iter(name, arg_types, [this] (functions::declared_t::iterator i) { _declared.erase(i); });
+    with_udf_iter(name, arg_types, [this] (auto it) { _declared.erase(it); });
 }
 
-std::optional<function_name> functions::used_by_user_aggregate(shared_ptr<user_function> func) {
+std::optional<function_name> functions::used_by_user_aggregate(shared_ptr<user_function> func) const {
     for (const shared_ptr<function>& fptr : _declared | boost::adaptors::map_values) {
         auto aggregate = dynamic_pointer_cast<user_aggregate>(fptr);
         if (aggregate && (same_signature(aggregate->sfunc(), func)
@@ -174,7 +172,7 @@ std::optional<function_name> functions::used_by_user_aggregate(shared_ptr<user_f
     return {};
 }
 
-std::optional<function_name> functions::used_by_user_function(const ut_name& user_type) {
+std::optional<function_name> functions::used_by_user_function(const ut_name& user_type) const {
     for (const shared_ptr<function>& fptr : _declared | boost::adaptors::map_values) {
         for (auto& arg_type : fptr->arg_types()) {
             if (arg_type->references_user_type(user_type.get_keyspace(), user_type.get_user_type_name())) {
@@ -190,7 +188,7 @@ std::optional<function_name> functions::used_by_user_function(const ut_name& use
 
 lw_shared_ptr<column_specification>
 functions::make_arg_spec(const sstring& receiver_ks, std::optional<const std::string_view> receiver_cf_opt,
-        const function& fun, size_t i) {
+        const function& fun, size_t i) const {
     auto&& name = fmt::to_string(fun.name());
     const std::string_view receiver_cf = receiver_cf_opt.has_value() ? *receiver_cf_opt : "<unknown_col_family>";
     std::transform(name.begin(), name.end(), name.begin(), ::tolower);
@@ -309,7 +307,7 @@ functions::get(data_dictionary::database db,
         const std::vector<shared_ptr<assignment_testable>>& provided_args,
         const sstring& receiver_ks,
         std::optional<const std::string_view> receiver_cf,
-        const column_specification* receiver) {
+        const column_specification* receiver) const {
 
     static const function_name TOKEN_FUNCTION_NAME = function_name::native_function("token");
     static const function_name TO_JSON_FUNCTION_NAME = function_name::native_function("tojson");
@@ -426,7 +424,7 @@ functions::get(data_dictionary::database db,
 }
 
 template<typename F>
-std::vector<shared_ptr<F>> functions::get_filtered_transformed(const sstring& keyspace) {
+std::vector<shared_ptr<F>> functions::get_filtered_transformed(const sstring& keyspace) const {
     auto filter = [&] (const std::pair<const function_name, shared_ptr<function>>& d) -> bool {
         return d.first.keyspace == keyspace && dynamic_cast<F*>(d.second.get());
     };
@@ -442,24 +440,24 @@ std::vector<shared_ptr<F>> functions::get_filtered_transformed(const sstring& ke
 }
 
 std::vector<shared_ptr<user_function>>
-functions::get_user_functions(const sstring& keyspace) {
+functions::get_user_functions(const sstring& keyspace) const {
     return get_filtered_transformed<user_function>(keyspace);
 }
 
 std::vector<shared_ptr<user_aggregate>>
-functions::get_user_aggregates(const sstring& keyspace) {
+functions::get_user_aggregates(const sstring& keyspace) const {
     return get_filtered_transformed<user_aggregate>(keyspace);
 }
 
-boost::iterator_range<functions::declared_t::iterator>
-functions::find(const function_name& name) {
+boost::iterator_range<functions::declared_t::const_iterator>
+functions::find(const function_name& name) const {
     assert(name.has_keyspace()); // : "function name not fully qualified";
     auto pair = _declared.equal_range(name);
     return boost::make_iterator_range(pair.first, pair.second);
 }
 
-functions::declared_t::iterator
-functions::find_iter(const function_name& name, const std::vector<data_type>& arg_types) {
+functions::declared_t::const_iterator
+functions::find_iter(const function_name& name, const std::vector<data_type>& arg_types) const {
     auto range = find(name);
     auto i = std::find_if(range.begin(), range.end(), [&] (const std::pair<const function_name, shared_ptr<function>>& d) {
         return type_equals(d.second->arg_types(), arg_types);
@@ -471,7 +469,7 @@ functions::find_iter(const function_name& name, const std::vector<data_type>& ar
 }
 
 shared_ptr<function>
-functions::find(const function_name& name, const std::vector<data_type>& arg_types) {
+functions::find(const function_name& name, const std::vector<data_type>& arg_types) const {
     auto i = find_iter(name, arg_types);
     if (i != _declared.end()) {
         return i->second;
@@ -489,7 +487,7 @@ functions::find(const function_name& name, const std::vector<data_type>& arg_typ
 // mock or serialize expressions and `functions::find()` is not enough,
 // because it does not search for dynamic aggregate functions
 shared_ptr<function>
-functions::mock_get(const function_name &name, const std::vector<data_type>& arg_types) {
+functions::mock_get(const function_name &name, const std::vector<data_type>& arg_types) const {
     auto func = find(name, arg_types);
     if (!func) {
         func = get_dynamic_aggregate(name, arg_types);
@@ -506,7 +504,7 @@ functions::validate_types(data_dictionary::database db,
                           shared_ptr<function> fun,
                           const std::vector<shared_ptr<assignment_testable>>& provided_args,
                           const sstring& receiver_ks,
-                          std::optional<const std::string_view> receiver_cf) {
+                          std::optional<const std::string_view> receiver_cf) const {
     if (provided_args.size() != fun->arg_types().size()) {
         throw exceptions::invalid_request_exception(
                 format("Invalid number of arguments in call to function {}: {:d} required but {:d} provided",
@@ -537,7 +535,7 @@ functions::match_arguments(data_dictionary::database db, const sstring& keyspace
         shared_ptr<function> fun,
         const std::vector<shared_ptr<assignment_testable>>& provided_args,
         const sstring& receiver_ks,
-        std::optional<const std::string_view> receiver_cf) {
+        std::optional<const std::string_view> receiver_cf) const {
     if (provided_args.size() != fun->arg_types().size()) {
         return assignment_testable::test_result::NOT_ASSIGNABLE;
     }
@@ -563,12 +561,13 @@ functions::match_arguments(data_dictionary::database db, const sstring& keyspace
 }
 
 bool
-functions::type_equals(const std::vector<data_type>& t1, const std::vector<data_type>& t2) {
+functions::type_equals(const std::vector<data_type>& t1, const std::vector<data_type>& t2) const {
     return t1 == t2;
 }
 
-functions& instance() {
-    static thread_local functions f;
+static thread_local functions f;
+
+const functions& instance() {
     return f;
 }
 
@@ -576,7 +575,11 @@ void change_batch::commit() {
     if (_declared.empty()) {
         return;
     }
-    instance()._declared = std::move(_declared);
+    f._declared = std::move(_declared);
+}
+
+void change_batch::clear_functions() noexcept {
+    _declared = init();
 }
 
 }

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -572,6 +572,13 @@ functions& instance() {
     return f;
 }
 
+void change_batch::commit() {
+    if (_declared.empty()) {
+        return;
+    }
+    instance()._declared = std::move(_declared);
+}
+
 }
 }
 

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -90,33 +90,6 @@ private:
             std::optional<const std::string_view> receiver_cf);
 
     static bool type_equals(const std::vector<data_type>& t1, const std::vector<data_type>& t2);
-
-#if 0
-    private static class FunctionsMigrationListener implements IMigrationListener
-    {
-        public void onCreateKeyspace(String ksName) { }
-        public void onCreateColumnFamily(String ksName, String cfName) { }
-        public void onCreateUserType(String ksName, String typeName) { }
-        public void onCreateFunction(String ksName, String functionName) { }
-        public void onCreateAggregate(String ksName, String aggregateName) { }
-
-        public void onUpdateKeyspace(String ksName) { }
-        public void onUpdateColumnFamily(String ksName, String cfName) { }
-        public void onUpdateUserType(String ksName, String typeName) {
-            for (Function function : all())
-                if (function instanceof UDFunction)
-                    ((UDFunction)function).userTypeUpdated(ksName, typeName);
-        }
-        public void onUpdateFunction(String ksName, String functionName) { }
-        public void onUpdateAggregate(String ksName, String aggregateName) { }
-
-        public void onDropKeyspace(String ksName) { }
-        public void onDropColumnFamily(String ksName, String cfName) { }
-        public void onDropUserType(String ksName, String typeName) { }
-        public void onDropFunction(String ksName, String functionName) { }
-        public void onDropAggregate(String ksName, String aggregateName) { }
-    }
-#endif
 };
 
 }

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -30,12 +30,10 @@ namespace functions {
 class functions {
     using declared_t = cql3::functions::declared_t;
     static thread_local declared_t _declared;
-private:
     static std::unordered_multimap<function_name, shared_ptr<function>> init() noexcept;
 public:
     static lw_shared_ptr<column_specification> make_arg_spec(const sstring& receiver_ks, std::optional<const std::string_view> receiver_cf,
             const function& fun, size_t i);
-public:
     static shared_ptr<function> get(data_dictionary::database db,
                                     const sstring& keyspace,
                                     const function_name& name,

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -29,12 +29,15 @@ namespace functions {
 
 class functions {
     using declared_t = cql3::functions::declared_t;
-    static thread_local declared_t _declared;
-    static std::unordered_multimap<function_name, shared_ptr<function>> init() noexcept;
+    declared_t _declared;
+    std::unordered_multimap<function_name, shared_ptr<function>> init() noexcept;
 public:
-    static lw_shared_ptr<column_specification> make_arg_spec(const sstring& receiver_ks, std::optional<const std::string_view> receiver_cf,
+    lw_shared_ptr<column_specification> make_arg_spec(const sstring& receiver_ks, std::optional<const std::string_view> receiver_cf,
             const function& fun, size_t i);
-    static shared_ptr<function> get(data_dictionary::database db,
+
+    functions() : _declared(init()) {}
+
+    shared_ptr<function> get(data_dictionary::database db,
                                     const sstring& keyspace,
                                     const function_name& name,
                                     const std::vector<shared_ptr<assignment_testable>>& provided_args,
@@ -42,7 +45,7 @@ public:
                                     std::optional<const std::string_view> receiver_cf,
                                     const column_specification* receiver = nullptr);
     template <typename AssignmentTestablePtrRange>
-    static shared_ptr<function> get(data_dictionary::database db,
+    shared_ptr<function> get(data_dictionary::database db,
                                     const sstring& keyspace,
                                     const function_name& name,
                                     AssignmentTestablePtrRange&& provided_args,
@@ -52,43 +55,46 @@ public:
         const std::vector<shared_ptr<assignment_testable>> args(std::begin(provided_args), std::end(provided_args));
         return get(db, keyspace, name, args, receiver_ks, receiver_cf, receiver);
     }
-    static std::vector<shared_ptr<user_function>> get_user_functions(const sstring& keyspace);
-    static std::vector<shared_ptr<user_aggregate>> get_user_aggregates(const sstring& keyspace);
-    static boost::iterator_range<declared_t::iterator> find(const function_name& name);
-    static declared_t::iterator find_iter(const function_name& name, const std::vector<data_type>& arg_types);
-    static shared_ptr<function> find(const function_name& name, const std::vector<data_type>& arg_types);
-    static shared_ptr<function> mock_get(const function_name& name, const std::vector<data_type>& arg_types);
-    static void clear_functions() noexcept;
-    static void add_function(shared_ptr<function>);
-    static void replace_function(shared_ptr<function>);
-    static void remove_function(const function_name& name, const std::vector<data_type>& arg_types);
-    static std::optional<function_name> used_by_user_aggregate(shared_ptr<user_function>);
-    static std::optional<function_name> used_by_user_function(const ut_name& user_type);
+    std::vector<shared_ptr<user_function>> get_user_functions(const sstring& keyspace);
+    std::vector<shared_ptr<user_aggregate>> get_user_aggregates(const sstring& keyspace);
+    boost::iterator_range<declared_t::iterator> find(const function_name& name);
+    declared_t::iterator find_iter(const function_name& name, const std::vector<data_type>& arg_types);
+    shared_ptr<function> find(const function_name& name, const std::vector<data_type>& arg_types);
+    shared_ptr<function> mock_get(const function_name& name, const std::vector<data_type>& arg_types);
+    void clear_functions() noexcept;
+    void add_function(shared_ptr<function>);
+    void replace_function(shared_ptr<function>);
+    void remove_function(const function_name& name, const std::vector<data_type>& arg_types);
+    std::optional<function_name> used_by_user_aggregate(shared_ptr<user_function>);
+    std::optional<function_name> used_by_user_function(const ut_name& user_type);
 private:
     template <typename F>
-    static void with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, F&& f);
+    void with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, F&& f);
 
     template <typename F>
-    static std::vector<shared_ptr<F>> get_filtered_transformed(const sstring& keyspace);
+    std::vector<shared_ptr<F>> get_filtered_transformed(const sstring& keyspace);
 
     // This method and matchArguments are somewhat duplicate, but this method allows us to provide more precise errors in the common
     // case where there is no override for a given function. This is thus probably worth the minor code duplication.
-    static void validate_types(data_dictionary::database db,
+    void validate_types(data_dictionary::database db,
                               const sstring& keyspace,
                               const schema* schema_opt,
                               shared_ptr<function> fun,
                               const std::vector<shared_ptr<assignment_testable>>& provided_args,
                               const sstring& receiver_ks,
                               std::optional<const std::string_view> receiver_cf);
-    static assignment_testable::test_result match_arguments(data_dictionary::database db, const sstring& keyspace,
+    assignment_testable::test_result match_arguments(data_dictionary::database db, const sstring& keyspace,
             const schema* schema_opt,
             shared_ptr<function> fun,
             const std::vector<shared_ptr<assignment_testable>>& provided_args,
             const sstring& receiver_ks,
             std::optional<const std::string_view> receiver_cf);
 
-    static bool type_equals(const std::vector<data_type>& t1, const std::vector<data_type>& t2);
+    bool type_equals(const std::vector<data_type>& t1, const std::vector<data_type>& t2);
 };
+
+// Getter for static functions object.
+functions& instance();
 
 }
 }

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -39,7 +39,7 @@ protected:
     functions(skip_init) {};
 public:
     lw_shared_ptr<column_specification> make_arg_spec(const sstring& receiver_ks, std::optional<const std::string_view> receiver_cf,
-            const function& fun, size_t i);
+            const function& fun, size_t i) const;
 
     functions() : _declared(init()) {}
 
@@ -49,7 +49,7 @@ public:
                                     const std::vector<shared_ptr<assignment_testable>>& provided_args,
                                     const sstring& receiver_ks,
                                     std::optional<const std::string_view> receiver_cf,
-                                    const column_specification* receiver = nullptr);
+                                    const column_specification* receiver = nullptr) const;
     template <typename AssignmentTestablePtrRange>
     shared_ptr<function> get(data_dictionary::database db,
                                     const sstring& keyspace,
@@ -57,29 +57,27 @@ public:
                                     AssignmentTestablePtrRange&& provided_args,
                                     const sstring& receiver_ks,
                                     std::optional<const std::string_view> receiver_cf,
-                                    const column_specification* receiver = nullptr) {
+                                    const column_specification* receiver = nullptr) const {
         const std::vector<shared_ptr<assignment_testable>> args(std::begin(provided_args), std::end(provided_args));
         return get(db, keyspace, name, args, receiver_ks, receiver_cf, receiver);
     }
-    std::vector<shared_ptr<user_function>> get_user_functions(const sstring& keyspace);
-    std::vector<shared_ptr<user_aggregate>> get_user_aggregates(const sstring& keyspace);
-    boost::iterator_range<declared_t::iterator> find(const function_name& name);
-    declared_t::iterator find_iter(const function_name& name, const std::vector<data_type>& arg_types);
-    shared_ptr<function> find(const function_name& name, const std::vector<data_type>& arg_types);
-    shared_ptr<function> mock_get(const function_name& name, const std::vector<data_type>& arg_types);
-    // Used only by unittest.
-    void clear_functions() noexcept;
+    std::vector<shared_ptr<user_function>> get_user_functions(const sstring& keyspace) const;
+    std::vector<shared_ptr<user_aggregate>> get_user_aggregates(const sstring& keyspace) const;
+    boost::iterator_range<declared_t::const_iterator> find(const function_name& name) const;
+    declared_t::const_iterator find_iter(const function_name& name, const std::vector<data_type>& arg_types) const;
+    shared_ptr<function> find(const function_name& name, const std::vector<data_type>& arg_types) const;
+    shared_ptr<function> mock_get(const function_name& name, const std::vector<data_type>& arg_types) const;
     void add_function(shared_ptr<function>);
     void replace_function(shared_ptr<function>);
     void remove_function(const function_name& name, const std::vector<data_type>& arg_types);
-    std::optional<function_name> used_by_user_aggregate(shared_ptr<user_function>);
-    std::optional<function_name> used_by_user_function(const ut_name& user_type);
+    std::optional<function_name> used_by_user_aggregate(shared_ptr<user_function>) const;
+    std::optional<function_name> used_by_user_function(const ut_name& user_type) const;
 private:
     template <typename F>
     void with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, F&& f);
 
     template <typename F>
-    std::vector<shared_ptr<F>> get_filtered_transformed(const sstring& keyspace);
+    std::vector<shared_ptr<F>> get_filtered_transformed(const sstring& keyspace) const;
 
     // This method and matchArguments are somewhat duplicate, but this method allows us to provide more precise errors in the common
     // case where there is no override for a given function. This is thus probably worth the minor code duplication.
@@ -89,19 +87,19 @@ private:
                               shared_ptr<function> fun,
                               const std::vector<shared_ptr<assignment_testable>>& provided_args,
                               const sstring& receiver_ks,
-                              std::optional<const std::string_view> receiver_cf);
+                              std::optional<const std::string_view> receiver_cf) const;
     assignment_testable::test_result match_arguments(data_dictionary::database db, const sstring& keyspace,
             const schema* schema_opt,
             shared_ptr<function> fun,
             const std::vector<shared_ptr<assignment_testable>>& provided_args,
             const sstring& receiver_ks,
-            std::optional<const std::string_view> receiver_cf);
+            std::optional<const std::string_view> receiver_cf) const;
 
-    bool type_equals(const std::vector<data_type>& t1, const std::vector<data_type>& t2);
+    bool type_equals(const std::vector<data_type>& t1, const std::vector<data_type>& t2) const;
 };
 
 // Getter for static functions object.
-functions& instance();
+const functions& instance();
 
 class change_batch : public functions {
 public:
@@ -112,6 +110,9 @@ public:
 
     // Commit allows to atomically apply changes to main functions instance.
     void commit();
+
+    // Used only by unittest.
+    void clear_functions() noexcept;
 };
 
 }

--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -199,7 +199,7 @@ future<std::vector<description>> types(replica::database& db, const lw_shared_pt
 }
     
 future<std::vector<description>> function(replica::database& db, const sstring& ks, const sstring& name) {
-    auto fs = functions::functions::find(functions::function_name(ks, name));
+    auto fs = functions::instance().find(functions::function_name(ks, name));
     if (fs.empty()) {
         throw exceptions::invalid_request_exception(format("Function '{}' not found in keyspace '{}'", name, ks));
     }
@@ -217,14 +217,14 @@ future<std::vector<description>> function(replica::database& db, const sstring& 
 }
 
 future<std::vector<description>> functions(replica::database& db,const sstring& ks, bool with_stmt = false) {
-    auto udfs = cql3::functions::functions::get_user_functions(ks);
+    auto udfs = cql3::functions::instance().get_user_functions(ks);
     auto elements = boost::copy_range<std::vector<shared_ptr<const keyspace_element>>>(udfs);
 
     co_return co_await generate_descriptions(db, elements, (with_stmt) ? std::optional(true) : std::nullopt);
 }
 
 future<std::vector<description>> aggregate(replica::database& db, const sstring& ks, const sstring& name) {
-    auto fs = functions::functions::find(functions::function_name(ks, name));
+    auto fs = functions::instance().find(functions::function_name(ks, name));
     if (fs.empty()) {
         throw exceptions::invalid_request_exception(format("Aggregate '{}' not found in keyspace '{}'", name, ks));
     }
@@ -242,7 +242,7 @@ future<std::vector<description>> aggregate(replica::database& db, const sstring&
 }
 
 future<std::vector<description>> aggregates(replica::database& db, const sstring& ks, bool with_stmt = false) {
-    auto udas = functions::functions::get_user_aggregates(ks);
+    auto udas = functions::instance().get_user_aggregates(ks);
     auto elements = boost::copy_range<std::vector<shared_ptr<const keyspace_element>>>(udas);
 
     co_return co_await generate_descriptions(db, elements, (with_stmt) ? std::optional(true) : std::nullopt);
@@ -762,7 +762,7 @@ future<std::vector<std::vector<bytes_opt>>> generic_describe_statement::describe
         co_return serialize_descriptions({type(replica_db, ks_meta, _name)});
     }
 
-    auto uf = functions::functions::find(functions::function_name(ks_name, _name));
+    auto uf = functions::instance().find(functions::function_name(ks_name, _name));
     if (!uf.empty()) {
         auto udfs = boost::copy_range<std::vector<shared_ptr<const keyspace_element>>>(uf | boost::adaptors::transformed([] (const auto& f) {
             return dynamic_pointer_cast<const functions::user_function>(f.second);

--- a/cql3/statements/drop_function_statement.cc
+++ b/cql3/statements/drop_function_statement.cc
@@ -33,7 +33,7 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_w
         if (!user_func) {
             throw exceptions::invalid_request_exception(format("'{}' is not a user defined function", func));
         }
-        if (auto aggregate = functions::functions::used_by_user_aggregate(user_func)) {
+        if (auto aggregate = functions::instance().used_by_user_aggregate(user_func)) {
             throw exceptions::invalid_request_exception(format("Cannot delete function {}, as it is used by user-defined aggregate {}", func, *aggregate));
         }
         auto muts = co_await service::prepare_function_drop_announcement(qp.proxy(), user_func, mc.write_timestamp());

--- a/cql3/statements/drop_type_statement.cc
+++ b/cql3/statements/drop_type_statement.cc
@@ -108,7 +108,7 @@ bool drop_type_statement::validate_while_executing(query_processor& qp) const {
             }
         }
 
-        if (auto&& fun_name = functions::functions::used_by_user_function(_name)) {
+        if (auto&& fun_name = functions::instance().used_by_user_function(_name)) {
             throw exceptions::invalid_request_exception(format("Cannot drop user type {}.{} as it is still used by function {}", keyspace, type->get_name_as_string(), *fun_name));
         }
         return true;

--- a/cql3/statements/function_statement.cc
+++ b/cql3/statements/function_statement.cc
@@ -34,12 +34,12 @@ future<> drop_function_statement_base::check_access(query_processor& qp, const s
     create_arg_types(qp);
     shared_ptr<functions::function> func;
     if (_args_present) {
-        func = functions::functions::find(_name, _arg_types);
+        func = functions::instance().find(_name, _arg_types);
         if (!func) {
             return make_ready_future<>();
         }
     } else {
-        auto funcs = functions::functions::find(_name);
+        auto funcs = functions::instance().find(_name);
         if (!funcs.empty()) {
             auto b = funcs.begin();
             auto i = b;
@@ -121,7 +121,7 @@ create_function_statement_base::create_function_statement_base(functions::functi
 
 seastar::future<shared_ptr<functions::function>> create_function_statement_base::validate_while_executing(query_processor& qp) const {
     create_arg_types(qp);
-    auto old = functions::functions::find(_name, _arg_types);
+    auto old = functions::instance().find(_name, _arg_types);
     if (!old || _or_replace) {
         co_return co_await create(qp, old.get());
     }
@@ -139,12 +139,12 @@ seastar::future<shared_ptr<db::functions::function>> drop_function_statement_bas
     create_arg_types(qp);
     shared_ptr<functions::function> func;
     if (_args_present) {
-        func = functions::functions::find(_name, _arg_types);
+        func = functions::instance().find(_name, _arg_types);
         if (!func && !_if_exists) {
             throw exceptions::invalid_request_exception(format("User function {}({}) doesn't exist", _name, _arg_types));
         }
     } else {
-        auto funcs = functions::functions::find(_name);
+        auto funcs = functions::instance().find(_name);
         if (!funcs.empty()) {
             auto b = funcs.begin();
             auto i = b;

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -49,6 +49,7 @@
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/rpc/rpc_types.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/on_internal_error.hh>
@@ -1893,7 +1894,7 @@ static seastar::future<shared_ptr<cql3::functions::user_function>> create_func(r
             row.get_nonnull<bool>("called_on_null_input"), std::move(*ctx));
 }
 
-static shared_ptr<cql3::functions::user_aggregate> create_aggregate(replica::database& db, const query::result_set_row& row, const query::result_set_row* scylla_row) {
+static shared_ptr<cql3::functions::user_aggregate> create_aggregate(replica::database& db, const query::result_set_row& row, const query::result_set_row* scylla_row, cql3::functions::change_batch& batch) {
     cql3::functions::function_name name{
             row.get_nonnull<sstring>("keyspace_name"), row.get_nonnull<sstring>("aggregate_name")};
     auto arg_types = read_arg_types(db, row, name.keyspace);
@@ -1902,10 +1903,20 @@ static shared_ptr<cql3::functions::user_aggregate> create_aggregate(replica::dat
     auto ffunc = row.get<sstring>("final_func");
     auto initcond_str = row.get<sstring>("initcond");
 
+    auto find_func = [&batch] (sstring ks, sstring name, const std::vector<data_type>& arg_types) {
+        // first search current batch because aggregate may depend on functions
+        // we're currently adding
+        auto fname = cql3::functions::function_name{std::move(ks), std::move(name)};
+        auto func = batch.find(fname, arg_types);
+        if (!func) {
+            func = cql3::functions::instance().find(fname, arg_types);
+        }
+        return func;
+    };
+
     std::vector<data_type> acc_types{state_type};
     acc_types.insert(acc_types.end(), arg_types.begin(), arg_types.end());
-    auto state_func = dynamic_pointer_cast<cql3::functions::scalar_function>(
-            cql3::functions::instance().find(cql3::functions::function_name{name.keyspace, sfunc}, acc_types));
+    auto state_func = dynamic_pointer_cast<cql3::functions::scalar_function>(find_func(name.keyspace, sfunc, acc_types));
     if (!state_func) {
         throw std::runtime_error(format("State function {} needed by aggregate {} not found", sfunc, name.name));
     }
@@ -1916,7 +1927,7 @@ static shared_ptr<cql3::functions::user_aggregate> create_aggregate(replica::dat
     ::shared_ptr<cql3::functions::scalar_function> reduce_func = nullptr;
     if (scylla_row) {
         auto rfunc_name = scylla_row->get<sstring>("reduce_func");
-        auto rfunc = cql3::functions::instance().find(cql3::functions::function_name{name.keyspace, rfunc_name.value()}, {state_type, state_type});
+        auto rfunc = find_func(name.keyspace, rfunc_name.value(), {state_type, state_type});
         if (!rfunc) {
             throw std::runtime_error(format("Reduce function {} needed by aggregate {} not found", rfunc_name.value(), name.name));
         }
@@ -1929,7 +1940,7 @@ static shared_ptr<cql3::functions::user_aggregate> create_aggregate(replica::dat
     ::shared_ptr<cql3::functions::scalar_function> final_func = nullptr;
     if (ffunc) {
         final_func = dynamic_pointer_cast<cql3::functions::scalar_function>(
-            cql3::functions::instance().find(cql3::functions::function_name{name.keyspace, ffunc.value()}, {state_type}));
+                find_func(name.keyspace, ffunc.value(), {state_type}));
         if (!final_func) {
             throw std::runtime_error(format("Final function {} needed by aggregate {} not found", ffunc.value(), name.name));
         }
@@ -1960,21 +1971,29 @@ static future<> merge_functions(distributed<service::storage_proxy>& proxy, sche
     auto diff = diff_rows(before, after);
 
     co_await proxy.local().get_db().invoke_on_all(coroutine::lambda([&] (replica::database& db) -> future<> {
+        cql3::functions::change_batch batch;
         for (const auto& val : diff.created) {
-            cql3::functions::instance().add_function(co_await create_func(db, *val));
+            batch.add_function(co_await create_func(db, *val));
         }
+        auto events = make_ready_future<>();
         for (const auto& val : diff.dropped) {
             cql3::functions::function_name name{
                 val->get_nonnull<sstring>("keyspace_name"), val->get_nonnull<sstring>("function_name")};
             auto arg_types = read_arg_types(db, *val, name.keyspace);
+            // as we don't yield between dropping cache and committing batch
+            // change there is no window between cache removal and declaration removal
             drop_cached_func(db, *val);
-            cql3::functions::instance().remove_function(name, arg_types);
-            co_await db.get_notifier().drop_function(name, arg_types);
+            batch.remove_function(name, arg_types);
+            events = events.then([&db, name, arg_types] () {
+                return db.get_notifier().drop_function(std::move(name), std::move(arg_types));
+            });
         }
         for (const auto& val : diff.altered) {
             drop_cached_func(db, *val);
-            cql3::functions::instance().replace_function(co_await create_func(db, *val));
+            batch.replace_function(co_await create_func(db, *val));
         }
+        batch.commit();
+        co_await std::move(events);
     }));
 }
 
@@ -1983,16 +2002,22 @@ static future<> merge_aggregates(distributed<service::storage_proxy>& proxy, sch
     auto diff = diff_aggregates_rows(before, after, scylla_before, scylla_after);
 
     co_await proxy.local().get_db().invoke_on_all([&] (replica::database& db)-> future<> {
+        cql3::functions::change_batch batch;
         for (const auto& val : diff.created) {
-            cql3::functions::instance().add_function(create_aggregate(db, *val.first, val.second));
+            batch.add_function(create_aggregate(db, *val.first, val.second, batch));
         }
+        auto events = make_ready_future<>();
         for (const auto& val : diff.dropped) {
             cql3::functions::function_name name{
                 val.first->get_nonnull<sstring>("keyspace_name"), val.first->get_nonnull<sstring>("aggregate_name")};
             auto arg_types = read_arg_types(db, *val.first, name.keyspace);
-            cql3::functions::instance().remove_function(name, arg_types);
-            co_await db.get_notifier().drop_aggregate(name, arg_types);
+            batch.remove_function(name, arg_types);
+            events = events.then([&db, name, arg_types] () {
+                return db.get_notifier().drop_aggregate(std::move(name), std::move(arg_types));
+            });
         }
+        batch.commit();
+        co_await std::move(events);
     });
 }
 
@@ -2192,7 +2217,7 @@ seastar::future<std::vector<shared_ptr<cql3::functions::user_function>>> create_
 }
 
 std::vector<shared_ptr<cql3::functions::user_aggregate>> create_aggregates_from_schema_partition(
-        replica::database& db, lw_shared_ptr<query::result_set> result, lw_shared_ptr<query::result_set> scylla_result) {
+        replica::database& db, lw_shared_ptr<query::result_set> result, lw_shared_ptr<query::result_set> scylla_result, cql3::functions::change_batch& batch) {
     std::unordered_multimap<sstring, const query::result_set_row*> scylla_aggs;
     if (scylla_result) {
         for (const auto& scylla_row : scylla_result->rows()) {
@@ -2213,7 +2238,7 @@ std::vector<shared_ptr<cql3::functions::user_aggregate>> create_aggregates_from_
                 break;
             }
         }
-        ret.emplace_back(create_aggregate(db, row, scylla_row_ptr));
+        ret.emplace_back(create_aggregate(db, row, scylla_row_ptr, batch));
     }
     return ret;
 }

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "cql3/functions/functions.hh"
 #include "mutation/mutation.hh"
 #include "schema/schema_fwd.hh"
 #include "schema_features.hh"
@@ -217,7 +218,7 @@ future<std::vector<user_type>> create_types_from_schema_partition(keyspace_metad
 
 seastar::future<std::vector<shared_ptr<cql3::functions::user_function>>> create_functions_from_schema_partition(replica::database& db, lw_shared_ptr<query::result_set> result);
 
-std::vector<shared_ptr<cql3::functions::user_aggregate>> create_aggregates_from_schema_partition(replica::database& db, lw_shared_ptr<query::result_set> result, lw_shared_ptr<query::result_set> scylla_result);
+std::vector<shared_ptr<cql3::functions::user_aggregate>> create_aggregates_from_schema_partition(replica::database& db, lw_shared_ptr<query::result_set> result, lw_shared_ptr<query::result_set> scylla_result, cql3::functions::change_batch& batch);
 
 std::vector<mutation> make_create_function_mutations(shared_ptr<cql3::functions::user_function> func, api::timestamp_type timestamp);
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -697,21 +697,23 @@ future<> database::parse_system_tables(distributed<service::storage_proxy>& prox
         }
         co_return;
     }));
+    cql3::functions::change_batch batch;
     co_await do_parse_schema_tables(proxy, db::schema_tables::FUNCTIONS, coroutine::lambda([&] (schema_result_value_type& v) -> future<> {
         auto&& user_functions = co_await create_functions_from_schema_partition(*this, v.second);
         for (auto&& func : user_functions) {
-            cql3::functions::instance().add_function(func);
+            batch.add_function(func);
         }
         co_return;
     }));
     co_await do_parse_schema_tables(proxy, db::schema_tables::AGGREGATES, coroutine::lambda([&] (schema_result_value_type& v) -> future<> {
         auto v2 = co_await read_schema_partition_for_keyspace(proxy, db::schema_tables::SCYLLA_AGGREGATES, v.first);
-        auto&& user_aggregates = create_aggregates_from_schema_partition(*this, v.second, v2.second);
+        auto&& user_aggregates = create_aggregates_from_schema_partition(*this, v.second, v2.second, batch);
         for (auto&& agg : user_aggregates) {
-            cql3::functions::instance().add_function(agg);
+            batch.add_function(agg);
         }
         co_return;
     }));
+    batch.commit();
     co_await do_parse_schema_tables(proxy, db::schema_tables::TABLES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
         std::map<sstring, schema_ptr> tables = co_await create_tables_from_tables_partition(proxy, v.second);
         co_await coroutine::parallel_for_each(tables.begin(), tables.end(), [&] (auto& t) -> future<> {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -700,7 +700,7 @@ future<> database::parse_system_tables(distributed<service::storage_proxy>& prox
     co_await do_parse_schema_tables(proxy, db::schema_tables::FUNCTIONS, coroutine::lambda([&] (schema_result_value_type& v) -> future<> {
         auto&& user_functions = co_await create_functions_from_schema_partition(*this, v.second);
         for (auto&& func : user_functions) {
-            cql3::functions::functions::add_function(func);
+            cql3::functions::instance().add_function(func);
         }
         co_return;
     }));
@@ -708,7 +708,7 @@ future<> database::parse_system_tables(distributed<service::storage_proxy>& prox
         auto v2 = co_await read_schema_partition_for_keyspace(proxy, db::schema_tables::SCYLLA_AGGREGATES, v.first);
         auto&& user_aggregates = create_aggregates_from_schema_partition(*this, v.second, v2.second);
         for (auto&& agg : user_aggregates) {
-            cql3::functions::functions::add_function(agg);
+            cql3::functions::instance().add_function(agg);
         }
         co_return;
     }));

--- a/service/mapreduce_service.cc
+++ b/service/mapreduce_service.cc
@@ -166,7 +166,7 @@ static std::vector<::shared_ptr<db::functions::aggregate_function>> get_function
             }
 
             auto name = db::functions::function_name::native_function("countRows");
-            auto func = cql3::functions::functions::find(name, {});
+            auto func = cql3::functions::instance().find(name, {});
             aggr = dynamic_pointer_cast<db::functions::aggregate_function>(func);
             if (!aggr) {
                 throw std::runtime_error("Count function not found.");
@@ -175,7 +175,7 @@ static std::vector<::shared_ptr<db::functions::aggregate_function>> get_function
             auto& info = request.aggregation_infos.value()[i];
             auto types = boost::copy_range<std::vector<data_type>>(info.column_names | boost::adaptors::transformed(name_as_type));
             
-            auto func = cql3::functions::functions::mock_get(info.name, types);
+            auto func = cql3::functions::instance().mock_get(info.name, types);
             if (!func) {
                 throw std::runtime_error(format("Cannot mock aggregate function {}", info.name));    
             }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -417,7 +417,7 @@ public:
             // FIXME: make the function storage non static
             auto clear_funcs = defer([] {
                 smp::invoke_on_all([] () {
-                    cql3::functions::functions::clear_functions();
+                    cql3::functions::instance().clear_functions();
                 }).get();
             });
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -417,7 +417,9 @@ public:
             // FIXME: make the function storage non static
             auto clear_funcs = defer([] {
                 smp::invoke_on_all([] () {
-                    cql3::functions::instance().clear_functions();
+                    cql3::functions::change_batch batch;
+                    batch.clear_functions();
+                    batch.commit();
                 }).get();
             });
 


### PR DESCRIPTION
This is the first patch from series which would allow us to unify raft command code. Property we want to achieve is that all modifications performed by a single raft command can be made visible atomically. This helps to exclude accidental dependencies across subsystem updates and make easier to reason about state.

Here we alter functions schema code so that changes are first applied to a copy of declared functions and then made visible atomically. Later work will apply similar strategy to the whole schema.

Relates scylladb/scylladb#19153