### PR TITLE
service: mark fmt::formatter<T>::format() as const

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -158,7 +158,7 @@ struct migration_candidate {
 template<>
 struct fmt::formatter<service::migration_badness> : fmt::formatter<std::string_view> {
     template <typename FormatContext>
-    auto format(const service::migration_badness& badness, FormatContext& ctx) {
+    auto format(const service::migration_badness& badness, FormatContext& ctx) const {
         return fmt::format_to(ctx.out(), "{{s: {:.4f}, n: {:.4f}}}", badness.shard_badness(), badness.node_badness());
     }
 };
@@ -166,7 +166,7 @@ struct fmt::formatter<service::migration_badness> : fmt::formatter<std::string_v
 template<>
 struct fmt::formatter<service::migration_candidate> : fmt::formatter<std::string_view> {
     template <typename FormatContext>
-    auto format(const service::migration_candidate& candidate, FormatContext& ctx) {
+    auto format(const service::migration_candidate& candidate, FormatContext& ctx) const {
         fmt::format_to(ctx.out(), "{{tablet: {}, {} -> {}, badness: {}", candidate.tablet, candidate.src,
                        candidate.dst, candidate.badness);
         if (candidate.badness.is_bad()) {


### PR DESCRIPTION
fmt 11 enforces the constness of `format()` member function, if it is not marked with `const`, the tree fails to build with fmt 11, like:

```
/usr/include/fmt/base.h:1393:23: error: no matching member function for call to 'format'
 1393 |     ctx.advance_to(cf.format(*static_cast<qualified_type*>(arg), ctx));
      |                    ~~~^~~~~~
/usr/include/fmt/base.h:1374:21: note: in instantiation of function template specialization 'fmt::detail::value<fmt::context>::format_custom_arg<service::migration_badness, fmt::formatter<service::migration_badness>>' requested here
 1374 |     custom.format = format_custom_arg<
      |                     ^
/home/kefu/dev/scylladb/service/tablet_allocator.cc:170:14: note: in instantiation of function template specialization 'fmt::format_to<fmt::basic_appender<char>, const locator::global_tablet_id &, const locator::tablet_replica &, const locator::tablet_replica &, const service::migration_badness &, 0>' requested here
  170 |         fmt::format_to(ctx.out(), "{{tablet: {}, {} -> {}, badness: {}", candidate.tablet, candidate.src,
      |              ^
/home/kefu/dev/scylladb/service/tablet_allocator.cc:161:10: note: candidate function template not viable: 'this' argument has type 'const fmt::formatter<service::migration_badness>', but method is not marked const
  161 |     auto format(const service::migration_badness& badness, FormatContext& ctx) {
      |          ^
```

so, in this change, we mark these two `format()` member functions const.

---

no need to backport, as this change addresses a FTBFS with fmt 11, which is not installed in our toolchain image yet.