### PR TITLE
test_tablets.py: limit concurrency in test_tablet_storage_freeing

### DIFF
--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -20,7 +20,7 @@ import time
 import random
 import os
 import glob
-
+import itertools
 
 logger = logging.getLogger(__name__)
 
@@ -1092,7 +1092,10 @@ async def test_tablet_storage_freeing(manager: ManagerClient):
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, v text) WITH compression = {'sstable_compression': ''};")
     insert_stmt = cql.prepare("INSERT INTO test.test (pk, v) VALUES (?, ?);")
     payload = "a"*10000
-    await asyncio.gather(*[cql.run_async(insert_stmt, [k, payload]) for k in range(n_partitions)])
+
+    max_concurrency = 100
+    for batch in itertools.batched(range(n_partitions), max_concurrency):
+        await asyncio.gather(*[cql.run_async(insert_stmt, [k, payload]) for k in batch])
     await manager.api.keyspace_flush(servers[0].ip_addr, "test")
 
     logger.info("Start second node.")


### PR DESCRIPTION
Apparently the python driver can't deal with the current concurrency sometimes. Lower it from 1000 to 100.

Fixes scylladb/scylladb#20489