### PR TITLE
build: cmake: point -ffile-prefix-map to build directory

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -83,7 +83,7 @@ function(get_padded_dynamic_linker_option output length)
   set(${output} "${dynamic_linker_option}=${padded_dynamic_linker}" PARENT_SCOPE)
 endfunction()
 
-add_compile_options("-ffile-prefix-map=${CMAKE_SOURCE_DIR}=.")
+add_compile_options("-ffile-prefix-map=${CMAKE_BINARY_DIR}=.")
 
 default_target_arch(target_arch)
 if(target_arch)


### PR DESCRIPTION
before this change, we included `-ffile-prefix-map=${CMAKE_SOURCE_DIR}=.` in cflags when building the tree with CMake, but this was wrong. as the "." directory is the build directory used by CMake. and this directory is specified by the `-B` option when generating the building system. if `configure.py --use-cmake` is used to build the tree, the build directory would be "build". so this option instructs the compiler to replace the directory of source file in the debug symbols and in `__FILE__` at compile time.

but, in a typical workspace, for instance, `build/main.cc` does not exist. the reason why this does not apply to CMake but applies to the rules generated by `configure.py` is that, `configure.py` puts the generated `build.ninja` right under the top source directory, so `.` is correct and it helps to create reproducible builds. because this practically erases the path prefixes in the build output. while CMake puts it under the specified build directory, replacing the source directory with the build directory with the file prefix map is just wrong.

there are two options to address this problem:

* stop passing this option. but this would lead to non-reproducible builds. as we would encode the build directory in the "scylla" executable. if a developer needs to rebuild an executable for debugging a coredump generated in production, he/she would have to either build the tree in the same directory as our CI does. or, he/she has to pass `-ffile-prefix-map=...` to map the local build directory to the one used by CI. this is not convenient.
* instead of using `${CMAKE_SOURCE_DIR}=.`, add `${CMAKE_BINARY_DIR}=.`. this erases the build directory in the outputs, but preserves the debuggability.

so we pick the second solution.

---

this change is an improvement of the debugging experience if the build is created with CMake, and CMake is not used in our CI, hence no need to backport.