### PR TITLE
cql: create default superuser if it doesn't exist

### DIFF
--- a/auth/maintenance_socket_role_manager.cc
+++ b/auth/maintenance_socket_role_manager.cc
@@ -44,6 +44,10 @@ future<> maintenance_socket_role_manager::stop() {
     return make_ready_future<>();
 }
 
+future<> maintenance_socket_role_manager::ensure_superuser_is_created() {
+    return make_ready_future<>();
+}
+
 template<typename T = void>
 future<T> operation_not_supported_exception(std::string_view operation) {
     return make_exception_future<T>(

--- a/auth/maintenance_socket_role_manager.hh
+++ b/auth/maintenance_socket_role_manager.hh
@@ -39,6 +39,8 @@ public:
 
     virtual future<> stop() override;
 
+    virtual future<> ensure_superuser_is_created() override;
+
     virtual future<> create(std::string_view role_name, const role_config&, ::service::group0_batch&) override;
 
     virtual future<> drop(std::string_view role_name, ::service::group0_batch& mc) override;

--- a/auth/role_manager.hh
+++ b/auth/role_manager.hh
@@ -108,6 +108,13 @@ public:
     virtual future<> stop() = 0;
 
     ///
+    /// Ensure that superuser role exists.
+    ///
+    /// \returns a future once it is ensured that the superuser role exists.
+    ///
+    virtual future<> ensure_superuser_is_created() = 0;
+
+    ///
     /// \returns an exceptional future with \ref role_already_exists for a role that has previously been created.
     ///
     virtual future<> create(std::string_view role_name, const role_config&, ::service::group0_batch&) = 0;

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -262,6 +262,10 @@ future<> service::stop() {
     });
 }
 
