### PR TITLE
alternator: refactor the item operation execution

### DIFF
--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -224,6 +224,9 @@ private:
     friend class rmw_operation;
 
     static void describe_key_schema(rjson::value& parent, const schema&, std::unordered_map<std::string,std::string> * = nullptr);
+
+    template<typename rmw_op>
+    future<request_return_type> execute_rmw_operation(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
     
 public:
     static void describe_key_schema(rjson::value& parent, const schema& schema, std::unordered_map<std::string,std::string>&);


### PR DESCRIPTION
Move the RMW operations common code to a single place. Making the method templated to allow for different types of operations.

This allows to share the common code between the different operations for easier maintenance and to avoid code duplication.