### PR TITLE
config: mark uuid_sstable_identifiers_enabled unused 

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1011,7 +1011,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , enable_sstables_md_format(this, "enable_sstables_md_format", value_status::Unused, true, "Enable SSTables 'md' format to be used as the default file format.  Deprecated, please use \"sstable_format\" instead.")
     , sstable_format(this, "sstable_format", value_status::Used, "me", "Default sstable file format", {"md", "me"})
     , uuid_sstable_identifiers_enabled(this,
-            "uuid_sstable_identifiers_enabled", liveness::LiveUpdate, value_status::Used, true, "If set to true, each newly created sstable will have a UUID "
+            "uuid_sstable_identifiers_enabled", value_status::Unused, true, "If set to true, each newly created sstable will have a UUID "
             "based generation identifier, and such files are not readable by previous Scylla versions.")
     , table_digest_insensitive_to_expiry(this, "table_digest_insensitive_to_expiry", liveness::MustRestart, value_status::Used, true,
             "When enabled, per-table schema digest calculation ignores empty partitions.")


### PR DESCRIPTION
the option of `uuid_sstable_identifier_enabled` was introduced in
https://github.com/tchaikov/scylladb/commit/f014ccf36962135889a84cff15b0478d711b2306 . the first version which has this change was 5.4, and
6.1 has been branched. during the discussion of backup and restore,
we realized that we've been taking efforts to address problems which
could have been addressed with the sstable with UUID-based identifier.
see also https://github.com/scylladb/scylladb/issues/10459 which is the issue which proposed to implement UUID-v1
based sstable identifier.

now that two major releases passed, we should have the luxury to mark
this option "unused". this option which was previously introduced to
keep the backward compatibility, and to allow user to opt-out of the
feature for some reasons.

so in this change,  mark the option unused, so that if any user still
sets this option with command line, they will get a clear error. but
we still parse and handle this setting in `scylla.yaml`, so that this
option is still respected for existing settings, and for existing tests,
which are not yet prepared for the uuid-based sstable identifiers.

Refs https://github.com/scylladb/scylladb/issues/10459
Fixes https://github.com/scylladb/scylladb/issues/20337

---

this is an enhancement, and should not be backported. otherwise could be breaking change.