### PR TITLE
docs: extend "forbidden operations" section for Raft-topology upgrade

### DIFF
--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology.rst
@@ -55,6 +55,7 @@ Make sure that administrative operations will not be running while upgrade is in
 In particular, you must abstain from:
 
 * :doc:`Cluster management procedures </operating-scylla/procedures/cluster-management/index>` (adding, replacing, removing, decommissioning nodes etc.).
+* :doc:`Version upgrade procedures </upgrade/index>`. You must ensure that all Scylla nodes are running the same version before proceeding.
 * Running :doc:`nodetool repair </operating-scylla/nodetool-commands/repair>`.
 * Running :doc:`nodetool checkAndRepairCdcStreams </operating-scylla/nodetool-commands/checkandrepaircdcstreams>`.
 * Any modifications of :doc:`authentication </operating-scylla/security/authentication>` and :doc:`authorization </operating-scylla/security/enable-authorization>` settings.


### PR DESCRIPTION
The Raft-topology upgrade procedure must not be run concurrently with version upgrade.