### PR TITLE
Improve timestamp heuristics for tombstone garbage collection

### DIFF
--- a/cache_mutation_reader.hh
+++ b/cache_mutation_reader.hh
@@ -795,7 +795,6 @@ void cache_mutation_reader::copy_from_cache_to_buffer() {
             };
 
             if (row_tomb_expired(t) || is_row_dead(row)) {
-                can_gc_fn always_gc = [&](tombstone) { return true; };
                 const schema& row_schema = _next_row.latest_row_schema();
 
                 _read_context.cache()._tracker.on_row_compacted();

--- a/collection_mutation.hh
+++ b/collection_mutation.hh
@@ -13,6 +13,7 @@
 #include "gc_clock.hh"
 #include "mutation/atomic_cell.hh"
 #include "mutation/compact_and_expire_result.hh"
+#include "compaction/compaction_garbage_collector.hh"
 #include <iosfwd>
 #include <forward_list>
 

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -889,11 +889,9 @@ private:
     virtual std::string_view report_start_desc() const = 0;
     virtual std::string_view report_finish_desc() const = 0;
 
-    std::function<api::timestamp_type(const dht::decorated_key&)> max_purgeable_func() {
+    max_purgeable_fn max_purgeable_func() {
         if (!tombstone_expiration_enabled()) {
-            return [] (const dht::decorated_key& dk) {
-                return api::min_timestamp;
-            };
+            return can_never_purge;
         }
         return [this] (const dht::decorated_key& dk) {
             return get_max_purgeable_timestamp(_table_s, *_selector, _compacting_for_max_purgeable_func, dk, _bloom_filter_checks, _compacting_max_timestamp, _tombstone_gc_state_with_commitlog_check_disabled.has_value());

--- a/compaction/compaction_garbage_collector.hh
+++ b/compaction/compaction_garbage_collector.hh
@@ -10,12 +10,18 @@
 
 #include "mutation/tombstone.hh"
 #include "schema/schema_fwd.hh"
+#include "dht/i_partitioner_fwd.hh"
 
 // Determines whether tombstone may be GC-ed.
 using can_gc_fn = std::function<bool(tombstone)>;
 
 extern can_gc_fn always_gc;
 extern can_gc_fn never_gc;
+
+using max_purgeable_fn = std::function<api::timestamp_type(const dht::decorated_key&)>;
+
+extern max_purgeable_fn can_always_purge;
+extern max_purgeable_fn can_never_purge;
 
 class atomic_cell;
 class row_marker;

--- a/compaction/compaction_garbage_collector.hh
+++ b/compaction/compaction_garbage_collector.hh
@@ -8,17 +8,21 @@
 
 #pragma once
 
+#include <seastar/util/bool_class.hh>
+
 #include "mutation/tombstone.hh"
 #include "schema/schema_fwd.hh"
 #include "dht/i_partitioner_fwd.hh"
 
+using is_shadowable = bool_class<struct is_shadowable_tag>;
+
 // Determines whether tombstone may be GC-ed.
-using can_gc_fn = std::function<bool(tombstone)>;
+using can_gc_fn = std::function<bool(tombstone, is_shadowable)>;
 
 extern can_gc_fn always_gc;
 extern can_gc_fn never_gc;
 
-using max_purgeable_fn = std::function<api::timestamp_type(const dht::decorated_key&)>;
+using max_purgeable_fn = std::function<api::timestamp_type(const dht::decorated_key&, is_shadowable)>;
 
 extern max_purgeable_fn can_always_purge;
 extern max_purgeable_fn can_never_purge;

--- a/compaction/compaction_garbage_collector.hh
+++ b/compaction/compaction_garbage_collector.hh
@@ -8,7 +8,14 @@
 
 #pragma once
 
+#include "mutation/tombstone.hh"
 #include "schema/schema_fwd.hh"
+
+// Determines whether tombstone may be GC-ed.
+using can_gc_fn = std::function<bool(tombstone)>;
+
+extern can_gc_fn always_gc;
+extern can_gc_fn never_gc;
 
 class atomic_cell;
 class row_marker;

--- a/compaction/table_state.hh
+++ b/compaction/table_state.hh
@@ -48,6 +48,8 @@ public:
     virtual sstables::shared_sstable make_sstable() const = 0;
     virtual sstables::sstable_writer_config configure_writer(sstring origin) const = 0;
     virtual api::timestamp_type min_memtable_timestamp() const = 0;
+    virtual api::timestamp_type min_memtable_live_timestamp() const = 0;
+    virtual api::timestamp_type min_memtable_live_row_marker_timestamp() const = 0;
     virtual bool memtable_has_key(const dht::decorated_key& key) const = 0;
     virtual future<> on_compaction_completion(sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy) = 0;
     virtual bool is_auto_compaction_disabled_by_user() const noexcept = 0;

--- a/docs/dev/sstable-scylla-format.md
+++ b/docs/dev/sstable-scylla-format.md
@@ -30,6 +30,7 @@ in individual sections
         | sstable_origin
         | scylla_build_id
         | scylla_version
+        | ext_timestamp_stats
 
 `sharding_metadata` (tag 1): describes what token sub-ranges are included in this
 sstable. This is used, when loading the sstable, to determine which shard(s)
@@ -54,6 +55,9 @@ Scylla executable that created the sstable.
 
 `scylla_version` (tag 8): a string containing the version of the
 Scylla executable that created the sstable.
+
+`ext_timestamp_stats` (tag 9): a `map<ext_timestamp_stats_type, int64_t>` with statistics
+about timestamps in the sstable, like: `min_live_timestamp`, and `min_live_row_marker_timestamp`.
 
 ## sharding_metadata subcomponent
 

--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -497,6 +497,9 @@ The content is dumped in JSON, using the following schema:
         "run_identifier": String, // UUID
         "large_data_stats": {"$key": $LARGE_DATA_STATS_METADATA, ...}
         "sstable_origin": String
+        "scylla_build_id": String
+        "scylla_version": String
+        "ext_timestamp_stats": {"$key": int64, ...}
     }
 
     $SHARDING_METADATA := {

--- a/mutation/atomic_cell.hh
+++ b/mutation/atomic_cell.hh
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <seastar/util/bool_class.hh>
+
 #include "bytes.hh"
 #include "timestamp.hh"
 #include "mutation/tombstone.hh"
@@ -31,6 +33,7 @@ template <mutable_view is_mutable>
 using atomic_cell_value_basic_view = managed_bytes_basic_view<is_mutable>;
 using atomic_cell_value_view = atomic_cell_value_basic_view<mutable_view::no>;
 using atomic_cell_value_mutable_view = atomic_cell_value_basic_view<mutable_view::yes>;
+using is_live = bool_class<struct is_live_tag>;
 
 template <typename T>
 requires std::is_trivial_v<T>

--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -144,7 +144,7 @@ template<compact_for_sstables SSTableCompaction>
 class compact_mutation_state {
     const schema& _schema;
     gc_clock::time_point _query_time;
-    std::function<api::timestamp_type(const dht::decorated_key&)> _get_max_purgeable;
+    max_purgeable_fn _get_max_purgeable;
     can_gc_fn _can_gc;
     api::timestamp_type _max_purgeable = api::missing_timestamp;
     std::optional<gc_clock::time_point> _gc_before;
@@ -312,7 +312,7 @@ public:
     }
 
     compact_mutation_state(const schema& s, gc_clock::time_point compaction_time,
-            std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable,
+            max_purgeable_fn get_max_purgeable,
             const tombstone_gc_state& gc_state)
         : _schema(s)
         , _query_time(compaction_time)
@@ -655,7 +655,7 @@ public:
 
     // Can only be used for compact_for_sstables::yes
     compact_mutation_v2(const schema& s, gc_clock::time_point compaction_time,
-            std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable,
+            max_purgeable_fn get_max_purgeable,
             const tombstone_gc_state& gc_state,
             Consumer consumer, GCConsumer gc_consumer = GCConsumer())
         : _state(make_lw_shared<compact_mutation_state<SSTableCompaction>>(s, compaction_time, get_max_purgeable, gc_state))

--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -14,6 +14,9 @@
 #include "tombstone_gc.hh"
 #include "full_position.hh"
 #include <type_traits>
+#include "log.hh"
+
+extern logging::logger mclog;
 
 static inline bool has_ck_selector(const query::clustering_row_ranges& ranges) {
     // Like PK range, an empty row range, should be considered an "exclude all" restriction
@@ -289,7 +292,9 @@ private:
         if (_max_purgeable == api::missing_timestamp) {
             _max_purgeable = _get_max_purgeable(*_dk, is_shadowable);
         }
-        return t.timestamp < _max_purgeable;
+        auto ret = t.timestamp < _max_purgeable;
+        mclog.debug("can_gc: t={} is_shadowable={} max_purgeable={}: ret={}", t, is_shadowable, _max_purgeable, ret);
+        return ret;
     };
 
 public:

--- a/mutation/mutation_fragment.hh
+++ b/mutation/mutation_fragment.hh
@@ -18,6 +18,7 @@
 
 #include "reader_permit.hh"
 #include "mutation_fragment_fwd.hh"
+#include "mutation/mutation_partition.hh"
 
 // mutation_fragments are the objects that streamed_mutation are going to
 // stream. They can represent:

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -203,7 +203,6 @@ stop_iteration mutation_partition::apply_monotonically(const schema& s, mutation
 
         while (i != end) {
             rows_entry& e = *i;
-            can_gc_fn never_gc = [](tombstone) { return false; };
 
             ++app_stats.rows_compacted_with_tombstones;
             bool all_dead = e.dummy() || !e.row().compact_and_expire(s,
@@ -1423,7 +1422,6 @@ rows_entry::rows_entry(rows_entry&& o) noexcept
 }
 
 void rows_entry::compact(const schema& s, tombstone t) {
-    can_gc_fn never_gc = [] (tombstone) { return false; };
     row().compact_and_expire(s,
                              t + _range_tombstone,
                              gc_clock::time_point::min(),  // no TTL expiration
@@ -2519,5 +2517,6 @@ future<> mutation_cleaner_impl::drain() {
 }
 
 can_gc_fn always_gc = [] (tombstone) { return true; };
+can_gc_fn never_gc = [] (tombstone) { return false; };
 
 logging::logger compound_logger("compound");

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -33,6 +33,7 @@
 #include "utils/unconst.hh"
 #include "mutation/async_utils.hh"
 
+logging::logger mclog("mutation_compactor");
 logging::logger mplog("mutation_partition");
 
 mutation_partition::mutation_partition(const schema& s, const mutation_partition& x)

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -20,6 +20,7 @@
 #include "mutation_compactor.hh"
 #include "counters.hh"
 #include "row_cache.hh"
+#include "timestamp.hh"
 #include "view_info.hh"
 #include "mutation_cleaner.hh"
 #include <seastar/core/execution_stage.hh>
@@ -2518,5 +2519,8 @@ future<> mutation_cleaner_impl::drain() {
 
 can_gc_fn always_gc = [] (tombstone) { return true; };
 can_gc_fn never_gc = [] (tombstone) { return false; };
+
+max_purgeable_fn can_always_purge = [] (const dht::decorated_key&) { return api::max_timestamp; };
+max_purgeable_fn can_never_purge = [] (const dht::decorated_key&) { return api::min_timestamp; };
 
 logging::logger compound_logger("compound");

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -778,8 +778,8 @@ public:
         return _shadowable;
     }
 
-    bool is_shadowable() const {
-        return _shadowable.tomb() > _regular;
+    is_shadowable is_shadowable() const {
+        return ::is_shadowable(_shadowable.tomb() > _regular);
     }
 
     void maybe_shadow(const row_marker& marker) noexcept {

--- a/mutation/tombstone.hh
+++ b/mutation/tombstone.hh
@@ -91,8 +91,3 @@ struct appending_hash<tombstone> {
         feed_hash(h, t.deletion_time);
     }
 };
-
-// Determines whether tombstone may be GC-ed.
-using can_gc_fn = std::function<bool(tombstone)>;
-
-extern can_gc_fn always_gc;

--- a/readers/compacting.hh
+++ b/readers/compacting.hh
@@ -10,7 +10,7 @@
 
 #include "gc_clock.hh"
 #include "readers/mutation_reader_fwd.hh"
-#include "timestamp.hh"
+#include "compaction/compaction_garbage_collector.hh"
 
 namespace dht {
 class decorated_key;
@@ -34,6 +34,6 @@ class tombstone_gc_state;
 /// Intra-partition forwarding: `fast_forward_to(position_range)` is supported
 /// if the source reader supports it
 mutation_reader make_compacting_reader(mutation_reader source, gc_clock::time_point compaction_time,
-        std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable,
+        max_purgeable_fn get_max_purgeable,
         const tombstone_gc_state& gc_state,
         streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no);

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -1460,7 +1460,7 @@ private:
 
 public:
     compacting_reader(mutation_reader source, gc_clock::time_point compaction_time,
-            std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable,
+            max_purgeable_fn get_max_purgeable,
             const tombstone_gc_state& gc_state,
             streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no)
         : impl(source.schema(), source.permit())
@@ -1547,7 +1547,7 @@ public:
 } // anonymous namespace
 
 mutation_reader make_compacting_reader(mutation_reader source, gc_clock::time_point compaction_time,
-        std::function<api::timestamp_type(const dht::decorated_key&)> get_max_purgeable,
+        max_purgeable_fn get_max_purgeable,
         const tombstone_gc_state& gc_state, streamed_mutation::forwarding fwd) {
     return make_mutation_reader<compacting_reader>(std::move(source), compaction_time, get_max_purgeable, gc_state, fwd);
 }

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -120,6 +120,10 @@ public:
     size_t memtable_count() const noexcept;
     // Returns minimum timestamp from memtable list
     api::timestamp_type min_memtable_timestamp() const;
+    // Returns minimum timestamp of live data from memtable list
+    api::timestamp_type min_memtable_live_timestamp() const;
+    // Returns minimum timestamp of live row markers from memtable list
+    api::timestamp_type min_memtable_live_row_marker_timestamp() const;
     // Returns true if memtable(s) contains key.
     bool memtable_has_key(const dht::decorated_key& key) const;
     // Add sstable to main set
@@ -234,6 +238,8 @@ public:
     future<> flush() noexcept;
     bool can_flush() const;
     api::timestamp_type min_memtable_timestamp() const;
+    api::timestamp_type min_memtable_live_timestamp() const;
+    api::timestamp_type min_memtable_live_row_marker_timestamp() const;
 
     bool compaction_disabled() const;
     // Returns true when all compacted sstables were already deleted.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -803,6 +803,9 @@ public:
     // Allow an action to be performed on each active memtable, each of which belongs to a different compaction group.
     void for_each_active_memtable(noncopyable_function<void(memtable&)> action);
     api::timestamp_type min_memtable_timestamp() const;
+    api::timestamp_type min_memtable_live_timestamp() const;
+    api::timestamp_type min_memtable_live_row_marker_timestamp() const;
+
     const row_cache& get_row_cache() const {
         return _cache;
     }

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -85,8 +85,11 @@ void memtable::memtable_encoding_stats_collector::update(const range_tombstone& 
 }
 
 void memtable::memtable_encoding_stats_collector::update(const row_marker& marker) noexcept {
+    if (marker.is_missing()) {
+        return;
+    }
     update_timestamp(marker.timestamp());
-    if (!marker.is_missing()) {
+    // FIXME: indentation
         if (!marker.is_live()) {
             update_ttl(gc_clock::duration(sstables::expired_liveness_ttl));
             update_local_deletion_time(marker.deletion_time());
@@ -94,7 +97,6 @@ void memtable::memtable_encoding_stats_collector::update(const row_marker& marke
             update_ttl(marker.ttl());
             update_local_deletion_time(marker.expiry());
         }
-    }
 }
 
 void memtable::memtable_encoding_stats_collector::update(const ::schema& s, const deletable_row& dr) {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -285,7 +285,7 @@ static mutation_reader maybe_compact_for_streaming(mutation_reader underlying, c
     return make_compacting_reader(
             std::move(underlying),
             compaction_time,
-            [compaction_can_gc] (const dht::decorated_key&) { return compaction_can_gc ? api::max_timestamp : api::min_timestamp; },
+            compaction_can_gc ? can_always_purge : can_never_purge,
             cm.get_tombstone_gc_state(),
             streamed_mutation::forwarding::no);
 }
@@ -2499,7 +2499,7 @@ table::sstables_as_snapshot_source() {
             return make_compacting_reader(
                 std::move(reader),
                 gc_clock::now(),
-                [](const dht::decorated_key&) { return api::max_timestamp; },
+                can_always_purge,
                 _compaction_manager.get_tombstone_gc_state(),
                 fwd);
         }, [this, sst_set] {

--- a/sstables/disk_types.hh
+++ b/sstables/disk_types.hh
@@ -87,7 +87,8 @@ struct disk_array_ref {
 
 template <typename Size, typename Key, typename Value>
 struct disk_hash {
-    std::unordered_map<Key, Value, std::hash<Key>> map;
+    using map_type = std::unordered_map<Key, Value, std::hash<Key>>;
+    map_type map;
 };
 
 template <typename TagType, TagType Tag, typename T>

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1494,7 +1494,10 @@ void writer::consume_end_of_stream() {
             { large_data_type::elements_in_collection, std::move(_elements_in_collection_entry) },
         }
     });
-    _sst.write_scylla_metadata(_shard, std::move(features), std::move(identifier), std::move(ld_stats));
+    std::optional<scylla_metadata::ext_timestamp_stats> ts_stats(scylla_metadata::ext_timestamp_stats{
+        .map = _collector.get_ext_timestamp_stats()
+    });
+    _sst.write_scylla_metadata(_shard, std::move(features), std::move(identifier), std::move(ld_stats), std::move(ts_stats));
     _sst.seal_sstable(_cfg.backup).get();
 }
 

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1082,12 +1082,15 @@ void writer::write_cell(bytes_ostream& writer, const clustering_key_prefix* clus
         maybe_record_large_cells(_sst, *_partition_key, clustering_key, cdef, size, 0);
     }
 
-    _c_stats.update_timestamp(cell.timestamp());
+    auto timestamp = cell.timestamp();
     if (is_deleted) {
+        _c_stats.update_timestamp(timestamp, is_live::no);
         _c_stats.update_local_deletion_time_and_tombstone_histogram(cell.deletion_time());
         _sst.get_stats().on_cell_tombstone_write();
         return;
     }
+
+    _c_stats.update_timestamp(timestamp, is_live::yes);
 
     if (is_cell_expiring) {
         _c_stats.update_ttl(cell.ttl());
@@ -1107,7 +1110,12 @@ void writer::write_liveness_info(bytes_ostream& writer, const row_marker& marker
     }
 
     api::timestamp_type timestamp = marker.timestamp();
-    _c_stats.update_timestamp(timestamp);
+    if (marker.is_live()) {
+        _c_stats.update_timestamp(timestamp, is_live::yes);
+        _c_stats.update_live_row_marker_timestamp(timestamp);
+    } else {
+        _c_stats.update_timestamp(timestamp, is_live::no);
+    }
     write_delta_timestamp(writer, timestamp);
 
     auto write_expiring_liveness_info = [this, &writer] (gc_clock::duration ttl, gc_clock::time_point ldt) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1355,6 +1355,10 @@ future<> sstable::open_data(sstable_open_config cfg) noexcept {
     if (origin) {
         _origin = sstring(to_sstring_view(bytes_view(origin->value)));
     }
+    auto* ts_stats = _components->scylla_metadata->data.get<scylla_metadata_type::ExtTimestampStats, scylla_metadata::ext_timestamp_stats>();
+    if (ts_stats) {
+        _ext_timestamp_stats.emplace(*ts_stats);
+    }
     _open_mode.emplace(open_flags::ro);
     _stats.on_open_for_reading();
 
@@ -1816,7 +1820,7 @@ sstable::read_scylla_metadata() noexcept {
 
 void
 sstable::write_scylla_metadata(shard_id shard, sstable_enabled_features features, struct run_identifier identifier,
-        std::optional<scylla_metadata::large_data_stats> ld_stats) {
+        std::optional<scylla_metadata::large_data_stats> ld_stats, std::optional<scylla_metadata::ext_timestamp_stats> ts_stats) {
     auto&& first_key = get_first_decorated_key();
     auto&& last_key = get_last_decorated_key();
 
@@ -1850,6 +1854,9 @@ sstable::write_scylla_metadata(shard_id shard, sstable_enabled_features features
     scylla_metadata::scylla_build_id build_id;
     build_id.value = bytes(to_bytes_view(sstring_view(get_build_id())));
     _components->scylla_metadata->data.set<scylla_metadata_type::ScyllaBuildId>(std::move(build_id));
+    if (ts_stats) {
+        _components->scylla_metadata->data.set<scylla_metadata_type::ExtTimestampStats>(std::move(*ts_stats));
+    }
 
     write_simple<component_type::Scylla>(*_components->scylla_metadata);
 }
@@ -3205,6 +3212,13 @@ std::optional<large_data_stats_entry> sstable::get_large_data_stat(large_data_ty
         }
     }
     return std::make_optional<large_data_stats_entry>();
+}
+
+scylla_metadata::ext_timestamp_stats::map_type sstable::get_ext_timestamp_stats() const noexcept {
+    if (_ext_timestamp_stats) {
+        return _ext_timestamp_stats->map;
+    }
+    return scylla_metadata::ext_timestamp_stats::map_type{};
 }
 
 // The gc_before returned by the function can only be used to estimate if the

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -36,6 +36,7 @@
 #include "sstables/shareable_components.hh"
 #include "sstables/storage.hh"
 #include "sstables/generation_type.hh"
+#include "sstables/types.hh"
 #include "mutation/mutation_fragment_stream_validator.hh"
 #include "readers/mutation_reader_fwd.hh"
 #include "readers/mutation_reader.hh"
@@ -594,6 +595,7 @@ private:
     // information in their scylla metadata.
     std::optional<scylla_metadata::large_data_stats> _large_data_stats;
     sstring _origin;
+    std::optional<scylla_metadata::ext_timestamp_stats> _ext_timestamp_stats;
 
     // Total reclaimable memory from all the components of the SSTable.
     // It is initialized to 0 to prevent the sstables manager from reclaiming memory
@@ -646,7 +648,8 @@ private:
     void write_scylla_metadata(shard_id shard,
                                sstable_enabled_features features,
                                run_identifier identifier,
-                               std::optional<scylla_metadata::large_data_stats> ld_stats);
+                               std::optional<scylla_metadata::large_data_stats> ld_stats,
+                               std::optional<scylla_metadata::ext_timestamp_stats> ts_stats);
 
     future<> read_filter(sstable_open_config cfg = {});
 
@@ -953,6 +956,10 @@ public:
     // iff _large_data_stats is available and the requested entry is in
     // the map.  Otherwise, return a disengaged optional.
     std::optional<large_data_stats_entry> get_large_data_stat(large_data_type t) const noexcept;
+
+    // Return the extended timestamp statistics map.
+    // Some or all entries may be missing if not present in scylla_metadata
+    scylla_metadata::ext_timestamp_stats::map_type get_ext_timestamp_stats() const noexcept;
 
     const sstring& get_origin() const noexcept {
         return _origin;

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -531,6 +531,7 @@ enum class scylla_metadata_type : uint32_t {
     SSTableOrigin = 6,
     ScyllaBuildId = 7,
     ScyllaVersion = 8,
+    ExtTimestampStats = 9,
 };
 
 // UUID is used for uniqueness across nodes, such that an imported sstable
@@ -565,12 +566,22 @@ struct large_data_stats_entry {
     auto describe_type(sstable_version_types v, Describer f) { return f(max_value, threshold, above_threshold); }
 };
 
+// Types of extended timestamp statistics.
+//
+// Note: For extensibility, never reuse an identifier,
+// only add new ones, since these are stored on stable storage.
+enum class ext_timestamp_stats_type : uint32_t {
+    min_live_timestamp = 1,
+    min_live_row_marker_timestamp = 2,
+};
+
 struct scylla_metadata {
     using extension_attributes = disk_hash<uint32_t, disk_string<uint32_t>, disk_string<uint32_t>>;
     using large_data_stats = disk_hash<uint32_t, large_data_type, large_data_stats_entry>;
     using sstable_origin = disk_string<uint32_t>;
     using scylla_build_id = disk_string<uint32_t>;
     using scylla_version = disk_string<uint32_t>;
+    using ext_timestamp_stats = disk_hash<uint32_t, ext_timestamp_stats_type, int64_t>;
 
     disk_set_of_tagged_union<scylla_metadata_type,
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::Sharding, sharding_metadata>,
@@ -580,7 +591,8 @@ struct scylla_metadata {
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::LargeDataStats, large_data_stats>,
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::SSTableOrigin, sstable_origin>,
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::ScyllaBuildId, scylla_build_id>,
-            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::ScyllaVersion, scylla_version>
+            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::ScyllaVersion, scylla_version>,
+            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::ExtTimestampStats, ext_timestamp_stats>
             > data;
 
     sstable_enabled_features get_features() const {
@@ -607,6 +619,9 @@ struct scylla_metadata {
     std::optional<run_id> get_optional_run_identifier() const {
         auto* m = data.get<scylla_metadata_type::RunIdentifier, run_identifier>();
         return m ? std::make_optional(m->id) : std::nullopt;
+    }
+    const ext_timestamp_stats* get_ext_timestamp_stats() const {
+        return data.get<scylla_metadata_type::ExtTimestampStats, ext_timestamp_stats>();
     }
 
     template <typename Describer>

--- a/test/boost/compaction_group_test.cc
+++ b/test/boost/compaction_group_test.cc
@@ -111,6 +111,8 @@ public:
     virtual sstables::shared_sstable make_sstable() const override { return _sstable_factory(); }
     virtual sstables::sstable_writer_config configure_writer(sstring origin) const override { return _sst_man.configure_writer(std::move(origin)); }
     virtual api::timestamp_type min_memtable_timestamp() const override { return api::min_timestamp; }
+    virtual api::timestamp_type min_memtable_live_timestamp() const override { return api::min_timestamp; }
+    virtual api::timestamp_type min_memtable_live_row_marker_timestamp() const override { return api::min_timestamp; }
     virtual bool memtable_has_key(const dht::decorated_key& key) const override { return false; }
     virtual future<> on_compaction_completion(sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy) override {
         testlog.info("Adding {} sstable(s), removing {} sstables", desc.new_sstables.size(), desc.old_sstables.size());

--- a/test/boost/mutation_reader_another_test.cc
+++ b/test/boost/mutation_reader_another_test.cc
@@ -1096,7 +1096,7 @@ SEASTAR_THREAD_TEST_CASE(test_reverse_reader_reads_in_native_reverse_order) {
     auto compacted = [] (mutation_reader rd) {
         return make_compacting_reader(std::move(rd),
                                       gc_clock::time_point::max(),
-                                      [] (const dht::decorated_key&) { return api::max_timestamp; },
+                                      can_always_purge,
                                       tombstone_gc_state(nullptr));
     };
 

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -2583,7 +2583,7 @@ SEASTAR_THREAD_TEST_CASE(test_compacting_reader_as_mutation_source) {
                     source = make_forwardable(std::move(source));
                 }
                 auto mr = make_compacting_reader(std::move(source), query_time,
-                        [] (const dht::decorated_key&) { return api::min_timestamp; },
+                        can_never_purge,
                         tombstone_gc_state(nullptr), fwd_sm);
                 if (single_fragment_buffer) {
                     mr.set_max_buffer_size(1);
@@ -2640,7 +2640,7 @@ SEASTAR_THREAD_TEST_CASE(test_compacting_reader_next_partition) {
 
         auto mr = make_compacting_reader(make_mutation_reader_from_fragments(ss.schema(), permit, std::move(mfs)),
                 gc_clock::now(),
-                [] (const dht::decorated_key&) { return api::min_timestamp; },
+                can_never_purge,
                 tombstone_gc_state(nullptr));
         mr.set_max_buffer_size(buffer_size);
 
@@ -2686,7 +2686,7 @@ SEASTAR_THREAD_TEST_CASE(test_compacting_reader_is_consistent_with_compaction) {
         .produces_range_tombstone_change({position_in_partition::for_range_end(r), {}})
         .produces_partition_end();
 
-    assert_that(make_compacting_reader(read_m(), gc_clock::time_point::min(), [] (const dht::decorated_key&) { return api::min_timestamp; }, tombstone_gc_state(nullptr)))
+    assert_that(make_compacting_reader(read_m(), gc_clock::time_point::min(), can_never_purge, tombstone_gc_state(nullptr)))
             .exact()
             .produces_partition_start(m.decorated_key(), p_tomb)
             .produces_partition_end();

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1604,8 +1604,6 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_upgrade_type_change) {
 // duplicated logic that decides if a row is expired, and this test verifies that they behave the same with respect
 // to TTL.
 SEASTAR_THREAD_TEST_CASE(test_row_marker_expiry) {
-    can_gc_fn never_gc = [] (tombstone) { return false; };
-
     auto must_be_alive = [&] (row_marker mark, gc_clock::time_point t) {
         testlog.trace("must_be_alive({}, {})", mark, t);
         BOOST_REQUIRE(mark.is_live(tombstone(), t));
@@ -1995,7 +1993,6 @@ SEASTAR_TEST_CASE(test_mutation_diff_with_random_generator) {
             }
         };
         const auto now = gc_clock::now();
-        can_gc_fn never_gc = [] (tombstone) { return false; };
         for_each_mutation_pair([&] (auto m1, auto m2, are_equal eq) {
             mutation_application_stats app_stats;
             auto s = m1.schema();
@@ -2841,7 +2838,6 @@ using purged_compacted_fragments_consumer = basic_compacted_fragments_consumer_b
 
 void run_compaction_data_stream_split_test(const schema& schema, reader_permit permit, gc_clock::time_point query_time,
         std::vector<mutation> mutations) {
-    auto never_gc = std::function<bool(tombstone)>([] (tombstone) { return false; });
     for (auto& mut : mutations) {
         mut.partition().compact_for_compaction(schema, never_gc, mut.decorated_key(), query_time, tombstone_gc_state(nullptr));
     }

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -12,6 +12,7 @@
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/range/algorithm_ext/push_back.hpp>
 #include <boost/range/combine.hpp>
+#include "compaction/compaction_garbage_collector.hh"
 #include "mutation_query.hh"
 #include "utils/assert.hh"
 #include "utils/hashers.hh"
@@ -2776,7 +2777,7 @@ public:
         , _mutation(_schema.shared_from_this()) {
     }
     void consume_new_partition(const dht::decorated_key& dk) {
-        _max_purgeable = _get_max_purgeable(dk);
+        _max_purgeable = _get_max_purgeable(dk, is_shadowable::no);
         _mutation.consume_new_partition(dk);
     }
     void consume(tombstone t) {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -983,13 +983,16 @@ SEASTAR_TEST_CASE(tombstone_purge_test) {
 
         auto make_insert = [&] (partition_key key) {
             mutation m(s, key);
-            m.set_clustered_cell(clustering_key::make_empty(), bytes("value"), data_value(int32_t(1)), next_timestamp());
+            auto timestamp = next_timestamp();
+            testlog.info("make_insert: key={} timestamp={}", dht::decorate_key(*s, key), timestamp);
+            m.set_clustered_cell(clustering_key::make_empty(), bytes("value"), data_value(int32_t(1)), timestamp);
             return m;
         };
 
         auto make_expiring = [&] (partition_key key, int ttl) {
             mutation m(s, key);
             auto timestamp = next_timestamp();
+            testlog.info("make_expliring: key={} ttl={} timestamp={}", dht::decorate_key(*s, key), ttl, timestamp);
             m.set_clustered_cell(clustering_key::make_empty(), bytes("value"), data_value(int32_t(1)),
                 timestamp, gc_clock::duration(ttl));
             return m;
@@ -998,6 +1001,7 @@ SEASTAR_TEST_CASE(tombstone_purge_test) {
         auto make_delete = [&] (partition_key key, gc_clock::time_point deletion_time = gc_clock::now()) {
             mutation m(s, key);
             tombstone tomb(next_timestamp(), deletion_time);
+            testlog.info("make_delete: {}", tomb);
             m.partition().apply(tomb);
             return m;
         };

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -989,8 +989,9 @@ SEASTAR_TEST_CASE(tombstone_purge_test) {
 
         auto make_expiring = [&] (partition_key key, int ttl) {
             mutation m(s, key);
+            auto timestamp = next_timestamp();
             m.set_clustered_cell(clustering_key::make_empty(), bytes("value"), data_value(int32_t(1)),
-                gc_clock::now().time_since_epoch().count(), gc_clock::duration(ttl));
+                timestamp, gc_clock::duration(ttl));
             return m;
         };
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2998,7 +2998,7 @@ SEASTAR_TEST_CASE(purged_tombstone_consumer_sstable_test) {
         };
 
         auto compact = [&] (std::vector<shared_sstable> all) -> std::pair<shared_sstable, shared_sstable> {
-            auto max_purgeable_func = [max_purgeable_ts] (const dht::decorated_key& dk) {
+            auto max_purgeable_func = [max_purgeable_ts] (const dht::decorated_key& dk, is_shadowable) {
                 return max_purgeable_ts;
             };
 

--- a/test/cql-pytest/test_compaction_tombstone_gc.py
+++ b/test/cql-pytest/test_compaction_tombstone_gc.py
@@ -1,0 +1,147 @@
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from util import new_materialized_view, new_test_table
+import nodetool
+import time
+
+# sleep to let a ttl (of `seconds`) expire and
+# the commitlog minimum gc time, in seconds,
+# to be greater than the tombstone deletion time
+def sleep_till_whole_second(seconds=1):
+    t = time.time()
+    time.sleep(seconds - (t - int(t)))
+
+def test_tombstone_gc_with_conflict_in_memtable(scylla_only, cql, test_keyspace):
+    """
+    Regression test for fixed https://github.com/scylladb/scylladb/issues/20423
+    """
+    schema = "k int, v int, primary key (k, v)"
+    with new_test_table(cql, test_keyspace, schema, extra="with gc_grace_seconds = 0") as table:
+        with nodetool.no_autocompaction_context(cql, table):
+            # Insert initial data into the base table:
+            # Row 1 is expected to be garbage collected after expiration
+            # This test case tests the ttl case, while `test_tombstone_gc_with_delete_in_memtable`
+            # test also explicit deletion.
+            cql.execute(f"insert into {table} (k, v) values (1, 1) using timestamp 1 and ttl 1")
+            cql.execute(f"insert into {table} (k, v) values (1, 2) using timestamp 2")
+            nodetool.flush(cql, table)
+            # Delete row 2, this deletion is expected to be kept
+            # when we insert backdated live data into the memtable
+            cql.execute(f"delete from {table} using timestamp 3 where k=1 and v=2")
+            # Flush all tables explicitly now, since this is skipped in the test on purpose by next major compaction.
+            nodetool.flush_all(cql)
+
+            sleep_till_whole_second()
+            # Re-insert backdated data into the memtable.  It should inhibit tombstone_gc
+            cql.execute(f"insert into {table} (k, v) values (1, 3) using timestamp 2")
+            # do not flush before major compaction
+            nodetool.compact(cql, table, flush_memtables=False)
+
+            res = cql.execute(f"select * from mutation_fragments({table})")
+            sstables = set()
+            keys = set()
+            rows = set()
+            for r in res:
+                if "sstable" in r.mutation_source:
+                    if r.mutation_fragment_kind == "partition start":
+                        sstables.add(r.mutation_source)
+                        keys.add(r.k)
+                    elif r.mutation_fragment_kind == "clustering row":
+                        rows.add(r.v)
+                        if r.v == 2:
+                            assert "tombstone" in r.metadata
+
+            assert len(sstables) == 1, f"Expected single sstable but saw {len(sstables)}: res={list(res)}"
+            assert keys == {1}, f"Expected keys=={1} but got {keys}: res={list(res)}"
+            assert rows == {2}, f"Expected rows=={2} but got {rows}: res={list(res)}"
+
+def test_tombstone_gc_with_delete_in_memtable(scylla_only, cql, test_keyspace):
+    """
+    Reproduce https://github.com/scylladb/scylladb/issues/20423
+    """
+    schema = "k int, v int, primary key (k, v)"
+    with new_test_table(cql, test_keyspace, schema, extra="with gc_grace_seconds = 0") as table:
+        with nodetool.no_autocompaction_context(cql, table):
+            # Insert initial data into the base table
+            # This test case tests the explicit deletion case, while `test_tombstone_gc_with_conflict_in_memtable
+            # tests the ttl expiration case
+            cql.execute(f"insert into {table} (k, v) values (1, 1) using timestamp 1 and ttl 1")
+            cql.execute(f"insert into {table} (k, v) values (1, 2) using timestamp 2")
+            cql.execute(f"insert into {table} (k, v) values (1, 3) using timestamp 3")
+            nodetool.flush(cql, table)
+            cql.execute(f"delete from {table} using timestamp 4 where k=1 and v=2")
+            # Flush all tables explicitly now, since this is skipped in the test on purpose by next major compaction.
+            nodetool.flush_all(cql)
+
+            sleep_till_whole_second()
+            # Insert backdated delete into the memtable.  It should not inhibit tombstone_gc
+            cql.execute(f"delete from {table} using timestamp 2 where k=1 and v=3")
+            # The following insert should not inhibit tombstone_gc since its timestamp is greater than the tombstones
+            cql.execute(f"insert into {table} (k, v) values (1, 4) using timestamp 5")
+            # do not flush before major compaction
+            nodetool.compact(cql, table, flush_memtables=False)
+
+            res = cql.execute(f"select * from mutation_fragments({table})")
+            sstables = set()
+            keys = set()
+            rows = set()
+            for r in res:
+                if "sstable" in r.mutation_source:
+                    print(r)
+                    if r.mutation_fragment_kind == "partition start":
+                        sstables.add(r.mutation_source)
+                        keys.add(r.k)
+                    elif r.mutation_fragment_kind == "clustering row":
+                        rows.add(r.v)
+                        assert not "tombstone" in r.metadata
+
+            assert len(sstables) == 1, f"Expected single sstable but saw {len(sstables)}: res={list(res)}"
+            assert keys == {1}, f"Expected keys=={1} but got {keys}: res={list(res)}"
+            assert rows == {3}, f"Expected rows=={3} but got {rows}: res={list(res)}"
+
+def test_tombstone_gc_with_materialized_view_update_in_memtable(scylla_only, cql, test_keyspace):
+    """
+    Reproduce https://github.com/scylladb/scylladb/issues/20424
+    """
+    schema = "k int primary key, v int, w int"
+    with new_test_table(cql, test_keyspace, schema) as table:
+        # Create a materialized view with same partition key as the base, and using a regular column in the base as a clustering key in the view
+        with new_materialized_view(cql, table, '*', 'k, v', 'k is not null and v is not null', extra="with gc_grace_seconds = 0") as mv:
+            with nodetool.no_autocompaction_context(cql, mv):
+                # Insert initial data into the base table
+                cql.execute(f"insert into {table} (k, v, w) values (1, 1, 1)")
+                # Flush the memtable so the following update won't get compacted in the memtable
+                nodetool.flush_keyspace(cql, test_keyspace)
+                # Update the regular column in the base table, causing a view update
+                # with a shadowable row tombstone for the old value and recent row_marker for the new value
+                cql.execute(f"insert into {table} (k, v) values (1, 2)")
+                # Flush all tables explicitly now, since this is skipped in the test on purpose by next major compaction.
+                nodetool.flush_all(cql)
+
+                sleep_till_whole_second()
+                # Insert new view update into the memtable by updating the regular column in the base table.
+                # It will generate a view update with a shadowable row tombstone for the previous value
+                # and the value of a new row with the old value of `w` (with timestamp 1) - that inhibits the purging
+                # of the shadowable tombstone in the sstable without the fix for #20424
+                cql.execute(f"insert into {table} (k, v) values (1, 3)")
+                # do not flush before major compaction
+                nodetool.compact(cql, mv, flush_memtables=False)
+
+                res = cql.execute(f"select * from mutation_fragments({mv})")
+                sstables = set()
+                keys = set()
+                rows = set()
+                for r in res:
+                    if "sstable" in r.mutation_source:
+                        if r.mutation_fragment_kind == "partition start":
+                            sstables.add(r.mutation_source)
+                            keys.add(r.k)
+                        elif r.mutation_fragment_kind == "clustering row":
+                            rows.add(r.v)
+                            assert "shadowable_tombstone" not in r.metadata
+
+                assert len(sstables) == 1, f"Expected single sstable but saw {len(sstables)}: res={list(res)}"
+                assert keys == {1}, f"Expected keys=={1} but got {keys}: res={list(res)}"
+                assert rows == {2}, f"Expected rows=={2} but got {keys}: res={list(res)}"

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -93,6 +93,12 @@ public:
     api::timestamp_type min_memtable_timestamp() const override {
         return table().min_memtable_timestamp();
     }
+    api::timestamp_type min_memtable_live_timestamp() const override {
+        return table().min_memtable_live_timestamp();
+    }
+    api::timestamp_type min_memtable_live_row_marker_timestamp() const override {
+        return table().min_memtable_live_row_marker_timestamp();
+    }
     bool memtable_has_key(const dht::decorated_key& key) const override { return false; }
     future<> on_compaction_completion(sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy) override {
         return table().try_get_table_state_with_static_sharding().on_compaction_completion(std::move(desc), offstrategy);

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -926,6 +926,8 @@ public:
     virtual sstables::shared_sstable make_sstable() const override { return do_make_sstable(); }
     virtual sstables::sstable_writer_config configure_writer(sstring origin) const override { return do_configure_writer(std::move(origin)); }
     virtual api::timestamp_type min_memtable_timestamp() const override { return api::min_timestamp; }
+    virtual api::timestamp_type min_memtable_live_timestamp() const override { return api::min_timestamp; }
+    virtual api::timestamp_type min_memtable_live_row_marker_timestamp() const override { return api::min_timestamp; }
     virtual bool memtable_has_key(const dht::decorated_key& key) const override { return false; }
     virtual future<> on_compaction_completion(sstables::compaction_completion_desc desc, sstables::offstrategy offstrategy) override { return make_ready_future<>(); }
     virtual bool is_auto_compaction_disabled_by_user() const noexcept override { return false; }

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1436,6 +1436,7 @@ const char* to_string(sstables::scylla_metadata_type t) {
         case sstables::scylla_metadata_type::SSTableOrigin: return "sstable_origin";
         case sstables::scylla_metadata_type::ScyllaVersion: return "scylla_version";
         case sstables::scylla_metadata_type::ScyllaBuildId: return "scylla_build_id";
+        case sstables::scylla_metadata_type::ExtTimestampStats: return "ext_timestamp_stats";
     }
     std::abort();
 }
@@ -1447,6 +1448,14 @@ const char* to_string(sstables::large_data_type t) {
         case sstables::large_data_type::cell_size: return "cell_size";
         case sstables::large_data_type::rows_in_partition: return "rows_in_partition";
         case sstables::large_data_type::elements_in_collection: return "elements_in_collection";
+    }
+    std::abort();
+}
+
+const char* to_string(sstables::ext_timestamp_stats_type t) {
+    switch (t) {
+        case sstables::ext_timestamp_stats_type::min_live_timestamp: return "min_live_timestamp";
+        case sstables::ext_timestamp_stats_type::min_live_row_marker_timestamp: return "min_live_row_marker_timestamp";
     }
     std::abort();
 }
@@ -1527,6 +1536,14 @@ public:
             _writer.Key("above_threshold");
             _writer.Uint(v.above_threshold);
             _writer.EndObject();
+        }
+        _writer.EndObject();
+    }
+    void operator()(const sstables::scylla_metadata::ext_timestamp_stats& val) const {
+        _writer.StartObject();
+        for (const auto& [k, v] : val.map) {
+            _writer.Key(to_string(k));
+            _writer.Int64(v);
         }
         _writer.EndObject();
     }


### PR DESCRIPTION
When purging regular tombstone consult the min_live_timestamp, if available.
This is safe since we don't need to protect dead data from resurrection, as it is already dead.

For shadowable_tombstones, consult the min_memtable_live_row_marker_timestamp,
if available, otherwise fallback to the min_live_timestamp.

If we see in a view table a shadowable tombstone with time T, then in any row where the row marker's timestamp is higher than T the shadowable tombstone is completely ignored and it doesn't hide any data in any column, so the shadowable tombstone can be safely purged without any effect or risk resurrecting any deleted data.

In other words, rows which might cause problems for purging a shadowable tombstone with time T are rows with row markers older or equal T. So to know if a whole sstable can cause problems for shadowable tombstone of time T, we need to check if the sstable's oldest row marker (and not oldest column) is older or equal T. And the same check applies similarly to the memtable.

If both extended timestamp statistics are missing, fallback to the legacy (and inaccurate) min_timestamp.

Fixes scylladb/scylladb#20423
Fixes scylladb/scylladb#20424

> [!NOTE]
> no backport needed at this time
> We may consider backport later on after given some soak time in master/enterprise
> since we do see tombstone accumulation in the field under some materialized views workloads
