### PR TITLE
Order API endpoints registration in main

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -73,6 +73,8 @@ future<> set_server_init(http_context& ctx) {
         set_error_injection(ctx, r);
         rb->register_function(r, "storage_proxy",
                 "The storage proxy API");
+        rb->register_function(r, "storage_service",
+                "The storage service API");
     });
 }
 
@@ -115,7 +117,7 @@ future<> unset_thrift_controller(http_context& ctx) {
 }
 
 future<> set_server_storage_service(http_context& ctx, sharded<service::storage_service>& ss, service::raft_group0_client& group0_client) {
-    return register_api(ctx, "storage_service", "The storage service API", [&ss, &group0_client] (http_context& ctx, routes& r) {
+    return ctx.http_server.set_routes([&ctx, &ss, &group0_client] (routes& r) {
             set_storage_service(ctx, r, ss, group0_client);
         });
 }

--- a/api/api.cc
+++ b/api/api.cc
@@ -258,6 +258,10 @@ future<> set_server_cache(http_context& ctx) {
             "The cache service API", set_cache_service);
 }
 
+future<> unset_server_cache(http_context& ctx) {
+    return ctx.http_server.set_routes([&ctx] (routes& r) { unset_cache_service(ctx, r); });
+}
+
 future<> set_hinted_handoff(http_context& ctx, sharded<service::storage_proxy>& proxy) {
     return register_api(ctx, "hinted_handoff",
                 "The hinted handoff API", [&proxy] (http_context& ctx, routes& r) {

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -119,6 +119,7 @@ future<> unset_server_stream_manager(http_context& ctx);
 future<> set_hinted_handoff(http_context& ctx, sharded<service::storage_proxy>& p);
 future<> unset_hinted_handoff(http_context& ctx);
 future<> set_server_cache(http_context& ctx);
+future<> unset_server_cache(http_context& ctx);
 future<> set_server_compaction_manager(http_context& ctx);
 future<> set_server_done(http_context& ctx);
 future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>& tm, lw_shared_ptr<db::config> cfg);

--- a/api/cache_service.cc
+++ b/api/cache_service.cc
@@ -320,5 +320,50 @@ void set_cache_service(http_context& ctx, routes& r) {
     });
 }
 
+void unset_cache_service(http_context& ctx, routes& r) {
+    cs::get_row_cache_save_period_in_seconds.unset(r);
+    cs::set_row_cache_save_period_in_seconds.unset(r);
+    cs::get_key_cache_save_period_in_seconds.unset(r);
+    cs::set_key_cache_save_period_in_seconds.unset(r);
+    cs::get_counter_cache_save_period_in_seconds.unset(r);
+    cs::set_counter_cache_save_period_in_seconds.unset(r);
+    cs::get_row_cache_keys_to_save.unset(r);
+    cs::set_row_cache_keys_to_save.unset(r);
+    cs::get_key_cache_keys_to_save.unset(r);
+    cs::set_key_cache_keys_to_save.unset(r);
+    cs::get_counter_cache_keys_to_save.unset(r);
+    cs::set_counter_cache_keys_to_save.unset(r);
+    cs::invalidate_key_cache.unset(r);
+    cs::invalidate_counter_cache.unset(r);
+    cs::set_row_cache_capacity_in_mb.unset(r);
+    cs::set_key_cache_capacity_in_mb.unset(r);
+    cs::set_counter_cache_capacity_in_mb.unset(r);
+    cs::save_caches.unset(r);
+    cs::get_key_capacity.unset(r);
+    cs::get_key_hits.unset(r);
+    cs::get_key_requests.unset(r);
+    cs::get_key_hit_rate.unset(r);
+    cs::get_key_hits_moving_avrage.unset(r);
+    cs::get_key_requests_moving_avrage.unset(r);
+    cs::get_key_size.unset(r);
+    cs::get_key_entries.unset(r);
+    cs::get_row_capacity.unset(r);
+    cs::get_row_hits.unset(r);
+    cs::get_row_requests.unset(r);
+    cs::get_row_hit_rate.unset(r);
+    cs::get_row_hits_moving_avrage.unset(r);
+    cs::get_row_requests_moving_avrage.unset(r);
+    cs::get_row_size.unset(r);
+    cs::get_row_entries.unset(r);
+    cs::get_counter_capacity.unset(r);
+    cs::get_counter_hits.unset(r);
+    cs::get_counter_requests.unset(r);
+    cs::get_counter_hit_rate.unset(r);
+    cs::get_counter_hits_moving_avrage.unset(r);
+    cs::get_counter_requests_moving_avrage.unset(r);
+    cs::get_counter_size.unset(r);
+    cs::get_counter_entries.unset(r);
+}
+
 }
 

--- a/api/cache_service.hh
+++ b/api/cache_service.hh
@@ -16,5 +16,6 @@ namespace api {
 
 struct http_context;
 void set_cache_service(http_context& ctx, seastar::httpd::routes& r);
+void unset_cache_service(http_context& ctx, seastar::httpd::routes& r);
 
 }

--- a/api/token_metadata.cc
+++ b/api/token_metadata.cc
@@ -21,6 +21,9 @@ using namespace json;
 void set_token_metadata(http_context& ctx, routes& r, sharded<locator::shared_token_metadata>& tm) {
     ss::local_hostid.set(r, [&tm](std::unique_ptr<http::request> req) {
         auto id = tm.local().get()->get_my_id();
+        if (!bool(id)) {
+            throw not_found_exception("local host ID is not yet set");
+        }
         return make_ready_future<json::json_return_type>(id.to_sstring());
     });
 

--- a/main.cc
+++ b/main.cc
@@ -1538,17 +1538,17 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 ss.stop().get();
             });
 
+            api::set_server_storage_service(ctx, ss, group0_client).get();
+            auto stop_ss_api = defer_verbose_shutdown("storage service API", [&ctx] {
+                api::unset_server_storage_service(ctx).get();
+            });
+
             supervisor::notify("initializing query processor remote part");
             // TODO: do this together with proxy.start_remote(...)
             qp.invoke_on_all(&cql3::query_processor::start_remote, std::ref(mm), std::ref(mapreduce_service),
                              std::ref(ss), std::ref(group0_client)).get();
             auto stop_qp_remote = defer_verbose_shutdown("query processor remote part", [&qp] {
                 qp.invoke_on_all(&cql3::query_processor::stop_remote).get();
-            });
-
-            api::set_server_storage_service(ctx, ss, group0_client).get();
-            auto stop_ss_api = defer_verbose_shutdown("storage service API", [&ctx] {
-                api::unset_server_storage_service(ctx).get();
             });
 
             supervisor::notify("initializing virtual tables");

--- a/main.cc
+++ b/main.cc
@@ -1829,6 +1829,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             api::set_server_cache(ctx).get();
+            auto stop_cache_api = defer_verbose_shutdown("cache API", [&ctx] {
+                api::unset_server_cache(ctx).get();
+            });
 
             if (cfg->maintenance_mode()) {
                 startlog.info("entering maintenance mode.");

--- a/main.cc
+++ b/main.cc
@@ -1828,8 +1828,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 api::unset_server_tasks_compaction_module(ctx).get();
             });
 
-            //FIXME: discarded future
-            (void)api::set_server_cache(ctx);
+            api::set_server_cache(ctx).get();
 
             if (cfg->maintenance_mode()) {
                 startlog.info("entering maintenance mode.");


### PR DESCRIPTION
There are few api::set_foo()-s left in main that are placed in ~~random~~ legacy order. This PR fixes it and makes few more associated cleanups.

refs: #2737 