### PR TITLE
nodetool: tasks: add nodetool commands to track task manager tasks

### DIFF
--- a/api/api-doc/task_manager.json
+++ b/api/api-doc/task_manager.json
@@ -197,6 +197,17 @@
                      "paramType":"query"
                   }
                ]
+            },
+            {
+               "method":"GET",
+               "summary":"Get current ttl value",
+               "type":"long",
+               "nickname":"get_ttl",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+               ]
             }
          ]
       }

--- a/api/api-doc/task_manager.json
+++ b/api/api-doc/task_manager.json
@@ -144,6 +144,14 @@
                      "allowMultiple":false,
                      "type":"string",
                      "paramType":"path"
+                  },
+                  {
+                     "name":"timeout",
+                     "description":"Timeout for waiting; if times out, 408 status code is returned",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"long",
+                     "paramType":"query"
                   }
                ]
             }

--- a/api/api-doc/task_manager.json
+++ b/api/api-doc/task_manager.json
@@ -115,7 +115,7 @@
                "parameters":[
                   {
                      "name":"task_id",
-                     "description":"The uuid of a task to abort",
+                     "description":"The uuid of a task to abort; if the task is not abortable, 403 status code is returned",
                      "required":true,
                      "allowMultiple":false,
                      "type":"string",

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -205,6 +205,11 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         }
         co_return json::json_return_type(ttl);
     });
+
+    tm::get_ttl.set(r, [&cfg] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        uint32_t ttl = cfg.task_ttl_seconds();
+        co_return json::json_return_type(ttl);
+    });
 }
 
 void unset_task_manager(http_context& ctx, routes& r) {
@@ -215,6 +220,7 @@ void unset_task_manager(http_context& ctx, routes& r) {
     tm::wait_task.unset(r);
     tm::get_task_status_recursively.unset(r);
     tm::get_and_update_ttl.unset(r);
+    tm::get_ttl.unset(r);
 }
 
 }

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -51,7 +51,7 @@ tm::task_status make_status(tasks::task_status status) {
     res.start_time = st;
     res.end_time = et;
     res.error = status.error;
-    res.parent_id = status.parent_id.to_sstring();
+    res.parent_id = status.parent_id ? status.parent_id.to_sstring() : "none";
     res.sequence_number = status.sequence_number;
     res.shard = status.shard;
     res.keyspace = status.keyspace;

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -155,6 +155,8 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
             co_await task.abort();
         } catch (tasks::task_manager::task_not_found& e) {
             throw bad_param_exception(e.what());
+        } catch (tasks::task_not_abortable& e) {
+            throw httpd::base_exception{e.what(), http::reply::status_type::forbidden};
         }
         co_return json_void();
     });

--- a/docs/dev/task_manager.md
+++ b/docs/dev/task_manager.md
@@ -71,7 +71,7 @@ Briefly:
         gets statuses of the task and all its descendants in BFS
         order, unregisters the task;
 - `/task_manager/ttl` -
-        sets new ttl, returns old value.
+        gets or sets new ttl.
 
 # Virtual tasks
 

--- a/docs/operating-scylla/nodetool-commands/tasks/abort.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/abort.rst
@@ -1,0 +1,22 @@
+Nodetool tasks abort
+====================
+**tasks abort** - Aborts a task manager task with the provided id if the task
+is abortable. If the task is not abortable, the appropriate message with failure
+reason will be printed.
+
+Syntax
+-------
+.. code-block:: console
+
+   nodetool tasks abort <task_id>
+
+For example:
+
+.. code-block:: shell
+
+   > nodetool tasks abort ef1b7a61-66c8-494c-bb03-6f65724e6eee
+
+See also
+--------
+
+-  :doc:`tasks list </operating-scylla/nodetool-commands/tasks/list>`

--- a/docs/operating-scylla/nodetool-commands/tasks/index.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/index.rst
@@ -1,0 +1,29 @@
+Nodetool tasks
+==============
+
+.. toctree::
+   :hidden:
+
+   abort <abort>
+   list <list>
+   modules <modules>
+   status <status>
+   tree <tree>
+   ttl <ttl>
+   wait <wait>
+
+**tasks** - Nodetool supercommand for managing task manager tasks.
+
+Task manager is an API-based tool for tracking long-running background operations, such as repair or compaction,
+which makes them observable and controllable. Task manager operates per node.
+
+Supported tasks suboperations
+-----------------------------
+
+* :doc:`abort </operating-scylla/nodetool-commands/tasks/abort>` - Aborts the task.
+* :doc:`list </operating-scylla/nodetool-commands/tasks/list>` - Lists tasks in the module.
+* :doc:`modules </operating-scylla/nodetool-commands/tasks/modules>` - Lists supported modules.
+* :doc:`status </operating-scylla/nodetool-commands/tasks/status>` - Gets status of the task.
+* :doc:`tree </operating-scylla/nodetool-commands/tasks/tree>` - Gets statuses of the task and all its descendants.
+* :doc:`ttl </operating-scylla/nodetool-commands/tasks/ttl>` - Gets or sets task_ttl value.
+* :doc:`wait </operating-scylla/nodetool-commands/tasks/wait>` - Waits for the task and gets its status.

--- a/docs/operating-scylla/nodetool-commands/tasks/list.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/list.rst
@@ -1,0 +1,64 @@
+Nodetool tasks list
+=========================
+**tasks list** - Gets the list of task manager tasks in a provided module.
+An operation may be repeated if appropriate flags are set.
+
+
+Syntax
+-------
+.. code-block:: console
+
+   nodetool tasks list <module> [--internal] [(--keyspace <keyspace> | -ks <keyspace>)]
+   [(--table <table> | -t <table>)] [--interval <time_in_seconds>] [(--iterations <number> | -i <number>)]
+
+Options
+-------
+
+* ``--internal`` - if set, internal tasks are listed. Internal tasks are the ones that
+  have a parent or cover an operation that is invoked internally.
+* ``--keyspace`` or ``-ks`` - shows only tasks on the specified keyspace.
+* ``--table`` or ``-t`` - shows only tasks on the specified table.
+* ``--interval`` - repeats the operation periodically at specified time intervals.
+* ``--iterations`` or ``-i`` - repeats the operation specified number of times.
+
+For example:
+
+Shows all repair tasks on keyspace `myks` and table `mytable`:
+
+.. code-block:: shell
+
+   > nodetool tasks list repair --internal -ks myks --table mytable
+
+Shows all non-internal compaction tasks and repeats the operation 3 times every 5 seconds:
+
+.. code-block:: shell
+
+   > nodetool tasks list compaction --interval 5 --i 3
+
+Example output
+--------------
+
+For single list:
+
+.. code-block:: shell
+
+    task_id                              type   kind scope    state sequence_number keyspace table entity
+    5116ddb6-85b5-4c3e-94fb-72128f15d7b4 repair node keyspace done  3               abc
+
+With repetition:
+
+.. code-block:: shell
+
+    task_id                              type   kind scope    state sequence_number keyspace table entity
+    d8926ee7-0faf-47b7-bfeb-82477e0c7b33 repair node keyspace done  5               abc
+    1e028cb8-31a3-45ed-8728-af7a1ab586f6 repair node keyspace done  4               abc
+
+    task_id                              type   kind scope    state sequence_number keyspace table entity
+    1e535f9b-97fa-4788-a956-8f3216a6ea8d repair node keyspace done  6               abc
+    d8926ee7-0faf-47b7-bfeb-82477e0c7b33 repair node keyspace done  5               abc
+    1e028cb8-31a3-45ed-8728-af7a1ab586f6 repair node keyspace done  4               abc
+
+See also
+--------
+
+-  :doc:`tasks status </operating-scylla/nodetool-commands/tasks/status>`

