### PR TITLE
Report rows_merged in compaction_history rest api and nodetool

### DIFF
--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -168,7 +168,9 @@ void set_compaction_manager(http_context& ctx, routes& r, sharded<compaction_man
                         h.compacted_at = entry.compacted_at;
                         h.bytes_in = entry.bytes_in;
                         h.bytes_out =  entry.bytes_out;
-                        for (auto it : entry.rows_merged) {
+
+                        std::map<int32_t, int64_t> items(entry.rows_merged.begin(), entry.rows_merged.end());
+                        for (auto it : items) {
                             httpd::compaction_manager_json::row_merged e;
                             e.key = it.first;
                             e.value = it.second;

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -502,6 +502,7 @@ protected:
     uint64_t _estimated_partitions = 0;
     double _estimated_droppable_tombstone_ratio = 0;
     uint64_t _bloom_filter_checks = 0;
+    combined_reader_statistics _reader_statistics;
     db::replay_position _rp;
     encoding_stats_collector _stats_collector;
     const bool _can_split_large_partition = false;
@@ -898,6 +899,7 @@ protected:
                 .start_size = _start_size,
                 .end_size = _end_size,
                 .bloom_filter_checks = _bloom_filter_checks,
+                .reader_statistics = std::move(_reader_statistics),
             },
         };
 
@@ -1157,7 +1159,9 @@ public:
                 std::move(trace),
                 sm_fwd,
                 mr_fwd,
-                unwrap_monitor_generator());
+                unwrap_monitor_generator(),
+                default_sstable_predicate(),
+                &_reader_statistics);
     }
 
     std::string_view report_start_desc() const override {

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -724,9 +724,9 @@ private:
                                                         const query::partition_slice& slice,
                                                         tracing::trace_state_ptr,
                                                         streamed_mutation::forwarding fwd,
-                                                        mutation_reader::forwarding) const = 0;
+                                                        mutation_reader::forwarding) = 0;
 
