### PR TITLE
Improve constness of functions schema code

### DIFF
--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -117,7 +117,7 @@ functions::init() noexcept {
     return ret;
 }
 
-void functions_changer::add_function(shared_ptr<function> func) {
+void functions::add_function(shared_ptr<function> func) {
     if (find(func->name(), func->arg_types())) {
         throw std::logic_error(format("duplicated function {}", func));
     }
@@ -125,7 +125,7 @@ void functions_changer::add_function(shared_ptr<function> func) {
 }
 
 template <typename F>
-void functions_changer::with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, F&& f) {
+void functions::with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, F&& f) {
     auto i = find_iter(name, arg_types);
     if (i == _declared.end() || i->second->is_native()) {
         log.error("attempted to remove or alter non existent user defined function {}({})", name, arg_types);
@@ -134,7 +134,7 @@ void functions_changer::with_udf_iter(const function_name& name, const std::vect
     f(i);
 }
 
-void functions_changer::replace_function(shared_ptr<function> func) {
+void functions::replace_function(shared_ptr<function> func) {
     with_udf_iter(func->name(), func->arg_types(), [func] (functions::declared_t::iterator i) {
         i->second = std::move(func);
     });
@@ -157,7 +157,7 @@ void functions_changer::replace_function(shared_ptr<function> func) {
     }
 }
 
-void functions_changer::remove_function(const function_name& name, const std::vector<data_type>& arg_types) {
+void functions::remove_function(const function_name& name, const std::vector<data_type>& arg_types) {
     with_udf_iter(name, arg_types, [this] (functions::declared_t::iterator i) { _declared.erase(i); });
 }
 

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -120,8 +120,7 @@ void functions::add_function(shared_ptr<function> func) {
     _declared.emplace(func->name(), func);
 }
 
-template <typename F>
-void functions::with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, F&& f) {
+void functions::with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, std::function<void(declared_t::iterator)> f) {
     auto cit = find_iter(name, arg_types);
     if (cit == _declared.end() || cit->second->is_native()) {
         log.error("attempted to remove or alter non existent user defined function {}({})", name, arg_types);

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -69,9 +69,15 @@ public:
     shared_ptr<function> mock_get(const function_name& name, const std::vector<data_type>& arg_types);
     // Used only by unittest.
     void clear_functions() noexcept;
+    void add_function(shared_ptr<function>);
+    void replace_function(shared_ptr<function>);
+    void remove_function(const function_name& name, const std::vector<data_type>& arg_types);
     std::optional<function_name> used_by_user_aggregate(shared_ptr<user_function>);
     std::optional<function_name> used_by_user_function(const ut_name& user_type);
 private:
+    template <typename F>
+    void with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, F&& f);
+
     template <typename F>
     std::vector<shared_ptr<F>> get_filtered_transformed(const sstring& keyspace);
 
@@ -97,23 +103,10 @@ private:
 // Getter for static functions object.
 functions& instance();
 
-// This class should be used via change_batch
-class functions_changer : public functions {
-public:
-    void add_function(shared_ptr<function>);
-    void replace_function(shared_ptr<function>);
-    void remove_function(const function_name& name, const std::vector<data_type>& arg_types);
-protected:
-    functions_changer(skip_init) : functions(skip_init{}) {}
-private:
-    template <typename F>
-    void with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, F&& f);
-};
-
-class change_batch : public functions_changer {
+class change_batch : public functions {
 public:
     // Skip init as we copy data from static instance.
-    change_batch() : functions_changer(skip_init{}) {
+    change_batch() : functions(skip_init{}) {
         _declared = instance()._declared;
     }
 

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -73,8 +73,7 @@ public:
     std::optional<function_name> used_by_user_aggregate(shared_ptr<user_function>) const;
     std::optional<function_name> used_by_user_function(const ut_name& user_type) const;
 private:
-    template <typename F>
-    void with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, F&& f);
+    void with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, std::function<void(declared_t::iterator)> f);
 
     template <typename F>
     std::vector<shared_ptr<F>> get_filtered_transformed(const sstring& keyspace) const;

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -39,7 +39,7 @@ protected:
     functions(skip_init) {};
 public:
     lw_shared_ptr<column_specification> make_arg_spec(const sstring& receiver_ks, std::optional<const std::string_view> receiver_cf,
-            const function& fun, size_t i);
+            const function& fun, size_t i) const;
 
     functions() : _declared(init()) {}
 
@@ -49,7 +49,7 @@ public:
                                     const std::vector<shared_ptr<assignment_testable>>& provided_args,
                                     const sstring& receiver_ks,
                                     std::optional<const std::string_view> receiver_cf,
-                                    const column_specification* receiver = nullptr);
+                                    const column_specification* receiver = nullptr) const;
     template <typename AssignmentTestablePtrRange>
     shared_ptr<function> get(data_dictionary::database db,
                                     const sstring& keyspace,
@@ -57,29 +57,27 @@ public:
                                     AssignmentTestablePtrRange&& provided_args,
                                     const sstring& receiver_ks,
                                     std::optional<const std::string_view> receiver_cf,
-                                    const column_specification* receiver = nullptr) {
+                                    const column_specification* receiver = nullptr) const {
         const std::vector<shared_ptr<assignment_testable>> args(std::begin(provided_args), std::end(provided_args));
         return get(db, keyspace, name, args, receiver_ks, receiver_cf, receiver);
     }
-    std::vector<shared_ptr<user_function>> get_user_functions(const sstring& keyspace);
-    std::vector<shared_ptr<user_aggregate>> get_user_aggregates(const sstring& keyspace);
-    boost::iterator_range<declared_t::iterator> find(const function_name& name);
-    declared_t::iterator find_iter(const function_name& name, const std::vector<data_type>& arg_types);
-    shared_ptr<function> find(const function_name& name, const std::vector<data_type>& arg_types);
-    shared_ptr<function> mock_get(const function_name& name, const std::vector<data_type>& arg_types);
-    // Used only by unittest.
-    void clear_functions() noexcept;
+    std::vector<shared_ptr<user_function>> get_user_functions(const sstring& keyspace) const;
+    std::vector<shared_ptr<user_aggregate>> get_user_aggregates(const sstring& keyspace) const;
+    boost::iterator_range<declared_t::const_iterator> find(const function_name& name) const;
+    declared_t::const_iterator find_iter(const function_name& name, const std::vector<data_type>& arg_types) const;
+    shared_ptr<function> find(const function_name& name, const std::vector<data_type>& arg_types) const;
+    shared_ptr<function> mock_get(const function_name& name, const std::vector<data_type>& arg_types) const;
     void add_function(shared_ptr<function>);
     void replace_function(shared_ptr<function>);
     void remove_function(const function_name& name, const std::vector<data_type>& arg_types);
-    std::optional<function_name> used_by_user_aggregate(shared_ptr<user_function>);
-    std::optional<function_name> used_by_user_function(const ut_name& user_type);
+    std::optional<function_name> used_by_user_aggregate(shared_ptr<user_function>) const;
+    std::optional<function_name> used_by_user_function(const ut_name& user_type) const;
 private:
     template <typename F>
     void with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, F&& f);
 
     template <typename F>
-    std::vector<shared_ptr<F>> get_filtered_transformed(const sstring& keyspace);
+    std::vector<shared_ptr<F>> get_filtered_transformed(const sstring& keyspace) const;
 
     // This method and matchArguments are somewhat duplicate, but this method allows us to provide more precise errors in the common
     // case where there is no override for a given function. This is thus probably worth the minor code duplication.
@@ -89,19 +87,19 @@ private:
                               shared_ptr<function> fun,
                               const std::vector<shared_ptr<assignment_testable>>& provided_args,
                               const sstring& receiver_ks,
-                              std::optional<const std::string_view> receiver_cf);
+                              std::optional<const std::string_view> receiver_cf) const;
     assignment_testable::test_result match_arguments(data_dictionary::database db, const sstring& keyspace,
             const schema* schema_opt,
             shared_ptr<function> fun,
             const std::vector<shared_ptr<assignment_testable>>& provided_args,
             const sstring& receiver_ks,
-            std::optional<const std::string_view> receiver_cf);
+            std::optional<const std::string_view> receiver_cf) const;
 