--- a/docs/operating-scylla/nodetool-commands/tasks/modules.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/modules.rst
@@ -1,0 +1,17 @@
+Nodetool tasks modules
+===========================
+**tasks modules** - Lists all modules supported by task manager.
+
+Syntax
+-------
+.. code-block:: console
+
+   nodetool tasks modules
+
+Example output
+--------------
+
+.. code-block:: shell
+
+    repair
+    compaction

--- a/docs/operating-scylla/nodetool-commands/tasks/status.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/status.rst
@@ -1,0 +1,47 @@
+Nodetool tasks status
+=========================
+**tasks status** - Gets the status of a task manager task. If the task was finished it is unregistered.
+
+Syntax
+-------
+.. code-block:: console
+
+   nodetool tasks status <task_id>
+
+For example:
+
+.. code-block:: shell
+
+   > nodetool tasks status ef1b7a61-66c8-494c-bb03-6f65724e6eee
+
+Example output
+--------------
+
+.. code-block:: shell
+
+   id: 52b69817-aac7-47bf-9d8d-0b487dd6866a
+   type: repair
+   kind: node
+   scope: keyspace
+   state: done
+   is_abortable: true
+   start_time: 2024-07-29T15:48:55Z
+   end_time: 2024-07-29T15:48:55Z
+   error:
+   parent_id: none
+   sequence_number: 5
+   shard: 0
+   keyspace: abc
+   table:
+   entity:
+   progress_units: ranges
+   progress_total: 4
+   progress_completed: 4
+   children_ids: [{task_id: 9de80fd8-296e-432b-837e-63daf7c93e17, node: 127.0.0.1 }, {task_id: fa1c1338-abd1-4f0c-8ce1-8a806486e5c3, node: 127.0.0.1 }]
+
+See also
+--------
+
+-  :doc:`tasks tree </operating-scylla/nodetool-commands/tasks/tree>`
+-  :doc:`tasks list </operating-scylla/nodetool-commands/tasks/list>`
+-  :doc:`tasks wait </operating-scylla/nodetool-commands/tasks/wait>`

