### PR TITLE
keep table directory open for flushing

### DIFF
--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -84,8 +84,9 @@ private:
     future<> move(const sstable& sst, sstring new_dir, generation_type generation, delayed_commit_changes* delay) override;
     future<> rename_new_file(const sstable& sst, sstring from_name, sstring to_name) const;
 
-    virtual void change_dir_for_test(sstring nd) override {
+    virtual future<> change_dir_for_test(sstring nd) override {
         _dir = opened_directory(nd);
+        return make_ready_future<>();
     }
 
 public:

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -402,7 +402,7 @@ future<> filesystem_storage::move(const sstable& sst, sstring new_dir, generatio
     auto temp_toc = sstable_version_constants::get_component_map(sst._version).at(component_type::TemporaryTOC);
     co_await sst.sstable_write_io_check(remove_file, sstable::filename(old_dir, sst._schema->ks_name(), sst._schema->cf_name(), sst._version, old_generation, sst._format, temp_toc));
     if (delay_commit == nullptr) {
-        co_await when_all(sst.sstable_write_io_check(sync_directory, old_dir), sst.sstable_write_io_check(sync_directory, new_dir)).discard_result();
+        co_await when_all(sst.sstable_write_io_check(sync_directory, old_dir), _dir.sync(sst._write_error_handler)).discard_result();
     } else {
         delay_commit->_dirs.insert(old_dir);
         delay_commit->_dirs.insert(new_dir);

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -42,7 +42,7 @@ class storage {
     friend class test;
 
     // Internal, but can also be used by tests
-    virtual void change_dir_for_test(sstring nd) {
+    virtual future<> change_dir_for_test(sstring nd) {
         assert(false && "Changing directory not implemented");
     }
     virtual future<> create_links(const sstable& sst, const std::filesystem::path& dir) const {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -129,8 +129,8 @@ public:
         _sst->_generation = generation;
     }
 
-    void change_dir(sstring dir) {
-        _sst->_storage->change_dir_for_test(dir);
+    future<> change_dir(sstring dir) {
+        return _sst->_storage->change_dir_for_test(dir);
     }
 
     void set_data_file_size(uint64_t size) {


### PR DESCRIPTION
`filesystem_storage` methods frequently call `sync_directory()`, for the sake of flushing (sync'ing) a directory. `sync_directory()` always brackets the sync with open and close, and given that most `sync_directory()` calls target the sstable base directory, those repeated opens and closes are considered wasteful. Rework the `filesystem_storage::_dir` member (from a mere pathname) so that it stand for an `opened_directory` object, which keeps the sstable base directory open, for the purpose of repeated sync'ing.

Resolves #2399.