### PR TITLE
test: Use single temp dir for sharded<sstables::test_env>

### DIFF
--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -99,7 +99,7 @@ public:
 
     void maybe_start_compaction_manager(bool enable = true);
 
-    explicit test_env(test_env_config cfg = {}, sstables::storage_manager* sstm = nullptr);
+    explicit test_env(test_env_config cfg = {}, sstables::storage_manager* sstm = nullptr, tmpdir* tmp = nullptr);
     ~test_env();
     test_env(test_env&&) noexcept;
 


### PR DESCRIPTION
The test-env in question is mostly started in one-shard mode. Also there are several boost tests that start sharded<> environment. In that case instances on different shards live in different temp dirs. That's not critical yet, but better to have single directory for the whole test.
