### PR TITLE
service_level_controller: stop: always call subscription on_abort

### DIFF
--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -119,10 +119,8 @@ future<> service_level_controller::stop() {
         co_return;
     }
 
-    if (*_early_abort_subscription) {
-        // Abort source didn't fire, so do it now
-        do_abort();
-    }
+    // If abort source didn't fire, do it now
+    _early_abort_subscription->on_abort(std::nullopt);
     
     _global_controller_db->notifications_serializer.broken();
     try {


### PR DESCRIPTION
We want to call `service_level_controller::do_abort()` in all cases. The current code (introduced in
535e5f4ae7f8c58a39e6d260574a3581dec327a8)
calls do_abort if abort was not requested, however, since it does so by checking the subscription bool operator, it would miss the case where abort was already requested before the subscription took place (in service_level_controller ctor).

With scylladb/seastar@470b539b1c1dd2b080eb13cc77b17eec5a83c21f and scylladb/seastar@8ecce18c51b3a239df5bcc4db0267d6a02d1f284 we can just unconditionally call the subscription `on_abort` method, that ensures only-once semantics, even if abort was already requested at subscription time.

Fixes scylladb/scylladb#19075

No backport required.

In case backport would be needed in the future, this change depends on seastar submodule update be880ab22cfeb5e9a1db646afc7f87fd2afad276 for the seastar patches mentioned above.