### PR TITLE
test: Remove sstable making helpers from table_for_tests

### DIFF
--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -49,7 +49,7 @@ void run_sstable_resharding_test(sstables::test_env& env) {
     auto s = get_schema();
     auto cf = env.make_table_for_tests(s);
     auto close_cf = deferred_stop(cf);
-    auto sst_gen = cf.make_sst_factory(version);
+    auto sst_gen = env.make_sst_factory(s, version);
     std::unordered_map<shard_id, std::vector<mutation>> muts;
     static constexpr auto keys_per_shard = 1000u;
 
@@ -72,7 +72,7 @@ void run_sstable_resharding_test(sstables::test_env& env) {
                 mt->apply(std::move(m));
             }
         }
-        return make_sstable_containing(cf.make_sstable(version), mt);
+        return make_sstable_containing(env.make_sstable(s, version), mt);
     });
 
     // FIXME: sstable write has a limitation in which it will generate sharding metadata only

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -66,29 +66,5 @@ struct table_for_tests {
 
     future<> stop();
 
-    sstables::shared_sstable make_sstable() {
-        auto& table = *_data->cf;
-        auto& sstables_manager = table.get_sstables_manager();
-        return sstables_manager.make_sstable(_data->s, table.dir(), _data->storage, table.calculate_generation_for_new_table());
-    }
-
-    sstables::shared_sstable make_sstable(sstables::sstable_version_types version) {
-        auto& table = *_data->cf;
-        auto& sstables_manager = table.get_sstables_manager();
-        return sstables_manager.make_sstable(_data->s, table.dir(), _data->storage, table.calculate_generation_for_new_table(), sstables::sstable_state::normal, version);
-    }
-
-    std::function<sstables::shared_sstable()> make_sst_factory() {
-        return [this] {
-            return make_sstable();
-        };
-    }
-
-    std::function<sstables::shared_sstable()> make_sst_factory(sstables::sstable_version_types version) {
-        return [this, version] {
-            return make_sstable(version);
-        };
-    }
-
     void set_tombstone_gc_enabled(bool tombstone_gc_enabled) noexcept;
 };


### PR DESCRIPTION
All users of it have sstable_test_env at hand (in fact -- they call env method to get table_for_test). And since sstable_test_env already has a bunch of methods to create sstable, the table_for_test wrapper doesn't need to duplicate this code.
