### PR TITLE
build: cmake: do not build storage_proxy.o by default

### DIFF
--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -51,15 +51,17 @@ target_link_libraries(service
 check_headers(check-headers service
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)
 
-add_library(storage_proxy.o
-  OBJECT
-    $<$<CONFIG:RelWithDebInfo,Debug>:storage_proxy.cc>)
+add_library(storage_proxy.o OBJECT EXCLUDE_FROM_ALL
+    storage_proxy.cc)
 target_include_directories(storage_proxy.o
   PRIVATE
     ${CMAKE_SOURCE_DIR})
 target_link_libraries(storage_proxy.o
+  absl::headers
   Seastar::seastar
   xxHash::xxhash
   idl)
+add_custom_target(maybe-storage-proxy
+  DEPENDS $<$<CONFIG:RelWithDebInfo,Debug>:storage_proxy.o>)
 add_dependencies(compiler-training
-  storage_proxy.o)
+  maybe-storage-proxy)


### PR DESCRIPTION
in 5ce07e5d84, the target named "storage_proxy.o" was added for training the build of clang. but the rule for building this target has two flaws:

* it was added a dependency of the "all" target, but we don't need to build `storage_proxy.cc` twice when building the tree in the regular build job. we only need to build it when creating the profile for training the build of clang.
* it misses the include directory of abseil library. that's why we have following build failure when building the default target:

  ``` [2024-08-18T14:58:37.494Z] /usr/local/bin/clang++ -DDEBUG -DDEBUG_LSA_SANITIZER -DFMT_SHARED -DSANITIZE -DSCYLLA_BUILD_MODE=debug -DSCYLLA_ENABLE_ERROR_INJECTION -DSEASTAR_API_LEVEL=7 -DSEASTAR_DEBUG -DSEASTAR_DEBUG_PROMISE -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_SSTRING -DSEASTAR_TYPE_ERASE_MORE -DXXH_PRIVATE_API -DCMAKE_INTDIR=\"Debug\" -I/jenkins/workspace/scylla-master/scylla-ci/scylla -I/jenkins/workspace/scylla-master/scylla-ci/scylla/seastar/include -I/jenkins/workspace/scylla-master/scylla-ci/scylla/build/seastar/gen/include -I/jenkins/workspace/scylla-master/scylla-ci/scylla/build/seastar/gen/src -I/jenkins/workspace/scylla-master/scylla-ci/scylla/build/gen -g -Og -g -gz -std=gnu++23 -fvisibility=hidden -Wall -Werror -Wextra -Wno-error=deprecated-declarations -Wimplicit-fallthrough -Wno-c++11-narrowing -Wno-deprecated-copy -Wno-mismatched-tags -Wno-missing-field-initializers -Wno-overloaded-virtual -Wno-unsupported-friend -Wno-enum-constexpr-conversion -Wno-unused-parameter -ffile-prefix-map=/jenkins/workspace/scylla-master/scylla-ci/scylla=. -march=westmere -Xclang -fexperimental-assignment-tracking=disabled -U_FORTIFY_SOURCE -Werror=unused-result -fstack-clash-protection -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr -MD -MT service/CMakeFiles/storage_proxy.o.dir/Debug/storage_proxy.cc.o -MF service/CMakeFiles/storage_proxy.o.dir/Debug/storage_proxy.cc.o.d -o service/CMakeFiles/storage_proxy.o.dir/Debug/storage_proxy.cc.o -c /jenkins/workspace/scylla-master/scylla-ci/scylla/service/storage_proxy.cc [2024-08-18T14:58:37.495Z] In file included from /jenkins/workspace/scylla-master/scylla-ci/scylla/service/storage_proxy.cc:17: [2024-08-18T14:58:37.495Z] In file included from /jenkins/workspace/scylla-master/scylla-ci/scylla/db/commitlog/commitlog.hh:19: [2024-08-18T14:58:37.495Z] In file included from /jenkins/workspace/scylla-master/scylla-ci/scylla/db/commitlog/commitlog_entry.hh:15: [2024-08-18T14:58:37.495Z] In file included from /jenkins/workspace/scylla-master/scylla-ci/scylla/mutation/frozen_mutation.hh:15: [2024-08-18T14:58:37.495Z] In file included from /jenkins/workspace/scylla-master/scylla-ci/scylla/mutation/mutation_partition_view.hh:16: [2024-08-18T14:58:37.495Z] In file included from /jenkins/workspace/scylla-master/scylla-ci/scylla/build/gen/idl/mutation.dist.impl.hh:14: [2024-08-18T14:58:37.495Z] /jenkins/workspace/scylla-master/scylla-ci/scylla/serializer_impl.hh:20:10: fatal error: 'absl/container/btree_set.h' file not found
  [2024-08-18T14:58:37.495Z]    20 | #include <absl/container/btree_set.h>
  [2024-08-18T14:58:37.495Z]       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
  [2024-08-18T14:58:37.495Z] 1 error generated.
  ```

so, in this change, we

* exclude this target from "all"
* link this target against abseil header library, so it has access
  to the abseil library. please note, we don't need to build an
  executable in this case, so the header would suffice.

---

it's a cmake related change, hence no need to backport.