### PR TITLE
tools/testing: update dist-check to use rockylinux and adapt to cmake

### DIFF
--- a/tools/testing/dist-check/dist-check.sh
+++ b/tools/testing/dist-check/dist-check.sh
@@ -59,7 +59,7 @@ do
     container_script="${container_image//:/-}"
     install_sh="$(pwd)/tools/testing/dist-check/$container_script.sh"
     if [ -f "$install_sh" ]; then
-        $contool run -i --rm -v $(pwd):$(pwd) $container_image /bin/bash -c "cd $(pwd) && $install_sh --mode $MODE"
+        $contool run -i --rm -v $(pwd):$(pwd):Z $container_image /bin/bash -c "cd $(pwd) && $install_sh --mode $MODE"
     else
         echo "internal error: $install_sh does not exist, please create one to verify packages on $container_image."
         exit 1

--- a/tools/testing/dist-check/dist-check.sh
+++ b/tools/testing/dist-check/dist-check.sh
@@ -51,7 +51,7 @@ if [ -f /.dockerenv ]; then
 fi
 
 container_images=(
-    docker.io/centos:7
+    docker.io/rockylinux:9
 )
 
 for container_image in "${container_images=[@]}"

--- a/tools/testing/dist-check/docker.io/rockylinux-9.sh
+++ b/tools/testing/dist-check/docker.io/rockylinux-9.sh
@@ -12,7 +12,5 @@ source "$(dirname $0)/util.sh"
 
 echo "Installing Scylla ($MODE) packages on $PRETTY_NAME..."
 
-rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-yum install -y -q deltarpm
-yum update -y -q
-yum install -y "${SCYLLA_RPMS[@]}"
+dnf update -y -q
+dnf install -y "${SCYLLA_RPMS[@]}"

--- a/tools/testing/dist-check/docker.io/util.sh
+++ b/tools/testing/dist-check/docker.io/util.sh
@@ -41,6 +41,32 @@ SCYLLA_JMX_PRODUCT=$(cat tools/jmx/build/SCYLLA-PRODUCT-FILE)
 SCYLLA_JMX_RELEASE=$(cat tools/jmx/build/SCYLLA-RELEASE-FILE)
 SCYLLA_TOOLS_PRODUCT=$(cat tools/java/build/SCYLLA-PRODUCT-FILE)
 SCYLLA_TOOLS_RELEASE=$(cat tools/java/build/SCYLLA-RELEASE-FILE)
