### PR TITLE
tool: Fix sharding metadata for sstable dump-scylla-metadata

### DIFF
--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -79,6 +79,9 @@ struct sstable_open_config {
     // Mimics behavior when a SSTable is streamed to a given shard, where SSTable
     // writer considers the shard that created the SSTable as its owner.
     bool current_shard_as_sstable_owner = false;
+    // Sharding metadata can take lots of memory, and it's only used for computing
+    // a set of shard owners, so it can be usually discarded afterward.
+    bool clear_sharding_metadata = true;
 };
 
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1314,7 +1314,7 @@ future<> sstable::open_data(sstable_open_config cfg) noexcept {
     co_await update_info_for_opened_data(cfg);
     assert(!_shards.empty());
     auto* sm = _components->scylla_metadata->data.get<scylla_metadata_type::Sharding, sharding_metadata>();
-    if (sm) {
+    if (sm && cfg.clear_sharding_metadata) {
         // Sharding information uses a lot of memory and once we're doing with this computation we will no longer use it.
         co_await utils::clear_gently(sm->token_ranges.elements);
         sm->token_ranges.elements = {};


### PR DESCRIPTION
Scylla clears sharding metadata on load, since it has significant footprint and is useless after sstable owners are computed.

But for the sstable tool, we need it to be available after loading the sstable. Additionally, let's fix formatting of token, we were interpreting token bytes as characters, which resulted in cryptic output.

**Please replace this line with justification for the backport/\* labels added to this PR**