### PR TITLE
repair: add tracing functionality for user-requested repair

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -829,6 +829,10 @@ struct repair_options {
     // to repair.
     sstring start_token;
     sstring end_token;
+    // If true, repair will store tracing information in system.traces.
+    // There is a primary tracing session created for the entire repair and
+    // secondary tracing session for each individual range repair.
+    bool trace = false;
     // column_families is the list of column families to repair in the given
     // keyspace. If this list is empty (the default), all the column families
     // in this keyspace are repaired
@@ -877,11 +881,8 @@ struct repair_options {
         string_opt(start_token, options, START_TOKEN);
         string_opt(end_token, options, END_TOKEN);
 
-        bool trace = false;
         bool_opt(trace, options, TRACE_KEY);
-        if (trace) {
-            throw std::runtime_error("unsupported trace");
-        }
+
         // Consume, ignore.
         int job_threads;
         int_opt(job_threads, options, JOB_THREADS_KEY);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -767,7 +767,7 @@ future<> repair::shard_repair_task_impl::repair_range(const dht::token_range& ra
         }
 
         auto dropped = co_await with_table_drop_silenced(db.local(), mm, table.id, [&] (const table_id& uuid) {
-            return repair_cf_range_row_level(*this, table.name, table.id, range, neighbors, _small_table_optimization);
+            return repair_cf_range_row_level(*this, table.name, table.id, range, neighbors, child_trace_state, _small_table_optimization);
         });
         if (dropped) {
             dropped_tables.insert(table.name);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -617,7 +617,8 @@ repair::shard_repair_task_impl::shard_repair_task_impl(tasks::task_manager::modu
         streaming::stream_reason reason_,
         bool hints_batchlog_flushed,
         bool small_table_optimization,
-        std::optional<int> ranges_parallelism)
+        std::optional<int> ranges_parallelism,
+        tracing::trace_state_ptr trace_state)
     : repair_task_impl(module, id, 0, "shard", keyspace, "", "", parent_id_.uuid(), reason_)
     , rs(repair)
     , db(repair.get_db())
@@ -635,6 +636,7 @@ repair::shard_repair_task_impl::shard_repair_task_impl(tasks::task_manager::modu
     , total_rf(erm->get_replication_factor())
     , _hints_batchlog_flushed(std::move(hints_batchlog_flushed))
     , _small_table_optimization(small_table_optimization)
+    , _trace_state(std::move(trace_state))
     , _user_ranges_parallelism(ranges_parallelism ? std::optional<semaphore>(semaphore(*ranges_parallelism)) : std::nullopt)
 {
     rlogger.debug("repair[{}]: Setting user_ranges_parallelism to {}", global_repair_id.uuid(),
@@ -1232,7 +1234,7 @@ future<int> repair_service::do_repair_start(sstring keyspace, std::unordered_map
 
             bool primary_replica_only = options.primary_range;
             auto ranges_parallelism = options.ranges_parallelism == -1 ? std::nullopt : std::optional<int>(options.ranges_parallelism);
-            co_await repair_tablets(id, keyspace, cfs, host2ip, primary_replica_only, options.ranges, options.data_centers, hosts, ignore_nodes, ranges_parallelism);
+            co_await repair_tablets(id, keyspace, cfs, host2ip, primary_replica_only, options.ranges, options.data_centers, hosts, ignore_nodes, ranges_parallelism, std::move(trace_state));
             co_return id.id;
         }
     }
@@ -1337,7 +1339,7 @@ future<int> repair_service::do_repair_start(sstring keyspace, std::unordered_map
     }
 
     auto ranges_parallelism = options.ranges_parallelism == -1 ? std::nullopt : std::optional<int>(options.ranges_parallelism);
-    auto task = co_await _repair_module->make_and_start_task<repair::user_requested_repair_task_impl>({}, id, std::move(keyspace), "", germs, std::move(cfs), std::move(ranges), std::move(options.hosts), std::move(options.data_centers), std::move(ignore_nodes), small_table_optimization, ranges_parallelism);
+    auto task = co_await _repair_module->make_and_start_task<repair::user_requested_repair_task_impl>({}, id, std::move(keyspace), "", germs, std::move(cfs), std::move(ranges), std::move(options.hosts), std::move(options.data_centers), std::move(ignore_nodes), small_table_optimization, ranges_parallelism, std::move(trace_state));
     co_return id.id;
 }
 
@@ -1409,13 +1411,28 @@ future<> repair::user_requested_repair_task_impl::run() {
 
         auto ranges_parallelism = _ranges_parallelism;
         bool small_table_optimization = _small_table_optimization;
+        auto trace_state = tracing::global_trace_state_ptr(_trace_state);
         for (auto shard : boost::irange(unsigned(0), smp::count)) {
             auto f = rs.container().invoke_on(shard, [keyspace, table_ids, id, ranges, hints_batchlog_flushed, ranges_parallelism, small_table_optimization,
-                    data_centers, hosts, ignore_nodes, parent_data = get_repair_uniq_id().task_info, germs] (repair_service& local_repair) mutable -> future<> {
+                    trace_state, data_centers, hosts, ignore_nodes, parent_data = get_repair_uniq_id().task_info, germs] (repair_service& local_repair) mutable -> future<> {
                 local_repair.get_metrics().repair_total_ranges_sum += ranges.size();
-                auto task = co_await local_repair._repair_module->make_and_start_task<repair::shard_repair_task_impl>(parent_data, tasks::task_id::create_random_id(), keyspace,
-                        local_repair, germs->get().shared_from_this(), std::move(ranges), std::move(table_ids),
-                        id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), streaming::stream_reason::repair, hints_batchlog_flushed, small_table_optimization, ranges_parallelism);
+                auto task = co_await local_repair._repair_module->make_and_start_task<repair::shard_repair_task_impl>(
+                        parent_data,
+                        tasks::task_id::create_random_id(),
+                        keyspace,
+                        local_repair,
+                        germs->get().shared_from_this(),
+                        std::move(ranges),
+                        std::move(table_ids),
+                        id,
+                        std::move(data_centers),
+                        std::move(hosts),
+                        std::move(ignore_nodes),
+                        streaming::stream_reason::repair,
+                        hints_batchlog_flushed,
+                        small_table_optimization,
+                        ranges_parallelism,
+                        trace_state.get());
                 co_await task->done();
             });
             repair_results.push_back(std::move(f));
@@ -1537,7 +1554,7 @@ future<> repair::data_sync_repair_task_impl::run() {
                 auto ranges_parallelism = std::nullopt;
                 auto task_impl_ptr = seastar::make_shared<repair::shard_repair_task_impl>(local_repair._repair_module, tasks::task_id::create_random_id(), keyspace,
                         local_repair, germs->get().shared_from_this(), std::move(ranges), std::move(table_ids),
-                        id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), reason, hints_batchlog_flushed, small_table_optimization, ranges_parallelism);
+                        id, std::move(data_centers), std::move(hosts), std::move(ignore_nodes), reason, hints_batchlog_flushed, small_table_optimization, ranges_parallelism, nullptr);
                 task_impl_ptr->neighbors = std::move(neighbors);
                 auto task = co_await local_repair._repair_module->make_task(std::move(task_impl_ptr), parent_data);
                 task->start();
@@ -2225,7 +2242,18 @@ static std::unordered_set<gms::inet_address> get_nodes_in_dcs(std::vector<sstrin
 }
 
 // Repair all tablets belong to this node for the given table
-future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_name, std::vector<sstring> table_names, host2ip_t host2ip, bool primary_replica_only, dht::token_range_vector ranges_specified, std::vector<sstring> data_centers, std::unordered_set<gms::inet_address> hosts, std::unordered_set<gms::inet_address> ignore_nodes, std::optional<int> ranges_parallelism) {
+future<> repair_service::repair_tablets(
+        repair_uniq_id rid,
+        sstring keyspace_name,
+        std::vector<sstring> table_names,
+        host2ip_t host2ip,
+        bool primary_replica_only,
+        dht::token_range_vector ranges_specified,
+        std::vector<sstring> data_centers,
+        std::unordered_set<gms::inet_address> hosts,
+        std::unordered_set<gms::inet_address> ignore_nodes,
+        std::optional<int> ranges_parallelism,
+        tracing::trace_state_ptr trace_state) {
     std::vector<tablet_repair_task_meta> task_metas;
     for (auto& table_name : table_names) {
         lw_shared_ptr<replica::table> t;
@@ -2394,7 +2422,8 @@ future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_nam
             }
         }
     }
-    auto task = co_await _repair_module->make_and_start_task<repair::tablet_repair_task_impl>({}, rid, keyspace_name, table_names, streaming::stream_reason::repair, std::move(task_metas), ranges_parallelism);
+    auto task = co_await _repair_module->make_and_start_task<repair::tablet_repair_task_impl>({}, rid, keyspace_name, table_names,
+            streaming::stream_reason::repair, std::move(task_metas), ranges_parallelism, std::move(trace_state));
 }
 
 future<> repair::tablet_repair_task_impl::run() {
@@ -2455,8 +2484,9 @@ future<> repair::tablet_repair_task_impl::run() {
             }
         });
 
