### PR TITLE
Ignore seed name resolution errors during the restart of a cluster member node.

### DIFF
--- a/init.hh
+++ b/init.hh
@@ -35,7 +35,9 @@ extern logging::logger startlog;
 
 class bad_configuration_error : public std::exception {};
 
-std::set<gms::inet_address> get_seeds_from_db_config(const db::config& cfg, gms::inet_address broadcast_address);
+[[nodiscard]] std::set<gms::inet_address> get_seeds_from_db_config(const db::config& cfg,
+                                                                   gms::inet_address broadcast_address,
+                                                                   bool fail_on_lookup_error);
 
 class service_set {
 public:

--- a/main.cc
+++ b/main.cc
@@ -1422,7 +1422,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 startlog.warn("Using default cluster name is not recommended. Using a unique cluster name will reduce the chance of adding nodes to the wrong cluster by mistake");
             }
             auto group0_id = sys_ks.local().get_raft_group0_id().get();
-            auto gossiper_seeds = get_seeds_from_db_config(*cfg, broadcast_addr);
+
+            // Fail on a gossiper seeds lookup error only if the node is not bootstrapped.
+            const bool fail_on_lookup_error = !sys_ks.local().bootstrap_complete();
+
+            auto gossiper_seeds = get_seeds_from_db_config(*cfg, broadcast_addr, fail_on_lookup_error);
 
             auto get_gossiper_cfg = sharded_parameter([&] {
                 gms::gossip_config gcfg;

--- a/test/topology/test_start_bootstrapped_with_invalid_seed.py
+++ b/test/topology/test_start_bootstrapped_with_invalid_seed.py
@@ -13,8 +13,8 @@ from test.pylib.manager_client import ManagerClient
 
 logger = logging.getLogger(__name__)
 
+
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="issue #14945")
 async def test_start_bootstrapped_with_invalid_seed(manager: ManagerClient):
     """
     Issue https://github.com/scylladb/scylladb/issues/14945.

--- a/test/topology/test_start_bootstrapped_with_invalid_seed.py
+++ b/test/topology/test_start_bootstrapped_with_invalid_seed.py
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import asyncio
+import pytest
+import logging
+
+from test.pylib.internal_types import IPAddress
+from test.pylib.manager_client import ManagerClient
+
+logger = logging.getLogger(__name__)
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(reason="issue #14945")
+async def test_start_bootstrapped_with_invalid_seed(manager: ManagerClient):
+    """
+    Issue https://github.com/scylladb/scylladb/issues/14945.
+
+    Check non-regression: try starting a non-bootstrapped node with an invalid seed.
+     1. Start a node with an invalid seed hostname in the seeds list config.
+     2. Make sure starting the node fails with an error message.
+
+    Check that when bootstrapped, having a non-resolving DNS name in
+    the config, does not prevent node restart.
+     1. Start a node and wait till it starts and joins the cluster.
+     2. Stop the node and restart it with an invalid seed hostname in the seeds list config.
+     3. Make sure the node started successfully since it's already bootstrapped (i.e. is a cluster member).
+    """
+
+    s1 = await manager.server_add(start=False)
+
+    # Start the node with an invalid seed and make sure it fails with an error message.
+    await manager.server_start(s1.server_id, seeds=[IPAddress("no_address")],
+                               expected_error="Bad configuration: invalid value in 'seeds'", wait_interval=20)
+
+    # Start the node with default seeds, to make it join the cluster.
+    await manager.server_start(s1.server_id, wait_interval=20)
+
+    # Stop the node.
+    await manager.server_stop_gracefully(s1.server_id)
+
+    # Start the node with an invalid seed. and make sure it starts successfully.
+    await manager.server_start(s1.server_id, seeds=[IPAddress("no_address")], wait_interval=20)


### PR DESCRIPTION
All seeds hostname resolution errors will be ignored during a node restart in case the node had already joined a cluster.  This will prevent restart errors if some seed names are not resolvable.

Fixes scylladb/scylladb#14945
