### PR TITLE
Reuse sstable::test_env::reusable_sst() helper for pre-exsting sstables

### DIFF
--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -552,11 +552,7 @@ static schema_ptr tombstone_overlap_schema() {
 
 
 static future<sstable_ptr> ka_sst(sstables::test_env& env, schema_ptr schema, sstring dir, sstables::generation_type::int_t generation) {
-    auto sst = env.make_sstable(std::move(schema), dir, sstables::generation_from_value(generation), sstables::sstable::version_types::ka, big);
-    auto fut = sst->load(sst->get_schema()->get_sharder());
-    return std::move(fut).then([sst = std::move(sst)] {
-        return make_ready_future<sstable_ptr>(std::move(sst));
-    });
+    return env.reusable_sst(std::move(schema), std::move(dir), sstables::generation_from_value(generation), sstables::sstable::version_types::ka, big, sstable_open_config{});
 }
 
 //  Considering the schema above, the sstable looks like:

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -136,7 +136,8 @@ public:
     // counting pointer to an sstable - allowing for the returned handle to
     // be passed around until no longer needed.
     future<shared_sstable> reusable_sst(schema_ptr schema, sstring dir, sstables::generation_type generation,
-            sstable::version_types version, sstable::format_types f = sstable::format_types::big);
+            sstable::version_types version, sstable::format_types f = sstable::format_types::big,
+            sstable_open_config cfg = { .load_first_and_last_position_metadata = true });
 
     future<shared_sstable> reusable_sst(schema_ptr schema, sstring dir, sstables::generation_type::int_t gen_value,
             sstable::version_types version, sstable::format_types f = sstable::format_types::big);

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -369,9 +369,8 @@ test_env::make_sst_factory(schema_ptr s, sstable::version_types version) {
 
 future<shared_sstable>
 test_env::reusable_sst(schema_ptr schema, sstring dir, sstables::generation_type generation,
-        sstable::version_types version, sstable::format_types f) {
+        sstable::version_types version, sstable::format_types f, sstable_open_config cfg) {
     auto sst = make_sstable(std::move(schema), dir, generation, version, f);
-    sstable_open_config cfg { .load_first_and_last_position_metadata = true };
     return sst->load(sst->get_schema()->get_sharder(), cfg).then([sst = std::move(sst)] {
         return make_ready_future<shared_sstable>(std::move(sst));
     });


### PR DESCRIPTION
Tests that try to access sstables from test/resource/ typically sstable::load() it after object creation. There's reusable_sst() helper for that. This PR fixes one more caller that still goes longer route by doing sstable and loading it on its own.