### PR TITLE
build: cmake: bump up the minimal required fmt to 10.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ target_link_libraries(Boost::regex
 find_package(Lua REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(ICU COMPONENTS uc i18n REQUIRED)
-find_package(fmt 9.0.0 REQUIRED)
+find_package(fmt 10.0.0 REQUIRED)
 find_package(libdeflate REQUIRED)
 find_package(libxcrypt REQUIRED)
 find_package(Snappy REQUIRED)


### PR DESCRIPTION
in cccec07581, we started using a featured introduced by {fmt} v10. so we need to bump up the required version in CMake as well.

---

cmake related change, hence no need to backport