### PR TITLE
test/boost/reader_concurrency_semaphore_test: un-flake test admission

### DIFF
--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -742,7 +742,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
 
     // inactive readers
     {
-        auto permit = semaphore.obtain_permit(schema, get_name(), 1024, db::timeout_clock::now(), {}).get();
+        auto permit = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}).get();
 
         require_can_admit(true, "!need_cpu");
         {


### PR DESCRIPTION
The admission test has a section which tests admission when the semaphore has inactive reads. This section (and therefore the enire test) became flaky lately, after a seemingly unrelated seastar upgrade, which improved timers.
The cause of the flakyness is the permit which is made inactive later: this permit is created with 0 timeout (times out immediately). For some time now, when the timeout timer of a permit fires, if the permit is inactive, it is evicted. This is what makes the test fail: the inactive read times out and ends up evicting this permit, which is not expected for the test. The reason this was not a problem before, is that the test finishes very quickly, usually, before the timer could even be polled by the reactor. The recent seastar changes changed this and now the timer sometimes get polled and fires, failing the test.

Fixes: #19801

No vulnerable versions, no backport needed.