### PR TITLE
Prevent ALTERing non-existing KS with tablets

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -772,38 +772,38 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 std::vector<canonical_mutation> updates;
                 sstring error;
                 if (_db.has_keyspace(ks_name)) {
-                auto& ks = _db.find_keyspace(ks_name);
-                auto tmptr = get_token_metadata_ptr();
-                size_t unimportant_init_tablet_count = 2; // must be a power of 2
-                locator::tablet_map new_tablet_map{unimportant_init_tablet_count};
+                    auto& ks = _db.find_keyspace(ks_name);
+                    auto tmptr = get_token_metadata_ptr();
+                    size_t unimportant_init_tablet_count = 2; // must be a power of 2
+                    locator::tablet_map new_tablet_map{unimportant_init_tablet_count};
 
-                for (const auto& table : ks.metadata()->tables()) {
-                    try {
-                        locator::tablet_map old_tablets = tmptr->tablets().get_tablet_map(table->id());
-                        locator::replication_strategy_params params{repl_opts, old_tablets.tablet_count()};
-                        auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params);
-                        new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table, tmptr, old_tablets);
-                    } catch (const std::exception& e) {
-                        error = e.what();
-                        rtlogger.error("Couldn't process global_topology_request::keyspace_rf_change, error: {},"
-                                       "desired new ks opts: {}", error, new_ks_props.get_replication_options());
-                        updates.clear(); // remove all tablets mutations ...
-                        break;           // ... and only create mutations deleting the global req
+                    for (const auto& table : ks.metadata()->tables()) {
+                        try {
+                            locator::tablet_map old_tablets = tmptr->tablets().get_tablet_map(table->id());
+                            locator::replication_strategy_params params{repl_opts, old_tablets.tablet_count()};
+                            auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params);
+                            new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table, tmptr, old_tablets);
+                        } catch (const std::exception& e) {
+                            error = e.what();
+                            rtlogger.error("Couldn't process global_topology_request::keyspace_rf_change, error: {},"
+                                           "desired new ks opts: {}", error, new_ks_props.get_replication_options());
+                            updates.clear(); // remove all tablets mutations ...
+                            break;           // ... and only create mutations deleting the global req
+                        }
+
+                        replica::tablet_mutation_builder tablet_mutation_builder(guard.write_timestamp(), table->id());
+                        co_await new_tablet_map.for_each_tablet([&](locator::tablet_id tablet_id, const locator::tablet_info& tablet_info) -> future<> {
+                            auto last_token = new_tablet_map.get_last_token(tablet_id);
+                            updates.emplace_back(co_await make_canonical_mutation_gently(
+                                    replica::tablet_mutation_builder(guard.write_timestamp(), table->id())
+                                            .set_new_replicas(last_token, tablet_info.replicas)
+                                            .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
+                                            .set_transition(last_token, locator::tablet_transition_kind::rebuild)
+                                            .build()
+                            ));
+                            co_await coroutine::maybe_yield();
+                        });
                     }
-
-                    replica::tablet_mutation_builder tablet_mutation_builder(guard.write_timestamp(), table->id());
-                    co_await new_tablet_map.for_each_tablet([&](locator::tablet_id tablet_id, const locator::tablet_info& tablet_info) -> future<> {
-                        auto last_token = new_tablet_map.get_last_token(tablet_id);
-                        updates.emplace_back(co_await make_canonical_mutation_gently(
-                                replica::tablet_mutation_builder(guard.write_timestamp(), table->id())
-                                        .set_new_replicas(last_token, tablet_info.replicas)
-                                        .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
-                                        .set_transition(last_token, locator::tablet_transition_kind::rebuild)
-                                        .build()
-                        ));
-                        co_await coroutine::maybe_yield();
-                    });
-                }
                 } else {
                     error = "Can't ALTER keyspace " + ks_name + ", keyspace doesn't exist";
                 }

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2898,6 +2898,12 @@ future<> topology_coordinator::run() {
                 co_await await_event();
                 rtlogger.debug("topology coordinator fiber got an event");
             }
