### PR TITLE
main: do not register redis and alternator services if not enabled

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -2112,9 +2112,13 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 #endif
 
-            ss.local().register_protocol_server(alternator_ctl, cfg->alternator_port() || cfg->alternator_https_port()).get();
+            if (bool enabled = cfg->alternator_port() || cfg->alternator_https_port()) {
+                ss.local().register_protocol_server(alternator_ctl, enabled).get();
+            }
 
-            ss.local().register_protocol_server(redis_ctl, cfg->redis_port() || cfg->redis_ssl_port()).get();
+            if (bool enabled = cfg->redis_port() || cfg->redis_ssl_port()) {
+                ss.local().register_protocol_server(redis_ctl, enabled).get();
+            }
 
             supervisor::notify("serving");
 


### PR DESCRIPTION
in main.cc, we start redis with `ss.local().register_protocol_server()` only if it is enabled. but `storage_service` always calls `stop_server()` with _all_ registered server, no matter if they have started or not. in general, it does not hurt. for instance,

`redis::controller::stop_server()` is a noop, if the controller is not started. but `storage_service` still print the logging message like:
```
INFO  2024-09-04 11:20:02,224 [shard 0:main] storage_service - Shutting down redis server
INFO  2024-09-04 11:20:02,224 [shard 0:main] storage_service - Shutting down redis server was successful
```

this could be confusing or at least distracting when a field engineer looks at the log. also, please note, `redis_port` and `redis_ssl_port` cannot be changed dynamically once scylla server is up, so we do not need to worry about "what if the redis server is started at runtime, how can is be stopped?".

the same applies to alternator service.

in this change, to avoid surprises, we conditionally register the protocol servers with the storage service based on their enabled statuses.

---

no need to backport, as it does not address a critical issue. it helps with the user experience when auditing the logging messages though.