### PR TITLE
tablets: load_balancer: Improve per-table balance

### DIFF
--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -154,6 +154,12 @@ public:
         return s.id;
     }
 
+    shard_id get_most_loaded_shard(host_id node) {
+        auto& n = ensure_node(node);
+        const shard_load& s = *std::prev(n._shards_by_load.end());
+        return s.id;
+    }
+
     void unload(host_id node, shard_id shard) {
         auto& n = _nodes.at(node);
         n.update_shard_load(shard, -1);

--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -137,6 +137,17 @@ public:
         std::make_heap(n._shards.begin(), n._shards.end(), shard_load_cmp());
     }
 
+    void pick(host_id node, shard_id shard) {
+        auto& n = _nodes.at(node);
+        for (auto& shard_load : n._shards) {
+            if (shard_load.id == shard) {
+                ++shard_load.load;
+                break;
+            }
+        }
+        std::make_heap(n._shards.begin(), n._shards.end(), shard_load_cmp());
+    }
+
     uint64_t get_load(host_id node) const {
         if (!_nodes.contains(node)) {
             return 0;
@@ -166,6 +177,13 @@ public:
         }
         auto& n = _nodes.at(node);
         return double(n.load()) / n._shards.size();
+    }
+
+    shard_id get_shard_count(host_id node) const {
+        if (!_nodes.contains(node)) {
+            return 0;
+        }
+        return _nodes.at(node)._shards.size();
     }
 
     // Returns the difference in tablet count between highest-loaded shard and lowest-loaded shard.

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1934,6 +1934,10 @@ public:
         _load_balancer_stats.unregister();
     }
 
+    load_balancer_stats_manager& stats() {
+        return _load_balancer_stats;
+    }
+
     // The splitting of tablets today is completely based on the power-of-two constraint.
     // A tablet of id X is split into 2 new tablets, which new ids are (x << 1) and
     // (x << 1) + 1.
@@ -1990,6 +1994,10 @@ tablet_allocator_impl& tablet_allocator::impl() {
 
 void tablet_allocator::on_leadership_lost() {
     impl().on_leadership_lost();
+}
+
+load_balancer_stats_manager& tablet_allocator::stats() {
+    return impl().stats();
 }
 
 }

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1023,7 +1023,6 @@ public:
 
             target = nodes_by_load_dst.back();
             auto& target_info = nodes[target];
-            auto& src_info = nodes[src.host];
             auto push_back_target_node = seastar::defer([&] {
                 std::push_heap(nodes_by_load_dst.begin(), nodes_by_load_dst.end(), nodes_dst_cmp);
             });
