### PR TITLE
view: move view_build_status to group0

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2851,10 +2851,13 @@ future<system_keyspace::view_builder_version_t> system_keyspace::get_view_builde
         co_return view_builder_version_t::v1;
     }
     auto& str = *str_opt;
-    if (str == "" || str == "1") {
+    if (str == "" || str == "10") {
         co_return view_builder_version_t::v1;
     }
-    if (str == "2") {
+    if (str == "15") {
+        co_return view_builder_version_t::v1_5;
+    }
+    if (str == "20") {
         co_return view_builder_version_t::v2;
     }
     on_internal_error(slogger, fmt::format("unexpected view_builder_version in scylla_local got {}", str));

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -182,6 +182,7 @@ public:
     static constexpr auto CDC_GENERATIONS_V3 = "cdc_generations_v3";
     static constexpr auto TABLETS = "tablets";
     static constexpr auto SERVICE_LEVELS_V2 = "service_levels_v2";
+    static constexpr auto VIEW_BUILD_STATUS_V2 = "view_build_status_v2";
 
     // auth
     static constexpr auto ROLES = "roles";
@@ -275,6 +276,7 @@ public:
     static schema_ptr cdc_generations_v3();
     static schema_ptr tablets();
     static schema_ptr service_levels_v2();
+    static schema_ptr view_build_status_v2();
 
     // auth
     static schema_ptr roles();

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -620,8 +620,9 @@ public:
     future<auth_version_t> get_auth_version();
 
     enum class view_builder_version_t: int64_t {
-        v1 = 1,
-        v2 = 2,
+        v1 = 10,
+        v1_5 = 15,
+        v2 = 20,
     };
 
     future<std::optional<mutation>> get_view_builder_version_mutation();

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -619,6 +619,15 @@ public:
     future<mutation> make_auth_version_mutation(api::timestamp_type ts, auth_version_t version);
     future<auth_version_t> get_auth_version();
 
+    enum class view_builder_version_t: int64_t {
+        v1 = 1,
+        v2 = 2,
+    };
+
+    future<std::optional<mutation>> get_view_builder_version_mutation();
+    future<mutation> make_view_builder_version_mutation(api::timestamp_type ts, view_builder_version_t version);
+    future<view_builder_version_t> get_view_builder_version();
+
     future<> sstables_registry_create_entry(sstring location, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc);
     future<> sstables_registry_update_entry_status(sstring location, sstables::generation_type gen, sstring status);
     future<> sstables_registry_update_entry_state(sstring location, sstables::generation_type gen, sstables::sstable_state state);

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1973,10 +1973,12 @@ future<> view_update_generator::mutate_MV(
     });
 }
 
-view_builder::view_builder(replica::database& db, db::system_keyspace& sys_ks, db::system_distributed_keyspace& sys_dist_ks, service::migration_notifier& mn, view_update_generator& vug)
+view_builder::view_builder(replica::database& db, db::system_keyspace& sys_ks, db::system_distributed_keyspace& sys_dist_ks, service::migration_notifier& mn, view_update_generator& vug, service::raft_group0_client& group0_client, cql3::query_processor& qp)
         : _db(db)
         , _sys_ks(sys_ks)
         , _sys_dist_ks(sys_dist_ks)
+        , _group0_client(group0_client)
+        , _qp(qp)
         , _mnotifier(mn)
         , _vug(vug)
         , _permit(_db.get_reader_concurrency_semaphore().make_tracking_only_permit(nullptr, "view_builder", db::no_timeout, {})) {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2371,8 +2371,31 @@ future<> view_builder::remove_view_build_status(sstring ks_name, sstring view_na
     }
 }
 
