### PR TITLE
dist/docker/debian/build_docker.sh: Build container based on Ubuntu24.04

### DIFF
--- a/dist/docker/debian/build_docker.sh
+++ b/dist/docker/debian/build_docker.sh
@@ -61,7 +61,7 @@ if [ -f build/build.ninja ]; then
    esac
 fi
 
-container="$(buildah from docker.io/ubuntu:22.04)"
+container="$(buildah from docker.io/ubuntu:24.04)"
 
 packages=(
     "build/dist/$config/debian/${product}_$version-$release-1_$arch.deb"


### PR DESCRIPTION
Now that we added support for Ubuntu24.04 and also migrated our images to be based on that
(https://github.com/scylladb/scylla-machine-image/pull/530), we should also modify our docker image

Fixes: https://github.com/scylladb/scylladb/issues/19738

*Update OS for docker image, no need for backport*