### PR TITLE
docs: fix redirect from cert-based auth to security/enable-auth page

### DIFF
--- a/docs/operating-scylla/security/certificate-authentication.rst
+++ b/docs/operating-scylla/security/certificate-authentication.rst
@@ -11,7 +11,7 @@ Procedure
 
 #. Enable authentication
 
-   Enable authentication and define authorized roles in the cluster as described in the `Enable Authentication </operating-scylla/security/authentication/>`_ document. 
+   Enable authentication and define authorized roles in the cluster as described in the :doc:`Enable Authentication </operating-scylla/security/authentication/>` document. 
 
 #. Enable CQL transport TLS using client certificate verification
    


### PR DESCRIPTION
## Motivation

I'm testing the "Enable Authentication" feature and saw that this link isn't working. 


### Fixes

- Added :doc: prefix to proper redirect to the respective page.