### PR TITLE
docs: run docs test on changing config params

### DIFF
--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -12,7 +12,8 @@ on:
       - enterprise
     paths:
       - "docs/**"
-
+      - "db/config.hh"
+      - "db/config.cc"
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

Triggers the "Build Docs" PR workflow whenever the `db/config.cc` or `db/config.h` files are edited, since these files are used to [produce documentation](https://opensource.docs.scylladb.com/stable/reference/configuration-parameters.html).

This change will help prevent the introduction of breaking changes to the documentation build when they are modified.

