### PR TITLE
replication_strategy: add fmt::formatter<replication_strategy_type>

### DIFF
--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -696,27 +696,34 @@ future<global_vnode_effective_replication_map> make_global_effective_replication
 
 } // namespace locator
 
-std::ostream& operator<<(std::ostream& os, locator::replication_strategy_type t) {
+auto fmt::formatter<locator::replication_strategy_type>::format(locator::replication_strategy_type t,
+                                                                fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    std::string_view name;
     switch (t) {
-    case locator::replication_strategy_type::simple:
-        return os << "simple";
-    case locator::replication_strategy_type::local:
-        return os << "local";
-    case locator::replication_strategy_type::network_topology:
-        return os << "network_topology";
-    case locator::replication_strategy_type::everywhere_topology:
-        return os << "everywhere_topology";
+    using enum locator::replication_strategy_type;
+    case simple:
+        name = "simple";
+        break;
+    case local:
+        name = "local";
+        break;
+    case network_topology:
+        name = "network_topology";
+        break;
+    case everywhere_topology:
+        name = "everywhere_topology";
+        break;
     };
-    std::abort();
+    return fmt::format_to(ctx.out(), "{}", name);
 }
 
-std::ostream& operator<<(std::ostream& os, const locator::vnode_effective_replication_map::factory_key& key) {
-    os << key.rs_type;
-    os << '.' << key.ring_version;
+auto fmt::formatter<locator::vnode_effective_replication_map::factory_key>::format(const locator::vnode_effective_replication_map::factory_key& key,
+                                                                                   fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    auto out = fmt::format_to(ctx.out(), "{}.{}", key.rs_type, key.ring_version);
     char sep = ':';
     for (const auto& [opt, val] : key.rs_config_options) {
-        os << sep << opt << '=' << val;
+        out = fmt::format_to(out, "{}{}={}", sep, opt, val);
         sep = ',';
     }
-    return os;
+    return out;
 }

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -458,21 +458,14 @@ future<global_vnode_effective_replication_map> make_global_effective_replication
 
 } // namespace locator
 
-std::ostream& operator<<(std::ostream& os, locator::replication_strategy_type);
-std::ostream& operator<<(std::ostream& os, const locator::vnode_effective_replication_map::factory_key& key);
+template <>
+struct fmt::formatter<locator::replication_strategy_type> : fmt::formatter<string_view> {
+    auto format(locator::replication_strategy_type, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
 
 template <>
-struct fmt::formatter<locator::vnode_effective_replication_map::factory_key> {
-    constexpr auto parse(format_parse_context& ctx) {
-        return ctx.end();
-    }
-
-    template <typename FormatContext>
-    auto format(const locator::vnode_effective_replication_map::factory_key& key, FormatContext& ctx) const {
-        std::ostringstream os;
-        os << key;
-        return fmt::format_to(ctx.out(), "{}", os.str());
-    }
+struct fmt::formatter<locator::vnode_effective_replication_map::factory_key> : fmt::formatter<string_view> {
+    auto format(const locator::vnode_effective_replication_map::factory_key&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
 template<>


### PR DESCRIPTION
so that we can use {fmt} with it without the help of fmt::streamed. also since we have a proper formatter for replication_strategy_type, let's implement
`formatter<vnode_effective_replication_map::factory_key>` as well.

since there are no callers of these two operator<<, let's drop them in this change.

---

it's a cleanup, hence no need to backport.