--- a/docs/operating-scylla/nodetool-commands/tasks/tree.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/tree.rst
@@ -1,0 +1,51 @@
+Nodetool tasks tree
+=======================
+**tasks tree** - Gets the statuses of a task manager task and all its descendants.
+The statuses are listed in BFS order. If the task was finished it is unregistered.
+
+If task_id isn't specified, trees of all non-internal tasks are printed
+(internal tasks are the ones that have a parent or cover an operation that
+is invoked internally).
+
+Syntax
+-------
+.. code-block:: console
+
+   nodetool tasks tree [<task_id>]
+
+For example:
+
+.. code-block:: shell
+
+   > nodetool tasks tree 2ef0a5b6-f243-4c01-876f-54539b453766
+
+Example output
+--------------
+
+For single task:
+
+.. code-block:: shell
+
+   id                                   type   kind scope    state is_abortable start_time           end_time             error parent_id                            sequence_number shard keyspace table entity progress_units total completed children_ids
+   be5559ea-bc5a-428c-b8ce-d14eac7a1765 repair node keyspace done  true         2024-07-29T16:06:46Z 2024-07-29T16:06:46Z       none                                 1               0     abc                   ranges         4     4         [{task_id: 542e38cb-9ad4-40aa-9010-de2630004e55, node: 127.0.0.1 }, {task_id: 8974ebcc-1e87-4040-88fe-f2438261f7fb, node: 127.0.0.1 }]
+   542e38cb-9ad4-40aa-9010-de2630004e55 repair node shard    done  false        2024-07-29T16:06:46Z 2024-07-29T16:06:46Z       be5559ea-bc5a-428c-b8ce-d14eac7a1765 1               0     abc                   ranges         2     2         []
+   8974ebcc-1e87-4040-88fe-f2438261f7fb repair node shard    done  false        2024-07-29T16:06:46Z 2024-07-29T16:06:46Z       be5559ea-bc5a-428c-b8ce-d14eac7a1765 1               1     abc                   ranges         2     2         []
+
+For all tasks:
+
+.. code-block:: shell
+
+   id                                   type                   kind    scope    state is_abortable start_time           end_time             error parent_id                            sequence_number shard keyspace table entity progress_units total completed children_ids
+   16eafb1e-8b2e-48e6-bd7a-432ca3d8b9fc repair                 node    keyspace done  true         2024-07-29T16:34:46Z 2024-07-29T16:34:46Z       none                                 1               0     abc                   ranges         4     4         [{task_id: e0aa1aa4-58ca-4bfb-b3e6-74e5f3a0f6ee, node: 127.0.0.1 }, {task_id: 49eb5797-b67e-46b0-9365-4460f7cf988a, node: 127.0.0.1 }]
+   e0aa1aa4-58ca-4bfb-b3e6-74e5f3a0f6ee repair                 node    shard    done  false        2024-07-29T16:34:46Z 2024-07-29T16:34:46Z       16eafb1e-8b2e-48e6-bd7a-432ca3d8b9fc 1               0     abc                   ranges         2     2         []
+   49eb5797-b67e-46b0-9365-4460f7cf988a repair                 node    shard    done  false        2024-07-29T16:34:46Z 2024-07-29T16:34:46Z       16eafb1e-8b2e-48e6-bd7a-432ca3d8b9fc 1               1     abc                   ranges         2     2         []
+   82d7b2a4-146e-4a72-ba93-c66d5b4e9867 offstrategy compaction node    keyspace done  true         2024-07-29T16:34:16Z 2024-07-29T16:34:16Z       none                                 954             0     abc                                  1     1         [{task_id: 9818277b-238d-4298-a56b-c0d2153bf140, node: 127.0.0.1 }, {task_id: c1eb0701-ad7a-45ff-956f-7b8d671fc5db, node: 127.0.0.1 }
+   9818277b-238d-4298-a56b-c0d2153bf140 offstrategy compaction node    shard    done  false        2024-07-29T16:34:16Z 2024-07-29T16:34:16Z       82d7b2a4-146e-4a72-ba93-c66d5b4e9867 954             0     abc                                  1     1         []
+   c1eb0701-ad7a-45ff-956f-7b8d671fc5db offstrategy compaction node    shard    done  false        2024-07-29T16:34:16Z 2024-07-29T16:34:16Z       82d7b2a4-146e-4a72-ba93-c66d5b4e9867 954             1     abc                                  1     1         []
+
+See also
+--------
+
+-  :doc:`tasks status </operating-scylla/nodetool-commands/tasks/status>`
+-  :doc:`tasks list </operating-scylla/nodetool-commands/tasks/list>`
+-  :doc:`tasks wait </operating-scylla/nodetool-commands/tasks/wait>`

--- a/docs/operating-scylla/nodetool-commands/tasks/ttl.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/ttl.rst
@@ -1,0 +1,34 @@
+Nodetool tasks ttl
+==================
+**tasks ttl** - Gets or sets task_ttl value in seconds, i.e. time for which tasks are kept in task manager after
+they are finished.
+
+The new value is set only in memory. To change the configuration, modify ``task_ttl_in_seconds`` in ``scylla.yaml``.
+You can also run Scylla with ``--task-ttl-in-seconds`` parameter.
+
+If task_ttl == 0, tasks are unregistered from task manager immediately after they are finished.
+
+Syntax
+-------
+.. code-block:: console
+
+   nodetool tasks ttl [--set <time_in_seconds>]
+
+Options
+-------
+
+* ``--set`` - sets task_ttl to the specified value.
+
+For example:
+
+Gets task_ttl value:
+
+.. code-block:: shell
+
+   > nodetool tasks ttl
+
+Sets task_ttl value to 10 seconds:
+
+.. code-block:: shell
+
+   > nodetool tasks ttl --set 10

--- a/docs/operating-scylla/nodetool-commands/tasks/wait.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/wait.rst
@@ -1,0 +1,68 @@
+Nodetool tasks wait
+===================
+**tasks wait** - Waits until a task manager task is finished and gets its status.
+If timeout is set and it expires, the appropriate message with failure reason
+will be printed.
+
+Syntax
+-------
+.. code-block:: console
+
+   nodetool tasks wait <task_id> [(--quiet|-q)] [--timeout <time_in_second>]
+
+Options
+-------
+
+* ``--quiet`` or ``-q`` - if set, status of a task isn't printed. Instead the proper exit code is returned:
+
+   * 0 - if task finished successfully
+   * 123 - if task failed
+   * 124 - if request timed out
+   * 125 - if an error occurred and the task status is undetermined
+
+* ``--timeout`` - timeout in seconds.
+
+Syntax
+-------
+.. code-block:: console
+
+   nodetool tasks wait <task_id>
+
+For example:
+
+.. code-block:: shell
+
+   > nodetool tasks wait ef1b7a61-66c8-494c-bb03-6f65724e6eee
+
+Example output
+--------------
+
+.. code-block:: shell
+
+   id : 29dd6552-1e9a-4f17-b2c9-231d088fbee6
+   type : repair
+   kind : node
+   scope : keyspace
+   state : done
+   is_abortable : true
+   start_time : 2024-07-29T17:00:53Z
+   end_time : 2024-07-29T17:00:53Z
+   error :
+   parent_id : none
+   sequence_number : 2
+   shard : 0
+   keyspace : abc
+   table :
+   entity :
+   progress_units : ranges
+   progress_total : 4
+   progress_completed : 4
+   children_ids : [{task_id: 5d74a62e-aaf6-4993-b0f1-973899d89cd0, node: 127.0.0.1 }, {task_id: 055d5a59-d97c-45a8-a7e6-dcad39ed61ca, node: 127.0.0.1 }]
+
+
+See also
+--------
+
+-  :doc:`tasks status </operating-scylla/nodetool-commands/tasks/status>`
+-  :doc:`tasks tree </operating-scylla/nodetool-commands/tasks/tree>`
+-  :doc:`tasks list </operating-scylla/nodetool-commands/tasks/list>`

--- a/docs/operating-scylla/nodetool.rst
+++ b/docs/operating-scylla/nodetool.rst
@@ -54,6 +54,7 @@ Nodetool
    nodetool-commands/status
    Nodetool stop compaction <nodetool-commands/stop>
    nodetool-commands/tablestats
+   nodetool-commands/tasks/index
    nodetool-commands/toppartitions
    nodetool-commands/upgradesstables
    nodetool-commands/viewbuildstatus
@@ -136,6 +137,7 @@ Operations that are not listed below are currently not available.
 * :doc:`stop </operating-scylla/nodetool-commands/stop/>` - Stop compaction operation.
 * **tablehistograms** see :doc:`cfhistograms <nodetool-commands/cfhistograms/>`
 * :doc:`tablestats </operating-scylla/nodetool-commands/tablestats/>` - Provides in-depth diagnostics regard table. 
+* :doc:`tasks </operating-scylla/nodetool-commands/tasks/index>` - Manage tasks manager tasks.
 * :doc:`toppartitions </operating-scylla/nodetool-commands/toppartitions/>` - Samples cluster writes and reads and reports the most active partitions in a specified table and time frame.
 * :doc:`upgradesstables </operating-scylla/nodetool-commands/upgradesstables>` - Upgrades each table that is not running the latest ScyllaDB version, by rewriting SSTables.
 * :doc:`viewbuildstatus </operating-scylla/nodetool-commands/viewbuildstatus/>` - Shows the progress of a materialized view build.

--- a/tasks/task_handler.hh
+++ b/tasks/task_handler.hh
@@ -65,7 +65,7 @@ public:
     {}
     future<task_stats> get_stats();
     future<task_status> get_status();
-    future<task_status> wait_for_task();
+    future<task_status> wait_for_task(std::optional<std::chrono::seconds> timeout);
     future<utils::chunked_vector<task_status>> get_status_recursively(bool local);
     future<> abort();
 private:

--- a/tasks/task_handler.hh
+++ b/tasks/task_handler.hh
@@ -72,4 +72,14 @@ private:
     future<status_helper> get_status_helper();
 };
 
