### PR TITLE
docs - HACKING.md: clarify the use of dbuild when running test.py

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -30,7 +30,7 @@ will be too old, and not support the new C++23 standard that Scylla uses.
 Alternatively, to avoid having to upgrade your build machine or install
 various packages on it, we provide another option - the **frozen toolchain**.
 This is a script, `./tools/toolchain/dbuild`, that can execute build or run
-commands inside a Docker image that contains exactly the right build tools and
+commands inside a container that contains exactly the right build tools and
 libraries. The `dbuild` technique is useful for beginners, but is also the way
 in which ScyllaDB produces official releases, so it is highly recommended.
 
@@ -41,6 +41,12 @@ and running Scylla becomes as easy as:
 $ ./tools/toolchain/dbuild ./configure.py
 $ ./tools/toolchain/dbuild ninja build/release/scylla
 $ ./tools/toolchain/dbuild ./build/release/scylla --developer-mode 1
+```
+
+Note: do not mix environemtns - either perform all your work with dbuild, or natively on the host.
+Note2: you can get to an interactive shell within dbuild by running it without any parameters:
+```bash
+$ ./tools/toolchain/dbuild
 ```
 
 ### Build system
@@ -114,6 +120,13 @@ Run all tests through the test execution wrapper with
 
 ```bash
 $ ./test.py --mode={debug,release}
+```
+
+or, if you are using `dbuild`, you need to build the code and the tests and then you can run them at will:
+
+```bash
+$ ./tools/toolchain/dbuild ninja {debug,release,dev}-build
+$ ./tools/toolchain/dbuild ./test.py --mode {debug,release,dev}
 ```
 
 The `--name` argument can be specified to run a particular test.


### PR DESCRIPTION
If you are using dbuild, that's where test.py needs to run.

Also, replace 'Docker image' with the more generic 'container' term.

No backport needed.