### PR TITLE
transport, service: move definition of destructors into .cc

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -187,6 +187,8 @@ storage_service::storage_service(abort_source& abort_source,
     init_messaging_service();
 }
 
+storage_service::~storage_service() = default;
+
 enum class node_external_status {
     UNKNOWN        = 0,
     STARTING       = 1,

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -213,6 +213,7 @@ public:
         cql3::query_processor& qp,
         sharded<qos::service_level_controller>& sl_controller,
         topology_state_machine& topology_state_machine);
+    ~storage_service();
 
     // Needed by distributed<>
     future<> stop();

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -304,6 +304,8 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
     _metrics.add_group("transport", std::move(transport_metrics));
 }
 
+cql_server::~cql_server() = default;
+
 shared_ptr<generic_server::connection>
 cql_server::make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr) {
     auto conn = make_shared<connection>(*this, server_addr, std::move(fd), std::move(addr));

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -172,6 +172,8 @@ public:
             gms::gossiper& g,
             scheduling_group_key stats_key,
             maintenance_socket_enabled used_by_maintenance_socket);
+    ~cql_server();
+
 public:
     using response = cql_transport::response;
     using result_with_foreign_response_ptr = exceptions::coordinator_result<foreign_ptr<std::unique_ptr<cql_server::response>>>;


### PR DESCRIPTION
this changeset includes two changes:

- service: move storage_service::~storage_service() into .cc
- transport: move the cql_server::~cql_server() into .cc

they intend to address the compile failures when building scylladb with clang-19. clang-19 is more picky when generating the defaulted destructors with incomplete types. but its behavior makes sense regarding to standard compliance. so let's update accordingly.

---

it's a cleanup, hence no need to backport.