### PR TITLE
extensions: Add exception types for IO extensions and handle in memtable write path

### DIFF
--- a/db/extensions.hh
+++ b/db/extensions.hh
@@ -15,6 +15,7 @@
 #include <variant>
 #include <vector>
 #include <unordered_set>
+#include <exception>
 
 #include <seastar/core/sstring.hh>
 
@@ -120,4 +121,35 @@ private:
     std::map<sstring, commitlog_file_extension_ptr> _commitlog_file_extensions;
     std::unordered_set<std::string> _extension_internal_keyspaces;
 };
+
+class extension_storage_exception : public std::exception {
+private:
+    std::string _message;
+public:
+    extension_storage_exception(std::string message) noexcept
+        : _message(std::move(message))
+    {}
+    extension_storage_exception(extension_storage_exception&&) = default;
+    extension_storage_exception(const extension_storage_exception&) = default;
+
+    const char* what() const noexcept override {
+        return _message.c_str();
+    }
+};
+
+class extension_storage_resource_unavailable : public extension_storage_exception {
+public:
+    using extension_storage_exception::extension_storage_exception;
+};
+
+class extension_storage_permission_error : public extension_storage_exception {
+public:
+    using extension_storage_exception::extension_storage_exception;
+};
+
+class extension_storage_misconfigured : public extension_storage_exception {
+public:
+    using extension_storage_exception::extension_storage_exception;
+};
+
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -34,6 +34,7 @@
 #include "compaction/table_state.hh"
 #include "sstables/sstable_directory.hh"
 #include "db/system_keyspace.hh"
+#include "db/extensions.hh"
 #include "query-result-writer.hh"
 #include "db/view/view_update_generator.hh"
 #include <boost/range/adaptor/transformed.hpp>
@@ -1299,6 +1300,8 @@ table::seal_active_memtable(compaction_group& cg, flush_permit&& flush_permit) n
                     allowed_retries = should_retry(ep) ? default_retries : 0;
                 } else if (auto ep = try_catch<storage_io_error>(ex)) {
                     allowed_retries = should_retry(ep) ? default_retries : 0;
+                } else if (try_catch<db::extension_storage_exception>(ex)) {
+                    allowed_retries = default_retries;
                 } else {
                     allowed_retries = 0;
                 }

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -7,6 +7,7 @@
  */
 
 #include <boost/test/unit_test.hpp>
+#include <boost/test/framework.hpp>
 #include "replica/database.hh"
 #include "db/config.hh"
 #include "utils/UUID_gen.hh"
@@ -1173,7 +1174,7 @@ SEASTAR_TEST_CASE(flushing_rate_is_reduced_if_compaction_doesnt_keep_up) {
     });
 }
 
