### PR TITLE
[test.py] Increase pool size for CI

### DIFF
--- a/test.py
+++ b/test.py
@@ -414,7 +414,15 @@ class PythonTestSuite(TestSuite):
 
         cluster_cfg = self.cfg.get("cluster", {"initial_size": 1})
         cluster_size = cluster_cfg["initial_size"]
-        pool_size = cfg.get("pool_size", 2)
+
+        env_pool_size = os.getenv("CLUSTER_POOL_SIZE")
+        if options.cluster_pool_size is not None:
+            pool_size = options.cluster_pool_size
+        elif env_pool_size is not None:
+            pool_size = env_pool_size
+        else:
+            pool_size = cfg.get("pool_size", 2)
+
         self.dirties_cluster = set(cfg.get("dirties_cluster", []))
 
         self.create_cluster = self.get_cluster_factory(cluster_size, options)
@@ -1349,6 +1357,9 @@ def parse_cmd_line() -> argparse.Namespace:
     parser.add_argument("--artifacts_dir_url", action='store', type=str, default=None, dest="artifacts_dir_url",
                         help="Provide the URL to artifacts directory to generate the link to failed tests directory "
                              "with logs")
+    parser.add_argument("--cluster-pool-size", action="store", default=None, type=int,
+                        help="Set the pool_size for PythonTest and its descendants. Alternatively environment variable "
+                             "CLUSTER_POOL_SIZE can be used to achieve the same")
     scylla_additional_options = parser.add_argument_group('Additional options for Scylla tests')
     scylla_additional_options.add_argument('--x-log2-compaction-groups', action="store", default="0", type=int,
                              help="Controls number of compaction groups to be used by Scylla tests. Value of 3 implies 8 groups.")

--- a/test/cql-pytest/suite.yaml
+++ b/test/cql-pytest/suite.yaml
@@ -1,5 +1,5 @@
 type: Python
-pool_size: 4
+pool_size: 10
 dirties_cluster:
   - test_native_transport
 extra_scylla_cmdline_options:

--- a/test/topology/suite.yaml
+++ b/test/topology/suite.yaml
@@ -1,5 +1,5 @@
 type: Topology
-pool_size: 4
+pool_size: 10
 cluster:
   initial_size: 3
 extra_scylla_config_options:

--- a/test/topology_custom/suite.yaml
+++ b/test/topology_custom/suite.yaml
@@ -1,5 +1,5 @@
 type: Topology
-pool_size: 4
+pool_size: 10
 cluster:
   initial_size: 0
 extra_scylla_config_options:

--- a/test/topology_experimental_raft/suite.yaml
+++ b/test/topology_experimental_raft/suite.yaml
@@ -1,5 +1,5 @@
 type: Topology
-pool_size: 4
+pool_size: 10
 cluster:
   initial_size: 0
 extra_scylla_config_options:


### PR DESCRIPTION
Currently, the resource utilization in CI is low. Increasing the number of clusters will increase how many tests are executed simultaneously. This will decrease the time it takes to execute and improve resource utilization.

Related: https://github.com/scylladb/qa-tasks/issues/1667
