### PR TITLE
abstract_replication_strategy: make get_ranges async

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -412,9 +412,9 @@ public:
 // range's primary owner, needed to implement should_skip().
 class ranges_holder_secondary {
     std::vector<std::pair<dht::token_range, gms::inet_address>> _token_ranges;
-    gms::gossiper& _gossiper;
+    const gms::gossiper& _gossiper;
 public:
-    ranges_holder_secondary(const locator::effective_replication_map_ptr& erm, gms::gossiper& g, gms::inet_address ep)
+    ranges_holder_secondary(const locator::effective_replication_map_ptr& erm, const gms::gossiper& g, gms::inet_address ep)
         : _token_ranges(get_secondary_ranges(erm, ep))
         , _gossiper(g) {}
     std::size_t size() const { return _token_ranges.size(); }

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -393,52 +393,48 @@ static std::vector<std::pair<dht::token_range, gms::inet_address>> get_secondary
 //
 // FIXME: Check if this algorithm is safe with tablet migration.
 // https://github.com/scylladb/scylladb/issues/16567
-enum primary_or_secondary_t {primary, secondary};
-template<primary_or_secondary_t primary_or_secondary>
-class token_ranges_owned_by_this_shard {
-    // ranges_holder_primary holds just the primary ranges themselves
-    class ranges_holder_primary {
-        const dht::token_range_vector _token_ranges;
-     public:
-        ranges_holder_primary(const locator::vnode_effective_replication_map_ptr& erm, gms::gossiper& g, gms::inet_address ep)
-            : _token_ranges(erm->get_primary_ranges(ep)) {}
-        std::size_t size() const { return _token_ranges.size(); }
-        const dht::token_range& operator[](std::size_t i) const {
-            return _token_ranges[i];
-        }
-        bool should_skip(std::size_t i) const {
-            return false;
-        }
-    };
-    // ranges_holder<secondary> holds the secondary token ranges plus each
-    // range's primary owner, needed to implement should_skip().
-    class ranges_holder_secondary {
-        std::vector<std::pair<dht::token_range, gms::inet_address>> _token_ranges;
-        gms::gossiper& _gossiper;
-     public:
-        ranges_holder_secondary(const locator::effective_replication_map_ptr& erm, gms::gossiper& g, gms::inet_address ep)
-            : _token_ranges(get_secondary_ranges(erm, ep))
-            , _gossiper(g) {}
-        std::size_t size() const { return _token_ranges.size(); }
-        const dht::token_range& operator[](std::size_t i) const {
-            return _token_ranges[i].first;
-        }
-        // range i should be skipped if its primary owner is alive.
-        bool should_skip(std::size_t i) const {
-            return _gossiper.is_alive(_token_ranges[i].second);
-        }
-    };
 
+// ranges_holder_primary holds just the primary ranges themselves
+class ranges_holder_primary {
+    const dht::token_range_vector _token_ranges;
+public:
+    ranges_holder_primary(const locator::vnode_effective_replication_map_ptr& erm, gms::gossiper& g, gms::inet_address ep)
+        : _token_ranges(erm->get_primary_ranges(ep)) {}
+    std::size_t size() const { return _token_ranges.size(); }
+    const dht::token_range& operator[](std::size_t i) const {
+        return _token_ranges[i];
+    }
+    bool should_skip(std::size_t i) const {
+        return false;
+    }
+};
+// ranges_holder<secondary> holds the secondary token ranges plus each
+// range's primary owner, needed to implement should_skip().
+class ranges_holder_secondary {
+    std::vector<std::pair<dht::token_range, gms::inet_address>> _token_ranges;
+    gms::gossiper& _gossiper;
+public:
+    ranges_holder_secondary(const locator::effective_replication_map_ptr& erm, gms::gossiper& g, gms::inet_address ep)
+        : _token_ranges(get_secondary_ranges(erm, ep))
+        , _gossiper(g) {}
+    std::size_t size() const { return _token_ranges.size(); }
+    const dht::token_range& operator[](std::size_t i) const {
+        return _token_ranges[i].first;
+    }
+    // range i should be skipped if its primary owner is alive.
+    bool should_skip(std::size_t i) const {
+        return _gossiper.is_alive(_token_ranges[i].second);
+    }
+};
+
+template<class primary_or_secondary_t>
+class token_ranges_owned_by_this_shard {
     schema_ptr _s;
     locator::effective_replication_map_ptr _erm;
     // _token_ranges will contain a list of token ranges owned by this node.
     // We'll further need to split each such range to the pieces owned by
     // the current shard, using _intersecter.
-    using ranges_holder = std::conditional_t<
-            primary_or_secondary == primary_or_secondary_t::primary,
-            ranges_holder_primary,
-            ranges_holder_secondary>;
-    const ranges_holder _token_ranges;
+    const primary_or_secondary_t _token_ranges;
     // NOTICE: _range_idx is used modulo _token_ranges size when accessing
     // the data to ensure that it doesn't go out of bounds
     size_t _range_idx;
@@ -731,7 +727,7 @@ static future<bool> scan_table(
     expiration_stats.scan_table++;
     // FIXME: need to pace the scan, not do it all at once.
     scan_ranges_context scan_ctx{s, proxy, std::move(column_name), std::move(member)};
-    token_ranges_owned_by_this_shard<primary> my_ranges(db.real_database(), gossiper, s);
+    token_ranges_owned_by_this_shard<ranges_holder_primary> my_ranges(db.real_database(), gossiper, s);
     while (std::optional<dht::partition_range> range = my_ranges.next_partition_range()) {
         // Note that because of issue #9167 we need to run a separate
         // query on each partition range, and can't pass several of
@@ -751,7 +747,7 @@ static future<bool> scan_table(
     // by tasking another node to take over scanning of the dead node's primary
     // ranges. What we do here is that this node will also check expiration
     // on its *secondary* ranges - but only those whose primary owner is down.
-    token_ranges_owned_by_this_shard<secondary> my_secondary_ranges(db.real_database(), gossiper, s);
+    token_ranges_owned_by_this_shard<ranges_holder_secondary> my_secondary_ranges(db.real_database(), gossiper, s);
     while (std::optional<dht::partition_range> range = my_secondary_ranges.next_partition_range()) {
         expiration_stats.secondary_ranges_scanned++;
         dht::partition_range_vector partition_ranges;

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -396,7 +396,7 @@ static std::vector<std::pair<dht::token_range, gms::inet_address>> get_secondary
 
 // ranges_holder_primary holds just the primary ranges themselves
 class ranges_holder_primary {
-    const dht::token_range_vector _token_ranges;
+    dht::token_range_vector _token_ranges;
 public:
     ranges_holder_primary(const locator::vnode_effective_replication_map_ptr& erm, gms::gossiper& g, gms::inet_address ep)
         : _token_ranges(erm->get_primary_ranges(ep)) {}

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -319,7 +319,7 @@ static size_t random_offset(size_t min, size_t max) {
 // this range's primary node is down. For this we need to return not just
 // a list of this node's secondary ranges - but also the primary owner of
 // each of those ranges.
-static std::vector<std::pair<dht::token_range, gms::inet_address>> get_secondary_ranges(
+static future<std::vector<std::pair<dht::token_range, gms::inet_address>>> get_secondary_ranges(
         const locator::effective_replication_map_ptr& erm,
         gms::inet_address ep) {
     const auto& tm = *erm->get_token_metadata_ptr();
@@ -330,6 +330,7 @@ static std::vector<std::pair<dht::token_range, gms::inet_address>> get_secondary
     }
     auto prev_tok = sorted_tokens.back();
     for (const auto& tok : sorted_tokens) {
+        co_await coroutine::maybe_yield();
         inet_address_vector_replica_set eps = erm->get_natural_endpoints(tok);
         if (eps.size() <= 1 || eps[1] != ep) {
             prev_tok = tok;
@@ -357,7 +358,7 @@ static std::vector<std::pair<dht::token_range, gms::inet_address>> get_secondary
         }
         prev_tok = tok;
     }
-    return ret;
+    co_return ret;
 }
 
 
@@ -399,8 +400,8 @@ class ranges_holder_primary {
     dht::token_range_vector _token_ranges;
 public:
     explicit ranges_holder_primary(dht::token_range_vector token_ranges) : _token_ranges(std::move(token_ranges)) {}
-    static ranges_holder_primary make(const locator::vnode_effective_replication_map_ptr& erm, gms::inet_address ep) {
-        return ranges_holder_primary(erm->get_primary_ranges(ep));
+    static future<ranges_holder_primary> make(const locator::vnode_effective_replication_map_ptr& erm, gms::inet_address ep) {
+        co_return ranges_holder_primary(co_await erm->get_primary_ranges(ep));
     }
     std::size_t size() const { return _token_ranges.size(); }
     const dht::token_range& operator[](std::size_t i) const {
@@ -419,8 +420,8 @@ public:
     explicit ranges_holder_secondary(std::vector<std::pair<dht::token_range, gms::inet_address>> token_ranges, const gms::gossiper& g)
         : _token_ranges(std::move(token_ranges))
         , _gossiper(g) {}
-    static ranges_holder_secondary make(const locator::effective_replication_map_ptr& erm, gms::inet_address ep, const gms::gossiper& g) {
-        return ranges_holder_secondary(get_secondary_ranges(erm, ep), g);
+    static future<ranges_holder_secondary> make(const locator::effective_replication_map_ptr& erm, gms::inet_address ep, const gms::gossiper& g) {
+        co_return ranges_holder_secondary(co_await get_secondary_ranges(erm, ep), g);
     }
     std::size_t size() const { return _token_ranges.size(); }
     const dht::token_range& operator[](std::size_t i) const {
@@ -733,7 +734,7 @@ static future<bool> scan_table(
     scan_ranges_context scan_ctx{s, proxy, std::move(column_name), std::move(member)};
     auto erm = db.real_database().find_keyspace(s->ks_name()).get_vnode_effective_replication_map();
     auto my_address = erm->get_topology().my_address();
-    token_ranges_owned_by_this_shard my_ranges(s, ranges_holder_primary::make(erm, my_address));
+    token_ranges_owned_by_this_shard my_ranges(s, co_await ranges_holder_primary::make(erm, my_address));
     while (std::optional<dht::partition_range> range = my_ranges.next_partition_range()) {
         // Note that because of issue #9167 we need to run a separate
         // query on each partition range, and can't pass several of
@@ -753,7 +754,7 @@ static future<bool> scan_table(
     // by tasking another node to take over scanning of the dead node's primary
     // ranges. What we do here is that this node will also check expiration
     // on its *secondary* ranges - but only those whose primary owner is down.
-    token_ranges_owned_by_this_shard my_secondary_ranges(s, ranges_holder_secondary::make(erm, my_address, gossiper));
+    token_ranges_owned_by_this_shard my_secondary_ranges(s, co_await ranges_holder_secondary::make(erm, my_address, gossiper));
     while (std::optional<dht::partition_range> range = my_secondary_ranges.next_partition_range()) {
         expiration_stats.secondary_ranges_scanned++;
         dht::partition_range_vector partition_ranges;

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -398,8 +398,10 @@ static std::vector<std::pair<dht::token_range, gms::inet_address>> get_secondary
 class ranges_holder_primary {
     dht::token_range_vector _token_ranges;
 public:
-    ranges_holder_primary(const locator::vnode_effective_replication_map_ptr& erm, gms::gossiper& g, gms::inet_address ep)
-        : _token_ranges(erm->get_primary_ranges(ep)) {}
+    explicit ranges_holder_primary(dht::token_range_vector token_ranges) : _token_ranges(std::move(token_ranges)) {}
+    static ranges_holder_primary make(const locator::vnode_effective_replication_map_ptr& erm, gms::inet_address ep) {
+        return ranges_holder_primary(erm->get_primary_ranges(ep));
+    }
     std::size_t size() const { return _token_ranges.size(); }
     const dht::token_range& operator[](std::size_t i) const {
         return _token_ranges[i];
@@ -414,9 +416,12 @@ class ranges_holder_secondary {
     std::vector<std::pair<dht::token_range, gms::inet_address>> _token_ranges;
     const gms::gossiper& _gossiper;
 public:
-    ranges_holder_secondary(const locator::effective_replication_map_ptr& erm, const gms::gossiper& g, gms::inet_address ep)
-        : _token_ranges(get_secondary_ranges(erm, ep))
+    explicit ranges_holder_secondary(std::vector<std::pair<dht::token_range, gms::inet_address>> token_ranges, const gms::gossiper& g)
+        : _token_ranges(std::move(token_ranges))
         , _gossiper(g) {}
+    static ranges_holder_secondary make(const locator::effective_replication_map_ptr& erm, gms::inet_address ep, const gms::gossiper& g) {
+        return ranges_holder_secondary(get_secondary_ranges(erm, ep), g);
+    }
     std::size_t size() const { return _token_ranges.size(); }
     const dht::token_range& operator[](std::size_t i) const {
         return _token_ranges[i].first;
@@ -441,11 +446,10 @@ class token_ranges_owned_by_this_shard {
     size_t _end_idx;
     std::optional<dht::selective_token_range_sharder> _intersecter;
 public:
-    token_ranges_owned_by_this_shard(replica::database& db, gms::gossiper& g, schema_ptr s)
+    token_ranges_owned_by_this_shard(schema_ptr s, primary_or_secondary_t token_ranges)
         :  _s(s)
         , _erm(s->table().get_effective_replication_map())
-        , _token_ranges(db.find_keyspace(s->ks_name()).get_vnode_effective_replication_map(),
-                g, _erm->get_topology().my_address())
+        , _token_ranges(std::move(token_ranges))
         , _range_idx(random_offset(0, _token_ranges.size() - 1))
         , _end_idx(_range_idx + _token_ranges.size())
     {
@@ -727,7 +731,9 @@ static future<bool> scan_table(
     expiration_stats.scan_table++;
     // FIXME: need to pace the scan, not do it all at once.
     scan_ranges_context scan_ctx{s, proxy, std::move(column_name), std::move(member)};
-    token_ranges_owned_by_this_shard<ranges_holder_primary> my_ranges(db.real_database(), gossiper, s);
+    auto erm = db.real_database().find_keyspace(s->ks_name()).get_vnode_effective_replication_map();
+    auto my_address = erm->get_topology().my_address();
+    token_ranges_owned_by_this_shard my_ranges(s, ranges_holder_primary::make(erm, my_address));
     while (std::optional<dht::partition_range> range = my_ranges.next_partition_range()) {
         // Note that because of issue #9167 we need to run a separate
         // query on each partition range, and can't pass several of
@@ -747,7 +753,7 @@ static future<bool> scan_table(
     // by tasking another node to take over scanning of the dead node's primary
     // ranges. What we do here is that this node will also check expiration
     // on its *secondary* ranges - but only those whose primary owner is down.
-    token_ranges_owned_by_this_shard<ranges_holder_secondary> my_secondary_ranges(db.real_database(), gossiper, s);
+    token_ranges_owned_by_this_shard my_secondary_ranges(s, ranges_holder_secondary::make(erm, my_address, gossiper));
     while (std::optional<dht::partition_range> range = my_secondary_ranges.next_partition_range()) {
         expiration_stats.secondary_ranges_scanned++;
         dht::partition_range_vector partition_ranges;

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -466,7 +466,16 @@ future<> shard_cleanup_keyspace_compaction_task_impl::run() {
 
 future<> table_cleanup_keyspace_compaction_task_impl::run() {
     co_await wait_for_your_turn(_cv, _current_task, _status.id);
-    auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(_db.get_keyspace_local_ranges(_status.keyspace));
+    // Note that we do not hold an effective_replication_map_ptr throughout
+    // the cleanup operation, so the topology might change.
+    // Since clenaup is an admin operation required for vnodes,
+    // it is the responsibility of the system operator to not
+    // perform additional incompatible range movements during cleanup.
+    auto get_owned_ranges = [&] (std::string_view ks_name) -> owned_ranges_ptr {
+        const auto& erm = _db.find_keyspace(ks_name).get_vnode_effective_replication_map();
+        return compaction::make_owned_ranges_ptr(_db.get_keyspace_local_ranges(erm));
+    };
+    auto owned_ranges_ptr = get_owned_ranges(_status.keyspace);
     co_await run_on_table("force_keyspace_cleanup", _db, _status.keyspace, _ti, [&] (replica::table& t) {
         // skip the flush, as cleanup_keyspace_compaction_task_impl::run should have done this.
         return t.perform_cleanup_compaction(owned_ranges_ptr, tasks::task_info{_status.id, _status.shard}, replica::table::do_flush::no);
@@ -535,7 +544,8 @@ future<> table_upgrade_sstables_compaction_task_impl::run() {
         if (ks.get_replication_strategy().is_per_table()) {
             return nullptr;
         }
-        return compaction::make_owned_ranges_ptr(_db.get_keyspace_local_ranges(sstring(keyspace_name)));
+        const auto& erm = ks.get_vnode_effective_replication_map();
+        return compaction::make_owned_ranges_ptr(_db.get_keyspace_local_ranges(erm));
     };
     auto owned_ranges_ptr = get_owned_ranges(_status.keyspace);
     tasks::task_info info{_status.id, _status.shard};

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -471,11 +471,11 @@ future<> table_cleanup_keyspace_compaction_task_impl::run() {
     // Since clenaup is an admin operation required for vnodes,
     // it is the responsibility of the system operator to not
     // perform additional incompatible range movements during cleanup.
-    auto get_owned_ranges = [&] (std::string_view ks_name) -> owned_ranges_ptr {
+    auto get_owned_ranges = [&] (std::string_view ks_name) -> future<owned_ranges_ptr> {
         const auto& erm = _db.find_keyspace(ks_name).get_vnode_effective_replication_map();
-        return compaction::make_owned_ranges_ptr(_db.get_keyspace_local_ranges(erm));
+        co_return compaction::make_owned_ranges_ptr(co_await _db.get_keyspace_local_ranges(erm));
     };
-    auto owned_ranges_ptr = get_owned_ranges(_status.keyspace);
+    auto owned_ranges_ptr = co_await get_owned_ranges(_status.keyspace);
     co_await run_on_table("force_keyspace_cleanup", _db, _status.keyspace, _ti, [&] (replica::table& t) {
         // skip the flush, as cleanup_keyspace_compaction_task_impl::run should have done this.
         return t.perform_cleanup_compaction(owned_ranges_ptr, tasks::task_info{_status.id, _status.shard}, replica::table::do_flush::no);
@@ -539,15 +539,15 @@ future<> shard_upgrade_sstables_compaction_task_impl::run() {
 
 future<> table_upgrade_sstables_compaction_task_impl::run() {
     co_await wait_for_your_turn(_cv, _current_task, _status.id);
-    auto get_owned_ranges = [&] (std::string_view keyspace_name) -> owned_ranges_ptr {
+    auto get_owned_ranges = [&] (std::string_view keyspace_name) -> future<owned_ranges_ptr> {
         const auto& ks = _db.find_keyspace(keyspace_name);
         if (ks.get_replication_strategy().is_per_table()) {
-            return nullptr;
+            co_return nullptr;
         }
         const auto& erm = ks.get_vnode_effective_replication_map();
-        return compaction::make_owned_ranges_ptr(_db.get_keyspace_local_ranges(erm));
+        co_return compaction::make_owned_ranges_ptr(co_await _db.get_keyspace_local_ranges(erm));
     };
-    auto owned_ranges_ptr = get_owned_ranges(_status.keyspace);
+    auto owned_ranges_ptr = co_await get_owned_ranges(_status.keyspace);
     tasks::task_info info{_status.id, _status.shard};
     co_await run_on_table("upgrade_sstables", _db, _status.keyspace, _ti, [&] (replica::table& t) -> future<> {
         return t.parallel_foreach_table_state([&] (compaction::table_state& ts) -> future<> {

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -227,7 +227,7 @@ insert_token_range_to_sorted_container_while_unwrapping(
     }
 }
 
-dht::token_range_vector
+future<dht::token_range_vector>
 vnode_effective_replication_map::do_get_ranges(noncopyable_function<stop_iteration(bool&, const inet_address&)> consider_range_for_endpoint) const {
     dht::token_range_vector ret;
     const auto& tm = *_tmptr;
@@ -245,11 +245,12 @@ vnode_effective_replication_map::do_get_ranges(noncopyable_function<stop_iterati
             insert_token_range_to_sorted_container_while_unwrapping(prev_tok, tok, ret);
         }
         prev_tok = tok;
+        co_await coroutine::maybe_yield();
     }
-    return ret;
+    co_return ret;
 }
 
-dht::token_range_vector
+future<dht::token_range_vector>
 vnode_effective_replication_map::get_ranges(inet_address ep) const {
     // The callback function below is called for each endpoint
     // in each token natural endpoints.
@@ -299,7 +300,7 @@ abstract_replication_strategy::get_ranges(locator::host_id ep, const token_metad
     co_return ret;
 }
 
-dht::token_range_vector
+future<dht::token_range_vector>
 vnode_effective_replication_map::get_primary_ranges(inet_address ep) const {
     // The callback function below is called for each endpoint
     // in each token natural endpoints.
@@ -312,7 +313,7 @@ vnode_effective_replication_map::get_primary_ranges(inet_address ep) const {
     });
 }
 
-dht::token_range_vector
+future<dht::token_range_vector>
 vnode_effective_replication_map::get_primary_ranges_within_dc(inet_address ep) const {
     const topology& topo = _tmptr->get_topology();
     sstring local_dc = topo.get_datacenter(ep);

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -262,7 +262,7 @@ public:
     // This function is not efficient, and not meant for the fast path.
     //
     // Note: must be called after token_metadata has been initialized.
-    virtual dht::token_range_vector get_ranges(inet_address ep) const = 0;
+    virtual future<dht::token_range_vector> get_ranges(inet_address ep) const = 0;
 
     shard_id shard_for_reads(const schema& s, dht::token t) const {
         return get_sharder(s).shard_for_reads(t);
@@ -334,7 +334,7 @@ public: // effective_replication_map
     bool has_pending_ranges(locator::host_id endpoint) const override;
     std::unique_ptr<token_range_splitter> make_splitter() const override;
     const dht::sharder& get_sharder(const schema& s) const override;
-    dht::token_range_vector get_ranges(inet_address ep) const override;
+    future<dht::token_range_vector> get_ranges(inet_address ep) const override;
 public:
     explicit vnode_effective_replication_map(replication_strategy_ptr rs, token_metadata_ptr tmptr, replication_map replication_map,
             ring_mapping pending_endpoints, ring_mapping read_endpoints, std::unordered_set<locator::host_id> dirty_endpoints, size_t replication_factor) noexcept
@@ -366,14 +366,14 @@ public:
     // StorageService.getPrimaryRangesForEndpoint().
     //
     // Note: must be called after token_metadata has been initialized.
-    dht::token_range_vector get_primary_ranges(inet_address ep) const;
+    future<dht::token_range_vector> get_primary_ranges(inet_address ep) const;
 
     // get_primary_ranges_within_dc() is similar to get_primary_ranges()
     // except it assigns a primary node for each range within each dc,
     // instead of one node globally.
     //
     // Note: must be called after token_metadata has been initialized.
-    dht::token_range_vector get_primary_ranges_within_dc(inet_address ep) const;
+    future<dht::token_range_vector> get_primary_ranges_within_dc(inet_address ep) const;
 
     future<std::unordered_map<dht::token_range, inet_address_vector_replica_set>>
     get_range_addresses() const;
@@ -388,7 +388,7 @@ public:
     std::unordered_set<locator::host_id> get_all_pending_nodes() const;
 
 private:
-    dht::token_range_vector do_get_ranges(noncopyable_function<stop_iteration(bool& add_range, const inet_address& natural_endpoint)> consider_range_for_endpoint) const;
+    future<dht::token_range_vector> do_get_ranges(noncopyable_function<stop_iteration(bool& add_range, const inet_address& natural_endpoint)> consider_range_for_endpoint) const;
     inet_address_vector_replica_set do_get_natural_endpoints(const token& tok, bool is_vnode) const;
     host_id_vector_replica_set do_get_replicas(const token& tok, bool is_vnode) const;
     stop_iteration for_each_natural_endpoint_until(const token& vnode_tok, const noncopyable_function<stop_iteration(const inet_address&)>& func) const;

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -700,8 +700,7 @@ public:
         return result;
     }
 
-    // FIXME: return a future object.
-    virtual dht::token_range_vector get_ranges(inet_address ep) const override {
+    virtual future<dht::token_range_vector> get_ranges(inet_address ep) const override {
         dht::token_range_vector ret;
 
         auto& tablet_map = get_tablet_map();
@@ -712,9 +711,10 @@ public:
             if (should_add_range) {
                 ret.push_back(tablet_map.get_token_range(tablet_id));
             }
+            co_await coroutine::maybe_yield();
         }
 
-        return ret;
+        co_return ret;
     }
 
     virtual inet_address_vector_topology_change get_pending_endpoints(const token& search_token) const override {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1246,15 +1246,15 @@ future<int> repair_service::do_repair_start(sstring keyspace, std::unordered_map
             // but instead of each range being assigned just one primary owner
             // across the entire cluster, here each range is assigned a primary
             // owner in each of the DCs.
-            ranges = erm.get_primary_ranges_within_dc(my_address);
+            ranges = co_await erm.get_primary_ranges_within_dc(my_address);
         } else if (options.data_centers.size() > 0 || options.hosts.size() > 0) {
             throw std::invalid_argument("You need to run primary range repair on all nodes in the cluster.");
         } else {
-            ranges = erm.get_primary_ranges(my_address);
+            ranges = co_await erm.get_primary_ranges(my_address);
         }
     } else {
         // get keyspace local ranges
-        ranges = erm.get_ranges(my_address);
+        ranges = co_await erm.get_ranges(my_address);
     }
 
     if (!options.data_centers.empty() && !options.hosts.empty()) {
@@ -1752,7 +1752,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
         streaming::stream_reason reason = is_removenode ? streaming::stream_reason::removenode : streaming::stream_reason::decommission;
         size_t nr_ranges_total = 0;
         for (const auto& [keyspace_name, erm] : ks_erms) {
-            dht::token_range_vector ranges = erm->get_ranges(leaving_node);
+            dht::token_range_vector ranges = erm->get_ranges(leaving_node).get();
             auto nr_tables = get_nr_tables(db, keyspace_name);
             nr_ranges_total += ranges.size() * nr_tables;
         }
@@ -1779,7 +1779,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
             }
             auto& strat = erm->get_replication_strategy();
             // First get all ranges the leaving node is responsible for
-            dht::token_range_vector ranges = erm->get_ranges(leaving_node);
+            dht::token_range_vector ranges = erm->get_ranges(leaving_node).get();
             auto nr_tables = get_nr_tables(db, keyspace_name);
             rlogger.info("{}: started with keyspace={}, leaving_node={}, nr_ranges={}", op, keyspace_name, leaving_node, ranges.size() * nr_tables);
             size_t nr_ranges_total = ranges.size() * nr_tables;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2569,9 +2569,9 @@ const sstring& database::get_snitch_name() const {
     return _cfg.endpoint_snitch();
 }
 
-dht::token_range_vector database::get_keyspace_local_ranges(sstring ks) {
-    auto my_address = get_token_metadata().get_topology().my_address();
-    return find_keyspace(ks).get_vnode_effective_replication_map()->get_ranges(my_address);
+dht::token_range_vector database::get_keyspace_local_ranges(locator::vnode_effective_replication_map_ptr erm) {
+    auto my_address = erm->get_topology().my_address();
+    return erm->get_ranges(my_address);
 }
 
 /*!

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2569,9 +2569,9 @@ const sstring& database::get_snitch_name() const {
     return _cfg.endpoint_snitch();
 }
 
-dht::token_range_vector database::get_keyspace_local_ranges(locator::vnode_effective_replication_map_ptr erm) {
+future<dht::token_range_vector> database::get_keyspace_local_ranges(locator::vnode_effective_replication_map_ptr erm) {
     auto my_address = erm->get_topology().my_address();
-    return erm->get_ranges(my_address);
+    co_return co_await erm->get_ranges(my_address);
 }
 
 /*!

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2574,16 +2574,6 @@ dht::token_range_vector database::get_keyspace_local_ranges(sstring ks) {
     return find_keyspace(ks).get_vnode_effective_replication_map()->get_ranges(my_address);
 }
 
-std::optional<dht::token_range_vector> database::maybe_get_keyspace_local_ranges(sstring ks) {
-    const auto& keyspace = find_keyspace(ks);
-    if (keyspace.get_replication_strategy().is_per_table()) {
-        // return nullopt if each tables have their own effective_replication_map
-        return std::nullopt;
-    }
-    auto my_address = get_token_metadata().get_topology().my_address();
-    return keyspace.get_vnode_effective_replication_map()->get_ranges(my_address);
-}
-
 /*!
  * \brief a helper function that gets a table name and returns a prefix
  * of the directory name of the table.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1783,7 +1783,7 @@ public:
 
     // Returns the list of ranges held by this endpoint
     // The returned list is sorted, and its elements are non overlapping and non wrap-around.
-    dht::token_range_vector get_keyspace_local_ranges(locator::vnode_effective_replication_map_ptr erm);
+    future<dht::token_range_vector> get_keyspace_local_ranges(locator::vnode_effective_replication_map_ptr erm);
 
     void set_format(sstables::sstable_version_types format) noexcept;
     void set_format_by_config();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1783,7 +1783,7 @@ public:
 
     // Returns the list of ranges held by this endpoint
     // The returned list is sorted, and its elements are non overlapping and non wrap-around.
-    dht::token_range_vector get_keyspace_local_ranges(sstring ks);
+    dht::token_range_vector get_keyspace_local_ranges(locator::vnode_effective_replication_map_ptr erm);
 
     void set_format(sstables::sstable_version_types format) noexcept;
     void set_format_by_config();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1784,7 +1784,6 @@ public:
     // Returns the list of ranges held by this endpoint
     // The returned list is sorted, and its elements are non overlapping and non wrap-around.
     dht::token_range_vector get_keyspace_local_ranges(sstring ks);
-    std::optional<dht::token_range_vector> maybe_get_keyspace_local_ranges(sstring ks);
 
     void set_format(sstables::sstable_version_types format) noexcept;
     void set_format_by_config();

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -208,7 +208,7 @@ distributed_loader::process_upload_dir(distributed<replica::database>& db, shard
         // - split the keyspace local ranges per compaction_group as done in table::perform_cleanup_compaction
         //   so that cleanup can be considered per compaction group
         const auto& erm = db.local().find_keyspace(ks).get_vnode_effective_replication_map();
-        auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(db.local().get_keyspace_local_ranges(erm));
+        auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(db.local().get_keyspace_local_ranges(erm).get());
         reshard(directory, db, ks, cf, make_sstable, owned_ranges_ptr).get();
         reshape(directory, db, sstables::reshape_mode::strict, ks, cf, make_sstable,
                 [] (const sstables::shared_sstable&) { return true; }).get();

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -207,7 +207,8 @@ distributed_loader::process_upload_dir(distributed<replica::database>& db, shard
         // - segregate resharded tables into compaction groups
         // - split the keyspace local ranges per compaction_group as done in table::perform_cleanup_compaction
         //   so that cleanup can be considered per compaction group
-        auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(db.local().get_keyspace_local_ranges(ks));
+        const auto& erm = db.local().find_keyspace(ks).get_vnode_effective_replication_map();
+        auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(db.local().get_keyspace_local_ranges(erm));
         reshard(directory, db, ks, cf, make_sstable, owned_ranges_ptr).get();
         reshape(directory, db, sstables::reshape_mode::strict, ks, cf, make_sstable,
                 [] (const sstables::shared_sstable&) { return true; }).get();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -619,7 +619,7 @@ public:
      * @param ep endpoint we are interested in.
      * @return ranges for the specified endpoint.
      */
-    dht::token_range_vector get_ranges_for_endpoint(const locator::effective_replication_map_ptr& erm, const gms::inet_address& ep) const;
+    future<dht::token_range_vector> get_ranges_for_endpoint(const locator::effective_replication_map_ptr& erm, const gms::inet_address& ep) const;
 
     /**
      * Get all ranges that span the ring given a set

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1220,7 +1220,8 @@ SEASTAR_TEST_CASE(upgrade_sstables) {
         e.db().invoke_on_all([] (replica::database& db) -> future<> {
             auto& cm = db.get_compaction_manager();
             for (auto& [ks_name, ks] : db.get_keyspaces()) {
-                auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(db.get_keyspace_local_ranges(ks_name));
+                const auto& erm = ks.get_vnode_effective_replication_map();
+                auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(db.get_keyspace_local_ranges(erm));
                 for (auto& [cf_name, schema] : ks.metadata()->cf_meta_data()) {
                     auto& t = db.find_column_family(schema->id());
                     constexpr bool exclude_current_version = false;

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1221,7 +1221,7 @@ SEASTAR_TEST_CASE(upgrade_sstables) {
             auto& cm = db.get_compaction_manager();
             for (auto& [ks_name, ks] : db.get_keyspaces()) {
                 const auto& erm = ks.get_vnode_effective_replication_map();
-                auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(db.get_keyspace_local_ranges(erm));
+                auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(co_await db.get_keyspace_local_ranges(erm));
                 for (auto& [cf_name, schema] : ks.metadata()->cf_meta_data()) {
                     auto& t = db.find_column_family(schema->id());
                     constexpr bool exclude_current_version = false;

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -69,10 +69,10 @@ static void verify_sorted(const dht::token_range_vector& trv) {
     BOOST_CHECK(boost::adjacent_find(trv, not_strictly_before) == trv.end());
 }
 
-static void check_ranges_are_sorted(vnode_effective_replication_map_ptr erm, gms::inet_address ep) {
-    verify_sorted(erm->get_ranges(ep));
-    verify_sorted(erm->get_primary_ranges(ep));
-    verify_sorted(erm->get_primary_ranges_within_dc(ep));
+static future<> check_ranges_are_sorted(vnode_effective_replication_map_ptr erm, gms::inet_address ep) {
+    verify_sorted(co_await erm->get_ranges(ep));
+    verify_sorted(co_await erm->get_primary_ranges(ep));
+    verify_sorted(co_await erm->get_primary_ranges_within_dc(ep));
 }
 
 void strategy_sanity_check(
@@ -179,7 +179,7 @@ void full_ring_check(const std::vector<ring_point>& ring_points,
         auto endpoints2 = erm->get_natural_endpoints(t2);
 
         endpoints_check(ars_ptr, tmptr, endpoints2, topo);
-        check_ranges_are_sorted(erm, rp.host);
+        check_ranges_are_sorted(erm, rp.host).get();
         BOOST_CHECK(endpoints1 == endpoints2);
     }
 }

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -1937,7 +1937,8 @@ SEASTAR_TEST_CASE(sstable_cleanup_correctness_test) {
             auto close_cf = deferred_stop(cf);
             cf->start();
 
-            auto local_ranges = compaction::make_owned_ranges_ptr(db.get_keyspace_local_ranges(ks_name));
+            const auto& erm = db.find_keyspace(ks_name).get_vnode_effective_replication_map();
+            auto local_ranges = compaction::make_owned_ranges_ptr(db.get_keyspace_local_ranges(erm));
             auto descriptor = sstables::compaction_descriptor({sst}, compaction_descriptor::default_level,
                 compaction_descriptor::default_max_sstable_bytes, run_identifier, compaction_type_options::make_cleanup(), std::move(local_ranges));
             auto ret = compact_sstables(env, std::move(descriptor), cf, sst_gen).get();

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -1938,7 +1938,7 @@ SEASTAR_TEST_CASE(sstable_cleanup_correctness_test) {
             cf->start();
 
             const auto& erm = db.find_keyspace(ks_name).get_vnode_effective_replication_map();
-            auto local_ranges = compaction::make_owned_ranges_ptr(db.get_keyspace_local_ranges(erm));
+            auto local_ranges = compaction::make_owned_ranges_ptr(db.get_keyspace_local_ranges(erm).get());
             auto descriptor = sstables::compaction_descriptor({sst}, compaction_descriptor::default_level,
                 compaction_descriptor::default_max_sstable_bytes, run_identifier, compaction_type_options::make_cleanup(), std::move(local_ranges));
             auto ret = compact_sstables(env, std::move(descriptor), cf, sst_gen).get();

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -582,7 +582,8 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly_with_owned
             data_dictionary::storage_options local;
             return cf.get_sstables_manager().make_sstable(cf.schema(), cf.dir(), local, generation, sstables::sstable_state::upload);
         };
-        auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(e.db().local().get_keyspace_local_ranges("ks"));
+        const auto& erm = e.db().local().find_keyspace("ks").get_vnode_effective_replication_map();
+        auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(e.db().local().get_keyspace_local_ranges(erm));
         distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", std::move(make_sstable), std::move(owned_ranges_ptr)).get();
         verify_that_all_sstables_are_local(sstdir, smp::count * smp::count).get();
       });

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -583,7 +583,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly_with_owned
             return cf.get_sstables_manager().make_sstable(cf.schema(), cf.dir(), local, generation, sstables::sstable_state::upload);
         };
         const auto& erm = e.db().local().find_keyspace("ks").get_vnode_effective_replication_map();
-        auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(e.db().local().get_keyspace_local_ranges(erm));
+        auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(e.db().local().get_keyspace_local_ranges(erm).get());
         distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", std::move(make_sstable), std::move(owned_ranges_ptr)).get();
         verify_that_all_sstables_are_local(sstdir, smp::count * smp::count).get();
       });


### PR DESCRIPTION
To prevent stalls due to large number of tokens.
For example, large cluster with say 70 nodes can have
more than 16K tokens.

Fixes #19757
