### PR TITLE
Sanitize open_sstables() helper in compaction test

### DIFF
--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -92,18 +92,14 @@ atomic_cell make_atomic_cell(data_type dt, bytes_view value, uint32_t ttl = 0, u
 
 // open_sstables() opens several generations of the same sstable, returning,
 // after all the tables have been open, their vector.
-static future<std::vector<sstables::shared_sstable>> open_sstables(test_env& env, schema_ptr s, sstring dir, std::vector<sstables::generation_type> generations) {
+static future<std::vector<sstables::shared_sstable>> open_sstables(test_env& env, schema_ptr s, sstring dir, std::vector<sstables::generation_type::int_t> gen_values) {
+    auto generations = generations_from_values(gen_values);
     std::vector<sstables::shared_sstable> ret;
     co_await coroutine::parallel_for_each(generations, [&env, &ret, &dir, s] (auto generation) -> future<> {
         auto sst = co_await env.reusable_sst(s, dir, generation);
         ret.push_back(std::move(sst));
     });
     co_return ret;
-}
-
-static future<std::vector<sstables::shared_sstable>> open_sstables(test_env& env, schema_ptr s, sstring dir, std::vector<sstables::generation_type::int_t> gen_values) {
-    auto generations = generations_from_values(gen_values);
-    return open_sstables(env, std::move(s), std::move(dir), std::move(generations));
 }
 
 // mutation_reader for sstable keeping all the required objects alive.

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -93,16 +93,12 @@ atomic_cell make_atomic_cell(data_type dt, bytes_view value, uint32_t ttl = 0, u
 // open_sstables() opens several generations of the same sstable, returning,
 // after all the tables have been open, their vector.
 static future<std::vector<sstables::shared_sstable>> open_sstables(test_env& env, schema_ptr s, sstring dir, std::vector<sstables::generation_type> generations) {
-    return do_with(std::vector<sstables::shared_sstable>(),
-            [&env, dir = std::move(dir), generations = std::move(generations), s] (auto& ret) mutable {
-        return parallel_for_each(generations, [&env, &ret, &dir, s] (auto generation) {
-            return env.reusable_sst(s, dir, generation).then([&ret] (sstables::shared_sstable sst) {
-                ret.push_back(std::move(sst));
-            });
-        }).then([&ret] {
-            return std::move(ret);
-        });
+    std::vector<sstables::shared_sstable> ret;
+    co_await coroutine::parallel_for_each(generations, [&env, &ret, &dir, s] (auto generation) -> future<> {
+        auto sst = co_await env.reusable_sst(s, dir, generation);
+        ret.push_back(std::move(sst));
     });
+    co_return ret;
 }
 
 static future<std::vector<sstables::shared_sstable>> open_sstables(test_env& env, schema_ptr s, sstring dir, std::vector<sstables::generation_type::int_t> gen_values) {


### PR DESCRIPTION
This includes
- coroutinization
- elimination of unused overload