### PR TITLE
[Backport 6.0] replica: remove rwlock for protecting iteration over storage group map

### DIFF
--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -551,10 +551,10 @@ public:
             return map_reduce_tables<stats>([] (replica::table& t) {
                 logalloc::occupancy_stats s;
                 uint64_t partition_count = 0;
-                for (replica::memtable* active_memtable : t.active_memtables()) {
-                    s += active_memtable->region().occupancy();
-                    partition_count += active_memtable->partition_count();
-                }
+                t.for_each_active_memtable([&] (replica::memtable& active_memtable) {
+                    s += active_memtable.region().occupancy();
+                    partition_count += active_memtable.partition_count();
+                });
                 return stats{s.total_space(), s.free_space(), partition_count};
             }, stats::reduce).then([] (stats s) {
                 return std::vector<std::pair<sstring, sstring>>{

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -59,8 +59,6 @@ class compaction_group {
     seastar::condition_variable _staging_done_condition;
     // Gates async operations confined to a single group.
     seastar::gate _async_gate;
-    using list_hook_t = boost::intrusive::list_member_hook<boost::intrusive::link_mode<boost::intrusive::auto_unlink>>;
-    list_hook_t _list_hook;
 private:
     // Adds new sstable to the set of sstables
     // Doesn't update the cache. The cache must be synchronized in order for reads to see
@@ -80,10 +78,6 @@ private:
     // it to be moved from its original sstable set (e.g. maintenance) into a new one (e.g. main).
     future<> delete_unused_sstables(sstables::compaction_completion_desc desc);
 public:
-    using list_t = boost::intrusive::list<compaction_group,
-        boost::intrusive::member_hook<compaction_group, compaction_group::list_hook_t, &compaction_group::_list_hook>,
-        boost::intrusive::constant_time_size<false>>;
-
     compaction_group(table& t, size_t gid, dht::token_range token_range);
 
     void update_id_and_range(size_t id, dht::token_range token_range) {
@@ -172,13 +166,13 @@ public:
     }
 
     compaction_manager& get_compaction_manager() noexcept;
+    const compaction_manager& get_compaction_manager() const noexcept;
 
     friend class storage_group;
 };
 
 using compaction_group_ptr = std::unique_ptr<compaction_group>;
 using compaction_group_vector = utils::chunked_vector<compaction_group_ptr>;
-using compaction_group_list = compaction_group::list_t;
 
 // Storage group is responsible for storage that belongs to a single tablet.
 // A storage group can manage 1 or more compaction groups, each of which can be compacted independently.
@@ -194,7 +188,7 @@ private:
     }
     size_t to_idx(locator::tablet_range_side) const;
 public:
-    storage_group(compaction_group_ptr cg, compaction_group_list* list);
+    storage_group(compaction_group_ptr cg);
 
     const dht::token_range& token_range() const noexcept;
 
@@ -206,39 +200,44 @@ public:
 
     uint64_t live_disk_space_used() const noexcept;
 
+    void for_each_compaction_group(std::function<void(compaction_group&)> action) const noexcept;
     utils::small_vector<compaction_group*, 3> compaction_groups() noexcept;
+    utils::small_vector<const compaction_group*, 3> compaction_groups() const noexcept;
 
     // Puts the storage group in split mode, in which it internally segregates data
     // into two sstable sets and two memtable sets corresponding to the two adjacent
     // tablets post-split.
     // Preexisting sstables and memtables are not split yet.
     // Returns true if post-conditions for split() are met.
-    bool set_split_mode(compaction_group_list&);
+    bool set_split_mode();
 
     // Like set_split_mode() but triggers splitting for old sstables and memtables and waits
     // for it:
     //  1) Flushes all memtables which were created in non-split mode, and waits for that to complete.
     //  2) Compacts all sstables which overlap with the split point
     // Returns a future which resolves when this process is complete.
-    future<> split(compaction_group_list&, sstables::compaction_type_options::split opt);
+    future<> split(sstables::compaction_type_options::split opt);
 
     // Make an sstable set spanning all sstables in the storage_group
     lw_shared_ptr<const sstables::sstable_set> make_sstable_set() const;
 
     // Flush all memtables.
     future<> flush() noexcept;
+    bool can_flush() const;
+    api::timestamp_type min_memtable_timestamp() const;
+
+    bool compaction_disabled() const;
+    // Returns true when all compacted sstables were already deleted.
+    bool no_compacted_sstable_undeleted() const;
 };
 
 using storage_group_map = absl::flat_hash_map<size_t, std::unique_ptr<storage_group>, absl::Hash<size_t>>;
 
 class storage_group_manager {
 protected:
-    // The compaction group list is only a helper for accessing the groups managed by the storage groups.
-    // The list entries are unlinked automatically when the storage group, they belong to, is removed.
-    compaction_group_list _compaction_groups;
     storage_group_map _storage_groups;
     // Prevents _storage_groups from having its elements inserted or deleted while other layer iterates
-    // over them (or over _compaction_groups).
+    // over them.
     seastar::rwlock _lock;
 public:
     virtual ~storage_group_manager();
@@ -247,15 +246,11 @@ public:
         return _lock;
     }
 
-    const compaction_group_list& compaction_groups() const noexcept {
-        return _compaction_groups;
-    }
-    compaction_group_list& compaction_groups() noexcept {
-        return _compaction_groups;
-    }
-
+    future<> parallel_foreach_storage_group(std::function<future<>(size_t, storage_group&)> f);
     future<> for_each_storage_group_gently(std::function<future<>(size_t, storage_group&)> f);
     void for_each_storage_group(std::function<void(size_t, storage_group&)> f) const;
+    const storage_group_map& storage_groups() const;
+
     void remove_storage_group(size_t id);
     // FIXME: Cannot return nullptr, signature can be changed to return storage_group&.
     storage_group* storage_group_for_id(const schema_ptr&, size_t i) const;

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -171,7 +171,8 @@ public:
     friend class storage_group;
 };
 
