### PR TITLE
[DONT MERGE] install.sh: fix offline installation on scylla-housekeeping

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -481,13 +481,16 @@ EOS
 EnvironmentFile=
 EnvironmentFile=$sysconfdir/scylla-housekeeping
 EOS
-            if ! $packaging; then
-                cat << EOS > "$retc"/systemd/system/scylla-housekeeping-$i.service.d/offline.conf
+        done
+    fi
+    if ! $packaging; then
+        for i in daily restart; do
+            install -d -m755 "$retc"/systemd/system/scylla-housekeeping-$i.service.d
+            cat << EOS > "$retc"/systemd/system/scylla-housekeeping-$i.service.d/offline.conf
 [Service]
 ExecStart=
 ExecStart=$rprefix/scripts/scylla-housekeeping --uuid-file \$UUID_FILE -q -c \$CONFIG_FILE version --mode ${i:0:1}
 EOS
-            fi
         done
     fi
 elif ! $without_systemd; then


### PR DESCRIPTION
Currently,
/etc/systemd/system/scylla-housekeeping-$mode.service.d/offline.conf is not correctly installed on offline mode.
This is because the installation code is mistakenly under $sysconfdir != /etc/sysconfig, it will break on Redhat variants. It should be out side of the condition.

Fixes #19964