### PR TITLE
sstable_directory: delete_atomically: allow sstables from multiple prefixes

### DIFF
--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -287,8 +287,9 @@ public:
 
     // Creates the deletion log for atomic deletion of sstables (helper for the
     // above function that's also used by tests)
-    // Returns a pair of "logilfe name" and "directory with sstables"
-    static future<std::pair<sstring, sstring>> create_pending_deletion_log(const std::vector<shared_sstable>& ssts);
+    // Returns an unordered_map of <directory with sstables, logfile_name> for every sstable prefix.
+    // Currently, atomicity is guranteed only within each unique prefix and not across prefixes (See #18862)
+    static future<std::unordered_map<sstring, sstring>> create_pending_deletion_log(const std::vector<shared_sstable>& ssts);
 
     static bool compare_sstable_storage_prefix(const sstring& a, const sstring& b) noexcept;
 };

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -508,32 +508,27 @@ future<> filesystem_storage::wipe(const sstable& sst, sync_dir sync) noexcept {
     }
 }
 
-class filesystem_atomic_delete_ctx : public atomic_delete_context_impl {
-public:
-    sstring log;
-    sstring directory;
-    filesystem_atomic_delete_ctx(sstring l, sstring dir) noexcept : log(std::move(l)), directory(std::move(dir)) {}
-};
-
 future<atomic_delete_context> filesystem_storage::atomic_delete_prepare(const std::vector<shared_sstable>& ssts) const {
-    auto [ pending_delete_log, sst_directory ] = co_await sstable_directory::create_pending_deletion_log(ssts);
-    co_return std::make_unique<filesystem_atomic_delete_ctx>(std::move(pending_delete_log), std::move(sst_directory));
+    return sstable_directory::create_pending_deletion_log(ssts);
 }
 
