### PR TITLE
major compaction: check only sstables being compacted for tombstone garbage collection

### DIFF
--- a/api/api-doc/column_family.json
+++ b/api/api-doc/column_family.json
@@ -93,6 +93,14 @@
                      "paramType":"query"
                   },
                   {
+                     "name":"consider_only_existing_data",
+                     "description":"Set to \"true\" to flush all memtables and force tombstone garbage collection to check only the sstables being compacted (false by default). The memtable, commitlog and other uncompacted sstables will not be checked during tombstone garbage collection.",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"boolean",
+                     "paramType":"query"
+                  },
+                  {
                      "name":"split_output",
                      "description":"true if the output of the major compaction should be split in several sstables",
                      "required":false,

--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -741,6 +741,14 @@
                      "allowMultiple":false,
                      "type":"boolean",
                      "paramType":"query"
+                  },
+                  {
+                     "name":"consider_only_existing_data",
+                     "description":"Set to \"true\" to flush all memtables and force tombstone garbage collection to check only the sstables being compacted (false by default). The memtable, commitlog and other uncompacted sstables will not be checked during tombstone garbage collection.",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"boolean",
+                     "paramType":"query"
                   }
                ]
             }
@@ -881,6 +889,14 @@
                   {
                      "name":"flush_memtables",
                      "description":"Controls flushing of memtables before compaction (true by default). Set to \"false\" to skip automatic flushing of memtables before compaction, e.g. when tables were flushed explicitly before invoking the compaction api.",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"boolean",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"consider_only_existing_data",
+                     "description":"Set to \"true\" to flush all memtables and force tombstone garbage collection to check only the sstables being compacted (false by default). The memtable, commitlog and other uncompacted sstables will not be checked during tombstone garbage collection.",
                      "required":false,
                      "allowMultiple":false,
                      "type":"boolean",

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -477,6 +477,8 @@ protected:
     // Garbage collected sstables that were added to SSTable set and should be eventually removed from it.
     std::vector<shared_sstable> _used_garbage_collected_sstables;
     utils::observable<> _stop_request_observable;
+    // optional tombstone_gc_state that is used when gc has to check only the compacting sstables to collect tombstones.
+    std::optional<tombstone_gc_state> _tombstone_gc_state_with_commitlog_check_disabled;
 private:
     // Keeps track of monitors for input sstable.
     // If _update_backlog_tracker is set to true, monitors are responsible for adjusting backlog as compaction progresses.
@@ -525,6 +527,7 @@ protected:
         , _owned_ranges(std::move(descriptor.owned_ranges))
         , _sharder(descriptor.sharder)
         , _owned_ranges_checker(_owned_ranges ? std::optional<dht::incremental_owned_ranges_checker>(*_owned_ranges) : std::nullopt)
+        , _tombstone_gc_state_with_commitlog_check_disabled(descriptor.gc_check_only_compacting_sstables ? std::make_optional(_table_s.get_tombstone_gc_state().with_commitlog_check_disabled()) : std::nullopt)
         , _progress_monitor(progress_monitor)
     {
         std::unordered_set<run_id> ssts_run_ids;
@@ -723,6 +726,10 @@ private:
         return _table_s.get_compaction_strategy().make_sstable_set(_schema);
     }
 
+    const tombstone_gc_state& get_tombstone_gc_state() const {
+        return _tombstone_gc_state_with_commitlog_check_disabled ? _tombstone_gc_state_with_commitlog_check_disabled.value() : _table_s.get_tombstone_gc_state();
+    }
+
     future<> setup() {
         auto ssts = make_lw_shared<sstables::sstable_set>(make_sstable_set_for_input());
         auto fully_expired = _table_s.fully_expired_sstables(_sstables, gc_clock::now());
@@ -756,7 +763,7 @@ private:
             // for a better estimate for the number of partitions in the merged
             // sstable than just adding up the lengths of individual sstables.
             _estimated_partitions += sst->get_estimated_key_count();
-            sum_of_estimated_droppable_tombstone_ratio += sst->estimate_droppable_tombstone_ratio(gc_clock::now(), _table_s.get_tombstone_gc_state(), _schema);
+            sum_of_estimated_droppable_tombstone_ratio += sst->estimate_droppable_tombstone_ratio(gc_clock::now(), get_tombstone_gc_state(), _schema);
             _compacting_data_file_size += sst->ondisk_data_size();
             _compacting_max_timestamp = std::max(_compacting_max_timestamp, sst->get_stats_metadata().max_timestamp);
             if (sst->originated_on_this_node().value_or(false) && sst_stats.position.shard_id() == this_shard_id()) {
@@ -788,7 +795,7 @@ private:
                 reader.consume_in_thread(std::move(cfc));
             });
         });