+static future<std::unordered_map<locator::host_id, sstring>>
+view_status_common(cql3::query_processor& qp, sstring ks_name, sstring cf_name, sstring view_ks_name, sstring view_name, db::consistency_level cl) {
+    return qp.execute_internal(
+            format("SELECT host_id, status FROM {}.{} WHERE keyspace_name = ? AND view_name = ?", ks_name, cf_name),
+            cl,
+            view_builder_query_state(),
+            { std::move(view_ks_name), std::move(view_name) },
+            cql3::query_processor::cache_internal::no).then([] (::shared_ptr<cql3::untyped_result_set> cql_result) {
+        return boost::copy_range<std::unordered_map<locator::host_id, sstring>>(*cql_result
+                | boost::adaptors::transformed([] (const cql3::untyped_result_set::row& row) {
+                    auto host_id = locator::host_id(row.get_as<utils::UUID>("host_id"));
+                    auto status = row.get_as<sstring>("status");
+                    return std::pair(std::move(host_id), std::move(status));
+                }));
+    });
+}
+
 future<std::unordered_map<locator::host_id, sstring>> view_builder::view_status(sstring ks_name, sstring view_name) const {
-    return _sys_dist_ks.view_status(std::move(ks_name), std::move(view_name));
+    if (_view_build_status_on_group0) {
+        co_return co_await view_status_common(_qp, db::system_keyspace::NAME, db::system_keyspace::VIEW_BUILD_STATUS_V2,
+                std::move(ks_name), std::move(view_name), db::consistency_level::LOCAL_ONE);
+    } else {
+        co_return co_await view_status_common(_qp, db::system_distributed_keyspace::NAME, db::system_distributed_keyspace::VIEW_BUILD_STATUS,
+                std::move(ks_name), std::move(view_name), db::consistency_level::ONE);
+    }
 }
 
 future<std::unordered_map<sstring, sstring>>

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -237,6 +237,11 @@ private:
     future<> mark_as_built(view_ptr);
     void setup_metrics();
 
+    future<> mark_view_build_started(sstring ks_name, sstring view_name);
+    future<> mark_view_build_success(sstring ks_name, sstring view_name);
+    future<> remove_view_build_status(sstring ks_name, sstring view_name);
+    future<std::unordered_map<locator::host_id, sstring>> view_status(sstring ks_name, sstring view_name) const;
+
     struct consumer;
 };
 

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -10,6 +10,7 @@
 
 #include "query-request.hh"
 #include "service/migration_listener.hh"
+#include "service/raft/raft_group0_client.hh"
 #include "utils/serialized_action.hh"
 #include "utils/cross-shard-barrier.hh"
 #include "replica/database.hh"
@@ -151,6 +152,8 @@ class view_builder final : public service::migration_listener::only_view_notific
     replica::database& _db;
     db::system_keyspace& _sys_ks;
     db::system_distributed_keyspace& _sys_dist_ks;
+    service::raft_group0_client& _group0_client;
+    cql3::query_processor& _qp;
     service::migration_notifier& _mnotifier;
     view_update_generator&  _vug;
     reader_permit _permit;
@@ -189,7 +192,8 @@ public:
     replica::database& get_db() noexcept { return _db; }
 
 public:
-    view_builder(replica::database&, db::system_keyspace&, db::system_distributed_keyspace&, service::migration_notifier&, view_update_generator& vug);
+    view_builder(replica::database&, db::system_keyspace&, db::system_distributed_keyspace&, service::migration_notifier&, view_update_generator& vug,
+            service::raft_group0_client& group0_client, cql3::query_processor& qp);
     view_builder(view_builder&&) = delete;
 
     /**

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -215,6 +215,8 @@ public:
      */
     future<> stop();
 
+    static future<> generate_mutations_on_node_left(replica::database& db, db::system_keyspace& sys_ks, api::timestamp_type timestamp, locator::host_id host_id, std::vector<canonical_mutation>& muts);
+
     static future<> migrate_to_v2(locator::token_metadata_ptr tmptr, db::system_keyspace& sys_ks, cql3::query_processor& qp, service::raft_group0_client& group0_client, abort_source& as, service::group0_guard guard);
 
     void upgrade_to_v2();

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -257,6 +257,22 @@ private:
     future<> mark_as_built(view_ptr);
     void setup_metrics();
 
+    template <typename Func1, typename Func2>
+    future<> write_view_build_status(Func1&& fn_group0, Func2&& fn_sys_dist) {
+        auto op = _upgrade_phaser.start();
+
+        // read locally so it doesn't change between async calls
+        const auto v = _view_build_status_on;
+
+        if (v == view_build_status_location::group0 || v == view_build_status_location::both) {
+            co_await fn_group0();
+        }
+
+        if (v == view_build_status_location::sys_dist_ks || v == view_build_status_location::both) {
+            co_await fn_sys_dist();
+        }
+    }
+
     future<> mark_view_build_started(sstring ks_name, sstring view_name);
     future<> mark_view_build_success(sstring ks_name, sstring view_name);
     future<> remove_view_build_status(sstring ks_name, sstring view_name);

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -214,6 +214,10 @@ public:
      */
     future<> stop();
 
