### PR TITLE
utils/rjson.cc: include the function name in exception message

### DIFF
--- a/utils/rjson.cc
+++ b/utils/rjson.cc
@@ -74,10 +74,10 @@ public:
         return _count;
     }
     // Not used in input streams, but unfortunately we still need to implement
-    Ch* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
-    void Put(Ch) { RAPIDJSON_ASSERT(false); }
-    void Flush() { RAPIDJSON_ASSERT(false); }
-    size_t PutEnd(Ch*) { RAPIDJSON_ASSERT(false); return 0; }
+    Ch* PutBegin() { RAPIDJSON_ASSERT(false && "PutBegin"); return 0; }
+    void Put(Ch) { RAPIDJSON_ASSERT(false && "Put"); }
+    void Flush() { RAPIDJSON_ASSERT(false && "Flush"); }
+    size_t PutEnd(Ch*) { RAPIDJSON_ASSERT(false && "PutEnd"); return 0; }
 
 };
 


### PR DESCRIPTION
recently, we are observing errors like:

```
stderr: error running operation: rjson::error (JSON SCYLLA_ASSERT failed on condition 'false', at: 0x60d6c8e 0x4d853fd 0x50d3ac8 0x518f5cd 0x51c4a4b 0x5fad446)
```

we only passed `false` to the `RAPIDJSON_ASSERT()` macro, so what we have is but the type of the error (rjson::error) and a backtrace. would be better if we can have more information without recompiling or fetching the debug symbols for decipher the backtrace.

Refs scylladb/scylladb#20533
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

this change improves the debugability, when facing parse failure with the JSON-encoded message, so no need to backport.