### PR TITLE
build: print out the default value of options

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -686,7 +686,7 @@ other = set([
 
 all_artifacts = apps | tests | other | wasms
 
-arg_parser = argparse.ArgumentParser('Configure scylla')
+arg_parser = argparse.ArgumentParser('Configure scylla', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 arg_parser.add_argument('--out', dest='buildfile', action='store', default='build.ninja',
                         help='Output build-file name (by default build.ninja)')
 arg_parser.add_argument('--out-final-name', dest="buildfile_final_name", action='store',


### PR DESCRIPTION
instead of using the default `argparse.HelpFormatter`, let's use `ArgumentDefaultsHelpFormatter`, so that the default values of options are displayed in the help messages.

this should help developer understand the behavior of the script better.

---

this change is supposed to improve the developer's experience when configuring the building system, so no need to backport it.