### PR TITLE
Relax sstable_directory::process_descriptor() call graph

### DIFF
--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -192,8 +192,9 @@ sstable_directory::process_descriptor(sstables::entry_descriptor desc, process_f
     if (flags.sort_sstables_according_to_owner) {
         co_await sort_sstable(std::move(desc), flags);
     } else {
+        auto sst = co_await load_sstable(std::move(desc), flags);
         dirlog.debug("Added {} to unsorted sstables list", sstable_filename(desc));
-        _unsorted_sstables.push_back(co_await load_sstable(std::move(desc), flags));
+        _unsorted_sstables.push_back(std::move(sst));
     }
 }
 

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -193,7 +193,7 @@ sstable_directory::process_descriptor(sstables::entry_descriptor desc, process_f
         co_await sort_sstable(std::move(desc), flags);
     } else {
         auto sst = co_await load_sstable(std::move(desc), flags);
-        dirlog.debug("Added {} to unsorted sstables list", sstable_filename(desc));
+        dirlog.debug("Added {} to unsorted sstables list", sst->get_filename());
         _unsorted_sstables.push_back(std::move(sst));
     }
 }
@@ -204,14 +204,14 @@ sstable_directory::sort_sstable(sstables::entry_descriptor desc, process_flags f
     auto shards = sst->get_shards_for_this_sstable();
     if (shards.size() == 1) {
         if (shards[0] == this_shard_id()) {
-            dirlog.trace("{} identified as a local unshared SSTable", sstable_filename(desc));
+            dirlog.trace("{} identified as a local unshared SSTable", sst->get_filename());
             _unshared_local_sstables.push_back(std::move(sst));
         } else {
-            dirlog.trace("{} identified as a remote unshared SSTable, shard={}", sstable_filename(desc), shards[0]);
+            dirlog.trace("{} identified as a remote unshared SSTable, shard={}", sst->get_filename(), shards[0]);
             _unshared_remote_sstables[shards[0]].push_back(std::move(desc));
         }
     } else {
-        dirlog.trace("{} identified as a shared SSTable, shards={}", sstable_filename(desc), shards);
+        dirlog.trace("{} identified as a shared SSTable, shards={}", sst->get_filename(), shards);
         _shared_sstable_info.push_back(co_await sst->get_open_info());
     }
 }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -216,10 +216,6 @@ sstable_directory::sort_sstable(sstables::entry_descriptor desc, process_flags f
     }
 }
 
-sstring sstable_directory::sstable_filename(const sstables::entry_descriptor& desc) const {
-    return sstable::filename(make_path(_table_dir, _state).native(), _schema->ks_name(), _schema->cf_name(), desc.version, desc.generation, desc.format, component_type::Data);
-}
-
 generation_type
 sstable_directory::highest_generation_seen() const {
     return _max_generation_seen;

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -197,18 +197,6 @@ sstable_directory::process_descriptor(sstables::entry_descriptor desc, process_f
     }
 }
 
-future<std::vector<shard_id>> sstable_directory::get_shards_for_this_sstable(const sstables::entry_descriptor& desc, process_flags flags) const {
-    auto sst = _manager.make_sstable(_schema, _table_dir, *_storage_opts, desc.generation, _state, desc.version, desc.format, gc_clock::now(), _error_handler_gen);
-    co_await sst->load_owner_shards(_sharder);
-    validate(sst, flags);
-    co_return sst->get_shards_for_this_sstable();
-}
-
-future<foreign_sstable_open_info> sstable_directory::get_open_info_for_this_sstable(const sstables::entry_descriptor& desc) const {
-    auto sst = co_await load_sstable(std::move(desc));
-    co_return co_await sst->get_open_info();
-}
-
 future<>
 sstable_directory::sort_sstable(sstables::entry_descriptor desc, process_flags flags) {
     auto sst = co_await load_sstable(desc, flags);

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -184,9 +184,6 @@ private:
     // Sort the sstable according to owner
     future<> sort_sstable(sstables::entry_descriptor desc, process_flags flags);
 
-    // Returns filename for a SSTable from its entry_descriptor.
-    sstring sstable_filename(const sstables::entry_descriptor& desc) const;
-
     sstable_directory(sstables_manager& manager,
           schema_ptr schema,
           std::variant<std::unique_ptr<dht::sharder>, const dht::sharder*> sharder,

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -181,9 +181,6 @@ private:
 
     future<> load_foreign_sstables(sstable_entry_descriptor_vector info_vec);
 
-    // Sort the sstable according to owner
-    future<> sort_sstable(sstables::entry_descriptor desc, process_flags flags);
-
     sstable_directory(sstables_manager& manager,
           schema_ptr schema,
           std::variant<std::unique_ptr<dht::sharder>, const dht::sharder*> sharder,

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -187,11 +187,6 @@ private:
     // Returns filename for a SSTable from its entry_descriptor.
     sstring sstable_filename(const sstables::entry_descriptor& desc) const;
 
-    // Compute owner of shards for a particular SSTable.
-    future<std::vector<shard_id>> get_shards_for_this_sstable(const sstables::entry_descriptor& desc, process_flags flags) const;
-    // Retrieves sstables::foreign_sstable_open_info for a particular SSTable.
-    future<foreign_sstable_open_info> get_open_info_for_this_sstable(const sstables::entry_descriptor& desc) const;
-
     sstable_directory(sstables_manager& manager,
           schema_ptr schema,
           std::variant<std::unique_ptr<dht::sharder>, const dht::sharder*> sharder,

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -177,7 +177,6 @@ private:
     future<> process_descriptor(sstables::entry_descriptor desc, process_flags flags);
     void validate(sstables::shared_sstable sst, process_flags flags) const;
     future<sstables::shared_sstable> load_sstable(sstables::entry_descriptor desc, sstables::sstable_open_config cfg = {}) const;
-    future<sstables::shared_sstable> load_sstable(sstables::entry_descriptor desc, process_flags flags) const;
 
     future<> load_foreign_sstables(sstable_entry_descriptor_vector info_vec);
 


### PR DESCRIPTION
The method logic is clean and simple -- load sstable from the descriptor and sort it into one of collections (local, shared, remote, unsorted). To achieve that there's a bunch of helper methods, but they duplicate functionality of each other. Squashing most of this code into process_descriptor() makes it easier to read and keeps sstable_directory private API much shorter.