### PR TITLE
Allow caller to specify the prefix in a more flexible way when performing backup

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -783,6 +783,14 @@
                           "paramType":"query"
                       },
                       {
+                           "name":"prefix",
+                           "description":"The prefix of the objects for the backuped sstables",
+                           "required":true,
+                           "allowMultiple":false,
+                           "type":"string",
+                           "paramType":"query"
+                      },
+                      {
                           "name":"keyspace",
                           "description":"Name of a keyspace to copy sstables from",
                           "required":true,

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1796,6 +1796,7 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
         auto endpoint = req->get_query_param("endpoint");
         auto keyspace = req->get_query_param("keyspace");
         auto bucket = req->get_query_param("bucket");
+        auto prefix = req->get_query_param("prefix");
         auto snapshot_name = req->get_query_param("snapshot");
         if (snapshot_name.empty()) {
             // TODO: If missing, snapshot should be taken by scylla, then removed
@@ -1803,7 +1804,7 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
         }
 
         auto& ctl = snap_ctl.local();
-        auto task_id = co_await ctl.start_backup(std::move(endpoint), std::move(bucket), std::move(keyspace), std::move(snapshot_name));
+        auto task_id = co_await ctl.start_backup(std::move(endpoint), std::move(bucket), std::move(prefix), std::move(keyspace), std::move(snapshot_name));
         co_return json::json_return_type(fmt::to_string(task_id));
     });
 

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -106,7 +106,7 @@ public:
      */
     future<> clear_snapshot(sstring tag, std::vector<sstring> keyspace_names, sstring cf_name);
 
-    future<tasks::task_id> start_backup(sstring endpoint, sstring bucket, sstring keyspace, sstring snapshot_name);
+    future<tasks::task_id> start_backup(sstring endpoint, sstring bucket, sstring prefix, sstring keyspace, sstring snapshot_name);
 
     future<std::unordered_map<sstring, db_snapshot_details>> get_snapshot_details();
 

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -22,6 +22,7 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     snapshot_ctl& _snap_ctl;
     shared_ptr<s3::client> _client;
     sstring _bucket;
+    sstring _prefix;
     sstring _ks;
     sstring _snapshot_name;
     std::exception_ptr _ex;
@@ -32,7 +33,13 @@ protected:
     virtual future<> run() override;
 
 public:
-    backup_task_impl(tasks::task_manager::module_ptr module, snapshot_ctl& ctl, shared_ptr<s3::client> cln, sstring bucket, sstring ks, sstring snapshot_name) noexcept;
+    backup_task_impl(tasks::task_manager::module_ptr module,
+                     snapshot_ctl& ctl,
+                     shared_ptr<s3::client> cln,
+                     sstring bucket,
+                     sstring prefix,
+                     sstring ks,
+                     sstring snapshot_name) noexcept;
 
     virtual std::string type() const override;
     virtual tasks::is_internal is_internal() const noexcept override;

--- a/docs/dev/object_storage.md
+++ b/docs/dev/object_storage.md
@@ -105,8 +105,9 @@ found [here](./api/api-doc/storage_service.json). Accepted parameters are
 * *snapshot*: the snapshot name to copy sstables from
 * *endpoint*: the key in the object storage configuration file
 * *bucket*: bucket name to put sstables' files in
+* *prefix*: prefix to put sstables' files under
 
 Currently only snapshot backup is possible, so first one needs to take [snapshot](docs/kb/snapshots.rst)
 
 All tables in a keyspace are uploaded, the destination object names will look like
-`s3://bucket/table-name-and-uuid/snapshot-name/...`
+`s3://bucket/some/prefix/to/store/data/.../sstable`

--- a/docs/operating-scylla/nodetool-commands/backup.rst
+++ b/docs/operating-scylla/nodetool-commands/backup.rst
@@ -14,6 +14,13 @@ Syntax
                --endpoint <endpoint> --bucket <bucket>
                [--nowait]
 
+Example
+-------
+
+.. code-block:: console
+
+    nodetool backup --endpoint s3.us-east-2.amazonaws.com  --bucket bucket-foo --prefix foo/bar/baz --keyspace ks --snapshot ss
+
 Options
 -------
 
