### PR TITLE
Add CQL-based RBAC support to Alternator

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -10,6 +10,7 @@
 #include <seastar/core/sleep.hh>
 #include "alternator/executor.hh"
 #include "cdc/log.hh"
+#include "auth/service.hh"
 #include "db/config.hh"
 #include "log.hh"
 #include "schema/schema_builder.hh"
@@ -3262,7 +3263,14 @@ future<executor::request_return_type> executor::get_item(client_state& client_st
     const rjson::value* expression_attribute_names = rjson::find(request, "ExpressionAttributeNames");
     verify_all_are_used(expression_attribute_names, used_attribute_names, "ExpressionAttributeNames", "GetItem");
 
-    return _proxy.query(schema, std::move(command), std::move(partition_ranges), cl,
+    if (!co_await client_state.check_has_permission(auth::command_desc(
+            auth::permission::SELECT,
+            auth::make_data_resource(schema->ks_name(), schema->cf_name())))) {
+        co_return api_error::access_denied(format(
+            "SELECT permissions denied on {}.{} by RBAC", schema->ks_name(), schema->cf_name()));
+    }
+
+    co_return co_await _proxy.query(schema, std::move(command), std::move(partition_ranges), cl,
             service::storage_proxy::coordinator_query_options(executor::default_timeout(), std::move(permit), client_state, trace_state)).then(
             [this, schema, partition_slice = std::move(partition_slice), selection = std::move(selection), attrs_to_get = std::move(attrs_to_get), start_time = std::move(start_time)] (service::storage_proxy::coordinator_query_result qr) mutable {
         _stats.api_operations.get_item_latency.mark(std::chrono::steady_clock::now() - start_time);

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -3181,10 +3181,18 @@ future<executor::request_return_type> executor::update_item(client_state& client
     auto op = make_shared<update_item_operation>(_proxy, std::move(request));
     tracing::add_table_name(trace_state, op->schema()->ks_name(), op->schema()->cf_name());
     const bool needs_read_before_write = op->needs_read_before_write();
+
+    if (!co_await client_state.check_has_permission(auth::command_desc(
+            auth::permission::MODIFY,
+            auth::make_data_resource(op->schema()->ks_name(), op->schema()->cf_name())))) {
+        co_return api_error::access_denied(format(
+            "MODIFY permissions denied on {}.{} by RBAC", op->schema()->ks_name(), op->schema()->cf_name()));
+    }
+
     if (auto shard = op->shard_for_execute(needs_read_before_write); shard) {
         _stats.api_operations.update_item--; // uncount on this shard, will be counted in other shard
         _stats.shard_bounce_for_lwt++;
-        return container().invoke_on(*shard, _ssg,
+        co_return co_await container().invoke_on(*shard, _ssg,
                 [request = std::move(*op).move_request(), cs = client_state.move_to_other_shard(), gt = tracing::global_trace_state_ptr(trace_state), permit = std::move(permit)]
                 (executor& e) mutable {
             return do_with(cs.get(), [&e, request = std::move(request), trace_state = tracing::trace_state_ptr(gt)]
@@ -3197,7 +3205,7 @@ future<executor::request_return_type> executor::update_item(client_state& client
             });
         });
     }
-    return op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats).finally([op, start_time, this] {
+    co_return co_await op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats).finally([op, start_time, this] {
         _stats.api_operations.update_item_latency.mark(std::chrono::steady_clock::now() - start_time);
     });
 }

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1909,10 +1909,18 @@ future<executor::request_return_type> executor::delete_item(client_state& client
     auto op = make_shared<delete_item_operation>(_proxy, std::move(request));
     tracing::add_table_name(trace_state, op->schema()->ks_name(), op->schema()->cf_name());
     const bool needs_read_before_write = op->needs_read_before_write();
+
+    if (!co_await client_state.check_has_permission(auth::command_desc(
+            auth::permission::MODIFY,
+            auth::make_data_resource(op->schema()->ks_name(), op->schema()->cf_name())))) {
+        co_return api_error::access_denied(format(
+            "MODIFY permissions denied on {}.{} by RBAC", op->schema()->ks_name(), op->schema()->cf_name()));
+    }
+
     if (auto shard = op->shard_for_execute(needs_read_before_write); shard) {
         _stats.api_operations.delete_item--; // uncount on this shard, will be counted in other shard
         _stats.shard_bounce_for_lwt++;
-        return container().invoke_on(*shard, _ssg,
+        co_return co_await container().invoke_on(*shard, _ssg,
                 [request = std::move(*op).move_request(), cs = client_state.move_to_other_shard(), gt = tracing::global_trace_state_ptr(trace_state), permit = std::move(permit)]
                 (executor& e) mutable {
             return do_with(cs.get(), [&e, request = std::move(request), trace_state = tracing::trace_state_ptr(gt)]
@@ -1925,7 +1933,7 @@ future<executor::request_return_type> executor::delete_item(client_state& client
             });
         });
     }
-    return op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats).finally([op, start_time, this] {
+    co_return co_await op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats).finally([op, start_time, this] {
         _stats.api_operations.delete_item_latency.mark(std::chrono::steady_clock::now() - start_time);
     });
 }

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -42,6 +42,11 @@ class server {
     bool _enforce_authorization;
     utils::small_vector<std::reference_wrapper<seastar::httpd::http_server>, 2> _enabled_servers;
     gate _pending_requests;
+    // In some places we will need a CQL updateable_timeout_config object even
+    // though it isn't really relevant for Alternator which defines its own
+    // timeouts separately. We can create this object only once.
+    updateable_timeout_config _timeout_config;
+
     alternator_callbacks_map _callbacks;
 
     semaphore* _memory_limiter;

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -98,6 +98,12 @@ future<executor::request_return_type> executor::update_time_to_live(client_state
     }
     sstring attribute_name(v->GetString(), v->GetStringLength());
 
+    if (!co_await client_state.check_has_permission(auth::command_desc(
+            auth::permission::ALTER, auth::make_data_resource(schema->ks_name(), schema->cf_name())))) {
+        co_return api_error::access_denied(format(
+            "ALTER permissions denied on {}.{} by RBAC", schema->ks_name(), schema->cf_name()));
+    }
+
     co_await db::modify_tags(_mm, schema->ks_name(), schema->cf_name(), [&](std::map<sstring, sstring>& tags_map) {
         if (enabled) {
             if (tags_map.contains(TTL_TAG_KEY)) {

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -108,7 +108,14 @@ exactly the same microsecond-resolution timestamp, the the result may be
 a mixture of both writes - some attributes from one and some from the
 other - instead of being just one or the other.
 
-## Authorization
+## Authentication and Authorization
+
+By default, Alternator does not enforce authentication or authorization,
+and any request from any connected client will be allowed. To enforce
+client authentication, and authorization of which client is allowed
+to do what, configure the following in ScyllaDB's configuration:
+
+    `alternator_enforce_authorization: true`
 
 Alternator implements the same [signature protocol](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
 as DynamoDB and the rest of AWS. Clients use, as usual, an access key ID and
@@ -116,10 +123,11 @@ a secret access key to prove their identity and the authenticity of their
 request. Alternator can then validate the authenticity and authorization of
 each request using a known list of authorized key pairs.
 
-In the current implementation, the user stores the list of allowed key pairs
-in the `system.roles` table: The access key ID is the `role` column, and
-the secret key is the `salted_hash`, i.e., the secret key can be found by
-`SELECT salted_hash from system.roles WHERE role = ID;`.
+To create a user for authentication, use the CQL "CREATE ROLE" command.
+When a client signs a request, it uses the name of this role as the access
+key ID, and the _salted hash_ of the role's password is the secret key.
+This secret key for role XYZ can be retrieved by the CQL request
+`SELECT salted_hash from system.roles WHERE role = XYZ;`.
 
 <!--- REMOVE IN FUTURE VERSIONS - Remove the note below in version 6.1 -->
 
@@ -127,19 +135,44 @@ the secret key is the `salted_hash`, i.e., the secret key can be found by
 [enabling consistent topology updates](../upgrade/upgrade-opensource/upgrade-guide-from-5.4-to-6.0/enable-consistent-topology.rst), 
 the table name is `system_auth.roles`.)
 
-By default, authorization is not enforced at all. It can be turned on
-by providing an entry in Scylla configuration:
-    `alternator_enforce_authorization: true`
+Alternator also implements authorization, or _access control_ - defining
+which authenticated user is allowed to do which operation, such as reading
+or writing to a specific table. The way this is supported in Alternator is
+currently _not_ compatible with DynamoDB's APIs (IAM or PutResourcePolicy).
+Instead, one needs to grant permissions to specific roles using CQL, with
+the "GRANT" command. For example, an Alternator table "xyz" is visible to
+CQL as `alternator_xyz.xyz`, and the following command will allow requests
+from user "myrole" to read this table (with GetItem and other read operations):
+`GRANT SELECT ON alternator_xyz.xyz TO myrole`. Refer to the CQL documentation
+on how to use GRANT and REVOKE to control permissions, and which permissions
+exist:
+<https://docs.scylladb.com/stable/operating-scylla/security/authorization.html>
 
-Although Alternator implements DynamoDB's authentication, including the
-possibility of listing multiple allowed key pairs, there is currently no
-implementation of _access control_. All authenticated key pairs currently get
-full access to the entire database. This is in contrast with DynamoDB which
-supports fine-grain access controls via "IAM policies" - which give each
-authenticated user access to a different subset of the tables, different
-allowed operations, and even different permissions for individual items.
-All of this is not yet implemented in Alternator.
-See <https://github.com/scylladb/scylla/issues/5047>.
+The following permissions are needed to run the following API operations:
+
+ * SELECT:      GetItem, Query, Scan, BatchGetItem, GetRecords
+ * MODIFY:      PutItem, DeleteItem, UpdateItem, BatchWriteItem
+ * CREATE:      CreateTable
+ * DROP:        DeleteTable
+ * ALTER:       UpdateTable, TagResource, UntagResource, UpdateTimeToLive
+ * none needed: ListTables, DescribeTable, DescribeEndpoints,
+                ListTagsOfResource, DescribeTimeToLive,
+                DescribeContinuousBackups, ListStreams, DescribeStream,
+                GetShardIterator
+
+Note that the required permissions depend on the type of operation, not on
+what it does. For example, even though the PutItem operation can read the
+value of an item (when used with `ReturnValues=ALL_OLD`), it still requires
+the MODIFY permission, not the SELECT permission.
+
+Permissions are separate for a base table and each of its GSI/LSI and CDC
+log, so it's possible to give a role permissions to read one index and
+not the base, or vice versa, and so on. To build the GRANT command, you
+need to know the CQL name of each of these objects. For example, the CQL
+name of GSI "abc" of Alternator table "xyz" is `alternator_xyz.xyz:abc`.
+If you don't know the name of the table, you can try a forbidden operation
+and the AccessDeniedException error will contain the name of the table
+that was lacking permissions.
 
 ## Metrics
 

--- a/docs/alternator/getting-started.md
+++ b/docs/alternator/getting-started.md
@@ -21,6 +21,12 @@ This section will guide you through the steps for setting up the cluster:
    `/etc/scylla/scylla.crt` and `/etc/scylla/scylla.key` must be inserted into
    the image, containing the SSL certificate and key to use.
 
+By default, ScyllaDB run in this way will not have authentication or
+authorization enabled, and any DynamoDB API request will be honored without
+requiring them to be signed appropriately. See the
+[Scylla Alternator for DynamoDB users](compatibility.md#authentication-and-authorization)
+document on how to configure authentication and authorization.
+
 ## Testing Scylla's DynamoDB API support:
 ### Running AWS Tic Tac Toe demo app to test the cluster:
 1. Follow the instructions on the [AWS github page](https://github.com/awsdocs/amazon-dynamodb-developer-guide/blob/master/doc_source/TicTacToe.Phase1.md)

--- a/test/cql-pytest/run.py
+++ b/test/cql-pytest/run.py
@@ -321,7 +321,7 @@ def run_scylla_cmd(pid, dir):
         '--strict-allow-filtering', 'true',
         '--strict-is-not-null-in-views', 'true',
         '--permissions-update-interval-in-ms', '100',
-        '--permissions-validity-in-ms', '100',
+        '--permissions-validity-in-ms', '5',
         '--shutdown-announce-in-ms', '0',
         '--maintenance-socket', 'workdir',
         '--service-levels-interval-ms', '500',

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -350,6 +350,7 @@ class ManagerClient():
                           property_file: Optional[dict[str, Any]] = None,
                           start: bool = True,
                           seeds: Optional[List[IPAddress]] = None,
+                          driver_connect_opts: dict[str, Any] = {},
                           expected_error: Optional[str] = None) -> List[ServerInfo]:
         """Add new servers concurrently.
         This function can be called only if the cluster uses consistent topology changes, which support
@@ -382,7 +383,7 @@ class ManagerClient():
             if self.cql:
                 self._driver_update()
             elif start:
-                await self.driver_connect()
+                await self.driver_connect(**driver_connect_opts)
         return s_infos
 
     async def remove_node(self, initiator_id: ServerNum, server_id: ServerNum,

--- a/test/topology_experimental_raft/test_alternator.py
+++ b/test/topology_experimental_raft/test_alternator.py
@@ -19,8 +19,10 @@ import logging
 import time
 import boto3
 import botocore
+from botocore.exceptions import ClientError
 import requests
 import json
+from cassandra.auth import PlainTextAuthProvider
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for
@@ -35,12 +37,12 @@ alternator_config = {
     'alternator_write_isolation': 'only_rmw_uses_lwt',
     'alternator_ttl_period_in_seconds': '0.5',
 }
-def get_alternator(ip):
+def get_alternator(ip, user='alternator', passwd='secret_pass'):
     url = f"http://{ip}:{alternator_config['alternator_port']}"
     return boto3.resource('dynamodb', endpoint_url=url,
         region_name='us-east-1',
-        aws_access_key_id='alternator',
-        aws_secret_access_key='secret_pass',
+        aws_access_key_id=user,
+        aws_secret_access_key=passwd,
         config=botocore.client.Config(
             retries={"max_attempts": 0},
             read_timeout=300)
@@ -319,3 +321,95 @@ async def test_localnodes_joining_nodes(manager: ManagerClient):
 # TODO: add a more thorough test for /localnodes, creating a cluster with
 # multiple nodes in multiple data centers, and check that we can get a list
 # of nodes in each data center.
+
+# We have in test/alternator/test_cql_rbac.py many functional tests for
+# CQL-based Role Based Access Control (RBAC) and all those tests use the
+# same one-node cluster with authentication and authorization enabled.
+# Here in this file we have the opportunity to create clusters with different
+# configurations, so we can check how these configuration settings affect RBAC.
+@pytest.mark.asyncio
+async def test_alternator_enforce_authorization_false(manager: ManagerClient):
+    """A basic test for how Alternator authentication and authorization
+       work when alternator_enfore_authorization is *false* (and CQL's
+       authenticator/authorizer options are also unset):
+       1. Username and signature is not checked - a request with a bad
+          username is accepted.
+       2. Any user (or even non-existent user) has permissions to do any
+          operation.
+    """
+    servers = await manager.servers_add(1, config=alternator_config)
+    # Requests from a non-existent user with garbage password work,
+    # and can perform privildged operations like CreateTable, etc.
+    alternator = get_alternator(servers[0].ip_addr, 'nonexistent_user', 'garbage')
+    table = alternator.create_table(TableName=unique_table_name(),
+        BillingMode='PAY_PER_REQUEST',
+        KeySchema=[ {'AttributeName': 'p', 'KeyType': 'HASH' } ],
+        AttributeDefinitions=[ {'AttributeName': 'p', 'AttributeType': 'N' } ])
+    table.put_item(Item={'p': 42})
+    table.get_item(Key={'p': 42})
+    table.delete()
+
+def get_secret_key(cql, user):
+    """The secret key used for a user in Alternator is its role's salted_hash.
+       This function retrieves it from the system table.
+    """
+    # Newer Scylla places the "roles" table in the "system" keyspace, but
+    # older versions used "system_auth_v2" or "system_auth"
+    for ks in ['system', 'system_auth_v2', 'system_auth']:
+        try:
+            e = list(cql.execute(f"SELECT salted_hash FROM {ks}.roles WHERE role = '{user}'"))
+            if e != [] and e[0].salted_hash is not None:
+                return e[0].salted_hash
+        except:
+            pass
+    pytest.fail(f"Couldn't get secret key for user {user}")
+
+@pytest.mark.asyncio
+async def test_alternator_enforce_authorization_true(manager: ManagerClient):
+    """A basic test for how Alternator authentication and authorization
+       work when authentication and authorization is enabled in CQL, and
+       additionally alternator_enfore_authorization is *true*:
+       1. The username and signature is verified (a request with a bad
+          username or password is rejected)
+       2. A new user works, and can do things that don't need permissions
+          (such as ListTables) but can't perform operations that do need
+          permissions (e.g., CreateTable).
+    """
+    config = alternator_config | {
+        'alternator_enforce_authorization': True,
+        'authenticator': 'PasswordAuthenticator',
+        'authorizer': 'CassandraAuthorizer'
+    }
+    servers = await manager.servers_add(1, config=config,
+        driver_connect_opts={'auth_provider': PlainTextAuthProvider(username='cassandra', password='cassandra')})
+    cql = manager.get_cql()
+    # Any requests from a non-existent user with garbage password is
+    # rejected - even requests that don't need special permissions
+    alternator = get_alternator(servers[0].ip_addr, 'nonexistent_user', 'garbage')
+    with pytest.raises(ClientError, match='UnrecognizedClientException'):
+        alternator.meta.client.list_tables()
+    # We know that Scylla is set up with a "cassandra" user. If we retrieve
+    # its correct secret key, the ListTables will work.
+    alternator = get_alternator(servers[0].ip_addr, 'cassandra', get_secret_key(cql, 'cassandra'))
+    alternator.meta.client.list_tables()
+    # Privileged operations also work for the superuser account "cassandra":
+    table = alternator.create_table(TableName=unique_table_name(),
+        BillingMode='PAY_PER_REQUEST',
+        KeySchema=[ {'AttributeName': 'p', 'KeyType': 'HASH' } ],
+        AttributeDefinitions=[ {'AttributeName': 'p', 'AttributeType': 'N' } ])
+    table.put_item(Item={'p': 42})
+    table.get_item(Key={'p': 42})
+    table.delete()
+    # Create a new role "user2" and make a new connection "alternator2" with it:
+    cql.execute("CREATE ROLE user2 WITH PASSWORD = 'user2' AND LOGIN=TRUE")
+    alternator2 = get_alternator(servers[0].ip_addr, 'user2', get_secret_key(cql, 'user2'))
+    # In the new role, ListTables works, but other privileged operations
+    # don't.
+    alternator2.meta.client.list_tables()
+    with pytest.raises(ClientError, match='AccessDeniedException'):
+        alternator2.create_table(TableName=unique_table_name(),
+            BillingMode='PAY_PER_REQUEST',
+            KeySchema=[ {'AttributeName': 'p', 'KeyType': 'HASH' } ],
+            AttributeDefinitions=[ {'AttributeName': 'p', 'AttributeType': 'N' } ])
+    # We could further test how GRANT works, but this would be unnecessary
+    # repeating of the tests in test/alternator/test_cql_rbac.py.


### PR DESCRIPTION
Alternator already supports **authentication** - the ability to to sign each request as a particular user. The users that can be used are the different "roles" that are created by CQL "CREATE ROLE" commands.
This series adds support for **authorization**, i.e., the ability to determine that only some of these roles are allowed to read or write particular tables, to create new tables, and so on. 

The way we chose to do this in this series is to support CQL's existing role-based access control (RBAC) commands - GRANT and REVOKE - on Alternator tables. For example, an Alternator table "xyz" is visible to CQL as "alternator_xyz.xyz", so a `GRANT SELECT ON alternator_xyz.xyz TO myrole` will allow read commands (e.g., GetItem) on that table, and without this GRANT, a GetItem will fail with `AccessDeniedException`.

This series adds the necessary checks to all relevant Alternator operations, and also adds extensive functional testing for this feature - i.e., that certain DynamoDB API operations are not allowed without the appropriate GRANTs.

The following permissions are needed for the following Alternator API operations:

 * **SELECT**:      `GetItem`, `Query`, `Scan`, `BatchGetItem`, `GetRecords`
 * **MODIFY**:      `PutItem`, `DeleteItem`, `UpdateItem`, `BatchWriteItem`
 * **CREATE**:      `CreateTable`
 * **DROP**:        `DeleteTable`
 * **ALTER**:       `UpdateTable`, `TagResource`, `UntagResource`, `UpdateTimeToLive`
 * _none needed_: `ListTables`, `DescribeTable`, `DescribeEndpoints`, `ListTagsOfResource`, `DescribeTimeToLive`, `DescribeContinuousBackups`, `ListStreams`, `DescribeStream`, `GetShardIterator`

Currently, I decided that for consistency each operation requires one permission only. For example, PutItem only requires MODIFY permission. This is despite the fact that in some cases (namely, `ReturnValues=ALL_OLD`) it can also _read_ the item. We should perhaps discuss this decision - and compare how it was done in CQL - e.g., what happens in LWT writes that may return old values?

Different permissions can be granted for a base table, each of its views, and the CDC table (Alternator streams). This adds power - e.g., we can allow a role to read only a view but not the base table, or read the table but not its history. GRANTing permissions on views or CDC logs require knowing their names, which are somewhat ugly (e.g., the name of GSI "abc" in table "xyz" is `alternator_xyz.xyz:abc`). But usefully, the error message when permissions are denied contains the full name of the table that was lacking permissions and which permissions were lacking, so users can easily add them.

In addition to permissions checking, this series also correctly supports _auto-grant_ (except #19798): When a role has permissions to `CreateTable`, any table it creates will automatically be granted all permissions for this role, so this role will be able to use the new table and eventually delete it. `DeleteTable` does the opposite - it removes permissions from tables being deleted, so that if later a second user re-creates a table with the same name, the first user will not have permissions over the new table.

The already-existing configuration parameter `alternator_enforce_authorization` (off by default), which previously only enabled authentication, now also enables authorization. Users that upgrade to the new version and already had `alternator_enforce_authorization=true` should verify that the users they use to authenticate either have the appropriate permissions or the "superuser" flag. Roles used to authenticate must also have the "login" flag.

Please note that although the new RBAC support implements the access control feature we asked for in #5047, this implementation is _not compatible_ with DynamoDB. In DynamoDB, the access control is configured through IAM operations or through the new `PutResourcePolicy` - operation, not through CQL (obviously!). DynamoDB also offers finer access-control granularity than we support (Scylla's RBAC works on entire tables, DynamoDB allows setting permissions on key prefixes, on individual attributes, and more). Despite this non-compatibility, I believe this feature, as is, will already be useful to Alternator users.

Fixes #5047 (after closing that issue, a new clean issue should be opened about the DynamoDB-compatible APIs that we didn't do - just so we remember this wasn't done yet).

New feature, should not be backported.