### PR TITLE
build: add --no-use-cmake option to configure.py

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -756,7 +756,7 @@ arg_parser.add_argument('--list-artifacts', dest='list_artifacts', action='store
                         help='List all available build artifacts, that can be passed to --with')
 arg_parser.add_argument('--date-stamp', dest='date_stamp', type=str,
                         help='Set datestamp for SCYLLA-VERSION-GEN')
-arg_parser.add_argument('--use-cmake', action='store_true', help='Use CMake as the build system')
+arg_parser.add_argument('--use-cmake', action=argparse.BooleanOptionalAction, default=False, help='Whether to use CMake as the build system')
 arg_parser.add_argument('--coverage', action = 'store_true', help = 'Compile scylla with coverage instrumentation')
 arg_parser.add_argument('--build-dir', action='store', default='build',
                         help='Build directory path')

--- a/configure.py
+++ b/configure.py
@@ -686,7 +686,7 @@ other = set([
 
 all_artifacts = apps | tests | other | wasms
 
-arg_parser = argparse.ArgumentParser('Configure scylla', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+arg_parser = argparse.ArgumentParser('Configure scylla', add_help=False, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 arg_parser.add_argument('--out', dest='buildfile', action='store', default='build.ninja',
                         help='Output build-file name (by default build.ninja)')
 arg_parser.add_argument('--out-final-name', dest="buildfile_final_name", action='store',
@@ -760,8 +760,11 @@ arg_parser.add_argument('--use-cmake', action='store_true', help='Use CMake as t
 arg_parser.add_argument('--coverage', action = 'store_true', help = 'Compile scylla with coverage instrumentation')
 arg_parser.add_argument('--build-dir', action='store', default='build',
                         help='Build directory path')
-
+arg_parser.add_argument('-h', '--help', action='store_true', help='show this help message and exit')
 args = arg_parser.parse_args()
+if args.help:
+    arg_parser.print_help()
+    arg_parser.exit()
 
 PROFILES_LIST_FILE_NAME = "coverage_sources.list"
 


### PR DESCRIPTION
as part of the efforts to address scylladb/scylladb#2717, we are
switching over to the CMake-based building system, and fade out the
mechinary to create the rules manually in `configure.py`.

in this change, we add `--no-use-cmake` to `configure.py`, it serves
two purposes:

* prepare for the change which enables cmake by default, by then,
  we would set the default value of `use_cmake` to True, and allow
  user to keep using the existing mechinary in the transition period
  using `--no-use-cmake`.
* allows the CI to tell if a tree is able to build with CMake.
  the command line option of `--use-cmake` is also used by the CI
  workflows, and is passed to `configure.py` if `BUILD_WITH_CMAKE`
  jenkins pipeline parameter is set. but not all branches with
  `--use-cmake` are ready to build with CMake -- only the latest
  master HEAD is ready. so the CI needs to check the capability of
  building with CMake by looking at the output of `configure.py --help`,
  to see if it includes `--no-use-cmake`.
  after this change lands. we will remove the `BUILD_WITH_CMAKE`
  parameter, and use cmake as long as `configure.py` supports
  `--no-use-cmake` option.

the existing mechinary will stay with us for a short transition
period so that developers can take time to get used to the
usage of the naming of targets and the new  directory arrangement.

as a side effect, #20079 will be fixed after switching to CMake.

---

this is a cmake-related change, hence no need to backport.