### PR TITLE
storage_service: Remove orphan forward declaration of a method

### DIFF
--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -403,7 +403,6 @@ private:
             std::chrono::milliseconds,
             start_hint_manager start_hm,
             gms::generation_type new_generation);
-    future<> start_sys_dist_ks();
 public:
 
     future<> rebuild(sstring source_dc);


### PR DESCRIPTION
The start_sys_dist_ks() itself was removed by bc051387c5
