### PR TITLE
Update SELECT grammar to define group_by_clause explicitly

### DIFF
--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -25,6 +25,7 @@ Querying data from data is done using a ``SELECT`` statement:
            : | `function_name` '(' [ `selector` ( ',' `selector` )* ] ')'
            : | COUNT '(' '*' ')'
    where_clause: `relation` ( AND `relation` )*
+   group_by_clause: `column_name` (',' `column_name` )*
    relation: `column_name` `operator` `term`
            : '(' `column_name` ( ',' `column_name` )* ')' `operator` `tuple_literal`
            : TOKEN '(' `column_name` ( ',' `column_name` )* ')' `operator` `term`


### PR DESCRIPTION
This PR addresses [this issue](https://github.com/scylladb/scylladb/issues/20045) (which I just opened), fixing the lack of `group_by_clause` definition in the `SELECT` documentation.

This update should match the plain english description and example in the [grouping results ](https://opensource.docs.scylladb.com/stable/cql/dml/select.html#grouping-results) section of these docs.

