### PR TITLE
Fixes: #20148 use submodules relative to a fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,23 +1,23 @@
 [submodule "seastar"]
 	path = seastar
-	url = ../seastar
+	url = ../../scylladb/seastar
 	ignore = dirty
 [submodule "swagger-ui"]
 	path = swagger-ui
-	url = ../scylla-swagger-ui
+	url = ../../scylladb/scylla-swagger-ui
 	ignore = dirty
 [submodule "abseil"]
 	path = abseil
-	url = ../abseil-cpp
+	url = ../../abseil/abseil-cpp
 [submodule "scylla-jmx"]
 	path = tools/jmx
-	url = ../scylla-jmx
+	url = ../../scylladb/scylla-jmx
 [submodule "scylla-tools"]
 	path = tools/java
-	url = ../scylla-tools-java
+	url = ../../scylladb/scylla-tools-java
 [submodule "scylla-python3"]
 	path = tools/python3
-	url = ../scylla-python3
+	url = ../../scylladb/scylla-python3
 [submodule "tools/cqlsh"]
 	path = tools/cqlsh
-	url = ../scylla-cqlsh
+	url = ../../scylladb/scylla-cqlsh


### PR DESCRIPTION
The submodules are now relative to a regular
fork position github:/<user>/scyllab
and not to github:/scylladb as it used to be.

This PR *must* be tested on a clone of scylladb without a fork before it is merged.


