### PR TITLE
build: cmake: use $<CONFIG:cfgs> when appropriate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,14 +61,14 @@ set(ABSL_PROPAGATE_CXX_STD ON CACHE BOOL "" FORCE)
 
 find_package(Sanitizers QUIET)
 set(sanitizer_cxx_flags
-    $<$<IN_LIST:$<CONFIG>,Debug;Sanitize>:$<TARGET_PROPERTY:Sanitizers::address,INTERFACE_COMPILE_OPTIONS>;$<TARGET_PROPERTY:Sanitizers::undefined_behavior,INTERFACE_COMPILE_OPTIONS>>)
+    $<$<CONFIG:Debug,Sanitize>:$<TARGET_PROPERTY:Sanitizers::address,INTERFACE_COMPILE_OPTIONS>;$<TARGET_PROPERTY:Sanitizers::undefined_behavior,INTERFACE_COMPILE_OPTIONS>>)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(ABSL_GCC_FLAGS ${sanitizer_cxx_flags})
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(ABSL_LLVM_FLAGS ${sanitizer_cxx_flags})
 endif()
 set(ABSL_DEFAULT_LINKOPTS
-    $<$<IN_LIST:$<CONFIG>,Debug;Sanitize>:$<TARGET_PROPERTY:Sanitizers::address,INTERFACE_LINK_LIBRARIES>;$<TARGET_PROPERTY:Sanitizers::undefined_behavior,INTERFACE_LINK_LIBRARIES>>)
+    $<$<CONFIG:Debug,Sanitize>:$<TARGET_PROPERTY:Sanitizers::address,INTERFACE_LINK_LIBRARIES>;$<TARGET_PROPERTY:Sanitizers::undefined_behavior,INTERFACE_LINK_LIBRARIES>>)
 add_subdirectory(abseil)
 add_library(absl-headers INTERFACE)
 target_include_directories(absl-headers SYSTEM INTERFACE


### PR DESCRIPTION
per
https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#genex:CONFIG, `cfgs` can be a comma-separated list. this is supported by CMake 3.19 and up, and our minimum required CMake version is 3.27. so let's switch over from the composition of `IN_LIST` and `CONFIG` generator expressions to a single one. simpler this way.

---

this is merely a cleanup, so no need to backport.