### PR TITLE
[Backport 6.0] repair: throw if batchlog manager isn't initialized

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2303,6 +2303,9 @@ future<repair_flush_hints_batchlog_response> repair_service::repair_flush_hints_
     db::hints::sync_point sync_point = co_await _sp.local().create_hint_sync_point(std::move(target_nodes));
     lowres_clock::time_point deadline = lowres_clock::now() + req.hints_timeout;
     try {
+        if (!_bm.local_is_initialized()) {
+            throw std::runtime_error("Backlog manager isn't initialized");
+        }
         co_await coroutine::all(
             [this, &from, &req, &sync_point, &deadline] () -> future<> {
                 rlogger.info("repair[{}]: Started to flush hints for repair_flush_hints_batchlog_request from node={}, target_nodes={}", req.repair_uuid, from, req.target_nodes);

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2303,7 +2303,8 @@ future<repair_flush_hints_batchlog_response> repair_service::repair_flush_hints_
     db::hints::sync_point sync_point = co_await _sp.local().create_hint_sync_point(std::move(target_nodes));
     lowres_clock::time_point deadline = lowres_clock::now() + req.hints_timeout;
     try {
-        if (!_bm.local_is_initialized()) {
+        bool bm_throw = utils::get_local_injector().enter("repair_flush_hints_batchlog_handler_bm_uninitialized");
+        if (!_bm.local_is_initialized() || bm_throw) {
             throw std::runtime_error("Backlog manager isn't initialized");
         }
         co_await coroutine::all(

--- a/test/topology_custom/test_repair.py
+++ b/test/topology_custom/test_repair.py
@@ -67,3 +67,26 @@ async def test_enable_compacting_data_for_streaming_and_repair_live_update(manag
     # After the update to the config above, the next repair should pick up the updated value.
     await manager.api.repair(node1.ip_addr, "ks", "tbl")
     assert (await get_injection_params(manager, node1.ip_addr, "maybe_compact_for_streaming"))["compaction_enabled"] == "true"
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_repair_succeeds_with_unitialized_bm(manager):
+    await manager.server_add()
+    await manager.server_add()
+    servers = await manager.running_servers()
+
+    cql = manager.get_cql()
+
+    cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
+    cql.execute("CREATE TABLE ks.tbl (pk int, ck int, PRIMARY KEY (pk, ck)) WITH tombstone_gc = {'mode': 'repair'}")
+
+    await manager.api.enable_injection(servers[1].ip_addr, "repair_flush_hints_batchlog_handler_bm_uninitialized", True, {})
+    logs = [await manager.server_open_log(srv.server_id) for srv in servers]
+    marks = [await log.mark() for log in logs]
+
+    await manager.api.repair(servers[0].ip_addr, "ks", "tbl")
+
+    matches = await logs[1].grep("Failed to process repair_flush_hints_batchlog_request", from_mark=marks[1])
+    assert len(matches) == 1
+    matches = await logs[0].grep("failed, continue to run repair", from_mark=marks[0])
+    assert len(matches) == 1


### PR DESCRIPTION
repair_service::repair_flush_hints_batchlog_handler may access batchlog
manager while it is uninitialized.

Throw if batchlog manager isn't initialized.

Fixes: https://github.com/scylladb/scylladb/issues/20236.

Needs backport to 6.0 and 6.1 as they suffer from the uninitialized bm access.

(cherry picked from commit https://github.com/scylladb/scylladb/commit/d8e43934185c46f67cc984d3765cc23b6c85e02a)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/f38bb6483a15119312f5785b798453ff221ccc20)

Refs https://github.com/scylladb/scylladb/pull/20251