### PR TITLE
Make sstables without on-disk path

### DIFF
--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <map>
 #include <variant>
 #include <seastar/core/sstring.hh>
@@ -17,6 +18,7 @@ namespace data_dictionary {
 
 struct storage_options {
     struct local {
+        std::filesystem::path dir;
         static constexpr std::string_view name = "LOCAL";
 
         static local from_map(const std::map<sstring, sstring>&);
@@ -26,6 +28,7 @@ struct storage_options {
     struct s3 {
         sstring bucket;
         sstring endpoint;
+        sstring prefix;
         static constexpr std::string_view name = "S3";
 
         static s3 from_map(const std::map<sstring, sstring>&);

--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -49,4 +49,10 @@ struct storage_options {
     static value_type from_map(std::string_view type, std::map<sstring, sstring> values);
 };
 
+inline storage_options make_local_options(std::filesystem::path dir) {
+    storage_options so;
+    so.value = data_dictionary::storage_options::local { .dir = std::move(dir) };
+    return so;
+}
+
 } // namespace data_dictionary

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1252,6 +1252,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
 }
 
 future<> table::init_storage() {
+    _storage_opts = sstables::make_storage_options_for_table(_sstables_manager.config(), *_schema, *_storage_opts);
     co_await coroutine::parallel_for_each(_config.all_datadirs, [this] (sstring cfdir) -> future<> {
         co_await _sstables_manager.init_table_storage(*_storage_opts, cfdir);
     });

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1253,9 +1253,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
 
 future<> table::init_storage() {
     _storage_opts = sstables::make_storage_options_for_table(_sstables_manager.config(), *_schema, *_storage_opts);
-    co_await coroutine::parallel_for_each(_config.all_datadirs, [this] (sstring cfdir) -> future<> {
-        co_await _sstables_manager.init_table_storage(*_storage_opts, cfdir);
-    });
+    co_await _sstables_manager.init_table_storage(*_schema, *_storage_opts);
 }
 
 future<> table::destroy_storage() {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1256,7 +1256,7 @@ future<> table::init_storage() {
 }
 
 future<> table::destroy_storage() {
-    return _sstables_manager.destroy_table_storage(*_storage_opts, _config.datadir);
+    return _sstables_manager.destroy_table_storage(*_storage_opts);
 }
 
 column_family& database::find_column_family(const schema_ptr& schema) {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1252,8 +1252,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
 }
 
 future<> table::init_storage() {
-    _storage_opts = sstables::make_storage_options_for_table(_sstables_manager.config(), *_schema, *_storage_opts);
-    co_await _sstables_manager.init_table_storage(*_schema, *_storage_opts);
+    _storage_opts = co_await _sstables_manager.init_table_storage(*_schema, *_storage_opts);
 }
 
 future<> table::destroy_storage() {

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -237,9 +237,9 @@ future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
 distributed_loader::get_sstables_from_object_store(distributed<replica::database>& db, sstring ks, sstring cf, sstring endpoint, sstring bucket, sstring prefix, sstables::sstable_open_config cfg) {
     return get_sstables_from(db, ks, cf, cfg, [bucket, endpoint, prefix] (auto& global_table, auto& directory) {
         return directory.start(global_table.as_sharded_parameter(),
-            sharded_parameter([bucket, endpoint] {
+            sharded_parameter([bucket, endpoint, prefix] {
                 data_dictionary::storage_options opts;
-                opts.value = data_dictionary::storage_options::s3{bucket, endpoint};
+                opts.value = data_dictionary::storage_options::s3{bucket, endpoint, prefix};
                 return make_lw_shared<const data_dictionary::storage_options>(std::move(opts));
             }), prefix, &error_handler_gen_for_upload_dir);
     });

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -241,7 +241,7 @@ distributed_loader::get_sstables_from_object_store(distributed<replica::database
                 data_dictionary::storage_options opts;
                 opts.value = data_dictionary::storage_options::s3{bucket, endpoint, prefix};
                 return make_lw_shared<const data_dictionary::storage_options>(std::move(opts));
-            }), prefix, &error_handler_gen_for_upload_dir);
+            }), &error_handler_gen_for_upload_dir);
     });
 }
 

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -193,7 +193,7 @@ distributed_loader::process_upload_dir(distributed<replica::database>& db, shard
             auto generation = sharded_gen.invoke_on(shard, [uuid_sstable_identifiers] (auto& gen) {
                 return gen(sstables::uuid_identifiers{uuid_sstable_identifiers});
             }).get();
-            return sstm.make_sstable(global_table->schema(), global_table->dir(), global_table->get_storage_options(),
+            return sstm.make_sstable(global_table->schema(), global_table->get_storage_options(),
                                      generation, sstables::sstable_state::upload, sstm.get_highest_supported_format(),
                                      sstables::sstable_format_types::big, gc_clock::now(), &error_handler_gen_for_upload_dir);
         };
@@ -360,7 +360,7 @@ future<> table_populator::start_subdir(sstables::sstable_state state) {
 }
 
 sstables::shared_sstable make_sstable(replica::table& table, sstables::sstable_state state, sstables::generation_type generation, sstables::sstable_version_types v) {
-    return table.get_sstables_manager().make_sstable(table.schema(), table.dir(), table.get_storage_options(), generation, state, v, sstables::sstable_format_types::big);
+    return table.get_sstables_manager().make_sstable(table.schema(), table.get_storage_options(), generation, state, v, sstables::sstable_format_types::big);
 }
 
 future<> table_populator::populate_subdir(sstables::sstable_state state, allow_offstrategy_compaction do_allow_offstrategy_compaction) {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -484,7 +484,7 @@ static bool belongs_to_other_shard(const std::vector<shard_id>& shards) {
 
 sstables::shared_sstable table::make_sstable(sstables::sstable_state state) {
     auto& sstm = get_sstables_manager();
-    return sstm.make_sstable(_schema, _config.datadir, *_storage_opts, calculate_generation_for_new_table(), state, sstm.get_highest_supported_format(), sstables::sstable::format_types::big);
+    return sstm.make_sstable(_schema, *_storage_opts, calculate_generation_for_new_table(), state, sstm.get_highest_supported_format(), sstables::sstable::format_types::big);
 }
 
 sstables::shared_sstable table::make_sstable() {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5918,7 +5918,7 @@ future<> storage_service::clone_locally_tablet_storage(locator::global_tablet_id
 
     auto load_sstable = [] (const dht::sharder& sharder, replica::table& t, sstables::entry_descriptor d) -> future<sstables::shared_sstable> {
         auto& mng = t.get_sstables_manager();
-        auto sst = mng.make_sstable(t.schema(), t.dir(), t.get_storage_options(), d.generation, d.state.value_or(sstables::sstable_state::normal),
+        auto sst = mng.make_sstable(t.schema(), t.get_storage_options(), d.generation, d.state.value_or(sstables::sstable_state::normal),
                                     d.version, d.format, gc_clock::now(), default_io_error_handler_gen());
         // The loader will consider current shard as sstable owner, despite the tablet sharder
         // will still point to leaving replica at this stage in migration. If node goes down,

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -92,7 +92,6 @@ sstable_directory::sstable_directory(replica::table& table,
         table.schema(),
         std::make_unique<dht::auto_refreshing_sharder>(table.shared_from_this()),
         table.get_storage_options_ptr(),
-        table.dir(),
         std::move(state),
         std::move(error_handler_gen)
     )
@@ -107,7 +106,6 @@ sstable_directory::sstable_directory(replica::table& table,
         table.schema(),
         std::make_unique<dht::auto_refreshing_sharder>(table.shared_from_this()),
         std::move(storage_opts),
-        table_dir,
         sstable_state::upload,
         std::move(error_handler_gen)
     )
@@ -124,7 +122,6 @@ sstable_directory::sstable_directory(sstables_manager& manager,
         std::move(schema),
         &sharder,
         make_lw_shared<const data_dictionary::storage_options>(data_dictionary::make_local_options(fs::path(table_dir))),
-        std::move(table_dir),
         state,
         std::move(error_handler_gen)
     )
@@ -136,13 +133,11 @@ sstable_directory::sstable_directory(sstables_manager& manager,
         schema_ptr schema,
         std::variant<unique_sharder_ptr, const dht::sharder*> sharder,
         lw_shared_ptr<const data_dictionary::storage_options> storage_opts,
-        sstring table_dir,
         sstable_state state,
         io_error_handler_gen error_handler_gen)
     : _manager(manager)
     , _schema(std::move(schema))
     , _storage_opts(std::move(storage_opts))
-    , _table_dir(std::move(table_dir))
     , _state(state)
     , _error_handler_gen(error_handler_gen)
     , _storage(make_storage(_manager, *_storage_opts, _state))

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -99,7 +99,6 @@ sstable_directory::sstable_directory(replica::table& table,
 
 sstable_directory::sstable_directory(replica::table& table,
         lw_shared_ptr<const data_dictionary::storage_options> storage_opts,
-        sstring table_dir,
         io_error_handler_gen error_handler_gen)
     : sstable_directory(
         table.get_sstables_manager(),

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -117,7 +117,7 @@ sstable_directory::sstable_directory(sstables_manager& manager,
         manager,
         std::move(schema),
         &sharder,
-        make_lw_shared<data_dictionary::storage_options>(), // local
+        make_lw_shared<const data_dictionary::storage_options>(data_dictionary::make_local_options(fs::path(table_dir))),
         std::move(table_dir),
         state,
         std::move(error_handler_gen)

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -196,7 +196,7 @@ void sstable_directory::validate(sstables::shared_sstable sst, process_flags fla
 }
 
 future<sstables::shared_sstable> sstable_directory::load_sstable(sstables::entry_descriptor desc, sstables::sstable_open_config cfg) const {
-    auto sst = _manager.make_sstable(_schema, _table_dir, *_storage_opts, desc.generation, _state, desc.version, desc.format, gc_clock::now(), _error_handler_gen);
+    auto sst = _manager.make_sstable(_schema, *_storage_opts, desc.generation, _state, desc.version, desc.format, gc_clock::now(), _error_handler_gen);
     co_await sst->load(_sharder, cfg);
     co_return sst;
 }
@@ -445,7 +445,7 @@ sstable_directory::move_foreign_sstables(sharded<sstable_directory>& source_dire
 }
 
 future<shared_sstable> sstable_directory::load_foreign_sstable(foreign_sstable_open_info& info) {
-    auto sst = _manager.make_sstable(_schema, _table_dir, *_storage_opts, info.generation, _state, info.version, info.format, gc_clock::now(), _error_handler_gen);
+    auto sst = _manager.make_sstable(_schema, *_storage_opts, info.generation, _state, info.version, info.format, gc_clock::now(), _error_handler_gen);
     co_await sst->load(std::move(info));
     co_return sst;
 }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -139,7 +139,7 @@ sstable_directory::sstable_directory(sstables_manager& manager,
     , _table_dir(std::move(table_dir))
     , _state(state)
     , _error_handler_gen(error_handler_gen)
-    , _storage(make_storage(_manager, *_storage_opts, _table_dir, _state))
+    , _storage(make_storage(_manager, *_storage_opts, _state))
     , _lister(make_components_lister())
     , _sharder_ptr(std::holds_alternative<unique_sharder_ptr>(sharder) ? std::move(std::get<unique_sharder_ptr>(sharder)) : nullptr)
     , _sharder(_sharder_ptr ? *_sharder_ptr : *std::get<const dht::sharder*>(sharder))

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -195,7 +195,6 @@ public:
             io_error_handler_gen error_handler_gen);
     sstable_directory(replica::table& table,
             lw_shared_ptr<const data_dictionary::storage_options> storage_opts,
-            sstring table_dir,
             io_error_handler_gen error_handler_gen);
     sstable_directory(sstables_manager& manager,
             schema_ptr schema,

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -146,7 +146,6 @@ private:
     sstables_manager& _manager;
     schema_ptr _schema;
     lw_shared_ptr<const data_dictionary::storage_options> _storage_opts;
-    sstring _table_dir;
     sstable_state _state;
     io_error_handler_gen _error_handler_gen;
     std::unique_ptr<storage> _storage;
@@ -188,7 +187,6 @@ private:
           schema_ptr schema,
           std::variant<std::unique_ptr<dht::sharder>, const dht::sharder*> sharder,
           lw_shared_ptr<const data_dictionary::storage_options> storage_opts,
-          sstring table_dir,
           sstable_state state,
           io_error_handler_gen error_handler_gen);
 public:

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3225,7 +3225,7 @@ sstable::sstable(schema_ptr schema,
     , _schema(std::move(schema))
     , _generation(generation)
     , _state(state)
-    , _storage(make_storage(manager, storage, std::move(table_dir), _state))
+    , _storage(make_storage(manager, storage, _state))
     , _version(v)
     , _format(f)
     , _index_cache(std::make_unique<partition_index_cache>(

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3210,7 +3210,6 @@ mutation_source sstable::as_mutation_source() {
 }
 
 sstable::sstable(schema_ptr schema,
-        sstring table_dir,
         const data_dictionary::storage_options& storage,
         generation_type generation,
         sstable_state state,

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -194,7 +194,6 @@ public:
     using integrity_check = bool_class<class integrity_check_tag>;
 public:
     sstable(schema_ptr schema,
-            sstring table_dir,
             const data_dictionary::storage_options& storage,
             generation_type generation,
             sstable_state state,

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -305,8 +305,8 @@ future<> sstables_manager::init_keyspace_storage(const data_dictionary::storage_
     return sstables::init_keyspace_storage(*this, so, dir);
 }
 
-future<> sstables_manager::destroy_table_storage(const data_dictionary::storage_options& so, sstring dir) {
-    return sstables::destroy_table_storage(so, dir);
+future<> sstables_manager::destroy_table_storage(const data_dictionary::storage_options& so) {
+    return sstables::destroy_table_storage(so);
 }
 
 void sstables_manager::validate_new_keyspace_storage_options(const data_dictionary::storage_options& so) {

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -297,8 +297,8 @@ void sstables_manager::unplug_sstables_registry() noexcept {
     _sstables_registry.reset();
 }
 
-future<> sstables_manager::init_table_storage(const data_dictionary::storage_options& so, sstring dir) {
-    return sstables::init_table_storage(so, dir);
+future<> sstables_manager::init_table_storage(const schema& s, const data_dictionary::storage_options& so) {
+    return sstables::init_table_storage(*this, s, so);
 }
 
 future<> sstables_manager::init_keyspace_storage(const data_dictionary::storage_options& so, sstring dir) {

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -297,7 +297,7 @@ void sstables_manager::unplug_sstables_registry() noexcept {
     _sstables_registry.reset();
 }
 
-future<> sstables_manager::init_table_storage(const schema& s, const data_dictionary::storage_options& so) {
+future<lw_shared_ptr<const data_dictionary::storage_options>> sstables_manager::init_table_storage(const schema& s, const data_dictionary::storage_options& so) {
     return sstables::init_table_storage(*this, s, so);
 }
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -123,7 +123,6 @@ bool sstables_manager::uuid_sstable_identifiers() const {
 }
 
 shared_sstable sstables_manager::make_sstable(schema_ptr schema,
-        sstring table_dir,
         const data_dictionary::storage_options& storage,
         generation_type generation,
         sstable_state state,

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -132,7 +132,7 @@ shared_sstable sstables_manager::make_sstable(schema_ptr schema,
         gc_clock::time_point now,
         io_error_handler_gen error_handler_gen,
         size_t buffer_size) {
-    return make_lw_shared<sstable>(std::move(schema), std::move(table_dir), storage, generation, state, v, f, get_large_data_handler(), *this, now, std::move(error_handler_gen), buffer_size);
+    return make_lw_shared<sstable>(std::move(schema), storage, generation, state, v, f, get_large_data_handler(), *this, now, std::move(error_handler_gen), buffer_size);
 }
 
 sstable_writer_config sstables_manager::configure_writer(sstring origin) const {

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -133,7 +133,7 @@ public:
                               noncopyable_function<locator::host_id()>&& resolve_host_id, const abort_source& abort, scheduling_group maintenance_sg = current_scheduling_group(), storage_manager* shared = nullptr);
     virtual ~sstables_manager();
 
-    shared_sstable make_sstable(schema_ptr schema, sstring table_dir,
+    shared_sstable make_sstable(schema_ptr schema,
             const data_dictionary::storage_options& storage,
             generation_type generation,
             sstable_state state = sstable_state::normal,

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -186,7 +186,7 @@ public:
     }
 
     future<> delete_atomically(std::vector<shared_sstable> ssts);
-    future<> init_table_storage(const data_dictionary::storage_options& so, sstring dir);
+    future<> init_table_storage(const schema& s, const data_dictionary::storage_options& so);
     future<> destroy_table_storage(const data_dictionary::storage_options& so, sstring dir);
     future<> init_keyspace_storage(const data_dictionary::storage_options& so, sstring dir);
 

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -187,7 +187,7 @@ public:
 
     future<> delete_atomically(std::vector<shared_sstable> ssts);
     future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage(const schema& s, const data_dictionary::storage_options& so);
-    future<> destroy_table_storage(const data_dictionary::storage_options& so, sstring dir);
+    future<> destroy_table_storage(const data_dictionary::storage_options& so);
     future<> init_keyspace_storage(const data_dictionary::storage_options& so, sstring dir);
 
     void validate_new_keyspace_storage_options(const data_dictionary::storage_options&);

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -186,7 +186,7 @@ public:
     }
 
     future<> delete_atomically(std::vector<shared_sstable> ssts);
-    future<> init_table_storage(const schema& s, const data_dictionary::storage_options& so);
+    future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage(const schema& s, const data_dictionary::storage_options& so);
     future<> destroy_table_storage(const data_dictionary::storage_options& so, sstring dir);
     future<> init_keyspace_storage(const data_dictionary::storage_options& so, sstring dir);
 

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -723,11 +723,11 @@ future<> init_table_storage(const sstables_manager& mgr, const schema& s, const 
         auto dir = format("{}/{}/{}", dd, s.ks_name(), replica::format_table_directory_name(s.cf_name(), s.id()));
         dirs.emplace_back(std::move(dir));
     }
-   co_await coroutine::parallel_for_each(dirs, [] (sstring dir) -> future<> {
-    co_await io_check([&dir] { return recursive_touch_directory(dir); });
-    co_await io_check([&dir] { return touch_directory(dir + "/upload"); });
-    co_await io_check([&dir] { return touch_directory(dir + "/staging"); });
-   });
+    co_await coroutine::parallel_for_each(dirs, [] (sstring dir) -> future<> {
+        co_await io_check([&dir] { return recursive_touch_directory(dir); });
+        co_await io_check([&dir] { return touch_directory(dir + "/upload"); });
+        co_await io_check([&dir] { return touch_directory(dir + "/staging"); });
+    });
 }
 
 future<> init_table_storage(const sstables_manager& mgr, const schema& s, const data_dictionary::storage_options::s3& so) {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -681,7 +681,7 @@ future<> s3_storage::snapshot(const sstable& sst, sstring dir, absolute_path abs
     co_await coroutine::return_exception(std::runtime_error("Snapshotting S3 objects not implemented"));
 }
 
-std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstring dir, sstable_state state) {
+std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstable_state state) {
     return std::visit(overloaded_functor {
         [state] (const data_dictionary::storage_options::local& loc) mutable -> std::unique_ptr<sstables::storage> {
             if (loc.dir.empty()) {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -734,8 +734,9 @@ future<> init_table_storage(const sstables_manager& mgr, const schema& s, const 
     co_return;
 }
 
-future<> init_table_storage(const sstables_manager& mgr, const schema& s, const data_dictionary::storage_options& so) {
+future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage(const sstables_manager& mgr, const schema& s, const data_dictionary::storage_options& so) {
     co_await std::visit([&mgr, &s] (const auto& so) { return init_table_storage(mgr, s, so); }, so.value);
+    co_return make_storage_options_for_table(mgr.config(), s, so);
 }
 
 future<> init_keyspace_storage(const sstables_manager& mgr, const data_dictionary::storage_options& so, sstring ks_name) {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -712,7 +712,7 @@ future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage
 
     data_dictionary::storage_options nopts;
     nopts.value = data_dictionary::storage_options::local {
-        .dir = fs::path(format("{}/{}/{}", mgr.config().data_file_directories()[0], s.ks_name(), replica::format_table_directory_name(s.cf_name(), s.id()))),
+        .dir = fs::path(std::move(dirs[0])),
     };
     co_return make_lw_shared<const data_dictionary::storage_options>(std::move(nopts));
 }

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -33,6 +33,7 @@
 #include "utils/s3/client.hh"
 #include "utils/exceptions.hh"
 #include "utils/to_string.hh"
+#include "replica/database.hh" // need to move format_table_directory_name here eventually
 
 #include "checked-file-impl.hh"
 
@@ -696,12 +697,14 @@ lw_shared_ptr<const data_dictionary::storage_options> make_storage_options_for_t
     nopts.value = std::visit(overloaded_functor {
         [&] (const data_dictionary::storage_options::local& o) -> data_dictionary::storage_options::value_type {
             return data_dictionary::storage_options::local {
+                .dir = fs::path(format("{}/{}/{}", cfg.data_file_directories()[0], s.ks_name(), replica::format_table_directory_name(s.cf_name(), s.id()))),
             };
         },
         [&] (const data_dictionary::storage_options::s3& o) -> data_dictionary::storage_options::value_type {
             return data_dictionary::storage_options::s3 {
                 .bucket = o.bucket,
                 .endpoint = o.endpoint,
+                .prefix = format("{}/{}/{}", cfg.data_file_directories()[0], s.ks_name(), replica::format_table_directory_name(s.cf_name(), s.id())),
             };
         }
     }, sopts.value);

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -79,7 +79,7 @@ public:
     virtual sstring prefix() const  = 0;
 };
 
-std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstring table_dir, sstable_state state);
+std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstable_state state);
 lw_shared_ptr<const data_dictionary::storage_options> make_storage_options_for_table(const db::config& cfg, const schema& s, const data_dictionary::storage_options& sopts);
 future<> init_table_storage(const data_dictionary::storage_options& so, sstring dir);
 future<> destroy_table_storage(const data_dictionary::storage_options& so, sstring dir);

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -22,9 +22,13 @@
 #include "sstables/component_type.hh"
 #include "sstables/generation_type.hh"
 
+class schema;
+
 namespace data_dictionary {
 class storage_options;
 }
+
+namespace db { class config; }
 
 namespace sstables {
 
@@ -76,6 +80,7 @@ public:
 };
 
 std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstring table_dir, sstable_state state);
+lw_shared_ptr<const data_dictionary::storage_options> make_storage_options_for_table(const db::config& cfg, const schema& s, const data_dictionary::storage_options& sopts);
 future<> init_table_storage(const data_dictionary::storage_options& so, sstring dir);
 future<> destroy_table_storage(const data_dictionary::storage_options& so, sstring dir);
 future<> init_keyspace_storage(const sstables_manager&, const data_dictionary::storage_options& so, sstring ks_name);

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -81,7 +81,7 @@ public:
 
 std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstable_state state);
 future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage(const sstables_manager&, const schema&, const data_dictionary::storage_options& so);
-future<> destroy_table_storage(const data_dictionary::storage_options& so, sstring dir);
+future<> destroy_table_storage(const data_dictionary::storage_options& so);
 future<> init_keyspace_storage(const sstables_manager&, const data_dictionary::storage_options& so, sstring ks_name);
 
 } // namespace sstables

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -81,7 +81,7 @@ public:
 
 std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstable_state state);
 lw_shared_ptr<const data_dictionary::storage_options> make_storage_options_for_table(const db::config& cfg, const schema& s, const data_dictionary::storage_options& sopts);
-future<> init_table_storage(const data_dictionary::storage_options& so, sstring dir);
+future<> init_table_storage(const sstables_manager&, const schema&, const data_dictionary::storage_options& so);
 future<> destroy_table_storage(const data_dictionary::storage_options& so, sstring dir);
 future<> init_keyspace_storage(const sstables_manager&, const data_dictionary::storage_options& so, sstring ks_name);
 

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -80,8 +80,7 @@ public:
 };
 
 std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstable_state state);
-lw_shared_ptr<const data_dictionary::storage_options> make_storage_options_for_table(const db::config& cfg, const schema& s, const data_dictionary::storage_options& sopts);
-future<> init_table_storage(const sstables_manager&, const schema&, const data_dictionary::storage_options& so);
+future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage(const sstables_manager&, const schema&, const data_dictionary::storage_options& so);
 future<> destroy_table_storage(const data_dictionary::storage_options& so, sstring dir);
 future<> init_keyspace_storage(const sstables_manager&, const data_dictionary::storage_options& so, sstring ks_name);
 

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -108,7 +108,7 @@ with_column_family(schema_ptr s, replica::column_family::config cfg, sstables::s
         tasks::task_manager tm;
         auto cm = make_lw_shared<compaction_manager>(tm, compaction_manager::for_testing_tag{});
         auto cl_stats = make_lw_shared<cell_locker_stats>();
-        auto s_opts = make_lw_shared<replica::storage_options>();
+        auto s_opts = make_lw_shared<replica::storage_options>(data_dictionary::make_local_options(fs::path(cfg.datadir)));
         auto cf = make_lw_shared<replica::column_family>(s, cfg, s_opts, *cm, sm, *cl_stats, *tracker, nullptr);
         cf->mark_ready_for_writes(nullptr);
         co_await func(*cf);

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -95,7 +95,7 @@ make_sstable_for_all_shards(replica::table& table, sstables::sstable_state state
         m.set_clustered_cell(clustering_key::make_empty(), bytes("c"), data_value(int32_t(0)), api::timestamp_type(0));
         mt->apply(std::move(m));
     }
-    auto sst = table.get_sstables_manager().make_sstable(s, table.dir(), table.get_storage_options(), generation, state);
+    auto sst = table.get_sstables_manager().make_sstable(s, table.get_storage_options(), generation, state);
     write_memtable_to_sstable(*mt, sst).get();
     mt->clear_gently().get();
     // We can't write an SSTable with bad sharding, so pretend
@@ -522,7 +522,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly) {
                 return gen(sstables::uuid_identifiers::no);
             }).get();
             auto& cf = e.local_db().find_column_family("ks", "cf");
-            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.dir(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
+            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
         };
         distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", std::move(make_sstable)).get();
         verify_that_all_sstables_are_local(sstdir, smp::count * smp::count).get();
@@ -574,7 +574,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly_with_owned
                 return gen(sstables::uuid_identifiers::no);
             }).get();
             auto& cf = e.local_db().find_column_family("ks", "cf");
-            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.dir(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
+            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
         };
         const auto& erm = e.db().local().find_keyspace("ks").get_vnode_effective_replication_map();
         auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(e.db().local().get_keyspace_local_ranges(erm).get());
@@ -627,7 +627,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_distributes_well_eve
                 return gen(sstables::uuid_identifiers::no);
             }).get();
             auto& cf = e.local_db().find_column_family("ks", "cf");
-            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.dir(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
+            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
         };
         distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", std::move(make_sstable)).get();
         verify_that_all_sstables_are_local(sstdir, smp::count * smp::count).get();
@@ -677,7 +677,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_respect_max_threshol
                 return gen(sstables::uuid_identifiers::no);
             }).get();
             auto& cf = e.local_db().find_column_family("ks", "cf");
-            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.dir(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
+            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
         };
         distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", std::move(make_sstable)).get();
         verify_that_all_sstables_are_local(sstdir, 2 * smp::count * smp::count).get();

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -355,7 +355,7 @@ test_env::make_sstable(schema_ptr schema, sstring dir, sstables::generation_type
         [&dir] (data_dictionary::storage_options::local& o) { o.dir = dir; },
         [&dir] (data_dictionary::storage_options::s3& o) { o.prefix = dir; },
     }, storage.value);
-    return _impl->mgr.make_sstable(std::move(schema), dir, storage, generation, sstables::sstable_state::normal, v, f, now, default_io_error_handler_gen(), buffer_size);
+    return _impl->mgr.make_sstable(std::move(schema), storage, generation, sstables::sstable_state::normal, v, f, now, default_io_error_handler_gen(), buffer_size);
 }
 
 shared_sstable

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -137,9 +137,15 @@ schema_ptr table_for_tests::make_default_schema() {
 table_for_tests::table_for_tests(sstables::sstables_manager& sstables_manager, compaction_manager& cm, schema_ptr s, replica::table::config cfg, data_dictionary::storage_options storage)
     : _data(make_lw_shared<data>())
 {
+    // FIXME -- the storage options here are from sstables::test_env that should have
+    // initialized it properly
+    std::visit(overloaded_functor {
+        [&cfg] (data_dictionary::storage_options::local& o) { o.dir = cfg.datadir; },
+        [&cfg] (data_dictionary::storage_options::s3& o) { o.prefix = cfg.datadir; },
+    }, storage.value);
     cfg.cf_stats = &_data->cf_stats;
     _data->s = s ? s : make_default_schema();
-    _data->cf = make_lw_shared<replica::column_family>(_data->s, std::move(cfg), make_lw_shared<replica::storage_options>(), cm, sstables_manager, _data->cl_stats, sstables_manager.get_cache_tracker(), nullptr);
+    _data->cf = make_lw_shared<replica::column_family>(_data->s, std::move(cfg), make_lw_shared<replica::storage_options>(storage), cm, sstables_manager, _data->cl_stats, sstables_manager.get_cache_tracker(), nullptr);
     _data->cf->mark_ready_for_writes(nullptr);
     _data->table_s = std::make_unique<table_state>(*_data, sstables_manager);
     cm.add(*_data->table_s);
@@ -342,7 +348,14 @@ shared_sstable
 test_env::make_sstable(schema_ptr schema, sstring dir, sstables::generation_type generation,
         sstable::version_types v, sstable::format_types f,
         size_t buffer_size, gc_clock::time_point now) {
-    return _impl->mgr.make_sstable(std::move(schema), dir, _impl->storage, generation, sstables::sstable_state::normal, v, f, now, default_io_error_handler_gen(), buffer_size);
+    // FIXME -- most of the callers work with _impl->dir's path, so
+    // test_env can initialize the .dir/.prefix only once, when constructed
+    auto storage = _impl->storage;
+    std::visit(overloaded_functor {
+        [&dir] (data_dictionary::storage_options::local& o) { o.dir = dir; },
+        [&dir] (data_dictionary::storage_options::s3& o) { o.prefix = dir; },
+    }, storage.value);
+    return _impl->mgr.make_sstable(std::move(schema), dir, storage, generation, sstables::sstable_state::normal, v, f, now, default_io_error_handler_gen(), buffer_size);
 }
 
 shared_sstable

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -502,7 +502,7 @@ schema_ptr do_load_schema_from_sstable(const db::config& dbcfg, std::filesystem:
 
     const auto ed = sstables::parse_path(sstable_path, keyspace, table);
     const auto dir_path = sstable_path.parent_path();
-    data_dictionary::storage_options local;
+    auto local = data_dictionary::make_local_options(dir_path);
     auto bootstrap_sst = sst_man.make_sstable(bootstrap_schema, dir_path.c_str(), local, ed.generation, sstables::sstable_state::normal, ed.version, ed.format);
 
     bootstrap_sst->load_metadata({}, false).get();

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -503,7 +503,7 @@ schema_ptr do_load_schema_from_sstable(const db::config& dbcfg, std::filesystem:
     const auto ed = sstables::parse_path(sstable_path, keyspace, table);
     const auto dir_path = sstable_path.parent_path();
     auto local = data_dictionary::make_local_options(dir_path);
-    auto bootstrap_sst = sst_man.make_sstable(bootstrap_schema, dir_path.c_str(), local, ed.generation, sstables::sstable_state::normal, ed.version, ed.format);
+    auto bootstrap_sst = sst_man.make_sstable(bootstrap_schema, local, ed.generation, sstables::sstable_state::normal, ed.version, ed.format);
 
     bootstrap_sst->load_metadata({}, false).get();
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -328,7 +328,7 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
         auto ed = sstables::parse_path(sst_path, schema->ks_name(), schema->cf_name());
         const auto dir_path = sst_path.parent_path();
         auto local = data_dictionary::make_local_options(dir_path);
-        auto sst = sst_man.make_sstable(schema, dir_path.c_str(), local, ed.generation, sstables::sstable_state::normal, ed.version, ed.format);
+        auto sst = sst_man.make_sstable(schema, local, ed.generation, sstables::sstable_state::normal, ed.version, ed.format);
 
         try {
             co_await sst->load(schema->get_sharder(), sstables::sstable_open_config{.load_first_and_last_position_metadata = false});
@@ -891,7 +891,7 @@ private:
             throw std::runtime_error(fmt::format("cannot create output sstable {}, file already exists", sst_name));
         }
         auto local = data_dictionary::make_local_options(_output_dir);
-        return _sst_man.make_sstable(_schema, _output_dir, local, generation, sstables::sstable_state::normal, version, format);
+        return _sst_man.make_sstable(_schema, local, generation, sstables::sstable_state::normal, version, format);
     }
     sstables::sstable_writer_config do_configure_writer(sstring origin) const {
         return _sst_man.configure_writer(std::move(origin));
@@ -2573,7 +2573,7 @@ void write_operation(schema_ptr schema, reader_permit permit, const std::vector<
     auto writer_cfg = manager.configure_writer("scylla-sstable");
     writer_cfg.validation_level = validation_level;
     auto local = data_dictionary::make_local_options(output_dir);
-    auto sst = manager.make_sstable(schema, output_dir, local, generation, sstables::sstable_state::normal, version, format);
+    auto sst = manager.make_sstable(schema, local, generation, sstables::sstable_state::normal, version, format);
 
     sst->write_components(std::move(reader), 1, schema, writer_cfg, encoding_stats{}).get();
 }
@@ -2635,7 +2635,6 @@ void shard_of_with_vnodes(const std::vector<sstables::shared_sstable>& sstables,
             shard_count, ignore_msb_bits).build();
         auto new_sst = sstable_manager.make_sstable(
             schema,
-            sst->get_storage().prefix(),
             data_dictionary::make_local_options(fs::path(sst->get_storage().prefix())),
             sst->generation(),
             sstable_state::normal,

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -327,7 +327,7 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
 
         auto ed = sstables::parse_path(sst_path, schema->ks_name(), schema->cf_name());
         const auto dir_path = sst_path.parent_path();
-        data_dictionary::storage_options local;
+        auto local = data_dictionary::make_local_options(dir_path);
         auto sst = sst_man.make_sstable(schema, dir_path.c_str(), local, ed.generation, sstables::sstable_state::normal, ed.version, ed.format);
 
         try {
@@ -890,7 +890,7 @@ private:
         if (file_exists(sst_name).get()) {
             throw std::runtime_error(fmt::format("cannot create output sstable {}, file already exists", sst_name));
         }
-        data_dictionary::storage_options local;
+        auto local = data_dictionary::make_local_options(_output_dir);
         return _sst_man.make_sstable(_schema, _output_dir, local, generation, sstables::sstable_state::normal, version, format);
     }
     sstables::sstable_writer_config do_configure_writer(sstring origin) const {
@@ -2572,7 +2572,7 @@ void write_operation(schema_ptr schema, reader_permit permit, const std::vector<
     auto reader = make_generating_reader_v2(schema, permit, std::move(parser));
     auto writer_cfg = manager.configure_writer("scylla-sstable");
     writer_cfg.validation_level = validation_level;
-    data_dictionary::storage_options local;
+    auto local = data_dictionary::make_local_options(output_dir);
     auto sst = manager.make_sstable(schema, output_dir, local, generation, sstables::sstable_state::normal, version, format);
 
     sst->write_components(std::move(reader), 1, schema, writer_cfg, encoding_stats{}).get();
@@ -2636,7 +2636,7 @@ void shard_of_with_vnodes(const std::vector<sstables::shared_sstable>& sstables,
         auto new_sst = sstable_manager.make_sstable(
             schema,
             sst->get_storage().prefix(),
-            data_dictionary::storage_options{},
+            data_dictionary::make_local_options(fs::path(sst->get_storage().prefix())),
             sst->generation(),
             sstable_state::normal,
             sst->get_version());


### PR DESCRIPTION
New sstables for a table are created by the table::make_sstable() method. The method then calls sstables_manager::make_sstable() and passes there a path to component files which, in turn, sits on table::config. Since some time ago having an on-disk path for an sstable had become optional, as sstables could be put on S3 storage without local paths involved. In that case the aforementioned "path" is ~~ab~~used as a key in the system.sstables registry, that references a record with information used to retrieve URLs of sstables' objects.

This PR removes the "path" argument from sstables_manager::make_sstable() and its sstable_sdirectory peer. The details of sstables' location are moved onto storage_options and depend on storage type. For now in both storage types this location is still the good-old $datadir/$keyspace/$table-$uuid string. S3 storage needs to be patched more to use more elegant "location" value.

Eventually the `table::config::{datadir|all_datadirs}` will be removed, this PR is the step towards it.

closes: #12707 