### PR TITLE
test: tasks: adjust tests to new wait_task behavior

### DIFF
--- a/test/rest_api/task_manager_utils.py
+++ b/test/rest_api/task_manager_utils.py
@@ -70,6 +70,8 @@ def check_child_parent_relationship(rest_api, status_tree, parent, allow_no_chil
 def drain_module_tasks(rest_api, module_name):
     tasks = [task for task in list_tasks(rest_api, module_name, True)]
     for task in tasks:
+        # Wait for task and unregister it.
         resp = rest_api.send("GET", f"task_manager/wait_task/{task['task_id']}")
+        resp = rest_api.send("GET", f"task_manager/task_status/{task['task_id']}")
         # The task may be already unregistered.
         assert resp.status_code == requests.codes.ok or resp.status_code == requests.codes.bad_request, "Invalid status code"

--- a/test/rest_api/test_task_manager.py
+++ b/test/rest_api/test_task_manager.py
@@ -108,8 +108,6 @@ def test_task_manager_wait(rest_api):
 
             x.join()
 
-            assert_task_does_not_exist(rest_api, task0)
-
 def test_task_manager_ttl(rest_api):
     with new_test_module(rest_api):
         args0 = {"keyspace": "keyspace0", "table": "table0"}


### PR DESCRIPTION
After c1b2b8cb2c35ec28a35d59619f6d56b895e9b2e3 /task_manager/wait_task/ does not unregister tasks anymore.

Delete the check if the task was unregistered from test_task_manager_wait. Check task status in drain_module_tasks to ensure that the task is removed from task manager.

Fixes: #19351.

Requires backport to 6.0 and 6.1, as they contain aforementioned change.