-    bool type_equals(const std::vector<data_type>& t1, const std::vector<data_type>& t2);
+    bool type_equals(const std::vector<data_type>& t1, const std::vector<data_type>& t2) const;
 };
 
 // Getter for static functions object.
-functions& instance();
+const functions& instance();
 
 class change_batch : public functions {
 public:
@@ -112,6 +110,9 @@ public:
 
     // Commit allows to atomically apply changes to main functions instance.
     void commit();
+
+    // Used only by unittest.
+    void clear_functions() noexcept;
 };
 
 }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -417,7 +417,9 @@ public:
             // FIXME: make the function storage non static
             auto clear_funcs = defer([] {
                 smp::invoke_on_all([] () {
-                    cql3::functions::instance().clear_functions();
+                    cql3::functions::change_batch batch;
+                    batch.clear_functions();
+                    batch.commit();
                 }).get();
             });
 


### PR DESCRIPTION
In v4 of https://github.com/scylladb/scylladb/pull/19598 the last commit of the patch was replaced but this change missed merge so submitting it in a separate patch.

In the current patch, the original functions class correctly marks methods as const where appropriate, and the instance() method now returns a const object. This ensures protection against accidental modifications, as all changes must go through the change_batch object.

Since the functions_changer class was intended to serve the same purpose, it is now redundant. Therefore, we are reverting the commit that introduced it.

Relates https://github.com/scylladb/scylladb/issues/19153