### PR TITLE
db/hints: Test `manager::too_many_in_flight_hints_for()`

### DIFF
--- a/db/hints/internal/hint_endpoint_manager.cc
+++ b/db/hints/internal/hint_endpoint_manager.cc
@@ -15,6 +15,7 @@
 #include <seastar/core/sleep.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/coroutine/exception.hh>
 
 // Scylla includes.
 #include "db/hints/internal/common.hh"
@@ -29,6 +30,7 @@
 // STD.
 #include <algorithm>
 #include <chrono>
+#include <exception>
 #include <utility>
 #include <vector>
 
@@ -44,35 +46,47 @@ constexpr std::chrono::seconds HINT_FILE_WRITE_TIMEOUT = std::chrono::seconds(2)
 bool hint_endpoint_manager::store_hint(schema_ptr s, lw_shared_ptr<const frozen_mutation> fm, tracing::trace_state_ptr tr_state) noexcept {
     try {
         // Future is waited on indirectly in `stop()` (via `_store_gate`).
-        (void)with_gate(_store_gate, [this, s = std::move(s), fm = std::move(fm), tr_state] () mutable {
+        (void) with_gate(_store_gate,
+                [this, s_ = std::move(s), fm_ = std::move(fm), tr_state_ = tr_state] () mutable -> future<> {
+            // We discard the future to this call to `with_gate()`, so wrapping this lambda
+            // within `coroutine::lambda` will NOT work. That's why we need to copy these
+            // variables by hand.
+            auto s = std::move(s_);
+            auto fm = std::move(fm_);
+            auto tr_state = std::move(tr_state_);
+
             ++_hints_in_progress;
             size_t mut_size = fm->representation().size();
             shard_stats().size_of_hints_in_progress += mut_size;
 
-            return with_shared(file_update_mutex(), [this, fm, s, tr_state] () mutable -> future<> {
-                return get_or_load().then([fm = std::move(fm), s = std::move(s), tr_state] (hints_store_ptr log_ptr) mutable {
-                    commitlog_entry_writer cew(s, *fm, db::commitlog::force_sync::no);
-                    return log_ptr->add_entry(s->id(), cew, db::timeout_clock::now() + HINT_FILE_WRITE_TIMEOUT);
-                }).then([this, tr_state] (db::rp_handle rh) {
-                    auto rp = rh.release();
-                    if (_last_written_rp < rp) {
-                        _last_written_rp = rp;
-                        manager_logger.debug("[{}] Updated last written replay position to {}", end_point_key(), rp);
-                    }
-                    ++shard_stats().written;
+            try {
+                const auto shared_lock = co_await get_shared_lock(file_update_mutex());
 
-                    manager_logger.trace("Hint to {} was stored", end_point_key());
-                    tracing::trace(tr_state, "Hint to {} was stored", end_point_key());
-                }).handle_exception([this, tr_state] (std::exception_ptr eptr) {
-                    ++shard_stats().errors;
+                hints_store_ptr log_ptr = co_await get_or_load();
+                commitlog_entry_writer cew(s, *fm, commitlog::force_sync::no);
 
-                    manager_logger.debug("store_hint(): got the exception when storing a hint to {}: {}", end_point_key(), eptr);
-                    tracing::trace(tr_state, "Failed to store a hint to {}: {}", end_point_key(), eptr);
-                });
-            }).finally([this, mut_size, fm, s] {
-                --_hints_in_progress;
-                shard_stats().size_of_hints_in_progress -= mut_size;
-            });;
+                rp_handle rh = co_await log_ptr->add_entry(s->id(), cew, db::timeout_clock::now() + HINT_FILE_WRITE_TIMEOUT);
+
+                const replay_position rp = rh.release();
+                if (_last_written_rp < rp) {
+                    _last_written_rp = rp;
+                    manager_logger.debug("[{}] Updated last written replay position to {}", end_point_key(), rp);
+                }
+
+                ++shard_stats().written;
+
+                manager_logger.trace("Hint to {} was stored", end_point_key());
+                tracing::trace(tr_state, "Hint to {} was stored", end_point_key());
+            } catch (...) {
+                ++shard_stats().errors;
+                const auto eptr = std::current_exception();
+
+                manager_logger.debug("store_hint(): got the exception when storing a hint to {}: {}", end_point_key(), eptr);
+                tracing::trace(tr_state, "Failed to store a hint to {}: {}", end_point_key(), eptr);
+            }
+
+            --_hints_in_progress;
+            shard_stats().size_of_hints_in_progress -= mut_size;
         });
     } catch (...) {
         manager_logger.trace("Failed to store a hint to {}: {}", end_point_key(), std::current_exception());
@@ -81,6 +95,7 @@ bool hint_endpoint_manager::store_hint(schema_ptr s, lw_shared_ptr<const frozen_
         ++shard_stats().dropped;
         return false;
     }
+
     return true;
 }
 

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -104,7 +104,6 @@ public:
     static inline const std::string FILENAME_PREFIX{"HintsLog" + commitlog::descriptor::SEPARATOR};
     // Non-const - can be modified with an error injection.
     static inline std::chrono::seconds hints_flush_period = std::chrono::seconds(10);
-    static constexpr std::chrono::seconds HINT_FILE_WRITE_TIMEOUT = std::chrono::seconds(2);
 private:
     static constexpr uint64_t MAX_SIZE_OF_HINTS_IN_PROGRESS = 10 * 1024 * 1024; // 10MB
 

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -304,6 +304,8 @@ private:
 
     hint_endpoint_manager& get_ep_manager(const endpoint_id& host_id, const gms::inet_address& ip);
 
+    uint64_t max_size_of_hints_in_progress() const noexcept;
+
 public:
     bool have_ep_manager(const std::variant<locator::host_id, gms::inet_address>& ep) const noexcept;
 


### PR DESCRIPTION
In 6e79d64, the behavior of `manager::too_many_in_flight_hints_for()`
was accidentally modified. It remained unnoticed for some time
and then fixed. In this commit, we add a test verifying that
the concurrency of hints being written to disk is indeed limited
and the limitations are imposed properly.

Refs scylladb/scylladb#17636
Fixes scylladb/scylladb#17660