### PR TITLE
exceptions/exceptions.hh: Wrap `#include <concepts>` within an `#ifdef`

### DIFF
--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -13,7 +13,6 @@
 #include "db/consistency_level_type.hh"
 #include "db/write_type.hh"
 #include "db/operation_type.hh"
-#include <concepts>
 #include <stdexcept>
 #include <seastar/core/sstring.hh>
 #include "bytes.hh"
@@ -319,9 +318,12 @@ public:
     function_execution_exception(sstring func_name_, sstring detail, sstring ks_name_, std::vector<sstring> args_) noexcept;
 };
 
-}
+} // namespace exceptions
 
 #if FMT_VERSION < 100000
+
+#include <concepts>
+
 // fmt v10 introduced formatter for std::exception
 template <std::derived_from<exceptions::cassandra_exception> T>
 struct fmt::formatter<T> : fmt::formatter<string_view> {


### PR DESCRIPTION
`GitHub Actions / Analyze #includes in source files` keeps reporting that the include shouldn't be present in the file. The reason is that we use FMT with version >10, so the fragment of the code that uses the include is not compiled. We move the include to a place where it's used, which should fix the warnings.