### PR TITLE
test: sstable_directory_test: use THREADSAFE_BOOST_REQUIRE_EQUAL when…

### DIFF
--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -314,7 +314,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_test_generation_sanity) {
             sstdir.invoke_on_all([&] (sstables::sstable_directory& sstdir) {
                 return seastar::async([&] {
                     sstdir.do_for_each_sstable([&] (const shared_sstable& sst) {
-                        THREADSAFE_BOOST_REQUIRE(sst->generation() == sst1->generation());
+                        THREADSAFE_BOOST_REQUIRE_EQUAL(sst->generation(), sst1->generation());
                         THREADSAFE_BOOST_REQUIRE(!gen1_seen[this_shard_id()]);
                         gen1_seen[this_shard_id()] = true;
                         return make_ready_future<>();


### PR DESCRIPTION
… appropriate

for better debugging experience.

before this change, we have

```
fatal error: in "sstable_directory_test_generation_sanity": critical check sst->generation() == sst1->generation() has failed
```
after this change, we have

```
fatal error: in "sstable_directory_test_generation_sanity": critical
check sst->generation() == sst1->generation() has failed [3ghm_0ntw_29vj625yegw7jodysc != 3ghm_0ntw_29vj625yegw7jodysd]
```
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

it's just an improvement in test, no need to backport.