### PR TITLE
test: do not define boost_test_print_type() for types with operator<<

### DIFF
--- a/test/boost/transport_test.cc
+++ b/test/boost/transport_test.cc
@@ -16,6 +16,17 @@
 #include "test/lib/random_utils.hh"
 #include "test/lib/test_utils.hh"
 
+namespace boost {
+
+template <typename F, typename R>
+requires fmt::is_formattable<std::ranges::range_value_t<R>>::value
+std::ostream& boost_test_print_type(std::ostream& os, const transformed_range<F, R>& rng) {
+    fmt::print(os, "{}", rng);
+    return os;
+}
+
+}
+
 namespace cql3 {
 
 bool operator==(const cql3::raw_value_view& a, const cql3::raw_value_view& b) {

--- a/test/lib/test_utils.hh
+++ b/test/lib/test_utils.hh
@@ -113,11 +113,20 @@ extern std::mutex boost_logger_mutex;
 
 }
 
+namespace internal {
+
+template<typename Lhs, typename Rhs>
+concept has_left_shift = requires(Lhs& lhs, const Rhs& rhs) {
+    { lhs << rhs } -> std::same_as<Lhs&>;
+};
+
+}
+
 namespace std {
 
 template <typename T>
 requires (fmt::is_formattable<T>::value &&
-          !boost::has_left_shift<T, std::ostream>::value)
+          !::internal::has_left_shift<std::ostream, T>)
 std::ostream& boost_test_print_type(std::ostream& os, const T& p) {
     fmt::print(os, "{}", p);
     return os;


### PR DESCRIPTION
in 30e82a81, we add a contraint to the template parameter of boost_test_print_type() to prevent it from being matched with types which can be formatted with operator<<. but it failed to work. we still have test failure reports like:

```
[Exception] - critical check ['s', 's', 't', '_', 'm', 'r', '.', 'i', 's', '_', 'e', 'n', 'd', '_', 'o', 'f', '_', 's', 't', 'r', 'e', 'a', 'm', '(', ')'] has failed
```

this is not what we expect. the reason is that we passed the template parameters to the `has_left_shift` trait in the wrong order, see https://live.boost.org/doc/libs/1_83_0/libs/type_traits/doc/html/boost_typetraits/reference/has_left_shift.html. we should have passed the lhs of operator<< expression as first parameter, and rhs the second.

so, in this change, we correct the type constraint by passing the template parameter in the right order, now the error message looks better, like:

```
test/boost/mutation_query_test.cc(110): error: in "test_partition_query_is_full": check !partition_slice_builder(*s) .with_range({}) .build() .is_full() has failed
```

---

this change fixes the formatting of the test description. the test description is printed when a boost test fails.  it has no impaction on the production, and only improves the developer's debugging experience. hence no need to backport.