### PR TITLE
test: scylla_cluster: support more test scenarios

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -216,11 +216,11 @@ class ManagerClient():
         await self.client.put_json(f"/cluster/server/{server_id}/stop_gracefully", timeout=timeout)
 
     async def server_start(self, server_id: ServerNum, expected_error: Optional[str] = None,
-                           wait_others: int = 0, wait_interval: float = 45,
+                           wait_others: int = 0, wait_interval: float = 45, seeds: Optional[List[IPAddress]] = None,
                            timeout: Optional[float] = None) -> None:
         """Start specified server and optionally wait for it to learn of other servers"""
         logger.debug("ManagerClient starting %s", server_id)
-        data = {"expected_error": expected_error}
+        data = {"expected_error": expected_error, "seeds": seeds}
         await self.client.put_json(f"/cluster/server/{server_id}/start", data, timeout=timeout)
         await self.server_sees_others(server_id, wait_others, interval = wait_interval)
         if expected_error is None:

--- a/test/topology_custom/test_different_group0_ids.py
+++ b/test/topology_custom/test_different_group0_ids.py
@@ -30,24 +30,10 @@ async def test_different_group0_ids(manager: ManagerClient):
     # Consistent topology changes are disabled to use repair based node operations.
     scylla_a = await manager.server_add(config={'force_gossip_topology_changes': True})
     scylla_b = await manager.server_add(start=False, config={'force_gossip_topology_changes': True})
-    await manager.server_update_config(scylla_b.server_id, key='seed_provider', value=[{
-            'class_name': 'org.apache.cassandra.locator.SimpleSeedProvider',
-            'parameters': [{
-                    'seeds': f'{scylla_b.ip_addr}'
-                }]
-            }]
-        )
-    await manager.server_start(scylla_b.server_id)
+    await manager.server_start(scylla_b.server_id, seeds=[scylla_b.ip_addr])
 
     await manager.server_stop(scylla_b.server_id)
-    await manager.server_update_config(scylla_b.server_id, key='seed_provider', value=[{
-            'class_name': 'org.apache.cassandra.locator.SimpleSeedProvider',
-            'parameters': [{
-                    'seeds': f'{scylla_a.ip_addr},{scylla_b.ip_addr}'
-                }]
-            }]
-        )
-    await manager.server_start(scylla_b.server_id)
+    await manager.server_start(scylla_b.server_id, seeds=[scylla_a.ip_addr, scylla_b.ip_addr])
 
     log_file_a = await manager.server_open_log(scylla_a.server_id)
     log_file_b = await manager.server_open_log(scylla_b.server_id)


### PR DESCRIPTION
We modify `ScyllaCluster.server_start` so that it changes seeds of the
starting node to all currently running nodes. This allows writing tests like
```python
s1 = await manager.server_add(start=False)
await manager.server_add()
await manager.server_start(s1.server_id)
```
However, it disallows writing tests that start multiple clusters. To fix this,
we add the `seeds` parameter to `server_start`.

We also improve the logic in `ScyllaCluster.add_server` to allow writing
tests like
```python
await manager.server_add(expected_error="...")
await manager.server_add()
```

This PR only adds improvements to the `test.py` framework, no need
to backport it.