### PR TITLE
Adding batch latency and batch size metrics to Alternator

### DIFF
--- a/alternator/stats.cc
+++ b/alternator/stats.cc
@@ -29,6 +29,8 @@ stats::stats() : api_operations{} {
 						                        seastar::metrics::description("Latency summary of an operation via Alternator API"), [this]{return to_metrics_summary(api_operations.name.summary());})(op(CamelCaseName)).set_skip_when_empty(),
             OPERATION(batch_get_item, "BatchGetItem")
             OPERATION(batch_write_item, "BatchWriteItem")
+            OPERATION(batch_get_item_batch_total, "BatchGetItemSize")
+            OPERATION(batch_write_item_batch_total, "BatchWriteItemSize")
             OPERATION(create_backup, "CreateBackup")
             OPERATION(create_global_table, "CreateGlobalTable")
             OPERATION(create_table, "CreateTable")
@@ -67,6 +69,8 @@ stats::stats() : api_operations{} {
             OPERATION_LATENCY(get_item_latency, "GetItem")
             OPERATION_LATENCY(delete_item_latency, "DeleteItem")
             OPERATION_LATENCY(update_item_latency, "UpdateItem")
+            OPERATION_LATENCY(batch_write_item_latency, "BatchWriteItem")
+            OPERATION_LATENCY(batch_get_item_latency, "BatchGetItem")
             OPERATION(list_streams, "ListStreams")
             OPERATION(describe_stream, "DescribeStream")
             OPERATION(get_shard_iterator, "GetShardIterator")

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -26,6 +26,8 @@ public:
     struct {
         uint64_t batch_get_item = 0;
         uint64_t batch_write_item = 0;
+        uint64_t batch_get_item_batch_total = 0;
+        uint64_t batch_write_item_batch_total = 0;
         uint64_t create_backup = 0;
         uint64_t create_global_table = 0;
         uint64_t create_table = 0;
@@ -69,6 +71,8 @@ public:
         utils::timed_rate_moving_average_summary_and_histogram get_item_latency;
         utils::timed_rate_moving_average_summary_and_histogram delete_item_latency;
         utils::timed_rate_moving_average_summary_and_histogram update_item_latency;
+        utils::timed_rate_moving_average_summary_and_histogram batch_write_item_latency;
+        utils::timed_rate_moving_average_summary_and_histogram batch_get_item_latency;
         utils::timed_rate_moving_average_summary_and_histogram get_records_latency;
     } api_operations;
     // Miscellaneous event counters

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -243,12 +243,16 @@ def check_sets_latency(metrics, operation_names):
 # Test latency metrics for PutItem, GetItem, DeleteItem, UpdateItem.
 # We can't check what exactly the latency is - just that it gets updated.
 def test_item_latency(test_table_s, metrics):
-    with check_sets_latency(metrics, ['DeleteItem', 'GetItem', 'PutItem', 'UpdateItem']):
+    with check_sets_latency(metrics, ['DeleteItem', 'GetItem', 'PutItem', 'UpdateItem', 'BatchWriteItem', 'BatchGetItem']):
         p = random_string()
         test_table_s.put_item(Item={'p': p})
         test_table_s.get_item(Key={'p': p})
         test_table_s.delete_item(Key={'p': p})
         test_table_s.update_item(Key={'p': p})
+        test_table_s.meta.client.batch_write_item(RequestItems = {
+            test_table_s.name: [{'PutRequest': {'Item': {'p': random_string(), 'a': 'hi'}}}]})
+        test_table_s.meta.client.batch_get_item(RequestItems = {
+            test_table_s.name: {'Keys': [{'p': random_string()}], 'ConsistentRead': True}})
 
 # Test latency metrics for GetRecords. Other Streams-related operations -
 # ListStreams, DescribeStream, and GetShardIterator, have an operation


### PR DESCRIPTION
This patch adds metrics for batch get_item and batch write_item.
The new metrics record summary and histogram for latencies and batch size.

Batch sizes are implemented as ever-growing counters. To get the average batch size divide the rate of
the batch size counter by the rate of the number of batch counter:
```rate(batch_get_item_batch_size)/rate(batch_get_item)```

Relates to #17615

New code, No need to backport