### PR TITLE
scylla_raid_setup: install update-initramfs when it's not available

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -325,6 +325,8 @@ WantedBy=local-fs.target
         os.chown(dpath, uid, gid)
 
     if is_debian_variant():
+        if not shutil.which('update-initramfs'):
+            pkg_install('initramfs-tools')
         run('update-initramfs -u', shell=True, check=True)
 
     if not udev_info.uuid_link:


### PR DESCRIPTION
scylla_raid_setup may fail on Ubuntu minimal image since it calls update-initramfs without installing.