### PR TITLE
tools: Enhance scylla sstable shard-of to support tablets

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1337,6 +1337,7 @@ scylla_tools = ['tools/read_mutation.cc',
                 'tools/scylla-sstable.cc',
                 'tools/scylla-nodetool.cc',
                 'tools/schema_loader.cc',
+                'tools/load_system_tablets.cc',
                 'tools/utils.cc',
                 'tools/lua_sstable_consumer.cc']
 scylla_perfs = ['test/perf/perf_alternator.cc',

--- a/configure.py
+++ b/configure.py
@@ -1332,7 +1332,8 @@ scylla_tests_dependencies = scylla_core + alternator + idls + scylla_tests_gener
 
 scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc', 'utils/error_injection.cc', 'utils/exceptions.cc']
 
-scylla_tools = ['tools/scylla-types.cc',
+scylla_tools = ['tools/read_mutation.cc',
+                'tools/scylla-types.cc',
                 'tools/scylla-sstable.cc',
                 'tools/scylla-nodetool.cc',
                 'tools/schema_loader.cc',
@@ -1488,7 +1489,7 @@ deps['test/boost/exceptions_optimized_test'] = ['test/boost/exceptions_optimized
 deps['test/boost/exceptions_fallback_test'] = ['test/boost/exceptions_fallback_test.cc', 'utils/exceptions.cc']
 
 deps['test/boost/duration_test'] += ['test/lib/exception_utils.cc']
-deps['test/boost/schema_loader_test'] += ['tools/schema_loader.cc']
+deps['test/boost/schema_loader_test'] += ['tools/schema_loader.cc', 'tools/read_mutation.cc']
 deps['test/boost/rust_test'] += ['rust/inc/src/lib.rs']
 
 deps['test/boost/group0_cmd_merge_test'] += ['test/lib/expr_test_utils.cc']

--- a/configure.py
+++ b/configure.py
@@ -1332,7 +1332,12 @@ scylla_tests_dependencies = scylla_core + alternator + idls + scylla_tests_gener
 
 scylla_raft_dependencies = scylla_raft_core + ['utils/uuid.cc', 'utils/error_injection.cc', 'utils/exceptions.cc']
 
-scylla_tools = ['tools/scylla-types.cc', 'tools/scylla-sstable.cc', 'tools/scylla-nodetool.cc', 'tools/schema_loader.cc', 'tools/utils.cc', 'tools/lua_sstable_consumer.cc']
+scylla_tools = ['tools/scylla-types.cc',
+                'tools/scylla-sstable.cc',
+                'tools/scylla-nodetool.cc',
+                'tools/schema_loader.cc',
+                'tools/utils.cc',
+                'tools/lua_sstable_consumer.cc']
 scylla_perfs = ['test/perf/perf_alternator.cc',
                 'test/perf/perf_fast_forward.cc',
                 'test/perf/perf_row_cache_update.cc',

--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -654,7 +654,7 @@ shard-of
 
 Print out the shards which own the specified SSTables.
 
-The content is dumped in JSON, using the following schema:
+The content is dumped in JSON, using the following schema when ``--vnodes`` command option is specified:
 
 .. code-block:: none
     :class: hide-copy-button

--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -71,6 +71,9 @@ std::optional<locator::tablet_metadata_change_hint> get_tablet_metadata_change_h
 /// If the mutation belongs to another table, no updates are done.
 void update_tablet_metadata_change_hint(locator::tablet_metadata_change_hint&, const mutation&);
 
+/// Reads the replica set from given cell value
+locator::tablet_replica_set tablet_replica_set_from_cell(const data_value&);
+
 /// Reads tablet metadata from system.tablets.
 future<locator::tablet_metadata> read_tablet_metadata(cql3::query_processor&);
 

--- a/test/cql-pytest/test_tools.py
+++ b/test/cql-pytest/test_tools.py
@@ -1180,7 +1180,7 @@ def _simple_table_with_keys(cql, keyspace: str, keys: Iterable[int]) -> tuple[st
     return table, schema
 
 
-def test_scylla_sstable_shard_of(cql, test_keyspace, scylla_path, scylla_data_dir) -> None:
+def test_scylla_sstable_shard_of_vnodes(cql, test_keyspace_vnodes, scylla_path, scylla_data_dir) -> None:
     # cql-pytest/run.py::run_scylla_cmd() passes "--smp 2" to scylla, so we
     # need to be consistent with it to get the correct sstable-shard mapping
     scylla_option_smp = 2
@@ -1190,9 +1190,10 @@ def test_scylla_sstable_shard_of(cql, test_keyspace, scylla_path, scylla_data_di
         all_keys_for_shard = _generate_key_for_shard(scylla_path, shards, shard_id)
         keys = itertools.islice(all_keys_for_shard, num_keys)
         table_factory = functools.partial(_simple_table_with_keys, keys=keys)
-        with scylla_sstable(table_factory, cql, test_keyspace, scylla_data_dir) as (schema_file, sstables):
+        with scylla_sstable(table_factory, cql, test_keyspace_vnodes, scylla_data_dir) as (schema_file, sstables):
             out = subprocess.check_output([scylla_path,
                                            "sstable", "shard-of",
+                                           "--vnodes",
                                            "--schema-file", schema_file,
                                            "--shards", str(shards)] +
                                           sstables)

--- a/test/cql-pytest/test_tools.py
+++ b/test/cql-pytest/test_tools.py
@@ -1205,6 +1205,26 @@ def test_scylla_sstable_shard_of_vnodes(cql, test_keyspace_vnodes, scylla_path, 
                 assert actual_json == expected_json
 
 
+def test_scylla_sstable_shard_of_tablets(cql, test_keyspace_tablets, scylla_path, scylla_data_dir) -> None:
+    # the token for 0 is mapped to shard 0, 142 is mapped to shard 1
+    shard_to_key = {0: 0, 1: 142}
+    for shard_id, key in shard_to_key.items():
+        table_factory = functools.partial(_simple_table_with_keys, keys=[key])
+        with scylla_sstable(table_factory, cql, test_keyspace_tablets, scylla_data_dir) as (schema_file, sstables):
+            with nodetool.no_autocompaction_context(cql, "system.tablets"):
+                nodetool.flush_keyspace(cql, "system")
+                out = subprocess.check_output([scylla_path,
+                                               "sstable", "shard-of",
+                                               "--tablets",
+                                               "--schema-file", schema_file] +
+                                              sstables)
+                sstables_json = json.loads(out)['sstables']
+                for replica_sets in sstables_json.values():
+                    for replica_set in replica_sets:
+                        actual_shard = replica_set['shard']
+                        assert actual_shard == shard_id
+
+
 def test_scylla_sstable_no_args(scylla_path):
     res = subprocess.run([scylla_path, "sstable"], capture_output=True, text=True)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(tools STATIC)
 target_sources(tools
   PRIVATE
+    read_mutation.cc
     scylla-types.cc
     scylla-sstable.cc
     scylla-nodetool.cc

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(tools STATIC)
 target_sources(tools
   PRIVATE
+    load_system_tablets.cc
     read_mutation.cc
     scylla-types.cc
     scylla-sstable.cc

--- a/tools/load_system_tablets.cc
+++ b/tools/load_system_tablets.cc
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "tools/load_system_tablets.hh"
+
+#include <seastar/core/thread.hh>
+#include <seastar/util/closeable.hh>
+
+#include "log.hh"
+#include "data_dictionary/keyspace_metadata.hh"
+#include "db/cql_type_parser.hh"
+#include "db/system_keyspace.hh"
+#include "mutation/mutation.hh"
+#include "readers/combined.hh"
+#include "replica/tablets.hh"
+#include "tools/read_mutation.hh"
+#include "types/list.hh"
+#include "types/tuple.hh"
+
+namespace {
+
+logging::logger logger{"load_sys_tablets"};
+
+future<utils::UUID> get_table_id(std::filesystem::path scylla_data_path,
+                                 std::string_view keyspace_name,
+                                 std::string_view table_name) {
+    auto path = co_await get_table_directory(scylla_data_path,
+                                             keyspace_name,
+                                             table_name);
+    // the part after "-" is the string representation of the table_id
+    //   "$scylla_data_path/system/tablets-fd4f7a4696bd3e7391bf99eb77e82a5c"
+    auto fn = path.filename().native();
+    auto dash_pos = fn.find_last_of('-');
+    assert(dash_pos != fn.npos);
+    if (dash_pos == fn.size()) {
+        throw std::runtime_error(fmt::format("failed parse system.tablets path {}: bad path", path));
+    }
+    co_return utils::UUID{fn.substr(dash_pos + 1).c_str()};
+}
+
+tools::tablets_t do_load_system_tablets(const db::config& dbcfg,
+                                        std::filesystem::path scylla_data_path,
+                                        std::string_view keyspace_name,
+                                        std::string_view table_name,
+                                        reader_permit permit) {
+    sharded<sstable_manager_service> sst_man;
+    sst_man.start(std::ref(dbcfg)).get();
+    auto stop_sst_man_service = deferred_stop(sst_man);
+
+    auto schema = db::system_keyspace::tablets();
+    auto tablets_table_directory = get_table_directory(scylla_data_path,
+                                                       db::system_keyspace::NAME,
+                                                       schema->cf_name()).get();
+    auto table_id = get_table_id(scylla_data_path, keyspace_name, table_name).get();
+    auto mut = read_mutation_from_table_offline(sst_man,
+                                                permit,
+                                                tablets_table_directory,
+                                                db::system_keyspace::NAME,
+                                                db::system_keyspace::tablets,
+                                                data_value(table_id),
+                                                {});
+    if (!mut || mut->partition().row_count() == 0) {
+        throw std::runtime_error(fmt::format("failed to find tablets for {}.{}", keyspace_name, table_name));
+    }
+
+    auto ks = make_lw_shared<data_dictionary::keyspace_metadata>(keyspace_name,
+                                                                 "org.apache.cassandra.locator.LocalStrategy",
+                                                                 std::map<sstring, sstring>{},
+                                                                 std::nullopt, false);
+    db::cql_type_parser::raw_builder ut_builder(*ks);
+
+    tools::tablets_t tablets;
+    query::result_set result_set{*mut};
+    for (auto& row : result_set.rows()) {
+        auto last_token = row.get_nonnull<int64_t>("last_token");
+        auto replica_set = row.get_data_value("replicas");
+        if (replica_set) {
+            tablets.emplace(last_token,
+                            replica::tablet_replica_set_from_cell(*replica_set));
+        }
+    }
+    return tablets;
+}
+
+} // anonymous namespace
+
+namespace tools {
+
+future<tablets_t> load_system_tablets(const db::config &dbcfg,
+                                      std::filesystem::path scylla_data_path,
+                                      std::string_view keyspace_name,
+                                      std::string_view table_name,
+                                      reader_permit permit) {
+    return async([=, &dbcfg] {
+        return do_load_system_tablets(dbcfg, scylla_data_path, keyspace_name, table_name, permit);
+    });
+}
+
+} // namespace tools

--- a/tools/load_system_tablets.hh
+++ b/tools/load_system_tablets.hh
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <filesystem>
+#include <map>
+#include <seastar/core/future.hh>
+
+#include "reader_permit.hh"
+#include "dht/token.hh"
+#include "locator/tablets.hh"
+#include "seastarx.hh"
+
+namespace db {
+class config;
+}
+
+namespace tools {
+
+using tablets_t = std::map<dht::token, locator::tablet_replica_set>;
+
+/// Load the rows of given table in "system.tablets" from its sstables
+///
+/// @param cfg the db config
+/// @param scylla_data_path path to the scylla data directory, which is usually
+///        /var/lib/scylla/data
+/// @param keyspace_name the keyspace name of the table
+/// @param table_name the table name of the table
+/// @param permit the permit for performing read ops
+/// @returns a map from last token to the replica set
+future<tablets_t> load_system_tablets(const db::config& dbcfg,
+                                      std::filesystem::path scylla_data_path,
+                                      std::string_view keyspace_name,
+                                      std::string_view tablet_name,
+                                      reader_permit permit);
+
+}

--- a/tools/read_mutation.cc
+++ b/tools/read_mutation.cc
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "tools/read_mutation.hh"
+#include "readers/combined.hh"
+#include "partition_slice_builder.hh"
+
+#include <algorithm>
+#include <seastar/util/closeable.hh>
+
+mutation_opt read_mutation_from_table_offline(sharded<sstable_manager_service>& sst_man,
+                                              reader_permit permit,
+                                              std::filesystem::path table_path,
+                                              std::string_view keyspace,
+                                              std::function<schema_ptr()> table_schema,
+                                              data_value primary_key,
+                                              std::optional<data_value> clustering_key) {
+    sharded<sstables::sstable_directory> sst_dirs;
+    sst_dirs.start(
+        sharded_parameter([&sst_man] { return std::ref(sst_man.local().sst_man); }),
+        sharded_parameter([&] { return table_schema(); }),
+        sharded_parameter([&] { return std::ref(table_schema()->get_sharder()); }),
+        table_path.native(),
+        sstables::sstable_state::normal,
+        sharded_parameter([] { return default_io_error_handler_gen(); })).get();
+    auto stop_sst_dirs = deferred_stop(sst_dirs);
+
+    using open_infos_t = std::vector<sstables::foreign_sstable_open_info>;
+    auto sstable_open_infos = sst_dirs.map_reduce0(
+        [] (sstables::sstable_directory& sst_dir) -> future<std::vector<sstables::foreign_sstable_open_info>> {
+            co_await sst_dir.process_sstable_dir(sstables::sstable_directory::process_flags{ .sort_sstables_according_to_owner = false });
+            const auto& unsorted_ssts = sst_dir.get_unsorted_sstables();
+            open_infos_t open_infos;
+            open_infos.reserve(unsorted_ssts.size());
+            for (auto& sst : unsorted_ssts) {
+                open_infos.push_back(co_await sst->get_open_info());
+            }
+            co_return open_infos;
+        },
+        open_infos_t{},
+        [] (open_infos_t new_infos, open_infos_t collected) {
+            std::ranges::move(new_infos, std::back_inserter(collected));
+            return collected;
+        }).get();
+    if (sstable_open_infos.empty()) {
+        return {};
+    }
+
+    std::vector<sstables::shared_sstable> sstables;
+    sstables.reserve(sstable_open_infos.size());
+    for (auto& open_info : sstable_open_infos) {
+        auto sst = sst_dirs.local().load_foreign_sstable(open_info).get();
+        sstables.push_back(std::move(sst));
+    }
+
+    auto schema = table_schema();
+    auto pk = partition_key::from_deeply_exploded(*schema, {std::move(primary_key)});
+    auto dk = dht::decorate_key(*schema, pk);
+    auto pr = dht::partition_range::make_singular(dk);
+    auto pb = partition_slice_builder(*schema);
+    if (clustering_key.has_value()) {
+        auto ck = clustering_key::from_deeply_exploded(*schema, {clustering_key.value()});
+        auto cr = query::clustering_range::make({ck, true}, {ck, true});
+        pb.with_range(cr);
+    }
+    auto ps = pb.build();
+
+    std::vector<mutation_reader> readers;
+    readers.reserve(sstables.size());
+    for (const auto& sst : sstables) {
+        readers.emplace_back(sst->make_reader(schema, permit, pr, ps));
+    }
+    auto reader = make_combined_reader(schema, permit, std::move(readers));
+    auto close_reader = deferred_close(reader);
+
+    return read_mutation_from_mutation_reader(reader).get();
+}

--- a/tools/read_mutation.hh
+++ b/tools/read_mutation.hh
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2021-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <filesystem>
+#include <functional>
+#include <string_view>
+#include <optional>
+
+#include "db/cache_tracker.hh"
+#include "db/config.hh"
+#include "db/large_data_handler.hh"
+#include "gms/feature_service.hh"
+#include "schema/schema_fwd.hh"
+#include "sstables/sstable_directory.hh"
+#include "sstables/sstables_manager.hh"
+#include "types/types.hh"
+#include "reader_permit.hh"
+
+struct sstable_manager_service {
+    db::nop_large_data_handler large_data_handler;
+    gms::feature_service feature_service;
+    cache_tracker tracker;
+    sstables::directory_semaphore dir_sem;
+    sstables::sstables_manager sst_man;
+    abort_source abort;
+
+    explicit sstable_manager_service(const db::config& dbcfg)
+        : feature_service(gms::feature_config_from_db_config(dbcfg))
+        , dir_sem(1)
+        , sst_man("schema_loader", large_data_handler, dbcfg, feature_service, tracker, memory::stats().total_memory(), dir_sem, []{ return locator::host_id{}; }, abort) {
+    }
+
+    future<> stop() {
+        return sst_man.close();
+    }
+};
+
+mutation_opt read_mutation_from_table_offline(sharded<sstable_manager_service>& sst_man,
+                                              reader_permit permit,
+                                              std::filesystem::path table_path,
+                                              std::string_view keyspace,
+                                              std::function<schema_ptr()> table_schema,
+                                              data_value primary_key,
+                                              std::optional<data_value> clustering_key);

--- a/tools/read_mutation.hh
+++ b/tools/read_mutation.hh
@@ -23,6 +23,10 @@
 #include "types/types.hh"
 #include "reader_permit.hh"
 
+future<std::filesystem::path> get_table_directory(std::filesystem::path scylla_data_path,
+                                                  std::string_view keyspace_name,
+                                                  std::string_view table_name);
+
 struct sstable_manager_service {
     db::nop_large_data_handler large_data_handler;
     gms::feature_service feature_service;

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -43,6 +43,7 @@
 #include "locator/abstract_replication_strategy.hh"
 #include "locator/local_strategy.hh"
 #include "tools/schema_loader.hh"
+#include "tools/read_mutation.hh"
 #include "view_info.hh"
 
 namespace {
@@ -379,138 +380,6 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
             boost::adaptors::transformed([] (const table& t) { return t.schema; }));
 }
 
-struct sstable_manager_service {
-    db::nop_large_data_handler large_data_handler;
-    gms::feature_service feature_service;
-    cache_tracker tracker;
-    sstables::directory_semaphore dir_sem;
-    sstables::sstables_manager sst_man;
-    abort_source abort;
-
-    explicit sstable_manager_service(const db::config& dbcfg)
-        : feature_service(gms::feature_config_from_db_config(dbcfg))
-        , dir_sem(1)
-        , sst_man("schema_loader", large_data_handler, dbcfg, feature_service, tracker, memory::stats().total_memory(), dir_sem, []{ return locator::host_id{}; }, abort) {
-    }
-
-    future<> stop() {
-        return sst_man.close();
-    }
-};
-
-mutation_opt read_schema_table_mutation(sharded<sstable_manager_service>& sst_man, std::filesystem::path schema_table_data_path,
-        std::function<schema_ptr()> schema_factory, reader_permit permit, std::string_view keyspace, std::vector<std::string_view> ck_strings) {
-    if (sllog.level() == log_level::trace) {
-        auto schema = schema_factory();
-        sllog.trace("read_schema_table_mutation(): path={}, table={}.{}, pk={}, ck={}",
-                schema_table_data_path.native(),
-                schema->ks_name(),
-                schema->cf_name(),
-                keyspace,
-                ck_strings);
-    }
-
-    sharded<sstables::sstable_directory> sst_dirs;
-    sst_dirs.start(
-        sharded_parameter([&sst_man] { return std::ref(sst_man.local().sst_man); }),
-        sharded_parameter([&schema_factory] { return schema_factory(); }),
-        sharded_parameter([&] { return std::ref(schema_factory()->get_sharder()); }),
-        schema_table_data_path.native(), sstables::sstable_state::normal,
-        sharded_parameter([] { return default_io_error_handler_gen(); })).get();
-    auto stop_sst_dirs = deferred_stop(sst_dirs);
-
-    auto sstable_open_infos = sst_dirs.map_reduce0(
-            [] (sstables::sstable_directory& sst_dir) -> future<std::vector<sstables::foreign_sstable_open_info>> {
-               co_await sst_dir.process_sstable_dir(sstables::sstable_directory::process_flags{ .sort_sstables_according_to_owner = false });
-               const auto& unsorted_ssts = sst_dir.get_unsorted_sstables();
-               std::vector<sstables::foreign_sstable_open_info> open_infos;
-               open_infos.reserve(unsorted_ssts.size());
-               for (auto& sst : unsorted_ssts) {
-                   open_infos.push_back(co_await sst->get_open_info());
-               }
-               co_return open_infos;
-            },
-            std::vector<sstables::foreign_sstable_open_info>{},
-            [] (std::vector<sstables::foreign_sstable_open_info> a, std::vector<sstables::foreign_sstable_open_info> b) {
-                std::move(b.begin(), b.end(), std::back_inserter(a));
-                return a;
-            }).get();
-
-    auto schema_table_schema = schema_factory();
-
-    if (sstable_open_infos.empty()) {
-        sllog.debug("read_schema_table_mutation(): no sstables found for path={}, table={}.{}, pk={}, ck={}",
-                schema_table_data_path.native(),
-                schema_table_schema->ks_name(),
-                schema_table_schema->cf_name(),
-                keyspace,
-                ck_strings);
-        return {};
-    }
-
-    std::vector<sstables::shared_sstable> sstables;
-    sstables.reserve(sstable_open_infos.size());
-    for (auto& open_info : sstable_open_infos) {
-        sstables.push_back(sst_dirs.local().load_foreign_sstable(open_info).get());
-    }
-
-    auto pk = partition_key::from_deeply_exploded(*schema_table_schema, {data_value(keyspace)});
-    auto dk = dht::decorate_key(*schema_table_schema, pk);
-    auto pr = dht::partition_range::make_singular(dk);
-
-    std::vector<data_value> raw_ck_values;
-    raw_ck_values.reserve(ck_strings.size());
-    for (const auto& ck_str : ck_strings) {
-        raw_ck_values.push_back(data_value(ck_str));
-    }
-    auto ck = clustering_key::from_deeply_exploded(*schema_table_schema, raw_ck_values);
-    auto cr = query::clustering_range::make({ck, true}, {ck, true});
-    auto ps = partition_slice_builder(*schema_table_schema)
-            .with_range(cr)
-            .build();
-
-    sllog.trace("read_schema_table_mutation(): preparing to read {} sstables for table={}.{}, pr={} ({}), cr={} ({})\n{}",
-            sstable_open_infos.size(),
-            schema_table_schema->ks_name(),
-            schema_table_schema->cf_name(),
-            pr,
-            keyspace,
-            cr,
-            ck_strings,
-            sstables);
-
-    std::vector<mutation_reader> readers;
-    readers.reserve(sstables.size());
-    for (const auto& sst : sstables) {
-        readers.emplace_back(sst->make_reader(schema_table_schema, permit, pr, ps));
-    }
-    auto reader = make_combined_reader(schema_table_schema, permit, std::move(readers));
-    auto close_reader = deferred_close(reader);
-
-    auto mut_opt = read_mutation_from_mutation_reader(reader).get();
-
-    if (mut_opt) {
-        sllog.debug("read_schema_table_mutation(): read mutation for table={}.{}, pr={} ({}), cr={} ({})\n{}",
-                schema_table_schema->ks_name(),
-                schema_table_schema->cf_name(),
-                pr,
-                keyspace,
-                cr,
-                ck_strings,
-                *mut_opt);
-    } else {
-        sllog.debug("read_schema_table_mutation(): read empty mutation for table={}.{}, pr={} ({}), cr={} ({})",
-                schema_table_schema->ks_name(),
-                schema_table_schema->cf_name(),
-                pr,
-                keyspace,
-                cr,
-                ck_strings);
-    }
-
-    return mut_opt;
-}
-
 class single_keyspace_user_types_storage : public data_dictionary::user_types_storage {
     data_dictionary::user_types_metadata _utm;
 public:
@@ -580,13 +449,14 @@ schema_ptr do_load_schema_from_schema_tables(const db::config& dbcfg, std::files
     };
     auto do_load = [&] (std::function<const schema_ptr()> schema_factory) {
         auto s = schema_factory();
-        return read_schema_table_mutation(
+        return read_mutation_from_table_offline(
                 sst_man,
-                schema_tables_path / schema_table_table_dir[s],
-                schema_factory,
                 rcs_sem.make_tracking_only_permit(s, "schema_mutation", db::no_timeout, {}),
+                schema_tables_path / schema_table_table_dir[s],
                 keyspace,
-                {table});
+                schema_factory,
+                data_value(keyspace),
+                data_value(table));
     };
     mutation_opt tables = do_load(db::schema_tables::tables);
     mutation_opt views = do_load(db::schema_tables::views);
@@ -603,12 +473,13 @@ schema_ptr do_load_schema_from_schema_tables(const db::config& dbcfg, std::files
 
     data_dictionary::user_types_metadata utm;
 
-    auto types_mut = read_schema_table_mutation(
+    auto types_mut = read_mutation_from_table_offline(
             sst_man,
-            schema_tables_path / schema_table_table_dir[db::schema_tables::types()],
-            db::schema_tables::types,
             rcs_sem.make_tracking_only_permit(db::schema_tables::types(), "types_mutation", db::no_timeout, {}),
+            schema_tables_path / schema_table_table_dir[db::schema_tables::types()],
             keyspace,
+            db::schema_tables::types,
+            data_value(keyspace),
             {});
     if (types_mut) {
         query::result_set result(*types_mut);


### PR DESCRIPTION
before this change, `scylla sstable shard-of` didn't support tablets,
because:

- with tablets enabled, data distribution uses the scheduler
- this replaces the previous method of mapping based on vnodes and shard numbers
- as a result, we can no longer deduce sstable mapping from token ranges

in this change, we:
- read `system.tablets` table to retrieve tablet information
- print the tablet's replica set (list of <host, shard> pairs)
- this helps users determine where a given sstable is hosted

This approach provides the closest equivalent functionality of
`shard-of` in the tablet era.

Fixes scylladb/scylladb#16488

---

no need to backport, it's an improvement, not a critical fix.