### PR TITLE
[Backport 6.0] cql3: add option to not unify bind variables with the same name

### DIFF
--- a/auth/common.cc
+++ b/auth/common.cc
@@ -72,7 +72,7 @@ static future<> create_legacy_metadata_table_if_missing_impl(
     assert(this_shard_id() == 0); // once_among_shards makes sure a function is executed on shard 0 only
 
     auto db = qp.db();
-    auto parsed_statement = cql3::query_processor::parse_statement(cql);
+    auto parsed_statement = cql3::query_processor::parse_statement(cql, cql3::dialect{});
     auto& parsed_cf_statement = static_cast<cql3::statements::raw::cf_statement&>(*parsed_statement);
 
     parsed_cf_statement.prepare_keyspace(meta::legacy::AUTH_KS);

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -180,7 +180,8 @@ using uexpression = uninitialized<expression>;
 
     bind_variable new_bind_variables(shared_ptr<cql3::column_identifier> name)
     {
-        if (name && _named_bind_variables_indexes.contains(*name)) {
+        if (_dialect.duplicate_bind_variable_names_refer_to_same_variable
+                && name && _named_bind_variables_indexes.contains(*name)) {
             return bind_variable{_named_bind_variables_indexes[*name]};
         }
         auto marker = bind_variable{_bind_variable_names.size()};

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -68,6 +68,7 @@ options {
 #include "cql3/statements/ks_prop_defs.hh"
 #include "cql3/selection/raw_selector.hh"
 #include "cql3/selection/selectable-expr.hh"
+#include "cql3/dialect.hh"
 #include "cql3/keyspace_element_name.hh"
 #include "cql3/constants.hh"
 #include "cql3/operation_impl.hh"
@@ -148,6 +149,8 @@ using uexpression = uninitialized<expression>;
 
     listener_type* listener;
 
+    dialect _dialect;
+
     // Keeps the names of all bind variables. For bind variables without a name ('?'), the name is nullptr.
     // Maps bind_index -> name.
     std::vector<::shared_ptr<cql3::column_identifier>> _bind_variable_names;
@@ -169,6 +172,10 @@ using uexpression = uninitialized<expression>;
             "bitstring",
         };
         return s;
+    }
+
+    void set_dialect(dialect d) {
+        _dialect = d;
     }
 
     bind_variable new_bind_variables(shared_ptr<cql3::column_identifier> name)

--- a/cql3/cql3_type.cc
+++ b/cql3/cql3_type.cc
@@ -454,7 +454,8 @@ sstring maybe_quote(const sstring& identifier) {
         // many keywords but allow keywords listed as "unreserved keywords".
         // So we can use any of them, for example cident.
         try {
-            cql3::util::do_with_parser(identifier, std::mem_fn(&cql3_parser::CqlParser::cident));
+            // In general it's not a good idea to use the default dialect, but for parsing an identifier, it's okay.
+            cql3::util::do_with_parser(identifier, dialect{}, std::mem_fn(&cql3_parser::CqlParser::cident));
             return identifier;
         } catch(exceptions::syntax_exception&) {
             // This alphanumeric string is not a valid identifier, so fall

--- a/cql3/dialect.hh
+++ b/cql3/dialect.hh
@@ -1,0 +1,31 @@
+// Copyright (C) 2024-present ScyllaDB
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+#include <fmt/core.h>
+
+namespace cql3 {
+
+struct dialect {
+    bool operator==(const dialect&) const = default;
+};
+
+inline
+dialect
+internal_dialect() {
+    return dialect{
+    };
+}
+
+}
+
+template <>
+struct fmt::formatter<cql3::dialect> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const cql3::dialect& d, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "cql3::dialect{{}}");
+    }
+};

--- a/cql3/dialect.hh
+++ b/cql3/dialect.hh
@@ -8,6 +8,7 @@
 namespace cql3 {
 
 struct dialect {
+    bool duplicate_bind_variable_names_refer_to_same_variable = true;  // if :a is found twice in a query, the two references are to the same variable (see #15559)
     bool operator==(const dialect&) const = default;
 };
 
@@ -15,6 +16,7 @@ inline
 dialect
 internal_dialect() {
     return dialect{
+        .duplicate_bind_variable_names_refer_to_same_variable = true,
     };
 }
 
@@ -26,6 +28,7 @@ struct fmt::formatter<cql3::dialect> {
 
     template <typename FormatContext>
     auto format(const cql3::dialect& d, FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "cql3::dialect{{}}");
+        return fmt::format_to(ctx.out(), "cql3::dialect{{duplicate_bind_variable_names_refer_to_same_variable={}}}",
+                d.duplicate_bind_variable_names_refer_to_same_variable);
     }
 };

--- a/cql3/prepared_statements_cache.hh
+++ b/cql3/prepared_statements_cache.hh
@@ -44,7 +44,6 @@ private:
     cache_key_type _key;
 
 public:
-    prepared_cache_key_type() = default;
     explicit prepared_cache_key_type(cql_prepared_id_type cql_id) : _key(std::move(cql_id), std::numeric_limits<int64_t>::max()) {}
     explicit prepared_cache_key_type(thrift_prepared_id_type thrift_id) : _key(cql_prepared_id_type(), thrift_id) {}
 

--- a/cql3/prepared_statements_cache.hh
+++ b/cql3/prepared_statements_cache.hh
@@ -14,6 +14,7 @@
 #include "utils/hash.hh"
 #include "cql3/statements/prepared_statement.hh"
 #include "cql3/column_specification.hh"
+#include "cql3/dialect.hh"
 
 namespace cql3 {
 
@@ -38,14 +39,20 @@ typedef int32_t thrift_prepared_id_type;
 /// and for Thrift - {CQL_PREP_ID_TYPE(0), THRIFT_PREP_ID}. This way CQL and Thrift keys' values will never collide.
 class prepared_cache_key_type {
 public:
-    using cache_key_type = std::pair<cql_prepared_id_type, int64_t>;
+    // derive from cql_prepared_id_type so we can customize the formatter of
+    // cache_key_type
+    struct cache_key_type : public std::pair<cql_prepared_id_type, int64_t> {
+        cache_key_type(std::pair<cql_prepared_id_type, int64_t>&& id, cql3::dialect d) : pair(std::move(id)), dialect(d) {}
+        cql3::dialect dialect; // Not part of hash, but we don't expect collisions because of that
+        bool operator==(const cache_key_type& other) const = default;
+    };
 
 private:
     cache_key_type _key;
 
 public:
-    explicit prepared_cache_key_type(cql_prepared_id_type cql_id) : _key(std::move(cql_id), std::numeric_limits<int64_t>::max()) {}
-    explicit prepared_cache_key_type(thrift_prepared_id_type thrift_id) : _key(cql_prepared_id_type(), thrift_id) {}
+    explicit prepared_cache_key_type(cql_prepared_id_type cql_id, dialect d) : _key({std::move(cql_id), std::numeric_limits<int64_t>::max()}, d) {}
+    explicit prepared_cache_key_type(thrift_prepared_id_type thrift_id, dialect d) : _key({cql_prepared_id_type(), thrift_id}, d) {}
 
     cache_key_type& key() { return _key; }
     const cache_key_type& key() const { return _key; }
@@ -172,7 +179,7 @@ struct hash<cql3::prepared_cache_key_type> final {
 template <> struct fmt::formatter<cql3::prepared_cache_key_type::cache_key_type> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     auto format(const cql3::prepared_cache_key_type::cache_key_type& p, fmt::format_context& ctx) const {
-        return fmt::format_to(ctx.out(), "{{cql_id: {}, thrift_id: {}}}", p.first, p.second);
+        return fmt::format_to(ctx.out(), "{{cql_id: {}, thrift_id: {}, dialect: {}}}", p.first, p.second, p.dialect);
     }
 };
 

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -21,6 +21,7 @@
 #include "cql3/authorized_prepared_statements_cache.hh"
 #include "cql3/statements/prepared_statement.hh"
 #include "cql3/cql_statement.hh"
+#include "cql3/dialect.hh"
 #include "exceptions/exceptions.hh"
 #include "service/migration_listener.hh"
 #include "timestamp.hh"
@@ -137,14 +138,16 @@ public:
 
     static prepared_cache_key_type compute_id(
             std::string_view query_string,
-            std::string_view keyspace);
+            std::string_view keyspace,
+            dialect d);
 
     static prepared_cache_key_type compute_thrift_id(
             const std::string_view& query_string,
-            const sstring& keyspace);
+            const sstring& keyspace,
+            dialect d);
 
-    static std::unique_ptr<statements::raw::parsed_statement> parse_statement(const std::string_view& query);
-    static std::vector<std::unique_ptr<statements::raw::parsed_statement>> parse_statements(std::string_view queries);
+    static std::unique_ptr<statements::raw::parsed_statement> parse_statement(const std::string_view& query, dialect d);
+    static std::vector<std::unique_ptr<statements::raw::parsed_statement>> parse_statements(std::string_view queries, dialect d);
 
     query_processor(service::storage_proxy& proxy, data_dictionary::database db, service::migration_notifier& mn, memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, wasm::manager& wasm);
 
@@ -253,10 +256,12 @@ public:
     execute_direct(
             const std::string_view& query_string,
             service::query_state& query_state,
+            dialect d,
             query_options& options) {
         return execute_direct_without_checking_exception_message(
                 query_string,
                 query_state,
+                d,
                 options)
                 .then(cql_transport::messages::propagate_exception_as_future<::shared_ptr<cql_transport::messages::result_message>>);
     }
@@ -267,6 +272,7 @@ public:
     execute_direct_without_checking_exception_message(
             const std::string_view& query_string,
             service::query_state& query_state,
+            dialect d,
             query_options& options);
 
     future<::shared_ptr<cql_transport::messages::result_message>>
@@ -401,10 +407,10 @@ public:
 
 
     future<::shared_ptr<cql_transport::messages::result_message::prepared>>
-    prepare(sstring query_string, service::query_state& query_state);
+    prepare(sstring query_string, service::query_state& query_state, dialect d);
 
     future<::shared_ptr<cql_transport::messages::result_message::prepared>>
-    prepare(sstring query_string, const service::client_state& client_state, bool for_thrift);
+    prepare(sstring query_string, const service::client_state& client_state, bool for_thrift, dialect d);
 
     future<> stop();
 
@@ -451,7 +457,8 @@ public:
 
     std::unique_ptr<statements::prepared_statement> get_statement(
             const std::string_view& query,
-            const service::client_state& client_state);
+            const service::client_state& client_state,
+            dialect d);
 
     friend class migration_subscriber;
 
