### PR TITLE
compaction: use structured binding and ranges library when appropriate

### DIFF
--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -17,7 +17,8 @@
 #include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/algorithm/min_element.hpp>
 #include <boost/range/algorithm/partial_sort.hpp>
-#include <boost/range/adaptor/reversed.hpp>
+
+#include <ranges>
 
 namespace sstables {
 
@@ -463,7 +464,7 @@ struct fmt::formatter<std::map<sstables::timestamp_type, std::vector<sstables::s
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     auto format(const std::map<sstables::timestamp_type, std::vector<sstables::shared_sstable>>& buckets, fmt::format_context& ctx) const {
         auto out = fmt::format_to(ctx.out(), "  buckets = {{\n");
-        for (auto& [timestamp, sstables] : buckets | boost::adaptors::reversed) {
+        for (auto& [timestamp, sstables] : buckets | std::views::reverse) {
             out = fmt::format_to(out, "    key={}, size={}\n", timestamp, sstables.size());
         }
         return fmt::format_to(out, "  }}\n");
@@ -478,7 +479,7 @@ time_window_compaction_strategy::newest_bucket(table_state& table_s, strategy_co
     auto& state = get_state(table_s);
     clogger.debug("time_window_compaction_strategy::newest_bucket:\n  now {}\n{}", now, buckets);
 
-    for (auto&& [key, bucket] : buckets | boost::adaptors::reversed) {
+    for (auto&& [key, bucket] : buckets | std::views::reverse) {
         bool last_active_bucket = is_last_active_bucket(key, now);
         if (last_active_bucket) {
             state.recent_active_windows.insert(key);

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -478,10 +478,7 @@ time_window_compaction_strategy::newest_bucket(table_state& table_s, strategy_co
     auto& state = get_state(table_s);
     clogger.debug("time_window_compaction_strategy::newest_bucket:\n  now {}\n{}", now, buckets);
 
-    for (auto&& key_bucket : buckets | boost::adaptors::reversed) {
-        auto key = key_bucket.first;
-        auto& bucket = key_bucket.second;
-
+    for (auto&& [key, bucket] : buckets | boost::adaptors::reversed) {
         bool last_active_bucket = is_last_active_bucket(key, now);
         if (last_active_bucket) {
             state.recent_active_windows.insert(key);
@@ -536,10 +533,7 @@ void time_window_compaction_strategy::update_estimated_compaction_by_tasks(time_
     int64_t n = 0;
     timestamp_type now = state.highest_window_seen;
 
-    for (auto& task : tasks) {
-        const bucket_t& bucket = task.second;
-        timestamp_type bucket_key = task.first;
-
+    for (auto& [bucket_key, bucket] : tasks) {
         switch (compaction_mode(state, bucket, bucket_key, now, min_threshold)) {
         case bucket_compaction_mode::size_tiered:
             n += size_tiered_compaction_strategy::estimated_pending_compactions(bucket, min_threshold, max_threshold, _stcs_options);


### PR DESCRIPTION
for better readability

---

it's a cleanup, hence no need to backport.