### PR TITLE
tools/toolchain/dbuild: prefer podman over docker

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -16,10 +16,10 @@ EOF
     exit 1
 }
 
-if which docker >/dev/null 2>&1 ; then
-  tool=${DBUILD_TOOL-docker}
-elif which podman >/dev/null 2>&1 ; then
+if which podman >/dev/null 2>&1 ; then
   tool=${DBUILD_TOOL-podman}
+elif which docker >/dev/null 2>&1 ; then
+  tool=${DBUILD_TOOL-docker}
 else
   die "Please make sure you install either podman or docker on this machine to run dbuild"
 fi


### PR DESCRIPTION
Check if podman is available before docker. If it is, use it. Otherwise, check for docker.

1. Podman is better. It runs with fewer resources, and I've had display issues with Docker (output was not shown consistently)
2. 'which docker' works even when the docker service and socket are turned off.

**No need to backport - improvement in toolchain**