### PR TITLE
test: Use shorter with_sstable_directory overload()

### DIFF
--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -367,7 +367,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_unshared_sstables_sanity_matched_gene
             }).get();
         }
 
-        with_sstable_directory(dir.path(), sstables::sstable_state::normal, env, [] (sharded<sstables::sstable_directory>& sstdir) {
+        with_sstable_directory(env, [] (sharded<sstables::sstable_directory>& sstdir) {
             distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get();
             verify_that_all_sstables_are_local(sstdir, smp::count).get();
         });
@@ -399,7 +399,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_unshared_sstables_sanity_unmatched_ge
             }).get();
         }
 
-        with_sstable_directory(dir.path(), sstables::sstable_state::normal, env, [] (sharded<sstables::sstable_directory>& sstdir) {
+        with_sstable_directory(env, [] (sharded<sstables::sstable_directory>& sstdir) {
             distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get();
             verify_that_all_sstables_are_local(sstdir, smp::count).get();
         });


### PR DESCRIPTION
In sstable directory test there are two of those -- one that works on path, state, env and callback, and the other one that just needs env and callback, getting path from env and assuming state is normal.

Two test cases in this test can enjoy the shorter one.
