### PR TITLE
cql: fix exception when validating KS in CREATE TABLE

### DIFF
--- a/test/cql-pytest/test_keyspace.py
+++ b/test/cql-pytest/test_keyspace.py
@@ -76,6 +76,16 @@ def test_create_keyspace_nonexistent_dc(cql):
         ks = unique_name()
         cql.execute(f"CREATE KEYSPACE {ks} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'nonexistentdc' : 1 }}")
 
+# Reproduces #20097
+def test_create_table_in_nonexistent_keyspace(cql):
+    no_ks = "nonexistent_keyspace"
+    table = unique_name()
+    with pytest.raises(InvalidRequest, match=no_ks):
+        cql.execute(f"CREATE TABLE {no_ks}.{table} (p int PRIMARY KEY)")
+    # reassert table doesn't exist
+    with pytest.raises(InvalidRequest, match=no_ks):
+        cql.execute(f"DROP TABLE {no_ks}.{table}")
+
 # Test that attempts to reproduce an issue with double WITH keyword in CREATE
 # KEYSPACE statement -- CASSANDRA-9565.
 def test_create_keyspace_double_with(cql):


### PR DESCRIPTION
https://github.com/scylladb/scylladb/commit/c70f321c6f581357afdf3fd8b4fe8e5c5bb9736e added an extra check if KS
exists. This check can throw `data_dictionary::no_such_keyspace`
exception, which is supposed to be caught and a more user-friendly
exception should be thrown instead.
This commit fixes the above problem and adds a testcase to validate it
doesn't appear ever again.
Additionally, I added an extra comment to both `no_such_keyspace` and
`no_such_column_family` exceptions explaining they should not be
returned directly to the caller, as they lack error code, which may not
trigger correct exceptions handling mechanisms on the driver side.

Fixes: #20097

No need to backport, it's not a major bug.