### PR TITLE
[Backport 6.0] message/messaging_service: recognize unknown tenant with $ prefix

### DIFF
--- a/cql3/statements/create_service_level_statement.cc
+++ b/cql3/statements/create_service_level_statement.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include "exceptions/exceptions.hh"
 #include "seastarx.hh"
 #include "cql3/statements/create_service_level_statement.hh"
 #include "service/qos/service_level_controller.hh"
@@ -38,6 +39,10 @@ create_service_level_statement::execute(query_processor& qp,
         service::query_state &state,
         const query_options &,
         std::optional<service::group0_guard> guard) const {
+    if (_service_level.starts_with('$')) {
+        throw exceptions::invalid_request_exception("Names starting with '$' are reserved for internal tenants. Use a different name.");
+    }
+
     qos::service_level_options slo = _slo.replace_defaults(qos::service_level_options{});
     return state.get_service_level_controller().add_distributed_service_level(_service_level, slo, _if_not_exists, std::move(guard)).then([] {
         using void_result_msg = cql_transport::messages::result_message::void_message;

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -164,6 +164,10 @@ future<> service_level_controller::update_service_levels_from_distributed_data()
             // firstly delete all that there is to be deleted and only then adding new
             // service levels.
             while (current_it != _service_levels_db.end() && new_state_it != service_levels.end()) {
+                if (current_it->first.starts_with('$')) {
+                    sl_logger.warn("Service level names starting with '$' are reserved for internal tenants. Rename service level \"{}\" to drop '$' prefix.", current_it->first.c_str());
+                }
+
                 if (current_it->first == new_state_it->first) {
                     //the service level exists on both the cureent and new state.
                     if (current_it->second.slo != new_state_it->second) {


### PR DESCRIPTION
Tenant names starting with $ are reserved for internal ones.

This patch forbids creating new service levels with names starting with $ and log warnings for existing service levels with this prefix.

In enterprise, any unknown tenant with $ prefix will use default scheduling group and not create a new service level for it. OSS version doesn't need this because it doesn't have scheduling groups for service levels and uses default scheduling group for any unknown tenant.

Fixes https://github.com/scylladb/scylladb/issues/20070
Refs https://github.com/scylladb/scylla-enterprise/issues/4403

(cherry picked from commit https://github.com/scylladb/scylladb/commit/d729d1b272c4f7dab071d96c0bf42bea8b9c8d43)

Refs https://github.com/scylladb/scylladb/pull/20122