### PR TITLE
reader_concurrency_semaphore: execution_loop(): move maybe_admit_waiters() to the inner loop

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -938,12 +938,15 @@ future<> reader_concurrency_semaphore::execution_loop() noexcept {
                 e.pr.set_exception(std::current_exception());
             }
 
+            // We now possibly have >= CPU concurrency, so even if the above read
+            // didn't release any resources, just dequeueing it from the
+            // _ready_list could allow us to admit new reads.
+            maybe_admit_waiters();
+
             if (need_preempt()) {
                 co_await coroutine::maybe_yield();
             }
         }
-
-        maybe_admit_waiters();
     }
 }
 


### PR DESCRIPTION
Now that the CPU concurency limit is configurable, new reads might be ready to execute right after the current one was executed. So move the check for admission into the inner loop, to prevent the situation where the loop yields and do_wait_admission() finds that there are waiters while it is possible to admit a new read, spamming the logs with the warning about this situation.

Refs: scylladb/scylladb#19017

Has to be backported everywhere https://github.com/scylladb/scylladb/pull/19018 is backported to.