### PR TITLE
Use boto3 in object_store test to list bucket

### DIFF
--- a/test/object_store/conftest.py
+++ b/test/object_store/conftest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 import os
+import boto3
 
 # use minio_server
 from test.pylib.minio_server import MinioServer
@@ -108,3 +109,15 @@ async def s3_server(pytestconfig, tmpdir):
         yield server
     finally:
         await server.stop()
+
+
+def get_s3_resource(s3_server):
+    """Creates boto3.resource object that can be used to communicate to the given server"""
+    return boto3.resource('s3',
+        endpoint_url=f'http://{s3_server.address}:{s3_server.port}',
+        aws_access_key_id=s3_server.acc_key,
+        aws_secret_access_key=s3_server.secret_key,
+        aws_session_token=None,
+        config=boto3.session.Config(signature_version='s3v4'),
+        verify=False
+    )


### PR DESCRIPTION
There's a test in object_store suite that verifies the contents of a bucket. It does with the plain http request, but unfortunately this doesn't work -- even local minio uses restricted bucket and using plain http request results in 403(Forbidden) error code. Test doesn't check it and continues working with empty list of objects which, in turn, is what it expects to see.

The fix is in using boto3. With it, the acc/secret pair is picked up and listing the bucket finally works.