### PR TITLE
reader_concurrency_semaphore: improve the diagnostics dump

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -226,13 +226,14 @@ private:
     void on_timeout() {
         auto keepalive = std::exchange(_aux_data.permit_keepalive, std::nullopt);
 
-        _ex = std::make_exception_ptr(timed_out_error{});
+        auto ex = named_semaphore_timed_out(_semaphore._name);
+        _ex = std::make_exception_ptr(ex);
 
         switch (_state) {
             case state::waiting_for_admission:
             case state::waiting_for_memory:
             case state::waiting_for_execution:
-                _aux_data.pr.set_exception(named_semaphore_timed_out(_semaphore._name));
+                _aux_data.pr.set_exception(ex);
                 maybe_dump_reader_permit_diagnostics(_semaphore, "timed out");
                 _semaphore.dequeue_permit(*this);
                 break;

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -797,6 +797,19 @@ static void do_dump_reader_permit_diagnostics(std::ostream& os, const reader_con
             semaphore.initial_resources().memory - semaphore.available_resources().memory,
             semaphore.initial_resources().memory,
             problem);
+
+    if (permit) {
+        const auto& schema = permit->get_schema();
+        fmt::print(os, "Trigger permit: count={}, memory={}, table={}.{}, operation={}, state={}\n",
+            permit->resources().count,
+            permit->resources().memory,
+            schema ? permit->get_schema()->ks_name() : "*",
+            schema ? permit->get_schema()->cf_name() : "*",
+            permit->get_op_name(),
+            permit->get_state());
+    }
+
+    fmt::print(os, "\n");
     total += do_dump_reader_permit_diagnostics(os, permits, max_lines);
     fmt::print(os, "\n");
     const auto& stats = semaphore.get_stats();

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -809,6 +809,21 @@ static void do_dump_reader_permit_diagnostics(std::ostream& os, const reader_con
             permit->get_state());
     }
 
+    std::vector<sstring> bottlenecks;
+    if (semaphore.get_stats().need_cpu_permits > 0) {
+        bottlenecks.push_back("CPU");
+    }
+    if (semaphore.available_resources().memory <= 0) {
+        bottlenecks.push_back("memory");
+    }
+    if (semaphore.available_resources().count <= 0) {
+        bottlenecks.push_back("disk");
+    }
+
+    if (!bottlenecks.empty()) {
+        fmt::print(os, "Identified bottleneck(s): {}\n", fmt::join(bottlenecks, ", "));
+    }
+
     fmt::print(os, "\n");
     total += do_dump_reader_permit_diagnostics(os, permits, max_lines);
     fmt::print(os, "\n");

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -69,7 +69,7 @@ struct fmt::formatter<reader_concurrency_semaphore::evict_reason> : fmt::formatt
 
 namespace {
 
-void maybe_dump_reader_permit_diagnostics(const reader_concurrency_semaphore& semaphore, std::string_view problem) noexcept;
+void maybe_dump_reader_permit_diagnostics(const reader_concurrency_semaphore& semaphore, std::string_view problem, reader_permit::impl* permit) noexcept;
 
 }
 
@@ -234,13 +234,13 @@ private:
             case state::waiting_for_memory:
             case state::waiting_for_execution:
                 _aux_data.pr.set_exception(ex);
-                maybe_dump_reader_permit_diagnostics(_semaphore, "timed out");
+                maybe_dump_reader_permit_diagnostics(_semaphore, "timed out", this);
                 _semaphore.dequeue_permit(*this);
                 break;
             case state::active:
             case state::active_need_cpu:
             case state::active_await:
-                maybe_dump_reader_permit_diagnostics(_semaphore, "timed out");
+                maybe_dump_reader_permit_diagnostics(_semaphore, "timed out", this);
                 break;
             case state::inactive:
                 _semaphore.evict(*this, reader_concurrency_semaphore::evict_reason::time);
@@ -780,7 +780,8 @@ static permit_stats do_dump_reader_permit_diagnostics(std::ostream& os, const pe
     return total;
 }
 
-static void do_dump_reader_permit_diagnostics(std::ostream& os, const reader_concurrency_semaphore& semaphore, std::string_view problem, unsigned max_lines = 20) {
+static void do_dump_reader_permit_diagnostics(std::ostream& os, const reader_concurrency_semaphore& semaphore, std::string_view problem,
+        reader_permit::impl* permit, unsigned max_lines = 20) {
     permit_groups permits;
 
     semaphore.foreach_permit([&] (const reader_permit::impl& permit) {
@@ -846,12 +847,12 @@ static void do_dump_reader_permit_diagnostics(std::ostream& os, const reader_con
             stats.sstables_read);
 }
 
-void maybe_dump_reader_permit_diagnostics(const reader_concurrency_semaphore& semaphore, std::string_view problem) noexcept {
+void maybe_dump_reader_permit_diagnostics(const reader_concurrency_semaphore& semaphore, std::string_view problem, reader_permit::impl* permit) noexcept {
     static thread_local logger::rate_limit rate_limit(std::chrono::seconds(30));
 
     rcslog.log(log_level::info, rate_limit, "{}", value_of([&] {
         std::ostringstream os;
-        do_dump_reader_permit_diagnostics(os, semaphore, problem);
+        do_dump_reader_permit_diagnostics(os, semaphore, problem, permit);
         return std::move(os).str();
     }));
 }
@@ -984,7 +985,7 @@ void reader_concurrency_semaphore::consume(reader_permit::impl& permit, resource
         if (permit.on_oom_kill()) {
             ++_stats.total_reads_killed_due_to_kill_limit;
         }
-        maybe_dump_reader_permit_diagnostics(*this, "kill limit triggered");
+        maybe_dump_reader_permit_diagnostics(*this, "kill limit triggered", &permit);
         throw utils::memory_limit_reached(format("kill limit triggered on semaphore {} by permit {}", _name, permit.description()));
     }
     _resources -= r;
@@ -1296,7 +1297,7 @@ bool reader_concurrency_semaphore::cpu_concurrency_limit_reached() const {
 std::exception_ptr reader_concurrency_semaphore::check_queue_size(std::string_view queue_name) {
     if (_stats.waiters >= _max_queue_length) {
         _stats.total_reads_shed_due_to_overload++;
-        maybe_dump_reader_permit_diagnostics(*this, fmt::format("{} queue overload", queue_name));
+        maybe_dump_reader_permit_diagnostics(*this, fmt::format("{} queue overload", queue_name), nullptr);
         return std::make_exception_ptr(std::runtime_error(fmt::format("{}: {} queue overload", _name, queue_name)));
     }
     return {};
@@ -1431,7 +1432,7 @@ future<> reader_concurrency_semaphore::do_wait_admission(reader_permit::impl& pe
             // Normally, the semaphore should admit waiters as soon as it can.
             // So at any point in time, there should either be no waiters, or it
             // shouldn't be able to admit new reads. Otherwise something went wrong.
-            maybe_dump_reader_permit_diagnostics(*this, "semaphore could admit new reads yet there are waiters");
+            maybe_dump_reader_permit_diagnostics(*this, "semaphore could admit new reads yet there are waiters", nullptr);
             maybe_admit_waiters();
         } else if (admit == can_admit::maybe) {
             tracing::trace(permit.trace_state(), "[reader concurrency semaphore {}] evicting inactive reads in the background to free up resources", _name);
@@ -1637,7 +1638,7 @@ void reader_concurrency_semaphore::broken(std::exception_ptr ex) {
 
 std::string reader_concurrency_semaphore::dump_diagnostics(unsigned max_lines) const {
     std::ostringstream os;
-    do_dump_reader_permit_diagnostics(os, *this, "user request", max_lines);
+    do_dump_reader_permit_diagnostics(os, *this, "user request", nullptr, max_lines);
     return std::move(os).str();
 }
 


### PR DESCRIPTION
* Also dump diagnostics when a read times out while active (not queued).
* Add the "Trigger permit" line, containing the details of the permit which caused the diagnostics dump (by e.g. timing out).
* Add the "Identified bottleneck(s)" line, containing the identified bottlenecks which lead to permits being queued. This line is missing if no such bottleneck can be identified.
* Document the new features, as well as the stat dump, which was added some time ago.

Example of the new dump format:
```
INFO  2024-09-12 08:09:48,046 [shard  0:main] reader_concurrency_semaphore - Semaphore reader_concurrency_semaphore_dump_reader_diganostics with 8/10 count and 106192275/32768 memory resources: timed out, dumping permit diagnostics:
Trigger permit: count=0, memory=0, table=ks.tbl0, operation=mutation-query, state=waiting_for_admission
Identified bottleneck(s): memory

permits count   memory  table/operation/state
3       2       26M     *.*/push-view-updates-2/active
3       2       16M     ks.tbl1/push-view-updates-1/active
1       1       15M     ks.tbl2/push-view-updates-1/active
1       0       13M     ks.tbl1/multishard-mutation-query/active
1       0       12M     ks.tbl0/push-view-updates-1/active
1       1       10M     ks.tbl3/push-view-updates-2/active
1       1       6060K   ks.tbl3/multishard-mutation-query/active
2       1       1930K   ks.tbl0/push-view-updates-2/active
1       0       1216K   ks.tbl0/multishard-mutation-query/active
6       0       0B      ks.tbl1/shard-reader/waiting_for_admission
3       0       0B      *.*/data-query/waiting_for_admission
9       0       0B      ks.tbl0/mutation-query/waiting_for_admission
2       0       0B      ks.tbl2/shard-reader/waiting_for_admission
4       0       0B      ks.tbl0/shard-reader/waiting_for_admission
9       0       0B      ks.tbl0/data-query/waiting_for_admission
7       0       0B      ks.tbl3/mutation-query/waiting_for_admission
5       0       0B      ks.tbl1/mutation-query/waiting_for_admission
2       0       0B      ks.tbl2/mutation-query/waiting_for_admission
8       0       0B      ks.tbl1/data-query/waiting_for_admission
1       0       0B      *.*/mutation-query/waiting_for_admission
26      0       0B      permits omitted for brevity

96      8       101M    total

Stats:
permit_based_evictions: 0
time_based_evictions: 0
inactive_reads: 0
total_successful_reads: 0
total_failed_reads: 0
total_reads_shed_due_to_overload: 0
total_reads_killed_due_to_kill_limit: 0
reads_admitted: 1
reads_enqueued_for_admission: 82
reads_enqueued_for_memory: 0
reads_admitted_immediately: 1
reads_queued_because_ready_list: 0
reads_queued_because_need_cpu_permits: 82
reads_queued_because_memory_resources: 0
reads_queued_because_count_resources: 0
reads_queued_with_eviction: 0
total_permits: 97
current_permits: 96
need_cpu_permits: 0
awaits_permits: 0
disk_reads: 0
sstables_read: 0
```

Fixes: https://github.com/scylladb/scylladb/issues/19535

Improvement, no backport needed.