### PR TITLE
alternator: implement TableClass attribute by changing compression

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -526,6 +526,13 @@ future<rjson::value> executor::fill_table_description(schema_ptr schema, table_s
     } else {
         rjson::add(table_description["BillingModeSummary"], "BillingMode", "PROVISIONED");
     }
+    auto compression_algorithm = schema->get_compressor_params().get_algorithm();
+    if (compression_algorithm == compression_parameters::algorithm::zstd_with_dicts ||
+            compression_algorithm == compression_parameters::algorithm::zstd) {
+        rjson::value table_class_summary = rjson::empty_object();
+        rjson::add(table_class_summary, "TableClass", "STANDARD_INFREQUENT_ACCESS");
+        rjson::add(table_description, "TableClassSummary", std::move(table_class_summary));
+    }
     rjson::add(table_description, "ProvisionedThroughput", rjson::empty_object());
     rjson::add(table_description["ProvisionedThroughput"], "ReadCapacityUnits", rcu);
     rjson::add(table_description["ProvisionedThroughput"], "WriteCapacityUnits", wcu);
@@ -1415,6 +1422,35 @@ static std::string get_similarity_function(const rjson::value& vector_index, std
     return sf;
 }
 
+// Parse the optional TableClass parameter from a CreateTable or UpdateTable
+// request and, if present, set the appropriate compressor on the builder.
+// Returns true if TableClass was present, false if absent.
+// Throws a ValidationException for unsupported or malformed values.
+static bool handle_table_class(const rjson::value& request, schema_builder& builder, const gms::feature_service& features) {
+    const rjson::value* table_class_value = rjson::find(request, "TableClass");
+    if (!table_class_value) {
+        return false;
+    }
+    if (!table_class_value->IsString()) {
+        throw api_error::validation("Invalid table-class parameter provided. Valid values are: [STANDARD, STANDARD_INFREQUENT_ACCESS].");
+    }
+
+    const bool dicts_enabled = bool(features.sstable_compression_dicts);
+    std::string_view table_class_name = rjson::to_string_view(*table_class_value);
+    if (table_class_name == "STANDARD") {
+        builder.set_compressor_params(dicts_enabled
+                ? compression_parameters::algorithm::lz4_with_dicts
+                : compression_parameters::algorithm::lz4);
+    } else if (table_class_name == "STANDARD_INFREQUENT_ACCESS") {
+        builder.set_compressor_params(dicts_enabled
+                ? compression_parameters::algorithm::zstd_with_dicts
+                : compression_parameters::algorithm::zstd);
+    } else {
+        throw api_error::validation("Invalid table-class parameter provided. Valid values are: [STANDARD, STANDARD_INFREQUENT_ACCESS].");
+    }
+    return true;
+}
+
 future<executor::request_return_type> executor::create_table_on_shard0(service::client_state&& client_state, tracing::trace_state_ptr trace_state, rjson::value request, bool enforce_authorization, bool warn_authorization,
             const db::tablets_mode_t::mode tablets_mode, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     throwing_assert(this_shard_id() == 0);
@@ -1457,6 +1493,8 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
     builder.with_column(bytes(executor::ATTRS_COLUMN_NAME), attrs_type(), column_kind::regular_column);
 
     billing_mode_type bm = verify_billing_mode(request);
+
+    handle_table_class(request, builder, _proxy.features());
 
     schema_ptr partial_schema = builder.build();
 

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1977,13 +1977,27 @@ future<executor::request_return_type> executor::update_table(client_state& clien
 
             schema_builder builder(tab);
 
-            if (handle_table_class(request, builder, p.local().features())) {
+            bool table_class_updated = handle_table_class(request, builder, p.local().features());
+            if (table_class_updated) {
                 empty_request = false;
+                if (rjson::find(request, "StreamSpecification") ||
+                    rjson::find(request, "GlobalSecondaryIndexUpdates") ||
+                    rjson::find(request, "VectorIndexUpdates") ||
+                    rjson::find(request, "BillingMode")) {
+                    co_return api_error::validation("TableClass modification must be the only operation in the request");
+                }
             }
 
             rjson::value* stream_specification = rjson::find(request, "StreamSpecification");
-            if (stream_specification && stream_specification->IsObject()) {
+            if (stream_specification) {
+                if (!stream_specification->IsObject()) {
+                    co_return api_error::validation("StreamSpecification must be an object");
+                }
                 empty_request = false;
+                if (rjson::find(request, "GlobalSecondaryIndexUpdates") ||
+                    rjson::find(request, "VectorIndexUpdates")) {
+                    co_return api_error::validation("You cannot create or delete index while changing stream status");
+                }
                 if (add_stream_options(*stream_specification, builder, p.local(), tab->cdc_options())) {
                     validate_cdc_log_name_length(builder.cf_name());
                     bool uses_tablets = p.local().local_db().find_keyspace(tab->ks_name()).get_replication_strategy().uses_tablets();

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1977,6 +1977,10 @@ future<executor::request_return_type> executor::update_table(client_state& clien
 
             schema_builder builder(tab);
 
+            if (handle_table_class(request, builder, p.local().features())) {
+                empty_request = false;
+            }
+
             rjson::value* stream_specification = rjson::find(request, "StreamSpecification");
             if (stream_specification && stream_specification->IsObject()) {
                 empty_request = false;
@@ -2287,7 +2291,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
             }
 
             if (empty_request) {
-                co_return api_error::validation("UpdateTable requires one of GlobalSecondaryIndexUpdates, VectorIndexUpdates, StreamSpecification or BillingMode to be specified");
+                co_return api_error::validation("UpdateTable requires one of GlobalSecondaryIndexUpdates, VectorIndexUpdates, StreamSpecification, BillingMode or TableClass to be specified");
             }
 
             co_await verify_permission(enforce_authorization, warn_authorization, client_state_other_shard.get(), schema, auth::permission::ALTER, e.local()._stats);

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -388,6 +388,41 @@ Alternator Streams differ in some respects from DynamoDB Streams:
   24 hours through the old StreamArn even after re-enabling.
   <https://scylladb.atlassian.net/browse/SCYLLADB-1873>
 
+## Table Class
+
+DynamoDB's _table class_ option allows choosing between two storage tiers with
+different cost/performance tradeoffs: `STANDARD` (the default) and
+`STANDARD_INFREQUENT_ACCESS`. In DynamoDB, the latter reduces storage costs by
+60% in exchange for 25% higher per-request costs.
+
+Alternator supports the `TableClass` option in `CreateTable` and `UpdateTable`,
+and reports it back in `DescribeTable`, by mapping it to different SSTable
+compression settings:
+
+* `STANDARD` uses LZ4 with dictionaries, which gives reasonable compression
+  at low CPU overhead.
+* `STANDARD_INFREQUENT_ACCESS` uses Zstandard (zstd) with dictionaries,
+  which gives better compression ratios with higher CPU and memory overheads.
+
+There are a few small differences from DynamoDB's behavior:
+
+* In DynamoDB, `DescribeTable` always returns a `TableClassSummary` object
+  when `TableClass` was explicitly set to `STANDARD` (either in `CreateTable`
+  or by `UpdateTable`). Alternator omits `TableClassSummary` in this case,
+  just like DynamoDB omits it in the default `STANDARD` case.
+
+* After `UpdateTable` changes the table class, DynamoDB returns a
+  `LastUpdateDateTime` field inside `TableClassSummary` in subsequent
+  `DescribeTable` calls. Alternator does not yet return this field.
+
+* In DynamoDB, changing the table class via `UpdateTable` triggers a background
+  operation to change the table's storage, and is limited to two changes per
+  30-day period. In Alternator, the compression setting in the schema is
+  updated immediately, but existing SSTables are **not** rewritten; only new
+  SSTables written by subsequent writes and compactions will use the new
+  compression. Alternator also does not enforce the two-changes-per-month
+  limit.
+
 ## Unimplemented API features
 
 In general, every DynamoDB API feature available in Amazon DynamoDB should
@@ -482,12 +517,6 @@ they should be easy to detect. Here is a list of these unimplemented features:
   and its operations ImportTable, DescribeImport, ListImports.
   This feature was added to DynamoDB in August 2022.
   <https://github.com/scylladb/scylla/issues/11739>
-
-* Alternator does not support the TableClass table option choosing between
-  several storage options with different cost/performance characteristics.
-  All Alternator tables are stored the same way. This table option was added
-  to DynamoDB in December 2021.
-  <https://github.com/scylladb/scylla/issues/10431>
 
 * Alternator does not support the table option DeletionProtectionEnabled
   that can be used to forbid table deletion. This table option was added to

--- a/test/alternator/test_describe_table.py
+++ b/test/alternator/test_describe_table.py
@@ -13,6 +13,7 @@
 #     feature.
 #  3. Tests for describing a restored table (RestoreSummary, TableId)
 #     will be together with tests devoted to the backup/restore feature.
+#  4. Tests for describing TableClass are in test_tableclass.py.
 
 import pytest
 from botocore.exceptions import ClientError

--- a/test/alternator/test_gsi_updatetable.py
+++ b/test/alternator/test_gsi_updatetable.py
@@ -573,6 +573,25 @@ def test_gsi_updatetable_errors(dynamodb, table1):
                 { 'Delete': {  'IndexName': 'ind2' } }
             ])
 
+# Test that a single UpdateTable cannot combine GlobalSecondaryIndexUpdates
+# (creating a GSI) with StreamSpecification (enabling streams) in one request.
+# DynamoDB rejects this combination with the error:
+# "You cannot create or delete index while changing stream status".
+def test_gsi_updatetable_combined_with_stream(dynamodb):
+    with new_test_table(dynamodb,
+            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+            AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' } ]) as table:
+        with pytest.raises(ClientError, match='ValidationException.*while'):
+            dynamodb.meta.client.update_table(
+                TableName=table.name,
+                AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'S' }],
+                GlobalSecondaryIndexUpdates=[ { 'Create': {
+                    'IndexName': 'gsi',
+                    'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
+                    'Projection': { 'ProjectionType': 'ALL' }
+                }}],
+                StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'NEW_AND_OLD_IMAGES'})
+
 # Whereas CreateTable rejects spurious entries in AttributeDefinitions
 # (entries which aren't used as a key of the table or any GSI or LSI),
 # as tested in test_table.py::test_create_table_spurious_attribute_definitions

--- a/test/alternator/test_tableclass.py
+++ b/test/alternator/test_tableclass.py
@@ -144,7 +144,6 @@ def wait_for_active(table):
 #    related variables. You can still access your table normally while it is
 #    converted. Note that no more than two table class updates on your table
 #    are allowed in a 30-day trailing period."
-@pytest.mark.xfail(reason="#10431 - TableClass not yet supported")
 def test_tableclass_update_table(dynamodb):
     schema = {
         'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],

--- a/test/alternator/test_tableclass.py
+++ b/test/alternator/test_tableclass.py
@@ -172,6 +172,23 @@ def test_tableclass_update_table(dynamodb):
         with pytest.raises(ClientError, match='ValidationException.*table.class'):
             table.meta.client.update_table(TableName=table.name, TableClass='junk')
 
+# Test that a single UpdateTable is NOT allowed to change TableClass together
+# with anything else. DynamoDB returns a ValidationException saying
+# "TableClass modification must be the only operation in the request".
+# We test this by attempting to change both TableClass and StreamSpecification
+# in a single UpdateTable.
+def test_tableclass_update_table_combined(dynamodb):
+    schema = {
+        'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+        'AttributeDefinitions': [{ 'AttributeName': 'p', 'AttributeType': 'S'}],
+    }
+    with new_test_table(dynamodb, **schema) as table:
+        with pytest.raises(ClientError, match='ValidationException.*only'):
+            table.meta.client.update_table(
+                TableName=table.name,
+                TableClass='STANDARD_INFREQUENT_ACCESS',
+                StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'NEW_AND_OLD_IMAGES'})
+
 # DynamoDB includes LastUpdateDateTime in TableClassSummary after an
 # UpdateTable that changes the TableClass. This is not yet implemented.
 @pytest.mark.xfail(reason="LastUpdateDateTime in TableClassSummary not yet implemented")

--- a/test/alternator/test_tableclass.py
+++ b/test/alternator/test_tableclass.py
@@ -45,7 +45,6 @@ def flush_and_drop_cache(optional_rest_api, table):
 
 # Test CreateTable creating a table with the non-default TableClass
 # "STANDARD_INFREQUENT_ACCESS".
-@pytest.mark.xfail(reason="#10431 - TableClass not yet supported")
 def test_tableclass_create_table_sia(dynamodb, optional_rest_api):
     schema = {
         'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
@@ -72,7 +71,6 @@ def test_tableclass_create_table_sia(dynamodb, optional_rest_api):
 
 # Test CreateTable creating a table with the default "STANDARD" TableClass
 # explicitly specified.
-@pytest.mark.xfail(reason="#10431 - TableClass not yet supported")
 def test_tableclass_create_table_standard(dynamodb, optional_rest_api):
     schema = {
         'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
@@ -105,10 +103,10 @@ def test_tableclass_describe_table_explicit_standard(dynamodb):
             'TableClass': 'STANDARD'
         }
 
+
 # Test that setting TableClass to unsupported names produces an error.
 # This test also confirms that the TableClass string is cases sensitive -
 # 'STANDARD' works (as we checked above) but lowercase 'standard' doesn't.
-@pytest.mark.xfail(reason="#10431 - TableClass not yet supported")
 def test_tableclass_create_table_bad_tableclass(dynamodb):
     for tableclass in ['invalid_tableclass_name', 'standard']:
         schema = {

--- a/test/alternator/test_tableclass.py
+++ b/test/alternator/test_tableclass.py
@@ -1,0 +1,236 @@
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+# Tests for the TableClass table option. See #10431.
+# DynamoDB announced this option in December 2021:
+# https://aws.amazon.com/blogs/aws/new-dynamodb-table-class-save-up-to-60-in-your-dynamodb-costs/
+# TableClass can be STANDARD or STANDARD_INFREQUENT_ACCESS, where the former
+# is the default and the latter gives lower storage costs and higher read and
+# write costs - but everything else, including performance, remains the same.
+
+import pytest
+import time
+import requests
+from botocore.exceptions import ClientError
+from test.alternator.util import new_test_table, full_query
+
+# DescribeTable should return the table's table class in a "TableClassSummary"
+# object. However, it turns out that a table that has the default TableClass
+# and it was never explicitly set, doesn't report a TableClassSummary at all.
+# This may have been a deliberate decision by the DynamoDB designers (so
+# an old application that doesn't set TableClass in CreateTable also doesn't
+# get it back in DescribeTable) - so let's implement it too.
+def test_tableclass_describe_table_default(test_table):
+    got = test_table.meta.client.describe_table(TableName=test_table.name)['Table']
+    assert 'TableClassSummary' not in got
+
+# When running on Alternator, this helper function flushes the given table's
+# memtables to sstable and drops the row cache (and sstable page caches) for
+# all tables. It does nothing when not running on Alternator. This function
+# is useful for tests that want to ensure that a configuration (like
+# compression) which are supposed to affect sstable storage, actually do
+# get tested with real sstable storage, and not just in-memory state.
+def flush_and_drop_cache(optional_rest_api, table):
+    if not optional_rest_api:
+        return
+    ks = 'alternator_' + table.name
+    response = requests.post(optional_rest_api + f'/storage_service/keyspace_flush/{ks}', params={'cf': table.name})
+    assert response.ok
+    # Drop both the row cache and sstable page caches so the next read is
+    # forced to come from sstable. Despite its name, the drop_sstable_caches
+    # endpoint also invalidates the row cache (for all tables).
+    response = requests.post(optional_rest_api + '/system/drop_sstable_caches')
+    assert response.ok
+
+# Test CreateTable creating a table with the non-default TableClass
+# "STANDARD_INFREQUENT_ACCESS".
+@pytest.mark.xfail(reason="#10431 - TableClass not yet supported")
+def test_tableclass_create_table_sia(dynamodb, optional_rest_api):
+    schema = {
+        'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+        'AttributeDefinitions': [{ 'AttributeName': 'p', 'AttributeType': 'S'}],
+        'TableClass' : 'STANDARD_INFREQUENT_ACCESS'
+    }
+    with new_test_table(dynamodb, **schema) as table:
+        # Check that DescribeTable reports correctly that the new table is
+        # in the STANDARD_INFREQUENT_ACCESS table class. TableClassSummary
+        # should contain the expected TableClass, but NOT contain
+        # LastUpdateDateTime (apparently it only gets set when UpdateTable
+        # changes the TableClass).
+        got = table.meta.client.describe_table(TableName=table.name)['Table']
+        assert got['TableClassSummary'] == {
+            'TableClass': 'STANDARD_INFREQUENT_ACCESS'
+        }
+        # Check that we can write to the table and read it back. On Alternator
+        # use flush_and_drop_cache to ensure that the data is really written
+        # and read from on-disk sstable, to make the test stronger.
+        table.put_item(Item={'p': 'hello', 'val': 'world'})
+        flush_and_drop_cache(optional_rest_api, table)
+        got_item = table.get_item(Key={'p': 'hello'}, ConsistentRead=True)['Item']
+        assert got_item == {'p': 'hello', 'val': 'world'}
+
+# Test CreateTable creating a table with the default "STANDARD" TableClass
+# explicitly specified.
+@pytest.mark.xfail(reason="#10431 - TableClass not yet supported")
+def test_tableclass_create_table_standard(dynamodb, optional_rest_api):
+    schema = {
+        'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+        'AttributeDefinitions': [{ 'AttributeName': 'p', 'AttributeType': 'S'}],
+        'TableClass' : 'STANDARD'
+    }
+    with new_test_table(dynamodb, **schema) as table:
+        table.put_item(Item={'p': 'hello', 'val': 'world'})
+        flush_and_drop_cache(optional_rest_api, table)
+        got_item = table.get_item(Key={'p': 'hello'}, ConsistentRead=True)['Item']
+        assert got_item == {'p': 'hello', 'val': 'world'}
+
+# Above in test_tableclass_describe_table_default we saw that when TableClass
+# is not explicitly set and the default STANDARD is used, DescribeTable doesn't
+# return a TableClassSummary at all. Here notice that TableClass is explicitly
+# set to STANDARD in CreateTable, it is also returned in DescribeTable.
+# To simplify the implementation - avoid needing to remember whether the
+# compression was set explicitly or implicitly - we decided not to support
+# this distinction, so this test xfails.
+@pytest.mark.xfail(reason="deliberate small deviation from DynamoDB")
+def test_tableclass_describe_table_explicit_standard(dynamodb):
+    schema = {
+        'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+        'AttributeDefinitions': [{ 'AttributeName': 'p', 'AttributeType': 'S'}],
+        'TableClass' : 'STANDARD'
+    }
+    with new_test_table(dynamodb, **schema) as table:
+        got = table.meta.client.describe_table(TableName=table.name)['Table']
+        assert got['TableClassSummary'] == {
+            'TableClass': 'STANDARD'
+        }
+
+# Test that setting TableClass to unsupported names produces an error.
+# This test also confirms that the TableClass string is cases sensitive -
+# 'STANDARD' works (as we checked above) but lowercase 'standard' doesn't.
+@pytest.mark.xfail(reason="#10431 - TableClass not yet supported")
+def test_tableclass_create_table_bad_tableclass(dynamodb):
+    for tableclass in ['invalid_tableclass_name', 'standard']:
+        schema = {
+            'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+            'AttributeDefinitions': [{ 'AttributeName': 'p', 'AttributeType': 'S'}],
+            'TableClass' : tableclass
+        }
+        # DynamoDB responds with the error: "Invalid table-class parameter
+        # provided. Please try again with a valid table-class value:
+        # [STANDARD, STANDARD_INFREQUENT_ACCESS]."
+        with pytest.raises(ClientError, match='ValidationException.*table.class'):
+            with new_test_table(dynamodb, **schema) as table:
+                pass
+
+# UpdateTable for changing the TableClass is an asynchronous operation.
+# While this change happening, we cannot do other changes to the table
+# or even delete it when the test ends - so we need to wait for the update
+# to finish. While the update is happening, the table's TableStatus is
+# changed from ACTIVE to UPDATING - and we need to wait for it to become
+# ACTIVE again.
+def wait_for_active(table):
+    timeout = time.time() + 60
+    while time.time() < timeout:
+        desc = table.meta.client.describe_table(TableName=table.name)
+        if desc['Table']['TableStatus'] == 'ACTIVE':
+            return
+        time.sleep(1)
+    raise AssertionError('wait_for_active did not complete until timeout')
+
+# UpdateTable allows changing the TableClass. The DynamoDB documentation
+# explains how this change happens in practice, and how it's limited to only
+# two changes per month:
+#   "Table class update is a background process. The time to update your
+#    table class depends on your table traffic, storage size, and other
+#    related variables. You can still access your table normally while it is
+#    converted. Note that no more than two table class updates on your table
+#    are allowed in a 30-day trailing period."
+@pytest.mark.xfail(reason="#10431 - TableClass not yet supported")
+def test_tableclass_update_table(dynamodb):
+    schema = {
+        'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+        'AttributeDefinitions': [{ 'AttributeName': 'p', 'AttributeType': 'S'}],
+        'TableClass' : 'STANDARD'
+    }
+    with new_test_table(dynamodb, **schema) as table:
+        # Update the table to STANDARD_INFREQUENT_ACCESS
+        table.meta.client.update_table(TableName=table.name, TableClass='STANDARD_INFREQUENT_ACCESS')
+        wait_for_active(table)
+        # DescribeTable should now list the new TableClass
+        got = table.meta.client.describe_table(TableName=table.name)['Table']
+        assert got['TableClassSummary']['TableClass'] == 'STANDARD_INFREQUENT_ACCESS'
+        # Update the table back to STANDARD. Should work (two changes are
+        # allowed per month).
+        table.meta.client.update_table(TableName=table.name, TableClass='STANDARD')
+        wait_for_active(table)
+        got = table.meta.client.describe_table(TableName=table.name)['Table']
+        # Allow TableClassSummary to be missing (default STANDARD) or be
+        # present with TableClass = STANDARD. DynamoDB does the latter, but
+        # we have other tests for this and don't want to mix this concern here
+        # too.
+        assert 'TableClassSummary' not in got or got['TableClassSummary']['TableClass'] == 'STANDARD'
+        # Trying to change the table class to non-existent class 'junk'
+        # should fail:
+        with pytest.raises(ClientError, match='ValidationException.*table.class'):
+            table.meta.client.update_table(TableName=table.name, TableClass='junk')
+
+# DynamoDB includes LastUpdateDateTime in TableClassSummary after an
+# UpdateTable that changes the TableClass. This is not yet implemented.
+@pytest.mark.xfail(reason="LastUpdateDateTime in TableClassSummary not yet implemented")
+def test_tableclass_update_table_last_update_datetime(dynamodb):
+    schema = {
+        'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+        'AttributeDefinitions': [{ 'AttributeName': 'p', 'AttributeType': 'S'}],
+        'TableClass' : 'STANDARD'
+    }
+    with new_test_table(dynamodb, **schema) as table:
+        table.meta.client.update_table(TableName=table.name, TableClass='STANDARD_INFREQUENT_ACCESS')
+        wait_for_active(table)
+        got = table.meta.client.describe_table(TableName=table.name)['Table']
+        assert 'LastUpdateDateTime' in got['TableClassSummary']
+
+# Utility function for getting - from Scylla-specific system tables - the
+# sstable compression options set for the given table.
+def scylla_get_compression(dynamodb, table):
+    info = dynamodb.Table('.scylla.alternator.system_schema.tables')
+    # We need to read just a single key, but strangely Alternator doesn't
+    # allow GetItem on system tables, just Query/Scan, so we use Query:
+    res = full_query(info,
+        KeyConditionExpression='keyspace_name=:ks and table_name=:cf',
+        ExpressionAttributeValues={
+            ':ks': 'alternator_'+table.name, ':cf' : table.name})
+    assert len(res) == 1
+    return res[0]['compression']
+
+# A Scylla-only test for checking the internal implications of setting the
+# TableClass. Here we check that the default (STANDARD) table class translates
+# to using LZ4 compression in the sstables.
+# If we ever change the implementation of what the different table classes
+# mean, we'll need to change this test.
+def test_tableclass_default_uses_lz4(dynamodb, test_table, scylla_only):
+    assert 'LZ4WithDictsCompressor' in scylla_get_compression(dynamodb, test_table)
+
+# And here we check that if we explicitly set the TableClass to STANDARD,
+# we should also get LZ4 compression.
+def test_tableclass_standard_uses_lz4(dynamodb, scylla_only):
+    schema = {
+        'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+        'AttributeDefinitions': [{ 'AttributeName': 'p', 'AttributeType': 'S'}],
+        'TableClass' : 'STANDARD'
+    }
+    with new_test_table(dynamodb, **schema) as table:
+        assert 'LZ4WithDictsCompressor' in scylla_get_compression(dynamodb, table)
+
+# And here we check that the STANDARD_INFREQUENT_ACCESS table class translates
+# to using ZSTD compression in the sstables.
+# If we ever change the implementation of what the different table classes
+# mean, we'll need to change this test.
+def test_tableclass_sia_uses_zstd(dynamodb, scylla_only):
+    schema = {
+        'KeySchema': [{ 'AttributeName': 'p', 'KeyType': 'HASH' }],
+        'AttributeDefinitions': [{ 'AttributeName': 'p', 'AttributeType': 'S'}],
+        'TableClass' : 'STANDARD_INFREQUENT_ACCESS'
+    }
+    with new_test_table(dynamodb, **schema) as table:
+        assert 'ZstdWithDictsCompressor' in scylla_get_compression(dynamodb, table)

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -878,6 +878,23 @@ def test_updatetable_vector_and_gsi_same_request(vs):
                     'Projection': {'ProjectionType': 'ALL'}
                 }}])
 
+# Similarly, it's not allowed to combine VectorIndexUpdates with
+# StreamSpecification in the same UpdateTable request. This mirrors
+# the same restriction on GlobalSecondaryIndexUpdates + StreamSpecification
+# ("You cannot create or delete index while changing stream status").
+def test_updatetable_vector_and_stream_same_request(vs):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        with pytest.raises(ClientError, match='ValidationException'):
+            table.meta.client.update_table(
+                TableName=table.name,
+                VectorIndexUpdates=[{'Create': {
+                    'IndexName': 'vec',
+                    'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}
+                }}],
+                StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'NEW_AND_OLD_IMAGES'})
+
 # Test that PutItem still works as expected on a table with a vector index
 # created by CreateTable or UpdateTable. It might not work if we set up CDC
 # in a broken way that breaks writes.


### PR DESCRIPTION
DynamoDB announced in December 2021 a new attribute of a table, called table class. The choice of "table class" doesn't change anything in the table's capabilities - it just controls the pricing of storage and access: There are currently two options - STANDARD (the default) and STANDARD_INFREQUENT_ACCESS. The latter is for infrequently-accessed tables, its the data storage costs are lower (in DynamoDB, by 60%), while reads and writes are more expensive (in DynamoDB, by 25%).

In this pull request we map the TableClass option in Scylla to different sstable compression settings:

STANDARD uses to the existing default compression of lz4-with-dictionaries, which gives reasonable compression ratios at small CPU overhead.

STANDARD_INFREQUENT_ACCESS uses zstd-with-dictionaries compression, which gives better compression ratios, with higher overhead.

There are a couple of insignificant deviations from DynamoDB in our implementation (which are described in the documentation in the last patch, as well as in xfailing tests in the first patch), but a more significant deviation is the following:

In DynamoDB, changing the table class via `UpdateTable` triggers a background  operation to change the table's storage, and is limited to two changes per 30-day period. In Alternator, the compression setting in the schema is updated immediately, but existing SSTables are **not** rewritten; only new SSTables written by subsequent writes and compactions will use the new compression.

Fixes #10431