+    static future<> migrate_to_v2(locator::token_metadata_ptr tmptr, db::system_keyspace& sys_ks, cql3::query_processor& qp, service::raft_group0_client& group0_client, abort_source& as, service::group0_guard guard);
+
+    void upgrade_to_v2();
+
     virtual void on_create_view(const sstring& ks_name, const sstring& view_name) override;
     virtual void on_update_view(const sstring& ks_name, const sstring& view_name, bool columns_changed) override;
     virtual void on_drop_view(const sstring& ks_name, const sstring& view_name) override;

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -173,6 +173,7 @@ class view_builder final : public service::migration_listener::only_view_notific
     stats _stats;
     metrics::metric_groups _metrics;
     bool _view_build_status_on_group0 = false;
+    bool _init_virtual_table_on_upgrade = false;
 
     struct view_builder_init_state {
         std::vector<future<>> bookkeeping_ops;
@@ -217,6 +218,7 @@ public:
     static future<> migrate_to_v2(locator::token_metadata_ptr tmptr, db::system_keyspace& sys_ks, cql3::query_processor& qp, service::raft_group0_client& group0_client, abort_source& as, service::group0_guard guard);
 
     void upgrade_to_v2();
+    void init_virtual_table();
 
     virtual void on_create_view(const sstring& ks_name, const sstring& view_name) override;
     virtual void on_update_view(const sstring& ks_name, const sstring& view_name, bool columns_changed) override;

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -172,6 +172,7 @@ class view_builder final : public service::migration_listener::only_view_notific
     std::unordered_map<std::pair<sstring, sstring>, seastar::shared_promise<>, utils::tuple_hash> _build_notifiers;
     stats _stats;
     metrics::metric_groups _metrics;
+    bool _view_build_status_on_group0 = false;
 
     struct view_builder_init_state {
         std::vector<future<>> bookkeeping_ops;

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -134,6 +134,7 @@ public:
     gms::feature topology_requests_type_column { *this, "TOPOLOGY_REQUESTS_TYPE_COLUMN"sv };
     gms::feature native_reverse_queries { *this, "NATIVE_REVERSE_QUERIES"sv };
     gms::feature zero_token_nodes { *this, "ZERO_TOKEN_NODES"sv };
+    gms::feature view_build_status_on_group0 { *this, "VIEW_BUILD_STATUS_ON_GROUP0"sv };
 
     // A feature just for use in tests. It must not be advertised unless
     // the "features_enable_test_feature" injection is enabled.

--- a/main.cc
+++ b/main.cc
@@ -1956,6 +1956,12 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 return std::chrono::duration_cast<steady_clock_type::duration>(std::chrono::milliseconds(cfg->service_levels_interval()));
             }, ss.local(), group0_client);
 
+            // Initialize virtual table in system_distributed keyspace after joining the cluster, so
+            // that the keyspace is ready
+            view_builder.invoke_on_all([] (db::view::view_builder& vb) {
+                vb.init_virtual_table();
+            }).get();
+
             const qualified_name qualified_authorizer_name(auth::meta::AUTH_PACKAGE_NAME, cfg->authorizer());
             const qualified_name qualified_authenticator_name(auth::meta::AUTH_PACKAGE_NAME, cfg->authenticator());
             const qualified_name qualified_role_manager_name(auth::meta::AUTH_PACKAGE_NAME, cfg->role_manager());

--- a/main.cc
+++ b/main.cc
@@ -1649,7 +1649,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             supervisor::notify("starting the view builder");
-            view_builder.start(std::ref(db), std::ref(sys_ks), std::ref(sys_dist_ks), std::ref(mm_notifier), std::ref(view_update_generator)).get();
+            view_builder.start(std::ref(db), std::ref(sys_ks), std::ref(sys_dist_ks), std::ref(mm_notifier), std::ref(view_update_generator), std::ref(group0_client), std::ref(qp)).get();
             auto stop_view_builder = defer_verbose_shutdown("view builder", [cfg] {
                 view_builder.stop().get();
             });

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1375,74 +1375,6 @@ request_class classify_request(const database_config& _dbcfg) {
     }
 }
 
