### PR TITLE
cql: improve validating RF's change in ALTER tablets KS

### DIFF
--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -87,7 +87,8 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
                 const std::map<sstring, sstring>& current_rfs = ks.metadata()->strategy_options();
                 for (const auto& [new_dc, new_rf] : _attrs->get_replication_options()) {
                     auto it = current_rfs.find(new_dc);
-                    if (it != current_rfs.end() && !validate_rf_difference(it->second, new_rf)) {
+                    sstring old_rf = it != current_rfs.end() ? it->second : "0";
+                    if (!validate_rf_difference(old_rf, new_rf)) {
                         throw exceptions::invalid_request_exception("Cannot modify replication factor of any DC by more than 1 at a time.");
                     }
                 }

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -130,6 +130,63 @@ bool cql3::statements::alter_keyspace_statement::changes_tablets(query_processor
     return ks.get_replication_strategy().uses_tablets() && !_attrs->get_replication_options().empty();
 }
 
+namespace {
+// These functions are used to flatten all the options in the keyspace definition into a single-level map<string, string>.
+// (Currently options are stored in a nested structure that looks more like a map<string, map<string, string>>).
+// Flattening is simply joining the keys of maps from both levels with a colon ':' character,
+// or in other words: prefixing the keys in the output map with the option type, e.g. 'replication', 'storage', etc.,
+// so that the output map contains entries like: "replication:dc1" -> "3".
+// This is done to avoid key conflicts and to be able to de-flatten the map back into the original structure.
+
+void add_prefixed_key(const sstring& prefix, const std::map<sstring, sstring>& in, std::map<sstring, sstring>& out) {
+    for (const auto& [in_key, in_value]: in) {
+        out[prefix + ":" + in_key] = in_value;
+    }
+};
+
+std::map<sstring, sstring> get_current_options_flattened(const shared_ptr<cql3::statements::ks_prop_defs>& ks,
+                                                         bool include_tablet_options,
+                                                         const gms::feature_service& feat) {
+    std::map<sstring, sstring> all_options;
+
+    add_prefixed_key(ks->KW_REPLICATION, ks->get_replication_options(), all_options);
+    add_prefixed_key(ks->KW_STORAGE, ks->get_storage_options().to_map(), all_options);
+    // if no tablet options are specified in ATLER KS statement,
+    // we want to preserve the old ones and hence cannot overwrite them with defaults
+    if (include_tablet_options) {
+        auto initial_tablets = ks->get_initial_tablets(std::nullopt);
+        add_prefixed_key(ks->KW_TABLETS,
+                         {{"enabled", initial_tablets ? "true" : "false"},
+                         {"initial", std::to_string(initial_tablets.value_or(0))}},
+                         all_options);
+    }
+    add_prefixed_key(ks->KW_DURABLE_WRITES,
+                     {{sstring(ks->KW_DURABLE_WRITES), to_sstring(ks->get_boolean(ks->KW_DURABLE_WRITES, true))}},
+                     all_options);
+
+    return all_options;
+}
+
+std::map<sstring, sstring> get_old_options_flattened(const data_dictionary::keyspace& ks, bool include_tablet_options) {
+    std::map<sstring, sstring> all_options;
+
+    using namespace cql3::statements;
+    add_prefixed_key(ks_prop_defs::KW_REPLICATION, ks.get_replication_strategy().get_config_options(), all_options);
+    add_prefixed_key(ks_prop_defs::KW_STORAGE, ks.metadata()->get_storage_options().to_map(), all_options);
+    if (include_tablet_options) {
+        add_prefixed_key(ks_prop_defs::KW_TABLETS,
+                         {{"enabled", ks.metadata()->initial_tablets() ? "true" : "false"},
+                          {"initial", std::to_string(ks.metadata()->initial_tablets().value_or(0))}},
+                         all_options);
+    }
+    add_prefixed_key(ks_prop_defs::KW_DURABLE_WRITES,
+                     {{sstring(ks_prop_defs::KW_DURABLE_WRITES), to_sstring(ks.metadata()->durable_writes())}},
+                     all_options);
+
+    return all_options;
+}
+} // <anonymous> namespace
+
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>>
 cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const {
     using namespace cql_transport;
@@ -142,11 +199,18 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
         auto ks_md_update = _attrs->as_ks_metadata_update(ks_md, tm, feat);
         std::vector<mutation> muts;
         std::vector<sstring> warnings;
-        auto ks_options = _attrs->get_all_options_flattened(feat);
+        bool include_tablet_options = _attrs->get_map(_attrs->KW_TABLETS).has_value();
+        auto old_ks_options = get_old_options_flattened(ks, include_tablet_options);
+        auto ks_options = get_current_options_flattened(_attrs, include_tablet_options, feat);
+        ks_options.merge(old_ks_options);
+
         auto ts = mc.write_timestamp();
         auto global_request_id = mc.new_group0_state_id();
 
         // we only want to run the tablets path if there are actually any tablets changes, not only schema changes
+        // TODO: the current `if (changes_tablets(qp))` is insufficient: someone may set the same RFs as before,
+        //       and we'll unnecessarily trigger the processing path for ALTER tablets KS,
+        //       when in reality nothing or only schema is being changed
         if (changes_tablets(qp)) {
             if (!qp.topology_global_queue_empty()) {
                 return make_exception_future<std::tuple<::shared_ptr<::cql_transport::event::schema_change>, cql3::cql_warnings_vec>>(

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -185,22 +185,6 @@ bool ks_prop_defs::get_durable_writes() const {
     return get_boolean(KW_DURABLE_WRITES, true);
 }
 
-std::map<sstring, sstring> ks_prop_defs::get_all_options_flattened(const gms::feature_service& feat) const {
-    std::map<sstring, sstring> all_options;
-
-    auto ingest_flattened_options = [&all_options](const std::map<sstring, sstring>& options, const sstring& prefix) {
-        for (auto& option: options) {
-            all_options[prefix + ":" + option.first] = option.second;
-        }
-    };
-    ingest_flattened_options(get_replication_options(), KW_REPLICATION);
-    ingest_flattened_options(get_storage_options().to_map(), KW_STORAGE);
-    ingest_flattened_options(get_map(KW_TABLETS).value_or(std::map<sstring, sstring>{}), KW_TABLETS);
-    ingest_flattened_options({{sstring(KW_DURABLE_WRITES), to_sstring(get_boolean(KW_DURABLE_WRITES, true))}}, KW_DURABLE_WRITES);
-
-    return all_options;
-}
-
 lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata(sstring ks_name, const locator::token_metadata& tm, const gms::feature_service& feat) {
     auto sc = get_replication_strategy_class().value();
     // if tablets options have not been specified, but tablets are globally enabled, set the value to 0 for N.T.S. only

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -58,7 +58,6 @@ public:
     std::optional<unsigned> get_initial_tablets(std::optional<unsigned> default_value) const;
     data_dictionary::storage_options get_storage_options() const;
     bool get_durable_writes() const;
-    std::map<sstring, sstring> get_all_options_flattened(const gms::feature_service& feat) const;
     lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata(sstring ks_name, const locator::token_metadata&, const gms::feature_service&);
     lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata&, const gms::feature_service&);
 };

--- a/cql3/statements/property_definitions.hh
+++ b/cql3/statements/property_definitions.hh
@@ -46,13 +46,13 @@ public:
 protected:
     std::optional<sstring> get_simple(const sstring& name) const;
 
-    std::optional<std::map<sstring, sstring>> get_map(const sstring& name) const;
-
     void remove_from_map_if_exists(const sstring& name, const sstring& key) const;
 public:
     bool has_property(const sstring& name) const;
 
     std::optional<value_type> get(const sstring& name) const;
+
+    std::optional<std::map<sstring, sstring>> get_map(const sstring& name) const;
 
     sstring get_string(sstring key, sstring default_value) const;
 

--- a/test/cql-pytest/test_tablets.py
+++ b/test/cql-pytest/test_tablets.py
@@ -299,11 +299,13 @@ def test_lwt_support_with_tablets(cql, test_keyspace, skip_without_tablets):
 # We want to ensure that we can only change the RF of any DC by at most 1 at a time
 # if we use tablets. That provides us with the guarantee that the old and the new QUORUM
 # overlap by at least one node.
-def test_alter_tablet_keyspace(cql, this_dc):
+def test_alter_tablet_keyspace_rf(cql, this_dc):
     with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }} "
                                 f"AND TABLETS = {{ 'enabled': true, 'initial': 128 }}") as keyspace:
         def change_opt_rf(rf_opt, new_rf):
-            cql.execute(f"ALTER KEYSPACE {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{rf_opt}' : {new_rf} }}")
+            cql.execute(f"ALTER KEYSPACE {keyspace} "
+                        f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{rf_opt}' : {new_rf} }}")
+
         def change_dc_rf(new_rf):
             change_opt_rf(this_dc, new_rf)
 

--- a/test/cql-pytest/test_tablets.py
+++ b/test/cql-pytest/test_tablets.py
@@ -309,12 +309,17 @@ def test_alter_tablet_keyspace_rf(cql, this_dc):
         def change_dc_rf(new_rf):
             change_opt_rf(this_dc, new_rf)
 
-        change_dc_rf(2)
-        change_dc_rf(3)
+        change_dc_rf(2)  # increase RF by 1 should be OK
+        change_dc_rf(3)  # increase RF by 1 again should be OK
+        change_dc_rf(3)  # setting the same RF shouldn't cause problems
+        change_dc_rf(4)  # increase RF by 1 again should be OK
+        change_dc_rf(3)  # decrease RF by 1 should be OK
 
         with pytest.raises(InvalidRequest):
-            change_dc_rf(5)
+            change_dc_rf(5)  # increase RF by 2 should fail
         with pytest.raises(InvalidRequest):
-            change_dc_rf(1)
+            change_dc_rf(1)  # decrease RF by 2 should fail
         with pytest.raises(InvalidRequest):
-            change_dc_rf(10)
+            change_dc_rf(10)  # increase RF by 2+ should fail
+        with pytest.raises(InvalidRequest):
+            change_dc_rf(0)  # decrease RF by 2+ should fail

--- a/test/cql-pytest/test_tablets.py
+++ b/test/cql-pytest/test_tablets.py
@@ -306,8 +306,6 @@ def test_alter_tablet_keyspace(cql, this_dc):
             cql.execute(f"ALTER KEYSPACE {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{rf_opt}' : {new_rf} }}")
         def change_dc_rf(new_rf):
             change_opt_rf(this_dc, new_rf)
-        def change_default_rf(new_rf):
-            change_opt_rf("replication_factor", new_rf)
 
         change_dc_rf(2)
         change_dc_rf(3)

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -200,23 +200,24 @@ async def test_multidc_alter_tablets_rf(request: pytest.FixtureRequest, manager:
     config = {"endpoint_snitch": "GossipingPropertyFileSnitch", "enable_tablets": "true"}
 
     logger.info("Creating a new cluster of 1 node in 1st DC and 2 nodes in 2nd DC")
-    await manager.server_add(config=config, property_file={'dc': f'dc1', 'rack': 'myrack'})
-    await manager.server_add(config=config, property_file={'dc': f'dc2', 'rack': 'myrack'})
-    await manager.server_add(config=config, property_file={'dc': f'dc2', 'rack': 'myrack'})
+    await manager.servers_add(3, config=config, property_file={'dc': f'dc1', 'rack': 'myrack'})
+    await manager.servers_add(2, config=config, property_file={'dc': f'dc2', 'rack': 'myrack'})
+    # await manager.server_add(config=config, property_file={'dc': f'dc2', 'rack': 'myrack'})
 
-    conn = manager.get_cql()
-    conn.execute("create keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1};")
-    conn.execute("create table ks.t (pk int primary key);")  # need a table to not only change schema, but also replicas
+    cql = manager.get_cql()
+    await cql.run_async("create keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}")
+    # need to create a table to not change only the schema, but also tablets replicas
+    await cql.run_async("create table ks.t (pk int primary key)")
     with pytest.raises(InvalidRequest, match="Cannot modify replication factor of any DC by more than 1 at a time."):
         # changing RF of dc2 from 0 to 2 should fail
-        conn.execute("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc2': 2};")
+        await cql.run_async("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc2': 2}")
 
     # changing RF of dc2 from 0 to 1 should succeed
-    conn.execute("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc2': 1};")
-    # also check that we can safely remove all replicas by changing RF of dc2 from 1 to 0 back again
-    conn.execute("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc2': 0};")
-    # we may also remove all the replicas from the cluster, i.e. change RF of dc1 from 1 to 0 as well:
-    conn.execute("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 0};")
+    await cql.run_async("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc2': 1}")
+    # we want to ensure that RFs of both DCs are equal to 1 now
+    res = await cql.run_async("SELECT * FROM system_schema.keyspaces  WHERE keyspace_name = 'ks'")
+    assert res[0].replication['dc1'] == '1'
+    assert res[0].replication['dc2'] == '1'
 
 
 # Reproducer for https://github.com/scylladb/scylladb/issues/18110

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -199,25 +199,43 @@ async def test_tablet_mutation_fragments_unowned_partition(manager: ManagerClien
 async def test_multidc_alter_tablets_rf(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     config = {"endpoint_snitch": "GossipingPropertyFileSnitch", "enable_tablets": "true"}
 
-    logger.info("Creating a new cluster of 1 node in 1st DC and 2 nodes in 2nd DC")
-    await manager.servers_add(3, config=config, property_file={'dc': f'dc1', 'rack': 'myrack'})
+    logger.info("Creating a new cluster of 2 nodes in 1st DC and 2 nodes in 2nd DC")
+    # we have to have at least 2 nodes in each DC if we want to try setting RF to 2 in each DC
+    await manager.servers_add(2, config=config, property_file={'dc': f'dc1', 'rack': 'myrack'})
     await manager.servers_add(2, config=config, property_file={'dc': f'dc2', 'rack': 'myrack'})
-    # await manager.server_add(config=config, property_file={'dc': f'dc2', 'rack': 'myrack'})
 
     cql = manager.get_cql()
     await cql.run_async("create keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}")
     # need to create a table to not change only the schema, but also tablets replicas
     await cql.run_async("create table ks.t (pk int primary key)")
-    with pytest.raises(InvalidRequest, match="Cannot modify replication factor of any DC by more than 1 at a time."):
+    with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
         # changing RF of dc2 from 0 to 2 should fail
         await cql.run_async("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc2': 2}")
 
     # changing RF of dc2 from 0 to 1 should succeed
     await cql.run_async("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc2': 1}")
-    # we want to ensure that RFs of both DCs are equal to 1 now
+    # ensure that RFs of both DCs are equal to 1 now, i.e. that omitting dc1 in above command didn't change it
     res = await cql.run_async("SELECT * FROM system_schema.keyspaces  WHERE keyspace_name = 'ks'")
     assert res[0].replication['dc1'] == '1'
     assert res[0].replication['dc2'] == '1'
+
+    # incrementing RF of 2 DCs at once should NOT succeed, because it'd leave 2 pending tablets replicas
+    with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
+        await cql.run_async("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 2}")
+    # as above, but decrementing
+    with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
+        await cql.run_async("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 0, 'dc2': 0}")
+    # as above, but decrement 1 RF and increment the other
+    with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
+        await cql.run_async("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 0}")
+    # as above, but RFs are swapped
+    with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
+        await cql.run_async("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 0, 'dc2': 2}")
+
+    # check that we can remove all replicas from dc2 by changing RF from 1 to 0
+    await cql.run_async("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc2': 0}")
+    # check that we can remove all replicas from the cluster, i.e. change RF of dc1 from 1 to 0 as well:
+    await cql.run_async("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 0}")
 
 
 # Reproducer for https://github.com/scylladb/scylladb/issues/18110

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
-from cassandra.protocol import ConfigurationException
+from cassandra.protocol import ConfigurationException, InvalidRequest
 from cassandra.query import SimpleStatement, ConsistencyLevel
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import HTTPError, read_barrier
@@ -188,6 +188,35 @@ async def test_tablet_mutation_fragments_unowned_partition(manager: ManagerClien
         host = await wait_for_cql_and_get_hosts(cql, [s], time.time() + 30)
         for k in range(4):
             await cql.run_async(f"SELECT partition_region FROM MUTATION_FRAGMENTS(test.test) WHERE pk={k}", host=host[0])
+
+
+# ALTER tablets KS cannot change RF of any DC by more than 1 at a time.
+# In a multi-dc environment, we can create replicas in a DC that didn't have replicas before,
+# but the above requirement should still be honoured, because we'd be changing RF from 0 to N in the new DC.
+# Reproduces https://github.com/scylladb/scylladb/issues/20039#issuecomment-2271365060
+# See also cql-pytest/test_tablets.py::test_alter_tablet_keyspace_rf for basic scenarios tested
+@pytest.mark.asyncio
+async def test_multidc_alter_tablets_rf(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    config = {"endpoint_snitch": "GossipingPropertyFileSnitch", "enable_tablets": "true"}
+
+    logger.info("Creating a new cluster of 1 node in 1st DC and 2 nodes in 2nd DC")
+    await manager.server_add(config=config, property_file={'dc': f'dc1', 'rack': 'myrack'})
+    await manager.server_add(config=config, property_file={'dc': f'dc2', 'rack': 'myrack'})
+    await manager.server_add(config=config, property_file={'dc': f'dc2', 'rack': 'myrack'})
+
+    conn = manager.get_cql()
+    conn.execute("create keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1};")
+    conn.execute("create table ks.t (pk int primary key);")  # need a table to not only change schema, but also replicas
+    with pytest.raises(InvalidRequest, match="Cannot modify replication factor of any DC by more than 1 at a time."):
+        # changing RF of dc2 from 0 to 2 should fail
+        conn.execute("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc2': 2};")
+
+    # changing RF of dc2 from 0 to 1 should succeed
+    conn.execute("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc2': 1};")
+    # also check that we can safely remove all replicas by changing RF of dc2 from 1 to 0 back again
+    conn.execute("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc2': 0};")
+    # we may also remove all the replicas from the cluster, i.e. change RF of dc1 from 1 to 0 as well:
+    conn.execute("alter keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 0};")
 
 
 # Reproducer for https://github.com/scylladb/scylladb/issues/18110


### PR DESCRIPTION
This patch series fixes a couple of bugs around validating if RF is not changed by too much when performing ALTER tablets KS.
RF cannot change by more than 1 in total, because tablets load balancer cannot handle more work at once. 
    
Fixes: #20039

Should be backported to 6.0 & 6.1 (wherever tablets feature is present), as this bug may break the cluster.
