### PR TITLE
data_dictionary/keyspace_element: Declare a virtual destructor

### DIFF
--- a/cql3/functions/user_aggregate.hh
+++ b/cql3/functions/user_aggregate.hh
@@ -19,6 +19,8 @@ namespace functions {
 class user_aggregate : public db::functions::aggregate_function, public data_dictionary::keyspace_element {
 public:
     user_aggregate(function_name fname, bytes_opt initcond, ::shared_ptr<scalar_function> sfunc, ::shared_ptr<scalar_function> reducefunc, ::shared_ptr<scalar_function> finalfunc);
+    virtual ~user_aggregate() override = default;
+
     bool has_finalfunc() const;
 
     virtual sstring keypace_name() const override { return name().keyspace; }

--- a/cql3/functions/user_function.hh
+++ b/cql3/functions/user_function.hh
@@ -46,6 +46,7 @@ private:
 public:
     user_function(function_name name, std::vector<data_type> arg_types, std::vector<sstring> arg_names, sstring body,
             sstring language, data_type return_type, bool called_on_null_input, context ctx);
+    virtual ~user_function() override = default;
 
     const std::vector<sstring>& arg_names() const { return _arg_names; }
 

--- a/data_dictionary/keyspace_element.hh
+++ b/data_dictionary/keyspace_element.hh
@@ -18,7 +18,7 @@ class database;
 namespace data_dictionary {
 
 /**
- * `keyspace_element` is a common interface used to describe elements of keyspace. 
+ * `keyspace_element` is a common interface used to describe elements of keyspace.
  * It is used in `describe_statement`.
  *
  * Currently the elements of keyspace are:
@@ -29,6 +29,8 @@ namespace data_dictionary {
 */
 class keyspace_element {
 public:
+    virtual ~keyspace_element() = default;
+
     virtual seastar::sstring keypace_name() const = 0;
     virtual seastar::sstring element_name() const = 0;
 

--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -43,6 +43,8 @@ public:
                  std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{},
                  user_types_metadata user_types = user_types_metadata{},
                  storage_options storage_opts = storage_options{});
+    virtual ~keyspace_metadata() override = default;
+
     static lw_shared_ptr<keyspace_metadata>
     new_keyspace(std::string_view name,
                  std::string_view strategy_name,

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -655,7 +655,7 @@ public:
     schema(const schema&);
     // See \ref make_reversed().
     schema(reversed_tag, const schema&);
-    ~schema();
+    virtual ~schema() override;
     const schema_static_props& static_props() const {
         return _static_props;
     }
@@ -915,7 +915,7 @@ public:
      * Index or Local Index).
      *
      * When `with_internals` is true, the description is extended with table's id and dropped columns.
-     * The dropped columns are present in column definitions and also the `ALTER DROP` statement 
+     * The dropped columns are present in column definitions and also the `ALTER DROP` statement
      * (and `ALTER ADD` if the column has been re-added) to the description.
      */
     virtual std::ostream& describe(replica::database& db, std::ostream& os, bool with_internals) const override;

--- a/types/user.hh
+++ b/types/user.hh
@@ -32,6 +32,8 @@ public:
                     [] (const bytes& field_name) { return utf8_type->to_string(field_name); })))
             , _is_multi_cell(is_multi_cell) {
     }
+    virtual ~user_type_impl() override = default;
+
     static shared_ptr<const user_type_impl> get_instance(sstring keyspace, bytes name,
             std::vector<bytes> field_names, std::vector<data_type> field_types, bool multi_cell);
     data_type field_type(size_t i) const { return type(i); }
@@ -48,12 +50,12 @@ public:
     sstring get_name_as_cql_string() const;
 
     /* Returns set of user-defined types referenced by this UDT
-     * 
+     *
      * Example:
      * create type some_udt {
      *   a frozen<udt_a>,
      *   m frozen<map<udt_a, udt_b>,
-     *   t frozen<tuple<int, list<udt_c>>   
+     *   t frozen<tuple<int, list<udt_c>>
      * }
      * get_all_referenced_user_types() will return {udt_a, udt_b, udt_c}.
      */


### PR DESCRIPTION
Not declaring a virtual destructor in a class that uses virtual methods may lead to calling the wrong destructor or memory leaks. Because of that, we declare a virtual destructor in `data_dictionary::keyspace_element` and the classes that derive from it.