-template <typename T>
-using foreign_unique_ptr = foreign_ptr<std::unique_ptr<T>>;
-
-class streaming_reader_lifecycle_policy
-    : public reader_lifecycle_policy_v2
-        , public enable_shared_from_this<streaming_reader_lifecycle_policy> {
-    struct reader_context {
-        foreign_ptr<lw_shared_ptr<const dht::partition_range>> range;
-        foreign_unique_ptr<utils::phased_barrier::operation> read_operation;
-        reader_concurrency_semaphore* semaphore;
-    };
-    distributed<replica::database>& _db;
-    table_id _table_id;
-    gc_clock::time_point _compaction_time;
-    std::vector<reader_context> _contexts;
-public:
-    streaming_reader_lifecycle_policy(distributed<replica::database>& db, table_id table_id, gc_clock::time_point compaction_time)
-        : _db(db)
-        , _table_id(table_id)
-        , _compaction_time(compaction_time)
-        , _contexts(smp::count) {
-    }
-    virtual mutation_reader create_reader(
-        schema_ptr schema,
-        reader_permit permit,
-        const dht::partition_range& range,
-        const query::partition_slice& slice,
-        tracing::trace_state_ptr,
-        mutation_reader::forwarding fwd_mr) override {
-        const auto shard = this_shard_id();
-        auto& cf = _db.local().find_column_family(schema);
-
-        _contexts[shard].range = make_foreign(make_lw_shared<const dht::partition_range>(range));
-        _contexts[shard].read_operation = make_foreign(std::make_unique<utils::phased_barrier::operation>(cf.read_in_progress()));
-        _contexts[shard].semaphore = &cf.streaming_read_concurrency_semaphore();
-
-        return cf.make_streaming_reader(std::move(schema), std::move(permit), *_contexts[shard].range, slice, fwd_mr, _compaction_time);
-    }
-    virtual const dht::partition_range* get_read_range() const override {
-        const auto shard = this_shard_id();
-        return _contexts[shard].range.get();
-    }
-    virtual void update_read_range(lw_shared_ptr<const dht::partition_range> range) override {
-        const auto shard = this_shard_id();
-        _contexts[shard].range = make_foreign(std::move(range));
-    }
-    virtual future<> destroy_reader(stopped_reader reader) noexcept override {
-        auto ctx = std::move(_contexts[this_shard_id()]);
-        auto reader_opt = ctx.semaphore->unregister_inactive_read(std::move(reader.handle));
-        if  (!reader_opt) {
-            return make_ready_future<>();
-        }
-        return reader_opt->close().finally([ctx = std::move(ctx)] {});
-    }
-    virtual reader_concurrency_semaphore& semaphore() override {
-        const auto shard = this_shard_id();
-        if (!_contexts[shard].semaphore) {
-            auto& cf = _db.local().find_column_family(_table_id);
-            _contexts[shard].semaphore = &cf.streaming_read_concurrency_semaphore();
-        }
-        return *_contexts[shard].semaphore;
-    }
-    virtual future<reader_permit> obtain_reader_permit(schema_ptr schema, const char* const description, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr) override {
-        auto& cf = _db.local().find_column_family(_table_id);
-        return semaphore().obtain_permit(schema, description, cf.estimate_read_memory_cost(), timeout, std::move(trace_ptr));
-    }
-};
-
 } // anonymous namespace
 
 static bool can_apply_per_partition_rate_limit(const schema& s, const database_config& dbcfg, db::operation_type op_type) {
@@ -2955,7 +2887,7 @@ mutation_reader make_multishard_streaming_reader(distributed<replica::database>&
             streamed_mutation::forwarding,
             mutation_reader::forwarding fwd_mr) {
         auto table_id = s->id();
-        return make_multishard_combining_reader_v2(seastar::make_shared<replica::streaming_reader_lifecycle_policy>(db, table_id, compaction_time),
+        return make_multishard_combining_reader_v2(seastar::make_shared<streaming_reader_lifecycle_policy>(db, table_id, compaction_time),
                 std::move(s), erm, std::move(permit), pr, ps, std::move(trace_state), fwd_mr);
     });
     auto&& full_slice = schema->full_slice();
@@ -2970,7 +2902,7 @@ mutation_reader make_multishard_streaming_reader(distributed<replica::database>&
     const auto& full_slice = schema->full_slice();
     auto erm = db.local().find_column_family(schema).get_effective_replication_map();
     return make_multishard_combining_reader_v2(
-        seastar::make_shared<replica::streaming_reader_lifecycle_policy>(db, table_id, compaction_time),
+        seastar::make_shared<streaming_reader_lifecycle_policy>(db, table_id, compaction_time),
         std::move(schema),
         std::move(erm),
         std::move(permit),

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -33,6 +33,7 @@
 #include "replica/database.hh"
 #include "replica/tablet_mutation_builder.hh"
 #include "replica/tablets.hh"
+#include "db/view/view_builder.hh"
 #include "service/qos/service_level_controller.hh"
 #include "service/migration_manager.hh"
 #include "service/raft/join_node.hh"
@@ -89,6 +90,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
     const service::raft_address_map& _address_map;
     service::topology_state_machine& _topo_sm;
     abort_source& _as;
+    gms::feature_service& _feature_service;
 
     raft::server& _raft;
     const raft::term_t _term;
@@ -1558,6 +1560,13 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 co_return true;
             }
 
+            if (auto guard_opt = co_await maybe_migrate_system_tables(std::move(guard)); !guard_opt) {
+                // The guard is consumed, it means we did migration
+                co_return true;
+            } else {
+                guard = std::move(*guard_opt);
+            }
+
             // If there is no other work, evaluate load and start tablet migration if there is imbalance.
             if (co_await maybe_start_tablet_migration(std::move(guard))) {
                 co_return true;
@@ -2418,6 +2427,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
         }
     }
 
+    // Returns the guard if no work done. Otherwise, performs a table migration and consumes the guard.
+    future<std::optional<group0_guard>> maybe_migrate_system_tables(group0_guard guard);
 
     // Returns true if the state machine was transitioned into tablet migration path.
     future<bool> maybe_start_tablet_migration(group0_guard);
@@ -2451,10 +2462,12 @@ public:
             service::topology_state_machine& topo_sm, abort_source& as, raft::server& raft_server,
             raft_topology_cmd_handler_type raft_topology_cmd_handler,
             tablet_allocator& tablet_allocator,
-            std::chrono::milliseconds ring_delay)
+            std::chrono::milliseconds ring_delay,
+            gms::feature_service& feature_service)
         : _sys_dist_ks(sys_dist_ks), _gossiper(gossiper), _messaging(messaging)
         , _shared_tm(shared_tm), _sys_ks(sys_ks), _db(db)
         , _group0(group0), _address_map(_group0.address_map()), _topo_sm(topo_sm), _as(as)
