### PR TITLE
repair: fix build on older compilers

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -46,6 +46,7 @@
 #include <exception>
 #include <cfloat>
 #include <atomic>
+#include <utility>
 
 #include "idl/partition_checksum.dist.hh"
 #include "utils/user_provided_param.hh"
@@ -2123,7 +2124,7 @@ future<> repair_service::do_rebuild_replace_with_repair(std::unordered_map<sstri
                         return sync_nodes.contains(node);
                     }) | boost::adaptors::transformed([&topology] (const auto& node) {
                         const auto& n = topology.get_node(node);
-                        return std::make_tuple(n.host_id(), n.endpoint());
+                        return std::make_pair(n.host_id(), n.endpoint());
                     })
                 );
                 rlogger.debug("{}: keyspace={}, range={}, natural_enpoints={}, neighbors={}", op, keyspace_name, r, natural_eps, neighbors);


### PR DESCRIPTION
The code tries to build as "neighbors" an unordered_map from an iterator of std::tuple, instead of the correct std::pair. Apparently, the tuples are transparently converted to pairs on the newest compilers and the whole works, but on slightly older compilers (like the one on Fedora 39) Scylla no longer compiles - the compiler complains it can't convert a tuple to a pair in this context.

So fix the code to use pairs, not tuples, and it fixes the build on Fedora 39.

No need to backport - older branches are almost always built with dbuild anyway.