### PR TITLE
Use yielding directory lister in sstable_directory

### DIFF
--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -315,11 +315,7 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
             abstract_lister::make<s3::client::bucket_lister>(_client, _bucket, _directory.native() + "/", &manifest_json_filter);
 
     co_await with_closeable(std::move(lister), coroutine::lambda([this, &directory] (abstract_lister& lister) -> future<> {
-        while (true) {
-            auto de = co_await lister.get();
-            if (!de) {
-                break;
-            }
+        while (auto de = co_await lister.get()) {
             auto component_path = _directory / de->name;
             auto comps = sstables::parse_path(component_path, directory._schema->ks_name(), directory._schema->cf_name());
             handle(std::move(comps), component_path);

--- a/utils/lister.hh
+++ b/utils/lister.hh
@@ -208,6 +208,8 @@ public:
         , _queue(512 / sizeof(std::optional<directory_entry>))
     { }
 
+    directory_lister(directory_lister&&) noexcept = default;
+
     ~directory_lister();
 
     future<std::optional<directory_entry>> get() override;


### PR DESCRIPTION
The yielding lister is considered to be better replacement that scan_dir(lambda) one.
Also, the sstable directory will be patched to scan the contents of S3 bucket and yielding lister fits better for generalization.