+        , _feature_service(feature_service)
         , _raft(raft_server), _term(raft_server.get_current_term())
         , _raft_topology_cmd_handler(std::move(raft_topology_cmd_handler))
         , _tablet_allocator(tablet_allocator)
@@ -2471,6 +2484,18 @@ public:
     virtual void on_up(const gms::inet_address& endpoint) {};
     virtual void on_down(const gms::inet_address& endpoint) { _topo_sm.event.broadcast(); };
 };
+
+future<std::optional<group0_guard>> topology_coordinator::maybe_migrate_system_tables(group0_guard guard) {
+    // Check if we can upgrade the view_build_status table to v2, being managed by group0.
+    const auto view_builder_version = co_await _sys_ks.get_view_builder_version();
+    if (view_builder_version == db::system_keyspace::view_builder_version_t::v1 && _feature_service.view_build_status_on_group0) {
+        auto tmptr = get_token_metadata_ptr();
+        co_await db::view::view_builder::migrate_to_v2(tmptr, _sys_ks, _sys_ks.query_processor(), _group0.client(), _as, std::move(guard));
+        co_return std::nullopt;
+    }
+
+    co_return std::move(guard);
+}
 
 future<bool> topology_coordinator::maybe_start_tablet_migration(group0_guard guard) {
     rtlogger.debug("Evaluating tablet balance");
@@ -3022,14 +3047,16 @@ future<> run_topology_coordinator(
         raft_topology_cmd_handler_type raft_topology_cmd_handler,
         tablet_allocator& tablet_allocator,
         std::chrono::milliseconds ring_delay,
-        endpoint_lifecycle_notifier& lifecycle_notifier) {
+        endpoint_lifecycle_notifier& lifecycle_notifier,
+        gms::feature_service& feature_service) {
 
     topology_coordinator coordinator{
             sys_dist_ks, gossiper, messaging, shared_tm,
             sys_ks, db, group0, topo_sm, as, raft,
             std::move(raft_topology_cmd_handler),
             tablet_allocator,
-            ring_delay};
+            ring_delay,
+            feature_service};
 
     std::exception_ptr ex;
     lifecycle_notifier.register_subscriber(&coordinator);

--- a/service/topology_coordinator.hh
+++ b/service/topology_coordinator.hh
@@ -16,6 +16,7 @@
 #include "log.hh"
 #include "raft/raft.hh"
 #include "gms/inet_address.hh"
+#include "gms/feature_service.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "service/topology_state_machine.hh"
 
@@ -72,7 +73,8 @@ future<> run_topology_coordinator(
         raft_topology_cmd_handler_type raft_topology_cmd_handler,
         tablet_allocator& tablet_allocator,
         std::chrono::milliseconds ring_delay,
-        endpoint_lifecycle_notifier& lifecycle_notifier);
+        endpoint_lifecycle_notifier& lifecycle_notifier,
+        gms::feature_service& feature_service);
 
 }
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -886,7 +886,7 @@ private:
 
             _sys_dist_ks.start(std::ref(_qp), std::ref(_mm), std::ref(_proxy)).get();
 
