### PR TITLE
cql3/statements/select_statement: `SELECT ... USING SERVICE LEVEL`

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -430,7 +430,7 @@ selectStatement returns [std::unique_ptr<raw::select_statement> expr]
       ( K_LIMIT rows=intValue { limit = std::move(rows); } )?
       ( K_ALLOW K_FILTERING  { allow_filtering = true; } )?
       ( K_BYPASS K_CACHE { bypass_cache = true; })?
-      ( usingTimeoutClause[attrs] )?
+      ( usingTimeoutServiceLevelClause[attrs] )?
       {
           auto params = make_lw_shared<raw::select_statement::parameters>(std::move(orderings), is_distinct, allow_filtering, statement_subtype, bypass_cache);
           $expr = std::make_unique<raw::select_statement>(std::move(cf), std::move(params),
@@ -564,6 +564,15 @@ usingTimeoutClause[std::unique_ptr<cql3::attributes::raw>& attrs]
 
 usingTimestampClause[std::unique_ptr<cql3::attributes::raw>& attrs]
     : K_USING K_TIMESTAMP ts=intValue { attrs->timestamp = std::move(ts); }
+    ;
+
+usingTimeoutServiceLevelClause[std::unique_ptr<cql3::attributes::raw>& attrs]
+    : K_USING usingTimeoutServiceLevelClauseObjective[attrs] ( K_AND usingTimeoutServiceLevelClauseObjective[attrs] )*
+    ;
+
+usingTimeoutServiceLevelClauseObjective[std::unique_ptr<cql3::attributes::raw>& attrs]
+    : K_TIMEOUT to=term { attrs->timeout = std::move(to); }
+    | serviceLevel sl_name=serviceLevelOrRoleName { attrs->service_level = std::move(sl_name); }
     ;
 
 /**

--- a/cql3/attributes.hh
+++ b/cql3/attributes.hh
@@ -14,6 +14,11 @@
 #include "cql3/expr/unset.hh"
 #include "db/timeout_clock.hh"
 
+namespace qos {
+class service_level_controller;
+struct service_level_options;
+}
+
 namespace cql3 {
 
 class query_options;
@@ -30,12 +35,14 @@ private:
     expr::unset_bind_variable_guard _time_to_live_unset_guard;
     std::optional<cql3::expr::expression> _time_to_live;
     std::optional<cql3::expr::expression> _timeout;
+    std::optional<sstring> _service_level;
 public:
     static std::unique_ptr<attributes> none();
 private:
     attributes(std::optional<cql3::expr::expression>&& timestamp,
                std::optional<cql3::expr::expression>&& time_to_live,
-               std::optional<cql3::expr::expression>&& timeout);
+               std::optional<cql3::expr::expression>&& timeout,
+               std::optional<sstring> service_level);
 public:
     bool is_timestamp_set() const;
 
@@ -43,11 +50,15 @@ public:
 
     bool is_timeout_set() const;
 
+    bool is_service_level_set() const;
+
     int64_t get_timestamp(int64_t now, const query_options& options);
 
     std::optional<int32_t> get_time_to_live(const query_options& options);
 
     db::timeout_clock::duration get_timeout(const query_options& options) const;
+
+    qos::service_level_options get_service_level(qos::service_level_controller& sl_controller) const;
 
     void fill_prepare_context(prepare_context& ctx);
 
@@ -56,6 +67,7 @@ public:
         std::optional<cql3::expr::expression> timestamp;
         std::optional<cql3::expr::expression> time_to_live;
         std::optional<cql3::expr::expression> timeout;
+        std::optional<sstring> service_level;
 
         std::unique_ptr<attributes> prepare(data_dictionary::database db, const sstring& ks_name, const sstring& cf_name) const;
     private:

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -259,6 +259,10 @@ public:
         return sl_it->second;
     }
 
+    bool has_service_level(const sstring& service_level_name) const {
+        return _service_levels_db.contains(service_level_name);
+    }
+
     future<> commit_mutations(::service::group0_batch&& mc) {
         if (_sl_data_accessor->is_v2()) {
             return _sl_data_accessor->commit_mutations(std::move(mc), _global_controller_db->group0_aborter);

--- a/test/cql-pytest/test_using_service_level.py
+++ b/test/cql-pytest/test_using_service_level.py
@@ -1,0 +1,47 @@
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Tests for USING SERVICE LEVEL extension
+
+from util import new_test_keyspace, unique_name, unique_key_int
+import pytest
+from cassandra.protocol import InvalidRequest, ReadTimeout, WriteTimeout, SyntaxException
+from cassandra.cluster import NoHostAvailable
+from cassandra.util import Duration
+
+# yields list of (service level name, bool if non-zero timeout)
+@pytest.fixture(scope="module")
+def service_levels(cql):
+    sls = [
+        (unique_name(), True),
+        (unique_name(), False),
+        (f'"{unique_name()}_esCaPeD"', True)
+    ]
+    for sl, should_fail in sls:
+        timeout = "0ns" if should_fail else "1h"
+        cql.execute(f"CREATE SERVICE LEVEL {sl} WITH timeout = {timeout}")
+    yield sls
+    for sl, _ in sls:
+        cql.execute(f"DROP SERVICE LEVEL {sl}")
+
+@pytest.fixture(scope="module")
+def test_table(cql, test_keyspace):
+    table = test_keyspace + "." + unique_name()
+    cql.execute("CREATE TABLE " + table +
+        "(p bigint, c int, v int, PRIMARY KEY (p,c))")
+    yield table
+    cql.execute("DROP TABLE " + table)
+
+def test_select_using_service_level(scylla_only, cql, service_levels, test_table):
+    for sl, should_fail in service_levels:
+        stmt = f"SELECT * FROM {test_table} USING SERVICE LEVEL {sl}"
+        if should_fail:
+            with pytest.raises(ReadTimeout):
+                cql.execute(stmt)
+        else:
+            cql.execute(stmt)
+
+def test_select_using_non_existing_service_level(scylla_only, cql, test_table):
+    with pytest.raises(InvalidRequest):
+        cql.execute(f"SELECT * FROM {test_table} USING SERVICE LEVEL {unique_name()}")


### PR DESCRIPTION
Allow to specify service level used in select statement `SELECT ... USING SERVICE LEVEL sl_name`.
In OSS, this only affects statement's timeout.

In case both service level and timeout are specified `SELECT ... USING SERVICE LEVEL sl_name AND TIMEOUT 1h`, the timeout has higher priority as statement's timeout.

Fixes scylladb/scylladb#18471