### PR TITLE
test/*/run: restore --vnodes into working order

### DIFF
--- a/test/alternator/run
+++ b/test/alternator/run
@@ -33,6 +33,8 @@ remove_scylla_options = []
 if '--vnodes' in sys.argv:
     sys.argv.remove('--vnodes')
     remove_scylla_options.append('--enable-tablets=true')
+    # Tablets are now enabled by default on some releases, it is not enough to remove the enable above.
+    extra_scylla_options.append('--enable-tablets=false')
 
 if "-h" in sys.argv or "--help" in sys.argv:
     run.run_pytest(sys.path[0], sys.argv)

--- a/test/cql-pytest/run
+++ b/test/cql-pytest/run
@@ -23,6 +23,8 @@ if '--vnodes' in sys.argv:
     def run_without_tablets(pid, dir):
         (c, e) = run_without_tablets.orig_cmd(pid, dir)
         c.remove('--enable-tablets=true')
+        # Tablets are now enabled by default on some releases, it is not enough to remove the enable above.
+        c.append('--enable-tablets=false')
         return (c, e)
     run_without_tablets.orig_cmd = cmd
     cmd = run_without_tablets

--- a/test/rest_api/run
+++ b/test/rest_api/run
@@ -25,6 +25,8 @@ if '--vnodes' in sys.argv:
     def run_without_tablets(pid, dir):
         (c, e) = run_without_tablets.orig_cmd(pid, dir)
         c.remove('--enable-tablets=true')
+        # Tablets are now enabled by default on some releases, it is not enough to remove the enable above.
+        c.append('--enable-tablets=false')
         return (c, e)
     run_without_tablets.orig_cmd = cmd
     cmd = run_without_tablets


### PR DESCRIPTION
This option was silently broken when --enable-tablet's default changed from false to true. The reason is that when --vnodes is passed, run only removes --enable-tablets=true from scylla's command line. With the new default this is not enough, we need to explicitely disable tablets to override the default.

Fixes a developer-only option in test, no backport needed.