### PR TITLE
service/qos: remove unused marked_for_deletion field from service_level struct

### DIFF
--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -541,7 +541,7 @@ future<> service_level_controller::do_add_service_level(sstring name, service_le
             return make_ready_future();
         }
     } else {
-        return do_with(service_level{.slo = slo, .is_static = is_static}, std::move(name), [this] (service_level& sl, sstring& name) {
+        return do_with(service_level(slo, false, is_static), std::move(name), [this] (service_level& sl, sstring& name) {
             return container().invoke_on_all(&service_level_controller::notify_service_level_added, name, sl);
         });
     }

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -541,7 +541,7 @@ future<> service_level_controller::do_add_service_level(sstring name, service_le
             return make_ready_future();
         }
     } else {
-        return do_with(service_level(slo, false, is_static), std::move(name), [this] (service_level& sl, sstring& name) {
+        return do_with(service_level(slo, is_static), std::move(name), [this] (service_level& sl, sstring& name) {
             return container().invoke_on_all(&service_level_controller::notify_service_level_added, name, sl);
         });
     }

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -42,14 +42,12 @@ namespace qos {
  */
 struct service_level {
      service_level_options slo;
-     bool marked_for_deletion = false;
      bool is_static = false;
 
      service_level() = default;
 
-     service_level(service_level_options slo, bool marked_for_deletion, bool is_static)
+     service_level(service_level_options slo, bool is_static)
             : slo(std::move(slo))
-            , marked_for_deletion(marked_for_deletion)
             , is_static(is_static)
      {}
 };
@@ -255,7 +253,7 @@ public:
      */
     service_level& get_service_level(sstring service_level_name) {
         auto sl_it = _service_levels_db.find(service_level_name);
-        if (sl_it == _service_levels_db.end() || sl_it->second.marked_for_deletion) {
+        if (sl_it == _service_levels_db.end()) {
             sl_it = _service_levels_db.find(default_service_level_name);
         }
         return sl_it->second;

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -42,8 +42,16 @@ namespace qos {
  */
 struct service_level {
      service_level_options slo;
-     bool marked_for_deletion;
-     bool is_static;
+     bool marked_for_deletion = false;
+     bool is_static = false;
+
+     service_level() = default;
+
+     service_level(service_level_options slo, bool marked_for_deletion, bool is_static)
+            : slo(std::move(slo))
+            , marked_for_deletion(marked_for_deletion)
+            , is_static(is_static)
+     {}
 };
 
 using update_both_cache_levels = bool_class<class update_both_cache_levels_tag>;


### PR DESCRIPTION
The `service_level::marked_for_deletion` field is always set to `false`. It might have served some purpose in the past, but now it can be just removed, simplifying the code and eliminating confusion about the field.

This is just code cleanup, no backport is needed.