-using compaction_group_ptr = std::unique_ptr<compaction_group>;
+using compaction_group_ptr = lw_shared_ptr<compaction_group>;
+using const_compaction_group_ptr = lw_shared_ptr<const compaction_group>;
 using compaction_group_vector = utils::chunked_vector<compaction_group_ptr>;
 
 // Storage group is responsible for storage that belongs to a single tablet.
@@ -182,6 +183,7 @@ using compaction_group_vector = utils::chunked_vector<compaction_group_ptr>;
 class storage_group {
     compaction_group_ptr _main_cg;
     std::vector<compaction_group_ptr> _split_ready_groups;
+    seastar::gate _async_gate;
 private:
     bool splitting_mode() const {
         return !_split_ready_groups.empty();
@@ -190,19 +192,23 @@ private:
 public:
     storage_group(compaction_group_ptr cg);
 
+    seastar::gate& async_gate() {
+        return _async_gate;
+    }
+
     const dht::token_range& token_range() const noexcept;
 
     size_t memtable_count() const noexcept;
 
-    compaction_group_ptr& main_compaction_group() noexcept;
-    std::vector<compaction_group_ptr> split_ready_compaction_groups() &&;
+    const compaction_group_ptr& main_compaction_group() const noexcept;
+    const std::vector<compaction_group_ptr>& split_ready_compaction_groups() const;
     compaction_group_ptr& select_compaction_group(locator::tablet_range_side) noexcept;
 
     uint64_t live_disk_space_used() const noexcept;
 
-    void for_each_compaction_group(std::function<void(compaction_group&)> action) const noexcept;
-    utils::small_vector<compaction_group*, 3> compaction_groups() noexcept;
-    utils::small_vector<const compaction_group*, 3> compaction_groups() const noexcept;
+    void for_each_compaction_group(std::function<void(const compaction_group_ptr&)> action) const noexcept;
+    utils::small_vector<compaction_group_ptr, 3> compaction_groups() noexcept;
+    utils::small_vector<const_compaction_group_ptr, 3> compaction_groups() const noexcept;
 
     // Puts the storage group in split mode, in which it internally segregates data
     // into two sstable sets and two memtable sets corresponding to the two adjacent
@@ -229,28 +235,67 @@ public:
     bool compaction_disabled() const;
     // Returns true when all compacted sstables were already deleted.
     bool no_compacted_sstable_undeleted() const;
+
+    future<> stop() noexcept;
 };
 
-using storage_group_map = absl::flat_hash_map<size_t, std::unique_ptr<storage_group>, absl::Hash<size_t>>;
+using storage_group_ptr = lw_shared_ptr<storage_group>;
+using storage_group_map = absl::flat_hash_map<size_t, storage_group_ptr, absl::Hash<size_t>>;
 
 class storage_group_manager {
 protected:
     storage_group_map _storage_groups;
-    // Prevents _storage_groups from having its elements inserted or deleted while other layer iterates
-    // over them.
-    seastar::rwlock _lock;
 public:
     virtual ~storage_group_manager();
 
-    seastar::rwlock& get_rwlock() noexcept {
-        return _lock;
-    }
+    //    How concurrent loop and updates on the group map works without a lock:
+    //
+    //    Firstly, all yielding loops will work on a copy of map, to prevent a
+    //    concurrent update to the map from interfering with it.
+    //
+    //    scenario 1:
+    //    T
+    //    1   loop on the map
+    //    2                               storage group X is stopped on cleanup
+    //    3   loop reaches X
+    //
+    //    Here, X is stopped before it is reached. This is handled by teaching
+    //    iteration to skip groups that were stopped by cleanup (implemented
+    //    using gate).
+    //    X survives its removal from the map since it is a lw_shared_ptr.
+    //
+    //
+    //    scenario 2:
+    //    T
+    //    1   loop on the map
+    //    2   loop reaches X
+    //    3                               storage group X is stopped on cleanup
+    //
+    //    Here, X is stopped while being used, but that also happens during shutdown.
+    //    When X is stopped, flush happens and compactions are all stopped (exception
+    //    is not propagated upwards) and new ones cannot start afterward.
+    //
+    //
+    //    scenario 3:
+    //    T
+    //    1   loop on the map
+    //    2                               storage groups are split
+    //    3   loop reaches old groups
+    //
+    //    Here, the loop continues post storage group split, which rebuilds the old
+    //    map into a new one. This is handled by allowing the old map to still access
+    //    the compaction groups that were reassigned according to the new tablet count.
+    //    We don't move the compaction groups, but rather they're still visible by old
+    //    and new storage groups.
 
-    future<> parallel_foreach_storage_group(std::function<future<>(size_t, storage_group&)> f);
-    future<> for_each_storage_group_gently(std::function<future<>(size_t, storage_group&)> f);
+    // Important to not return storage_group_id in yielding variants, since ids can be
+    // invalidated when storage group count changes (e.g. split or merge).
+    future<> parallel_foreach_storage_group(std::function<future<>(storage_group&)> f);
+    future<> for_each_storage_group_gently(std::function<future<>(storage_group&)> f);
     void for_each_storage_group(std::function<void(size_t, storage_group&)> f) const;
     const storage_group_map& storage_groups() const;
 
+    future<> stop_storage_groups() noexcept;
     void remove_storage_group(size_t id);
     // FIXME: Cannot return nullptr, signature can be changed to return storage_group&.
     storage_group* storage_group_for_id(const schema_ptr&, size_t i) const;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -197,12 +197,11 @@ table::add_memtables_to_reader_list(std::vector<flat_mutation_reader_v2>& reader
         }
         return;
     }
-    reserve_fn(boost::accumulate(compaction_groups() | boost::adaptors::transformed(std::mem_fn(&compaction_group::memtable_count)), uint64_t(0)));
     auto token_range = range.transform(std::mem_fn(&dht::ring_position::token));
-    for (compaction_group& cg : compaction_groups()) {
-        if (cg.token_range().overlaps(token_range, dht::token_comparator())) {
-            add_memtables_from_cg(cg);
-        }
+    auto cgs = compaction_groups_for_token_range(token_range);
+    reserve_fn(boost::accumulate(cgs | boost::adaptors::transformed(std::mem_fn(&compaction_group::memtable_count)), uint64_t(0)));
+    for (auto& cg : cgs) {
+        add_memtables_from_cg(*cg);
     }
 }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -190,11 +190,12 @@ table::add_memtables_to_reader_list(std::vector<flat_mutation_reader_v2>& reader
     // point queries can be optimized as they span a single compaction group.
     if (range.is_singular() && range.start()->value().has_key()) {
         const dht::ring_position& pos = range.start()->value();
+
         auto sg = storage_group_for_token(pos.token());
         reserve_fn(sg->memtable_count());
-        for (auto& cg : sg->compaction_groups()) {
+        sg->for_each_compaction_group([&] (const compaction_group_ptr& cg) {
             add_memtables_from_cg(*cg);
-        }
+        });
         return;
     }
     auto token_range = range.transform(std::mem_fn(&dht::ring_position::token));
@@ -555,17 +556,28 @@ void table::enable_off_strategy_trigger() {
 
 storage_group_manager::~storage_group_manager() = default;
 
-future<> storage_group_manager::parallel_foreach_storage_group(std::function<future<>(size_t, storage_group&)> f) {
-    rwlock::holder shared_lock = co_await get_rwlock().hold_read_lock();
-    co_await coroutine::parallel_for_each(_storage_groups, [&] (std::pair<size_t, const std::unique_ptr<storage_group>&> p) -> future<> {
-        co_await f(p.first, *p.second.get());
+// exception-less attempt to hold gate.
+// TODO: move it to seastar.
+static std::optional<gate::holder> try_hold_gate(gate& g) noexcept {
+    return g.is_closed() ? std::nullopt : std::make_optional(g.hold());
+}
+
+future<> storage_group_manager::parallel_foreach_storage_group(std::function<future<>(storage_group&)> f) {
+    co_await coroutine::parallel_for_each(_storage_groups | boost::adaptors::map_values, [&] (const storage_group_ptr sg) -> future<> {
+        // Table-wide ops, like 'nodetool compact', are inherently racy with migrations, so it's okay to skip
+        // storage of tablets being migrated away.
+        if (auto holder = try_hold_gate(sg->async_gate())) {
+            co_await f(*sg.get());
+        }
     });
 }
 
-future<> storage_group_manager::for_each_storage_group_gently(std::function<future<>(size_t, storage_group&)> f) {
-    rwlock::holder shared_lock = co_await get_rwlock().hold_read_lock();
-    for (auto& [id, sg]: _storage_groups) {
-        co_await f(id, *sg);
+future<> storage_group_manager::for_each_storage_group_gently(std::function<future<>(storage_group&)> f) {
+    auto storage_groups = boost::copy_range<std::vector<storage_group_ptr>>(_storage_groups | boost::adaptors::map_values);
+    for (auto& sg: storage_groups) {
+        if (auto holder = try_hold_gate(sg->async_gate())) {
+            co_await f(*sg.get());
+        }
     }
 }
 
@@ -577,6 +589,10 @@ void storage_group_manager::for_each_storage_group(std::function<void(size_t, st
 
 const storage_group_map& storage_group_manager::storage_groups() const {
     return _storage_groups;
+}
+
+future<> storage_group_manager::stop_storage_groups() noexcept {
+    return parallel_for_each(_storage_groups | boost::adaptors::map_values, std::mem_fn(&storage_group::stop));
 }
 
 void storage_group_manager::remove_storage_group(size_t id) {
@@ -608,9 +624,9 @@ public:
         : _t(t)
     {
         storage_group_map r;
-        auto cg = std::make_unique<compaction_group>(_t, size_t(0), dht::token_range::make_open_ended_both_sides());
+        auto cg = make_lw_shared<compaction_group>(_t, size_t(0), dht::token_range::make_open_ended_both_sides());
         _single_cg = cg.get();
-        auto sg = std::make_unique<storage_group>(std::move(cg));
+        auto sg = make_lw_shared<storage_group>(std::move(cg));
         _single_sg = sg.get();
         r[0] = std::move(sg);
         _storage_groups = std::move(r);
@@ -709,8 +725,8 @@ public:
 
             if (tmap.has_replica(tid, local_replica)) {
                 tlogger.debug("Tablet with id {} and range {} present for {}.{}", tid, range, schema()->ks_name(), schema()->cf_name());
-                auto cg = std::make_unique<compaction_group>(_t, tid.value(), std::move(range));
-                ret[tid.value()] = std::make_unique<storage_group>(std::move(cg));
+                auto cg = make_lw_shared<compaction_group>(_t, tid.value(), std::move(range));
+                ret[tid.value()] = make_lw_shared<storage_group>(std::move(cg));
             }
         }
         _storage_groups = std::move(ret);
@@ -769,12 +785,12 @@ const dht::token_range& storage_group::token_range() const noexcept {
     return _main_cg->token_range();
 }
 
-compaction_group_ptr& storage_group::main_compaction_group() noexcept {
+const compaction_group_ptr& storage_group::main_compaction_group() const noexcept {
     return _main_cg;
 }
 
-std::vector<compaction_group_ptr> storage_group::split_ready_compaction_groups() && {
-    return std::exchange(_split_ready_groups, {});
+const std::vector<compaction_group_ptr>& storage_group::split_ready_compaction_groups() const {
+    return _split_ready_groups;
 }
 
 size_t storage_group::to_idx(locator::tablet_range_side side) const {
@@ -788,25 +804,25 @@ compaction_group_ptr& storage_group::select_compaction_group(locator::tablet_ran
     return _main_cg;
 }
 
-void storage_group::for_each_compaction_group(std::function<void(compaction_group&)> action) const noexcept {
-    action(*_main_cg.get());
+void storage_group::for_each_compaction_group(std::function<void(const compaction_group_ptr&)> action) const noexcept {
+    action(_main_cg);
     for (auto& cg : _split_ready_groups) {
-        action(*cg.get());
+        action(cg);
     }
 }
 
-utils::small_vector<compaction_group*, 3> storage_group::compaction_groups() noexcept {
-    utils::small_vector<compaction_group*, 3> cgs;
-    for_each_compaction_group([&cgs] (compaction_group& cg) {
-        cgs.push_back(&cg);
+utils::small_vector<compaction_group_ptr, 3> storage_group::compaction_groups() noexcept {
+    utils::small_vector<compaction_group_ptr, 3> cgs;
+    for_each_compaction_group([&cgs] (const compaction_group_ptr& cg) {
+        cgs.push_back(cg);
     });
     return cgs;
 }
 
-utils::small_vector<const compaction_group*, 3> storage_group::compaction_groups() const noexcept {
-    utils::small_vector<const compaction_group*, 3> cgs;
-    for_each_compaction_group([&cgs] (const compaction_group& cg) {
-        cgs.push_back(&cg);
+utils::small_vector<const_compaction_group_ptr, 3> storage_group::compaction_groups() const noexcept {
+    utils::small_vector<const_compaction_group_ptr, 3> cgs;
+    for_each_compaction_group([&cgs] (const compaction_group_ptr& cg) {
+        cgs.push_back(cg);
     });
     return cgs;
 }
@@ -815,8 +831,7 @@ bool storage_group::set_split_mode() {
     if (!splitting_mode()) {
         auto create_cg = [this] () -> compaction_group_ptr {
             // TODO: use the actual sub-ranges instead, to help incremental selection on the read path.
-            auto cg = std::make_unique<compaction_group>(_main_cg->_t, _main_cg->group_id(), _main_cg->token_range());
-            return cg;
+            return make_lw_shared<compaction_group>(_main_cg->_t, _main_cg->group_id(), _main_cg->token_range());
         };
         std::vector<compaction_group_ptr> split_ready_groups(2);
         split_ready_groups[to_idx(locator::tablet_range_side::left)] = create_cg();
@@ -886,7 +901,7 @@ sstables::compaction_type_options::split tablet_storage_group_manager::split_com
 future<> tablet_storage_group_manager::split_all_storage_groups() {
     sstables::compaction_type_options::split opt = split_compaction_options();
 
-    co_await for_each_storage_group_gently([opt] (size_t i, storage_group& storage_group) {
+    co_await for_each_storage_group_gently([opt] (storage_group& storage_group) {
         return storage_group.split(opt);
     });
 }
@@ -967,7 +982,7 @@ utils::chunked_vector<compaction_group*> tablet_storage_group_manager::compactio
         auto& sg = it->second;
         for (auto& cg : sg->compaction_groups()) {
             if (cg && tr.overlaps(cg->token_range(), cmp)) {
-                ret.push_back(cg);
+                ret.push_back(cg.get());
             }
         }
     }
@@ -1010,25 +1025,35 @@ compaction_group& table::compaction_group_for_sstable(const sstables::shared_sst
 }
 
 future<> table::parallel_foreach_compaction_group(std::function<future<>(compaction_group&)> action) {
-    co_await _sg_manager->parallel_foreach_storage_group([&] (size_t, storage_group& sg) -> future<> {
-        co_await coroutine::parallel_for_each(sg.compaction_groups(), [&] (compaction_group* cg) -> future<> {
-            co_await action(*cg);
+    co_await _sg_manager->parallel_foreach_storage_group([&] (storage_group& sg) -> future<> {
+        co_await utils::get_local_injector().inject("foreach_compaction_group_wait", [this, &sg] (auto& handler) -> future<> {
+            tlogger.info("foreach_compaction_group_wait: waiting");
+            while (!handler.poll_for_message() && !_async_gate.is_closed() && !sg.async_gate().is_closed()) {
+                co_await sleep(std::chrono::milliseconds(5));
+            }
+            tlogger.info("foreach_compaction_group_wait: released");
+        });
+
+        co_await coroutine::parallel_for_each(sg.compaction_groups(), [&] (compaction_group_ptr cg) -> future<> {
+            if (auto holder = try_hold_gate(cg->async_gate())) {
+                co_await action(*cg);
+            }
         });
     });
 }
 
 void table::for_each_compaction_group(std::function<void(compaction_group&)> action) {
     _sg_manager->for_each_storage_group([&] (size_t, storage_group& sg) {
-        sg.for_each_compaction_group([&] (compaction_group& cg) {
-           action(cg);
+        sg.for_each_compaction_group([&] (const compaction_group_ptr& cg) {
+           action(*cg);
        });
     });
 }
 
 void table::for_each_const_compaction_group(std::function<void(const compaction_group&)> action) const {
     _sg_manager->for_each_storage_group([&] (size_t, storage_group& sg) {
-        sg.for_each_compaction_group([&] (const compaction_group& cg) {
-            action(cg);
+        sg.for_each_compaction_group([&] (const compaction_group_ptr& cg) {
+            action(*cg);
         });
     });
 }
@@ -1074,9 +1099,9 @@ future<utils::chunked_vector<sstables::entry_descriptor>>
 table::clone_tablet_storage(locator::tablet_id tid) {
     utils::chunked_vector<sstables::entry_descriptor> ret;
     auto holder = async_gate().hold();
-    // FIXME: guard storage group with shared lock.
 
     auto* sg = storage_group_for_id(tid.value());
+    auto sg_holder = sg->async_gate().hold();
     co_await sg->flush();
     auto set = sg->make_sstable_set();
     co_await safe_foreach_sstable(*set, [&] (const sstables::shared_sstable& sst) -> future<> {
@@ -1470,7 +1495,7 @@ table::stop() {
     // while they may still hold the table _async_gate
     auto gate_closed_fut = _async_gate.close();
     co_await await_pending_ops();
-    co_await parallel_foreach_compaction_group(std::mem_fn(&compaction_group::stop));
+    co_await _sg_manager->stop_storage_groups();
     co_await _sstable_deletion_gate.close();
     co_await std::move(gate_closed_fut);
     co_await get_row_cache().invalidate(row_cache::external_updater([this] {
@@ -2005,7 +2030,7 @@ std::vector<sstables::shared_sstable> table::select_sstables(const dht::partitio
 }
 
 bool storage_group::no_compacted_sstable_undeleted() const {
-    return std::ranges::all_of(compaction_groups(), [] (const compaction_group* cg) {
+    return std::ranges::all_of(compaction_groups(), [] (const_compaction_group_ptr& cg) {
         return cg->compacted_undeleted_sstables().empty();
     });
 }
@@ -2068,7 +2093,7 @@ future<> compaction_group::stop() noexcept {
     if (_async_gate.is_closed()) {
         co_return;
     }
-    co_await _async_gate.close();
+    auto closed_gate_fut = _async_gate.close();
 
     auto flush_future = co_await seastar::coroutine::as_future(flush());
     co_await _t._compaction_manager.remove(as_table_state());
@@ -2076,6 +2101,7 @@ future<> compaction_group::stop() noexcept {
     if (flush_future.failed()) {
         co_await seastar::coroutine::return_exception_ptr(flush_future.get_exception());
     }
+    co_await std::move(closed_gate_fut);
 }
 
 bool compaction_group::empty() const noexcept {
@@ -2168,7 +2194,7 @@ future<> tablet_storage_group_manager::handle_tablet_split_completion(const loca
                                               id, table_id));
         }
         // Remove old main groups, they're unused, but they need to be deregistered properly
-        auto cg_ptr = std::move(sg->main_compaction_group());
+        auto cg_ptr = sg->main_compaction_group();
         auto f = cg_ptr->stop();
         if (!f.available() || f.failed()) [[unlikely]] {
             stop_fut = stop_fut.then([f = std::move(f), cg_ptr = std::move(cg_ptr)] () mutable {
@@ -2178,14 +2204,14 @@ future<> tablet_storage_group_manager::handle_tablet_split_completion(const loca
             });
         }
         unsigned first_new_id = id << growth_factor;
-        auto split_ready_groups = std::move(*sg).split_ready_compaction_groups();
+        auto split_ready_groups = sg->split_ready_compaction_groups();
         if (split_ready_groups.size() != split_size) {
             on_internal_error(tlogger, format("Found {} split ready compaction groups, but expected {} instead.", split_ready_groups.size(), split_size));
         }
         for (unsigned i = 0; i < split_size; i++) {
             auto group_id = first_new_id + i;
             split_ready_groups[i]->update_id_and_range(group_id, new_tmap.get_token_range(locator::tablet_id(group_id)));
-            new_storage_groups[group_id] = std::make_unique<storage_group>(std::move(split_ready_groups[i]));
+            new_storage_groups[group_id] = make_lw_shared<storage_group>(std::move(split_ready_groups[i]));
         }
 
         tlogger.debug("Remapping tablet {} of table {} into new tablets [{}].",
@@ -2224,8 +2250,8 @@ future<> tablet_storage_group_manager::update_effective_replication_map(const lo
         auto transition_info = transition.second;
         if (!_storage_groups.contains(tid.value()) && tablet_migrates_in(transition_info)) {
             auto range = new_tablet_map->get_token_range(tid);
-            auto cg = std::make_unique<compaction_group>(_t, tid.value(), std::move(range));
-            _storage_groups[tid.value()] = std::make_unique<storage_group>(std::move(cg));
+            auto cg = make_lw_shared<compaction_group>(_t, tid.value(), std::move(range));
+            _storage_groups[tid.value()] = make_lw_shared<storage_group>(std::move(cg));
             tablet_migrating_in = true;
         }
     }
@@ -2241,10 +2267,6 @@ future<> tablet_storage_group_manager::update_effective_replication_map(const lo
 }
 
 future<> table::update_effective_replication_map(locator::effective_replication_map_ptr erm) {
-    // Exclusive lock is meant to protect storage groups, but we hold it here to prevent preemption
-    // between erm and storage groups updates as they need to be consistent.
-    rwlock::holder exclusive_lock = co_await _sg_manager->get_rwlock().hold_write_lock();
-
     auto old_erm = std::exchange(_erm, std::move(erm));
 
     auto refresh_mutation_source = [this] {
@@ -2621,7 +2643,7 @@ future<> table::clear() {
 }
 
 bool storage_group::compaction_disabled() const {
-    return std::ranges::all_of(compaction_groups(), [] (const compaction_group* cg) {
+    return std::ranges::all_of(compaction_groups(), [] (const_compaction_group_ptr& cg) {
         return cg->get_compaction_manager().compaction_disabled(cg->as_table_state()); });
 }
 
@@ -3580,11 +3602,24 @@ future<> table::clear_inactive_reads_for_tablet(database& db, storage_group* sg)
     }
 }
 
-future<> table::stop_compaction_groups(storage_group* sg) {
-    // Synchronizes with in-flight writes if any, and also takes care of flushing if needed.
-    for (auto& cg_ptr : sg->compaction_groups()) {
-        co_await cg_ptr->stop();
+future<> storage_group::stop() noexcept {
+    if (_async_gate.is_closed()) {
+        co_return;
     }
+    // Carefully waits for close of gate after stopping compaction groups, since we don't want
+    // to wait on an ongoing compaction, *but* start it earlier to prevent iterations from
+    // picking this group that is being stopped.
+    auto closed_gate_fut = _async_gate.close();
+
+    // Synchronizes with in-flight writes if any, and also takes care of flushing if needed.
+    co_await coroutine::parallel_for_each(compaction_groups(), [] (const compaction_group_ptr& cg_ptr) {
+        return cg_ptr->stop();
+    });
+    co_await std::move(closed_gate_fut);
+}
+
+future<> table::stop_compaction_groups(storage_group* sg) {
+    return sg->stop();
 }
 
 future<> table::flush_compaction_groups(storage_group* sg) {
@@ -3616,7 +3651,6 @@ future<> table::cleanup_compaction_groups(database& db, db::system_keyspace& sys
 
 future<> table::cleanup_tablet(database& db, db::system_keyspace& sys_ks, locator::tablet_id tid) {
     auto holder = async_gate().hold();
-    rwlock::holder exclusive_lock = co_await _sg_manager->get_rwlock().hold_write_lock();
     auto* sg = storage_group_for_id(tid.value());
 
     co_await clear_inactive_reads_for_tablet(db, sg);
@@ -3628,8 +3662,6 @@ future<> table::cleanup_tablet(database& db, db::system_keyspace& sys_ks, locato
 
 future<> table::cleanup_tablet_without_deallocation(database& db, db::system_keyspace& sys_ks, locator::tablet_id tid) {
     auto holder = async_gate().hold();
-    // Hold shared lock to keep storage group alive.
-    rwlock::holder shared_lock = co_await _sg_manager->get_rwlock().hold_read_lock();
     auto* sg = storage_group_for_id(tid.value());
 
     co_await clear_inactive_reads_for_tablet(db, sg);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -481,6 +481,14 @@ inline void table::remove_sstable_from_backlog_tracker(compaction_backlog_tracke
 }
 
 void compaction_group::backlog_tracker_adjust_charges(const std::vector<sstables::shared_sstable>& old_sstables, const std::vector<sstables::shared_sstable>& new_sstables) {
+    // If group was closed / is being closed, it's ok to ignore request to adjust backlog tracker,
+    // since that might result in an exception due to the group being deregistered from compaction
+    // manager already. And the group is being removed anyway, so that won't have any practical
+    // impact.
+    if (_async_gate.is_closed()) {
+        return;
+    }
+
     auto& tracker = get_backlog_tracker();
     tracker.replace_sstables(old_sstables, new_sstables);
 }
@@ -3612,7 +3620,13 @@ future<> storage_group::stop() noexcept {
     auto closed_gate_fut = _async_gate.close();
 
     // Synchronizes with in-flight writes if any, and also takes care of flushing if needed.
-    co_await coroutine::parallel_for_each(compaction_groups(), [] (const compaction_group_ptr& cg_ptr) {
+
+    // The reason we have to stop main cg first, is because an ongoing split always run in main cg
+    // and output will be written to left and right groups. If either left or right are stopped before
+    // main, split completion will add sstable to a closed group, and that might in turn trigger an
+    // exception while running under row_cache::external_updater::execute, resulting in node crash.
+    co_await _main_cg->stop();
+    co_await coroutine::parallel_for_each(_split_ready_groups, [] (const compaction_group_ptr& cg_ptr) {
         return cg_ptr->stop();
     });
     co_await std::move(closed_gate_fut);

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -617,7 +617,10 @@ class absl_container:
                 break
             if ctrl_t >= 0:
                 # NOTE: this only works for flat_hash_map
-                yield slots[i]['key'], slots[i]['value']
+                if slots[i]['value'].type.name.find("::map_slot_type") != -1:
+                    yield slots[i]['key'], slots[i]['value']['second']
+                else:
+                    yield slots[i]['key'], slots[i]['value']
 
     def __nonzero__(self):
         return self.size > 0
@@ -4492,6 +4495,17 @@ class scylla_memtables(gdb.Command):
     def invoke(self, arg, from_tty):
         for table in for_each_table():
             gdb.write('table %s:\n' % schema_ptr(table['_schema']).table_name())
+            try:
+                sg_manager = std_unique_ptr(table["_sg_manager"]).get().dereference()
+                for (sg_id, sg_ptr) in absl_container(sg_manager["_storage_groups"]):
+                    sg = seastar_lw_shared_ptr(sg_ptr).get()
+                    scylla_memtables.dump_compaction_group_memtables(seastar_lw_shared_ptr(sg["_main_cg"]).get())
+                    for cg_ptr in std_vector(sg["_split_ready_groups"]):
+                        scylla_memtables.dump_compaction_group_memtables(seastar_lw_shared_ptr(cg_ptr).get())
+                return
+            except gdb.error:
+                pass
+
             try:
                 sg_manager = std_unique_ptr(table["_sg_manager"]).get().dereference()
                 for cg in intrusive_list(sg_manager["_compaction_groups"], link='_list_hook'):

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -926,7 +926,7 @@ SEASTAR_TEST_CASE(test_commitlog_replay_invalid_key){
         auto& cl = *table.commitlog();
         auto s = table.schema();
         auto& sharder = table.get_effective_replication_map()->get_sharder(*table.schema());
-        auto memtables = table.active_memtables();
+        auto memtables = active_memtables(table);
 
         auto add_entry = [&cl, s, &sharder] (const partition_key& key) mutable {
             auto md = tests::data_model::mutation_description(key.explode());

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -1053,7 +1053,7 @@ SEASTAR_TEST_CASE(failed_flush_prevents_writes) {
         mm.announce(service::prepare_new_column_family_announcement(mm.get_storage_proxy(), s, ts).get(), std::move(group0_guard), "").get();
 
         replica::table& t = db.find_column_family("ks", "cf");
-        auto memtables = t.active_memtables();
+        auto memtables = active_memtables(t);
 
         // Insert something so that we have data in memtable to flush
         // it has to be somewhat large, as automatic flushing picks the

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -48,6 +48,7 @@
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/random_utils.hh"
 #include "test/lib/simple_schema.hh"
+#include "test/lib/sstable_utils.hh"
 #include "test/lib/test_utils.hh"
 #include "test/lib/log.hh"
 #include "types/map.hh"
@@ -598,7 +599,7 @@ SEASTAR_TEST_CASE(test_flush_in_the_middle_of_a_scan) {
                 assert_that_scanner3.produces(mutations[i]);
             }
 
-            auto ms = cf.active_memtables(); // held by scanners
+            auto ms = active_memtables(cf); // held by scanners
 
             auto flushed = cf.flush();
 

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -41,6 +41,14 @@ lw_shared_ptr<replica::memtable> make_memtable(schema_ptr s, const std::vector<m
     return mt;
 }
 
+std::vector<replica::memtable*> active_memtables(replica::table& t) {
+    std::vector<replica::memtable*> active_memtables;
+    t.for_each_active_memtable([&] (replica::memtable& mt) {
+        active_memtables.push_back(&mt);
+    });
+    return active_memtables;
+}
+
 sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, lw_shared_ptr<replica::memtable> mt) {
     return make_sstable_containing(sst_factory(), std::move(mt));
 }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -270,3 +270,4 @@ inline shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::me
 }
 
 lw_shared_ptr<replica::memtable> make_memtable(schema_ptr s, const std::vector<mutation>& muts);
+std::vector<replica::memtable*> active_memtables(replica::table& t);


### PR DESCRIPTION
rwlock was added to protect iterations against concurrent updates to the map.

the updates can happen when allocating a new tablet replica or removing an old one (tablet cleanup).

the rwlock is very problematic because it can result in topology changes blocked, as updating token metadata takes the exclusive lock, which is serialized with table wide ops like split / major / explicit flush (and those can take a long time).

to get rid of the lock, we can copy the storage group map and guard individual groups with a gate (not a problem since map is expected to have a maximum of ~100 elements). so cleanup can close that gate (carefully closed after stopping individual groups such that migrations aren't blocked by long-running ops like major), and ongoing iterations (e.g. triggered by nodetool flush) can skip a group that was closed, as such a group is being migrated out.

Fixes https://github.com/scylladb/scylladb/issues/18821.

```
WRITE
=====

./build/release/scylla perf-simple-query --smp 1 --memory 2G --initial-tablets 10 --tablets --write

- BEFORE

65559.52 tps ( 59.6 allocs/op,  16.4 logallocs/op,  14.3 tasks/op,   52841 insns/op,   30946 cycles/op,        0 errors)
67408.05 tps ( 59.3 allocs/op,  16.0 logallocs/op,  14.3 tasks/op,   53018 insns/op,   30874 cycles/op,        0 errors)
67714.72 tps ( 59.3 allocs/op,  16.0 logallocs/op,  14.3 tasks/op,   53026 insns/op,   30881 cycles/op,        0 errors)
67825.57 tps ( 59.3 allocs/op,  16.0 logallocs/op,  14.3 tasks/op,   53015 insns/op,   30821 cycles/op,        0 errors)
67810.74 tps ( 59.3 allocs/op,  16.0 logallocs/op,  14.3 tasks/op,   53009 insns/op,   30828 cycles/op,        0 errors)

         throughput: mean=67263.72 standard-deviation=967.40 median=67714.72 median-absolute-deviation=547.02 maximum=67825.57 minimum=65559.52
instructions_per_op: mean=52981.61 standard-deviation=79.09 median=53014.96 median-absolute-deviation=36.54 maximum=53025.79 minimum=52840.56
  cpu_cycles_per_op: mean=30869.90 standard-deviation=50.23 median=30874.06 median-absolute-deviation=42.11 maximum=30945.94 minimum=30820.89


- AFTER
65448.76 tps ( 59.5 allocs/op,  16.4 logallocs/op,  14.3 tasks/op,   52788 insns/op,   31013 cycles/op,        0 errors)
67290.83 tps ( 59.3 allocs/op,  16.0 logallocs/op,  14.3 tasks/op,   53025 insns/op,   30950 cycles/op,        0 errors)
67646.81 tps ( 59.3 allocs/op,  16.0 logallocs/op,  14.3 tasks/op,   53025 insns/op,   30909 cycles/op,        0 errors)
67565.90 tps ( 59.3 allocs/op,  16.0 logallocs/op,  14.3 tasks/op,   53058 insns/op,   30951 cycles/op,        0 errors)
67537.32 tps ( 59.3 allocs/op,  16.0 logallocs/op,  14.3 tasks/op,   52983 insns/op,   30963 cycles/op,        0 errors)

         throughput: mean=67097.93 standard-deviation=931.44 median=67537.32 median-absolute-deviation=467.97 maximum=67646.81 minimum=65448.76
instructions_per_op: mean=52975.85 standard-deviation=108.07 median=53024.55 median-absolute-deviation=49.45 maximum=53057.99 minimum=52788.49
  cpu_cycles_per_op: mean=30957.17 standard-deviation=37.43 median=30951.31 median-absolute-deviation=7.51 maximum=31013.01 minimum=30908.62


READ
=====

./build/release/scylla perf-simple-query --smp 1 --memory 2G --initial-tablets 10 --tablets

- BEFORE

79423.36 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   41840 insns/op,   26820 cycles/op,        0 errors)
81076.70 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   41837 insns/op,   26583 cycles/op,        0 errors)
80927.36 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   41829 insns/op,   26629 cycles/op,        0 errors)
80539.44 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   41841 insns/op,   26735 cycles/op,        0 errors)
80793.10 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   41864 insns/op,   26662 cycles/op,        0 errors)

         throughput: mean=80551.99 standard-deviation=661.12 median=80793.10 median-absolute-deviation=375.37 maximum=81076.70 minimum=79423.36
instructions_per_op: mean=41842.20 standard-deviation=13.26 median=41840.14 median-absolute-deviation=5.68 maximum=41864.50 minimum=41829.29
  cpu_cycles_per_op: mean=26685.88 standard-deviation=93.31 median=26662.18 median-absolute-deviation=56.47 maximum=26820.08 minimum=26582.68


- AFTER
79464.70 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   41799 insns/op,   26761 cycles/op,        0 errors)
80954.58 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   41803 insns/op,   26605 cycles/op,        0 errors)
81160.90 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   41811 insns/op,   26555 cycles/op,        0 errors)
81263.10 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   41814 insns/op,   26527 cycles/op,        0 errors)
81162.97 tps ( 63.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   41806 insns/op,   26549 cycles/op,        0 errors)

         throughput: mean=80801.25 standard-deviation=755.54 median=81160.90 median-absolute-deviation=361.72 maximum=81263.10 minimum=79464.70
instructions_per_op: mean=41806.47 standard-deviation=5.85 median=41806.05 median-absolute-deviation=4.05 maximum=41813.86 minimum=41799.36
  cpu_cycles_per_op: mean=26599.22 standard-deviation=94.84 median=26554.54 median-absolute-deviation=50.51 maximum=26761.06 minimum=26527.05
```
(cherry picked from commit https://github.com/scylladb/scylladb/commit/ad5c5bca5fa4ed3b669ac0d0f618b56cab33254a)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/c539b7c861eb1afd6f68c102243158428b438481)

Refs https://github.com/scylladb/scylladb/pull/19469