### PR TITLE
build: cmake: define SCYLLA_ENABLE_PREEMPTION_SOURCE for dev build

### DIFF
--- a/cmake/mode.Dev.cmake
+++ b/cmake/mode.Dev.cmake
@@ -11,7 +11,8 @@ set(Seastar_DEFINITIONS_DEV
   SCYLLA_BUILD_MODE=${scylla_build_mode_Dev}
   DEVEL
   SEASTAR_ENABLE_ALLOC_FAILURE_INJECTION
-  SCYLLA_ENABLE_ERROR_INJECTION)
+  SCYLLA_ENABLE_ERROR_INJECTION
+  SCYLLA_ENABLE_PREEMPTION_SOURCE)
 foreach(definition ${Seastar_DEFINITIONS_DEV})
   add_compile_definitions(
     $<$<CONFIG:Dev>:${definition}>)


### PR DESCRIPTION
in fabab2f4, we introduced preemption_source, and added `SCYLLA_ENABLE_PREEMPTION_SOURCE` preprocessor macro to enable opt-in the pluggable preemption check.

but CMake building system was not updated accordingly.

so, in this change, let's sync the CMake building system with `configure.py`.

---

it's a cmake change, hence no need to backport