### PR TITLE
test.py: Fix boost XML conversion to allure when XML file is empty

### DIFF
--- a/test.py
+++ b/test.py
@@ -1705,10 +1705,6 @@ def boost_to_junit(boost_xml, junit_xml):
     boost_root = ET.parse(boost_xml).getroot()
     junit_root = ET.Element('testsuites')
 
-    # report produced {write_consolidated_boost_junit_xml} have the next structure suite_boost -> [suite1, suite2, ...]
-    # so we are excluding the upper suite with name boost
-    test_suites = boost_root.find('TestSuite').findall('TestSuite')
-
     def parse_tag_output(test_case_element: ET.Element, tag_output: str) -> str:
         text_template = '''
             [{level}] - {level_message}
@@ -1723,37 +1719,43 @@ def boost_to_junit(boost_xml, junit_xml):
                                              file_name=tag_output.get('file'), line_number=tag_output.get('line'))
         return text
 
-    for test_suite in test_suites:
-        suite_time = 0.0
-        suite_test_total = 0
-        suite_test_fails_number = 0
+    # report produced {write_consolidated_boost_junit_xml} have the next structure suite_boost -> [suite1, suite2, ...]
+    # so we are excluding the upper suite with name boost
+    boost_suite = boost_root.find('TestSuite')
+    if boost_suite is not None:
+        test_suites = boost_suite.findall('TestSuite')
 
-        junit_test_suite = ET.SubElement(junit_root, 'testsuite')
-        junit_test_suite.attrib['name'] = test_suite.attrib['name']
+        for test_suite in test_suites:
+            suite_time = 0.0
+            suite_test_total = 0
+            suite_test_fails_number = 0
 
-        test_cases = test_suite.findall('TestCase')
-        for test_case in test_cases:
-            # convert the testing time: boost uses microseconds and Junit uses seconds
-            test_case_time = int(test_case.find('TestingTime').text) / 1_000_000
-            suite_time += test_case_time
-            suite_test_total += 1
+            junit_test_suite = ET.SubElement(junit_root, 'testsuite')
+            junit_test_suite.attrib['name'] = test_suite.attrib['name']
 
-            junit_test_case = ET.SubElement(junit_test_suite, 'testcase')
-            junit_test_case.set('name', test_case.get('name'))
-            junit_test_case.set('time', str(test_case_time))
-            junit_test_case.set('file', test_case.get('file'))
-            junit_test_case.set('line', test_case.get('line'))
+            test_cases = test_suite.findall('TestCase')
+            for test_case in test_cases:
+                # convert the testing time: boost uses microseconds and Junit uses seconds
+                test_case_time = int(test_case.find('TestingTime').text) / 1_000_000
+                suite_time += test_case_time
+                suite_test_total += 1
 
-            system_out = ET.SubElement(junit_test_case, 'system-out')
-            system_out.text = ''
-            for tag in ['Info', 'Message', 'Exception']:
-                output = parse_tag_output(test_case, tag)
-                if output:
-                    system_out.text += output
+                junit_test_case = ET.SubElement(junit_test_suite, 'testcase')
+                junit_test_case.set('name', test_case.get('name'))
+                junit_test_case.set('time', str(test_case_time))
+                junit_test_case.set('file', test_case.get('file'))
+                junit_test_case.set('line', test_case.get('line'))
 
-        junit_test_suite.set('tests', str(suite_test_total))
-        junit_test_suite.set('time', str(suite_time))
-        junit_test_suite.set('failures', str(suite_test_fails_number))
+                system_out = ET.SubElement(junit_test_case, 'system-out')
+                system_out.text = ''
+                for tag in ['Info', 'Message', 'Exception']:
+                    output = parse_tag_output(test_case, tag)
+                    if output:
+                        system_out.text += output
+
+            junit_test_suite.set('tests', str(suite_test_total))
+            junit_test_suite.set('time', str(suite_time))
+            junit_test_suite.set('failures', str(suite_test_fails_number))
     ET.ElementTree(junit_root).write(junit_xml, encoding='UTF-8')
 
 


### PR DESCRIPTION
The method cannot find the TestSuite in the XML file and fails the whole job, however tests are passed. The issue was in incorrect understanding of boost summarization method. It creates one file for all modes, so there is no need to go through all modes to convert the XML file for allure.

Closes: https://github.com/scylladb/scylladb/issues/20161