@@ -22,6 +29,11 @@ Options
 * ``--snapshot`` - Name of a snapshot to copy sstables from
 * ``--endpoint`` - ID of the configured object storage endpoint to copy SSTables to
 * ``--bucket`` - Name of the bucket to backup SSTables to
+* ``--prefix`` - Prefix to backup SSTables to
 * ``--nowait`` - Don't wait on the backup process
+
+See also
+
+:doc:`Nodetool restore </operating-scylla/nodetool-commands/restore/>`
 
 .. include:: nodetool-index.rst

--- a/docs/operating-scylla/nodetool-commands/restore.rst
+++ b/docs/operating-scylla/nodetool-commands/restore.rst
@@ -15,6 +15,13 @@ Syntax
                --keyspace <keyspace> [--table <table>]
                [--nowait]
 
+Example
+-------
+
+.. code-block:: console
+
+   nodetool restore --endpoint s3.us-east-2.amazonaws.com  --bucket bucket-foo --snapshot ss --keyspace ks
+
 Options
 -------
 
@@ -25,5 +32,9 @@ Options
 * ``--keyspace`` - Name of a keyspace to load SSTables into
 * ``--table`` - Name of a table to load SSTables into
 * ``--nowait`` - Don't wait on the restore process
+
+See also
+
+:doc:`Nodetool backup </operating-scylla/nodetool-commands/backup/>`
 
 .. include:: nodetool-index.rst

--- a/test/nodetool/test_backup.py
+++ b/test/nodetool/test_backup.py
@@ -35,10 +35,12 @@ def test_statusbackup(nodetool):
 def test_backup(nodetool, scylla_only, nowait, task_state, task_error):
     endpoint = "s3.us-east-2.amazonaws.com"
     bucket = "bucket-foo"
+    prefix = "foo/bar/baz"
     keyspace = "ks"
     snapshot = "ss"
     params = {"endpoint": endpoint,
               "bucket": bucket,
+              "prefix": prefix,
               "keyspace": keyspace,
               "snapshot": snapshot}
     task_id = "2c4a3e5f"
@@ -70,6 +72,7 @@ def test_backup(nodetool, scylla_only, nowait, task_state, task_error):
     args = ["backup",
             "--endpoint", endpoint,
             "--bucket", bucket,
+            "--prefix", prefix,
             "--keyspace", keyspace,
             "--snapshot", snapshot]
     if nowait:

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -307,11 +307,12 @@ class ScyllaRESTAPIClient():
         """Flush keyspace"""
         await self.client.post(f"/storage_service/keyspace_flush/{ks}", host=node_ip)
 
-    async def backup(self, node_ip: str, ks: str, tag: str, dest: str, bucket: str) -> str:
+    async def backup(self, node_ip: str, ks: str, tag: str, dest: str, bucket: str, prefix: str) -> str:
         """Backup keyspace's snapshot"""
         params = {"keyspace": ks,
                   "endpoint": dest,
                   "bucket": bucket,
+                  "prefix": prefix,
                   "snapshot": tag}
         return await self.client.post_json(f"/storage_service/backup", host=node_ip, params=params)
 

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -390,7 +390,7 @@ const std::map<operation, operation_action>& get_operations_with_func();
 
 void backup_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     std::unordered_map<sstring, sstring> params;
-    for (auto required_param : {"endpoint", "bucket", "keyspace"}) {
+    for (auto required_param : {"endpoint", "bucket", "prefix", "keyspace"}) {
         if (!vm.contains(required_param)) {
             throw std::invalid_argument(fmt::format("missing required parameter: {}", required_param));
         }
@@ -3245,6 +3245,7 @@ For more information, see: {}"
                     typed_option<sstring>("snapshot", "Name of a snapshot to copy SSTables from"),
                     typed_option<sstring>("endpoint", "ID of the configured object storage endpoint to copy SSTables to"),
                     typed_option<sstring>("bucket", "Name of the bucket to backup SSTables to"),
+                    typed_option<sstring>("prefix", "The prefix to backup SSTables under"),
                     typed_option<>("nowait", "Don't wait on the backup process"),
                 },
             },


### PR DESCRIPTION
Fixes #20335 by allowing the caller to pass the prefix when performing backup and restore