### PR TITLE
[Backport 6.0] repair: use find_column_family in insert_repair_meta

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3348,9 +3348,7 @@ repair_service::insert_repair_meta(
             reason,
             compaction_time] (schema_ptr s) {
         auto& db = get_db();
-        auto& cf = db.local().find_column_family(s->id());
-        return db.local().obtain_reader_permit(cf, "repair-meta", db::no_timeout, {}).then([s = std::move(s),
-                &cf,
+        return db.local().obtain_reader_permit(db.local().find_column_family(s->id()), "repair-meta", db::no_timeout, {}).then([s = std::move(s),
                 this,
                 from,
                 repair_meta_id,
@@ -3363,7 +3361,7 @@ repair_service::insert_repair_meta(
                 compaction_time] (reader_permit permit) mutable {
         node_repair_meta_id id{from, repair_meta_id};
         auto rm = seastar::make_shared<repair_meta>(*this,
-                cf,
+                get_db().local().find_column_family(s->id()),
                 s,
                 std::move(permit),
                 range,


### PR DESCRIPTION
repair_service::insert_repair_meta gets the reference to a table and passes it to continuations. If the table is dropped in the meantime, the reference becomes invalid.

Use find_column_family at each table occurrence in insert_repair_meta instead.

Fixes: #20057

(cherry picked from commit 719999b34c6d20cbbd6184294ba1e1d2c1e93ac0)

Refs #19953