### PR TITLE
compaction: remove unnecessary share bump for split, scrub, and upgrade

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1582,9 +1582,6 @@ protected:
 
             setup_new_compaction(descriptor.run_identifier);
 
-            compaction_backlog_tracker user_initiated(std::make_unique<user_initiated_backlog_tracker>(_cm._compaction_controller.backlog_of_shares(200), _cm.available_memory()));
-            _cm.register_backlog_tracker(user_initiated);
-
             std::exception_ptr ex;
             try {
                 sstables::compaction_result res = co_await compact_sstables_and_update_history(std::move(descriptor), _compaction_data, on_replace, _can_purge);


### PR DESCRIPTION
When split, scrub, and upgrade compactions ran under the compaction group, they had to bump up their shares to a minimum of 200 to prevent slow progress as they neared completion, especially in workloads with inconsistent ingestion rates. Since commit e86965c2 moved these compactions to run under the maintenance group, this share bump is no longer necessary. This patch removes the unnecessary share allocation.

Fixes #20224

No need to backport as this an improvement. 