### PR TITLE
doc: replace a link on the CDC+Kafka page

### DIFF
--- a/docs/using-scylla/integrations/scylla-cdc-source-connector-quickstart.rst
+++ b/docs/using-scylla/integrations/scylla-cdc-source-connector-quickstart.rst
@@ -18,8 +18,8 @@ ScyllaDB installation
 ^^^^^^^^^^^^^^^^^^^^^
 
 For the purpose of this quickstart, we will configure a ScyllaDB instance using Docker. You can skip this 
-section if you have already installed ScyllaDB. To learn more about installing ScyllaDB in production
-environments, please refer to the :doc:`Install ScyllaDB page </getting-started/install-scylla/index>`.
+section if you have already installed ScyllaDB. To learn more about installing and configuring ScyllaDB in production
+environments, please refer to the :doc:`Getting Started guide </getting-started/index>`.
 
 #. Using `Docker <https://hub.docker.com/r/scylladb/scylla/>`_, follow the instructions to launch ScyllaDB.
 #. Start the Docker container, replacing the ``--name`` and ``--host name`` parameters with your own information. For example:


### PR DESCRIPTION
This PR replaces a link to the installation section with a link to the getting started section.

- This PR must be backported to branch-6.0 to fix the errors on branch-2024.2 (which is based on 6.0).