### PR TITLE
replica/table: return full scan reader in make_reader() when appropriate

### DIFF
--- a/query-request.hh
+++ b/query-request.hh
@@ -255,6 +255,15 @@ public:
         return options.contains<query::partition_slice::option::reversed>();
     }
 
+    bool is_full() const {
+        if (_specific_ranges) {
+            return false;
+        }
+        if (_row_ranges.empty() || _row_ranges.size() > 1) {
+            return false;
+        }
+        return _row_ranges.front().is_full();
+    }
     friend std::ostream& operator<<(std::ostream& out, const partition_slice& ps);
     friend std::ostream& operator<<(std::ostream& out, const specific_ranges& ps);
 };

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1704,9 +1704,19 @@ static mutation_reader make_reader(
         streamed_mutation::forwarding fwd,
         mutation_reader::forwarding fwd_mr,
         read_monitor& monitor) {
-    return make_mutation_reader<mx_sstable_mutation_reader>(
-        std::move(sstable), std::move(schema), std::move(permit), range,
-        std::move(slice), std::move(trace_state), fwd, fwd_mr, monitor);
+    if (range.is_full() &&
+        slice.get().is_full() && !slice.get().is_reversed() &&
+        fwd == streamed_mutation::forwarding::no &&
+        fwd_mr == mutation_reader::forwarding::no) {
+        return make_full_scan_reader(
+            std::move(sstable), std::move(schema), std::move(permit),
+            std::move(trace_state), monitor,
+            sstable::integrity_check::no);
+    } else {
+        return make_mutation_reader<mx_sstable_mutation_reader>(
+            std::move(sstable), std::move(schema), std::move(permit), range,
+            std::move(slice), std::move(trace_state), fwd, fwd_mr, monitor);
+    }
 }
 
 mutation_reader make_reader(


### PR DESCRIPTION
there are two cases when performing streaming a given sstable:

- streaming the full range
- streaming a partial of the range

in the first case, we do not need to seek to the given token, so the crawling reader is a better fit. and per testing, it has slightly better performance than the regular partitioned reader.

| reader   | mean (partitions / sec) | stderr (partitions / sec) |
| -------- | ----------------------- | ------------------------- |
| range    | 514692.33               | 3502.87                   |
| crawling | 558914.36               | 4547.98                   |

so, in this change, we specialize for the first case, and use the crawling reader.

Refs: scylladb/scylladb#19989

---

no need to backport, this change is not a critical fix. and only brings a slight improvement in the performance to stream-n-load.