### PR TITLE
build: cmake: use per-mode build dir

### DIFF
--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -120,7 +120,7 @@ add_custom_command(
     "${unified_dist_pkg}"
   COMMAND
     ${CMAKE_SOURCE_DIR}/unified/build_unified.sh
-      --build-dir ${CMAKE_BINARY_DIR}
+      --build-dir ${CMAKE_BINARY_DIR}/$<CONFIG>
       --pkgs "${dist_pkgs}"
       --unified-pkg ${unified_dist_pkg}
   DEPENDS


### PR DESCRIPTION
The `build_unified.sh` script accepts a `--build-dir` option, which specifies the directory used for storing temporary files extracted from tarballs defined by the `--pkgs` option. When performing parallel builds of multiple modes, it's crucial that each build uses a unique build directory. Reusing the same build directory for different modes can lead to conflicts, resulting in build failures or, more seriously, the creation of tarballs containing corrupted files.

so, in this change, we specify a different directory for each mode, so that they don't share the same one.

Refs scylladb/scylladb#2717
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

cmake related change, hence no need to backport.