### PR TITLE
test: do not define boost_test_print_type() for types with operator<<

### DIFF
--- a/test/lib/test_utils.hh
+++ b/test/lib/test_utils.hh
@@ -116,7 +116,8 @@ extern std::mutex boost_logger_mutex;
 namespace std {
 
 template <typename T>
-requires fmt::is_formattable<T>::value
+requires (fmt::is_formattable<T>::value &&
+          !boost::has_left_shift<T, std::ostream>::value)
 std::ostream& boost_test_print_type(std::ostream& os, const T& p) {
     fmt::print(os, "{}", p);
     return os;


### PR DESCRIPTION
before this change, we provide `boost_test_print_type()` for all types which can be formatted using {fmt}. these types includes those who fulfill the concept of range, and their element can be formatted using {fmt}. if the compilation unit happens to include `fmt/ranges.h`. the ranges are formatted with `boost_test_print_type()` as well. this is what we expect. in other words, we use {fmt} to format types which do not natively support {fmt}, but they fulfill the range concept.

but `boost::unit_test::basic_cstring` is one of them

- it can be formatted using operator<<, but it does not provide fmt::format specialization
- it fulfills the concept of range
- and its element type is `char const`, which can be formatted using {fmt}

that's why it's formatted like:

```
test/boost/sstable_directory_test.cc(317): fatal error: in "sstable_directory_test_generation_sanity": critical check ['s', 's', 't', '-', '>', 'g', 'e', 'n', 'e', 'r', 'a', 't', 'i', 'o', 'n', '(', ')', ' ', '=', '=', ' ', 's', 's', 't', '1', '-', '>', 'g', 'e', 'n', 'e', 'r', 'a', 't', 'i', 'o', 'n', '(', ')'] has failed`
```

where the string is formatted as a sequence-alike container. this is far from readable.

so, in this change, we do not define `boost_test_print_type()` for the types which natively support `operator<<` anymore. so they can be printed with `operator<<` when  boost::test prints them.

Fixes scylladb/scylladb#19637
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

no need to backport, this change improves developer's experience.