+class task_not_abortable : public std::exception {
+    sstring _cause;
+public:
+    explicit task_not_abortable(task_id tid)
+        : _cause(format("task with id {} cannot be aborted", tid))
+    { }
+
+    virtual const char* what() const noexcept override { return _cause.c_str(); }
+};
+
 }

--- a/test/nodetool/test_help.py
+++ b/test/nodetool/test_help.py
@@ -43,7 +43,7 @@ def test_help_command_too_many_args(nodetool, scylla_only):
             nodetool,
             ("help", "compact", "foo", "bar"),
             {},
-            ["error: too many positional options have been specified on the command line"])
+            ["error processing arguments: unknown command compact foo bar"])
 
 
 def test_help_consistent(nodetool, scylla_only):

--- a/test/nodetool/test_tasks.py
+++ b/test/nodetool/test_tasks.py
@@ -1,0 +1,133 @@
+#
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from test.nodetool.rest_api_mock import expected_request
+from test.nodetool.utils import check_nodetool_fails_with_error_contains
+
+def test_failure(nodetool, scylla_only):
+    check_nodetool_fails_with_error_contains(
+            nodetool,
+            ("tasks"),
+            {"expected_requests": []},
+            ["unrecognized operation argument"])
+
+def test_abort(nodetool, scylla_only):
+    nodetool("tasks", "abort", "675ed9f4-6564-6dbd-can8-43fddce952gy", expected_requests=[
+        expected_request("POST", "/task_manager/abort_task/675ed9f4-6564-6dbd-can8-43fddce952gy")])
+
+    res = nodetool("tasks", "abort", "675ed9f4-6564-6dbd-can8-43fddce952gy", expected_requests=[
+        expected_request("POST", "/task_manager/abort_task/675ed9f4-6564-6dbd-can8-43fddce952gy", response=[], response_status=403)])
+    assert "Task with id 675ed9f4-6564-6dbd-can8-43fddce952gy is not abortable" in res.stdout
+
+def test_abort_failure(nodetool, scylla_only):
+    check_nodetool_fails_with_error_contains(
+            nodetool,
+            ("tasks", "abort"),
+            {"expected_requests": []},
+            ["required parameter is missing"])
+
+def test_list(nodetool, scylla_only):
+    nodetool("tasks", "list", "repair", expected_requests=[
+        expected_request("GET", "/task_manager/list_module_tasks/repair", response=[])])
+
+    params = {
+        "keyspace": "ks",
+        "table": "t"
+    }
+    nodetool("tasks", "list", "compaction", "--keyspace", params["keyspace"], "--table", params["table"],
+        expected_requests=[expected_request("GET", "/task_manager/list_module_tasks/compaction", params, response=[])])
+
+    params = {
+        "internal": "true"
+    }
+    nodetool("tasks", "list", "repair", "--internal", expected_requests=[
+        expected_request("GET", "/task_manager/list_module_tasks/repair", params, response=[])])
+
+    iterations = 2
+    nodetool("tasks", "list", "repair", "--interval", "1", "--iterations", str(iterations), expected_requests=[
+        expected_request("GET", "/task_manager/list_module_tasks/repair", response=[]) for _ in range(0, iterations + 1)])
+
+def test_list_failure(nodetool, scylla_only):
+    check_nodetool_fails_with_error_contains(
+            nodetool,
+            ("tasks", "list"),
+            {"expected_requests": []},
+            ["required parameter is missing"])
+
+    check_nodetool_fails_with_error_contains(
+            nodetool,
+            ("tasks", "list", "repair", "--x"),
+            {"expected_requests": []},
+            ["unrecognised option"])
+
+def test_modules(nodetool, scylla_only):
+    nodetool("tasks", "modules", expected_requests=[
+        expected_request("GET", "/task_manager/list_modules", response=[])])
+
+def test_status(nodetool, scylla_only):
+    nodetool("tasks", "status", "675ed9f4-6564-6dbd-can8-43fddce952gy", expected_requests=[
+        expected_request("GET", "/task_manager/task_status/675ed9f4-6564-6dbd-can8-43fddce952gy")])
+
+def test_status_failure(nodetool, scylla_only):
+    check_nodetool_fails_with_error_contains(
+            nodetool,
+            ("tasks", "status"),
+            {"expected_requests": []},
+            ["required parameter is missing"])
+
+def test_tree(nodetool, scylla_only):
+    nodetool("tasks", "tree", "675ed9f4-6564-6dbd-can8-43fddce952gy", expected_requests=[
+        expected_request("GET", "/task_manager/task_status_recursive/675ed9f4-6564-6dbd-can8-43fddce952gy", response=[])])
+
+    nodetool("tasks", "tree", expected_requests=[
+        expected_request("GET", "/task_manager/list_modules", response=["repair"]),
+        expected_request("GET", "/task_manager/list_module_tasks/repair", response=[{ "task_id": "675ed9f4-6564-6dbd-can8-43fddce952gy" }]),
+        expected_request("GET", "/task_manager/task_status_recursive/675ed9f4-6564-6dbd-can8-43fddce952gy", response=[])])
+
+def test_tree_failure(nodetool, scylla_only):
+    check_nodetool_fails_with_error_contains(
+            nodetool,
+            ("tasks", "tree", "foo", "bar"),
+            {"expected_requests": []},
+            ["cannot be specified more than once"])
+
+def test_ttl(nodetool, scylla_only):
+    nodetool("tasks", "ttl", expected_requests=[
+        expected_request("GET", "/task_manager/ttl")])
+
+    params = { "ttl": "10" }
+    nodetool("tasks", "ttl", "--set", params["ttl"], expected_requests=[
+        expected_request("POST", "/task_manager/ttl", params)])
+
+def test_wait(nodetool, scylla_only):
+    nodetool("tasks", "wait", "675ed9f4-6564-6dbd-can8-43fddce952gy", expected_requests=[
+        expected_request("GET", "/task_manager/wait_task/675ed9f4-6564-6dbd-can8-43fddce952gy")])
+
+    res = nodetool("tasks", "wait", "675ed9f4-6564-6dbd-can8-43fddce952gy", "--timeout", "10", expected_requests=[
+        expected_request("GET", "/task_manager/wait_task/675ed9f4-6564-6dbd-can8-43fddce952gy", params={ "timeout": "10" }, response=[], response_status=408)], check_return_code=False)
+
+def test_wait_quiet(nodetool, scylla_only):
+    nodetool("tasks", "wait", "675ed9f4-6564-6dbd-can8-43fddce952gy", "--quiet", expected_requests=[
+        expected_request("GET", "/task_manager/wait_task/675ed9f4-6564-6dbd-can8-43fddce952gy", response={ "state": "done" })])
+
+    res = nodetool("tasks", "wait", "675ed9f4-6564-6dbd-can8-43fddce952gy", "--quiet", expected_requests=[
+        expected_request("GET", "/task_manager/wait_task/675ed9f4-6564-6dbd-can8-43fddce952gy", response={ "state": "failed" })], check_return_code=False)
+    assert res.returncode == 123
+
+    res = nodetool("tasks", "wait", "675ed9f4-6564-6dbd-can8-43fddce952gy", "--quiet", "--timeout", "10", expected_requests=[
+        expected_request("GET", "/task_manager/wait_task/675ed9f4-6564-6dbd-can8-43fddce952gy", params={ "timeout": "10" }, response=[], response_status=408)], check_return_code=False)
+    assert res.returncode == 124
+
+    res = nodetool("tasks", "wait", "675ed9f4-6564-6dbd-can8-43fddce952gy", "--quiet", expected_requests=[
+        expected_request("GET", "/task_manager/wait_task/675ed9f4-6564-6dbd-can8-43fddce952gy", response=[], response_status=400)], check_return_code=False)
+    assert res.returncode == 125
+
+def test_wait_failure(nodetool, scylla_only):
+    check_nodetool_fails_with_error_contains(
+            nodetool,
+            ("tasks", "wait"),
+            {"expected_requests": []},
+            ["required parameter is missing"])

