### PR TITLE
config, option_set: allow round-trip string conversion

### DIFF
--- a/test/cql-pytest/test_guardrail_replication_strategy.py
+++ b/test/cql-pytest/test_guardrail_replication_strategy.py
@@ -146,3 +146,12 @@ def test_given_restrict_replication_simplestrategy_when_it_is_set_should_emulate
         config_modifications.enter_context(config_value_context(cql, 'restrict_replication_simplestrategy', 'warn'))
         create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : 'SimpleStrategy', 'replication_factor' : 3 }}",
                                                  warnings_count=1, fails_count=0)
+
+def test_config_replication_strategy_warn_list_roundtrips_quotes(cql):
+    # Use direct SELECT/UPDATE to avoid trippy config_value_context behavior
+    value = cql.execute("SELECT value FROM system.config WHERE name = 'replication_strategy_warn_list'").one().value
+    assert value == '["SimpleStrategy"]' # our lovely default
+    # try without quotes
+    cql.execute("UPDATE system.config SET value = '[SimpleStrategy]' WHERE name = 'replication_strategy_warn_list'")
+    # reproduces #
+    cql.execute("UPDATE system.config SET value = '[\"SimpleStrategy\"]' WHERE name = 'replication_strategy_warn_list'")

--- a/utils/enum_option.hh
+++ b/utils/enum_option.hh
@@ -17,6 +17,7 @@
 #include <sstream>
 #include <type_traits>
 #include <fmt/ostream.h>
+#include <concepts>
 
 template<typename T>
 concept HasMapInterface = requires(T t) {
@@ -102,6 +103,11 @@ class enum_option {
     friend std::istream& operator>>(std::istream& s, enum_option<Mapper>& opt) {
         typename map_t::key_type key;
         s >> key;
+        if constexpr (requires { requires std::ranges::range<typename map_t::key_type>;  requires std::same_as<typename map_t::key_type::value_type, char>; }) {
+            if (key.size() >= 2 && key.front() == '"' && key.back() == '"') {
+                key = key.substr(1, key.size() - 2);
+            }
+        }
         auto map = Mapper::map();
         const auto found = map.find(key);
         if (found == map.end()) {


### PR DESCRIPTION
The default configuration for replication_strategy_warn_list is ["SimpleStrategy"], but one cannot set this via CQL:

cqlsh> select * from system.config where name = 'replication_strategy_warn_list';

 name                           | source  | type                      | value
--------------------------------+---------+---------------------------+--------------------
 replication_strategy_warn_list | default | replication strategy list | ["SimpleStrategy"]

(1 rows)
cqlsh> update system.config set value  = '[NetworkTopologyStrategy]' where name = 'replication_strategy_warn_list'; cqlsh> select * from system.config where name = 'replication_strategy_warn_list';

 name                           | source | type                      | value
--------------------------------+--------+---------------------------+-----------------------------
 replication_strategy_warn_list |    cql | replication strategy list | ["NetworkTopologyStrategy"]

(1 rows)
cqlsh> update system.config set value  = '["NetworkTopologyStrategy"]' where name = 'replication_strategy_warn_list'; WriteFailure: Error from server: code=1500 [Replica(s) failed to execute write] message="Operation failed for system.config - received 0 responses and 1 failures from 1 CL=ONE." info={'consistency': 'ONE', 'required_responses': 1, 'received_responses': 0, 'failures': 1}

Fix by allowing quotes in enum_set parsing.

Bug present since 8c464b2ddb100b ("guardrails: restrict replication strategy (RS)", 6.0).

Fixes #19604.

Backport needed for 6.0 - it's confusing if the system doesn't accept the values it itself produces. Pre 6.0 did not have this configuration.