### PR TITLE
github: use needs.read-toolchain.outputs.image for iwyu's container

### DIFF
--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -26,7 +26,7 @@ jobs:
     needs:
       - read-toolchain
     runs-on: ubuntu-latest
-    container: ${{ needs.read-toolchain.image }}
+    container: ${{ needs.read-toolchain.outputs.image }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
in 9a71543fd29e3ac181b41b964ea870bd5fb742e6, we introduced a regression, which failed to use the proper value for the container image in which the iwyu workflow is run.

in this change, we pass the correct value, as we do in clang-tidy.yaml workflow.

Refs 9a71543fd29e3ac181b41b964ea870bd5fb742e6
Fixes https://github.com/scylladb/scylladb/issues/19704

---

no need to backport, it addresses a recent regression in our CI.