### PR TITLE
alternator: improve RBAC access denied error messages

### DIFF
--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -262,4 +262,9 @@ public:
 // add more than a couple of levels in its own output construction.
 bool is_big(const rjson::value& val, int big_size = 100'000);
 
+// Check CQL's Role-Based Access Control (RBAC) permission (MODIFY,
+// SELECT, DROP, etc.) on the given table. When permission is denied an
+// appropriate user-readable api_error::access_denied is thrown.
+future<> verify_permission(const service::client_state&, const schema_ptr&, auth::permission);
+
 }

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -98,12 +98,7 @@ future<executor::request_return_type> executor::update_time_to_live(client_state
     }
     sstring attribute_name(v->GetString(), v->GetStringLength());
 
-    if (!co_await client_state.check_has_permission(auth::command_desc(
-            auth::permission::ALTER, auth::make_data_resource(schema->ks_name(), schema->cf_name())))) {
-        co_return api_error::access_denied(format(
-            "ALTER permissions denied on {}.{} by RBAC", schema->ks_name(), schema->cf_name()));
-    }
-
+    co_await verify_permission(client_state, schema, auth::permission::ALTER);
     co_await db::modify_tags(_mm, schema->ks_name(), schema->cf_name(), [&](std::map<sstring, sstring>& tags_map) {
         if (enabled) {
             if (tags_map.contains(TTL_TAG_KEY)) {


### PR DESCRIPTION
This patch address two requests made by reviewers of the original "Add CQL-based RBAC support to Alternator" series. Both requests were about the error messages produced when access is denied:

1. The error message is improved to use more proper English, and also to include the name of the role which was denied access.

2. The permission-check and error-message-formatting code is de-duplicated, using a common function verify_permission().

   This de-duplication required moving the access-denied error path to throwing an exception instead of the previous exception-free implementation. However, it can be argued that this change is actually a good thing, because it makes the successful case, when access is allowed, faster.

   The de-duplicated code is shorter and simpler, and allowed changing the text of the error message in just one place.

Not necessary to backport - the functional changes are just cosmetics of error message.