-
-        rs.container().invoke_on_all([&idx, id, metas = _metas, parent_data, reason = _reason, tables = _tables, ranges_parallelism = _ranges_parallelism] (repair_service& rs) -> future<> {
+        auto trace_state = tracing::global_trace_state_ptr(_trace_state);
+        rs.container().invoke_on_all([&idx, id, metas = _metas, parent_data, reason = _reason, tables = _tables, ranges_parallelism = _ranges_parallelism,
+                trace_state = std::move(trace_state)] (repair_service& rs) -> future<> {
             std::exception_ptr error;
             for (auto& m : metas) {
                 if (m.master_shard_id != this_shard_id()) {
@@ -2491,7 +2521,7 @@ future<> repair::tablet_repair_task_impl::run() {
 
                 auto task_impl_ptr = seastar::make_shared<repair::shard_repair_task_impl>(rs._repair_module, tasks::task_id::create_random_id(),
                         m.keyspace_name, rs, erm, std::move(ranges), std::move(table_ids), id, std::move(data_centers), std::move(hosts),
-                        std::move(ignore_nodes), reason, hints_batchlog_flushed, small_table_optimization, ranges_parallelism);
+                        std::move(ignore_nodes), reason, hints_batchlog_flushed, small_table_optimization, ranges_parallelism, trace_state.get());
                 task_impl_ptr->neighbors = std::move(neighbors);
                 auto task = co_await rs._repair_module->make_task(std::move(task_impl_ptr), parent_data);
                 task->start();

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -170,7 +170,18 @@ private:
             shared_ptr<node_ops_info> ops_info);
 
 public:
-    future<> repair_tablets(repair_uniq_id id, sstring keyspace_name, std::vector<sstring> table_names, host2ip_t host2ip, bool primary_replica_only = true, dht::token_range_vector ranges_specified = {}, std::vector<sstring> dcs = {}, std::unordered_set<gms::inet_address> hosts = {}, std::unordered_set<gms::inet_address> ignore_nodes = {}, std::optional<int> ranges_parallelism = std::nullopt);
+    future<> repair_tablets(
+            repair_uniq_id id,
+            sstring keyspace_name,
+            std::vector<sstring> table_names,
+            host2ip_t host2ip,
+            bool primary_replica_only = true,
+            dht::token_range_vector ranges_specified = {},
+            std::vector<sstring> dcs = {},
+            std::unordered_set<gms::inet_address> hosts = {},
+            std::unordered_set<gms::inet_address> ignore_nodes = {},
+            std::optional<int> ranges_parallelism = std::nullopt,
+            tracing::trace_state_ptr trace_state = {});
 
 private:
 

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -274,9 +274,14 @@ class repair_row;
 class repair_hasher;
 class repair_writer;
 
-future<> repair_cf_range_row_level(repair::shard_repair_task_impl& shard_task,
-        sstring cf_name, table_id table_id, dht::token_range range,
-        const std::vector<gms::inet_address>& all_peer_nodes, bool small_table_optimization);
+future<> repair_cf_range_row_level(
+        repair::shard_repair_task_impl& shard_task,
+        sstring cf_name,
+        table_id table_id,
+        dht::token_range range,
+        const std::vector<gms::inet_address>& all_peer_nodes,
+        tracing::trace_state_ptr trace_state,
+        bool small_table_optimization);
 future<std::list<repair_row>> to_repair_rows_list(repair_rows_on_wire rows,
         schema_ptr s, uint64_t seed, repair_master is_master,
         reader_permit permit, repair_hasher hasher);

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -49,8 +49,22 @@ private:
     std::unordered_set<gms::inet_address> _ignore_nodes;
     bool _small_table_optimization;
     std::optional<int> _ranges_parallelism;
+    tracing::trace_state_ptr _trace_state;
 public:
-    user_requested_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, std::string keyspace, std::string entity, lw_shared_ptr<locator::global_vnode_effective_replication_map> germs, std::vector<sstring> cfs, dht::token_range_vector ranges, std::vector<sstring> hosts, std::vector<sstring> data_centers, std::unordered_set<gms::inet_address> ignore_nodes, bool small_table_optimization, std::optional<int> ranges_parallelism) noexcept
+    user_requested_repair_task_impl(
+            tasks::task_manager::module_ptr module,
+            repair_uniq_id id,
+            std::string keyspace,
+            std::string entity,
+            lw_shared_ptr<locator::global_vnode_effective_replication_map> germs,
+            std::vector<sstring> cfs,
+            dht::token_range_vector ranges,
+            std::vector<sstring> hosts,
+            std::vector<sstring> data_centers,
+            std::unordered_set<gms::inet_address> ignore_nodes,
+            bool small_table_optimization,
+            std::optional<int> ranges_parallelism,
+            tracing::trace_state_ptr trace_state) noexcept
         : repair_task_impl(module, id.uuid(), id.id, "keyspace", std::move(keyspace), "", std::move(entity), tasks::task_id::create_null_id(), streaming::stream_reason::repair)
         , _germs(germs)
         , _cfs(std::move(cfs))
@@ -60,6 +74,7 @@ public:
         , _ignore_nodes(std::move(ignore_nodes))
         , _small_table_optimization(small_table_optimization)
         , _ranges_parallelism(ranges_parallelism)
+        , _trace_state(std::move(trace_state))
     {}
 
     virtual tasks::is_abortable is_abortable() const noexcept override {
@@ -108,13 +123,23 @@ private:
     std::vector<tablet_repair_task_meta> _metas;
     optimized_optional<abort_source::subscription> _abort_subscription;
     std::optional<int> _ranges_parallelism;
+    tracing::trace_state_ptr _trace_state;
 public:
-    tablet_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, sstring keyspace, std::vector<sstring> tables, streaming::stream_reason reason, std::vector<tablet_repair_task_meta> metas, std::optional<int> ranges_parallelism)
+    tablet_repair_task_impl(
+            tasks::task_manager::module_ptr module,
+            repair_uniq_id id,
+            sstring keyspace,
+            std::vector<sstring> tables,
+            streaming::stream_reason reason,
+            std::vector<tablet_repair_task_meta> metas,
+            std::optional<int> ranges_parallelism,
+            tracing::trace_state_ptr trace_state)
         : repair_task_impl(module, id.uuid(), id.id, "keyspace", keyspace, "", "", tasks::task_id::create_null_id(), reason)
         , _keyspace(std::move(keyspace))
         , _tables(std::move(tables))
         , _metas(std::move(metas))
         , _ranges_parallelism(ranges_parallelism)
+        , _trace_state(std::move(trace_state))
     {
     }
 
@@ -153,6 +178,7 @@ public:
     bool _hints_batchlog_flushed = false;
     std::unordered_set<gms::inet_address> nodes_down;
     bool _small_table_optimization = false;
+    tracing::trace_state_ptr _trace_state;
 private:
     bool _aborted = false;
     std::optional<sstring> _failed_because;
@@ -173,7 +199,8 @@ public:
             streaming::stream_reason reason_,
             bool hints_batchlog_flushed,
             bool small_table_optimization,
-            std::optional<int> ranges_parallelism);
+            std::optional<int> ranges_parallelism,
+            tracing::trace_state_ptr trace_state);
     void check_failed_ranges();
     void check_in_abort_or_shutdown();
     repair_neighbors get_repair_neighbors(const dht::token_range& range);


### PR DESCRIPTION
Cassandra allows tracing repairs, just like it allows tracing queries. We never implemented this, although one can find stubs related to this functionality in the code:
* `tracing::trace_type` has a `REPAIR` member;
* the `/storage_service/repair_async` REST API has a `trace` option;
* nodetool (both the legacy and the native one) has a `--trace` option;

This PR implements the functionality of tracing support for repair, using the above mentioned stubs. When specifying the `--trace` option using `nodetool repair`, or if passing `trace: true` parameter to the `/storage_service/repair_async` REST endpoint, ScyllaDB will setup a tracing session for the user-requested repair.
One user-requested repair can spawn 1 or more row level repair instances. To avoid mixing tracing events from different row-level repair instances, a separate tracing session is setup for each row level repair instance. These child instances are linked to the user-requested repair (parent) tracing session, by adding so called "link" messages, which contain the tracing session id of the related tracing session. The parent tracing session contains a tracing event for every child session spawned, including the id of said child session. Similarly, the child tracing sessions all have a tracing event, containing the session id of the parent tracing session.
The log message printed at the start of the user-requested repair now also contains the session id of the user-requested (parent) repair tracing session. This way, once the user starts the repair, they can extract the parent tracing session id from the logs, then query `system_tracing.sessions` and `system_tracing.events` and follow the progress of the overall repair, as well as the progress of the individual row-level repair instances.

For now, only a handful of messages are added, just to demonstrate the functionality. More tracing messages can be added in later versions of this PR, or in follow-up PRs.

Fixes: scylladb/scylladb#20241

## Example - repairing a tablets table, with 2 tablets.

Nodetool command:
```
./node1/scylla nodetool -h 127.66.0.1 repair ks --trace
[2024-08-23 07:32:14,672] Starting repair command #1, repairing 1 ranges for keyspace ks (parallelism=SEQUENTIAL, full=true)
[2024-08-23 07:32:14,672] Repair session 1
[2024-08-23 07:32:14,873] Repair session 1 finished
```

Scylla logs:
```
INFO  2024-08-23 07:32:14,671 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: starting user-requested repair for keyspace ks, repair id 1, tracing session id 587795f0-6143-11ef-8cfb-fb90df83e10d, options {"trace": "true", "primaryRange": "false", "jobThreads": "1", "incremental": "false", "parallelism": "parallel"}                                                                                                                                                                            
INFO  2024-08-23 07:32:14,672 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21] Repair 1 out of 2 tablets: table=ks.tbl range=(minimum token,-1] replicas=[7134227a-5ba9-4e04-a2f1-9033d5e4b843:0, 21654fff-2e26-4cf3-8f00-c45b71e06907:0]  
INFO  2024-08-23 07:32:14,672 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Sending repair_flush_hints_batchlog to node=127.66.0.1, participants=[127.66.0.1, 127.66.0.2], started                                                     
INFO  2024-08-23 07:32:14,672 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Sending repair_flush_hints_batchlog to node=127.66.0.2, participants=[127.66.0.1, 127.66.0.2], started                                                     
INFO  2024-08-23 07:32:14,672 [shard 1:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21] Repair 2 out of 2 tablets: table=ks.tbl range=(-1,9223372036854775807] replicas=[7134227a-5ba9-4e04-a2f1-9033d5e4b843:1, 21654fff-2e26-4cf3-8f00-c45b71e06907:1]                                                                                                                                                                                                                                                           
INFO  2024-08-23 07:32:14,672 [shard 1:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Sending repair_flush_hints_batchlog to node=127.66.0.1, participants=[127.66.0.1, 127.66.0.2], started                                                     
INFO  2024-08-23 07:32:14,672 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Started to process repair_flush_hints_batchlog_request from node=127.66.0.1, target_nodes=[127.66.0.1, 127.66.0.2], hints_timeout=300s, batchlog_timeout=300s                                                                                                                                                                                                                                                             
INFO  2024-08-23 07:32:14,672 [shard 1:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Sending repair_flush_hints_batchlog to node=127.66.0.2, participants=[127.66.0.1, 127.66.0.2], started                                                     
INFO  2024-08-23 07:32:14,672 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Started to flush hints for repair_flush_hints_batchlog_request from node=127.66.0.1, target_nodes=[127.66.0.1, 127.66.0.2]                                 
INFO  2024-08-23 07:32:14,672 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Started to flush batchlog for repair_flush_hints_batchlog_request from node=127.66.0.1, target_nodes=[127.66.0.1, 127.66.0.2]                              
INFO  2024-08-23 07:32:14,672 [shard 1:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Started to process repair_flush_hints_batchlog_request from node=127.66.0.1, target_nodes=[127.66.0.1, 127.66.0.2], hints_timeout=300s, batchlog_timeout=300s                                                                                                                                                                                                                                                             
INFO  2024-08-23 07:32:14,673 [shard 1:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Started to flush hints for repair_flush_hints_batchlog_request from node=127.66.0.1, target_nodes=[127.66.0.1, 127.66.0.2]                                 
INFO  2024-08-23 07:32:14,673 [shard 1:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Started to flush batchlog for repair_flush_hints_batchlog_request from node=127.66.0.1, target_nodes=[127.66.0.1, 127.66.0.2]                              
INFO  2024-08-23 07:32:14,673 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Finished to flush hints for repair_flush_hints_batchlog_request from node=127.66.0.1, target_hosts=[127.66.0.1, 127.66.0.2]                                
INFO  2024-08-23 07:32:14,673 [shard 1:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Finished to flush hints for repair_flush_hints_batchlog_request from node=127.66.0.1, target_hosts=[127.66.0.1, 127.66.0.2]                                
INFO  2024-08-23 07:32:14,673 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Finished to flush batchlog for repair_flush_hints_batchlog_request from node=127.66.0.1, target_nodes=[127.66.0.1, 127.66.0.2]                             
INFO  2024-08-23 07:32:14,673 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Finished to process repair_flush_hints_batchlog_request from node=127.66.0.1, target_nodes=[127.66.0.1, 127.66.0.2]                                        
INFO  2024-08-23 07:32:14,673 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Started to repair 1 out of 1 tables in keyspace=ks, table=tbl, table_id=e1382f40-6084-11ef-856f-834c8cf5d0c4, repair_reason=repair                         
INFO  2024-08-23 07:32:14,674 [shard 1:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Finished to flush batchlog for repair_flush_hints_batchlog_request from node=127.66.0.1, target_nodes=[127.66.0.1, 127.66.0.2]                             
INFO  2024-08-23 07:32:14,674 [shard 1:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Finished to process repair_flush_hints_batchlog_request from node=127.66.0.1, target_nodes=[127.66.0.1, 127.66.0.2]                                        
INFO  2024-08-23 07:32:14,674 [shard 1:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Started to repair 1 out of 1 tables in keyspace=ks, table=tbl, table_id=e1382f40-6084-11ef-856f-834c8cf5d0c4, repair_reason=repair                         
INFO  2024-08-23 07:32:14,677 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: stats: repair_reason=repair, keyspace=ks, tables=["tbl"], ranges_nr=1, round_nr=2, round_nr_fast_path_already_synced=2, round_nr_fast_path_same_combined_hashes=0, round_nr_slow_path=0, rpc_call_nr=6, tx_hashes_nr=0, rx_hashes_nr=0, duration=0.003561227 seconds, tx_row_nr=0, rx_row_nr=0, tx_row_bytes=0, rx_row_bytes=0, row_from_disk_bytes={127.66.0.1: 1624, 127.66.0.2: 1624}, row_from_disk_nr={127.66.0.1: 7, 127.66.0.2: 7}, row_from_disk_bytes_per_sec={127.66.0.1: 0.43489707, 127.66.0.2: 0.43489707} MiB/s, row_from_disk_rows_per_sec={127.66.0.1: 1965.6147, 127.66.0.2: 1965.6147} Rows/s, tx_row_nr_peer={}, rx_row_nr_peer={}                                    
INFO  2024-08-23 07:32:14,677 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: completed successfully, keyspace=ks                                                                                                                        
INFO  2024-08-23 07:32:14,677 [shard 1:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: stats: repair_reason=repair, keyspace=ks, tables=["tbl"], ranges_nr=1, round_nr=2, round_nr_fast_path_already_synced=2, round_nr_fast_path_same_combined_hashes=0, round_nr_slow_path=0, rpc_call_nr=6, tx_hashes_nr=0, rx_hashes_nr=0, duration=0.003294101 seconds, tx_row_nr=0, rx_row_nr=0, tx_row_bytes=0, rx_row_bytes=0, row_from_disk_bytes={127.66.0.1: 928, 127.66.0.2: 928}, row_from_disk_nr={127.66.0.1: 4, 127.66.0.2: 4}, row_from_disk_bytes_per_sec={127.66.0.1: 0.26866505, 127.66.0.2: 0.26866505} MiB/s, row_from_disk_rows_per_sec={127.66.0.1: 1214.2919, 127.66.0.2: 1214.2919} Rows/s, tx_row_nr_peer={}, rx_row_nr_peer={}                                      
INFO  2024-08-23 07:32:14,677 [shard 1:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: completed successfully, keyspace=ks                                                                                                                        
INFO  2024-08-23 07:32:14,677 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Finished user-requested repair for tablet keyspace=ks tables=["tbl"] repair_id=1 tablets_repaired=2 duration=0.00547206s                                   
INFO  2024-08-23 07:32:14,677 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Started to shutdown off-strategy compaction updater                                                                                                        
INFO  2024-08-23 07:32:14,677 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: Finished to shutdown off-strategy compaction updater                                                                                                       
INFO  2024-08-23 07:32:14,677 [shard 0:strm] repair - repair[6ca02740-6cb7-476a-8aed-df1c74267c21]: completed successfully   
```

Note the mention of the tracing session id in the `starting user-requested repair for ...` message. This is the entry point for the user, for finding the tracing sessions.

Tracing sessions:
```cql
cqlsh> select * from system_traces.sessions;

 session_id                           | client    | command | coordinator | duration | parameters                                                                                                                                                                                                                                                 | request               | request_size | response_size | started_at                      | username
--------------------------------------+-----------+---------+-------------+----------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------+--------------+---------------+---------------------------------+---------------------------
 58780b20-6143-11ef-8cfb-fb90df83e10d | 127.0.0.1 |  REPAIR |  127.66.0.1 |     3058 |       {'keyspace': 'ks', 'neighbors': '[127.66.0.2]', 'parent_session_id': '587795f0-6143-11ef-8cfb-fb90df83e10d', 'range': '(minimum token,-1]', 'small_table_optimization': 'false', 'table': 'tbl', 'table_id': 'e1382f40-6084-11ef-856f-834c8cf5d0c4'} |          repair range |            0 |             0 | 2024-08-23 11:32:14.674000+0000 | <unauthenticated request>
 587795f0-6143-11ef-8cfb-fb90df83e10d | 127.0.0.1 |  REPAIR |  127.66.0.1 |     6207 |                                 {'keyspace': 'ks', 'options': '{"trace": "true", "primaryRange": "false", "jobThreads": "1", "incremental": "false", "parallelism": "parallel"}', 'repair_id': '1', 'repair_uuid': '6ca02740-6cb7-476a-8aed-df1c74267c21'} | user requested repair |            0 |             0 | 2024-08-23 11:32:14.671000+0000 | <unauthenticated request>
 58780b20-6143-11ef-b2f1-fb8fdf83e10d | 127.0.0.1 |  REPAIR |  127.66.0.1 |     2772 | {'keyspace': 'ks', 'neighbors': '[127.66.0.2]', 'parent_session_id': '587795f0-6143-11ef-8cfb-fb90df83e10d', 'range': '(-1,9223372036854775807]', 'small_table_optimization': 'false', 'table': 'tbl', 'table_id': 'e1382f40-6084-11ef-856f-834c8cf5d0c4'} |          repair range |            0 |             0 | 2024-08-23 11:32:14.674000+0000 | <unauthenticated request>

(3 rows)
```

Note that parent session (`587795f0-6143-11ef-8cfb-fb90df83e10d`) and the two child sessions: `58780b20-6143-11ef-8cfb-fb90df83e10d` and `58780b20-6143-11ef-b2f1-fb8fdf83e10d`. Note how the child sessions link to their parent in the `parameters` map, this is to allow scripts to connect the sessions, without having to parse event messages.

The parent session:
```cql
cqlsh> select * from system_traces.events where session_id = 587795f0-6143-11ef-8cfb-fb90df83e10d;

 session_id                           | event_id                             | activity                                                                                                                                                                              | scylla_parent_id | scylla_span_id  | source     | source_elapsed | thread
--------------------------------------+--------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+-----------------+------------+----------------+---------
 587795f0-6143-11ef-8cfb-fb90df83e10d | 58780fa6-6143-11ef-8cfb-fb90df83e10d |       repair_range(): table.id: e1382f40-6084-11ef-856f-834c8cf5d0c4, table.name: tbl, range: (minimum token,-1], child repair trace session id: 58780b20-6143-11ef-8cfb-fb90df83e10d |                0 | 127783278429257 | 127.66.0.1 |           2320 | shard 0
 587795f0-6143-11ef-8cfb-fb90df83e10d | 58782f02-6143-11ef-b2f1-fb8fdf83e10d | repair_range(): table.id: e1382f40-6084-11ef-856f-834c8cf5d0c4, table.name: tbl, range: (-1,9223372036854775807], child repair trace session id: 58780b20-6143-11ef-b2f1-fb8fdf83e10d |  127783278429257 | 495589102935561 | 127.66.0.1 |            571 | shard 1

(2 rows)
```

Note the link to the child session ids, in the two tracing events.

Child session `58780b20-6143-11ef-8cfb-fb90df83e10d`:
```cql
cqlsh> select * from system_traces.events where session_id = 58780b20-6143-11ef-8cfb-fb90df83e10d;

 session_id                           | event_id                             | activity                                                                                                                                                                                                                  | scylla_parent_id | scylla_span_id  | source     | source_elapsed | thread
--------------------------------------+--------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+-----------------+------------+----------------+---------
 58780b20-6143-11ef-8cfb-fb90df83e10d | 58780fc8-6143-11ef-8cfb-fb90df83e10d |                                          repair_range(): table.id: e1382f40-6084-11ef-856f-834c8cf5d0c4, table.name: tbl, range: (minimum token,-1], parent repair trace session id: 587795f0-6143-11ef-8cfb-fb90df83e10d |                0 | 193435118323341 | 127.66.0.1 |             21 | shard 0
 58780b20-6143-11ef-8cfb-fb90df83e10d | 5878116f-6143-11ef-8cfb-fb90df83e10d |                                                                                                                                                                                                 starting row-level repair |                0 | 193435118323341 | 127.66.0.1 |             64 | shard 0
 58780b20-6143-11ef-8cfb-fb90df83e10d | 58781648-6143-11ef-8cfb-fb90df83e10d |                                       repair meta id: 0, diff detection algorithm: send_full_set_rpc_stream, max_row_buf_size: 33554432; memory budget: wanted=67108864, available=142396620, max_repair_memory=209505484 |                0 | 193435118323341 | 127.66.0.1 |            188 | shard 0
 58780b20-6143-11ef-8cfb-fb90df83e10d | 58782ad6-6143-11ef-8cfb-fb90df83e10d |                                                                                                negotiate_sync_boundary(): round: 0, _last_sync_boundary: none, _current_sync_boundary: none, _skipped_sync_boundary: none |                0 | 193435118323341 | 127.66.0.1 |            714 | shard 0
 58780b20-6143-11ef-8cfb-fb90df83e10d | 5878603a-6143-11ef-8cfb-fb90df83e10d | negotiate_sync_boundary(): round: 1, _last_sync_boundary: none, _current_sync_boundary: none, _skipped_sync_boundary: optional({ {key: pk{000400000004}, token: -2729420104000364805}, {position: clustered, ckp{}, 0} }) |                0 | 193435118323341 | 127.66.0.1 |           2081 | shard 0
 58780b20-6143-11ef-8cfb-fb90df83e10d | 58788554-6143-11ef-8cfb-fb90df83e10d |                            finished row-level repair: tx_hashes_nr=0, rx_hashes_nr=0, tx_row_nr=0, rx_row_nr=0, row_from_disk_bytes={127.66.0.1: 1624, 127.66.0.2: 1624}, row_from_disk_nr={127.66.0.1: 7, 127.66.0.2: 7} |                0 | 193435118323341 | 127.66.0.1 |           3031 | shard 0

(6 rows)
```

Child session `58780b20-6143-11ef-b2f1-fb8fdf83e10d`:
```cql
cqlsh> select * from system_traces.events where session_id = 58780b20-6143-11ef-b2f1-fb8fdf83e10d;

 session_id                           | event_id                             | activity                                                                                                                                                                                                                 | scylla_parent_id | scylla_span_id  | source     | source_elapsed | thread
--------------------------------------+--------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+-----------------+------------+----------------+---------
 58780b20-6143-11ef-b2f1-fb8fdf83e10d | 58782f1a-6143-11ef-b2f1-fb8fdf83e10d |                                   repair_range(): table.id: e1382f40-6084-11ef-856f-834c8cf5d0c4, table.name: tbl, range: (-1,9223372036854775807], parent repair trace session id: 587795f0-6143-11ef-8cfb-fb90df83e10d |                0 | 338169636681865 | 127.66.0.1 |             15 | shard 1
 58780b20-6143-11ef-b2f1-fb8fdf83e10d | 58782ff3-6143-11ef-b2f1-fb8fdf83e10d |                                                                                                                                                                                                starting row-level repair |                0 | 338169636681865 | 127.66.0.1 |             37 | shard 1
 58780b20-6143-11ef-b2f1-fb8fdf83e10d | 587835e0-6143-11ef-b2f1-fb8fdf83e10d |                                      repair meta id: 1, diff detection algorithm: send_full_set_rpc_stream, max_row_buf_size: 33554432; memory budget: wanted=67108864, available=142396620, max_repair_memory=209505484 |                0 | 338169636681865 | 127.66.0.1 |            189 | shard 1
 58780b20-6143-11ef-b2f1-fb8fdf83e10d | 5878453d-6143-11ef-b2f1-fb8fdf83e10d |                                                                                               negotiate_sync_boundary(): round: 0, _last_sync_boundary: none, _current_sync_boundary: none, _skipped_sync_boundary: none |                0 | 338169636681865 | 127.66.0.1 |            582 | shard 1
 58780b20-6143-11ef-b2f1-fb8fdf83e10d | 5878670b-6143-11ef-b2f1-fb8fdf83e10d | negotiate_sync_boundary(): round: 1, _last_sync_boundary: none, _current_sync_boundary: none, _skipped_sync_boundary: optional({ {key: pk{000400000003}, token: 9010454139840013625}, {position: clustered, ckp{}, 0} }) |                0 | 338169636681865 | 127.66.0.1 |           1447 | shard 1
 58780b20-6143-11ef-b2f1-fb8fdf83e10d | 587899ab-6143-11ef-b2f1-fb8fdf83e10d |                             finished row-level repair: tx_hashes_nr=0, rx_hashes_nr=0, tx_row_nr=0, rx_row_nr=0, row_from_disk_bytes={127.66.0.1: 928, 127.66.0.2: 928}, row_from_disk_nr={127.66.0.1: 4, 127.66.0.2: 4} |                0 | 338169636681865 | 127.66.0.1 |           2743 | shard 1

(6 rows)
```

Note in both cases, that the parent tracing session id is mentioned in the first tracing event message.

---

New functionality, no backport required.