--- a/test/rest_api/test_task_manager.py
+++ b/test/rest_api/test_task_manager.py
@@ -82,7 +82,7 @@ def test_task_manager_not_abortable(rest_api):
             print(f"created test task {task0}")
 
             resp = rest_api.send("POST", f"task_manager/abort_task/{task0}")
-            assert resp.status_code == requests.codes.internal_server_error, "Aborted unabortable task"
+            assert resp.status_code == requests.codes.forbidden, "Aborted unabortable task"
 
 def wait_and_check_status(rest_api, id, sequence_number, keyspace, table):
     status = wait_for_task(rest_api, id)

--- a/test/topology_tasks/test_node_ops_tasks.py
+++ b/test/topology_tasks/test_node_ops_tasks.py
@@ -22,8 +22,6 @@ from test.topology_tasks.task_manager_types import TaskID, TaskStats, TaskStatus
 
 logger = logging.getLogger(__name__)
 
-empty_task_id = "00000000-0000-0000-0000-000000000000"
-
 async def get_status_allow_peer_connection_failure(tm: TaskManagerClient, node_ip: IPAddress, task_id: TaskID) -> Optional[TaskStatus]:
     ret = await tm.api.client.get_json(f"/task_manager/task_status/{task_id}", host = node_ip, allow_failed = True)
     resp_status = ret.get("code", 200)