+case $MODE in
+    debug)
+        config=Debug
+        ;;
+    release)
+        config=RelWithDebInfo
+        ;;
+    dev)
+        config=Dev
+        ;;
+    sanitize)
+        config=Sanitize
+        ;;
+    coverage)
+        config=Coverage
+        ;;
+    *)
+        echo "unknown mode: $MODE"
+        exit 1
+        ;;
+esac
+
+if [ ! -e build/dist/$MODE ]; then
+  # fallback to cmake directory
+  MODE=$config
+fi
 
 SCYLLA_RPMS=(
     build/dist/$MODE/redhat/RPMS/x86_64/$SCYLLA_PRODUCT-*$SCYLLA_RELEASE*.rpm

--- a/tools/testing/dist-check/docker.io/util.sh
+++ b/tools/testing/dist-check/docker.io/util.sh
@@ -36,17 +36,17 @@ fi
 
 SCYLLA_PRODUCT=$(cat build/SCYLLA-PRODUCT-FILE)
 SCYLLA_RELEASE=$(cat build/SCYLLA-RELEASE-FILE)
-SCYLLA_PYTHON_RELEASE=$(cat build/redhat/scylla-python3/SCYLLA-RELEASE-FILE)
-SCYLLA_JMX_PRODUCT=$(cat scylla-jmx/build/SCYLLA-PRODUCT-FILE)
-SCYLLA_JMX_RELEASE=$(cat scylla-jmx/build/SCYLLA-RELEASE-FILE)
-SCYLLA_TOOLS_PRODUCT=$(cat scylla-tools/build/SCYLLA-PRODUCT-FILE)
-SCYLLA_TOOLS_RELEASE=$(cat scylla-tools/build/SCYLLA-RELEASE-FILE)
+SCYLLA_PYTHON_RELEASE=$(cat tools/python3/build/SCYLLA-RELEASE-FILE)
+SCYLLA_JMX_PRODUCT=$(cat tools/jmx/build/SCYLLA-PRODUCT-FILE)
+SCYLLA_JMX_RELEASE=$(cat tools/jmx/build/SCYLLA-RELEASE-FILE)
+SCYLLA_TOOLS_PRODUCT=$(cat tools/java/build/SCYLLA-PRODUCT-FILE)
+SCYLLA_TOOLS_RELEASE=$(cat tools/java/build/SCYLLA-RELEASE-FILE)
 
 SCYLLA_RPMS=(
     build/dist/$MODE/redhat/RPMS/x86_64/$SCYLLA_PRODUCT-*$SCYLLA_RELEASE*.rpm
-    build/redhat/RPMS/x86_64/$SCYLLA_PRODUCT-python3-*$SCYLLA_PYTHON_RELEASE*.rpm
-    scylla-jmx/build/redhat/RPMS/noarch/$SCYLLA_JMX_PRODUCT*$SCYLLA_JMX_RELEASE*.rpm
-    scylla-tools/build/redhat/RPMS/noarch/$SCYLLA_TOOLS_PRODUCT*$SCYLLA_TOOLS_RELEASE*.rpm
+    tools/python3/build/redhat/RPMS/x86_64/$SCYLLA_PRODUCT-python3-*$SCYLLA_PYTHON_RELEASE*.rpm
+    tools/jmx/build/redhat/RPMS/noarch/$SCYLLA_JMX_PRODUCT*$SCYLLA_JMX_RELEASE*.rpm
+    tools/java/build/redhat/RPMS/noarch/$SCYLLA_TOOLS_PRODUCT*$SCYLLA_TOOLS_RELEASE*.rpm
 )
 
 source /etc/os-release

--- a/tools/testing/dist-check/docker.io/util.sh
+++ b/tools/testing/dist-check/docker.io/util.sh
@@ -41,6 +41,9 @@ SCYLLA_JMX_PRODUCT=$(cat tools/jmx/build/SCYLLA-PRODUCT-FILE)
 SCYLLA_JMX_RELEASE=$(cat tools/jmx/build/SCYLLA-RELEASE-FILE)
 SCYLLA_TOOLS_PRODUCT=$(cat tools/java/build/SCYLLA-PRODUCT-FILE)
 SCYLLA_TOOLS_RELEASE=$(cat tools/java/build/SCYLLA-RELEASE-FILE)
+SCYLLA_CQLSH_PRODUCT=$(cat tools/cqlsh/build/SCYLLA-PRODUCT-FILE)
+SCYLLA_CQLSH_RELEASE=$(cat tools/cqlsh/build/SCYLLA-RELEASE-FILE)
+
 case $MODE in
     debug)
         config=Debug
@@ -73,6 +76,7 @@ SCYLLA_RPMS=(
     tools/python3/build/redhat/RPMS/x86_64/$SCYLLA_PRODUCT-python3-*$SCYLLA_PYTHON_RELEASE*.rpm
     tools/jmx/build/redhat/RPMS/noarch/$SCYLLA_JMX_PRODUCT*$SCYLLA_JMX_RELEASE*.rpm
     tools/java/build/redhat/RPMS/noarch/$SCYLLA_TOOLS_PRODUCT*$SCYLLA_TOOLS_RELEASE*.rpm
+    tools/cqlsh/build/redhat/RPMS/x86_64/$SCYLLA_CQLSH_PRODUCT-cqlsh-*$SCYLLA_CQLSH_RELEASE*.rpm
 )
 
 source /etc/os-release


### PR DESCRIPTION
`dist-check` tests the generated rpm packages by installing them in a centos 7 container. but this script is terribly outdated

- centos 7 is deprecated. we should use a new distro's latest stable release.
- cqlsh was added to the family of rpms a while ago. we should test it as well.
- the directory hierarchy has been changed. we should read the artifacts from the new directories. 
- cmake uses a different directory hierarchy. we should check the directory used by cmake as well.

to address these breaking changes, the scripts are updated accordingly.

---

this change gives an overhaul to a test, which is not used in production. so no need to backport.