### PR TITLE
test/perf/perf_sstables: use test_modes as the type of its option

### DIFF
--- a/test/perf/perf_sstable.cc
+++ b/test/perf/perf_sstable.cc
@@ -151,16 +151,18 @@ int scylla_sstable_main(int argc, char** argv) {
                 throw std::invalid_argument("Invalid mode");
             }
         }).then([test, mode] {
-            if (mode == test_modes::index_read) {
+            switch (mode) {
+            using enum test_modes;
+            case index_read:
                 return test_index_read(*test).then([test] {});
-            } else if (mode == test_modes::sequential_read) {
+            case sequential_read:
                 return test_sequential_read(*test).then([test] {});
-            } else if ((mode == test_modes::index_write) || (mode == test_modes::write)) {
+            case index_write:
+                [[fallthrough]];
+            case write:
                 return test_write(*test).then([test] {});
-            } else if (mode == test_modes::compaction) {
+            case compaction:
                 return test_compaction(*test).then([test] {});
-            } else {
-                throw std::invalid_argument("Invalid mode");
             }
         }).then([] {
             return engine().exit(0);

--- a/test/perf/perf_sstable.cc
+++ b/test/perf/perf_sstable.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <boost/program_options/errors.hpp>
 #include <seastar/core/distributed.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sstring.hh>
@@ -60,13 +61,33 @@ enum class test_modes {
     compaction,
 };
 
-static std::unordered_map<sstring, test_modes> test_mode = {
+static const std::unordered_map<sstring, test_modes> test_mode = {
     {"sequential_read", test_modes::sequential_read },
     {"index_read", test_modes::index_read },
     {"write", test_modes::write },
     {"index_write", test_modes::index_write },
     {"compaction", test_modes::compaction },
 };
+
+std::istream& operator>>(std::istream& is, test_modes& mode) {
+    std::string token;
+    is >> token;
+    try {
+        mode = test_mode.at(token);
+    } catch (const std::out_of_range&) {
+        throw boost::program_options::invalid_option_value(token);
+    }
+    return is;
+}
+
+std::ostream& operator<<(std::ostream& os, test_modes mode) {
+    for (auto& [name, m] : test_mode) {
+        if (m == mode) {
+            return os << name;
+        }
+    }
+    assert(false && "unreachable");
+}
 
 namespace perf {
 
@@ -82,7 +103,7 @@ int scylla_sstable_main(int argc, char** argv) {
         ("num_columns", bpo::value<unsigned>()->default_value(5), "number of columns per row")
         ("column_size", bpo::value<unsigned>()->default_value(64), "size in bytes for each column")
         ("sstables", bpo::value<unsigned>()->default_value(1), "number of sstables (valid only for compaction mode)")
-        ("mode", bpo::value<sstring>()->default_value("index_write"), "one of: sequential_read, index_read, write, compaction, index_write (default)")
+        ("mode", bpo::value<test_modes>()->default_value(test_modes::index_write), "one of: sequential_read, index_read, write, compaction, index_write")
         ("testdir", bpo::value<sstring>()->default_value("/var/lib/scylla/perf-tests"), "directory in which to store the sstables")
         ("compaction-strategy", bpo::value<sstring>()->default_value("SizeTieredCompactionStrategy"), "compaction strategy to use, one of "
              "(SizeTieredCompactionStrategy, LeveledCompactionStrategy, DateTieredCompactionStrategy, TimeWindowCompactionStrategy)")
@@ -100,7 +121,7 @@ int scylla_sstable_main(int argc, char** argv) {
         cfg.sstables = app.configuration()["sstables"].as<unsigned>();
         sstring dir = app.configuration()["testdir"].as<sstring>();
         cfg.dir = dir;
-        auto mode = test_mode[app.configuration()["mode"].as<sstring>()];
+        auto mode = app.configuration()["mode"].as<test_modes>();
         if ((mode == test_modes::index_read) || (mode == test_modes::index_write)) {
             cfg.num_columns = 0;
             cfg.column_size = 0;


### PR DESCRIPTION
before this change, we look up for the mode using the command line
option as the key, but that's incorrect if the command line option does
not match with any of the known names. in that case, `test_mode` just
create another pair of <sstring, test_modes>, and return the second
component of this pair. and the second component is not what we expect.
we should have thrown an exception.

in this change

* the test_mode map is marked const.
* the overloads for parsing / formatting the `test_modes` type are
  added, so that boost::program_options can parse and format it.

after this change, we  print more user friendly error, like

```
/scylla perf-sstable --mode index-foo
error: the argument ('index-foo') for option '--mode' is invalid

Try --help.
```

instead of a bunch of output which is printed as if we passes the correct option as the argument of the `--mode` option.

---

it's an improvement of developer experience, hence no need to backport.