### PR TITLE
[Backport 6.0] raft: fix the shutdown phase being stuck

### DIFF
--- a/auth/common.cc
+++ b/auth/common.cc
@@ -122,7 +122,7 @@ static future<> announce_mutations_with_guard(
         ::service::raft_group0_client& group0_client,
         std::vector<canonical_mutation> muts,
         ::service::group0_guard group0_guard,
-        seastar::abort_source* as,
+        seastar::abort_source& as,
         std::optional<::service::raft_timeout> timeout) {
     auto group0_cmd = group0_client.prepare_command(
         ::service::write_mutations{
@@ -138,7 +138,7 @@ future<> announce_mutations_with_batching(
         ::service::raft_group0_client& group0_client,
         start_operation_func_t start_operation_func,
         std::function<mutations_generator(api::timestamp_type& t)> gen,
-        seastar::abort_source* as,
+        seastar::abort_source& as,
         std::optional<::service::raft_timeout> timeout) {
     // account for command's overhead, it's better to use smaller threshold than constantly bounce off the limit
     size_t memory_threshold = group0_client.max_command_size() * 0.75;
@@ -189,7 +189,7 @@ future<> announce_mutations(
         ::service::raft_group0_client& group0_client,
         const sstring query_string,
         std::vector<data_value_or_unset> values,
-        seastar::abort_source* as,
+        seastar::abort_source& as,
         std::optional<::service::raft_timeout> timeout) {
     auto group0_guard = co_await group0_client.start_operation(as, timeout);
     auto timestamp = group0_guard.write_timestamp();

--- a/auth/common.hh
+++ b/auth/common.hh
@@ -84,7 +84,7 @@ future<> create_legacy_metadata_table_if_missing(
 // Execute update query via group0 mechanism, mutations will be applied on all nodes.
 // Use this function when need to perform read before write on a single guard or if
 // you have more than one mutation and potentially exceed single command size limit.
-using start_operation_func_t = std::function<future<::service::group0_guard>(abort_source*)>;
+using start_operation_func_t = std::function<future<::service::group0_guard>(abort_source&)>;
 using mutations_generator = coroutine::experimental::generator<mutation>;
 future<> announce_mutations_with_batching(
         ::service::raft_group0_client& group0_client,
@@ -93,7 +93,7 @@ future<> announce_mutations_with_batching(
         // function here
         start_operation_func_t start_operation_func,
         std::function<mutations_generator(api::timestamp_type& t)> gen,
-        seastar::abort_source* as,
+        seastar::abort_source& as,
         std::optional<::service::raft_timeout> timeout);
 
 // Execute update query via group0 mechanism, mutations will be applied on all nodes.
@@ -102,7 +102,7 @@ future<> announce_mutations(
         ::service::raft_group0_client& group0_client,
         const sstring query_string,
         std::vector<data_value_or_unset> values,
-        seastar::abort_source* as,
+        seastar::abort_source& as,
         std::optional<::service::raft_timeout> timeout);
 
 }

--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -203,7 +203,7 @@ default_authorizer::modify(
                 cql3::query_processor::cache_internal::no).discard_result();
     }
     co_return co_await announce_mutations(_qp, _group0_client, query,
-        {permissions::to_strings(set), sstring(role_name), resource.name()}, &_as, ::service::raft_timeout{});
+        {permissions::to_strings(set), sstring(role_name), resource.name()}, _as, ::service::raft_timeout{});
 }
 
 
@@ -256,7 +256,7 @@ future<> default_authorizer::revoke_all(std::string_view role_name) {
                     {sstring(role_name)},
                     cql3::query_processor::cache_internal::no).discard_result();
         } else {
-            co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name)}, &_as, ::service::raft_timeout{});
+            co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name)}, _as, ::service::raft_timeout{});
         }
     } catch (exceptions::request_execution_exception& e) {
         alogger.warn("CassandraAuthorizer failed to revoke all permissions of {}: {}", role_name, e);
@@ -346,9 +346,9 @@ future<> default_authorizer::revoke_all(const resource& resource) {
         const auto timeout = ::service::raft_timeout{};
         co_await announce_mutations_with_batching(
                 _group0_client,
-                [this, timeout](abort_source* as) { return _group0_client.start_operation(as, timeout); },
+                [this, timeout](abort_source& as) { return _group0_client.start_operation(as, timeout); },
                 std::move(gen),
-                &_as,
+                _as,
             timeout);
     } catch (exceptions::request_execution_exception& e) {
         alogger.warn("CassandraAuthorizer failed to revoke all permissions on {}: {}", name, e);

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -136,7 +136,7 @@ future<> password_authenticator::create_default_if_missing() {
         plogger.info("Created default superuser authentication record.");
     } else {
         co_await announce_mutations(_qp, _group0_client, query,
-            {salted_pwd, _superuser}, &_as, ::service::raft_timeout{});
+            {salted_pwd, _superuser}, _as, ::service::raft_timeout{});
         plogger.info("Created default superuser authentication record.");
     }
 }
