### PR TITLE
test: Remove unused directory semaphore

### DIFF
--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -150,12 +150,6 @@ static void with_sstable_directory(
 
     testlog.debug("with_sstable_directory: {}/{}", path, state);
 
-    sharded<sstables::directory_semaphore> sstdir_sem;
-    sstdir_sem.start(1).get();
-    auto stop_sstdir_sem = defer([&sstdir_sem] {
-        sstdir_sem.stop().get();
-    });
-
     sharded<sstable_directory> sstdir;
     auto stop_sstdir = defer([&sstdir] {
         // The func is allowed to stop sstdir, and some tests actually do it


### PR DESCRIPTION
The with_sstable_dir() helper no longer needs one, it used to pass it as argument to sstable_directory constructor, but now the directory doesn't need it (takes semaphore via table object).