-    mutation_reader setup_sstable_reader() const {
+    mutation_reader setup_sstable_reader() {
         if (!_owned_ranges_checker) {
             return make_sstable_reader(_schema,
                                        _permit,
@@ -1149,7 +1149,7 @@ public:
                                                 const query::partition_slice& slice,
                                                 tracing::trace_state_ptr trace,
                                                 streamed_mutation::forwarding sm_fwd,
-                                                mutation_reader::forwarding mr_fwd) const override {
+                                                mutation_reader::forwarding mr_fwd) override {
         return _compacting->make_local_shard_sstable_reader(std::move(s),
                 std::move(permit),
                 range,
@@ -1296,7 +1296,7 @@ public:
                                                 const query::partition_slice& slice,
                                                 tracing::trace_state_ptr trace,
                                                 streamed_mutation::forwarding sm_fwd,
-                                                mutation_reader::forwarding mr_fwd) const override {
+                                                mutation_reader::forwarding mr_fwd) override {
         return _compacting->make_local_shard_sstable_reader(std::move(s),
                 std::move(permit),
                 range,
@@ -1600,7 +1600,7 @@ private:
     std::string _scrub_start_description;
     mutable std::string _scrub_finish_description;
     uint64_t _bucket_count = 0;
-    mutable uint64_t _validation_errors = 0;
+    uint64_t _validation_errors = 0;
 
 public:
     scrub_compaction(table_state& table_s, compaction_descriptor descriptor, compaction_data& cdata, compaction_type_options::scrub options, compaction_progress_monitor& progress_monitor)
@@ -1627,7 +1627,7 @@ public:
                                                 const query::partition_slice& slice,
                                                 tracing::trace_state_ptr trace,
                                                 streamed_mutation::forwarding sm_fwd,
-                                                mutation_reader::forwarding mr_fwd) const override {
+                                                mutation_reader::forwarding mr_fwd) override {
         if (!range.is_full()) {
             on_internal_error(clogger, fmt::format("Scrub compaction in mode {} expected full partition range, but got {} instead", _options.operation_mode, range));
         }
@@ -1728,7 +1728,7 @@ public:
                                                 const query::partition_slice& slice,
                                                 tracing::trace_state_ptr trace,
                                                 streamed_mutation::forwarding sm_fwd,
-                                                mutation_reader::forwarding mr_fwd) const override {
+                                                mutation_reader::forwarding mr_fwd) override {
         return _compacting->make_range_sstable_reader(std::move(s),
                 std::move(permit),
                 range,

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "readers/combined_reader_stats.hh"
 #include "sstables/shared_sstable.hh"
 #include "compaction/compaction_descriptor.hh"
 #include "gc_clock.hh"
@@ -77,6 +78,7 @@ struct compaction_stats {
     uint64_t validation_errors = 0;
     // Bloom filter checks during max purgeable calculation
     uint64_t bloom_filter_checks = 0;
+    combined_reader_statistics reader_statistics;
 
     compaction_stats& operator+=(const compaction_stats& r) {
         ended_at = std::max(ended_at, r.ended_at);

--- a/readers/combined.cc
+++ b/readers/combined.cc
@@ -295,7 +295,7 @@ class list_reader_selector : public reader_selector {
 
 public:
     explicit list_reader_selector(schema_ptr s, std::vector<mutation_reader> readers)
-        : reader_selector(s, dht::ring_position_view::min())
+        : reader_selector(s, dht::ring_position_view::min(), readers.size())
         , _readers(std::move(readers)) {
     }
 

--- a/readers/combined.hh
+++ b/readers/combined.hh
@@ -20,8 +20,10 @@ class reader_selector {
 protected:
     schema_ptr _s;
     dht::ring_position_view _selector_position;
+    size_t _max_reader_count;
 public:
-    reader_selector(schema_ptr s, dht::ring_position_view rpv) noexcept : _s(std::move(s)), _selector_position(std::move(rpv)) {}
+    reader_selector(schema_ptr s, dht::ring_position_view rpv, size_t max_reader_count) noexcept
+    : _s(std::move(s)), _selector_position(std::move(rpv)), _max_reader_count(max_reader_count) {}
 
     virtual ~reader_selector() = default;
     // Call only if has_new_readers() returned true.
@@ -32,6 +34,10 @@ public:
     bool has_new_readers(const std::optional<dht::ring_position_view>& pos) const noexcept {
         dht::ring_position_comparator cmp(*_s);
         return !_selector_position.is_max() && (!pos || cmp(*pos, _selector_position) >= 0);
+    }
+
+    size_t max_reader_count() const {
+        return _max_reader_count;
     }
 };
 

--- a/readers/combined.hh
+++ b/readers/combined.hh
@@ -14,6 +14,7 @@
 #include "readers/mutation_reader.hh"
 
 class reader_permit;
+struct combined_reader_statistics;
 
 class reader_selector {
 protected:

--- a/readers/combined.hh
+++ b/readers/combined.hh
@@ -48,15 +48,18 @@ mutation_reader make_combined_reader(schema_ptr schema,
         reader_permit permit,
         std::vector<mutation_reader>,
         streamed_mutation::forwarding fwd_sm = streamed_mutation::forwarding::no,
-        mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes);
+        mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes,
+        combined_reader_statistics* statistics = nullptr);
 mutation_reader make_combined_reader(schema_ptr schema,
         reader_permit permit,
         std::unique_ptr<reader_selector>,
         streamed_mutation::forwarding,
-        mutation_reader::forwarding);
+        mutation_reader::forwarding,
+        combined_reader_statistics* statistics = nullptr);
 mutation_reader make_combined_reader(schema_ptr schema,
         reader_permit permit,
         mutation_reader&& a,
         mutation_reader&& b,
         streamed_mutation::forwarding fwd_sm = streamed_mutation::forwarding::no,
-        mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes);
+        mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes,
+        combined_reader_statistics* statistics = nullptr);

--- a/readers/combined_reader_stats.hh
+++ b/readers/combined_reader_stats.hh
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+struct combined_reader_statistics {
+    // Histogram describing a distribution of clustering keys. The vector
+    // gathers a number of clustering keys merged (value) from a given
+    // number of sstable files (index). The length of the vector is equal
+    // to the number of compacted sstables + 1
+    std::vector<int64_t> rows_merged_histogram;
+};

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -797,7 +797,7 @@ public:
             const dht::partition_range& pr,
             tracing::trace_state_ptr trace_state,
             sstable_reader_factory_type fn)
-        : reader_selector(s, pr.start() ? pr.start()->value() : dht::ring_position_view::min())
+        : reader_selector(s, pr.start() ? pr.start()->value() : dht::ring_position_view::min(), sstables->size())
         , _pr(&pr)
         , _sstables(std::move(sstables))
         , _trace_state(std::move(trace_state))

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -1366,7 +1366,8 @@ sstable_set::make_local_shard_sstable_reader(
         streamed_mutation::forwarding fwd,
         mutation_reader::forwarding fwd_mr,
         read_monitor_generator& monitor_generator,
-        const sstable_predicate& predicate) const
+        const sstable_predicate& predicate,
+        combined_reader_statistics* statistics) const
 {
     auto reader_factory_fn = [s, permit, &slice, trace_state, fwd, fwd_mr, &monitor_generator, &predicate]
             (shared_sstable& sst, const dht::partition_range& pr) mutable {
@@ -1392,7 +1393,8 @@ sstable_set::make_local_shard_sstable_reader(
                     std::move(trace_state),
                     std::move(reader_factory_fn)),
             fwd,
-            fwd_mr);
+            fwd_mr,
+            statistics);
 }
 
 mutation_reader sstable_set::make_full_scan_reader(

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -23,6 +23,8 @@ namespace utils {
 class estimated_histogram;
 }
 
+struct combined_reader_statistics;
+
 namespace sstables {
 
 struct sstable_first_key_less_comparator {
@@ -239,7 +241,8 @@ public:
         streamed_mutation::forwarding,
         mutation_reader::forwarding,
         read_monitor_generator& rmg = default_read_monitor_generator(),
-        const sstable_predicate& p = default_sstable_predicate()) const;
+        const sstable_predicate& p = default_sstable_predicate(),
+        combined_reader_statistics* statistics = nullptr) const;
 
     mutation_reader make_full_scan_reader(
             schema_ptr,

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -680,7 +680,7 @@ class selector_of_empty_readers : public reader_selector {
     size_t _remaining;
 public:
     selector_of_empty_readers(schema_ptr s, reader_permit permit, size_t count)
-        : reader_selector(s, dht::ring_position_view::min())
+        : reader_selector(s, dht::ring_position_view::min(), count)
         , _schema(s)
         , _permit(std::move(permit))
         , _remaining(count) {
@@ -858,7 +858,8 @@ public:
             std::vector<std::vector<mutation>> reader_mutations,
             dht::partition_range pr = query::full_partition_range,
             streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no)
-        : reader_selector(s, dht::ring_position_view::min())
+        : reader_selector(s, dht::ring_position_view::min(),
+                          std::accumulate(reader_mutations.begin(), reader_mutations.end(), 0, [](size_t count, const auto& readers) { return count + readers.size(); }))
         , _schema(s)
         , _permit(std::move(permit))
         , _position(dht::ring_position::min())

--- a/test/rest_api/test_compactionhistory.py
+++ b/test/rest_api/test_compactionhistory.py
@@ -1,0 +1,103 @@
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import requests
+import sys
+import time
+from collections import defaultdict
+
+# Use the util.py library from ../cql-pytest:
+sys.path.insert(1, sys.path[0] + '/test/cql-pytest')
+from util import new_test_table, new_test_keyspace
+
+
+def extractRowsMergedAsSortedList(response, ks):
+    '''
+    Extract rows_merged statistics for a given keyspace ks from the response and squash it as
+    there will be as many items as the number of shards. Return a sorted list of the form
+    [{"key": <number of sstables>, "value": <number ob rows>}...]
+    '''
+    total = defaultdict(int)
+    for data in response.json():
+        if data["ks"] == ks:
+            for rows in data["rows_merged"]:
+                total[rows["key"]] += rows["value"]
+
+    return [{"key": key, "value": value} for key, value in sorted(total.items())]
+
+
+def test_compactionhistory_rows_merged_null_compaction_strategy(cql, rest_api):
+    with new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
+        with new_test_table(cql, ks, "pk int, ck int, v int, PRIMARY KEY (pk, ck)", "WITH compaction = {'class': 'NullCompactionStrategy'};") as cf:
+            stmt = cql.prepare(f"INSERT INTO {cf} (pk, ck, v) VALUES (?, ?, ?)")
+            cql.execute(stmt, [1, 111, 0])
+            cql.execute(stmt, [1, 122, 0])
+            cql.execute(stmt, [1, 133, 0])
+            cql.execute(stmt, [2, 222, 0])
+            cql.execute(stmt, [3, 333, 0])
+            cql.execute(stmt, [3, 344, 0])
+            cql.execute(stmt, [3, 355, 0])
+            cql.execute(stmt, [3, 366, 0])
+            cql.execute(stmt, [3, 377, 0])
+            cql.execute(stmt, [4, 444, 0])
+            cql.execute(stmt, [5, 555, 0])
+
+            response = rest_api.send("POST", f"storage_service/keyspace_flush/{ks}")
+            assert response.status_code == requests.codes.ok
+
+            cql.execute(f"DELETE FROM {cf} WHERE pk=1 and ck=122")
+            cql.execute(f"DELETE FROM {cf} WHERE pk=5 and ck=555")
+            cql.execute(f"DELETE FROM {cf} WHERE pk=3 and ck>333 AND ck <366")
+            cql.execute(f"UPDATE {cf} SET v=100 WHERE pk=2 AND ck=222")
+            cql.execute(f"DELETE FROM {cf} WHERE pk=5")
+            response = rest_api.send("POST", f"storage_service/keyspace_flush/{ks}")
+            assert response.status_code == requests.codes.ok
+
+            response = rest_api.send("POST", "storage_service/compact")
+            assert response.status_code == requests.codes.ok
+
+            response = rest_api.send("GET", "compaction_manager/compaction_history")
+            assert response.status_code == requests.codes.ok
+            assert extractRowsMergedAsSortedList(response, ks) == [{"key": 1, "value": 13}, {"key": 2, "value": 10}]
+
+
+def test_compactionhistory_rows_merged_time_window_compaction_strategy(cql, rest_api):
+    with new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
+        with new_test_table(cql, ks, "pk int, ck int, v int, PRIMARY KEY (pk, ck)", "WITH compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_unit': 'MINUTES', 'compaction_window_size': 1};") as cf:
+            rest_api.send("POST", f"/column_family/autocompaction/{ks}:{cf.split('.')[-1]}")
+            current_time = int(time.time())
+
+            # Spread data across 2 windows by simulating a write process. `USING TIMESTAMP` is
+            # provided to distribute the writes in the first one-minute window while updates and
+            # deletes are propagated into the second 1-minute window.
+            stmt = cql.prepare(f"INSERT INTO {cf} (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP ?")
+            cql.execute(stmt, [1, 111, 0, current_time - 60 + 1])
+            cql.execute(stmt, [1, 122, 0, current_time - 60 + 2])
+            cql.execute(stmt, [1, 133, 0, current_time - 60 + 3])
+            cql.execute(stmt, [2, 222, 0, current_time - 60 + 4])
+            cql.execute(stmt, [3, 333, 0, current_time - 60 + 5])
+            cql.execute(stmt, [3, 344, 0, current_time - 60 + 6])
+            cql.execute(stmt, [3, 355, 0, current_time - 60 + 7])
+            cql.execute(stmt, [3, 366, 0, current_time - 60 + 8])
+            cql.execute(stmt, [3, 377, 0, current_time - 60 + 9])
+            cql.execute(stmt, [4, 444, 0, current_time - 60 + 10])
+            cql.execute(stmt, [5, 555, 0, current_time - 60 + 11])
+
+            response = rest_api.send("POST", f"storage_service/keyspace_flush/{ks}")
+            assert response.status_code == requests.codes.ok
+
+            cql.execute(f"DELETE FROM {cf} WHERE pk=1 and ck=122")
+            cql.execute(f"DELETE FROM {cf} WHERE pk=5 AND ck=555")
+            cql.execute(f"DELETE FROM {cf} WHERE pk=3 and ck>333 AND ck <366")
+            cql.execute(f"UPDATE {cf} SET v=100 WHERE pk=2 AND ck=222")
+            cql.execute(f"DELETE FROM {cf} WHERE pk=5")
+            response = rest_api.send("POST", f"storage_service/keyspace_flush/{ks}")
+            assert response.status_code == requests.codes.ok
+
+            response = rest_api.send("POST", "storage_service/compact")
+            assert response.status_code == requests.codes.ok
+
+            response = rest_api.send("GET", "compaction_manager/compaction_history")
+            assert response.status_code == requests.codes.ok
+            assert extractRowsMergedAsSortedList(response, ks) == [{"key": 1, "value": 13}, {"key": 2, "value": 10}]


### PR DESCRIPTION
Currently, running the `nodetool compactionhistory` command or using the rest api `curl -X GET --header "Accept: application/json" "http://localhost:10000/compaction_manager/compaction_history"` return compaction history without the `row_merged` field.

The series computes rows merged during compaction and provides this information to users via both the nodetool command and the rest api. The `rows_merged` field contains information on merged clustering keys across multiple sstable files. For instance, compacting two sstables of a table consisting of 7 rows where two rows are part of the both sstables, the output would have the following format: {1: 5, 2: 2}.

No backport is required. It extends the existing compaction history output.

Fixes https://github.com/scylladb/scylladb/issues/666