### PR TITLE
sstable_directory: Simplify special-purpose local-only constructor

### DIFF
--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -81,7 +81,6 @@ sstable_directory::sstable_directory(replica::table& table,
 sstable_directory::sstable_directory(sstables_manager& manager,
         schema_ptr schema,
         const dht::sharder& sharder,
-        lw_shared_ptr<const data_dictionary::storage_options> storage_opts,
         sstring table_dir,
         sstable_state state,
         io_error_handler_gen error_handler_gen)
@@ -89,7 +88,7 @@ sstable_directory::sstable_directory(sstables_manager& manager,
         manager,
         std::move(schema),
         &sharder,
-        std::move(storage_opts),
+        make_lw_shared<data_dictionary::storage_options>(), // local
         std::move(table_dir),
         state,
         std::move(error_handler_gen)

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -194,7 +194,6 @@ public:
     sstable_directory(sstables_manager& manager,
             schema_ptr schema,
             const dht::sharder& sharder,
-            lw_shared_ptr<const data_dictionary::storage_options> storage_opts,
             sstring table_dir,
             sstable_state state,
             io_error_handler_gen error_handler_gen);

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -165,7 +165,6 @@ static void with_sstable_directory(
     sstdir.start(seastar::sharded_parameter([&env_wrap] { return std::ref(env_wrap.get_manager()); }),
             seastar::sharded_parameter([] { return test_table_schema(); }),
             seastar::sharded_parameter([] { return std::ref(test_table_schema()->get_sharder()); }),
-            seastar::sharded_parameter([] { return make_lw_shared<data_dictionary::storage_options>(); }),
             path.native(), state, default_io_error_handler_gen()).get();
 
     func(sstdir);

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -415,7 +415,6 @@ mutation_opt read_schema_table_mutation(sharded<sstable_manager_service>& sst_ma
         sharded_parameter([&sst_man] { return std::ref(sst_man.local().sst_man); }),
         sharded_parameter([&schema_factory] { return schema_factory(); }),
         sharded_parameter([&] { return std::ref(schema_factory()->get_sharder()); }),
-        sharded_parameter([] { return make_lw_shared<const data_dictionary::storage_options>(); }),
         schema_table_data_path.native(), sstables::sstable_state::normal,
         sharded_parameter([] { return default_io_error_handler_gen(); })).get();
     auto stop_sst_dirs = deferred_stop(sst_dirs);


### PR DESCRIPTION
Typically the sstable_directory is constructed out of a table object. Some code, namely tests and schema-loader, don't have table at hand and construct directory out of schema, sharder, path-to-sstables, etc. This code doesn't work with any storage options other than local ones, so there's no need (yet) to carry this argument over.
