### PR TITLE
table_helper: complete coroutinization

### DIFF
--- a/table_helper.cc
+++ b/table_helper.cc
@@ -134,13 +134,9 @@ future<> table_helper::cache_table_info(cql3::query_processor& qp, service::migr
 
 future<> table_helper::insert(cql3::query_processor& qp, service::migration_manager& mm, service::query_state& qs, noncopyable_function<cql3::query_options ()> opt_maker) {
     co_await cache_table_info(qp, mm, qs);
-    {
-        auto opts = opt_maker();
-        {
-            opts.prepare(_prepared_stmt->bound_names);
-            co_await _insert_stmt->execute(qp, qs, opts, std::nullopt);
-        }
-    }
+    auto opts = opt_maker();
+    opts.prepare(_prepared_stmt->bound_names);
+    co_await _insert_stmt->execute(qp, qs, opts, std::nullopt);
 }
 
 future<> table_helper::setup_keyspace(cql3::query_processor& qp, service::migration_manager& mm, std::string_view keyspace_name, sstring replication_factor, service::query_state& qs, std::vector<table_helper*> tables) {

--- a/table_helper.hh
+++ b/table_helper.hh
@@ -41,7 +41,9 @@ private:
      * Should be changed alongside every _insert_stmt reassignment
      * */
     bool _is_fallback_stmt = false;
-
+private:
+    // Returns true is prepare succeeded, false if failed and there's still a chance to recover, exception if prepare failed and it's not possible to recover
+    future<bool> try_prepare(bool fallback, cql3::query_processor& qp, service::query_state& qs);
 public:
     table_helper(std::string_view keyspace, std::string_view name, sstring create_cql, sstring insert_cql, std::optional<sstring> insert_cql_fallback = std::nullopt)
         : _keyspace(keyspace)


### PR DESCRIPTION
table_helper has some quite awkward code, improve it a little.

Code cleanup, so no reason to backport.