### PR TITLE
Alternator store ProvisionedThroughput

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -58,6 +58,10 @@ using namespace std::chrono_literals;
 logging::logger elogger("alternator-executor");
 
 namespace alternator {
+// We write the provisioned read and write capacity on a table using the
+// tags RCU_TAG_KEY and WCU_TAG_KEY.
+static const sstring RCU_TAG_KEY("system:provisioned_rcu");
+static const sstring WCU_TAG_KEY("system:provisioned_wcu");
 
 enum class table_status {
     active = 0,
@@ -446,6 +450,8 @@ static rjson::value generate_arn_for_index(const schema& schema, std::string_vie
 static rjson::value fill_table_description(schema_ptr schema, table_status tbl_status, service::storage_proxy const& proxy)
 {
     rjson::value table_description = rjson::empty_object();
+    auto tags_ptr = db::get_tags_of_table(schema);
+
     rjson::add(table_description, "TableName", rjson::from_string(schema->cf_name()));
     // FIXME: take the tables creation time, not the current time!
     size_t creation_date_seconds = std::chrono::duration_cast<std::chrono::seconds>(gc_clock::now().time_since_epoch()).count();
@@ -458,16 +464,35 @@ static rjson::value fill_table_description(schema_ptr schema, table_status tbl_s
     rjson::add(table_description, "TableStatus", rjson::from_string(table_status_to_sstring(tbl_status)));
     rjson::add(table_description, "TableArn", generate_arn_for_table(*schema));
     rjson::add(table_description, "TableId", rjson::from_string(schema->id().to_sstring()));
-    // FIXME: Instead of hardcoding, we should take into account which mode was chosen
-    // when the table was created. But, Spark jobs expect something to be returned
-    // and PAY_PER_REQUEST seems closer to reality than PROVISIONED.
     rjson::add(table_description, "BillingModeSummary", rjson::empty_object());
-    rjson::add(table_description["BillingModeSummary"], "BillingMode", "PAY_PER_REQUEST");
     rjson::add(table_description["BillingModeSummary"], "LastUpdateToPayPerRequestDateTime", rjson::value(creation_date_seconds));
     // In PAY_PER_REQUEST billing mode, provisioned capacity should return 0
+    int rcu = 0;
+    int wcu = 0;
+    bool is_pay_per_request = true;
+
+    if (tags_ptr) {
+        auto rcu_tag = tags_ptr->find(RCU_TAG_KEY);
+        auto wcu_tag = tags_ptr->find(WCU_TAG_KEY);
+        if (rcu_tag != tags_ptr->end() && wcu_tag != tags_ptr->end()) {
+            try {
+                rcu = std::stoi(rcu_tag->second);
+                wcu = std::stoi(wcu_tag->second);
+                is_pay_per_request = false;
+            } catch (...) {
+                rcu = 0;
+                wcu = 0;
+            }
+        }
+    }
+    if (is_pay_per_request) {
+        rjson::add(table_description["BillingModeSummary"], "BillingMode", "PAY_PER_REQUEST");
+    } else {
+        rjson::add(table_description["BillingModeSummary"], "BillingMode", "PROVISIONED");
+    }
     rjson::add(table_description, "ProvisionedThroughput", rjson::empty_object());
-    rjson::add(table_description["ProvisionedThroughput"], "ReadCapacityUnits", 0);
-    rjson::add(table_description["ProvisionedThroughput"], "WriteCapacityUnits", 0);
+    rjson::add(table_description["ProvisionedThroughput"], "ReadCapacityUnits", rcu);
+    rjson::add(table_description["ProvisionedThroughput"], "WriteCapacityUnits", wcu);
     rjson::add(table_description["ProvisionedThroughput"], "NumberOfDecreasesToday", 0);
 
    
@@ -957,8 +982,14 @@ future<executor::request_return_type> executor::list_tags_of_resource(client_sta
     return make_ready_future<executor::request_return_type>(make_jsonable(std::move(ret)));
 }
 
-static void verify_billing_mode(const rjson::value& request) {
-        // Alternator does not yet support billing or throughput limitations, but
+struct billing_mode_type {
+    bool provisioned = false;
+    int rcu;
+    int wcu;
+};
+
+static billing_mode_type verify_billing_mode(const rjson::value& request) {
+    // Alternator does not yet support billing or throughput limitations, but
     // let's verify that BillingMode is at least legal.
     std::string billing_mode = get_string_attribute(request, "BillingMode", "PROVISIONED");
     if (billing_mode == "PAY_PER_REQUEST") {
@@ -966,12 +997,24 @@ static void verify_billing_mode(const rjson::value& request) {
             throw api_error::validation("When BillingMode=PAY_PER_REQUEST, ProvisionedThroughput cannot be specified.");
         }
     } else if (billing_mode == "PROVISIONED") {
-        if (!rjson::find(request, "ProvisionedThroughput")) {
+        const rjson::value *provisioned_throughput = rjson::find(request, "ProvisionedThroughput");
+        if (!provisioned_throughput) {
             throw api_error::validation("When BillingMode=PROVISIONED, ProvisionedThroughput must be specified.");
         }
+        const rjson::value& throughput = *provisioned_throughput;
+        auto rcu = get_int_attribute(throughput, "ReadCapacityUnits");
+        auto wcu = get_int_attribute(throughput, "WriteCapacityUnits");
+        if (!rcu.has_value()) {
+            throw api_error::validation("provisionedThroughput.readCapacityUnits is missing, when BillingMode=PROVISIONED, ProvisionedThroughput must be specified.");
+        }
+        if (!wcu.has_value()) {
+            throw api_error::validation("provisionedThroughput.writeCapacityUnits is missing, when BillingMode=PROVISIONED, ProvisionedThroughput must be specified.");
+        }
+        return billing_mode_type{true, *rcu, *wcu};
     } else {
         throw api_error::validation("Unknown BillingMode={}. Must be PAY_PER_REQUEST or PROVISIONED.");
     }
+    return billing_mode_type();
 }
 
 // Validate that a AttributeDefinitions parameter in CreateTable is valid, and
@@ -1033,7 +1076,7 @@ static future<executor::request_return_type> create_table_on_shard0(service::cli
     }
     builder.with_column(bytes(executor::ATTRS_COLUMN_NAME), attrs_type(), column_kind::regular_column);
 
-    verify_billing_mode(request);
+    billing_mode_type bm = verify_billing_mode(request);
 
     schema_ptr partial_schema = builder.build();
 
@@ -1193,6 +1236,10 @@ static future<executor::request_return_type> create_table_on_shard0(service::cli
     std::map<sstring, sstring> tags_map;
     if (tags && tags->IsArray()) {
         update_tags_map(*tags, tags_map, update_tags_action::add_tags);
+    }
+    if (bm.provisioned) {
+        tags_map[RCU_TAG_KEY] = std::to_string(bm.rcu);
+        tags_map[WCU_TAG_KEY] = std::to_string(bm.wcu);
     }
     builder.add_extension(db::tags_extension::NAME, ::make_shared<db::tags_extension>(tags_map));
 

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -16,9 +16,9 @@ provision that - Scylla requires you to provision your cluster. You need
 to reason about the number and size of your nodes - not the throughput.
 
 When creating a table, the BillingMode and ProvisionedThroughput options
-are ignored by Scylla. Tables default to a Billing mode of `PAY_PER_REQUEST`
-and `DescribeTable` API calls will return a value of 0 for the RCUs, WCUs
-and NumberOfDecreasesToday within the response.
+are ignored by Scylla. Tables default to a Billing mode of `PAY_PER_REQUEST`.
+`DescribeTable` API calls will return the provisioned value of the RCUs, WCUs
+but the NumberOfDecreasesToday will be zero within the response.
 
 ## Scan ordering
 

--- a/test/alternator/test_provisioned_throughput.py
+++ b/test/alternator/test_provisioned_throughput.py
@@ -1,0 +1,66 @@
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Test for ProvisionedThroughput
+# ProvisionedThroughput is part of a table definition
+# The following tests make sure we can get, set and update its value
+
+import pytest
+from botocore.exceptions import ClientError
+from decimal import Decimal
+from test.alternator.util import random_string, random_bytes, new_test_table
+
+# When creating a table with PROVISIONED billing mode, ProvisionedThroughput must be explicitly set,
+# and the same values should be reflected when the table is described.
+def test_create_table(dynamodb):
+    KeySchema=[ { 'AttributeName': 'p123', 'KeyType': 'HASH' },
+                    { 'AttributeName': 'c4567', 'KeyType': 'RANGE' }
+        ]
+    AttributeDefinitions=[
+                { 'AttributeName': 'p123', 'AttributeType': 'S' },
+                { 'AttributeName': 'c4567', 'AttributeType': 'S' },
+    ]
+
+    ProvisionedThroughput={
+        'ReadCapacityUnits': 2,
+        'WriteCapacityUnits': 3
+    }
+    with new_test_table(dynamodb,
+                        KeySchema=KeySchema,
+        AttributeDefinitions=AttributeDefinitions,
+        BillingMode='PROVISIONED',
+        ProvisionedThroughput=ProvisionedThroughput) as table:
+        got = table.meta.client.describe_table(TableName=table.name)['Table']
+        if 'BillingModeSummary' in got:
+            # PROVISIONED BillingMode is the default and can be omitted, only check if it's present
+            assert got['BillingModeSummary']['BillingMode'] == 'PROVISIONED'
+        assert got['ProvisionedThroughput']['ReadCapacityUnits'] == ProvisionedThroughput['ReadCapacityUnits']
+        assert got['ProvisionedThroughput']['WriteCapacityUnits'] == ProvisionedThroughput['WriteCapacityUnits']
+
+# When creating a table with PROVISIONED billing mode, ProvisionedThroughput must be explicitly set,
+# and both Read and Write capacity should be present.
+def test_create_table_missing_units(dynamodb):
+    KeySchema=[ { 'AttributeName': 'p123', 'KeyType': 'HASH' },
+                    { 'AttributeName': 'c4567', 'KeyType': 'RANGE' }
+        ]
+    AttributeDefinitions=[
+                { 'AttributeName': 'p123', 'AttributeType': 'S' },
+                { 'AttributeName': 'c4567', 'AttributeType': 'S' },
+    ]
+    for ProvisionedThroughput in [{'WriteCapacityUnits': 1}, {'ReadCapacityUnits': 5}]:
+        with pytest.raises(ClientError, match='ValidationException.*provisionedThroughput.*CapacityUnits.*'):
+            with new_test_table(dynamodb,
+                                KeySchema=KeySchema,
+                AttributeDefinitions=AttributeDefinitions,
+                BillingMode='PROVISIONED',
+                ProvisionedThroughput=ProvisionedThroughput):
+                    table.meta.client.describe_table(TableName=table.name)
+
+# When creating a table with PAY_PER_REQUEST billing mode, RCU and WCU should be zero
+def test_create_pay_per_request_units(test_table):
+    got = test_table.meta.client.describe_table(TableName=test_table.name)['Table']
+    assert got['BillingModeSummary']['BillingMode'] == 'PAY_PER_REQUEST'
+    assert got['ProvisionedThroughput']['ReadCapacityUnits'] == 0
+    assert got['ProvisionedThroughput']['WriteCapacityUnits'] == 0
+

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -136,9 +136,14 @@ unique_table_name.last_ms = 0
 
 def create_test_table(dynamodb, **kwargs):
     name = unique_table_name()
+    BillingMode = 'PAY_PER_REQUEST'
+    if 'BillingMode' in kwargs:
+        BillingMode = kwargs['BillingMode']
+        del kwargs['BillingMode']
+
     print("fixture creating new table {}".format(name))
     table = dynamodb.create_table(TableName=name,
-        BillingMode='PAY_PER_REQUEST', **kwargs)
+        BillingMode=BillingMode, **kwargs)
     waiter = table.meta.client.get_waiter('table_exists')
     # recheck every second instead of the default, lower, frequency. This can
     # save a few seconds on AWS with its very slow table creation, but can


### PR DESCRIPTION
When users create a table using the Alternator API, they can decide if the billing is PROVISIONED of PAY_PER_REQUEST.
If the billing is set to PROVISIONED, they need to set the ProvisionedThroughput ReadCapacityUnits (RCU) and WriteCapacityUnits (WCU).

This series adds support for getting and setting the ProvisionedThroughput. The values will be stored as table extension tags.
Following how TTL is stored within the Alternator, we will use ```system:rcu_attribute``` and ```system:wcu_attribute``` for the labels.

The series adds a test that sets ProvisionedThroughput and validates that it gets the value back. It was tested with both Alternator and AWS.

This series is part of the effort to monitor, limit, and bill Alternator operations.


New code, no need to backport.