### PR TITLE
db/hints: Make sync points be created for all hosts when not specified

### DIFF
--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -278,6 +278,9 @@ public:
     }
 
     /// \brief Returns a set of replay positions for hint queues towards endpoints from the `target_eps`.
+    ///
+    /// \param target_eps The list of endpoints the sync point should correspond to. When empty, the function assumes all endpoints.
+    /// \return Sync point corresponding to the specified endpoints.
     sync_point::shard_rps calculate_current_sync_point(std::span<const gms::inet_address> target_eps) const;
 
     /// \brief Waits until hint replay reach replay positions described in `rps`.

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6575,11 +6575,7 @@ future<db::hints::sync_point> storage_proxy::create_hint_sync_point(std::vector<
     spoint.regular_per_shard_rps.resize(smp::count);
     spoint.mv_per_shard_rps.resize(smp::count);
     spoint.host_id = get_token_metadata_ptr()->get_my_id();
-    if (target_hosts.empty()) {
-        // No target_hosts specified means that we should wait for hints for all nodes to be sent
-        const auto members_set = remote().gossiper().get_live_members();
-        std::copy(members_set.begin(), members_set.end(), std::back_inserter(target_hosts));
-    }
+
     // sharded::invoke_on does not have a const-method version, so we cannot use it here
     co_await smp::invoke_on_all([&sharded_sp = container(), &target_hosts, &spoint] {
         const storage_proxy& sp = sharded_sp.local();

--- a/test/topology_custom/test_hints.py
+++ b/test/topology_custom/test_hints.py
@@ -13,11 +13,22 @@ import re
 from cassandra.cluster import ConnectionException, NoHostAvailable  # type: ignore
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
+from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error
+from test.pylib.util import wait_for
 
 
 logger = logging.getLogger(__name__)
+
+def get_hint_manager_metric(server: ServerInfo, metric_name: str) -> int:
+    result = 0
+    metrics = requests.get(f"http://{server.ip_addr}:9180/metrics").text
+    pattern = re.compile(f"^scylla_hints_manager_{metric_name}")
+    for metric in metrics.split('\n'):
+        if pattern.match(metric) is not None:
+            result += int(float(metric.split()[1]))
+    return result
 
 # Write with RF=1 and CL=ANY to a dead node should write hints and succeed
 @pytest.mark.asyncio
@@ -32,13 +43,7 @@ async def test_write_cl_any_to_dead_node_generates_hints(manager: ManagerClient)
     await manager.server_stop_gracefully(servers[1].server_id)
 
     def get_hints_written_count(server):
-        c = 0
-        metrics = requests.get(f"http://{server.ip_addr}:9180/metrics").text
-        pattern = re.compile("^scylla_hints_manager_written")
-        for metric in metrics.split('\n'):
-            if pattern.match(metric) is not None:
-                c += int(float(metric.split()[1]))
-        return c
+        return get_hint_manager_metric(server, "written")
 
     hints_before = get_hints_written_count(servers[0])
 
@@ -77,3 +82,69 @@ async def test_limited_concurrency_of_writes(manager: ManagerClient):
         except NoHostAvailable as e:
             for _, err in e.errors.items():
                 assert err.summary == "Coordinator node overloaded" and re.match(r"Too many in flight hints: \d+", err.message)
+
+@pytest.mark.asyncio
+async def test_sync_point(manager: ManagerClient):
+    """
+    We want to verify that the sync point API is compliant with its design.
+    This test concerns one particular aspect of it: Scylla should create a sync point
+    for ALL nodes if the parameter `target_hosts` of a request is empty, not just
+    live nodes.
+    """
+    node_count = 3
+    [node1, node2, node3] = await manager.servers_add(node_count)
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}")
+    await cql.run_async("CREATE TABLE ks.t (pk int primary key, v int)")
+
+    # Creates a sync point for ALL hosts.
+    def create_sync_point(node: ServerInfo) -> str:
+        return requests.post(f"http://{node.ip_addr}:10000/hinted_handoff/sync_point/").json()
+
+    def await_sync_point(node: ServerInfo, sync_point: str, timeout: int) -> bool:
+        params = {
+            "id": sync_point,
+            "timeout": str(timeout)
+        }
+
+        response = requests.get(f"http://{node.ip_addr}:10000/hinted_handoff/sync_point", params=params).json()
+        match response:
+            case "IN_PROGRESS":
+                return False
+            case "DONE":
+                return True
+            case _:
+                pytest.fail(f"Unexpected response from the server: {response}")
+
+    await manager.server_stop_gracefully(node2.server_id)
+    await manager.server_stop_gracefully(node3.server_id)
+
+    await manager.server_not_sees_other_server(node1.ip_addr, node2.ip_addr)
+    await manager.server_not_sees_other_server(node1.ip_addr, node3.ip_addr)
+
+    mutation_count = 5
+    for primary_key in range(mutation_count):
+        await cql.run_async(SimpleStatement(f"INSERT INTO ks.t (pk, v) VALUES ({primary_key}, {primary_key})", consistency_level=ConsistencyLevel.ONE))
+
+    # Mutations need to be applied to hinted handoff's commitlog before we create the sync point.
+    # Otherwise, the sync point will correspond to no hints at all.
+
+    # We need to wrap the function in an async function to make `wait_for` be able to use it below.
+    async def check_no_hints_in_progress_node1() -> bool:
+        return get_hint_manager_metric(node1, "size_of_hints_in_progress") == 0
+
+    deadline = time.time() + 30
+    await wait_for(check_no_hints_in_progress_node1, deadline)
+
+    sync_point1 = create_sync_point(node1)
+
+    await manager.server_start(node2.server_id)
+    await manager.server_sees_other_server(node1.ip_addr, node2.ip_addr)
+
+    assert not await_sync_point(node1, sync_point1, 30)
+
+    await manager.server_start(node3.server_id)
+    await manager.server_sees_other_server(node1.ip_addr, node3.ip_addr)
+
+    assert await_sync_point(node1, sync_point1, 30)


### PR DESCRIPTION
Sync points are created, via POST HTTP requests, for a subset of nodes in the cluster. Those nodes are specified in a request's parameter `target_hosts`. When the parameter is empty, Scylla should assume the user wants to create a sync point for ALL nodes.

Before these changes, sync points were created only for LIVE nodes. If a node was dead but still part of the cluster and the user requested creating a sync point leaving the parameter `target_hosts` empty, the dead node was skipped during the creation of the sync point. That was inconsistent with the guarantees the sync point API provides.

In this commit, we fix that issue and add a test verifying that the changes have made the implementation compliant with the design of the sync point API -- the test only passes after this commit.

Fixes scylladb/scylladb#9413