-static future<> exceptions_in_flush_helper(std::unique_ptr<sstables::file_io_extension> mep, bool& should_fail, const bool& did_fail) {
+static future<> exceptions_in_flush_helper(std::unique_ptr<sstables::file_io_extension> mep, bool& should_fail, const bool& did_fail, bool expect_isolate) {
     auto ext = std::make_shared<db::extensions>();
     auto cfg = seastar::make_shared<db::config>(ext);
 
@@ -1207,32 +1208,37 @@ static future<> exceptions_in_flush_helper(std::unique_ptr<sstables::file_io_ext
         testlog.debug("Reset fail trigger");
 
         should_fail = false;
-        bool isolated = false;
-        // can't use eventually_true here, because neither we nor the invoke on shard 0 is in seastar
-        // thread.
-        for (int i = 0; i < 10; ++i) {
-            isolated = co_await env.get_storage_service().invoke_on(0, [&](service::storage_service& ss) {
-                return ss.is_isolated(); 
-            });
-            if (isolated) {
-                break;
+
+        if (expect_isolate) {
+            bool isolated = false;
+            // can't use eventually_true here, because neither we nor the invoke on shard 0 is in seastar
+            // thread.
+            for (int i = 0; i < 10; ++i) {
+                isolated = co_await env.get_storage_service().invoke_on(0, [&](service::storage_service& ss) {
+                    return ss.is_isolated(); 
+                });
+                if (isolated) {
+                    break;
+                }
+                // isolation is not syncnronous;
+                co_await sleep(2s);
             }
-            // isolation is not syncnronous;
-            co_await sleep(2s);
+
+            BOOST_REQUIRE(isolated);
         }
 
-        BOOST_REQUIRE(isolated);
         testlog.debug("Trying to stop");
 
         co_await std::move(f);
     }, cfg);
 }
 
-SEASTAR_TEST_CASE(test_exceptions_in_flush_on_sstable_write) {
+static future<> exceptions_in_flush_on_sstable_write_helper(std::function<void()> throw_func, bool expect_isolate = true) {
     class myext : public sstables::file_io_extension {
     public:
         bool should_fail = false;
         bool did_fail = false;
+        std::function<void()> throw_func;
 
         future<file> wrap_file(sstable& t, component_type type, file f, open_flags flags) override {
             if (should_fail) {
@@ -1248,7 +1254,7 @@ SEASTAR_TEST_CASE(test_exceptions_in_flush_on_sstable_write) {
                         if (_myext.should_fail) {
                             _myext.did_fail = true;
                             testlog.debug("Throwing exception");
-                            throw std::system_error(EACCES, std::system_category());
+                            _myext.throw_func();
                         }
                     }
                     future<size_t> write_dma(uint64_t pos, const void* buffer, size_t len, io_intent* intent) override {
@@ -1315,10 +1321,36 @@ SEASTAR_TEST_CASE(test_exceptions_in_flush_on_sstable_write) {
     };
     auto mep = std::make_unique<myext>();
     auto& me = *mep;
-    co_await exceptions_in_flush_helper(std::move(mep), me.should_fail, me.did_fail);
+    me.throw_func = std::move(throw_func);
+    co_await exceptions_in_flush_helper(std::move(mep), me.should_fail, me.did_fail, expect_isolate);
 }
 
-SEASTAR_TEST_CASE(test_exceptions_in_flush_on_sstable_open) {
+SEASTAR_TEST_CASE(test_exceptions_in_flush_on_sstable_write) {
+    co_await exceptions_in_flush_on_sstable_write_helper(
+        [] { throw std::system_error(EACCES, std::system_category()); }
+    );
+}
+
+SEASTAR_TEST_CASE(test_ext_permission_exceptions_in_flush_on_sstable_write) {
+    co_await exceptions_in_flush_on_sstable_write_helper(
+        [] { throw db::extension_storage_permission_error(get_name()); }
+    );
+}
+
+SEASTAR_TEST_CASE(test_ext_resource_exceptions_in_flush_on_sstable_write) {
+    co_await exceptions_in_flush_on_sstable_write_helper(
+        [] { throw db::extension_storage_resource_unavailable(get_name()); }
+        , false // equal no ENOENT
+    );
+}
+
+SEASTAR_TEST_CASE(test_ext_config_exceptions_in_flush_on_sstable_write) {
+    co_await exceptions_in_flush_on_sstable_write_helper(
+        [] { throw db::extension_storage_misconfigured(get_name()); }
+    );
+}
+
+static future<> exceptions_in_flush_on_sstable_open_helper(std::function<void()> throw_func, bool expect_isolate = true) {
     auto ext = std::make_shared<db::extensions>();
     auto cfg = seastar::make_shared<db::config>(ext);
 
@@ -1326,17 +1358,44 @@ SEASTAR_TEST_CASE(test_exceptions_in_flush_on_sstable_open) {
     public:
         bool should_fail = false;
         bool did_fail = false;
+        std::function<void()> throw_func;
 
         future<file> wrap_file(sstable& t, component_type type, file f, open_flags flags) override {
             if (should_fail) {
                 did_fail = true;
                 testlog.debug("Throwing exception");
-                throw std::system_error(EACCES, std::system_category());
+                throw_func();
             }
             co_return f;
         }
     };
     auto mep = std::make_unique<myext>();
     auto& me = *mep;
-    co_await exceptions_in_flush_helper(std::move(mep), me.should_fail, me.did_fail);
+    me.throw_func = std::move(throw_func);;
+    co_await exceptions_in_flush_helper(std::move(mep), me.should_fail, me.did_fail, expect_isolate);
+}
+
+SEASTAR_TEST_CASE(test_exceptions_in_flush_on_sstable_open) {
+    co_await exceptions_in_flush_on_sstable_open_helper(
+        [] { throw std::system_error(EACCES, std::system_category()); }
+    );
+}
+
+SEASTAR_TEST_CASE(test_ext_permission_exceptions_in_flush_on_sstable_open) {
+    co_await exceptions_in_flush_on_sstable_open_helper(
+        [] { throw db::extension_storage_permission_error(get_name()); }
+    );
+}
+
+SEASTAR_TEST_CASE(test_ext_resource_exceptions_in_flush_on_sstable_open) {
+    co_await exceptions_in_flush_on_sstable_open_helper(
+        [] { throw db::extension_storage_resource_unavailable(get_name()); }
+        , false // equal no ENOENT
+    );
+}
+
+SEASTAR_TEST_CASE(test_ext_config_exceptions_in_flush_on_sstable_open) {
+    co_await exceptions_in_flush_on_sstable_open_helper(
+        [] { throw db::extension_storage_misconfigured(get_name()); }
+    );
 }

--- a/utils/disk-error-handler.cc
+++ b/utils/disk-error-handler.cc
@@ -5,6 +5,7 @@
 /* SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "db/extensions.hh"
 #include "utils/disk-error-handler.hh"
 #include "utils/exceptions.hh"
 
@@ -24,6 +25,11 @@ io_error_handler default_io_error_handler(disk_error_signal_type& signal) {
                 signal();
                 throw storage_io_error(e);
             }
+        } catch (db::extension_storage_resource_unavailable&) {
+            throw; // by same logic as found in should_stop_on_system_error - not avail -> no isolate.
+        } catch (db::extension_storage_exception& e) {
+            signal();
+            throw;
         }
     };
 }


### PR DESCRIPTION
Fixes #19960

Write path for sstables/commitlog need to handle the fact that IO extensions can generate errors, some of which should be considered retry-able, and some that should, similar to system IO errors, cause the node to go into isolate mode.

One option would of course be for extensions to simply generate std::system_errors, with system_category and appropriate codes. But this is probably a bad idea, since it makes it more muddy at which level an error happened, as well as limits the expressibility of the error.

This adds three distinct types (sharing base) distinguishing permission, availabilty and configuration errors. These are treated akin to EACCESS, ENOENT and EINVAL in disk error handler and memtable write loop.

Tests updated to use and verify behaviour.

