### PR TITLE
doc: move Alternator in the page tree and remove it's redundant ToC

### DIFF
--- a/docs/alternator/alternator.md
+++ b/docs/alternator/alternator.md
@@ -208,6 +208,7 @@ with Tablets enabled.
 ```{eval-rst}
 .. toctree::
     :maxdepth: 2
+    :hidden:
 
     getting-started
     compatibility

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,6 +56,7 @@ In addition, you can read our `blog <https://www.scylladb.com/blog/>`_ and atten
   operating-scylla/index
   using-scylla/index
   cql/index
+  alternator/alternator
   features/index
   architecture/index
   troubleshooting/index
@@ -63,4 +64,4 @@ In addition, you can read our `blog <https://www.scylladb.com/blog/>`_ and atten
   reference/index
   faq
   Contribute to ScyllaDB <contribute>
-  alternator/alternator
+


### PR DESCRIPTION
This PR hides the ToC on the Alternator page, as we don't need it, especially at the end of the page.

The ToC must be hidden rather than removed because removing it would, in turn, remove the "Getting Started With ScyllaDB Alternator" and "ScyllaDB Alternator for DynamoDB users" from the page tree and make them inaccessible.

In addition, this PR moves Alternator higher in the page tree.

Fixes https://github.com/scylladb/scylladb/issues/19823