### PR TITLE
raft: store_snapshot_descriptor to use actually preserved items number when truncating the local log table 

### DIFF
--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -1019,8 +1019,12 @@ bool fsm::apply_snapshot(snapshot_descriptor snp, size_t max_trailing_entries, s
     // If the snapshot is local, _commit_idx is larger than snp.idx.
     // Otherwise snp.idx becomes the new commit index.
     _commit_idx = std::max(_commit_idx, snp.idx);
-    _output.snp.emplace(fsm_output::applied_snapshot{snp, local, max_trailing_entries});
-    size_t units = _log.apply_snapshot(std::move(snp), max_trailing_entries, max_trailing_bytes);
+    auto [units, new_first_index] =
+        _log.apply_snapshot(std::move(snp), max_trailing_entries, max_trailing_bytes);
+    _output.snp.emplace(
+        fsm_output::applied_snapshot{.snp = _log.get_snapshot(),
+                                     .is_local = local,
+                                     .preserve_log_entries = _log.get_snapshot().idx - new_first_index});
     if (is_leader()) {
         logger.trace("apply_snapshot[{}]: signal {} available units", _my_id, units);
         leader_state().log_limiter_semaphore->signal(units);

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -24,9 +24,7 @@ struct fsm_output {
         bool is_local;
 
         // Always 0 for non-local snapshots.
-        size_t max_trailing_entries;
-
-        // FIXME: include max_trailing_bytes here and in store_snapshot_descriptor
+        size_t preserve_log_entries;
     };
     std::optional<std::pair<term_t, server_id>> term_and_vote;
     std::vector<log_entry_ptr> log_entries;

--- a/raft/log.cc
+++ b/raft/log.cc
@@ -228,7 +228,8 @@ const configuration* log::get_prev_configuration() const {
     return nullptr;
 }
 
-size_t log::apply_snapshot(snapshot_descriptor&& snp, size_t max_trailing_entries, size_t max_trailing_bytes) {
+std::tuple<size_t, index_t> log::apply_snapshot(snapshot_descriptor&& snp, size_t max_trailing_entries,
+                                                size_t max_trailing_bytes) {
     SCYLLA_ASSERT (snp.idx > _snapshot.idx);
 
     size_t released_memory;
@@ -274,7 +275,7 @@ size_t log::apply_snapshot(snapshot_descriptor&& snp, size_t max_trailing_entrie
 
     _snapshot = std::move(snp);
 
-    return released_memory;
+    return {released_memory, _first_idx};
 }
 
 } // end of namespace raft

--- a/raft/log.hh
+++ b/raft/log.hh
@@ -134,8 +134,10 @@ public:
     // This call will update the log to point to the new snapshot
     // and will truncate the log prefix so that the number of
     // remaining applied entries is <= max_trailing_entries and their total size is <= max_trailing_bytes.
-    // Return value specifies the size in bytes of the dropped log entries.
-    size_t apply_snapshot(snapshot_descriptor&& snp, size_t max_trailing_entries, size_t max_trailing_bytes);
+    // Return: the value that specifies the size in bytes of the dropped log entries and the first index
+    //         in the log after tranction
+    std::tuple<size_t, index_t> apply_snapshot(snapshot_descriptor&& snp, size_t max_trailing_entries,
+        size_t max_trailing_bytes);
 
     // 3.5
     // Raft maintains the following properties, which

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -1078,10 +1078,10 @@ future<> server_impl::process_fsm_output(index_t& last_stable, fsm_output&& batc
     }
 
     if (batch.snp) {
-        auto& [snp, is_local, max_trailing_entries] = *batch.snp;
+        const auto& [snp, is_local, preserve_log_entries] = *batch.snp;
         logger.trace("[{}] io_fiber storing snapshot {}", _id, snp.id);
         // Persist the snapshot
-        co_await _persistence->store_snapshot_descriptor(snp, max_trailing_entries);
+        co_await _persistence->store_snapshot_descriptor(snp, preserve_log_entries);
         _snapshot_desc_idx = snp.idx;
         _snapshot_desc_idx_changed.broadcast();
         _stats.store_snapshot++;

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -1353,10 +1353,7 @@ future<> server_impl::applier_fiber() {
                 // of taking snapshots ourselves but comparing our last index directly with what's currently in _fsm.
                 const auto last_snap_idx = _fsm->log_last_snapshot_idx();
 
-                // Error injection to be set with one_shot
-                utils::get_local_injector().inject("raft_server_snapshot_reduce_threshold",
-                    [this] { _config.snapshot_threshold = 3; _config.snapshot_trailing = 1; });
-
+                // Use error injection to override the snapshot thresholds.
                 co_await override_snapshot_thresholds();
 
                 bool force_snapshot = utils::get_local_injector().enter("raft_server_force_snapshot");

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -1344,44 +1344,44 @@ future<> server_impl::applier_fiber() {
                     _stats.applied_entries += size;
                 }
 
-               _applied_idx = last_idx;
-               _applied_index_changed.broadcast();
-               notify_waiters(_awaited_applies, batch);
+                _applied_idx = last_idx;
+                _applied_index_changed.broadcast();
+                notify_waiters(_awaited_applies, batch);
 
-               // It may happen that _fsm has already applied a later snapshot (from remote) that we didn't yet 'observe'
-               // (i.e. didn't yet receive from _apply_entries queue) but will soon. We avoid unnecessary work
-               // of taking snapshots ourselves but comparing our last index directly with what's currently in _fsm.
-               auto last_snap_idx = _fsm->log_last_snapshot_idx();
+                // It may happen that _fsm has already applied a later snapshot (from remote) that we didn't yet 'observe'
+                // (i.e. didn't yet receive from _apply_entries queue) but will soon. We avoid unnecessary work
+                // of taking snapshots ourselves but comparing our last index directly with what's currently in _fsm.
+                const auto last_snap_idx = _fsm->log_last_snapshot_idx();
 
-               // Error injection to be set with one_shot
-               utils::get_local_injector().inject("raft_server_snapshot_reduce_threshold",
-                   [this] { _config.snapshot_threshold = 3; _config.snapshot_trailing = 1; });
+                // Error injection to be set with one_shot
+                utils::get_local_injector().inject("raft_server_snapshot_reduce_threshold",
+                    [this] { _config.snapshot_threshold = 3; _config.snapshot_trailing = 1; });
 
-               co_await override_snapshot_thresholds();
+                co_await override_snapshot_thresholds();
 
-               bool force_snapshot = utils::get_local_injector().enter("raft_server_force_snapshot");
+                bool force_snapshot = utils::get_local_injector().enter("raft_server_force_snapshot");
 
-               if (force_snapshot || (_applied_idx > last_snap_idx &&
-                   (_applied_idx - last_snap_idx >= _config.snapshot_threshold ||
-                   _fsm->log_memory_usage() >= _config.snapshot_threshold_log_size)))
-               {
-                   snapshot_descriptor snp;
-                   snp.term = last_term;
-                   snp.idx = _applied_idx;
-                   snp.config = _fsm->log_last_conf_for(_applied_idx);
-                   logger.trace("[{}] applier fiber: taking snapshot term={}, idx={}", _id, snp.term, snp.idx);
-                   snp.id = co_await _state_machine->take_snapshot();
-                   // Note that at this point (after the `co_await`), _fsm may already have applied a later snapshot.
-                   // That's fine, `_fsm->apply_snapshot` will simply ignore our current attempt; we will soon receive
-                   // a later snapshot from the queue.
-                   auto max_trailing = force_snapshot ? 0 : _config.snapshot_trailing;
-                   auto max_trailing_bytes = force_snapshot ? 0 : _config.snapshot_trailing_size;
-                   if (!_fsm->apply_snapshot(snp, max_trailing, max_trailing_bytes, true)) {
-                       logger.trace("[{}] applier fiber: while taking snapshot term={} idx={} id={},"
-                              " fsm received a later snapshot at idx={}", _id, snp.term, snp.idx, snp.id, _fsm->log_last_snapshot_idx());
-                   }
-                   _stats.snapshots_taken++;
-               }
+                if (force_snapshot || (_applied_idx > last_snap_idx &&
+                    (_applied_idx - last_snap_idx >= _config.snapshot_threshold ||
+                    _fsm->log_memory_usage() >= _config.snapshot_threshold_log_size)))
+                {
+                    snapshot_descriptor snp;
+                    snp.term = last_term;
+                    snp.idx = _applied_idx;
+                    snp.config = _fsm->log_last_conf_for(_applied_idx);
+                    logger.trace("[{}] applier fiber: taking snapshot term={}, idx={}", _id, snp.term, snp.idx);
+                    snp.id = co_await _state_machine->take_snapshot();
+                    // Note that at this point (after the `co_await`), _fsm may already have applied a later snapshot.
+                    // That's fine, `_fsm->apply_snapshot` will simply ignore our current attempt; we will soon receive
+                    // a later snapshot from the queue.
+                    auto max_trailing = force_snapshot ? 0 : _config.snapshot_trailing;
+                    auto max_trailing_bytes = force_snapshot ? 0 : _config.snapshot_trailing_size;
+                    if (!_fsm->apply_snapshot(snp, max_trailing, max_trailing_bytes, true)) {
+                        logger.trace("[{}] applier fiber: while taking snapshot term={} idx={} id={},"
+                                " fsm received a later snapshot at idx={}", _id, snp.term, snp.idx, snp.id, _fsm->log_last_snapshot_idx());
+                    }
+                    _stats.snapshots_taken++;
+                }
             },
             [this] (snapshot_descriptor& snp) -> future<> {
                 SCYLLA_ASSERT(snp.idx >= _applied_idx);

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -335,6 +335,8 @@ private:
     }
     future<> do_on_leader_with_retries(seastar::abort_source* as, AsyncAction&& action);
 
+    future<> override_snapshot_thresholds();
+
     friend std::ostream& operator<<(std::ostream& os, const server_impl& s);
 };
 
@@ -1355,6 +1357,8 @@ future<> server_impl::applier_fiber() {
                utils::get_local_injector().inject("raft_server_snapshot_reduce_threshold",
                    [this] { _config.snapshot_threshold = 3; _config.snapshot_trailing = 1; });
 
+               co_await override_snapshot_thresholds();
+
                bool force_snapshot = utils::get_local_injector().enter("raft_server_force_snapshot");
 
                if (force_snapshot || (_applied_idx > last_snap_idx &&
@@ -1888,4 +1892,27 @@ std::ostream& operator<<(std::ostream& os, const server_impl& s) {
     return os;
 }
 
+future<> server_impl::override_snapshot_thresholds() {
+    return utils::get_local_injector().inject(
+        "raft_server_set_snapshot_thresholds", [this](auto& handler) -> future<> {
+            const auto set_parm = [&handler](auto& target, const std::string_view name) -> void {
+                const auto from = handler.get(name);
+                if (from) {
+                    try {
+                        target = boost::lexical_cast<std::remove_reference_t<decltype(target)>>(*from);
+                        logger.info("Applied _config.{}={}", name, *from);
+                    } catch (const boost::bad_lexical_cast& e) {
+                        logger.info("Could not apply a snapshot threshold param: {}, value: {}, error: {}",
+                                    name, *from, e.what());
+                    }
+                }
+            };
+
+            set_parm(_config.snapshot_threshold, "snapshot_threshold");
+            set_parm(_config.snapshot_threshold_log_size, "snapshot_threshold_log_size");
+            set_parm(_config.snapshot_trailing, "snapshot_trailing");
+            set_parm(_config.snapshot_trailing_size, "snapshot_trailing_size");
+            co_return;
+        });
+}
 } // end of namespace raft

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -183,17 +183,7 @@ future<> raft_sys_table_storage::store_snapshot_descriptor(const raft::snapshot_
                     cql3::query_processor::cache_internal::yes);
         }
 
-        if (preserve_log_entries > snap.idx) {
-            static const auto store_latest_id_cql = format("INSERT INTO system.{} (group_id, snapshot_id) VALUES (?, ?)",
-                db::system_keyspace::RAFT);
-            co_await _qp.execute_internal(
-                store_latest_id_cql,
-                {_group_id.id, snap.id.id},
-                cql3::query_processor::cache_internal::yes
-            );
-        } else {
-            co_await update_snapshot_and_truncate_log_tail(snap, preserve_log_entries);
-        }
+        co_await update_snapshot_and_truncate_log_tail(snap, preserve_log_entries);
     });
 }
 

--- a/test/topology/test_mutation_schema_change.py
+++ b/test/topology/test_mutation_schema_change.py
@@ -35,7 +35,8 @@ async def test_mutation_schema_change(manager, random_tables):
     manager.driver_close()
     # Reduce the snapshot thresholds
     await manager.mark_dirty()
-    errs = [inject_error_one_shot(manager.api, s.ip_addr, 'raft_server_snapshot_reduce_threshold')
+    errs = [inject_error_one_shot(manager.api, s.ip_addr, "raft_server_set_snapshot_thresholds",
+                                  parameters={'snapshot_threshold': '3', 'snapshot_trailing': '1'})
             for s in [server_a, server_b, server_c]]
     await asyncio.gather(*errs)
 
@@ -96,7 +97,8 @@ async def test_mutation_schema_change_restart(manager, random_tables):
     manager.driver_close()
     # Reduce the snapshot thresholds
     await manager.mark_dirty()
-    errs = [inject_error_one_shot(manager.api, s.ip_addr, 'raft_server_snapshot_reduce_threshold')
+    errs = [inject_error_one_shot(manager.api, s.ip_addr, "raft_server_set_snapshot_thresholds",
+                                  parameters={'snapshot_threshold': '3', 'snapshot_trailing': '1'})
             for s in [server_a, server_b, server_c]]
     await asyncio.gather(*errs)
 

--- a/test/topology/test_snapshot.py
+++ b/test/topology/test_snapshot.py
@@ -27,7 +27,8 @@ async def test_snapshot(manager, random_tables):
     server_a, server_b, server_c = await manager.running_servers()
     await manager.mark_dirty()
     # Reduce the snapshot thresholds
-    errs = [inject_error_one_shot(manager.api, s.ip_addr, 'raft_server_snapshot_reduce_threshold')
+    errs = [inject_error_one_shot(manager.api, s.ip_addr, "raft_server_set_snapshot_thresholds",
+                                  parameters={'snapshot_threshold': '3', 'snapshot_trailing': '1'})
             for s in [server_a, server_b, server_c]]
     await asyncio.gather(*errs)
 

--- a/test/topology_custom/test_raft_snapshot_truncation.py
+++ b/test/topology_custom/test_raft_snapshot_truncation.py
@@ -1,0 +1,76 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import asyncio
+import pytest
+import time
+import logging
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from test.topology.util import reconnect_driver, trigger_snapshot, get_topology_coordinator
+from test.pylib.rest_client import inject_error_one_shot
+from test.pylib.random_tables import RandomTables
+
+logger = logging.getLogger(__name__)
+
+
+async def get_raft_log_size(cql, host) -> int:
+    query = "select count(\"index\") from system.raft"
+    return (await cql.run_async(query, host=host))[0][0]
+
+
+async def get_raft_snap_id(cql, host) -> str:
+    query = "select snapshot_id from system.raft limit 1"
+    return (await cql.run_async(query, host=host))[0].snapshot_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(reason="issue ##16817")
+async def test_raft_snapshot_truncation(manager: ManagerClient):
+    # Check that after snapshot creation, snapshot_trailing_size is taken in to consideration,
+    # issue https://github.com/scylladb/scylladb/issues/16817
+    #
+    # 1. Start 3 nodes
+    # 2. Set snapshot thresholds to 0 to trigger snapshot creation on the next schema change
+    #    also set snapshot_trailing to 5 and snapshot_trailing_size, practially setting
+    #    desired number of log entries after log trancation to 0
+    # 3. Generate a schema change event
+    # 4. Check that truncated log contains 0 entries
+
+    cmdline = [
+        '--logger-log-level', 'raft=trace',
+    ]
+    servers = await manager.servers_add(3, cmdline=cmdline)
+    cql = manager.get_cql()
+
+    s1 = servers[0]
+    h1 = (await wait_for_cql_and_get_hosts(cql, [s1], time.time() + 60))[0]
+
+    log_size = await get_raft_log_size(cql, h1)
+    logger.info(f"Log size on {s1}: {log_size}")
+    assert (log_size > 0)
+
+    await cql.run_async("create keyspace ks with replication = {'class': 'SimpleStrategy', 'replication_factor': 1}")
+
+    log_size = await get_raft_log_size(cql, h1)
+    logger.info(f"After add table Log size on {s1}: {log_size}")
+
+    # Set up snapshot creation thresholds and trailing items
+    errs = [inject_error_one_shot(manager.api, s.ip_addr, "raft_server_set_snapshot_thresholds",
+                                  parameters={'snapshot_threshold': '0', 'snapshot_threshold_log_size': '0',
+                                              'snapshot_trailing': '5', 'snapshot_trailing_size': '0'})
+            for s in servers]
+    await asyncio.gather(*errs)
+
+    # Change schema - trigger log truncation
+    await cql.run_async("drop keyspace ks")
+
+    log_size = await get_raft_log_size(cql, h1)
+    logger.info(f"After drop table Log size on {s1}: {log_size}")
+
+    # Verify that after snapshot was created, log size is 0 due to setting 'snapshot_trailing_size': '0'
+    assert (log_size == 0)

--- a/test/topology_custom/test_raft_snapshot_truncation.py
+++ b/test/topology_custom/test_raft_snapshot_truncation.py
@@ -29,7 +29,6 @@ async def get_raft_snap_id(cql, host) -> str:
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="issue ##16817")
 async def test_raft_snapshot_truncation(manager: ManagerClient):
     # Check that after snapshot creation, snapshot_trailing_size is taken in to consideration,
     # issue https://github.com/scylladb/scylladb/issues/16817
@@ -40,6 +39,12 @@ async def test_raft_snapshot_truncation(manager: ManagerClient):
     #    desired number of log entries after log trancation to 0
     # 3. Generate a schema change event
     # 4. Check that truncated log contains 0 entries
+    #
+    # Check regression:
+    # 1. Set snapshot threshold to 2
+    # 2. Generate 2 schema change events
+    # 3. Trigger snapshot creation by setting snapshot threshold to 0
+    # 4. Check that truncated log contains 2 entries
 
     cmdline = [
         '--logger-log-level', 'raft=trace',
@@ -74,3 +79,31 @@ async def test_raft_snapshot_truncation(manager: ManagerClient):
 
     # Verify that after snapshot was created, log size is 0 due to setting 'snapshot_trailing_size': '0'
     assert (log_size == 0)
+
+    # Now test, that after truncation the records are preserved if snapshot_trailing higher than zero
+
+    # Set snapshot thresholds to a higher level
+    errs = [inject_error_one_shot(manager.api, s.ip_addr, "raft_server_set_snapshot_thresholds",
+                                  parameters={'snapshot_threshold': '1024', 'snapshot_threshold_log_size': '2000000',
+                                              'snapshot_trailing': '2', 'snapshot_trailing_size': '2000000'})
+            for s in servers]
+    await asyncio.gather(*errs)
+
+    await cql.run_async("create keyspace ks with replication = {'class': 'SimpleStrategy', 'replication_factor': 1}")
+
+    log_size = await get_raft_log_size(cql, h1)
+    logger.info(f"After add table Log size on {s1}: {log_size}")
+
+    # Set snapshot thresholds to 0 to trigger on the next schema change
+    errs = [inject_error_one_shot(manager.api, s.ip_addr, "raft_server_set_snapshot_thresholds",
+                                  parameters={'snapshot_threshold': '0', 'snapshot_threshold_log_size': '0'})
+            for s in servers]
+
+    # Change schema - trigger log truncation
+    await cql.run_async("drop keyspace ks")
+
+    log_size = await get_raft_log_size(cql, h1)
+    logger.info(f"After drop table Log size on {s1}: {log_size}")
+
+    # check the log size, which should be 2, as we set snapshot_trailing to 2 and we generated 2 schema chenges
+    assert (log_size == 2)

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -235,7 +235,7 @@ public:
         }
 
         template <typename T = std::string_view>
-        std::optional<T> get(std::string_view key) {
+        std::optional<T> get(std::string_view key) const {
             if (!_shared_data) {
                 on_internal_error(errinj_logger, "injection_shared_data is not initialized");
             }


### PR DESCRIPTION
io_fiber/store_snapshot_descriptor now gets the actual number of items preserved when the log is truncated, fixing extra entries remained after log snapshot creation. Also removes incorrect check for the number of truncated items in the raft_sys_table_storage::store_snapshot_descriptor.  
Minor change: Added error_injection test API for changing snapshot thresholds settings

Fixes #16817
Fixes #20080