+            co_await utils::get_local_injector().inject("wait-after-topology-coordinator-gets-event", [] (auto& handler) -> future<> {
+                rtlogger.info("wait-after-topology-coordinator-gets-event injection hit");
+                co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::seconds{30});
+                rtlogger.info("wait-after-topology-coordinator-gets-event injection done");
+            });
+
         } catch (...) {
             sleep = handle_topology_coordinator_error(std::current_exception());
         }

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -763,8 +763,6 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             rtlogger.info("keyspace_rf_change requested");
             while (true) {
                 sstring ks_name = *_topo_sm._topology.new_keyspace_rf_change_ks_name;
-                auto& ks = _db.find_keyspace(ks_name);
-                auto tmptr = get_token_metadata_ptr();
                 std::unordered_map<sstring, sstring> saved_ks_props = *_topo_sm._topology.new_keyspace_rf_change_data;
                 cql3::statements::ks_prop_defs new_ks_props{std::map<sstring, sstring>{saved_ks_props.begin(), saved_ks_props.end()}};
 
@@ -773,6 +771,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 utils::UUID req_uuid = *_topo_sm._topology.global_request_id;
                 std::vector<canonical_mutation> updates;
                 sstring error;
+                if (_db.has_keyspace(ks_name)) {
+                auto& ks = _db.find_keyspace(ks_name);
+                auto tmptr = get_token_metadata_ptr();
                 size_t unimportant_init_tablet_count = 2; // must be a power of 2
                 locator::tablet_map new_tablet_map{unimportant_init_tablet_count};
 
@@ -802,6 +803,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         ));
                         co_await coroutine::maybe_yield();
                     });
+                }
+                } else {
+                    error = "Can't ALTER keyspace " + ks_name + ", keyspace doesn't exist";
                 }
 
                 updates.push_back(canonical_mutation(topology_mutation_builder(guard.write_timestamp())

--- a/test/topology_custom/test_tablets_cql.py
+++ b/test/topology_custom/test_tablets_cql.py
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import asyncio
+import logging
+
+import pytest
+from cassandra.protocol import InvalidRequest
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.rest_client import inject_error_one_shot
+from test.topology.conftest import skip_mode
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_alter_dropped_tablets_keyspace(manager: ManagerClient) -> None:
+    config = {
+        'enable_tablets': 'true'
+    }
+
+    logger.info("starting a node (the leader)")
+    servers = [await manager.server_add(config=config)]
+
+    logger.info("starting a second node (the follower)")
+    servers += [await manager.server_add(config=config)]
+
+    await manager.get_cql().run_async("create keyspace ks with "
+                                      "replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} and "
+                                      "tablets = {'enabled': true}")
+    await manager.get_cql().run_async("create table ks.t (pk int primary key)")
+
+    logger.info(f"injecting wait-after-topology-coordinator-gets-event into the leader node {servers[0]}")
+    injection_handler = await inject_error_one_shot(manager.api, servers[0].ip_addr,
+                                                    'wait-after-topology-coordinator-gets-event')
+
+    async def alter_tablets_ks_without_waiting_to_complete():
+        res = await manager.get_cql().run_async("select data_center from system.local")
+        # ALTER tablets KS only accepts a specific DC, it rejects the generic 'replication_factor' tag
+        this_dc = res[0].data_center
+        await manager.get_cql().run_async("alter keyspace ks "
+                                    f"with replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': 1}}")
+
+    # by creating a task this way we ensure it's immediately executed, but we won't wait until it's completed
+    task = asyncio.create_task(alter_tablets_ks_without_waiting_to_complete())
+
+    logger.info(f"waiting for the leader node {servers[0]} to start handling the keyspace-rf-change request")
+    leader_log_file = await manager.server_open_log(servers[0].server_id)
+    await leader_log_file.wait_for("wait-after-topology-coordinator-gets-event injection hit", timeout=10)
+
+    logger.info(f"dropping KS from the follower node {servers[1]} so that the leader, which hangs on injected sleep, "
+                f"wakes up with the drop applied")
+    host = manager.get_cql().cluster.metadata.get_host(servers[1].ip_addr)
+    await manager.get_cql().run_async("drop keyspace ks", host=host)
+
+    logger.info("Waking up the leader to continue processing ALTER with KS that doesn't exist (has been just dropped)")
+    await injection_handler.message()
+
+    matches = await leader_log_file.grep("topology change coordinator fiber got error "
+                                         "data_dictionary::no_such_keyspace \(Can't find a keyspace ks\)")
+    assert not matches
+
+    with pytest.raises(InvalidRequest, match="Can't ALTER keyspace ks, keyspace doesn't exist") as e:
+        await task


### PR DESCRIPTION
ALTER tablets KS executes in 2 steps:
1. ALTER KS's cql handler forms a global topo req, and saves data required to execute this req,
2. global topo req is executed by topo coordinator, which reads data attached to the req.

The KS name is among the data attached to the req. There's a time window between these steps where a to-be-altered KS could have been DROPped, which results in topo coordinator forever trying to ALTER a non-existing KS. In order to avoid it, the code has been changed to first check if a to-be-altered KS exists, and if it's not the case, it doesn't perform any schema/tablets mutations, but just removes the global topo req from the coordinator's queue.
BTW. just adding this extra check resulted in broader than expected changes, which is due to the fact that the code is written badly and needs to be refactored - an effort that's already planned under #19126
(I suggest to disable displaying whitespace differences when reviewing this PR).

Fixes: #19576

Requires 6.0 backport