### PR TITLE
test.py: Increase pool size to 10

### DIFF
--- a/test/alternator/suite.yaml
+++ b/test/alternator/suite.yaml
@@ -1,5 +1,5 @@
 type: Python
-pool_size: 4
+pool_size: 6
 run_first:
     - test_streams
     - test_scan

--- a/test/auth_cluster/suite.yaml
+++ b/test/auth_cluster/suite.yaml
@@ -1,5 +1,5 @@
 type: Topology
-pool_size: 2
+pool_size: 10
 cluster:
   initial_size: 0
 extra_scylla_config_options:

--- a/test/object_store/suite.yaml
+++ b/test/object_store/suite.yaml
@@ -1,5 +1,5 @@
 type: Topology
-pool_size: 4
+pool_size: 10
 cluster:
   initial_size: 0
 extra_scylla_config_options:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -50,7 +50,7 @@ from cassandra.policies import WhiteListRoundRobinPolicy  # type: ignore
 from cassandra.connection import UnixSocketEndPoint
 
 
-io_executor = concurrent.futures.ThreadPoolExecutor(max_workers=8)
+io_executor = concurrent.futures.ThreadPoolExecutor(max_workers=20)
 
 async def async_rmtree(directory, *args, **kwargs):
     loop = asyncio.get_event_loop()

--- a/test/rest_api/suite.yaml
+++ b/test/rest_api/suite.yaml
@@ -1,5 +1,5 @@
 type: Python
-pool_size: 1
+pool_size: 10
 
 skip_in_release:
     - test_task_manager

--- a/test/topology_tasks/suite.yaml
+++ b/test/topology_tasks/suite.yaml
@@ -1,5 +1,5 @@
 type: Topology
-pool_size: 4
+pool_size: 10
 cluster:
   initial_size: 0
 extra_scylla_config_options:


### PR DESCRIPTION
Increase pool size changes were recently reverted because of the flakiness of the test_gossip_boot test. Test started to fail on adding the node to the cluster without any issues in the Scylla log file. In test logs, it looked like the installation process for the new node just hanged. After investigating the problem, I've found out that the issue is that test.py was draining the io_executor pool for cleaning the directory during install that was set to eight workers. So to resolve the issue, io_executor pool should be increased to more or less the same ratio as it was: doubled cluster pool size.

[Here](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/xtrey/job/byo_scylladb/106/allure) is the job with dev and debug modes with repeat 100 for test_gossip_boot.
[Here](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/xtrey/job/byo_scylladb/107/allure) is the job with three modes and repeat set to three as normal CI is executed.
[Here](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/xtrey/job/byo_scylladb/108/allure) is the job with dev and debug modes with repeat 250 for test_gossip_boot.
There were no fails during all these runs.

Related: https://github.com/scylladb/scylladb/issues/20116