### PR TITLE
Make Summary support histogram with infinite bucket vlaues

### DIFF
--- a/utils/histogram.hh
+++ b/utils/histogram.hh
@@ -372,7 +372,8 @@ public:
         for (size_t i = 0; i < _current_histogram.size(); i++) {
             total_diff += _current_histogram[i] - _previous_histogram[i];
             while (pos < _summary.size() && total_diff >= _summary[pos]) {
-                _summary[pos] = _current_histogram.get_bucket_upper_limit(i);
+                _summary[pos] = (i + 1 < _current_histogram.size()) ? _current_histogram.get_bucket_upper_limit(i):
+                        _current_histogram.get_bucket_lower_limit(i);
                 pos++;
             }
             _previous_histogram[i] = _current_histogram[i];


### PR DESCRIPTION
This series fixes an issue where histogram Summaries return an infinite value.

It updated the quantile calculation logic to address cases where values fall into the infinite bucket of a histogram. 
Now, instead of returning infinite (max int), the calculation will return the last bucket limit, ensuring finite outputs in all cases.

The series adds a test for summaries with a specific test case for this scenario.

Fixes #20255
Need backport to 6.0, 6.1 and 2023.1 and above