### PR TITLE
repair: row_level: coroutinize some slow-path functions

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -383,10 +383,11 @@ future<> repair_reader::on_end_of_stream() noexcept {
 }
 
 future<> repair_reader::close() noexcept {
-    return _reader.close().then([this] {
+    co_await _reader.close();
+    {
         _permit.release_base_resources();
         _reader_handle.reset();
-    });
+    }
 }
 
 void repair_reader::set_current_dk(const dht::decorated_key& key) {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1510,27 +1510,23 @@ private:
             gms::inet_address remote_node,
             unsigned node_idx,
             rpc::source<repair_hash_with_cmd>& source) {
-        return repeat([this, current_hashes, remote_node, node_idx, &source] () mutable {
-            return source().then([this, current_hashes, remote_node, node_idx] (std::optional<std::tuple<repair_hash_with_cmd>> hash_cmd_opt) mutable {
-                if (hash_cmd_opt) {
+        while (std::optional<std::tuple<repair_hash_with_cmd>> hash_cmd_opt = co_await source()) {
                     repair_hash_with_cmd hash_cmd = std::get<0>(hash_cmd_opt.value());
                     rlogger.trace("get_full_row_hashes: Got repair_hash_with_cmd from peer={}, hash={}, cmd={}", remote_node, hash_cmd.hash, int(hash_cmd.cmd));
                     if (hash_cmd.cmd == repair_stream_cmd::hash_data) {
                         current_hashes->insert(hash_cmd.hash);
-                        return make_ready_future<stop_iteration>(stop_iteration::no);
                     } else if (hash_cmd.cmd == repair_stream_cmd::end_of_current_hash_set) {
-                        return make_ready_future<stop_iteration>(stop_iteration::yes);
+                        co_return;
                     } else if (hash_cmd.cmd == repair_stream_cmd::error) {
                         throw std::runtime_error("get_full_row_hashes: Peer failed to process");
                     } else {
                         throw std::runtime_error("get_full_row_hashes: Got unexpected repair_stream_cmd");
                     }
-                } else {
+        }
+        {
                     _sink_source_for_get_full_row_hashes.mark_source_closed(node_idx);
                     throw std::runtime_error("get_full_row_hashes: Got unexpected end of stream");
-                }
-            });
-        });
+        }
     }
 
     future<> get_full_row_hashes_sink_op(rpc::sink<repair_stream_cmd>& sink) {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1798,28 +1798,35 @@ private:
             needs_all_rows_t needs_all_rows,
             rpc::sink<repair_hash_with_cmd>& sink,
             gms::inet_address remote_node) {
-        return do_with(std::move(set_diff), [needs_all_rows, &sink] (repair_hash_set& set_diff) mutable {
+        std::exception_ptr ep;
+        try {
             if (inject_rpc_stream_error) {
-                return make_exception_future<>(std::runtime_error("get_row_diff: Inject sender error in sink loop"));
+                throw std::runtime_error("get_row_diff: Inject sender error in sink loop");
             }
             if (needs_all_rows) {
                 rlogger.trace("get_row_diff: request with repair_stream_cmd::needs_all_rows");
-                return sink(repair_hash_with_cmd{repair_stream_cmd::needs_all_rows, repair_hash()}).then([&sink] () mutable {
-                    return sink.flush();
-                });
+                co_await sink(repair_hash_with_cmd{repair_stream_cmd::needs_all_rows, repair_hash()});
+                {
+                    co_await sink.flush();
+                    co_return;
+                }
             }
-            return do_for_each(set_diff, [&sink] (const repair_hash& hash) mutable {
-                return sink(repair_hash_with_cmd{repair_stream_cmd::hash_data, hash});
-            }).then([&sink] () mutable {
-                return sink(repair_hash_with_cmd{repair_stream_cmd::end_of_current_hash_set, repair_hash()});
-            }).then([&sink] () mutable {
-                return sink.flush();
-            });
-        }).handle_exception([&sink] (std::exception_ptr ep) {
-            return sink.close().then([ep = std::move(ep)] () mutable {
-                return make_exception_future<>(std::move(ep));
-            });
-        });
+            for (const repair_hash& hash : set_diff) {
+                co_await sink(repair_hash_with_cmd{repair_stream_cmd::hash_data, hash});
+            }
+            {
+                co_await sink(repair_hash_with_cmd{repair_stream_cmd::end_of_current_hash_set, repair_hash()});
+            }
+            {
+                co_await sink.flush();
+            }
+        } catch (...) {
+            ep = std::current_exception();
+        }
+        if (ep) {
+            co_await sink.close();
+            std::rethrow_exception(ep);
+        }
     }
 
 public:

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1328,13 +1328,16 @@ private:
 
     future<std::list<repair_row>>
     copy_rows_from_working_row_buf() {
-        return do_with(std::list<repair_row>(), [this] (std::list<repair_row>& rows) {
-            return do_for_each(_working_row_buf, [&rows] (const repair_row& r) {
+        std::list<repair_row> rows;
+        {
+            for (const repair_row& r : _working_row_buf) {
                 rows.push_back(r);
-            }).then([&rows] {
-                return std::move(rows);
-            });
-        });
+                co_await coroutine::maybe_yield();
+            }
+            {
+                co_return rows;
+            }
+        }
     }
 
     future<std::list<repair_row>>

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1064,10 +1064,12 @@ private:
     }
 
     future<> set_estimated_partitions(uint64_t estimated_partitions) {
-        return with_gate(_gate, [this, estimated_partitions] {
+        auto gate_held = _gate.hold();
+        {
             _estimated_partitions = estimated_partitions;
             _repair_writer->set_estimated_partitions(_estimated_partitions);
-        });
+        }
+        co_return;
     }
 
     dht::static_sharder make_remote_sharder() {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2007,11 +2007,12 @@ public:
 
     // RPC handler
     future<> put_row_diff_handler(repair_rows_on_wire rows, gms::inet_address from) {
-        return with_gate(_gate, [this, rows = std::move(rows)] () mutable {
+        auto gate_held = _gate.hold();
+        {
             auto& cf = _db.local().find_column_family(_schema->id());
             cf.update_off_strategy_trigger();
-            return apply_rows_on_follower(std::move(rows));
-        });
+            co_await apply_rows_on_follower(std::move(rows));
+        }
     }
 };
 

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -374,11 +374,12 @@ repair_reader::read_mutation_fragment() {
 }
 
 future<> repair_reader::on_end_of_stream() noexcept {
-    return _reader.close().then([this] {
+    co_await _reader.close();
+    {
         _permit.release_base_resources();
         _reader = mutation_fragment_v1_stream(make_empty_flat_reader_v2(_schema, _permit));
         _reader_handle.reset();
-    });
+    }
 }
 
 future<> repair_reader::close() noexcept {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1086,13 +1086,16 @@ private:
     }
 
     future<size_t> get_repair_rows_size(const std::list<repair_row>& rows) const {
-        return do_with(size_t(0), [&rows] (size_t& sz) {
-            return do_for_each(rows, [&sz] (const repair_row& r) mutable {
+        size_t sz = 0;
+        {
+            for (const repair_row& r : rows) {
                 sz += r.size();
-            }).then([&sz] {
-                return sz;
-            });
-        });
+                co_await coroutine::maybe_yield();
+            }
+            {
+                co_return sz;
+            }
+        }
     }
 
     // Get the size of rows in _row_buf


### PR DESCRIPTION
This series coroutinizes up some functions in repair/row_level.cc. This enhances
readability and reduces bloat:

```
size  build/release/repair/row_level.o.{before,after}
   text	   data	    bss	    dec	    hex	filename
1650619	     48	    524	1651191	 1931f7	build/release/repair/row_level.o.before
1604610	     48	    524	1605182	 187e3e	build/release/repair/row_level.o.after
```

46kB of text were saved.

Functions that only touch a single mutation fragment were not coroutinized to avoid
adding a allocation in a fast path. In one case a function was split into a fast path and a
slow path.

Clean-up series, backport not needed.