### PR TITLE
tool/scylla-nodetool: refresh: improve error-message on missing ks/tbl args

### DIFF
--- a/test/nodetool/test_refresh.py
+++ b/test/nodetool/test_refresh.py
@@ -35,7 +35,7 @@ def test_refresh_no_table(nodetool):
             ("refresh", "ks"),
             {"expected_requests": []},
             ["nodetool: refresh requires ks and cf args",
-             "error processing arguments: required parameters are missing: keyspace and/or table"])
+             "error processing arguments: required parameter is missing: table"])
 
 
 def test_refresh_no_table_no_keyspace(nodetool):
@@ -44,7 +44,7 @@ def test_refresh_no_table_no_keyspace(nodetool):
             ("refresh",),
             {"expected_requests": []},
             ["nodetool: refresh requires ks and cf args",
-             "error processing arguments: required parameters are missing: keyspace and/or table"])
+             "error processing arguments: required parameters are missing: keyspace and table"])
 
 
 def test_refresh_primary_replica_only(nodetool, scylla_only):

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1253,8 +1253,11 @@ void rebuild_operation(scylla_rest_client& client, const bpo::variables_map& vm)
 }
 
 void refresh_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
-    if (!vm.count("keyspace") || !vm.count("table")) {
-        throw std::invalid_argument("required parameters are missing: keyspace and/or table");
+    if (!vm.count("keyspace")) {
+        throw std::invalid_argument("required parameters are missing: keyspace and table");
+    }
+    if (!vm.count("table")) {
+        throw std::invalid_argument("required parameter is missing: table");
     }
     std::unordered_map<sstring, sstring> params{{"cf", vm["table"].as<sstring>()}};
     if (vm.count("load-and-stream")) {


### PR DESCRIPTION
The command has a singl check for the missing keyspace and/or table parameters and if the check fails, there is a combined error message. Apparently this is confusing, so split the check so that missing keyspace and missing table args have its own check and error message.

Fixes: #19984

Minor UX improvement, no backport needed.