### PR TITLE
build: cmake: add "dist" target

### DIFF
--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -130,4 +130,12 @@ add_custom_command(
 add_custom_target(dist-unified ALL
   DEPENDS ${unified_dist_pkg})
 
+add_custom_target(dist)
+add_dependencies(dist
+  dist-cqlsh
+  dist-tools
+  dist-jmx
+  dist-python3
+  dist-server)
+
 add_subdirectory(debuginfo)


### PR DESCRIPTION
since the rules generated by `configure.py` has this target, we need to have an equivalent target as well in CMake-based buidling system.

---

this is a cmake-related change, hence no need to backport.