### PR TITLE
repair: row_level: coroutinize more functions

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1598,10 +1598,10 @@ public:
     // RPC API
     future<> repair_row_level_stop(gms::inet_address remote_node, sstring ks_name, sstring cf_name, dht::token_range range, shard_id dst_cpu_id) {
         if (remote_node == myip()) {
-            return stop();
+            co_return co_await stop();
         }
         stats().rpc_call_nr++;
-        return _messaging.send_repair_row_level_stop(msg_addr(remote_node),
+        co_return co_await _messaging.send_repair_row_level_stop(msg_addr(remote_node),
                 _repair_meta_id, std::move(ks_name), std::move(cf_name), std::move(range), dst_cpu_id);
     }
 

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1673,11 +1673,12 @@ public:
     // RPC handler
     future<get_sync_boundary_response>
     get_sync_boundary_handler(std::optional<repair_sync_boundary> skipped_sync_boundary) {
-        return with_gate(_gate, [this, skipped_sync_boundary = std::move(skipped_sync_boundary)] () mutable {
+        auto gate_held = _gate.hold();
+        {
             auto& cf = _db.local().find_column_family(_schema->id());
             cf.update_off_strategy_trigger();
-            return get_sync_boundary(std::move(skipped_sync_boundary));
-        });
+            co_return co_await get_sync_boundary(std::move(skipped_sync_boundary));
+        }
     }
 
     // RPC API

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1642,10 +1642,10 @@ public:
     // RPC API
     future<> repair_set_estimated_partitions(gms::inet_address remote_node, uint64_t estimated_partitions, shard_id dst_cpu_id) {
         if (remote_node == myip()) {
-            return set_estimated_partitions(estimated_partitions);
+            co_return co_await set_estimated_partitions(estimated_partitions);
         }
         stats().rpc_call_nr++;
-        return _messaging.send_repair_set_estimated_partitions(msg_addr(remote_node), _repair_meta_id, estimated_partitions, dst_cpu_id);
+        co_return co_await _messaging.send_repair_set_estimated_partitions(msg_addr(remote_node), _repair_meta_id, estimated_partitions, dst_cpu_id);
     }
 
 

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1664,10 +1664,10 @@ public:
     future<get_sync_boundary_response>
     get_sync_boundary(gms::inet_address remote_node, std::optional<repair_sync_boundary> skipped_sync_boundary, shard_id dst_cpu_id) {
         if (remote_node == myip()) {
-            return get_sync_boundary_handler(skipped_sync_boundary);
+            co_return co_await get_sync_boundary_handler(skipped_sync_boundary);
         }
         stats().rpc_call_nr++;
-        return _messaging.send_repair_get_sync_boundary(msg_addr(remote_node), _repair_meta_id, skipped_sync_boundary, dst_cpu_id);
+        co_return co_await _messaging.send_repair_get_sync_boundary(msg_addr(remote_node), _repair_meta_id, skipped_sync_boundary, dst_cpu_id);
     }
 
     // RPC handler

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1208,9 +1208,10 @@ private:
     }
 
     future<> clear_working_row_buf() {
-        return utils::clear_gently(_working_row_buf).then([this] {
+        co_await utils::clear_gently(_working_row_buf);
+        {
             _working_row_buf_combined_hash.clear();
-        });
+        }
     }
 
     // Read rows from disk until _max_row_buf_size of rows are filled into _row_buf.

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3404,14 +3404,15 @@ repair_service::remove_repair_meta(const gms::inet_address& from,
     auto it = repair_meta_map().find(id);
     if (it == repair_meta_map().end()) {
         rlogger.warn("remove_repair_meta: repair_meta_id {} for node {} does not exist", id.repair_meta_id, id.ip);
-        return make_ready_future<>();
+        co_return;
     } else {
         auto rm = it->second;
         repair_meta_map().erase(it);
         rlogger.debug("remove_repair_meta: Stop repair_meta_id {} for node {} started", id.repair_meta_id, id.ip);
-        return rm->stop().then([rm, id] {
+        co_await rm->stop();
+        {
             rlogger.debug("remove_repair_meta: Stop repair_meta_id {} for node {} finished", id.repair_meta_id, id.ip);
-        });
+        }
     }
 }
 

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1406,11 +1406,12 @@ private:
     future<>
     apply_rows_on_follower(repair_rows_on_wire rows) {
         if (rows.empty()) {
-            return make_ready_future<>();
+            co_return;
         }
-        return to_repair_rows_list(std::move(rows), _schema, _seed, _repair_master, _permit, _repair_hasher).then([this] (std::list<repair_row> row_diff) {
-            return do_apply_rows(std::move(row_diff), update_working_row_buf::no);
-        });
+        std::list<repair_row> row_diff = co_await to_repair_rows_list(std::move(rows), _schema, _seed, _repair_master, _permit, _repair_hasher);
+        {
+            co_await do_apply_rows(std::move(row_diff), update_working_row_buf::no);
+        }
     }
 
     future<repair_rows_on_wire> to_repair_rows_on_wire(std::list<repair_row> row_list) {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1632,10 +1632,11 @@ public:
     static future<uint64_t> repair_get_estimated_partitions_handler(repair_service& rs, gms::inet_address from, uint32_t repair_meta_id) {
         auto rm = rs.get_repair_meta(from, repair_meta_id);
         rm->set_repair_state_for_local_node(repair_state::get_estimated_partitions_started);
-        return rm->get_estimated_partitions().then([rm] (uint64_t partitions) {
+        uint64_t partitions = co_await rm->get_estimated_partitions();
+        {
             rm->set_repair_state_for_local_node(repair_state::get_estimated_partitions_finished);
-            return partitions;
-        });
+            co_return partitions;
+        }
     }
 
     // RPC API

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1612,9 +1612,10 @@ public:
                 rs.my_address(), from, repair_meta_id, ks_name, cf_name, range);
         auto rm = rs.get_repair_meta(from, repair_meta_id);
         rm->set_repair_state_for_local_node(repair_state::row_level_stop_started);
