### PR TITLE
service/migration_manager: do not move away a const reference

### DIFF
--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -865,7 +865,7 @@ future<std::vector<mutation>> prepare_view_update_announcement(storage_proxy& sp
 future<std::vector<mutation>> prepare_view_drop_announcement(storage_proxy& sp, const sstring& ks_name, const sstring& cf_name, api::timestamp_type ts) {
     auto& db = sp.local_db();
     try {
-        auto& view = db.find_column_family(ks_name, cf_name).schema();
+        const auto& view = db.find_column_family(ks_name, cf_name).schema();
         if (!view->is_view()) {
             throw exceptions::invalid_request_exception("Cannot use DROP MATERIALIZED VIEW on Table");
         }
@@ -874,7 +874,7 @@ future<std::vector<mutation>> prepare_view_drop_announcement(storage_proxy& sp, 
         }
         auto keyspace = db.find_keyspace(ks_name).metadata();
         mlogger.info("Drop view '{}.{}'", view->ks_name(), view->cf_name());
-        auto mutations = db::schema_tables::make_drop_view_mutations(keyspace, view_ptr(std::move(view)), ts);
+        auto mutations = db::schema_tables::make_drop_view_mutations(keyspace, view_ptr(view), ts);
         // notifiers must run in seastar thread
         co_await seastar::async([&] {
             db.get_notifier().before_drop_column_family(*view, mutations, ts);


### PR DESCRIPTION
despite that `std::move()` makes its argument a rvalue reference, in this case, its argument is already a lvalue reference. what `std::move(view)` returns is a
`std::remove_reference<const schema_ptr&>::type`, i.e, `const schema_ptr`.

so we cannot benefit from "moving away" from it, and what gets called is the copy constructor of `schema_ptr` when calling `view_ptr(std::move(view))`.

so, in this change, we make this more obvious by

* changing the type of `view` to `const auto&`
* remove the `std::move()`. it's but confusing.

this change is a cleanup to improve the readability.

---

it's a cleanup, hence no need to backport.