### PR TITLE
test: cql-pytest: config_value_context: remove strange ast.literal_eval call

### DIFF
--- a/test/cql-pytest/test_guardrail_replication_strategy.py
+++ b/test/cql-pytest/test_guardrail_replication_strategy.py
@@ -44,8 +44,8 @@ def test_given_default_config_when_creating_ks_should_only_produce_warning_for_s
 
 def test_given_cleared_guardrails_when_creating_ks_should_not_get_warning_nor_error(cql, this_dc):
     with ExitStack() as config_modifications:
-        config_modifications.enter_context(config_value_context(cql, 'replication_strategy_warn_list', ''))
-        config_modifications.enter_context(config_value_context(cql, 'replication_strategy_fail_list', ''))
+        config_modifications.enter_context(config_value_context(cql, 'replication_strategy_warn_list', '[]'))
+        config_modifications.enter_context(config_value_context(cql, 'replication_strategy_fail_list', '[]'))
 
         for key, value in {'SimpleStrategy': 'replication_factor', 'NetworkTopologyStrategy': this_dc,
                            'EverywhereStrategy': 'replication_factor', 'LocalStrategy': 'replication_factor'}.items():
@@ -56,8 +56,7 @@ def test_given_cleared_guardrails_when_creating_ks_should_not_get_warning_nor_er
 def test_given_non_empty_warn_list_when_creating_ks_should_only_warn_when_listed_strategy_used(cql, this_dc):
     with ExitStack() as config_modifications:
         config_modifications.enter_context(config_value_context(cql, 'replication_strategy_warn_list',
-                                                                'SimpleStrategy, LocalStrategy, '
-                                                                'NetworkTopologyStrategy, EverywhereStrategy'))
+                                                                'SimpleStrategy,LocalStrategy,NetworkTopologyStrategy,EverywhereStrategy'))
         for key, value in {'SimpleStrategy': 'replication_factor', 'NetworkTopologyStrategy': this_dc,
                            'EverywhereStrategy': 'replication_factor', 'LocalStrategy': 'replication_factor'}.items():
             create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 3 }}",
@@ -67,10 +66,10 @@ def test_given_non_empty_warn_list_when_creating_ks_should_only_warn_when_listed
 def test_given_non_empty_warn_and_fail_lists_when_creating_ks_should_fail_query_when_listed_strategy_used(cql, this_dc):
     with ExitStack() as config_modifications:
         config_modifications.enter_context(
-            config_value_context(cql, 'replication_strategy_warn_list', 'SimpleStrategy, EverywhereStrategy'))
+            config_value_context(cql, 'replication_strategy_warn_list', 'SimpleStrategy,EverywhereStrategy'))
         config_modifications.enter_context(config_value_context(cql, 'replication_strategy_fail_list',
-                                                                'SimpleStrategy, LocalStrategy, '
-                                                                'NetworkTopologyStrategy, EverywhereStrategy'))
+                                                                'SimpleStrategy,LocalStrategy,'
+                                                                'NetworkTopologyStrategy,EverywhereStrategy'))
         for key, value in {'SimpleStrategy': 'replication_factor', 'NetworkTopologyStrategy': this_dc,
                            'EverywhereStrategy': 'replication_factor', 'LocalStrategy': 'replication_factor'}.items():
             # note: even though warn list is not empty, no warnings should be generated, because failures come first -

--- a/test/cql-pytest/util.py
+++ b/test/cql-pytest/util.py
@@ -6,7 +6,6 @@
 # Various utility functions which are useful for multiple tests.
 # Note that fixtures aren't here - they are in conftest.py.
 
-from ast import literal_eval
 import string
 import random
 import time
@@ -328,13 +327,12 @@ class config_value_context:
         self._key = key
         self._value = value
         self._original_value = None
+        self._select = cql.prepare("SELECT value FROM system.config WHERE name=?")
+        self._update = cql.prepare("UPDATE system.config SET value=? WHERE name=?")
 
     def __enter__(self):
-        self._original_value = literal_eval(
-            self._cql.execute(f"SELECT value FROM system.config WHERE name='{self._key}'").one().value)
-        if isinstance(self._original_value, list):
-            self._original_value = "".join(c for c in self._original_value if c.isalnum())
-        self._cql.execute(f"UPDATE system.config SET value='{self._value}' WHERE name='{self._key}'")
+        self._original_value = self._cql.execute(self._select, (self._key,)).one().value
+        self._cql.execute(self._update, (self._value, self._key))
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        self._cql.execute(f"UPDATE system.config SET value='{self._original_value}' WHERE name='{self._key}'")
+        self._cql.execute(self._update, (self._original_value, self._key))


### PR DESCRIPTION
cql-pytest's config_value_context is used to run a code sequence with different ScyllaDB configuration applied for a while. When it reads the original value (in order to restore it later), it applies ast.literal_eval() to it. This is strange, since the config variable isn't a Python literal.

It was added in 8c464b2ddb1 ("guardrails: restrict replication strategy (RS)"). Presumably, as a workaround for #19604 - it sufficiently massaged the input we read via SELECT to be acceptable later via UPDATE.

Now that #19604 is fixed, we can remove the call to ast.literal_eval, but have to fix up the parameters to config_value_context to something that will be accepted without further massaging.

This is a step towards fixing #15559, where we want to run some tests with a boolean configuration variable changed, and literal_eval is transforming the string representation of integers to integers and confusing the driver.

No backport needed for its own sake as it's just a cleanup. If we backport #15559 this is a dependency.