### PR TITLE
test: Call table::make_sstable() directly in compaction test

### DIFF
--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4131,9 +4131,8 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
         }
 
         auto sst_gen = [&] (size_t idx) mutable {
-            auto s = schemas[idx];
             auto t = tables[idx];
-            return env.make_sstable(s, t->dir());
+            return t->make_sstable();
         };
 
         auto add_single_fully_expired_sstable_to_table = [&] (auto idx) {


### PR DESCRIPTION
The test in question generates a bunch of table_for_tests objects and creates sstables for each. For that it calls test_env::make_sstable(), but it can be made shorter, by calling table method directly.

The hidden goal of this change is to remove the explicit caller of table::dir() method. The latter is going away.
