### PR TITLE
test: raft: replace the use of read_barrier work-around

### DIFF
--- a/test/auth_cluster/test_auth_raft_command_split.py
+++ b/test/auth_cluster/test_auth_raft_command_split.py
@@ -7,8 +7,8 @@
 import asyncio
 from test.pylib.manager_client import ManagerClient
 import pytest
-from test.pylib.rest_client import inject_error, inject_error_one_shot
-from test.pylib.util import read_barrier, unique_name, wait_for_cql_and_get_hosts
+from test.pylib.rest_client import inject_error, read_barrier
+from test.pylib.util import unique_name
 
 
 """
@@ -37,10 +37,10 @@ async def test_auth_raft_command_split(manager: ManagerClient) -> None:
                             'auth_announce_mutations_command_max_size'):
         await cql.run_async(f"DROP ROLE IF EXISTS {shared_role}", execution_profile='whitelist')
 
-    cql, hosts = await manager.get_ready_cql(servers)
+    cql, _ = await manager.get_ready_cql(servers)
 
     # auth reads are eventually consistent so we need to sync all nodes
-    await asyncio.gather(*(read_barrier(cql, host) for host in hosts))
+    await asyncio.gather(*(read_barrier(manager.api, s.ip_addr) for s in servers))
 
     # confirm that deleted shared_role is not attached to any other role
     assert await cql.run_async(f"SELECT * FROM system.role_permissions WHERE resource = 'role/{shared_role}' ALLOW FILTERING") == []
@@ -48,6 +48,6 @@ async def test_auth_raft_command_split(manager: ManagerClient) -> None:
     # cleanup
     for user in users:
         await cql.run_async(f"DROP ROLE IF EXISTS {user}")
-    await asyncio.gather(*(read_barrier(cql, host) for host in hosts))
+    await asyncio.gather(*(read_barrier(manager.api, s.ip_addr) for s in servers))
     current_perms = await cql.run_async("SELECT * FROM system.role_permissions")
     assert initial_perms == current_perms

--- a/test/auth_cluster/test_raft_service_levels.py
+++ b/test/auth_cluster/test_raft_service_levels.py
@@ -7,7 +7,8 @@ import pytest
 import time
 import asyncio
 import logging
-from test.pylib.util import unique_name, wait_for_cql_and_get_hosts, read_barrier
+from test.pylib.rest_client import get_host_api_address, read_barrier
+from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
 from test.pylib.manager_client import ManagerClient
 from test.pylib.internal_types import ServerInfo
 from test.topology.util import trigger_snapshot, wait_until_topology_upgrade_finishes, enter_recovery_state, reconnect_driver, \
@@ -98,7 +99,7 @@ async def test_service_levels_upgrade(request, manager: ManagerClient):
     sl_v2 = "sl" + unique_name()
     await cql.run_async(f"CREATE SERVICE LEVEL {sl_v2}")
 
-    await asyncio.gather(*(read_barrier(cql, host) for host in hosts))
+    await asyncio.gather(*(read_barrier(manager.api, get_host_api_address(host)) for host in hosts))
     result_with_sl_v2 = await cql.run_async(f"SELECT service_level FROM system.service_levels_v2")
     assert set([sl.service_level for sl in result_with_sl_v2]) == set(sls + [sl_v2])
 

--- a/test/pylib/random_tables.py
+++ b/test/pylib/random_tables.py
@@ -40,7 +40,8 @@ from typing import Optional, Type, List, Set, Union, TYPE_CHECKING
 if TYPE_CHECKING:
     from cassandra.cluster import Session as CassandraSession            # type: ignore
     from test.pylib.manager_client import ManagerClient
-from test.pylib.util import get_available_host, read_barrier
+from test.pylib.rest_client import get_host_api_address, read_barrier
+from test.pylib.util import get_available_host
 
 
 logger = logging.getLogger('random_tables')
@@ -340,7 +341,7 @@ class RandomTables():
             # Issue a read barrier on some node and then keep using that node to do the queries.
             # This ensures that the queries return recent data (at least all data committed
             # when `verify_schema` was called).
-            await read_barrier(cql, host)
+            await read_barrier(self.manager.api, get_host_api_address(host))
 
         res1 = {row.table_name for row in await cql.run_async(cql_stmt1, host=host)}
         assert not tables - res1, f"Tables {tables - res1} not present"

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -15,6 +15,7 @@ from contextlib import asynccontextmanager
 from aiohttp import request, BaseConnector, UnixConnector, ClientTimeout
 import pytest
 from test.pylib.internal_types import IPAddress, HostID
+from cassandra.pool import Host                          # type: ignore # pylint: disable=no-name-in-module
 
 
 logger = logging.getLogger(__name__)
@@ -501,3 +502,12 @@ async def read_barrier(api: ScyllaRESTAPIClient, node_ip: IPAddress, group_id: O
         params["group_id"] = group_id
 
     await api.client.post("/raft/read_barrier", host=node_ip, params=params)
+
+
+def get_host_api_address(host: Host) -> IPAddress:
+    """ Returns the API address of the host.
+
+        The API address can be different than the RPC (node) address under certain circumstances.
+        In particular, in case the RPC address has been modified.
+    """
+    return host.listen_address if host.listen_address else host.address

--- a/test/pylib/tablets.py
+++ b/test/pylib/tablets.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 
-from test.pylib.util import read_barrier
 from test.pylib.manager_client import ManagerClient
 from test.pylib.internal_types import ServerInfo, HostID
+from test.pylib.rest_client import read_barrier
 from typing import NamedTuple
 
 class TabletReplicas(NamedTuple):
@@ -25,7 +25,7 @@ async def get_all_tablet_replicas(manager: ManagerClient, server: ServerInfo, ke
 
     # read_barrier is needed to ensure that local tablet metadata on the queried node
     # reflects the finalized tablet movement.
-    await read_barrier(manager.get_cql(), host)
+    await read_barrier(manager.api, server.ip_addr)
 
     table_id = await manager.get_table_id(keyspace_name, table_name)
     rows = await manager.get_cql().run_async(f"SELECT last_token, replicas FROM system.tablets where "

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -137,15 +137,6 @@ async def get_available_host(cql: Session, deadline: float) -> Host:
     return await wait_for(find_host, deadline)
 
 
-async def read_barrier(cql: Session, host: Host):
-    """To issue a read barrier it is sufficient to attempt dropping a
-    non-existing table. We need to use `if exists`, otherwise the statement
-    would fail on prepare/validate step which happens before a read barrier is
-    performed.
-    """
-    await cql.run_async("drop table if exists nosuchkeyspace.nosuchtable", host = host)
-
-
 # Wait for the given feature to be enabled.
 async def wait_for_feature(feature: str, cql: Session, host: Host, deadline: float) -> None:
     async def feature_is_enabled():

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -6,9 +6,8 @@
 from cassandra.protocol import ConfigurationException
 from cassandra.query import SimpleStatement, ConsistencyLevel
 from test.pylib.manager_client import ManagerClient
-from test.pylib.rest_client import HTTPError
+from test.pylib.rest_client import HTTPError, read_barrier
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
-from test.pylib.util import read_barrier
 from test.topology.conftest import skip_mode
 from test.topology.util import wait_for_cql_and_get_hosts
 import time
@@ -156,7 +155,7 @@ async def test_tablet_rf_change(manager: ManagerClient, direction):
     for s in servers:
         host_id = await manager.get_host_id(s.server_id)
         host = await wait_for_cql_and_get_hosts(cql, [s], time.time() + 30)
-        await read_barrier(manager.get_cql(), host[0]) # scylladb/scylladb#18199
+        await read_barrier(manager.api, s.ip_addr)  # scylladb/scylladb#18199
         for k in fragments:
             res = await cql.run_async(f"SELECT partition_region FROM MUTATION_FRAGMENTS(test.test) WHERE pk={k}", host=host[0])
             for fragment in res:

--- a/test/topology_custom/test_tablets_migration.py
+++ b/test/topology_custom/test_tablets_migration.py
@@ -5,9 +5,8 @@
 #
 from cassandra.query import SimpleStatement, ConsistencyLevel
 from test.pylib.manager_client import ManagerClient
-from test.pylib.rest_client import HTTPError
+from test.pylib.rest_client import HTTPError, read_barrier
 from test.pylib.tablets import get_all_tablet_replicas
-from test.pylib.util import read_barrier
 from test.topology.conftest import skip_mode
 from test.topology.util import wait_for_cql_and_get_hosts
 import time
@@ -84,7 +83,7 @@ async def test_tablet_transition_sanity(manager: ManagerClient, action):
     for h, s in zip(host_ids, servers):
         host = await wait_for_cql_and_get_hosts(cql, [s], time.time() + 30)
         if h != host_ids[0]:
-            await read_barrier(manager.get_cql(), host[0]) # host-0 did the barrier in get_all_tablet_replicas above
+            await read_barrier(manager.api, host[0].address)  # host-0 did the barrier in get_all_tablet_replicas above
         res = await cql.run_async("SELECT COUNT(*) FROM MUTATION_FRAGMENTS(test.test)", host=host[0])
         logger.info(f"Host {h} reports {res} as mutation fragments count")
         if h in replicas:

--- a/test/topology_experimental_raft/test_mv_tablets.py
+++ b/test/topology_experimental_raft/test_mv_tablets.py
@@ -7,7 +7,8 @@
 # Tests for interaction of materialized views with *tablets*
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for_cql_and_get_hosts, read_barrier
+from test.pylib.rest_client import read_barrier
+from test.pylib.util import wait_for_cql_and_get_hosts
 from test.pylib.internal_types import ServerInfo
 from test.topology.conftest import skip_mode
 
@@ -16,7 +17,6 @@ from .test_alternator import get_alternator, alternator_config, full_query
 import pytest
 import asyncio
 import logging
-import random
 import time
 
 
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 # information to propagate to all servers).
 async def get_tablet_replicas(manager: ManagerClient, server: ServerInfo, keyspace_name: str, table_or_view_name: str, token: int):
     host = (await wait_for_cql_and_get_hosts(manager.cql, [server], time.time() + 60))[0]
-    await read_barrier(manager.cql, host)
+    await read_barrier(manager.api, server.ip_addr)
 
     rows = await manager.cql.run_async(f"SELECT last_token, replicas FROM system.tablets where "
                                        f"keyspace_name = '{keyspace_name}' and "

--- a/test/topology_experimental_raft/test_node_isolation.py
+++ b/test/topology_experimental_raft/test_node_isolation.py
@@ -3,20 +3,17 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
-import asyncio
 import logging
 import pytest
-import time
 
-from cassandra.cluster import ConsistencyLevel, ExecutionProfile, EXEC_PROFILE_DEFAULT # type: ignore
-from cassandra.cluster import NoHostAvailable, OperationTimedOut # type: ignore
-from cassandra.query import SimpleStatement # type: ignore
+from cassandra.cluster import ConsistencyLevel, ExecutionProfile, EXEC_PROFILE_DEFAULT  # type: ignore
+from cassandra.cluster import NoHostAvailable, OperationTimedOut  # type: ignore
+from cassandra.cluster import Cluster  # type: ignore
+from cassandra.query import SimpleStatement  # type: ignore
 from cassandra.policies import WhiteListRoundRobinPolicy  # type: ignore
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for_cql_and_get_hosts, read_barrier
-
-from cassandra.cluster import Cluster
+from test.pylib.rest_client import read_barrier
 
 
 logger = logging.getLogger(__name__)
@@ -48,8 +45,7 @@ async def test_banned_node_cannot_communicate(manager: ManagerClient) -> None:
     await manager.remove_node(srvs[0].server_id, srvs[2].server_id)
     # Perform a read barrier on srvs[1] so it learns about the ban.
     logger.info(f"Performing read barrier on server {srvs[1]}")
-    host = (await wait_for_cql_and_get_hosts(cql, [srvs[1]], time.time() + 60))[0]
-    await read_barrier(cql, host)
+    await read_barrier(manager.api, srvs[1].ip_addr)
     logger.info(f"Unpausing {srvs[2]}")
     await manager.server_unpause(srvs[2].server_id)
 

--- a/test/topology_experimental_raft/test_tablets_intranode.py
+++ b/test/topology_experimental_raft/test_tablets_intranode.py
@@ -10,7 +10,7 @@ from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot, HTTPError
 from test.pylib.rest_client import inject_error
-from test.pylib.util import wait_for_cql_and_get_hosts, read_barrier, start_writes
+from test.pylib.util import wait_for_cql_and_get_hosts, start_writes
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
 from test.topology.conftest import skip_mode
 from test.topology.util import reconnect_driver


### PR DESCRIPTION
Replaced the old `read_barrier` helper from "test/pylib/util.py" by the new helper from "test/pylib/rest_client.py" that is calling the newly introduced direct REST API.

Replaced in all relevant tests and decommissioned the old helper.

Introduced a new helper `get_host_api_address` to retrieve the host API address - which in come cases can be different from the host address (e.g. if the RPC address is changed).

Fixes: scylladb/scylladb#19662