### PR TITLE
build: regenerate toolchain for optimized clang

### DIFF
--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-40-20240621
+docker.io/scylladb/scylla-toolchain:fedora-40-20240710


### PR DESCRIPTION
Generate a profile-guided-optimization build of clang and install it. See bd34f2fe46e1421dc2059d34d7e554acc2f5cdc3.

The optimized clang package can be found in

  https://devpkg.scylladb.com/clang/clang-18.1.6-Fedora-40-x86_64.tar.gz
  https://devpkg.scylladb.com/clang/clang-18.1.6-Fedora-40-aarch64.tar.gz

No backport needed - optimizing the current toolchain compiler.