### PR TITLE
api: Get compaction througput via compaction manager

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1040,7 +1040,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     });
 
     ss::get_compaction_throughput_mb_per_sec.set(r, [&ctx](std::unique_ptr<http::request> req) {
-        int value = ctx.db.local().get_config().compaction_throughput_mb_per_sec();
+        int value = ctx.db.local().get_compaction_manager().throughput_mbs();
         return make_ready_future<json::json_return_type>(value);
     });
 


### PR DESCRIPTION
Now the endpoint hanler gets the value from db::config which is not nice from several perspectives. First, it gets config (ab)using database. Second, it's compaction manager that "knows" its throughput, global config is the initial source of that information.