@@ -535,14 +542,15 @@ private:
     prepare_one(
             sstring query_string,
             const service::client_state& client_state,
+            dialect d,
             PreparedKeyGenerator&& id_gen,
             IdGetter&& id_getter) {
         return do_with(
                 id_gen(query_string, client_state.get_raw_keyspace()),
                 std::move(query_string),
-                [this, &client_state, &id_getter](const prepared_cache_key_type& key, const sstring& query_string) {
-            return _prepared_cache.get(key, [this, &query_string, &client_state] {
-                auto prepared = get_statement(query_string, client_state);
+                [this, &client_state, &id_getter, d](const prepared_cache_key_type& key, const sstring& query_string) {
+            return _prepared_cache.get(key, [this, &query_string, &client_state, d] {
+                auto prepared = get_statement(query_string, client_state, d);
                 auto bound_terms = prepared->statement->get_bound_terms();
                 if (bound_terms > std::numeric_limits<uint16_t>::max()) {
                     throw exceptions::invalid_request_exception(

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -384,7 +384,8 @@ std::pair<schema_builder, std::vector<view_ptr>> alter_table_statement::prepare_
                     auto new_where = util::rename_column_in_where_clause(
                             view->view_info()->where_clause(),
                             column_identifier::raw(view_from->text(), true),
-                            column_identifier::raw(view_to->text(), true));
+                            column_identifier::raw(view_to->text(), true),
+                            cql3::dialect{});
                     builder.with_view_info(view->view_info()->base_id(), view->view_info()->base_name(),
                             view->view_info()->include_all_columns(), std::move(new_where));
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2562,7 +2562,9 @@ std::unique_ptr<cql3::statements::raw::select_statement> build_select_statement(
     if (!where_clause.empty()) {
         out << " WHERE " << where_clause << " ALLOW FILTERING";
     }
-    return do_with_parser(out.str(), std::mem_fn(&cql3_parser::CqlParser::selectStatement));
+    // In general it's not a good idea to use the default dialect, but here the database is talking to
+    // itself, so we can hope the dialects are mutually compatible here.
+    return do_with_parser(out.str(), dialect{}, std::mem_fn(&cql3_parser::CqlParser::selectStatement));
 }
 
 }

--- a/cql3/util.hh
+++ b/cql3/util.hh
@@ -21,18 +21,19 @@
 #include "cql3/CqlParser.hpp"
 #include "cql3/error_collector.hh"
 #include "cql3/statements/raw/select_statement.hh"
+#include "cql3/dialect.hh"
 
 namespace cql3 {
 
 namespace util {
 
 
-void do_with_parser_impl(const sstring_view& cql, noncopyable_function<void (cql3_parser::CqlParser& p)> func);
+void do_with_parser_impl(const sstring_view& cql, dialect d, noncopyable_function<void (cql3_parser::CqlParser& p)> func);
 
 template <typename Func, typename Result = cql3_parser::unwrap_uninitialized_t<std::result_of_t<Func(cql3_parser::CqlParser&)>>>
-Result do_with_parser(const sstring_view& cql, Func&& f) {
+Result do_with_parser(const sstring_view& cql, dialect d, Func&& f) {
     std::optional<Result> ret;
-    do_with_parser_impl(cql, [&] (cql3_parser::CqlParser& parser) {
+    do_with_parser_impl(cql, d, [&] (cql3_parser::CqlParser& parser) {
         ret.emplace(f(parser));
     });
     return std::move(*ret);
@@ -40,9 +41,9 @@ Result do_with_parser(const sstring_view& cql, Func&& f) {
 
 sstring relations_to_where_clause(const expr::expression& e);
 
-expr::expression where_clause_to_relations(const sstring_view& where_clause);
+expr::expression where_clause_to_relations(const sstring_view& where_clause, dialect d);
 
-sstring rename_column_in_where_clause(const sstring_view& where_clause, column_identifier::raw from, column_identifier::raw to);
+sstring rename_column_in_where_clause(const sstring_view& where_clause, column_identifier::raw from, column_identifier::raw to, dialect d);
 
 /// build a CQL "select" statement with the desired parameters.
 /// If select_all_columns==true, all columns are selected and the value of

--- a/db/config.cc
+++ b/db/config.cc
@@ -100,6 +100,21 @@ error_injection_list_to_json(const std::vector<db::config::error_injection_at_st
 }
 
 template <>
+bool
+config_from_string(std::string_view value) {
+    // boost::lexical_cast doesn't accept true/false, which are our output representations
+    // for bools. We want round-tripping, so we need to accept true/false. For backward
+    // compatibility, we also accept 1/0. #19791.
+    if (value == "true" || value == "1") {
+        return true;
+    } else if (value == "false" || value == "0") {
+        return false;
+    } else {
+        throw boost::bad_lexical_cast(typeid(std::string_view), typeid(bool));
+    }
+}
+
+template <>
 const config_type config_type_for<bool> = config_type("bool", value_to_json<bool>);
 
 template <>
@@ -177,7 +192,7 @@ struct convert<seastar::log_level> {
         if (!convert<std::string>::decode(node, tmp)) {
             return false;
         }
-        rhs = boost::lexical_cast<seastar::log_level>(tmp);
+        rhs = utils::config_from_string<seastar::log_level>(tmp);
         return true;
     }
 };

--- a/db/config.cc
+++ b/db/config.cc
@@ -1089,6 +1089,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
             "Make the system.config table UPDATEable.")
     , enable_parallelized_aggregation(this, "enable_parallelized_aggregation", liveness::LiveUpdate, value_status::Used, true,
             "Use on a new, parallel algorithm for performing aggregate queries.")
+    , cql_duplicate_bind_variable_names_refer_to_same_variable(this, "cql_duplicate_bind_variable_names_refer_to_same_variable", liveness::LiveUpdate, value_status::Used, true,
+            "A bind variable that appears twice in a CQL query refers to a single variable (if false, no name matching is performed).")
     , alternator_port(this, "alternator_port", value_status::Used, 0, "Alternator API port.")
     , alternator_https_port(this, "alternator_https_port", value_status::Used, 0, "Alternator API HTTPS port.")
     , alternator_address(this, "alternator_address", value_status::Used, "0.0.0.0", "Alternator API listening address.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -406,6 +406,7 @@ public:
     named_value<bool> enable_optimized_reversed_reads;
     named_value<bool> enable_cql_config_updates;
     named_value<bool> enable_parallelized_aggregation;
+    named_value<bool> cql_duplicate_bind_variable_names_refer_to_same_variable;
 
     named_value<uint16_t> alternator_port;
     named_value<uint16_t> alternator_https_port;

--- a/db/cql_type_parser.cc
+++ b/db/cql_type_parser.cc
@@ -20,7 +20,9 @@
 #include "utils/sorting.hh"
 
 static ::shared_ptr<cql3::cql3_type::raw> parse_raw(const sstring& str) {
-    return cql3::util::do_with_parser(str,
+    // In general it's a bad idea to use the default dialect, but type parsing
+    // should be dialect-agnostic.
+    return cql3::util::do_with_parser(str, cql3::dialect{},
         [] (cql3_parser::CqlParser& parser) {
             return parser.comparator_type(true);
         });

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2012,7 +2012,9 @@ static shared_ptr<cql3::functions::user_aggregate> create_aggregate(replica::dat
 
     bytes_opt initcond = std::nullopt;
     if (initcond_str) {
-        auto expr = cql3::util::do_with_parser(*initcond_str, std::mem_fn(&cql3_parser::CqlParser::term));
+        // In general using the default dialect is wrong, but here the database is communicating with itself,
+        // not the user, so any dialect should work.
+        auto expr = cql3::util::do_with_parser(*initcond_str, cql3::dialect{}, std::mem_fn(&cql3_parser::CqlParser::term));
         auto dummy_ident = ::make_shared<cql3::column_identifier>("", true);
         auto column_spec = make_lw_shared<cql3::column_specification>("", "", dummy_ident, state_type);
         auto raw = cql3::expr::evaluate(prepare_expression(expr, db.as_data_dictionary(), "", nullptr, {column_spec}), cql3::query_options::DEFAULT);

--- a/docs/cql/cql-extensions.md
+++ b/docs/cql/cql-extensions.md
@@ -377,6 +377,20 @@ FINALFUNC final_fct
 INITCOND (0, 0);
 ```
 
+### Behavior of bind variables references with the same name
+
+If a bind variable is referred to twice (example: `WHERE aa = :var AND bb = :var`; `:var`
+is referenced twice), ScyllaDB and Cassandra treat it differently:
+
+ - Cassandra ignores the double reference and treats the two as two separate variables. They
+   can have different types, and occupy two slots in the bind variable metadata (used by
+   drivers when the user provides a bind variable tuple rather than a map)
+ - ScyllaDB treats the two references as referring to the same variable. The two references
+   must have the same type, and occupy one slot in the bind variable metadata.
+
+ScyllaDB can revert to the Cassandra treatment by setting the configuration item
+`cql_duplicate_bind_variable_names_refer_to_same_variable` to `false`.
+
 ### Lists elements for filtering
 
 Subscripting a list in a WHERE clause is supported as are maps.

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -21,7 +21,7 @@ static logging::logger tlogger("table_helper");
 static schema_ptr parse_new_cf_statement(cql3::query_processor& qp, const sstring& create_cql) {
     auto db = qp.db();
 
-    auto parsed = cql3::query_processor::parse_statement(create_cql);
+    auto parsed = cql3::query_processor::parse_statement(create_cql, cql3::dialect{});
 
     cql3::statements::raw::cf_statement* parsed_cf_stmt = static_cast<cql3::statements::raw::cf_statement*>(parsed.get());
     (void)parsed_cf_stmt->keyspace(); // This will assert if cql statement did not contain keyspace
@@ -76,7 +76,7 @@ future<> table_helper::cache_table_info(cql3::query_processor& qp, service::migr
         return now();
     }
 
-    return qp.prepare(_insert_cql, qs.get_client_state(), false)
+    return qp.prepare(_insert_cql, qs.get_client_state(), false, cql3::dialect())
             .then([this] (shared_ptr<cql_transport::messages::result_message::prepared> msg_ptr) noexcept {
         _prepared_stmt = std::move(msg_ptr->get_prepared());
         shared_ptr<cql3::cql_statement> cql_stmt = _prepared_stmt->statement;
@@ -91,7 +91,7 @@ future<> table_helper::cache_table_info(cql3::query_processor& qp, service::migr
             // we have already prepared the fallback statement
             return now();
         }
-        return qp.prepare(_insert_cql_fallback.value(), qs.get_client_state(), false)
+        return qp.prepare(_insert_cql_fallback.value(), qs.get_client_state(), false, cql3::dialect())
                 .then([this] (shared_ptr<cql_transport::messages::result_message::prepared> msg_ptr) noexcept {
             _prepared_stmt = std::move(msg_ptr->get_prepared());
             shared_ptr<cql3::cql_statement> cql_stmt = _prepared_stmt->statement;

--- a/table_helper.hh
+++ b/table_helper.hh
@@ -18,6 +18,7 @@ class migration_manager;
 
 namespace cql3 {
 class query_processor;
+class dialect;
 namespace statements {
 class modification_statement;
 }}
@@ -41,7 +42,6 @@ private:
      * Should be changed alongside every _insert_stmt reassignment
      * */
     bool _is_fallback_stmt = false;
-
 public:
     table_helper(std::string_view keyspace, std::string_view name, sstring create_cql, sstring insert_cql, std::optional<sstring> insert_cql_fallback = std::nullopt)
         : _keyspace(keyspace)

--- a/test/boost/cql_auth_syntax_test.cc
+++ b/test/boost/cql_auth_syntax_test.cc
@@ -132,7 +132,7 @@ using modifier_rule_ptr = void (cql3_parser::CqlParser::*)(T&);
 template <typename T>
 static T test_valid(std::string_view cql_fragment, producer_rule_ptr<T> rule) {
     T v;
-    BOOST_REQUIRE_NO_THROW(v = cql3::util::do_with_parser(cql_fragment, std::mem_fn(rule)));
+    BOOST_REQUIRE_NO_THROW(v = cql3::util::do_with_parser(cql_fragment, cql3::dialect{}, std::mem_fn(rule)));
     return v;
 }
 
@@ -143,7 +143,7 @@ static T test_valid(std::string_view cql_fragment, producer_rule_ptr<T> rule) {
 template <typename T>
 void test_valid(std::string_view cql_fragment, modifier_rule_ptr<T> rule, T& v) {
     BOOST_REQUIRE_NO_THROW(
-            cql3::util::do_with_parser(cql_fragment, [rule, &v](cql3_parser::CqlParser& parser) {
+            cql3::util::do_with_parser(cql_fragment, cql3::dialect{}, [rule, &v](cql3_parser::CqlParser& parser) {
                 (parser.*rule)(v);
                  // Any non-`void` value will do.
                  return 0;
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE(user_name) {
 
     // Not worth generalizing `test_valid`.
     BOOST_REQUIRE_THROW(
-            (cql3::util::do_with_parser("\"Ring-bearer\"", std::mem_fn(&cql3_parser::CqlParser::username))),
+            (cql3::util::do_with_parser("\"Ring-bearer\"", cql3::dialect{}, std::mem_fn(&cql3_parser::CqlParser::username))),
             exceptions::syntax_exception);
 }
 

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -5730,6 +5730,26 @@ SEASTAR_TEST_CASE(test_bind_variable_type_checking) {
     });
 }
 
+SEASTAR_TEST_CASE(test_bind_variable_type_checking_disabled) {
+    auto db_config = make_shared<db::config>();
+    db_config->cql_duplicate_bind_variable_names_refer_to_same_variable(false);
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        e.execute_cql("CREATE TABLE tab1 (p int primary key, a int, b text, c int)").get();
+
+        // Test :var needing to have two conflicting types; will fail without
+        // cql_duplicate_bind_variable_names_refer_to_same_variable = false
+        auto prepared = e.prepare("INSERT INTO tab1 (p, a, b) VALUES (0, :var, :var)").get();
+
+        // Verify that the parameters passed positionally work (non-positional won't make sense)
+        auto a = int32_type->decompose(1);
+        auto b = utf8_type->decompose("abc");
+        e.execute_prepared(prepared, {cql3::raw_value::make_value(a), cql3::raw_value::make_value(b)}).get();
+
+        auto msg = e.execute_cql("SELECT a, b FROM tab1 WHERE p = 0").get();
+        assert_that(msg).is_rows().with_rows({{a, b}});
+    }, cql_test_config{db_config});
+}
+
 SEASTAR_TEST_CASE(test_setting_synchronous_updates_property) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         e.execute_cql("create table base (k int, v int, primary key (k));").get();

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -345,7 +345,7 @@ BOOST_AUTO_TEST_CASE(expr_printer_parse_and_print_test) {
     };
 
     for(const char* test : tests) {
-        expression parsed_where = cql3::util::where_clause_to_relations(test);
+        expression parsed_where = cql3::util::where_clause_to_relations(test, cql3::dialect{});
         sstring printed_where = cql3::util::relations_to_where_clause(parsed_where);
 
         BOOST_REQUIRE_EQUAL(sstring(test), printed_where);

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -47,7 +47,7 @@ query::clustering_row_ranges slice(
 query::clustering_row_ranges slice_parse(
         sstring_view where_clause, cql_test_env& env,
         const sstring& table_name = "t", const sstring& keyspace_name = "ks") {
-    return slice(boolean_factors(cql3::util::where_clause_to_relations(where_clause)), env, table_name, keyspace_name);
+    return slice(boolean_factors(cql3::util::where_clause_to_relations(where_clause, cql3::dialect{})), env, table_name, keyspace_name);
 }
 
 auto I(int32_t x) { return int32_type->decompose(x); }

--- a/test/cql-pytest/test_guardrail_replication_strategy.py
+++ b/test/cql-pytest/test_guardrail_replication_strategy.py
@@ -44,8 +44,8 @@ def test_given_default_config_when_creating_ks_should_only_produce_warning_for_s
 
 def test_given_cleared_guardrails_when_creating_ks_should_not_get_warning_nor_error(cql, this_dc):
     with ExitStack() as config_modifications:
-        config_modifications.enter_context(config_value_context(cql, 'replication_strategy_warn_list', ''))
-        config_modifications.enter_context(config_value_context(cql, 'replication_strategy_fail_list', ''))
+        config_modifications.enter_context(config_value_context(cql, 'replication_strategy_warn_list', '[]'))
+        config_modifications.enter_context(config_value_context(cql, 'replication_strategy_fail_list', '[]'))
 
         for key, value in {'SimpleStrategy': 'replication_factor', 'NetworkTopologyStrategy': this_dc,
                            'EverywhereStrategy': 'replication_factor', 'LocalStrategy': 'replication_factor'}.items():
@@ -56,8 +56,7 @@ def test_given_cleared_guardrails_when_creating_ks_should_not_get_warning_nor_er
 def test_given_non_empty_warn_list_when_creating_ks_should_only_warn_when_listed_strategy_used(cql, this_dc):
     with ExitStack() as config_modifications:
         config_modifications.enter_context(config_value_context(cql, 'replication_strategy_warn_list',
-                                                                'SimpleStrategy, LocalStrategy, '
-                                                                'NetworkTopologyStrategy, EverywhereStrategy'))
+                                                                'SimpleStrategy,LocalStrategy,NetworkTopologyStrategy,EverywhereStrategy'))
         for key, value in {'SimpleStrategy': 'replication_factor', 'NetworkTopologyStrategy': this_dc,
                            'EverywhereStrategy': 'replication_factor', 'LocalStrategy': 'replication_factor'}.items():
             create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 3 }}",
@@ -67,10 +66,10 @@ def test_given_non_empty_warn_list_when_creating_ks_should_only_warn_when_listed
 def test_given_non_empty_warn_and_fail_lists_when_creating_ks_should_fail_query_when_listed_strategy_used(cql, this_dc):
     with ExitStack() as config_modifications:
         config_modifications.enter_context(
-            config_value_context(cql, 'replication_strategy_warn_list', 'SimpleStrategy, EverywhereStrategy'))
+            config_value_context(cql, 'replication_strategy_warn_list', 'SimpleStrategy,EverywhereStrategy'))
         config_modifications.enter_context(config_value_context(cql, 'replication_strategy_fail_list',
-                                                                'SimpleStrategy, LocalStrategy, '
-                                                                'NetworkTopologyStrategy, EverywhereStrategy'))
+                                                                'SimpleStrategy,LocalStrategy,'
+                                                                'NetworkTopologyStrategy,EverywhereStrategy'))
         for key, value in {'SimpleStrategy': 'replication_factor', 'NetworkTopologyStrategy': this_dc,
                            'EverywhereStrategy': 'replication_factor', 'LocalStrategy': 'replication_factor'}.items():
             # note: even though warn list is not empty, no warnings should be generated, because failures come first -

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -184,6 +184,7 @@ private:
 private:
     cql3::dialect test_dialect() {
         return cql3::dialect{
+            .duplicate_bind_variable_names_refer_to_same_variable = _db.local().get_config().cql_duplicate_bind_variable_names_refer_to_same_variable(),
         };
     }
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -182,6 +182,11 @@ private:
     };
     distributed<core_local_state> _core_local;
 private:
+    cql3::dialect test_dialect() {
+        return cql3::dialect{
+        };
+    }
+
     auto make_query_state() {
         if (_db.local().has_keyspace(ks_name)) {
             _core_local.local().client_state.set_keyspace(_db.local(), ks_name);
@@ -217,7 +222,7 @@ public:
         testlog.trace("{}(\"{}\")", __FUNCTION__, text);
         auto qs = make_query_state();
         auto qo = make_shared<cql3::query_options>(cql3::query_options::DEFAULT);
-        return local_qp().execute_direct_without_checking_exception_message(text, *qs, *qo).then([qs, qo] (auto msg) {
+        return local_qp().execute_direct_without_checking_exception_message(text, *qs, test_dialect(), *qo).then([qs, qo] (auto msg) {
             return cql_transport::messages::propagate_exception_as_future(std::move(msg));
         });
     }
@@ -229,7 +234,7 @@ public:
         testlog.trace("{}(\"{}\")", __FUNCTION__, text);
         auto qs = make_query_state();
         auto& lqo = *qo;
-        return local_qp().execute_direct_without_checking_exception_message(text, *qs, lqo).then([qs, qo = std::move(qo)] (auto msg) {
+        return local_qp().execute_direct_without_checking_exception_message(text, *qs, test_dialect(), lqo).then([qs, qo = std::move(qo)] (auto msg) {
             return cql_transport::messages::propagate_exception_as_future(std::move(msg));
         });
     }
@@ -237,9 +242,9 @@ public:
     virtual future<cql3::prepared_cache_key_type> prepare(sstring query) override {
         return qp().invoke_on_all([query, this] (auto& local_qp) {
             auto qs = this->make_query_state();
-            return local_qp.prepare(query, *qs).finally([qs] {}).discard_result();
+            return local_qp.prepare(query, *qs, test_dialect()).finally([qs] {}).discard_result();
         }).then([query, this] {
-            return local_qp().compute_id(query, ks_name);
+            return local_qp().compute_id(query, ks_name, test_dialect());
         });
     }
 
@@ -282,7 +287,7 @@ public:
 
     virtual future<std::vector<mutation>> get_modification_mutations(const sstring& text) override {
         auto qs = make_query_state();
-        auto cql_stmt = local_qp().get_statement(text, qs->get_client_state())->statement;
+        auto cql_stmt = local_qp().get_statement(text, qs->get_client_state(), test_dialect())->statement;
         auto modif_stmt = dynamic_pointer_cast<cql3::statements::modification_statement>(std::move(cql_stmt));
         if (!modif_stmt) {
             throw std::runtime_error(format("get_stmt_mutations: not a modification statement: {}", text));
@@ -1001,7 +1006,7 @@ public:
         using cql3::statements::modification_statement;
         std::vector<batch_statement::single_statement> modifications;
         boost::transform(queries, back_inserter(modifications), [this](const auto& query) {
-            auto stmt = local_qp().get_statement(query, _core_local.local().client_state);
+            auto stmt = local_qp().get_statement(query, _core_local.local().client_state, test_dialect());
             if (!dynamic_cast<modification_statement*>(stmt->statement.get())) {
                 throw exceptions::invalid_request_exception(
                     "Invalid statement in batch: only UPDATE, INSERT and DELETE statements are allowed.");

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -264,7 +264,8 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
             // fall-though to below
         }
         auto raw_statement = cql3::query_processor::parse_statement(
-                fmt::format("CREATE KEYSPACE {} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': '1'}}", name));
+                fmt::format("CREATE KEYSPACE {} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': '1'}}", name),
+                cql3::dialect{});
         auto prepared_statement = raw_statement->prepare(db, cql_stats);
         auto* statement = prepared_statement->statement.get();
         auto p = dynamic_cast<cql3::statements::create_keyspace_statement*>(statement);
@@ -276,7 +277,7 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
 
     std::vector<std::unique_ptr<cql3::statements::raw::parsed_statement>> raw_statements;
     try {
-        raw_statements = cql3::query_processor::parse_statements(schema_str);
+        raw_statements = cql3::query_processor::parse_statements(schema_str, cql3::dialect{});
     } catch (...) {
         throw std::runtime_error(format("tools:do_load_schemas(): failed to parse CQL statements: {}", std::current_exception()));
     }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -242,6 +242,7 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
     , _config(std::move(config))
     , _max_request_size(_config.max_request_size)
     , _max_concurrent_requests(db_cfg.max_concurrent_requests_per_shard)
+    , _cql_duplicate_bind_variable_names_refer_to_same_variable(db_cfg.cql_duplicate_bind_variable_names_refer_to_same_variable)
     , _memory_available(ml.get_semaphore())
     , _notifier(std::make_unique<event_notifier>(*this))
     , _auth_service(auth_service)
@@ -1279,6 +1280,7 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
 cql3::dialect
 cql_server::connection::get_dialect() const {
     return cql3::dialect{
+        .duplicate_bind_variable_names_refer_to_same_variable = _server._cql_duplicate_bind_variable_names_refer_to_same_variable,
     };
 }
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -963,20 +963,20 @@ make_result(int16_t stream, messages::result_message& msg, const tracing::trace_
 template<typename Process>
 future<cql_server::result_with_foreign_response_ptr>
 cql_server::connection::process_on_shard(::shared_ptr<messages::result_message::bounce_to_shard> bounce_msg, uint16_t stream, fragmented_temporary_buffer::istream is,
-        service::client_state& cs, service_permit permit, tracing::trace_state_ptr trace_state, Process process_fn) {
+        service::client_state& cs, service_permit permit, tracing::trace_state_ptr trace_state, cql3::dialect dialect, Process process_fn) {
     return _server.container().invoke_on(*bounce_msg->move_to_shard(), _server._config.bounce_request_smp_service_group,
             [this, is = std::move(is), cs = cs.move_to_other_shard(), stream, permit = std::move(permit), process_fn,
              gt = tracing::global_trace_state_ptr(std::move(trace_state)),
-             cached_vals = std::move(bounce_msg->take_cached_pk_function_calls())] (cql_server& server) {
+             cached_vals = std::move(bounce_msg->take_cached_pk_function_calls()), dialect] (cql_server& server) {
         service::client_state client_state = cs.get();
         return do_with(bytes_ostream(), std::move(client_state), std::move(cached_vals),
                 [this, &server, is = std::move(is), stream, process_fn,
-                 trace_state = tracing::trace_state_ptr(gt)] (bytes_ostream& linearization_buffer,
+                 trace_state = tracing::trace_state_ptr(gt), dialect] (bytes_ostream& linearization_buffer,
                     service::client_state& client_state,
                     cql3::computed_function_values& cached_vals) mutable {
             request_reader in(is, linearization_buffer);
             return process_fn(client_state, server._query_processor, in, stream, _version,
-                    /* FIXME */empty_service_permit(), std::move(trace_state), false, std::move(cached_vals)).then([] (auto msg) {
+                    /* FIXME */empty_service_permit(), std::move(trace_state), false, std::move(cached_vals), dialect).then([] (auto msg) {
                 // result here has to be foreign ptr
                 return std::get<cql_server::result_with_foreign_response_ptr>(std::move(msg));
             });
@@ -998,13 +998,14 @@ cql_server::connection::process(uint16_t stream, request_reader in, service::cli
         tracing::trace_state_ptr trace_state, Process process_fn) {
     fragmented_temporary_buffer::istream is = in.get_stream();
 
+    auto dialect = get_dialect();
     return process_fn(client_state, _server._query_processor, in, stream,
-            _version, permit, trace_state, true, {})
-            .then([stream, &client_state, this, is, permit, process_fn, trace_state]
+            _version, permit, trace_state, true, {}, dialect)
+            .then([stream, &client_state, this, is, permit, process_fn, trace_state, dialect]
                    (process_fn_return_type msg) mutable {
         auto* bounce_msg = std::get_if<shared_ptr<messages::result_message::bounce_to_shard>>(&msg);
         if (bounce_msg) {
-            return process_on_shard(*bounce_msg, stream, is, client_state, std::move(permit), trace_state, process_fn);
+            return process_on_shard(*bounce_msg, stream, is, client_state, std::move(permit), trace_state, dialect, process_fn);
         }
         auto ptr = std::get<cql_server::result_with_foreign_response_ptr>(std::move(msg));
         return make_ready_future<cql_server::result_with_foreign_response_ptr>(std::move(ptr));
@@ -1014,7 +1015,8 @@ cql_server::connection::process(uint16_t stream, request_reader in, service::cli
 static future<process_fn_return_type>
 process_query_internal(service::client_state& client_state, distributed<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
-        service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls) {
+        service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls,
+        cql3::dialect dialect) {
     auto query = in.read_long_string_view();
     auto q_state = std::make_unique<cql_query_state>(client_state, trace_state, std::move(permit));
     auto& query_state = q_state->query_state;
@@ -1035,7 +1037,7 @@ process_query_internal(service::client_state& client_state, distributed<cql3::qu
         tracing::begin(trace_state, "Execute CQL3 query", client_state.get_client_address());
     }
 
-    return qp.local().execute_direct_without_checking_exception_message(query, query_state, options).then([q_state = std::move(q_state), stream, skip_metadata, version] (auto msg) {
+    return qp.local().execute_direct_without_checking_exception_message(query, query_state, dialect, options).then([q_state = std::move(q_state), stream, skip_metadata, version] (auto msg) {
         if (msg->move_to_shard()) {
             return process_fn_return_type(dynamic_pointer_cast<messages::result_message::bounce_to_shard>(msg));
         } else if (msg->is_exception()) {
@@ -1056,23 +1058,24 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_pr
         tracing::trace_state_ptr trace_state) {
 
     auto query = sstring(in.read_long_string_view());
+    auto dialect = get_dialect();
 
     tracing::add_query(trace_state, query);
     tracing::begin(trace_state, "Preparing CQL3 query", client_state.get_client_address());
 
     auto cpu_id = this_shard_id();
     auto cpus = boost::irange(0u, smp::count);
-    return parallel_for_each(cpus.begin(), cpus.end(), [this, query, cpu_id, &client_state] (unsigned int c) mutable {
+    return parallel_for_each(cpus.begin(), cpus.end(), [this, query, cpu_id, &client_state, dialect] (unsigned int c) mutable {
         if (c != cpu_id) {
-            return smp::submit_to(c, [this, query, &client_state] () mutable {
-                return _server._query_processor.local().prepare(std::move(query), client_state, false).discard_result();
+            return smp::submit_to(c, [this, query, &client_state, dialect] () mutable {
+                return _server._query_processor.local().prepare(std::move(query), client_state, false, dialect).discard_result();
             });
         } else {
             return make_ready_future<>();
         }
-    }).then([this, query, stream, &client_state, trace_state] () mutable {
+    }).then([this, query, stream, &client_state, trace_state, dialect] () mutable {
         tracing::trace(trace_state, "Done preparing on remote shards");
-        return _server._query_processor.local().prepare(std::move(query), client_state, false).then([this, stream, trace_state] (auto msg) {
+        return _server._query_processor.local().prepare(std::move(query), client_state, false, dialect).then([this, stream, trace_state] (auto msg) {
             tracing::trace(trace_state, "Done preparing on a local shard - preparing a result. ID is [{}]", seastar::value_of([&msg] {
                 return messages::result_message::prepared::cql::get_id(msg);
             }));
@@ -1084,8 +1087,9 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_pr
 static future<process_fn_return_type>
 process_execute_internal(service::client_state& client_state, distributed<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
-        service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls) {
-    cql3::prepared_cache_key_type cache_key(in.read_short_bytes());
+        service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls,
+        cql3::dialect dialect) {
+    cql3::prepared_cache_key_type cache_key(in.read_short_bytes(), dialect);
     auto& id = cql3::prepared_cache_key_type::cql_id(cache_key);
     bool needs_authorization = false;
 
@@ -1159,7 +1163,7 @@ future<cql_server::result_with_foreign_response_ptr> cql_server::connection::pro
 static future<process_fn_return_type>
 process_batch_internal(service::client_state& client_state, distributed<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
-        service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls) {
+        service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls, cql3::dialect dialect) {
     const auto type = in.read_byte();
     const unsigned n = in.read_short();
 
@@ -1184,7 +1188,7 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
         switch (kind) {
         case 0: {
             auto query = in.read_long_string_view();
-            stmt_ptr = qp.local().get_statement(query, client_state);
+            stmt_ptr = qp.local().get_statement(query, client_state, dialect);
             ps = stmt_ptr->checked_weak_from_this();
             if (init_trace) {
                 tracing::add_query(trace_state, query);
@@ -1192,7 +1196,7 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
             break;
         }
         case 1: {
-            cql3::prepared_cache_key_type cache_key(in.read_short_bytes());
+            cql3::prepared_cache_key_type cache_key(in.read_short_bytes(), dialect);
             auto& id = cql3::prepared_cache_key_type::cql_id(cache_key);
 
             // First, try to lookup in the cache of already authorized statements. If the corresponding entry is not found there
@@ -1270,6 +1274,12 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
             return process_fn_return_type(make_foreign(make_result(stream, *msg, trace_state, version)));
         }
     });
+}
+
+cql3::dialect
+cql_server::connection::get_dialect() const {
+    return cql3::dialect{
+    };
 }
 
 future<cql_server::result_with_foreign_response_ptr>

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -28,6 +28,7 @@
 #include "generic_server.hh"
 #include "service/query_state.hh"
 #include "cql3/query_options.hh"
+#include "cql3/dialect.hh"
 #include "transport/messages/result_message.hh"
 #include "utils/chunked_vector.hh"
 #include "exceptions/coordinator_result.hh"
@@ -262,6 +263,8 @@ private:
         std::unique_ptr<cql_server::response> make_auth_success(int16_t, bytes, const tracing::trace_state_ptr& tr_state) const;
         std::unique_ptr<cql_server::response> make_auth_challenge(int16_t, bytes, const tracing::trace_state_ptr& tr_state) const;
 
+        cql3::dialect get_dialect() const;
+
         // Helper functions to encapsulate bounce_to_shard processing for query, execute and batch verbs
         template<typename Process>
         future<result_with_foreign_response_ptr>
@@ -270,7 +273,7 @@ private:
         template<typename Process>
         future<result_with_foreign_response_ptr>
         process_on_shard(::shared_ptr<messages::result_message::bounce_to_shard> bounce_msg, uint16_t stream, fragmented_temporary_buffer::istream is, service::client_state& cs,
-                service_permit permit, tracing::trace_state_ptr trace_state, Process process_fn);
+                service_permit permit, tracing::trace_state_ptr trace_state, cql3::dialect dialect, Process process_fn);
 
         void write_response(foreign_ptr<std::unique_ptr<cql_server::response>>&& response, service_permit permit = empty_service_permit(), cql_compression compression = cql_compression::none);
 

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -155,6 +155,7 @@ private:
     cql_server_config _config;
     size_t _max_request_size;
     utils::updateable_value<uint32_t> _max_concurrent_requests;
+    utils::updateable_value<bool> _cql_duplicate_bind_variable_names_refer_to_same_variable;
     semaphore& _memory_available;
     seastar::metrics::metric_groups _metrics;
     std::unique_ptr<event_notifier> _notifier;

--- a/utils/config_file_impl.hh
+++ b/utils/config_file_impl.hh
@@ -22,6 +22,18 @@
 
 #include <seastar/json/json_elements.hh>
 
+namespace utils {
+
+template <typename T>
+T config_from_string(std::string_view string_representation) {
+    return boost::lexical_cast<T>(string_representation);
+}
+
+template <>
+bool config_from_string(std::string_view string_representation);
+
+}
+
 namespace YAML {
 
 /*
@@ -84,7 +96,7 @@ std::istream& operator>>(std::istream& is, std::unordered_map<K, V, Args...>& ma
     is >> tmp;
 
     for (auto& p : tmp) {
-        map[boost::lexical_cast<K>(p.first)] = boost::lexical_cast<V>(p.second);
+        map[utils::config_from_string<K>(p.first)] = utils::config_from_string<V>(p.second);
     }
     return is;
 }
@@ -94,7 +106,7 @@ std::istream& operator>>(std::istream& is, std::vector<V, Args...>& dst) {
     std::vector<seastar::sstring> tmp;
     is >> tmp;
     for (auto& v : tmp) {
-        dst.emplace_back(boost::lexical_cast<V>(v));
+        dst.emplace_back(utils::config_from_string<V>(v));
     }
     return is;
 }
@@ -126,7 +138,7 @@ void validate(boost::any& out, const std::vector<std::string>& in, std::unordere
                 ve = s.begin() + i->position();
             }
 
-            (*p)[boost::lexical_cast<K>(k)] = boost::lexical_cast<V>(sstring(vs, ve));
+            (*p)[utils::config_from_string<K>(k)] = utils::config_from_string<V>(sstring(vs, ve));
         }
     }
 }
@@ -210,7 +222,7 @@ bool utils::config_file::named_value<T>::set_value(sstring value, config_source 
         return false;
     }
 
-    (*this)(boost::lexical_cast<T>(value), src);
+    (*this)(config_from_string<T>(value), src);
     return true;
 }
 
@@ -232,7 +244,7 @@ future<bool> utils::config_file::named_value<T>::set_value_on_all_shards(sstring
         co_return false;
     }
 
-    co_await smp::invoke_on_all([this, value = boost::lexical_cast<T>(value), src] () {
+    co_await smp::invoke_on_all([this, value = config_from_string<T>(value), src] () {
         (*this)(value, src);
     });
     co_return true;


### PR DESCRIPTION
Bind variables in CQL have two formats: positional (?) where a variable is referred to by its relative position in the statement, and named (:var), where the user is expected to supply a name->value mapping.

In https://github.com/scylladb/scylladb/commit/19a6e69001f26133a7f7a0a13e89935888884e1a we identified the case where a named bind variable appears twice in a query, and collapsed it to a single entry in the statement metadata. Without this, a driver using the named variable syntax cannot disambiguate which variable is referred to.

However, it turns out that users can use the positional call form even with the named variable syntax, by using the positional API of the driver. To support this use case, we add a configuration variable to disable the same-variable detection.

Because the detection has to happen when the entire statement is visible, we have to supply the configuration to the parser. We call it the dialect and pass it from all callers. The alternative would be to add a pre-prepare call similar to fill_prepare_context that rewrites all expressions in a statement to deduplicate variables.

A unit test is added.

Fixes https://github.com/scylladb/scylladb/issues/15559

This may be useful to users transitioning from Cassandra, so merits a backport.

(cherry picked from commit https://github.com/scylladb/scylladb/commit/f9322799af02a7a39db962812a3769b786b49f1f)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/d69bf4f0101db3a3c2df53e0f35e8534c629bfc2)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/ea8441dfa3023cce04c7dfa1745039cdd8e2ee56)

Refs https://github.com/scylladb/scylladb/pull/19493

Subsumes #20389