### PR TITLE
Use cross shard barrier to start view builder

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1915,7 +1915,7 @@ void view_builder::setup_metrics() {
     });
 }
 
-future<> view_builder::start(service::migration_manager& mm) {
+future<> view_builder::start(service::migration_manager& mm, utils::cross_shard_barrier barrier) {
     _started = do_with(view_builder_init_state{}, [this, &mm] (view_builder_init_state& vbi) {
         return seastar::async([this, &mm, &vbi] {
             // Guard the whole startup routine with a semaphore,

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1916,8 +1916,9 @@ void view_builder::setup_metrics() {
 }
 
 future<> view_builder::start(service::migration_manager& mm, utils::cross_shard_barrier barrier) {
-    _started = do_with(view_builder_init_state{}, [this, &mm] (view_builder_init_state& vbi) {
-        return seastar::async([this, &mm, &vbi] {
+    _started = do_with(view_builder_init_state{}, [this, &mm, barrier = std::move(barrier)] (view_builder_init_state& vbi) {
+        return seastar::async([this, &mm, &vbi, barrier = std::move(barrier)] mutable {
+            auto fail = defer([&barrier] mutable { barrier.abort(); });
             // Guard the whole startup routine with a semaphore,
             // so that it's not intercepted by `on_drop_view`, `on_create_view`
             // or `on_update_view` events.
@@ -1928,7 +1929,6 @@ future<> view_builder::start(service::migration_manager& mm, utils::cross_shard_
             auto built = _sys_ks.load_built_views().get();
             auto in_progress = _sys_ks.load_view_build_progress().get();
             setup_shard_build_step(vbi, std::move(built), std::move(in_progress));
-        }).then_wrapped([this] (future<>&& f) {
             // All shards need to arrive at the same decisions on whether or not to
             // restart a view build at some common token (reshard), and which token
             // to restart at. So we need to wait until all shards have read the view
@@ -1936,28 +1936,8 @@ future<> view_builder::start(service::migration_manager& mm, utils::cross_shard_
             // If we don't synchronize here, a fast shard may make a decision, start
             // building and finish a build step - before the slowest shard even read
             // the view build information.
-            std::exception_ptr eptr;
-            if (f.failed()) {
-                eptr = f.get_exception();
-            }
-
-            return container().invoke_on(0, [eptr = std::move(eptr)] (view_builder& builder) {
-                // The &builder is alive, because it can only be destroyed in
-                // sharded<view_builder>::stop(), which, in turn, waits for all
-                // view_builder::stop()-s to finish, and each stop() waits for
-                // the shard's current future (called _started) to resolve.
-                if (!eptr) {
-                    if (++builder._shards_finished_read == smp::count) {
-                        builder._shards_finished_read_promise.set_value();
-                    }
-                } else {
-                    if (builder._shards_finished_read < smp::count) {
-                        builder._shards_finished_read = smp::count;
-                        builder._shards_finished_read_promise.set_exception(std::move(eptr));
-                    }
-                }
-                return builder._shards_finished_read_promise.get_shared_future();
-            });
+            fail.cancel();
+            barrier.arrive_and_wait().get();
         }).then([this, &vbi] {
             return calculate_shard_build_step(vbi);
         }).then([this] {
@@ -1976,6 +1956,8 @@ future<> view_builder::start(service::migration_manager& mm, utils::cross_shard_
             } catch (const seastar::sleep_aborted& e) {
                 ll = log_level::debug;
             } catch (const seastar::abort_requested_exception& e) {
+                ll = log_level::debug;
+            } catch (const utils::barrier_aborted_exception& e) {
                 ll = log_level::debug;
             }
             vlogger.log(ll, "start aborted: {}", ex);

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -11,6 +11,7 @@
 #include "query-request.hh"
 #include "service/migration_listener.hh"
 #include "utils/serialized_action.hh"
+#include "utils/cross-shard-barrier.hh"
 #include "replica/database.hh"
 
 #include <seastar/core/abort_source.hh>
@@ -198,7 +199,7 @@ public:
      * Requires that all views have been loaded from the system tables and are accessible
      * through the database, and that the commitlog has been replayed.
      */
-    future<> start(service::migration_manager&);
+    future<> start(service::migration_manager&, utils::cross_shard_barrier b = utils::cross_shard_barrier(utils::cross_shard_barrier::solo{}));
 
     /**
      * Drains view building in order to prepare it for shutdown.

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -165,10 +165,6 @@ class view_builder final : public service::migration_listener::only_view_notific
     future<> _started = make_ready_future<>();
     // Used to coordinate between shards the conclusion of the build process for a particular view.
     std::unordered_set<table_id> _built_views;
-    // Counter and promise (both on shard 0 only!) allowing to wait for all
-    // shards to have read the view build statuses
-    unsigned _shards_finished_read = 0;
-    seastar::shared_promise<> _shards_finished_read_promise;
     // Used for testing.
     std::unordered_map<std::pair<sstring, sstring>, seastar::shared_promise<>, utils::tuple_hash> _build_notifiers;
     stats _stats;

--- a/main.cc
+++ b/main.cc
@@ -2031,7 +2031,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }
 
             if (cfg->view_building()) {
-                view_builder.invoke_on_all(&db::view::view_builder::start, std::ref(mm)).get();
+                view_builder.invoke_on_all(&db::view::view_builder::start, std::ref(mm), utils::cross_shard_barrier()).get();
             }
 
             api::set_server_view_builder(ctx, view_builder).get();


### PR DESCRIPTION
When starting, view builder wants all shards to synchronize with each other in the middle of initialization. For that they all synchronize via shard-0's instance counter and a shared future. There's cross-shard barrier in utils/ that provides the same facility.