### PR TITLE
storage_service: avoid processing same table unnecessarily in split monitor

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5278,7 +5278,7 @@ future<> storage_service::load_tablet_metadata(const locator::tablet_metadata_ch
     }, acquire_merge_lock::no);
 }
 
-future<> storage_service::process_tablet_split_candidate(table_id table) {
+future<> storage_service::process_tablet_split_candidate(table_id table) noexcept {
     auto all_compaction_groups_split = [&] () mutable {
         return _db.map_reduce0([table_ = table] (replica::database& db) {
             auto all_split = db.find_column_family(table_).all_storage_groups_split();
@@ -5306,7 +5306,7 @@ future<> storage_service::process_tablet_split_candidate(table_id table) {
             }
 
             if (co_await all_compaction_groups_split()) {
-                slogger.info0("All compaction groups of table {} are split ready.", table);
+                slogger.debug("All compaction groups of table {} are split ready.", table);
                 release_guard(std::move(guard));
                 break;
             } else {
@@ -5340,13 +5340,17 @@ void storage_service::register_tablet_split_candidate(table_id table) noexcept {
 }
 
 future<> storage_service::run_tablet_split_monitor() {
-    while (!_async_gate.is_closed() && !_group0_as.abort_requested()) {
-        while (!_tablet_split_candidates.empty()) {
-            auto candidate = _tablet_split_candidates.front();
-            _tablet_split_candidates.pop_front();
+    auto can_proceed = [this] { return !_async_gate.is_closed() && !_group0_as.abort_requested(); };
+    while (can_proceed()) {
+        auto tablet_split_candidates = std::exchange(_tablet_split_candidates, {});
+        for (auto candidate : tablet_split_candidates) {
             co_await process_tablet_split_candidate(candidate);
         }
-        co_await _tablet_split_monitor_event.when();
+        co_await utils::clear_gently(tablet_split_candidates);
+        // Returns if there is more work to do, or shutdown was requested.
+        co_await _tablet_split_monitor_event.when([&] {
+            return _tablet_split_candidates.size() > 0 || !can_proceed();
+        });
     }
 }
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -46,6 +46,7 @@
 #include "service/topology_state_machine.hh"
 #include "service/tablet_allocator.hh"
 #include "utils/user_provided_param.hh"
+#include "utils/sequenced_set.hh"
 
 class node_ops_cmd_request;
 class node_ops_cmd_response;
@@ -173,7 +174,7 @@ private:
     gate _async_gate;
 
     condition_variable _tablet_split_monitor_event;
-    std::deque<table_id> _tablet_split_candidates;
+    utils::sequenced_set<table_id> _tablet_split_candidates;
     future<> _tablet_split_monitor = make_ready_future<>();
 
     std::unordered_map<node_ops_id, node_ops_meta_data> _node_ops;
@@ -200,7 +201,7 @@ private:
     inet_address host2ip(locator::host_id) const;
     // Handler for table load stats RPC.
     future<locator::load_stats> load_stats_for_tablet_based_tables();
-    future<> process_tablet_split_candidate(table_id);
+    future<> process_tablet_split_candidate(table_id) noexcept;
     void register_tablet_split_candidate(table_id) noexcept;
     future<> run_tablet_split_monitor();
 public:


### PR DESCRIPTION
If there's a token metadata for a given table, and it is in split mode, it will be registered such that split monitor can look at it, for example, to start split work, or do nothing if table completed it.

during topology change, e.g. drain, split is stalled since it cannot take over the state machine.
It was noticed that the log is being spammed with a message saying the table completed split work, since every tablet metadata update, means waking up the monitor on behalf of a table. So it makes sense to demote the logging level to debug. That persists until drain completes and split can finally complete.

Another thing that was noticed is that during drain, a table can be submitted for processing faster than the monitor can handle, so the candidate queue may end up with multiple duplicated entries for same table, which means unnecessary work. That is fixed by using a sequenced set, which keeps the current FIFO behavior.

Fixes #20339.

backport reason: avoids unneeded work in split monitor if split runs concurrently to topology changes. also avoids spamming the logs, in that scenario.

