### PR TITLE
hints: send hints with CL=ALL if target is leaving

### DIFF
--- a/db/hints/internal/hint_sender.hh
+++ b/db/hints/internal/hint_sender.hh
@@ -238,6 +238,10 @@ private:
     /// If the original destination end point is still a replica for the given mutation - send the mutation directly
     /// to it, otherwise execute the mutation "from scratch" with CL=ALL.
     ///
+    /// The mutation will be sent with CL=ALL semantics to all current replicas also in case if the original destination
+    /// is leaving the cluster - otherwise the hint might be applied only on the leaving node and streaming might
+    /// miss it.
+    ///
     /// \param m mutation to send
     /// \return future that resolves when the mutation sending processing is complete.
     future<> send_one_mutation(frozen_mutation_and_schema m);

--- a/db/hints/internal/hint_sender.hh
+++ b/db/hints/internal/hint_sender.hh
@@ -233,18 +233,10 @@ private:
     /// \return
     const column_mapping& get_column_mapping(lw_shared_ptr<send_one_file_ctx> ctx_ptr, const frozen_mutation& fm, const hint_entry_reader& hr);
 
-    /// \brief Perform a single mutation send attempt.
+    /// \brief Send one mutation out.
     ///
     /// If the original destination end point is still a replica for the given mutation - send the mutation directly
     /// to it, otherwise execute the mutation "from scratch" with CL=ALL.
