### PR TITLE
gms/feature_service: allow to suppress features

### DIFF
--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -15,6 +15,7 @@
 #include <unordered_map>
 #include <functional>
 #include <set>
+#include <unordered_set>
 #include "seastarx.hh"
 #include "db/schema_features.hh"
 #include "gms/feature.hh"
@@ -63,10 +64,14 @@ class feature_service final : public peering_sharded_service<feature_service> {
     void unregister_feature(feature& f);
     friend class feature;
     std::unordered_map<sstring, std::reference_wrapper<feature>> _registered_features;
+    std::unordered_set<sstring> _suppressed_features;
 
     feature_config _config;
 
     future<> enable_features_on_startup(db::system_keyspace&);
+#ifdef SCYLLA_ENABLE_ERROR_INJECTION
+    void initialize_suppressed_features_set();
+#endif
 public:
     explicit feature_service(feature_config cfg);
     ~feature_service() = default;

--- a/test/topology_custom/test_deprecating_cluster_features.py
+++ b/test/topology_custom/test_deprecating_cluster_features.py
@@ -7,11 +7,13 @@ import asyncio
 import time
 
 from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for_cql_and_get_hosts
 import pytest
 
 
 TEST_FEATURE_ENABLE_ERROR_INJECTION = "features_enable_test_feature"
 TEST_FEATURE_ENABLE_AS_DEPRECATED_ERROR_INJECTION = "features_enable_test_feature_as_deprecated"
+SUPPRESS_FEATURES = "suppress_features"
 ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY = "error_injections_at_startup"
 
 
@@ -35,3 +37,42 @@ async def test_feature_deprecation_works(manager: ManagerClient) -> None:
     await manager.server_start(srv.server_id)
 
     # The node should restart successfully
+
+async def check_features_status(cql, features, enabled):
+    scylla_local_features = await cql.run_async("select value from system.scylla_local where key='enabled_features'")
+    topology_features = await cql.run_async("select enabled_features, supported_features from system.topology")
+
+    check_feature = lambda v, f: (f in v) == enabled
+
+    for feature in features:
+        assert check_feature(scylla_local_features[0].value, feature)
+        assert check_feature(topology_features[0].enabled_features, feature)
+        assert check_feature(topology_features[0].supported_features, feature)
+
+
+@pytest.mark.asyncio
+async def test_features_suppress_works(manager: ManagerClient, mode) -> None:
+    """ `suppress_features` error injection allows to revoke support for
+        specified cluster features. It can be used to simulate upgrade process.
+    """
+    if mode == "release":
+        return
+
+    features_to_suppress = ["PARALLELIZED_AGGREGATION", "UDA_NATIVE_PARALLELIZED_AGGREGATION"]
+
+    srv = await manager.server_add(config={
+        ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY: [
+            {
+                'name': SUPPRESS_FEATURES,
+                'value': ";".join(features_to_suppress)
+            }
+        ]
+    })
+    await manager.server_start(srv.server_id)
+    await check_features_status(manager.get_cql(), features_to_suppress, False)
+
+    await manager.server_stop_gracefully(srv.server_id)
+    await manager.server_update_config(srv.server_id, ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY, [])
+    await manager.server_start(srv.server_id)
+    await wait_for_cql_and_get_hosts(manager.get_cql(), [srv], time.time() + 60)
+    await check_features_status(manager.get_cql(), features_to_suppress, True)


### PR DESCRIPTION
This patch adds `suppress_features` error injection. It allows to revoke support for some features and it can be used to simulate upgrade process in test.py.

Features to suppress are passed as injection's value, separated by `;`. Example: `PARALLELIZED_AGGREGATION;UDA_NATIVE_PARALLELIZED_AGGREGATION`

Fixes scylladb/scylladb#20034