### PR TITLE
utils/div_ceil: add constraints to template arguments

### DIFF
--- a/utils/div_ceil.hh
+++ b/utils/div_ceil.hh
@@ -8,10 +8,9 @@
 
 #pragma once
 
-template <typename Dividend, typename Divisor>
-inline
-// requires Integral<Dividend> && Integral<Divisor>
-auto
-div_ceil(Dividend dividend, Divisor divisor) {
+#include <concepts>
+
+inline auto
+div_ceil(std::integral auto dividend, std::integral auto divisor) {
     return (dividend + divisor - 1) / divisor;
 }


### PR DESCRIPTION
to better reflect what we expect from the arguments.

----

it's a cleanup, hence no need to backport.