### PR TITLE
cql3: simplify runtime component of selection filtering

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -460,6 +460,14 @@ statement_restrictions::statement_restrictions(data_dictionary::database db,
                     | std::ranges::to<std::vector>(),
         };
     }
+
+    if (ck_restrictions_need_filtering()) {
+        _clustering_key_filter = expr::conjunction{
+            .children = _single_column_clustering_key_restrictions
+                    | std::ranges::views::values
+                    | std::ranges::to<std::vector>(),
+        };
+    }
 }
 
 bool

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -535,6 +535,10 @@ int statement_restrictions::score(const secondary_index::index& index) const {
 }
 
 std::pair<std::optional<secondary_index::index>, expr::expression> statement_restrictions::find_idx(const secondary_index::secondary_index_manager& sim) const {
+    if (!_uses_secondary_indexing) {
+        return {std::nullopt, expr::conjunction({})};
+    }
+
     std::optional<secondary_index::index> chosen_index;
     int chosen_index_score = 0;
     expr::expression chosen_index_restrictions = expr::conjunction({});

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -450,6 +450,8 @@ statement_restrictions::statement_restrictions(data_dictionary::database db,
     if (_uses_secondary_indexing && !(for_view || allow_filtering)) {
         validate_secondary_index_selections(selects_only_static_columns);
     }
+
+    calculate_column_defs_for_filtering(db);
 }
 
 bool
@@ -576,6 +578,10 @@ bool statement_restrictions::has_eq_restriction_on_column(const column_definitio
 }
 
 std::vector<const column_definition*> statement_restrictions::get_column_defs_for_filtering(data_dictionary::database db) const {
+    return _column_defs_for_filtering;
+}
+
+void statement_restrictions::calculate_column_defs_for_filtering(data_dictionary::database db) {
     std::vector<const column_definition*> column_defs_for_filtering;
     if (need_filtering()) {
         std::optional<secondary_index::index> opt_idx;
@@ -622,7 +628,7 @@ std::vector<const column_definition*> statement_restrictions::get_column_defs_fo
             }
         }
     }
-    return column_defs_for_filtering;
+    _column_defs_for_filtering = std::move(column_defs_for_filtering);
 }
 
 void statement_restrictions::add_restriction(const expr::binary_operator& restr, schema_ptr schema, bool allow_filtering, bool for_view) {

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1933,17 +1933,6 @@ void statement_restrictions::validate_secondary_index_selections(bool selects_on
     }
 }
 
