### PR TITLE
.github: remove pull_request_template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,0 @@
-**Please replace this line with justification for the backport/\* labels added to this PR**


### PR DESCRIPTION
The reason for the PR template is to explain why we need to backport a PR.

On release branches, there is no need for it
