### PR TITLE
test: test_raft_no_quorum: increase raft timeout in debug mode

### DIFF
--- a/test/topology_custom/test_raft_no_quorum.py
+++ b/test/topology_custom/test_raft_no_quorum.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture
 def raft_op_timeout(mode):
-    return 5000 if mode == 'debug' else 1000
+    return 10000 if mode == 'debug' else 1000
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The test cases in this file use an error injection to reduce raft group 0 timeouts (from the default 1 minute), in order to speed up the tests; the scenarios expect these timeouts to happen, so we want them to happen as quick as possible, but we don't want to reduce timeouts so much that it will make other operations fail when we don't expect them to (e.g. when the test wants to add a node to the cluster).

Unfortunately the selected 5 seconds in debug mode was not enough and made the tests flaky: scylladb/scylladb#20111.

Increase it to 10 seconds. This unfortunately will slow down these tests as they have to sometimes wait for 10 seconds for the timeout to happen. But better to have this than a flaky test.

Fixes: scylladb/scylladb#20111

Should backport to all branches running this test to unflake the CI all around.