### PR TITLE
[Backport 6.0] db/hints: Add logging when ignoring hint directories

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -577,6 +577,8 @@ future<> manager::change_host_filter(host_filter filter) {
             });
 
             if (!maybe_host_id_and_ip) {
+                manager_logger.warn("Encountered a hint directory of invalid name while changing the host filter: {}. "
+                        "Hints stored in it won't be replayed.", de.name);
                 co_return;
             }
 
@@ -756,6 +758,8 @@ future<> manager::initialize_endpoint_managers() {
 
         // The directory is invalid, so there's nothing more to do.
         if (!maybe_host_id_or_ep) {
+            manager_logger.warn("Encountered a hint directory of invalid name while initializing endpoint managers: {}. "
+                    "Hints stored in it won't be replayed", de.name);
             co_return;
         }
 

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -179,6 +179,8 @@ void space_watchdog::on_timer() {
                 // Case 3: The directory isn't managed by an endpoint manager, and it represents neither an IP address,
                 //         nor a host ID.
                 else {
+                    // We use trace here to prevent flooding logs with unnecessary information.
+                    resource_manager_logger.trace("Encountered a hint directory of invalid name while scanning: {}", de.name);
                     return scan_one_ep_dir(dir / de.name, shard_manager, {});
                 }
             }).get();


### PR DESCRIPTION
In 2446cce, we stopped trying to attempt to create endpoint managers for invalid hint directories
even when their names represented IP addresses or
host IDs. In this commit, we add logging informing the user about it.

Refs scylladb/scylladb#19173

(cherry picked from commit a5528a2)