### PR TITLE
update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,9 +7,9 @@ row_cache* @tgrabiec
 test/boost/mvcc* @tgrabiec
 
 # CDC
-cdc/* @kbr- @elcallio @piodul @jul-stas
-test/cql/cdc_* @kbr- @elcallio @piodul @jul-stas
-test/boost/cdc_* @kbr- @elcallio @piodul @jul-stas
+cdc/* @kbr- @elcallio @piodul
+test/cql/cdc_* @kbr- @elcallio @piodul
+test/boost/cdc_* @kbr- @elcallio @piodul
 
 # COMMITLOG / BATCHLOG
 db/commitlog/* @elcallio @eliransin
@@ -28,12 +28,12 @@ transport/*
 cql3/* @tgrabiec
 
 # COUNTERS
-counters* @jul-stas
-tests/counter_test* @jul-stas
+counters*
+tests/counter_test*
 
 # DOCS
 docs/* @annastuchlik @tzach
-docs/alternator @annastuchlik @tzach @nyh @havaker @nuivall
+docs/alternator @annastuchlik @tzach @nyh @nuivall
 
 # GOSSIP
 gms/* @tgrabiec @asias
@@ -74,8 +74,8 @@ streaming/* @tgrabiec @asias
 service/storage_service.* @tgrabiec @asias
 
 # ALTERNATOR
-alternator/* @havaker @nuivall
-test/alternator/* @havaker @nuivall
+alternator/* @nuivall
+test/alternator/* @nuivall
 
 # HINTED HANDOFF
 db/hints/* @piodul @vladzcloudius @eliransin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,7 @@ docs/* @annastuchlik @tzach
 docs/alternator @annastuchlik @tzach @nyh @nuivall @ptrsmrn @KrzaQ
 
 # GOSSIP
-gms/* @tgrabiec @asias
+gms/* @tgrabiec @asias @kbr-scylla
 
 # DOCKER
 dist/docker/*

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,9 +7,9 @@ row_cache* @tgrabiec
 test/boost/mvcc* @tgrabiec
 
 # CDC
-cdc/* @kbr- @elcallio @piodul
-test/cql/cdc_* @kbr- @elcallio @piodul
-test/boost/cdc_* @kbr- @elcallio @piodul
+cdc/* @kbr-scylla @elcallio @piodul
+test/cql/cdc_* @kbr-scylla @elcallio @piodul
+test/boost/cdc_* @kbr-scylla @elcallio @piodul
 
 # COMMITLOG / BATCHLOG
 db/commitlog/* @elcallio @eliransin
@@ -94,8 +94,8 @@ test/boost/querier_cache_test.cc @denesb
 test/cql-pytest/* @nyh
 
 # RAFT
-raft/* @kbr- @gleb-cloudius @kostja
-test/raft/* @kbr- @gleb-cloudius @kostja
+raft/* @kbr-scylla @gleb-cloudius @kostja
+test/raft/* @kbr-scylla @gleb-cloudius @kostja
 
 # HEAT-WEIGHTED LOAD BALANCING
 db/heat_load_balance.* @nyh @gleb-cloudius

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # AUTH
-auth/* @elcallio @vladzcloudius
+auth/* @nuivall @ptrsmrn @KrzaQ
 
 # CACHE
 row_cache* @tgrabiec
@@ -25,15 +25,15 @@ compaction/* @raphaelsc
 transport/*
 
 # CQL QUERY LANGUAGE
-cql3/* @tgrabiec
+cql3/* @tgrabiec @nuivall @ptrsmrn @KrzaQ
 
 # COUNTERS
-counters*
-tests/counter_test*
+counters* @nuivall @ptrsmrn @KrzaQ
+tests/counter_test* @nuivall @ptrsmrn @KrzaQ
 
 # DOCS
 docs/* @annastuchlik @tzach
-docs/alternator @annastuchlik @tzach @nyh @nuivall
+docs/alternator @annastuchlik @tzach @nyh @nuivall @ptrsmrn @KrzaQ
 
 # GOSSIP
 gms/* @tgrabiec @asias
@@ -74,8 +74,8 @@ streaming/* @tgrabiec @asias
 service/storage_service.* @tgrabiec @asias
 
 # ALTERNATOR
-alternator/* @nuivall
-test/alternator/* @nuivall
+alternator/* @nyh @nuivall @ptrsmrn @KrzaQ
+test/alternator/* @nyh @nuivall @ptrsmrn @KrzaQ
 
 # HINTED HANDOFF
 db/hints/* @piodul @vladzcloudius @eliransin


### PR DESCRIPTION
Removed people that no longer contribute to the scylladb.git and added/substituted reviewers responsible for maintaining the frontend components.

No need to backport, this is just an information for the github tool.