### PR TITLE
config: round-trip boolean configuration variables

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -177,7 +177,7 @@ struct convert<seastar::log_level> {
         if (!convert<std::string>::decode(node, tmp)) {
             return false;
         }
-        rhs = boost::lexical_cast<seastar::log_level>(tmp);
+        rhs = utils::config_from_string<seastar::log_level>(tmp);
         return true;
     }
 };

--- a/db/config.cc
+++ b/db/config.cc
@@ -100,6 +100,21 @@ error_injection_list_to_json(const std::vector<db::config::error_injection_at_st
 }
 
 template <>
+bool
+config_from_string(std::string_view value) {
+    // boost::lexical_cast doesn't accept true/false, which are our output representations
+    // for bools. We want round-tripping, so we need to accept true/false. For backward
+    // compatibility, we also accept 1/0. #19791.
+    if (value == "true" || value == "1") {
+        return true;
+    } else if (value == "false" || value == "0") {
+        return false;
+    } else {
+        throw boost::bad_lexical_cast(typeid(std::string_view), typeid(bool));
+    }
+}
+
+template <>
 const config_type config_type_for<bool> = config_type("bool", value_to_json<bool>);
 
 template <>

--- a/utils/config_file_impl.hh
+++ b/utils/config_file_impl.hh
@@ -29,6 +29,9 @@ T config_from_string(std::string_view string_representation) {
     return boost::lexical_cast<T>(string_representation);
 }
 
+template <>
+bool config_from_string(std::string_view string_representation);
+
 }
 
 namespace YAML {


### PR DESCRIPTION
When you SELECT a boolean from system.config, it reads as true/false, but this isn't accepted
on UPDATE (instead, we accept 1/0). This is surprising and annoying, so accept true/false in
both directions.

Not a regression, so a backport isn't strictly necessary.