### PR TITLE
cql3/statements: mark format string as `constexpr const`

### DIFF
--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -248,7 +248,7 @@ void create_index_statement::validate_for_collection(const index_target& target,
             [[fallthrough]];
         case index_target::target_type::keys_and_values:
             if (!cd.type->is_map()) {
-                const char* msg_format = "Cannot create secondary index on {} of column {} with non-map type";
+                constexpr const char* msg_format = "Cannot create secondary index on {} of column {} with non-map type";
                 throw exceptions::invalid_request_exception(format(msg_format, to_sstring(target.type), cd.name_as_text()));
             }
             break;


### PR DESCRIPTION
after switching over to the new `seastar::format()` which enables the compile-time format check, the fmt string should be a constexpr, otherwise `fmt::format()` is not able to perform the check at compile time.

to prepare for bumping up the seastar module to a version which contains the change of `seastar::format()`, let's mark the format string with `constexpr const`.

---

this change prepares for the bump of of seastar submodule, which does not include a critical fix, so no need to backport.