### PR TITLE
cql_test_env: ensure shutdown() before stop() for system_keyspace

### DIFF
--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -647,7 +647,10 @@ private:
             _sl_controller.invoke_on_all(&qos::service_level_controller::start).get();
 
             _sys_ks.start(std::ref(_qp), std::ref(_db)).get();
-            auto stop_sys_kd = defer([this] { _sys_ks.stop().get(); });
+            auto stop_sys_kd = defer([this] {
+                _sys_ks.invoke_on_all(&db::system_keyspace::shutdown).get();
+                _sys_ks.stop().get();
+            });
 
             replica::distributed_loader::init_system_keyspace(_sys_ks, _erm_factory, _db).get();
             _db.local().init_schema_commitlog();
@@ -852,9 +855,6 @@ private:
             }
 
             group0_client.init().get();
-            auto stop_system_keyspace = defer([this] {
-                _sys_ks.invoke_on_all(&db::system_keyspace::shutdown).get();
-            });
 
             auto shutdown_db = defer([this] {
                 _db.invoke_on_all(&replica::database::shutdown).get();


### PR DESCRIPTION
If system_keyspace::stop() is called before system_keyspace::shutdown(), it will never finish, because the uncleared shared pointers will keep it alive indefinitely.

Currently this can happen if an exception is thrown before the construction of the shutdown() defer. This patch moves the shutdown() call to immediately before stop(). I see no reason why it should be elsewhere.

Fixes scylladb/scylla-enterprise#4380

It should be backported because it can turn exceptions into test timeouts even in older branches.