### PR TITLE
storage_service: raft snapshot rpc tables chosen by receiver

### DIFF
--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -134,6 +134,7 @@ public:
     gms::feature topology_requests_type_column { *this, "TOPOLOGY_REQUESTS_TYPE_COLUMN"sv };
     gms::feature native_reverse_queries { *this, "NATIVE_REVERSE_QUERIES"sv };
     gms::feature zero_token_nodes { *this, "ZERO_TOKEN_NODES"sv };
+    gms::feature snapshot_rpc_receiver_side { *this, "SNAPSHOT_RPC_RECEIVER_SIDE"sv };
 
     // A feature just for use in tests. It must not be advertised unless
     // the "features_enable_test_feature" injection is enabled.

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -108,7 +108,9 @@ class group0_state_machine : public raft_state_machine {
     seastar::gate _gate;
     abort_source _abort_source;
     bool _topology_change_enabled;
+    bool _snapshot_rpc_receiver_side_enabled = false;
     gms::feature::listener_registration _topology_on_raft_support_listener;
+    gms::feature::listener_registration _snapshot_rpc_receiver_side_listener;
 
     modules_to_reload get_modules_to_reload(const std::vector<canonical_mutation>& mutations);
     future<> reload_modules(modules_to_reload modules);


### PR DESCRIPTION
We change the raft snapshot RPC so that the receiver of the RPC chooses which tables should be included in the snapshot instead of the RPC sender requesting specific tables in the RPC parameter.

The reason the receiver should choose the tables is that the node who requests the snapshot may be a new node that joins the cluster, for example, or it doesn't know yet about a feature that was enabled, so it doesn't know if a table should be requested or not.

We reuse the same RPC code but change the meaning of the parameter such that an empty parameter indicates the receiver should choose the tables. This doesn't cause confusion because previously we wouldn't send an RPC with an empty parameter.

Fixes scylladb/scylladb#19990