### PR TITLE
tools/nodetool: improve backup and restore commands

### DIFF
--- a/test/nodetool/test_backup.py
+++ b/test/nodetool/test_backup.py
@@ -73,7 +73,8 @@ def test_backup(nodetool, scylla_only, nowait):
             "--snapshot", snapshot]
     if nowait:
         args.append("--nowait")
-        expected_output = ""
+        res = nodetool(*args, expected_requests=expected_requests)
+        assert task_id in res.stdout
     else:
         # wait for the completion of backup task
         expected_requests.append(
@@ -81,9 +82,9 @@ def test_backup(nodetool, scylla_only, nowait):
                 "GET",
                 f"/task_manager/wait_task/{task_id}",
                 response=task_status))
+        res = nodetool(*args, expected_requests=expected_requests)
         expected_output = f"""{state}
 start: {start_time}
 end: {end_time}
 """
-    res = nodetool(*args, expected_requests=expected_requests)
-    assert res.stdout == expected_output
+        assert res.stdout == expected_output

--- a/test/nodetool/test_backup.py
+++ b/test/nodetool/test_backup.py
@@ -29,8 +29,10 @@ def test_statusbackup(nodetool):
     assert res.stdout == "running\n"
 
 
-@pytest.mark.parametrize("nowait", [False, True])
-def test_backup(nodetool, scylla_only, nowait):
+@pytest.mark.parametrize("nowait,task_state,task_error", [(False, "failed", "error"),
+                                                          (False, "done", ""),
+                                                          (True, "", "")])
+def test_backup(nodetool, scylla_only, nowait, task_state, task_error):
     endpoint = "s3.us-east-2.amazonaws.com"
     bucket = "bucket-foo"
     keyspace = "ks"
@@ -42,17 +44,16 @@ def test_backup(nodetool, scylla_only, nowait):
     task_id = "2c4a3e5f"
     start_time = "2024-08-08T14:29:25Z"
     end_time = "2024-08-08T14:30:42Z"
-    state = "done"
     task_status = {
         "id": task_id,
         "type": "backup",
         "kind": "node",
         "scope": "node",
-        "state": state,
+        "state": task_state,
         "is_abortable": False,
         "start_time": start_time,
         "end_time": end_time,
-        "error": "",
+        "error": task_error,
         "sequence_number": 0,
         "shard": 0,
         "progress_total": 1.0,
@@ -82,9 +83,18 @@ def test_backup(nodetool, scylla_only, nowait):
                 "GET",
                 f"/task_manager/wait_task/{task_id}",
                 response=task_status))
-        res = nodetool(*args, expected_requests=expected_requests)
-        expected_output = f"""{state}
+        res = nodetool(*args, expected_requests=expected_requests, check_return_code=False)
+        if task_state == "done":
+            expected_returncode = 0
+            expected_output = f"""{task_state}
 start: {start_time}
 end: {end_time}
 """
+        else:
+            expected_returncode = 1
+            expected_output = f"""{task_state}: {task_error}
+start: {start_time}
+end: {end_time}
+"""
+        assert res.returncode == expected_returncode
         assert res.stdout == expected_output

--- a/test/nodetool/test_restore.py
+++ b/test/nodetool/test_restore.py
@@ -63,7 +63,8 @@ def test_restore(nodetool, scylla_only, table, nowait):
         args.extend(["--table", table])
     if nowait:
         args.append("--nowait")
-        expected_output = ""
+        res = nodetool(*args, expected_requests=expected_requests)
+        assert task_id in res.stdout
     else:
         # wait for the completion of backup task
         expected_requests.append(
@@ -71,9 +72,9 @@ def test_restore(nodetool, scylla_only, table, nowait):
                 "GET",
                 f"/task_manager/wait_task/{task_id}",
                 response=task_status))
+        res = nodetool(*args, expected_requests=expected_requests)
         expected_output = f"""{state}
 start: {start_time}
 end: {end_time}
 """
-    res = nodetool(*args, expected_requests=expected_requests)
-    assert res.stdout == expected_output
+        assert res.stdout == expected_output

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -10,6 +10,7 @@
 #include <cctype>
 #include <chrono>
 #include <concepts>
+#include <cstdlib>
 #include <future>
 #include <limits>
 #include <iterator>
@@ -413,7 +414,9 @@ Please use the 'task' subcommands to manage the task.
     const auto& status = wait_res.GetObject();
     auto state = rjson::to_string_view(status["state"]);
     fmt::print("{}", state);
+    int exit_code = EXIT_SUCCESS;
     if (state != "done") {
+        exit_code = EXIT_FAILURE;
         fmt::print(": {}", rjson::to_string_view(status["error"]));
     }
     fmt::print(R"(
@@ -422,6 +425,9 @@ end: {}
 )",
                rjson::to_string_view(status["start_time"]),
                rjson::to_string_view(status["end_time"]));
+    if (exit_code != EXIT_SUCCESS) {
+        throw operation_failed_with_status{exit_code};
+    }
 }
 
 void checkandrepaircdcstreams_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
@@ -1512,7 +1518,9 @@ Please use the 'task' subcommands to manage the task.
     const auto& status = wait_res.GetObject();
     auto state = rjson::to_string_view(status["state"]);
     fmt::print("{}", state);
+    int exit_code = EXIT_SUCCESS;
     if (state != "done") {
+        exit_code = EXIT_FAILURE;
         fmt::print(": {}", rjson::to_string_view(status["error"]));
     }
     fmt::print(R"(
@@ -1521,6 +1529,9 @@ end: {}
 )",
                rjson::to_string_view(status["start_time"]),
                rjson::to_string_view(status["end_time"]));
+    if (exit_code != EXIT_SUCCESS) {
+        throw operation_failed_with_status{exit_code};
+    }
 }
 
 struct host_stat {

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -399,11 +399,15 @@ void backup_operation(scylla_rest_client& client, const bpo::variables_map& vm) 
         params["snapshot"] = vm["snapshot"].as<sstring>();
     }
     const auto backup_res = client.post("/storage_service/backup", std::move(params));
+    const auto task_id = rjson::to_string_view(backup_res);
     if (vm.contains("nowait")) {
+        fmt::print(R"(The task id of this operation is {}
+Please use the 'task' subcommands to manage the task.
+)",
+                   task_id);
         return;
     }
 
-    const auto task_id = rjson::to_string_view(backup_res);
     const auto url = seastar::format("/task_manager/wait_task/{}", task_id);
     const auto wait_res = client.get(url);
     const auto& status = wait_res.GetObject();
@@ -1494,11 +1498,15 @@ void restore_operation(scylla_rest_client& client, const bpo::variables_map& vm)
         params["table"] = vm["table"].as<sstring>();
     }
     const auto restore_res = client.post("/storage_service/restore", std::move(params));
+    const auto task_id = rjson::to_string_view(restore_res);
     if (vm.count("nowait")) {
+        fmt::print(R"(The task id of this operation is {}
+Please use the 'task' subcommands to manage the task.
+)",
+                   task_id);
         return;
     }
 
-    const auto task_id = rjson::to_string_view(restore_res);
     const auto url = seastar::format("/task_manager/wait_task/{}", task_id);
     const auto wait_res = client.get(url);
     const auto& status = wait_res.GetObject();


### PR DESCRIPTION
this change contains two improvements to "backup" and "restore" commands:

- let them print task id
- let them return 1 as the exist status code upon operation failure

----

these changes are improvements to the newly introduced commands, which are not in any LTS branches yet, so no need to backport.