### PR TITLE
tools/scylla-nodetool: do not check if rpc_server is up

### DIFF
--- a/test/nodetool/test_info.py
+++ b/test/nodetool/test_info.py
@@ -100,7 +100,8 @@ def test_info(request, nodetool, display_all_tokens):
     expected_requests = [
         expected_request('GET', '/storage_service/gossiping', response=True),
         expected_request('GET', '/storage_service/hostid/local', response=host_id),
-        expected_request('GET', '/storage_service/rpc_server', response=False),
+        # scylla does not check if rpc_server is up, it always considers it down.
+        expected_request('GET', '/storage_service/rpc_server', response=False, multiple=expected_request.ANY),
         expected_request('GET', '/storage_service/native_transport', response=True),
         expected_request('GET', '/storage_service/load', response=load),
         expected_request('GET', '/storage_service/generation_number', response=generation_number),

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -997,7 +997,8 @@ void info_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     auto gossip_running = client.get("/storage_service/gossiping").GetBool();
     fmt::print("{:<23}: {}\n", "ID", rjson::to_string_view(client.get("/storage_service/hostid/local")));
     fmt::print("{:<23}: {}\n", "Gossip active", gossip_running);
-    fmt::print("{:<23}: {}\n", "Thrift active", client.get("/storage_service/rpc_server").GetBool());
+    // thrift protocol is not supported anymore
+    fmt::print("{:<23}: {}\n", "Thrift active", false);
     fmt::print("{:<23}: {}\n", "Native Transport active", client.get("/storage_service/native_transport").GetBool());
     fmt::print("{:<23}: {}\n", "Load", file_size_printer(client.get("/storage_service/load").GetDouble()));
     if (gossip_running) {


### PR DESCRIPTION
thrift support was removed in ad649be1, the API for checking / starting / stopping rpc_server (thrift_server) was removed as well. so, the existing clients using this API would have 404 when querying it.

so in this change, let's just hardwire the result to "false" instead of querying this removed RESTful API.

the test is updated accordingly. since in new installations, we still package the java-based nodetool, which still queries this API, this API is preserved for the backward compatiblity.

Fixes scylladb/scylladb#19923
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

----

no need to backport, this is a UX issue, which surfaces when server is booting.