### PR TITLE
Update tracing.rst

### DIFF
--- a/docs/using-scylla/tracing.rst
+++ b/docs/using-scylla/tracing.rst
@@ -223,7 +223,7 @@ With these tables, one may get the relevant traces using a query like the one be
 
 .. code-block:: cql
 
-   SELECT * from system_traces.sessions_time_idx where minutes in ('2016-09-07 16:56:00-0700') and started_at > '2016-09-07 16:56:30-0700';
+   SELECT * from system_traces.sessions_time_idx where minute in ('2016-09-07 16:56:00-0700') and started_at > '2016-09-07 16:56:30-0700';
 
 Storing 
 ^^^^^^^


### PR DESCRIPTION
The example query in the following section is invalid.
https://opensource.docs.scylladb.com/stable/using-scylla/tracing.html#id4

```
SELECT * from system_traces.sessions_time_idx where minutes in ('2016-09-07 16:56:00-0700') and started_at > '2016-09-07 16:56:30-0700';
```

Table system_traces.sessions_time_idx does not have a column minutes. There is a column minute.  The query is updated accordingly

