### PR TITLE
doc: extract the info about tablets defaut to a separate file

### DIFF
--- a/docs/cql/_common/tablets-default.rst
+++ b/docs/cql/_common/tablets-default.rst
@@ -1,0 +1,3 @@
+By default, a keyspace is created with tablets enabled. The ``tablets`` option 
+is used to opt out a keyspace from tablets-based distribution; see :ref:`Enabling Tablets <tablets-enable-tablets>`
+for details.

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -116,7 +116,7 @@ name                 kind       mandatory   default   description
                                                       details below).
 ``durable_writes``   *simple*   no          true      Whether to use the commit log for updates on this keyspace
                                                       (disable this option at your own risk!).
-``tablets``          *map*      no                    Enables or disables tablets for the keyspace (see :ref:`tablets<tablets>`)
+``tablets``          *map*      no                    Enables or disables tablets for the keyspace (see :ref:`tablets <tablets>`)
 =================== ========== =========== ========= ===================================================================
 
 The ``replication`` property is mandatory and must at least contains the ``'class'`` sub-option, which defines the
@@ -232,9 +232,7 @@ sub-option                             type  description
 ``'initial'``                          int   The number of tablets to start with
 ===================================== ====== =============================================
 
-By default, a keyspace is created with tablets enabled. The ``tablets`` option 
-is used to opt out a keyspace from tablets-based distribution; see :ref:`Enabling Tablets <tablets-enable-tablets>`
-for details.
+.. scylladb_include_flag:: tablets-default.rst
 
 A good rule of thumb to calculate initial tablets is to divide the expected total storage used
 by tables in this keyspace by (``replication_factor`` * 5GB). For example, if you expect a 30TB


### PR DESCRIPTION
This PR extracts the information about the default for tables in keyspace creation to a separate file in the _common folder. The file is then included using the `scylladb_include_flag` directive.

The purpose of this commit is to make it possible to include a different file in the _scylla-enterprise_ repo - with a different default.

Refs https://github.com/scylladb/scylla-enterprise/issues/4585

This PR must be backported to both branch-6.1 and branch-6.0, as it is critical for version 6.0.