@@ -271,7 +271,7 @@ future<> password_authenticator::create(std::string_view role_name, const authen
                 cql3::query_processor::cache_internal::no).discard_result();
     } else {
         co_await announce_mutations(_qp, _group0_client, query,
-                {passwords::hash(*options.password, rng_for_salt), sstring(role_name)}, &_as, ::service::raft_timeout{});
+                {passwords::hash(*options.password, rng_for_salt), sstring(role_name)}, _as, ::service::raft_timeout{});
     }
 }
 
@@ -294,7 +294,7 @@ future<> password_authenticator::alter(std::string_view role_name, const authent
                 cql3::query_processor::cache_internal::no).discard_result();
     } else {
         co_await announce_mutations(_qp, _group0_client, query,
-            {passwords::hash(*options.password, rng_for_salt), sstring(role_name)}, &_as, ::service::raft_timeout{});
+            {passwords::hash(*options.password, rng_for_salt), sstring(role_name)}, _as, ::service::raft_timeout{});
     }
 }
 
@@ -311,7 +311,7 @@ future<> password_authenticator::drop(std::string_view name) {
                 {sstring(name)},
                 cql3::query_processor::cache_internal::no).discard_result();
     } else {
-        co_await announce_mutations(_qp, _group0_client, query, {sstring(name)}, &_as, ::service::raft_timeout{});
+        co_await announce_mutations(_qp, _group0_client, query, {sstring(name)}, _as, ::service::raft_timeout{});
     }
 }
 

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -663,7 +663,7 @@ future<> migrate_to_auth_v2(db::system_keyspace& sys_ks, ::service::raft_group0_
     co_await announce_mutations_with_batching(g0,
             start_operation_func,
             std::move(gen),
-            &as,
+            as,
             std::nullopt);
 }
 

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -190,7 +190,7 @@ future<> standard_role_manager::create_default_role_if_missing() {
                     {_superuser},
                     cql3::query_processor::cache_internal::no).discard_result();
         } else {
-            co_await announce_mutations(_qp, _group0_client, query, {_superuser}, &_as, ::service::raft_timeout{});
+            co_await announce_mutations(_qp, _group0_client, query, {_superuser}, _as, ::service::raft_timeout{});
         }
         log.info("Created default superuser role '{}'.", _superuser);
     } catch(const exceptions::unavailable_exception& e) {
@@ -285,7 +285,7 @@ future<> standard_role_manager::create_or_replace(std::string_view role_name, co
                 {sstring(role_name), c.is_superuser, c.can_login},
                 cql3::query_processor::cache_internal::yes).discard_result();
     } else {
-        co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name), c.is_superuser, c.can_login}, &_as, ::service::raft_timeout{});
+        co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name), c.is_superuser, c.can_login}, _as, ::service::raft_timeout{});
     }
 }
 
