### PR TITLE
doc: comment out redirections for pages under Features

### DIFF
--- a/docs/_utils/redirects.yaml
+++ b/docs/_utils/redirects.yaml
@@ -2,25 +2,28 @@
 #old path: new path
 
 
-# Move up the Features section
 
-/stable/using-scylla/features.html: /stable/features/index.html
-/stable/using-scylla/lwt.html: /stable/features/lwt.html
-/stable/using-scylla/secondary-indexes.html: /stable/features/secondary-indexes.html
-/stable/using-scylla/local-secondary-indexes.html: /stable/features/local-secondary-indexes.html
-/stable/using-scylla/materialized-views.html: /stable/features/materialized-views.html
-/stable/using-scylla/counters.html: /stable/features/counters.html
-/stable/using-scylla/workload-attributes.html: /stable/features/workload-attributes.html
-/stable/using-scylla/cdc/index.html: /stable/features/cdc/index.html
-/stable/using-scylla/cdc/cdc-intro.html: /stable/features/cdc/cdc-intro.html
-/stable/using-scylla/cdc/cdc-log-table.html: /stable/features/cdc/cdc-log-table.html
-/stable/using-scylla/cdc/cdc-basic-operations.html: /stable/features/cdc/cdc-basic-operations.html
-/stable/using-scylla/cdc/cdc-streams.html: /stable/features/cdc/cdc-streams.html
-/stable/using-scylla/cdc/cdc-stream-generations.html: /stable/features/cdc/cdc-stream-generations.html
-/stable/using-scylla/cdc/cdc-querying-streams.html: /stable/features/cdc/cdc-querying-streams.html
-/stable/using-scylla/cdc/cdc-advanced-types.html: /stable/features/cdc/cdc-advanced-types.html
-/stable/using-scylla/cdc/cdc-preimages.html: /stable/features/cdc/cdc-preimages.html
-/stable/using-scylla/cdc/cdc-consistency.html: /stable/features/cdc/cdc-consistency.html
+# Move up the Features section
+# THESE REDIRECTIOSN SHOULD BE UNCOMMENTED WHEN 6.2 IS RELEASED
+# Before 6.2 documentation is available, these redirections result in 404
+
+#/stable/using-scylla/features.html: /stable/features/index.html
+#/stable/using-scylla/lwt.html: /stable/features/lwt.html
+#/stable/using-scylla/secondary-indexes.html: /stable/features/secondary-indexes.html
+#/stable/using-scylla/local-secondary-indexes.html: /stable/features/local-secondary-indexes.html
+#/stable/using-scylla/materialized-views.html: /stable/features/materialized-views.html
+#/stable/using-scylla/counters.html: /stable/features/counters.html
+#/stable/using-scylla/workload-attributes.html: /stable/features/workload-attributes.html
+#/stable/using-scylla/cdc/index.html: /stable/features/cdc/index.html
+#/stable/using-scylla/cdc/cdc-intro.html: /stable/features/cdc/cdc-intro.html
+#/stable/using-scylla/cdc/cdc-log-table.html: /stable/features/cdc/cdc-log-table.html
+#/stable/using-scylla/cdc/cdc-basic-operations.html: /stable/features/cdc/cdc-basic-operations.html
+#/stable/using-scylla/cdc/cdc-streams.html: /stable/features/cdc/cdc-streams.html
+#/stable/using-scylla/cdc/cdc-stream-generations.html: /stable/features/cdc/cdc-stream-generations.html
+#/stable/using-scylla/cdc/cdc-querying-streams.html: /stable/features/cdc/cdc-querying-streams.html
+#/stable/using-scylla/cdc/cdc-advanced-types.html: /stable/features/cdc/cdc-advanced-types.html
+#/stable/using-scylla/cdc/cdc-preimages.html: /stable/features/cdc/cdc-preimages.html
+#/stable/using-scylla/cdc/cdc-consistency.html: /stable/features/cdc/cdc-consistency.html
 
 # Remove the Cluster membership changes and LWT consistency page
 


### PR DESCRIPTION
This commit temporarily disables redirections for all pages under Features that were moved with this PR: https://github.com/scylladb/scylladb/pull/20401

Redirections work for all versions. This means that pages in 6.1 are redirected to URLs that are not available yet (because 6.2 has not been released yet).

The redirections are correct and should be enabled when 6.2 is released: I've created an issue to do it: https://github.com/scylladb/scylladb/issues/20428
