### PR TITLE
README: Update the version of C++ to C++23

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -19,13 +19,13 @@ $ git submodule update --init --recursive
 ### Dependencies
 
 Scylla is fairly fussy about its build environment, requiring a very recent
-version of the C++20 compiler and numerous tools and libraries to build.
+version of the C++23 compiler and numerous tools and libraries to build.
 
 Run `./install-dependencies.sh` (as root) to use your Linux distributions's
 package manager to install the appropriate packages on your build machine.
 However, this will only work on very recent distributions. For example,
 currently Fedora users must upgrade to Fedora 32 otherwise the C++ compiler
-will be too old, and not support the new C++20 standard that Scylla uses.
+will be too old, and not support the new C++23 standard that Scylla uses.
 
 Alternatively, to avoid having to upgrade your build machine or install
 various packages on it, we provide another option - the **frozen toolchain**.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more information, please see the [ScyllaDB web site].
 ## Build Prerequisites
 
 Scylla is fairly fussy about its build environment, requiring very recent
-versions of the C++20 compiler and of many libraries to build. The document
+versions of the C++23 compiler and of many libraries to build. The document
 [HACKING.md](HACKING.md) includes detailed information on building and
 developing Scylla, but to get Scylla building quickly on (almost) any build
 machine, Scylla offers a [frozen toolchain](tools/toolchain/README.md),
@@ -84,11 +84,11 @@ Documentation can be found [here](docs/dev/README.md).
 Seastar documentation can be found [here](http://docs.seastar.io/master/index.html).
 User documentation can be found [here](https://docs.scylladb.com/).
 
-## Training 
+## Training
 
-Training material and online courses can be found at [Scylla University](https://university.scylladb.com/). 
-The courses are free, self-paced and include hands-on examples. They cover a variety of topics including Scylla data modeling, 
-administration, architecture, basic NoSQL concepts, using drivers for application development, Scylla setup, failover, compactions, 
+Training material and online courses can be found at [Scylla University](https://university.scylladb.com/).
+The courses are free, self-paced and include hands-on examples. They cover a variety of topics including Scylla data modeling,
+administration, architecture, basic NoSQL concepts, using drivers for application development, Scylla setup, failover, compactions,
 multi-datacenters and how Scylla integrates with third-party applications.
 
 ## Contributing to Scylla


### PR DESCRIPTION
Scylla has started being built with C++23. We update the information in the relevant documents accordingly.