### PR TITLE
build: cmake: add and use Scylla_CLANG_INLINE_THRESHOLD cmake parameter

### DIFF
--- a/cmake/mode.RelWithDebInfo.cmake
+++ b/cmake/mode.RelWithDebInfo.cmake
@@ -16,10 +16,11 @@ set(scylla_build_mode_RelWithDebInfo "release")
 add_compile_definitions(
     $<$<CONFIG:RelWithDebInfo>:SCYLLA_BUILD_MODE=${scylla_build_mode_RelWithDebInfo}>)
 
-set(clang_inline_threshold 2500)
+set(Scylla_CLANG_INLINE_THRESHOLD "2500" CACHE STRING
+  "LLVM-specific inline threshold compilation parameter")
 add_compile_options(
   "$<$<AND:$<CONFIG:RelWithDebInfo>,$<CXX_COMPILER_ID:GNU>>:--param;inline-unit-growth=300>"
-  "$<$<AND:$<CONFIG:RelWithDebInfo>,$<CXX_COMPILER_ID:Clang>>:-mllvm;-inline-threshold=${clang_inline_threshold}>")
+  "$<$<AND:$<CONFIG:RelWithDebInfo>,$<CXX_COMPILER_ID:Clang>>:-mllvm;-inline-threshold=${Scylla_CLANG_INLINE_THRESHOLD}>")
 # clang generates 16-byte loads that break store-to-load forwarding
 # gcc also has some trouble: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103554
 check_cxx_compiler_flag("-fno-slp-vectorize" _slp_vectorize_supported)

--- a/configure.py
+++ b/configure.py
@@ -2542,6 +2542,8 @@ def configure_using_cmake(args):
         settings['Scylla_DATE_STAMP'] = args.date_stamp
     if args.staticboost:
         settings['Boost_USE_STATIC_LIBS'] = 'ON'
+    if args.clang_inline_threshold != -1:
+        settings['Scylla_CLANG_INLINE_THRESHOLD'] = args.clang_inline_threshold
 
     source_dir = os.path.realpath(os.path.dirname(__file__))
     build_dir = os.path.join(source_dir, 'build')


### PR DESCRIPTION
so that we can set this the parameter passed to `-inline-threshold` with `configure.py` when building with CMake.

---

it's a cmake-related change, and cmake is not used to build any of LTS branches, so no need to backport.