### PR TITLE
scylla-gdb.py: use functools.cached_property when appropriate

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -120,8 +120,7 @@ def downcast_vptr(ptr):
 
 class intrusive_list:
     @classmethod
-    @property
-    @functools.cache
+    @functools.cached_property
     def size_t(cls):
         return gdb.lookup_type('size_t')
 
@@ -166,8 +165,7 @@ class intrusive_list:
 
 class intrusive_slist:
     @classmethod
-    @property
-    @functools.cache
+    @functools.cached_property
     def size_t(cls):
         return gdb.lookup_type('size_t')
 
@@ -250,8 +248,7 @@ class std_tuple:
 
 class intrusive_set:
     @classmethod
-    @property
-    @functools.cache
+    @functools.cached_property
     def size_t(cls):
         return gdb.lookup_type('size_t')
 
@@ -442,8 +439,7 @@ class std_variant:
 
 class std_map:
     @classmethod
-    @property
-    @functools.cache
+    @functools.cached_property
     def size_t(cls):
         return gdb.lookup_type('size_t')
 
@@ -3908,8 +3904,7 @@ class scylla_fiber(gdb.Command):
     """
 
     @classmethod
-    @property
-    @functools.cache
+    @functools.cached_property
     def _vptr_type(cls):
         return gdb.lookup_type('uintptr_t').pointer()
 
@@ -4197,8 +4192,7 @@ class scylla_find(gdb.Command):
       thread 1, small (size <= 56), live (0x6000008a1230 +32)
     """
     @classmethod
-    @property
-    @functools.cache
+    @functools.cached_property
     def _vptr_type(cls):
         return gdb.lookup_type('uintptr_t').pointer()
 

--- a/test/scylla_gdb/test_misc.py
+++ b/test/scylla_gdb/test_misc.py
@@ -200,7 +200,7 @@ def test_run_without_scylla(scylla_gdb):
     # commands themselves when they get exuecuted. To address potential
     # failures, consider moving code that references debug symbols into a code
     # path executed only when debug symbols is loaded. If the value of the
-    # symbol is a constant, consider caching it. using functools.cache
+    # symbol is a constant, consider caching it using functools.cached_property
     # decorator.
     _ = scylla_gdb
 


### PR DESCRIPTION
for better readability. and shorter this way.

Refs 7dd63c891f648f2e42a48607d25f861f5c084fa5
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

it's a cleanup, hence no need to backport.