### PR TITLE
locator: retry HTTP request to GCE/Azure metadata service

### DIFF
--- a/locator/azure_snitch.hh
+++ b/locator/azure_snitch.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "locator/production_snitch_base.hh"
+#include "utils/exponential_backoff_retry.hh"
 
 namespace locator {
 
@@ -16,6 +17,7 @@ class azure_snitch : public production_snitch_base {
 public:
     static constexpr auto AZURE_SERVER_ADDR = "169.254.169.254";
     static constexpr auto AZURE_QUERY_PATH_TEMPLATE = "/metadata/instance/compute/{}?api-version=2020-09-01&format=text";
+    static constexpr int AZURE_API_CALL_RETRIES = 10;
 
     static const std::string REGION_NAME_QUERY_PATH;
     static const std::string ZONE_NAME_QUERY_PATH;
@@ -29,6 +31,9 @@ protected:
     future<> load_config();
     future<sstring> azure_api_call(sstring path);
     future<sstring> read_property_file();
+private:
+    exponential_backoff_retry _azure_api_retry = exponential_backoff_retry(std::chrono::seconds(5), std::chrono::seconds(2560));
+    future<sstring> azure_api_call_once(sstring path);
 };
 
 } // namespace locator

--- a/locator/gce_snitch.cc
+++ b/locator/gce_snitch.cc
@@ -80,6 +80,31 @@ future<> gce_snitch::start() {
 }
 
 future<sstring> gce_snitch::gce_api_call(sstring addr, sstring cmd) {
+    return do_with(int(0), [this, addr, cmd] (int& i) {
+        return repeat_until_value([this, addr, cmd, &i]() -> future<std::optional<sstring>> {
+            ++i;
+            return gce_api_call_once(addr, cmd).then([] (auto res) {
+                return make_ready_future<std::optional<sstring>>(std::move(res));
+            }).handle_exception([this, &i] (auto ep) {
+                try {
+                    std::rethrow_exception(ep);
+                } catch (const std::system_error &e) {
+                    if (i >= GCE_API_CALL_RETRIES - 1) {
+                        logger().error("GCE API call failed: {}. Maximum number of retries exceeded", e.what());
+                        throw e;
+                    } else {
+                        logger().error("GCE API call failed: {}. Will retry in {} seconds", e.what(), std::chrono::duration_cast<std::chrono::seconds>(_gce_api_retry.sleep_time()).count());
+                    }
+                }
+                return _gce_api_retry.retry().then([] {
+                    return make_ready_future<std::optional<sstring>>(std::nullopt);
+                });
+            });
+        });
+    });
+}
+
+future<sstring> gce_snitch::gce_api_call_once(sstring addr, sstring cmd) {
     return seastar::async([addr = std::move(addr), cmd = std::move(cmd)] () -> sstring {
         using namespace boost::algorithm;
 

--- a/locator/gce_snitch.hh
+++ b/locator/gce_snitch.hh
@@ -10,6 +10,7 @@
 
 #include "locator/production_snitch_base.hh"
 #include <seastar/http/response_parser.hh>
+#include "utils/exponential_backoff_retry.hh"
 
 namespace locator {
 
@@ -17,6 +18,7 @@ class gce_snitch : public production_snitch_base {
 public:
     static constexpr const char* ZONE_NAME_QUERY_REQ = "/computeMetadata/v1/instance/zone";
     static constexpr const char* GCE_QUERY_SERVER_ADDR = "metadata.google.internal";
+    static constexpr int GCE_API_CALL_RETRIES = 10;
 
     explicit gce_snitch(const snitch_config&);
     virtual future<> start() override;
@@ -30,6 +32,8 @@ protected:
 
 private:
     sstring _meta_server_url;
+    exponential_backoff_retry _gce_api_retry = exponential_backoff_retry(std::chrono::seconds(5), std::chrono::seconds(2560));
+    future<sstring> gce_api_call_once(sstring addr, const sstring cmd);
 };
 
 } // namespace locator


### PR DESCRIPTION
Like we already do on EC2, implement retrying request to the metadata service on GCE and Azure.

Closes #19817