### PR TITLE
s3/client: Unmark put-object lambdas from mutable

### DIFF
--- a/utils/memory_data_sink.hh
+++ b/utils/memory_data_sink.hh
@@ -23,6 +23,7 @@ class memory_data_sink_buffers {
 public:
     size_t size() const { return _size; }
     buffers_type& buffers() { return _bufs; }
+    const buffers_type& buffers() const { return _bufs; }
 
     // Strong exception guarantees
     void put(temporary_buffer<char>&& buf) {

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -403,7 +403,7 @@ future<> client::put_object(sstring object_name, temporary_buffer<char> buf) {
     s3l.trace("PUT {}", object_name);
     auto req = http::request::make("PUT", _host, object_name);
     auto len = buf.size();
-    req.write_body("bin", len, [buf = std::move(buf)] (output_stream<char>&& out_) mutable -> future<> {
+    req.write_body("bin", len, [buf = std::move(buf)] (output_stream<char>&& out_) -> future<> {
         auto out = std::move(out_);
         std::exception_ptr ex;
         try {
@@ -427,7 +427,7 @@ future<> client::put_object(sstring object_name, ::memory_data_sink_buffers bufs
     s3l.trace("PUT {} (buffers)", object_name);
     auto req = http::request::make("PUT", _host, object_name);
     auto len = bufs.size();
-    req.write_body("bin", len, [bufs = std::move(bufs)] (output_stream<char>&& out_) mutable -> future<> {
+    req.write_body("bin", len, [bufs = std::move(bufs)] (output_stream<char>&& out_) -> future<> {
         auto out = std::move(out_);
         std::exception_ptr ex;
         try {


### PR DESCRIPTION
They don't need to modify the captured objects. In fact, they must not do it in the first place, because the request can be called more than once and the buffers must not change between those invocations.

For the memory_sink_buffers there must be const method to get the vector of temporary_buffers themselves.