-    ///
-    /// \param m mutation to send
-    /// \param ermp points to the effective_replication_map used to obtain \c natural_endpoints
-    /// \param natural_endpoints current replicas for the given mutation
-    /// \return future that resolves when the operation is complete
-    future<> do_send_one_mutation(frozen_mutation_and_schema m, locator::effective_replication_map_ptr ermp, const inet_address_vector_replica_set& natural_endpoints);
-
-    /// \brief Send one mutation out.
     ///
     /// \param m mutation to send
     /// \return future that resolves when the mutation sending processing is complete.

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1886,6 +1886,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             }
                 break;
             case topology::transition_state::write_both_read_new: {
+                while (utils::get_local_injector().enter("topology_coordinator_pause_after_streaming")) {
+                    co_await sleep_abortable(std::chrono::milliseconds(10), _as);
+                }
                 auto node = get_node_to_work_on(std::move(guard));
                 bool barrier_failed = false;
                 // In this state writes goes to old and new replicas but reads start to be done from new replicas

--- a/test/topology/util.py
+++ b/test/topology/util.py
@@ -23,7 +23,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import get_host_api_address, read_barrier
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, get_available_host, unique_name
 from contextlib import asynccontextmanager
-from typing import Optional
+from typing import Optional, List
 
 
 logger = logging.getLogger(__name__)
@@ -92,6 +92,13 @@ async def get_topology_coordinator(manager: ManagerClient) -> HostID:
     host_address = get_host_api_address(host)
     await read_barrier(manager.api, host_address)
     return await manager.api.get_raft_leader(host_address)
+
+
+async def find_server_by_host_id(manager: ManagerClient, servers: List[ServerInfo], host_id: HostID) -> ServerInfo:
+    for s in servers:
+        if await manager.get_host_id(s.server_id) == host_id:
+            return s
+    raise Exception(f"Host ID {host_id} not found in {servers}")
 
 
 async def check_token_ring_and_group0_consistency(manager: ManagerClient) -> None:

--- a/test/topology_custom/test_hints.py
+++ b/test/topology_custom/test_hints.py
@@ -18,6 +18,9 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error
 from test.pylib.util import wait_for
 
+from test.topology.conftest import skip_mode
+from test.topology.util import get_topology_coordinator, find_server_by_host_id
+
 
 logger = logging.getLogger(__name__)
 
@@ -148,3 +151,87 @@ async def test_sync_point(manager: ManagerClient):
     await manager.server_sees_other_server(node1.ip_addr, node3.ip_addr)
 
     assert await_sync_point(node1, sync_point1, 30)
+
+
+@pytest.mark.asyncio
+@skip_mode('release', "error injections aren't enabled in release mode")
+async def test_hints_consistency_during_decommission(manager: ManagerClient):
+    """
+    This test reproduces the failure observed in scylladb/scylla-dtest#4582
+    in a more reliable way than the test_hintedhandoff_decom dtest.
+
+    We want to make sure that data stored in hints will not get lost if hints replay
+    happens in parallel to streaming during decommission.
+
+    The test is vnodes-specific.
+    """
+    (server1, server2, server3) = await manager.servers_add(3, config={
+        "error_injections_at_startup": ["decrease_hints_flush_period"]
+    })
+    cql = manager.cql
+
+    logger.info("Creatting a keyspace with RF=1 and a table")
+    await cql.run_async("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = { 'enabled': false }")
+    await cql.run_async("CREATE TABLE ks.t (pk int primary key, v int)")
+
+    logger.info("Stopping node 3")
+    await manager.server_stop_gracefully(server3.server_id)
+    await manager.others_not_see_server(server3.ip_addr)
+
+    # Write 100 rows with CL=ANY. Some of the rows will only be stored as hints because of RF=1
+    logger.info("Writing 100 rows with CL=ANY")
+    for i in range(100):
+        await cql.run_async(SimpleStatement(f"INSERT INTO ks.t (pk, v) VALUES ({i}, {i + 1})", consistency_level=ConsistencyLevel.ANY))
+
+    # Temporarily pause hints replay, we will unpause it after decommission starts and streaming is done,
+    # but before switching to writing to new nodes
+    logger.info("Pause hints replay on nodes 1 and 2")
+    for srv in (server1, server2):
+        await manager.api.enable_injection(srv.ip_addr, "hinted_handoff_pause_hint_replay", one_shot=False)
+
+    # Start the node
+    logger.info("Start node 3")
+    await manager.server_start(server3.server_id)
+    await manager.servers_see_each_other([server1, server2, server3])
+
+    # Record the current position of hints so that we can wait for them later
+    sync_points = [create_sync_point(srv) for srv in (server1, server2)]
+
+    async with asyncio.TaskGroup() as tg:
+        coord = await get_topology_coordinator(manager)
+        coord_srv = await find_server_by_host_id(manager, [server1, server2, server3], coord)
+
+        # Make sure topology coordinator will pause right after streaming
+        logger.info("Enabling injection on the topology coordinator that will tell it to pause streaming")
+        await manager.api.enable_injection(coord_srv.ip_addr, "topology_coordinator_pause_after_streaming", one_shot=False)
+        coord_log = await manager.server_open_log(coord_srv.server_id)
+        coord_mark = await coord_log.mark()
+
+        # Start decommission - it will get stuck on error injection so do it in the background
+        logger.info("Starting decommission in the background")
+        decommission_result = tg.create_task(manager.decommission_node(server3.server_id))
+
+        # Wait until streaming ends
+        logger.info("Wait until decomission finishes streaming")
+        await coord_log.wait_for(f'decommissioning: streaming completed for node', from_mark=coord_mark)
+
+        # Now, unpause hints and let them be replayed
+        logger.info("Unpause hints replay on nodes 1 and 2")
+        for srv in (server1, server2):
+            await manager.api.disable_injection(srv.ip_addr, "hinted_handoff_pause_hint_replay")
+
+        logger.info("Wait until hints are replayed from nodes 1 and 2")
+        await asyncio.gather(*(asyncio.to_thread(await_sync_point, srv, pt, timeout=30) for srv, pt in zip((server1, server2), sync_points)))
+
+        # Unpause streaming and let decommission finish
+        logger.info("Unpause streaming")
+        await manager.api.disable_injection(coord_srv.ip_addr, "topology_coordinator_pause_after_streaming")
+
+        logger.info("Wait until decomission finishes")
+        await decommission_result
+
+    # Verify that no data has been lost - if the hints replay only sent the hints to the original destination (server3),
+    # then they will be only present on server3 which already left the cluster
+    logger.info("Verify that no data stored in hints have been lost")
+    for i in range(100):
+        assert list(await cql.run_async(f"SELECT v FROM ks.t WHERE pk = {i}")) == [(i + 1,)]

--- a/test/topology_experimental_raft/test_mv_tablets_replace.py
+++ b/test/topology_experimental_raft/test_mv_tablets_replace.py
@@ -17,17 +17,10 @@ import asyncio
 import logging
 
 from test.topology.conftest import skip_mode
-from test.topology.util import get_topology_coordinator
+from test.topology.util import get_topology_coordinator, find_server_by_host_id
 from test.topology_experimental_raft.test_mv_tablets import get_tablet_replicas
 
 logger = logging.getLogger(__name__)
-
-
-async def find_server_by_host_id(manager: ManagerClient, servers: List[ServerInfo], host_id: HostID) -> ServerInfo:
-    for s in servers:
-        if await manager.get_host_id(s.server_id) == host_id:
-            return s
-    raise Exception(f"Host ID {host_id} not found in {servers}")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Currently, when attempting to send a hint, we might choose its recipients in one of two ways:

- If the original destination is a natural endpoint of the hint, we only send the hint to that node and none other,
- Otherwise, we send the hint to all current replicas of the mutation.

There is a problem when we decommission a node: while data is streamed away from that node, it is still considered to be a natural endpoint of the data that it used to own. Because of that, it might happen that a hint is sent directly to it but streaming will miss it, effectively resulting in the hint being discarded.

As sending the hint _only_ to the leaving replica is a rather bad idea, send the hint to all replicas also in the case when the original destination of the hint is leaving.

Note that this is a conservative fix written only with the decommission + vnode-based keyspaces combo in mind. In general, such "data loss" can occur in other situations where the replica set is changing and we go through a streaming phase, i.e. other topology operations in case of vnodes and tablet load balancing. However, the consistency guarantees of hinted handoff in the face of topology changes are not defined and it is not clear what they should be, if there should be any at all. The picture is further complicated by the fact that hints are used by materialized views, and sending view updates to more replicas than necessary can introduce inconsistencies in the form of "ghost rows". This fix was developed in response to a failing test which checked the hint replay + decommission scenario, and it makes it work again.

Fixes scylladb/scylla-dtest#4582
Refs scylladb/scylladb#19835

Should be backported to 6.0 and 6.1; the dtest started failing due to topology on raft, which sped up execution of the test and exposed the preexisting problem.