### PR TITLE
Apply sstable io error handler to exceptions generated when opening file

### DIFF
--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -528,6 +528,7 @@ private:
     sharded<service::tablet_allocator>& _tablet_allocator;
     sharded<cdc::generation_service>& _cdc_gens;
     sharded<db::view::view_builder>& _view_builder;
+    bool _isolated = false;
 private:
     /**
      * Handle node bootstrap
@@ -710,6 +711,10 @@ public:
     // Must run on shard 0.
     future<> check_and_repair_cdc_streams();
 
+    // for testing
+    bool is_isolated() const {
+        return _isolated;
+    }
 private:
     promise<> _drain_finished;
     std::optional<shared_future<>> _transport_stopped;

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -389,6 +389,10 @@ public:
         return _sstm;
     }
 
+    virtual sharded<service::storage_service>& get_storage_service() override {
+        return _ss;
+    }
+
     virtual future<> refresh_client_state() override {
         return _core_local.invoke_on_all([] (core_local_state& state) {
             return state.client_state.maybe_update_per_service_level_params();

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -179,6 +179,8 @@ public:
 
     virtual sharded<sstables::storage_manager>& get_sstorage_manager() = 0;
 
+    virtual sharded<service::storage_service>& get_storage_service() = 0;
+
     data_dictionary::database data_dictionary();
 };
 


### PR DESCRIPTION
Fixes #19753

SSTable file open provides an `io_error_handler` instance which is applied to a file-wrapper to process any IO errors happing during read/write via the handler in `storage_service`, which in turn will effectively disable the node. However, this is not applied to the actual open operation itself, i.e. any exception generated by the file open call itself will instead just escape to caller. 

This PR adds filtering via the `error_handler` to sstable open + makes `storage_service` "isolate" mechanism non-module-static (thus making it testable) and adds tests to check we exhibit the same behaviour in both cases. 

The main motivation for this issue it discussions that secondary level IO issues (i.e. caused by extensions) should trigger the same behaviour as, for example, running out of disk space. 