### PR TITLE
Coroutinize sstable_directory::remove_unshared_sstables()

### DIFF
--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -507,8 +507,7 @@ sstable_directory::remove_unshared_sstables(std::vector<sstables::shared_sstable
     // list. So not only do we have to remove them, we also have to update the list. Because we're
     // dealing with a vector it's easier to just reconstruct the list.
     dirlog.debug("Removing {} unshared SSTables", sstlist.size());
-    return do_with(std::move(sstlist), std::unordered_set<sstables::shared_sstable>(),
-            [this] (std::vector<sstables::shared_sstable>& sstlist, std::unordered_set<sstables::shared_sstable>& exclude) {
+    std::unordered_set<sstables::shared_sstable> exclude;
 
         for (auto& sst : sstlist) {
             exclude.insert(sst);
@@ -524,10 +523,8 @@ sstable_directory::remove_unshared_sstables(std::vector<sstables::shared_sstable
 
         // Do this last for exception safety. If there is an exception on unlink we
         // want to at least leave the SSTable unshared list in a sane state.
-        return remove_sstables(std::move(sstlist)).then([] {
+        co_await remove_sstables(std::move(sstlist));
             dirlog.debug("Finished removing all SSTables");
-        });
-    });
 }
 
 

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -509,22 +509,22 @@ sstable_directory::remove_unshared_sstables(std::vector<sstables::shared_sstable
     dirlog.debug("Removing {} unshared SSTables", sstlist.size());
     std::unordered_set<sstables::shared_sstable> exclude;
 
-        for (auto& sst : sstlist) {
-            exclude.insert(sst);
+    for (auto& sst : sstlist) {
+        exclude.insert(sst);
+    }
+
+    auto old = std::exchange(_unshared_local_sstables, {});
+
+    for (auto& sst : old) {
+        if (!exclude.contains(sst)) {
+            _unshared_local_sstables.push_back(sst);
         }
+    }
 
-        auto old = std::exchange(_unshared_local_sstables, {});
-
-        for (auto& sst : old) {
-            if (!exclude.contains(sst)) {
-                _unshared_local_sstables.push_back(sst);
-            }
-        }
-
-        // Do this last for exception safety. If there is an exception on unlink we
-        // want to at least leave the SSTable unshared list in a sane state.
-        co_await remove_sstables(std::move(sstlist));
-            dirlog.debug("Finished removing all SSTables");
+    // Do this last for exception safety. If there is an exception on unlink we
+    // want to at least leave the SSTable unshared list in a sane state.
+    co_await remove_sstables(std::move(sstlist));
+    dirlog.debug("Finished removing all SSTables");
 }
 
 


### PR DESCRIPTION
This one is pretty simple

```
    return do_with(std::move(data), [] {
        toss_data(data);
        return remove(std::move(data));
    });
```

it doesn't really need to do_with() since "toss_data" is non-preemptive. Still, convert it into

```
    toss_data(data);
    co_await remove(std::move(data));
```