### PR TITLE
github: use clang-20 in clang-nightly workflow

### DIFF
--- a/.github/workflows/clang-nightly.yaml
+++ b/.github/workflows/clang-nightly.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   # use the development branch explicitly
-  CLANG_VERSION: 19
+  CLANG_VERSION: 20
   BUILD_DIR: build
 
 permissions: {}


### PR DESCRIPTION
since clang 19 has been branched. let's track the development brach, which is clang 20.

---

this is a change in CI, hence no need to backport.
