### PR TITLE
db: system_keyspace: change version of topology_requests schema

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -259,6 +259,7 @@ schema_ptr system_keyspace::topology() {
 }
 
 schema_ptr system_keyspace::topology_requests() {
+    constexpr uint16_t schema_version_offset = 1;   // request_type
     static thread_local auto schema = [] {
         auto id = generate_legacy_id(NAME, TOPOLOGY_REQUESTS);
         return schema_builder(NAME, TOPOLOGY_REQUESTS, std::optional(id))
@@ -270,7 +271,7 @@ schema_ptr system_keyspace::topology_requests() {
             .with_column("error", utf8_type)
             .with_column("end_time", timestamp_type)
             .set_comment("Topology request tracking")
-            .with_version(generate_schema_version(id))
+            .with_version(generate_schema_version(id, schema_version_offset))
             .build();
     }();
     return schema;


### PR DESCRIPTION
In 880058073b2ffeed71e530987db4c5153d0ef359 a new column (request_type) was added to topology_requests table, but the table's schema version wasn't changed. Due to that during cluster upgrade, the old and the new versions occur but they are not distinguishable.

Add offset to schema version of topology_requests table if it contains request_type column.

Fixes: #20299.

No backport needed, the bug was introduced after 6.1