### PR TITLE
docs/dev/maintainer.md: clarify "Updating submodule references"

### DIFF
--- a/docs/dev/maintainer.md
+++ b/docs/dev/maintainer.md
@@ -179,7 +179,8 @@ latest submodules.
     updated.
  3. Edit the submodule update commits with any necessary additional
     information. For example, amend the message with `Fixes` tags.
- 4. Use `git push` to publish your work.
+ 4. Use `git push` to push the submodule update commits to the remote
+    `next` branch.
 
 By default `refresh-submodules.sh` will refresh all submodules from their
 master branches. It's possible to specify submodules and branches as command


### PR DESCRIPTION
Before the introduction of "scripts/refresh-submodules.sh", there was indeed some manual work for the maintainer to do, hence "publish your work" must have sounded correct. Today, the phrase "publish your work" sounds confusing.

Commit 71da4e6e795f ("docs: Document sync-submodules.sh script in maintainer.md", 2020-06-18) should have arguably reworded the last step of the submodule refresh procedure; let's do it now.

No need to backport, trivial developer documentation cleanup.