### PR TITLE
test: Fix max_ongoing_compaction_test test

### DIFF
--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4059,9 +4059,11 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
             return builder.build();
         };
 
-        auto next_timestamp = [] (auto step) {
+        // makes sure all data belonging to a table falls into the same time bucket.
+        auto now = gc_clock::now();
+        auto next_timestamp = [&now] (auto step) {
             using namespace std::chrono;
-            return (gc_clock::now().time_since_epoch() - duration_cast<microseconds>(step)).count();
+            return (now.time_since_epoch() - duration_cast<microseconds>(step)).count();
         };
         auto make_expiring_cell = [&] (schema_ptr s, std::chrono::hours step) {
             static thread_local int32_t value = 1;
@@ -4118,6 +4120,7 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
 
         // Make sure everything is expired
         forward_jump_clocks(std::chrono::hours(100));
+        now = gc_clock::now();
 
         auto compact_all_tables = [&] (size_t expected_before, size_t expected_after) {
             for (auto& t : tables) {
@@ -4148,7 +4151,7 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
             return max_ongoing_compaction;
         };
 
-        // Allow fully expired sstables to be compacted in parallel
+        // Allow fully expired sstables to be compacted in parallel, as they have the same weight 0 (== weightless).
         BOOST_REQUIRE_LE(compact_all_tables(1, 0), num_tables);
 
         auto add_sstables_to_table = [&] (auto idx, size_t num_sstables) {
@@ -4165,7 +4168,7 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
             add_sstables_to_table(i, DEFAULT_MIN_COMPACTION_THRESHOLD);
         }
 
-        // All buckets are expected to have the same weight (0)
+        // All buckets are expected to have the same weight (>0)
         // and therefore their compaction is expected to be serialized
         BOOST_REQUIRE_EQUAL(compact_all_tables(DEFAULT_MIN_COMPACTION_THRESHOLD, 1), 1);
     });


### PR DESCRIPTION
```
DEBUG 2024-07-03 00:59:58,291 [shard 0:main] compaction_manager - Compaction task 0x51800002a480 for table tests.3 compaction_group=0 [0x503000062050]: switch_state: none -> pending: pending=2 active=0 done=0 errors=0

DEBUG 2024-07-03 01:00:02,868 [shard 0:main] compaction - Checking droppable sstables in tests.3, candidates=0
DEBUG 2024-07-03 01:00:02,868 [shard 0:main] compaction - time_window_compaction_strategy::newest_bucket:
  now 1720314000000000
  buckets = {
    key=1720314000000000, size=2
    key=1720310400000000, size=2

1720314000000000: GMT: Sunday, July 7, 2024 1:00:00 AM
1720310400000000: GMT: Sunday, July 7, 2024 12:00:00 AM
```

the test failed to complete when ran across different clock hours, as it expected all sstables produced to belong to same window of 1h size. let's fix it by reusing timestamps, so it's always consistent.

Fixes #13280.
Fixes #18564.

**Please replace this line with justification for the backport/\* labels added to this PR**