### PR TITLE
sstables::maybe_rebuild_filter_from_index: log sstable origin

### DIFF
--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1470,7 +1470,7 @@ void writer::consume_end_of_stream() {
         _sst._schema, _sst.get_first_decorated_key(), _sst.get_last_decorated_key(), _enc_stats);
     close_data_writer();
     _sst.write_summary();
-    _sst.maybe_rebuild_filter_from_index(_num_partitions_consumed);
+    _sst.maybe_rebuild_filter_from_index(_num_partitions_consumed, _cfg.origin);
     _sst.write_filter();
     _sst.write_statistics();
     _sst.write_compression();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1410,7 +1410,7 @@ void sstable::write_filter() {
     write_simple<component_type::Filter>(filter_ref);
 }
 
-void sstable::maybe_rebuild_filter_from_index(uint64_t num_partitions) {
+void sstable::maybe_rebuild_filter_from_index(uint64_t num_partitions, sstring origin) {
     if (!has_component(component_type::Filter)) {
         return;
     }
@@ -1440,8 +1440,8 @@ void sstable::maybe_rebuild_filter_from_index(uint64_t num_partitions) {
     // Replace the existing filter with a new one that can optimally represent the given num_partitions.
     // The rebuilding is done in-place as this method is only called before the sstable is sealed.
     _components->filter = utils::i_filter::get_filter(num_partitions, _schema->bloom_filter_fp_chance(), get_filter_format(_version));
-    sstlog.info("Rebuilding bloom filter {}: resizing bitset from {} bytes to {} bytes.", filename(component_type::Filter), curr_bitset_size,
-                static_cast<utils::filter::bloom_filter*>(_components->filter.get())->bits().memory_size());
+    sstlog.info("Rebuilding bloom filter {}: resizing bitset from {} bytes to {} bytes. sstable origin: {}", filename(component_type::Filter), curr_bitset_size,
+                static_cast<utils::filter::bloom_filter*>(_components->filter.get())->bits().memory_size(), origin);
 
     auto index_file = open_file(component_type::Index, open_flags::ro).get();
     auto index_file_closer = deferred_action([&index_file] {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -658,7 +658,7 @@ private:
     // partitions, if the partition estimate provided during bloom
     // filter initialisation was not good.
     // This should be called only before an sstable is sealed.
-    void maybe_rebuild_filter_from_index(uint64_t num_partitions);
+    void maybe_rebuild_filter_from_index(uint64_t num_partitions, sstring origin);
 
     future<> read_summary() noexcept;
 


### PR DESCRIPTION
Log the sstable origin when its bloom filter is being rebuilt. The origin has to be passed to the method by the caller as it is not available in the sstable object when the filter is rebuilt.