### PR TITLE
distributed_loader: Remove load_prio_keyspaces

### DIFF
--- a/db/extensions.cc
+++ b/db/extensions.cc
@@ -59,14 +59,8 @@ void db::extensions::add_extension_internal_keyspace(std::string ks) {
     _extension_internal_keyspaces.emplace(std::move(ks));
 }
 
-// TODO: remove once this is backmerged to ent once, and relevant code is updated.
-extern bool is_load_prio_keyspace(std::string_view name);
-
 bool db::extensions::is_extension_internal_keyspace(const std::string& ks) const {
     if (_extension_internal_keyspaces.count(ks)) {
-        return true;
-    }
-    if (::is_load_prio_keyspace(ks)) {
         return true;
     }
     return false;

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -78,17 +78,6 @@ public:
     static future<> init_system_keyspace(sharded<db::system_keyspace>&, distributed<locator::effective_replication_map_factory>&, distributed<replica::database>&);
     static future<> init_non_system_keyspaces(distributed<replica::database>& db, distributed<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks);
 
-    /**
-     * Marks a keyspace (by name) as "prioritized" on bootstrap.
-     * This will effectively let it bypass concurrency control.
-     * The only real use for this is to avoid certain chicken and
-     * egg issues.
-     *
-     * May only be called pre-bootstrap on main shard.
-     * Required for enterprise. Do _not_ remove.
-     */
-    static void mark_keyspace_as_load_prio(const sstring&);
-
     // Scan sstables under upload directory. Return a vector with smp::count entries.
     // Each entry with index of idx should be accessed on shard idx only.
     // Each entry contains a vector of sstables for this shard.


### PR DESCRIPTION
Fixes #13334

All required code paths (see enterprise) now uses
extensions::is_extension_internal_keyspace.
The old mechanism can be removed. One less global var.