@@ -1076,7 +1075,7 @@ public:
             std::unordered_map<sstring, int> rack_load; // Will be built if check_rack_load
 
             if (nodes_to_drain.empty()) {
-                check_rack_load = target_info.rack() != src_info.rack();
+                check_rack_load = target_info.rack() != src_node_info.rack();
                 for (auto&& r: tmap.get_tablet_info(source_tablet.tablet).replicas) {
                     if (r.host == target) {
                         has_replica_on_target = true;
@@ -1113,8 +1112,8 @@ public:
             auto& target_load_sketch = co_await target_info.get_load_sketch(_tm);
             auto dst = global_shard_id {target, target_load_sketch.next_shard(target)};
 
-            tablet_transition_kind kind = (src_info.state() == locator::node::state::being_removed
-                                           || src_info.state() == locator::node::state::left)
+            tablet_transition_kind kind = (src_node_info.state() == locator::node::state::being_removed
+                                           || src_node_info.state() == locator::node::state::left)
                        ? tablet_transition_kind::rebuild : tablet_transition_kind::migration;
             auto mig = tablet_migration_info {kind, source_tablet, src, dst};
             auto& src_tinfo = tmap.get_tablet_info(source_tablet.tablet);

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1373,6 +1373,15 @@ public:
         };
 
         for (auto&& [host, node_load] : nodes) {
+            if (lblogger.is_enabled(seastar::log_level::debug)) {
+                shard_id shard = 0;
+                for (auto&& shard_load : node_load.shards) {
+                    lblogger.debug("shard {}: all tablets: {}, candidates: {}, tables: {}", tablet_replica {host, shard},
+                                   shard_load.tablet_count, shard_load.candidate_count(), shard_load.tablet_count_per_table);
+                    shard++;
+                }
+            }
+
             if (host != target && (nodes_to_drain.empty() || nodes_to_drain.contains(host))) {
                 nodes_by_load.push_back(host);
                 std::make_heap(node_load.shards_by_load.begin(), node_load.shards_by_load.end(),
@@ -1517,6 +1526,15 @@ public:
             auto unload_target_load_sketch = seastar::defer([&] {
                 nodes[dst.host].target_load_sketch->unload(dst.host, dst.shard);
             });
+
+            if (lblogger.is_enabled(seastar::log_level::trace)) {
+                shard_id shard = 0;
+                for (auto&& shard_load : target_info.shards) {
+                    lblogger.trace("shard {}: all tablets: {}, candidates: {}, tables: {}", tablet_replica {dst.host, shard},
+                                   shard_load.tablet_count, shard_load.candidate_count(), shard_load.tablet_count_per_table);
+                    shard++;
+                }
+            }
 
             // Pick tablet movement.
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -995,7 +995,7 @@ public:
             } else {
                 std::pop_heap(src_shards.begin(), src_shards.end(), node_load.shards_by_load_cmp());
                 src = src_shards.back();
-                dst = sketch.next_shard(host);
+                dst = sketch.get_least_loaded_shard(host);
             }
 
             auto push_back = seastar::defer([&] {
@@ -1057,6 +1057,8 @@ public:
             src_info.tablet_count--;
             dst_info.tablet_count_per_table[tablet.table]++;
             src_info.tablet_count_per_table[tablet.table]--;
+            sketch.pick(host, dst);
+            sketch.unload(host, src);
         }
 
         co_return plan;

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1367,7 +1367,7 @@ public:
                 }
             }
 
-            if (host != target && (nodes_to_drain.empty() || nodes_to_drain.contains(host))) {
+            if (host != target && (nodes_to_drain.empty() || node_load.drained)) {
                 nodes_by_load.push_back(host);
                 std::make_heap(node_load.shards_by_load.begin(), node_load.shards_by_load.end(),
                                node_load.shards_by_load_cmp());
@@ -1764,7 +1764,7 @@ public:
             load.update();
             _stats.for_node(dc, host).load = load.avg_load;
 
-            if (!nodes_to_drain.contains(host)) {
+            if (!load.drained) {
                 if (!min_load_node || load.avg_load < min_load) {
                     min_load = load.avg_load;
                     min_load_node = host;

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -311,6 +311,15 @@ class load_balancer {
     // Data structure used for making load-balancing decisions over a set of nodes.
     using node_load_map = std::unordered_map<host_id, node_load>;
 
+    // Less-comparator which orders nodes by load.
+    struct nodes_by_load_cmp {
+        node_load_map& nodes;
+
+        bool operator()(host_id a, host_id b) const {
+            return nodes[a].avg_load < nodes[b].avg_load;
+        }
+    };
+
     // We have split and merge thresholds, which work respectively as (target) upper and lower
     // bound for average size of tablets.
     //
@@ -884,9 +893,7 @@ public:
         std::vector<host_id> nodes_by_load_dst;
         nodes_by_load_dst.reserve(nodes.size());
 
-        auto nodes_cmp = [&] (const host_id& a, const host_id& b) {
-            return nodes[a].avg_load < nodes[b].avg_load;
-        };
+        auto nodes_cmp = nodes_by_load_cmp(nodes);
         auto nodes_dst_cmp = [&] (const host_id& a, const host_id& b) {
             return nodes_cmp(b, a);
         };

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -32,6 +32,26 @@ struct load_balancer_dc_stats {
     uint64_t stop_no_candidates = 0;
     uint64_t stop_skip_limit = 0;
     uint64_t stop_batch_size = 0;
+
+    load_balancer_dc_stats operator-(const load_balancer_dc_stats& other) const {
+        return {
+            calls - other.calls,
+            migrations_produced - other.migrations_produced,
+            migrations_from_skiplist - other.migrations_from_skiplist,
+            candidates_evaluated - other.candidates_evaluated,
+            bad_first_candidates - other.bad_first_candidates,
+            bad_migrations - other.bad_migrations,
+            intranode_migrations_produced - other.intranode_migrations_produced,
+            migrations_skipped - other.migrations_skipped,
+            tablets_skipped_node - other.tablets_skipped_node,
+            tablets_skipped_rack - other.tablets_skipped_rack,
+            stop_balance - other.stop_balance,
+            stop_load_inversion - other.stop_load_inversion,
+            stop_no_candidates - other.stop_no_candidates,
+            stop_skip_limit - other.stop_skip_limit,
+            stop_batch_size - other.stop_batch_size,
+        };
+    }
 };
 
 struct load_balancer_node_stats {
@@ -172,6 +192,8 @@ public:
     /// The algorithm takes care of limiting the streaming load on the system, also by taking active migrations into account.
     ///
     future<migration_plan> balance_tablets(locator::token_metadata_ptr, locator::load_stats_ptr = {}, std::unordered_set<locator::host_id> = {});
+
+    load_balancer_stats_manager& stats();
 
     void set_use_table_aware_balancing(bool);
 

--- a/test/perf/tablet_load_balancing.cc
+++ b/test/perf/tablet_load_balancing.cc
@@ -378,6 +378,10 @@ future<results> test_load_balancing_with_many_tables(params p, bool tablet_aware
 future<> run_simulation(const params& p, const sstring& name = "") {
     testlog.info("[run {}] params: {}", name, p);
 
+    auto total_tablet_count = p.tablets1.value_or(0) * p.rf1 + p.tablets2.value_or(0) * p.rf2;
+    testlog.info("[run {}] tablet count: {}", name, total_tablet_count);
+    testlog.info("[run {}] tablet count / shard: {:.3f}", name, double(total_tablet_count) / (p.nodes * p.shards));
+
     auto res = co_await test_load_balancing_with_many_tables(p, true);
     testlog.info("[run {}] Overcommit       : init : {}", name, res.init);
     testlog.info("[run {}] Overcommit       : worst: {}", name, res.worst);

--- a/test/perf/tablet_load_balancing.cc
+++ b/test/perf/tablet_load_balancing.cc
@@ -348,10 +348,20 @@ future<> run_simulation(const params& p, const sstring& name = "") {
     testlog.info("[run {}] Overcommit       : worst: {}", name, res.worst);
     testlog.info("[run {}] Overcommit       : last : {}", name, res.last);
 
-    res = co_await test_load_balancing_with_many_tables(p, false);
-    testlog.info("[run {}] Overcommit (old) : init : {}", name, res.init);
-    testlog.info("[run {}] Overcommit (old) : worst: {}", name, res.worst);
-    testlog.info("[run {}] Overcommit (old) : last : {}", name, res.last);
+    auto old_res = co_await test_load_balancing_with_many_tables(p, false);
+    testlog.info("[run {}] Overcommit (old) : init : {}", name, old_res.init);
+    testlog.info("[run {}] Overcommit (old) : worst: {}", name, old_res.worst);
+    testlog.info("[run {}] Overcommit (old) : last : {}", name, old_res.last);
+
+    for (int i = 0; i < nr_tables; ++i) {
+        if (res.worst.tables[i].shard_overcommit > old_res.worst.tables[i].shard_overcommit) {
+            testlog.warn("[run {}] table{} shard overcommit worse!", name, i + 1);
+        }
+        auto overcommit = res.worst.tables[i].shard_overcommit;
+        if (overcommit > 1.2) {
+            testlog.warn("[run {}] table{} shard overcommit {:.2f} > 1.2!", name, i + 1, overcommit);
+        }
+    }
 }
 
 future<> run_simulations(const boost::program_options::variables_map& app_cfg) {

--- a/test/perf/tablet_load_balancing.cc
+++ b/test/perf/tablet_load_balancing.cc
@@ -426,11 +426,11 @@ future<> run_simulation(const params& p, const sstring& name = "") {
 
 future<> run_simulations(const boost::program_options::variables_map& app_cfg) {
     for (auto i = 0; i < app_cfg["runs"].as<int>(); i++) {
-        auto shards = 1 << tests::random::get_int(0, 6);
+        auto shards = 1 << tests::random::get_int(0, 8);
         auto rf1 = tests::random::get_int(1, 3);
         auto rf2 = tests::random::get_int(1, 3);
-        auto scale1 = 1 << tests::random::get_int(0, 3);
-        auto scale2 = 1 << tests::random::get_int(0, 3);
+        auto scale1 = 1 << tests::random::get_int(0, 5);
+        auto scale2 = 1 << tests::random::get_int(0, 5);
         auto nodes = tests::random::get_int(3, 6);
         params p {
             .iterations = app_cfg["iterations"].as<int>(),

--- a/test/perf/tablet_load_balancing.cc
+++ b/test/perf/tablet_load_balancing.cc
@@ -376,6 +376,8 @@ future<results> test_load_balancing_with_many_tables(params p, bool tablet_aware
 }
 
 future<> run_simulation(const params& p, const sstring& name = "") {
+    testlog.info("[run {}] params: {}", name, p);
+
     auto res = co_await test_load_balancing_with_many_tables(p, true);
     testlog.info("[run {}] Overcommit       : init : {}", name, res.init);
     testlog.info("[run {}] Overcommit       : worst: {}", name, res.worst);
@@ -426,7 +428,6 @@ future<> run_simulations(const boost::program_options::variables_map& app_cfg) {
         };
 
         auto name = format("#{}", i);
-        testlog.info("[run {}] params: {}", name, p);
         co_await run_simulation(p, name);
     }
 }


### PR DESCRIPTION
Tablet load balancer tries to equalize tablet load between shards by
moving tablets. Currently, the tablet load balancer assumes that each
tablet has the same hotness. This may not be true, and some tables may
be hotter than others. If some nodes end up getting more tablets of
the hot table, we can end up with request load imbalance and reduced
performance.

In https://github.com/scylladb/scylladb/commit/79d0711c7e37e34ee28cc4a871da0c3e86bcc559 we implemented a
mitigation for the problem by randomly choosing the table whose tablet
replica should be moved. This should improve fairness of
movement. However, this proved to not be enough to get a good
distribution of tablets.

This change improves candidate selection to not relay on randomness
but rather evaluating candidates with respect to the impact on load
imbalance.  Also, if there is no good candidate, we consider picking
other source shards, not the most-loaded one. This is helpful because
when finishing node drain we get just a few candidates per shard, all
of which may belong to a single table, and the destination may already
be overloaded with that table. Another shard may contain tablets of
another table which is not yet overloaded on the destination. And
shards may be of similar load, so it doesn't matter much which shard
we choose to unload.

We also consider other destinations, not the least-loaded one. This
helps when draining nodes and the source node has few shard
candidates. Shards on the destination may have similar load so there
is more than one good destinatin candidate. By limiting ourselves to a
single shard, we increase the chance that we're overload the table on
that shard.

The algorithm was evaluated using "scylla perf-load-balancing", which
simulates a sequeunce of 8 node bootstraps and decommissions for
different node and shard counts, RF, and tablet counts.

For example, for the following parameters:

  params: {iterations=8, nodes=5, tablets1=128 (2.4/sh), tablets2=512 (9.6/sh), rf1=3, rf2=3, shards=32}

The results are:

Before:

  Overcommit (old) : init : {table1={shard=1.25 (best=1.25), node=1.00}, table2={shard=1.04 (best=1.04), node=1.00}}
  Overcommit (old) : worst: {table1={shard=4.00 (best=1.25), node=1.81}, table2={shard=1.25 (best=1.04), node=1.11}}
  Overcommit (old) : last : {table1={shard=2.50 (best=1.25), node=1.41}, table2={shard=1.25 (best=1.04), node=1.05}}

After:

  Overcommit       : init : {table1={shard=1.25 (best=1.25), node=1.00}, table2={shard=1.04 (best=1.04), node=1.00}}
  Overcommit       : worst: {table1={shard=1.50 (best=1.25), node=1.02}, table2={shard=1.12 (best=1.04), node=1.01}}
  Overcommit       : last : {table1={shard=1.25 (best=1.25), node=1.00}, table2={shard=1.04 (best=1.04), node=1.00}}


So worst shard overcommit for table1 was reduced from 4 to 1.5. Overcommit
of 4 means that the most-loaded shard has 4 times more tablets than
the average per-shard load in the cluster.

Also, node overcommit for table1 was reduced from 1.81 to 1.02.

The magnitude of improvement depends greatly on test configurtion, so on topology and tablet distribution.

The algorithm is not perfect, it finds a local optimum. In the above
test, overcommit of 1.5 is not the best possible (1.25).

One of the reason why the current algorithm doesn't achieve best
distribution is that it works with a single movement at a time and
replication constraints limit the choice of destinations. Viable
destinations for remaining candidates may by only on nodes which are
not least-loaded, and we won't be able to fill the least loaded
node. Doing so would require more complex movement involving moving a
tablet from one of the destination nodes which doesn't have a replica
on the least loaded node and then replacing it with the candidate from
the source node.

Another limitation is that the algorithm can only fix balance by
moving tablets away from most loaded nodes, and it does so due to
imbalance between nodes. So it cannot fix the imbalance which is
already present on the nodes if there is not much to move due to
similar load between nodes. It is designed to not make the imbalance
worse, so it works good if we started in a good shape.

Fixes https://github.com/scylladb/scylladb/issues/16824