### PR TITLE
[test.py] Enable allure for python test

### DIFF
--- a/test.py
+++ b/test.py
@@ -614,6 +614,7 @@ class Test:
         self.shortname = shortname
         self.mode = suite.mode
         self.suite = suite
+        self.allure_dir = pathlib.Path(suite.options.tmpdir) / self.mode / 'allure'
         # Unique file name, which is also readable by human, as filename prefix
         self.uname = "{}.{}.{}".format(self.suite.name, self.shortname, self.id)
         self.log_filename = pathlib.Path(suite.options.tmpdir) / self.mode / (self.uname + ".log")
@@ -812,6 +813,7 @@ class CQLApprovalTest(Test):
             "--run_id={}".format(self.id),
             "--mode={}".format(self.mode),
         ]
+        self.args.append(f"--alluredir={self.allure_dir}")
 
     async def run(self, options: argparse.Namespace) -> Test:
         self.success = False
@@ -925,6 +927,7 @@ class RunTest(Test):
             "-o",
             "junit_suite_name={}".format(self.suite.name)
         ]
+        self.args.append(f"--alluredir={self.allure_dir}")
         RunTest._reset(self)
 
     def _reset(self):
@@ -967,6 +970,7 @@ class PythonTest(Test):
             "--run_id={}".format(self.id),
             "--mode={}".format(self.mode)
         ]
+        self.args.append(f"--alluredir={self.allure_dir}")
         if options.markers:
             self.args.append(f"-m={options.markers}")
 
@@ -1097,6 +1101,7 @@ class ToolTest(Test):
             "--mode={}".format(self.mode),
             "--run_id={}".format(self.id)
         ]
+        self.args.append(f"--alluredir={self.allure_dir}")
         if options.markers:
             self.args.append(f"-m={options.markers}")
 

--- a/test.py
+++ b/test.py
@@ -1054,9 +1054,7 @@ class TopologyTest(PythonTest):
 
         test_path = os.path.join(self.suite.options.tmpdir, self.mode)
         async with get_cluster_manager(self.mode + '/' + self.uname, self.suite.clusters, test_path) as manager:
-            self.args.insert(0, "--run_id={}".format(self.id))
             self.args.insert(0, "--tmpdir={}".format(options.tmpdir))
-            self.args.insert(0, "--mode={}".format(self.mode))
             self.args.insert(0, "--manager-api={}".format(manager.sock_path))
             if options.artifacts_dir_url:
                 self.args.insert(0, "--artifacts_dir_url={}".format(options.artifacts_dir_url))

--- a/test/pylib/report_plugin.py
+++ b/test/pylib/report_plugin.py
@@ -1,7 +1,16 @@
+import logging
+
+import allure
 import pytest
+
+logger = logging.getLogger(name=__name__)
 
 
 class ReportPlugin:
+    config = None
+    mode = None
+    run_id = None
+
     # Pytest hook to modify test name to include mode and run_id
     def pytest_configure(self, config):
         self.config = config
@@ -13,3 +22,16 @@ class ReportPlugin:
         outcome = yield
         report = outcome.get_result()
         report.nodeid = f"{report.nodeid}.{self.mode}.{self.run_id}"
+
+    @pytest.fixture(scope="function", autouse=True)
+    def allure_set_mode(self, request):
+        """
+        Add mode tag to be able to search by it.
+        Add parameters to make allure distinguish them and not put them to retries.
+        """
+        run_id = request.config.getoption('run_id')
+        mode = request.config.getoption('mode')
+        request.node.name = f"{request.node.name}.{mode}.{run_id}"
+        allure.dynamic.tag(mode)
+        allure.dynamic.parameter('mode', mode)
+        allure.dynamic.parameter('run_id', run_id)

--- a/test/pylib/report_plugin.py
+++ b/test/pylib/report_plugin.py
@@ -1,9 +1,12 @@
-import logging
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
 
 import allure
 import pytest
 
-logger = logging.getLogger(name=__name__)
 
 
 class ReportPlugin:


### PR DESCRIPTION
To enhance the test reports UX:
1. switching off/on passed/failed/skipped test for better visibility 
2. better searching in test results
3. understanding the trends of execution for each test
4. better configurability of the final report

Enable allure adapter for all python tests.
Add tags and parameters to the test to be able to distinguish them across modes and runs.

Related: https://github.com/scylladb/qa-tasks/issues/1665

Related: https://github.com/scylladb/scylladb/pull/19335

Related: https://github.com/scylladb/scylladb/pull/18169

