### PR TITLE
test: do not define boost_test_print_type() for types with operator<<

### DIFF
--- a/test/lib/test_utils.hh
+++ b/test/lib/test_utils.hh
@@ -115,10 +115,10 @@ extern std::mutex boost_logger_mutex;
 
 namespace std {
 
-template <typename T>
+template <typename T, typename OutStream>
 requires (fmt::is_formattable<T>::value &&
-          !boost::has_left_shift<T, std::ostream>::value)
-std::ostream& boost_test_print_type(std::ostream& os, const T& p) {
+          !boost::has_left_shift<T, OutStream>::value)
+OutStream& boost_test_print_type(OutStream& os, const T& p) {
     fmt::print(os, "{}", p);
     return os;
 }


### PR DESCRIPTION
in 30e82a81e892b2e630cbc01490a2e3cc9908058a, we add a contraint to the template parameter of boost_test_print_type() to prevent it from being matched with types which can be formatted with operator<<. but it turns out Boost.Test has its own ostream-alike implementation -- `unit_test_log_t`,
which is not a derived class of `std::ostream`, so the contraint fail to work, and we have test failure report like:

```
[Exception] - critical check ['s', 's', 't', '_', 'm', 'r', '.', 'i', 's', '_', 'e', 'n', 'd', '_', 'o', 'f', '_', 's', 't', 'r', 'e', 'a', 'm', '(', ')'] has failed
```
this is not what we expect.

so, in this change, we tighten the contraint so that as long as a type has operator<< defined, it cannot be matched.

---

no need to backport, it improves the developer experience when looking at a test failure report from a boost.test.