### PR TITLE
[Backport 6.0] : boost/sstable_datafile_test: wait for total memory reclaimed update

### DIFF
--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -3343,8 +3343,8 @@ SEASTAR_TEST_CASE(test_bloom_filter_reclaim_during_reload) {
         // resume reloading sst1 filter
         utils::get_local_injector().receive_message("reload_reclaimed_components/pause");
         REQUIRE_EVENTUALLY_EQUAL(sst1->filter_memory_size(), sst1_bf_memory);
+        REQUIRE_EVENTUALLY_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst3_bf_memory);
         BOOST_REQUIRE_EQUAL(sst_mgr.get_total_reclaimable_memory(), sst1_bf_memory);
-        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), sst3_bf_memory);
 
         utils::get_local_injector().disable("reload_reclaimed_components/pause");
     }, {


### PR DESCRIPTION
The testcase `test_bloom_filter_reclaim_during_reload` checks the SSTable manager's `_total_memory_reclaimed` against an expected value to verify that a Bloom filter was reloaded. However, it does not wait for the manager to update the variable, causing the check to fail if the update has not occurred yet. Fix it by making the testcase wait until the variable is updated to the expected value.

Fixes #19879

Signed-off-by: Lakshmi Narayanan Sreethar <lakshmi.sreethar@scylladb.com>

Closes scylladb/scylladb#19883

(cherry picked from commit 27b305b9d12093c66f2b50fef4211d93b2fb43c6)

Backported from #19883 to 6.0.