### PR TITLE
table: calculate_tablet_count: use sg_manager storage_groups size

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2380,20 +2380,7 @@ int64_t table::calculate_tablet_count() const {
         return 0;
     }
 
-    const auto& token_metadata = _erm->get_token_metadata();
-    const auto& tablet_map = token_metadata.tablets().get_tablet_map(_schema->id());
-    const auto this_host_id = token_metadata.get_topology().my_host_id();
-
-    int64_t new_tablet_count{0};
-    auto local_replica = locator::tablet_replica{this_host_id, this_shard_id()};
-
-    for (auto tablet_id : tablet_map.tablet_ids()) {
-        if (tablet_map.has_replica(tablet_id, local_replica)) {
-            ++new_tablet_count;
-        }
-    }
-
-    return new_tablet_count;
+    return _sg_manager->storage_groups().size();
 }
 
 partition_presence_checker


### PR DESCRIPTION
Now, when each shard storage_group_manager keeps
only the storage_groups for the tablet replica it owns, we can simple return the storage_group map size
instead of counting the number of tablet replicas
mapped to this shard.

Add a unit test that sums the tablet count
on all shards and tests that the sum is equal
to the configured default `initial_tablets.

Fixes #18909

Optimization.  No backport required.