### PR TITLE
Coroutinize sstable::read_summary() method

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1307,21 +1307,23 @@ void sstable::rewrite_statistics() {
 
 future<> sstable::read_summary() noexcept {
     if (_components->summary) {
-        return make_ready_future<>();
+        co_return;
     }
 
-    return read_toc().then([this] {
+    co_await read_toc();
+
         // We'll try to keep the main code path exception free, but if an exception does happen
         // we can try to regenerate the Summary.
         if (has_component(component_type::Summary)) {
-            return read_simple<component_type::Summary>(_components->summary).handle_exception([this] (auto ep) {
+          try {
+            co_return co_await read_simple<component_type::Summary>(_components->summary);
+          } catch (...) {
+            auto ep = std::current_exception();
                 sstlog.warn("Couldn't read summary file {}: {}. Recreating it.", this->filename(component_type::Summary), ep);
-                return this->generate_summary();
-            });
-        } else {
-            return generate_summary();
+          }
         }
-    });
+
+    co_await generate_summary();
 }
 
 future<file> sstable::open_file(component_type type, open_flags flags, file_open_options opts) const noexcept {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1312,16 +1312,16 @@ future<> sstable::read_summary() noexcept {
 
     co_await read_toc();
 
+    if (has_component(component_type::Summary)) {
         // We'll try to keep the main code path exception free, but if an exception does happen
         // we can try to regenerate the Summary.
-        if (has_component(component_type::Summary)) {
-          try {
+        try {
             co_return co_await read_simple<component_type::Summary>(_components->summary);
-          } catch (...) {
+        } catch (...) {
             auto ep = std::current_exception();
-                sstlog.warn("Couldn't read summary file {}: {}. Recreating it.", this->filename(component_type::Summary), ep);
-          }
+            sstlog.warn("Couldn't read summary file {}: {}. Recreating it.", this->filename(component_type::Summary), ep);
         }
+    }
 
     co_await generate_summary();
 }


### PR DESCRIPTION
Shorter and simpler this way. Hopefully it doesn't sit on critical paths