### PR TITLE
sstable::open_sstable: pass origin from the writer

### DIFF
--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -797,7 +797,7 @@ public:
         // exactly what callers used to do anyway.
         estimated_partitions = std::max(uint64_t(1), estimated_partitions);
 
-        _sst.open_sstable();
+        _sst.open_sstable(cfg.origin);
         _sst.create_data().get();
         _compression_enabled = !_sst.has_component(component_type::CRC);
         init_file_writers();

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1470,7 +1470,7 @@ void writer::consume_end_of_stream() {
         _sst._schema, _sst.get_first_decorated_key(), _sst.get_last_decorated_key(), _enc_stats);
     close_data_writer();
     _sst.write_summary();
-    _sst.maybe_rebuild_filter_from_index(_num_partitions_consumed, _cfg.origin);
+    _sst.maybe_rebuild_filter_from_index(_num_partitions_consumed);
     _sst.write_filter();
     _sst.write_statistics();
     _sst.write_compression();
@@ -1485,7 +1485,7 @@ void writer::consume_end_of_stream() {
             { large_data_type::elements_in_collection, std::move(_elements_in_collection_entry) },
         }
     });
-    _sst.write_scylla_metadata(_shard, std::move(features), std::move(identifier), std::move(ld_stats), _cfg.origin);
+    _sst.write_scylla_metadata(_shard, std::move(features), std::move(identifier), std::move(ld_stats));
     _sst.seal_sstable(_cfg.backup).get();
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -934,7 +934,8 @@ future<file_writer> sstable::make_component_file_writer(component_type c, file_o
     });
 }
 
-void sstable::open_sstable() {
+void sstable::open_sstable(const sstring& origin) {
+    _origin = origin;
     generate_toc();
     _storage->open(*this);
 }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -638,7 +638,7 @@ private:
             open_flags oflags = open_flags::wo | open_flags::create | open_flags::exclusive) noexcept;
 
     void generate_toc();
-    void open_sstable();
+    void open_sstable(const sstring& origin);
 
     future<> read_compression();
     void write_compression();

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -648,8 +648,7 @@ private:
     void write_scylla_metadata(shard_id shard,
                                sstable_enabled_features features,
                                run_identifier identifier,
-                               std::optional<scylla_metadata::large_data_stats> ld_stats,
-                               sstring origin);
+                               std::optional<scylla_metadata::large_data_stats> ld_stats);
 
     future<> read_filter(sstable_open_config cfg = {});
 
@@ -658,7 +657,7 @@ private:
     // partitions, if the partition estimate provided during bloom
     // filter initialisation was not good.
     // This should be called only before an sstable is sealed.
-    void maybe_rebuild_filter_from_index(uint64_t num_partitions, sstring origin);
+    void maybe_rebuild_filter_from_index(uint64_t num_partitions);
 
     future<> read_summary() noexcept;
 

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -149,7 +149,7 @@ public:
         _sst->_recognized_components.erase(component_type::Index);
         _sst->_recognized_components.erase(component_type::Data);
         return seastar::async([sst = _sst] {
-            sst->open_sstable();
+            sst->open_sstable("test");
             sst->write_statistics();
             sst->write_compression();
             sst->write_filter();


### PR DESCRIPTION
Pass origin when opening the sstable from the writer and store it in the
sstable object. This will make the origin available for the entire write
path.