### PR TITLE
treewide: change assert() to SCYLLA_ASSERT()

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -30,6 +30,7 @@
 #include "conditions.hh"
 #include "cql3/util.hh"
 #include <optional>
+#include "utils/assert.hh"
 #include "utils/overloaded_functor.hh"
 #include <seastar/json/json_elements.hh>
 #include <boost/algorithm/cxx11/any_of.hpp>
@@ -85,7 +86,7 @@ static map_type attrs_type() {
 
 static const column_definition& attrs_column(const schema& schema) {
     const column_definition* cdef = schema.get_column_definition(bytes(executor::ATTRS_COLUMN_NAME));
-    assert(cdef);
+    SCYLLA_ASSERT(cdef);
     return *cdef;
 }
 
@@ -931,7 +932,7 @@ static void validate_attribute_definitions(const rjson::value& attribute_definit
 }
 
 static future<executor::request_return_type> create_table_on_shard0(tracing::trace_state_ptr trace_state, rjson::value request, service::storage_proxy& sp, service::migration_manager& mm, gms::gossiper& gossiper) {
-    assert(this_shard_id() == 0);
+    SCYLLA_ASSERT(this_shard_id() == 0);
 
     // We begin by parsing and validating the content of the CreateTable
     // command. We can't inspect the current database schema at this point
@@ -1677,7 +1678,7 @@ future<executor::request_return_type> rmw_operation::execute(service::storage_pr
         }
     } else if (_write_isolation != write_isolation::LWT_ALWAYS) {
         std::optional<mutation> m = apply(nullptr, api::new_timestamp());
-        assert(m); // !needs_read_before_write, so apply() did not check a condition
+        SCYLLA_ASSERT(m); // !needs_read_before_write, so apply() did not check a condition
         return proxy.mutate(std::vector<mutation>{std::move(*m)}, db::consistency_level::LOCAL_QUORUM, executor::default_timeout(), trace_state, std::move(permit), db::allow_per_partition_rate_limit::yes).then([this] () mutable {
             return rmw_operation_return(std::move(_return_attributes));
         });
@@ -3844,7 +3845,7 @@ static future<executor::request_return_type> do_query(service::storage_proxy& pr
 }
 
 static dht::token token_for_segment(int segment, int total_segments) {
-    assert(total_segments > 1 && segment >= 0 && segment < total_segments);
+    SCYLLA_ASSERT(total_segments > 1 && segment >= 0 && segment < total_segments);
     uint64_t delta = std::numeric_limits<uint64_t>::max() / total_segments;
     return dht::token::from_int64(std::numeric_limits<int64_t>::min() + delta * segment);
 }

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -18,6 +18,7 @@
 #include "seastarx.hh"
 #include "error.hh"
 #include "service/qos/service_level_controller.hh"
+#include "utils/assert.hh"
 #include "utils/rjson.hh"
 #include "auth.hh"
 #include <cctype>
@@ -405,7 +406,7 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
         ++_executor._stats.requests_blocked_memory;
     }
     auto units = co_await std::move(units_fut);
-    assert(req->content_stream);
+    SCYLLA_ASSERT(req->content_stream);
     chunked_content content = co_await util::read_entire_stream(*req->content_stream);
     auto username = co_await verify_signature(*req, content);
 

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -35,6 +35,7 @@
 #include "mutation/mutation.hh"
 #include "types/types.hh"
 #include "types/map.hh"
+#include "utils/assert.hh"
 #include "utils/rjson.hh"
 #include "utils/big_decimal.hh"
 #include "cql3/selection/selection.hh"
@@ -551,7 +552,7 @@ static future<> scan_table_ranges(
         expiration_service::stats& expiration_stats)
 {
     const schema_ptr& s = scan_ctx.s;
-    assert (partition_ranges.size() == 1); // otherwise issue #9167 will cause incorrect results.
+    SCYLLA_ASSERT (partition_ranges.size() == 1); // otherwise issue #9167 will cause incorrect results.
     auto p = service::pager::query_pagers::pager(proxy, s, scan_ctx.selection, *scan_ctx.query_state_ptr,
             *scan_ctx.query_options, scan_ctx.command, std::move(partition_ranges), nullptr);
     while (!p->is_exhausted()) {

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -15,6 +15,7 @@
 #include <seastar/http/exception.hh>
 #include "sstables/sstables.hh"
 #include "sstables/metadata_collector.hh"
+#include "utils/assert.hh"
 #include "utils/estimated_histogram.hh"
 #include <algorithm>
 #include "db/system_keyspace.hh"
@@ -103,7 +104,7 @@ class autocompaction_toggle_guard {
     replica::database& _db;
 public:
     autocompaction_toggle_guard(replica::database& db) : _db(db) {
-        assert(this_shard_id() == 0);
+        SCYLLA_ASSERT(this_shard_id() == 0);
         if (!_db._enable_autocompaction_toggle) {
             throw std::runtime_error("Autocompaction toggle is busy");
         }
@@ -112,7 +113,7 @@ public:
     autocompaction_toggle_guard(const autocompaction_toggle_guard&) = delete;
     autocompaction_toggle_guard(autocompaction_toggle_guard&&) = default;
     ~autocompaction_toggle_guard() {
-        assert(this_shard_id() == 0);
+        SCYLLA_ASSERT(this_shard_id() == 0);
         _db._enable_autocompaction_toggle = true;
     }
 };

--- a/auth/common.cc
+++ b/auth/common.cc
@@ -16,6 +16,7 @@
 #include "mutation/canonical_mutation.hh"
 #include "schema/schema_fwd.hh"
 #include "timestamp.hh"
+#include "utils/assert.hh"
 #include "utils/exponential_backoff_retry.hh"
 #include "cql3/query_processor.hh"
 #include "cql3/statements/create_table_statement.hh"
@@ -68,7 +69,7 @@ static future<> create_legacy_metadata_table_if_missing_impl(
         cql3::query_processor& qp,
         std::string_view cql,
         ::service::migration_manager& mm) {
-    assert(this_shard_id() == 0); // once_among_shards makes sure a function is executed on shard 0 only
+    SCYLLA_ASSERT(this_shard_id() == 0); // once_among_shards makes sure a function is executed on shard 0 only
 
     auto db = qp.db();
     auto parsed_statement = cql3::query_processor::parse_statement(cql);

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -36,6 +36,7 @@
 #include "service/migration_manager.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "timestamp.hh"
+#include "utils/assert.hh"
 #include "utils/class_registrator.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "data_dictionary/keyspace_metadata.hh"
@@ -194,7 +195,7 @@ service::service(
 }
 
 future<> service::create_legacy_keyspace_if_missing(::service::migration_manager& mm) const {
-    assert(this_shard_id() == 0); // once_among_shards makes sure a function is executed on shard 0 only
+    SCYLLA_ASSERT(this_shard_id() == 0); // once_among_shards makes sure a function is executed on shard 0 only
     auto db = _qp.db();
 
     while (!db.has_keyspace(meta::legacy::AUTH_KS)) {

--- a/bytes_ostream.hh
+++ b/bytes_ostream.hh
@@ -11,6 +11,7 @@
 #include <boost/range/iterator_range.hpp>
 
 #include "bytes.hh"
+#include "utils/assert.hh"
 #include "utils/managed_bytes.hh"
 #include <seastar/core/simple-stream.hh>
 #include <seastar/core/loop.hh>
@@ -269,7 +270,7 @@ public:
 
     // Call only when is_linearized()
     bytes_view view() const {
-        assert(is_linearized());
+        SCYLLA_ASSERT(is_linearized());
         if (!_current) {
             return bytes_view();
         }

--- a/cache_mutation_reader.hh
+++ b/cache_mutation_reader.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <vector>
 #include "row_cache.hh"
 #include "mutation/mutation_fragment.hh"
@@ -283,7 +284,7 @@ future<> cache_mutation_reader::process_static_row() {
         return ensure_underlying().then([this] {
             return (*_underlying)().then([this] (mutation_fragment_v2_opt&& sr) {
                 if (sr) {
-                    assert(sr->is_static_row());
+                    SCYLLA_ASSERT(sr->is_static_row());
                     maybe_add_to_cache(sr->as_static_row());
                     push_mutation_fragment(std::move(*sr));
                 }
@@ -382,7 +383,7 @@ future<> cache_mutation_reader::do_fill_buffer() {
     if (_state == state::reading_from_underlying) {
         return read_from_underlying();
     }
-    // assert(_state == state::reading_from_cache)
+    // SCYLLA_ASSERT(_state == state::reading_from_cache)
     return _lsa_manager.run_in_read_section([this] {
         auto next_valid = _next_row.iterators_valid();
         clogger.trace("csm {}: reading_from_cache, range=[{}, {}), next={}, valid={}, rt={}", fmt::ptr(this), _lower_bound,
@@ -990,7 +991,7 @@ void cache_mutation_reader::offer_from_underlying(mutation_fragment_v2&& mf) {
         maybe_add_to_cache(mf.as_clustering_row());
         add_clustering_row_to_buffer(std::move(mf));
     } else {
-        assert(mf.is_range_tombstone_change());
+        SCYLLA_ASSERT(mf.is_range_tombstone_change());
         auto& chg = mf.as_range_tombstone_change();
         if (maybe_add_to_cache(chg)) {
             add_to_buffer(std::move(mf).as_range_tombstone_change());

--- a/cdc/change_visitor.hh
+++ b/cdc/change_visitor.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "mutation/mutation.hh"
 
 /*
@@ -246,7 +247,7 @@ void inspect_mutation(const mutation& m, V& v) {
 
         if (r.deleted_at()) {
             auto t = r.deleted_at().tomb();
-            assert(t.timestamp != api::missing_timestamp);
+            SCYLLA_ASSERT(t.timestamp != api::missing_timestamp);
             v.clustered_row_delete(cr.key(), t);
             if (v.finished()) {
                 return;
@@ -255,7 +256,7 @@ void inspect_mutation(const mutation& m, V& v) {
     }
 
     for (auto& rt: p.row_tombstones()) {
-        assert(rt.tombstone().tomb.timestamp != api::missing_timestamp);
+        SCYLLA_ASSERT(rt.tombstone().tomb.timestamp != api::missing_timestamp);
         v.range_delete(rt.tombstone());
         if (v.finished()) {
             return;

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -26,6 +26,7 @@
 #include "gms/inet_address.hh"
 #include "gms/gossiper.hh"
 #include "gms/feature_service.hh"
+#include "utils/assert.hh"
 #include "utils/error_injection.hh"
 #include "utils/UUID_gen.hh"
 #include "utils/to_string.hh"
@@ -107,8 +108,8 @@ stream_id::stream_id(dht::token token, size_t vnode_index)
     copy_int_to_bytes(dht::token::to_int64(token), 0, _value);
     copy_int_to_bytes(low_qword, sizeof(int64_t), _value);
     // not a hot code path. make sure we did not mess up the shifts and masks.
-    assert(version() == version_1);
-    assert(index() == vnode_index);
+    SCYLLA_ASSERT(version() == version_1);
+    SCYLLA_ASSERT(index() == vnode_index);
 }
 
 stream_id::stream_id(bytes b)
@@ -126,7 +127,7 @@ bool stream_id::is_set() const {
 }
 
 static int64_t bytes_to_int64(bytes_view b, size_t offset) {
-    assert(b.size() >= offset + sizeof(int64_t));
+    SCYLLA_ASSERT(b.size() >= offset + sizeof(int64_t));
     int64_t res;
     std::copy_n(b.begin() + offset, sizeof(int64_t), reinterpret_cast<int8_t *>(&res));
     return net::ntoh(res);
@@ -411,7 +412,7 @@ future<cdc::generation_id> generation_service::legacy_make_new_generation(const 
 
     // Our caller should ensure that there are normal tokens in the token ring.
     auto normal_token_owners = tmptr->count_normal_token_owners();
-    assert(normal_token_owners);
+    SCYLLA_ASSERT(normal_token_owners);
 
     if (_feature_service.cdc_generations_v2) {
         cdc_log.info("Inserting new generation data at UUID {}", uuid);
@@ -811,7 +812,7 @@ future<> generation_service::stop() {
 }
 
 generation_service::~generation_service() {
-    assert(_stopped);
+    SCYLLA_ASSERT(_stopped);
 }
 
 future<> generation_service::after_join(std::optional<cdc::generation_id>&& startup_gen_id) {

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -32,6 +32,7 @@
 #include "cql3/statements/select_statement.hh"
 #include "cql3/untyped_result_set.hh"
 #include "log.hh"
+#include "utils/assert.hh"
 #include "utils/rjson.hh"
 #include "utils/UUID_gen.hh"
 #include "utils/managed_bytes.hh"
@@ -148,7 +149,7 @@ public:
         _ctxt._migration_notifier.register_listener(this);
     }
     ~impl() {
-        assert(_stopped);
+        SCYLLA_ASSERT(_stopped);
     }
 
     future<> stop() {
@@ -455,7 +456,7 @@ schema_ptr get_base_table(const replica::database& db, sstring_view ks_name,std:
 }
 
 seastar::sstring base_name(std::string_view log_name) {
-    assert(is_log_name(log_name));
+    SCYLLA_ASSERT(is_log_name(log_name));
     return sstring(log_name.data(), log_name.size() - cdc_log_suffix.size());
 }
 
@@ -655,7 +656,7 @@ private:
 
 template<>
 void collection_iterator<std::pair<managed_bytes_view, managed_bytes_view>>::parse() {
-    assert(_rem > 0);
+    SCYLLA_ASSERT(_rem > 0);
     _next = _v;
     auto k = read_collection_key(_next);
     auto v = read_collection_value_nonnull(_next);
@@ -664,7 +665,7 @@ void collection_iterator<std::pair<managed_bytes_view, managed_bytes_view>>::par
 
 template<>
 void collection_iterator<managed_bytes_view>::parse() {
-    assert(_rem > 0);
+    SCYLLA_ASSERT(_rem > 0);
     _next = _v;
     auto k = read_collection_key(_next);
     _current = k;
@@ -672,7 +673,7 @@ void collection_iterator<managed_bytes_view>::parse() {
 
 template<>
 void collection_iterator<managed_bytes_view_opt>::parse() {
-    assert(_rem > 0);
+    SCYLLA_ASSERT(_rem > 0);
     _next = _v;
     auto k = read_collection_value_nonnull(_next);
     _current = k;
@@ -1065,7 +1066,7 @@ struct process_row_visitor {
     void update_row_state(const column_definition& cdef, managed_bytes_opt value) {
         if (!_row_state) {
             // static row always has a valid state, so this must be a clustering row missing
-            assert(_base_ck);
+            SCYLLA_ASSERT(_base_ck);
             auto [it, _] = _clustering_row_states.try_emplace(*_base_ck);
             _row_state = &it->second;
         }
@@ -1496,12 +1497,12 @@ public:
     }
 
     void generate_image(operation op, const clustering_key* ck, const one_kind_column_set* affected_columns) {
-        assert(op == operation::pre_image || op == operation::post_image);
+        SCYLLA_ASSERT(op == operation::pre_image || op == operation::post_image);
 
-        // assert that post_image is always full
-        assert(!(op == operation::post_image && affected_columns));
+        // SCYLLA_ASSERT that post_image is always full
+        SCYLLA_ASSERT(!(op == operation::post_image && affected_columns));
 
-        assert(_builder);
+        SCYLLA_ASSERT(_builder);
 
         const auto kind = ck ? column_kind::regular_column : column_kind::static_column;
 
@@ -1571,7 +1572,7 @@ public:
     // TODO: is pre-image data based on query enough. We only have actual column data. Do we need
     // more details like tombstones/ttl? Probably not but keep in mind.
     void process_change(const mutation& m) override {
-        assert(_builder);
+        SCYLLA_ASSERT(_builder);
         process_change_visitor v {
             ._touched_parts = _touched_parts,
             ._builder = *_builder,
@@ -1584,7 +1585,7 @@ public:
     }
 
     void end_record() override {
-        assert(_builder);
+        SCYLLA_ASSERT(_builder);
         _builder->end_record();
     }
 

--- a/cell_locking.hh
+++ b/cell_locking.hh
@@ -10,6 +10,7 @@
 
 #include <boost/intrusive/unordered_set.hpp>
 
+#include "utils/assert.hh"
 #include "utils/small_vector.hh"
 #include "mutation/mutation_partition.hh"
 #include "utils/xx_hasher.hh"
@@ -342,7 +343,7 @@ public:
     { }
 
     ~cell_locker() {
-        assert(_partitions.empty());
+        SCYLLA_ASSERT(_partitions.empty());
     }
 
     void set_schema(schema_ptr s) {

--- a/clustering_interval_set.hh
+++ b/clustering_interval_set.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "schema/schema_fwd.hh"
 #include "mutation/position_in_partition.hh"
 #include <boost/icl/interval_set.hpp>
@@ -87,8 +88,8 @@ public:
         }
     };
     static interval::type make_interval(const schema& s, const position_range& r) {
-        assert(r.start().has_clustering_key());
-        assert(r.end().has_clustering_key());
+        SCYLLA_ASSERT(r.start().has_clustering_key());
+        SCYLLA_ASSERT(r.end().has_clustering_key());
         return interval::right_open(
             position_in_partition_with_schema(s.shared_from_this(), r.start()),
             position_in_partition_with_schema(s.shared_from_this(), r.end()));

--- a/clustering_ranges_walker.hh
+++ b/clustering_ranges_walker.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "schema/schema.hh"
 #include "query-request.hh"
 #include "mutation/mutation_fragment.hh"
@@ -249,7 +250,7 @@ public:
             auto range_end = position_in_partition_view::for_range_end(rng);
             if (!less(rt.position(), range_start) && !less(range_end, rt.end_position())) {
                 // Fully enclosed by this range.
-                assert(!first);
+                SCYLLA_ASSERT(!first);
                 return std::move(rt);
             }
             auto this_range_rt = rt;

--- a/collection_mutation.cc
+++ b/collection_mutation.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "types/collection.hh"
 #include "types/user.hh"
 #include "concrete_types.hh"
@@ -391,7 +392,7 @@ deserialize_collection_mutation(collection_mutation_input_stream& in, F&& read_k
         ret.cells.push_back(read_kv(in));
     }
 
-    assert(in.empty());
+    SCYLLA_ASSERT(in.empty());
     return ret;
 }
 

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -46,6 +46,7 @@
 #include "mutation_writer/partition_based_splitting_writer.hh"
 #include "mutation/mutation_source_metadata.hh"
 #include "mutation/mutation_fragment_stream_validator.hh"
+#include "utils/assert.hh"
 #include "utils/error_injection.hh"
 #include "utils/pretty_printers.hh"
 #include "readers/multi_range.hh"
@@ -283,7 +284,7 @@ private:
 
     utils::observer<> make_stop_request_observer(utils::observable<>& sro) {
         return sro.observe([this] () mutable {
-            assert(!_unclosed_partition);
+            SCYLLA_ASSERT(!_unclosed_partition);
             consume_end_of_stream();
         });
     }

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -22,6 +22,7 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include "sstables/exceptions.hh"
 #include "sstables/sstable_directory.hh"
+#include "utils/assert.hh"
 #include "utils/error_injection.hh"
 #include "utils/UUID_gen.hh"
 #include "db/system_keyspace.hh"
@@ -958,7 +959,7 @@ compaction_manager::compaction_manager(tasks::task_manager& tm)
 compaction_manager::~compaction_manager() {
     // Assert that compaction manager was explicitly stopped, if started.
     // Otherwise, fiber(s) will be alive after the object is stopped.
-    assert(_state == state::none || _state == state::stopped);
+    SCYLLA_ASSERT(_state == state::none || _state == state::stopped);
 }
 
 future<> compaction_manager::update_throughput(uint32_t value_mbs) {
@@ -998,7 +999,7 @@ void compaction_manager::register_metrics() {
 }
 
 void compaction_manager::enable() {
-    assert(_state == state::none || _state == state::disabled);
+    SCYLLA_ASSERT(_state == state::none || _state == state::disabled);
     _state = state::enabled;
     _compaction_submission_timer.arm_periodic(periodic_compaction_submission_interval());
     _waiting_reevalution = postponed_compactions_reevaluation();

--- a/compaction/leveled_manifest.hh
+++ b/compaction/leveled_manifest.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "sstables/sstables.hh"
 #include "size_tiered_compaction_strategy.hh"
 #include "interval.hh"
@@ -311,7 +312,7 @@ public:
 
     template <typename T>
     static std::vector<sstables::shared_sstable> overlapping(const schema& s, const std::vector<sstables::shared_sstable>& candidates, const T& others) {
-        assert(!candidates.empty());
+        SCYLLA_ASSERT(!candidates.empty());
         /*
          * Picking each sstable from others that overlap one of the sstable of candidates is not enough
          * because you could have the following situation:
@@ -350,7 +351,7 @@ public:
      */
     template <typename T>
     static std::vector<sstables::shared_sstable> overlapping(const schema& s, dht::token start, dht::token end, const T& sstables) {
-        assert(start <= end);
+        SCYLLA_ASSERT(start <= end);
 
         std::vector<sstables::shared_sstable> overlapped;
         auto range = ::wrapping_interval<dht::token>::make(start, end);
@@ -459,7 +460,7 @@ private:
      * for prior failure), will return an empty list.  Never returns null.
      */
     candidates_info get_candidates_for(int level, const std::vector<std::optional<dht::decorated_key>>& last_compacted_keys) {
-        assert(!get_level(level).empty());
+        SCYLLA_ASSERT(!get_level(level).empty());
 
         logger.debug("Choosing candidates for L{}", level);
 
@@ -517,7 +518,7 @@ public:
             new_level = 0;
         } else {
             new_level = (minimum_level == maximum_level && can_promote) ? maximum_level + 1 : maximum_level;
-            assert(new_level > 0);
+            SCYLLA_ASSERT(new_level > 0);
         }
         return new_level;
     }

--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "sstables/sstables.hh"
 #include "size_tiered_compaction_strategy.hh"
 #include "cql3/statements/property_definitions.hh"
@@ -114,7 +115,7 @@ size_tiered_compaction_strategy::create_sstable_and_length_pairs(const std::vect
 
     for(auto& sstable : sstables) {
         auto sstable_size = sstable->data_size();
-        assert(sstable_size != 0);
+        SCYLLA_ASSERT(sstable_size != 0);
 
         sstable_length_pairs.emplace_back(sstable, sstable_size);
     }

--- a/compound.hh
+++ b/compound.hh
@@ -14,6 +14,7 @@
 #include <span>
 #include <boost/range/iterator_range.hpp>
 #include <boost/range/adaptor/transformed.hpp>
+#include "utils/assert.hh"
 #include "utils/serialization.hh"
 #include <seastar/util/backtrace.hh>
 
@@ -65,15 +66,15 @@ private:
         for (auto&& val : values) {
             using val_type = std::remove_cvref_t<decltype(val)>;
             if constexpr (FragmentedView<val_type>) {
-                assert(val.size_bytes() <= std::numeric_limits<size_type>::max());
+                SCYLLA_ASSERT(val.size_bytes() <= std::numeric_limits<size_type>::max());
                 write<size_type>(out, size_type(val.size_bytes()));
                 write_fragmented(out, val);
             } else if constexpr (std::same_as<val_type, managed_bytes>) {
-                assert(val.size() <= std::numeric_limits<size_type>::max());
+                SCYLLA_ASSERT(val.size() <= std::numeric_limits<size_type>::max());
                 write<size_type>(out, size_type(val.size()));
                 write_fragmented(out, managed_bytes_view(val));
             } else {
-                assert(val.size() <= std::numeric_limits<size_type>::max());
+                SCYLLA_ASSERT(val.size() <= std::numeric_limits<size_type>::max());
                 write<size_type>(out, size_type(val.size()));
                 write_fragmented(out, single_fragmented_view(val));
             }
@@ -135,7 +136,7 @@ public:
         partial.reserve(values.size());
         auto i = _types.begin();
         for (auto&& component : values) {
-            assert(i != _types.end());
+            SCYLLA_ASSERT(i != _types.end());
             partial.push_back((*i++)->decompose(component));
         }
         return serialize_value(partial);
@@ -256,7 +257,7 @@ public:
     }
     // Returns true iff given prefix has no missing components
     bool is_full(managed_bytes_view v) const {
-        assert(AllowPrefixes == allow_prefixes::yes);
+        SCYLLA_ASSERT(AllowPrefixes == allow_prefixes::yes);
         return std::distance(begin(v), end(v)) == (ssize_t)_types.size();
     }
     bool is_empty(managed_bytes_view v) const {

--- a/converting_mutation_partition_applier.cc
+++ b/converting_mutation_partition_applier.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "converting_mutation_partition_applier.hh"
 #include "concrete_types.hh"
 
@@ -53,7 +54,7 @@ converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, c
 
     visit(old_type, make_visitor(
         [&] (const collection_type_impl& old_ctype) {
-            assert(new_def.type->is_collection()); // because is_compatible
+            SCYLLA_ASSERT(new_def.type->is_collection()); // because is_compatible
             auto& new_ctype = static_cast<const collection_type_impl&>(*new_def.type);
 
             auto& new_value_type = *new_ctype.value_comparator();
@@ -67,13 +68,13 @@ converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, c
             }
         },
         [&] (const user_type_impl& old_utype) {
-            assert(new_def.type->is_user_type()); // because is_compatible
+            SCYLLA_ASSERT(new_def.type->is_user_type()); // because is_compatible
             auto& new_utype = static_cast<const user_type_impl&>(*new_def.type);
 
             for (auto& c : old_view.cells) {
                 if (c.second.timestamp() > new_def.dropped_at()) {
                     auto idx = deserialize_field_index(c.first);
-                    assert(idx < new_utype.size() && idx < old_utype.size());
+                    SCYLLA_ASSERT(idx < new_utype.size() && idx < old_utype.size());
 
                     new_view.cells.emplace_back(c.first, upgrade_cell(
                             *new_utype.type(idx), *old_utype.type(idx), c.second, atomic_cell::collection_member::yes));

--- a/counters.cc
+++ b/counters.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "counters.hh"
 #include "mutation/mutation.hh"
 #include "combine.hh"
@@ -104,8 +105,8 @@ void counter_cell_view::apply(const column_definition& cdef, atomic_cell_or_coll
         return;
     }
 
-    assert(!dst_ac.is_counter_update());
-    assert(!src_ac.is_counter_update());
+    SCYLLA_ASSERT(!dst_ac.is_counter_update());
+    SCYLLA_ASSERT(!src_ac.is_counter_update());
 
     auto src_ccv = counter_cell_view(src_ac);
     auto dst_ccv = counter_cell_view(dst_ac);
@@ -132,8 +133,8 @@ void counter_cell_view::apply(const column_definition& cdef, atomic_cell_or_coll
 
 std::optional<atomic_cell> counter_cell_view::difference(atomic_cell_view a, atomic_cell_view b)
 {
-    assert(!a.is_counter_update());
-    assert(!b.is_counter_update());
+    SCYLLA_ASSERT(!a.is_counter_update());
+    SCYLLA_ASSERT(!b.is_counter_update());
 
     if (!b.is_live() || !a.is_live()) {
         if (b.is_live() || (!a.is_live() && compare_atomic_cell_for_merge(b, a) < 0)) {

--- a/counters.hh
+++ b/counters.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <boost/range/iterator_range.hpp>
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/range/numeric.hpp>
@@ -311,8 +312,8 @@ public:
     explicit basic_counter_cell_view(basic_atomic_cell_view<is_mutable> ac) noexcept
         : _cell(ac)
     {
-        assert(_cell.is_live());
-        assert(!_cell.is_counter_update());
+        SCYLLA_ASSERT(_cell.is_live());
+        SCYLLA_ASSERT(!_cell.is_counter_update());
     }
 
     api::timestamp_type timestamp() const { return _cell.timestamp(); }

--- a/cql3/column_specification.cc
+++ b/cql3/column_specification.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include "cql3/column_specification.hh"
 
 namespace cql3 {
@@ -22,7 +23,7 @@ column_specification::column_specification(std::string_view ks_name_, std::strin
 
 bool column_specification::all_in_same_table(const std::vector<lw_shared_ptr<column_specification>>& names)
 {
-    assert(!names.empty());
+    SCYLLA_ASSERT(!names.empty());
 
     auto first = names.front();
     return std::all_of(std::next(names.begin()), names.end(), [first] (auto&& spec) {

--- a/cql3/cql3_type.cc
+++ b/cql3/cql3_type.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <iterator>
 #include <boost/regex.hpp>
 
@@ -47,8 +48,8 @@ static cql3_type::kind get_cql3_kind(const abstract_type& t) {
         cql3_type::kind operator()(const uuid_type_impl&) { return cql3_type::kind::UUID; }
         cql3_type::kind operator()(const varint_type_impl&) { return cql3_type::kind::VARINT; }
         cql3_type::kind operator()(const reversed_type_impl& r) { return get_cql3_kind(*r.underlying_type()); }
-        cql3_type::kind operator()(const tuple_type_impl&) { assert(0 && "no kind for this type"); }
-        cql3_type::kind operator()(const collection_type_impl&) { assert(0 && "no kind for this type"); }
+        cql3_type::kind operator()(const tuple_type_impl&) { SCYLLA_ASSERT(0 && "no kind for this type"); }
+        cql3_type::kind operator()(const collection_type_impl&) { SCYLLA_ASSERT(0 && "no kind for this type"); }
     };
     return visit(t, visitor{});
 }
@@ -147,7 +148,7 @@ public:
     }
 
     virtual cql3_type prepare_internal(const sstring& keyspace, const data_dictionary::user_types_metadata& user_types) override {
-        assert(_values); // "Got null values type for a collection";
+        SCYLLA_ASSERT(_values); // "Got null values type for a collection";
 
         if (_values->is_counter()) {
             throw exceptions::invalid_request_exception(format("Counters are not allowed inside collections: {}", *this));
@@ -187,7 +188,7 @@ private:
             }
             return cql3_type(set_type_impl::get_instance(_values->prepare_internal(keyspace, user_types).get_type(), !is_frozen()));
         } else if (_kind == abstract_type::kind::map) {
-            assert(_keys); // "Got null keys type for a collection";
+            SCYLLA_ASSERT(_keys); // "Got null keys type for a collection";
             if (_keys->is_duration()) {
                 throw exceptions::invalid_request_exception(format("Durations are not allowed as map keys: {}", *this));
             }

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "functions.hh"
 #include "token_fct.hh"
 #include "cql3/ut_name.hh"
@@ -450,7 +451,7 @@ functions::get_user_aggregates(const sstring& keyspace) const {
 
 boost::iterator_range<functions::declared_t::const_iterator>
 functions::find(const function_name& name) const {
-    assert(name.has_keyspace()); // : "function name not fully qualified";
+    SCYLLA_ASSERT(name.has_keyspace()); // : "function name not fully qualified";
     auto pair = _declared.equal_range(name);
     return boost::make_iterator_range(pair.first, pair.second);
 }

--- a/cql3/keyspace_element_name.cc
+++ b/cql3/keyspace_element_name.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include "cql3/keyspace_element_name.hh"
 
 namespace cql3 {
@@ -24,7 +25,7 @@ bool keyspace_element_name::has_keyspace() const
 
 const sstring& keyspace_element_name::get_keyspace() const
 {
-    assert(_ks_name);
+    SCYLLA_ASSERT(_ks_name);
     return *_ks_name;
 }
 

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -13,6 +13,7 @@
 #include "cql3/expr/expr-utils.hh"
 #include <boost/iterator/transform_iterator.hpp>
 #include "types/list.hh"
+#include "utils/assert.hh"
 #include "utils/UUID_gen.hh"
 #include "mutation/mutation.hh"
 
@@ -62,7 +63,7 @@ lists::setter_by_index::fill_prepare_context(prepare_context& ctx) {
 void
 lists::setter_by_index::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
     // we should not get here for frozen lists
-    assert(column.type->is_multi_cell()); // "Attempted to set an individual element on a frozen list";
+    SCYLLA_ASSERT(column.type->is_multi_cell()); // "Attempted to set an individual element on a frozen list";
 
     auto index = expr::evaluate(_idx, params._options);
     if (index.is_null()) {
@@ -105,7 +106,7 @@ lists::setter_by_uuid::requires_read() const {
 void
 lists::setter_by_uuid::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
     // we should not get here for frozen lists
-    assert(column.type->is_multi_cell()); // "Attempted to set an individual element on a frozen list";
+    SCYLLA_ASSERT(column.type->is_multi_cell()); // "Attempted to set an individual element on a frozen list";
 
     auto index = expr::evaluate(_idx, params._options);
     auto value = expr::evaluate(*_e, params._options);
@@ -133,7 +134,7 @@ lists::setter_by_uuid::execute(mutation& m, const clustering_key_prefix& prefix,
 void
 lists::appender::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
     const cql3::raw_value value = expr::evaluate(*_e, params._options);
-    assert(column.type->is_multi_cell()); // "Attempted to append to a frozen list";
+    SCYLLA_ASSERT(column.type->is_multi_cell()); // "Attempted to append to a frozen list";
     do_append(value, m, prefix, column, params);
 }
 
@@ -189,7 +190,7 @@ lists::do_append(const cql3::raw_value& list_value,
 
 void
 lists::prepender::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
-    assert(column.type->is_multi_cell()); // "Attempted to prepend to a frozen list";
+    SCYLLA_ASSERT(column.type->is_multi_cell()); // "Attempted to prepend to a frozen list";
     cql3::raw_value lvalue = expr::evaluate(*_e, params._options);
     if (lvalue.is_null()) {
         return;
@@ -244,7 +245,7 @@ lists::discarder::requires_read() const {
 
 void
 lists::discarder::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
-    assert(column.type->is_multi_cell()); // "Attempted to delete from a frozen list";
+    SCYLLA_ASSERT(column.type->is_multi_cell()); // "Attempted to delete from a frozen list";
 
     auto&& existing_list = params.get_prefetched_list(m.key(), prefix, column);
     // We want to call bind before possibly returning to reject queries where the value provided is not a list.
@@ -300,7 +301,7 @@ lists::discarder_by_index::requires_read() const {
 
 void
 lists::discarder_by_index::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
-    assert(column.type->is_multi_cell()); // "Attempted to delete an item by index from a frozen list";
+    SCYLLA_ASSERT(column.type->is_multi_cell()); // "Attempted to delete an item by index from a frozen list";
     cql3::raw_value index = expr::evaluate(*_e, params._options);
     if (index.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null value for list index");

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include "maps.hh"
 #include "operation.hh"
 #include "update_parameters.hh"
@@ -44,7 +45,7 @@ maps::setter_by_key::fill_prepare_context(prepare_context& ctx) {
 void
 maps::setter_by_key::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
     using exceptions::invalid_request_exception;
-    assert(column.type->is_multi_cell()); // "Attempted to set a value for a single key on a frozen map"m
+    SCYLLA_ASSERT(column.type->is_multi_cell()); // "Attempted to set a value for a single key on a frozen map"m
     auto key = expr::evaluate(_k, params._options);
     auto value = expr::evaluate(*_e, params._options);
     if (key.is_null()) {
@@ -62,7 +63,7 @@ maps::setter_by_key::execute(mutation& m, const clustering_key_prefix& prefix, c
 
 void
 maps::putter::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
-    assert(column.type->is_multi_cell()); // "Attempted to add items to a frozen map";
+    SCYLLA_ASSERT(column.type->is_multi_cell()); // "Attempted to add items to a frozen map";
     cql3::raw_value value = expr::evaluate(*_e, params._options);
     do_put(m, prefix, params, value, column);
 }
@@ -95,7 +96,7 @@ maps::do_put(mutation& m, const clustering_key_prefix& prefix, const update_para
 
 void
 maps::discarder_by_key::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
-    assert(column.type->is_multi_cell()); // "Attempted to delete a single key in a frozen map";
+    SCYLLA_ASSERT(column.type->is_multi_cell()); // "Attempted to delete a single key in a frozen map";
     cql3::raw_value key = expr::evaluate(*_e, params._options);
     if (key.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null map key");

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -27,6 +27,7 @@
 #include "transport/messages/result_message.hh"
 #include "service/client_state.hh"
 #include "service/broadcast_tables/experimental/query_result.hh"
+#include "utils/assert.hh"
 #include "utils/observable.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "types/types.hh"
@@ -542,7 +543,7 @@ private:
                                    bound_terms,
                                    std::numeric_limits<uint16_t>::max()));
                 }
-                assert(bound_terms == prepared->bound_names.size());
+                SCYLLA_ASSERT(bound_terms == prepared->bound_names.size());
                 return make_ready_future<std::unique_ptr<statements::prepared_statement>>(std::move(prepared));
             }).then([&key, &id_getter, &client_state] (auto prep_ptr) {
                 const auto& warnings = prep_ptr->warnings;

--- a/cql3/restrictions/bounds_slice.hh
+++ b/cql3/restrictions/bounds_slice.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <seastar/core/shared_ptr.hh>
 #include "index/secondary_index_manager.hh"
 #include "cql3/expr/expression.hh"
@@ -88,10 +89,10 @@ public:
      */
     void merge(const bounds_slice& other) {
         if (has_bound(statements::bound::START)) {
-            assert(!other.has_bound(statements::bound::START));
+            SCYLLA_ASSERT(!other.has_bound(statements::bound::START));
             _bounds[get_idx(statements::bound::END)] = other._bounds[get_idx(statements::bound::END)];
         } else {
-            assert(!other.has_bound(statements::bound::END));
+            SCYLLA_ASSERT(!other.has_bound(statements::bound::END));
             _bounds[get_idx(statements::bound::START)] = other._bounds[get_idx(statements::bound::START)];
         }
     }

--- a/cql3/result_set.cc
+++ b/cql3/result_set.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include "cql3/result_set.hh"
 
 namespace cql3 {
@@ -49,7 +50,7 @@ void metadata::set_paging_state(lw_shared_ptr<const service::pager::paging_state
 }
 
 void metadata::maybe_set_paging_state(lw_shared_ptr<const service::pager::paging_state> paging_state) {
-    assert(paging_state);
+    SCYLLA_ASSERT(paging_state);
     if (paging_state->get_remaining() > 0) {
         set_paging_state(std::move(paging_state));
     } else {
@@ -114,7 +115,7 @@ bool result_set::empty() const {
 }
 
 void result_set::add_row(std::vector<managed_bytes_opt> row) {
-    assert(row.size() == _metadata->value_count());
+    SCYLLA_ASSERT(row.size() == _metadata->value_count());
     _rows.emplace_back(std::move(row));
 }
 

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "bytes.hh"
 #include "schema/schema_fwd.hh"
 #include "query-result-reader.hh"
@@ -331,7 +332,7 @@ public:
                     add_value(*def, static_row_iterator);
                     break;
                 default:
-                    assert(0);
+                    SCYLLA_ASSERT(0);
                 }
             }
             _builder.complete_row();

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "sets.hh"
 #include "types/set.hh"
 #include "cql3/expr/evaluate.hh"
@@ -32,7 +33,7 @@ sets::setter::execute(mutation& m, const clustering_key_prefix& row_key, const u
 void
 sets::adder::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {
     const cql3::raw_value value = expr::evaluate(*_e, params._options);
-    assert(column.type->is_multi_cell()); // "Attempted to add items to a frozen set";
+    SCYLLA_ASSERT(column.type->is_multi_cell()); // "Attempted to add items to a frozen set";
     do_add(m, row_key, params, value, column);
 }
 
@@ -75,7 +76,7 @@ sets::adder::do_add(mutation& m, const clustering_key_prefix& row_key, const upd
 
 void
 sets::discarder::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {
-    assert(column.type->is_multi_cell()); // "Attempted to remove items from a frozen set";
+    SCYLLA_ASSERT(column.type->is_multi_cell()); // "Attempted to remove items from a frozen set";
 
     cql3::raw_value svalue = expr::evaluate(*_e, params._options);
     if (svalue.is_null()) {
@@ -96,7 +97,7 @@ sets::discarder::execute(mutation& m, const clustering_key_prefix& row_key, cons
 
 void sets::element_discarder::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params)
 {
-    assert(column.type->is_multi_cell() && "Attempted to remove items from a frozen set");
+    SCYLLA_ASSERT(column.type->is_multi_cell() && "Attempted to remove items from a frozen set");
     cql3::raw_value elt = expr::evaluate(*_e, params._options);
     if (elt.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null set element");

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include <seastar/core/coroutine.hh>
 #include "cql3/query_options.hh"
 #include "cql3/statements/alter_table_statement.hh"
@@ -304,7 +305,7 @@ std::pair<schema_builder, std::vector<view_ptr>> alter_table_statement::prepare_
 
     switch (_type) {
     case alter_table_statement::type::add:
-        assert(_column_changes.size());
+        SCYLLA_ASSERT(_column_changes.size());
         if (s->is_dense()) {
             throw exceptions::invalid_request_exception("Cannot add new column to a COMPACT STORAGE table");
         }
@@ -312,12 +313,12 @@ std::pair<schema_builder, std::vector<view_ptr>> alter_table_statement::prepare_
         break;
 
     case alter_table_statement::type::alter:
-        assert(_column_changes.size() == 1);
+        SCYLLA_ASSERT(_column_changes.size() == 1);
         invoke_column_change_fn(std::mem_fn(&alter_table_statement::alter_column));
         break;
 
     case alter_table_statement::type::drop:
-        assert(_column_changes.size());
+        SCYLLA_ASSERT(_column_changes.size());
         if (!s->is_cql3_table()) {
             throw exceptions::invalid_request_exception("Cannot drop columns from a non-CQL3 table");
         }

--- a/cql3/statements/cas_request.hh
+++ b/cql3/statements/cas_request.hh
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 #pragma once
+#include "utils/assert.hh"
 #include "service/paxos/cas_request.hh"
 #include "cql3/statements/modification_statement.hh"
 
@@ -49,7 +50,7 @@ public:
           , _key(std::move(key_arg))
           , _rows(schema_arg)
     {
-        assert(_key.size() == 1 && query::is_single_partition(_key.front()));
+        SCYLLA_ASSERT(_key.size() == 1 && query::is_single_partition(_key.front()));
     }
 
     dht::partition_range_vector key() const {

--- a/cql3/statements/cf_statement.cc
+++ b/cql3/statements/cf_statement.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include "raw/cf_statement.hh"
 #include "service/client_state.hh"
 
@@ -40,13 +41,13 @@ void cf_statement::prepare_keyspace(std::string_view keyspace)
 }
 
 bool cf_statement::has_keyspace() const {
-    assert(_cf_name.has_value());
+    SCYLLA_ASSERT(_cf_name.has_value());
     return _cf_name->has_keyspace();
 }
 
 const sstring& cf_statement::keyspace() const
 {
-    assert(_cf_name->has_keyspace()); // "The statement hasn't be prepared correctly";
+    SCYLLA_ASSERT(_cf_name->has_keyspace()); // "The statement hasn't be prepared correctly";
     return _cf_name->get_keyspace();
 }
 

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -9,6 +9,7 @@
  */
 
 
+#include "utils/assert.hh"
 #include <inttypes.h>
 #include <boost/regex.hpp>
 
@@ -128,7 +129,7 @@ void create_table_statement::apply_properties_to(schema_builder& builder, const 
 
 void create_table_statement::add_column_metadata_from_aliases(schema_builder& builder, std::vector<bytes> aliases, const std::vector<data_type>& types, column_kind kind) const
 {
-    assert(aliases.size() == types.size());
+    SCYLLA_ASSERT(aliases.size() == types.size());
     for (size_t i = 0; i < aliases.size(); i++) {
         if (!aliases[i].empty()) {
             builder.with_column(aliases[i], types[i], kind);
@@ -212,7 +213,7 @@ std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepa
                 for (auto&& inner: type->all_types()) {
                     if (inner->is_multi_cell()) {
                         // a nested non-frozen UDT should have already been rejected when defining the type
-                        assert(inner->is_collection());
+                        SCYLLA_ASSERT(inner->is_collection());
                         throw exceptions::invalid_request_exception("Non-frozen UDTs with nested non-frozen collections are not supported");
                     }
                 }

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include <unordered_set>
 #include <vector>
 
@@ -61,7 +62,7 @@ future<> create_view_statement::check_access(query_processor& qp, const service:
 
 static const column_definition* get_column_definition(const schema& schema, column_identifier::raw& identifier) {
     auto prepared = identifier.prepare(schema);
-    assert(dynamic_pointer_cast<column_identifier>(prepared));
+    SCYLLA_ASSERT(dynamic_pointer_cast<column_identifier>(prepared));
     auto id = static_pointer_cast<column_identifier>(prepared);
     return schema.get_column_definition(id->name());
 }

--- a/cql3/statements/delete_statement.cc
+++ b/cql3/statements/delete_statement.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/range/adaptors.hpp>
 
@@ -102,7 +103,7 @@ delete_statement::delete_statement(cf_name name,
     , _deletions(std::move(deletions))
     , _where_clause(std::move(where_clause))
 {
-    assert(!_attrs->time_to_live.has_value());
+    SCYLLA_ASSERT(!_attrs->time_to_live.has_value());
 }
 
 }

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include "cql3/statements/ks_prop_defs.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include "data_dictionary/keyspace_metadata.hh"
@@ -158,7 +159,7 @@ ks_prop_defs::init_tablets_options ks_prop_defs::get_initial_tablets(const sstri
         if (enabled == "true") {
             ret = init_tablets_options{ .enabled = true, .specified_count = 0 }; // even if 'initial' is not set, it'll start with auto-detection
         } else if (enabled == "false") {
-            assert(!ret.enabled);
+            SCYLLA_ASSERT(!ret.enabled);
             return ret;
         } else {
             throw exceptions::configuration_exception(sstring("Tablets enabled value must be true or false; found: ") + enabled);

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include "cql3/cql_statement.hh"
 #include "cql3/statements/modification_statement.hh"
 #include "cql3/statements/strongly_consistent_modification_statement.hh"
@@ -422,7 +423,7 @@ modification_statement::process_where_clause(data_dictionary::database db, expr:
      * partition to check conditions.
      */
     if (_if_exists || _if_not_exists) {
-        assert(!_has_static_column_conditions && !_has_regular_column_conditions);
+        SCYLLA_ASSERT(!_has_static_column_conditions && !_has_regular_column_conditions);
         if (s->has_static_columns() && !_restrictions->has_clustering_columns_restriction()) {
             _has_static_column_conditions = true;
         } else {
@@ -604,13 +605,13 @@ modification_statement::prepare_conditions(data_dictionary::database db, const s
 
         if (_if_not_exists) {
             // To have both 'IF NOT EXISTS' and some other conditions doesn't make sense.
-            // So far this is enforced by the parser, but let's assert it for sanity if ever the parse changes.
-            assert(!_conditions);
-            assert(!_if_exists);
+            // So far this is enforced by the parser, but let's SCYLLA_ASSERT it for sanity if ever the parse changes.
+            SCYLLA_ASSERT(!_conditions);
+            SCYLLA_ASSERT(!_if_exists);
             stmt.set_if_not_exist_condition();
         } else if (_if_exists) {
-            assert(!_conditions);
-            assert(!_if_not_exists);
+            SCYLLA_ASSERT(!_conditions);
+            SCYLLA_ASSERT(!_if_not_exists);
             stmt.set_if_exist_condition();
         } else {
             stmt._condition = column_condition_prepare(*_conditions, db, keyspace(), schema);

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -44,6 +44,7 @@
 #include "test/lib/select_statement_utils.hh"
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include "gms/feature_service.hh"
+#include "utils/assert.hh"
 #include "utils/result_combinators.hh"
 #include "utils/result_loop.hh"
 #include "replica/database.hh"
@@ -815,7 +816,7 @@ select_statement::execute_without_checking_exception_message_non_aggregate_unpag
     auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
     if (needs_post_query_ordering() && _limit) {
         return do_with(std::forward<dht::partition_range_vector>(partition_ranges), [this, &qp, &state, &options, cmd, timeout](auto& prs) {
-            assert(cmd->partition_limit == query::max_partitions);
+            SCYLLA_ASSERT(cmd->partition_limit == query::max_partitions);
             query::result_merger merger(cmd->get_row_limit() * prs.size(), query::max_partitions);
             return utils::result_map_reduce(prs.begin(), prs.end(), [this, &qp, &state, &options, cmd, timeout] (auto& pr) {
                 dht::partition_range_vector prange { pr };
@@ -1110,7 +1111,7 @@ indexed_table_select_statement::do_execute(query_processor& qp,
             ? source_selector::INTERNAL : source_selector::USER;
     ++_stats.query_cnt(src_sel, _ks_sel, cond_selector::NO_CONDITIONS, statement_type::SELECT);
 
-    assert(_restrictions->uses_secondary_indexing());
+    SCYLLA_ASSERT(_restrictions->uses_secondary_indexing());
 
     _stats.unpaged_select_queries(_ks_sel) += options.get_page_size() <= 0;
 
@@ -1842,8 +1843,8 @@ mutation_fragments_select_statement::do_execute(query_processor& qp, service::qu
 namespace raw {
 
 static void validate_attrs(const cql3::attributes::raw& attrs) {
-    assert(!attrs.timestamp.has_value());
-    assert(!attrs.time_to_live.has_value());
+    SCYLLA_ASSERT(!attrs.timestamp.has_value());
+    SCYLLA_ASSERT(!attrs.time_to_live.has_value());
 }
 
 select_statement::select_statement(cf_name cf_name,
@@ -1975,7 +1976,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
     bool is_reversed_ = false;
 
     if (!_parameters->orderings().empty()) {
-        assert(!for_view);
+        SCYLLA_ASSERT(!for_view);
         verify_ordering_is_allowed(*_parameters, *restrictions);
         prepared_orderings_type prepared_orderings = prepare_orderings(*schema);
         verify_ordering_is_valid(prepared_orderings, *schema, *restrictions);

--- a/cql3/statements/truncate_statement.cc
+++ b/cql3/statements/truncate_statement.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include "cql3/statements/raw/truncate_statement.hh"
 #include "cql3/statements/truncate_statement.hh"
 #include "cql3/statements/prepared_statement.hh"
@@ -30,8 +31,8 @@ truncate_statement::truncate_statement(cf_name name, std::unique_ptr<attributes:
 {
     // Validate the attributes.
     // Currently, TRUNCATE supports only USING TIMEOUT
-    assert(!_attrs->timestamp.has_value());
-    assert(!_attrs->time_to_live.has_value());
+    SCYLLA_ASSERT(!_attrs->timestamp.has_value());
+    SCYLLA_ASSERT(!_attrs->time_to_live.has_value());
 }
 
 std::unique_ptr<prepared_statement> truncate_statement::prepare(data_dictionary::database db, cql_stats& stats) {

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include "update_statement.hh"
 #include "cql3/expr/expression.hh"
 #include "cql3/expr/evaluate.hh"
@@ -121,7 +122,7 @@ void update_statement::add_update_for_key(mutation& m, const query::clustering_r
         auto rb = s->regular_begin();
         if (rb->name().empty() || rb->type == empty_type) {
             // There is no column outside the PK. So no operation could have passed through validation
-            assert(_column_operations.empty());
+            SCYLLA_ASSERT(_column_operations.empty());
             constants::setter(*s->regular_begin(), expr::constant(cql3::raw_value::make_value(bytes()), empty_type)).execute(m, prefix, params);
         } else {
             // dense means we don't have a row marker, so don't accept to set only the PK. See CASSANDRA-5648.
@@ -438,7 +439,7 @@ insert_json_statement::prepare_internal(data_dictionary::database db, schema_ptr
 {
     // FIXME: handle _if_not_exists. For now, mark it used to quiet the compiler. #8682
     (void)_if_not_exists;
-    assert(expr::is<cql3::expr::untyped_constant>(_json_value) || expr::is<cql3::expr::bind_variable>(_json_value));
+    SCYLLA_ASSERT(expr::is<cql3::expr::untyped_constant>(_json_value) || expr::is<cql3::expr::bind_variable>(_json_value));
     auto json_column_placeholder = ::make_shared<column_identifier>("", true);
     auto prepared_json_value = prepare_expression(_json_value, db, "", nullptr, make_lw_shared<column_specification>("", "", json_column_placeholder, utf8_type));
     expr::verify_no_aggregate_functions(prepared_json_value, "JSON clause");

--- a/cql3/update_parameters.cc
+++ b/cql3/update_parameters.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include "cql3/update_parameters.hh"
 #include "cql3/selection/selection.hh"
 #include "cql3/expr/expression.hh"
@@ -50,7 +51,7 @@ update_parameters::get_prefetched_list(const partition_key& pkey, const clusteri
     }
 
     // Ensured by collections_as_maps flag in read_command flags
-    assert(type->is_map());
+    SCYLLA_ASSERT(type->is_map());
 
     auto cell = type->deserialize(managed_bytes_view(*val));
     const map_type_impl& map_type = static_cast<const map_type_impl&>(*cell.type());
@@ -104,7 +105,7 @@ public:
     }
 
     void accept_new_partition(uint64_t row_count) {
-        assert(0);
+        SCYLLA_ASSERT(0);
     }
 
     void accept_new_row(const clustering_key& key, const query::result_row_view& static_row,
@@ -118,7 +119,7 @@ public:
     }
 
     void accept_new_row(const query::result_row_view& static_row, const query::result_row_view& row) {
-        assert(0);
+        SCYLLA_ASSERT(0);
     }
 
     void accept_partition_end(const query::result_row_view& static_row) {

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include "cql3/user_types.hh"
 
 #include "cql3/expr/evaluate.hh"
@@ -49,7 +50,7 @@ void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_k
             const auto& elems = expr::get_user_type_elements(ut_value, type);
             // There might be fewer elements given than fields in the type
             // (e.g. when the user uses a short tuple literal), but never more.
-            assert(elems.size() <= type.size());
+            SCYLLA_ASSERT(elems.size() <= type.size());
 
             for (size_t i = 0; i < elems.size(); ++i) {
                 if (!elems[i]) {
@@ -73,7 +74,7 @@ void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_k
 }
 
 void user_types::setter_by_field::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {
-    assert(column.type->is_user_type() && column.type->is_multi_cell());
+    SCYLLA_ASSERT(column.type->is_user_type() && column.type->is_multi_cell());
 
     auto value = expr::evaluate(*_e, params._options);
 
@@ -88,7 +89,7 @@ void user_types::setter_by_field::execute(mutation& m, const clustering_key_pref
 }
 
 void user_types::deleter_by_field::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {
-    assert(column.type->is_user_type() && column.type->is_multi_cell());
+    SCYLLA_ASSERT(column.type->is_user_type() && column.type->is_multi_cell());
 
     collection_mutation_description mut;
     mut.cells.emplace_back(serialize_field_index(_field_idx), params.make_dead_cell());

--- a/cql3/util.cc
+++ b/cql3/util.cc
@@ -4,6 +4,7 @@
 
 /* Copyright 2020-present ScyllaDB */
 
+#include "utils/assert.hh"
 #include "util.hh"
 #include "cql3/expr/expr-utils.hh"
 
@@ -88,7 +89,7 @@ void do_with_parser_impl(const sstring_view& cql, noncopyable_function<void (cql
     };
     ucontext_t uc;
     auto r = getcontext(&uc);
-    assert(r == 0);
+    SCYLLA_ASSERT(r == 0);
     if (stack.get() <= (char*)&uc && (char*)&uc < stack.get() + stack_size) {
         // We are already running on the large stack, so just call the
         // parser directly.

--- a/data_dictionary/user_types_metadata.hh
+++ b/data_dictionary/user_types_metadata.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <unordered_map>
 
 #include "bytes.hh"
@@ -26,7 +27,7 @@ public:
     }
     void add_type(user_type type) {
         auto i = _user_types.find(type->_name);
-        assert(i == _user_types.end() || type->is_compatible_with(*i->second));
+        SCYLLA_ASSERT(i == _user_types.end() || type->is_compatible_with(*i->second));
         _user_types.insert_or_assign(i, type->_name, type);
     }
     void remove_type(user_type type) {

--- a/db/commitlog/commitlog_entry.hh
+++ b/db/commitlog/commitlog_entry.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <optional>
 
 #include "commitlog_types.hh"
@@ -111,7 +112,7 @@ public:
     }
 
     size_t size() const {
-        assert(_size != std::numeric_limits<size_t>::max());
+        SCYLLA_ASSERT(_size != std::numeric_limits<size_t>::max());
         return _size;
     }
 

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include <memory>
 #include <vector>
 #include <algorithm>
@@ -69,7 +70,7 @@ public:
     };
 
     // move start/stop of the thread local bookkeep to "top level"
-    // and also make sure to assert on it actually being started.
+    // and also make sure to SCYLLA_ASSERT on it actually being started.
     future<> start() {
         return _column_mappings.start();
     }
@@ -164,7 +165,7 @@ future<> db::commitlog_replayer::impl::init() {
 
 future<db::commitlog_replayer::impl::stats>
 db::commitlog_replayer::impl::recover(sstring file, const sstring& fname_prefix) const {
-    assert(_column_mappings.local_is_initialized());
+    SCYLLA_ASSERT(_column_mappings.local_is_initialized());
 
     replay_position rp{commitlog::descriptor(file, fname_prefix)};
     auto gp = min_pos(rp.shard_id());

--- a/db/heat_load_balance.hh
+++ b/db/heat_load_balance.hh
@@ -27,6 +27,7 @@
  *    uniformly, and we need to choose K nodes and forward the request
  *    to them).
  */
+#include "utils/assert.hh"
 #include <vector>
 #include <cassert>
 #include <fmt/ranges.h>
@@ -70,7 +71,7 @@ public:
     std::vector<Node> get() {
         auto n = _pp.size();
         auto ke = _k + (_extra ? 1 : 0);
-        assert(ke <= n);
+        SCYLLA_ASSERT(ke <= n);
         std::vector<Node> ret;
         ret.reserve(ke);
         std::vector<int> r = ssample(_k, _pp);
@@ -97,7 +98,7 @@ public:
                 }
             }
         }
-        assert(ret.size() == ke);
+        SCYLLA_ASSERT(ret.size() == ke);
         return ret;
     }
 };

--- a/db/hints/internal/hint_endpoint_manager.cc
+++ b/db/hints/internal/hint_endpoint_manager.cc
@@ -24,6 +24,7 @@
 #include "db/hints/manager.hh"
 #include "db/timeout_clock.hh"
 #include "replica/database.hh"
+#include "utils/assert.hh"
 #include "utils/disk-error-handler.hh"
 #include "utils/error_injection.hh"
 #include "utils/runtime.hh"
@@ -173,7 +174,7 @@ hint_endpoint_manager::hint_endpoint_manager(hint_endpoint_manager&& other)
 {}
 
 hint_endpoint_manager::~hint_endpoint_manager() {
-    assert(stopped());
+    SCYLLA_ASSERT(stopped());
 }
 
 future<hints_store_ptr> hint_endpoint_manager::get_or_load() {

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -10,6 +10,7 @@
 #pragma once
 
 // Seastar features.
+#include "utils/assert.hh"
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -167,7 +168,7 @@ public:
     manager& operator=(manager&&) = delete;
 
     ~manager() noexcept {
-        assert(_ep_managers.empty());
+        SCYLLA_ASSERT(_ep_managers.empty());
     }
 
 public:

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <seastar/core/print.hh>
 #include <seastar/core/coroutine.hh>
 #include "db/system_keyspace.hh"
@@ -36,7 +37,7 @@ large_data_handler::large_data_handler(uint64_t partition_threshold_bytes, uint6
 }
 
 future<large_data_handler::partition_above_threshold> large_data_handler::maybe_record_large_partitions(const sstables::sstable& sst, const sstables::key& key, uint64_t partition_size, uint64_t rows, uint64_t range_tombstones, uint64_t dead_rows) {
-    assert(running());
+    SCYLLA_ASSERT(running());
     partition_above_threshold above_threshold{partition_size > _partition_threshold_bytes, rows > _rows_count_threshold};
     static_assert(std::is_same_v<decltype(above_threshold.size), bool>);
     _stats.partitions_bigger_than_threshold += above_threshold.size; // increment if true
@@ -79,7 +80,7 @@ sstring large_data_handler::sst_filename(const sstables::sstable& sst) {
 }
 
 future<> large_data_handler::maybe_delete_large_data_entries(sstables::shared_sstable sst) {
-    assert(running());
+    SCYLLA_ASSERT(running());
     auto schema = sst->get_schema();
     auto filename = sst_filename(*sst);
     using ldt = sstables::large_data_type;
@@ -237,7 +238,7 @@ future<> cql_table_large_data_handler::record_large_rows(const sstables::sstable
 }
 
 future<> cql_table_large_data_handler::delete_large_data_entries(const schema& s, sstring sstable_name, std::string_view large_table_name) const {
-    assert(_sys_ks);
+    SCYLLA_ASSERT(_sys_ks);
     const sstring req =
             format("DELETE FROM system.{} WHERE keyspace_name = ? AND table_name = ? AND sstable_name = ?",
                     large_table_name);

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -12,6 +12,7 @@
 #include "schema/schema_fwd.hh"
 #include "system_keyspace.hh"
 #include "sstables/shared_sstable.hh"
+#include "utils/assert.hh"
 #include "utils/updateable_value.hh"
 
 namespace sstables {
@@ -78,7 +79,7 @@ public:
 
     future<bool> maybe_record_large_rows(const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, uint64_t row_size) {
-        assert(running());
+        SCYLLA_ASSERT(running());
         if (__builtin_expect(row_size > _row_threshold_bytes, false)) {
             return with_sem([&sst, &partition_key, clustering_key, row_size, this] {
                 return record_large_rows(sst, partition_key, clustering_key, row_size);
@@ -98,7 +99,7 @@ public:
 
     future<bool> maybe_record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,
             const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) {
-        assert(running());
+        SCYLLA_ASSERT(running());
         if (__builtin_expect(cell_size > _cell_threshold_bytes || collection_elements > _collection_elements_count_threshold, false)) {
             return with_sem([&sst, &partition_key, clustering_key, &cdef, cell_size, collection_elements, this] {
                 return record_large_cells(sst, partition_key, clustering_key, cdef, cell_size, collection_elements);

--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <boost/range/adaptor/indirected.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/transformed.hpp>
@@ -188,7 +189,7 @@ static future<std::vector<token_range>> get_local_ranges(replica::database& db, 
         auto ranges = db.get_token_metadata().get_primary_ranges_for(std::move(tokens));
         std::vector<token_range> local_ranges;
         auto to_bytes = [](const std::optional<dht::token_range::bound>& b) {
-            assert(b);
+            SCYLLA_ASSERT(b);
             return utf8_type->decompose(b->value().to_sstring());
         };
         // We merge the ranges to be compatible with how Cassandra shows it's size estimates table.

--- a/db/sstables-format-selector.cc
+++ b/db/sstables-format-selector.cc
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <seastar/core/coroutine.hh>
 #include "sstables-format-selector.hh"
 #include "log.hh"
@@ -82,7 +83,7 @@ future<> sstables_format_listener::maybe_select_format(sstables::sstable_version
 }
 
 future<> sstables_format_listener::start() {
-    assert(this_shard_id() == 0);
+    SCYLLA_ASSERT(this_shard_id() == 0);
     // The listener may fire immediately, create a thread for that case.
     co_await seastar::async([this] {
         _me_feature_listener.on_enabled();

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "db/system_distributed_keyspace.hh"
 
 #include "cql3/untyped_result_set.hh"
@@ -220,7 +221,7 @@ static schema_ptr get_current_service_levels(data_dictionary::database db) {
 }
 
 static schema_ptr get_updated_service_levels(data_dictionary::database db) {
-    assert(this_shard_id() == 0);
+    SCYLLA_ASSERT(this_shard_id() == 0);
     auto schema = get_current_service_levels(db);
     schema_builder b(schema);
     for (const auto& col : new_columns) {

--- a/db/view/row_locking.cc
+++ b/db/view/row_locking.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "row_locking.hh"
 #include "log.hh"
 
@@ -152,14 +153,14 @@ row_locker::unlock(const dht::decorated_key* pk, bool partition_exclusive,
             mylog.error("column_family::local_base_lock_holder::~local_base_lock_holder() can't find lock for partition", *pk);
             return;
         }
-        assert(&pli->first == pk);
+        SCYLLA_ASSERT(&pli->first == pk);
         if (cpk) {
             auto rli = pli->second._row_locks.find(*cpk);
             if (rli == pli->second._row_locks.end()) {
                 mylog.error("column_family::local_base_lock_holder::~local_base_lock_holder() can't find lock for row", *cpk);
                 return;
             }
-            assert(&rli->first == cpk);
+            SCYLLA_ASSERT(&rli->first == cpk);
             mylog.debug("releasing {} lock for row {} in partition {}", (row_exclusive ? "exclusive" : "shared"), *cpk, *pk);
             auto& lock = rli->second;
             if (row_exclusive) {

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -12,6 +12,7 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include "dht/ring_position.hh"
 #include "dht/token-sharding.hh"
+#include "utils/assert.hh"
 #include "utils/class_registrator.hh"
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/irange.hpp>
@@ -423,7 +424,7 @@ future<dht::partition_range_vector> subtract_ranges(const schema& schema, const 
             ++range_to_subtract;
             break;
         default:
-            assert(size <= 2);
+            SCYLLA_ASSERT(size <= 2);
         }
         co_await coroutine::maybe_yield();
     }
@@ -442,7 +443,7 @@ dht::token_range_vector split_token_range_msb(unsigned most_significant_bits) {
     }
     uint64_t number_of_ranges = 1 << most_significant_bits;
     ret.reserve(number_of_ranges);
-    assert(most_significant_bits < 64);
+    SCYLLA_ASSERT(most_significant_bits < 64);
     dht::token prev_last_token;
     for (uint64_t i = 0; i < number_of_ranges; i++) {
         std::optional<dht::token_range::bound> start_bound;

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -18,6 +18,7 @@
 #include <fmt/ranges.h>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/sleep.hh>
+#include "utils/assert.hh"
 #include "utils/stall_free.hh"
 
 namespace dht {
@@ -118,7 +119,7 @@ range_streamer::get_all_ranges_with_sources_for(const sstring& keyspace_name, lo
 std::unordered_map<dht::token_range, std::vector<inet_address>>
 range_streamer::get_all_ranges_with_strict_sources_for(const sstring& keyspace_name, locator::vnode_effective_replication_map_ptr erm, dht::token_range_vector desired_ranges, gms::gossiper& gossiper) {
     logger.debug("{} ks={}", __func__, keyspace_name);
-    assert (_tokens.empty() == false);
+    SCYLLA_ASSERT (_tokens.empty() == false);
 
     auto& strat = erm->get_replication_strategy();
 

--- a/dht/token-sharding.hh
+++ b/dht/token-sharding.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "dht/token.hh"
 #include <seastar/core/smp.hh>
 #include <boost/container/static_vector.hpp>
@@ -62,7 +63,7 @@ public:
      *
      *   [] (const token& t) {
      *      auto shards = shard_for_writes();
-     *      assert(shards.size() <= 1);
+     *      SCYLLA_ASSERT(shards.size() <= 1);
      *      return shards.empty() ? 0 : shards[0];
      *   }
      *

--- a/enum_set.hh
+++ b/enum_set.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <boost/iterator/transform_iterator.hpp>
 #include <seastar/core/bitset-iter.hh>
 
@@ -31,9 +32,9 @@
  *
  *   static_assert(my_enumset::frozen<x::A, x::B>::contains<x::A>(), "it should...");
  *
- *   assert(my_enumset::frozen<x::A, x::B>::contains(my_enumset::prepare<x::A>()));
+ *   SCYLLA_ASSERT(my_enumset::frozen<x::A, x::B>::contains(my_enumset::prepare<x::A>()));
  *
- *   assert(my_enumset::frozen<x::A, x::B>::contains(x::A));
+ *   SCYLLA_ASSERT(my_enumset::frozen<x::A, x::B>::contains(x::A));
  *
  */
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -17,6 +17,7 @@
 #include <boost/range/adaptor/map.hpp>
 #include "gms/gossiper.hh"
 #include "gms/i_endpoint_state_change_subscriber.hh"
+#include "utils/assert.hh"
 #include "utils/error_injection.hh"
 #include "service/storage_service.hh"
 
@@ -59,7 +60,7 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
     case sstables::sstable_version_types::me:
         break;
     default:
-        assert(false && "Invalid sstable_format");
+        SCYLLA_ASSERT(false && "Invalid sstable_format");
     }
 
     if (!cfg.enable_user_defined_functions()) {
@@ -101,7 +102,7 @@ future<> feature_service::stop() {
 
 void feature_service::register_feature(feature& f) {
     auto i = _registered_features.emplace(f.name(), f);
-    assert(i.second);
+    SCYLLA_ASSERT(i.second);
 }
 
 void feature_service::unregister_feature(feature& f) {

--- a/gms/generation-number.cc
+++ b/gms/generation-number.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <cassert>
 #include <chrono>
 #include <utility>
@@ -22,7 +23,7 @@ generation_type get_generation_number() {
     int generation_number = duration_cast<seconds>(now).count();
     auto ret = generation_type(generation_number);
     // Make sure the clock didn't overflow the 32 bits value
-    assert(ret.value() == generation_number);
+    SCYLLA_ASSERT(ret.value() == generation_number);
     return ret;
 }
 

--- a/interval.hh
+++ b/interval.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <list>
 #include <vector>
 #include <optional>
@@ -138,7 +139,7 @@ public:
     // the point is before the interval (works only for non wrapped intervals)
     // Comparator must define a total ordering on T.
     bool before(const T& point, IntervalComparatorFor<T> auto&& cmp) const {
-        assert(!is_wrap_around(cmp));
+        SCYLLA_ASSERT(!is_wrap_around(cmp));
         if (!start()) {
             return false; //open start, no points before
         }
@@ -154,8 +155,8 @@ public:
     // the other interval is before this interval (works only for non wrapped intervals)
     // Comparator must define a total ordering on T.
     bool other_is_before(const wrapping_interval<T>& o, IntervalComparatorFor<T> auto&& cmp) const {
-        assert(!is_wrap_around(cmp));
-        assert(!o.is_wrap_around(cmp));
+        SCYLLA_ASSERT(!is_wrap_around(cmp));
+        SCYLLA_ASSERT(!o.is_wrap_around(cmp));
         if (!start() || !o.end()) {
             return false;
         }
@@ -181,7 +182,7 @@ public:
     // the point is after the interval (works only for non wrapped intervals)
     // Comparator must define a total ordering on T.
     bool after(const T& point, IntervalComparatorFor<T> auto&& cmp) const {
-        assert(!is_wrap_around(cmp));
+        SCYLLA_ASSERT(!is_wrap_around(cmp));
         if (!end()) {
             return false; //open end, no points after
         }
@@ -211,8 +212,8 @@ public:
         }
 
         // No interval should reach this point as wrap around.
-        assert(!this_wraps);
-        assert(!other_wraps);
+        SCYLLA_ASSERT(!this_wraps);
+        SCYLLA_ASSERT(!other_wraps);
 
         // if both this and other have an open start, the two intervals will overlap.
         if (!start() && !other.start()) {
@@ -377,7 +378,7 @@ public:
     // split_point will belong to first interval
     // Comparator must define a total ordering on T.
     std::pair<wrapping_interval<T>, wrapping_interval<T>> split(const T& split_point, IntervalComparatorFor<T> auto&& cmp) const {
-        assert(contains(split_point, std::forward<decltype(cmp)>(cmp)));
+        SCYLLA_ASSERT(contains(split_point, std::forward<decltype(cmp)>(cmp)));
         wrapping_interval left(start(), bound(split_point));
         wrapping_interval right(bound(split_point, false), end());
         return std::make_pair(std::move(left), std::move(right));
@@ -584,7 +585,7 @@ public:
     // split_point will belong to first interval
     // Comparator must define a total ordering on T.
     std::pair<interval<T>, interval<T>> split(const T& split_point, IntervalComparatorFor<T> auto&& cmp) const {
-        assert(contains(split_point, std::forward<decltype(cmp)>(cmp)));
+        SCYLLA_ASSERT(contains(split_point, std::forward<decltype(cmp)>(cmp)));
         interval left(start(), bound(split_point));
         interval right(bound(split_point, false), end());
         return std::make_pair(std::move(left), std::move(right));

--- a/lang/lua.cc
+++ b/lang/lua.cc
@@ -12,6 +12,7 @@
 #include "lang/lua_scylla_types.hh"
 #include "exceptions/exceptions.hh"
 #include "concrete_types.hh"
+#include "utils/assert.hh"
 #include "utils/utf8.hh"
 #include "utils/ascii.hh"
 #include "utils/date.h"
@@ -41,7 +42,7 @@ struct alloc_state {
         : max(max)
         , max_contiguous(max_contiguous) {
         // The max and max_contiguous limits are responsible for avoiding overflows.
-        assert(max + max_contiguous >= max);
+        SCYLLA_ASSERT(max + max_contiguous >= max);
     }
 };
 
@@ -79,7 +80,7 @@ static void* lua_alloc(void* ud, void* ptr, size_t osize, size_t nsize) {
     size_t next = s->allocated + nsize;
 
     // The max and max_contiguous limits should be small enough to avoid overflows.
-    assert(next >= s->allocated);
+    SCYLLA_ASSERT(next >= s->allocated);
 
     if (ptr) {
         next -= osize;
@@ -119,7 +120,7 @@ static void debug_hook(lua_State* l, lua_Debug* ar) {
         return;
     }
     if (lua_yield(l, 0)) {
-        assert(0 && "lua_yield failed");
+        SCYLLA_ASSERT(0 && "lua_yield failed");
     }
 }
 
@@ -223,7 +224,7 @@ requires CanHandleRawLuaTypes<Func>
 static auto visit_lua_raw_value(lua_State* l, int index, Func&& f) {
     switch (lua_type(l, index)) {
     case LUA_TNONE:
-        assert(0 && "Invalid index");
+        SCYLLA_ASSERT(0 && "Invalid index");
     case LUA_TNUMBER:
         if (lua_isinteger(l, index)) {
             return f(lua_tointeger(l, index));
@@ -244,9 +245,9 @@ static auto visit_lua_raw_value(lua_State* l, int index, Func&& f) {
         return f(*get_decimal(l, index));
     case LUA_TTHREAD:
     case LUA_TLIGHTUSERDATA:
-        assert(0 && "We never make thread or light user data visible to scripts");
+        SCYLLA_ASSERT(0 && "We never make thread or light user data visible to scripts");
     }
-    assert(0 && "invalid lua type");
+    SCYLLA_ASSERT(0 && "invalid lua type");
 }
 
 template <typename Func>
@@ -362,7 +363,7 @@ static const big_decimal& get_decimal_in_binary_op(lua_State* l) {
     if (a == nullptr) {
         lua_insert(l, 1);
         a = get_decimal(l, 1);
-        assert(a);
+        SCYLLA_ASSERT(a);
     }
     return *a;
 }

--- a/locator/ec2_snitch.cc
+++ b/locator/ec2_snitch.cc
@@ -8,6 +8,7 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 
+#include "utils/assert.hh"
 #include "utils/class_registrator.hh"
 
 namespace locator {
@@ -29,13 +30,13 @@ future<> ec2_snitch::load_config(bool prefer_local) {
     if (this_shard_id() == io_cpu_id()) {
         auto token = co_await aws_api_call(AWS_QUERY_SERVER_ADDR, AWS_QUERY_SERVER_PORT, TOKEN_REQ_ENDPOINT, std::nullopt);
         auto az = co_await aws_api_call(AWS_QUERY_SERVER_ADDR, AWS_QUERY_SERVER_PORT, ZONE_NAME_QUERY_REQ, token);
-        assert(az.size());
+        SCYLLA_ASSERT(az.size());
 
         std::vector<std::string> splits;
 
         // Split "us-east-1a" or "asia-1a" into "us-east"/"1a" and "asia"/"1a".
         split(splits, az, is_any_of("-"));
-        assert(splits.size() > 1);
+        SCYLLA_ASSERT(splits.size() > 1);
 
         sstring my_rack = splits[splits.size() - 1];
 

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -22,6 +22,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/range/adaptors.hpp>
 #include "exceptions/exceptions.hh"
+#include "utils/assert.hh"
 #include "utils/class_registrator.hh"
 #include "utils/hash.hh"
 
@@ -195,7 +196,7 @@ public:
         , _racks(_tp.get_datacenter_racks())
     {
         // not aware of any cluster members
-        assert(!_all_endpoints.empty() && !_racks.empty());
+        SCYLLA_ASSERT(!_all_endpoints.empty() && !_racks.empty());
 
         auto size_for = [](auto& map, auto& k) {
             auto i = map.find(k);

--- a/locator/production_snitch_base.hh
+++ b/locator/production_snitch_base.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <unordered_map>
 #include <unordered_set>
 
@@ -73,17 +74,17 @@ protected:
     std::unordered_map<sstring, sstring> _prop_values;
 
     sharded<snitch_ptr>& container() noexcept {
-        assert(_backreference != nullptr);
+        SCYLLA_ASSERT(_backreference != nullptr);
         return _backreference->container();
     }
 
     snitch_ptr& local() noexcept {
-        assert(_backreference != nullptr);
+        SCYLLA_ASSERT(_backreference != nullptr);
         return *_backreference;
     }
 
     const snitch_ptr& local() const noexcept {
-        assert(_backreference != nullptr);
+        SCYLLA_ASSERT(_backreference != nullptr);
         return *_backreference;
     }
 

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -11,6 +11,7 @@
 
 #include "simple_strategy.hh"
 #include "exceptions/exceptions.hh"
+#include "utils/assert.hh"
 #include "utils/class_registrator.hh"
 #include <boost/algorithm/string.hpp>
 
@@ -50,7 +51,7 @@ future<host_id_set> simple_strategy::calculate_natural_endpoints(const token& t,
         }
 
         auto ep = tm.get_endpoint(token);
-        assert(ep);
+        SCYLLA_ASSERT(ep);
 
         endpoints.push_back(*ep);
         co_await coroutine::maybe_yield();

--- a/locator/snitch_base.hh
+++ b/locator/snitch_base.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <boost/signals2.hpp>
 #include <boost/signals2/dummy_mutex.hpp>
 
@@ -81,7 +82,7 @@ public:
      */
     virtual gms::application_state_map get_app_states() const = 0;
 
-    virtual ~i_endpoint_snitch() { assert(_state == snitch_state::stopped); };
+    virtual ~i_endpoint_snitch() { SCYLLA_ASSERT(_state == snitch_state::stopped); };
 
     // noop by default
     virtual future<> stop() {

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -21,6 +21,7 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include <boost/range/adaptors.hpp>
 #include <seastar/core/smp.hh>
+#include "utils/assert.hh"
 #include "utils/stall_free.hh"
 
 namespace locator {
@@ -1216,7 +1217,7 @@ future<> shared_token_metadata::mutate_token_metadata(seastar::noncopyable_funct
 
 future<> shared_token_metadata::mutate_on_all_shards(sharded<shared_token_metadata>& stm, seastar::noncopyable_function<future<> (token_metadata&)> func) {
     auto base_shard = this_shard_id();
-    assert(base_shard == 0);
+    SCYLLA_ASSERT(base_shard == 0);
     auto lk = co_await stm.local().get_lock();
 
     std::vector<mutable_token_metadata_ptr> pending_token_metadata_ptr;

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -15,6 +15,7 @@
 #include "log.hh"
 #include "locator/topology.hh"
 #include "locator/production_snitch_base.hh"
+#include "utils/assert.hh"
 #include "utils/stall_free.hh"
 #include "utils/to_string.hh"
 
@@ -117,7 +118,7 @@ topology::topology(topology&& o) noexcept
     , _sort_by_proximity(o._sort_by_proximity)
     , _datacenters(std::move(o._datacenters))
 {
-    assert(_shard == this_shard_id());
+    SCYLLA_ASSERT(_shard == this_shard_id());
     tlogger.trace("topology[{}]: move from [{}]", fmt::ptr(this), fmt::ptr(&o));
 
     for (auto& n : _nodes) {

--- a/main.cc
+++ b/main.cc
@@ -21,6 +21,7 @@
 #include <seastar/core/timer.hh>
 #include "service/qos/raft_service_level_distributed_data_accessor.hh"
 #include "tasks/task_manager.hh"
+#include "utils/assert.hh"
 #include "utils/build_id.hh"
 #include "supervisor.hh"
 #include "replica/database.hh"
@@ -528,7 +529,7 @@ static auto defer_verbose_shutdown(const char* what, Func&& func) {
 
                 // Call _exit() rather than exit() to exit immediately
                 // without calling exit handlers, avoiding
-                // boost::intrusive::detail::destructor_impl assert failure
+                // boost::intrusive::detail::destructor_impl SCYLLA_ASSERT failure
                 // from ~segment_pool exit handler.
                 _exit(255);
             }

--- a/mutation/atomic_cell.hh
+++ b/mutation/atomic_cell.hh
@@ -12,6 +12,7 @@
 #include "timestamp.hh"
 #include "mutation/tombstone.hh"
 #include "gc_clock.hh"
+#include "utils/assert.hh"
 #include "utils/managed_bytes.hh"
 #include <seastar/net//byteorder.hh>
 #include <seastar/util/bool_class.hh>
@@ -126,18 +127,18 @@ public:
     }
     // Can be called only when is_dead() is true.
     static gc_clock::time_point deletion_time(atomic_cell_value_view cell) {
-        assert(is_dead(cell));
+        SCYLLA_ASSERT(is_dead(cell));
         return gc_clock::time_point(gc_clock::duration(get_field<int64_t>(cell, deletion_time_offset)));
     }
     // Can be called only when is_live_and_has_ttl() is true.
     static gc_clock::time_point expiry(atomic_cell_value_view cell) {
-        assert(is_live_and_has_ttl(cell));
+        SCYLLA_ASSERT(is_live_and_has_ttl(cell));
         auto expiry = get_field<int64_t>(cell, expiry_offset);
         return gc_clock::time_point(gc_clock::duration(expiry));
     }
     // Can be called only when is_live_and_has_ttl() is true.
     static gc_clock::duration ttl(atomic_cell_value_view cell) {
-        assert(is_live_and_has_ttl(cell));
+        SCYLLA_ASSERT(is_live_and_has_ttl(cell));
         return gc_clock::duration(get_field<int32_t>(cell, ttl_offset));
     }
     static managed_bytes make_dead(api::timestamp_type timestamp, gc_clock::time_point deletion_time) {

--- a/mutation/mutation.hh
+++ b/mutation/mutation.hh
@@ -13,6 +13,7 @@
 #include "mutation_partition.hh"
 #include "keys.hh"
 #include "schema/schema_fwd.hh"
+#include "utils/assert.hh"
 #include "utils/hashing.hh"
 #include "mutation_fragment_v2.hh"
 #include "mutation_consumer.hh"
@@ -302,7 +303,7 @@ std::optional<stop_iteration> consume_clustering_fragments(schema_ptr s, mutatio
       if (crs_it == crs_end && rts_it == rts_end) {
         flush_tombstones(position_in_partition::after_all_clustered_rows());
       } else {
-        assert(preempt && need_preempt());
+        SCYLLA_ASSERT(preempt && need_preempt());
         return std::nullopt;
       }
     }

--- a/mutation/mutation_fragment.cc
+++ b/mutation/mutation_fragment.cc
@@ -11,6 +11,7 @@
 #include "mutation_fragment.hh"
 #include "mutation_fragment_v2.hh"
 #include "clustering_interval_set.hh"
+#include "utils/assert.hh"
 #include "utils/hashing.hh"
 #include "utils/xx_hasher.hh"
 
@@ -172,13 +173,13 @@ struct get_key_visitor {
 
 const clustering_key_prefix& mutation_fragment::key() const
 {
-    assert(has_key());
+    SCYLLA_ASSERT(has_key());
     return visit(get_key_visitor());
 }
 
 void mutation_fragment::apply(const schema& s, mutation_fragment&& mf)
 {
-    assert(mergeable_with(mf));
+    SCYLLA_ASSERT(mergeable_with(mf));
     switch (_kind) {
     case mutation_fragment::kind::partition_start:
         _data->_partition_start.partition_tombstone().apply(mf._data->_partition_start.partition_tombstone());
@@ -257,13 +258,13 @@ auto fmt::formatter<mutation_fragment::printer>::format(const mutation_fragment:
 
 const clustering_key_prefix& mutation_fragment_v2::key() const
 {
-    assert(has_key());
+    SCYLLA_ASSERT(has_key());
     return visit(get_key_visitor());
 }
 
 void mutation_fragment_v2::apply(const schema& s, mutation_fragment_v2&& mf)
 {
-    assert(mergeable_with(mf));
+    SCYLLA_ASSERT(mergeable_with(mf));
     switch (_kind) {
     case mutation_fragment_v2::kind::partition_start:
         _data->_partition_start.partition_tombstone().apply(mf._data->_partition_start.partition_tombstone());

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -24,6 +24,7 @@
 #include "atomic_cell_or_collection.hh"
 #include "hashing_partition_visitor.hh"
 #include "range_tombstone_list.hh"
+#include "utils/assert.hh"
 #include "utils/intrusive_btree.hh"
 #include "utils/preempt.hh"
 #include "utils/lru.hh"
@@ -1486,7 +1487,7 @@ private:
 
     void check_schema(const schema& s) const {
 #ifdef SEASTAR_DEBUG
-        assert(s.version() == _schema_version);
+        SCYLLA_ASSERT(s.version() == _schema_version);
 #endif
     }
 };

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <iosfwd>
 #include <boost/intrusive/set.hpp>
 #include <boost/range/iterator_range.hpp>
@@ -268,7 +269,7 @@ private:
 
     void check_schema(const schema& s) const {
 #ifdef SEASTAR_DEBUG
-        assert(s.version() == _schema_version);
+        SCYLLA_ASSERT(s.version() == _schema_version);
 #endif
     }
 };

--- a/mutation/mutation_partition_view.cc
+++ b/mutation/mutation_partition_view.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <seastar/core/simple-stream.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
@@ -103,7 +104,7 @@ collection_mutation read_collection_cell(const abstract_type& type, ser::collect
             for (auto&& e : elements) {
                 bytes key = e.key();
                 auto idx = deserialize_field_index(key);
-                assert(idx < utype.size());
+                SCYLLA_ASSERT(idx < utype.size());
 
                 mut.cells.emplace_back(key, read_atomic_cell(*utype.type(idx), e.value(), atomic_cell::collection_member::yes));
             }

--- a/mutation/mutation_rebuilder.hh
+++ b/mutation/mutation_rebuilder.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "mutation.hh"
 #include "range_tombstone_assembler.hh"
 
@@ -20,31 +21,31 @@ public:
 
     // Returned reference is valid until consume_end_of_stream() or flush() is called.
     const mutation& consume_new_partition(const dht::decorated_key& dk) {
-        assert(!_m);
+        SCYLLA_ASSERT(!_m);
         _m = mutation(_s, dk);
         return *_m;
     }
 
     stop_iteration consume(tombstone t) {
-        assert(_m);
+        SCYLLA_ASSERT(_m);
         _m->partition().apply(t);
         return stop_iteration::no;
     }
 
     stop_iteration consume(range_tombstone&& rt) {
-        assert(_m);
+        SCYLLA_ASSERT(_m);
         _m->partition().apply_row_tombstone(*_s, std::move(rt));
         return stop_iteration::no;
     }
 
     stop_iteration consume(static_row&& sr) {
-        assert(_m);
+        SCYLLA_ASSERT(_m);
         _m->partition().static_row().apply(*_s, column_kind::static_column, std::move(sr.cells()));
         return stop_iteration::no;
     }
 
     stop_iteration consume(clustering_row&& cr) {
-        assert(_m);
+        SCYLLA_ASSERT(_m);
         auto& dr = _m->partition().clustered_row(*_s, std::move(cr.key()));
         dr.apply(cr.tomb());
         dr.apply(cr.marker());
@@ -53,7 +54,7 @@ public:
     }
 
     stop_iteration consume_end_of_partition() {
-        assert(_m);
+        SCYLLA_ASSERT(_m);
         return stop_iteration::yes;
     }
 
@@ -64,7 +65,7 @@ public:
     // Can be used to split the processing of a large mutation into
     // multiple smaller `mutation` objects (which add up to the full mutation).
     mutation flush() {
-        assert(_m);
+        SCYLLA_ASSERT(_m);
         return std::exchange(*_m, mutation(_s, _m->decorated_key()));
     }
 

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -10,6 +10,7 @@
 
 #include "mutation_partition.hh"
 #include "mutation_partition_v2.hh"
+#include "utils/assert.hh"
 #include "utils/anchorless_list.hh"
 #include "utils/logalloc.hh"
 #include "utils/coroutine.hh"
@@ -208,13 +209,13 @@ public:
         : _schema(std::move(s))
         , _partition(*_schema)
     {
-        assert(_schema);
+        SCYLLA_ASSERT(_schema);
     }
     explicit partition_version(mutation_partition_v2 mp, schema_ptr s) noexcept
         : _schema(std::move(s))
         , _partition(std::move(mp))
     {
-        assert(_schema);
+        SCYLLA_ASSERT(_schema);
     }
 
     partition_version(partition_version&& pv) noexcept;
@@ -251,7 +252,7 @@ public:
         : _version(&pv)
         , _unique_owner(unique_owner)
     {
-        assert(!_version->_backref);
+        SCYLLA_ASSERT(!_version->_backref);
         _version->_backref = this;
     }
     ~partition_version_ref() {
@@ -279,19 +280,19 @@ public:
     explicit operator bool() const { return _version; }
 
     partition_version& operator*() {
-        assert(_version);
+        SCYLLA_ASSERT(_version);
         return *_version;
     }
     const partition_version& operator*() const {
-        assert(_version);
+        SCYLLA_ASSERT(_version);
         return *_version;
     }
     partition_version* operator->() {
-        assert(_version);
+        SCYLLA_ASSERT(_version);
         return _version;
     }
     const partition_version* operator->() const {
-        assert(_version);
+        SCYLLA_ASSERT(_version);
         return _version;
     }
 
@@ -669,9 +670,9 @@ public:
                 // If entry is being updated, we will get reads for non-latest phase, and
                 // they must attach to the non-current version.
                 partition_version* second = _version->next();
-                assert(second && second->is_referenced());
+                SCYLLA_ASSERT(second && second->is_referenced());
                 auto&& snp = partition_snapshot::referer_of(*second);
-                assert(phase == snp._phase);
+                SCYLLA_ASSERT(phase == snp._phase);
                 return *second;
             } else { // phase > _snapshot->_phase
                 add_version(s, t);

--- a/mutation/partition_version_list.hh
+++ b/mutation/partition_version_list.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "partition_version.hh"
 
 // Double-ended chained list of partition_version objects
@@ -29,13 +30,13 @@ public:
             }
             _head = partition_version_ref(v, true);
 #ifdef SEASTAR_DEBUG
-            assert(!_head->is_referenced_from_entry());
+            SCYLLA_ASSERT(!_head->is_referenced_from_entry());
 #endif
         } else {
             v.insert_after(*_tail);
             _tail = partition_version_ref(v, true);
 #ifdef SEASTAR_DEBUG
-            assert(!_tail->is_referenced_from_entry());
+            SCYLLA_ASSERT(!_tail->is_referenced_from_entry());
 #endif
         }
     }
@@ -63,7 +64,7 @@ public:
         if (next) {
             _head = partition_version_ref(*next, true);
 #ifdef SEASTAR_DEBUG
-            assert(!_head->is_referenced_from_entry());
+            SCYLLA_ASSERT(!_head->is_referenced_from_entry());
 #endif
         }
     }

--- a/mutation/position_in_partition.hh
+++ b/mutation/position_in_partition.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "types/types.hh"
 #include "keys.hh"
 #include "clustering_bounds_comparator.hh"
@@ -238,12 +239,12 @@ public:
 
     // Can be called only when !is_static_row && !is_clustering_row().
     bound_view as_start_bound_view() const {
-        assert(_bound_weight != bound_weight::equal);
+        SCYLLA_ASSERT(_bound_weight != bound_weight::equal);
         return bound_view(*_ck, _bound_weight == bound_weight::before_all_prefixed ? bound_kind::incl_start : bound_kind::excl_start);
     }
 
     bound_view as_end_bound_view() const {
-        assert(_bound_weight != bound_weight::equal);
+        SCYLLA_ASSERT(_bound_weight != bound_weight::equal);
         return bound_view(*_ck, _bound_weight == bound_weight::before_all_prefixed ? bound_kind::excl_end : bound_kind::incl_end);
     }
 

--- a/mutation/range_tombstone_list.cc
+++ b/mutation/range_tombstone_list.cc
@@ -8,6 +8,7 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 #include "range_tombstone_list.hh"
+#include "utils/assert.hh"
 #include "utils/allocation_strategy.hh"
 #include <seastar/util/variant_utils.hh>
 
@@ -409,7 +410,7 @@ void range_tombstone_list::nop_reverter::update(range_tombstones_type::iterator 
 
 void range_tombstone_list::insert_undo_op::undo(const schema& s, range_tombstone_list& rt_list) noexcept {
     auto it = rt_list.find(s, _new_rt);
-    assert (it != rt_list.end());
+    SCYLLA_ASSERT (it != rt_list.end());
     rt_list._tombstones.erase_and_dispose(it, current_deleter<range_tombstone_entry>());
 }
 
@@ -419,7 +420,7 @@ void range_tombstone_list::erase_undo_op::undo(const schema& s, range_tombstone_
 
 void range_tombstone_list::update_undo_op::undo(const schema& s, range_tombstone_list& rt_list) noexcept {
     auto it = rt_list.find(s, _new_rt);
-    assert (it != rt_list.end());
+    SCYLLA_ASSERT (it != rt_list.end());
     *it = std::move(_old_rt);
 }
 

--- a/mutation/range_tombstone_list.hh
+++ b/mutation/range_tombstone_list.hh
@@ -11,6 +11,7 @@
 #include <seastar/util/defer.hh>
 #include "range_tombstone.hh"
 #include "query-request.hh"
+#include "utils/assert.hh"
 #include "utils/preempt.hh"
 #include "utils/chunked_vector.hh"
 #include <variant>
@@ -238,7 +239,7 @@ public:
     // The list is assumed not to be empty
     range_tombstone pop_front_and_lock() {
         range_tombstone_entry* rt = _tombstones.unlink_leftmost_without_rebalance();
-        assert(rt != nullptr);
+        SCYLLA_ASSERT(rt != nullptr);
         auto _ = seastar::defer([rt] () noexcept { current_deleter<range_tombstone_entry>()(rt); });
         return std::move(rt->tombstone());
     }

--- a/mutation_writer/multishard_writer.cc
+++ b/mutation_writer/multishard_writer.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "mutation_writer/multishard_writer.hh"
 #include "mutation/mutation_fragment_v2.hh"
 #include "schema/schema_registry.hh"
@@ -150,7 +151,7 @@ future<stop_iteration> multishard_writer::handle_mutation_fragment(mutation_frag
         }
     }
     return f.then([this, mf = std::move(mf)] () mutable {
-        assert(!_current_shards.empty());
+        SCYLLA_ASSERT(!_current_shards.empty());
         if (_current_shards.size() == 1) [[likely]] {
             return _queue_reader_handles[_current_shards[0]]->push(std::move(mf));
         }

--- a/partition_snapshot_row_cursor.hh
+++ b/partition_snapshot_row_cursor.hh
@@ -10,6 +10,7 @@
 
 #include "mutation/partition_version.hh"
 #include "row_cache.hh"
+#include "utils/assert.hh"
 #include "utils/small_vector.hh"
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/algorithm/find_if.hpp>
@@ -314,7 +315,7 @@ class partition_snapshot_row_cursor final {
     bool advance(bool keep) {
         memory::on_alloc_point();
         version_heap_less_compare heap_less(*this);
-        assert(iterators_valid());
+        SCYLLA_ASSERT(iterators_valid());
         for (auto&& curr : _current_row) {
             if (!keep && curr.unique_owner) {
                 mutation_partition::rows_type::key_grabber kg(curr.it);
@@ -382,7 +383,7 @@ public:
 
     // If is_in_latest_version() then this returns an iterator to the entry under cursor in the latest version.
     mutation_partition::rows_type::iterator get_iterator_in_latest_version() const {
-        assert(_latest_it);
+        SCYLLA_ASSERT(_latest_it);
         return *_latest_it;
     }
 
@@ -688,7 +689,7 @@ public:
         position_in_partition::less_compare less(_schema);
         if (!iterators_valid() || less(position(), pos)) {
             auto has_entry = maybe_advance_to(pos);
-            assert(has_entry); // evictable snapshots must have a dummy after all rows.
+            SCYLLA_ASSERT(has_entry); // evictable snapshots must have a dummy after all rows.
         }
         auto&& rows = _snp.version()->partition().mutable_clustered_rows();
         auto latest_i = get_iterator_in_latest_version();

--- a/query-result-reader.hh
+++ b/query-result-reader.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/numeric.hpp>
 
@@ -186,7 +187,7 @@ public:
 
     full_position calculate_last_position() const {
         auto ps = _v.partitions();
-        assert(!ps.empty());
+        SCYLLA_ASSERT(!ps.empty());
         auto pit = ps.begin();
         auto pnext = pit;
         while (++pnext != ps.end()) {

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -9,6 +9,7 @@
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/on_internal_error.hh>
+#include "utils/assert.hh"
 #include "utils/small_vector.hh"
 #include "raft.hh"
 #include "tracker.hh"
@@ -314,7 +315,7 @@ private:
 
     // Issue the next read identifier
     read_id next_read_id() {
-        assert(is_leader());
+        SCYLLA_ASSERT(is_leader());
         ++leader_state().last_read_id;
         leader_state().last_read_id_changed = true;
         _sm_events.signal();
@@ -399,7 +400,7 @@ public:
 
     // Ask to search for a leader if one is not known.
     void ping_leader() {
-        assert(!current_leader());
+        SCYLLA_ASSERT(!current_leader());
         _ping_leader = true;
     }
 

--- a/raft/log.hh
+++ b/raft/log.hh
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include "utils/assert.hh"
 #include "raft.hh"
 
 namespace raft {
@@ -78,12 +79,12 @@ public:
             // All log entries following the snapshot must
             // be present, otherwise we will not be able to
             // perform an initial state transfer.
-            assert(_first_idx <= _snapshot.idx + 1);
+            SCYLLA_ASSERT(_first_idx <= _snapshot.idx + 1);
         }
         _memory_usage = range_memory_usage(_log.begin(), _log.end());
         // The snapshot index is at least 0, so _first_idx
         // is at least 1
-        assert(_first_idx > 0);
+        SCYLLA_ASSERT(_first_idx > 0);
         stable_to(last_idx());
         init_last_conf_idx();
     }

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include "utils/assert.hh"
 #include <concepts>
 #include <vector>
 #include <unordered_set>
@@ -228,7 +229,7 @@ struct configuration {
 
     // Transition from C_old + C_new to C_new.
     void leave_joint() {
-        assert(is_joint());
+        SCYLLA_ASSERT(is_joint());
         previous.clear();
     }
 };

--- a/raft/tracker.cc
+++ b/raft/tracker.cc
@@ -5,6 +5,7 @@
 /*
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+#include "utils/assert.hh"
 #include "tracker.hh"
 #include <seastar/core/coroutine.hh>
 
@@ -45,7 +46,7 @@ bool follower_progress::is_stray_reject(const append_reply::rejected& rejected) 
         // any reject during snapshot transfer is stray one
         return true;
     default:
-        assert(false);
+        SCYLLA_ASSERT(false);
     }
     return false;
 }
@@ -86,7 +87,7 @@ bool follower_progress::can_send_to() {
         // before starting to sync the log.
         return false;
     }
-    assert(false);
+    SCYLLA_ASSERT(false);
     return false;
 }
 

--- a/raft/tracker.hh
+++ b/raft/tracker.hh
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include "utils/assert.hh"
 #include <seastar/core/condition-variable.hh>
 #include <fmt/core.h>
 #include "raft.hh"
@@ -89,7 +90,7 @@ class tracker: private progress {
     // Hide size() function we inherited from progress since
     // it is never right to use it directly in case of joint config
     size_t size() const {
-        assert(false);
+        SCYLLA_ASSERT(false);
     }
 public:
     using progress::begin, progress::end, progress::cbegin, progress::cend, progress::size;
@@ -177,7 +178,7 @@ public:
         if (_granted >= quorum) {
             return vote_result::WON;
         }
-        assert(_responded.size() <= _suffrage.size());
+        SCYLLA_ASSERT(_responded.size() <= _suffrage.size());
         auto unknown = _suffrage.size() - _responded.size();
         return _granted + unknown >= quorum ? vote_result::UNKNOWN : vote_result::LOST;
     }

--- a/read_context.hh
+++ b/read_context.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "schema/schema_fwd.hh"
 #include "query-request.hh"
 #include "mutation/mutation_fragment.hh"
@@ -73,7 +74,7 @@ public:
         }
         auto mfopt = co_await (*_reader)();
         if (mfopt) {
-            assert(mfopt->is_partition_start());
+            SCYLLA_ASSERT(mfopt->is_partition_start());
             _new_last_key = mfopt->as_partition_start().key();
         }
         co_return std::move(mfopt);

--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <boost/range/algorithm/heap_algorithm.hpp>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
@@ -281,7 +282,7 @@ public:
 };
 
 void evictable_reader_v2::do_pause(mutation_reader reader) noexcept {
-    assert(!_irh);
+    SCYLLA_ASSERT(!_irh);
     _irh = _permit.semaphore().register_inactive_read(std::move(reader));
 }
 

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "clustering_key_filter.hh"
 #include "clustering_ranges_walker.hh"
 #include "mutation/mutation.hh"
@@ -58,7 +59,7 @@ public:
         switch (mf.mutation_fragment_kind()) {
             case mutation_fragment_v2::kind::partition_start:
                 // can't happen
-                assert(false);
+                SCYLLA_ASSERT(false);
                 break;
             case mutation_fragment_v2::kind::static_row:
                 break;
@@ -1130,7 +1131,7 @@ make_mutation_reader_from_fragments(schema_ptr schema, reader_permit permit, std
     for (auto it = fragments.begin(); it != fragments.end(); ) {
         auto&& mf = *it++;
         auto kind = mf.mutation_fragment_kind();
-        assert(kind == mutation_fragment_v2::kind::partition_start);
+        SCYLLA_ASSERT(kind == mutation_fragment_v2::kind::partition_start);
         partition_slicer slicer(schema, permit, slice.row_ranges(*schema, mf.as_partition_start().key().key()),
                                 [&filtered] (mutation_fragment_v2 mf) {
                                     filtered.push_back(std::move(mf));

--- a/readers/mutation_source.hh
+++ b/readers/mutation_source.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "query-request.hh"
 #include "tracing/trace_state.hh"
 #include "readers/mutation_reader_fwd.hh"
@@ -81,7 +82,7 @@ public:
                     tracing::trace_state_ptr,
                     streamed_mutation::forwarding fwd,
                     mutation_reader::forwarding) {
-        assert(!fwd);
+        SCYLLA_ASSERT(!fwd);
         return fn(std::move(s), std::move(permit), range, slice);
     }) {}
     mutation_source(std::function<mutation_reader(schema_ptr, reader_permit, partition_range range)> fn)
@@ -92,7 +93,7 @@ public:
                     tracing::trace_state_ptr,
                     streamed_mutation::forwarding fwd,
                     mutation_reader::forwarding) {
-        assert(!fwd);
+        SCYLLA_ASSERT(!fwd);
         return fn(std::move(s), std::move(permit), range);
     }) {}
 

--- a/redis/keyspace_utils.cc
+++ b/redis/keyspace_utils.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include "redis/keyspace_utils.hh"
@@ -138,7 +139,7 @@ schema_ptr zsets_schema(sstring ks_name) {
 }
 
 future<> create_keyspace_if_not_exists_impl(seastar::sharded<service::storage_proxy>& proxy, data_dictionary::database db, seastar::sharded<service::migration_manager>& mm, db::config& config, int default_replication_factor) {
-    assert(this_shard_id() == 0);
+    SCYLLA_ASSERT(this_shard_id() == 0);
     auto keyspace_replication_strategy_options = config.redis_keyspace_replication_strategy_options();
     if (!keyspace_replication_strategy_options.contains("class")) {
         keyspace_replication_strategy_options["class"] = "SimpleStrategy";

--- a/release.cc
+++ b/release.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "version.hh"
 #include "build_mode.hh"
 
@@ -40,7 +41,7 @@ std::string doc_link(std::string_view url_tail) {
         std::vector<std::string> components;
         boost::split(components, version, boost::algorithm::is_any_of("."));
         // Version is compiled into the binary, testing will step on this immediately.
-        assert(components.size() >= 2);
+        SCYLLA_ASSERT(components.size() >= 2);
         branch = fmt::format("branch-{}.{}", components[0], components[1]);
     }
 

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -20,6 +20,7 @@
 #include "mutation_writer/multishard_writer.hh"
 #include "dht/i_partitioner.hh"
 #include "dht/sharder.hh"
+#include "utils/assert.hh"
 #include "utils/xx_hasher.hh"
 #include "utils/UUID.hh"
 #include "replica/database.hh"
@@ -889,7 +890,7 @@ public:
             } else {
                 add_to_repair_meta_for_followers(*this);
             }
-            assert(all_live_peer_shards.size() == all_live_peer_nodes.size());
+            SCYLLA_ASSERT(all_live_peer_shards.size() == all_live_peer_nodes.size());
             _all_node_states.push_back(repair_node_state(myip(), this_shard_id()));
             for (unsigned i = 0; i < all_live_peer_nodes.size(); i++) {
                 _all_node_states.push_back(repair_node_state(all_live_peer_nodes[i], all_live_peer_shards[i].value_or(repair_unspecified_shard)));
@@ -926,7 +927,7 @@ public:
 
 public:
     std::optional<shard_id> get_peer_node_dst_cpu_id(uint32_t peer_node_idx) {
-        assert(peer_node_idx + 1 < all_nodes().size());
+        SCYLLA_ASSERT(peer_node_idx + 1 < all_nodes().size());
         return all_nodes()[peer_node_idx + 1].shard;
     }
 
@@ -3229,7 +3230,7 @@ future<> repair_service::stop() {
 }
 
 repair_service::~repair_service() {
-    assert(_stopped);
+    SCYLLA_ASSERT(_stopped);
 }
 
 static shard_id repair_id_to_shard(tasks::task_id& repair_id) {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -14,6 +14,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/execution_stage.hh>
+#include "utils/assert.hh"
 #include "utils/hash.hh"
 #include "db_clock.hh"
 #include "gc_clock.hh"
@@ -1767,12 +1768,12 @@ public:
     const db::extensions& extensions() const;
 
     sstables::sstables_manager& get_user_sstables_manager() const noexcept {
-        assert(_user_sstables_manager);
+        SCYLLA_ASSERT(_user_sstables_manager);
         return *_user_sstables_manager;
     }
 
     sstables::sstables_manager& get_system_sstables_manager() const noexcept {
-        assert(_system_sstables_manager);
+        SCYLLA_ASSERT(_system_sstables_manager);
         return *_system_sstables_manager;
     }
 

--- a/replica/dirty_memory_manager.cc
+++ b/replica/dirty_memory_manager.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 
+#include "utils/assert.hh"
 #include "dirty_memory_manager.hh"
 #include "database.hh" // for memtable_list
 #include <seastar/core/metrics_api.hh>
@@ -43,7 +44,7 @@ region_group_binomial_group_sanity_check(const region_group::region_heap& bh) {
         auto t = r->evictable_occupancy().total_space();
         fmt::print(" r = {} (id={}), occupancy = {}\n", fmt::ptr(r), r->id(), t);
     }
-    assert(0);
+    SCYLLA_ASSERT(0);
 #endif
 }
 
@@ -63,7 +64,7 @@ dirty_memory_manager_logalloc::size_tracked_region* region_group::get_largest_re
 void
 region_group::add(logalloc::region* child_r) {
     auto child = static_cast<size_tracked_region*>(child_r);
-    assert(!child->_heap_handle);
+    SCYLLA_ASSERT(!child->_heap_handle);
     child->_heap_handle = std::make_optional(_regions.push(child));
     region_group_binomial_group_sanity_check(_regions);
     update_unspooled(child_r->occupancy().total_space());

--- a/replica/dirty_memory_manager.hh
+++ b/replica/dirty_memory_manager.hh
@@ -15,6 +15,7 @@
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/semaphore.hh>
 #include "replica/database_fwd.hh"
+#include "utils/assert.hh"
 #include "utils/logalloc.hh"
 
 class test_region_group;
@@ -257,7 +258,7 @@ public:
         // If we set a throttle threshold, we'd be postponing many operations. So shutdown must be
         // called.
         if (reclaimer_can_block()) {
-            assert(_shutdown_requested);
+            SCYLLA_ASSERT(_shutdown_requested);
         }
     }
     region_group& operator=(const region_group&) = delete;

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <fmt/std.h>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/smp.hh>
@@ -43,7 +44,7 @@ static std::unordered_set<sstring> load_prio_keyspaces;
 static bool population_started = false;
 
 void replica::distributed_loader::mark_keyspace_as_load_prio(const sstring& ks) {
-    assert(!population_started);
+    SCYLLA_ASSERT(!population_started);
     load_prio_keyspaces.insert(ks);
 }
 
@@ -288,11 +289,11 @@ public:
     ~table_populator() {
         // All directories must have been stopped
         // using table_populator::stop()
-        assert(_sstable_directories.empty());
+        SCYLLA_ASSERT(_sstable_directories.empty());
     }
 
     future<> start() {
-        assert(this_shard_id() == 0);
+        SCYLLA_ASSERT(this_shard_id() == 0);
 
         for (auto state : { sstables::sstable_state::normal, sstables::sstable_state::staging, sstables::sstable_state::quarantine }) {
             co_await start_subdir(state);

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "memtable.hh"
 #include "replica/database.hh"
 #include "mutation/frozen_mutation.hh"
@@ -205,7 +206,7 @@ future<> memtable::clear_gently() noexcept {
 
 partition_entry&
 memtable::find_or_create_partition_slow(partition_key_view key) {
-    assert(!reclaiming_enabled());
+    SCYLLA_ASSERT(!reclaiming_enabled());
 
     // FIXME: Perform lookup using std::pair<token, partition_key_view>
     // to avoid unconditional copy of the partition key.
@@ -223,7 +224,7 @@ memtable::find_or_create_partition_slow(partition_key_view key) {
 
 partition_entry&
 memtable::find_or_create_partition(const dht::decorated_key& key) {
-    assert(!reclaiming_enabled());
+    SCYLLA_ASSERT(!reclaiming_enabled());
 
     // call lower_bound so we have a hint for the insert, just in case.
     partitions_type::bound_hint hint;
@@ -555,7 +556,7 @@ public:
         : _mt(mt)
 	{}
     ~flush_memory_accounter() {
-        assert(_mt._flushed_memory <= _mt.occupancy().total_space());
+        SCYLLA_ASSERT(_mt._flushed_memory <= _mt.occupancy().total_space());
     }
     uint64_t compute_size(memtable_entry& e, partition_snapshot& snp) {
         return e.size_in_allocator_without_rows(_mt.allocator())
@@ -851,7 +852,7 @@ void memtable_entry::upgrade_schema(logalloc::region& r, const schema_ptr& s, mu
 
 void memtable::upgrade_entry(memtable_entry& e) {
     if (e.schema() != _schema) {
-        assert(!reclaiming_enabled());
+        SCYLLA_ASSERT(!reclaiming_enabled());
         e.upgrade_schema(region(), _schema, cleaner());
     }
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -25,6 +25,7 @@
 #include "sstables/sstables_manager.hh"
 #include "db/schema_tables.hh"
 #include "cell_locking.hh"
+#include "utils/assert.hh"
 #include "utils/logalloc.hh"
 #include "checked-file-impl.hh"
 #include "view_info.hh"
@@ -84,7 +85,7 @@ void table::update_sstables_known_generation(sstables::generation_type generatio
 }
 
 sstables::generation_type table::calculate_generation_for_new_table() {
-    assert(_sstable_generation_generator);
+    SCYLLA_ASSERT(_sstable_generation_generator);
     auto ret = std::invoke(*_sstable_generation_generator,
                            sstables::uuid_identifiers{_sstables_manager.uuid_sstable_identifiers()});
     tlogger.debug("{}.{} new sstable generation {}", schema()->ks_name(), schema()->cf_name(), ret);
@@ -368,7 +369,7 @@ mutation_reader table::make_nonpopulating_cache_reader(schema_ptr schema, reader
 }
 
 future<std::vector<locked_cell>> table::lock_counter_cells(const mutation& m, db::timeout_clock::time_point timeout) {
-    assert(m.schema() == _counter_cell_locks->schema());
+    SCYLLA_ASSERT(m.schema() == _counter_cell_locks->schema());
     return _counter_cell_locks->lock_cells(m.decorated_key(), partition_cells_range(m.partition()), timeout);
 }
 
@@ -2826,7 +2827,7 @@ db::commitlog* table::commitlog() const {
 }
 
 void table::set_schema(schema_ptr s) {
-    assert(s->is_counter() == _schema->is_counter());
+    SCYLLA_ASSERT(s->is_counter() == _schema->is_counter());
     tlogger.debug("Changing schema version of {}.{} ({}) from {} to {}",
                 _schema->ks_name(), _schema->cf_name(), _schema->id(), _schema->version(), s->version());
 

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <functional>
 #include <optional>
 #include <unordered_map>
@@ -356,7 +357,7 @@ public:
         return is_primary_key();
     }
     uint32_t component_index() const {
-        assert(has_component_index());
+        SCYLLA_ASSERT(has_component_index());
         return id;
     }
     uint32_t position() const {
@@ -962,8 +963,8 @@ public:
     //
     //      auto schema = make_schema();
     //      auto reverse_schema = schema->get_reversed();
-    //      assert(reverse_schema->get_reversed().get() == schema.get());
-    //      assert(schema->get_reversed().get() == reverse_schema.get());
+    //      SCYLLA_ASSERT(reverse_schema->get_reversed().get() == schema.get());
+    //      SCYLLA_ASSERT(schema->get_reversed().get() == reverse_schema.get());
     //
     schema_ptr get_reversed() const;
 };
@@ -982,7 +983,7 @@ class view_ptr final {
 public:
     explicit view_ptr(schema_ptr schema) noexcept : _schema(schema) {
         if (schema) {
-            assert(_schema->is_view());
+            SCYLLA_ASSERT(_schema->is_view());
         }
     }
 

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <seastar/core/sharded.hh>
 
 #include "schema_registry.hh"
@@ -39,7 +40,7 @@ schema_registry_entry::schema_registry_entry(table_schema_version v, schema_regi
 {
     _erase_timer.set_callback([this] {
         slogger.debug("Dropping {}", _version);
-        assert(!_schema);
+        SCYLLA_ASSERT(!_schema);
         try {
             _registry._entries.erase(_version);
         } catch (...) {
@@ -246,7 +247,7 @@ void schema_registry_entry::detach_schema() noexcept {
 }
 
 frozen_schema schema_registry_entry::frozen() const {
-    assert(_state >= state::LOADED);
+    SCYLLA_ASSERT(_state >= state::LOADED);
     return *_frozen_schema;
 }
 
@@ -313,7 +314,7 @@ global_schema_ptr::global_schema_ptr(const global_schema_ptr& o)
 
 global_schema_ptr::global_schema_ptr(global_schema_ptr&& o) noexcept {
     auto current = this_shard_id();
-    assert(o._cpu_of_origin == current);
+    SCYLLA_ASSERT(o._cpu_of_origin == current);
     _ptr = std::move(o._ptr);
     _cpu_of_origin = current;
     _base_schema = std::move(o._base_schema);

--- a/serializer.hh
+++ b/serializer.hh
@@ -9,6 +9,7 @@
 
 #include <seastar/core/sstring.hh>
 #include <optional>
+#include "utils/assert.hh"
 #include "utils/managed_bytes.hh"
 #include "bytes_ostream.hh"
 #include <seastar/core/simple-stream.hh>
@@ -377,7 +378,7 @@ serialize_gc_clock_duration_value(Output& out, int64_t v) {
     if (!gc_clock_using_3_1_0_serialization) {
         // This should have been caught by the CQL layer, so this is just
         // for extra safety.
-        assert(int32_t(v) == v);
+        SCYLLA_ASSERT(int32_t(v) == v);
         serializer<int32_t>::write(out, v);
     } else {
         serializer<int64_t>::write(out, v);

--- a/service/broadcast_tables/experimental/lang.cc
+++ b/service/broadcast_tables/experimental/lang.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "lang.hh"
 
 #include <seastar/core/future.hh>
@@ -73,7 +74,7 @@ future<query_result> execute_broadcast_table_query(
                 co_return query_result_select{};
             }
 
-            assert(rs->partitions().size() == 1); // In this version only one value per partition key is allowed.
+            SCYLLA_ASSERT(rs->partitions().size() == 1); // In this version only one value per partition key is allowed.
 
             const auto& p = rs->partitions()[0];
             auto mutation = p.mut().unfreeze(schema);
@@ -92,7 +93,7 @@ future<query_result> execute_broadcast_table_query(
 
             bool found = !rs->partitions().empty();
 
-            assert(!found || rs->partitions().size() == 1); // In this version at most one value per partition key is allowed.
+            SCYLLA_ASSERT(!found || rs->partitions().size() == 1); // In this version at most one value per partition key is allowed.
 
             auto new_mutation = found
                 ? rs->partitions()[0].mut().unfreeze(schema)

--- a/service/load_broadcaster.hh
+++ b/service/load_broadcaster.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "replica/database_fwd.hh"
 #include "gms/i_endpoint_state_change_subscriber.hh"
 #include "gms/gossiper.hh"
@@ -32,7 +33,7 @@ public:
         _gossiper.register_(shared_from_this());
     }
     ~load_broadcaster() {
-        assert(_stopped);
+        SCYLLA_ASSERT(_stopped);
     }
 
     virtual future<> on_change(gms::inet_address endpoint, const gms::application_state_map& states, gms::permit_id pid) override {

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <boost/algorithm/string/join.hpp>
 #include <chrono>
 
@@ -222,7 +223,7 @@ future<> service_level_controller::update_service_levels_from_distributed_data()
 }
 
 void service_level_controller::stop_legacy_update_from_distributed_data() {
-    assert(this_shard_id() == global_controller);
+    SCYLLA_ASSERT(this_shard_id() == global_controller);
 
     if (_global_controller_db->dist_data_update_aborter.abort_requested()) {
         return;

--- a/service/raft/discovery.cc
+++ b/service/raft/discovery.cc
@@ -5,6 +5,7 @@
 /*
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+#include "utils/assert.hh"
 #include "service/raft/discovery.hh"
 
 namespace service {
@@ -61,7 +62,7 @@ void discovery::step(const peer_list& peers) {
             // If we have this peer, its ID must be the
             // same as we know (with the exceptions of seeds,
             // for which servers might not know ids at first).
-            assert(it == _peers.end() || it->id == addr.id || addr.id == raft::server_id{});
+            SCYLLA_ASSERT(it == _peers.end() || it->id == addr.id || addr.id == raft::server_id{});
         }
     }
     if (refresh_peer_list) {
@@ -114,7 +115,7 @@ std::optional<discovery::peer_list> discovery::request(const peer_list& peers) {
 }
 
 void discovery::response(discovery_peer from, const peer_list& peers) {
-    assert(_peers.contains(from));
+    SCYLLA_ASSERT(_peers.contains(from));
     _responded.emplace(from);
     step(peers);
 }

--- a/service/raft/raft_address_map.hh
+++ b/service/raft/raft_address_map.hh
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include "utils/assert.hh"
 #include "gms/inet_address.hh"
 #include "gms/generation-number.hh"
 #include "raft/raft.hh"
@@ -277,12 +278,12 @@ public:
     {}
 
     future<> stop() {
-        assert(_replication_fiber);
+        SCYLLA_ASSERT(_replication_fiber);
         co_await *std::exchange(_replication_fiber, std::nullopt);
     }
 
     ~raft_address_map_t() {
-        assert(!_replication_fiber);
+        SCYLLA_ASSERT(!_replication_fiber);
     }
 
     // Find a mapping with a given id.

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -22,6 +22,7 @@
 #include "idl/group0_state_machine.dist.impl.hh"
 #include "service/raft/group0_state_machine.hh"
 #include "replica/database.hh"
+#include "utils/assert.hh"
 #include "utils/to_string.hh"
 
 
@@ -116,7 +117,7 @@ struct group0_guard::impl {
     {}
 
     void release_read_apply_mutex() {
-        assert(_read_apply_mutex_holder.count() == 1);
+        SCYLLA_ASSERT(_read_apply_mutex_holder.count() == 1);
         _read_apply_mutex_holder.return_units(1);
     }
 };

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -12,6 +12,7 @@
 #include "replica/database.hh"
 #include "service/migration_listener.hh"
 #include "service/tablet_allocator.hh"
+#include "utils/assert.hh"
 #include "utils/error_injection.hh"
 #include "utils/stall_free.hh"
 #include "db/config.hh"
@@ -1945,7 +1946,7 @@ public:
     tablet_allocator_impl(tablet_allocator_impl&&) = delete; // "this" captured.
 
     ~tablet_allocator_impl() {
-        assert(_stopped);
+        SCYLLA_ASSERT(_stopped);
     }
 
     future<> stop() {

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "db/system_keyspace.hh"
 #include "topology_mutation.hh"
 #include "types/tuple.hh"
@@ -34,7 +35,7 @@ topology_node_mutation_builder::topology_node_mutation_builder(topology_mutation
 template<typename Builder>
 Builder& topology_mutation_builder_base<Builder>::apply_atomic(const char* cell, const data_value& value) {
     const column_definition* cdef = self().schema().get_column_definition(cell);
-    assert(cdef);
+    SCYLLA_ASSERT(cdef);
     self().row().apply(*cdef, atomic_cell::make_live(*cdef->type, self().timestamp(), cdef->type->decompose(value), self().ttl()));
     return self();
 }
@@ -44,7 +45,7 @@ template<std::ranges::range C>
 requires std::convertible_to<std::ranges::range_value_t<C>, data_value>
 Builder& topology_mutation_builder_base<Builder>::apply_set(const char* cell, collection_apply_mode apply_mode, const C& c) {
     const column_definition* cdef = self().schema().get_column_definition(cell);
-    assert(cdef);
+    SCYLLA_ASSERT(cdef);
     auto vtype = static_pointer_cast<const set_type_impl>(cdef->type)->get_elements_type();
 
     std::set<bytes, serialized_compare> cset(vtype->as_less_comparator());
@@ -69,7 +70,7 @@ Builder& topology_mutation_builder_base<Builder>::apply_set(const char* cell, co
 template<typename Builder>
 Builder& topology_mutation_builder_base<Builder>::del(const char* cell) {
     auto cdef = self().schema().get_column_definition(cell);
-    assert(cdef);
+    SCYLLA_ASSERT(cdef);
     if (!cdef->type->is_multi_cell()) {
         self().row().apply(*cdef, atomic_cell::make_dead(self().timestamp(), gc_clock::now()));
     } else {

--- a/sstables/compress.cc
+++ b/sstables/compress.cc
@@ -20,6 +20,7 @@
 #include "exceptions.hh"
 #include "unimplemented.hh"
 #include "segmented_compress_params.hh"
+#include "utils/assert.hh"
 #include "utils/class_registrator.hh"
 #include "reader_permit.hh"
 
@@ -155,7 +156,7 @@ void compression::segmented_offsets::state::update_position_trackers(std::size_t
 }
 
 void compression::segmented_offsets::init(uint32_t chunk_size) {
-    assert(chunk_size != 0);
+    SCYLLA_ASSERT(chunk_size != 0);
 
     _chunk_size = chunk_size;
 
@@ -436,7 +437,7 @@ public:
 
     virtual future<temporary_buffer<char>> skip(uint64_t n) override {
         _pos += n;
-        assert(_pos <= _end_pos);
+        SCYLLA_ASSERT(_pos <= _end_pos);
         if (_pos == _end_pos) {
             return make_ready_future<temporary_buffer<char>>();
         }

--- a/sstables/compress.hh
+++ b/sstables/compress.hh
@@ -33,6 +33,7 @@
 // are read using O_DIRECT), nor uncompressed data. We intend to cache high-
 // level Cassandra rows, not disk blocks.
 
+#include "utils/assert.hh"
 #include <vector>
 #include <cstdint>
 #include <iterator>
@@ -171,7 +172,7 @@ struct compression {
             const_iterator(const const_iterator& other) = default;
 
             const_iterator& operator=(const const_iterator& other) {
-                assert(&_offsets == &other._offsets);
+                SCYLLA_ASSERT(&_offsets == &other._offsets);
                 _index = other._index;
                 return *this;
             }

--- a/sstables/consumer.hh
+++ b/sstables/consumer.hh
@@ -17,6 +17,7 @@
 #include <seastar/net/byteorder.hh>
 #include "bytes.hh"
 #include "reader_permit.hh"
+#include "utils/assert.hh"
 #include "utils/fragmented_temporary_buffer.hh"
 #include "utils/small_vector.hh"
 
@@ -307,7 +308,7 @@ private:
     // Reads bytes belonging to an integer of size len. Returns true
     // if a full integer is now available.
     bool process_int(temporary_buffer<char>& data, unsigned len) {
-        assert(_pos < len);
+        SCYLLA_ASSERT(_pos < len);
         auto n = std::min((size_t)(len - _pos), data.size());
         std::copy(data.begin(), data.begin() + n, _read_int.bytes + _pos);
         data.trim_front(n);
@@ -534,7 +535,7 @@ public:
         while (data || (!primitive_consumer::active() && non_consuming())) {
             // The primitive_consumer must finish before the enclosing state machine can continue.
             if (__builtin_expect(primitive_consumer::consume(data) == read_status::waiting, false)) {
-                assert(data.size() == 0);
+                SCYLLA_ASSERT(data.size() == 0);
                 return proceed::yes;
             }
             auto ret = state_processor().process_state(data);
@@ -584,7 +585,7 @@ public:
             }, [this, &data, orig_data_size](skip_bytes skip) {
                 // we only expect skip_bytes to be used if reader needs to skip beyond the provided buffer
                 // otherwise it should just trim_front and proceed as usual
-                assert(data.size() == 0);
+                SCYLLA_ASSERT(data.size() == 0);
                 _remain -= orig_data_size;
                 if (skip.get_value() >= _remain) {
                     skip_bytes skip_remaining(_remain);
@@ -602,11 +603,11 @@ public:
     }
 
     future<> fast_forward_to(size_t begin, size_t end) {
-        assert(begin >= _stream_position.position);
+        SCYLLA_ASSERT(begin >= _stream_position.position);
         auto n = begin - _stream_position.position;
         _stream_position.position = begin;
 
-        assert(end >= _stream_position.position);
+        SCYLLA_ASSERT(end >= _stream_position.position);
         _remain = end - _stream_position.position;
 
         primitive_consumer::reset();

--- a/sstables/downsampling.hh
+++ b/sstables/downsampling.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <vector>
 #include <array>
 #include <algorithm>
@@ -43,14 +44,14 @@ public:
      * @return A list of `sampling_level` unique indices between 0 and `sampling_level`
      */
     static const std::vector<int>& get_sampling_pattern(int sampling_level) {
-        assert(sampling_level > 0 && sampling_level <= BASE_SAMPLING_LEVEL);
+        SCYLLA_ASSERT(sampling_level > 0 && sampling_level <= BASE_SAMPLING_LEVEL);
         auto& entry = _sample_pattern_cache[sampling_level-1];
         if (!entry.empty()) {
             return entry;
         }
 
         if (sampling_level <= 1) {
-            assert(_sample_pattern_cache[0].empty());
+            SCYLLA_ASSERT(_sample_pattern_cache[0].empty());
             _sample_pattern_cache[0].push_back(0);
             return _sample_pattern_cache[0];
         }
@@ -95,7 +96,7 @@ public:
      * @return a list of original indexes for current summary entries
      */
     static const std::vector<int>& get_original_indexes(int sampling_level) {
-        assert(sampling_level > 0 && sampling_level <= BASE_SAMPLING_LEVEL);
+        SCYLLA_ASSERT(sampling_level > 0 && sampling_level <= BASE_SAMPLING_LEVEL);
         auto& entry = _original_index_cache[sampling_level-1];
         if (!entry.empty()) {
             return entry;
@@ -127,7 +128,7 @@ public:
      * @return the number of partitions before the next index summary entry, inclusive on one end
      */
     static int get_effective_index_interval_after_index(int index, int sampling_level, int min_index_interval) {
-        assert(index >= -1);
+        SCYLLA_ASSERT(index >= -1);
         const std::vector<int>& original_indexes = get_original_indexes(sampling_level);
         if (index == -1) {
             return original_indexes[0] * min_index_interval;

--- a/sstables/generation_type.hh
+++ b/sstables/generation_type.hh
@@ -21,6 +21,7 @@
 #include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
 #include "types/types.hh"
+#include "utils/assert.hh"
 #include "utils/UUID_gen.hh"
 #include "log.hh"
 
@@ -180,7 +181,7 @@ public:
     /// way to determine that is overlapping its partition-ranges with the shard's
     /// owned ranges.
     static bool maybe_owned_by_this_shard(const sstables::generation_type& gen) {
-        assert(bool(gen));
+        SCYLLA_ASSERT(bool(gen));
         int64_t hint = 0;
         if (gen.is_uuid_based()) {
             hint = std::hash<utils::UUID>{}(gen.as_uuid());

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -7,6 +7,7 @@
  */
 
 #pragma once
+#include "utils/assert.hh"
 #include "sstables.hh"
 #include "consumer.hh"
 #include "downsampling.hh"
@@ -520,7 +521,7 @@ private:
     // Must be called for non-decreasing summary_idx.
     future<> advance_to_page(index_bound& bound, uint64_t summary_idx) {
         sstlog.trace("index {}: advance_to_page({}), bound {}", fmt::ptr(this), summary_idx, fmt::ptr(&bound));
-        assert(!bound.current_list || bound.current_summary_idx <= summary_idx);
+        SCYLLA_ASSERT(!bound.current_list || bound.current_summary_idx <= summary_idx);
         if (bound.current_list && bound.current_summary_idx == summary_idx) {
             sstlog.trace("index {}: same page", fmt::ptr(this));
             return make_ready_future<>();
@@ -626,7 +627,7 @@ private:
 
     // Valid if partition_data_ready(bound)
     index_entry& current_partition_entry(index_bound& bound) {
-        assert(bound.current_list);
+        SCYLLA_ASSERT(bound.current_list);
         return *bound.current_list->_entries[bound.current_index_idx];
     }
 
@@ -691,7 +692,7 @@ private:
         // is no G in that bucket so we read the following one to get the
         // position (see the advance_to_page() call below). After we've got it, it's time to
         // get J] position. Again, summary points us to the first bucket and we
-        // hit an assert since the reader is already at the second bucket and we
+        // hit an SCYLLA_ASSERT since the reader is already at the second bucket and we
         // cannot go backward.
         // The solution is this condition above. If our lookup requires reading
         // the previous bucket we assume that the entry doesn't exist and return
@@ -739,7 +740,7 @@ private:
         // So need to make sure first that it is read
         if (!partition_data_ready(_lower_bound)) {
             return read_partition_data().then([this, pos] {
-                assert(partition_data_ready());
+                SCYLLA_ASSERT(partition_data_ready());
                 return advance_upper_past(pos);
             });
         }
@@ -816,12 +817,12 @@ public:
     // Ensures that partition_data_ready() returns true.
     // Can be called only when !eof()
     future<> read_partition_data() {
-        assert(!eof());
+        SCYLLA_ASSERT(!eof());
         if (partition_data_ready(_lower_bound)) {
             return make_ready_future<>();
         }
         // The only case when _current_list may be missing is when the cursor is at the beginning
-        assert(_lower_bound.current_summary_idx == 0);
+        SCYLLA_ASSERT(_lower_bound.current_summary_idx == 0);
         return advance_to_page(_lower_bound, 0);
     }
 
@@ -920,7 +921,7 @@ public:
         if (!partition_data_ready()) {
             return read_partition_data().then([this, pos] {
                 sstlog.trace("index {}: page done", fmt::ptr(this));
-                assert(partition_data_ready(_lower_bound));
+                SCYLLA_ASSERT(partition_data_ready(_lower_bound));
                 return advance_to(pos);
             });
         }
@@ -1008,7 +1009,7 @@ public:
         // so need to make sure first that the lower bound partition data is in memory.
         if (!partition_data_ready(_lower_bound)) {
             return read_partition_data().then([this, pos] {
-                assert(partition_data_ready());
+                SCYLLA_ASSERT(partition_data_ready());
                 return advance_reverse(pos);
             });
         }
@@ -1053,7 +1054,7 @@ public:
     //
     // Preconditions: sstable version >= mc, partition_data_ready().
     future<std::optional<uint64_t>> last_block_offset() {
-        assert(partition_data_ready());
+        SCYLLA_ASSERT(partition_data_ready());
 
         auto cur = current_clustered_cursor();
         if (!cur) {

--- a/sstables/mutation_fragment_filter.hh
+++ b/sstables/mutation_fragment_filter.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "mutation/mutation_fragment.hh"
 #include "clustering_ranges_walker.hh"
 #include "clustering_key_filter.hh"
@@ -129,7 +130,7 @@ public:
      * query ranges tracked by _walker.
      */
     std::optional<position_in_partition_view> fast_forward_to(position_range r) {
-        assert(_fwd);
+        SCYLLA_ASSERT(_fwd);
         _fwd_end = std::move(r).end();
         _out_of_range = !_walker.advance_to(r.start(), _fwd_end);
 

--- a/sstables/mx/bsearch_clustered_cursor.hh
+++ b/sstables/mx/bsearch_clustered_cursor.hh
@@ -12,6 +12,7 @@
 #include "sstables/column_translation.hh"
 #include "parsers.hh"
 #include "schema/schema.hh"
+#include "utils/assert.hh"
 #include "utils/cached_file.hh"
 #include "utils/to_string.hh"
 
@@ -106,13 +107,13 @@ public:
         const schema& _s;
 
         bool operator()(const promoted_index_block& lhs, position_in_partition_view rhs) const {
-            assert(lhs.start);
+            SCYLLA_ASSERT(lhs.start);
             position_in_partition::less_compare less(_s);
             return less(*lhs.start, rhs);
         }
 
         bool operator()(position_in_partition_view lhs, const promoted_index_block& rhs) const {
-            assert(rhs.start);
+            SCYLLA_ASSERT(rhs.start);
             position_in_partition::less_compare less(_s);
             return less(lhs, *rhs.start);
         }

--- a/sstables/mx/parsers.hh
+++ b/sstables/mx/parsers.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "sstables/consumer.hh"
 #include "sstables/types.hh"
 #include "sstables/column_translation.hh"
@@ -282,7 +283,7 @@ public:
             }
             [[fallthrough]];
         case state::END_OPEN_MARKER_FLAG:
-            assert(_primitive._i64 + width_base > 0);
+            SCYLLA_ASSERT(_primitive._i64 + width_base > 0);
             _width = (_primitive._i64 + width_base);
             if (_primitive.read_8(data) != read_status::ready) {
                 _state = state::END_OPEN_MARKER_LOCAL_DELETION_TIME;

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -14,6 +14,7 @@
 #include "sstables/m_format_read_helpers.hh"
 #include "sstables/sstable_mutation_reader.hh"
 #include "sstables/processing_result_generator.hh"
+#include "utils/assert.hh"
 #include "utils/to_string.hh"
 
 namespace sstables {
@@ -516,7 +517,7 @@ public:
             return consume_range_tombstone_boundary(std::move(pos), end_tombstone, start_tombstone);
         }
         default:
-            assert(false && "Invalid boundary type");
+            SCYLLA_ASSERT(false && "Invalid boundary type");
         }
     }
 
@@ -1330,7 +1331,7 @@ public:
                         " partition range: {}", pr));
             }
             // FIXME: if only the defaults were better...
-            //assert(fwd_mr == mutation_reader::forwarding::no);
+            //SCYLLA_ASSERT(fwd_mr == mutation_reader::forwarding::no);
         }
     }
 
@@ -1375,7 +1376,7 @@ private:
                 _read_enabled = false;
                 return make_ready_future<>();
             }
-            assert(_index_reader->element_kind() == indexable_element::partition);
+            SCYLLA_ASSERT(_index_reader->element_kind() == indexable_element::partition);
             return skip_to(_index_reader->element_kind(), start).then([this] {
                 _sst->get_stats().on_partition_seek();
             });
@@ -1455,7 +1456,7 @@ private:
         if (!pos || pos->is_before_all_fragments(*_schema)) {
             return make_ready_future<>();
         }
-        assert (_current_partition_key);
+        SCYLLA_ASSERT (_current_partition_key);
         return [this] {
             if (!_index_in_current_partition) {
                 _index_in_current_partition = true;
@@ -1473,7 +1474,7 @@ private:
                     // The reversing data source will notice the skip and update the data ranges
                     // from which it prepares the data given to us.
 
-                    assert(_reversed_read_sstable_position);
+                    SCYLLA_ASSERT(_reversed_read_sstable_position);
                     auto ip = _index_reader->data_file_positions();
                     if (ip.end >= *_reversed_read_sstable_position) {
                         // The reversing data source was already ahead (in reverse - its position was smaller)
@@ -1542,7 +1543,7 @@ private:
         }
 
         auto [begin, end] = _index_reader->data_file_positions();
-        assert(end);
+        SCYLLA_ASSERT(end);
 
         if (_single_partition_read) {
             _read_enabled = (begin != *end);
@@ -1601,11 +1602,11 @@ public:
                 _partition_finished = true;
                 _before_partition = true;
                 _end_of_stream = false;
-                assert(_index_reader);
+                SCYLLA_ASSERT(_index_reader);
                 auto f1 = _index_reader->advance_to(pr);
                 return f1.then([this] {
                     auto [start, end] = _index_reader->data_file_positions();
-                    assert(end);
+                    SCYLLA_ASSERT(end);
                     if (start != *end) {
                         _read_enabled = true;
                         _index_in_current_partition = true;
@@ -2029,7 +2030,7 @@ public:
         case bound_kind_m::excl_end_incl_start:
             return consume_range_tombstone(ecp, bound_kind::incl_start, start_tombstone);
         default:
-            assert(false && "Invalid boundary type");
+            SCYLLA_ASSERT(false && "Invalid boundary type");
         }
     }
 

--- a/sstables/mx/types.hh
+++ b/sstables/mx/types.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "clustering_bounds_comparator.hh"
 #include <iosfwd>
 
@@ -62,7 +63,7 @@ inline bool is_start(bound_kind_m kind) {
 }
 
 inline bound_kind to_bound_kind(bound_kind_m kind) {
-    assert(is_bound_kind(kind));
+    SCYLLA_ASSERT(is_bound_kind(kind));
     using underlying_type = std::underlying_type_t<bound_kind_m>;
     return bound_kind{static_cast<underlying_type>(kind)};
 }
@@ -73,12 +74,12 @@ inline bound_kind_m to_bound_kind_m(bound_kind kind) {
 }
 
 inline bound_kind boundary_to_start_bound(bound_kind_m kind) {
-    assert(is_boundary_between_adjacent_intervals(kind));
+    SCYLLA_ASSERT(is_boundary_between_adjacent_intervals(kind));
     return (kind == bound_kind_m::incl_end_excl_start) ? bound_kind::excl_start : bound_kind::incl_start;
 }
 
 inline bound_kind boundary_to_end_bound(bound_kind_m kind) {
-    assert(is_boundary_between_adjacent_intervals(kind));
+    SCYLLA_ASSERT(is_boundary_between_adjacent_intervals(kind));
     return (kind == bound_kind_m::incl_end_excl_start) ? bound_kind::incl_end : bound_kind::excl_end;
 }
 

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -16,6 +16,7 @@
 #include "sstables/mx/types.hh"
 #include "db/config.hh"
 #include "mutation/atomic_cell.hh"
+#include "utils/assert.hh"
 #include "utils/exceptions.hh"
 #include "db/large_data_handler.hh"
 
@@ -91,7 +92,7 @@ public:
         {}
 
         void increment() {
-            assert(_range);
+            SCYLLA_ASSERT(_range);
             if (!_range->next()) {
                 _range = nullptr;
             }
@@ -102,7 +103,7 @@ public:
         }
 
         const ValueType dereference() const {
-            assert(_range);
+            SCYLLA_ASSERT(_range);
             return _range->get_value();
         }
 
@@ -153,7 +154,7 @@ public:
         auto limit = std::min(_serialization_limit_size, _offset + clustering_block::max_block_size);
 
         _current_block = {};
-        assert (_offset % clustering_block::max_block_size == 0);
+        SCYLLA_ASSERT (_offset % clustering_block::max_block_size == 0);
         while (_offset < limit) {
             auto shift = _offset % clustering_block::max_block_size;
             if (_offset < _prefix.size(_schema)) {
@@ -280,7 +281,7 @@ public:
                     ++_current_index;
                 }
             } else {
-                assert(_mode == encoding_mode::large_encode_missing);
+                SCYLLA_ASSERT(_mode == encoding_mode::large_encode_missing);
                 while (_current_index < total_size) {
                     auto cell = _row.find_cell(_columns[_current_index].get().id);
                     if (!cell) {
@@ -1062,7 +1063,7 @@ void writer::write_cell(bytes_ostream& writer, const clustering_key_prefix* clus
 
     if (cdef.is_counter()) {
         if (!is_deleted) {
-            assert(!cell.is_counter_update());
+            SCYLLA_ASSERT(!cell.is_counter_update());
             auto ccv = counter_cell_view(cell);
             write_counter_value(ccv, writer, _sst.get_version(), [] (bytes_ostream& out, uint32_t value) {
                 return write_vint(out, value);
@@ -1334,7 +1335,7 @@ template <typename W>
 requires Writer<W>
 static void write_clustering_prefix(sstable_version_types v, W& writer, bound_kind_m kind,
     const schema& s, const clustering_key_prefix& clustering) {
-    assert(kind != bound_kind_m::static_clustering);
+    SCYLLA_ASSERT(kind != bound_kind_m::static_clustering);
     write(v, writer, kind);
     auto is_ephemerally_full = ephemerally_full_prefix{s.is_compact_table()};
     if (kind != bound_kind_m::clustering) {

--- a/sstables/partition_index_cache.hh
+++ b/sstables/partition_index_cache.hh
@@ -13,6 +13,7 @@
 #include <seastar/core/loop.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+#include "utils/assert.hh"
 #include "utils/bptree.hh"
 #include "utils/lru.hh"
 #include "utils/lsa/weak_ptr.hh"
@@ -57,7 +58,7 @@ private:
                 // Live entry_ptr should keep the entry alive, except when the entry failed on loading.
                 // In that case, entry_ptr holders are not supposed to use the pointer, so it's safe
                 // to nullify those entry_ptrs.
-                assert(!ready());
+                SCYLLA_ASSERT(!ready());
             }
         }
 
@@ -206,7 +207,7 @@ public:
             return with_allocator(_region.allocator(), [&] {
                 auto it_and_flag = _cache.emplace(key, this, key);
                 entry &cp = *it_and_flag.first;
-                assert(it_and_flag.second);
+                SCYLLA_ASSERT(it_and_flag.second);
                 try {
                     return share(cp);
                 } catch (...) {

--- a/sstables/promoted_index_blocks_reader.hh
+++ b/sstables/promoted_index_blocks_reader.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "consumer.hh"
 #include "column_translation.hh"
 #include "sstables/mx/parsers.hh"
@@ -172,7 +173,7 @@ public:
         std::visit([this, &data] (auto& ctx) mutable { return process_state(data, ctx); }, _ctx);
 
         if (_mode == consuming_mode::consume_until) {
-            assert(_pos);
+            SCYLLA_ASSERT(_pos);
             auto cmp_with_start = [this, pos_cmp = promoted_index_block_compare(_s)]
                     (position_in_partition_view pos, const promoted_index_block& block) -> bool {
                 return pos_cmp(pos, block.start(_s));

--- a/sstables/random_access_reader.hh
+++ b/sstables/random_access_reader.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <memory>
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>
@@ -25,7 +26,7 @@ protected:
     virtual input_stream<char> open_at(uint64_t pos) = 0;
 
     void set(input_stream<char> in) {
-        assert(!_in);
+        SCYLLA_ASSERT(!_in);
         _in = std::make_unique<input_stream<char>>(std::move(in));
     }
 

--- a/sstables/scanning_clustered_index_cursor.hh
+++ b/sstables/scanning_clustered_index_cursor.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "sstables/index_entry.hh"
 #include "sstables/promoted_index_blocks_reader.hh"
 #include "schema/schema.hh"
@@ -95,7 +96,7 @@ private:
             // End open marker can be only engaged in SSTables 3.x ('mc' format) and never in ka/la
             auto end_pos = prev->end(_s);
             position_in_partition_view* open_rt_pos = std::get_if<position_in_partition_view>(&end_pos);
-            assert(open_rt_pos);
+            SCYLLA_ASSERT(open_rt_pos);
             return skip_info{offset, tombstone(*prev->end_open_marker()), position_in_partition{*open_rt_pos}};
         }
     }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -20,6 +20,7 @@
 #include "compaction/compaction_manager.hh"
 #include "log.hh"
 #include "sstable_directory.hh"
+#include "utils/assert.hh"
 #include "utils/lister.hh"
 #include "utils/overloaded_functor.hh"
 #include "utils/directories.hh"
@@ -433,7 +434,7 @@ sstable_directory::move_foreign_sstables(sharded<sstable_directory>& source_dire
             return make_ready_future<>();
         }
         // Should be empty, since an SSTable that belongs to this shard is not remote.
-        assert(shard_id != this_shard_id());
+        SCYLLA_ASSERT(shard_id != this_shard_id());
         dirlog.debug("Moving {} unshared SSTables to shard {} ", info_vec.size(), shard_id);
         return source_directory.invoke_on(shard_id, &sstables::sstable_directory::load_foreign_sstables, std::move(info_vec));
     });
@@ -469,7 +470,7 @@ sstable_directory::collect_output_unshared_sstables(std::vector<sstables::shared
     dirlog.debug("Collecting {} output SSTables (remote={})", resharded_sstables.size(), remote_ok);
     return parallel_for_each(std::move(resharded_sstables), [this, remote_ok] (sstables::shared_sstable sst) {
         auto shards = sst->get_shards_for_this_sstable();
-        assert(shards.size() == 1);
+        SCYLLA_ASSERT(shards.size() == 1);
         auto shard = shards[0];
 
         if (shard == this_shard_id()) {

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <seastar/util/defer.hh>
 
 #include <boost/icl/interval_map.hpp>
@@ -693,8 +694,8 @@ public:
 
         // by !empty(bound) and `_it` invariant:
         //      _it != _end, _it->first <= bound, and filter(*_it->second) == true
-        assert(_cmp(_it->first, bound) <= 0);
-        // we don't assert(filter(*_it->second)) due to the requirement that `filter` is called at most once for each sstable
+        SCYLLA_ASSERT(_cmp(_it->first, bound) <= 0);
+        // we don't SCYLLA_ASSERT(filter(*_it->second)) due to the requirement that `filter` is called at most once for each sstable
 
         // Find all sstables with the same position as `_it` (they form a contiguous range in the container).
         auto next = std::find_if(std::next(_it), _end, [this] (const value_t& v) { return _cmp(v.first, _it->first) != 0; });
@@ -1264,7 +1265,7 @@ sstable_set::create_single_key_sstable_reader(
         streamed_mutation::forwarding fwd,
         mutation_reader::forwarding fwd_mr,
         const sstable_predicate& predicate) const {
-    assert(pr.is_singular() && pr.start()->value().has_key());
+    SCYLLA_ASSERT(pr.is_singular() && pr.start()->value().has_key());
     return _impl->create_single_key_sstable_reader(cf, std::move(schema),
             std::move(permit), sstable_histogram, pr, slice, std::move(trace_state), fwd, fwd_mr, predicate);
 }
@@ -1368,7 +1369,7 @@ sstable_set::make_local_shard_sstable_reader(
 {
     auto reader_factory_fn = [s, permit, &slice, trace_state, fwd, fwd_mr, &monitor_generator, &predicate]
             (shared_sstable& sst, const dht::partition_range& pr) mutable {
-        assert(!sst->is_shared());
+        SCYLLA_ASSERT(!sst->is_shared());
         if (!predicate(*sst)) {
             return make_empty_flat_reader_v2(s, permit);
         }

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -16,6 +16,7 @@
 #include "db/config.hh"
 #include "gms/feature.hh"
 #include "gms/feature_service.hh"
+#include "utils/assert.hh"
 #include "utils/s3/client.hh"
 #include "exceptions/exceptions.hh"
 
@@ -46,9 +47,9 @@ sstables_manager::sstables_manager(
 }
 
 sstables_manager::~sstables_manager() {
-    assert(_closing);
-    assert(_active.empty());
-    assert(_undergoing_close.empty());
+    SCYLLA_ASSERT(_closing);
+    SCYLLA_ASSERT(_active.empty());
+    SCYLLA_ASSERT(_undergoing_close.empty());
 }
 
 storage_manager::storage_manager(const db::config& cfg, config stm_cfg)

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -12,6 +12,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sharded.hh>
 
+#include "utils/assert.hh"
 #include "utils/disk-error-handler.hh"
 #include "gc_clock.hh"
 #include "sstables/sstables.hh"
@@ -143,12 +144,12 @@ public:
             size_t buffer_size = default_sstable_buffer_size);
 
     shared_ptr<s3::client> get_endpoint_client(sstring endpoint) const {
-        assert(_storage != nullptr);
+        SCYLLA_ASSERT(_storage != nullptr);
         return _storage->get_endpoint_client(std::move(endpoint));
     }
 
     bool is_known_endpoint(sstring endpoint) const {
-        assert(_storage != nullptr);
+        SCYLLA_ASSERT(_storage != nullptr);
         return _storage->is_known_endpoint(std::move(endpoint));
     }
 
@@ -180,7 +181,7 @@ public:
 
     // Only for sstable::storage usage
     sstables::sstables_registry& sstables_registry() const noexcept {
-        assert(_sstables_registry && "sstables_registry is not plugged");
+        SCYLLA_ASSERT(_sstables_registry && "sstables_registry is not plugged");
         return *_sstables_registry;
     }
 

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -25,6 +25,7 @@
 #include "sstables/sstable_version.hh"
 #include "sstables/integrity_checked_file_impl.hh"
 #include "sstables/writer.hh"
+#include "utils/assert.hh"
 #include "utils/lister.hh"
 #include "utils/overloaded_functor.hh"
 #include "utils/memory_data_sink.hh"
@@ -127,7 +128,7 @@ future<data_sink> filesystem_storage::make_data_or_index_sink(sstable& sst, comp
     options.buffer_size = sst.sstable_buffer_size;
     options.write_behind = 10;
 
-    assert(type == component_type::Data || type == component_type::Index);
+    SCYLLA_ASSERT(type == component_type::Data || type == component_type::Index);
     return make_file_data_sink(type == component_type::Data ? std::move(sst._data_file) : std::move(sst._index_file), options);
 }
 
@@ -606,7 +607,7 @@ future<file> s3_storage::open_component(const sstable& sst, component_type type,
 }
 
 future<data_sink> s3_storage::make_data_or_index_sink(sstable& sst, component_type type) {
-    assert(type == component_type::Data || type == component_type::Index);
+    SCYLLA_ASSERT(type == component_type::Data || type == component_type::Index);
     // FIXME: if we have file size upper bound upfront, it's better to use make_upload_sink() instead
     co_return _client->make_upload_jumbo_sink(make_s3_object_name(sst, type));
 }

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <filesystem>
 
 #include <seastar/core/file.hh>
@@ -40,13 +41,13 @@ class storage {
 
     // Internal, but can also be used by tests
     virtual future<> change_dir_for_test(sstring nd) {
-        assert(false && "Changing directory not implemented");
+        SCYLLA_ASSERT(false && "Changing directory not implemented");
     }
     virtual future<> create_links(const sstable& sst, const std::filesystem::path& dir) const {
-        assert(false && "Direct links creation not implemented");
+        SCYLLA_ASSERT(false && "Direct links creation not implemented");
     }
     virtual future<> move(const sstable& sst, sstring new_dir, generation_type generation, delayed_commit_changes* delay) {
-        assert(false && "Direct move not implemented");
+        SCYLLA_ASSERT(false && "Direct move not implemented");
     }
 
 public:

--- a/streaming/session_info.cc
+++ b/streaming/session_info.cc
@@ -8,12 +8,13 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include "streaming/session_info.hh"
 
 namespace streaming {
 
 void session_info::update_progress(progress_info new_progress) {
-    assert(peer == new_progress.peer);
+    SCYLLA_ASSERT(peer == new_progress.peer);
     auto& current_files = new_progress.dir == progress_info::direction::IN
         ? receiving_files : sending_files;
     current_files[new_progress.file_name] = new_progress;

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -30,6 +30,7 @@
 #include "consumer.hh"
 #include "readers/generating_v2.hh"
 #include "service/topology_guard.hh"
+#include "utils/assert.hh"
 #include "utils/error_injection.hh"
 
 namespace streaming {
@@ -543,7 +544,7 @@ void stream_session::add_transfer_ranges(sstring keyspace, dht::token_range_vect
         if (it == _transfers.end()) {
             stream_transfer_task task(shared_from_this(), cf_id, ranges);
             auto inserted = _transfers.emplace(cf_id, std::move(task)).second;
-            assert(inserted);
+            SCYLLA_ASSERT(inserted);
         } else {
             it->second.append_ranges(ranges);
         }

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include "table_helper.hh"
@@ -24,7 +25,7 @@ static schema_ptr parse_new_cf_statement(cql3::query_processor& qp, const sstrin
     auto parsed = cql3::query_processor::parse_statement(create_cql);
 
     cql3::statements::raw::cf_statement* parsed_cf_stmt = static_cast<cql3::statements::raw::cf_statement*>(parsed.get());
-    (void)parsed_cf_stmt->keyspace(); // This will assert if cql statement did not contain keyspace
+    (void)parsed_cf_stmt->keyspace(); // This will SCYLLA_ASSERT if cql statement did not contain keyspace
     ::shared_ptr<cql3::statements::create_table_statement> statement =
                     static_pointer_cast<cql3::statements::create_table_statement>(
                                     parsed_cf_stmt->prepare(db, qp.get_cql_stats())->statement);

--- a/test/boost/bptree_test.cc
+++ b/test/boost/bptree_test.cc
@@ -12,6 +12,7 @@
 #include <boost/test/unit_test.hpp>
 #include <fmt/core.h>
 
+#include "utils/assert.hh"
 #include "utils/bptree.hh"
 #include "test/unit/tree_test_key.hh"
 
@@ -253,7 +254,7 @@ public:
     tree_data(int key, int cookie) : _key(key), _cookie(cookie) {}
     int cookie() const { return _cookie; }
     int key() const {
-        assert(_key != -1);
+        SCYLLA_ASSERT(_key != -1);
         return _key;
     }
 };

--- a/test/boost/bytes_ostream_test.cc
+++ b/test/boost/bytes_ostream_test.cc
@@ -8,6 +8,7 @@
 
 #define BOOST_TEST_MODULE core
 
+#include "utils/assert.hh"
 #include <boost/range/algorithm/for_each.hpp>
 
 #include <seastar/util/variant_utils.hh>
@@ -27,7 +28,7 @@ void append_sequence(bytes_ostream& buf, int count) {
 
 void assert_sequence(bytes_ostream& buf, int count) {
     auto in = ser::as_input_stream(buf.linearize());
-    assert(buf.size() == count * sizeof(int));
+    SCYLLA_ASSERT(buf.size() == count * sizeof(int));
     for (int i = 0; i < count; i++) {
         auto val = ser::deserialize(in, boost::type<int>());
         BOOST_REQUIRE_EQUAL(val, i);
@@ -163,7 +164,7 @@ BOOST_AUTO_TEST_CASE(test_fragment_iteration) {
 
     // If this fails, we will only have one fragment, and the test will be weak.
     // Bump up the 'count' if this is triggered.
-    assert(!buf2.is_linearized());
+    SCYLLA_ASSERT(!buf2.is_linearized());
 
     assert_sequence(buf2, count);
 }

--- a/test/boost/cache_mutation_reader_test.cc
+++ b/test/boost/cache_mutation_reader_test.cc
@@ -8,6 +8,7 @@
  */
 
 
+#include "utils/assert.hh"
 #include <boost/test/unit_test.hpp>
 
 #include "test/lib/scylla_test_case.hh"
@@ -72,7 +73,7 @@ static void add_tombstone(mutation& m, range_tombstone rt) {
 
 static void set_row_continuous(mutation_partition& mp, int ck, is_continuous value) {
     auto it = mp.clustered_rows().find(make_ck(ck), rows_entry::tri_compare(*SCHEMA));
-    assert(it != mp.clustered_rows().end());
+    SCYLLA_ASSERT(it != mp.clustered_rows().end());
     it->set_continuous(value);
 }
 

--- a/test/boost/cdc_generation_test.cc
+++ b/test/boost/cdc_generation_test.cc
@@ -8,6 +8,7 @@
 
 #define BOOST_TEST_MODULE core
 
+#include "utils/assert.hh"
 #include <boost/test/unit_test.hpp>
 #include <vector>
 
@@ -139,7 +140,7 @@ BOOST_AUTO_TEST_CASE(test_cdc_generation_limitting_multiple_vnodes_should_limit)
 
     cdc::topology_description result = cdc::limit_number_of_streams_if_needed(std::move(given));
 
-    assert(streams_count_per_vnode.size() <= cdc::limit_of_streams_in_topology_description());
+    SCYLLA_ASSERT(streams_count_per_vnode.size() <= cdc::limit_of_streams_in_topology_description());
     size_t per_vnode_limit = cdc::limit_of_streams_in_topology_description() / streams_count_per_vnode.size();
     for (auto& count : streams_count_per_vnode) {
         count = std::min(count, per_vnode_limit);

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -31,6 +31,7 @@
 
 #include "cql3/column_identifier.hh"
 
+#include "utils/assert.hh"
 #include "utils/UUID_gen.hh"
 #include "utils/to_string.hh"
 
@@ -269,7 +270,7 @@ SEASTAR_THREAD_TEST_CASE(test_permissions_of_cdc_description) {
 
         for (auto& t : {generations_v2, streams, timestamps}) {
             auto dot_pos = t.find_first_of('.');
-            assert(dot_pos != std::string_view::npos && dot_pos != 0 && dot_pos != t.size() - 1);
+            SCYLLA_ASSERT(dot_pos != std::string_view::npos && dot_pos != 0 && dot_pos != t.size() - 1);
             BOOST_REQUIRE(e.local_db().has_schema(t.substr(0, dot_pos), t.substr(dot_pos + 1)));
 
             // Disallow DROP

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -29,6 +29,7 @@
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/closeable.hh>
 
+#include "utils/assert.hh"
 #include "utils/UUID_gen.hh"
 #include "test/lib/tmpdir.hh"
 #include "db/commitlog/commitlog.hh"
@@ -802,7 +803,7 @@ SEASTAR_TEST_CASE(test_commitlog_chunk_truncation) {
                 // Reading this segment will now get corruption at the above position,
                 // right before where we have truncated the file. It will try to skip
                 // to next chunk, which is past actual EOF. If #15269 is broken, this
-                // will assert and crash in file_data_source_impl. If not, we should 
+                // will SCYLLA_ASSERT and crash in file_data_source_impl. If not, we should 
                 // get a corruption exception and no more entries past the corrupt one.
                 db::position_type pos = 0;
                 try {
@@ -888,7 +889,7 @@ SEASTAR_TEST_CASE(test_allocation_failure){
 
             // Use us loads of memory so we can OOM at the appropriate place
             try {
-                assert(fragmented_temporary_buffer::default_fragment_size < size);
+                SCYLLA_ASSERT(fragmented_temporary_buffer::default_fragment_size < size);
                 for (;;) {
                     junk->emplace_back(new char[fragmented_temporary_buffer::default_fragment_size]);
                 }

--- a/test/boost/cql_functions_test.cc
+++ b/test/boost/cql_functions_test.cc
@@ -22,6 +22,7 @@
 
 #include <seastar/core/future-util.hh>
 #include "transport/messages/result_message.hh"
+#include "utils/assert.hh"
 #include "utils/big_decimal.hh"
 #include "types/map.hh"
 #include "types/list.hh"
@@ -316,7 +317,7 @@ SEASTAR_TEST_CASE(test_aggregate_functions_timeuuid_type) {
             timeuuid_native_type{utils::UUID("00000000-0000-1000-0000-000000000000")},
             timeuuid_native_type{utils::UUID("00000000-0000-1000-0000-000000000001")},
             timeuuid_native_type{utils::UUID("00000000-0000-1000-0000-000000000002")}
-        ).test_count(); // min and max will fail, because we assert using UUID order, not timestamp order.
+        ).test_count(); // min and max will fail, because we SCYLLA_ASSERT using UUID order, not timestamp order.
     });
 }
 

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -29,6 +29,7 @@
 #include "transport/messages/result_message.hh"
 #include "transport/messages/result_message_base.hh"
 #include "types/types.hh"
+#include "utils/assert.hh"
 #include "utils/big_decimal.hh"
 #include "types/map.hh"
 #include "types/list.hh"
@@ -3026,10 +3027,10 @@ SEASTAR_TEST_CASE(test_query_with_range_tombstones) {
 SEASTAR_TEST_CASE(test_alter_table_validation) {
     return do_with_cql_env([] (cql_test_env& e) {
         return e.execute_cql("create table tatv (p1 int, c1 int, c2 int, r1 int, r2 set<int>, PRIMARY KEY (p1, c1, c2));").discard_result().then_wrapped([&e] (future<> f) {
-            assert(!f.failed());
+            SCYLLA_ASSERT(!f.failed());
             return e.execute_cql("alter table tatv drop r2;").discard_result();
         }).then_wrapped([&e] (future<> f) {
-            assert(!f.failed());
+            SCYLLA_ASSERT(!f.failed());
             return e.execute_cql("alter table tatv add r2 list<int>;").discard_result();
         }).then_wrapped([&e] (future<> f) {
             assert_that_failed(f);
@@ -3038,7 +3039,7 @@ SEASTAR_TEST_CASE(test_alter_table_validation) {
             assert_that_failed(f);
             return e.execute_cql("alter table tatv add r2 set<int>;").discard_result();
         }).then_wrapped([&e] (future<> f) {
-            assert(!f.failed());
+            SCYLLA_ASSERT(!f.failed());
             return e.execute_cql("alter table tatv rename r2 to r3;").discard_result();
         }).then_wrapped([&e] (future<> f) {
             assert_that_failed(f);
@@ -3050,16 +3051,16 @@ SEASTAR_TEST_CASE(test_alter_table_validation) {
             assert_that_failed(f);
             return e.execute_cql("alter table tatv add r3 map<int, int>;").discard_result();
         }).then_wrapped([&e] (future<> f) {
-            assert(!f.failed());
+            SCYLLA_ASSERT(!f.failed());
             return e.execute_cql("alter table tatv add r4 set<text>;").discard_result();
         }).then_wrapped([&e] (future<> f) {
-            assert(!f.failed());
+            SCYLLA_ASSERT(!f.failed());
             return e.execute_cql("alter table tatv drop r3;").discard_result();
         }).then_wrapped([&e] (future<> f) {
-            assert(!f.failed());
+            SCYLLA_ASSERT(!f.failed());
             return e.execute_cql("alter table tatv drop r4;").discard_result();
         }).then_wrapped([&e] (future<> f) {
-            assert(!f.failed());
+            SCYLLA_ASSERT(!f.failed());
             return e.execute_cql("alter table tatv add r3 map<int, text>;").discard_result();
         }).then_wrapped([&e] (future<> f) {
             assert_that_failed(f);
@@ -3068,10 +3069,10 @@ SEASTAR_TEST_CASE(test_alter_table_validation) {
             assert_that_failed(f);
             return e.execute_cql("alter table tatv add r3 map<int, blob>;").discard_result();
         }).then_wrapped([&e] (future<> f) {
-            assert(!f.failed());
+            SCYLLA_ASSERT(!f.failed());
             return e.execute_cql("alter table tatv add r4 set<blob>;").discard_result();
         }).then_wrapped([] (future<> f) {
-            assert(!f.failed());
+            SCYLLA_ASSERT(!f.failed());
         });
     });
 }
@@ -4706,7 +4707,7 @@ SEASTAR_TEST_CASE(test_select_serial_consistency) {
         auto check_fails = [&e] (const sstring& query, const source_location& loc = source_location::current()) {
             try {
                 prepared_on_shard(e, query, {}, {}, db::consistency_level::SERIAL);
-                assert(false);
+                SCYLLA_ASSERT(false);
             } catch (const exceptions::invalid_request_exception& e) {
                 testlog.info("Query '{}' failed as expected with error: {}", query, e);
             } catch (...) {

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -27,6 +27,7 @@
 #include "test/lib/key_utils.hh"
 
 #include "replica/database.hh"
+#include "utils/assert.hh"
 #include "utils/lister.hh"
 #include "partition_slice_builder.hh"
 #include "mutation/frozen_mutation.hh"
@@ -788,7 +789,7 @@ SEASTAR_TEST_CASE(clear_multiple_snapshots) {
         testlog.debug("Clearing all snapshots in {}.{} after it had been dropped", ks_name, table_name);
         e.local_db().clear_snapshot("", {ks_name}, table_name).get();
 
-        assert(!fs::exists(table_dir));
+        SCYLLA_ASSERT(!fs::exists(table_dir));
 
         // after all snapshots had been cleared,
         // the dropped table directory is expected to be removed.

--- a/test/boost/exceptions_test.inc.cc
+++ b/test/boost/exceptions_test.inc.cc
@@ -23,6 +23,7 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/util/log.hh>
 
+#include "utils/assert.hh"
 #include "utils/exceptions.hh"
 
 class base_exception : public std::exception {};
@@ -67,7 +68,7 @@ static void check_catch(Throw&& ex) {
         BOOST_CHECK_EQUAL(typed_eptr, &t);
     } catch (...) {
         // Can happen if the first check fails, just skip
-        assert(typed_eptr == nullptr);
+        SCYLLA_ASSERT(typed_eptr == nullptr);
     }
 }
 

--- a/test/boost/fragmented_temporary_buffer_test.cc
+++ b/test/boost/fragmented_temporary_buffer_test.cc
@@ -9,6 +9,7 @@
 #include <seastar/core/thread.hh>
 #include "test/lib/scylla_test_case.hh"
 
+#include "utils/assert.hh"
 #include "utils/fragmented_temporary_buffer.hh"
 
 #include "test/lib/random_utils.hh"
@@ -245,7 +246,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_pod) {
 
 SEASTAR_THREAD_TEST_CASE(test_read_to) {
     auto test = [&] (bytes_view expected_value1, bytes_view expected_value2, fragmented_temporary_buffer& ftb) {
-        assert(expected_value2.size() < expected_value1.size());
+        SCYLLA_ASSERT(expected_value2.size() < expected_value1.size());
 
         bytes actual_value;
 
@@ -281,7 +282,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_to) {
 
 SEASTAR_THREAD_TEST_CASE(test_read_view) {
     auto test = [&] (bytes_view expected_value1, bytes_view expected_value2, fragmented_temporary_buffer& ftb) {
-        assert(expected_value2.size() < expected_value1.size());
+        SCYLLA_ASSERT(expected_value2.size() < expected_value1.size());
 
         auto in = ftb.get_istream();
         BOOST_CHECK_EQUAL(in.bytes_left(), expected_value1.size() + expected_value2.size());
@@ -312,7 +313,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_view) {
 SEASTAR_THREAD_TEST_CASE(test_read_bytes_view) {
     auto linearization_buffer = bytes_ostream();
     auto test = [&] (bytes_view expected_value1, bytes_view expected_value2, fragmented_temporary_buffer& ftb) {
-        assert(expected_value2.size() < expected_value1.size());
+        SCYLLA_ASSERT(expected_value2.size() < expected_value1.size());
 
         auto in = ftb.get_istream();
         BOOST_CHECK_EQUAL(in.read_bytes_view(0, linearization_buffer), bytes_view());

--- a/test/boost/idl_test.cc
+++ b/test/boost/idl_test.cc
@@ -8,6 +8,7 @@
 
 #define BOOST_TEST_MODULE core
 
+#include "utils/assert.hh"
 #include <boost/test/unit_test.hpp>
 
 #include <seastar/util/variant_utils.hh>
@@ -241,7 +242,7 @@ BOOST_AUTO_TEST_CASE(test_vector)
     BOOST_REQUIRE_EQUAL(vec1.size(), first_view.size());
     for (size_t i = 0; i < first_view.size(); i++) {
         auto fv = first_view[i];
-        assert(vec1[i].foo == fv.foo());
+        SCYLLA_ASSERT(vec1[i].foo == fv.foo());
         BOOST_REQUIRE_EQUAL(vec1[i].foo, first_view[i].foo());
         BOOST_REQUIRE_EQUAL(vec1[i].bar, first_view[i].bar());
     }

--- a/test/boost/large_paging_state_test.cc
+++ b/test/boost/large_paging_state_test.cc
@@ -7,6 +7,7 @@
  */
 
 
+#include "utils/assert.hh"
 #include <boost/test/unit_test.hpp>
 #include "test/lib/scylla_test_case.hh"
 
@@ -69,7 +70,7 @@ SEASTAR_TEST_CASE(test_use_high_bits_of_remaining_rows_in_paging_state) {
             test_remaining = test_remaining - rows_fetched;
             if (has_more_pages(msg)) {
                 paging_state = extract_paging_state(msg);
-                assert(paging_state);
+                SCYLLA_ASSERT(paging_state);
                 BOOST_REQUIRE_EQUAL(test_remaining, paging_state->get_remaining());
             }
         }
@@ -107,7 +108,7 @@ SEASTAR_TEST_CASE(test_use_high_bits_of_remaining_rows_in_paging_state_filtering
             test_remaining = test_remaining - rows_fetched;
             if (has_more_pages(msg)) {
                 paging_state = extract_paging_state(msg);
-                assert(paging_state);
+                SCYLLA_ASSERT(paging_state);
                 BOOST_REQUIRE_EQUAL(test_remaining, paging_state->get_remaining());
             }
         }

--- a/test/boost/limiting_data_source_test.cc
+++ b/test/boost/limiting_data_source_test.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "utils/limiting_data_source.hh"
 
 #include <boost/test/unit_test.hpp>
@@ -79,7 +80,7 @@ data_source prepare_test_skip() {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_get_smaller_than_limit) {
-    assert(test_data_source_impl::chunk_limit > 1);
+    SCYLLA_ASSERT(test_data_source_impl::chunk_limit > 1);
     test_get(test_data_source_impl::chunk_limit - 1);
 }
 

--- a/test/boost/lister_test.cc
+++ b/test/boost/lister_test.cc
@@ -20,6 +20,7 @@
 #include "test/lib/random_utils.hh"
 #include "test/lib/test_utils.hh"
 
+#include "utils/assert.hh"
 #include "utils/lister.hh"
 
 class expected_exception : public std::exception {
@@ -82,7 +83,7 @@ SEASTAR_TEST_CASE(test_lister_abort) {
     std::unordered_set<std::string> dir_names;
 
     auto count = co_await generate_random_content(tmp, file_names, dir_names, 1, tests::random::get_int(100, 1000));
-    assert(count > 0);
+    SCYLLA_ASSERT(count > 0);
     BOOST_TEST_MESSAGE(fmt::format("Generated {} dir entries", count));
 
     size_t initial = tests::random::get_int<size_t>(1, count);

--- a/test/boost/locator_topology_test.cc
+++ b/test/boost/locator_topology_test.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <boost/test/unit_test.hpp>
 
 #include <fmt/ranges.h>
@@ -182,7 +183,7 @@ SEASTAR_THREAD_TEST_CASE(test_add_or_update_by_host_id) {
 
     // In this test we check that add_or_update_endpoint searches by host_id first.
     // We create two nodes, one matches by id, another - by ip,
-    // and assert that add_or_update_endpoint updates the first.
+    // and SCYLLA_ASSERT that add_or_update_endpoint updates the first.
     // We need to make the second node 'being_decommissioned', so that
     // it gets removed from ip index and we don't get the non-unique IP error.
 

--- a/test/boost/log_heap_test.cc
+++ b/test/boost/log_heap_test.cc
@@ -11,6 +11,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "utils/assert.hh"
 #include "utils/log_heap.hh"
 
 template<const log_heap_options& opts>
@@ -52,7 +53,7 @@ void test_with_options() {
             ++count;
             auto key = t.v;
             if (prev_key) {
-                assert(key > prev_key);
+                SCYLLA_ASSERT(key > prev_key);
             }
             max_key = std::max(max_key, key);
         }

--- a/test/boost/logalloc_test.cc
+++ b/test/boost/logalloc_test.cc
@@ -24,6 +24,7 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
 
+#include "utils/assert.hh"
 #include "utils/logalloc.hh"
 #include "utils/managed_ref.hh"
 #include "utils/managed_bytes.hh"
@@ -544,7 +545,7 @@ SEASTAR_THREAD_TEST_CASE(test_hold_reserve) {
 
     as.with_reserve(region, [&] {
         with_allocator(region.allocator(), [&] {
-            assert(sizeof(entry) + 128 < current_allocator().preferred_max_contiguous_allocation());
+            SCYLLA_ASSERT(sizeof(entry) + 128 < current_allocator().preferred_max_contiguous_allocation());
             logalloc::reclaim_lock rl(region);
 
             // Reserve a segment.

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "multishard_mutation_query.hh"
 #include "schema/schema_registry.hh"
 #include "db/config.hh"
@@ -303,7 +304,7 @@ read_partitions_with_generic_paged_scan(distributed<replica::database>& db, sche
         while (!ranges->front().contains(res_builder.last_pkey(), cmp)) {
             ranges->erase(ranges->begin());
         }
-        assert(!ranges->empty());
+        SCYLLA_ASSERT(!ranges->empty());
 
         const auto pkrange_begin_inclusive = res_builder.last_ckey() && res_builder.last_pkey_rows() < slice.partition_row_limit();
 
@@ -896,7 +897,7 @@ namespace {
 
 template <typename RandomEngine>
 static interval<int> generate_range(RandomEngine& rnd_engine, int start, int end, bool allow_open_ended_start = true) {
-    assert(start < end);
+    SCYLLA_ASSERT(start < end);
 
     std::uniform_int_distribution<int> defined_bound_dist(0, 7);
     std::uniform_int_distribution<int8_t> inclusive_dist(0, 1);

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -7,6 +7,7 @@
  */
 
 
+#include "utils/assert.hh"
 #include <fmt/ranges.h>
 
 #include <boost/range/adaptor/transformed.hpp>
@@ -50,19 +51,19 @@ static schema_ptr make_schema() {
 
 struct mutation_less_cmp {
     bool operator()(const mutation& m1, const mutation& m2) const {
-        assert(m1.schema() == m2.schema());
+        SCYLLA_ASSERT(m1.schema() == m2.schema());
         return m1.decorated_key().less_compare(*m1.schema(), m2.decorated_key());
     }
 };
 static mutation_source make_source(std::vector<mutation> mutations) {
     return mutation_source([mutations = std::move(mutations)] (schema_ptr s, reader_permit permit, const dht::partition_range& range, const query::partition_slice& slice,
             tracing::trace_state_ptr, streamed_mutation::forwarding fwd, mutation_reader::forwarding fwd_mr) {
-        assert(range.is_full()); // slicing not implemented yet
+        SCYLLA_ASSERT(range.is_full()); // slicing not implemented yet
         for (auto&& m : mutations) {
             if (slice.is_reversed()) {
-                assert(m.schema()->make_reversed()->version() == s->version());
+                SCYLLA_ASSERT(m.schema()->make_reversed()->version() == s->version());
             } else {
-                assert(m.schema() == s);
+                SCYLLA_ASSERT(m.schema() == s);
             }
         }
         return make_mutation_reader_from_mutations_v2(s, std::move(permit), mutations, slice, fwd);

--- a/test/boost/mutation_reader_another_test.cc
+++ b/test/boost/mutation_reader_another_test.cc
@@ -24,6 +24,7 @@
 #include "replica/memtable.hh"
 #include "row_cache.hh"
 #include "mutation/mutation_rebuilder.hh"
+#include "utils/assert.hh"
 #include "utils/to_string.hh"
 
 #include "test/lib/simple_schema.hh"
@@ -574,7 +575,7 @@ void test_flat_stream(schema_ptr s, std::vector<mutation> muts, reversed_partiti
 
     auto consume_fn = [&] (mutation_reader& fmr, flat_stream_consumer fsc) {
         if (thread) {
-            assert(bool(!reversed));
+            SCYLLA_ASSERT(bool(!reversed));
             return fmr.consume_in_thread(std::move(fsc));
         } else {
             if (reversed) {

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -48,6 +48,7 @@
 #include "replica/database.hh"
 #include "partition_slice_builder.hh"
 #include "schema/schema_registry.hh"
+#include "utils/assert.hh"
 #include "utils/ranges.hh"
 #include "mutation/mutation_rebuilder.hh"
 
@@ -695,7 +696,7 @@ public:
         return ret;
     }
     virtual std::vector<mutation_reader> fast_forward_to(const dht::partition_range& pr) override {
-        assert(false); // Fast forward not supported by this reader
+        SCYLLA_ASSERT(false); // Fast forward not supported by this reader
         return {};
     }
 };
@@ -3310,7 +3311,7 @@ SEASTAR_THREAD_TEST_CASE(test_evictable_reader_drop_flags) {
         }
         size_t add_mutation_fragment(mutation_fragment_v2&& mf, bool only_to_frags = false) {
             if (!only_to_frags) {
-                assert(mut_rebuilder);
+                SCYLLA_ASSERT(mut_rebuilder);
                 mut_rebuilder->consume(mutation_fragment_v2(*s.schema(), permit, mf));
             }
             size += frags.emplace_back(*s.schema(), permit, std::move(mf)).memory_usage();
@@ -3803,7 +3804,7 @@ struct clustering_order_merger_test_generator {
 
         std::vector<position_range> fwd_ranges;
         for (size_t i = 0; i < num_ranges; ++i) {
-            assert(2*i+1 < positions.size());
+            SCYLLA_ASSERT(2*i+1 < positions.size());
             fwd_ranges.push_back(position_range(std::move(positions[2*i]), std::move(positions[2*i+1])));
         }
 
@@ -3935,7 +3936,7 @@ static future<> do_test_clustering_order_merger_sstable_set(bool reversed) {
                 // for our partition (not even `partition_start`). For that we create an sstable
                 // with a different partition.
                 auto pk = pkeys[1];
-                assert(!pk.equal(*g._s, g._pk));
+                SCYLLA_ASSERT(!pk.equal(*g._s, g._pk));
 
                 sst = make_sstable_containing(sst_factory, {mutation(table_schema, pk)});
                 sst_set.insert(sst);
@@ -4009,7 +4010,7 @@ SEASTAR_THREAD_TEST_CASE(clustering_combined_reader_mutation_source_test) {
             , _it(std::partition_point(_readers.begin(), _readers.end(), [this, cmp = dht::ring_position_comparator(*_schema)]
                     (auto& r) { return _range.get().before(r.first, cmp); }))
         {
-            assert(!_readers.empty());
+            SCYLLA_ASSERT(!_readers.empty());
         }
 
         virtual future<> fill_buffer() override {
@@ -4033,7 +4034,7 @@ SEASTAR_THREAD_TEST_CASE(clustering_combined_reader_mutation_source_test) {
                     // => current partition is _it, we need to move forward
                     //    _it might be the end of current forwarding range, but that's no problem;
                     //    in that case we'll go into eos mode until forwarded
-                    assert(_it != _readers.end());
+                    SCYLLA_ASSERT(_it != _readers.end());
                     _inside_partition = false;
                     ++_it;
                 } else {
@@ -4062,7 +4063,7 @@ SEASTAR_THREAD_TEST_CASE(clustering_combined_reader_mutation_source_test) {
                 // while inside partition. But if it happens for whatever reason just do nothing
                 return make_ready_future<>();
             }
-            assert(_it != _readers.end());
+            SCYLLA_ASSERT(_it != _readers.end());
             // all fragments currently in the buffer come from the current position range
             // and pr must be strictly greater, so just clear the buffer
             clear_buffer();

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -13,6 +13,7 @@
 #include <boost/range/algorithm_ext/push_back.hpp>
 #include <boost/range/combine.hpp>
 #include "mutation_query.hh"
+#include "utils/assert.hh"
 #include "utils/hashers.hh"
 #include "utils/preempt.hh"
 #include "utils/xx_hasher.hh"
@@ -2927,13 +2928,13 @@ SEASTAR_THREAD_TEST_CASE(test_compaction_data_stream_split) {
             if (destination == tests::timestamp_destination::partition_tombstone ||
                     destination == tests::timestamp_destination::row_tombstone ||
                     destination == tests::timestamp_destination::range_tombstone) {
-                assert(min_timestamp < tomb_ts_max);
+                SCYLLA_ASSERT(min_timestamp < tomb_ts_max);
                 return tests::random::get_int<api::timestamp_type>(tomb_ts_min, tomb_ts_max, engine);
             } else if (destination == tests::timestamp_destination::collection_tombstone) {
-                assert(min_timestamp < collection_tomb_ts_max);
+                SCYLLA_ASSERT(min_timestamp < collection_tomb_ts_max);
                 return tests::random::get_int<api::timestamp_type>(collection_tomb_ts_min, collection_tomb_ts_max, engine);
             } else {
-                assert(min_timestamp < other_ts_max);
+                SCYLLA_ASSERT(min_timestamp < other_ts_max);
                 return tests::random::get_int<api::timestamp_type>(other_ts_min, other_ts_max, engine);
             }
         };
@@ -2962,13 +2963,13 @@ SEASTAR_THREAD_TEST_CASE(test_compaction_data_stream_split) {
             if (destination == tests::timestamp_destination::partition_tombstone ||
                     destination == tests::timestamp_destination::row_tombstone ||
                     destination == tests::timestamp_destination::range_tombstone) {
-                assert(min_timestamp < tomb_ts_max);
+                SCYLLA_ASSERT(min_timestamp < tomb_ts_max);
                 return tests::random::get_int<api::timestamp_type>(tomb_ts_min, tomb_ts_max, engine);
             } else if (destination == tests::timestamp_destination::collection_tombstone) {
-                assert(min_timestamp < tomb_ts_max);
+                SCYLLA_ASSERT(min_timestamp < tomb_ts_max);
                 return tests::random::get_int<api::timestamp_type>(collection_tomb_ts_min, collection_tomb_ts_max, engine);
             } else {
-                assert(min_timestamp < other_ts_max);
+                SCYLLA_ASSERT(min_timestamp < other_ts_max);
                 return tests::random::get_int<api::timestamp_type>(other_ts_min, other_ts_max, engine);
             }
         };

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -7,6 +7,7 @@
  */
 
 
+#include "utils/assert.hh"
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/range/algorithm_ext/push_back.hpp>
@@ -207,7 +208,7 @@ void mvcc_partition::apply_to_evictable(partition_entry&& src, schema_ptr src_sc
 }
 
 mvcc_partition& mvcc_partition::operator+=(mvcc_partition&& src) {
-    assert(_evictable);
+    SCYLLA_ASSERT(_evictable);
     apply_to_evictable(std::move(src.entry()), src.schema());
     return *this;
 }

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -11,6 +11,7 @@
 #include <fmt/ranges.h>
 #include "gms/inet_address.hh"
 #include "locator/types.hh"
+#include "utils/assert.hh"
 #include "utils/UUID_gen.hh"
 #include "utils/sequenced_set.hh"
 #include "utils/to_string.hh"
@@ -747,7 +748,7 @@ static locator::host_id_set calculate_natural_endpoints(
         racks = tp.get_datacenter_racks();
 
     // not aware of any cluster members
-    assert(!all_endpoints.empty() && !racks.empty());
+    SCYLLA_ASSERT(!all_endpoints.empty() && !racks.empty());
 
     for (auto& next : tm.ring_range(search_token)) {
 

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -21,6 +21,7 @@
 #include "schema/schema.hh"
 #include "types/types.hh"
 #include "schema/schema_builder.hh"
+#include "utils/assert.hh"
 #include "utils/to_string.hh"
 
 #include "test/lib/simple_schema.hh"
@@ -631,11 +632,11 @@ SEASTAR_THREAD_TEST_CASE(test_find_first_token_for_shard) {
     auto second_boundary = sharder.token_for_next_shard_for_reads(dht::minimum_token(), 2);
     auto third_boundary = sharder.token_for_next_shard_for_reads(dht::minimum_token(), 0);
     auto next_token = [] (dht::token t) {
-        assert(dht::token::to_int64(t) < std::numeric_limits<int64_t>::max());
+        SCYLLA_ASSERT(dht::token::to_int64(t) < std::numeric_limits<int64_t>::max());
         return dht::token::from_int64(dht::token::to_int64(t) + 1);
     };
     auto prev_token = [] (dht::token t) {
-        assert(dht::token::to_int64(t) > std::numeric_limits<int64_t>::min() + 1);
+        SCYLLA_ASSERT(dht::token::to_int64(t) > std::numeric_limits<int64_t>::min() + 1);
         return dht::token::from_int64(dht::token::to_int64(t) - 1);
     };
 

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <seastar/util/closeable.hh>
 #include <seastar/core/file.hh>
 #include "reader_concurrency_semaphore.hh"
@@ -121,7 +122,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_abandoned_handle_clos
     {
         auto handle = semaphore.register_inactive_read(make_empty_flat_reader_v2(s.schema(), permit));
         // The handle is destroyed here, triggering the destrution of the inactive read.
-        // If the test fails an assert() is triggered due to the reader being
+        // If the test fails an SCYLLA_ASSERT() is triggered due to the reader being
         // destroyed without having been closed before.
     }
 }

--- a/test/boost/reusable_buffer_test.cc
+++ b/test/boost/reusable_buffer_test.cc
@@ -11,6 +11,7 @@
 
 #include <boost/range/algorithm/copy.hpp>
 
+#include "utils/assert.hh"
 #include "utils/reusable_buffer.hh"
 #include <seastar/core/manual_clock.hh>
 #include <seastar/testing/test_case.hh>
@@ -139,7 +140,7 @@ SEASTAR_TEST_CASE(test_decay) {
     // It isn't strictly required from the implementation to use
     // power-of-2 sizes, just sizes coarse enough to limit the number
     // of allocations.
-    // If the implementation is modified, this assert can be freely changed.
+    // If the implementation is modified, this SCYLLA_ASSERT can be freely changed.
     BOOST_REQUIRE_EQUAL(buffer.size(), std::bit_ceil(size_t(1'000'001)));
     co_await advance_clock(1500ms);
     get_buffer(1'000);

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -23,6 +23,7 @@
 #include "test/lib/random_utils.hh"
 #include "test/lib/test_utils.hh"
 #include "test/lib/tmpdir.hh"
+#include "utils/assert.hh"
 #include "utils/s3/client.hh"
 #include "utils/s3/creds.hh"
 #include "utils/exceptions.hh"
@@ -209,7 +210,7 @@ future<> test_client_upload_file(std::string_view test_name, size_t total_size, 
         auto output = co_await make_file_output_stream(std::move(f));
         std::string_view data = "1234567890ABCDEF";
         // so we can test !with_remainder case properly with multiple writes
-        assert(total_size % data.size() == 0);
+        SCYLLA_ASSERT(total_size % data.size() == 0);
 
         for (size_t bytes_written = 0;
              bytes_written < total_size;

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -19,6 +19,7 @@
 #include "types/list.hh"
 #include "types/set.hh"
 #include "cql3/statements/select_statement.hh"
+#include "utils/assert.hh"
 #include "utils/error_injection.hh"
 
 using namespace std::chrono_literals;
@@ -445,7 +446,7 @@ SEASTAR_TEST_CASE(test_simple_index_paging) {
         auto extract_paging_state = [] (::shared_ptr<cql_transport::messages::result_message> res) {
             auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(res);
             auto paging_state = rows->rs().get_metadata().paging_state();
-            assert(paging_state);
+            SCYLLA_ASSERT(paging_state);
             return make_lw_shared<service::pager::paging_state>(*paging_state);
         };
 
@@ -829,7 +830,7 @@ SEASTAR_TEST_CASE(test_local_index_paging) {
         auto extract_paging_state = [] (::shared_ptr<cql_transport::messages::result_message> res) {
             auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(res);
             auto paging_state = rows->rs().get_metadata().paging_state();
-            assert(paging_state);
+            SCYLLA_ASSERT(paging_state);
             return make_lw_shared<service::pager::paging_state>(*paging_state);
         };
 

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <set>
 #include <iterator>
 
@@ -5609,7 +5610,7 @@ SEASTAR_TEST_CASE(test_compression_premature_eof) {
 // Creates an sstable with a newer schema, and populates
 // it with a reader created with an older schema.
 // 
-// Before the fixes, it would have resulted in an assert violation.
+// Before the fixes, it would have resulted in an SCYLLA_ASSERT violation.
 SEASTAR_TEST_CASE(test_alter_bloom_fp_chance_during_write) {
     return test_env::do_with_async([] (test_env& env) {
         auto s1 = schema_builder("ks", "t")

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -7,6 +7,7 @@
  */
 
 
+#include "utils/assert.hh"
 #include <boost/test/unit_test.hpp>
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
@@ -137,7 +138,7 @@ SEASTAR_TEST_CASE(test_sstable_conforms_to_mutation_source_md_large) {
     return test_sstable_conforms_to_mutation_source(writable_sstable_versions[1], block_sizes[2]);
 }
 
-// This assert makes sure we don't miss writable vertions
+// This SCYLLA_ASSERT makes sure we don't miss writable vertions
 static_assert(writable_sstable_versions.size() == 3);
 
 // `keys` may contain repetitions.
@@ -219,7 +220,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_reversing_reader_random_schema) {
 
     std::vector<query::clustering_range> ranges;
     for (auto& r: fwd_ranges) {
-        assert(position_in_partition::less_compare(*query_schema)(r.start(), r.end()));
+        SCYLLA_ASSERT(position_in_partition::less_compare(*query_schema)(r.start(), r.end()));
         auto cr_opt = position_range_to_clustering_range(r, *query_schema);
         if (!cr_opt) {
             continue;

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <fmt/ranges.h>
 
 #include <seastar/core/sstring.hh>
@@ -2057,7 +2058,7 @@ SEASTAR_TEST_CASE(sstable_owner_shards) {
         };
 
         auto assert_sstable_owners = [&] (std::unordered_set<unsigned> expected_owners, unsigned ignore_msb, unsigned smp_count) {
-            assert(expected_owners.size() <= smp_count);
+            SCYLLA_ASSERT(expected_owners.size() <= smp_count);
             auto sst = make_shared_sstable(expected_owners, ignore_msb, smp_count);
             auto owners = boost::copy_range<std::unordered_set<unsigned>>(sst->get_shards_for_this_sstable());
             BOOST_REQUIRE(boost::algorithm::all_of(expected_owners, [&] (unsigned expected_owner) {
@@ -2596,7 +2597,7 @@ SEASTAR_TEST_CASE(test_zero_estimated_partitions) {
             auto close_mr = deferred_close(sst_mr);
             auto sst_mut = read_mutation_from_mutation_reader(sst_mr).get();
 
-            // The real test here is that we don't assert() in
+            // The real test here is that we don't SCYLLA_ASSERT() in
             // sstables::prepare_summary() with the write_components() call above,
             // this is only here as a sanity check.
             BOOST_REQUIRE(sst_mr.is_buffer_empty());

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "types/map.hh"
 #include "sstables/sstables.hh"
 #include "replica/database.hh"
@@ -378,7 +379,7 @@ inline void match(const row& row, const schema& s, bytes col, const data_value& 
 
     auto expected = cdef->type->decompose(value);
     auto val = c.value().linearize();
-    assert(val == expected);
+    SCYLLA_ASSERT(val == expected);
     BOOST_REQUIRE(c.value().linearize() == expected);
     if (timestamp) {
         BOOST_REQUIRE(c.timestamp() == timestamp);

--- a/test/lib/cql_assertions.cc
+++ b/test/lib/cql_assertions.cc
@@ -13,6 +13,7 @@
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/eventually.hh"
 #include "transport/messages/result_message.hh"
+#include "utils/assert.hh"
 #include "utils/to_string.hh"
 #include "bytes.hh"
 
@@ -260,23 +261,23 @@ future<> require_column_has_value(cql_test_env& e, const sstring& table_name,
       auto& cf = db.find_column_family("ks", table_name);
       auto schema = cf.schema();
       return cf.find_row(schema, make_reader_permit(e), dk, ckey).then([schema, column_name, exp] (auto row) {
-        assert(row != nullptr);
+        SCYLLA_ASSERT(row != nullptr);
         auto col_def = schema->get_column_definition(utf8_type->decompose(column_name));
-        assert(col_def != nullptr);
+        SCYLLA_ASSERT(col_def != nullptr);
         const atomic_cell_or_collection* cell = row->find_cell(col_def->id);
         if (!cell) {
-            assert(((void)"column not set", 0));
+            SCYLLA_ASSERT(((void)"column not set", 0));
         }
         bytes actual;
         if (!col_def->type->is_multi_cell()) {
             auto c = cell->as_atomic_cell(*col_def);
-            assert(c.is_live());
+            SCYLLA_ASSERT(c.is_live());
             actual = c.value().linearize();
         } else {
             actual = linearized(serialize_for_cql(*col_def->type,
                     cell->as_collection_mutation()));
         }
-        assert(col_def->type->equal(actual, exp));
+        SCYLLA_ASSERT(col_def->type->equal(actual, exp));
       });
     });
 }

--- a/test/lib/cql_assertions.hh
+++ b/test/lib/cql_assertions.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "test/lib/cql_test_env.hh"
 #include "transport/messages/result_message_base.hh"
 #include "bytes.hh"
@@ -50,7 +51,7 @@ void assert_that_failed(future<T>& f)
 {
     try {
         f.get();
-        assert(f.failed());
+        SCYLLA_ASSERT(f.failed());
     }
     catch (...) {
     }
@@ -61,7 +62,7 @@ void assert_that_failed(future<T>&& f)
 {
     try {
         f.get();
-        assert(f.failed());
+        SCYLLA_ASSERT(f.failed());
     }
     catch (...) {
     }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -57,6 +57,7 @@
 #include "db/system_distributed_keyspace.hh"
 #include "db/sstables-format-selector.hh"
 #include "repair/row_level.hh"
+#include "utils/assert.hh"
 #include "utils/class_registrator.hh"
 #include "utils/cross-shard-barrier.hh"
 #include "streaming/stream_manager.hh"
@@ -270,7 +271,7 @@ public:
         }
         auto stmt = prepared->statement;
 
-        assert(stmt->get_bound_terms() == qo->get_values_count());
+        SCYLLA_ASSERT(stmt->get_bound_terms() == qo->get_values_count());
         qo->prepare(prepared->bound_names);
 
         auto qs = make_query_state();
@@ -415,7 +416,7 @@ public:
             auto deactivate = defer([] {
                 bool old_active = true;
                 auto success = active.compare_exchange_strong(old_active, false);
-                assert(success);
+                SCYLLA_ASSERT(success);
             });
 
             // FIXME: make the function storage non static
@@ -691,7 +692,7 @@ private:
 
             // Normally the auth server is already stopped in here,
             // but if there is an initialization failure we have to
-            // make sure to stop it now or ~sharded will assert.
+            // make sure to stop it now or ~sharded will SCYLLA_ASSERT.
             auto stop_auth_server = defer([this] {
                 _auth_service.stop().get();
             });

--- a/test/lib/mutation_reader_assertions.hh
+++ b/test/lib/mutation_reader_assertions.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <boost/test/unit_test.hpp>
 #include <seastar/util/backtrace.hh>
 #include "readers/mutation_reader.hh"
@@ -261,7 +262,7 @@ public:
                 BOOST_FAIL(format("Expected row with column {}, but it is not present", columns[i].name));
             }
             auto& cdef = _reader.schema()->regular_column_at(columns[i].id);
-            assert (!cdef.is_multi_cell());
+            SCYLLA_ASSERT (!cdef.is_multi_cell());
             auto cmp = compare_unsigned(columns[i].value, cell->as_atomic_cell(cdef).value().linearize());
             if (cmp != 0) {
                 BOOST_FAIL(format("Expected row with column {} having value {}, but it has value {}",

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -34,6 +34,7 @@
 #include "types/list.hh"
 #include "types/set.hh"
 #include <seastar/util/closeable.hh>
+#include "utils/assert.hh"
 #include "utils/UUID_gen.hh"
 
 // partitions must be sorted by decorated key
@@ -67,7 +68,7 @@ public:
     void fast_forward_if_needed(flat_reader_assertions_v2& mr, const mutation& expected, bool verify_eos = true) {
         while (!current_range().contains(expected.decorated_key(), dht::ring_position_comparator(*expected.schema()))) {
             _current_position++;
-            assert(_current_position < _ranges.size());
+            SCYLLA_ASSERT(_current_position < _ranges.size());
             if (verify_eos) {
                 mr.produces_end_of_stream();
             }
@@ -409,7 +410,7 @@ static void test_streamed_mutation_forwarding_guarantees(tests::reader_concurren
     };
 
     const int n_keys = 1001;
-    assert(!contains_key(n_keys - 1)); // so that we can form a range with position greater than all keys
+    SCYLLA_ASSERT(!contains_key(n_keys - 1)); // so that we can form a range with position greater than all keys
 
     mutation m(s, table.make_pkey());
     std::vector<clustering_key> keys;
@@ -1959,7 +1960,7 @@ void for_each_mutation_pair(std::function<void(const mutation&, const mutation&,
     auto&& ms = get_mutation_sets();
     for (auto&& mutations : ms.equal) {
         auto i = mutations.begin();
-        assert(i != mutations.end());
+        SCYLLA_ASSERT(i != mutations.end());
         const mutation& first = *i++;
         while (i != mutations.end()) {
             callback(first, *i, are_equal::yes);
@@ -1968,7 +1969,7 @@ void for_each_mutation_pair(std::function<void(const mutation&, const mutation&,
     }
     for (auto&& mutations : ms.unequal) {
         auto i = mutations.begin();
-        assert(i != mutations.end());
+        SCYLLA_ASSERT(i != mutations.end());
         const mutation& first = *i++;
         while (i != mutations.end()) {
             callback(first, *i, are_equal::no);
@@ -2100,7 +2101,7 @@ public:
     }
 
     void set_key_cardinality(size_t n_keys) {
-        assert(n_keys <= n_blobs);
+        SCYLLA_ASSERT(n_keys <= n_blobs);
         _ck_index_dist = std::uniform_int_distribution<size_t>{0, n_keys - 1};
     }
 
@@ -2308,7 +2309,7 @@ public:
                 case 1: return row_marker(random_tombstone(timestamp_level::row_marker_tombstone));
                 case 2: return row_marker(gen_timestamp(timestamp_level::data));
                 case 3: return row_marker(gen_timestamp(timestamp_level::data), std::chrono::seconds(1), new_expiry());
-                default: assert(0);
+                default: SCYLLA_ASSERT(0);
             }
             abort();
         };
@@ -2769,33 +2770,33 @@ mutation forwardable_reader_to_mutation(mutation_reader r, const std::vector<pos
             , _builder(builder) { }
 
         void consume_new_partition(const dht::decorated_key& dk) {
-            assert(!_builder);
+            SCYLLA_ASSERT(!_builder);
             _builder = mutation_rebuilder_v2(std::move(_s));
             _builder->consume_new_partition(dk);
         }
 
         stop_iteration consume(tombstone t) {
-            assert(_builder);
+            SCYLLA_ASSERT(_builder);
             return _builder->consume(t);
         }
 
         stop_iteration consume(range_tombstone_change&& rt) {
-            assert(_builder);
+            SCYLLA_ASSERT(_builder);
             return _builder->consume(std::move(rt));
         }
 
         stop_iteration consume(static_row&& sr) {
-            assert(_builder);
+            SCYLLA_ASSERT(_builder);
             return _builder->consume(std::move(sr));
         }
 
         stop_iteration consume(clustering_row&& cr) {
-            assert(_builder);
+            SCYLLA_ASSERT(_builder);
             return _builder->consume(std::move(cr));
         }
 
         stop_iteration consume_end_of_partition() {
-            assert(_builder);
+            SCYLLA_ASSERT(_builder);
             return stop_iteration::yes;
         }
 

--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -22,6 +22,7 @@
 #include "types/set.hh"
 #include "types/tuple.hh"
 #include "types/user.hh"
+#include "utils/assert.hh"
 #include "utils/big_decimal.hh"
 #include "utils/UUID_gen.hh"
 
@@ -178,7 +179,7 @@ public:
         , _regular_column_count_dist(regular_column_count_dist)
         , _static_column_count_dist(static_column_count_dist)
         , _type_generator(*this) {
-        assert(_partition_column_count_dist.a() > 0);
+        SCYLLA_ASSERT(_partition_column_count_dist.a() > 0);
     }
     virtual sstring table_name(std::mt19937& engine) override {
         return format("table{}", generate_unique_id(engine, _used_table_ids));
@@ -447,7 +448,7 @@ data_value generate_utf8_value(std::mt19937& engine, size_t min_size_in_bytes, s
     char* to_next;
     std::mbstate_t mb{};
     auto res = f.out(mb, &wstr[0], &wstr[wstr.size()], from_next, &utf8_str[0], &utf8_str[utf8_str.size()], to_next);
-    assert(res == codec::ok);
+    SCYLLA_ASSERT(res == codec::ok);
     utf8_str.resize(to_next - &utf8_str[0]);
 
     return data_value(std::move(utf8_str));
@@ -513,44 +514,44 @@ data_value generate_duration_value(std::mt19937& engine, size_t, size_t) {
 }
 
 data_value generate_frozen_tuple_value(std::mt19937& engine, const tuple_type_impl& type, value_generator& val_gen, size_t min_size_in_bytes, size_t max_size_in_bytes) {
-    assert(!type.is_multi_cell());
+    SCYLLA_ASSERT(!type.is_multi_cell());
     return make_tuple_value(type.shared_from_this(), generate_frozen_tuple_values(engine, val_gen, type.all_types(), min_size_in_bytes, max_size_in_bytes));
 }
 
 data_value generate_frozen_user_value(std::mt19937& engine, const user_type_impl& type, value_generator& val_gen, size_t min_size_in_bytes, size_t max_size_in_bytes) {
-    assert(!type.is_multi_cell());
+    SCYLLA_ASSERT(!type.is_multi_cell());
     return make_user_value(type.shared_from_this(), generate_frozen_tuple_values(engine, val_gen, type.all_types(), min_size_in_bytes, max_size_in_bytes));
 }
 
 data_model::mutation_description::collection generate_list_value(std::mt19937& engine, const list_type_impl& type, value_generator& val_gen) {
-    assert(type.is_multi_cell());
+    SCYLLA_ASSERT(type.is_multi_cell());
     return generate_collection(engine, *type.name_comparator(), *type.value_comparator(), val_gen);
 }
 
 data_value generate_frozen_list_value(std::mt19937& engine, const list_type_impl& type, value_generator& val_gen, size_t min_size_in_bytes, size_t max_size_in_bytes) {
-    assert(!type.is_multi_cell());
+    SCYLLA_ASSERT(!type.is_multi_cell());
     return make_list_value(type.shared_from_this(),
             generate_frozen_list(engine, *type.get_elements_type(), val_gen, min_size_in_bytes, max_size_in_bytes));
 }
 
 data_model::mutation_description::collection generate_set_value(std::mt19937& engine, const set_type_impl& type, value_generator& val_gen) {
-    assert(type.is_multi_cell());
+    SCYLLA_ASSERT(type.is_multi_cell());
     return generate_collection(engine, *type.name_comparator(), *type.value_comparator(), val_gen);
 }
 
 data_value generate_frozen_set_value(std::mt19937& engine, const set_type_impl& type, value_generator& val_gen, size_t min_size_in_bytes, size_t max_size_in_bytes) {
-    assert(!type.is_multi_cell());
+    SCYLLA_ASSERT(!type.is_multi_cell());
     return make_set_value(type.shared_from_this(),
             generate_frozen_set(engine, *type.get_elements_type(), val_gen, min_size_in_bytes, max_size_in_bytes));
 }
 
 data_model::mutation_description::collection generate_map_value(std::mt19937& engine, const map_type_impl& type, value_generator& val_gen) {
-    assert(type.is_multi_cell());
+    SCYLLA_ASSERT(type.is_multi_cell());
     return generate_collection(engine, *type.name_comparator(), *type.value_comparator(), val_gen);
 }
 
 data_value generate_frozen_map_value(std::mt19937& engine, const map_type_impl& type, value_generator& val_gen, size_t min_size_in_bytes, size_t max_size_in_bytes) {
-    assert(!type.is_multi_cell());
+    SCYLLA_ASSERT(!type.is_multi_cell());
     return make_map_value(type.shared_from_this(),
             generate_frozen_map(engine, *type.get_keys_type(), *type.get_values_type(), val_gen, min_size_in_bytes, max_size_in_bytes));
 }
@@ -562,7 +563,7 @@ data_value value_generator::generate_atomic_value(std::mt19937& engine, const ab
 }
 
 data_value value_generator::generate_atomic_value(std::mt19937& engine, const abstract_type& type, size_t min_size_in_bytes, size_t max_size_in_bytes) {
-    assert(!type.is_multi_cell());
+    SCYLLA_ASSERT(!type.is_multi_cell());
     return get_atomic_value_generator(type)(engine, min_size_in_bytes, max_size_in_bytes);
 }
 
@@ -596,7 +597,7 @@ value_generator::value_generator()
 }
 
 size_t value_generator::min_size(const abstract_type& type) {
-    assert(!type.is_multi_cell());
+    SCYLLA_ASSERT(!type.is_multi_cell());
 
     auto it = _regular_value_min_sizes.find(&type);
     if (it != _regular_value_min_sizes.end()) {
@@ -633,7 +634,7 @@ size_t value_generator::min_size(const abstract_type& type) {
 }
 
 value_generator::atomic_value_generator value_generator::get_atomic_value_generator(const abstract_type& type) {
-    assert(!type.is_multi_cell());
+    SCYLLA_ASSERT(!type.is_multi_cell());
 
     auto it = _regular_value_generators.find(&type);
     if (it != _regular_value_generators.end()) {
@@ -807,7 +808,7 @@ schema_ptr build_random_schema(uint32_t seed, random_schema_specification& spec)
     auto builder = schema_builder(spec.keyspace_name(), spec.table_name(engine));
 
     auto pk_columns = spec.partition_key_columns(engine);
-    assert(!pk_columns.empty()); // Let's not pull in boost::test here
+    SCYLLA_ASSERT(!pk_columns.empty()); // Let's not pull in boost::test here
     for (size_t pk = 0; pk < pk_columns.size(); ++pk) {
         builder.with_column(to_bytes(format("pk{}", pk)), std::move(pk_columns[pk]), column_kind::partition_key);
     }
@@ -947,7 +948,7 @@ void decorate_with_timestamps(const schema& schema, std::mt19937& engine, timest
                         }
                         for (auto& [ key, value ] : c.elements) {
                             value.timestamp = ts_gen(engine, timestamp_destination::collection_cell_timestamp, c.tomb.timestamp);
-                            assert(!c.tomb || value.timestamp > c.tomb.timestamp);
+                            SCYLLA_ASSERT(!c.tomb || value.timestamp > c.tomb.timestamp);
                             if (auto expiry_opt = exp_gen(engine, timestamp_destination::collection_cell_timestamp)) {
                                 value.expiring = data_model::mutation_description::expiry_info{expiry_opt->ttl, expiry_opt->expiry_point};
                             }
@@ -977,7 +978,7 @@ data_model::mutation_description::key random_schema::make_partition_key(uint32_t
 }
 
 data_model::mutation_description::key random_schema::make_clustering_key(uint32_t n, value_generator& gen) const {
-    assert(_schema->clustering_key_size() > 0);
+    SCYLLA_ASSERT(_schema->clustering_key_size() > 0);
     return make_key(n, gen, _schema->clustering_key_columns(), std::numeric_limits<clustering_key::compound::element_type::size_type>::max());
 }
 

--- a/test/lib/random_utils.hh
+++ b/test/lib/random_utils.hh
@@ -16,6 +16,7 @@
 #include <seastar/testing/test_runner.hh>
 
 #include "bytes.hh"
+#include "utils/assert.hh"
 #include "utils/preempt.hh"
 
 namespace tests::random {
@@ -164,7 +165,7 @@ inline sstring get_sstring() {
 // Picks a random subset of size `m` from the given vector.
 template <typename T>
 std::vector<T> random_subset(std::vector<T> v, unsigned m, std::mt19937& engine) {
-    assert(m <= v.size());
+    SCYLLA_ASSERT(m <= v.size());
     std::shuffle(v.begin(), v.end(), engine);
     return {v.begin(), v.begin() + m};
 }
@@ -172,7 +173,7 @@ std::vector<T> random_subset(std::vector<T> v, unsigned m, std::mt19937& engine)
 // Picks a random subset of size `m` from the set {0, ..., `n` - 1}.
 template<typename T>
 std::vector<T> random_subset(unsigned n, unsigned m, std::mt19937& engine) {
-    assert(m <= n);
+    SCYLLA_ASSERT(m <= n);
 
     std::vector<T> the_set(n);
     std::iota(the_set.begin(), the_set.end(), T{});

--- a/test/lib/reader_lifecycle_policy.hh
+++ b/test/lib/reader_lifecycle_policy.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "readers/multishard.hh"
 #include <seastar/core/gate.hh>
 
@@ -62,12 +63,12 @@ public:
     }
     virtual const dht::partition_range* get_read_range() const override {
         const auto shard = this_shard_id();
-        assert(_contexts[shard]);
+        SCYLLA_ASSERT(_contexts[shard]);
         return _contexts[shard]->range.get();
     }
     void update_read_range(lw_shared_ptr<const dht::partition_range> range) override {
         const auto shard = this_shard_id();
-        assert(_contexts[shard]);
+        SCYLLA_ASSERT(_contexts[shard]);
         _contexts[shard]->range = std::move(range);
     }
     virtual future<> destroy_reader(stopped_reader reader) noexcept override {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -17,6 +17,7 @@
 #include "gms/feature_service.hh"
 #include "repair/row_level.hh"
 #include "replica/compaction_group.hh"
+#include "utils/assert.hh"
 #include "utils/overloaded_functor.hh"
 #include <boost/program_options.hpp>
 #include <iostream>
@@ -224,7 +225,7 @@ test_env::impl::impl(test_env_config cfg, sstables::storage_manager* sstm)
     }
     if (!storage.is_local_type()) {
         // remote storage requires uuid-based identifier for naming sstables
-        assert(use_uuid == uuid_identifiers::yes);
+        SCYLLA_ASSERT(use_uuid == uuid_identifiers::yes);
     }
 }
 

--- a/test/manual/enormous_table_scan_test.cc
+++ b/test/manual/enormous_table_scan_test.cc
@@ -7,6 +7,7 @@
  */
 
 
+#include "utils/assert.hh"
 #include <boost/test/unit_test.hpp>
 #include <seastar/testing/test_case.hh>
 
@@ -52,7 +53,7 @@ public:
 
             auto ck_to_int = [] (const clustering_key& ck) -> int64_t {
                 auto exploded = ck.explode();
-                assert(exploded.size() == 1);
+                SCYLLA_ASSERT(exploded.size() == 1);
                 return value_cast<int64_t>(long_type->deserialize(exploded[0]));
             };
 

--- a/test/perf/memory_footprint_test.cc
+++ b/test/perf/memory_footprint_test.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <boost/range/irange.hpp>
 
 #include <seastar/util/defer.hh>
@@ -186,7 +187,7 @@ static sizes calculate_sizes(cache_tracker& tracker, const mutation_settings& se
 
     auto cache_initial_occupancy = tracker.region().occupancy().used_space();
 
-    assert(mt->occupancy().used_space() == 0);
+    SCYLLA_ASSERT(mt->occupancy().used_space() == 0);
 
     std::vector<mutation> muts;
     for (size_t i = 0; i < settings.partition_count; ++i) {

--- a/test/perf/perf_collection.cc
+++ b/test/perf/perf_collection.cc
@@ -29,6 +29,7 @@ struct perf_key_tri_compare {
     }
 };
 
+#include "utils/assert.hh"
 #include "utils/bptree.hh"
 
 using namespace seastar;
@@ -98,7 +99,7 @@ public:
     virtual void insert(per_key_t k) override { _t.emplace(k, 0); }
     virtual void lower_bound(per_key_t k) override {
         auto i = _t.lower_bound(k);
-        assert(i != _t.end());
+        SCYLLA_ASSERT(i != _t.end());
     }
     virtual void scan(int batch) override {
         scan_collection(_t, batch);
@@ -118,7 +119,7 @@ public:
     virtual void clone() override { }
     virtual void insert_and_erase(per_key_t k) override {
         auto i = _t.emplace(k, 0);
-        assert(i.second);
+        SCYLLA_ASSERT(i.second);
         i.first.erase(perf_key_compare{});
     }
     virtual void show_stats() override {
@@ -149,7 +150,7 @@ public:
     virtual void insert(per_key_t k) override { _t.emplace(k, 0); }
     virtual void lower_bound(per_key_t k) override {
         auto i = _t.get(k);
-        assert(i != nullptr);
+        SCYLLA_ASSERT(i != nullptr);
     }
     virtual void scan(int batch) override {
         scan_collection(_t, batch);
@@ -194,7 +195,7 @@ public:
     virtual void insert(per_key_t k) override { _t.insert(std::make_unique<perf_intrusive_key>(k), _cmp); }
     virtual void lower_bound(per_key_t k) override {
         auto i = _t.lower_bound(k, _cmp);
-        assert(i != _t.end());
+        SCYLLA_ASSERT(i != _t.end());
     }
     virtual void erase(per_key_t k) override { _t.erase_and_dispose(k, _cmp, [] (perf_intrusive_key* k) noexcept { delete k; }); }
     virtual void drain(int batch) override {
@@ -240,7 +241,7 @@ public:
     virtual void insert(per_key_t k) override { _s.insert(k); }
     virtual void lower_bound(per_key_t k) override {
         auto i = _s.lower_bound(k);
-        assert(i != _s.end());
+        SCYLLA_ASSERT(i != _s.end());
     }
     virtual void scan(int batch) override {
         scan_collection(_s, batch);
@@ -260,7 +261,7 @@ public:
     virtual void clone() override { }
     virtual void insert_and_erase(per_key_t k) override {
         auto i = _s.insert(k);
-        assert(i.second);
+        SCYLLA_ASSERT(i.second);
         _s.erase(i.first);
     }
     virtual void show_stats() override { }
@@ -273,7 +274,7 @@ public:
     virtual void insert(per_key_t k) override { _m[k] = 0; }
     virtual void lower_bound(per_key_t k) override {
         auto i = _m.lower_bound(k);
-        assert(i != _m.end());
+        SCYLLA_ASSERT(i != _m.end());
     }
     virtual void scan(int batch) override {
         scan_collection(_m, batch);
@@ -293,7 +294,7 @@ public:
     virtual void clone() override { }
     virtual void insert_and_erase(per_key_t k) override {
         auto i = _m.insert({k, 0});
-        assert(i.second);
+        SCYLLA_ASSERT(i.second);
         _m.erase(i.first);
     }
     virtual void show_stats() override { }

--- a/test/perf/perf_commitlog.cc
+++ b/test/perf/perf_commitlog.cc
@@ -30,6 +30,7 @@
 #include "db/config.hh"
 #include "db/extensions.hh"
 #include "db/commitlog/commitlog.hh"
+#include "utils/assert.hh"
 #include "utils/UUID_gen.hh"
 
 struct test_config {
@@ -120,7 +121,7 @@ struct commitlog_service {
     {}
 
     future<> init(const db::commitlog::config& cfg) {
-        assert(!log);
+        SCYLLA_ASSERT(!log);
         log.emplace(co_await db::commitlog::create_commitlog(cfg));
         fa.emplace(log->add_flush_handler(std::bind(&commitlog_service::flush_handler, this, std::placeholders::_1, std::placeholders::_2)));
     }

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/join.hpp>
@@ -502,7 +503,7 @@ public:
 
         Json::Value stats_value;
       if (summary_result) {
-        assert(values.size() == 1);
+        SCYLLA_ASSERT(values.size() == 1);
         for (size_t i = 0; i < stats_names.size(); ++i) {
             write_test_values_impl(stats_value, stats_names, values.front());
         }
@@ -781,8 +782,8 @@ uint64_t consume_all_with_next_partition(mutation_reader& rd) {
 
 static void assert_partition_start(mutation_reader& rd) {
     auto mfopt = rd().get();
-    assert(mfopt);
-    assert(mfopt->is_partition_start());
+    SCYLLA_ASSERT(mfopt);
+    SCYLLA_ASSERT(mfopt->is_partition_start());
 }
 
 // A dataset with one large partition with many clustered fragments.
@@ -1194,8 +1195,8 @@ table_config read_config(cql_test_env& env, const sstring& name) {
 }
 
 static unsigned cardinality(int_range r) {
-    assert(r.start());
-    assert(r.end());
+    SCYLLA_ASSERT(r.start());
+    SCYLLA_ASSERT(r.end());
     return r.end()->value() - r.start()->value() + r.start()->is_inclusive() + r.end()->is_inclusive() - 1;
 }
 
@@ -1281,7 +1282,7 @@ public:
             results.resize(rs.size());
         }
         {
-            assert(rs.size() == results.size());
+            SCYLLA_ASSERT(rs.size() == results.size());
             for (auto j = 0u; j < rs.size(); j++) {
                 results[j].emplace_back(rs[j]);
             }
@@ -1387,7 +1388,7 @@ void test_large_partition_single_key_slice(app_template &app, replica::column_fa
       };
     });
 
-    assert(n_rows > 200); // assumed below
+    SCYLLA_ASSERT(n_rows > 200); // assumed below
 
     run_test_case(app, [&] { // adjacent, no overlap
         return test_result_vector {

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/range/irange.hpp>
@@ -384,7 +385,7 @@ static std::vector<perf_result> do_alternator_test(std::string isolation_level,
         sharded<service::migration_manager>& mm,
         sharded<gms::gossiper>& gossiper,
         test_config& cfg) {
-    assert(cfg.frontend == test_config::frontend_type::alternator);
+    SCYLLA_ASSERT(cfg.frontend == test_config::frontend_type::alternator);
     std::cout << "Running test with config: " << cfg << std::endl;
 
     alternator_test_env env(gossiper, qp.local().proxy().container(), mm, qp);
@@ -417,7 +418,7 @@ static std::vector<perf_result> do_alternator_test(std::string isolation_level,
 }
 
 static std::vector<perf_result> do_cql_test(cql_test_env& env, test_config& cfg) {
-    assert(cfg.frontend == test_config::frontend_type::cql);
+    SCYLLA_ASSERT(cfg.frontend == test_config::frontend_type::cql);
 
     std::cout << "Running test with config: " << cfg << std::endl;
     env.create_table([&cfg] (auto ks_name) {

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <seastar/util/closeable.hh>
 
 #include "sstables/sstables.hh"
@@ -245,12 +246,12 @@ public:
 
                 auto partitions_per_sstable = _cfg.partitions / _cfg.sstables;
                 if (_cfg.compaction_strategy != sstables::compaction_strategy_type::time_window) {
-                    assert(ret.new_sstables.size() == 1);
+                    SCYLLA_ASSERT(ret.new_sstables.size() == 1);
                 }
                 auto total_keys_written = std::accumulate(ret.new_sstables.begin(), ret.new_sstables.end(), uint64_t(0), [] (uint64_t n, const sstables::shared_sstable& sst) {
                     return n + sst->get_estimated_key_count();
                 });
-                assert(total_keys_written >= partitions_per_sstable);
+                SCYLLA_ASSERT(total_keys_written >= partitions_per_sstable);
 
                 auto duration = std::chrono::duration<double>(end - start).count();
                 return total_keys_written / duration;

--- a/test/perf/perf_tablets.cc
+++ b/test/perf/perf_tablets.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <fmt/ranges.h>
 
 #include <seastar/core/distributed.hh>
@@ -82,7 +83,7 @@ static future<> test_basic_operations(app_template& app) {
                 for (int k = 0; k < rf; ++k) {
                     replicas.push_back({h1, 0});
                 }
-                assert(std::cmp_equal(replicas.size(), rf));
+                SCYLLA_ASSERT(std::cmp_equal(replicas.size(), rf));
                 tmap.set_tablet(j, tablet_info{std::move(replicas)});
                 ++total_tablets;
             }
@@ -117,7 +118,7 @@ static future<> test_basic_operations(app_template& app) {
         auto time_to_read = duration_in_seconds([&] {
             tm2 = read_tablet_metadata(e.local_qp()).get();
         });
-        assert(tm == tm2);
+        SCYLLA_ASSERT(tm == tm2);
 
         testlog.info("Read in {:.6f} [ms]", time_to_read.count() * 1000);
 

--- a/test/raft/future_set.hh
+++ b/test/raft/future_set.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/weak_ptr.hh>
 #include <seastar/core/condition-variable.hh>
@@ -53,7 +54,7 @@ public:
             co_await _container.v.wait(wake_condition);
         }
 
-        assert(wake_condition());
+        SCYLLA_ASSERT(wake_condition());
 
         for (auto& f : _futures) {
             if (f.available()) {
@@ -65,7 +66,7 @@ public:
         }
 
         // No future was available, so `wake_condition()` implies:
-        assert(timer.now() >= timeout);
+        SCYLLA_ASSERT(timer.now() >= timeout);
         co_return std::nullopt;
     }
 
@@ -88,6 +89,6 @@ public:
     }
 
     ~future_set() {
-        assert(_futures.empty());
+        SCYLLA_ASSERT(_futures.empty());
     }
 };

--- a/test/raft/helpers.cc
+++ b/test/raft/helpers.cc
@@ -10,6 +10,7 @@
 // Helper functions for raft tests
 //
 
+#include "utils/assert.hh"
 #include <seastar/core/sharded.hh>
 
 #include "helpers.hh"
@@ -35,7 +36,7 @@ void election_timeout(raft::fsm& fsm) {
 }
 
 void make_candidate(raft::fsm& fsm) {
-    assert(fsm.is_follower());
+    SCYLLA_ASSERT(fsm.is_follower());
     // NOTE: single node skips candidate state
     while (fsm.is_follower()) {
         fsm.tick();
@@ -55,8 +56,8 @@ bool compare_log_entry(raft::log_entry_ptr le1, raft::log_entry_ptr le2) {
 }
 
 bool compare_log_entries(raft::log& log1, raft::log& log2, size_t from, size_t to) {
-    assert(to <= log1.last_idx());
-    assert(to <= log2.last_idx());
+    SCYLLA_ASSERT(to <= log1.last_idx());
+    SCYLLA_ASSERT(to <= log2.last_idx());
     for (size_t i = from; i <= to; ++i) {
         if (!compare_log_entry(log1[i], log2[i])) {
             return false;

--- a/test/raft/helpers.hh
+++ b/test/raft/helpers.hh
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <boost/test/unit_test.hpp>
 #include "test/lib/log.hh"
 #include "test/lib/random_utils.hh"
@@ -89,7 +90,7 @@ public:
     }
 
     bool leadership_transfer_active() const {
-        assert(is_leader());
+        SCYLLA_ASSERT(is_leader());
         return bool(leader_state().stepdown);
     }
 };

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -26,6 +26,7 @@
 #include "raft/server.hh"
 #include "serializer.hh"
 #include "serializer_impl.hh"
+#include "utils/assert.hh"
 #include "utils/xx_hasher.hh"
 #include "utils/to_string.hh"
 #include "test/raft/helpers.hh"
@@ -1287,7 +1288,7 @@ future<> raft_cluster<Clock>::partition(::partition p) {
         } else if (std::holds_alternative<struct range>(s)) {
             auto range = std::get<struct range>(s);
             for (size_t id = range.start; id <= range.end; id++) {
-                assert(id < _servers.size());
+                SCYLLA_ASSERT(id < _servers.size());
                 partition_servers.insert(id);
             }
         } else {

--- a/test/raft/ticker.hh
+++ b/test/raft/ticker.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <seastar/core/reactor.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future-util.hh>
@@ -29,13 +30,13 @@ public:
     ticker(ticker&&) = delete;
 
     ~ticker() {
-        assert(!_ticker);
+        SCYLLA_ASSERT(!_ticker);
     }
 
     using on_tick_t = noncopyable_function<future<>(uint64_t)>;
 
     void start(on_tick_t fun, uint64_t limit = std::numeric_limits<uint64_t>::max()) {
-        assert(!_ticker);
+        SCYLLA_ASSERT(!_ticker);
         _ticker = tick(std::move(fun), limit);
     }
 
@@ -58,6 +59,6 @@ private:
         }
 
         _logger.error("ticker: limit reached");
-        assert(false);
+        SCYLLA_ASSERT(false);
     }
 };

--- a/test/unit/bptree_compaction_test.cc
+++ b/test/unit/bptree_compaction_test.cc
@@ -16,6 +16,7 @@
 constexpr int TEST_NODE_SIZE = 7;
 
 #include "tree_test_key.hh"
+#include "utils/assert.hh"
 #include "utils/bptree.hh"
 #include "bptree_validation.hh"
 #include "collection_stress.hh"
@@ -63,7 +64,7 @@ int main(int argc, char **argv) {
                 /* insert */ [&] (int key) {
                     test_key k(key);
                     auto ti = t->emplace(copy_key(k), k);
-                    assert(ti.second);
+                    SCYLLA_ASSERT(ti.second);
                 },
                 /* erase */ [&] (int key) {
                     t->erase(test_key(key));

--- a/test/unit/bptree_stress_test.cc
+++ b/test/unit/bptree_stress_test.cc
@@ -14,6 +14,7 @@
 constexpr int TEST_NODE_SIZE = 16;
 
 #include "tree_test_key.hh"
+#include "utils/assert.hh"
 #include "utils/bptree.hh"
 #include "bptree_validation.hh"
 #include "collection_stress.hh"
@@ -78,7 +79,7 @@ int main(int argc, char **argv) {
 
                     if (rep % 2 != 1) {
                         auto ir = t->emplace(copy_key(k), k);
-                        assert(ir.second);
+                        SCYLLA_ASSERT(ir.second);
                     } else {
                         auto ir = t->lower_bound(k);
                         ir.emplace_before(copy_key(k), test_key_compare{}, k);
@@ -107,7 +108,7 @@ int main(int argc, char **argv) {
                         auto ni = ri;
                         ni++;
                         auto eni = ri.erase(test_key_compare{});
-                        assert(ni == eni);
+                        SCYLLA_ASSERT(ni == eni);
                     }
                     oracle.erase(key);
 

--- a/test/unit/btree_compaction_test.cc
+++ b/test/unit/btree_compaction_test.cc
@@ -14,6 +14,7 @@ constexpr int TEST_NODE_SIZE = 7;
 constexpr int TEST_LINEAR_THRESHOLD = 19;
 
 #include "tree_test_key.hh"
+#include "utils/assert.hh"
 #include "utils/intrusive_btree.hh"
 #include "btree_validation.hh"
 #include "collection_stress.hh"
@@ -58,7 +59,7 @@ int main(int argc, char **argv) {
                 /* insert */ [&] (int key) {
                     auto k = alloc_strategy_unique_ptr<test_key>(current_allocator().construct<test_key>(key));
                     auto ti = t->insert(std::move(k), test_key_tri_compare{});
-                    assert(ti.second);
+                    SCYLLA_ASSERT(ti.second);
                 },
                 /* erase */ [&] (int key) {
                     auto deleter = current_deleter<test_key>();

--- a/test/unit/btree_stress_test.cc
+++ b/test/unit/btree_stress_test.cc
@@ -16,6 +16,7 @@
 constexpr int TEST_NODE_SIZE = 8;
 constexpr int TEST_LINEAR_THRESH = 21;
 
+#include "utils/assert.hh"
 #include "utils/intrusive_btree.hh"
 #include "btree_validation.hh"
 #include "test/unit/tree_test_key.hh"
@@ -68,7 +69,7 @@ int main(int argc, char **argv) {
             stress_collection(cfg,
                 /* insert */ [&] (int key) {
                     auto ir = t->insert(std::make_unique<test_key>(key), cmp);
-                    assert(ir.second);
+                    SCYLLA_ASSERT(ir.second);
                     oracle[key] = key;
 
                     if (itv++ % 7 == 0) {

--- a/test/unit/collection_stress.hh
+++ b/test/unit/collection_stress.hh
@@ -12,6 +12,7 @@
 #include <random>
 #include <string>
 #include <seastar/core/thread.hh>
+#include "utils/assert.hh"
 #include "utils/logalloc.hh"
 
 struct stress_config {
@@ -112,13 +113,13 @@ public:
     }
 
     void link(reference& other) {
-        assert(_ref == nullptr);
+        SCYLLA_ASSERT(_ref == nullptr);
         _ref = &other;
         other._ref = this;
     }
 
     reference* get() {
-        assert(_ref != nullptr);
+        SCYLLA_ASSERT(_ref != nullptr);
         return _ref;
     }
 };

--- a/test/unit/radix_tree_compaction_test.cc
+++ b/test/unit/radix_tree_compaction_test.cc
@@ -11,6 +11,7 @@
 #include <string>
 #include <fmt/core.h>
 
+#include "utils/assert.hh"
 #include "utils/compact-radix-tree.hh"
 #include "radix_tree_printer.hh"
 #include "collection_stress.hh"
@@ -86,11 +87,11 @@ int main(int argc, char **argv) {
                         unsigned nr = 0;
                         auto ti = t->begin();
                         while (ti != t->end()) {
-                            assert(ti->value() == ti.key());
+                            SCYLLA_ASSERT(ti->value() == ti.key());
                             nr++;
                             ti++;
                         }
-                        assert(nr == col_size);
+                        SCYLLA_ASSERT(nr == col_size);
                     },
                     /* clear */ [&] {
                         t->clear();

--- a/test/unit/radix_tree_stress_test.cc
+++ b/test/unit/radix_tree_stress_test.cc
@@ -14,6 +14,7 @@
 #include <fmt/ostream.h>
 #include <fmt/ranges.h>
 
+#include "utils/assert.hh"
 #include "utils/compact-radix-tree.hh"
 #include "radix_tree_printer.hh"
 #include "collection_stress.hh"
@@ -97,30 +98,30 @@ int main(int argc, char **argv) {
                         if (vld == validate::oracle) {
                             for (auto&& d : oracle) {
                                 test_data* td = t->get(d.first);
-                                assert(td != nullptr);
-                                assert(td->value() == d.second.value());
+                                SCYLLA_ASSERT(td != nullptr);
+                                SCYLLA_ASSERT(td->value() == d.second.value());
                             }
                             vld = validate::iterator;
                         } else if (vld == validate::iterator) {
                             unsigned nr = 0;
                             auto ti = t->begin();
                             while (ti != t->end()) {
-                                assert(ti->value() == ti.key());
+                                SCYLLA_ASSERT(ti->value() == ti.key());
                                 nr++;
                                 ti++;
-                                assert(nr <= col_size);
+                                SCYLLA_ASSERT(nr <= col_size);
                             }
-                            assert(nr == col_size);
+                            SCYLLA_ASSERT(nr == col_size);
                             vld = validate::walk;
                         } else if (vld == validate::walk) {
                             unsigned nr = 0;
                             t->walk([&nr, col_size] (unsigned idx, test_data& td) {
-                                assert(idx == td.value());
+                                SCYLLA_ASSERT(idx == td.value());
                                 nr++;
-                                assert(nr <= col_size);
+                                SCYLLA_ASSERT(nr <= col_size);
                                 return true;
                             });
-                            assert(nr == col_size);
+                            SCYLLA_ASSERT(nr == col_size);
                             vld = validate::lower_bound;
                         } else if (vld == validate::lower_bound) {
                             unsigned nr = 0;
@@ -130,12 +131,12 @@ int main(int argc, char **argv) {
                                 if (td == nullptr) {
                                     break;
                                 }
-                                assert(td->value() >= idx);
+                                SCYLLA_ASSERT(td->value() >= idx);
                                 nr++;
                                 idx = td->value() + 1;
-                                assert(nr <= col_size);
+                                SCYLLA_ASSERT(nr <= col_size);
                             }
-                            assert(nr == col_size);
+                            SCYLLA_ASSERT(nr == col_size);
                             vld = validate::oracle;
                         }
                     },

--- a/test/unit/row_cache_stress_test.cc
+++ b/test/unit/row_cache_stress_test.cc
@@ -14,6 +14,7 @@
 #include "replica/memtable.hh"
 #include "row_cache.hh"
 #include "partition_slice_builder.hh"
+#include "utils/assert.hh"
 #include "utils/int_range.hh"
 #include "utils/div_ceil.hh"
 #include "utils/to_string.hh"
@@ -411,8 +412,8 @@ int main(int argc, char** argv) {
             t.tracker.cleaner().drain().get();
             t.tracker.memtable_cleaner().drain().get();
 
-            assert(t.tracker.get_stats().partitions == 0);
-            assert(t.tracker.get_stats().rows == 0);
+            SCYLLA_ASSERT(t.tracker.get_stats().partitions == 0);
+            SCYLLA_ASSERT(t.tracker.get_stats().rows == 0);
         });
     });
 }

--- a/test/unit/tree_test_key.hh
+++ b/test/unit/tree_test_key.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <fmt/core.h>
 #include <cassert>
 
@@ -98,7 +99,7 @@ public:
         if (_cookie != nullptr) {
             delete _cookie;
         }
-        assert(_p_cookie != nullptr);
+        SCYLLA_ASSERT(_p_cookie != nullptr);
         delete _p_cookie;
     }
 };

--- a/tools/lua_sstable_consumer.cc
+++ b/tools/lua_sstable_consumer.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <boost/algorithm/string/join.hpp>
 #include <fmt/chrono.h>
 #include <lua.hpp>
@@ -64,7 +65,7 @@ template <> struct type_to_metatable<json_writer> { static constexpr const char*
 template <typename T>
 const char* get_metatable_name() {
     const auto metatable_name = type_to_metatable<std::remove_cv_t<T>>::metatable_name;
-    assert(metatable_name);
+    SCYLLA_ASSERT(metatable_name);
     return metatable_name;
 }
 

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
 #include <fmt/ranges.h>
@@ -270,7 +271,7 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
         auto prepared_statement = raw_statement->prepare(db, cql_stats);
         auto* statement = prepared_statement->statement.get();
         auto p = dynamic_cast<cql3::statements::create_keyspace_statement*>(statement);
-        assert(p);
+        SCYLLA_ASSERT(p);
         real_db.keyspaces.emplace_back(p->get_keyspace_metadata(*token_metadata.local().get(), feature_service));
         return db.find_keyspace(name);
     };

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -43,6 +43,7 @@
 #include "release.hh"
 #include "tools/format_printers.hh"
 #include "tools/utils.hh"
+#include "utils/assert.hh"
 #include "utils/estimated_histogram.hh"
 #include "utils/http.hh"
 #include "utils/pretty_printers.hh"
@@ -1533,7 +1534,7 @@ std::string last_token_in_hosts(const std::vector<std::pair<sstring, std::string
                                    [&last_host] (auto& token_endpoint) {
                                        return token_endpoint.second == last_host.endpoint;
                                    });
-    assert(last_token != tokens_endpoint.rend());
+    SCYLLA_ASSERT(last_token != tokens_endpoint.rend());
     return last_token->first;
 }
 

--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -15,6 +15,7 @@
 #include "db/config.hh"
 #include "db/extensions.hh"
 #include "tools/utils.hh"
+#include "utils/assert.hh"
 #include "utils/logalloc.hh"
 #include "init.hh"
 
@@ -220,7 +221,7 @@ int tool_app_template::run_async(int argc, char** argv, noncopyable_function<int
             ns.notify_all(configurable::system_state::started).get();
 
             logalloc::use_standard_allocator_segment_pool_backend(_cfg.lsa_segment_pool_backend_size_mb * 1024 * 1024).get();
-            assert(found_op);
+            SCYLLA_ASSERT(found_op);
             auto res = main_func(*found_op, app.configuration());
 
             ns.notify_all(configurable::system_state::stopped).get();

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -16,6 +16,7 @@
 #include "cql3/cql_config.hh"
 #include "types/set.hh"
 #include "types/map.hh"
+#include "utils/assert.hh"
 #include "utils/UUID_gen.hh"
 #include "utils/class_registrator.hh"
 #include "service/storage_proxy.hh"
@@ -436,7 +437,7 @@ future<> trace_keyspace_helper::flush_one_session_mutations(lw_shared_ptr<one_se
         return with_semaphore(write_sem, 1, [this, records, session_record_is_ready, &events_records] {
             // This code is inside the _pending_writes gate and the qp pointer
             // is cleared on ::stop() after the gate is closed.
-            assert(_qp_anchor != nullptr && _mm_anchor != nullptr);
+            SCYLLA_ASSERT(_qp_anchor != nullptr && _mm_anchor != nullptr);
             cql3::query_processor& qp = *_qp_anchor;
             service::migration_manager& mm = *_mm_anchor;
             return apply_events_mutation(qp, mm, records, events_records).then([this, &qp, &mm, session_record_is_ready, records] {

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include <grp.h>
 #include "transport/controller.hh"
 #include <seastar/core/sharded.hh>
@@ -272,7 +273,7 @@ future<> controller::do_start_server() {
 }
 
 future<> controller::stop_server() {
-    assert(this_shard_id() == 0);
+    SCYLLA_ASSERT(this_shard_id() == 0);
 
     if (!_stopped) {
         co_await _ops_sem.wait();

--- a/transport/event.cc
+++ b/transport/event.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include "transport/event.hh"
 
 namespace cql_transport {
@@ -57,17 +58,17 @@ event::schema_change::schema_change(change_type change, target_type target, sstr
 {
     switch (target) {
     case event::schema_change::target_type::KEYSPACE:
-        assert(this->arguments.empty());
+        SCYLLA_ASSERT(this->arguments.empty());
         break;
     case event::schema_change::target_type::TYPE:
     case event::schema_change::target_type::TABLE:
         // just the name
-        assert(this->arguments.size() == 1);
+        SCYLLA_ASSERT(this->arguments.size() == 1);
         break;
     case event::schema_change::target_type::FUNCTION:
     case event::schema_change::target_type::AGGREGATE:
         // at least the name
-        assert(this->arguments.size() >= 1);
+        SCYLLA_ASSERT(this->arguments.size() >= 1);
         break;
     }
 }

--- a/transport/messages/result_message.hh
+++ b/transport/messages/result_message.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <concepts>
 
 #include "cql3/result_set.hh"
@@ -69,7 +70,7 @@ public:
     void visit(const result_message::prepared::cql&) override {};
     void visit(const result_message::schema_change&) override {};
     void visit(const result_message::rows&) override {};
-    void visit(const result_message::bounce_to_shard&) override { assert(false); };
+    void visit(const result_message::bounce_to_shard&) override { SCYLLA_ASSERT(false); };
     void visit(const result_message::exception&) override;
 };
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -36,6 +36,7 @@
 #include <seastar/util/lazy.hh>
 #include <seastar/util/short_streams.hh>
 #include <seastar/core/execution_stage.hh>
+#include "utils/assert.hh"
 #include "utils/result_try.hh"
 #include "utils/result_combinators.hh"
 #include "db/operation_type.hh"
@@ -160,7 +161,7 @@ sstring to_string(const event::schema_change::change_type t) {
     case event::schema_change::change_type::UPDATED: return "UPDATED";
     case event::schema_change::change_type::DROPPED: return "DROPPED";
     }
-    assert(false && "unreachable");
+    SCYLLA_ASSERT(false && "unreachable");
 }
 
 sstring to_string(const event::schema_change::target_type t) {
@@ -171,7 +172,7 @@ sstring to_string(const event::schema_change::target_type t) {
     case event::schema_change::target_type::FUNCTION: return "FUNCTION";
     case event::schema_change::target_type::AGGREGATE:return "AGGREGATE";
     }
-    assert(false && "unreachable");
+    SCYLLA_ASSERT(false && "unreachable");
 }
 
 event::event_type parse_event_type(const sstring& value)
@@ -1499,7 +1500,7 @@ public:
             break;
         }
         default:
-            assert(0);
+            SCYLLA_ASSERT(0);
         }
     }
 

--- a/utils/UUID.hh
+++ b/utils/UUID.hh
@@ -20,6 +20,7 @@
 #include <seastar/core/print.hh>
 #include <seastar/net/byteorder.hh>
 #include "bytes.hh"
+#include "utils/assert.hh"
 #include "utils/hashing.hh"
 #include "utils/serialization.hh"
 
@@ -57,7 +58,7 @@ public:
         //if (version() != 1) {
         //     throw new UnsupportedOperationException("Not a time-based UUID");
         //}
-        assert(is_timestamp());
+        SCYLLA_ASSERT(is_timestamp());
 
         return ((most_sig_bits & 0xFFF) << 48) |
                (((most_sig_bits >> 16) & 0xFFFF) << 32) |

--- a/utils/UUID_gen.hh
+++ b/utils/UUID_gen.hh
@@ -9,6 +9,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
+#include "utils/assert.hh"
 #include <stdint.h>
 #include <assert.h>
 
@@ -83,7 +84,7 @@ private:
     UUID_gen()
     {
         // make sure someone didn't whack the clockSeqAndNode by changing the order of instantiation.
-        assert(clock_seq_and_node != 0);
+        SCYLLA_ASSERT(clock_seq_and_node != 0);
     }
 
     // Return decimicrosecond time based on the system time,
@@ -118,7 +119,7 @@ public:
     static UUID get_time_UUID()
     {
         auto uuid = UUID(_instance.create_time_safe(), clock_seq_and_node);
-        assert(uuid.is_timestamp());
+        SCYLLA_ASSERT(uuid.is_timestamp());
         return uuid;
     }
 
@@ -130,7 +131,7 @@ public:
     static UUID get_time_UUID(std::chrono::system_clock::time_point tp)
     {
         auto uuid = UUID(create_time(from_unix_timestamp(tp.time_since_epoch())), clock_seq_and_node);
-        assert(uuid.is_timestamp());
+        SCYLLA_ASSERT(uuid.is_timestamp());
         return uuid;
     }
 
@@ -142,14 +143,14 @@ public:
     static UUID get_time_UUID(milliseconds when, int64_t clock_seq_and_node = UUID_gen::clock_seq_and_node)
     {
         auto uuid = UUID(create_time(from_unix_timestamp(when)), clock_seq_and_node);
-        assert(uuid.is_timestamp());
+        SCYLLA_ASSERT(uuid.is_timestamp());
         return uuid;
     }
 
     static UUID get_time_UUID_raw(decimicroseconds when, int64_t clock_seq_and_node)
     {
         auto uuid = UUID(create_time(when), clock_seq_and_node);
-        assert(uuid.is_timestamp());
+        SCYLLA_ASSERT(uuid.is_timestamp());
         return uuid;
     }
 
@@ -169,7 +170,7 @@ public:
         static thread_local std::uniform_int_distribution<int64_t> rand_dist(std::numeric_limits<int64_t>::min());
 
         auto uuid = UUID(create_time(from_unix_timestamp(when_in_micros)), rand_dist(rand_gen));
-        assert(uuid.is_timestamp());
+        SCYLLA_ASSERT(uuid.is_timestamp());
         return uuid;
     }
     // Generate a time-based (Version 1) UUID using
@@ -230,7 +231,7 @@ public:
 
     /** creates uuid from raw bytes. */
     static UUID get_UUID(bytes raw) {
-        assert(raw.size() == 16);
+        SCYLLA_ASSERT(raw.size() == 16);
         return get_UUID(raw.begin());
     }
 
@@ -294,7 +295,7 @@ public:
     static UUID min_time_UUID(decimicroseconds timestamp = decimicroseconds{0})
     {
         auto uuid = UUID(create_time(from_unix_timestamp(timestamp)), MIN_CLOCK_SEQ_AND_NODE);
-        assert(uuid.is_timestamp());
+        SCYLLA_ASSERT(uuid.is_timestamp());
         return uuid;
     }
 
@@ -312,7 +313,7 @@ public:
         // precision by taking 10000, but rather 19999.
         decimicroseconds uuid_tstamp = from_unix_timestamp(timestamp + milliseconds(1)) - decimicroseconds(1);
         auto uuid = UUID(create_time(uuid_tstamp), MAX_CLOCK_SEQ_AND_NODE);
-        assert(uuid.is_timestamp());
+        SCYLLA_ASSERT(uuid.is_timestamp());
         return uuid;
     }
 
@@ -386,7 +387,7 @@ public:
         // timeuuid time must fit in 60 bits
         if ((0xf000000000000000UL & msb)) {
             // We hope callers would try to avoid this case, but they don't
-            // always do, so assert() would be bad here - and caused #17035.
+            // always do, so SCYLLA_ASSERT() would be bad here - and caused #17035.
             utils::on_internal_error("timeuuid time must fit in 60 bits");
         }
         return ((0x00000000ffffffffL & msb) << 32 |
@@ -401,8 +402,8 @@ public:
     //
     //      auto original_uuid = UUID_gen::get_time_UUID();
     //      auto negated_uuid = UUID_gen::negate(original_uuid);
-    //      assert(original_uuid != negated_uuid);
-    //      assert(original_uuid == UUID_gen::negate(negated_uuid));
+    //      SCYLLA_ASSERT(original_uuid != negated_uuid);
+    //      SCYLLA_ASSERT(original_uuid == UUID_gen::negate(negated_uuid));
     static UUID negate(UUID);
 };
 

--- a/utils/assert.hh
+++ b/utils/assert.hh
@@ -1,0 +1,9 @@
+// Copyright 2024-present ScyllaDB
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+#include <cassert>
+
+/// Like assert(), but independent of NDEBUG. Active in all build modes.
+#define SCYLLA_ASSERT(x) do { if (!(x)) { __assert_fail(#x, __FILE__, __LINE__, __PRETTY_FUNCTION__); } } while (0)

--- a/utils/big_decimal.cc
+++ b/utils/big_decimal.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "big_decimal.hh"
 #include <cassert>
 #include "marshal_exception.hh"
@@ -186,7 +187,7 @@ big_decimal big_decimal::operator-(const big_decimal& other) const {
 big_decimal big_decimal::div(const ::uint64_t y, const rounding_mode mode) const
 {
     if (mode != rounding_mode::HALF_EVEN) {
-        assert(0);
+        SCYLLA_ASSERT(0);
     }
 
     // Implementation of Division with Half to Even (aka Bankers) Rounding

--- a/utils/bloom_calculations.hh
+++ b/utils/bloom_calculations.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <seastar/core/print.hh>
 #include "exceptions/exceptions.hh"
 
@@ -56,8 +57,8 @@ namespace bloom_calculations {
      * @return A spec that minimizes the false positive rate.
      */
     inline bloom_specification compute_bloom_spec(int buckets_per_element) {
-        assert(buckets_per_element >= 1);
-        assert(buckets_per_element <= int(probs.size()) - 1);
+        SCYLLA_ASSERT(buckets_per_element >= 1);
+        SCYLLA_ASSERT(buckets_per_element <= int(probs.size()) - 1);
         return bloom_specification(opt_k_per_buckets[buckets_per_element], buckets_per_element);
     }
 
@@ -76,8 +77,8 @@ namespace bloom_calculations {
      * @throws unsupported_operation_exception if a filter satisfying the parameters cannot be met
      */
     inline bloom_specification compute_bloom_spec(int max_buckets_per_element, double max_false_pos_prob) {
-        assert(max_buckets_per_element >= 1);
-        assert(max_buckets_per_element <= int(probs.size()) - 1);
+        SCYLLA_ASSERT(max_buckets_per_element >= 1);
+        SCYLLA_ASSERT(max_buckets_per_element <= int(probs.size()) - 1);
 
         auto max_k = int(probs[max_buckets_per_element].size()) - 1;
 
@@ -219,8 +220,8 @@ class BloomCalculations {
      */
     public static BloomSpecification computeBloomSpec(int bucketsPerElement)
     {
-        assert bucketsPerElement >= 1;
-        assert bucketsPerElement <= probs.length - 1;
+        SCYLLA_ASSERT bucketsPerElement >= 1;
+        SCYLLA_ASSERT bucketsPerElement <= probs.length - 1;
         return new BloomSpecification(optKPerBuckets[bucketsPerElement], bucketsPerElement);
     }
 
@@ -261,8 +262,8 @@ class BloomCalculations {
      */
     public static BloomSpecification computeBloomSpec(int maxBucketsPerElement, double maxFalsePosProb)
     {
-        assert maxBucketsPerElement >= 1;
-        assert maxBucketsPerElement <= probs.length - 1;
+        SCYLLA_ASSERT maxBucketsPerElement >= 1;
+        SCYLLA_ASSERT maxBucketsPerElement <= probs.length - 1;
         int maxK = probs[maxBucketsPerElement].length - 1;
 
         // Handle the trivial cases

--- a/utils/build_id.cc
+++ b/utils/build_id.cc
@@ -2,6 +2,7 @@
  * Copyright (C) 2019-present ScyllaDB
  */
 
+#include "utils/assert.hh"
 #include "build_id.hh"
 #include <fmt/ostream.h>
 #include <link.h>
@@ -38,7 +39,7 @@ static const Elf64_Nhdr* get_nt_build_id(dl_phdr_info* info) {
         }
     }
 
-    assert(0 && "no NT_GNU_BUILD_ID note");
+    SCYLLA_ASSERT(0 && "no NT_GNU_BUILD_ID note");
 }
 
 static int callback(dl_phdr_info* info, size_t size, void* data) {
@@ -46,7 +47,7 @@ static int callback(dl_phdr_info* info, size_t size, void* data) {
     std::ostringstream os;
 
     // The first DSO is always the main program, which has an empty name.
-    assert(strlen(info->dlpi_name) == 0);
+    SCYLLA_ASSERT(strlen(info->dlpi_name) == 0);
 
     auto* n = get_nt_build_id(info);
     auto* p = reinterpret_cast<const unsigned char*>(n);
@@ -68,7 +69,7 @@ static int callback(dl_phdr_info* info, size_t size, void* data) {
 static std::string really_get_build_id() {
     std::string ret;
     int r = dl_iterate_phdr(callback, &ret);
-    assert(r == 1);
+    SCYLLA_ASSERT(r == 1);
     return ret;
 }
 

--- a/utils/cached_file.hh
+++ b/utils/cached_file.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "reader_permit.hh"
+#include "utils/assert.hh"
 #include "utils/div_ceil.hh"
 #include "utils/bptree.hh"
 #include "utils/logalloc.hh"
@@ -97,7 +98,7 @@ private:
         }
 
         ~cached_page() {
-            assert(!_use_count);
+            SCYLLA_ASSERT(!_use_count);
         }
 
         void on_evicted() noexcept override;
@@ -364,7 +365,7 @@ public:
 
     ~cached_file() {
         evict_range(_cache.begin(), _cache.end());
-        assert(_cache.empty());
+        SCYLLA_ASSERT(_cache.empty());
     }
 
     /// \brief Invalidates [start, end) or less.

--- a/utils/composite_abort_source.hh
+++ b/utils/composite_abort_source.hh
@@ -1,4 +1,5 @@
 #include <seastar/core/abort_source.hh>
+#include "utils/assert.hh"
 #include "utils/small_vector.hh"
 #include "seastarx.hh"
 
@@ -14,7 +15,7 @@ public:
     void add(abort_source& as) {
         as.check();
         auto sub = as.subscribe([this]() noexcept { _as.request_abort(); });
-        assert(sub);
+        SCYLLA_ASSERT(sub);
         _subscriptions.push_back(std::move(*sub));
     }
     abort_source& abort_source() noexcept {

--- a/utils/cross-shard-barrier.hh
+++ b/utils/cross-shard-barrier.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <atomic>
 #include <vector>
 #include <optional>
@@ -99,7 +100,7 @@ public:
         // barrier, because it will likely be copied between sharded
         // users on sharded::start. The best check in this situation
         // is to make sure the local promise is not set up.
-        assert(!_b->wakeup[this_shard_id()].has_value());
+        SCYLLA_ASSERT(!_b->wakeup[this_shard_id()].has_value());
         auto i = _b->counter.fetch_add(-1);
         return i == 1 ? complete() : wait();
     }
@@ -130,7 +131,7 @@ private:
             if (this_shard_id() != sid) {
                 std::optional<promise<>>& w = b->wakeup[this_shard_id()];
                 if (alive) {
-                    assert(w.has_value());
+                    SCYLLA_ASSERT(w.has_value());
                     w->set_value();
                     w.reset();
                 } else if (w.has_value()) {

--- a/utils/double-decker.hh
+++ b/utils/double-decker.hh
@@ -10,6 +10,7 @@
 
 #include <type_traits>
 #include <seastar/util/concepts.hh>
+#include "utils/assert.hh"
 #include "utils/bptree.hh"
 #include "utils/intrusive-array.hh"
 #include "utils/collection-concepts.hh"
@@ -197,7 +198,7 @@ public:
 
     template <typename... Args>
     iterator emplace_before(iterator i, Key k, const bound_hint& hint, Args&&... args) {
-        assert(!hint.match);
+        SCYLLA_ASSERT(!hint.match);
         outer_iterator& bucket = i._bucket;
 
         if (!hint.key_match) {
@@ -363,7 +364,7 @@ public:
             arr->for_each(disp);
         });
 
-        assert(nb == end._bucket);
+        SCYLLA_ASSERT(nb == end._bucket);
 
         /*
          * Drop the head of the ending bucket. Every erased element is the 0th

--- a/utils/entangled.hh
+++ b/utils/entangled.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <boost/intrusive/parent_from_member.hpp>
 #include <assert.h>
 
@@ -33,7 +34,7 @@ class entangled final {
 private:
     struct init_tag {};
     entangled(init_tag, entangled& other) {
-        assert(!other._ref);
+        SCYLLA_ASSERT(!other._ref);
         _ref = &other;
         other._ref = this;
     }

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <seastar/core/future.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/seastar.hh>
@@ -274,7 +275,7 @@ private:
             , shared_data(make_lw_shared<injection_shared_data>(std::move(parameters), injection_name)) {}
 
         void receive_message() {
-            assert(shared_data);
+            SCYLLA_ASSERT(shared_data);
 
             ++shared_data->received_message_count;
             shared_data->received_message_cv.broadcast();

--- a/utils/estimated_histogram.hh
+++ b/utils/estimated_histogram.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <cmath>
 #include <algorithm>
 #include <vector>
@@ -557,7 +558,7 @@ public:
      * @return estimated value at given percentile
      */
     int64_t percentile(double perc) const {
-        assert(perc >= 0 && perc <= 1.0);
+        SCYLLA_ASSERT(perc >= 0 && perc <= 1.0);
         auto last_bucket = buckets.size() - 1;
 
         auto c = count();

--- a/utils/file_lock.cc
+++ b/utils/file_lock.cc
@@ -7,6 +7,7 @@
  */
 
 
+#include "utils/assert.hh"
 #include <seastar/core/seastar.hh>
 #include <seastar/core/posix.hh>
 #include <unistd.h>
@@ -30,9 +31,9 @@ public:
         if (!_path.empty()) {
             ::unlink(_path.c_str());
         }
-        assert(_fd.get() != -1);
+        SCYLLA_ASSERT(_fd.get() != -1);
         auto r = ::lockf(_fd.get(), F_ULOCK, 0);
-        assert(r == 0);
+        SCYLLA_ASSERT(r == 0);
     }
     fs::path _path;
     file_desc _fd;

--- a/utils/i_filter.cc
+++ b/utils/i_filter.cc
@@ -10,6 +10,7 @@
 #include "log.hh"
 #include "bloom_filter.hh"
 #include "bloom_calculations.hh"
+#include "utils/assert.hh"
 #include "utils/murmur_hash.hh"
 #include <seastar/core/thread.hh>
 
@@ -17,7 +18,7 @@ namespace utils {
 static logging::logger filterlog("bloom_filter");
 
 filter_ptr i_filter::get_filter(int64_t num_elements, double max_false_pos_probability, filter_format fformat) {
-    assert(seastar::thread::running_in_thread());
+    SCYLLA_ASSERT(seastar::thread::running_in_thread());
 
     if (max_false_pos_probability > 1.0) {
         throw std::invalid_argument(format("Invalid probability {:f}: must be lower than 1.0", max_false_pos_probability));

--- a/utils/int_range.hh
+++ b/utils/int_range.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "interval.hh"
 #include <seastar/core/print.hh>
 
@@ -17,8 +18,8 @@ using int_range = interval<int>;
 
 inline
 unsigned cardinality(const int_range& r) {
-    assert(r.start());
-    assert(r.end());
+    SCYLLA_ASSERT(r.start());
+    SCYLLA_ASSERT(r.end());
     return r.end()->value() - r.start()->value() + r.start()->is_inclusive() + r.end()->is_inclusive() - 1;
 }
 

--- a/utils/intrusive-array.hh
+++ b/utils/intrusive-array.hh
@@ -12,6 +12,7 @@
 #include <cassert>
 #include <seastar/util/concepts.hh>
 
+#include "utils/assert.hh"
 #include "utils/allocation_strategy.hh"
 #include "utils/collection-concepts.hh"
 
@@ -140,7 +141,7 @@ public:
             new (&_data[i].object) T(std::move(from._data[i - off].object));
         }
 
-        assert(grow.add_pos <= i && i < max_len);
+        SCYLLA_ASSERT(grow.add_pos <= i && i < max_len);
 
         new (&_data[grow.add_pos].object) T(std::forward<Args>(args)...);
 
@@ -212,15 +213,15 @@ public:
      * altogether if needed
      */
     void erase(int pos) noexcept {
-        assert(!is_single_element());
-        assert(pos < max_len);
+        SCYLLA_ASSERT(!is_single_element());
+        SCYLLA_ASSERT(pos < max_len);
 
         bool with_train = _data[0].object.with_train();
         bool tail = _data[pos].object.is_tail();
         _data[pos].object.~T();
 
         if (tail) {
-            assert(pos > 0);
+            SCYLLA_ASSERT(pos > 0);
             _data[pos - 1].object.set_tail(true);
         } else {
             while (!tail) {
@@ -233,7 +234,7 @@ public:
 
         _data[0].object.set_train(true);
         unsigned short train_len = with_train ? _data[pos + 1].train_len : 0;
-        assert(train_len < max_len);
+        SCYLLA_ASSERT(train_len < max_len);
         _data[pos].train_len = train_len + 1;
     }
 
@@ -324,7 +325,7 @@ public:
     static intrusive_array& from_element(T* ptr, int& idx) noexcept {
         idx = 0;
         while (!ptr->is_head()) {
-            assert(idx < max_len); // may the force be with us...
+            SCYLLA_ASSERT(idx < max_len); // may the force be with us...
             idx++;
             ptr--;
         }

--- a/utils/large_bitset.cc
+++ b/utils/large_bitset.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "large_bitset.hh"
 #include "stall_free.hh"
 
@@ -15,7 +16,7 @@
 using namespace seastar;
 
 large_bitset::large_bitset(size_t nr_bits) : _nr_bits(nr_bits) {
-    assert(thread::running_in_thread());
+    SCYLLA_ASSERT(thread::running_in_thread());
 
     size_t nr_ints = align_up(nr_bits, bits_per_int()) / bits_per_int();
     utils::reserve_gently(_storage, nr_ints).get();
@@ -28,7 +29,7 @@ large_bitset::large_bitset(size_t nr_bits) : _nr_bits(nr_bits) {
 
 void
 large_bitset::clear() {
-    assert(thread::running_in_thread());
+    SCYLLA_ASSERT(thread::running_in_thread());
     for (auto&& pos: _storage) {
         pos = 0;
         thread::maybe_yield();

--- a/utils/lister.cc
+++ b/utils/lister.cc
@@ -3,6 +3,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/util/log.hh>
+#include "utils/assert.hh"
 #include "utils/lister.hh"
 #include "checked-file-impl.hh"
 
@@ -90,7 +91,7 @@ future<std::optional<directory_entry>> directory_lister::get() {
         auto walker = [this] (fs::path dir, directory_entry de) {
             return _queue.push_eventually(std::make_optional<directory_entry>(std::move(de)));
         };
-        assert(!_lister);
+        SCYLLA_ASSERT(!_lister);
         _lister = std::make_unique<lister>(std::move(dir), _type, std::move(walker), _filter, _dir, _do_show_hidden);
         _opt_done_fut = _lister->done().then_wrapped([this] (future<> f) {
             if (f.failed()) [[unlikely]] {

--- a/utils/loading_cache.hh
+++ b/utils/loading_cache.hh
@@ -26,6 +26,7 @@
 #include <seastar/core/gate.hh>
 
 #include "exceptions/exceptions.hh"
+#include "utils/assert.hh"
 #include "utils/loading_shared_values.hh"
 #include "utils/chunked_vector.hh"
 #include "log.hh"
@@ -144,7 +145,7 @@ class loading_cache {
         timestamped_val(timestamped_val&&) = default;
 
         timestamped_val& operator=(value_type new_val) {
-            assert(_lru_entry_ptr);
+            SCYLLA_ASSERT(_lru_entry_ptr);
 
             _value = std::move(new_val);
             _loaded = loading_cache_clock_type::now();
@@ -305,7 +306,7 @@ public:
     requires std::is_invocable_r_v<future<value_type>, LoadFunc, const key_type&>
     future<value_ptr> get_ptr(const Key& k, LoadFunc&& load) {
         // We shouldn't be here if caching is disabled
-        assert(caching_enabled());
+        SCYLLA_ASSERT(caching_enabled());
 
         return _loading_values.get_or_load(k, [load = std::forward<LoadFunc>(load)] (const Key& k) mutable {
             return load(k).then([] (value_type val) {

--- a/utils/loading_shared_values.hh
+++ b/utils/loading_shared_values.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <vector>
 #include <memory>
 #include <seastar/core/shared_future.hh>
@@ -200,7 +201,7 @@ public:
     loading_shared_values(loading_shared_values&&) = default;
     loading_shared_values(const loading_shared_values&) = delete;
     ~loading_shared_values() {
-         assert(!_set.size());
+         SCYLLA_ASSERT(!_set.size());
     }
 
     /// \brief

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -18,6 +18,7 @@
 #include "allocation_strategy.hh"
 #include "seastarx.hh"
 #include "db/timeout_clock.hh"
+#include "utils/assert.hh"
 #include "utils/entangled.hh"
 #include "utils/memory_limit_reached.hh"
 
@@ -304,7 +305,7 @@ public:
     tracker& get_tracker() { return _tracker; }
 
     void set_reclaiming_enabled(bool enabled) noexcept {
-        assert(this_shard_id() == _cpu);
+        SCYLLA_ASSERT(this_shard_id() == _cpu);
         _reclaiming_enabled = enabled;
     }
 
@@ -494,7 +495,7 @@ public:
     //
     template<typename Func>
     decltype(auto) with_reclaiming_disabled(logalloc::region& r, Func&& fn) {
-        assert(r.reclaiming_enabled());
+        SCYLLA_ASSERT(r.reclaiming_enabled());
         maybe_decay_reserve();
         while (true) {
             try {

--- a/utils/lru.hh
+++ b/utils/lru.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <boost/intrusive/list.hpp>
 #include <seastar/core/memory.hh>
 
@@ -37,7 +38,7 @@ protected:
     // in the destructor, we can't perform proper accounting for that without access to the
     // head of the containing list.
     ~evictable() {
-        assert(!_lru_link.is_linked());
+        SCYLLA_ASSERT(!_lru_link.is_linked());
     }
     evictable() = default;
     evictable(evictable&&) noexcept = default;

--- a/utils/on_internal_error.hh
+++ b/utils/on_internal_error.hh
@@ -6,8 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-// Seastar's on_internal_error() is a replacement for assert(). Instead of
-// crashing like assert(), on_internal_error() logs a message with a
+// Seastar's on_internal_error() is a replacement for SCYLLA_ASSERT(). Instead of
+// crashing like SCYLLA_ASSERT(), on_internal_error() logs a message with a
 // backtrace and throws an exception (and optionally also crashes - this can
 // be useful for testing). However, Seastar's function is inconvenient because
 // it requires specifying a logger. This makes it hard to call it from source
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include <string_view>
 
 namespace utils {

--- a/utils/pretty_printers.cc
+++ b/utils/pretty_printers.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "utils/assert.hh"
 #include "pretty_printers.hh"
 #include <tuple>
 #include <cassert>
@@ -13,7 +14,7 @@
 template <typename Suffixes>
 static constexpr std::tuple<size_t, std::string_view, std::string_view>
 do_format(size_t n, Suffixes suffixes, unsigned scale, unsigned precision, bool bytes) {
-    assert(scale < precision);
+    SCYLLA_ASSERT(scale < precision);
     size_t factor = n;
     const char* suffix = "";
     size_t remainder = 0;

--- a/utils/result_try.hh
+++ b/utils/result_try.hh
@@ -10,6 +10,7 @@
 
 #include <concepts>
 #include <type_traits>
+#include "utils/assert.hh"
 #include "utils/result.hh"
 
 namespace utils {
@@ -63,7 +64,7 @@ concept ConvertsWithTo = std::convertible_to<typename Converter::template wrappe
 
 // We require forall<ExceptionContainerResult R> ExceptionHandle<H, R>.
 // However, C++ does not support quantification like that in the constraints.
-// Here, we use the dummy_result to assert that the handles defined below
+// Here, we use the dummy_result to SCYLLA_ASSERT that the handles defined below
 // at least work with dummy_result.
 template<typename T = void>
 using dummy_result = result_with_exception<T, std::exception>;

--- a/utils/reusable_buffer.hh
+++ b/utils/reusable_buffer.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/assert.hh"
 #include "utils/fragmented_temporary_buffer.hh"
 #include <seastar/core/timer.hh>
 #include <seastar/core/memory.hh>
@@ -42,7 +43,7 @@ protected:
     reusable_buffer_impl() = default;
 
     ~reusable_buffer_impl() {
-        assert(_refcount == 0);
+        SCYLLA_ASSERT(_refcount == 0);
     }
 
     void resize(size_t new_size) & {
@@ -214,7 +215,7 @@ private:
     period_type _decay_period;
 
     void decay() & {
-        assert(_refcount == 0);
+        SCYLLA_ASSERT(_refcount == 0);
         if (_high_watermark <= _buf_size / 16) {
             // We shrink when the size falls at least by four power-of-2
             // notches, instead of just one notch. This adds hysteresis:
@@ -238,10 +239,10 @@ public:
     }
 };
 
-/* Exists only to assert that there exists at most one reference to the
+/* Exists only to SCYLLA_ASSERT that there exists at most one reference to the
  * reusable_buffer, to hopefully make it less of a footgun.
  *
- * The reference/use counts exist only for assert purposes.
+ * The reference/use counts exist only for SCYLLA_ASSERT purposes.
  * They don't influence the program otherwise.
  *
  * Never keep the guard across preemption points.
@@ -258,7 +259,7 @@ private:
     bool used = false;
 private:
     void mark_used() {
-        assert(!used);
+        SCYLLA_ASSERT(!used);
         used = true;
     }
 public:
@@ -268,7 +269,7 @@ public:
     reusable_buffer_guard(reusable_buffer_impl& _buf)
         : _buf(_buf)
     {
-        assert(_buf._refcount == 0);
+        SCYLLA_ASSERT(_buf._refcount == 0);
         _buf._refcount += 1;
     }
 

--- a/utils/rjson.hh
+++ b/utils/rjson.hh
@@ -29,6 +29,7 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include "utils/assert.hh"
 #include "utils/base64.hh"
 
 #include <seastar/core/future.hh>
@@ -50,12 +51,12 @@ public:
 
 // rapidjson configuration macros
 #define RAPIDJSON_HAS_STDSTRING 1
-// Default rjson policy is to use assert() - which is dangerous for two reasons:
-// 1. assert() can be turned off with -DNDEBUG
-// 2. assert() crashes a program
+// Default rjson policy is to use SCYLLA_ASSERT() - which is dangerous for two reasons:
+// 1. SCYLLA_ASSERT() can be turned off with -DNDEBUG
+// 2. SCYLLA_ASSERT() crashes a program
 // Fortunately, the default policy can be overridden, and so rapidjson errors will
 // throw an rjson::error exception instead.
-#define RAPIDJSON_ASSERT(x) do { if (!(x)) throw rjson::error(fmt::format("JSON assert failed on condition '{}', at: {}", #x, current_backtrace_tasklocal())); } while (0)
+#define RAPIDJSON_ASSERT(x) do { if (!(x)) throw rjson::error(fmt::format("JSON SCYLLA_ASSERT failed on condition '{}', at: {}", #x, current_backtrace_tasklocal())); } while (0)
 // This macro is used for functions which are called for every json char making it
 // quite costly if not inlined, by default rapidjson only enables it if NDEBUG
 // is defined which isn't the case for us.

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -35,6 +35,7 @@
 #include <seastar/util/lazy.hh>
 #include <seastar/http/request.hh>
 #include <seastar/http/exception.hh>
+#include "utils/assert.hh"
 #include "utils/s3/client.hh"
 #include "utils/http.hh"
 #include "utils/memory_data_sink.hh"
@@ -287,7 +288,7 @@ future<stats> client::get_object_stats(sstring object_name) {
 
 static rapidxml::xml_node<>* first_node_of(rapidxml::xml_node<>* root,
                                            std::initializer_list<std::string_view> names) {
-    assert(root);
+    SCYLLA_ASSERT(root);
     auto* node = root;
     for (auto name : names) {
         node = node->first_node(name.data(), name.size());
@@ -577,7 +578,7 @@ future<> dump_multipart_upload_parts(output_stream<char> out, const utils::chunk
 
         unsigned nr = 1;
         for (auto& etag : etags) {
-            assert(!etag.empty());
+            SCYLLA_ASSERT(!etag.empty());
             co_await out.write(format(multipart_upload_complete_entry.data(), etag, nr));
             nr++;
         }
@@ -981,8 +982,8 @@ class client::do_upload_file {
     }
 
     static size_t div_ceil(size_t x, size_t y) {
-        assert(std::in_range<long long>(x));
-        assert(std::in_range<long long>(y));
+        SCYLLA_ASSERT(std::in_range<long long>(x));
+        SCYLLA_ASSERT(std::in_range<long long>(y));
         auto [quot, rem] = std::lldiv(x, y);
         return rem ? quot + 1 : quot;
     }

--- a/utils/throttle.hh
+++ b/utils/throttle.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "utils/assert.hh"
 #include <seastar/core/future.hh>
 #include <optional>
 
@@ -51,7 +52,7 @@ public:
     }
 
     void unblock() {
-        assert(_block_counter);
+        SCYLLA_ASSERT(_block_counter);
         if (--_block_counter == 0) {
             _p.set_value();
         }

--- a/utils/top_k.hh
+++ b/utils/top_k.hh
@@ -52,6 +52,7 @@
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
+#include "utils/assert.hh"
 #include "utils/chunked_vector.hh"
 
 namespace utils {
@@ -146,9 +147,9 @@ public:
                     (*counter_it)->bucket_it = new_bucket_it;
                 } else {
                     buckets_iterator min_bucket = _buckets.begin();
-                    assert(min_bucket != _buckets.end());
+                    SCYLLA_ASSERT(min_bucket != _buckets.end());
                     counter_it = min_bucket->counters.begin();
-                    assert(counter_it != min_bucket->counters.end());
+                    SCYLLA_ASSERT(counter_it != min_bucket->counters.end());
                     counter_ptr ctr = *counter_it;
                     _counters_map.erase(ctr->item);
                     dropped_item = std::exchange(ctr->item, std::move(item));


### PR DESCRIPTION
assert() is traditionally disabled in release builds, but not in scylladb. This hasn't caused problems so far, but the latest abseil release includes a commit [1] that causes a 1000 insn/op regression when NDEBUG is not defined.

Clearly, we must move towards a build system where NDEBUG is defined in release builds. But we can't just define it blindly without vetting all the assert() calls, as some were written with the expectation that they are enabled in release mode.

To solve the conundrum, change all assert() calls to a new SCYLLA_ASSERT() macro in utils/assert.hh. This macro is always defined and is not conditional on NDEBUG, so we can later (after vetting Seastar) enable NDEBUG in release mode.

[1] https://github.com/abseil/abseil-cpp/commit/66ef711d6846771b8e725e377de37bedae6c1527

No backport needed, this is to prepare ScyllaDB for the wider ecosystem.