### PR TITLE
sstables: fix a typo in comment

### DIFF
--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -288,7 +288,7 @@ public:
     // Creates the deletion log for atomic deletion of sstables (helper for the
     // above function that's also used by tests)
     // Returns an unordered_map of <directory with sstables, logfile_name> for every sstable prefix.
-    // Currently, atomicity is guranteed only within each unique prefix and not across prefixes (See #18862)
+    // Currently, atomicity is guaranteed only within each unique prefix and not across prefixes (See #18862)
     static future<std::unordered_map<sstring, sstring>> create_pending_deletion_log(const std::vector<shared_sstable>& ssts);
 
     static bool compare_sstable_storage_prefix(const sstring& a, const sstring& b) noexcept;


### PR DESCRIPTION
s/guranteed/guaranteed/

---

it's a cleanup, hence no need to backport.