### PR TITLE
scylla-housekeeping: fix exception on parsing version string v2

### DIFF
--- a/dist/common/scripts/scylla-housekeeping
+++ b/dist/common/scripts/scylla-housekeeping
@@ -96,11 +96,9 @@ def sanitize_version(version):
     false negative version_compare() checks.
     """
     if version and '-' in version:
-        version = version.split('-', 1)[0]
-    # Newer setuptools does not accept ~dev in version strings, need to
-    # replace it to .dev0
-    if version and version.endswith('~dev'):
-        version = version.replace('~dev', '.dev0')
+        return version.split('-', 1)[0]
+    else:
+        return version
 
 
 def get_repo_file(dir):

--- a/dist/common/scripts/scylla-housekeeping
+++ b/dist/common/scripts/scylla-housekeeping
@@ -80,8 +80,20 @@ def get_api(path):
     return get_json_from_url("http://" + api_address + path)
 
 
+def parse_scylla_version(version):
+    # Newer setuptools does not accept ~dev in version strings, need to
+    # replace it to X.Y.Z.dev0
+    if version and version.endswith('~dev'):
+        version = version.replace('~dev', '.dev0')
+    # Newer setuptools does not accept ~rcN in version strings, need to
+    # replace it to X.Y.ZrcN
+    if version and '~rc' in version:
+        version = version.replace('~', '')
+    return parse_version(version)
+
+
 def version_compare(a, b):
-    return parse_version(a) < parse_version(b)
+    return parse_scylla_version(a) < parse_scylla_version(b)
 
 
 def create_uuid_file(fl):


### PR DESCRIPTION
This reverts https://github.com/scylladb/scylladb/commit/65fbf72ed0f0980381c3307cda5a6d1b1fde2dfb and introduce new version of the patch which fixes SCT breakage after the commit merged.


----

Since Python 3.12, version parsing becomes strict, parse_version() does
not accept the version string like '6.1.0~dev'.
To fix this, we need to pass acceptable version string to parse_version() like
'6.1.0.dev0', which is allowed on Python version scheme.

reference: https://packaging.python.org/en/latest/specifications/version-specifiers/

Fixes https://github.com/scylladb/scylladb/issues/19564

Closes https://github.com/scylladb/scylladb/pull/19572