### PR TITLE
replica: fix copy constructor of tablet_sstable_set

### DIFF
--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -512,14 +512,6 @@ public:
         });
     }
 
-    tablet_sstable_set(const tablet_sstable_set& o)
-        : _schema(o._schema)
-        , _tablet_map(o._tablet_map.tablet_count())
-        , _sstable_sets(o._sstable_sets)
-        , _size(o._size)
-        , _bytes_on_disk(o._bytes_on_disk)
-    {}
-
     static lw_shared_ptr<sstables::sstable_set> make(schema_ptr s, const storage_group_manager& sgm, const locator::tablet_map& tmap) {
         return make_lw_shared<sstables::sstable_set>(std::make_unique<tablet_sstable_set>(std::move(s), sgm, tmap));
     }

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -54,6 +54,10 @@ public:
     static sstables::generation_type calculate_generation_for_new_table(replica::column_family& cf) {
         return cf.calculate_generation_for_new_table();
     }
+
+    static const std::unique_ptr<replica::storage_group_manager>& get_storage_group_manager(replica::column_family& cf) {
+        return cf._sg_manager;
+    }
 };
 
 namespace sstables {


### PR DESCRIPTION
Commit https://github.com/scylladb/scylladb/commit/9f93dd9fa3376cfe560c65fb9c9c938ff1d3f99d changed `tablet_sstable_set::_sstable_sets` to be a `absl::flat_hash_map` and in addition, `std::set<size_t> _sstable_set_ids` was added. `_sstable_set_ids` is set up in the `tablet_sstable_set(schema_ptr s, const storage_group_manager& sgm, const locator::tablet_map& tmap)` constructor, but it is not copied in `tablet_sstable_set(const tablet_sstable_set& o)`. 

This affects the `tablet_sstable_set::tablet_sstable_set` method as it depends on the copy constructor. Since sstable set can be cloned when a new sstable set is added, the issue will cause ids not being copied into the new sstable set. It's healed only after compaction, since the sstable set is rebuilt from scratch there.

This PR fixes this issue by removing the existing copy constructor of `tablet_sstable_set` to enable the implicit default copy constructor.

Fixes #19519 