### PR TITLE
utils/div_ceil: sanity check to abort when integer overflow

### DIFF
--- a/utils/div_ceil.hh
+++ b/utils/div_ceil.hh
@@ -9,8 +9,18 @@
 #pragma once
 
 #include <concepts>
+#include <limits>
+#include "utils/assert.hh"
 
+template <std::integral Divdend, std::integral Divisor>
 inline auto
-div_ceil(std::integral auto dividend, std::integral auto divisor) {
-    return (dividend + divisor - 1) / divisor;
+div_ceil(Divdend dividend, Divisor divisor) {
+    SCYLLA_ASSERT(dividend >= 0);
+    SCYLLA_ASSERT(divisor > 0);
+    Divisor max_remainder = divisor - 1;
+    using common_t = std::common_type_t<Divdend, Divisor>;
+    // check for overflow in (dividend + divisor - 1)
+    SCYLLA_ASSERT(static_cast<common_t>(dividend) <=
+                  std::numeric_limits<common_t>::max() - max_remainder);
+    return (dividend + max_remainder) / divisor;
 }


### PR DESCRIPTION
integer overflow can occur when adding or subtracting two integers, particularly when the result exceeeds the maximum or the minimum value that can be represented by the integer data type of the result. so, in this change, we check and abort the application if we run into such integer overflow.

Refs #20000
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

no nee to check, it's just a safe-belt of the correctness of the application so that we fail hard if we really have integer overflow at runtime.