### PR TITLE
convert the rest of `test/boost/sstable_test.cc` to co-routines and seastar::thread

### DIFF
--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -180,8 +180,9 @@ static future<sstable_ptr> do_write_sst(test_env& env, schema_ptr schema, sstrin
 }
 
 static future<> write_sst_info(schema_ptr schema, sstring load_dir, sstring write_dir, sstables::generation_type generation) {
-    return test_env::do_with([schema = std::move(schema), load_dir = std::move(load_dir), write_dir = std::move(write_dir), generation] (test_env& env) {
-        return do_write_sst(env, std::move(schema), load_dir, write_dir, generation).then([] (auto ptr) { return make_ready_future<>(); });
+    return test_env::do_with_async([schema = std::move(schema), load_dir = std::move(load_dir), write_dir = std::move(write_dir),
+                                    generation = std::move(generation)] (test_env& env) {
+        (void)do_write_sst(env, std::move(schema), std::move(load_dir), std::move(write_dir), std::move(generation)).get();
     });
 }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -167,7 +167,6 @@ SEASTAR_TEST_CASE(missing_summary_first_last_sane) {
         BOOST_REQUIRE(summary.entries.size() == 1);
         BOOST_REQUIRE(bytes_view(summary.first_key) == as_bytes("vinna"));
         BOOST_REQUIRE(bytes_view(summary.last_key) == as_bytes("finna"));
-        return make_ready_future<>();
     });
 }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -290,7 +290,6 @@ SEASTAR_TEST_CASE(find_key_map) {
 
         auto key = sstables::key::from_deeply_exploded(*s, kk);
         BOOST_REQUIRE(sstables::test(sstp).binary_search(s->get_partitioner(), summary.entries, key) == 0);
-        return make_ready_future<>();
     });
 }
 
@@ -312,7 +311,6 @@ SEASTAR_TEST_CASE(find_key_set) {
 
         auto key = sstables::key::from_deeply_exploded(*s, kk);
         BOOST_REQUIRE(sstables::test(sstp).binary_search(s->get_partitioner(), summary.entries, key) == 0);
-        return make_ready_future<>();
     });
 }
 
@@ -334,7 +332,6 @@ SEASTAR_TEST_CASE(find_key_list) {
 
         auto key = sstables::key::from_deeply_exploded(*s, kk);
         BOOST_REQUIRE(sstables::test(sstp).binary_search(s->get_partitioner(), summary.entries, key) == 0);
-        return make_ready_future<>();
     });
 }
 
@@ -353,7 +350,6 @@ SEASTAR_TEST_CASE(find_key_composite) {
 
         auto key = sstables::key::from_deeply_exploded(*s, kk);
         BOOST_REQUIRE(sstables::test(sstp).binary_search(s->get_partitioner(), summary.entries, key) == 0);
-        return make_ready_future<>();
     });
 }
 
@@ -366,7 +362,6 @@ SEASTAR_TEST_CASE(all_in_place) {
             auto key = sstables::key::from_bytes(bytes(e.key));
             BOOST_REQUIRE(sstables::test(sstp).binary_search(sstp->get_schema()->get_partitioner(), summary.entries, key) == idx++);
         }
-        return make_ready_future<>();
     });
 }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -200,11 +200,11 @@ SEASTAR_TEST_CASE(check_compressed_info_func) {
 }
 
 future<>
-write_and_validate_sst(schema_ptr s, sstring dir, noncopyable_function<future<> (shared_sstable sst1, shared_sstable sst2)> func) {
+write_and_validate_sst(schema_ptr s, sstring dir, noncopyable_function<void (shared_sstable sst1, shared_sstable sst2)> func) {
     return test_env::do_with_async([s = std::move(s), dir = std::move(dir), func = std::move(func)] (test_env& env) mutable {
         auto sst1 = do_write_sst(env, s, dir, env.tempdir().path().native(), env.new_generation()).get();
         auto sst2 = env.make_sstable(s, sst1->get_version());
-        func(std::move(sst1), std::move(sst2)).get();
+        func(std::move(sst1), std::move(sst2));
     }, test_env_config{ .use_uuid = false });
 }
 
@@ -221,7 +221,6 @@ SEASTAR_TEST_CASE(check_summary_func) {
         BOOST_REQUIRE(sst1_s.entries == sst2_s.entries);
         BOOST_REQUIRE(sst1_s.first_key.value == sst2_s.first_key.value);
         BOOST_REQUIRE(sst1_s.last_key.value == sst2_s.last_key.value);
-        return make_ready_future<>();
     });
 }
 
