### PR TITLE
Alternator: tests and other preparation towards allowing adding a GSI to an existing table

### DIFF
--- a/alternator/serialization.cc
+++ b/alternator/serialization.cc
@@ -277,8 +277,7 @@ bytes get_key_column_value(const rjson::value& item, const column_definition& co
 // mentioned in the exception message).
 // If the type does match, a reference to the encoded value is returned.
 static const rjson::value& get_typed_value(const rjson::value& key_typed_value, std::string_view type_str, std::string_view name, std::string_view value_name) {
-    if (!key_typed_value.IsObject() || key_typed_value.MemberCount() != 1 ||
-            !key_typed_value.MemberBegin()->value.IsString()) {
+    if (!key_typed_value.IsObject() || key_typed_value.MemberCount() != 1) {
         throw api_error::validation(
                 format("Malformed value object for {} {}: {}",
                         value_name, name, key_typed_value));
@@ -289,6 +288,14 @@ static const rjson::value& get_typed_value(const rjson::value& key_typed_value, 
         throw api_error::validation(
                 format("Type mismatch: expected type {} for {} {}, got type {}",
                         type_str, value_name, name, it->name));
+    }
+    // We assume this function is called just for key types (S, B, N), and
+    // all of those always have a string value in the JSON.
+    if (!it->value.IsString()) {
+        throw api_error::validation(
+            format("Malformed value object for {} {}: {}",
+                    value_name, name, key_typed_value));
+
     }
     return it->value;
 }

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -629,6 +629,15 @@ public:
     vector_type operator()(const column_definition& cdef) {
         column_position++;
 
+        // Note that in the following lines, if the key column exists in the
+        // base table, then it will be used and the requested computed column
+        // will be outright ignored.
+        // I'm not sure why we chose this surprising logic, but it turns out
+        // to be useful in Alternator when combining an LSI (which puts its
+        // key attribute a real base column) and GSI (which uses a computed
+        // column) - and this logic means the GSI will read the real column
+        // stored by the LSI, which turns out to be the right thing to do
+        // (see the test test_gsi.py::test_gsi_and_lsi_same_key).
         auto* base_col = _base.get_column_definition(cdef.name());
         if (!base_col) {
             return handle_computed_column(cdef);

--- a/test/alternator/test_batch.py
+++ b/test/alternator/test_batch.py
@@ -192,7 +192,7 @@ def test_batch_write_invalid_operation(test_table_s):
             for item in items:
                 batch.put_item(item)
     for p in [p1, p2]:
-        assert not 'item' in test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
+        assert not 'Item' in test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
     # test missing key attribute:
     p1 = random_string()
     p2 = random_string()
@@ -202,7 +202,7 @@ def test_batch_write_invalid_operation(test_table_s):
             for item in items:
                 batch.put_item(item)
     for p in [p1, p2]:
-        assert not 'item' in test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
+        assert not 'Item' in test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
 
 # In test_item.py we have a bunch of test_empty_* tests on different ways to
 # create an empty item (which in Scylla requires the special CQL row marker

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -488,15 +488,12 @@ def test_gsi_wrong_type_attribute_update_nested(test_table_gsi_2):
     test_table_gsi_2.put_item(Item={'p':  p, 'x': x})
     # We can't write a map into a GSI key column, which in this case can only
     # be a string and in any case can never be a map. DynamoDB and Alternator
-    # report different errors here: DynamoDB reports a type mismatch (exactly
-    # like in test test_gsi_wrong_type_attribute_update), but Alternator
-    # reports the obscure message "Malformed value object for key column x".
-    # Alternator's error message should probably be improved here, but let's
-    # not test it in this test.
-    with pytest.raises(ClientError, match='ValidationException'):
+    # both report a "type mismatch" error, exactly like in the test
+    # test_gsi_wrong_type_attribute_update.
+    with pytest.raises(ClientError, match='ValidationException.*mismatch'):
         test_table_gsi_2.update_item(Key={'p': p}, UpdateExpression='SET x = :val1',
             ExpressionAttributeValues={':val1': {'a': 3, 'b': 4}})
-    # Here we try to set x.y for the GSI key column x. Again DynamoDB and
+    # Here we try to set x.y for the GSI key column x. Here DynamoDB and
     # Alternator produce different error messages - but both make sense.
     # DynamoDB says "Key attributes must be scalars; list random access '[]'
     # and map # lookup '.' are not allowed: IndexKey: x", while Alternator

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -367,6 +367,59 @@ def test_gsi_2(test_table_gsi_2):
     assert_index_query(test_table_gsi_2, 'hello', expected_items,
         KeyConditions={'x': {'AttributeValueList': [x2], 'ComparisonOperator': 'EQ'}})
 
+# The previous tests just need to create rows in the materialized view.
+# This test adds more elaborate operations which need to create new rows,
+# modify existing rows, and delete rows of the materialized view.
+# We use the schema test_table_gsi_2, and create, modify and delete the
+# attribute "x" (a regular attribute in the base table, a key in the GSI)
+# to cause all these different operations on the view rows, and check
+# various code paths in the view update code.
+def test_update_gsi_pk(test_table_gsi_2):
+    p = random_string()
+    x1 = random_string()
+    y = random_string()
+    z = random_string()
+
+    # Create a new GSI row (x1), see that it appears
+    test_table_gsi_2.put_item(Item={'p': p, 'x': x1, 'y': y, 'z': z})
+    assert_index_query(test_table_gsi_2, 'hello', [{'p': p, 'x': x1, 'y': y, 'z': z}],
+        KeyConditions={'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
+
+    # Update only the unrelated attribute y. Should leave the same row in
+    # the GSI (x=x1), just with a modified y (and unmodified z)
+    y = random_string()
+    test_table_gsi_2.update_item(Key={'p': p}, AttributeUpdates={'y': {'Value': y, 'Action': 'PUT'}})
+    assert_index_query(test_table_gsi_2, 'hello', [{'p': p, 'x': x1, 'y': y, 'z': z}],
+        KeyConditions={'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
+
+    # Update the GSI's key attribute x to x2. The old row (x=x1) should
+    # disappear from the GSI, and the new row (x=x2) should appear, with the
+    # base row's "y" and "z" value that weren't changed in this update.
+    x2 = random_string()
+    test_table_gsi_2.update_item(Key={'p': p}, AttributeUpdates={'x': {'Value': x2, 'Action': 'PUT'}})
+    assert_index_query(test_table_gsi_2, 'hello', [],
+        KeyConditions={'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
+    assert_index_query(test_table_gsi_2, 'hello', [{'p': p, 'x': x2, 'y': y, 'z': z}],
+        KeyConditions={'x': {'AttributeValueList': [x2], 'ComparisonOperator': 'EQ'}})
+
+    # Delete only the attribute x from our base-table row. The row should
+    # remain in the table (with no x), but disappear from the view
+    test_table_gsi_2.update_item(Key={'p': p}, AttributeUpdates={'x': {'Action': 'DELETE'}})
+    assert test_table_gsi_2.get_item(Key={'p': p}, ConsistentRead=True)['Item'] == {'p': p, 'y': y, 'z': z}
+    assert_index_query(test_table_gsi_2, 'hello', [],
+        KeyConditions={'x': {'AttributeValueList': [x2], 'ComparisonOperator': 'EQ'}})
+
+    # Set x again to x1, see the view item re-appears in the view:
+    test_table_gsi_2.update_item(Key={'p': p}, AttributeUpdates={'x': {'Value': x1, 'Action': 'PUT'}})
+    assert_index_query(test_table_gsi_2, 'hello', [{'p': p, 'x': x1, 'y': y, 'z': z}],
+        KeyConditions={'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
+
+    # Delete the entire item in the base table, the view row should also
+    # disappear
+    test_table_gsi_2.delete_item(Key={'p': p})
+    assert_index_query(test_table_gsi_2, 'hello', [],
+        KeyConditions={'x': {'AttributeValueList': [x1], 'ComparisonOperator': 'EQ'}})
+
 # Test that when a table has a GSI, if the indexed attribute is missing, the
 # item is added to the base table but not the index.
 def test_gsi_missing_attribute(test_table_gsi_2):

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -117,6 +117,8 @@ def freeze(item):
         return frozenset((key, freeze(value)) for key, value in item.items())
     elif isinstance(item, list):
         return tuple(freeze(value) for value in item)
+    elif isinstance(item, bytearray):
+        return bytes(item)
     return item
 
 def multiset(items):


### PR DESCRIPTION
This series prepares us for working on #11567 -  allow adding a GSI to a pre-existing table. This will require changing the implementation of GSIs in Alternator to not use real columns in the schema for the materialized view, and instead of a computed column - a function which extracts the desired member from the `:attrs` map and de-serializes it.

This series does not contain the GSI re-implementation itself. Rather it contains a few small cleanups and mostly - new regression tests that cover this area, of adding and removing a GSI, and **using** a GSI, in more details than the tests we already had. I developed most of these tests while working on **buggy** fixes for #11567; The bugs in those implementations were exposed by the tests added here - they exposed bugs both in the new feature of adding or removing a GSI, and also regressions to the ordinary operation of GSI. So these tests should be helpful for whoever ends up fixing #11567, be it me based on my buggy implementation (which is _not_ included in this patch series), or someone else.

No backports needed - this is part of a new feature, which we don't usually backport.