### PR TITLE
add missing header guards

### DIFF
--- a/api/scrub_status.hh
+++ b/api/scrub_status.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 namespace api {
 
 enum class scrub_status {

--- a/db/heat_load_balance.hh
+++ b/db/heat_load_balance.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 /*
  * Given a vector of cache hit ratio (hits per request) for each of N nodes,
  * and knowing which of them is the current node, our goal is to return a

--- a/db/size_estimates_virtual_reader.hh
+++ b/db/size_estimates_virtual_reader.hh
@@ -8,6 +8,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include "readers/mutation_reader_fwd.hh"
 #include "readers/mutation_reader.hh"
 #include "db/system_keyspace.hh"

--- a/db/system_keyspace_sstables_registry.hh
+++ b/db/system_keyspace_sstables_registry.hh
@@ -1,6 +1,8 @@
 // Copyright (C) 2024-present ScyllaDB
 // SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
 
+#pragma once
+
 #include "system_keyspace.hh"
 #include "sstables/sstables_registry.hh"
 

--- a/db/view/build_progress_virtual_reader.hh
+++ b/db/view/build_progress_virtual_reader.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include "replica/database.hh"
 #include "db/system_keyspace.hh"
 #include "readers/mutation_reader.hh"

--- a/db/view/delete_ghost_rows_visitor.hh
+++ b/db/view/delete_ghost_rows_visitor.hh
@@ -4,6 +4,8 @@
 
 /* Copyright 2022-present ScyllaDB */
 
+#pragma once
+
 #include "query-result-reader.hh"
 #include "replica/database_fwd.hh"
 #include "db/timeout_clock.hh"

--- a/index/built_indexes_virtual_reader.hh
+++ b/index/built_indexes_virtual_reader.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include "replica/database.hh"
 #include "db/system_keyspace.hh"
 #include "readers/mutation_reader.hh"

--- a/lang/lua_scylla_types.hh
+++ b/lang/lua_scylla_types.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include <lua.hpp>
 #include "types/types.hh"
 

--- a/locator/token_metadata_fwd.hh
+++ b/locator/token_metadata_fwd.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#pragma once
+
 #include <seastar/core/shared_ptr.hh>
 #include "seastarx.hh"
 

--- a/mutation/json.hh
+++ b/mutation/json.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include "dht/token.hh"
 #include "schema/schema.hh"
 #include "utils/rjson.hh"

--- a/replica/query.hh
+++ b/replica/query.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 /*
  * Utilities for executing queries on the local replica.
  *

--- a/sstables/sstable_mutation_reader.hh
+++ b/sstables/sstable_mutation_reader.hh
@@ -5,6 +5,9 @@
 /*
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
+#pragma once
+
 #include <seastar/core/future-util.hh>
 #include <seastar/core/coroutine.hh>
 #include "keys.hh"

--- a/streaming/consumer.hh
+++ b/streaming/consumer.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include "sstables/sstable_set.hh"
 #include "streaming/stream_reason.hh"
 #include "service/topology_guard.hh"

--- a/test/lib/fragment_scatterer.hh
+++ b/test/lib/fragment_scatterer.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include "mutation/mutation.hh"
 #include "mutation/mutation_rebuilder.hh"
 

--- a/test/lib/simple_position_reader_queue.hh
+++ b/test/lib/simple_position_reader_queue.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include "readers/clustering_combined.hh"
 #include "readers/mutation_reader.hh"
 

--- a/test/lib/sstable_run_based_compaction_strategy_for_tests.hh
+++ b/test/lib/sstable_run_based_compaction_strategy_for_tests.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include <vector>
 #include <map>
 #include "compaction/compaction_strategy_impl.hh"

--- a/test/perf/entry_point.hh
+++ b/test/perf/entry_point.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include <functional>
 
 #include "db/config.hh"

--- a/tools/entry_point.hh
+++ b/tools/entry_point.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 namespace tools {
 
 int scylla_types_main(int argc, char** argv);

--- a/tools/json_writer.hh
+++ b/tools/json_writer.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include "mutation/json.hh"
 #include "sstables/sstables.hh"
 

--- a/tools/schema_loader.hh
+++ b/tools/schema_loader.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include <filesystem>
 #include <seastar/core/future.hh>
 

--- a/tools/utils.hh
+++ b/tools/utils.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include <boost/program_options.hpp>
 #include <seastar/core/app-template.hh>
 #include "seastarx.hh"

--- a/utils/http.hh
+++ b/utils/http.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/shared_future.hh>

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include <seastar/core/file.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>

--- a/utils/sorting.hh
+++ b/utils/sorting.hh
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#pragma once
+
 #include <stdexcept>
 #include <vector>
 #include <map>


### PR DESCRIPTION
The following command had been executed to get the
list of headers that did not contain '#pragma once':
'grep -rnw . -e "#pragma once" --include *.hh -L'
    
This change adds missing include guard to headers
that did not contain any guard.