### PR TITLE
docs: install poetry>=1.8.0

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -27,7 +27,7 @@ all: dirhtml
 # Setup commands
 .PHONY: setupenv
 setupenv:
-	pip install -q poetry
+	pip install -q 'poetry>=1.8.0'
 
 .PHONY: setup
 setup:


### PR DESCRIPTION
in 57def6f1, we specified "package-mode" for poetry, but this option was introduced in poetry 1.8.0, as the "non-package" mode support. see https://github.com/python-poetry/poetry/releases/tag/1.8.0

this change practically bumps up the minimum required poetry version to 1.8.0, we did update `pyproject.tombl` to reflect this change. but wefailed to update the `Makefile`.

in this change, we update `Makefile` to ensure that user which happens have an older version of poetry can install the version which supports this version when running `make setupenv`.

Refs scylladb/scylladb#20284
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

this addresses the build failure of document in an environment where we have an older version of poetry, and this does not impact the production environment, so no need to backport.