### PR TITLE
compaction: drop compaction executors' possibility to bypass task manager

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -575,7 +575,7 @@ requires std::is_base_of_v<compaction_task_executor, TaskExecutor> &&
 requires (compaction_manager& cm, throw_if_stopping do_throw_if_stopping, Args&&... args) {
     {TaskExecutor(cm, do_throw_if_stopping, std::forward<Args>(args)...)} -> std::same_as<TaskExecutor>;
 }
-future<compaction_manager::compaction_stats_opt> compaction_manager::perform_compaction(throw_if_stopping do_throw_if_stopping, std::optional<tasks::task_info> parent_info, Args&&... args) {
+future<compaction_manager::compaction_stats_opt> compaction_manager::perform_compaction(throw_if_stopping do_throw_if_stopping, tasks::task_info parent_info, Args&&... args) {
     auto task_executor = seastar::make_shared<TaskExecutor>(*this, do_throw_if_stopping, std::forward<Args>(args)...);
     _tasks.push_back(task_executor);
     auto unregister_task = defer([this, task_executor] {
@@ -583,14 +583,10 @@ future<compaction_manager::compaction_stats_opt> compaction_manager::perform_com
         task_executor->switch_state(compaction_task_executor::state::none);
     });
 
-    if (parent_info) {
-        auto task = co_await get_task_manager_module().make_task(task_executor, parent_info.value());
-        task->start();
-        co_await task->done();
-        co_return task_executor->get_stats();
-    } else {
-        co_return co_await perform_task(std::move(task_executor), do_throw_if_stopping);
-    }
+    auto task = co_await get_task_manager_module().make_task(task_executor, parent_info);
+    task->start();
+    co_await task->done();
+    co_return task_executor->get_stats();
 }
 
 std::optional<gate::holder> compaction_manager::start_compaction(table_state& t) {
@@ -606,13 +602,13 @@ std::optional<gate::holder> compaction_manager::start_compaction(table_state& t)
     return it->second.gate.hold();
 }
 
-future<> compaction_manager::perform_major_compaction(table_state& t, std::optional<tasks::task_info> info) {
+future<> compaction_manager::perform_major_compaction(table_state& t, tasks::task_info info) {
     auto gh = start_compaction(t);
     if (!gh) {
         co_return;
     }
 
-    co_await perform_compaction<major_compaction_task_executor>(throw_if_stopping::no, info, &t, info.value_or(tasks::task_info{}).id).discard_result();
+    co_await perform_compaction<major_compaction_task_executor>(throw_if_stopping::no, info, &t, info.id).discard_result();
 }
 
 namespace compaction {
@@ -669,13 +665,13 @@ protected:
 
 }
 
-future<> compaction_manager::run_custom_job(table_state& t, sstables::compaction_type type, const char* desc, noncopyable_function<future<>(sstables::compaction_data&, sstables::compaction_progress_monitor&)> job, std::optional<tasks::task_info> info, throw_if_stopping do_throw_if_stopping) {
+future<> compaction_manager::run_custom_job(table_state& t, sstables::compaction_type type, const char* desc, noncopyable_function<future<>(sstables::compaction_data&, sstables::compaction_progress_monitor&)> job, tasks::task_info info, throw_if_stopping do_throw_if_stopping) {
     auto gh = start_compaction(t);
     if (!gh) {
         co_return;
     }
 
-    co_return co_await perform_compaction<custom_compaction_task_executor>(do_throw_if_stopping, info, &t, info.value_or(tasks::task_info{}).id, type, desc, std::move(job)).discard_result();
+    co_return co_await perform_compaction<custom_compaction_task_executor>(do_throw_if_stopping, info, &t, info.id, type, desc, std::move(job)).discard_result();
 }
 
 future<> compaction_manager::update_static_shares(float static_shares) {
@@ -1500,14 +1496,14 @@ protected:
 
 }
 
-future<bool> compaction_manager::perform_offstrategy(table_state& t, std::optional<tasks::task_info> info) {
+future<bool> compaction_manager::perform_offstrategy(table_state& t, tasks::task_info info) {
     auto gh = start_compaction(t);
     if (!gh) {
         co_return false;
     }
 
     bool performed;
-    co_await perform_compaction<offstrategy_compaction_task_executor>(throw_if_stopping::no, info, &t, info.value_or(tasks::task_info{}).id, performed);
+    co_await perform_compaction<offstrategy_compaction_task_executor>(throw_if_stopping::no, info, &t, info.id, performed);
     co_return performed;
 }
 
@@ -1642,7 +1638,7 @@ protected:
 template<typename TaskType, typename... Args>
 requires std::derived_from<TaskType, compaction_task_executor> &&
          std::derived_from<TaskType, compaction_task_impl>
-future<compaction_manager::compaction_stats_opt> compaction_manager::perform_task_on_all_files(std::optional<tasks::task_info> info, table_state& t, sstables::compaction_type_options options, owned_ranges_ptr owned_ranges_ptr, get_candidates_func get_func, Args... args) {
+future<compaction_manager::compaction_stats_opt> compaction_manager::perform_task_on_all_files(tasks::task_info info, table_state& t, sstables::compaction_type_options options, owned_ranges_ptr owned_ranges_ptr, get_candidates_func get_func, Args... args) {
     auto gh = start_compaction(t);
     if (!gh) {
         co_return std::nullopt;
@@ -1670,12 +1666,12 @@ future<compaction_manager::compaction_stats_opt> compaction_manager::perform_tas
     if (sstables.empty()) {
         co_return std::nullopt;
     }
-    co_return co_await perform_compaction<TaskType>(throw_if_stopping::no, info, &t, info.value_or(tasks::task_info{}).id, std::move(options), std::move(owned_ranges_ptr), std::move(sstables), std::move(compacting), std::forward<Args>(args)...);
+    co_return co_await perform_compaction<TaskType>(throw_if_stopping::no, info, &t, info.id, std::move(options), std::move(owned_ranges_ptr), std::move(sstables), std::move(compacting), std::forward<Args>(args)...);
 }
 
 future<compaction_manager::compaction_stats_opt>
 compaction_manager::rewrite_sstables(table_state& t, sstables::compaction_type_options options, owned_ranges_ptr owned_ranges_ptr,
-                                     get_candidates_func get_func, std::optional<tasks::task_info> info, can_purge_tombstones can_purge,
+                                     get_candidates_func get_func, tasks::task_info info, can_purge_tombstones can_purge,
                                      sstring options_desc) {
     return perform_task_on_all_files<rewrite_sstables_compaction_task_executor>(info, t, std::move(options), std::move(owned_ranges_ptr), std::move(get_func), can_purge, std::move(options_desc));
 }
@@ -1744,14 +1740,14 @@ static std::vector<sstables::shared_sstable> get_all_sstables(table_state& t) {
     return s;
 }
 
-future<compaction_manager::compaction_stats_opt> compaction_manager::perform_sstable_scrub_validate_mode(table_state& t, std::optional<tasks::task_info> info) {
+future<compaction_manager::compaction_stats_opt> compaction_manager::perform_sstable_scrub_validate_mode(table_state& t, tasks::task_info info) {
     auto gh = start_compaction(t);
     if (!gh) {
         co_return compaction_stats_opt{};
     }
     // All sstables must be included, even the ones being compacted, such that everything in table is validated.
     auto all_sstables = get_all_sstables(t);
-    co_return co_await perform_compaction<validate_sstables_compaction_task_executor>(throw_if_stopping::no, info, &t, info.value_or(tasks::task_info{}).id, std::move(all_sstables));
+    co_return co_await perform_compaction<validate_sstables_compaction_task_executor>(throw_if_stopping::no, info, &t, info.id, std::move(all_sstables));
 }
 
 namespace compaction {
@@ -1917,7 +1913,7 @@ const std::unordered_set<sstables::shared_sstable>& compaction_manager::sstables
     return cs.sstables_requiring_cleanup;
 }
 
-future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_ranges, table_state& t, std::optional<tasks::task_info> info) {
+future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_ranges, table_state& t, tasks::task_info info) {
     auto gh = start_compaction(t);
     if (!gh) {
         co_return;
@@ -1962,7 +1958,7 @@ future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_range
     }
 }
 
-future<> compaction_manager::try_perform_cleanup(owned_ranges_ptr sorted_owned_ranges, table_state& t, std::optional<tasks::task_info> info) {
+future<> compaction_manager::try_perform_cleanup(owned_ranges_ptr sorted_owned_ranges, table_state& t, tasks::task_info info) {
     auto check_for_cleanup = [this, &t] {
         return boost::algorithm::any_of(_tasks, [&t] (auto& task) {
             return task->compacting_table() == &t && task->compaction_type() == sstables::compaction_type::Cleanup;
@@ -2019,7 +2015,7 @@ future<> compaction_manager::try_perform_cleanup(owned_ranges_ptr sorted_owned_r
 }
 
 // Submit a table to be upgraded and wait for its termination.
-future<> compaction_manager::perform_sstable_upgrade(owned_ranges_ptr sorted_owned_ranges, table_state& t, bool exclude_current_version, std::optional<tasks::task_info> info) {
+future<> compaction_manager::perform_sstable_upgrade(owned_ranges_ptr sorted_owned_ranges, table_state& t, bool exclude_current_version, tasks::task_info info) {
     auto get_sstables = [this, &t, exclude_current_version] {
         std::vector<sstables::shared_sstable> tables;
 
@@ -2046,7 +2042,7 @@ future<> compaction_manager::perform_sstable_upgrade(owned_ranges_ptr sorted_own
     return rewrite_sstables(t, sstables::compaction_type_options::make_upgrade(), std::move(sorted_owned_ranges), std::move(get_sstables), info).discard_result();
 }
 
-future<compaction_manager::compaction_stats_opt> compaction_manager::perform_split_compaction(table_state& t, sstables::compaction_type_options::split opt, std::optional<tasks::task_info> info) {
+future<compaction_manager::compaction_stats_opt> compaction_manager::perform_split_compaction(table_state& t, sstables::compaction_type_options::split opt, tasks::task_info info) {
     auto get_sstables = [this, &t] {
         return make_ready_future<std::vector<sstables::shared_sstable>>(get_candidates(t));
     };
@@ -2057,7 +2053,7 @@ future<compaction_manager::compaction_stats_opt> compaction_manager::perform_spl
 }
 
 // Submit a table to be scrubbed and wait for its termination.
-future<compaction_manager::compaction_stats_opt> compaction_manager::perform_sstable_scrub(table_state& t, sstables::compaction_type_options::scrub opts, std::optional<tasks::task_info> info) {
+future<compaction_manager::compaction_stats_opt> compaction_manager::perform_sstable_scrub(table_state& t, sstables::compaction_type_options::scrub opts, tasks::task_info info) {
     auto scrub_mode = opts.operation_mode;
     if (scrub_mode == sstables::compaction_type_options::scrub::mode::validate) {
         return perform_sstable_scrub_validate_mode(t, info);

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -131,7 +131,7 @@ distribute_reshard_jobs(sstables::sstable_directory::sstable_open_info_vector so
 // A creator function must be passed that will create an SSTable object in the correct shard,
 // and an I/O priority must be specified.
 future<> reshard(sstables::sstable_directory& dir, sstables::sstable_directory::sstable_open_info_vector shared_info, replica::table& table,
-                           sstables::compaction_sstable_creator_fn creator, compaction::owned_ranges_ptr owned_ranges_ptr, std::optional<tasks::task_info> parent_info)
+                           sstables::compaction_sstable_creator_fn creator, compaction::owned_ranges_ptr owned_ranges_ptr, tasks::task_info parent_info)
 {
     // Resharding doesn't like empty sstable sets, so bail early. There is nothing
     // to reshard in this shard.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -925,7 +925,7 @@ public:
     // Start a compaction of all sstables in a process known as major compaction
     // Active memtable is flushed first to guarantee that data like tombstone,
     // sitting in the memtable, will be compacted with shadowed data.
-    future<> compact_all_sstables(std::optional<tasks::task_info> info = std::nullopt, do_flush = do_flush::yes);
+    future<> compact_all_sstables(tasks::task_info info, do_flush = do_flush::yes);
 
     future<bool> snapshot_exists(sstring name);
 
@@ -997,9 +997,9 @@ public:
     // Performs offstrategy compaction, if needed, returning
     // a future<bool> that is resolved when offstrategy_compaction completes.
     // The future value is true iff offstrategy compaction was required.
-    future<bool> perform_offstrategy_compaction(std::optional<tasks::task_info> info = std::nullopt);
+    future<bool> perform_offstrategy_compaction(tasks::task_info info);
     future<> perform_cleanup_compaction(owned_ranges_ptr sorted_owned_ranges,
-                                        std::optional<tasks::task_info> info = std::nullopt,
+                                        tasks::task_info info,
                                         do_flush = do_flush::yes);
     unsigned estimate_pending_compactions() const;
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -851,7 +851,7 @@ future<> storage_group::split(sstables::compaction_type_options::split opt) {
     }
 
     co_await _main_cg->flush();
-    co_await _main_cg->get_compaction_manager().perform_split_compaction(_main_cg->as_table_state(), std::move(opt));
+    co_await _main_cg->get_compaction_manager().perform_split_compaction(_main_cg->as_table_state(), std::move(opt), tasks::task_info{});
 }
 
 lw_shared_ptr<const sstables::sstable_set> storage_group::make_sstable_set() const {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1833,7 +1833,7 @@ compaction_group::update_main_sstable_list_on_compaction_completion(sstables::co
 }
 
 future<>
-table::compact_all_sstables(std::optional<tasks::task_info> info, do_flush do_flush) {
+table::compact_all_sstables(tasks::task_info info, do_flush do_flush) {
     if (do_flush) {
         co_await flush();
     }
@@ -1882,7 +1882,7 @@ void table::trigger_offstrategy_compaction() {
     });
 }
 
-future<bool> table::perform_offstrategy_compaction(std::optional<tasks::task_info> info) {
+future<bool> table::perform_offstrategy_compaction(tasks::task_info info) {
     // If the user calls trigger_offstrategy_compaction() to trigger
     // off-strategy explicitly, cancel the timeout based automatic trigger.
     _off_strategy_trigger.cancel();
@@ -1894,7 +1894,7 @@ future<bool> table::perform_offstrategy_compaction(std::optional<tasks::task_inf
 }
 
 future<> table::perform_cleanup_compaction(compaction::owned_ranges_ptr sorted_owned_ranges,
-                                           std::optional<tasks::task_info> info,
+                                           tasks::task_info info,
                                            do_flush do_flush) {
     auto* cg = try_get_compaction_group_with_static_sharding();
     if (!cg) {

--- a/test/boost/compaction_group_test.cc
+++ b/test/boost/compaction_group_test.cc
@@ -156,7 +156,7 @@ SEASTAR_TEST_CASE(basic_compaction_group_splitting_test) {
                 return sstable_needs_split(sst) ? sst->bytes_on_disk() : size_t(0);
             }), int64_t(0));
 
-            auto ret = cm.perform_split_compaction(*compaction_group, sstables::compaction_type_options::split{classifier}).get();
+            auto ret = cm.perform_split_compaction(*compaction_group, sstables::compaction_type_options::split{classifier}, tasks::task_info{}).get();
             BOOST_REQUIRE_EQUAL(ret->start_size, expected_compaction_size);
 
             BOOST_REQUIRE(compaction_group->main_sstable_set().size() == expected_output);

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -125,7 +125,7 @@ SEASTAR_THREAD_TEST_CASE(test_large_data) {
         flush(e);
         e.db().invoke_on_all([] (replica::database& dbi) {
             return dbi.get_tables_metadata().parallel_for_each_table([&dbi] (table_id, lw_shared_ptr<replica::table> t) {
-                return dbi.get_compaction_manager().perform_major_compaction(t->try_get_table_state_with_static_sharding());
+                return dbi.get_compaction_manager().perform_major_compaction(t->try_get_table_state_with_static_sharding(), tasks::task_info{});
             });
         }).get();
 

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1222,7 +1222,7 @@ SEASTAR_TEST_CASE(upgrade_sstables) {
                     auto& t = db.find_column_family(schema->id());
                     constexpr bool exclude_current_version = false;
                     co_await t.parallel_foreach_table_state([&] (compaction::table_state& ts) {
-                        return cm.perform_sstable_upgrade(owned_ranges_ptr, ts, exclude_current_version);
+                        return cm.perform_sstable_upgrade(owned_ranges_ptr, ts, exclude_current_version, tasks::task_info{});
                     });
                 }
             }

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -1026,7 +1026,7 @@ SEASTAR_TEST_CASE(sstable_compaction_does_not_resurrect_data) {
 
         // Trigger compaction. If all goes well, compaction should check if a relevant row is in the memtable
         // and should not purge the tombstone.
-        t.compact_all_sstables().get();
+        t.compact_all_sstables(tasks::task_info{}).get();
 
         // If we get additional row (1, 2, 4), that means the tombstone was purged and data was resurrected
         assert_that(env.execute_cql(format("SELECT * FROM {}.{};", ks_name, table_name)).get())

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2123,7 +2123,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_scrub_validate_mode_test) {
         sstables::compaction_type_options::scrub opts = {
             .operation_mode = sstables::compaction_type_options::scrub::mode::validate,
         };
-        table->get_compaction_manager().perform_sstable_scrub(ts, opts).get();
+        table->get_compaction_manager().perform_sstable_scrub(ts, opts, tasks::task_info{}).get();
 
         BOOST_REQUIRE(sst->is_quarantined());
         BOOST_REQUIRE(in_strategy_sstables(ts).empty());
@@ -2145,7 +2145,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_scrub_validate_mode_test_valid_sstable) {
         sstables::compaction_type_options::scrub opts = {
             .operation_mode = sstables::compaction_type_options::scrub::mode::validate,
         };
-        table->get_compaction_manager().perform_sstable_scrub(ts, opts).get();
+        table->get_compaction_manager().perform_sstable_scrub(ts, opts, tasks::task_info{}).get();
 
         BOOST_REQUIRE(!sst->is_quarantined());
         BOOST_REQUIRE_EQUAL(in_strategy_sstables(ts).size(), 1);
@@ -2281,7 +2281,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_scrub_abort_mode_test) {
         // We expect the scrub with mode=srub::mode::abort to stop on the first invalid fragment.
         sstables::compaction_type_options::scrub opts = {};
         opts.operation_mode = sstables::compaction_type_options::scrub::mode::abort;
-        BOOST_REQUIRE_THROW(table->get_compaction_manager().perform_sstable_scrub(ts, opts).get(), sstables::compaction_aborted_exception);
+        BOOST_REQUIRE_THROW(table->get_compaction_manager().perform_sstable_scrub(ts, opts, tasks::task_info{}).get(), sstables::compaction_aborted_exception);
 
         BOOST_REQUIRE(in_strategy_sstables(ts).size() == 1);
         BOOST_REQUIRE(in_strategy_sstables(ts).front() == sst);
@@ -2327,7 +2327,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_scrub_skip_mode_test) {
         // We expect the scrub with mode=srub::mode::skip to get rid of all invalid data.
         sstables::compaction_type_options::scrub opts = {};
         opts.operation_mode = sstables::compaction_type_options::scrub::mode::skip;
-        table->get_compaction_manager().perform_sstable_scrub(ts, opts).get();
+        table->get_compaction_manager().perform_sstable_scrub(ts, opts, tasks::task_info{}).get();
 
         BOOST_REQUIRE(in_strategy_sstables(ts).size() == 1);
         BOOST_REQUIRE(in_strategy_sstables(ts).front() != sst);
@@ -2368,7 +2368,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_scrub_segregate_mode_test) {
         // We expect the scrub with mode=srub::mode::segregate to fix all out-of-order data.
         sstables::compaction_type_options::scrub opts = {};
         opts.operation_mode = sstables::compaction_type_options::scrub::mode::segregate;
-        table->get_compaction_manager().perform_sstable_scrub(ts, opts).get();
+        table->get_compaction_manager().perform_sstable_scrub(ts, opts, tasks::task_info{}).get();
 
         testlog.info("Scrub resulted in {} sstables", in_strategy_sstables(ts).size());
         BOOST_REQUIRE(in_strategy_sstables(ts).size() > 1);
@@ -2410,7 +2410,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_scrub_quarantine_mode_test) {
             // We expect the scrub with mode=scrub::mode::validate to quarantine the sstable.
             sstables::compaction_type_options::scrub opts = {};
             opts.operation_mode = sstables::compaction_type_options::scrub::mode::validate;
-            table->get_compaction_manager().perform_sstable_scrub(ts, opts).get();
+            table->get_compaction_manager().perform_sstable_scrub(ts, opts, tasks::task_info{}).get();
 
             BOOST_REQUIRE(in_strategy_sstables(ts).empty());
             BOOST_REQUIRE(sst->is_quarantined());
@@ -2421,7 +2421,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_scrub_quarantine_mode_test) {
             // We expect the scrub with mode=scrub::mode::segregate to fix all out-of-order data.
             opts.operation_mode = sstables::compaction_type_options::scrub::mode::segregate;
             opts.quarantine_operation_mode = qmode;
-            table->get_compaction_manager().perform_sstable_scrub(ts, opts).get();
+            table->get_compaction_manager().perform_sstable_scrub(ts, opts, tasks::task_info{}).get();
 
             switch (qmode) {
             case sstables::compaction_type_options::scrub::quarantine_mode::include:
@@ -2924,7 +2924,7 @@ SEASTAR_TEST_CASE(partial_sstable_run_filtered_out_test) {
 
         // register partial sstable run
         run_compaction_task(env, partial_sstable_run_identifier, cf.as_table_state(), [&cf] (sstables::compaction_data&) {
-            return cf->compact_all_sstables();
+            return cf->compact_all_sstables(tasks::task_info{});
         }).get();
 
         // make sure partial sstable run has none of its fragments compacted.
@@ -3712,7 +3712,7 @@ SEASTAR_TEST_CASE(test_offstrategy_sstable_compaction) {
                 auto sst = make_sstable_containing(sst_gen, {mut});
                 cf->add_sstable_and_update_cache(std::move(sst), sstables::offstrategy::yes).get();
             }
-            BOOST_REQUIRE(cf->perform_offstrategy_compaction().get());
+            BOOST_REQUIRE(cf->perform_offstrategy_compaction(tasks::task_info{}).get());
         }
     });
 }
@@ -4388,7 +4388,7 @@ SEASTAR_TEST_CASE(test_major_does_not_miss_data_in_memtable) {
         }();
         cf->apply(deletion_mut);
 
-        cf->compact_all_sstables().get();
+        cf->compact_all_sstables(tasks::task_info{}).get();
         assert_table_sstable_count(cf, 1);
         auto new_sst = *(cf->get_sstables()->begin());
         BOOST_REQUIRE(new_sst->generation() != sst->generation());
@@ -5055,7 +5055,7 @@ static future<> run_incremental_compaction_test(sstables::offstrategy offstrateg
 
 SEASTAR_TEST_CASE(cleanup_incremental_compaction_test) {
     return run_incremental_compaction_test(sstables::offstrategy::no, [] (table_for_tests& t, owned_ranges_ptr owned_ranges) -> future<> {
-        return t->perform_cleanup_compaction(std::move(owned_ranges));
+        return t->perform_cleanup_compaction(std::move(owned_ranges), tasks::task_info{});
     });
 }
 
@@ -5145,7 +5145,7 @@ SEASTAR_TEST_CASE(cleanup_during_offstrategy_incremental_compaction_test) {
             }
             ssts = {}; // releases references
             auto owned_ranges_ptr = make_lw_shared<const dht::token_range_vector>(std::move(owned_token_ranges));
-            t->perform_cleanup_compaction(std::move(owned_ranges_ptr)).get();
+            t->perform_cleanup_compaction(std::move(owned_ranges_ptr), tasks::task_info{}).get();
             BOOST_REQUIRE(cm.sstables_requiring_cleanup(t->try_get_table_state_with_static_sharding()).empty());
             testlog.info("Cleanup has finished");
         }

--- a/test/boost/view_complex_test.cc
+++ b/test/boost/view_complex_test.cc
@@ -842,7 +842,7 @@ void test_commutative_row_deletion(cql_test_env& e, std::function<void()>&& mayb
         }});
     });
 
-    e.local_db().get_compaction_manager().perform_major_compaction(e.local_db().find_column_family("ks", "vcf").try_get_table_state_with_static_sharding()).get();
+    e.local_db().get_compaction_manager().perform_major_compaction(e.local_db().find_column_family("ks", "vcf").try_get_table_state_with_static_sharding(), tasks::task_info{}).get();
 }
 
 SEASTAR_TEST_CASE(test_commutative_row_deletion_without_flush) {
@@ -1078,7 +1078,7 @@ void test_update_with_column_timestamp_bigger_than_pk(cql_test_env& e, std::func
         }});
     });
 
-    e.local_db().get_compaction_manager().perform_major_compaction(e.local_db().find_column_family("ks", "vcf").try_get_table_state_with_static_sharding()).get();
+    e.local_db().get_compaction_manager().perform_major_compaction(e.local_db().find_column_family("ks", "vcf").try_get_table_state_with_static_sharding(), tasks::task_info{}).get();
     eventually([&] {
         auto msg = e.execute_cql("select * from vcf limit 1").get();
         assert_that(msg).is_rows().with_rows({{

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -1807,7 +1807,7 @@ void populate(const std::vector<dataset*>& datasets, cql_test_env& env, const ta
         }).get();
 
         std::cout << "compacting...\n";
-        cf.compact_all_sstables().get();
+        cf.compact_all_sstables(tasks::task_info{}).get();
     }
 }
 


### PR DESCRIPTION
If parent_info argument of compaction_manager::perform_compaction
is std::nullopt, then created compaction executor isn't tracked by task 
manager. Currently, all compaction operations should by visible in task 
manager.

Modify split methods to keep split executor in task manager. Get rid of
the option to bypass task manager.