@@ -333,7 +333,7 @@ standard_role_manager::alter(std::string_view role_name, const role_config_updat
                     {sstring(role_name)},
                     cql3::query_processor::cache_internal::no).discard_result();
         } else {
-            return announce_mutations(_qp, _group0_client, std::move(query), {sstring(role_name)}, &_as, ::service::raft_timeout{});
+            return announce_mutations(_qp, _group0_client, std::move(query), {sstring(role_name)}, _as, ::service::raft_timeout{});
         }
     });
 }
@@ -383,7 +383,7 @@ future<> standard_role_manager::drop(std::string_view role_name) {
             co_await _qp.execute_internal(query, {sstring(role_name)},
                 cql3::query_processor::cache_internal::yes).discard_result();
         } else {
-            co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name)}, &_as, ::service::raft_timeout{});
+            co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name)}, _as, ::service::raft_timeout{});
         }
     };
     // Finally, delete the role itself.
@@ -401,7 +401,7 @@ future<> standard_role_manager::drop(std::string_view role_name) {
                     {sstring(role_name)},
                     cql3::query_processor::cache_internal::no).discard_result();
         } else {
-            co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name)}, &_as, ::service::raft_timeout{});
+            co_await announce_mutations(_qp, _group0_client, query, {sstring(role_name)}, _as, ::service::raft_timeout{});
         }
     };
 
@@ -434,7 +434,7 @@ standard_role_manager::modify_membership(
                     cql3::query_processor::cache_internal::no).discard_result();
         } else {
             co_await announce_mutations(_qp, _group0_client, std::move(query),
-                    {role_set{sstring(role_name)}, sstring(grantee_name)}, &_as, ::service::raft_timeout{});
+                    {role_set{sstring(role_name)}, sstring(grantee_name)}, _as, ::service::raft_timeout{});
         }
     };
 
@@ -453,7 +453,7 @@ standard_role_manager::modify_membership(
                             cql3::query_processor::cache_internal::no).discard_result();
                 } else {
                     co_return co_await announce_mutations(_qp, _group0_client, insert_query,
-                            {sstring(role_name), sstring(grantee_name)}, &_as, ::service::raft_timeout{});
+                            {sstring(role_name), sstring(grantee_name)}, _as, ::service::raft_timeout{});
                 }
             }
 
@@ -470,7 +470,7 @@ standard_role_manager::modify_membership(
                             cql3::query_processor::cache_internal::no).discard_result();
                 } else {
                     co_return co_await announce_mutations(_qp, _group0_client, delete_query,
-                            {sstring(role_name), sstring(grantee_name)}, &_as, ::service::raft_timeout{});
+                            {sstring(role_name), sstring(grantee_name)}, _as, ::service::raft_timeout{});
                 }
             }
         }
@@ -644,7 +644,7 @@ future<> standard_role_manager::set_attribute(std::string_view role_name, std::s
         co_await _qp.execute_internal(query, {sstring(role_name), sstring(attribute_name), sstring(attribute_value)}, cql3::query_processor::cache_internal::yes).discard_result();
     } else {
         co_await announce_mutations(_qp, _group0_client, query,
-                {sstring(role_name), sstring(attribute_name), sstring(attribute_value)}, &_as, ::service::raft_timeout{});
+                {sstring(role_name), sstring(attribute_name), sstring(attribute_value)}, _as, ::service::raft_timeout{});
     }
 }
 
@@ -659,7 +659,7 @@ future<> standard_role_manager::remove_attribute(std::string_view role_name, std
         co_await _qp.execute_internal(query, {sstring(role_name), sstring(attribute_name)}, cql3::query_processor::cache_internal::yes).discard_result();
     } else {
         co_await announce_mutations(_qp, _group0_client, query,
-                {sstring(role_name), sstring(attribute_name)}, &_as, ::service::raft_timeout{});
+                {sstring(role_name), sstring(attribute_name)}, _as, ::service::raft_timeout{});
     }
 }
 }

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -966,7 +966,7 @@ future<> migration_manager::announce_with_raft(std::vector<mutation> schema, gro
         },
         guard, std::move(description));
 
