### PR TITLE
generic_server: make shutdown() reentrant

### DIFF
--- a/generic_server.hh
+++ b/generic_server.hh
@@ -16,6 +16,7 @@
 
 #include <seastar/core/file-types.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/shared_future.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/net/api.hh>
 #include <seastar/net/tls.hh>
@@ -79,7 +80,7 @@ protected:
     sstring _server_name;
     logging::logger& _logger;
     seastar::gate _gate;
-    future<> _all_connections_stopped = make_ready_future<>();
+    shared_future<> _shutting_down;
     uint64_t _total_connections = 0;
     future<> _listeners_stopped = make_ready_future<>();
     using connections_list_t = boost::intrusive::list<connection>;


### PR DESCRIPTION
Express the "shutting down" state via a shared future. The underlying future depends on:
- initiating shutdown on all connections,
- all connections actually exiting,
- all listeners stopping.

A shared future can be in one of four states:
- disengaged (invalid),
- valid and in progress,
- valid and resolved successfully,
- valid and resoved with an exception.

When shutdown() is called for the first time, enter the "shutting down" state, by setting up the above tree of futures, wrapped into the "_shutting_down" shared future. Every time shutdown() is called (including the first time), return a one-off, independent future, extracted from the "_shutting_down" shared future. shutdown() will never block or suspend, and can be called arbitrarily many times.

stop() can be called just as frequently, even from different fibers; one-off futures extracted from the "_shutting_down" shared future can always re-report the shutdown state (in progress or completed).

Use "_shutting_down.valid()" as the shutdown signal in do_accepts().

Futhermore, we need not hold the gate in do_accepts(); "_listeners_stopped" will resolve only when do_accepts() resolves, anyway.

Fixes #20309.

Backport should not be necessary; this is supposed to fix a difficult to hit race.