### PR TITLE
utils/tagged_integer: remove conversion to underlying integer

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2415,7 +2415,7 @@ future<> system_keyspace::get_repair_history(::table_id table_id, repair_history
     });
 }
 
-future<int> system_keyspace::increment_and_get_generation() {
+future<gms::generation_type> system_keyspace::increment_and_get_generation() {
     auto req = format("SELECT gossip_generation FROM system.{} WHERE key='{}'", LOCAL, LOCAL);
     auto rs = co_await _qp.execute_internal(req, cql3::query_processor::cache_internal::yes);
     gms::generation_type generation;

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -498,7 +498,7 @@ public:
     // may depend on it.
     future<> save_local_enabled_features(std::set<sstring> features, bool visible_before_cl_replay);
 
-    future<int> increment_and_get_generation();
+    future<gms::generation_type> increment_and_get_generation();
     bool bootstrap_needed() const;
     bool bootstrap_complete() const;
     bool bootstrap_in_progress() const;

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1625,7 +1625,7 @@ std::optional<endpoint_state> gossiper::get_state_for_version_bigger_than(inet_a
     return reqd_endpoint_state;
 }
 
-generation_type::value_type gossiper::compare_endpoint_startup(inet_address addr1, inet_address addr2) const {
+std::strong_ordering gossiper::compare_endpoint_startup(inet_address addr1, inet_address addr2) const {
     auto ep1 = get_endpoint_state_ptr(addr1);
     auto ep2 = get_endpoint_state_ptr(addr2);
     if (!ep1 || !ep2) {
@@ -1633,7 +1633,7 @@ generation_type::value_type gossiper::compare_endpoint_startup(inet_address addr
         logger.warn("{}", err);
         throw std::runtime_error(err);
     }
-    return ep1->get_heart_beat_state().get_generation() - ep2->get_heart_beat_state().get_generation();
+    return ep1->get_heart_beat_state().get_generation() <=> ep2->get_heart_beat_state().get_generation();
 }
 
 sstring gossiper::get_rpc_address(const inet_address& endpoint) const {

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -148,7 +148,7 @@ void gossiper::do_sort(utils::chunked_vector<gossip_digest>& g_digest_list) cons
         auto ep = g_digest.get_endpoint();
         auto ep_state = this->get_endpoint_state_ptr(ep);
         version_type version = ep_state ? this->get_max_endpoint_state_version(*ep_state) : version_type();
-        int32_t diff_version = ::abs(version - g_digest.get_max_version());
+        int32_t diff_version = ::abs((version - g_digest.get_max_version()).value());
         diff_digests.emplace_back(gossip_digest(ep, g_digest.get_generation(), version_type(diff_version)));
     }
 

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -475,7 +475,7 @@ public:
     /**
      * determine which endpoint started up earlier
      */
-    generation_type::value_type compare_endpoint_startup(inet_address addr1, inet_address addr2) const;
+    std::strong_ordering compare_endpoint_startup(inet_address addr1, inet_address addr2) const;
 
     /**
      * Return the rpc address associated with an endpoint as a string.

--- a/raft/log.hh
+++ b/raft/log.hh
@@ -79,12 +79,12 @@ public:
             // All log entries following the snapshot must
             // be present, otherwise we will not be able to
             // perform an initial state transfer.
-            SCYLLA_ASSERT(_first_idx <= _snapshot.idx + 1);
+            SCYLLA_ASSERT(_first_idx <= _snapshot.idx + index_t{1});
         }
         _memory_usage = range_memory_usage(_log.begin(), _log.end());
         // The snapshot index is at least 0, so _first_idx
         // is at least 1
-        SCYLLA_ASSERT(_first_idx > 0);
+        SCYLLA_ASSERT(_first_idx > index_t{0});
         stable_to(last_idx());
         init_last_conf_idx();
     }

--- a/raft/tracker.cc
+++ b/raft/tracker.cc
@@ -38,7 +38,7 @@ bool follower_progress::is_stray_reject(const append_reply::rejected& rejected) 
         // In PROBE state we send a single append request `req` with `req.prev_log_idx == next_idx - 1`.
         // When the follower generates a rejected response `r`, it sets `r.non_matching_idx = req.prev_log_idx`.
         // Thus the reject either satisfies `rejected.non_matching_idx == next_idx - 1` or is stray.
-        if (rejected.non_matching_idx != index_t(next_idx - 1)) {
+        if (rejected.non_matching_idx != next_idx - index_t(1)) {
             return true;
         }
         break;

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -183,7 +183,7 @@ future<> raft_sys_table_storage::store_snapshot_descriptor(const raft::snapshot_
                     cql3::query_processor::cache_internal::yes);
         }
 
-        if (preserve_log_entries > snap.idx) {
+        if (preserve_log_entries > snap.idx.value()) {
             static const auto store_latest_id_cql = format("INSERT INTO system.{} (group_id, snapshot_id) VALUES (?, ?)",
                 db::system_keyspace::RAFT);
             co_await _qp.execute_internal(

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -52,7 +52,7 @@ future<> raft_sys_table_storage::store_term_and_vote(raft::term_t term, raft::se
             db::system_keyspace::RAFT);
         return _qp.execute_internal(
             store_cql,
-            {_group_id.id, int64_t(term), vote.id}, cql3::query_processor::cache_internal::yes).discard_result();
+            {_group_id.id, int64_t(term.value()), vote.id}, cql3::query_processor::cache_internal::yes).discard_result();
     });
 }
 
@@ -63,7 +63,7 @@ future<std::pair<raft::term_t, raft::server_id>> raft_sys_table_storage::load_te
         co_return std::pair(raft::term_t(), raft::server_id());
     }
     const auto& static_row = rs->one();
-    raft::term_t vote_term = raft::term_t(static_row.get_or<int64_t>("vote_term", raft::term_t{}));
+    raft::term_t vote_term = raft::term_t(static_row.get_or<int64_t>("vote_term", raft::term_t{}.value()));
     raft::server_id vote{static_row.get_or<utils::UUID>("vote", raft::server_id{}.id)};
     co_return std::pair(vote_term, vote);
 }
@@ -74,7 +74,7 @@ future<> raft_sys_table_storage::store_commit_idx(raft::index_t idx) {
             db::system_keyspace::RAFT);
         return _qp.execute_internal(
             store_cql,
-            {_group_id.id, int64_t(idx)},
+            {_group_id.id, int64_t(idx.value())},
             cql3::query_processor::cache_internal::yes).discard_result();
     });
 }
@@ -86,7 +86,7 @@ future<raft::index_t> raft_sys_table_storage::load_commit_idx() {
         co_return raft::index_t(0);
     }
     const auto& static_row = rs->one();
-    co_return raft::index_t(static_row.get_or<int64_t>("commit_idx", raft::index_t{}));
+    co_return raft::index_t(static_row.get_or<int64_t>("commit_idx", raft::index_t{}.value()));
 }
 
 
@@ -163,7 +163,7 @@ future<> raft_sys_table_storage::store_snapshot_descriptor(const raft::snapshot_
             db::system_keyspace::RAFT_SNAPSHOTS);
         co_await _qp.execute_internal(
             store_snp_cql,
-            {_group_id.id, snap.id.id, int64_t(snap.idx), int64_t(snap.term)},
+            {_group_id.id, snap.id.id, int64_t(snap.idx.value()), int64_t(snap.term.value())},
             cql3::query_processor::cache_internal::yes
         );
         // remove old configs
@@ -230,8 +230,8 @@ future<size_t> raft_sys_table_storage::do_store_log_entries_one_batch(const std:
         // Silly workaround for https://bugs.llvm.org/show_bug.cgi?id=51515
         single_stmt_values.reserve(3);
         single_stmt_values.emplace_back(cql3::raw_value::make_value(timeuuid_type->decompose(_group_id.id)));
-        single_stmt_values.emplace_back(cql3::raw_value::make_value(long_type->decompose(int64_t(eptr->term))));
-        single_stmt_values.emplace_back(cql3::raw_value::make_value(long_type->decompose(int64_t(eptr->idx))));
+        single_stmt_values.emplace_back(cql3::raw_value::make_value(long_type->decompose(int64_t(eptr->term.value()))));
+        single_stmt_values.emplace_back(cql3::raw_value::make_value(long_type->decompose(int64_t(eptr->idx.value()))));
 
         stmt_values.emplace_back(std::move(single_stmt_values));
         stmt_data_views.emplace_back(std::move(data_tmp_buf));
@@ -297,7 +297,7 @@ future<> raft_sys_table_storage::truncate_log(raft::index_t idx) {
     return execute_with_linearization_point([this, idx] {
         static const auto truncate_cql = format("DELETE FROM system.{} WHERE group_id = ? AND \"index\" >= ?",
             db::system_keyspace::RAFT); 
-        return _qp.execute_internal(truncate_cql, {_group_id.id, int64_t(idx)}, cql3::query_processor::cache_internal::yes).discard_result();
+        return _qp.execute_internal(truncate_cql, {_group_id.id, int64_t(idx.value())}, cql3::query_processor::cache_internal::yes).discard_result();
     });
 }
 
@@ -318,7 +318,7 @@ future<> raft_sys_table_storage::update_snapshot_and_truncate_log_tail(const raf
         db::system_keyspace::RAFT, db::system_keyspace::RAFT);
     return _qp.execute_internal(
         store_latest_id_and_truncate_log_tail_cql,
-        {_group_id.id, snap.id.id, _group_id.id, int64_t(log_tail_idx)},
+        {_group_id.id, snap.id.id, _group_id.id, int64_t(log_tail_idx.value())},
         cql3::query_processor::cache_internal::yes
     ).discard_result();
 }

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -309,7 +309,7 @@ future<> raft_sys_table_storage::abort() {
 
 future<> raft_sys_table_storage::update_snapshot_and_truncate_log_tail(const raft::snapshot_descriptor &snap, size_t preserve_log_entries) {
     // Update snapshot and truncate logs in `system.raft` atomically
-    raft::index_t log_tail_idx = raft::index_t(static_cast<uint64_t>(snap.idx) - static_cast<uint64_t>(preserve_log_entries));
+    raft::index_t log_tail_idx(snap.idx.value() - preserve_log_entries);
     static const auto store_latest_id_and_truncate_log_tail_cql = format(
         "BEGIN UNLOGGED BATCH"
         "   INSERT INTO system.{} (group_id, snapshot_id) VALUES (?, ?);"   // store latest id

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2339,7 +2339,7 @@ future<> storage_service::handle_state_normal(inet_address endpoint, gms::permit
         if (*existing == get_broadcast_address()) {
             slogger.warn("Not updating host ID {} for {} because it's mine", host_id, endpoint);
             do_remove_node(endpoint);
-        } else if (_gossiper.compare_endpoint_startup(endpoint, *existing) > 0) {
+        } else if (std::is_gt(_gossiper.compare_endpoint_startup(endpoint, *existing))) {
             // The new IP has greater generation than the existing one.
             // Here we remap the host_id to the new IP. The 'owned_tokens' calculation logic below
             // won't detect any changes - the branch 'endpoint == current_owner' will be taken.
@@ -2436,7 +2436,7 @@ future<> storage_service::handle_state_normal(inet_address endpoint, gms::permit
             slogger.info("handle_state_normal: endpoint={} == current_owner={} token {}", endpoint, current_owner, t);
             // set state back to normal, since the node may have tried to leave, but failed and is now back up
             owned_tokens.insert(t);
-        } else if (_gossiper.compare_endpoint_startup(endpoint, current_owner) > 0) {
+        } else if (std::is_gt(_gossiper.compare_endpoint_startup(endpoint, current_owner))) {
             slogger.debug("handle_state_normal: endpoint={} > current_owner={}, token {}", endpoint, current_owner, t);
             owned_tokens.insert(t);
             slogger.info("handle_state_normal: remove endpoint={} token={}", current_owner, t);

--- a/test/raft/etcd_test.cc
+++ b/test/raft/etcd_test.cc
@@ -284,10 +284,10 @@ BOOST_AUTO_TEST_CASE(test_leader_election_overwrite_newer_logs) {
     make_candidate(fsm1);
     communicate(fsm1, fsm2, fsm3, fsm4, fsm5);
 
-    // BOOST_CHECK(compare_log_entries(fsm1.get_log(), fsm3.get_log(), 1, 2));
-    BOOST_CHECK(compare_log_entries(fsm1.get_log(), fsm3.get_log(), 1, 2));
-    BOOST_CHECK(compare_log_entries(fsm1.get_log(), fsm4.get_log(), 1, 2));
-    BOOST_CHECK(compare_log_entries(fsm1.get_log(), fsm5.get_log(), 1, 2));
+    // BOOST_CHECK(compare_log_entries(fsm1.get_log(), fsm3.get_log(), index_t{1}, index_t{2}));
+    BOOST_CHECK(compare_log_entries(fsm1.get_log(), fsm3.get_log(), index_t{1}, index_t{2}));
+    BOOST_CHECK(compare_log_entries(fsm1.get_log(), fsm4.get_log(), index_t{1}, index_t{2}));
+    BOOST_CHECK(compare_log_entries(fsm1.get_log(), fsm5.get_log(), index_t{1}, index_t{2}));
 }
 
 // TestVoteFromAnyState
@@ -563,10 +563,10 @@ BOOST_AUTO_TEST_CASE(test_cannot_commit_without_new_term_entry) {
     raft::command cmd = create_command(5);
     fsm2.add_entry(std::move(cmd));
     communicate(fsm2, fsm1, fsm3, fsm4, fsm5);
-    BOOST_CHECK(compare_log_entries(fsm2.get_log(), fsm1.get_log(), 1, 5));
-    BOOST_CHECK(compare_log_entries(fsm2.get_log(), fsm3.get_log(), 1, 5));
-    BOOST_CHECK(compare_log_entries(fsm2.get_log(), fsm4.get_log(), 1, 5));
-    BOOST_CHECK(compare_log_entries(fsm2.get_log(), fsm5.get_log(), 1, 5));
+    BOOST_CHECK(compare_log_entries(fsm2.get_log(), fsm1.get_log(), index_t{1}, index_t{5}));
+    BOOST_CHECK(compare_log_entries(fsm2.get_log(), fsm3.get_log(), index_t{1}, index_t{5}));
+    BOOST_CHECK(compare_log_entries(fsm2.get_log(), fsm4.get_log(), index_t{1}, index_t{5}));
+    BOOST_CHECK(compare_log_entries(fsm2.get_log(), fsm5.get_log(), index_t{1}, index_t{5}));
 }
 
 // TODO TestCommitWithoutNewTermEntry tests the entries could be committed
@@ -722,8 +722,8 @@ BOOST_AUTO_TEST_CASE(test_old_messages) {
             BOOST_REQUIRE_NO_THROW(std::get<raft::command>(res1[i]->data));
         }
     }
-    BOOST_CHECK(compare_log_entries(res1, fsm2.get_log(), 1, 4));
-    BOOST_CHECK(compare_log_entries(res1, fsm3.get_log(), 1, 4));
+    BOOST_CHECK(compare_log_entries(res1, fsm2.get_log(), index_t{1}, index_t{4}));
+    BOOST_CHECK(compare_log_entries(res1, fsm3.get_log(), index_t{1}, index_t{4}));
 }
 
 void handle_proposal(unsigned nodes, std::vector<int> accepting_int) {

--- a/test/raft/helpers.cc
+++ b/test/raft/helpers.cc
@@ -55,11 +55,11 @@ bool compare_log_entry(raft::log_entry_ptr le1, raft::log_entry_ptr le2) {
     return true;
 }
 
-bool compare_log_entries(raft::log& log1, raft::log& log2, size_t from, size_t to) {
+bool compare_log_entries(raft::log& log1, raft::log& log2, raft::index_t from, raft::index_t to) {
     SCYLLA_ASSERT(to <= log1.last_idx());
     SCYLLA_ASSERT(to <= log2.last_idx());
-    for (size_t i = from; i <= to; ++i) {
-        if (!compare_log_entry(log1[i], log2[i])) {
+    for (raft::index_t i = from; i <= to; ++i) {
+        if (!compare_log_entry(log1[i.value()], log2[i.value()])) {
             return false;
         }
     }

--- a/test/raft/helpers.hh
+++ b/test/raft/helpers.hh
@@ -97,7 +97,7 @@ public:
 
 // NOTE: it doesn't compare data contents, just the data type
 bool compare_log_entry(raft::log_entry_ptr le1, raft::log_entry_ptr le2);
-bool compare_log_entries(raft::log& log1, raft::log& log2, size_t from, size_t to);
+bool compare_log_entries(raft::log& log1, raft::log& log2, raft::index_t from, raft::index_t to);
 using raft_routing_map = std::unordered_map<raft::server_id, raft::fsm*>;
 
 bool deliver(raft_routing_map& routes, raft::server_id from,

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -945,7 +945,12 @@ public:
             return;
         }
 
-        auto first_to_remain = snap.idx + 1 >= preserve_log_entries ? raft::index_t{snap.idx + 1 - preserve_log_entries} : raft::index_t{0};
+        raft::index_t first_to_remain = snap.idx + raft::index_t{1};
+        if (first_to_remain.value() >= preserve_log_entries) {
+            first_to_remain -= raft::index_t{preserve_log_entries};
+        } else {
+            first_to_remain = raft::index_t{0};
+        }
         _stored_entries.erase(_stored_entries.begin(), find(first_to_remain));
     }
 

--- a/test/raft/replication.cc
+++ b/test/raft/replication.cc
@@ -41,7 +41,7 @@ size_t test_case::get_first_val() {
         first_val += initial_states[initial_leader].le.size();
     }
     if (initial_leader < initial_snapshots.size()) {
-        first_val = initial_snapshots[initial_leader].snap.idx;
+        first_val = initial_snapshots[initial_leader].snap.idx.value();
     }
     return first_val;
 }

--- a/test/raft/replication.cc
+++ b/test/raft/replication.cc
@@ -75,16 +75,16 @@ size_t apply_changes(raft::server_id id, const std::vector<raft::command_cref>& 
     return entries;
 }
 
-std::vector<raft::log_entry> create_log(std::vector<log_entry> list, unsigned start_idx) {
+std::vector<raft::log_entry> create_log(std::vector<log_entry> list, raft::index_t start_idx) {
     std::vector<raft::log_entry> log;
 
-    unsigned i = start_idx;
+    raft::index_t i = start_idx;
     for (auto e : list) {
         if (std::holds_alternative<int>(e.data)) {
-            log.push_back(raft::log_entry{raft::term_t(e.term), raft::index_t(i++),
+            log.push_back(raft::log_entry{raft::term_t(e.term), i++,
                     create_command(std::get<int>(e.data))});
         } else {
-            log.push_back(raft::log_entry{raft::term_t(e.term), raft::index_t(i++),
+            log.push_back(raft::log_entry{raft::term_t(e.term), i++,
                     std::get<raft::configuration>(e.data)});
         }
     }

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -1019,7 +1019,7 @@ void raft_cluster<Clock>::set_ticker_callback(size_t id) noexcept {
     });
 }
 
-std::vector<raft::log_entry> create_log(std::vector<log_entry> list, unsigned start_idx);
+std::vector<raft::log_entry> create_log(std::vector<log_entry> list, raft::index_t start_idx);
 
 size_t apply_changes(raft::server_id id, const std::vector<raft::command_cref>& commands,
         lw_shared_ptr<hasher_int> hasher);
@@ -1407,12 +1407,12 @@ std::vector<initial_state> raft_cluster<Clock>::get_states(test_case test, bool 
 
     // Server initial logs, etc
     for (size_t i = 0; i < states.size(); ++i) {
-        size_t start_idx = 1;
+        raft::index_t start_idx{1};
         if (i < test.initial_snapshots.size()) {
             states[i].snapshot = test.initial_snapshots[i].snap;
             states[i].snp_value.hasher = hasher_int::hash_range(test.initial_snapshots[i].snap.idx);
             states[i].snp_value.idx = test.initial_snapshots[i].snap.idx;
-            start_idx = states[i].snapshot.idx + 1;
+            start_idx = states[i].snapshot.idx + raft::index_t{1};
         }
         if (i < test.initial_states.size()) {
             auto state = test.initial_states[i];

--- a/utils/tagged_integer.hh
+++ b/utils/tagged_integer.hh
@@ -35,7 +35,6 @@ public:
     }
 
     value_type value() const noexcept { return _value; }
-    operator value_type() const noexcept { return _value; }
 
     explicit operator bool() const { return _value != 0; }
 


### PR DESCRIPTION
~~~
utils/tagged_integer: remove conversion to underlying integer

Silently converting a tagged (i.e., "dimension-ful") integer to a naked
("dimensionless") integer defeats the purpose of having tagged integers,
and is a source of practical bugs, such as
<https://github.com/scylladb/scylladb/issues/20080>.

We could make the conversion operator explicit, for enforcing

  static_cast<TAGGED_INTEGER_TYPE::value_type>(TAGGED_INTEGER_VALUE)

in every conversion location -- but that's a mouthful to write. Instead,
remove the conversion operator, and let clients call the (identically
behaving) value() member function.
~~~

No backport needed (refactoring).

The series is supposed to solve #20081.

Two patches in the series touch up code that is known to be (orthogonally) buggy; see
- `service/raft_sys_table_storage: tweak dead code` (#20080)
- `test/raft/replication: untag index_t in test_case::get_first_val()` (#20151)

Fixes for those (independent) issues will have to be rebased on this series, or this series will have to be rebased on those (due to context conflicts).

The series builds at every stage. The debug and release unit test suites pass at the end.