@@ -59,7 +57,7 @@ def check_virtual_task_status(virtual_task: TaskStatus, expected_state: str, exp
     assert virtual_task.kind == "cluster"
     assert virtual_task.scope == "cluster"
     assert not virtual_task.is_abortable
-    assert virtual_task.parent_id == empty_task_id
+    assert virtual_task.parent_id == "none"
     assert len(virtual_task.children_ids) == expected_children_num
 
 def check_regular_task_status(task: TaskStatus, expected_state: str, expected_type: str, expected_scope: str,

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -363,6 +363,18 @@ keyspace_and_table parse_keyspace_and_table(scylla_rest_client& client, const bp
 }
 
 using operation_func = void(*)(scylla_rest_client&, const bpo::variables_map&);
+struct operation_action{
+    std::optional<operation_func> func = std::nullopt;
+    std::map<sstring, operation_action> suboperation_funcs = {};
+
+    operation_action(operation_func f)
+        : func(std::move(f))
+    {}
+
+    operation_action(std::map<sstring, operation_action> subfs)
+        : suboperation_funcs(std::move(subfs))
+    {}
+};
 
 std::map<operation, operation_func> get_operations_with_func();
 

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -376,7 +376,7 @@ struct operation_action{
     {}
 };
 
-std::map<operation, operation_func> get_operations_with_func();
+const std::map<operation, operation_action>& get_operations_with_func();
 
 void backup_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     std::unordered_map<sstring, sstring> params;
@@ -2886,9 +2886,9 @@ const std::map<std::string_view, std::string_view> option_substitutions{
     {"-hf", "--hex-format"},
 };
 
-std::map<operation, operation_func> get_operations_with_func() {
+const std::map<operation, operation_action>& get_operations_with_func() {
 
-    const static std::map<operation, operation_func> operations_with_func {
+    const static std::map<operation, operation_action> operations_with_func {
         {
             {
                 "backup",
@@ -2917,7 +2917,9 @@ bootstrapping or decommissioning a node.
 For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/checkandrepaircdcstreams.html")),
             },
-            checkandrepaircdcstreams_operation
+            {
+                checkandrepaircdcstreams_operation
+            }
         },
         {
             {
@@ -2940,7 +2942,9 @@ For more information, see: {}
                     typed_option<std::vector<sstring>>("cleanup_arg", "[<keyspace> <tables>...]", -1),
                 }
             },
-            cleanup_operation
+            {
+                cleanup_operation
+            }
         },
         {
             {
@@ -2958,7 +2962,9 @@ For more information, see: {}
                     typed_option<std::vector<sstring>>("keyspaces", "[<keyspaces>...]", -1),
                 }
             },
-            clearsnapshot_operation
+            {
+                clearsnapshot_operation
+            }
         },
         {
             {
@@ -2988,7 +2994,9 @@ For more information, see: {}
                     typed_option<std::vector<sstring>>("compaction_arg", "[<keyspace> <tables>...] or [<SStable files>...] ", -1),
                 }
             },
-            compact_operation
+            {
+                compact_operation
+            }
         },
         {
             {
@@ -3001,7 +3009,9 @@ For more information, see: {}
                     typed_option<sstring>("format,F", "text", "Output format, one of: (json, yaml or text); defaults to text"),
                 },
             },
-            compactionhistory_operation
+            {
+                compactionhistory_operation
+            }
         },
         {
             {
@@ -3014,7 +3024,9 @@ For more information, see: {}
                     typed_option<bool>("human-readable,H", false, "Display bytes in human readable form, i.e. KiB, MiB, GiB, TiB"),
                 },
             },
-            compactionstats_operation
+            {
+                compactionstats_operation
+            }
         },
         {
             {
@@ -3024,7 +3036,9 @@ fmt::format(R"(
 For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/decommission.html")),
             },
-            decommission_operation
+            {
+                decommission_operation
+            }
         },
         {
             {
@@ -3042,7 +3056,9 @@ For more information, see: {}
                     typed_option<std::vector<sstring>>("table", "The table to describe the ring for (for tablet keyspaces)", -1),
                 },
             },
-            describering_operation
+            {
+                describering_operation
+            }
         },
         {
             {
@@ -3052,7 +3068,9 @@ fmt::format(R"(
 For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/describecluster.html")),
             },
-            describecluster_operation
+            {
+                describecluster_operation
+            }
         },
         {
             {
@@ -3067,7 +3085,9 @@ For more information, see: {}
                     typed_option<std::vector<sstring>>("table", "The table(s) to disable automatic compaction for", -1),
                 }
             },
-            disableautocompaction_operation
+            {
+                disableautocompaction_operation
+            }
         },
         {
             {
@@ -3077,7 +3097,9 @@ fmt::format(R"(
 For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/disablebackup.html")),
             },
-            disablebackup_operation
+            {
+                disablebackup_operation
+            }
         },
         {
             {
@@ -3087,7 +3109,9 @@ fmt::format(R"(
 For more information, see: {}"
 )", doc_link("operating-scylla/nodetool-commands/disablebinary.html")),
             },
-            disablebinary_operation
+            {
+                disablebinary_operation
+            }
         },
         {
             {
@@ -3097,7 +3121,9 @@ fmt::format(R"(
 For more information, see: {}"
 )", doc_link("operating-scylla/nodetool-commands/disablegossip.html")),
             },
-            disablegossip_operation
+            {
+                disablegossip_operation
+            }
         },
         {
             {
@@ -3114,7 +3140,9 @@ flush command.
 For more information, see: {}"
 )", doc_link("operating-scylla/nodetool-commands/drain.html")),
             },
-            drain_operation
+            {
+                drain_operation
+            }
         },
         {
             {
@@ -3129,7 +3157,9 @@ For more information, see: {}"
                     typed_option<std::vector<sstring>>("table", "The table(s) to enable automatic compaction for", -1),
                 }
             },
-            enableautocompaction_operation
+            {
+                enableautocompaction_operation
+            }
         },
         {
             {
@@ -3139,7 +3169,9 @@ fmt::format(R"(
 For more information, see: {}"
 )", doc_link("operating-scylla/nodetool-commands/enablebackup.html")),
             },
-            enablebackup_operation
+            {
+                enablebackup_operation
+            }
         },
         {
             {
@@ -3151,7 +3183,9 @@ The native protocol is enabled by default.
 For more information, see: {}"
 )", doc_link("operating-scylla/nodetool-commands/enablebinary.html")),
             },
-            enablebinary_operation
+            {
+                enablebinary_operation
+            }
         },
         {
             {
@@ -3163,7 +3197,9 @@ The gossip protocol is enabled by default.
 For more information, see: {}"
 )", doc_link("operating-scylla/nodetool-commands/enablegossip.html")),
             },
-            enablegossip_operation
+            {
+                enablegossip_operation
+            }
         },
         {
             {
@@ -3182,7 +3218,9 @@ For more information, see: {}"
                     typed_option<std::vector<sstring>>("table", "The table(s) to flush", -1),
                 }
             },
-            flush_operation
+            {
+                flush_operation
+            }
         },
         {
             {
@@ -3198,7 +3236,9 @@ For more information, see: {}"
                     typed_option<sstring>("key", "The partition key for which we need to find the endpoint", 1),
                 },
             },
-            getendpoints_operation
+            {
+                getendpoints_operation
+            }
         },
         {
             {
@@ -3208,7 +3248,9 @@ R"(
 Prints a table with the name and current logging level for each logger in ScyllaDB.
 )",
             },
-            getlogginglevels_operation
+            {
+                getlogginglevels_operation
+            }
         },
         {
             {
@@ -3226,7 +3268,9 @@ For more information, see: {}"
                     typed_option<sstring>("key", "The partition key for which we need to find the sstables", 1),
                 },
             },
-            getsstables_operation
+            {
+                getsstables_operation
+            }
         },
         {
             {
@@ -3238,7 +3282,9 @@ This value is the probability for tracing a request. To change this value see se
 For more information, see: {}"
 )", doc_link("operating-scylla/nodetool-commands/gettraceprobability.html")),
             },
-            gettraceprobability_operation
+            {
+                gettraceprobability_operation
+            }
         },
         {
             {
@@ -3248,7 +3294,9 @@ fmt::format(R"(
 For more information, see: {}"
 )", doc_link("operating-scylla/nodetool-commands/gossipinfo.html")),
             },
-            gossipinfo_operation
+            {
+                gossipinfo_operation
+            }
         },
         {
             {
@@ -3260,7 +3308,9 @@ For more information, see: {}"
                     typed_option<sstring>("command", "The command to get more information about", 1),
                 },
             },
-            [] (scylla_rest_client&, const bpo::variables_map&) {}
+            {
+                [] (scylla_rest_client&, const bpo::variables_map&) {}
+            }
         },
         {
             {
@@ -3273,7 +3323,9 @@ For more information, see: {}"
                     typed_option<>("tokens,T", "Display all tokens"),
                 },
             },
-            info_operation
+            {
+                info_operation
+            }
         },
         {
             {
@@ -3287,7 +3339,9 @@ For more information, see: {}"
                 { },
                 { },
             },
-            listsnapshots_operation
+            {
+                listsnapshots_operation
+            }
         },
         {
             {
@@ -3301,7 +3355,9 @@ This operation is not supported.
                     typed_option<sstring>("new-token", "The new token to move to this node", 1),
                 },
             },
-            move_operation
+            {
+                move_operation
+            }
         },
         {
             {
@@ -3315,7 +3371,9 @@ For more information, see: {}"
                 },
                 { },
             },
