### PR TITLE
storage_proxy: fix uninitialized LWT contention counter

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6232,7 +6232,7 @@ future<bool> storage_proxy::cas(schema_ptr schema, shared_ptr<cas_request> reque
     db::consistency_level cl = cl_for_paxos == db::consistency_level::LOCAL_SERIAL ?
         db::consistency_level::LOCAL_QUORUM : db::consistency_level::QUORUM;
 
-    unsigned contentions;
+    unsigned contentions = 0;
 
     dht::token token = partition_ranges[0].start()->value().as_decorated_key().token();
     utils::latency_counter lc;


### PR DESCRIPTION
When debugging the issue of high LWT contention metric, we (the drivers team) discovered that at least 3 drivers (Go, Java, Rust) cause high numbers in that metrics in LWT workloads - we doubted that all those drivers route LWT queries badly. We tried to understand that metric and its semantics. It took  people over 10 hours to figure out what it is supposed to count.

People from core team suspected that it was the drivers sending requests to different shards, causing contention. Then we ran the workload against a ingle node single shard cluster... and observed contention. Finally, we looked into the Scylla code and saw it.

**Uninitialized stack value.**

The core member was shocked. But we, the drivers people, felt we always knew it. It's yet another time that we are blamed for a server-side issue. We  ebuilt scylla with the variable initialized to 0 and the metric kept being 0.

To prevent such errors in the future, let's consider some lints that warn against uninitialized variables. This is such an obvious feature of e.g. Rust, and yet this has shown to be cause a painful bug in 2024.

Fixes: #19654