### PR TITLE
build: cmake: add compiler-training target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,8 @@ include(check_headers)
 check_headers(check-headers scylla-main
   GLOB ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)
 
+add_custom_target(compiler-training)
+
 add_subdirectory(api)
 add_subdirectory(alternator)
 add_subdirectory(db)
@@ -279,5 +281,10 @@ target_link_libraries(scylla PRIVATE
 target_include_directories(scylla PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${scylla_gen_build_dir}")
+
+add_custom_target(maybe-scylla
+  DEPENDS $<$<CONFIG:Dev>:$<TARGET_FILE:scylla>>)
+add_dependencies(compiler-training
+  maybe-scylla)
 
 add_subdirectory(dist)

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -50,3 +50,16 @@ target_link_libraries(service
 
 check_headers(check-headers service
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)
+
+add_library(storage_proxy.o
+  OBJECT
+    $<$<CONFIG:RelWithDebInfo,Debug>:storage_proxy.cc>)
+target_include_directories(storage_proxy.o
+  PRIVATE
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(storage_proxy.o
+  Seastar::seastar
+  xxHash::xxhash
+  idl)
+add_dependencies(compiler-training
+  storage_proxy.o)


### PR DESCRIPTION
`tools/toolchain/optimized_clang.sh` builds this target for creating the profile in order to build clang optimized with this profile data.

so let's be compatible with `configure.py`, and add this target to CMake building system as well.

---

this is a cmake related change, hence no need to backport.