### PR TITLE
github: disable scheduled workflow on forks

### DIFF
--- a/.github/workflows/build-scylla.yaml
+++ b/.github/workflows/build-scylla.yaml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'scylladb/scylladb'
     runs-on: ubuntu-latest
     # be consistent with tools/toolchain/image
     container: scylladb/scylla-toolchain:fedora-40-20240621

--- a/.github/workflows/clang-nightly.yaml
+++ b/.github/workflows/clang-nightly.yaml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   clang-dev:
     name: Build with clang nightly
+    if: github.repository == 'scylladb/scylladb'
     runs-on: ubuntu-latest
     container: fedora:40
     strategy:

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -10,9 +10,6 @@ on:
       - 'docs/**'
       - '.github/**'
   workflow_dispatch:
-  schedule:
-    # only at 5AM Saturday
-    - cron: '0 5 * * SAT'
 
 env:
   BUILD_TYPE: RelWithDebInfo

--- a/.github/workflows/reproducible-build.yaml
+++ b/.github/workflows/reproducible-build.yaml
@@ -19,6 +19,7 @@ jobs:
     with:
       build_mode: release
   compare-checksum:
+    if: github.repository == 'scylladb/scylladb'
     runs-on: ubuntu-latest
     needs:
       - build-a


### PR DESCRIPTION
as these workflows are scheduled periodically, and if they fail, notifications are sent to the repo's owner. to minimize the surprises to the contributors using github, let's disable these workflows on fork repos.

---

it's a CI-related change, no need to backport.