### PR TITLE
dbuild: pass --tty only if --interactive

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -192,6 +192,10 @@ if [[ "${OSTYPE}" == "darwin"* ]]; then
   hard_limit=1024000
 fi
 
+if [[ -n "$interactive" || -t 0 ]]; then
+    docker_common_args+=("--tty")
+fi
+
 docker_common_args+=(
        --security-opt seccomp=unconfined \
        --security-opt label=disable \
@@ -210,7 +214,6 @@ docker_common_args+=(
        "$image" \
        "${args[@]}"
 )
-
 cleanup() {
     rm -rf "$tmpdir"
     if [ -v TMP_PASSWD ]; then
@@ -224,7 +227,7 @@ if [[ -n "$interactive" || -n "$is_podman" ]]; then
 
     # We also avoid detached mode with podman, which doesn't need it
     # (it does not proxy SIGTERM) and doesn't work well with it.
-    $tool run --tty --rm "${docker_common_args[@]}"
+    $tool run --rm "${docker_common_args[@]}"
     ret=$?
     cleanup
     exit $ret


### PR DESCRIPTION
in 947e2814, we pass `--tty` as long as we are using podman _or_ we are in interactive mode. but if we build the tree using podman using jenkins, we are seeing that ninja is displaying the output as if it's in an interactive mode. and the output includes ASCII escape codes. this is distracting.

the reason is that we

* are using podman, and
* ninja tells if it should displaying with a "smart" terminal by checking istty() and the "TERM" environmental variable.

so, in this change, we add --tty only if

* we are in the interactive mode.
* or stdin is associated with a terminal. this is the use case where user uses dbuild to interactively build scylla

---

this change improves the experience of developers when reading the output of jenkins, hence no impact on production. i don't think we should backport it.