-        return rs.remove_repair_meta(from, repair_meta_id, std::move(ks_name), std::move(cf_name), std::move(range)).then([rm] {
+        co_await rs.remove_repair_meta(from, repair_meta_id, std::move(ks_name), std::move(cf_name), std::move(range));
+        {
             rm->set_repair_state_for_local_node(repair_state::row_level_stop_finished);
-        });
+        }
     }
 
     // RPC API

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1526,15 +1526,16 @@ public:
     future<get_combined_row_hash_response>
     get_combined_row_hash(std::optional<repair_sync_boundary> common_sync_boundary, gms::inet_address remote_node, shard_id dst_cpu_id) {
         if (remote_node == myip()) {
-            return get_combined_row_hash_handler(common_sync_boundary);
+            co_return co_await get_combined_row_hash_handler(common_sync_boundary);
         }
-        return _messaging.send_repair_get_combined_row_hash(msg_addr(remote_node),
-                _repair_meta_id, common_sync_boundary, dst_cpu_id).then([this] (get_combined_row_hash_response resp) {
+        get_combined_row_hash_response resp = co_await _messaging.send_repair_get_combined_row_hash(msg_addr(remote_node),
+                _repair_meta_id, common_sync_boundary, dst_cpu_id);
+        {
             stats().rpc_call_nr++;
             stats().rx_hashes_nr++;
             _metrics.rx_hashes_nr++;
-            return resp;
-        });
+            co_return resp;
+        }
     }
 
     // RPC handler

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1653,9 +1653,10 @@ public:
     static future<> repair_set_estimated_partitions_handler(repair_service& rs, gms::inet_address from, uint32_t repair_meta_id, uint64_t estimated_partitions) {
         auto rm = rs.get_repair_meta(from, repair_meta_id);
         rm->set_repair_state_for_local_node(repair_state::set_estimated_partitions_started);
-        return rm->set_estimated_partitions(estimated_partitions).then([rm] {
+        co_await rm->set_estimated_partitions(estimated_partitions);
+        {
             rm->set_repair_state_for_local_node(repair_state::set_estimated_partitions_finished);
-        });
+        }
     }
 
     // RPC API

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1544,11 +1544,12 @@ public:
         // We can not call this function twice. The good thing is we do not use
         // retransmission at messaging_service level, so no message will be retransmitted.
         rlogger.trace("Calling get_combined_row_hash_handler");
-        return with_gate(_gate, [this, common_sync_boundary = std::move(common_sync_boundary)] () mutable {
+        auto gate_held = _gate.hold();
+        {
             auto& cf = _db.local().find_column_family(_schema->id());
             cf.update_off_strategy_trigger();
-            return request_row_hashes(common_sync_boundary);
-        });
+            co_return co_await request_row_hashes(common_sync_boundary);
+        }
     }
 
     // RPC API

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3428,13 +3428,15 @@ repair_service::remove_repair_meta(gms::inet_address from) {
             it++;
         }
     }
-    return parallel_for_each(*repair_metas, [repair_metas] (auto& rm) {
-        return rm->stop().then([&rm] {
+    co_await coroutine::parallel_for_each(*repair_metas, [&] (auto& rm) -> future<> {
+        co_await rm->stop();
+        {
             rm = {};
-        });
-    }).then([repair_metas, from] {
-        rlogger.debug("Removed all repair_meta for single node {}", from);
+        }
     });
+    {
+        rlogger.debug("Removed all repair_meta for single node {}", from);
+    }
 }
 
 future<>

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1621,10 +1621,10 @@ public:
     // RPC API
     future<uint64_t> repair_get_estimated_partitions(gms::inet_address remote_node, shard_id dst_cpu_id) {
         if (remote_node == myip()) {
-            return get_estimated_partitions();
+            co_return co_await get_estimated_partitions();
         }
         stats().rpc_call_nr++;
-        return _messaging.send_repair_get_estimated_partitions(msg_addr(remote_node), _repair_meta_id, dst_cpu_id);
+        co_return co_await _messaging.send_repair_get_estimated_partitions(msg_addr(remote_node), _repair_meta_id, dst_cpu_id);
     }
 
 

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1517,9 +1517,8 @@ public:
     // RPC handler
     future<repair_hash_set>
     get_full_row_hashes_handler() {
-        return with_gate(_gate, [this] {
-            return working_row_hashes();
-        });
+        auto gate_held = _gate.hold();
+        co_return co_await working_row_hashes();
     }
 
     // RPC API


### PR DESCRIPTION
Coroutinize more functions in row-level repair to improve maintainability.

The functions all deal with repair buffers, so coroutinization does not affect performance.

Cleanup, no reason to backport