### PR TITLE
[test.py]: Fail test teardown in case of task leakage

### DIFF
--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -153,9 +153,11 @@ class ManagerClient():
         logging.getLogger().removeHandler(self.test_log_fh)
         pathlib.Path(self.test_log_fh.baseFilename).unlink()
         logger.debug("after_test for %s (success: %s)", test_case_name, success)
-        cluster_str = await _client.put_json(f"/cluster/after-test/{success}",
+        cluster_status = await _client.put_json(f"/cluster/after-test/{success}",
                                                  response_type = "json")
-        logger.info("Cluster after test %s: %s", test_case_name, cluster_str)
+        logger.info("Cluster after test %s: %s", test_case_name, cluster_status)
+
+        return cluster_status
 
     async def gather_related_logs(self, failed_test_path_dir: Path, logs: Dict[str, Path]) -> None:
         for server in await self.all_servers():

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1292,7 +1292,7 @@ class ScyllaClusterManager:
                 @wraps(handler)
                 async def inner_wrapper(request):
                     if blockable and self.server_broken_event.is_set():
-                        raise Exception("ScyllaClusterManager BROKEN")
+                        raise Exception("ScyllaClusterManager BROKEN, Previous test broke ScyllaClusterManager server")
                     self.logger.info("[ScyllaClusterManager][%s] %s", asyncio.current_task().get_name(), request.url)
                     self.tasks_history[asyncio.current_task()] = request
                     return await handler(request)
@@ -1377,7 +1377,7 @@ class ScyllaClusterManager:
         cluster_str = await self._before_test(request.match_info['test_case_name'])
         return cluster_str
 
-    async def _after_test(self, _request) -> str:
+    async def _after_test(self, _request) -> dict[str, bool]:
         assert self.cluster is not None
         assert self.current_test_case_full_name
         self.logger.info(self.repr_tasks_history())
@@ -1392,12 +1392,12 @@ class ScyllaClusterManager:
                     self.logger.info("wait for task:%s, request:%s", task, request.path_qs)
                     await asyncio.wait_for(task, timeout=120)
         except asyncio.TimeoutError:
-            self.break_manager(f"error on waiting coro {task.get_name()}")
+            self.break_manager(f"error on waiting coro {task.get_name()}", self.current_test_case_full_name)
 
         # check on tasks leakage
         await asyncio.sleep(0.1)
         if self.tasks_history:
-            self.break_manager(f"tasks leakage found  {self.tasks_history}")
+            self.break_manager(f"tasks leakage found  {self.tasks_history}", self.current_test_case_full_name)
 
         success = _request.match_info["success"] == "True"
         self.logger.info("Test %s %s, cluster: %s", self.current_test_case_full_name,
@@ -1410,11 +1410,12 @@ class ScyllaClusterManager:
             self.current_test_case_full_name = ''
         self.is_after_test_ok = True
         cluster_str = str(self.cluster)
-        return cluster_str
 
-    def break_manager(self, reason):
+        return {"cluster_str":cluster_str, "server_broken":self.server_broken_event.is_set()}
+
+    def break_manager(self, reason, test):
         # make ScyllaClusterManager not operatable from client side
-        self.logger.error(" %s, BREAK ScyllaClusterManager", reason)
+        self.logger.error(" %s, test case {test} BROKE ScyllaClusterManager", reason)
         self.server_broken_event.set()
         self._mark_dirty(None)
 

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -219,8 +219,10 @@ async def manager(request, manager_internal, record_property, mode):
             full_url = f"<a href={request.config.getoption('artifacts_dir_url')}/{dir_path_relative}>failed_test_logs</a>"
             record_property("TEST_LOGS", full_url)
 
-    await manager_internal.after_test(test_case_name, not failed)
+    cluster_status = await manager_internal.after_test(test_case_name, not failed)
     await manager_internal.stop()  # Stop client session and close driver after each test
+    if cluster_status["server_broken"]:
+        pytest.fail(f"test case {test_case_name} leave unfinished tasks on Scylla server. Server marked as broken")
 
 # "cql" fixture: set up client object for communicating with the CQL API.
 # Since connection is managed by manager just return that object


### PR DESCRIPTION
In test.py every asyncio task spawned during the test must be finished before the next test, otherwise, tests might affect each other results.
The developers are responsible for writing asyncio code in a way that doesn’t leave task objects unfinished.
Test.py has a mechanism that helps test writers avoid such tasks. At the end of each test case, it verifies that the test did not produce/leave any tasks and sets an event object that fails the next test at the start if this is the case(issue https://github.com/scylladb/scylladb/issues/16472)
The problem with this was that breaking the next test was counterintuitive, and the logging for this situation was insufficient and unobvious.

notes:  Task.cancel() is not an option to avoid task leakage
        1) Calling cancel() Does Not Cancel The Task :  the cancel() method just  request that the target task cancel.
        2) Calling cancel() Does Not Block Until The Task is Cancelled:  If the caller needs to know the task is cancelled and done, it could await for the target
        3) In particular PR, task.cancel() cancell task on client(ManagerClient) but not on http server(ScyllaManager). so "await" is needed.

