### PR TITLE
docs: cql: document ZstdCompressor for CREATE TABLE

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -757,8 +757,8 @@ available:
 ========================= =============== =============================================================================
  Option                    Default         Description
 ========================= =============== =============================================================================
- ``sstable_compression``   LZ4Compressor   The compression algorithm to use. Default compressors are
-                                           LZ4Compressor, SnappyCompressor, and DeflateCompressor.
+ ``sstable_compression``   LZ4Compressor   The compression algorithm to use. Available compressors are
+                                           LZ4Compressor, SnappyCompressor, DeflateCompressor, and ZstdCompressor.
                                            A custom compressor can be provided by specifying the full class
                                            name as a “string constant”:#constants.
  ``chunk_length_in_kb``    4               On disk SSTables are compressed by block (to allow random reads). This


### PR DESCRIPTION
Adjust the wording slightly to be less awkward.

While a minor documentation update, this merits backport as it exposes an important compression feature.