### PR TITLE
sstable_directory: use return_exception_ptr() when appropriate

### DIFF
--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -314,9 +314,7 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
     co_await lister.close();
     if (ex) {
         dirlog.debug("Could not process sstable directory {}: {}", _directory, ex);
-        // FIXME: waiting for https://github.com/scylladb/seastar/pull/1090
-        // co_await coroutine::return_exception(std::move(ex));
-        std::rethrow_exception(std::move(ex));
+        co_await coroutine::return_exception_ptr(std::move(ex));
     }
 
     // Always okay to delete files with a temporary TOC. We want to do it before we process


### PR DESCRIPTION
instead of using `std::rethrow_exception()`, use
`coroutine::return_exception_ptr()` which is a little bit  more efficient.

See also 6cafd83e1cc1fad28ca01d15e89a0e258a33c39b

---

it's a cleanup, hence no need to backport.