### PR TITLE
scylla-housekeeping: use raw string to avoid using escape sequence

### DIFF
--- a/dist/common/scripts/scylla-housekeeping
+++ b/dist/common/scripts/scylla-housekeeping
@@ -119,7 +119,7 @@ def get_repo_file(dir):
     for name in files:
         with open(name, 'r') as myfile:
             for line in myfile:
-                match = re.search(".*http.?://repositories.*/scylladb/([^/\s]+)/.*/([^/\s]+)/scylladb-.*", line)
+                match = re.search(r".*http.?://repositories.*/scylladb/([^/\s]+)/.*/([^/\s]+)/scylladb-.*", line)
                 if match:
                     return match.group(2), match.group(1)
     return None, None


### PR DESCRIPTION
before this change, when running `scylla-housekeeping`:
```
/opt/scylladb/scripts/libexec/scylla-housekeeping:122: SyntaxWarning: invalid escape sequence '\s'
  match = re.search(".*http.?://repositories.*/scylladb/([^/\s]+)/.*/([^/\s]+)/scylladb-.*", line)
```

we could have the warning above. because `\s` is not a valid escape sequence, but the Python interpreter accepts it as two separated characters of `\s` after complaining. but it's still annoying.

so, let's use a raw string here.

Refs scylladb/scylladb#20317
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

this change addresses a warning, but as explained in the commit message, it's but a warning. so no need to backport.