+future<> service::ensure_superuser_is_created() {
+    return _role_manager->ensure_superuser_is_created();
+}
+
 void service::update_cache_config() {
     auto db = _qp.db();
 

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -132,6 +132,8 @@ public:
 
     future<> stop();
 
+    future<> ensure_superuser_is_created();
+
     void update_cache_config();
 
     void reset_authorization_cache();

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -280,6 +280,10 @@ future<> standard_role_manager::stop() {
     return _stopped.handle_exception_type([] (const sleep_aborted&) { }).handle_exception_type([](const abort_requested_exception&) {});;
 }
 
+future<> standard_role_manager::ensure_superuser_is_created() {
+    co_return;
+}
+
 future<> standard_role_manager::create_or_replace(std::string_view role_name, const role_config& c, ::service::group0_batch& mc) {
     const sstring query = seastar::format("INSERT INTO {}.{} ({}, is_superuser, can_login) VALUES (?, ?, ?)",
             get_auth_ks_name(_qp),

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -249,26 +249,28 @@ future<> standard_role_manager::start() {
         }
 
         auto handler = [this] () -> future<> {
-            try {
-                if (legacy_mode(_qp)) {
-                    co_await _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as);
-
-                    if (co_await any_nondefault_role_row_satisfies(_qp, &has_can_login)) {
-                        if (legacy_metadata_exists()) {
-                            log.warn("Ignoring legacy user metadata since nondefault roles already exist.");
-                        }
-                        co_return;
-                    }
-
-                    if (legacy_metadata_exists()) {
-                        co_await migrate_legacy_metadata();
-                        co_return;
-                    }
+            const bool legacy = legacy_mode(_qp);
+            if (legacy) {
+                if (!_superuser_created_promise.available()) {
+                    _superuser_created_promise.set_value();
                 }
-                co_await create_default_role_if_missing();
-            } catch (...) {
-                log.error("Failed to create default role: unknown error");
-                throw;
+                co_await _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as);
+
+                if (co_await any_nondefault_role_row_satisfies(_qp, &has_can_login)) {
+                    if (legacy_metadata_exists()) {
+                        log.warn("Ignoring legacy user metadata since nondefault roles already exist.");
+                    }
+                    co_return;
+                }
+
+                if (legacy_metadata_exists()) {
+                    co_await migrate_legacy_metadata();
+                    co_return;
+                }
+            }
+            co_await create_default_role_if_missing();
+            if (!legacy) {
+                _superuser_created_promise.set_value();
             }
         };
 
@@ -283,7 +285,8 @@ future<> standard_role_manager::stop() {
 }
 
 future<> standard_role_manager::ensure_superuser_is_created() {
-    co_return;
+    SCYLLA_ASSERT(this_shard_id() == 0);
+    return _superuser_created_promise.get_shared_future();
 }
 
 future<> standard_role_manager::create_or_replace(std::string_view role_name, const role_config& c, ::service::group0_batch& mc) {

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -243,35 +243,37 @@ future<> standard_role_manager::migrate_legacy_metadata() {
 }
 
 future<> standard_role_manager::start() {
-    return once_among_shards([this] {
-        return futurize_invoke([this] () {
-            if (legacy_mode(_qp)) {
-                return create_legacy_metadata_tables_if_missing();
-            }
-            return make_ready_future<>();
-        }).then([this] {
-            _stopped = auth::do_after_system_ready(_as, [this] {
-                return seastar::async([this] {
-                    if (legacy_mode(_qp)) {
-                        _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as).get();
+    return once_among_shards([this] () -> future<> {
+        if (legacy_mode(_qp)) {
+            co_await create_legacy_metadata_tables_if_missing();
+        }
 
-                        if (any_nondefault_role_row_satisfies(_qp, &has_can_login).get()) {
-                            if (legacy_metadata_exists()) {
-                                log.warn("Ignoring legacy user metadata since nondefault roles already exist.");
-                            }
+        auto handler = [this] () -> future<> {
+            try {
+                if (legacy_mode(_qp)) {
+                    co_await _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as);
 
-                            return;
-                        }
-
+                    if (co_await any_nondefault_role_row_satisfies(_qp, &has_can_login)) {
                         if (legacy_metadata_exists()) {
-                            migrate_legacy_metadata().get();
-                            return;
+                            log.warn("Ignoring legacy user metadata since nondefault roles already exist.");
                         }
+                        co_return;
                     }
-                    create_default_role_if_missing().get();
-                });
-            });
-        });
+
+                    if (legacy_metadata_exists()) {
+                        co_await migrate_legacy_metadata();
+                        co_return;
+                    }
+                }
+                co_await create_default_role_if_missing();
+            } catch (...) {
+                log.error("Failed to create default role: unknown error");
+                throw;
+            }
+        };
+
+        _stopped = auth::do_after_system_ready(_as, handler);
+        co_return;
     });
 }
 

--- a/auth/standard_role_manager.hh
+++ b/auth/standard_role_manager.hh
@@ -50,6 +50,8 @@ public:
 
     virtual future<> stop() override;
 
+    virtual future<> ensure_superuser_is_created() override;
+
     virtual future<> create(std::string_view role_name, const role_config&, ::service::group0_batch&) override;
 
     virtual future<> drop(std::string_view role_name, ::service::group0_batch& mc) override;

--- a/auth/standard_role_manager.hh
+++ b/auth/standard_role_manager.hh
@@ -38,6 +38,7 @@ class standard_role_manager final : public role_manager {
     future<> _stopped;
     abort_source _as;
     std::string _superuser;
+    shared_promise<> _superuser_created_promise;
 
 public:
     standard_role_manager(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&);

--- a/main.cc
+++ b/main.cc
@@ -2129,6 +2129,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 ss.local().drain_on_shutdown().get();
             });
 
+            auth_service.local().ensure_superuser_is_created().get();
             ss.local().register_protocol_server(cql_server_ctl, cfg->start_native_transport()).get();
             api::set_transport_controller(ctx, cql_server_ctl).get();
             auto stop_transport_controller = defer_verbose_shutdown("transport controller API", [&ctx] {

--- a/test/topology_experimental_raft/test_restart_cluster.py
+++ b/test/topology_experimental_raft/test_restart_cluster.py
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+"""
+Test clusters can restart fine after all nodes are stopped gracefully
+"""
+
+import logging
+import time
+
+import pytest
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for_cql_and_get_hosts
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_restart_cluster(manager: ManagerClient) -> None:
+    """Test that cluster can restart fine after all nodes are stopped gracefully"""
+    servers = await manager.servers_add(3)
+    cql = manager.get_cql()
+
+    logger.info(f"Servers {servers}, gracefully stopping servers {[s.server_id for s in servers]} to check if all will go up")
+    for s in servers:
+        await manager.server_stop_gracefully(s.server_id)
+
+    logger.info(f"Starting servers {[s.server_id for s in servers]}")
+    for s in servers:
+        await manager.server_start(s.server_id)
+
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)


### PR DESCRIPTION
This change reorganizes the way standard_role_manager startup is handled: role_manager::ensure_superuser_is_created() is added, which returns a future that resolves once the superuser is available. We wait for this future before starting the CQL server.

There is a change in behavior auth::do_after_system_ready is potentially an infinite loop, and we await its result.

Fixes #10481

Reason for no backports: it's not a regresson and it's an issue that may only affect a tiny time window during the cluster startup.