-const expr::single_column_restrictions_map& statement_restrictions::get_single_column_partition_key_restrictions() const {
-    return _single_column_partition_key_restrictions;
-}
-
-/**
- * @return clustering key restrictions split into single column restrictions (e.g. for filtering support).
- */
-const expr::single_column_restrictions_map& statement_restrictions::get_single_column_clustering_key_restrictions() const {
-    return _single_column_clustering_key_restrictions;
-}
-
 void statement_restrictions::prepare_indexed_global(const schema& idx_tbl_schema) {
     if (!_partition_range_is_simple) {
         return;

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -496,6 +496,14 @@ statement_restrictions::statement_restrictions(data_dictionary::database db,
     };
 
     _clustering_row_level_filter = expr::make_conjunction(std::move(_clustering_row_level_filter), std::move(regular_columns_filter));
+
+    auto multi_column_restrictions = expr::conjunction{
+        .children = expr::boolean_factors(_clustering_columns_restrictions)
+                | std::ranges::views::filter(expr::contains_multi_column_restriction)
+                | std::ranges::to<std::vector>()
+    };
+
+    _clustering_row_level_filter = expr::make_conjunction(std::move(_clustering_row_level_filter), std::move(multi_column_restrictions));
 }
 
 bool

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -613,8 +613,8 @@ void statement_restrictions::calculate_column_defs_for_filtering(data_dictionary
                     num_clustering_prefix_columns_that_need_not_be_filtered();
             for (auto&& cdef : expr::get_sorted_column_defs(_clustering_columns_restrictions)) {
                 const expr::expression* single_col_restr = nullptr;
-                auto it = _single_column_partition_key_restrictions.find(cdef);
-                if (it != _single_column_partition_key_restrictions.end()) {
+                auto it = _single_column_clustering_key_restrictions.find(cdef);
+                if (it != _single_column_clustering_key_restrictions.end()) {
                     single_col_restr = &it->second;
                 }
                 if (cdef->id >= first_filtering_id && !column_uses_indexing(cdef, single_col_restr)) {

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -452,6 +452,14 @@ statement_restrictions::statement_restrictions(data_dictionary::database db,
     }
 
     calculate_column_defs_for_filtering_and_erase_restrictions_used_for_index(db);
+
+    if (pk_restrictions_need_filtering()) {
+        _partition_key_filter = expr::conjunction{
+            .children = _single_column_partition_key_restrictions
+                    | std::ranges::views::values
+                    | std::ranges::to<std::vector>(),
+        };
+    }
 }
 
 bool

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -130,9 +130,9 @@ public:
         const expr::expression& where_clause,
         prepare_context& ctx,
         bool selects_only_static_columns,
-        bool for_view = false,
-        bool allow_filtering = false,
-        check_indexes do_check_indexes = check_indexes::yes);
+        bool for_view,
+        bool allow_filtering,
+        check_indexes do_check_indexes);
 
     const std::vector<expr::expression>& index_restrictions() const;
 

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -58,6 +58,10 @@ private:
 
     expr::single_column_restrictions_map _single_column_nonprimary_key_restrictions;
 
+    expr::expression _static_columns_filter = expr::conjunction({});
+    expr::expression _regular_columns_filter = expr::conjunction({});
+
+
     std::unordered_set<const column_definition*> _not_null_columns;
 
     /**
@@ -365,6 +369,18 @@ public:
     // This is equivalent to ck_restrictions_need_filtering() + get_single_column_clustering_key_restrictions().
     const std::optional<expr::expression>& get_clustering_key_filter() const {
         return _clustering_key_filter;
+    }
+
+    // Returns any filter that needs to be applied to the static row. If a column is used for a secondary index, it will
+    // not be in the filter.
+    const expr::expression& get_static_columns_filter() const {
+        return _static_columns_filter;
+    }
+
+    // Returns any filter that needs to be applied to regular columns. If a column is used for a secondary index, it will
+    // not be in the filter.
+    const expr::expression& get_regular_columns_filter() const {
+        return _regular_columns_filter;
     }
 
     /**

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -49,6 +49,7 @@ private:
     expr::expression _clustering_columns_restrictions = expr::conjunction({});
 
     expr::single_column_restrictions_map _single_column_clustering_key_restrictions;
+    std::optional<expr::expression> _clustering_key_filter;
 
     /**
      * Restriction on non-primary key columns (i.e. secondary index restrictions)
@@ -356,6 +357,14 @@ public:
     // This is equivalent to pk_restrictions_need_filtering() + get_single_column_partition_key_restrictions().
     const std::optional<expr::expression>& get_partition_key_filter() const {
         return _partition_key_filter;
+    }
+
+    // Returns any filter that needs to be applied to the clustering key. If the clustering key restriction is translated
+    // to read_command, it will not be in the filter.
+    //
+    // This is equivalent to ck_restrictions_need_filtering() + get_single_column_clustering_key_restrictions().
+    const std::optional<expr::expression>& get_clustering_key_filter() const {
+        return _clustering_key_filter;
     }
 
     /**

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -41,7 +41,7 @@ private:
     expr::expression _partition_key_restrictions = expr::conjunction({});
 
     expr::single_column_restrictions_map _single_column_partition_key_restrictions;
-    std::optional<expr::expression> _partition_key_filter;
+    expr::expression _partition_level_filter = expr::conjunction({});
 
     /**
      * Restrictions on clustering columns
@@ -58,7 +58,6 @@ private:
 
     expr::single_column_restrictions_map _single_column_nonprimary_key_restrictions;
 
-    expr::expression _static_columns_filter = expr::conjunction({});
     expr::expression _regular_columns_filter = expr::conjunction({});
 
 
@@ -355,12 +354,12 @@ public:
      */
     const expr::single_column_restrictions_map& get_single_column_partition_key_restrictions() const;
 
-    // Returns any filter that needs to be applied to the partition key. If the partition key restriction is translated
-    // to read_command, it will not be in the filter.
+    // Returns any filter that needs to be applied to a row, but if it fails, it will fail for all rows in the partition.
+    // If a column is used for a secondary index, it will not be in the filter.
     //
-    // This is equivalent to pk_restrictions_need_filtering() + get_single_column_partition_key_restrictions().
-    const std::optional<expr::expression>& get_partition_key_filter() const {
-        return _partition_key_filter;
+    // This filter will only reference partition key columns and static columns.
+    const expr::expression& get_partition_level_filter() const {
+        return _partition_level_filter;
     }
 
     // Returns any filter that needs to be applied to the clustering key. If the clustering key restriction is translated
@@ -369,12 +368,6 @@ public:
     // This is equivalent to ck_restrictions_need_filtering() + get_single_column_clustering_key_restrictions().
     const std::optional<expr::expression>& get_clustering_key_filter() const {
         return _clustering_key_filter;
-    }
-
-    // Returns any filter that needs to be applied to the static row. If a column is used for a secondary index, it will
-    // not be in the filter.
-    const expr::expression& get_static_columns_filter() const {
-        return _static_columns_filter;
     }
 
     // Returns any filter that needs to be applied to regular columns. If a column is used for a secondary index, it will

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -349,11 +349,6 @@ public:
         return _single_column_nonprimary_key_restrictions;
     }
 
-    /**
-     * @return partition key restrictions split into single column restrictions (e.g. for filtering support).
-     */
-    const expr::single_column_restrictions_map& get_single_column_partition_key_restrictions() const;
-
     // Returns any filter that needs to be applied to a row, but if it fails, it will fail for all rows in the partition.
     // If a column is used for a secondary index, it will not be in the filter.
     //
@@ -367,11 +362,6 @@ public:
     const expr::expression& get_clustering_row_level_filter() const {
         return _clustering_row_level_filter;
     }
-
-    /**
-     * @return clustering key restrictions split into single column restrictions (e.g. for filtering support).
-     */
-    const expr::single_column_restrictions_map& get_single_column_clustering_key_restrictions() const;
 
     /// Prepares internal data for evaluating index-table queries.  Must be called before
     /// get_local_index_clustering_ranges().

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -41,6 +41,7 @@ private:
     expr::expression _partition_key_restrictions = expr::conjunction({});
 
     expr::single_column_restrictions_map _single_column_partition_key_restrictions;
+    std::optional<expr::expression> _partition_key_filter;
 
     /**
      * Restrictions on clustering columns
@@ -348,6 +349,14 @@ public:
      * @return partition key restrictions split into single column restrictions (e.g. for filtering support).
      */
     const expr::single_column_restrictions_map& get_single_column_partition_key_restrictions() const;
+
+    // Returns any filter that needs to be applied to the partition key. If the partition key restriction is translated
+    // to read_command, it will not be in the filter.
+    //
+    // This is equivalent to pk_restrictions_need_filtering() + get_single_column_partition_key_restrictions().
+    const std::optional<expr::expression>& get_partition_key_filter() const {
+        return _partition_key_filter;
+    }
 
     /**
      * @return clustering key restrictions split into single column restrictions (e.g. for filtering support).

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -287,7 +287,7 @@ private:
     void add_clustering_restrictions_to_idx_ck_prefix(const schema& idx_tbl_schema);
 
     unsigned int num_clustering_prefix_columns_that_need_not_be_filtered() const;
-    void calculate_column_defs_for_filtering(data_dictionary::database db);
+    void calculate_column_defs_for_filtering_and_erase_restrictions_used_for_index(data_dictionary::database db);
 public:
     /**
      * Returns the specified range of the partition key.

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -49,7 +49,7 @@ private:
     expr::expression _clustering_columns_restrictions = expr::conjunction({});
 
     expr::single_column_restrictions_map _single_column_clustering_key_restrictions;
-    std::optional<expr::expression> _clustering_key_filter;
+    expr::expression _clustering_row_level_filter = expr::conjunction({});
 
     /**
      * Restriction on non-primary key columns (i.e. secondary index restrictions)
@@ -362,18 +362,10 @@ public:
         return _partition_level_filter;
     }
 
-    // Returns any filter that needs to be applied to the clustering key. If the clustering key restriction is translated
+    // Returns any filter that needs to be applied to each clustering row. If one of the column restrictions is translated
     // to read_command, it will not be in the filter.
-    //
-    // This is equivalent to ck_restrictions_need_filtering() + get_single_column_clustering_key_restrictions().
-    const std::optional<expr::expression>& get_clustering_key_filter() const {
-        return _clustering_key_filter;
-    }
-
-    // Returns any filter that needs to be applied to regular columns. If a column is used for a secondary index, it will
-    // not be in the filter.
-    const expr::expression& get_regular_columns_filter() const {
-        return _regular_columns_filter;
+    const expr::expression& get_clustering_row_level_filter() const {
+        return _clustering_row_level_filter;
     }
 
     /**

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -114,6 +114,7 @@ private:
 
 
     check_indexes _check_indexes = check_indexes::yes;
+    std::vector<const column_definition*> _column_defs_for_filtering;
 public:
     /**
      * Creates a new empty <code>StatementRestrictions</code>.
@@ -286,7 +287,7 @@ private:
     void add_clustering_restrictions_to_idx_ck_prefix(const schema& idx_tbl_schema);
 
     unsigned int num_clustering_prefix_columns_that_need_not_be_filtered() const;
-
+    void calculate_column_defs_for_filtering(data_dictionary::database db);
 public:
     /**
      * Returns the specified range of the partition key.

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -673,23 +673,6 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
         }
     }
 
-    const expr::expression& clustering_columns_restrictions = _restrictions->get_clustering_columns_restrictions();
-    if (expr::contains_multi_column_restriction(clustering_columns_restrictions)) {
-        clustering_key_prefix ckey = clustering_key_prefix::from_exploded(clustering_key);
-        bool multi_col_clustering_satisfied = expr::is_satisfied_by(
-                clustering_columns_restrictions,
-                expr::evaluation_inputs{
-                    .partition_key = partition_key,
-                    .clustering_key = clustering_key,
-                    .static_and_regular_columns = static_and_regular_columns,
-                    .selection = &selection,
-                    .options = &_options,
-                });
-        if (!multi_col_clustering_satisfied) {
-            return false;
-        }
-    }
-
     auto static_row_iterator = static_row.iterator();
     auto row_iterator = row ? std::optional<query::result_row_view::iterator_type>(row->iterator()) : std::nullopt;
     for (auto&& cdef : selection.get_columns()) {

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -642,11 +642,11 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
         return false;
     }
 
+    auto static_and_regular_columns = expr::get_non_pk_values(selection, static_row, row);
+
     const expr::expression& clustering_columns_restrictions = _restrictions->get_clustering_columns_restrictions();
     if (expr::contains_multi_column_restriction(clustering_columns_restrictions)) {
         clustering_key_prefix ckey = clustering_key_prefix::from_exploded(clustering_key);
-        // FIXME: push to upper layer so it happens once per row
-        auto static_and_regular_columns = expr::get_non_pk_values(selection, static_row, row);
         bool multi_col_clustering_satisfied = expr::is_satisfied_by(
                 clustering_columns_restrictions,
                 expr::evaluation_inputs{
@@ -678,8 +678,6 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
                 return false;
             }
             const expr::expression& single_col_restriction = restr_it->second;
-            // FIXME: push to upper layer so it happens once per row
-            auto static_and_regular_columns = expr::get_non_pk_values(selection, static_row, row);
             bool regular_restriction_matches = expr::is_satisfied_by(
                     single_col_restriction,
                     expr::evaluation_inputs{

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -644,33 +644,29 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
 
     auto static_and_regular_columns = expr::get_non_pk_values(selection, static_row, row);
 
-    {
-        if (!expr::is_satisfied_by(
-                        _partition_level_filter,
-                        expr::evaluation_inputs{
-                            .partition_key = partition_key,
-                            .clustering_key = clustering_key,
-                            .static_and_regular_columns = static_and_regular_columns,
-                            .selection = &selection,
-                            .options = &_options,
-                        })) {
-            _current_partition_does_not_match = true;
-            return false;
-        }
+    if (!expr::is_satisfied_by(
+                    _partition_level_filter,
+                    expr::evaluation_inputs{
+                        .partition_key = partition_key,
+                        .clustering_key = clustering_key,
+                        .static_and_regular_columns = static_and_regular_columns,
+                        .selection = &selection,
+                        .options = &_options,
+                    })) {
+        _current_partition_does_not_match = true;
+        return false;
     }
 
-    {
-        if (!expr::is_satisfied_by(
-                        _clustering_row_level_filter,
-                        expr::evaluation_inputs{
-                            .partition_key = partition_key,
-                            .clustering_key = clustering_key,
-                            .static_and_regular_columns = static_and_regular_columns,
-                            .selection = &selection,
-                            .options = &_options,
-                        })) {
-            return false;
-        }
+    if (!expr::is_satisfied_by(
+                    _clustering_row_level_filter,
+                    expr::evaluation_inputs{
+                        .partition_key = partition_key,
+                        .clustering_key = clustering_key,
+                        .static_and_regular_columns = static_and_regular_columns,
+                        .selection = &selection,
+                        .options = &_options,
+                    })) {
+        return false;
     }
 
     return true;

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -673,27 +673,6 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
         }
     }
 
-    auto static_row_iterator = static_row.iterator();
-    auto row_iterator = row ? std::optional<query::result_row_view::iterator_type>(row->iterator()) : std::nullopt;
-    for (auto&& cdef : selection.get_columns()) {
-        switch (cdef->kind) {
-        case column_kind::static_column:
-            // fallthrough
-        case column_kind::regular_column: {
-            }
-            break;
-        case column_kind::partition_key: {
-            // handled via _partition_key_filter
-            }
-            break;
-        case column_kind::clustering_key: {
-            // handled via _clustering_key_filter
-            }
-            break;
-        default:
-            break;
-        }
-    }
     return true;
 }
 

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -208,7 +208,7 @@ public:
     class restrictions_filter {
         const ::shared_ptr<const restrictions::statement_restrictions> _restrictions;
         const query_options& _options;
-        const bool _skip_pk_restrictions;
+        const std::optional<expr::expression>& _partition_key_filter;
         const bool _skip_ck_restrictions;
         mutable bool _current_partition_key_does_not_match = false;
         mutable bool _current_static_row_does_not_match = false;

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -210,6 +210,8 @@ public:
         const query_options& _options;
         const std::optional<expr::expression>& _partition_key_filter;
         const std::optional<expr::expression>& _clustering_key_filter;
+        const expr::expression& _static_columns_filter;
+        const expr::expression& _regular_columns_filter;
         mutable bool _current_partition_key_does_not_match = false;
         mutable bool _current_static_row_does_not_match = false;
         mutable uint64_t _rows_dropped = 0;

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -208,12 +208,10 @@ public:
     class restrictions_filter {
         const ::shared_ptr<const restrictions::statement_restrictions> _restrictions;
         const query_options& _options;
-        const std::optional<expr::expression>& _partition_key_filter;
+        const expr::expression& _partition_level_filter;
         const std::optional<expr::expression>& _clustering_key_filter;
-        const expr::expression& _static_columns_filter;
         const expr::expression& _regular_columns_filter;
-        mutable bool _current_partition_key_does_not_match = false;
-        mutable bool _current_static_row_does_not_match = false;
+        mutable bool _current_partition_does_not_match = false;
         mutable uint64_t _rows_dropped = 0;
         mutable uint64_t _remaining;
         schema_ptr _schema;

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -209,7 +209,7 @@ public:
         const ::shared_ptr<const restrictions::statement_restrictions> _restrictions;
         const query_options& _options;
         const std::optional<expr::expression>& _partition_key_filter;
-        const bool _skip_ck_restrictions;
+        const std::optional<expr::expression>& _clustering_key_filter;
         mutable bool _current_partition_key_does_not_match = false;
         mutable bool _current_static_row_does_not_match = false;
         mutable uint64_t _rows_dropped = 0;

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -209,8 +209,7 @@ public:
         const ::shared_ptr<const restrictions::statement_restrictions> _restrictions;
         const query_options& _options;
         const expr::expression& _partition_level_filter;
-        const std::optional<expr::expression>& _clustering_key_filter;
-        const expr::expression& _regular_columns_filter;
+        const expr::expression& _clustering_row_level_filter;
         mutable bool _current_partition_does_not_match = false;
         mutable uint64_t _rows_dropped = 0;
         mutable uint64_t _remaining;

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -416,7 +416,7 @@ void modification_statement::build_cas_result_set_metadata() {
 void
 modification_statement::process_where_clause(data_dictionary::database db, expr::expression where_clause, prepare_context& ctx) {
     _restrictions = restrictions::statement_restrictions(db, s, type, where_clause, ctx,
-            applies_only_to_static_columns(), _selects_a_collection, false);
+            applies_only_to_static_columns(), _selects_a_collection, false /* allow_filtering */, restrictions::check_indexes::no);
     /*
      * If there's no clustering columns restriction, we may assume that EXISTS
      * check only selects static columns and hence we can use any row from the

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -38,7 +38,8 @@ query::clustering_row_ranges slice(
             ctx,
             /*contains_only_static_columns=*/false,
             /*for_view=*/false,
-            /*allow_filtering=*/true)
+            /*allow_filtering=*/true,
+            restrictions::check_indexes::yes)
             .get_clustering_bounds(query_options({}));
 }
 


### PR DESCRIPTION
Most of the analysis of the WHERE clause is done in statement_restrictions. It determines
what parts to use for the primary or secondary index, and what parts to use for filtering.

The difficult part is that it has a very wide interface. After construction, the user must pick
the correct bits from many public functions. There are subtle interactions between them
that are hard to untangle.

This series simplifies the interface as it is used for selection filtering. In the end, only
two public functions are used, both returning expressions: one for the partition-level
filtering, one for the clustering row level filtering.

In the end, the WHERE clause is factored into three parts:
 - one part goes into the read_command of the primary or secondary index
 - another part (that references only partition key columns and static key columns) is used to filter entire partitions
 - another part (that currently references only clustering key columns and regular columns, but one day may reference other columns) is used to filter clustering rows


Refactoring, no backport.