### PR TITLE
sstables: do not reload components of unlinked sstables

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2994,6 +2994,7 @@ sstable::unlink(storage::sync_dir sync) noexcept {
 
     co_await std::move(remove_fut);
     _stats.on_delete();
+    _manager.on_unlink(this);
 }
 
 thread_local sstables_stats::stats sstables_stats::_shard_stats;

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -325,6 +325,9 @@ void sstables_manager::validate_new_keyspace_storage_options(const data_dictiona
     }, so.value);
 }
 
+void sstables_manager::on_unlink(sstable* sst) {
+}
+
 sstables_registry::~sstables_registry() = default;
 
 }   // namespace sstables

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -326,6 +326,8 @@ void sstables_manager::validate_new_keyspace_storage_options(const data_dictiona
 }
 
 void sstables_manager::on_unlink(sstable* sst) {
+    // Remove the sst from manager's reclaimed list to prevent any attempts to reload its components.
+    _reclaimed.erase(*sst);
 }
 
 sstables_registry::~sstables_registry() = default;

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -193,6 +193,9 @@ public:
 
     const abort_source& get_abort_source() const noexcept { return _abort; }
 
+    // To be called by the sstable to signal its unlinking
+    void on_unlink(sstable* sst);
+
 private:
     void add(sstable* sst);
     // Transition the sstable to the "inactive" state. It has no

--- a/test/boost/suite.yaml
+++ b/test/boost/suite.yaml
@@ -44,5 +44,7 @@ custom_args:
         - '-c1 -m256M'
     commitlog_cleanup_test:
         - '-c1 -m2G'
+    bloom_filter_test:
+        - '-c1'
 run_in_debug:
     - logalloc_standard_allocator_segment_pool_backend_test

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -61,6 +61,10 @@ public:
     void remove_sst_from_reclaimed(sstable* sst) {
         _reclaimed.erase(*sst);
     }
+
+    auto& get_reclaimed_set() {
+        return _reclaimed;
+    }
 };
 
 class test_env_compaction_manager {

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -57,6 +57,10 @@ public:
     size_t get_total_reclaimable_memory() {
         return _total_reclaimable_memory;
     }
+
+    void remove_sst_from_reclaimed(sstable* sst) {
+        _reclaimed.erase(*sst);
+    }
 };
 
 class test_env_compaction_manager {


### PR DESCRIPTION
The SSTable is removed from the reclaimed memory tracking logic only
when its object is deleted. However, there is a risk that the Bloom
filter reloader may attempt to reload the SSTable after it has been
unlinked but before the SSTable object is destroyed. Prevent this by
removing the SSTable from the reclaimed list maintained by the manager
as soon as it is unlinked. 

The original logic that updated the memory tracking in
`sstables_manager::deactivate()` is left in place as (a) the variables
have to be updated only when the SSTable object is actually deleted, as
the memory used by the filter is not freed as long as the SSTable is
alive, and (b) the `_reclaimed.erase(*sst)` is still useful during
shutdown, for example, when the SSTable is not unlinked but just
destroyed.
    
Fixes https://github.com/scylladb/scylladb/issues/19722