### PR TITLE
Remove make_shared_schema() helper

### DIFF
--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -483,27 +483,6 @@ schema::schema(reversed_tag, const schema& o)
 {
 }
 
-lw_shared_ptr<const schema> make_shared_schema(std::optional<table_id> id, std::string_view ks_name,
-    std::string_view cf_name, std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key,
-    std::vector<schema::column> regular_columns, std::vector<schema::column> static_columns,
-    data_type regular_column_name_type, sstring comment) {
-    schema_builder builder(std::move(ks_name), std::move(cf_name), std::move(id), std::move(regular_column_name_type));
-    for (auto&& column : partition_key) {
-        builder.with_column(std::move(column.name), std::move(column.type), column_kind::partition_key);
-    }
-    for (auto&& column : clustering_key) {
-        builder.with_column(std::move(column.name), std::move(column.type), column_kind::clustering_key);
-    }
-    for (auto&& column : regular_columns) {
-        builder.with_column(std::move(column.name), std::move(column.type));
-    }
-    for (auto&& column : static_columns) {
-        builder.with_column(std::move(column.name), std::move(column.type), column_kind::static_column);
-    }
-    builder.set_comment(comment);
-    return builder.build();
-}
-
 schema::~schema() {
     if (_registry_entry) {
         _registry_entry->detach_schema();

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -969,10 +969,6 @@ public:
     schema_ptr get_reversed() const;
 };
 
-lw_shared_ptr<const schema> make_shared_schema(std::optional<table_id> id, std::string_view ks_name, std::string_view cf_name,
-    std::vector<schema::column> partition_key, std::vector<schema::column> clustering_key, std::vector<schema::column> regular_columns,
-    std::vector<schema::column> static_columns, data_type regular_column_name_type, sstring comment = "");
-
 bool operator==(const schema&, const schema&);
 
 /**

--- a/test/boost/broken_sstable_test.cc
+++ b/test/boost/broken_sstable_test.cc
@@ -49,7 +49,7 @@ static future<> broken_sst(sstring dir, sstables::generation_type::int_t generat
 static future<> broken_sst(sstring dir, sstables::generation_type::int_t generation, sstring msg, std::optional<sstring> sst_name = std::nullopt) {
     // Using an empty schema for this function, which is only about loading
     // a malformed component and checking that it fails.
-    auto s = make_shared_schema({}, "ks", "cf", {}, {}, {}, {}, utf8_type);
+    auto s = schema_builder("ks", "cf", {}, utf8_type).build();
     return broken_sst(dir, generation, s, msg, sst_name);
 }
 

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -119,8 +119,11 @@ SEASTAR_TEST_CASE(test_mutation_is_applied) {
     return seastar::async([] {
         tests::reader_concurrency_semaphore_wrapper semaphore;
 
-        auto s = make_shared_schema({}, some_keyspace, some_column_family,
-            {{"p1", utf8_type}}, {{"c1", int32_type}}, {{"r1", int32_type}}, {}, utf8_type);
+        auto s = schema_builder(some_keyspace, some_column_family)
+                    .with_column("p1", utf8_type, column_kind::partition_key)
+                    .with_column("c1", int32_type, column_kind::clustering_key)
+                    .with_column("r1", int32_type)
+                    .build();
 
         auto mt = make_lw_shared<replica::memtable>(s);
 
@@ -144,10 +147,13 @@ SEASTAR_TEST_CASE(test_mutation_is_applied) {
 }
 
 SEASTAR_TEST_CASE(test_multi_level_row_tombstones) {
-    auto s = make_shared_schema({}, some_keyspace, some_column_family,
-        {{"p1", utf8_type}},
-        {{"c1", int32_type}, {"c2", int32_type}, {"c3", int32_type}},
-        {{"r1", int32_type}}, {}, utf8_type);
+    auto s = schema_builder(some_keyspace, some_column_family)
+                .with_column("p1", utf8_type, column_kind::partition_key)
+                .with_column("c1", int32_type, column_kind::clustering_key)
+                .with_column("c2", int32_type, column_kind::clustering_key)
+                .with_column("c3", int32_type, column_kind::clustering_key)
+                .with_column("r1", int32_type)
+                .build();
 
     auto ttl = gc_clock::now() + std::chrono::seconds(1);
 
@@ -179,8 +185,12 @@ SEASTAR_TEST_CASE(test_multi_level_row_tombstones) {
 }
 
 SEASTAR_TEST_CASE(test_row_tombstone_updates) {
-    auto s = make_shared_schema({}, some_keyspace, some_column_family,
-        {{"p1", utf8_type}}, {{"c1", int32_type}, {"c2", int32_type}}, {{"r1", int32_type}}, {}, utf8_type);
+    auto s = schema_builder(some_keyspace, some_column_family)
+                .with_column("p1", utf8_type, column_kind::partition_key)
+                .with_column("c1", int32_type, column_kind::clustering_key)
+                .with_column("c2", int32_type, column_kind::clustering_key)
+                .with_column("r1", int32_type)
+                .build();
 
     auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
     auto c_key1 = clustering_key::from_deeply_exploded(*s, {1, 0});
@@ -224,8 +234,11 @@ SEASTAR_TEST_CASE(test_map_mutations) {
         tests::reader_concurrency_semaphore_wrapper semaphore;
 
         auto my_map_type = map_type_impl::get_instance(int32_type, utf8_type, true);
-        auto s = make_shared_schema({}, some_keyspace, some_column_family,
-            {{"p1", utf8_type}}, {{"c1", int32_type}}, {}, {{"s1", my_map_type}}, utf8_type);
+        auto s = schema_builder(some_keyspace, some_column_family)
+                    .with_column("p1", utf8_type, column_kind::partition_key)
+                    .with_column("c1", int32_type, column_kind::clustering_key)
+                    .with_column("s1", my_map_type, column_kind::static_column)
+                    .build();
         auto mt = make_lw_shared<replica::memtable>(s);
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         auto& column = *s->get_column_definition("s1");
@@ -262,8 +275,11 @@ SEASTAR_TEST_CASE(test_set_mutations) {
         tests::reader_concurrency_semaphore_wrapper semaphore;
 
         auto my_set_type = set_type_impl::get_instance(int32_type, true);
-        auto s = make_shared_schema({}, some_keyspace, some_column_family,
-            {{"p1", utf8_type}}, {{"c1", int32_type}}, {}, {{"s1", my_set_type}}, utf8_type);
+        auto s = schema_builder(some_keyspace, some_column_family)
+                    .with_column("p1", utf8_type, column_kind::partition_key)
+                    .with_column("c1", int32_type, column_kind::clustering_key)
+                    .with_column("s1", my_set_type, column_kind::static_column)
+                    .build();
         auto mt = make_lw_shared<replica::memtable>(s);
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         auto& column = *s->get_column_definition("s1");
@@ -300,8 +316,11 @@ SEASTAR_TEST_CASE(test_list_mutations) {
         tests::reader_concurrency_semaphore_wrapper semaphore;
 
         auto my_list_type = list_type_impl::get_instance(int32_type, true);
-        auto s = make_shared_schema({}, some_keyspace, some_column_family,
-            {{"p1", utf8_type}}, {{"c1", int32_type}}, {}, {{"s1", my_list_type}}, utf8_type);
+        auto s = schema_builder(some_keyspace, some_column_family)
+                    .with_column("p1", utf8_type, column_kind::partition_key)
+                    .with_column("c1", int32_type, column_kind::clustering_key)
+                    .with_column("s1", my_list_type, column_kind::static_column)
+                    .build();
         auto mt = make_lw_shared<replica::memtable>(s);
         auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
         auto& column = *s->get_column_definition("s1");
@@ -343,8 +362,11 @@ SEASTAR_THREAD_TEST_CASE(test_udt_mutations) {
             {int32_type, utf8_type, long_type, utf8_type},
             true);
 
-    auto s = make_shared_schema({}, some_keyspace, some_column_family,
-        {{"p1", utf8_type}}, {{"c1", int32_type}}, {}, {{"s1", ut}}, utf8_type);
+    auto s = schema_builder(some_keyspace, some_column_family)
+                .with_column("p1", utf8_type, column_kind::partition_key)
+                .with_column("c1", int32_type, column_kind::clustering_key)
+                .with_column("s1", ut, column_kind::static_column)
+                .build();
     auto mt = make_lw_shared<replica::memtable>(s);
     auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
     auto& column = *s->get_column_definition("s1");
@@ -496,8 +518,11 @@ SEASTAR_THREAD_TEST_CASE(test_large_collection_serialization_exception_safety) {
 
 SEASTAR_TEST_CASE(test_multiple_memtables_one_partition) {
     return sstables::test_env::do_with_async([] (sstables::test_env& env) {
-    auto s = make_shared_schema({}, some_keyspace, some_column_family,
-        {{"p1", utf8_type}}, {{"c1", int32_type}}, {{"r1", int32_type}}, {}, utf8_type);
+    auto s = schema_builder(some_keyspace, some_column_family)
+                .with_column("p1", utf8_type, column_kind::partition_key)
+                .with_column("c1", int32_type, column_kind::clustering_key)
+                .with_column("r1", int32_type)
+                .build();
 
     auto cf_stats = make_lw_shared<replica::cf_stats>();
     replica::column_family::config cfg = env.make_table_config();
@@ -628,8 +653,11 @@ SEASTAR_TEST_CASE(test_flush_in_the_middle_of_a_scan) {
 
 SEASTAR_TEST_CASE(test_multiple_memtables_multiple_partitions) {
     return sstables::test_env::do_with_async([] (sstables::test_env& env) {
-    auto s = make_shared_schema({}, some_keyspace, some_column_family,
-            {{"p1", int32_type}}, {{"c1", int32_type}}, {{"r1", int32_type}}, {}, utf8_type);
+    auto s = schema_builder(some_keyspace, some_column_family)
+                .with_column("p1", int32_type, column_kind::partition_key)
+                .with_column("c1", int32_type, column_kind::clustering_key)
+                .with_column("r1", int32_type)
+                .build();
 
     auto cf_stats = make_lw_shared<replica::cf_stats>();
 
@@ -1328,8 +1356,10 @@ SEASTAR_TEST_CASE(test_large_blobs) {
     return seastar::async([] {
         tests::reader_concurrency_semaphore_wrapper semaphore;
 
-        auto s = make_shared_schema({}, some_keyspace, some_column_family,
-            {{"p1", utf8_type}}, {}, {}, {{"s1", bytes_type}}, utf8_type);
+        auto s = schema_builder(some_keyspace, some_column_family)
+                    .with_column("p1", utf8_type, column_kind::partition_key)
+                    .with_column("s1", bytes_type, column_kind::static_column)
+                    .build();
 
         auto mt = make_lw_shared<replica::memtable>(s);
 
@@ -1948,8 +1978,10 @@ SEASTAR_TEST_CASE(test_trim_rows) {
 
 SEASTAR_TEST_CASE(test_collection_cell_diff) {
     return seastar::async([] {
-        auto s = make_shared_schema({}, some_keyspace, some_column_family,
-            {{"p", utf8_type}}, {}, {{"v", list_type_impl::get_instance(bytes_type, true)}}, {}, utf8_type);
+        auto s = schema_builder(some_keyspace, some_column_family)
+                    .with_column("p", utf8_type, column_kind::partition_key)
+                    .with_column("v", list_type_impl::get_instance(bytes_type, true))
+                    .build();
 
         auto& col = s->column_at(column_kind::regular_column, 0);
         auto k = dht::decorate_key(*s, partition_key::from_single_value(*s, to_bytes("key")));

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -158,9 +158,11 @@ static void assert_table_sstable_count(table_for_tests& t, size_t expected_count
 SEASTAR_TEST_CASE(compaction_manager_basic_test) {
   return test_env::do_with_async([] (test_env& env) {
     BOOST_REQUIRE(smp::count == 1);
-    auto s = make_shared_schema({}, some_keyspace, some_column_family,
-        {{"p1", utf8_type}}, {{"c1", utf8_type}}, {{"r1", int32_type}}, {}, utf8_type);
-
+    auto s = schema_builder(some_keyspace, some_column_family)
+                .with_column("p1", utf8_type, column_kind::partition_key)
+                .with_column("c1", utf8_type, column_kind::clustering_key)
+                .with_column("r1", int32_type)
+                .build();
     auto cf = env.make_table_for_tests(s);
     auto& cm = cf->get_compaction_manager();
     auto close_cf = deferred_stop(cf);
@@ -323,8 +325,10 @@ static future<compact_sstables_result> compact_sstables(test_env& env, std::vect
     BOOST_REQUIRE(smp::count == 1);
     return seastar::async(
             [&env, sstables = std::move(sstables_to_compact), create_sstables, min_sstable_size, strategy] () mutable {
-        schema_builder builder(make_shared_schema({}, some_keyspace, some_column_family,
-            {{"p1", utf8_type}}, {{"c1", utf8_type}}, {{"r1", utf8_type}}, {}, utf8_type));
+        schema_builder builder(some_keyspace, some_column_family);
+        builder.with_column("p1", utf8_type, column_kind::partition_key);
+        builder.with_column("c1", utf8_type, column_kind::clustering_key);
+        builder.with_column("r1", utf8_type);
         builder.set_compressor_params(compression_parameters::no_compression());
         builder.set_min_compaction_threshold(4);
         auto s = builder.build(schema_builder::compact_storage::no);
@@ -411,9 +415,11 @@ static future<compact_sstables_result> compact_sstables(test_env& env, std::vect
 
 static future<> check_compacted_sstables(test_env& env, compact_sstables_result res) {
     return seastar::async([&env, res = std::move(res)] {
-        auto s = make_shared_schema({}, some_keyspace, some_column_family,
-            {{"p1", utf8_type}}, {{"c1", utf8_type}}, {{"r1", utf8_type}}, {}, utf8_type);
-
+        auto s = schema_builder(some_keyspace, some_column_family)
+                .with_column("p1", utf8_type, column_kind::partition_key)
+                .with_column("c1", utf8_type, column_kind::clustering_key)
+                .with_column("r1", utf8_type)
+                .build();
         BOOST_REQUIRE_EQUAL(res.output_sstables.size(), 1);
         auto sst = env.reusable_sst(s, res.output_sstables[0]).get();
         auto reader = sstable_reader(sst, s, env.make_reader_permit()); // reader holds sst and s alive.
@@ -849,8 +855,8 @@ SEASTAR_TEST_CASE(leveled_invariant_fix) {
 
 SEASTAR_TEST_CASE(leveled_stcs_on_L0) {
   return test_env::do_with_async([] (test_env& env) {
-    schema_builder builder(make_shared_schema({}, some_keyspace, some_column_family,
-        {{"p1", utf8_type}}, {}, {}, {}, utf8_type));
+    schema_builder builder(some_keyspace, some_column_family);
+    builder.with_column("p1", utf8_type, column_kind::partition_key);
     builder.set_min_compaction_threshold(4);
     auto s = builder.build(schema_builder::compact_storage::no);
 
@@ -1181,8 +1187,11 @@ SEASTAR_TEST_CASE(tombstone_purge_test) {
 SEASTAR_TEST_CASE(sstable_rewrite) {
     BOOST_REQUIRE(smp::count == 1);
     return test_env::do_with_async([] (test_env& env) {
-        auto s = make_shared_schema({}, some_keyspace, some_column_family,
-            {{"p1", utf8_type}}, {{"c1", utf8_type}}, {{"r1", utf8_type}}, {}, utf8_type);
+        auto s = schema_builder(some_keyspace, some_column_family)
+                .with_column("p1", utf8_type, column_kind::partition_key)
+                .with_column("c1", utf8_type, column_kind::clustering_key)
+                .with_column("r1", utf8_type)
+                .build();
         auto sst_gen = env.make_sst_factory(s);
 
         const column_definition& r1_col = *s->get_column_definition("r1");
@@ -3411,9 +3420,7 @@ SEASTAR_TEST_CASE(test_bug_6472) {
 
 SEASTAR_TEST_CASE(sstable_needs_cleanup_test) {
   return test_env::do_with_async([] (test_env& env) {
-    auto s = make_shared_schema({}, some_keyspace, some_column_family,
-        {{"p1", utf8_type}}, {}, {}, {}, utf8_type);
-
+    auto s = schema_builder(some_keyspace, some_column_family).with_column("p1", utf8_type, column_kind::partition_key).build();
     const auto keys = tests::generate_partition_keys(10, s);
 
     auto sst_gen = [&env, s] (const dht::decorated_key& first, const dht::decorated_key& last) mutable {
@@ -4206,8 +4213,7 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
 
 SEASTAR_TEST_CASE(compound_sstable_set_incremental_selector_test) {
     return test_env::do_with_async([] (test_env& env) {
-        auto s = make_shared_schema({}, some_keyspace, some_column_family,
-                                    {{"p1", utf8_type}}, {}, {}, {}, utf8_type);
+        auto s = schema_builder(some_keyspace, some_column_family).with_column("p1", utf8_type, column_kind::partition_key).build();
         auto cs = sstables::make_compaction_strategy(sstables::compaction_strategy_type::leveled, s->compaction_strategy_options());
         const auto keys = tests::generate_partition_keys(8, s);
 

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -46,22 +46,10 @@ public:
 
 schema_ptr test_table_schema() {
     static thread_local auto s = [] {
-        schema_builder builder(make_shared_schema(
-                generate_legacy_id("ks", "cf"), "ks", "cf",
-        // partition key
-        {{"p", bytes_type}},
-        // clustering key
-        {},
-        // regular columns
-        {{"c", int32_type}},
-        // static columns
-        {},
-        // regular column name type
-        bytes_type,
-        // comment
-        ""
-       ));
-       return builder.build(schema_builder::compact_storage::no);
+        schema_builder builder("ks", "cf", generate_legacy_id("ks", "cf"), bytes_type);
+        builder.with_column("p", bytes_type, column_kind::partition_key);
+        builder.with_column("c", int32_type);
+        return builder.build(schema_builder::compact_storage::no);
     }();
     return s;
 }

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -51,7 +51,7 @@ SEASTAR_TEST_CASE(uncompressed_data) {
 }
 
 static auto make_schema_for_compressed_sstable() {
-    return make_shared_schema({}, "ks", "cf", {{"pk", utf8_type}}, {}, {}, {}, utf8_type);
+    return schema_builder("ks", "cf").with_column("pk", utf8_type, column_kind::partition_key).build();
 }
 
 SEASTAR_TEST_CASE(compressed_data) {
@@ -429,22 +429,11 @@ SEASTAR_TEST_CASE(statistics_rewrite) {
 
 static schema_ptr large_partition_schema() {
     static thread_local auto s = [] {
-        schema_builder builder(make_shared_schema(
-                generate_legacy_id("try1", "data"), "try1", "data",
-        // partition key
-        {{"t1", utf8_type}},
-        // clustering key
-        {{"t2", utf8_type}},
-        // regular columns
-        {{"t3", utf8_type}},
-        // static columns
-        {},
-        // regular column name type
-        utf8_type,
-        // comment
-        ""
-       ));
-       return builder.build(schema_builder::compact_storage::no);
+        schema_builder builder("try1", "data", generate_legacy_id("try1", "data"));
+        builder.with_column("t1", utf8_type, column_kind::partition_key);
+        builder.with_column("t2", utf8_type, column_kind::clustering_key);
+        builder.with_column("t3", utf8_type);
+        return builder.build(schema_builder::compact_storage::no);
     }();
     return s;
 }

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -74,21 +74,12 @@ inline sstring get_test_dir(const sstring& name, const schema_ptr s)
 
 inline schema_ptr composite_schema() {
     static thread_local auto s = [] {
-        schema_builder builder(make_shared_schema({}, "tests", "composite",
+        schema_builder builder("tests", "composite");
         // partition key
-        {{"name", bytes_type}, {"col1", bytes_type}},
-        // clustering key
-        {},
-        // regular columns
-        {},
-        // static columns
-        {},
-        // regular column name type
-        utf8_type,
-        // comment
-        "Table with a composite key as pkey"
-       ));
-       return builder.build(schema_builder::compact_storage::no);
+        builder.with_column("name", bytes_type, column_kind::partition_key);
+        builder.with_column("col1", bytes_type, column_kind::partition_key);
+        builder.set_comment("Table with a composite key as pkey");
+        return builder.build(schema_builder::compact_storage::no);
     }();
     return s;
 }
@@ -96,23 +87,11 @@ inline schema_ptr composite_schema() {
 inline schema_ptr set_schema() {
     static thread_local auto s = [] {
         auto my_set_type = set_type_impl::get_instance(bytes_type, false);
-        schema_builder builder(make_shared_schema({}, "tests", "set_pk",
-        // partition key
-        {{"ss", my_set_type}},
-        // clustering key
-        {},
-        // regular columns
-        {
-            {"ns", utf8_type},
-        },
-        // static columns
-        {},
-        // regular column name type
-        utf8_type,
-        // comment
-        "Table with a set as pkeys"
-       ));
-       return builder.build(schema_builder::compact_storage::no);
+        schema_builder builder("tests", "set_pk");
+        builder.with_column("ss", my_set_type, column_kind::partition_key);
+        builder.with_column("ns", utf8_type);
+        builder.set_comment("Table with a set as pkeys");
+        return builder.build(schema_builder::compact_storage::no);
     }();
     return s;
 }
@@ -120,23 +99,12 @@ inline schema_ptr set_schema() {
 inline schema_ptr map_schema() {
     static thread_local auto s = [] {
         auto my_map_type = map_type_impl::get_instance(bytes_type, bytes_type, false);
-        schema_builder builder(make_shared_schema({}, "tests", "map_pk",
+        schema_builder builder("tests", "map_pk");
         // partition key
-        {{"ss", my_map_type}},
-        // clustering key
-        {},
-        // regular columns
-        {
-            {"ns", utf8_type},
-        },
-        // static columns
-        {},
-        // regular column name type
-        utf8_type,
-        // comment
-        "Table with a map as pkeys"
-       ));
-       return builder.build(schema_builder::compact_storage::no);
+        builder.with_column("ss", my_map_type, column_kind::partition_key);
+        builder.with_column("ns", utf8_type);
+        builder.set_comment("Table with a map as pkeys");
+        return builder.build(schema_builder::compact_storage::no);
     }();
     return s;
 }
@@ -144,43 +112,24 @@ inline schema_ptr map_schema() {
 inline schema_ptr list_schema() {
     static thread_local auto s = [] {
         auto my_list_type = list_type_impl::get_instance(bytes_type, false);
-        schema_builder builder(make_shared_schema({}, "tests", "list_pk",
+        schema_builder builder("tests", "list_pk");
         // partition key
-        {{"ss", my_list_type}},
-        // clustering key
-        {},
-        // regular columns
-        {
-            {"ns", utf8_type},
-        },
-        // static columns
-        {},
-        // regular column name type
-        utf8_type,
-        // comment
-        "Table with a list as pkeys"
-       ));
-       return builder.build(schema_builder::compact_storage::no);
+        builder.with_column("ss", my_list_type, column_kind::partition_key);
+        builder.with_column("ns", utf8_type);
+        builder.set_comment("Table with a list as pkeys");
+        return builder.build(schema_builder::compact_storage::no);
     }();
     return s;
 }
 
 inline schema_ptr uncompressed_schema(int32_t min_index_interval = 0) {
     auto uncompressed = [=] {
-        schema_builder builder(make_shared_schema(generate_legacy_id("ks", "uncompressed"), "ks", "uncompressed",
+        schema_builder builder("ks", "uncompressed", generate_legacy_id("ks", "uncompressed"));
         // partition key
-        {{"name", utf8_type}},
-        // clustering key
-        {},
-        // regular columns
-        {{"col1", utf8_type}, {"col2", int32_type}},
-        // static columns
-        {},
-        // regular column name type
-        utf8_type,
-        // comment
-        "Uncompressed data"
-       ));
+        builder.with_column("name", utf8_type, column_kind::partition_key);
+        builder.with_column("col1", utf8_type);
+        builder.with_column("col2", int32_type);
+        builder.set_comment("Uncompressed data");
        builder.set_compressor_params(compression_parameters());
        if (min_index_interval) {
            builder.set_min_index_interval(min_index_interval);
@@ -202,121 +151,74 @@ inline schema_ptr complex_schema() {
         auto my_fset_type = set_type_impl::get_instance(bytes_type, false);
         auto my_set_static_type = set_type_impl::get_instance(bytes_type, true);
 
-        schema_builder builder(make_shared_schema({}, "tests", "complex_schema",
-        // partition key
-        {{"key", bytes_type}},
-        // clustering key
-        {{"clust1", bytes_type}, {"clust2", bytes_type}},
-        // regular columns
-        {
-            {"reg_set", my_set_type},
-            {"reg_list", my_list_type},
-            {"reg_map", my_map_type},
-            {"reg_fset", my_fset_type},
-            {"reg", bytes_type},
-        },
-        // static columns
-        {{"static_obj", bytes_type}, {"static_collection", my_set_static_type}},
-        // regular column name type
-        bytes_type,
-        // comment
-        "Table with a complex schema, including collections and static keys"
-       ));
-       return builder.build(schema_builder::compact_storage::no);
+        schema_builder builder("tests", "complex_schema", {}, bytes_type);
+        builder.with_column("key", bytes_type, column_kind::partition_key);
+        builder.with_column("clust1", bytes_type, column_kind::clustering_key);
+        builder.with_column("clust2", bytes_type, column_kind::clustering_key);
+        builder.with_column("reg_set", my_set_type);
+        builder.with_column("reg_list", my_list_type);
+        builder.with_column("reg_map", my_map_type);
+        builder.with_column("reg_fset", my_fset_type);
+        builder.with_column("reg", bytes_type);
+        builder.with_column("static_obj", bytes_type, column_kind::static_column);
+        builder.with_column("static_collection", my_set_static_type, column_kind::static_column);
+        builder.set_comment("Table with a complex schema, including collections and static keys");
+        return builder.build(schema_builder::compact_storage::no);
     }();
     return s;
 }
 
 inline schema_ptr columns_schema() {
     static thread_local auto columns = [] {
-        schema_builder builder(make_shared_schema(generate_legacy_id("name", "columns"), "name", "columns",
-        // partition key
-        {{"keyspace_name", utf8_type}},
-        // clustering key
-        {{"columnfamily_name", utf8_type}, {"column_name", utf8_type}},
-        // regular columns
-        {
-            {"component_index", int32_type},
-            {"index_name", utf8_type},
-            {"index_options", utf8_type},
-            {"index_type", utf8_type},
-            {"type", utf8_type},
-            {"validator", utf8_type},
-        },
-        // static columns
-        {},
-        // regular column name type
-        utf8_type,
-        // comment
-        "column definitions"
-       ));
-       return builder.build(schema_builder::compact_storage::no);
+        schema_builder builder("name", "columns", generate_legacy_id("name", "columns"));
+        builder.with_column("keyspace_name", utf8_type, column_kind::partition_key);
+        builder.with_column("columnfamily_name", utf8_type, column_kind::clustering_key);
+        builder.with_column("column_name", utf8_type, column_kind::clustering_key);
+        builder.with_column("component_index", int32_type);
+        builder.with_column("index_name", utf8_type);
+        builder.with_column("index_options", utf8_type);
+        builder.with_column("index_type", utf8_type);
+        builder.with_column("type", utf8_type);
+        builder.with_column("validator", utf8_type);
+        builder.set_comment("column definitions");
+        return builder.build(schema_builder::compact_storage::no);
     }();
     return columns;
 }
 
 inline schema_ptr compact_simple_dense_schema() {
     static thread_local auto s = [] {
-        schema_builder builder(make_shared_schema({}, "tests", "compact_simple_dense",
-        // partition key
-        {{"ks", bytes_type}},
-        // clustering key
-        {{"cl1", bytes_type}},
-        // regular columns
-        {{"cl2", bytes_type}},
-        // static columns
-        {},
-        // regular column name type
-        utf8_type,
-        // comment
-        "Table with a compact storage, and a single clustering key"
-       ));
-       return builder.build(schema_builder::compact_storage::yes);
+        schema_builder builder("tests", "compact_simple_dense");
+        builder.with_column("ks", bytes_type, column_kind::partition_key);
+        builder.with_column("cl1", bytes_type, column_kind::clustering_key);
+        builder.with_column("cl2", bytes_type);
+        builder.set_comment("Table with a compact storage, and a single clustering key");
+        return builder.build(schema_builder::compact_storage::yes);
     }();
     return s;
 }
 
 inline schema_ptr compact_dense_schema() {
     static thread_local auto s = [] {
-        schema_builder builder(make_shared_schema({}, "tests", "compact_simple_dense",
-        // partition key
-        {{"ks", bytes_type}},
-        // clustering key
-        {{"cl1", bytes_type}, {"cl2", bytes_type}},
-        // regular columns
-        {{"cl3", bytes_type}},
-        // static columns
-        {},
-        // regular column name type
-        utf8_type,
-        // comment
-        "Table with a compact storage, and a compound clustering key"
-       ));
-       return builder.build(schema_builder::compact_storage::yes);
+        schema_builder builder("tests", "compact_simple_dense");
+        builder.with_column("ks", bytes_type, column_kind::partition_key);
+        builder.with_column("cl1", bytes_type, column_kind::clustering_key);
+        builder.with_column("cl2", bytes_type, column_kind::clustering_key);
+        builder.with_column("cl3", bytes_type);
+        builder.set_comment("Table with a compact storage, and a compound clustering key");
+        return builder.build(schema_builder::compact_storage::yes);
     }();
     return s;
 }
 
 inline schema_ptr compact_sparse_schema() {
     static thread_local auto s = [] {
-        schema_builder builder(make_shared_schema({}, "tests", "compact_sparse",
-        // partition key
-        {{"ks", bytes_type}},
-        // clustering key
-        {},
-        // regular columns
-        {
-            {"cl1", bytes_type},
-            {"cl2", bytes_type},
-        },
-        // static columns
-        {},
-        // regular column name type
-        utf8_type,
-        // comment
-        "Table with a compact storage, but no clustering keys"
-       ));
-       return builder.build(schema_builder::compact_storage::yes);
+        schema_builder builder("tests", "compact_sparse");
+        builder.with_column("ks", bytes_type, column_kind::partition_key);
+        builder.with_column("cl1", bytes_type);
+        builder.with_column("cl2", bytes_type);
+        builder.set_comment("Table with a compact storage, but no clustering keys");
+        return builder.build(schema_builder::compact_storage::yes);
     }();
     return s;
 }
@@ -327,30 +229,18 @@ inline schema_ptr compact_sparse_schema() {
 //    sure we are testing the exact some one we have in our test dir.
 inline schema_ptr peers_schema() {
     static thread_local auto peers = [] {
-        schema_builder builder(make_shared_schema(generate_legacy_id("system", "peers"), "system", "peers",
-        // partition key
-        {{"peer", inet_addr_type}},
-        // clustering key
-        {},
-        // regular columns
-        {
-                {"data_center", utf8_type},
-                {"host_id", uuid_type},
-                {"preferred_ip", inet_addr_type},
-                {"rack", utf8_type},
-                {"release_version", utf8_type},
-                {"rpc_address", inet_addr_type},
-                {"schema_version", uuid_type},
-                {"tokens", set_type_impl::get_instance(utf8_type, true)},
-        },
-        // static columns
-        {},
-        // regular column name type
-        utf8_type,
-        // comment
-        "information about known peers in the cluster"
-       ));
-       return builder.build(schema_builder::compact_storage::no);
+        schema_builder builder("system", "peers", generate_legacy_id("system", "peers"));
+        builder.with_column("peer", inet_addr_type, column_kind::partition_key);
+        builder.with_column("data_center", utf8_type);
+        builder.with_column("host_id", uuid_type);
+        builder.with_column("preferred_ip", inet_addr_type);
+        builder.with_column("rack", utf8_type);
+        builder.with_column("release_version", utf8_type);
+        builder.with_column("rpc_address", inet_addr_type);
+        builder.with_column("schema_version", uuid_type);
+        builder.with_column("tokens", set_type_impl::get_instance(utf8_type, true));
+        builder.set_comment("information about known peers in the cluster");
+        return builder.build(schema_builder::compact_storage::no);
     }();
     return peers;
 }

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -130,11 +130,11 @@ inline schema_ptr uncompressed_schema(int32_t min_index_interval = 0) {
         builder.with_column("col1", utf8_type);
         builder.with_column("col2", int32_type);
         builder.set_comment("Uncompressed data");
-       builder.set_compressor_params(compression_parameters());
-       if (min_index_interval) {
-           builder.set_min_index_interval(min_index_interval);
-       }
-       return builder.build(schema_builder::compact_storage::no);
+        builder.set_compressor_params(compression_parameters());
+        if (min_index_interval) {
+            builder.set_min_index_interval(min_index_interval);
+        }
+        return builder.build(schema_builder::compact_storage::no);
     }();
     return uncompressed;
 }

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -43,22 +43,11 @@ using namespace std::literals::chrono_literals;
 
 schema_ptr test_table_schema() {
     static thread_local auto s = [] {
-        schema_builder builder(make_shared_schema(
-                generate_legacy_id("try1", "data"), "try1", "data",
-        // partition key
-        {{"p", utf8_type}},
-        // clustering key
-        {{"c", utf8_type}},
-        // regular columns
-        {{"v", utf8_type}},
-        // static columns
-        {},
-        // regular column name type
-        utf8_type,
-        // comment
-        ""
-       ));
-       return builder.build(schema_builder::compact_storage::no);
+        schema_builder builder("try1", "data", generate_legacy_id("try1", "data"));
+        builder.with_column("p", utf8_type, column_kind::partition_key);
+        builder.with_column("c", utf8_type, column_kind::clustering_key);
+        builder.with_column("v", utf8_type);
+        return builder.build(schema_builder::compact_storage::no);
     }();
     return s;
 }

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -131,26 +131,12 @@ private:
     std::vector<shared_sstable> _sst;
 
     schema_ptr create_schema(sstables::compaction_strategy_type type) {
-        std::vector<schema::column> columns;
-
+        schema_builder builder("ks", "perf-test", generate_legacy_id("ks", "perf-test"));
+        builder.with_column("name", utf8_type, column_kind::partition_key);
         for (unsigned i = 0; i < _cfg.num_columns; ++i) {
-            columns.push_back(schema::column{ to_bytes(format("column{:04d}", i)), utf8_type });
+            builder.with_column(to_bytes(format("column{:04d}", i)), utf8_type);
         }
-
-        schema_builder builder(make_shared_schema(generate_legacy_id("ks", "perf-test"), "ks", "perf-test",
-            // partition key
-            {{"name", utf8_type}},
-            // clustering key
-            {},
-            // regular columns
-            { columns },
-            // static columns
-            {},
-            // regular column name type
-            utf8_type,
-            // comment
-            "Perf tests"
-        ));
+        builder.set_comment("Perf tests");
         builder.set_compaction_strategy(type);
         return builder.build(schema_builder::compact_storage::no);
     }


### PR DESCRIPTION
This function was obsoleted by schema_builder some time ago. Not to patch all its callers, that helper became wrapper around it. Remained users are all in tests, and patching the to use builder directory makes the code shorter in many cases.