### PR TITLE
.github/script/label_promoted_commit.py: add label only if ref is PR

### DIFF
--- a/.github/scripts/label_promoted_commits.py
+++ b/.github/scripts/label_promoted_commits.py
@@ -1,8 +1,9 @@
-from github import Github
 import argparse
 import re
 import sys
 import os
+from github import Github
+from github.GithubException import UnknownObjectException
 
 try:
     github_token = os.environ["GITHUB_TOKEN"]
@@ -77,9 +78,12 @@ def main():
                     comment = f'Closed via {commit.sha}'
                     add_comment_and_close_pr(pr, comment)
             else:
-                print(f'master branch, pr number is: {pr_number}')
-                pr = repo.get_pull(pr_number)
-                pr.add_to_labels('promoted-to-master')
+                try:
+                    pr = repo.get_pull(pr_number)
+                    pr.add_to_labels('promoted-to-master')
+                    print(f'master branch, pr number is: {pr_number}')
+                except UnknownObjectException:
+                    print(f'{pr_number} is not a PR but an issue, no need to add label')
             processed_prs.add(pr_number)
 
 


### PR DESCRIPTION
we got a failure during check-commit action:
```
Run python .github/scripts/label_promoted_commits.py --commit_before_merge 30e82a81e892b2e630cbc01490a2e3cc9908058a --commit_after_merge f31d5e3204f87c43a3eb7fd2ca6bc7548dbf2367 --repository scylladb/scylladb --ref refs/heads/master

Commit sha is: d5a149fc01f168bb22bbeb69f03a8634b9b0a171
Commit sha is: 415457be2bf6a71c3bdf7498fb3e200c38f2241d
Commit sha is: d3b1ccd03aafb01e514cd2e2344a3241b339ffaa
Commit sha is: 1fca3415142935f08b5f361a30d9a097c82d38ce
Commit sha is: f784be6a7ee182cf762ad5199ce36f84c0513d39
Commit sha is: 80986c17c3048538c3edb295d8b2319df3990b73
Commit sha is: 492d0a5c86e9c5fec1f1ba41df82796f1f917411
Commit sha is: 7b3f55a65fbee2ee4a7df511cd08c977cefdcf28
Commit sha is: 78d6471ce472cfb3ebf4631f0d3cbb2bafb7a0e1
Commit sha is: 7a69d9070fe16c4606ad213418c2db3e476f4825
Commit sha is: a9e985fcc90d0917669ceb16f0531707a0989aa7
master branch, pr number is: 19213
Traceback (most recent call last):
  File "/home/runner/work/scylladb/scylladb/.github/scripts/label_promoted_commits.py", line 87, in <module>
    main()
  File "/home/runner/work/scylladb/scylladb/.github/scripts/label_promoted_commits.py", line 81, in main
    pr = repo.get_pull(pr_number)
  File "/usr/lib/python3/dist-packages/github/Repository.py", line 2746, in get_pull
    headers, data = self._requester.requestJsonAndCheck(
  File "/usr/lib/python3/dist-packages/github/Requester.py", line 353, in requestJsonAndCheck
    return self.__check(
  File "/usr/lib/python3/dist-packages/github/Requester.py", line 378, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.UnknownObjectException: 404 {"message": "Not Found", "documentation_url": "https://docs.github.com/rest/pulls/pulls#get-a-pull-request", "status": "404"}
Error: Process completed with exit code 1.
```

The reason for this failure is since in one of the promoted commits (a9e985fcc90d0917669ceb16f0531707a0989aa7) had a reference of `Closes` to an issue.

Fixes: https://github.com/scylladb/scylladb/issues/19677

**This bug can happen in release branches as well, should be backported to 5.4 and 6.0** 