### PR TITLE
Drop datadir from keyspace::config

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2125,14 +2125,12 @@ keyspace::config
 database::make_keyspace_config(const keyspace_metadata& ksm) {
     keyspace::config cfg;
     if (_cfg.data_file_directories().size() > 0) {
-        cfg.datadir = format("{}/{}", _cfg.data_file_directories()[0], ksm.name());
         cfg.enable_disk_writes = !_cfg.enable_in_memory_data_store();
         cfg.enable_disk_reads = true; // we always read from disk
         cfg.enable_commitlog = _cfg.enable_commitlog() && !_cfg.enable_in_memory_data_store();
         cfg.enable_cache = _cfg.enable_cache();
 
     } else {
-        cfg.datadir = "";
         cfg.enable_disk_writes = false;
         cfg.enable_disk_reads = false;
         cfg.enable_commitlog = false;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1347,10 +1347,7 @@ database::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::
     }
 
     co_await create_in_memory_keyspace(ksm, erm_factory, system);
-    auto& ks = _keyspaces.at(ksm->name());
-    if (ks.datadir() != "") {
-        co_await get_sstables_manager(system).init_keyspace_storage(ks.metadata()->get_storage_options(), ks.datadir());
-    }
+    co_await get_sstables_manager(system).init_keyspace_storage(ksm->get_storage_options(), ksm->name());
 }
 
 future<> database::create_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ks_metadata) {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1253,7 +1253,6 @@ using keyspace_metadata = data_dictionary::keyspace_metadata;
 class keyspace {
 public:
     struct config {
-        sstring datadir;
         bool enable_commitlog = true;
         bool enable_disk_reads = true;
         bool enable_disk_writes = true;
@@ -1330,10 +1329,6 @@ public:
 
     void set_incremental_backups(bool val) {
         _config.enable_incremental_backups = val;
-    }
-
-    const sstring& datadir() const {
-        return _config.datadir;
     }
 };
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -302,7 +302,7 @@ future<> sstables_manager::init_table_storage(const data_dictionary::storage_opt
 }
 
 future<> sstables_manager::init_keyspace_storage(const data_dictionary::storage_options& so, sstring dir) {
-    return sstables::init_keyspace_storage(so, dir);
+    return sstables::init_keyspace_storage(*this, so, dir);
 }
 
 future<> sstables_manager::destroy_table_storage(const data_dictionary::storage_options& so, sstring dir) {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -706,7 +706,7 @@ future<> init_table_storage(const data_dictionary::storage_options& so, sstring 
     }, so.value);
 }
 
-future<> init_keyspace_storage(const data_dictionary::storage_options& so, sstring dir) {
+future<> init_keyspace_storage(const sstables_manager& mgr, const data_dictionary::storage_options& so, sstring dir) {
     co_await std::visit(overloaded_functor {
         [&dir] (const data_dictionary::storage_options::local&) -> future<> {
             co_await io_check([&dir] { return touch_directory(dir); });

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -80,6 +80,6 @@ public:
 std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstring table_dir, sstable_state state);
 future<> init_table_storage(const data_dictionary::storage_options& so, sstring dir);
 future<> destroy_table_storage(const data_dictionary::storage_options& so, sstring dir);
-future<> init_keyspace_storage(const data_dictionary::storage_options& so, sstring dir);
+future<> init_keyspace_storage(const sstables_manager&, const data_dictionary::storage_options& so, sstring dir);
 
 } // namespace sstables

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -80,6 +80,6 @@ public:
 std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstring table_dir, sstable_state state);
 future<> init_table_storage(const data_dictionary::storage_options& so, sstring dir);
 future<> destroy_table_storage(const data_dictionary::storage_options& so, sstring dir);
-future<> init_keyspace_storage(const sstables_manager&, const data_dictionary::storage_options& so, sstring dir);
+future<> init_keyspace_storage(const sstables_manager&, const data_dictionary::storage_options& so, sstring ks_name);
 
 } // namespace sstables


### PR DESCRIPTION
Commit ad0e6b79 (replica: Remove all_datadir from keyspace config) removed all_datadirs from keyspace config, now it's datadir turn. After this change keyspace no longer references any on-disk directories, only the sstables's storage driver attached to keyspace's tables does.

refs #12707