### PR TITLE
raft topology: improve logging

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3618,13 +3618,16 @@ future<> storage_service::raft_decommission() {
         break;
     }
 
+    rtlogger.info("decommission: waiting for completion (request ID: {})", request_id);
     auto error = co_await wait_for_topology_request_completion(request_id);
 
     if (error.empty()) {
         // Need to set it otherwise gossiper will try to send shutdown on exit
+        rtlogger.info("decommission: successfully removed from topology (request ID: {}), updating gossip status", request_id);
         co_await _gossiper.add_local_application_state(std::pair(gms::application_state::STATUS, gms::versioned_value::left({}, _gossiper.now().time_since_epoch().count())));
+        rtlogger.info("Decommission succeeded. Request ID: {}", request_id);
     } else  {
-        auto err = fmt::format("Decommission failed. See earlier errors ({})", error);
+        auto err = fmt::format("Decommission failed. See earlier errors ({}). Request ID: {}", error, request_id);
         rtlogger.error("{}", err);
         throw std::runtime_error(err);
     }
@@ -3982,19 +3985,21 @@ future<> storage_service::raft_removenode(locator::host_id host_id, std::list<lo
         break;
     }
 
-    rtlogger.info("removenode: wait for completion");
+    rtlogger.info("removenode: waiting for completion (request ID: {})", request_id);
 
     // Wait until request completes
     auto error = co_await wait_for_topology_request_completion(request_id);
 
     if (error.empty()) {
+        rtlogger.info("removenode: successfully removed from topology (request ID: {}), removing from group 0 configuration", request_id);
         try {
             co_await _group0->remove_from_raft_config(id);
         } catch (raft::not_a_member&) {
             rtlogger.info("removenode: already removed from the raft config by the topology coordinator");
         }
+        rtlogger.info("Removenode succeeded. Request ID: {}", request_id);
     } else {
-        auto err = fmt::format("Removenode failed. See earlier errors ({})", error);
+        auto err = fmt::format("Removenode failed. See earlier errors ({}). Request ID: {}", error, request_id);
         rtlogger.error("{}", err);
         throw std::runtime_error(err);
     }

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -294,7 +294,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
      };
 
     future<group0_guard> start_operation() {
+        rtlogger.debug("obtaining group 0 guard...");
         auto guard = co_await _group0.client().start_operation(_as);
+        rtlogger.debug("guard taken, prev_state_id: {}, new_state_id: {}, coordinator term: {}, current Raft term: {}",
+                       guard.observed_group0_state_id(), guard.new_group0_state_id(), _term, _raft.get_current_term());
 
         if (_term != _raft.get_current_term()) {
             throw term_changed_error{};
@@ -2338,7 +2341,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 topology_mutation_builder builder(node.guard.write_timestamp());
                 builder.with_node(id).set("cleanup_status", cleanup_status::needed);
                 muts.emplace_back(builder.build());
-                rtlogger.trace("mark node {} as needed cleanup", id);
+                rtlogger.debug("mark node {} as needed for cleanup", id);
             }
         }
         return muts;
@@ -2359,7 +2362,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 topology_mutation_builder builder(guard.write_timestamp());
                 builder.with_node(id).set("cleanup_status", cleanup_status::running);
                 muts.emplace_back(builder.build());
-                rtlogger.trace("mark node {} as cleanup running", id);
+                rtlogger.debug("mark node {} as cleanup running", id);
             }
         }
         if (!muts.empty()) {

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -149,6 +149,7 @@ SCYLLA_CMDLINE_OPTIONS = [
     '--abort-on-ebadf', '1',
     '--logger-log-level', 'raft_topology=debug',
     '--logger-log-level', 'query_processor=debug',
+    '--logger-log-level', 'group0_raft_sm=trace',
 ]
 
 # [--smp, 1], [--smp, 2] -> [--smp, 2]

--- a/test/topology/test_coordinator_queue_management.py
+++ b/test/topology/test_coordinator_queue_management.py
@@ -48,8 +48,8 @@ async def test_coordinator_queue_management(manager: ManagerClient):
 
     await wait_for_first_completed([l.wait_for("received request to join from host_id", m) for l, m in zip(logs[:3], marks[:3])])
 
-    marks[0] = await logs[0].wait_for("raft_topology - removenode: wait for completion", marks[0])
-    marks[0] = await logs[0].wait_for("raft_topology - removenode: wait for completion", marks[0])
+    marks[0] = await logs[0].wait_for("raft_topology - removenode: waiting for completion", marks[0])
+    marks[0] = await logs[0].wait_for("raft_topology - removenode: waiting for completion", marks[0])
 
     [await manager.api.message_injection(s.ip_addr, inj) for s in servers[:3]]
 
@@ -68,10 +68,7 @@ async def test_coordinator_queue_management(manager: ManagerClient):
 
     await wait_for_first_completed([l.wait_for("received request to join from host_id", m) for l, m in zip(logs[:3], marks[:3])])
 
-    # FIXME: we aren't actually awaiting this log -- this line is missing an `await`.
-    # But this log was actually removed in commit d576ed31dce292997d1cf32af5a9e89768b154d7.
-    # Should we be waiting for something else, or for nothing at all?
-    logs[1].wait_for("raft_topology - decommission: wait for completion", marks[1])
+    await logs[1].wait_for("raft_topology - decommission: waiting for completion", marks[1])
 
     [await manager.api.message_injection(s.ip_addr, inj) for s in servers[:3]]
 


### PR DESCRIPTION
Add more logging for raft-based topology operations in INFO and DEBUG levels.

Improve the existing logging, adding more details.

Enable group0_state_machine logging at TRACE level in tests. These logs are relatively rare (group 0 commands are used for metadata operations) and relatively small, mostly consist of printing `system.group0_history` mutation in the applied command, for example:
```
TRACE 2024-08-02 18:47:12,238 [shard 0: gms] group0_raft_sm - apply() is called with 1 commands
TRACE 2024-08-02 18:47:12,238 [shard 0: gms] group0_raft_sm - cmd: prev_state_id: optional(dd9d47c6-50ee-11ef-d77f-500b8e1edde3), new_state_id: dd9ea5c6-50ee-11ef-ae64-dfbcd08d72c3, creator_addr: 127.219.233.1, creator_id: 02679305-b9d1-41ef-866d-d69be156c981
TRACE 2024-08-02 18:47:12,238 [shard 0: gms] group0_raft_sm - cmd.history_append: {canonical_mutation: table_id 027e42f5-683a-3ed7-b404-a0100762063c schema_version c9c345e1-428f-36e0-b7d5-9af5f985021e partition_key pk{0007686973746f7279} partition_tombstone {tombstone: none}, row tombstone {range_tombstone: start={position: clustered, ckp{0010b4ba65c64b6e11ef8080808080808080}, 1}, end={position: clustered, ckp{}, 1}, {tombstone: timestamp=1722617232237511, deletion_time=1722617232}}{row {position: clustered, ckp{0010dd9ea5c650ee11efae64dfbcd08d72c3}, 0} tombstone {row_tombstone: none} marker {row_marker: 1722617232237511 0 0}, column description atomic_cell{ create system_distributed keyspace; create system_distributed_everywhere keyspace; create and update system_distributed(_everywhere) tables,ts=1722617232237511,expiry=-1,ttl=0}}}
```
note that the mutation contains a human-readable description of the command -- like "create system_distributed keyspace" above.

These logs might help debugging various issues (e.g. when `apply` hangs waiting for read_apply mutex, or takes too long to apply a command).

Ref: scylladb/scylladb#19105
Ref: scylladb/scylladb#19945