### PR TITLE
optimized_clang.sh: add missing symbolic links to clang (for ccache)

### DIFF
--- a/tools/toolchain/optimized_clang.sh
+++ b/tools/toolchain/optimized_clang.sh
@@ -156,3 +156,6 @@ fi
 cd "${CLANG_BUILD_DIR}"
 ninja -C build install-distribution-stripped
 dnf remove -y clang clang-libs
+# above package removal might have removed those symbolic links, which will cause ccache not to work later on. Manually restore them.
+ln -sf /usr/bin/ccache /usr/lib64/ccache/clang
+ln -sf /usr/bin/ccache /usr/lib64/ccache/clang++


### PR DESCRIPTION
The removal of clang removes the symblic links ccache uses to mask itself as clang/clang++ Manually add them back, so ccache can work.


Fixes: https://github.com/scylladb/scylladb/issues/20490

Backport is not needed, this is an improvement to the local build performance.