### PR TITLE
build: cmake: add dist-check target

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -51,3 +51,5 @@ build_submodule(python3 python3
 
 check_headers(check-headers tools
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)
+
+add_subdirectory(testing/dist-check)

--- a/tools/testing/dist-check/CMakeLists.txt
+++ b/tools/testing/dist-check/CMakeLists.txt
@@ -1,0 +1,18 @@
+if(CMAKE_CONFIGURATION_TYPES)
+  foreach(config ${CMAKE_CONFIGURATION_TYPES})
+    string(APPEND build_mode
+      "$<$<CONFIG:${config}>:${scylla_build_mode_${config}}>")
+  endforeach()
+else()
+  set(build_mode ${scylla_build_mode_${CMAKE_BUILD_TYPE}})
+endif()
+
+add_custom_target(dist-check
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/dist-check.sh --mode ${build_mode}
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_dependencies(dist-check
+  dist-server-rpm
+  dist-python3-rpm
+  dist-jmx-rpm
+  dist-tools-rpm
+  dist-cqlsh-rpm)


### PR DESCRIPTION
to achieve feature parity with our existing building system, we need to implement a new build target "dist-check" in the CMake-based building system.

in this change, "dist-check" is added to CMake-based building system.

---

this is a cmake-related change, hence no need to backport.