### PR TITLE
Always pass `abort_source&` to `raft_group0_client::hold_read_apply_mutex`

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1458,12 +1458,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     ss::reload_raft_topology_state.set(r,
             [&ss, &group0_client] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         co_await ss.invoke_on(0, [&group0_client] (service::storage_service& ss) -> future<> {
-            apilog.info("Waiting for group 0 read/apply mutex before reloading Raft topology state...");
-            auto holder = co_await group0_client.hold_read_apply_mutex();
-            apilog.info("Reloading Raft topology state");
-            // Using topology_transition() instead of topology_state_load(), because the former notifies listeners
-            co_await ss.topology_transition();
-            apilog.info("Reloaded Raft topology state");
+            return ss.reload_raft_topology_state(group0_client);
         });
         co_return json_void();
     });

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -434,14 +434,6 @@ future<> raft_group0_client::wait_until_group0_upgraded(abort_source& as) {
     }
 }
 
-future<semaphore_units<>> raft_group0_client::hold_read_apply_mutex() {
-    if (this_shard_id() != 0) {
-        on_internal_error(logger, "hold_read_apply_mutex: must run on shard 0");
-    }
-
-    return get_units(_read_apply_mutex, 1);
-}
-
 future<semaphore_units<>> raft_group0_client::hold_read_apply_mutex(abort_source& as) {
     if (this_shard_id() != 0) {
         on_internal_error(logger, "hold_read_apply_mutex: must run on shard 0");

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -177,7 +177,6 @@ public:
     // Wait until group 0 upgrade enters the `use_post_raft_procedures` state.
     future<> wait_until_group0_upgraded(abort_source&);
 
-    future<semaphore_units<>> hold_read_apply_mutex();
     future<semaphore_units<>> hold_read_apply_mutex(abort_source&);
 
     db::system_keyspace& sys_ks();


### PR DESCRIPTION
There are two versions of `raft_group0_client::hold_read_apply_mutex`, one takes `abort_source&`, the other doesn't. Modify all call sites that used the non-abort-source version to pass an `abort_source&`, allowing us to remove the other overload.

If there is no explicit reason not to pass an `abort_source&`, then one should be passed by default -- it often prevents hangs during shutdown.

---

No backport needed -- no known issues affected by this change.