### PR TITLE
doc: set 6.1 as the latest stable version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,9 +18,9 @@ BASE_URL = 'https://opensource.docs.scylladb.com'
 TAGS = []
 BRANCHES = ["master", "branch-5.1", "branch-5.2", "branch-5.4", "branch-6.0", "branch-6.1"]
 # Set the latest version. 
-LATEST_VERSION = "branch-6.0"
+LATEST_VERSION = "branch-6.1"
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = ["master", "branch-6.1"]
+UNSTABLE_VERSIONS = ["master"]
 # Set which versions are deprecated.
 DEPRECATED_VERSIONS = [""]
 


### PR DESCRIPTION
This PR  updates the configuration for ScyllaDB documentation so that:
- 6.1 is the latest version.
- 6.1 is removed from the list of unstable versions.

It must be merged when ScyllaDB 6.1 is released.

Fixes https://github.com/scylladb/scylladb/issues/20141

No backport is required.

