### PR TITLE
compaction_manager: Keep flush-all-before-major option on own config

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -85,6 +85,7 @@ public:
         size_t available_memory = 0;
         utils::updateable_value<float> static_shares = utils::updateable_value<float>(0);
         utils::updateable_value<uint32_t> throughput_mb_per_sec = utils::updateable_value<uint32_t>(0);
+        std::chrono::seconds flush_all_tables_before_major = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::days(1));
     };
 
 public:
@@ -281,6 +282,10 @@ public:
 
     uint32_t throughput_mbs() const noexcept {
         return _cfg.throughput_mb_per_sec.get();
+    }
+
+    std::chrono::seconds flush_all_tables_before_major() const noexcept {
+        return _cfg.flush_all_tables_before_major;
     }
 
     void register_metrics();

--- a/main.cc
+++ b/main.cc
@@ -1095,6 +1095,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     .available_memory = dbcfg.available_memory,
                     .static_shares = cfg->compaction_static_shares,
                     .throughput_mb_per_sec = cfg->compaction_throughput_mb_per_sec,
+                    .flush_all_tables_before_major = cfg->compaction_flush_all_tables_before_major_seconds() * 1s,
                 };
             });
             cm.start(std::move(get_cm_cfg), std::ref(stop_signal.as_sharded_abort_source()), std::ref(task_manager)).get();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -568,6 +568,7 @@ private:
                     .available_memory = dbcfg.available_memory,
                     .static_shares = cfg->compaction_static_shares,
                     .throughput_mb_per_sec = cfg->compaction_throughput_mb_per_sec,
+                    .flush_all_tables_before_major = cfg->compaction_flush_all_tables_before_major_seconds() * 1s,
                 };
             });
             _cm.start(std::move(get_cm_cfg), std::ref(abort_sources), std::ref(_task_manager)).get();


### PR DESCRIPTION
Currently the major compaction task impl grabs this (non-updateable) value from db::config. That's not good, all services including compaction manager have their own configs from which they take options. Said that, this patch puts the said option onto
compaction_manager::config, makes use of it and configures one from db::config on start (and tests).