@@ -243,7 +242,6 @@ SEASTAR_TEST_CASE(check_statistics_func) {
             BOOST_REQUIRE(boost::get<0>(e).second ==  boost::get<1>(e).second);
         }
         // TODO: compare the field contents from both sstables.
-        return make_ready_future<>();
     });
 }
 
@@ -255,7 +253,6 @@ SEASTAR_TEST_CASE(check_toc_func) {
         auto& sst2_c = sstables::test(sst2).get_components();
 
         BOOST_REQUIRE(sst1_c == sst2_c);
-        return make_ready_future<>();
     });
 }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -68,7 +68,7 @@ inline future<>
 test_using_reusable_sst(schema_ptr s, sstring dir, sstables::generation_type::int_t gen, Func&& func) {
     return test_env::do_with_async([s = std::move(s), dir = std::move(dir), gen, func = std::move(func)] (test_env& env) {
         auto sst = env.reusable_sst(std::move(s), std::move(dir), generation_from_value(gen)).get();
-        futurize_invoke(func, env, std::move(sst)).get();
+        func(env, std::move(sst));
     });
 }
 
@@ -77,7 +77,7 @@ inline future<T>
 test_using_reusable_sst_returning(schema_ptr s, sstring dir, sstables::generation_type::int_t gen, Func&& func) {
     return test_env::do_with_async_returning<T>([s = std::move(s), dir = std::move(dir), gen, func = std::move(func)] (test_env& env) {
         auto sst = env.reusable_sst(std::move(s), std::move(dir), generation_from_value(gen)).get();
-        return futurize_invoke(func, env, std::move(sst)).get();
+        return func(env, std::move(sst));
     });
 }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -110,7 +110,10 @@ future<> summary_query(schema_ptr schema, sstring path, sstables::generation_typ
 
 template<uint64_t Position, uint64_t EntryPosition, uint64_t EntryKeySize>
 future<> summary_query_fail(schema_ptr schema, sstring path, sstables::generation_type::int_t generation) {
-    return summary_query<Position, EntryPosition, EntryKeySize>(std::move(schema), path, generation).handle_exception_type([] (const std::out_of_range&) {});
+    try {
+        co_await summary_query<Position, EntryPosition, EntryKeySize>(std::move(schema), std::move(path), generation);
+    } catch (const std::out_of_range&) {
+    }
 }
 
 SEASTAR_TEST_CASE(small_summary_query_ok) {

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -258,22 +258,16 @@ SEASTAR_TEST_CASE(check_toc_func) {
 
 SEASTAR_TEST_CASE(uncompressed_random_access_read) {
     return test_using_reusable_sst(uncompressed_schema(), uncompressed_dir(), 1, [] (auto& env, auto sstp) {
-        // note: it's important to pass on a shared copy of sstp to prevent its
-        // destruction until the continuation finishes reading!
-        return sstables::test(sstp).data_read(env.make_reader_permit(), 97, 6).then([sstp] (temporary_buffer<char> buf) {
-            BOOST_REQUIRE(sstring(buf.get(), buf.size()) == "gustaf");
-            return make_ready_future<>();
-        });
+        temporary_buffer<char> buf = sstables::test(sstp).data_read(env.make_reader_permit(), 97, 6).get();
+        BOOST_REQUIRE(sstring(buf.get(), buf.size()) == "gustaf");
     });
 }
 
 SEASTAR_TEST_CASE(compressed_random_access_read) {
     auto s = make_schema_for_compressed_sstable();
     return test_using_reusable_sst(std::move(s), "test/resource/sstables/compressed", 1, [] (auto& env, auto sstp) {
-        return sstables::test(sstp).data_read(env.make_reader_permit(), 97, 6).then([sstp] (temporary_buffer<char> buf) {
-            BOOST_REQUIRE(sstring(buf.get(), buf.size()) == "gustaf");
-            return make_ready_future<>();
-        });
+        temporary_buffer<char> buf = sstables::test(sstp).data_read(env.make_reader_permit(), 97, 6).get();
+        BOOST_REQUIRE(sstring(buf.get(), buf.size()) == "gustaf");
     });
 }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -232,19 +232,18 @@ SEASTAR_TEST_CASE(check_filter_func) {
 SEASTAR_TEST_CASE(check_statistics_func) {
     auto s = make_schema_for_compressed_sstable();
     return write_and_validate_sst(std::move(s), "test/resource/sstables/compressed", [] (shared_sstable sst1, shared_sstable sst2) {
-        return sstables::test(sst2).read_statistics().then([sst1, sst2] {
-            statistics& sst1_s = sstables::test(sst1).get_statistics();
-            statistics& sst2_s = sstables::test(sst2).get_statistics();
+        sstables::test(sst2).read_statistics().get();
+        statistics& sst1_s = sstables::test(sst1).get_statistics();
+        statistics& sst2_s = sstables::test(sst2).get_statistics();
 
-            BOOST_REQUIRE(sst1_s.offsets.elements.size() == sst2_s.offsets.elements.size());
-            BOOST_REQUIRE(sst1_s.contents.size() == sst2_s.contents.size());
+        BOOST_REQUIRE(sst1_s.offsets.elements.size() == sst2_s.offsets.elements.size());
+        BOOST_REQUIRE(sst1_s.contents.size() == sst2_s.contents.size());
 
-            for (auto&& e : boost::combine(sst1_s.offsets.elements, sst2_s.offsets.elements)) {
-                BOOST_REQUIRE(boost::get<0>(e).second ==  boost::get<1>(e).second);
-            }
-            // TODO: compare the field contents from both sstables.
-            return make_ready_future<>();
-        });
+        for (auto&& e : boost::combine(sst1_s.offsets.elements, sst2_s.offsets.elements)) {
+            BOOST_REQUIRE(boost::get<0>(e).second ==  boost::get<1>(e).second);
+        }
+        // TODO: compare the field contents from both sstables.
+        return make_ready_future<>();
     });
 }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -83,10 +83,9 @@ test_using_reusable_sst_returning(schema_ptr s, sstring dir, sstables::generatio
 
 future<std::vector<partition_key>> index_read(schema_ptr schema, sstring path) {
     return test_using_reusable_sst_returning<std::vector<partition_key>>(std::move(schema), std::move(path), 1, [] (test_env& env, sstable_ptr ptr) {
-        return sstables::test(ptr).read_indexes(env.make_reader_permit()).then([] (auto&& indexes) {
-            return boost::copy_range<std::vector<partition_key>>(
-                    indexes | boost::adaptors::transformed([] (const sstables::test::index_entry& e) { return e.key; }));
-        });
+        auto indexes = sstables::test(ptr).read_indexes(env.make_reader_permit()).get();
+        return boost::copy_range<std::vector<partition_key>>(
+                indexes | boost::adaptors::transformed([] (const sstables::test::index_entry& e) { return e.key; }));
     });
 }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -41,8 +41,8 @@ bytes as_bytes(const sstring& s) {
 }
 
 future<> test_using_working_sst(schema_ptr s, sstring dir) {
-    return test_env::do_with([s = std::move(s), dir = std::move(dir)] (test_env& env) {
-        return env.reusable_sst(std::move(s), std::move(dir)).discard_result();
+    return test_env::do_with_async([s = std::move(s), dir = std::move(dir)] (test_env& env) {
+        (void)env.reusable_sst(std::move(s), std::move(dir)).get();
     });
 }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -471,7 +471,6 @@ SEASTAR_TEST_CASE(promoted_index_read) {
   return for_each_sstable_version([] (const sstables::sstable::version_types version) {
     return test_env::do_with_async([version] (test_env& env) {
         auto sstp = load_large_partition_sst(env, version).get();
-        schema_ptr s = large_partition_schema();
         std::vector<sstables::test::index_entry> vec = sstables::test(sstp).read_indexes(env.make_reader_permit()).get();
         BOOST_REQUIRE(vec.size() == 1);
         BOOST_REQUIRE(vec[0].promoted_index_size > 0);

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -102,11 +102,9 @@ SEASTAR_TEST_CASE(composite_index_read) {
 template<uint64_t Position, uint64_t EntryPosition, uint64_t EntryKeySize>
 future<> summary_query(schema_ptr schema, sstring path, sstables::generation_type::int_t generation) {
     return test_using_reusable_sst(std::move(schema), path, generation, [] (test_env& env, sstable_ptr ptr) {
-        return sstables::test(ptr).read_summary_entry(Position).then([ptr] (auto entry) {
-            BOOST_REQUIRE(entry.position == EntryPosition);
-            BOOST_REQUIRE(entry.key.size() == EntryKeySize);
-            return make_ready_future<>();
-        });
+        auto entry = sstables::test(ptr).read_summary_entry(Position).get();
+        BOOST_REQUIRE(entry.position == EntryPosition);
+        BOOST_REQUIRE(entry.key.size() == EntryKeySize);
     });
 }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -250,13 +250,12 @@ SEASTAR_TEST_CASE(check_statistics_func) {
 SEASTAR_TEST_CASE(check_toc_func) {
     auto s = make_schema_for_compressed_sstable();
     return write_and_validate_sst(std::move(s), "test/resource/sstables/compressed", [] (shared_sstable sst1, shared_sstable sst2) {
-        return sstables::test(sst2).read_toc().then([sst1, sst2] {
-            auto& sst1_c = sstables::test(sst1).get_components();
-            auto& sst2_c = sstables::test(sst2).get_components();
+        sstables::test(sst2).read_toc().get();
+        auto& sst1_c = sstables::test(sst1).get_components();
+        auto& sst2_c = sstables::test(sst2).get_components();
 
-            BOOST_REQUIRE(sst1_c == sst2_c);
-            return make_ready_future<>();
-        });
+        BOOST_REQUIRE(sst1_c == sst2_c);
+        return make_ready_future<>();
     });
 }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -391,7 +391,6 @@ SEASTAR_TEST_CASE(not_find_key_composite_bucket0) {
         auto key = sstables::key::from_deeply_exploded(*s, kk);
         // (result + 1) * -1 -1 = 0
         BOOST_REQUIRE(sstables::test(sstp).binary_search(s->get_partitioner(), summary.entries, key) == -2);
-        return make_ready_future<>();
     });
 }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -367,13 +367,12 @@ SEASTAR_TEST_CASE(all_in_place) {
 
 SEASTAR_TEST_CASE(full_index_search) {
     return test_using_reusable_sst(uncompressed_schema(), uncompressed_dir(), 1, [] (auto& env, auto sstp) {
-        return sstables::test(sstp).read_indexes(env.make_reader_permit()).then([sstp] (auto&& index_list) {
-            int idx = 0;
-            for (auto& e : index_list) {
-                auto key = key::from_partition_key(*sstp->get_schema(), e.key);
-                BOOST_REQUIRE(sstables::test(sstp).binary_search(sstp->get_schema()->get_partitioner(), index_list, key) == idx++);
-            }
-        });
+        auto index_list = sstables::test(sstp).read_indexes(env.make_reader_permit()).get();
+        int idx = 0;
+        for (auto& e : index_list) {
+            auto key = key::from_partition_key(*sstp->get_schema(), e.key);
+            BOOST_REQUIRE(sstables::test(sstp).binary_search(sstp->get_schema()->get_partitioner(), index_list, key) == idx++);
+        }
     });
 }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -90,15 +90,13 @@ future<std::vector<partition_key>> index_read(schema_ptr schema, sstring path) {
 }
 
 SEASTAR_TEST_CASE(simple_index_read) {
-    return index_read(uncompressed_schema(), uncompressed_dir()).then([] (auto vec) {
-        BOOST_REQUIRE(vec.size() == 4);
-    });
+    auto vec = co_await index_read(uncompressed_schema(), uncompressed_dir());
+    BOOST_REQUIRE(vec.size() == 4);
 }
 
 SEASTAR_TEST_CASE(composite_index_read) {
-    return index_read(composite_schema(), "test/resource/sstables/composite").then([] (auto vec) {
-        BOOST_REQUIRE(vec.size() == 20);
-    });
+    auto vec = co_await index_read(composite_schema(), "test/resource/sstables/composite");
+    BOOST_REQUIRE(vec.size() == 20);
 }
 
 template<uint64_t Position, uint64_t EntryPosition, uint64_t EntryKeySize>

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -211,17 +211,17 @@ write_and_validate_sst(schema_ptr s, sstring dir, noncopyable_function<future<> 
 SEASTAR_TEST_CASE(check_summary_func) {
     auto s = make_schema_for_compressed_sstable();
     return write_and_validate_sst(std::move(s), "test/resource/sstables/compressed", [] (shared_sstable sst1, shared_sstable sst2) {
-        return sstables::test(sst2).read_summary().then([sst1, sst2] {
-            summary& sst1_s = sstables::test(sst1).get_summary();
-            summary& sst2_s = sstables::test(sst2).get_summary();
+        sstables::test(sst2).read_summary().get();
 
-            BOOST_REQUIRE(::memcmp(&sst1_s.header, &sst2_s.header, sizeof(summary::header)) == 0);
-            BOOST_REQUIRE(sst1_s.positions == sst2_s.positions);
-            BOOST_REQUIRE(sst1_s.entries == sst2_s.entries);
-            BOOST_REQUIRE(sst1_s.first_key.value == sst2_s.first_key.value);
-            BOOST_REQUIRE(sst1_s.last_key.value == sst2_s.last_key.value);
-            return make_ready_future<>();
-        });
+        summary& sst1_s = sstables::test(sst1).get_summary();
+        summary& sst2_s = sstables::test(sst2).get_summary();
+
+        BOOST_REQUIRE(::memcmp(&sst1_s.header, &sst2_s.header, sizeof(summary::header)) == 0);
+        BOOST_REQUIRE(sst1_s.positions == sst2_s.positions);
+        BOOST_REQUIRE(sst1_s.entries == sst2_s.entries);
+        BOOST_REQUIRE(sst1_s.first_key.value == sst2_s.first_key.value);
+        BOOST_REQUIRE(sst1_s.last_key.value == sst2_s.last_key.value);
+        return make_ready_future<>();
     });
 }
 


### PR DESCRIPTION
This is a followup to #19937, for #19803. See in particular [this comment](https://github.com/scylladb/scylladb/issues/19803#issuecomment-2258371923).

The primary conversion target is coroutines. However, while coroutines are the most convenient style, they are only infrequently usable in this case, for the following reasons:
- Wherever we have a `future::finally()` that calls a cleanup function that returns a future (which must be awaited), we cannot use `co_await`. We can only use `seastar::async()` with `deferred_close` or `defer()`.
- The code passes lots of lambdas, and `co_await` cannot be used in lambdas. First, I tried, and the compiler rejects it; second, a capturing lambda that is a coroutine is a trap [[1]](https://devblogs.microsoft.com/oldnewthing/20211103-00/?p=105870) [[2]](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rcoro-capture).

In most cases, I didn't have to use naked `seastar::async()`; there were specialized wrappers in place already. Thus, most of the changes target `seastar::thread` context under existent `seastar::async()` wrappers, and only a few functions end up as coroutines.

The last patch in the series (`test/sstable: remove useless variable from promoted_index_read()`) is an independent micro-cleanup, the opportunity for which I thought to have noticed while reading the code.

The tail of `test/boost/sstable_test.cc` (the stuff following `promoted_index_read()`) is already written as `seastar::thread`. That's already better (for readability) than future chaining; but could have I perhaps further converted those functions to coroutines? My answer was "no":
- Some of the candidate functions relied on deferred cleanups that might need to yield (all three variants of `count_rows()`).
- Some had been implemented by passing lambdas to wrappers of `seastar::async()` (`sub_partition_read()`, `sub_partitions_read()`).
- The test case `test_skipping_in_compressed_stream()` initially looked promising for co-routinization (from its starting point `seastar::async()`), because it seemed to employ no deferred cleanup (that might need to yield). However, the function uses three lambdas that must be able to yield internally, and one of those (`make_is()`) is even capturing.
- The rest (`test_empty_key_view_comparison()`, `test_parse_path_good()`, `test_parse_path_bad()`) was synchronous code to begin with.

```
 test/boost/sstable_test.cc | 188 +++++++++-----------
 1 file changed, 83 insertions(+), 105 deletions(-)
```

Refactoring; no backport needed.