-            netstats_operation
+            {
+                netstats_operation
+            }
         },
         {
             {
@@ -3332,7 +3390,9 @@ For more information, see: {}"
                     typed_option<std::vector<sstring>>("table", "<keyspace> <table>, <keyspace>.<table> or <keyspace>-<table>", 2),
                 }
             },
-            proxyhistograms_operation
+            {
+                proxyhistograms_operation
+            }
         },
         {
             {
@@ -3354,7 +3414,9 @@ For more information, see: {}"
                     typed_option<sstring>("source-dc", "DC from which to stream data (default: any DC)", 1),
                 },
             },
-            rebuild_operation
+            {
+                rebuild_operation
+            }
         },
         {
             {
@@ -3378,7 +3440,9 @@ For more information, see: {}"
                     typed_option<sstring>("table", "The table to load sstable(s) into", 1),
                 },
             },
-            refresh_operation
+            {
+                refresh_operation
+            }
         },
         {
             {
@@ -3399,7 +3463,9 @@ For more information, see: {}"
                     typed_option<sstring>("remove-operation", "status|force|$HOST_ID - show status of current node removal, force completion of pending removal, or remove provided ID", 1),
                 },
             },
-            removenode_operation
+            {
+                removenode_operation
+            }
         },
         {
             {
@@ -3437,7 +3503,9 @@ For more information, see: {}"
                     typed_option<std::vector<sstring>>("table", "The table(s) to repair, if missing all tables are repaired", -1),
                 },
             },
-            repair_operation
+            {
+                repair_operation
+            }
         },
         {
             {
@@ -3449,7 +3517,9 @@ For more information, see: https://opensource.docs.scylladb.com/stable/operating
                 { },
                 { },
             },
-            resetlocalschema_operation
+            {
+                resetlocalschema_operation
+            }
         },
         {
             {
@@ -3466,7 +3536,9 @@ For more information, see: {}"
                     typed_option<sstring>("table", "The table to print the ring for (needed for tablet keyspaces)", 1),
                 },
             },
-            ring_operation
+            {
+                ring_operation
+            }
         },
         {
             {
@@ -3489,7 +3561,9 @@ For more information, see: {}"
                     typed_option<std::vector<sstring>>("table", "The table(s) to scrub (if unspecified, all tables in the keyspace are scrubbed)", -1),
                 },
             },
-            scrub_operation
+            {
+                scrub_operation
+            }
         },
         {
             {
@@ -3506,7 +3580,9 @@ For more information, see: {}"
                     typed_option<sstring>("level", "The log level to set, one of (trace, debug, info, warn and error), if unspecified, default level is reset to default log level", 1),
                 },
             },
-            setlogginglevel_operation
+            {
+                setlogginglevel_operation
+            }
         },
         {
             {
@@ -3524,7 +3600,9 @@ For more information, see: {}"
                     typed_option<double>("trace_probability", "trace probability value, must between 0 and 1, e.g. 0.2", 1),
                 },
             },
-            settraceprobability_operation
+            {
+                settraceprobability_operation
+            }
         },
         {
             {
@@ -3543,7 +3621,9 @@ For more information, see: {}"
                     typed_option<std::vector<sstring>>("keyspaces", "The keyspaces to snapshot", -1),
                 },
             },
-            snapshot_operation
+            {
+                snapshot_operation
+            }
         },
         {
             {
@@ -3558,7 +3638,9 @@ For more information, see: {}"
                     typed_option<std::vector<sstring>>("table", "The table names (optional)", -1),
                 },
             },
-            sstableinfo_operation,
+            {
+                sstableinfo_operation,
+            }
         },
         {
             {
@@ -3575,7 +3657,9 @@ For more information, see: {}"
                     typed_option<sstring>("table", "The table name (needed to display load information, if the keyspace uses tablets)", 1),
                 },
             },
-            status_operation
+            {
+                status_operation
+            }
         },
         {
             {
@@ -3589,7 +3673,9 @@ By default, the incremental backup status is `not running`.
 For more information, see: {}"
 )", doc_link("operating-scylla/nodetool-commands/statusbackup.html")),
             },
-            statusbackup_operation
+            {
+                statusbackup_operation
+            }
         },
         {
             {
@@ -3606,7 +3692,9 @@ By default, the native transport is `running`.
 For more information, see: {}"
 )", doc_link("operating-scylla/nodetool-commands/statusbinary.html")),
             },
-            statusbinary_operation
+            {
+                statusbinary_operation
+            }
         },
         {
             {
@@ -3621,7 +3709,9 @@ By default, the gossip protocol is `running`.
 For more information, see: {}"
 )", doc_link("operating-scylla/nodetool-commands/statusgossip.html")),
             },
-            statusgossip_operation
+            {
+                statusgossip_operation
+            }
         },
         {
             {
@@ -3639,7 +3729,9 @@ For more information, see: {}"
                     typed_option<sstring>("compaction_type", "The type of compaction to be stopped", 1),
                 },
             },
-            stop_operation
+            {
+                stop_operation
+            }
         },
         {
             {
@@ -3660,7 +3752,9 @@ For more information, see: {}"
                     typed_option<std::vector<sstring>>("table", "<keyspace> <table>, <keyspace>.<table> or <keyspace>-<table>", 2),
                 }
             },
-            tablehistograms_operation
+            {
+                tablehistograms_operation
+            }
         },
         {
             {
@@ -3679,7 +3773,9 @@ For more information, see: {}"
                     typed_option<std::vector<sstring>>("tables", "List of tables (or keyspace) names", -1),
                 },
             },
-            table_stats_operation
+            {
+                table_stats_operation
+            }
         },
         {
             {
@@ -3702,7 +3798,9 @@ For more information, see: {}"
                     typed_option<int>("duration-milli", "Duration in milliseconds", 1),
                 },
             },
-            toppartitions_operation
+            {
+                toppartitions_operation
+            }
         },
         {
             {
@@ -3726,7 +3824,9 @@ For more information, see: {}"
                     typed_option<std::vector<sstring>>("table", "Table to upgrade sstables for, if missing, all tables in the keyspace are upgraded", -1),
                 },
             },
-            upgradesstables_operation
+            {
+                upgradesstables_operation
+            }
         },
         {
             {
@@ -3740,7 +3840,9 @@ For more information, see: {}"
                     typed_option<std::vector<sstring>>("keyspace_view", "<keyspace> <view> | <keyspace.view>, The keyspace and view name ", -1),
                 },
             },
