### PR TITLE
configure.py: move default target in x86_64 to Broadwell

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -24,9 +24,8 @@ add_compile_options(
   ${_supported_warnings})
 
 function(default_target_arch arch)
-  set(x86_instruction_sets i386 i686 x86_64)
-  if(CMAKE_SYSTEM_PROCESSOR IN_LIST x86_instruction_sets)
-    set(${arch} "westmere" PARENT_SCOPE)
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    set(${arch} "broadwell" PARENT_SCOPE)
   elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
     # we always use intrinsics like vmull.p64 for speeding up crc32 calculations
     # on the aarch64 architectures, and they require the crypto extension, so

--- a/configure.py
+++ b/configure.py
@@ -205,8 +205,8 @@ class Source(object):
 
 
 def default_target_arch():
-    if platform.machine() in ['i386', 'i686', 'x86_64']:
-        return 'westmere'   # support PCLMUL
+    if platform.machine() == 'x86_64':
+        return 'broadwell'
     elif platform.machine() == 'aarch64':
         return 'armv8-a+crc+crypto'
     else:
@@ -1722,7 +1722,7 @@ def configure_seastar(build_dir, mode, mode_config):
     if dpdk is None:
         dpdk = platform.machine() == 'x86_64' and mode == 'release'
     if dpdk:
-        seastar_cmake_args += ['-DSeastar_DPDK=ON', '-DSeastar_DPDK_MACHINE=westmere']
+        seastar_cmake_args += ['-DSeastar_DPDK=ON', '-DSeastar_DPDK_MACHINE=broadwell']
     if args.split_dwarf:
         seastar_cmake_args += ['-DSeastar_SPLIT_DWARF=ON']
     if args.alloc_failure_injector:

--- a/docs/getting-started/system-requirements.rst
+++ b/docs/getting-started/system-requirements.rst
@@ -39,7 +39,7 @@ ScyllaDB requires modern Intel/AMD CPUs that support the SSE4.2 instruction set 
 
 ScyllaDB supports the following CPUs:
 
-* Intel core: Westmere and later (2010)
+* Intel core: Broadwell and later (2014)
 * Intel atom: Goldmont and later (2016)
 * AMD low power: Jaguar and later (2013)
 * AMD standard: Bulldozer and later (2011)


### PR DESCRIPTION
Broadwell is the underlying x864_64 architecture for i3, which is probably the lowest hardware we support (t3.micro is Skylake). I think we can safely move the default architecture to it.

Improvement - no need to backport.