### PR TITLE
build: do not regenerate building system for seastar or abseil

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1677,6 +1677,9 @@ def real_relpath(path, start):
 
 def configure_seastar(build_dir, mode, mode_config):
     seastar_build_dir = os.path.join(build_dir, mode, 'seastar')
+    if os.path.exists(os.path.join(seastar_build_dir, 'build.ninja')):
+        # the build system has been already generated, and it can take care of itself
+        return
 
     seastar_cxx_ld_flags = mode_config['cxx_ld_flags']
     # We want to "undo" coverage for seastar if we have it enabled.
@@ -1734,6 +1737,11 @@ def configure_seastar(build_dir, mode, mode_config):
 
 
 def configure_abseil(build_dir, mode, mode_config):
+    abseil_build_dir = os.path.join(build_dir, mode, 'abseil')
+    if os.path.exists(os.path.join(abseil_build_dir, 'build.ninja')):
+        # the build system has been already generated, and it can take care of itself
+        return
+
     abseil_cflags = mode_config['lib_cflags']
     cxx_flags = mode_config['cxxflags']
     if '-DSANITIZE' in cxx_flags:
@@ -1759,7 +1767,6 @@ def configure_abseil(build_dir, mode, mode_config):
         '-DABSL_PROPAGATE_CXX_STD=ON',
     ]
 
-    abseil_build_dir = os.path.join(build_dir, mode, 'abseil')
     abseil_cmd = ['cmake', '-G', 'Ninja', real_relpath('abseil', abseil_build_dir)] + abseil_cmake_args
 
     os.makedirs(abseil_build_dir, exist_ok=True)


### PR DESCRIPTION
before this change, we regenerate the building systems for seastar and abseil even if their building systems, i.e., `build.ninja` have been generated. this works fine alebit that if, for instance, seastar has been built, after regenerating `build.ninja`, all source files are rebuilt. this is a waste of time. because to update the build dependencies of a certain .o file, ninja needs to regenerate the corresponding .o.d file, but we just generate the .o and .o.d in a single pass, so the source files are always recompiled even when it's not necessary.

in this change, if the `build.ninja` file exists in the build directory, instead of rerunning `cmake` to generate this file, we just skip the step to generate the building system. as the `build.ninja` script generated by CMake is able to regenerate itself when its dependencies are updated, and the rule for generating it is named `RERUN_CMAKE`, which just reruns `cmake` with cached command line arguments passed to this tool in previous run. this helps us to avoid the unnecessary compilation of seastar and abseil after regenerating `build.ninja` using `configure.py`.

Fixes scylladb/scylladb#20079
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

this improves the developer's experience when rebuilding the tree after regenerating `build.ninja`, hence no need to backport. 