-    return _group0_client.add_entry(std::move(group0_cmd), std::move(guard), &_as);
+    return _group0_client.add_entry(std::move(group0_cmd), std::move(guard), _as);
 }
 
 future<> migration_manager::announce_without_raft(std::vector<mutation> schema, group0_guard guard) {
@@ -1053,7 +1053,7 @@ future<> migration_manager::announce<topology_change>(std::vector<mutation> sche
 
 future<group0_guard> migration_manager::start_group0_operation() {
     assert(this_shard_id() == 0);
-    return _group0_client.start_operation(&_as, raft_timeout{});
+    return _group0_client.start_operation(_as, raft_timeout{});
 }
 
 /**

--- a/service/qos/raft_service_level_distributed_data_accessor.cc
+++ b/service/qos/raft_service_level_distributed_data_accessor.cc
@@ -53,7 +53,7 @@ future<> raft_service_level_distributed_data_accessor::do_raft_command(service::
     };
 
     auto group0_cmd = _group0_client.prepare_command(change, guard, description);
-    co_await _group0_client.add_entry(std::move(group0_cmd), std::move(guard), &as);
+    co_await _group0_client.add_entry(std::move(group0_cmd), std::move(guard), as);
 }
 
 static void validate_state(const service::raft_group0_client& group0_client, const std::optional<service::group0_guard>& guard) {
@@ -87,7 +87,7 @@ future<> raft_service_level_distributed_data_accessor::set_service_level(sstring
 future<> raft_service_level_distributed_data_accessor::drop_service_level(sstring service_level_name, std::optional<service::group0_guard> guard, abort_source& as) const {
     //FIXME: remove this when `role_manager::remove_attribute()` will be done in one raft command
     if (!guard) {
-        guard = co_await _group0_client.start_operation(&as);
+        guard = co_await _group0_client.start_operation(as);
     }
 
     validate_state(_group0_client, guard);

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -492,7 +492,7 @@ future<> service_level_controller::migrate_to_v2(size_t nodes_count, db::system_
         val_binders_str += ", ?";
     }
     
-    auto guard = co_await group0_client.start_operation(&as);
+    auto guard = co_await group0_client.start_operation(as);
 
     std::vector<mutation> migration_muts;
     for (const auto& row: *rows) {
@@ -527,7 +527,7 @@ future<> service_level_controller::migrate_to_v2(size_t nodes_count, db::system_
         .mutations{migration_muts.begin(), migration_muts.end()},
     };
     auto group0_cmd = group0_client.prepare_command(change, guard, "migrate service levels to v2");
-    co_await group0_client.add_entry(std::move(group0_cmd), std::move(guard), &as);
+    co_await group0_client.add_entry(std::move(group0_cmd), std::move(guard), as);
 }
 
 future<> service_level_controller::do_remove_service_level(sstring name, bool remove_static) {

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -154,7 +154,7 @@ semaphore& raft_group0_client::operation_mutex() {
     return _operation_mutex;
 }
 
-future<> raft_group0_client::add_entry(group0_command group0_cmd, group0_guard guard, seastar::abort_source* as,
+future<> raft_group0_client::add_entry(group0_command group0_cmd, group0_guard guard, seastar::abort_source& as,
         std::optional<raft_timeout> timeout)
 {
     if (this_shard_id() != 0) {
@@ -238,7 +238,7 @@ static utils::UUID generate_group0_state_id(utils::UUID prev_state_id) {
     return utils::UUID_gen::get_random_time_UUID_from_micros(std::chrono::microseconds{ts});
 }
 
-future<group0_guard> raft_group0_client::start_operation(seastar::abort_source* as, std::optional<raft_timeout> timeout) {
+future<group0_guard> raft_group0_client::start_operation(seastar::abort_source& as, std::optional<raft_timeout> timeout) {
     if (this_shard_id() != 0) {
         on_internal_error(logger, "start_group0_operation: must run on shard 0");
     }
@@ -251,7 +251,7 @@ future<group0_guard> raft_group0_client::start_operation(seastar::abort_source* 
     switch (upgrade_state) {
         case group0_upgrade_state::use_post_raft_procedures: {
             auto operation_holder = co_await get_units(_operation_mutex, 1);
-            co_await _raft_gr.group0_with_timeouts().read_barrier(as, timeout);
+            co_await _raft_gr.group0_with_timeouts().read_barrier(&as, timeout);
 
             // Take `_group0_read_apply_mutex` *after* read barrier.
             // Read barrier may wait for `group0_state_machine::apply` which also takes this mutex.

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -250,12 +250,12 @@ future<group0_guard> raft_group0_client::start_operation(seastar::abort_source& 
     auto [upgrade_lock_holder, upgrade_state] = co_await get_group0_upgrade_state();
     switch (upgrade_state) {
         case group0_upgrade_state::use_post_raft_procedures: {
-            auto operation_holder = co_await get_units(_operation_mutex, 1);
+            auto operation_holder = co_await get_units(_operation_mutex, 1, as);
             co_await _raft_gr.group0_with_timeouts().read_barrier(&as, timeout);
 
             // Take `_group0_read_apply_mutex` *after* read barrier.
             // Read barrier may wait for `group0_state_machine::apply` which also takes this mutex.
-            auto read_apply_holder = co_await hold_read_apply_mutex();
+            auto read_apply_holder = co_await hold_read_apply_mutex(as);
 
             auto observed_group0_state_id = co_await _sys_ks.get_last_group0_state_id();
             auto new_group0_state_id = generate_group0_state_id(observed_group0_state_id);

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -107,7 +107,7 @@ public:
     // Call after `system_keyspace` is initialized.
     future<> init();
 
-    future<> add_entry(group0_command group0_cmd, group0_guard guard, seastar::abort_source* as, std::optional<raft_timeout> timeout = std::nullopt);
+    future<> add_entry(group0_command group0_cmd, group0_guard guard, seastar::abort_source& as, std::optional<raft_timeout> timeout = std::nullopt);
 
     future<> add_entry_unguarded(group0_command group0_cmd, seastar::abort_source* as);
 
@@ -131,7 +131,7 @@ public:
     // FIXME?: this is kind of annoying for the user.
     // we could forward the call to shard 0, have group0_guard keep a foreign_ptr to the internal data structures on shard 0,
     // and add_entry would again forward to shard 0.
-    future<group0_guard> start_operation(seastar::abort_source* as, std::optional<raft_timeout> timeout = std::nullopt);
+    future<group0_guard> start_operation(seastar::abort_source& as, std::optional<raft_timeout> timeout = std::nullopt);
 
     template<typename Command>
     requires std::same_as<Command, broadcast_table_query> || std::same_as<Command, write_mutations>

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -515,11 +515,11 @@ raft_server_with_timeouts::run_with_timeout(Op&& op, const char* op_name,
 }
 
 future<> raft_server_with_timeouts::add_entry(raft::command command, raft::wait_type type,
-        seastar::abort_source* as, std::optional<raft_timeout> timeout)
+        seastar::abort_source& as, std::optional<raft_timeout> timeout)
 {
     return run_with_timeout([&](abort_source* as) {
             return _group_server.server->add_entry(std::move(command), type, as);
-        }, "add_entry", as, timeout);
+        }, "add_entry", &as, timeout);
 }
 
 future<> raft_server_with_timeouts::modify_config(std::vector<raft::config_member> add, std::vector<raft::server_id> del,

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -92,7 +92,7 @@ class raft_server_with_timeouts {
     run_with_timeout(Op&& op, const char* op_name, seastar::abort_source* as, std::optional<raft_timeout> timeout);
 public:
     raft_server_with_timeouts(raft_server_for_group& group_server, raft_group_registry& registry);
-    future<> add_entry(raft::command command, raft::wait_type type, seastar::abort_source* as, std::optional<raft_timeout> timeout);
+    future<> add_entry(raft::command command, raft::wait_type type, seastar::abort_source& as, std::optional<raft_timeout> timeout);
     future<> modify_config(std::vector<raft::config_member> add, std::vector<raft::server_id> del, seastar::abort_source* as, std::optional<raft_timeout> timeout);
     future<> read_barrier(seastar::abort_source* as, std::optional<raft_timeout> timeout);
 };

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1011,7 +1011,7 @@ future<> storage_service::sstable_cleanup_fiber(raft::server& server, sharded<se
 
             {
                 // The scope for the guard
-                auto guard = co_await _group0->client().start_operation(&_group0_as);
+                auto guard = co_await _group0->client().start_operation(_group0_as);
                 auto me = _topology_state_machine._topology.find(server.id());
                 // Recheck that cleanup is needed after the barrier
                 if (!me || me->second.cleanup != cleanup_status::running) {
@@ -1048,7 +1048,7 @@ future<> storage_service::sstable_cleanup_fiber(raft::server& server, sharded<se
             rtlogger.info("cleanup ended");
 
             while (true) {
-                auto guard = co_await _group0->client().start_operation(&_group0_as);
+                auto guard = co_await _group0->client().start_operation(_group0_as);
                 topology_mutation_builder builder(guard.write_timestamp());
                 builder.with_node(server.id()).set("cleanup_status", cleanup_status::clean);
 
@@ -1056,7 +1056,7 @@ future<> storage_service::sstable_cleanup_fiber(raft::server& server, sharded<se
                 group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, ::format("cleanup completed for {}", server.id()));
 
                 try {
-                    co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as);
+                    co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as);
                 } catch (group0_concurrent_modification&) {
                     rtlogger.info("cleanup flag clearing: concurrent operation is detected, retrying.");
                     continue;
@@ -1273,7 +1273,7 @@ future<> storage_service::raft_initialize_discovery_leader(const join_node_reque
         }
 
         rtlogger.info("adding myself as the first node to the topology");
-        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+        auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
 
         auto insert_join_request_mutations = build_mutation_from_join_params(params, guard);
 
@@ -1296,7 +1296,7 @@ future<> storage_service::raft_initialize_discovery_leader(const join_node_reque
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard,
                 "bootstrap: adding myself as the first node to the topology");
         try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
         } catch (group0_concurrent_modification&) {
             rtlogger.info("bootstrap: concurrent operation is detected, retrying.");
         }
@@ -1345,7 +1345,7 @@ future<> storage_service::update_topology_with_local_metadata(raft::server& raft
     while (true) {
         rtlogger.info("refreshing topology to check if it's synchronized with local metadata");
 
-        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+        auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
 
         if (synchronized()) {
             break;
@@ -1383,7 +1383,7 @@ future<> storage_service::update_topology_with_local_metadata(raft::server& raft
                 std::move(change), guard, ::format("{}: update topology with local metadata", raft_server.id()));
 
         try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
         } catch (group0_concurrent_modification&) {
             rtlogger.info("update topology with local metadata:"
                          " concurrent operation is detected, retrying.");
@@ -1420,7 +1420,7 @@ future<> storage_service::start_upgrade_to_raft_topology() {
     }
 
     while (true) {
-        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+        auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
 
         if (_topology_state_machine._topology.upgrade_state != topology::upgrade_state_type::not_upgraded) {
             co_return;
@@ -1433,7 +1433,7 @@ future<> storage_service::start_upgrade_to_raft_topology() {
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, "upgrade: start");
 
         try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
             break;
         } catch (group0_concurrent_modification&) {
             rtlogger.info("upgrade: concurrent operation is detected, retrying.");
@@ -3531,7 +3531,7 @@ future<> storage_service::raft_decommission() {
     utils::UUID request_id;
 
     while (true) {
-        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+        auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
 
         auto it = _topology_state_machine._topology.find(raft_server.id());
         if (!it) {
@@ -3561,7 +3561,7 @@ future<> storage_service::raft_decommission() {
 
         request_id = guard.new_group0_state_id();
         try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
         } catch (group0_concurrent_modification&) {
             rtlogger.info("decommission: concurrent operation is detected, retrying.");
             continue;
@@ -3864,7 +3864,7 @@ future<> storage_service::raft_removenode(locator::host_id host_id, std::list<lo
     utils::UUID request_id;
 
     while (true) {
-        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+        auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
 
         auto it = _topology_state_machine._topology.find(id);
 
@@ -3921,7 +3921,7 @@ future<> storage_service::raft_removenode(locator::host_id host_id, std::list<lo
         try {
             // Make non voter during request submission for better HA
             co_await _group0->make_nonvoters(ignored_ids, _group0_as, raft_timeout{});
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
         } catch (group0_concurrent_modification&) {
             rtlogger.info("removenode: concurrent operation is detected, retrying.");
             continue;
@@ -4495,7 +4495,7 @@ future<> storage_service::do_cluster_cleanup() {
     auto& raft_server = _group0->group0_server();
 
     while (true) {
-        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+        auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
 
         auto curr_req = _topology_state_machine._topology.global_request;
         if (curr_req && *curr_req != global_topology_request::cleanup) {
@@ -4523,7 +4523,7 @@ future<> storage_service::do_cluster_cleanup() {
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, ::format("cleanup: cluster cleanup requested"));
 
         try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
         } catch (group0_concurrent_modification&) {
             rtlogger.info("cleanup: concurrent operation is detected, retrying.");
             continue;
@@ -4553,11 +4553,11 @@ future<sstring> storage_service::wait_for_topology_request_completion(utils::UUI
 }
 
 future<> storage_service::wait_for_topology_not_busy() {
-    auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+    auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
     while (_topology_state_machine._topology.is_busy()) {
         release_guard(std::move(guard));
         co_await _topology_state_machine.event.wait();
-        guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+        guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
     }
 }
 
@@ -4566,7 +4566,7 @@ future<> storage_service::raft_rebuild(sstring source_dc) {
     utils::UUID request_id;
 
     while (true) {
-        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+        auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
 
         auto it = _topology_state_machine._topology.find(raft_server.id());
         if (!it) {
@@ -4599,7 +4599,7 @@ future<> storage_service::raft_rebuild(sstring source_dc) {
         request_id = guard.new_group0_state_id();
 
         try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
         } catch (group0_concurrent_modification&) {
             rtlogger.info("rebuild: concurrent operation is detected, retrying.");
             continue;
@@ -4619,7 +4619,7 @@ future<> storage_service::raft_check_and_repair_cdc_streams() {
 
     while (true) {
         rtlogger.info("request check_and_repair_cdc_streams, refreshing topology");
-        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+        auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
         auto curr_req = _topology_state_machine._topology.global_request;
         if (curr_req && *curr_req != global_topology_request::new_cdc_generation) {
             // FIXME: replace this with a queue
@@ -4645,7 +4645,7 @@ future<> storage_service::raft_check_and_repair_cdc_streams() {
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard,
                 ::format("request check+repair CDC generation from {}", _group0->group0_server().id()));
         try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
         } catch (group0_concurrent_modification&) {
             rtlogger.info("request check+repair CDC: concurrent operation is detected, retrying.");
             continue;
@@ -5217,7 +5217,7 @@ future<> storage_service::process_tablet_split_candidate(table_id table) {
     while (!_async_gate.is_closed() && !_group0_as.abort_requested()) {
         try {
             // Ensures that latest changes to tablet metadata, in group0, are visible
-            auto guard = co_await _group0->client().start_operation(&_group0_as);
+            auto guard = co_await _group0->client().start_operation(_group0_as);
             auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
             if (!tmap.needs_split()) {
                 release_guard(std::move(guard));
@@ -6150,7 +6150,7 @@ future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables(
 
 future<> storage_service::transit_tablet(table_id table, dht::token token, noncopyable_function<std::tuple<std::vector<canonical_mutation>, sstring>(const locator::tablet_map&, api::timestamp_type)> prepare_mutations) {
     while (true) {
-        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+        auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
 
         while (_topology_state_machine._topology.is_busy()) {
             const auto tstate = *_topology_state_machine._topology.tstate;
@@ -6161,7 +6161,7 @@ future<> storage_service::transit_tablet(table_id table, dht::token token, nonco
             rtlogger.debug("transit_tablet(): topology state machine is busy: {}", tstate);
             release_guard(std::move(guard));
             co_await _topology_state_machine.event.wait();
-            guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+            guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
         }
 
         auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
@@ -6183,7 +6183,7 @@ future<> storage_service::transit_tablet(table_id table, dht::token token, nonco
         topology_change change{std::move(updates)};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, reason);
         try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
             break;
         } catch (group0_concurrent_modification&) {
             rtlogger.debug("transit_tablet(): concurrent modification, retrying");
@@ -6208,7 +6208,7 @@ future<> storage_service::set_tablet_balancing_enabled(bool enabled) {
     }
 
     while (true) {
-        group0_guard guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+        group0_guard guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
 
         std::vector<canonical_mutation> updates;
         updates.push_back(canonical_mutation(topology_mutation_builder(guard.write_timestamp())
@@ -6220,7 +6220,7 @@ future<> storage_service::set_tablet_balancing_enabled(bool enabled) {
         topology_change change{std::move(updates)};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, reason);
         try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
             break;
         } catch (group0_concurrent_modification&) {
             rtlogger.debug("set_tablet_balancing_enabled(): concurrent modification");
@@ -6361,7 +6361,7 @@ future<join_node_request_result> storage_service::join_node_request_handler(join
     }
 
     while (true) {
-        auto guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+        auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
 
         if (const auto *p = _topology_state_machine._topology.find(params.host_id)) {
             const auto& rs = p->second;
@@ -6415,7 +6415,7 @@ future<join_node_request_result> storage_service::join_node_request_handler(join
         try {
             // Make replaced node and ignored nodes non voters earlier for better HA
             co_await _group0->make_nonvoters(ignored_nodes_from_join_params(params), _group0_as, raft_timeout{});
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), &_group0_as, raft_timeout{});
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
             break;
         } catch (group0_concurrent_modification&) {
             rtlogger.info("join_node_request: concurrent operation is detected, retrying.");


### PR DESCRIPTION
Some of the calls inside the raft_group0_client::start_operation() method were missing the abort source parameter. This caused the repair test to be stuck in the shutdown phase - the abort source has been triggered, but the operations were not checking it.

This was in particular the case of operations that try to take the ownership of the raft group semaphore (get_units(semaphore)) - these waits should be cancelled when the abort source is triggered.

This should fix the following tests that were failing in some percentage of dtest runs (about 1-3 of 100):
* TestRepairAdditional::test_repair_kill_1
* TestRepairAdditional::test_repair_kill_3

Fixes #19223

(cherry picked from commit 2dbe9ef2f27c848152e82b2c31ea8c438d530a17)

(cherry picked from commit 5dfc50d35413f541ef02a88bde352f54f3945ceb)

Refs #19860