-            viewbuildstatus_operation
+            {
+                viewbuildstatus_operation
+            }
         },
         {
             {
@@ -3754,7 +3856,9 @@ run `scylla --version`.
 For more information, see: {}"
 )", doc_link("operating-scylla/nodetool-commands/version.html")),
             },
-            version_operation
+            {
+                version_operation
+            }
         },
     };
 
@@ -3869,7 +3973,7 @@ For more information, see: {})";
                     port = app_config["port"].as<uint16_t>();
                 }
                 scylla_rest_client client(app_config["host"].as<sstring>(), port);
-                get_operations_with_func().at(operation)(client, app_config);
+                get_operations_with_func().at(operation).func.value()(client, app_config);
             }
         } catch (std::invalid_argument& e) {
             fmt::print(std::cerr, "error processing arguments: {}\n", e.what());

--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -24,7 +24,7 @@ namespace bpo = boost::program_options;
 namespace tools::utils {
 
 bool operation::matches(std::string_view name) const {
-    return _name == name || std::ranges::find(_aliases, name) != _aliases.end();
+    return _name[0] == name || std::ranges::find(_aliases, name) != _aliases.end();
 }
 
 namespace {

--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -29,6 +29,21 @@ bool operation::matches(std::string_view name) const {
 
 namespace {
 
+bool is_help(const sstring& op) {
+    return op == "--help" || op == "-h";
+}
+
+std::vector<std::string_view> get_all_operation_names(const std::vector<operation>& operations) {
+    std::vector<std::string_view> all_operation_names;
+    for (const auto& op : operations) {
+        all_operation_names.push_back(op.name());
+        for (const auto& alias : op.aliases()) {
+            all_operation_names.push_back(alias);
+        }
+    }
+    return all_operation_names;
+}
+
 // Extract the operation from the argv.
 //
 // Do an initial parsing of command-line options to identify the operation
@@ -94,21 +109,31 @@ const operation* get_selected_operation(int& ac, char**& av, const std::vector<o
             if (op_name == av[i]) {
                 std::shift_left(av + i, av + ac, 1);
                 --ac;
+                while (!found->suboperations().empty()) {
+                    sstring subop = i < ac ? av[i] : "";
+                    if (is_help(subop)) {
+                        break;
+                    }
+                    auto& suboperations = found->suboperations();
+                    found = std::ranges::find_if(suboperations, [&subop] (auto& op) {
+                        return op.matches(subop);
+                    });
+                    if (found != suboperations.end()) {
+                        op_name += format(" {}", subop);
+                        std::shift_left(av + i, av + ac, 1);
+                        --ac;
+                        continue;
+                    }
+                    fmt::print(std::cerr, "error: unrecognized suboperation of {}: expected one of ({}), got {}\n", op_name, get_all_operation_names(suboperations), subop);
+                    exit(100);
+                }
                 break;
             }
         }
         return &*found;
     }
 
-    std::vector<std::string_view> all_operation_names;
-    for (const auto& op : operations) {
-        all_operation_names.push_back(op.name());
-        for (const auto& alias : op.aliases()) {
-            all_operation_names.push_back(alias);
-        }
-    }
-
-    fmt::print(std::cerr, "error: unrecognized operation argument: expected one of ({}), got {}\n", all_operation_names, op_name);
+    fmt::print(std::cerr, "error: unrecognized operation argument: expected one of ({}), got {}\n", get_all_operation_names(operations), op_name);
     exit(100);
 }
 

--- a/tools/utils.hh
+++ b/tools/utils.hh
@@ -83,13 +83,13 @@ public:
 };
 
 class operation {
-    std::string _name;
+    std::vector<std::string> _name = {};
     std::vector<std::string> _aliases;
     std::string _summary;
     std::string _description;
     std::vector<operation_option> _options;
     std::vector<operation_option> _positional_options;
-
+    std::vector<operation> _suboperations;
 public:
     operation(
             std::string name,
@@ -97,13 +97,18 @@ public:
             std::string summary,
             std::string description,
             std::vector<operation_option> options = {},
-            std::vector<operation_option> positional_options = {})
-        : _name(std::move(name))
+            std::vector<operation_option> positional_options = {},
+            std::vector<operation> suboperations = {})
+        : _name({std::move(name)})
         , _aliases(std::move(aliases))
         , _summary(std::move(summary))
         , _description(std::move(description))
         , _options(std::move(options))
-        , _positional_options(std::move(positional_options)) {
+        , _positional_options(std::move(positional_options))
+        , _suboperations(std::move(suboperations)) {
+        for (auto& op: _suboperations) {
+            op.set_superoperation_name(_name[0]);
+        }
     }
 
     operation(
@@ -111,19 +116,29 @@ public:
             std::string summary,
             std::string description,
             std::vector<operation_option> options = {},
-            std::vector<operation_option> positional_options = {})
-        : operation(std::move(name), {}, std::move(summary), std::move(description), std::move(options), std::move(positional_options))
+            std::vector<operation_option> positional_options = {},
+            std::vector<operation> suboperations = {})
+        : operation(std::move(name), {}, std::move(summary), std::move(description), std::move(options), std::move(positional_options), std::move(suboperations))
     {}
 
-    const std::string& name() const { return _name; }
+    const std::string& name() const { return _name[0]; }
+    const std::vector<std::string>& fullname() const { return _name; }
     const std::vector<std::string>& aliases() const { return _aliases; }
     const std::string& summary() const { return _summary; }
     const std::string& description() const { return _description; }
     const std::vector<operation_option>& options() const { return _options; }
     const std::vector<operation_option>& positional_options() const { return _positional_options; }
+    const std::vector<operation>& suboperations() const { return _suboperations; }
 
     // Does the name or any of the aliases matches the provided name?
     bool matches(std::string_view name) const;
+private:
+    void set_superoperation_name(std::string& name) {
+        _name.push_back(name);
+        for (auto& op: _suboperations) {
+            op.set_superoperation_name(name);
+        }
+    }
 };
 
 inline bool operator<(const operation& a, const operation& b) {


### PR DESCRIPTION
Add nodetool commands to manage task manager tasks:
- tasks abort - aborts the task
- tasks list - lists all tasks in the module
- tasks modules - lists all modules
- tasks set-ttl - sets task ttl
- tasks status - gets status of the task
- tasks tree - gets statuses of the task and all its desendent's
- tasks ttl - gets task ttl
- tasks wait - waits for the task and gets its status

Fixes: https://github.com/scylladb/scylladb/issues/19201.