### PR TITLE
test/alternator: add another check to test_stream_list_tables

### DIFF
--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -1595,11 +1595,14 @@ def test_stream_list_tables(dynamodb):
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
         AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' }, ]
     ) as table:
-            # Check that the long and unique table name (created by
-            # unique_table_name()) isn't a substring of any table name,
-            # except of course the table itself:
-            for listed_name in list_tables(dynamodb):
-                assert table.name == listed_name or table.name not in listed_name
+            # Check that the test table is listed by ListTable, but its long
+            # and unique name (created by unique_table_name()) isn't a proper
+            # substring of any other table's name.
+            tables = list_tables(dynamodb)
+            assert table.name in tables
+            for listed_name in tables:
+                if table.name != listed_name:
+                    assert table.name not in listed_name
 
 # TODO: tests on multiple partitions
 # TODO: write a test that disabling the stream and re-enabling it works, but


### PR DESCRIPTION
The test test_streams.py::test_stream_list_tables reproduces a bug where
enabling streams added a spurious result to ListTables. A reviewer of
that patch asked to also add a check that name of the table itself
doesn't disappear from ListTables when a stream is enabled, so this is
what this patch adds.
    
This theoretical scenario (a table's name disappearing from ListTables)
never happened, so the new check doesn't reproduce any known bug, but
I guess it never hurts to make the test stronger for regression testing.

No need to backport, just a test improvement