### PR TITLE
cql3: selection: don't ignore regular column restriction if a regular row is not present

### DIFF
--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -669,12 +669,13 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
         case column_kind::static_column:
             // fallthrough
         case column_kind::regular_column: {
-            if (cdef->kind == column_kind::regular_column && !row_iterator) {
-                continue;
-            }
             auto restr_it = non_pk_restrictions_map.find(cdef);
             if (restr_it == non_pk_restrictions_map.end()) {
                 continue;
+            }
+            if (cdef->kind == column_kind::regular_column && !row_iterator) {
+                // Since we don't have IS NULL, no restriction on a regular column can be satisfied if the column is NULL (#10357)
+                return false;
             }
             const expr::expression& single_col_restriction = restr_it->second;
             // FIXME: push to upper layer so it happens once per row

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_limit_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_limit_test.py
@@ -494,7 +494,6 @@ def testIndexOnRegularColumnWithPartitionWithoutRows(cql, test_keyspace):
                           row(1, 1, 9, 1),
                           row(4, 1, 9, 1))
 
-@pytest.mark.xfail(reason="issue #10357")
 def testFilteringWithPartitionWithoutRows(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int, c int, s int static, v int, PRIMARY KEY (pk, c))") as table:
         execute(cql, table, "INSERT INTO %s (pk, c, s, v) VALUES (?, ?, ?, ?)", 1, 1, 9, 1)

--- a/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
+++ b/test/cql-pytest/cassandra_tests/validation/operations/select_test.py
@@ -878,7 +878,6 @@ def testAlias(cql, test_keyspace):
 
 
 # Reproduces issue #10357
-@pytest.mark.xfail(reason="#10357")
 def testAllowFilteringOnPartitionKeyOnStaticColumnsWithRowsWithOnlyStaticValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, s int static, c int, d int, PRIMARY KEY (a, b))") as table:
         for i in range(5):
@@ -902,7 +901,6 @@ def testAllowFilteringOnPartitionKeyOnStaticColumnsWithRowsWithOnlyStaticValues(
                                     [3, 2, 3, 2, 5])
 
 # Reproduces issue #10357
-@pytest.mark.xfail(reason="#10357")
 def testFilteringOnStaticColumnsWithRowsWithOnlyStaticValues(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, s int static, c int, d int, PRIMARY KEY (a, b))") as table:
         for i in range(5):
@@ -917,7 +915,7 @@ def testFilteringOnStaticColumnsWithRowsWithOnlyStaticValues(cql, test_keyspace)
                        [4, 2, 4, 2, 6])
 
 # Reproduces #10357, #10358
-@pytest.mark.xfail(reason="#10357, #10358")
+@pytest.mark.xfail(reason="#10358")
 def testFilteringWithoutIndices(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, s int static, PRIMARY KEY (a, b))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (1, 2, 4, 8)")

--- a/test/cql-pytest/test_static.py
+++ b/test/cql-pytest/test_static.py
@@ -88,7 +88,6 @@ def test_filter_with_static(cql, table1):
 # test (test_filter_with_static), but here the partition has only a static
 # column value, and no clustering row at all. We expect to get back nothing
 # when using a filtering on a regular column.
-@pytest.mark.xfail(reason="issue #10357")
 def test_filter_with_only_static(cql, table1):
     p = unique_key_int()
     cql.execute(f'INSERT INTO {table1}(p, s) values ({p}, 1)')

--- a/test/cql-pytest/test_tombstone_limit.py
+++ b/test/cql-pytest/test_tombstone_limit.py
@@ -306,7 +306,7 @@ def test_static_row_tombstone_prefix(cql, test_keyspace, lowered_tombstone_limit
         statement = SimpleStatement(f"SELECT * FROM {table}", fetch_size=10)
         check_pages_many_partitions(cql.execute(statement), {-1: all_pks[-1]})
 
-        statement = SimpleStatement(f"SELECT * FROM {table} WHERE v = 0 ALLOW FILTERING", fetch_size=10)
+        statement = SimpleStatement(f"SELECT * FROM {table} WHERE s = 0 ALLOW FILTERING", fetch_size=10)
         check_pages_many_partitions(cql.execute(statement), {-1: all_pks[-1]})
 
 
@@ -327,7 +327,7 @@ def test_static_row_tombstone_span(cql, test_keyspace, lowered_tombstone_limit, 
         statement = SimpleStatement(f"SELECT * FROM {table}", fetch_size=10)
         check_pages_many_partitions(cql.execute(statement), {0: all_pks[0], -1: all_pks[-1]})
 
-        statement = SimpleStatement(f"SELECT * FROM {table} WHERE v = 0 ALLOW FILTERING", fetch_size=10)
+        statement = SimpleStatement(f"SELECT * FROM {table} WHERE s = 0 ALLOW FILTERING", fetch_size=10)
         check_pages_many_partitions(cql.execute(statement), {0: all_pks[0], -1: all_pks[-1]})
 
 


### PR DESCRIPTION
If a regular row isn't present, no regular column restriction
(say, r=3) can pass since all regular columns are presented as NULL,
and we don't have an IS NULL predicate. Yet we just ignore it.

Handle the restriction on a missing column by return false, signifying
the row was filtered out.

We have to move the check after the conditional checking whether there's
any restriction at all, otherwise we exit early with a false failure.

Unit test marked xfail on this issue are now unmarked.

A subtest of test_tombstone_limit is adjusted since it depended on this
bug. It tested a regular column which wasn't there, and this bug caused
the filter to be ignored. Change to test a static column that is there.

A test for a bug found while developing the patch is also added. It is
also tested by test_tombstone_limit, but better to have a dedicated test.

Fixes https://github.com/scylladb/scylladb/issues/10357