### PR TITLE
auth/authentication_options: move fmt::formatter up

### DIFF
--- a/auth/authentication_options.hh
+++ b/auth/authentication_options.hh
@@ -25,6 +25,25 @@ enum class authentication_option {
     options
 };
 
+}
+
+template <>
+struct fmt::formatter<auth::authentication_option> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const auth::authentication_option a, FormatContext& ctx) const {
+        using enum auth::authentication_option;
+        switch (a) {
+        case password:
+            return formatter<string_view>::format("PASSWORD", ctx);
+        case options:
+            return formatter<string_view>::format("OPTIONS", ctx);
+        }
+        std::abort();
+    }
+};
+
+namespace auth {
+
 using authentication_option_set = std::unordered_set<authentication_option>;
 
 using custom_options = std::unordered_map<sstring, sstring>;
@@ -46,18 +65,3 @@ public:
 };
 
 }
-
-template <>
-struct fmt::formatter<auth::authentication_option> : fmt::formatter<string_view> {
-    template <typename FormatContext>
-    auto format(const auth::authentication_option a, FormatContext& ctx) const {
-        using enum auth::authentication_option;
-        switch (a) {
-        case password:
-            return formatter<string_view>::format("PASSWORD", ctx);
-        case options:
-            return formatter<string_view>::format("OPTIONS", ctx);
-        }
-        std::abort();
-    }
-};


### PR DESCRIPTION
so that it is accessible from its caller. if we enforce the compile-time format string check, the formatter would need the access to the specialization of `fmt::formatter` of the arguments being foramtted. to be prepared for this change, let's move the `fmt::formatter` specialization up, otherwise we'd have following error after switching to the compile-time format string check introduced by a recent seastar change:

```
In file included from ./auth/authenticator.hh:22:                                                                                                             ./auth/authentication_options.hh:50:49: error: call to consteval function 'fmt::basic_format_string<char, auth::authentication_option &>::basic_format_string<
char[32], 0>' is not a constant expression
   50 |             : std::invalid_argument(fmt::format("The {} option is not supported.", k)) {
      |                                                 ^                                                                                                     ./auth/authentication_options.hh:57:13: error: explicit specialization of 'fmt::formatter<auth::authentication_option>' after instantiation
   57 | struct fmt::formatter<auth::authentication_option> : fmt::formatter<string_view> {
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1228:17: note: implicit instantiation first required here
 1228 |     -> decltype(typename Context::template formatter_type<T>().format(
      |                 ^
In file included from replica/distributed_loader.cc:30:
```

---

this change addresses a build failure due a new change in seastar, hence no impacts on the production. so no need to backport.