### PR TITLE
Add ability to list S3 bucket contents

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1226,4 +1226,113 @@ future<> client::close() {
     });
 }
 
+client::bucket_lister::bucket_lister(shared_ptr<client> client, sstring bucket, sstring prefix, size_t objects_per_page, size_t entries_batch)
+    : _client(std::move(client))
+    , _bucket(std::move(bucket))
+    , _prefix(std::move(prefix))
+    , _max_keys(format("{}", objects_per_page))
+    , _queue(entries_batch)
+{
+}
+
+static std::pair<std::vector<sstring>, sstring> parse_list_of_objects(sstring body) {
+    auto doc = std::make_unique<rapidxml::xml_document<>>();
+    try {
+        doc->parse<0>(body.data());
+    } catch (const rapidxml::parse_error& e) {
+        s3l.warn("cannot parse list-objects-v2 response: {}", e.what());
+        throw std::runtime_error("cannot parse objects list response");
+    }
+
+    std::vector<sstring> names;
+    auto root_node = doc->first_node("ListBucketResult");
+    for (auto contents = root_node->first_node("Contents"); contents; contents = contents->next_sibling()) {
+        auto key = contents->first_node("Key");
+        names.push_back(key->value());
+    }
+
+    sstring continuation_token;
+    auto is_truncated = root_node->first_node("IsTruncated");
+    if (is_truncated && std::string_view(is_truncated->value()) == "true") {
+        auto continuation = root_node->first_node("NextContinuationToken");
+        if (!continuation) {
+            throw std::runtime_error("no continuation token in truncated list of objects");
+        }
+        continuation_token = continuation->value();
+    }
+
+    return {std::move(names), std::move(continuation_token)};
+}
+
+future<> client::bucket_lister::start_listing() {
+    // This is the implementation of paged ListObjectsV2 API call
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
+    sstring continuation_token;
+    do {
+        s3l.trace("GET /?list-type=2 (prefix={})", _prefix);
+        auto req = http::request::make("GET", _client->_host, format("/{}", _bucket));
+        req.query_parameters.emplace("list-type", "2");
+        req.query_parameters.emplace("max-keys", _max_keys);
+        if (!continuation_token.empty()) {
+            req.query_parameters.emplace("continuation-token", std::exchange(continuation_token, ""));
+        }
+        if (!_prefix.empty()) {
+            req.query_parameters.emplace("prefix", _prefix);
+        }
+
+        std::vector<sstring> names;
+        try {
+            co_await _client->make_request(std::move(req),
+                [&names, &continuation_token] (const http::reply& reply, input_stream<char>&& in) mutable -> future<> {
+                    auto input = std::move(in);
+                    auto body = co_await util::read_entire_stream_contiguous(input);
+                    auto list = parse_list_of_objects(std::move(body));
+                    names = std::move(list.first);
+                    continuation_token = std::move(list.second);
+                }
+            );
+        } catch (...) {
+            _queue.abort(std::current_exception());
+            co_return;
+        }
+
+        for (auto&& o : names) {
+            co_await _queue.push_eventually(directory_entry{std::move(o)});
+        }
+    } while (!continuation_token.empty());
+    co_await _queue.push_eventually(std::nullopt);
+}
+
+future<std::optional<directory_entry>> client::bucket_lister::get() {
+    if (!_opt_done_fut) {
+        _opt_done_fut = start_listing();
+    }
+
+    std::exception_ptr ex;
+    try {
+        auto ret = co_await _queue.pop_eventually();
+        if (ret) {
+            co_return ret;
+        }
+    } catch (...) {
+        ex = std::current_exception();
+    }
+    co_await close();
+    if (ex) {
+        co_return coroutine::exception(std::move(ex));
+    }
+    co_return std::nullopt;
+}
+
+future<> client::bucket_lister::close() noexcept {
+    if (_opt_done_fut) {
+        _queue.abort(std::make_exception_ptr(broken_pipe_exception()));
+        try {
+            co_await std::exchange(_opt_done_fut, std::make_optional<future<>>(make_ready_future<>())).value();
+        } catch (...) {
+            // ignore all errors
+        }
+    }
+}
+
 } // s3 namespace

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -134,7 +134,7 @@ void client::authorize(http::request& req) {
     }
     unsigned query_nr = query_parameters.size();
     for (const auto& q : query_parameters) {
-        query_string += format("{}={}{}", q.first, q.second, query_nr == 1 ? "" : "&");
+        query_string += format("{}={}{}", http::internal::url_encode(q.first), http::internal::url_encode(q.second), query_nr == 1 ? "" : "&");
         query_nr--;
     }
     auto sig = utils::aws::get_signature(

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -12,6 +12,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/metrics.hh>
+#include <seastar/core/queue.hh>
 #include <seastar/http/client.hh>
 #include <filesystem>
 #include "utils/s3/creds.hh"
@@ -86,6 +87,7 @@ class client : public enable_shared_from_this<client> {
 
     future<> get_object_header(sstring object_name, http::experimental::client::reply_handler handler);
 public:
+
     explicit client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global_factory gf, private_tag);
     static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, semaphore& memory, global_factory gf = {});
 
@@ -127,6 +129,24 @@ public:
         shared_ptr<client> to_client() && {
             return _gf(std::move(_host));
         }
+    };
+
+    class bucket_lister {
+        shared_ptr<client> _client;
+        sstring _bucket;
+        sstring _prefix;
+        sstring _max_keys;
+        std::optional<future<>> _opt_done_fut;
+        seastar::queue<std::optional<directory_entry>> _queue;
+
+        future<> start_listing();
+
+    public:
+
+        bucket_lister(shared_ptr<client> client, sstring bucket, sstring prefix = "", size_t objects_per_page = 64, size_t entries_batch = 512 / sizeof(std::optional<directory_entry>));
+
+        future<std::optional<directory_entry>> get();
+        future<> close() noexcept;
     };
 
     future<> close();


### PR DESCRIPTION
This is prerequisite for "restore from object storage" feature. In order to collect the sstables in bucket one would need to list the bucket contents with the given prefix. The ListObjectsV2 provides a way for it and here's the respective s3::client extension.