### PR TITLE
main: throw on early stop signal

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -130,6 +130,7 @@ private:
         if (_caught) {
             return;
         }
+        startlog.info("caught stop signal");
         _caught = true;
         _cond.broadcast();
         _broadcasts_to_abort_sources_done = _broadcasts_to_abort_sources_done.then([this] {
@@ -155,8 +156,17 @@ public:
     bool stopping() const {
         return _caught;
     }
-    abort_source& as_local_abort_source() { return _abort_sources.local(); }
-    sharded<abort_source>& as_sharded_abort_source() { return _abort_sources; }
+    void check() const {
+        _abort_sources.local().check();
+    }
+    abort_source& as_local_abort_source() {
+        check();
+        return _abort_sources.local();
+    }
+    sharded<abort_source>& as_sharded_abort_source() {
+        check();
+        return _abort_sources;
+    }
 };
 
 struct object_storage_endpoint_param {


### PR DESCRIPTION
Currently, if the stop signal is caught during
main start sequence, we happily continue to start
new service until one of them realizes that abort
is requested and throws.

This causes the service_level_controller to
hang on stop(), since it calls its `do_abort()`
function only `if (*_early_abort_subscription)`
and `_early_abort_subscription` would be default-constructed if abort was already requested on the `abort_source`, leading to `do_abort` never to be called,
and the `update_from_distributed_data` loop to never get aborted.

Instead, make sure to check the abort_source in
`stop_signal::as_*_abort_source`, so `abort_requested_exception` will be thrown right after the stop signal is caught. Plus, add a log printout for that signal interception.

Fixes scylladb/scylladb#19075

The issue in service_level_controller has been introduced in 535e5f4ae7f8c58a39e6d260574a3581dec327a8
so no backport is required at the moment.

That said, the fix is safe to be backported to older versions as well and in general I think the main start sequence is safer with the fix than without it.
