### PR TITLE
alternator: return error on unused AttributeDefinitions

### DIFF
--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -687,6 +687,17 @@ def test_delete_table_description_with_si(dynamodb):
         assert i in got_describe
         assert not i in got_delete
 
+# Test that CreateTable rejects spurious entries in AttributeDefinitions
+# (entries which aren't used as a key of the table or any GSI or LSI).
+# Reproduces issue #19784.
+def test_create_table_spurious_attribute_definitions(dynamodb):
+    with pytest.raises(ClientError, match='ValidationException.*AttributeDefinitions'):
+        with new_test_table(dynamodb,
+            KeySchema=[{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+            AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' },
+                                  { 'AttributeName': 'c', 'AttributeType': 'S' }]) as table:
+                pass
+
 # Currently, because of incomplete LWT support, Alternator tables do not use
 # tablets by default - even if the tablets experimental feature is enabled.
 # This test enshrines this fact - that an Alternator table doesn't use tablets.


### PR DESCRIPTION
A CreateTable request defines the KeySchema of the base table and each of its GSIs and LSIs. It also needs to give an AttributeDefinition for each attribute used in a KeySchema - which among other things specifies this attribute's type (e.g., S, N, etc.). Other, non-key, attributes *do not* have a specified type, and accordingly must not be mentioned in AttributeDefinitions.

Before this patch, Alternator just ignored unused AttributeDefinitions entries, whereas DynamoDB throws an error in this case. This patch fixes Alternator's behavior to match DynamoDB's - and adds a test to verify this.

Besides being more error-path-compatible with DynamoDB, this extra check can also help users: We already had one user complaining that an AttributeDefinitions setting he was using was ignored, not realizing that it wasn't used by any KeySchema. A clear error message would have saved this user hours of investigation.

Fixes #19784.

This is a minor error-path UX improvement so doesn't need backporting.