### PR TITLE
docs: do not install scylla/ppa repo when perform upgrade

### DIFF
--- a/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.2-to-2023.1/upgrade-guide-from-5.2-to-2023.1-generic.rst
+++ b/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.2-to-2023.1/upgrade-guide-from-5.2-to-2023.1-generic.rst
@@ -123,12 +123,7 @@ Download and install the new release
 
         **To upgrade ScyllaDB:**
 
-        #. Update the |SCYLLA_DEB_NEW_REPO| to |NEW_VERSION| and and enable scylla/ppa repo:
-
-            .. code-block:: console
-
-               sudo add-apt-repository -y ppa:scylladb/ppa
-
+        #. Update the |SCYLLA_DEB_NEW_REPO| to |NEW_VERSION|
         #. Configure Java 1.8:
 
             .. code-block:: console

--- a/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.4-to-2024.1/upgrade-guide-from-5.4-to-2024.1-generic.rst
+++ b/docs/upgrade/upgrade-to-enterprise/upgrade-guide-from-5.4-to-2024.1/upgrade-guide-from-5.4-to-2024.1-generic.rst
@@ -137,12 +137,7 @@ This guide only covers |SRC_VERSION|.x to |NEW_VERSION|.y upgrades.
 
         **To upgrade ScyllaDB:**
 
-        #. Update the |SCYLLA_DEB_NEW_REPO| to |NEW_VERSION| and enable scylla/ppa repo:
-
-            .. code-block:: console
-
-               sudo add-apt-repository -y ppa:scylladb/ppa
-
+        #. Update the |SCYLLA_DEB_NEW_REPO| to |NEW_VERSION|
         #. Configure Java 1.8:
 
             .. code-block:: console


### PR DESCRIPTION
for following reasons:

1. the ppa in question does not provide the build for the latest ubuntu's LTS release. it only builds for trusty, xenial, bionic and jammy. according to https://wiki.ubuntu.com/Releases, the latest LTS release is ubuntu noble at the time of writing.
2. the ppa in question does not provide the packages used in production. it does provides the package for *building* scylla
3. after we introduced the relocatable package, there is no need to provide extra user space dependencies apart from scylla packages.

so, in this change, we remove all references to enabling the Scylla/PPA repository.

Fixes scylladb/scylladb#20449

---

this change corrects the outdated documents, so all impacted LTS branches should have its backport.