### PR TITLE
compaction: wait until cg gate is closed before removing compaction s…

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -394,7 +394,7 @@ public:
 
     // Remove a table from the compaction manager.
     // Cancel requests on table and wait for possible ongoing compactions.
-    future<> remove(compaction::table_state& t) noexcept;
+    future<> remove(compaction::table_state& t, future<> cg_closed_gate_fut = make_ready_future()) noexcept;
 
     const stats& get_stats() const {
         return _stats;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2185,12 +2185,11 @@ future<> compaction_group::stop() noexcept {
     auto closed_gate_fut = _async_gate.close();
 
     auto flush_future = co_await seastar::coroutine::as_future(flush());
-    co_await _t._compaction_manager.remove(as_table_state());
+    co_await _t._compaction_manager.remove(as_table_state(), std::move(closed_gate_fut));
 
     if (flush_future.failed()) {
         co_await seastar::coroutine::return_exception_ptr(flush_future.get_exception());
     }
-    co_await std::move(closed_gate_fut);
 }
 
 bool compaction_group::empty() const noexcept {


### PR DESCRIPTION
…tate

In compaction_group::stop compaction group's gate close() is awaited after all other compaction info is removed. Due to that an operation that entered cg's gate may attempt to access other compaction group related data that was already removed.

Await for cg's closed gate future before associated compaction_state is erased from compaction manager.

Fixes: #19873.