-future<> filesystem_storage::atomic_delete_complete(atomic_delete_context ctx_) const {
-    auto& ctx = static_cast<filesystem_atomic_delete_ctx&>(*ctx_);
+future<> filesystem_storage::atomic_delete_complete(atomic_delete_context ctx) const {
+    co_await coroutine::parallel_for_each(ctx, [] (const auto& x) -> future<> {
+        const auto& dir = x.first;
+        const auto& log = x.second;
 
-    co_await sync_directory(ctx.directory);
+        co_await sync_directory(dir);
 
-    // Once all sstables are deleted, the log file can be removed.
-    // Note: the log file will be removed also if unlink failed to remove
-    // any sstable and ignored the error.
-    try {
-        co_await remove_file(ctx.log);
-        sstlog.debug("{} removed.", ctx.log);
-    } catch (...) {
-        sstlog.warn("Error removing {}: {}. Ignoring.", ctx.log, std::current_exception());
-    }
+        // Once all sstables are deleted, the log file can be removed.
+        // Note: the log file will be removed also if unlink failed to remove
+        // any sstable and ignored the error.
+        try {
+            co_await remove_file(log);
+            sstlog.debug("{} removed.", log);
+        } catch (...) {
+            sstlog.warn("Error removing {}: {}. Ignoring.", log, std::current_exception());
+        }
+    });
 }
 
 future<> filesystem_storage::remove_by_registry_entry(entry_descriptor desc) {
@@ -648,7 +643,7 @@ future<> s3_storage::wipe(const sstable& sst, sync_dir) noexcept {
 
 future<atomic_delete_context> s3_storage::atomic_delete_prepare(const std::vector<shared_sstable>&) const {
     // FIXME -- need atomicity, see #13567
-    co_return nullptr;
+    co_return atomic_delete_context{};
 }
 
 future<> s3_storage::atomic_delete_complete(atomic_delete_context ctx) const {

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -32,11 +32,8 @@ class delayed_commit_changes;
 class sstable;
 class sstables_manager;
 class entry_descriptor;
-class atomic_delete_context_impl {
-public:
-    virtual ~atomic_delete_context_impl() {}
-};
-using atomic_delete_context = std::unique_ptr<atomic_delete_context_impl>;
+
+using atomic_delete_context = std::unordered_map<sstring, sstring>;
 
 class storage {
     friend class test;

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -7,6 +7,7 @@
  */
 
 
+#include <fmt/format.h>
 #include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/util/file.hh>
@@ -145,7 +146,7 @@ static void with_sstable_directory(
     wrapped_test_env env_wrap,
     noncopyable_function<void (sharded<sstable_directory>&)> func) {
 
-    testlog.debug("with_sstable_directory: {}", path);
+    testlog.debug("with_sstable_directory: {}/{}", path, state);
 
     sharded<sstables::directory_semaphore> sstdir_sem;
     sstdir_sem.start(1).get();
@@ -782,14 +783,24 @@ SEASTAR_THREAD_TEST_CASE(test_system_datadir_layout) {
 
 SEASTAR_TEST_CASE(test_pending_log_garbage_collection) {
     return sstables::test_env::do_with_sharded_async([] (auto& env) {
+      for (auto state : {sstables::sstable_state::normal, sstables::sstable_state::staging}) {
+        auto base = env.local().tempdir().path() / fmt::to_string(table_id::create_random_id());
+        auto dir = base / fmt::to_string(state);
+        recursive_touch_directory(dir.native()).get();
+
+        auto new_sstable = [&] {
+            return env.local().make_sstable(test_table_schema(), dir.native());
+        };
         std::vector<shared_sstable> ssts_to_keep;
         for (int i = 0; i < 2; i++) {
-            ssts_to_keep.emplace_back(make_sstable_for_this_shard(std::bind(new_env_sstable, std::ref(env.local()))));
+            ssts_to_keep.emplace_back(make_sstable_for_this_shard(new_sstable));
         }
+        testlog.debug("SSTables to keep: {}", ssts_to_keep);
         std::vector<shared_sstable> ssts_to_remove;
         for (int i = 0; i < 3; i++) {
-            ssts_to_remove.emplace_back(make_sstable_for_this_shard(std::bind(new_env_sstable, std::ref(env.local()))));
+            ssts_to_remove.emplace_back(make_sstable_for_this_shard(new_sstable));
         }
+        testlog.debug("SSTables to remove: {}", ssts_to_remove);
 
         // Now start atomic deletion -- create the pending deletion log for all
         // three sstables, move TOC file for one of them into temporary-TOC, and 
@@ -799,7 +810,16 @@ SEASTAR_TEST_CASE(test_pending_log_garbage_collection) {
         rename_file(test(ssts_to_remove[2]).filename(sstables::component_type::TOC).native(), test(ssts_to_remove[2]).filename(sstables::component_type::TemporaryTOC).native()).get();
         remove_file(test(ssts_to_remove[2]).filename(sstables::component_type::Data).native()).get();
 
-        with_sstable_directory(env, [&] (sharded<sstables::sstable_directory>& sstdir) {
+        // mimic distributed_loader table_populator::start order
+        // as the pending_delete_dir is now shared, at the table base directory
+        if (state != sstables::sstable_state::normal) {
+            with_sstable_directory(base, sstables::sstable_state::normal, env, [&] (sharded<sstables::sstable_directory>& sstdir) {
+                auto expect_ok = distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true, .garbage_collect = true });
+                BOOST_REQUIRE_NO_THROW(expect_ok.get());
+            });
+        }
+
+        with_sstable_directory(base, state, env, [&] (sharded<sstables::sstable_directory>& sstdir) {
             auto expect_ok = distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true, .garbage_collect = true });
             BOOST_REQUIRE_NO_THROW(expect_ok.get());
 
@@ -827,5 +847,6 @@ SEASTAR_TEST_CASE(test_pending_log_garbage_collection) {
 
             BOOST_REQUIRE_EQUAL(expected, collected);
         });
+      }
     });
 }


### PR DESCRIPTION
Currently, delete_atomically can be called with
a list of sstables from mixed prefixes in two cases:
1. truncate: where we delete all the sstables in the table directory
2. tablet cleanup: similar to truncate but restricted to sstables in a single tablet replica

In both cases, it is possible that sstables in staging (or quarantine) are mixed with sstables in the base directory.

Until a more comprehensive fix is in place,
(see https://github.com/scylladb/scylladb/pull/19555) this change just lifts the ban on atomic deletion
of sstables from different prefixes, and acknowledging that the implementation is not atomic across
prefixes.  This is better than crashing for now,
and can be backported more easily to branches
that support tablets so tablet migration can
be done safely in the presence of repair of
tables with views.

Refs scylladb/scylladb#18862

Please backport to 6.0 and 6.1 that support tablets
since the issue is hit frequently enough with tablet cleanup, post migration, in the presence of views and repair.