-        const auto& gc_state = _table_s.get_tombstone_gc_state();
+        const auto& gc_state = get_tombstone_gc_state();
         return consumer(make_compacting_reader(setup_sstable_reader(), compaction_time, max_purgeable_func(), gc_state));
     }
 
@@ -809,7 +816,7 @@ private:
                     using compact_mutations = compact_for_compaction_v2<compacted_fragments_writer, compacted_fragments_writer>;
                     auto cfc = compact_mutations(*schema(), now,
                         max_purgeable_func(),
-                        _table_s.get_tombstone_gc_state(),
+                        get_tombstone_gc_state(),
                         get_compacted_fragments_writer(),
                         get_gc_compacted_fragments_writer());
 
@@ -819,7 +826,7 @@ private:
                 using compact_mutations = compact_for_compaction_v2<compacted_fragments_writer, noop_compacted_fragments_consumer>;
                 auto cfc = compact_mutations(*schema(), now,
                     max_purgeable_func(),
-                    _table_s.get_tombstone_gc_state(),
+                    get_tombstone_gc_state(),
                     get_compacted_fragments_writer(),
                     noop_compacted_fragments_consumer());
                 reader.consume_in_thread(std::move(cfc));

--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -171,6 +171,16 @@ struct compaction_descriptor {
     // Denotes if this compaction task is comprised solely of completely expired SSTables
     sstables::has_only_fully_expired has_only_fully_expired = has_only_fully_expired::no;
 
+    // If set to true, gc will check only the compacting sstables to collect tombstones.
+    // If set to false, gc will check the memtables, commit log and other uncompacting
+    // sstables to decide if a tombstone can be collected. Note that these checks are
+    // not perfect. W.r.to memtables and uncompacted SSTables, if their minimum timestamp
+    // is less than that of the tombstone and they contain the key, the tombstone will
+    // not be collected. No row-level, cell-level check takes place. W.r.to the commit
+    // log, there is currently no way to check if the key exists; only the minimum
+    // timestamp comparison, similar to memtables, is performed.
+    bool gc_check_only_compacting_sstables = false;
+
     compaction_descriptor() = default;
 
     static constexpr int default_level = 0;

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -342,7 +342,7 @@ public:
     future<compaction_stats_opt> perform_sstable_scrub(compaction::table_state& t, sstables::compaction_type_options::scrub opts, tasks::task_info info);
 
     // Submit a table for major compaction.
-    future<> perform_major_compaction(compaction::table_state& t, tasks::task_info info);
+    future<> perform_major_compaction(compaction::table_state& t, tasks::task_info info, bool consider_only_existing_data = false);
 
     // Splits a compaction group by segregating all its sstable according to the classifier[1].
     // [1]: See sstables::compaction_type_options::splitting::classifier.

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -354,7 +354,7 @@ static future<bool> maybe_flush_commitlog(sharded<replica::database>& db, bool f
 future<> global_major_compaction_task_impl::run() {
     bool flushed_all_tables = false;
     if (_flush_mode == flush_mode::all_tables) {
-        flushed_all_tables = co_await maybe_flush_commitlog(_db, false);
+        flushed_all_tables = co_await maybe_flush_commitlog(_db, _consider_only_existing_data);
     }
 
     std::unordered_map<sstring, std::vector<table_info>> tables_by_keyspace;
@@ -371,7 +371,7 @@ future<> global_major_compaction_task_impl::run() {
     flush_mode fm = flushed_all_tables ? flush_mode::skip : _flush_mode;
     for (auto& [ks, table_infos] : tables_by_keyspace) {
         auto task = co_await _module->make_and_start_task<major_keyspace_compaction_task_impl>(parent_info, ks, parent_info.id, _db, table_infos, fm,
-                &cv, &current_task);
+                _consider_only_existing_data, &cv, &current_task);
         keyspace_tasks.emplace_back(std::move(task), ks, std::move(table_infos));
     }
     co_await run_keyspace_tasks(_db.local(), keyspace_tasks, cv, current_task, false);
@@ -387,14 +387,14 @@ future<> major_keyspace_compaction_task_impl::run() {
 
     bool flushed_all_tables = false;
     if (_flush_mode == flush_mode::all_tables) {
-        flushed_all_tables = co_await maybe_flush_commitlog(_db, false);
+        flushed_all_tables = co_await maybe_flush_commitlog(_db, _consider_only_existing_data);
     }
 
     flush_mode fm = flushed_all_tables ? flush_mode::skip : _flush_mode;
     co_await _db.invoke_on_all([&] (replica::database& db) -> future<> {
         tasks::task_info parent_info{_status.id, _status.shard};
         auto& module = db.get_compaction_manager().get_task_manager_module();
-        auto task = co_await module.make_and_start_task<shard_major_keyspace_compaction_task_impl>(parent_info, _status.keyspace, _status.id, db, _table_infos, fm);
+        auto task = co_await module.make_and_start_task<shard_major_keyspace_compaction_task_impl>(parent_info, _status.keyspace, _status.id, db, _table_infos, fm, _consider_only_existing_data);
         co_await task->done();
     });
 }
@@ -405,7 +405,7 @@ future<> shard_major_keyspace_compaction_task_impl::run() {
     tasks::task_info parent_info{_status.id, _status.shard};
     std::vector<table_tasks_info> table_tasks;
     for (auto& ti : _local_tables) {
-        table_tasks.emplace_back(co_await _module->make_and_start_task<table_major_keyspace_compaction_task_impl>(parent_info, _status.keyspace, ti.name, _status.id, _db, ti, cv, current_task, _flush_mode), ti);
+        table_tasks.emplace_back(co_await _module->make_and_start_task<table_major_keyspace_compaction_task_impl>(parent_info, _status.keyspace, ti.name, _status.id, _db, ti, cv, current_task, _flush_mode, _consider_only_existing_data), ti);
     }
 
     co_await run_table_tasks(_db, std::move(table_tasks), cv, current_task, true);
@@ -415,8 +415,8 @@ future<> table_major_keyspace_compaction_task_impl::run() {
     co_await wait_for_your_turn(_cv, _current_task, _status.id);
     tasks::task_info info{_status.id, _status.shard};
     replica::table::do_flush do_flush(_flush_mode != flush_mode::skip);
-    co_await run_on_table("force_keyspace_compaction", _db, _status.keyspace, _ti, [info, do_flush] (replica::table& t) {
-        return t.compact_all_sstables(info, do_flush);
+    co_await run_on_table("force_keyspace_compaction", _db, _status.keyspace, _ti, [info, do_flush, consider_only_existing_data = _consider_only_existing_data] (replica::table& t) {
+        return t.compact_all_sstables(info, do_flush, consider_only_existing_data);
     });
 }
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -928,7 +928,7 @@ public:
     // Start a compaction of all sstables in a process known as major compaction
     // Active memtable is flushed first to guarantee that data like tombstone,
     // sitting in the memtable, will be compacted with shadowed data.
-    future<> compact_all_sstables(tasks::task_info info, do_flush = do_flush::yes);
+    future<> compact_all_sstables(tasks::task_info info, do_flush = do_flush::yes, bool consider_only_existing_data = false);
 
     future<bool> snapshot_exists(sstring name);
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1802,6 +1802,8 @@ public:
     // Note: force_new_active_segment in the commitlog, so that
     // flushing all tables will allow reclaiming of all commitlog segments
     future<> flush_all_tables();
+    // a wrapper around flush_all_tables, allowing the caller to express intent more clearly
+    future<> flush_commitlog() { return flush_all_tables(); }
 
     static future<db_clock::time_point> get_all_tables_flushed_at(sharded<database>& sharded_db);
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1864,15 +1864,15 @@ compaction_group::update_main_sstable_list_on_compaction_completion(sstables::co
 }
 
 future<>
-table::compact_all_sstables(tasks::task_info info, do_flush do_flush) {
+table::compact_all_sstables(tasks::task_info info, do_flush do_flush, bool consider_only_existing_data) {
     if (do_flush) {
         co_await flush();
     }
     // Forces off-strategy before major, so sstables previously sitting on maintenance set will be included
     // in the compaction's input set, to provide same semantics as before maintenance set came into existence.
     co_await perform_offstrategy_compaction(info);
-    co_await parallel_foreach_compaction_group([this, info] (compaction_group& cg) {
-        return _compaction_manager.perform_major_compaction(cg.as_table_state(), info);
+    co_await parallel_foreach_compaction_group([this, info, consider_only_existing_data] (compaction_group& cg) {
+        return _compaction_manager.perform_major_compaction(cg.as_table_state(), info, consider_only_existing_data);
     });
 }
 

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -349,10 +349,12 @@ class ScyllaRESTAPIClient():
             url += f"?cf={table}"
         await self.client.post(url, host=node_ip)
 
-    async def keyspace_compaction(self, node_ip: str, keyspace: str, table: Optional[str] = None) -> None:
+    async def keyspace_compaction(self, node_ip: str, keyspace: str, table: Optional[str] = None, consider_only_existing_data: bool = False) -> None:
         """Compact the specified or all tables in the keyspace"""
         url = f"/storage_service/keyspace_compaction/{keyspace}"
-        params = {}
+        params = {
+            "consider_only_existing_data": str(consider_only_existing_data),
+        }
         if table is not None:
             params["cf"] = table
         await self.client.post(url, host=node_ip, params=params)

--- a/test/topology_custom/test_major_compaction.py
+++ b/test/topology_custom/test_major_compaction.py
@@ -1,0 +1,88 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import pytest
+import logging
+import asyncio
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.rest_client import inject_error_one_shot
+from test.topology.conftest import skip_mode
+
+logger = logging.getLogger(__name__)
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("consider_only_existing_data", [True, False])
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_major_compaction_consider_only_existing_data(manager: ManagerClient, consider_only_existing_data):
+    """
+    Test compactions drop tombstones when consider_only_existing_data is enabled.
+    1. Create a single node cluster.
+    2. Write some keys and then delete a few to create tombstones.
+    3. Start major compaction with consider_only_existing_data=true but make it wait
+        through error injection right after it has collected the sstables for compaction.
+    4. Insert the deleted keys with backdated data into memtables and flush one
+        of them into a new sstable that will not be a part of the compaction.
+    5. Resume the major compaction and let it complete.
+    6. Verify the results.
+       - If consider_only_existing_data is False, the tombstones should not be purged and the backdated rows should not be visible
+       - If consider_only_existing_data is True, the tombstones should be purged and the backdated rows should be visible
+    """
+    logger.info("Bootstrapping cluster")
+    server = (await manager.servers_add(1))[0]
+
+    logger.info("Creating table")
+    ks = "test_consider_only_existing_data"
+    cf = "t1"
+    cql = manager.get_cql()
+    await cql.run_async(f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}")
+    await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY) WITH tombstone_gc = {{'mode': 'immediate'}}")
+
+    logger.info("Disabling autocompaction across keyspaces")
+    await manager.api.disable_autocompaction(server.ip_addr, ks)
+    await manager.api.disable_autocompaction(server.ip_addr, "system")
+    await manager.api.disable_autocompaction(server.ip_addr, "system_schema")
+
+    logger.info("Populating table")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.{cf} (pk) VALUES ({k});") for k in range(20)])
+    await asyncio.gather(*[cql.run_async(f"DELETE FROM {ks}.{cf} WHERE pk = {k};") for k in range(10)])
+    await manager.api.keyspace_flush(server.ip_addr, ks, cf)
+
+    # let a second pass, so that the tombstones are eligible for gc
+    await asyncio.sleep(1)
+
+    # error injection to make compaction wait after collecting sstables
+    injection = "major_compaction_wait"
+    injection_handler = await inject_error_one_shot(manager.api, server.ip_addr, injection)
+
+    logger.info("Start major compaction")
+    log = await manager.server_open_log(server.server_id)
+    mark = await log.mark()
+    compaction_task = asyncio.create_task(manager.api.keyspace_compaction(server.ip_addr, ks, cf, consider_only_existing_data=consider_only_existing_data))
+    # wait for the injection to pause the compaction
+    await log.wait_for("major_compaction_wait: waiting", from_mark=mark, timeout=30)
+
+    # insert new backdated rows with deleted keys and flush them
+    # into a new sstable that will not be part of the major compaction
+    logger.info("Insert backdated data into the table")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.{cf} (pk) VALUES ({k}) USING TIMESTAMP 1;") for k in range(5)])
+    await manager.api.keyspace_flush(server.ip_addr, ks, cf)
+
+    # insert few more rows with deleted keys with backdated data into memtable
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.{cf} (pk) VALUES ({k}) USING TIMESTAMP 1;") for k in range(5, 10)])
+
+    # resume compaction
+    await injection_handler.message()
+    await compaction_task
+
+    # evict cache to make backdated data visible for consider_only_existing_data mode
+    if consider_only_existing_data:
+        await manager.api.drop_sstable_caches(server.ip_addr)
+
+    logger.info("Verify major compaction results")
+    expected_count = 1 if consider_only_existing_data else 0
+    for k in range(10):
+        assert len(await cql.run_async(f"SELECT * FROM {ks}.{cf} WHERE pk = {k}")) == expected_count

--- a/tombstone_gc.hh
+++ b/tombstone_gc.hh
@@ -69,6 +69,9 @@ public:
     gc_clock::time_point get_gc_before_for_key(schema_ptr s, const dht::decorated_key& dk, const gc_clock::time_point& query_time) const;
 
     void update_repair_time(table_id id, const dht::token_range& range, gc_clock::time_point repair_time);
+
+    // returns a tombstone_gc_state copy with the commitlog check disabled (i.e.) without _gc_min_source.
+    tombstone_gc_state with_commitlog_check_disabled() const { return tombstone_gc_state(_repair_history_maps); }
 };
 
 std::map<sstring, sstring> get_default_tombstonesonte_gc_mode(data_dictionary::database db, sstring ks_name);

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -482,6 +482,10 @@ void compact_operation(scylla_rest_client& client, const bpo::variables_map& vm)
         params["flush_memtables"] = vm["flush-memtables"].as<bool>() ? "true" : "false";
     }
 
+    if (vm.contains("consider-only-existing-data")) {
+        params["consider_only_existing_data"] = vm["consider-only-existing-data"].as<bool>() ? "true" : "false";
+    }
+
     if (vm.contains("compaction_arg")) {
         const auto [keyspace, tables] = parse_keyspace_and_tables(client, vm, "compaction_arg");
         if (!tables.empty()) {
@@ -3324,6 +3328,7 @@ For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/compact.html")),
                 {
                     typed_option<bool>("flush-memtables", "Control flushing of tables before major compaction (true by default)"),
+                    typed_option<bool>("consider-only-existing-data", "Check only the SSTables being compacted to garbage collect the tombstones and do not check memtables, commit log and other uncompacting SSTables (false by default). Enabling this will also force flush all memtables before starting major compaction."),
 
                     typed_option<>("split-output,s", "Don't create a single big file (unused)"),
                     typed_option<>("user-defined", "Submit listed SStable files for user-defined compaction (unused)"),


### PR DESCRIPTION
Any expired tombstone can be garbage collected if it doesn't shadow data in the commit log, memtable, or uncompacting SSTables.

This PR introduces a new mode to major compaction, enabled by the `consider_only_existing_data` flag that bypasses these checks. When enabled, memtables and old commitlog segments are cleared with a system-wide flush and all the sstables (after flush) are included in the compaction, so that it works with all data generated up to a given time point.

This new mode works with the assumption that newly written data will not be shadowed by expired tombstones. So it ignores new sstables (and new data written to memtable) created after compaction started. Since there was a system wide flush, commitlog checks can also be skipped when garbage collecting tombstones. Introducing data shadowed by a tombstone during compaction can lead to undefined behavior, even without this PR, as the tombstone may or may not have already been garbage collected.

Fixes #19728