### PR TITLE
test: avoid silly "no_mode.1" labels when running tests outside test.py

### DIFF
--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -50,9 +50,9 @@ def pytest_addoption(parser):
         help='Omit scylla\'s output from the test output')
     parser.addoption('--host', action='store', default='localhost',
         help='Scylla server host to connect to')
-    parser.addoption('--mode', action='store', default='no_mode',
+    parser.addoption('--mode', action='store', default=None,
                      help='Scylla build mode. Tests can use it to adjust their behavior.')
-    parser.addoption('--run_id', action='store', default=1,
+    parser.addoption('--run_id', action='store', default=None,
                      help='Run id for the test run')
 def pytest_configure(config):
     config.addinivalue_line("markers", "veryslow: mark test as very slow to run")

--- a/test/cql-pytest/conftest.py
+++ b/test/cql-pytest/conftest.py
@@ -45,9 +45,9 @@ def pytest_addoption(parser):
     # presence.
     parser.addoption('--omit-scylla-output', action='store_true',
         help='Omit scylla\'s output from the test output')
-    parser.addoption('--mode', action='store', default='no_mode',
+    parser.addoption('--mode', action='store', default=None,
                      help='Scylla build mode. Tests can use it to adjust their behavior.')
-    parser.addoption('--run_id', action='store', default=1,
+    parser.addoption('--run_id', action='store', default=None,
                      help='Run id for the test run')
 
 # "cql" fixture: set up client object for communicating with the CQL API.

--- a/test/pylib/report_plugin.py
+++ b/test/pylib/report_plugin.py
@@ -24,7 +24,8 @@ class ReportPlugin:
     def pytest_runtest_makereport(self):
         outcome = yield
         report = outcome.get_result()
-        report.nodeid = f"{report.nodeid}.{self.mode}.{self.run_id}"
+        if self.mode is not None or self.run_id is not None:
+            report.nodeid = f"{report.nodeid}.{self.mode}.{self.run_id}"
 
     @pytest.fixture(scope="function", autouse=True)
     def allure_set_mode(self, request):


### PR DESCRIPTION
For the benefit of running test.py inside CI, we recently added to test/cql-pytest and test/alternator the knowledge of which "Scylla mode" (--mode) and "run number" is running (--run_id), although these concepts are alien to these two test frameworks (remember that those test frameworks can also run tests against unknown versions of Scylla or even our competitors' implementations).

One unfortunate result of this change is that now if you run a test by using pytest directly (or test/*/run) instead of test.py, for example:

    $ cd test/alternator
    $ pytest --aws test_item.py::test_basic_string_put_and_get

The test's success or failure reports the ugly name

    test_item.py::test_basic_string_put_and_get.no_mode.1

This unnecessary "no_mode.1" come from the the default values for --mode and --run_id, respectively. But there is no reason for these silly defaults. In this patch we change these defaults to None, and when they are None, they aren't tacked onto the test's name.

This patch shouldn't affect running tests through test.py, because test.py always sets the --mode and --run_id options, and doesn't leave them as the default.

Fixes #20512

Minor improvement to developers' experience - no backports necessary.