### PR TITLE
sstable: extract file_writer out

### DIFF
--- a/sstables/file_writer.hh
+++ b/sstables/file_writer.hh
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <optional>
+#include <utility>
+
+#include <seastar/core/sstring.hh>
+#include <seastar/core/iostream.hh>
+
+#include "sstables/progress_monitor.hh"
+#include "bytes.hh"
+#include "seastarx.hh"
+
+namespace sstables {
+
+class file_writer {
+    output_stream<char> _out;
+    writer_offset_tracker _offset;
+    std::optional<sstring> _filename;
+    bool _closed = false;
+public:
+    file_writer(output_stream<char>&& out, sstring filename) noexcept
+        : _out(std::move(out))
+        , _filename(std::move(filename))
+    {}
+
+    file_writer(output_stream<char>&& out) noexcept
+        : _out(std::move(out))
+    {}
+
+    // Must be called in a seastar thread.
+    virtual ~file_writer();
+    file_writer(const file_writer&) = delete;
+    file_writer(file_writer&& x) noexcept
+        : _out(std::move(x._out))
+        , _offset(std::move(x._offset))
+        , _filename(std::move(x._filename))
+        , _closed(x._closed)
+    {
+        x._closed = true;   // don't auto-close in destructor
+    }
+    // Must be called in a seastar thread.
+    void write(const char* buf, size_t n) {
+        _offset.offset += n;
+        _out.write(buf, n).get();
+    }
+    // Must be called in a seastar thread.
+    void write(bytes_view s) {
+        _offset.offset += s.size();
+        _out.write(reinterpret_cast<const char*>(s.begin()), s.size()).get();
+    }
+    // Must be called in a seastar thread.
+    void close();
+
+    uint64_t offset() const {
+        return _offset.offset;
+    }
+
+    const writer_offset_tracker& offset_tracker() const {
+        return _offset;
+    }
+
+private:
+    const char* get_filename() const noexcept;
+};
+
+}

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -17,6 +17,7 @@
 #include "utils/streaming_histogram.hh"
 #include "utils/estimated_histogram.hh"
 #include "sstables/key.hh"
+#include "sstables/file_writer.hh"
 #include "db/commitlog/replay_position.hh"
 #include "version.hh"
 #include <vector>
@@ -234,8 +235,6 @@ private:
     unsigned _summary_index_pos = 0;
 };
 using summary = summary_ka;
-
-class file_writer;
 
 struct metadata {
     virtual ~metadata() {}

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -12,7 +12,6 @@
 #include <seastar/core/fstream.hh>
 #include "sstables/types.hh"
 #include "checksum_utils.hh"
-#include "progress_monitor.hh"
 #include "vint-serialization.hh"
 #include <seastar/core/byteorder.hh>
 #include "version.hh"
@@ -30,57 +29,6 @@ namespace sstables {
 class index_sampling_state;
 class compression;
 class metadata_collector;
-
-class file_writer {
-    output_stream<char> _out;
-    writer_offset_tracker _offset;
-    std::optional<sstring> _filename;
-    bool _closed = false;
-public:
-    file_writer(output_stream<char>&& out, sstring filename) noexcept
-        : _out(std::move(out))
-        , _filename(std::move(filename))
-    {}
-
-    file_writer(output_stream<char>&& out) noexcept
-        : _out(std::move(out))
-    {}
-
-    // Must be called in a seastar thread.
-    virtual ~file_writer();
-    file_writer(const file_writer&) = delete;
-    file_writer(file_writer&& x) noexcept
-        : _out(std::move(x._out))
-        , _offset(std::move(x._offset))
-        , _filename(std::move(x._filename))
-        , _closed(x._closed)
-    {
-        x._closed = true;   // don't auto-close in destructor
-    }
-    // Must be called in a seastar thread.
-    void write(const char* buf, size_t n) {
-        _offset.offset += n;
-        _out.write(buf, n).get();
-    }
-    // Must be called in a seastar thread.
-    void write(bytes_view s) {
-        _offset.offset += s.size();
-        _out.write(reinterpret_cast<const char*>(s.begin()), s.size()).get();
-    }
-    // Must be called in a seastar thread.
-    void close();
-
-    uint64_t offset() const {
-        return _offset.offset;
-    }
-
-    const writer_offset_tracker& offset_tracker() const {
-        return _offset;
-    }
-
-private:
-    const char* get_filename() const noexcept;
-};
 
 
 class sizing_data_sink : public data_sink_impl {


### PR DESCRIPTION
`sstables::write()` has multiple overloads, which are defined in `sstables/writer.hh`. two of these overloads are template functions, which have a template parameter named `W`, which has a type constraint requiring it to fulfill the `Writer` concept. but in `types.hh`, when the compiler tries to instantiate the template function with signature of `write(sstable_version_types v, W& out, const T& t)` with `file_writer` as the template parameter of `w`, `file_writer` is only forward-declared using `class file_writer` in the same header file, so this type is still an incomplete type at that moment. that's why the compiler is not able to determine if `file_writer` fulfills the constraint or not. actually, the declaration of `file_writer` is located in `sstables/writer.hh`, which in turn includes `types.hh`. so they form a cyclic dependency.

in this change, in order to break this cycle, we extract file_writer out into a separate header file, so that both `sstables/writer.hh` and `sstables/types.hh` can include it. this address the build failure.

Fixes scylladb/scylladb#19667
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

it's a cleanup, hence no need to backport.