### PR TITLE
compaction: refactor compaction_manager::can_proceed()

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1147,7 +1147,14 @@ void compaction_manager::do_stop() noexcept {
 }
 
 inline bool compaction_manager::can_proceed(table_state* t) const {
-    return (_state == state::enabled) && _compaction_state.contains(t) && !_compaction_state.at(t).compaction_disabled();
+    if (_state != state::enabled) {
+        return false;
+    }
+    auto found = _compaction_state.find(t);
+    if (found == _compaction_state.end()) {
+        return false;
+    }
+    return !found->second.compaction_disabled();
 }
 
 future<> compaction_task_executor::perform() {


### PR DESCRIPTION
instead of chaining the conditions with '&&', break them down. for two reasons:

* for better readability: to group the conditions with the same purpose together
* so we don't look up the table twice. it's an anti-pattern of using STL, and it could be confusing at first glance.

this change is a cleanup, so it does not change the behavior.

---

it's a cleanup, hence no need to backport.