### PR TITLE
compaction: change compaction stop reason 

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -2132,7 +2132,7 @@ void compaction_manager::add(table_state& t) {
     }
 }
 
-future<> compaction_manager::remove(table_state& t) noexcept {
+future<> compaction_manager::remove(table_state& t, sstring reason) noexcept {
     auto& c_state = get_compaction_state(&t);
     auto erase_state = defer([&t, &c_state, this] () noexcept {
        c_state.backlog_tracker->disable();
@@ -2148,7 +2148,7 @@ future<> compaction_manager::remove(table_state& t) noexcept {
     // and prevent new tasks from entering the gate.
     if (!c_state.gate.is_closed()) {
         auto close_gate = c_state.gate.close();
-        co_await stop_ongoing_compactions("table removal", &t);
+        co_await stop_ongoing_compactions(reason, &t);
         co_await std::move(close_gate);
     }
 

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -397,7 +397,7 @@ public:
 
     // Remove a table from the compaction manager.
     // Cancel requests on table and wait for possible ongoing compactions.
-    future<> remove(compaction::table_state& t) noexcept;
+    future<> remove(compaction::table_state& t, sstring reason = "table removal") noexcept;
 
     const stats& get_stats() const {
         return _stats;

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -92,7 +92,7 @@ public:
 
     // Stops all activity in the group, synchronizes with in-flight writes, before
     // flushing memtable(s), so all data can be found in the SSTable set.
-    future<> stop() noexcept;
+    future<> stop(sstring reason) noexcept;
 
     bool empty() const noexcept;
 
@@ -239,7 +239,7 @@ public:
     // Returns true when all compacted sstables were already deleted.
     bool no_compacted_sstable_undeleted() const;
 
-    future<> stop() noexcept;
+    future<> stop(sstring reason = "table removal") noexcept;
 };
 
 using storage_group_ptr = lw_shared_ptr<storage_group>;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -592,7 +592,7 @@ const storage_group_map& storage_group_manager::storage_groups() const {
 }
 
 future<> storage_group_manager::stop_storage_groups() noexcept {
-    return parallel_for_each(_storage_groups | boost::adaptors::map_values, std::mem_fn(&storage_group::stop));
+    return parallel_for_each(_storage_groups | boost::adaptors::map_values, [] (auto sg) { return sg->stop("table removal"); });
 }
 
 void storage_group_manager::remove_storage_group(size_t id) {
@@ -2209,14 +2209,14 @@ compaction_group::compaction_group(table& t, size_t group_id, dht::token_range t
 
 compaction_group::~compaction_group() = default;
 
-future<> compaction_group::stop() noexcept {
+future<> compaction_group::stop(sstring reason) noexcept {
     if (_async_gate.is_closed()) {
         co_return;
     }
     auto closed_gate_fut = _async_gate.close();
 
     auto flush_future = co_await seastar::coroutine::as_future(flush());
-    co_await _t._compaction_manager.remove(as_table_state());
+    co_await _t._compaction_manager.remove(as_table_state(), reason);
 
     if (flush_future.failed()) {
         co_await seastar::coroutine::return_exception_ptr(flush_future.get_exception());
@@ -2315,7 +2315,7 @@ future<> tablet_storage_group_manager::handle_tablet_split_completion(const loca
         }
         // Remove old main groups, they're unused, but they need to be deregistered properly
         auto cg_ptr = sg->main_compaction_group();
-        auto f = cg_ptr->stop();
+        auto f = cg_ptr->stop("tablet split");
         if (!f.available() || f.failed()) [[unlikely]] {
             stop_fut = stop_fut.then([f = std::move(f), cg_ptr = std::move(cg_ptr)] () mutable {
                 return std::move(f).handle_exception([cg_ptr = std::move(cg_ptr)] (std::exception_ptr ex) {
@@ -3646,7 +3646,7 @@ future<> table::clear_inactive_reads_for_tablet(database& db, storage_group& sg)
     }
 }
 
-future<> storage_group::stop() noexcept {
+future<> storage_group::stop(sstring reason) noexcept {
     if (_async_gate.is_closed()) {
         co_return;
     }
@@ -3661,15 +3661,15 @@ future<> storage_group::stop() noexcept {
     // and output will be written to left and right groups. If either left or right are stopped before
     // main, split completion will add sstable to a closed group, and that might in turn trigger an
     // exception while running under row_cache::external_updater::execute, resulting in node crash.
-    co_await _main_cg->stop();
-    co_await coroutine::parallel_for_each(_split_ready_groups, [] (const compaction_group_ptr& cg_ptr) {
-        return cg_ptr->stop();
+    co_await _main_cg->stop(reason);
+    co_await coroutine::parallel_for_each(_split_ready_groups, [&reason] (const compaction_group_ptr& cg_ptr) {
+        return cg_ptr->stop(reason);
     });
     co_await std::move(closed_gate_fut);
 }
 
 future<> table::stop_compaction_groups(storage_group& sg) {
-    return sg.stop();
+    return sg.stop("tablet cleanup");
 }
 
 future<> table::flush_compaction_groups(storage_group& sg) {

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -902,7 +902,7 @@ async def test_concurrent_tablet_migration_and_major(manager: ManagerClient, inj
 
     if injection_error == "major_compaction_wait":
         logger.info("Check that major was successfully aborted on migration")
-        await s1_log.wait_for(f"Compaction for test/test was stopped due to: table removal", from_mark=s1_mark)
+        await s1_log.wait_for("Compaction for test/test was stopped due to: tablet cleanup", from_mark=s1_mark)
 
     await check()
 


### PR DESCRIPTION
Currently "table removal" is logged as a reason of compaction stop for table drop, 
tablet cleanup and tablet split. Modify log to reflect the reason.