### PR TITLE
docs/dev/maintainer.md: fix formatting

### DIFF
--- a/docs/dev/maintainer.md
+++ b/docs/dev/maintainer.md
@@ -10,7 +10,7 @@ considering a pull request for merging.
 
 The command
 
-    git config --global rerere.enabled true
+    git config set --global rerere.enabled true
 
 will record merge conflict resolutions and replay them
 when git encounters the same conflict. This is helpful
@@ -21,7 +21,7 @@ when managing multiple branches that see similar conflicts.
 
 The command
 
-    git config --global diff.conflictstyle = diff3
+    git config set --global diff.conflictstyle diff3
 
 will set the conflict markers to three-way diff style.
 This records not only "ours" and "theirs", but also the
@@ -181,7 +181,7 @@ latest submodules.
     information. For example, amend the message with `Fixes` tags.
  4. Use `git push` to publish your work.
 
-By default refresh-submodules.sh will refresh all submodules from their
+By default `refresh-submodules.sh` will refresh all submodules from their
 master branches. It's possible to specify submodules and branches as command
 line arguments. Each is treated by the script as `name[:branch]`, so for
 example the `refresh-submodules.sh seastar` will only refresh the seastar
@@ -219,7 +219,7 @@ creating a Seastar branch. This is done in a separate repository:
  4. Create a new branch (e.g. `git checkout -b branch-3.2`)
     corresponding to the release series you are backporting to.
     Note, the regular branch name is used, not the next branch.
- 5. Use `git push -u scylla-seastar branch-3.2' to publish the
+ 5. Use `git push -u scylla-seastar branch-3.2` to publish the
     branch. Note, scylla-seastar here is a git remote that refers
     to https://github.com/scylladb/scylla-seastar.git, a
     repository used for holding seastar backports for scylla.git.


### PR DESCRIPTION
 * in the "Backporting Seastar commits" section, there's a single quote instead of a backtick in this line, so fix it.
 * add backticks around `refresh-submodules.sh`, which is a filename.
 * correct the command line setting a git config option, because `git-config` does not support this command line syntax,

    ```console
    $ git config --global diff.conflictstyle = diff3
    $ git config --global --get diff.conflictstyle
    =
    $ git config --global diff.conflictstyle diff3
    $ git config --global --get diff.conflictstyle
    diff3
    ```
    
    quote from git-config(1)
    
    > ```
    > git config set [<file-option>] [--type=<type>] [--all] [--value=<value>] [--fixed-value] <name> <value>
    > ```
 * stop using the deprecated mode of the `git-config` command, and use subcommand instead. as git-config(1) puts:

   > ```
   > git config <name> <value> [<value-pattern>]
   >   Replaced by git config set [--value=<pattern>] <name> <value>.
   > ```

---

this is a change of the document targeting developers, so no need to backport.
