### PR TITLE
tasks: fix task handler

### DIFF
--- a/tasks/task_handler.cc
+++ b/tasks/task_handler.cc
@@ -117,8 +117,9 @@ future<task_status> task_handler::wait_for_task() {
                 });
             },
             [id] (task_manager::virtual_task_ptr task) -> future<task_status> {
-                auto status = co_await task->get_status(id);
-                co_return get_virtual_task_info(id, status);
+                auto id_ = id;
+                auto status = co_await task->wait(id_);
+                co_return get_virtual_task_info(id_, status);
             }
         }, task_v);
     }));
@@ -165,6 +166,7 @@ future<utils::chunked_vector<task_status>> task_handler::get_status_recursively(
                 auto status = task_status{
                     .task_id = task.task_status.id,
                     .type = task.type,
+                    .kind = task_kind::node,
                     .scope = task.task_status.scope,
                     .state = task.task_status.state,
                     .is_abortable = task.abortable,

--- a/test/rest_api/task_manager_utils.py
+++ b/test/rest_api/task_manager_utils.py
@@ -63,6 +63,7 @@ def check_child_parent_relationship(rest_api, status_tree, parent, allow_no_chil
 
     for child in get_children(status_tree, parent["id"]):
         child_id = child["id"]
+        assert child["kind"] == "node", "Child task isn't marked as local"
         assert parent["sequence_number"] == child["sequence_number"], f"Child task with id {child_id} did not inherit parent's sequence number"
         assert child["parent_id"] == parent["id"], f"Parent id of task with id {child_id} is not set"
         check_child_parent_relationship(rest_api, status_tree, child, True)


### PR DESCRIPTION
There are some bugs missed in task handler:
- wait_for_task does not wait until virtual tasks are done, but returns the status immediately;
- wait_for_task suffers from use after return;
- get_status_recursively does not set the kind of task essentials.

Fix the aforementioned.