### PR TITLE
Integrated restore

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -795,6 +795,62 @@
           ]
       },
       {
+          "path":"/storage_service/restore",
+          "operations":[
+              {
+                  "method":"POST",
+                  "summary":"Starts copying SSTables from a designated bucket in object storage to a specified keyspace",
+                  "type":"string",
+                  "nickname":"start_restore",
+                  "produces":[
+                      "application/json"
+                  ],
+                  "parameters":[
+                      {
+                          "name":"endpoint",
+                          "description":"ID of the configured object storage endpoint to copy SSTables from",
+                          "required":true,
+                          "allowMultiple":false,
+                          "type":"string",
+                          "paramType":"query"
+                      },
+                      {
+                          "name":"bucket",
+                          "description":"Name of the bucket to read SSTables from",
+                          "required":true,
+                          "allowMultiple":false,
+                          "type":"string",
+                          "paramType":"query"
+                      },
+                      {
+                          "name":"snapshot",
+                          "description":"Name of a snapshot to copy SSTables from",
+                          "required":true,
+                          "allowMultiple":false,
+                          "type":"string",
+                          "paramType":"query"
+                      },
+                      {
+                          "name":"keyspace",
+                          "description":"Name of a keyspace to copy SSTables to",
+                          "required":true,
+                          "allowMultiple":false,
+                          "type":"string",
+                          "paramType":"query"
+                      },
+                      {
+                          "name":"table",
+                          "description":"Name of a table to copy SSTables to",
+                          "required":false,
+                          "allowMultiple":false,
+                          "type":"string",
+                          "paramType":"query"
+                      }
+                  ]
+              }
+          ]
+      },
+      {
          "path":"/storage_service/keyspace_compaction/{keyspace}",
          "operations":[
             {

--- a/dist/common/nodetool-completion
+++ b/dist/common/nodetool-completion
@@ -149,6 +149,7 @@ have nodetool && have cqlsh &&
             relocatesstables
             removenode
             repair
+            restore
             scrub
             setcachecapacity
             setcachekeystosave

--- a/docs/operating-scylla/nodetool-commands/restore.rst
+++ b/docs/operating-scylla/nodetool-commands/restore.rst
@@ -1,0 +1,29 @@
+================
+Nodetool restore
+================
+
+**restore** - Load SSTables from a designated bucket in object store into a specified keyspace or table
+
+Syntax
+------
+
+.. code-block:: console
+
+   nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
+               --endpoint <endpoint> --bucket <bucket>
+               --snapshot <snapshot>
+               --keyspace <keyspace> [--table <table>]
+               [--nowait]
+
+Options
+-------
+
+* ``-h <host>`` or ``--host <host>`` - Node hostname or IP address.
+* ``--endpoint`` - ID of the configured object storage endpoint to load SSTables from
+* ``--bucket`` - Name of the bucket to load SSTables from
+* ``--snapshot`` - Name of a snapshot to load SSTables from
+* ``--keyspace`` - Name of a keyspace to load SSTables into
+* ``--table`` - Name of a table to load SSTables into
+* ``--nowait`` - Don't wait on the restore process
+
+.. include:: nodetool-index.rst

--- a/docs/operating-scylla/nodetool.rst
+++ b/docs/operating-scylla/nodetool.rst
@@ -42,6 +42,7 @@ Nodetool
    nodetool-commands/removenode
    nodetool-commands/repair
    nodetool-commands/resetlocalschema
+   nodetool-commands/restore
    nodetool-commands/ring
    nodetool-commands/scrub
    nodetool-commands/settraceprobability
@@ -122,6 +123,7 @@ Operations that are not listed below are currently not available.
 * :doc:`refresh </operating-scylla/nodetool-commands/refresh/>`- Load newly placed SSTables to the system without restart
 * :doc:`removenode </operating-scylla/nodetool-commands/removenode/>`- Remove node with the provided ID
 * :doc:`repair <nodetool-commands/repair/>`  :code:`<keyspace>` :code:`<table>` - Repair one or more tables
+* :doc:`restore </operating-scylla/nodetool-commands/restore/>` - Load SSTables from a designated bucket in object store into a specified keyspace or table
 * :doc:`resetlocalschema </operating-scylla/nodetool-commands/resetlocalschema/>` - Reset the node's local schema.
 * :doc:`ring <nodetool-commands/ring/>` - The nodetool ring command display the token ring information.
 * :doc:`scrub </operating-scylla/nodetool-commands/scrub>` :code:`[-m mode] [--no-snapshot] <keyspace> [<table>...]` - Scrub the SSTable files in the specified keyspace or table(s)

--- a/main.cc
+++ b/main.cc
@@ -1868,7 +1868,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             supervisor::notify("starting sstables loader");
-            sst_loader.start(std::ref(db), std::ref(messaging), std::ref(view_builder), std::ref(task_manager), maintenance_scheduling_group).get();
+            sst_loader.start(std::ref(db), std::ref(messaging), std::ref(view_builder), std::ref(task_manager), std::ref(sstm), maintenance_scheduling_group).get();
             auto stop_sst_loader = defer_verbose_shutdown("sstables loader", [&sst_loader] {
                 sst_loader.stop().get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1868,7 +1868,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             supervisor::notify("starting sstables loader");
-            sst_loader.start(std::ref(db), std::ref(messaging), std::ref(view_builder), maintenance_scheduling_group).get();
+            sst_loader.start(std::ref(db), std::ref(messaging), std::ref(view_builder), std::ref(task_manager), maintenance_scheduling_group).get();
             auto stop_sst_loader = defer_verbose_shutdown("sstables loader", [&sst_loader] {
                 sst_loader.stop().get();
             });

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -88,6 +88,8 @@ public:
     // The table UUID is returned too.
     static future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
             get_sstables_from_upload_dir(distributed<replica::database>& db, sstring ks, sstring cf, sstables::sstable_open_config cfg);
+    static future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
+            get_sstables_from_object_store(distributed<replica::database>& db, sstring ks, sstring cf, sstring endpoint, sstring bucket, sstring prefix, sstables::sstable_open_config cfg);
     static future<> process_upload_dir(distributed<replica::database>& db, sharded<db::view::view_builder>& vb, sstring ks_name, sstring cf_name);
 };
 

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -74,6 +74,9 @@ class distributed_loader {
             sharded<replica::database>& db, sharded<db::view::view_builder>& vb,
             bool needs_view_update, sstring ks, sstring cf);
     static future<> populate_keyspace(distributed<replica::database>& db, sharded<db::system_keyspace>& sys_ks, keyspace& ks, sstring ks_name);
+    static future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
+        get_sstables_from(distributed<replica::database>& db, sstring ks, sstring cf, sstables::sstable_open_config cfg,
+        noncopyable_function<future<>(global_table_ptr&, sharded<sstables::sstable_directory>&)> start_dir);
 
 public:
     static future<> init_system_keyspace(sharded<db::system_keyspace>&, distributed<locator::effective_replication_map_factory>&, distributed<replica::database>&);

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -274,7 +274,7 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
     // - If all shards scan in parallel, they can start loading sooner. That is faster than having
     //   a separate step to fetch all files, followed by another step to distribute and process.
 
-    directory_lister lister(_directory, lister::dir_entry_types::of<directory_entry_type::regular>(), &manifest_json_filter);
+    auto lister = abstract_lister::make<directory_lister>(_directory, lister::dir_entry_types::of<directory_entry_type::regular>(), &manifest_json_filter);
     std::exception_ptr ex;
     try {
         while (true) {

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -283,7 +283,7 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
                 break;
             }
             auto component_path = _directory / de->name;
-            auto [ comps, ks, cf ] = sstables::parse_path(component_path);
+            auto comps = sstables::parse_path(component_path, directory._schema->ks_name(), directory._schema->cf_name());
             handle(std::move(comps), component_path);
         }
     } catch (...) {

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -195,6 +195,10 @@ public:
     sstable_directory(replica::table& table,
             sstable_state state,
             io_error_handler_gen error_handler_gen);
+    sstable_directory(replica::table& table,
+            lw_shared_ptr<const data_dictionary::storage_options> storage_opts,
+            sstring table_dir,
+            io_error_handler_gen error_handler_gen);
     sstable_directory(sstables_manager& manager,
             schema_ptr schema,
             const dht::sharder& sharder,

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -27,6 +27,7 @@
 #include "sstables/sstables_registry.hh"
 
 class compaction_manager;
+namespace s3 { class client; }
 
 namespace sstables {
 
@@ -104,6 +105,8 @@ public:
 
         std::filesystem::path _directory;
         std::unique_ptr<scan_state> _state;
+        shared_ptr<s3::client> _client;
+        sstring _bucket;
 
         future<> garbage_collect(storage&);
         future<> cleanup_column_family_temp_sst_dirs();
@@ -113,6 +116,7 @@ public:
 
     public:
         filesystem_components_lister(std::filesystem::path dir);
+        filesystem_components_lister(std::filesystem::path dir, sstables_manager&, const data_dictionary::storage_options::s3&);
 
         virtual future<> process(sstable_directory& directory, process_flags flags) override;
         virtual future<> commit() override;

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -583,6 +583,9 @@ sstring s3_storage::make_s3_object_name(const sstable& sst, component_type type)
     if (!sst.generation().is_uuid_based()) {
         throw std::runtime_error("'S3' STORAGE only works with uuid_sstable_identifier enabled");
     }
+    if (sst.is_uploaded()) {
+        return format("/{}/{}", _bucket, sst.filename(type));
+    }
     return format("/{}/{}/{}", _bucket, sst.generation(), sstable_version_constants::get_component_map(sst.get_version()).at(type));
 }
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -446,3 +446,14 @@ future<> sstables_loader::load_new_sstables(sstring ks_name, sstring cf_name,
     _loading_new_sstables = false;
     co_return;
 }
+
+sstables_loader::sstables_loader(sharded<replica::database>& db,
+        netw::messaging_service& messaging,
+        sharded<db::view::view_builder>& vb,
+        seastar::scheduling_group sg)
+    : _db(db)
+    , _messaging(messaging)
+    , _view_builder(vb)
+    , _sched_group(std::move(sg))
+{
+}

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -451,11 +451,13 @@ sstables_loader::sstables_loader(sharded<replica::database>& db,
         netw::messaging_service& messaging,
         sharded<db::view::view_builder>& vb,
         tasks::task_manager& tm,
+        sstables::storage_manager& sstm,
         seastar::scheduling_group sg)
     : _db(db)
     , _messaging(messaging)
     , _view_builder(vb)
     , _task_manager_module(make_shared<task_manager_module>(tm))
+    , _storage_manager(sstm)
     , _sched_group(std::move(sg))
 {
     tm.register_module("sstables_loader", _task_manager_module);

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -450,10 +450,17 @@ future<> sstables_loader::load_new_sstables(sstring ks_name, sstring cf_name,
 sstables_loader::sstables_loader(sharded<replica::database>& db,
         netw::messaging_service& messaging,
         sharded<db::view::view_builder>& vb,
+        tasks::task_manager& tm,
         seastar::scheduling_group sg)
     : _db(db)
     , _messaging(messaging)
     , _view_builder(vb)
+    , _task_manager_module(make_shared<task_manager_module>(tm))
     , _sched_group(std::move(sg))
 {
+    tm.register_module("sstables_loader", _task_manager_module);
+}
+
+future<> sstables_loader::stop() {
+    co_await _task_manager_module->stop();
 }

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -83,4 +83,12 @@ public:
      */
     future<> load_new_sstables(sstring ks_name, sstring cf_name,
             bool load_and_stream, bool primary_replica_only);
+
+    /**
+     * Download new SSTables not currently tracked by the system from object store
+     */
+    future<tasks::task_id> download_new_sstables(sstring ks_name, sstring cf_name,
+            sstring endpoint, sstring bucket, sstring snapshot);
+
+    class download_task_impl;
 };

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -51,13 +51,7 @@ public:
     sstables_loader(sharded<replica::database>& db,
             netw::messaging_service& messaging,
             sharded<db::view::view_builder>& vb,
-            seastar::scheduling_group sg)
-        : _db(db)
-        , _messaging(messaging)
-        , _view_builder(vb)
-        , _sched_group(std::move(sg))
-    {
-    }
+            seastar::scheduling_group sg);
 
     /**
      * Load new SSTables not currently tracked by the system

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -19,6 +19,8 @@ namespace replica {
 class database;
 }
 
+namespace sstables { class storage_manager; }
+
 namespace netw { class messaging_service; }
 namespace db {
 namespace view {
@@ -42,6 +44,7 @@ private:
     netw::messaging_service& _messaging;
     sharded<db::view::view_builder>& _view_builder;
     shared_ptr<task_manager_module> _task_manager_module;
+    sstables::storage_manager& _storage_manager;
     seastar::scheduling_group _sched_group;
 
     // Note that this is obviously only valid for the current shard. Users of
@@ -61,6 +64,7 @@ public:
             netw::messaging_service& messaging,
             sharded<db::view::view_builder>& vb,
             tasks::task_manager& tm,
+            sstables::storage_manager& sstm,
             seastar::scheduling_group sg);
 
     future<> stop();

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -384,8 +384,8 @@ static std::unordered_set<sstring> populate_bucket(shared_ptr<s3::client> client
 
     for (int i = 0; i < nr_objects; i++) {
         temporary_buffer<char> data = sstring("1234567890").release();
-        auto name = format("{}obj.{}", prefix, i);
-        client->put_object(format("/{}/{}", bucket, name), std::move(data)).get();
+        auto name = format("obj.{}", i);
+        client->put_object(format("/{}/{}{}", bucket, prefix, name), std::move(data)).get();
         names.insert(name);
     }
 

--- a/test/nodetool/test_restore.py
+++ b/test/nodetool/test_restore.py
@@ -1,0 +1,79 @@
+#
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import pytest
+
+from test.nodetool.rest_api_mock import expected_request
+
+@pytest.mark.parametrize("table",
+                         ["cf",
+                          pytest.param("",
+                                       marks=pytest.mark.xfail(
+                                           reason="full keyspace restore not implemented yet"))])
+@pytest.mark.parametrize("nowait", [False, True])
+def test_restore(nodetool, scylla_only, table, nowait):
+    endpoint = "s3.us-east-2.amazonaws.com"
+    bucket = "bucket-foo"
+    keyspace = "ks"
+
+    snapshot = "ss"
+    params = {"endpoint": endpoint,
+              "bucket": bucket,
+              "snapshot": snapshot,
+              "keyspace": keyspace}
+    if table:
+        params["table"] = table
+
+    task_id = "2c4a3e5f"
+    start_time = "2024-08-08T14:29:25Z"
+    end_time = "2024-08-08T14:30:42Z"
+    state = "done"
+    task_status = {
+        "id": task_id,
+        "type": "download_sstables",
+        "kind": "node",
+        "scope": "node",
+        "state": state,
+        "is_abortable": False,
+        "start_time": start_time,
+        "end_time": end_time,
+        "error": "",
+        "sequence_number": 0,
+        "shard": 0,
+        "progress_total": 1.0,
+        "progress_completed": 1.0,
+        "children_ids": []
+    }
+    expected_requests = [
+        expected_request(
+            "POST",
+            "/storage_service/restore",
+            params,
+            response=task_id)
+    ]
+    args = ["restore",
+            "--endpoint", endpoint,
+            "--bucket", bucket,
+            "--snapshot", snapshot,
+            "--keyspace", keyspace]
+    if table:
+        args.extend(["--table", table])
+    if nowait:
+        args.append("--nowait")
+        expected_output = ""
+    else:
+        # wait for the completion of backup task
+        expected_requests.append(
+            expected_request(
+                "GET",
+                f"/task_manager/wait_task/{task_id}",
+                response=task_status))
+        expected_output = f"""{state}
+start: {start_time}
+end: {end_time}
+"""
+    res = nodetool(*args, expected_requests=expected_requests)
+    assert res.stdout == expected_output

--- a/test/object_store/test_backup.py
+++ b/test/object_store/test_backup.py
@@ -30,7 +30,7 @@ def create_ks_and_cf(cql):
 
     return ks, cf
 
-async def prepare_snapshot_for_backup(manager: ManagerClient, server):
+async def prepare_snapshot_for_backup(manager: ManagerClient, server, snap_name = 'backup'):
     cql = manager.get_cql()
     workdir = await manager.server_get_workdir(server.server_id)
     print(f'Create keyspace')
@@ -38,7 +38,7 @@ async def prepare_snapshot_for_backup(manager: ManagerClient, server):
     print('Flush keyspace')
     await manager.api.flush_keyspace(server.ip_addr, ks)
     print('Take keyspace snapshot')
-    await manager.api.take_snapshot(server.ip_addr, ks, 'backup')
+    await manager.api.take_snapshot(server.ip_addr, ks, snap_name)
 
     return ks, cf
 

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -315,6 +315,15 @@ class ScyllaRESTAPIClient():
                   "snapshot": tag}
         return await self.client.post_json(f"/storage_service/backup", host=node_ip, params=params)
 
+    async def restore(self, node_ip: str, ks: str, cf: str, tag: str, dest: str, bucket: str) -> str:
+        """Restore keyspace:table from backup"""
+        params = {"keyspace": ks,
+                  "table": cf,
+                  "endpoint": dest,
+                  "bucket": bucket,
+                  "snapshot": tag}
+        return await self.client.post_json(f"/storage_service/restore", host=node_ip, params=params)
+
     async def take_snapshot(self, node_ip: str, ks: str, tag: str) -> None:
         """Take keyspace snapshot"""
         params = { 'kn': ks, 'tag': tag }

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -138,6 +138,7 @@ public:
         sstring _prefix;
         sstring _max_keys;
         std::optional<future<>> _opt_done_fut;
+        lister::filter_type _filter;
         seastar::queue<std::optional<directory_entry>> _queue;
 
         future<> start_listing();
@@ -145,6 +146,7 @@ public:
     public:
 
         bucket_lister(shared_ptr<client> client, sstring bucket, sstring prefix = "", size_t objects_per_page = 64, size_t entries_batch = 512 / sizeof(std::optional<directory_entry>));
+        bucket_lister(shared_ptr<client> client, sstring bucket, sstring prefix, lister::filter_type filter, size_t objects_per_page = 64, size_t entries_batch = 512 / sizeof(std::optional<directory_entry>));
 
         future<std::optional<directory_entry>> get() override;
         future<> close() noexcept override;

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -15,6 +15,7 @@
 #include <seastar/core/queue.hh>
 #include <seastar/http/client.hh>
 #include <filesystem>
+#include "utils/lister.hh"
 #include "utils/s3/creds.hh"
 
 using namespace seastar;
@@ -131,7 +132,7 @@ public:
         }
     };
 
-    class bucket_lister {
+    class bucket_lister final : public abstract_lister::impl {
         shared_ptr<client> _client;
         sstring _bucket;
         sstring _prefix;
@@ -145,8 +146,8 @@ public:
 
         bucket_lister(shared_ptr<client> client, sstring bucket, sstring prefix = "", size_t objects_per_page = 64, size_t entries_batch = 512 / sizeof(std::optional<directory_entry>));
 
-        future<std::optional<directory_entry>> get();
-        future<> close() noexcept;
+        future<std::optional<directory_entry>> get() override;
+        future<> close() noexcept override;
     };
 
     future<> close();


### PR DESCRIPTION
Handed over from https://github.com/scylladb/scylladb/pull/20149

This adds minimal implementation of the start-restore API call.

The method starts a task that runs load-and-stream functionality against sstables from S3 bucket. Arguments are:

```
endpoint -- the ID in object_store.yaml config file
bucket -- the target bucket to get objects from
keyspace -- the keyspace to work on
table -- the table to work on
snapshot -- the name of the snapshot from which the backup was taken
```
The task runs in the background, its task_id is returned from the method once it's spawned and it should be used via /task_manager API to track the task execution and completion.

Remote sstables components are scanned as if they were placed in local upload/ directory. Then colelcted sstables are fed into load-and-stream.

This branch has https://github.com/scylladb/scylladb/pull/19890 (Integrated backup), https://github.com/scylladb/scylladb/pull/20120 (S3 lister) and few more minor PRs merged in. The restore branch itself starts with [utils: Introduce abstract (directory) lister](https://github.com/scylladb/scylladb/commit/29c867b54d40b7068af274517221fc9d31164392) commit.

refs: https://github.com/scylladb/scylladb/issues/18392