### PR TITLE
sstables: correct the debugging message printed when removing temp dir

### DIFF
--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -233,9 +233,7 @@ future<> filesystem_storage::remove_temp_dir() {
     if (!_temp_dir) {
         co_return;
     }
-    std::optional<int> opt;
-    sstlog.debug("Removing temp_dir={}", opt);
-    //sstlog.debug("Removing temp_dir={}", _temp_dir);
+    sstlog.debug("Removing temp_dir={}", _temp_dir);
     try {
         co_await remove_file(_temp_dir->native());
     } catch (...) {


### PR DESCRIPTION
in 372a4d1b79bb3c5d9941d7f79cd96a6eaf65deba, we introduced a change which was for debugging the logging message. but the logging message intended for printing the temp_dir not prints an `optional<int>`. this could be confusing, and more importantly, it hurts the debuggability.

in this change, the related change is reverted.

Fixes scylladb/scylladb#20408

---

372a4d1b79bb3c5d9941d7f79cd96a6eaf65deba is included by both 6.0 and 6.1 branches, and this change addresses a regression introduced by this commit. despite that the regression only hurts the debuggability, we'd better fix it. as it's an issue in production.