### PR TITLE
Generalize multipart upload implementations in S3 client

### DIFF
--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -45,6 +45,7 @@ struct stats {
 future<> ignore_reply(const http::reply& rep, input_stream<char>&& in_);
 
 class client : public enable_shared_from_this<client> {
+    class multipart_upload;
     class upload_sink_base;
     class upload_sink;
     class upload_jumbo_sink;


### PR DESCRIPTION
There are two currently -- upload_sink_base and do_upload_file. This PR merges as much code as possible (spoiler: it's already mostly copy-n-pase-d, so squashing is pretty straightforward)