### PR TITLE
cql: add checks for CREATEing vnodes KS when tablets are turned on

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -605,8 +605,9 @@ maintenance_socket: ignore
 # replication_strategy_fail_list:
 
 # Enables the tablets feature.
-# When enabled, newly created keyspaces will have tablets enabled by default.
-# That can be explicitly disabled in the CREATE KEYSPACE query
+# When enabled, newly created keyspaces will have tablets enabled by default,
+# if they use NetworkTopologyStrategy, otherwise tablets will be disabled.
+# Tablets can be explicitly disabled in the CREATE KEYSPACE query
 # by using the `tablets = {'enabled': false}` replication option.
 #
 # When the tablets feature is disabled, there is no way to enable tablets

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -141,7 +141,7 @@ data_dictionary::storage_options ks_prop_defs::get_storage_options() const {
 
 ks_prop_defs::init_tablets_options ks_prop_defs::get_initial_tablets(const sstring& strategy_class, bool enabled_by_default) const {
     // FIXME -- this should be ignored somehow else
-    init_tablets_options ret{ .enabled = false, .specified_count = std::nullopt };
+    init_tablets_options ret{ .enabled = false, .enabled_via_cql = false, .specified_count = std::nullopt };
     if (locator::abstract_replication_strategy::to_qualified_class_name(strategy_class) != "org.apache.cassandra.locator.NetworkTopologyStrategy") {
         return ret;
     }
@@ -157,7 +157,8 @@ ks_prop_defs::init_tablets_options ks_prop_defs::get_initial_tablets(const sstri
         tablets_options->erase(it);
 
         if (enabled == "true") {
-            ret = init_tablets_options{ .enabled = true, .specified_count = 0 }; // even if 'initial' is not set, it'll start with auto-detection
+            // even if 'initial' is not set, it'll start with auto-detection
+            ret = init_tablets_options{ .enabled = true, .enabled_via_cql = true, .specified_count = 0 };
         } else if (enabled == "false") {
             SCYLLA_ASSERT(!ret.enabled);
             return ret;
@@ -169,7 +170,7 @@ ks_prop_defs::init_tablets_options ks_prop_defs::get_initial_tablets(const sstri
     it = tablets_options->find("initial");
     if (it != tablets_options->end()) {
         try {
-            ret = init_tablets_options{ .enabled = true, .specified_count = std::stol(it->second)};
+            ret = init_tablets_options{ .enabled = true, .enabled_via_cql = true, .specified_count = std::stol(it->second)};
         } catch (...) {
             throw exceptions::configuration_exception(sstring("Initial tablets value should be numeric; found ") + it->second);
         }

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -51,6 +51,7 @@ private:
 public:
     struct init_tablets_options {
         bool enabled;
+        bool enabled_via_cql;
         std::optional<unsigned> specified_count;
     };
 

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -228,7 +228,8 @@ keyspace_metadata::keyspace_metadata(std::string_view name,
 void keyspace_metadata::validate(const gms::feature_service& fs, const locator::topology& topology) const {
     using namespace locator;
     locator::replication_strategy_params params(strategy_options(), initial_tablets());
-    abstract_replication_strategy::validate_replication_strategy(name(), strategy_name(), params, fs, topology);
+    auto strategy = locator::abstract_replication_strategy::create_replication_strategy(strategy_name(), params);
+    strategy->validate_options(fs);
 }
 
 lw_shared_ptr<keyspace_metadata>

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -229,7 +229,7 @@ void keyspace_metadata::validate(const gms::feature_service& fs, const locator::
     using namespace locator;
     locator::replication_strategy_params params(strategy_options(), initial_tablets());
     auto strategy = locator::abstract_replication_strategy::create_replication_strategy(strategy_name(), params);
-    strategy->validate_options(fs);
+    strategy->validate_options(fs, topology);
 }
 
 lw_shared_ptr<keyspace_metadata>

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -49,16 +49,6 @@ abstract_replication_strategy::ptr_type abstract_replication_strategy::create_re
     }
 }
 
-void abstract_replication_strategy::validate_replication_strategy(const sstring& ks_name,
-                                                                  const sstring& strategy_name,
-                                                                  replication_strategy_params params,
-                                                                  const gms::feature_service& fs,
-                                                                  const topology& topology)
-{
-    auto strategy = create_replication_strategy(strategy_name, params);
-    strategy->validate_options(fs);
-}
-
 future<endpoint_set> abstract_replication_strategy::calculate_natural_ips(const token& search_token, const token_metadata& tm) const {
     const auto host_ids = co_await calculate_natural_endpoints(search_token, tm);
     co_return resolve_endpoints<endpoint_set>(host_ids, tm);

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -57,15 +57,6 @@ void abstract_replication_strategy::validate_replication_strategy(const sstring&
 {
     auto strategy = create_replication_strategy(strategy_name, params);
     strategy->validate_options(fs);
-    auto expected = strategy->recognized_options(topology);
-    if (expected) {
-        for (auto&& item : params.options) {
-            sstring key = item.first;
-            if (!expected->contains(key)) {
-                 throw exceptions::configuration_exception(format("Unrecognized strategy option {{{}}} passed to {} for keyspace {}", key, strategy_name, ks_name));
-            }
-        }
-    }
 }
 
 future<endpoint_set> abstract_replication_strategy::calculate_natural_ips(const token& search_token, const token_metadata& tm) const {

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -120,7 +120,7 @@ public:
 
     static sstring to_qualified_class_name(std::string_view strategy_class_name);
 
-    virtual void validate_options(const gms::feature_service&) const = 0;
+    virtual void validate_options(const gms::feature_service&, const locator::topology&) const = 0;
     virtual size_t get_replication_factor(const token_metadata& tm) const = 0;
     // Decide if the replication strategy allow removing the node being
     // replaced from the natural endpoints when a node is being replaced in the

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -126,7 +126,6 @@ public:
     static sstring to_qualified_class_name(std::string_view strategy_class_name);
 
     virtual void validate_options(const gms::feature_service&) const = 0;
-    virtual std::optional<std::unordered_set<sstring>> recognized_options(const topology&) const = 0;
     virtual size_t get_replication_factor(const token_metadata& tm) const = 0;
     // Decide if the replication strategy allow removing the node being
     // replaced from the natural endpoints when a node is being replaced in the

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -116,11 +116,6 @@ public:
 
     virtual ~abstract_replication_strategy() {}
     static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params);
-    static void validate_replication_strategy(const sstring& ks_name,
-                                              const sstring& strategy_name,
-                                              replication_strategy_params params,
-                                              const gms::feature_service& fs,
-                                              const topology& topology);
     static long parse_replication_factor(sstring rf);
 
     static sstring to_qualified_class_name(std::string_view strategy_class_name);

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -20,7 +20,7 @@ public:
 
     virtual future<host_id_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
 
-    virtual void validate_options(const gms::feature_service&) const override { /* noop */ }
+    virtual void validate_options(const gms::feature_service&, const locator::topology&) const override { /* noop */ }
 
     virtual size_t get_replication_factor(const token_metadata& tm) const override;
 

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -22,11 +22,6 @@ public:
 
     virtual void validate_options(const gms::feature_service&) const override { /* noop */ }
 
-    std::optional<std::unordered_set<sstring>> recognized_options(const topology&) const override {
-        // We explicitly allow all options
-        return std::nullopt;
-    }
-
     virtual size_t get_replication_factor(const token_metadata& tm) const override;
 
     virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const override {

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -22,9 +22,6 @@ future<host_id_set> local_strategy::calculate_natural_endpoints(const token& t, 
     return make_ready_future<host_id_set>(host_id_set{host_id{}});
 }
 
-void local_strategy::validate_options(const gms::feature_service&) const {
-}
-
 size_t local_strategy::get_replication_factor(const token_metadata&) const {
     return 1;
 }

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -25,11 +25,6 @@ future<host_id_set> local_strategy::calculate_natural_endpoints(const token& t, 
 void local_strategy::validate_options(const gms::feature_service&) const {
 }
 
-std::optional<std::unordered_set<sstring>> local_strategy::recognized_options(const topology&) const {
-    // LocalStrategy doesn't expect any options.
-    return {};
-}
-
 size_t local_strategy::get_replication_factor(const token_metadata&) const {
     return 1;
 }

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -30,8 +30,6 @@ public:
 
     virtual void validate_options(const gms::feature_service&) const override;
 
-    virtual std::optional<std::unordered_set<sstring>> recognized_options(const topology&) const override;
-
     virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const override {
         return false;
     }

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -28,7 +28,7 @@ public:
 
     virtual future<host_id_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
 
-    virtual void validate_options(const gms::feature_service&) const override;
+    virtual void validate_options(const gms::feature_service&, const locator::topology&) const override { /* noop */ }
 
     virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const override {
         return false;

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -266,15 +266,20 @@ network_topology_strategy::calculate_natural_endpoints(
     co_return std::move(tracker.replicas());
 }
 
-void network_topology_strategy::validate_options(const gms::feature_service& fs) const {
+void network_topology_strategy::validate_options(const gms::feature_service& fs, const locator::topology& topology) const {
     if(_config_options.empty()) {
         throw exceptions::configuration_exception("Configuration for at least one datacenter must be present");
     }
+    auto dcs = topology.get_datacenters();
     validate_tablet_options(*this, fs, _config_options);
     for (auto& c : _config_options) {
         if (c.first == sstring("replication_factor")) {
             on_internal_error(rslogger, format("'replication_factor' tag should be unrolled into a list of DC:RF by now."
                                                "_config_options:{}", _config_options));
+        }
+        if (!dcs.contains(c.first)) {
+            throw exceptions::configuration_exception(format("Unrecognized strategy option {{{}}} "
+                "passed to NetworkTopologyStrategy", this->to_qualified_class_name(c.first)));
         }
         parse_replication_factor(c.second);
     }

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -56,10 +56,11 @@ network_topology_strategy::network_topology_strategy(replication_strategy_params
             continue;
         }
 
-        if (boost::iequals(key, "replication_factor")) {
-            throw exceptions::configuration_exception(
-                "replication_factor is an option for SimpleStrategy, not "
-                "NetworkTopologyStrategy");
+        if (boost::equals(key, "replication_factor")) {
+            on_internal_error(rslogger, "replication_factor should have been replaced with a DC:RF mapping by now");
+        } else if (boost::iequals(key, "replication_factor")) {
+            throw exceptions::configuration_exception(format(
+                "'{}' is not a valid option, did you mean (lowercase) 'replication_factor'?", key));
         }
 
         auto rf = parse_replication_factor(val);
@@ -272,9 +273,8 @@ void network_topology_strategy::validate_options(const gms::feature_service& fs)
     validate_tablet_options(*this, fs, _config_options);
     for (auto& c : _config_options) {
         if (c.first == sstring("replication_factor")) {
-            throw exceptions::configuration_exception(
-                "replication_factor is an option for simple_strategy, not "
-                "network_topology_strategy");
+            on_internal_error(rslogger, format("'replication_factor' tag should be unrolled into a list of DC:RF by now."
+                                               "_config_options:{}", _config_options));
         }
         parse_replication_factor(c.second);
     }

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -270,11 +270,7 @@ void network_topology_strategy::validate_options(const gms::feature_service& fs)
         throw exceptions::configuration_exception("Configuration for at least one datacenter must be present");
     }
     validate_tablet_options(*this, fs, _config_options);
-    auto tablet_opts = recognized_tablet_options();
     for (auto& c : _config_options) {
-        if (tablet_opts.contains(c.first)) {
-            continue;
-        }
         if (c.first == sstring("replication_factor")) {
             throw exceptions::configuration_exception(
                 "replication_factor is an option for simple_strategy, not "
@@ -282,13 +278,6 @@ void network_topology_strategy::validate_options(const gms::feature_service& fs)
         }
         parse_replication_factor(c.second);
     }
-}
-
-std::optional<std::unordered_set<sstring>> network_topology_strategy::recognized_options(const topology& topology) const {
-    // We only allow datacenter names as options
-    auto opts = topology.get_datacenters();
-    opts.merge(recognized_tablet_options());
-    return opts;
 }
 
 effective_replication_map_ptr network_topology_strategy::make_replication_map(table_id table, token_metadata_ptr tm) const {

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -56,8 +56,6 @@ protected:
 
     virtual void validate_options(const gms::feature_service&) const override;
 
-    virtual std::optional<std::unordered_set<sstring>> recognized_options(const topology&) const override;
-
 private:
     future<tablet_replica_set> reallocate_tablets(schema_ptr, const locator::topology&, load_sketch&, const tablet_map& cur_tablets, tablet_id tb) const;
     future<tablet_replica_set> add_tablets_in_dc(schema_ptr, const locator::topology&, load_sketch&, tablet_id,

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -54,7 +54,7 @@ protected:
     virtual future<host_id_set> calculate_natural_endpoints(
         const token& search_token, const token_metadata& tm) const override;
 
-    virtual void validate_options(const gms::feature_service&) const override;
+    virtual void validate_options(const gms::feature_service&, const locator::topology& topology) const override;
 
 private:
     future<tablet_replica_set> reallocate_tablets(schema_ptr, const locator::topology&, load_sketch&, const tablet_map& cur_tablets, tablet_id tb) const;

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -64,7 +64,7 @@ size_t simple_strategy::get_replication_factor(const token_metadata&) const {
     return _replication_factor;
 }
 
-void simple_strategy::validate_options(const gms::feature_service&) const {
+void simple_strategy::validate_options(const gms::feature_service&, const locator::topology&) const {
     auto it = _config_options.find("replication_factor");
     if (it == _config_options.end()) {
         throw exceptions::configuration_exception("SimpleStrategy requires a replication_factor strategy option.");

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -72,10 +72,6 @@ void simple_strategy::validate_options(const gms::feature_service&) const {
     parse_replication_factor(it->second);
 }
 
-std::optional<std::unordered_set<sstring>>simple_strategy::recognized_options(const topology&) const {
-    return {{ "replication_factor" }};
-}
-
 using registry = class_registrator<abstract_replication_strategy, simple_strategy, replication_strategy_params>;
 static registry registrator("org.apache.cassandra.locator.SimpleStrategy");
 static registry registrator_short_name("SimpleStrategy");

--- a/locator/simple_strategy.hh
+++ b/locator/simple_strategy.hh
@@ -19,7 +19,7 @@ public:
     simple_strategy(replication_strategy_params params);
     virtual ~simple_strategy() {};
     virtual size_t get_replication_factor(const token_metadata& tm) const override;
-    virtual void validate_options(const gms::feature_service&) const override;
+    virtual void validate_options(const gms::feature_service&, const locator::topology& topology) const override;
     virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const override {
         return true;
     }

--- a/locator/simple_strategy.hh
+++ b/locator/simple_strategy.hh
@@ -20,7 +20,6 @@ public:
     virtual ~simple_strategy() {};
     virtual size_t get_replication_factor(const token_metadata& tm) const override;
     virtual void validate_options(const gms::feature_service&) const override;
-    virtual std::optional<std::unordered_set<sstring>> recognized_options(const topology&) const override;
     virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const override {
         return true;
     }

--- a/locator/tablet_replication_strategy.hh
+++ b/locator/tablet_replication_strategy.hh
@@ -28,7 +28,6 @@ private:
 protected:
     void validate_tablet_options(const abstract_replication_strategy&, const gms::feature_service&, const replication_strategy_config_options&) const;
     void process_tablet_options(abstract_replication_strategy&, replication_strategy_config_options&, replication_strategy_params);
-    std::unordered_set<sstring> recognized_tablet_options() const;
     size_t get_initial_tablets() const { return _initial_tablets; }
     effective_replication_map_ptr do_make_replication_map(table_id,
                                                           replication_strategy_ptr,

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -858,11 +858,6 @@ void tablet_aware_replication_strategy::process_tablet_options(abstract_replicat
     }
 }
 
-std::unordered_set<sstring> tablet_aware_replication_strategy::recognized_tablet_options() const {
-    std::unordered_set<sstring> opts;
-    return opts;
-}
-
 effective_replication_map_ptr tablet_aware_replication_strategy::do_make_replication_map(
         table_id table, replication_strategy_ptr rs, token_metadata_ptr tm, size_t replication_factor) const {
     return seastar::make_shared<tablet_effective_replication_map>(table, std::move(rs), std::move(tm), replication_factor);

--- a/test/cql-pytest/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/alter_test.py
@@ -222,15 +222,14 @@ def testAlterKeyspaceWithNoOptionThrowsConfigurationException(cql, test_keyspace
 
 # Test {@link ConfigurationException} thrown when altering a keyspace to
 # invalid DC option in replication configuration.
-@pytest.mark.skip("reintroduce when fixed")
 def testAlterKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, test_keyspace, this_dc):
     # Create a keyspace with expected DC name.
     with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 }") as ks:
         # try modifying the keyspace
-        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy for keyspace " + ks, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', 'INVALID_DC' : 2 }")
+        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy", ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', 'INVALID_DC' : 2 }")
         execute(cql, ks, "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 3 }")
         # Mix valid and invalid, should throw an exception
-        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy for keyspace " + ks, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 , 'INVALID_DC': 1}")
+        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy", ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 , 'INVALID_DC': 1}")
 
 def testAlterKeyspaceWithMultipleInstancesOfSameDCThrowsSyntaxException(cql, test_keyspace, this_dc):
     # Create a keyspace

--- a/test/cql-pytest/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/alter_test.py
@@ -222,6 +222,7 @@ def testAlterKeyspaceWithNoOptionThrowsConfigurationException(cql, test_keyspace
 
 # Test {@link ConfigurationException} thrown when altering a keyspace to
 # invalid DC option in replication configuration.
+@pytest.mark.skip("reintroduce when fixed")
 def testAlterKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, test_keyspace, this_dc):
     # Create a keyspace with expected DC name.
     with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 }") as ks:

--- a/test/cql-pytest/cassandra_tests/validation/operations/create_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/create_test.py
@@ -309,6 +309,7 @@ def testKeyspace(cql):
     execute(cql, n, "DROP KEYSPACE %s")
 
 #  Test {@link ConfigurationException} is thrown on create keyspace with invalid DC option in replication configuration .
+@pytest.mark.skip("reintroduce when fixed")
 def testCreateKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, this_dc):
     n = unique_name()
     assertInvalidThrow(cql, n, ConfigurationException, "CREATE KEYSPACE %s WITH replication = { 'class' : 'NetworkTopologyStrategy', 'INVALID_DC' : 2 }")

--- a/test/cql-pytest/cassandra_tests/validation/operations/create_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/create_test.py
@@ -309,7 +309,6 @@ def testKeyspace(cql):
     execute(cql, n, "DROP KEYSPACE %s")
 
 #  Test {@link ConfigurationException} is thrown on create keyspace with invalid DC option in replication configuration .
-@pytest.mark.skip("reintroduce when fixed")
 def testCreateKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, this_dc):
     n = unique_name()
     assertInvalidThrow(cql, n, ConfigurationException, "CREATE KEYSPACE %s WITH replication = { 'class' : 'NetworkTopologyStrategy', 'INVALID_DC' : 2 }")

--- a/test/cql-pytest/test_guardrail_replication_strategy.py
+++ b/test/cql-pytest/test_guardrail_replication_strategy.py
@@ -118,7 +118,7 @@ def test_given_rf_and_strategy_guardrails_when_creating_ks_should_print_2_warnin
         config_modifications.enter_context(config_value_context(cql, 'minimum_replication_factor_warn_threshold', '3'))
         create_ks_and_assert_warnings_and_errors(cql,
                                                  f" WITH REPLICATION = {{ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }}",
-                                                 warnings_count=2, fails_count=0)
+                                                 warnings_count=3, fails_count=0)
 
 
 def test_given_rf_and_strategy_guardrails_when_violating_fail_rf_limit_and_warn_strategy_limit_should_fail_the_query_without_warning(cql):
@@ -144,7 +144,7 @@ def test_given_restrict_replication_simplestrategy_when_it_is_set_should_emulate
                                                  warnings_count=0, fails_count=1)
         config_modifications.enter_context(config_value_context(cql, 'restrict_replication_simplestrategy', 'warn'))
         create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : 'SimpleStrategy', 'replication_factor' : 3 }}",
-                                                 warnings_count=1, fails_count=0)
+                                                 warnings_count=2, fails_count=0)
 
 def test_config_replication_strategy_warn_list_roundtrips_quotes(cql):
     # Use direct SELECT/UPDATE to avoid trippy config_value_context behavior

--- a/test/cql-pytest/test_keyspace.py
+++ b/test/cql-pytest/test_keyspace.py
@@ -71,7 +71,6 @@ def test_create_keyspace_invalid_name(cql, this_dc):
 
 # Test trying to ALTER a keyspace with invalid options.
 # Reproduces #7595.
-@pytest.mark.skip("reintroduce when fixed")
 def test_create_keyspace_nonexistent_dc(cql):
     with pytest.raises(ConfigurationException):
         ks = unique_name()
@@ -156,7 +155,6 @@ def test_alter_keyspace_missing_rf(cql, this_dc, scylla_only, has_tablets):
 
 # Test trying to ALTER a keyspace with invalid options.
 # Reproduces #7595.
-@pytest.mark.skip("reintroduce when fixed")
 def test_alter_keyspace_nonexistent_dc(cql, this_dc):
     with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as keyspace:
         with pytest.raises(ConfigurationException):

--- a/test/cql-pytest/test_keyspace.py
+++ b/test/cql-pytest/test_keyspace.py
@@ -71,6 +71,7 @@ def test_create_keyspace_invalid_name(cql, this_dc):
 
 # Test trying to ALTER a keyspace with invalid options.
 # Reproduces #7595.
+@pytest.mark.skip("reintroduce when fixed")
 def test_create_keyspace_nonexistent_dc(cql):
     with pytest.raises(ConfigurationException):
         ks = unique_name()
@@ -142,6 +143,7 @@ def test_alter_keyspace_missing_rf(cql, this_dc, scylla_only, has_tablets):
 
 # Test trying to ALTER a keyspace with invalid options.
 # Reproduces #7595.
+@pytest.mark.skip("reintroduce when fixed")
 def test_alter_keyspace_nonexistent_dc(cql, this_dc):
     with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as keyspace:
         with pytest.raises(ConfigurationException):

--- a/test/cql-pytest/test_keyspace.py
+++ b/test/cql-pytest/test_keyspace.py
@@ -85,6 +85,19 @@ def test_create_keyspace_double_with(cql):
     with pytest.raises(SyntaxException):
         cql.execute('CREATE KEYSPACE ks WITH WITH DURABLE_WRITES = true')
 
+# Scylla accepts 'replication_factor' in CREATE KEYSPACE statement,
+# but while CQL syntax is case-insensitive, tags within json are case-sensitive,
+# hence anything else than the lowercase 'replication_factor' should be rejected.
+# Reproduces #15336
+def test_create_keyspace_with_case_sensitive_replication_factor_tag(cql):
+    ks = unique_name()
+    # lowercase 'replication_factor' should be accepted
+    with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 }"):
+        pass
+    # 'replication_factor' in any other case than the lowercase should be rejected
+    with pytest.raises(ConfigurationException):
+        cql.execute(f"CREATE KEYSPACE {ks} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'Replication_factor' : 3 }}")
+
 # Test trying a non-existent keyspace - with or without the IF EXISTS flag.
 # This test demonstrates a change of the exception produced between Cassandra 4.0
 # and earlier versions (with Scylla behaving like the earlier versions).

--- a/test/cql/locator_test.result
+++ b/test/cql/locator_test.result
@@ -3,7 +3,7 @@
 > -- Fail on wrong DC name
 > --
 > CREATE KEYSPACE t WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'nosuchdc' : 3 } AND DURABLE_WRITES = true;
-<Error from server: code=2300 [Query invalid because of configuration issue] message="Unrecognized strategy option {nosuchdc} passed to org.apache.cassandra.locator.NetworkTopologyStrategy for keyspace t">
+<Error from server: code=2300 [Query invalid because of configuration issue] message="Unrecognized strategy option {nosuchdc} passed to NetworkTopologyStrategy">
 > CREATE KEYSPACE t WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 3 } AND DURABLE_WRITES = true;
 OK
 > DROP KEYSPACE t;


### PR DESCRIPTION
Tablets-enabled keyspaces support only NetworkTopologyStrategy, so CREATE KS with any other type of strategy should be rejected - with these changes it is, when tablets are enabled expicitly in CQL, but in order to keep backward compatibility, we allow creating keyspaces when tablets are turned on in the configuration but not explicitly in CQL.
Interestingly, ALTER KS validates replication strategies, so we just missed this validation for CREATE KS.

Fixes: #19743

This should be backported to 6.0 & 6.1, as the bug may be very confusing for the users. 