### PR TITLE
dist: tune LimitNOFILES for large nodes

### DIFF
--- a/dist/common/scripts/scylla_nofile_setup
+++ b/dist/common/scripts/scylla_nofile_setup
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright 2024-present ScyllaDB
+#
+
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import os
+import sys
+import argparse
+import psutil
+from scylla_util import *
+
+if __name__ == '__main__':
+    if not is_nonroot() and os.getuid() > 0:
+        print('Requires root permission.')
+        sys.exit(1)
+    parser = argparse.ArgumentParser(description='LimitNOFILE setup script for Scylla.')
+    parser.add_argument('--limitnofile', type=int,
+                        help='Specify LimitNOFILE size (default: auto-configure)')
+    args = parser.parse_args()
+
+    if args.limitnofile:
+        limitnofile = args.limitnofile
+    else:
+        cpu = psutil.cpu_count()
+        mem_gb = int(psutil.virtual_memory().total/1024/1024/1024)
+        limitnofile = 10000 + (1200 * mem_gb) + (10000 * cpu)
+    if limitnofile < 800000:
+        print('No need to enlarge LimitNOFILE, skipping setup.')
+        sys.exit(0)
+    else:
+        print(f'Set LimitNOFILE to {limitnofile}')
+    unit_data = f'''
+[Service]
+LimitNOFILE={limitnofile}
+'''[1:-1]
+    os.makedirs('/etc/systemd/system/scylla-server.service.d/', exist_ok=True)
+    with open('/etc/systemd/system/scylla-server.service.d/limitnofile.conf', 'w') as f:
+        f.write(unit_data)
+    systemd_unit.reload()

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -271,6 +271,8 @@ if __name__ == '__main__':
                         help='skip swap setup')
     parser.add_argument('--no-rsyslog-setup', action='store_true', default=False,
                         help='skip rsyslog setup')
+    parser.add_argument('--no-nofiles-setup', action='store_true', default=False,
+                        help='skip LimitNOFILES setup')
     parser.add_argument('--rsyslog-server',
                         help='specify a remote rsyslog server to send Scylla logs to. Use ip:port format, if no port is given, Scylla-Monitoring rsyslog will be used')
     if len(sys.argv) == 1:
@@ -317,6 +319,7 @@ if __name__ == '__main__':
     memory_setup = not args.no_memory_setup
     swap_setup = not args.no_swap_setup
     rsyslog_setup = not args.no_rsyslog_setup
+    nofiles_setup = not args.no_nofiles_setup
     rsyslog_server = args.rsyslog_server
     selinux_reboot_required = False
     set_clocksource = False
@@ -550,6 +553,10 @@ if __name__ == '__main__':
                     rsyslog_server = interactive_ask_rsyslog_server()
                 if rsyslog_server:
                     run_setup_script('rsyslog', 'scylla_rsyslog_setup --remote-server ' + rsyslog_server)
+
+    nofiles_setup = interactive_ask_service('Do you want to tune LimitNOFILES run Scylla on large node?', 'Yes - tune LimitNOFILES. No - skip this setup.', nofiles_setup)
+    if nofiles_setup:
+        run_setup_script('LimitNOFILE tuneup', 'scylla_nofile_setup')
 
     print('ScyllaDB setup finished.')
 

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -144,6 +144,7 @@ ln -sfT /etc/scylla /var/lib/scylla/conf
 %ghost /etc/systemd/system/scylla-helper.slice.d/memory.conf
 %ghost /etc/systemd/system/scylla-server.service.d/capabilities.conf
 %ghost /etc/systemd/system/scylla-server.service.d/mounts.conf
+%ghost /etc/systemd/system/scylla-server.service.d/limitnofile.conf
 /etc/systemd/system/scylla-server.service.d/dependencies.conf
 %ghost %config /etc/systemd/system/var-lib-systemd-coredump.mount
 %ghost /etc/systemd/system/scylla-cpupower.service


### PR DESCRIPTION
On very large node, LimitNOFILES=80000 may not enough size, it can cause "Too many files" error.

To avoid that, let's increase LimitNOFILES on scylla_setup stage, generate optimal value calurated from memory size and number of cpus.

Closes scylladb/scylla-enterprise#4304