### PR TITLE
storage_service: raft topology: warn when `raft_topology_cmd_handler` fails due to abort

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5666,8 +5666,10 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                 break;
             }
         }
+    } catch (const raft::request_aborted& e) {
+        rtlogger.warn("raft_topology_cmd {} failed with: {}", cmd.cmd, e);
     } catch (...) {
-        rtlogger.error("raft_topology_cmd failed with: {}", std::current_exception());
+        rtlogger.error("raft_topology_cmd {} failed with: {}", cmd.cmd, std::current_exception());
     }
     co_return result;
 }


### PR DESCRIPTION
Currently we print an ERROR on all exceptions in
`raft_topology_cmd_handler`. This log level is too high, in some cases exceptions are expected -- like during shutdown. And it causes dtest failures.

Turn exceptions from aborts into WARN level.

Also improve logging by printing the command that failed.

Fixes scylladb/scylladb#19754

Affects all branches with Raft-based topology, so backport to 6.0 and 6.1 applies.