-            _view_builder.start(std::ref(_db), std::ref(_sys_ks), std::ref(_sys_dist_ks), std::ref(_mnotifier), std::ref(_view_update_generator)).get();
+            _view_builder.start(std::ref(_db), std::ref(_sys_ks), std::ref(_sys_dist_ks), std::ref(_mnotifier), std::ref(_view_update_generator), std::ref(group0_client), std::ref(_qp)).get();
             auto stop_view_builder = defer([this] {
                 _view_builder.stop().get();
             });

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -233,9 +233,16 @@ async def start_writes(cql: Session, keyspace: str, table: str, concurrency: int
 
     return finish
 
-async def wait_for_view(cql: Session, name: str, node_count: int, timeout: int = 120):
+async def wait_for_view_v1(cql: Session, name: str, node_count: int, timeout: int = 120):
     async def view_is_built():
         done = await cql.run_async(f"SELECT COUNT(*) FROM system_distributed.view_build_status WHERE status = 'SUCCESS' AND view_name = '{name}' ALLOW FILTERING")
+        return done[0][0] == node_count or None
+    deadline = time.time() + timeout
+    await wait_for(view_is_built, deadline)
+
+async def wait_for_view(cql: Session, name: str, node_count: int, timeout: int = 120):
+    async def view_is_built():
+        done = await cql.run_async(f"SELECT COUNT(*) FROM system.view_build_status_v2 WHERE status = 'SUCCESS' AND view_name = '{name}' ALLOW FILTERING")
         return done[0][0] == node_count or None
     deadline = time.time() + timeout
     await wait_for(view_is_built, deadline)

--- a/test/topology_custom/test_view_build_status.py
+++ b/test/topology_custom/test_view_build_status.py
@@ -1,0 +1,163 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import pytest
+import time
+import asyncio
+import logging
+from test.pylib.util import unique_name, wait_for_cql_and_get_hosts, wait_for, wait_for_view
+from test.pylib.manager_client import ManagerClient
+from test.pylib.internal_types import ServerInfo
+from test.topology.util import trigger_snapshot, wait_until_topology_upgrade_finishes, enter_recovery_state, reconnect_driver, \
+        delete_raft_topology_state, delete_raft_data_and_upgrade_state, wait_until_upgrade_finishes
+from test.topology.conftest import skip_mode
+from cassandra import ConsistencyLevel
+from cassandra.query import SimpleStatement
+from cassandra.protocol import InvalidRequest
+
+
+logger = logging.getLogger(__name__)
+
+async def create_keyspace(cql):
+    ks_name = 'ks'
+    await cql.run_async(f"CREATE KEYSPACE {ks_name} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}")
+    return ks_name
+
+async def create_table(cql):
+    await cql.run_async(f"CREATE TABLE ks.t (p int, c int, PRIMARY KEY (p, c))")
+
+async def create_mv(cql, view_name):
+    await cql.run_async(f"CREATE MATERIALIZED VIEW ks.{view_name} AS SELECT * FROM ks.t WHERE c IS NOT NULL and p IS NOT NULL PRIMARY KEY (c, p)")
+
+async def get_view_builder_version(cql, **kwargs):
+    result = await cql.run_async("SELECT value FROM system.scylla_local WHERE key='view_builder_version'", **kwargs)
+    if len(result) == 0:
+        return 1
+    else:
+        return int(result[0].value)
+
+async def view_builder_is_v2(cql, **kwargs):
+    v = await get_view_builder_version(cql, **kwargs)
+    return v == 2 or None
+
+async def view_is_built_v2(cql, ks_name, view_name, node_count, **kwargs):
+    done = await cql.run_async(f"SELECT COUNT(*) FROM system.view_build_status_v2 WHERE keyspace_name='{ks_name}' \
+                                 AND view_name = '{view_name}' AND status = 'SUCCESS' ALLOW FILTERING", **kwargs)
+    return done[0][0] == node_count or None
+
+async def wait_for_view_v2(cql, ks_name, view_name, node_count, **kwargs):
+    await wait_for(lambda: view_is_built_v2(cql, ks_name, view_name, node_count, **kwargs), time.time() + 60)
+
+# Verify a new cluster uses the view_build_status_v2 table.
+# Create a materialized view and check that the view's build status
+# is stored in view_build_status_v2 and all nodes see all the other
+# node's statuses.
+@pytest.mark.asyncio
+async def test_view_build_status_v2_table(manager: ManagerClient):
+    node_count = 3
+    servers = await manager.servers_add(node_count)
+    cql, hosts = await manager.get_ready_cql(servers)
+
+    # The cluster should init with view_builder v2
+    for h in hosts:
+        v = await get_view_builder_version(cql, host=h)
+        assert v == 2
+
+    await create_keyspace(cql)
+    await create_table(cql)
+    await create_mv(cql, "vt")
+
+    await asyncio.gather(*(wait_for_view_v2(cql, 'ks', 'vt', node_count, host=h) for h in hosts))
+
+# Cluster with 3 nodes.
+# Create materialized views. Start new server and it should get a snapshot on bootstrap.
+# Stop 3 `old` servers and query the new server to validate if it has the same view build status.
+@pytest.mark.asyncio
+async def test_view_build_status_snapshot(manager: ManagerClient):
+    servers = await manager.servers_add(3)
+    cql, _ = await manager.get_ready_cql(servers)
+
+    await create_keyspace(cql)
+    await create_table(cql)
+
+    await create_mv(cql, "vt1")
+    await create_mv(cql, "vt2")
+
+    for s in servers:
+        await manager.driver_connect(server=s)
+        cql = manager.get_cql()
+        await wait_for_view(cql, "vt1", 3)
+        await wait_for_view(cql, "vt2", 3)
+
+    # we don't know who the leader is, so trigger the snapshot on all nodes
+    await asyncio.gather(*(trigger_snapshot(manager, s) for s in servers))
+
+    # Add a new server which will recover from the snapshot
+    new_server = await manager.server_add()
+    all_servers = servers + [new_server]
+    await wait_for_cql_and_get_hosts(cql, all_servers, time.time() + 60)
+    await manager.servers_see_each_other(all_servers)
+
+    await asyncio.gather(*(manager.server_stop_gracefully(s.server_id) for s in servers))
+
+    # Read the table on the new server, verify it contains all the previous table content
+    await manager.driver_connect(server=new_server)
+    cql = manager.get_cql()
+    await wait_for_view(cql, "vt1", 4)
+    await wait_for_view(cql, "vt2", 4)
+
+# Start cluster in view_builder v1 mode and migrate to v2.
+# Verify the migration copies the v1 data, and the new v2 table
+# is used after the migration.
+@pytest.mark.asyncio
+async def test_view_build_status_migration_to_v2(request, manager: ManagerClient):
+    # First, force the first node to start in legacy mode
+    cfg = {'force_gossip_topology_changes': True}
+
+    servers = [await manager.server_add(config=cfg)]
+    # Enable raft-based node operations for subsequent nodes - they should fall back to
+    # using gossiper-based node operations
+    del cfg['force_gossip_topology_changes']
+
+    servers += [await manager.server_add(config=cfg) for _ in range(2)]
+
+    logging.info("Waiting until driver connects to every server")
+    cql, hosts = await manager.get_ready_cql(servers)
+
+    logging.info("Checking the upgrade state on all nodes")
+    for host in hosts:
+        status = await manager.api.raft_topology_upgrade_status(host.address)
+        assert status == "not_upgraded"
+
+    await create_keyspace(cql)
+    await create_table(cql)
+    await create_mv(cql, "vt1")
+
+    # Verify we're using v1 now
+    v = await get_view_builder_version(cql)
+    assert v == 1
+
+    result = await cql.run_async("SELECT * FROM system_distributed.view_build_status")
+    assert len(result) == 3
+
+    result = await cql.run_async("SELECT * FROM system.view_build_status_v2")
+    assert len(result) == 0
+
+    logging.info("Triggering upgrade to raft topology")
+    await manager.api.upgrade_to_raft_topology(hosts[0].address)
+
+    logging.info("Waiting until upgrade finishes")
+    await asyncio.gather(*(wait_until_topology_upgrade_finishes(manager, h.address, time.time() + 60) for h in hosts))
+
+    logging.info("Checking migrated data in system")
+
+    await asyncio.gather(*(wait_for(lambda: view_builder_is_v2(cql, host=h), time.time() + 60) for h in hosts))
+
+    # Check that new writes are written to the v2 table
+    await create_mv(cql, "vt2")
+    await wait_for_view_v2(cql, "ks", "vt2", 3)
+
+    result = await cql.run_async("SELECT * FROM system.view_build_status_v2")
+    assert len(result) == 6

--- a/test/topology_custom/test_view_build_status.py
+++ b/test/topology_custom/test_view_build_status.py
@@ -7,7 +7,7 @@ import pytest
 import time
 import asyncio
 import logging
-from test.pylib.util import unique_name, wait_for_cql_and_get_hosts, wait_for, wait_for_view
+from test.pylib.util import unique_name, wait_for_cql_and_get_hosts, wait_for, wait_for_view, wait_for_view_v1
 from test.pylib.manager_client import ManagerClient
 from test.pylib.internal_types import ServerInfo
 from test.topology.util import trigger_snapshot, wait_until_topology_upgrade_finishes, enter_recovery_state, reconnect_driver, \
@@ -406,7 +406,7 @@ async def test_view_build_status_migration_to_v2_with_cleanup(request, manager: 
     await create_table(cql)
     await create_mv(cql, "vt1")
 
-    await wait_for_view(cql, "vt1", 4)
+    await wait_for_view_v1(cql, "vt1", 4)
 
     result = await cql.run_async("SELECT * FROM system_distributed.view_build_status")
     assert len(result) == 4


### PR DESCRIPTION
Migrate the `system_distributed.view_build_status` table to `system.view_build_status_v2`. The writes to the v2 table are done via raft group0 operations.

The new parameter `view_builder_version` stored in `scylla_local` indicates whether nodes should use the old or the new table.

New clusters use v2. Otherwise, the migration to v2 is initiated by the topology coordinator when the feature is enabled. It reads all the rows from the old table and writes them to the new table, and sets `view_builder_version` to v2. When the change is applied, all view_builder services are updated to write and read from the v2 table.

The old table `system_distributed.view_build_status` is set to read virtually from the new table in order to maintain compatibility.

When removing a node from the cluster, we remove its rows from the table atomically (fixes https://github.com/scylladb/scylladb/issues/11836). Also, during the migration, we remove all invalid rows.

Fixes #15329 

dtest https://github.com/scylladb/scylla-dtest/pull/4827