### PR TITLE
test/pylib: fix keyspace_compaction method

### DIFF
--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -330,9 +330,10 @@ class ScyllaRESTAPIClient():
     async def keyspace_compaction(self, node_ip: str, keyspace: str, table: Optional[str] = None) -> None:
         """Compact the specified or all tables in the keyspace"""
         url = f"/storage_service/keyspace_compaction/{keyspace}"
+        params = {}
         if table is not None:
-            url += "?cf={table}"
-        await self.client.post(url, host=node_ip)
+            params["cf"] = table
+        await self.client.post(url, host=node_ip, params=params)
 
     async def dump_llvm_profile(self, node_ip : str):
         """Dump llvm profile to disk that can later be used for PGO or coverage reporting.


### PR DESCRIPTION
The [keyspace_compaction](https://github.com/scylladb/scylladb/blob/39dd08837456d517b82121ac062703c6e2f73a11/test/pylib/rest_client.py#L330) method incorrectly appends the column family parameter to the URL using a regular string, `"?cf={table}"`, instead of an f-string `f"?cf={table}"`.

Due to this, the call - `keyspace_compaction(node_ip, keyspace='ks', table='cf')` generates this URL for the POST request : `/storage_service/keyspace_compaction/ks?cf={table}`, (i.e) the table parameter never gets substituted and the POST request fails trying to find a column family named `{table}`.

Fix this issue by passing the parameter to the POST request using a dictionary instead of appending it to the URL.

Fixes #20264 

Backport needed: This isn't a critical fix, but it's necessary for any test cases using this method to work properly if backported.