### PR TITLE
Add tablet merge support

### DIFF
--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -369,7 +369,7 @@ emits a decision to finalize the split request. The finalization is serialized w
 doubling tablet count would interfere with the migration process.
 
 When the state machine leaves the migration track, and there are tablets waiting for tablet split to
-be finalized, the topology will transition into `tablet_split_finalization` state. At this moment, there will
+be finalized, the topology will transition into `tablet_resize_finalization` state. At this moment, there will
 be no migration running in the system. A global token metadata barrier is executed to make sure that no
 process e.g. repair will be holding stale metadata when finalizing split. After that, the new tablet map,
 which is a result of splitting each preexisting tablet into two, is committed to group0.

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -145,6 +145,7 @@ public:
     gms::feature maintenance_tenant { *this, "MAINTENANCE_TENANT"sv };
 
     gms::feature tablet_repair_scheduler { *this, "TABLET_REPAIR_SCHEDULER"sv };
+    gms::feature tablet_merge { *this, "TABLET_MERGE"sv };
 
     // A feature just for use in tests. It must not be advertised unless
     // the "features_enable_test_feature" injection is enabled.

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -30,6 +30,14 @@ namespace locator {
 
 seastar::logger tablet_logger("tablets");
 
+std::optional<std::pair<tablet_id, tablet_id>> tablet_map::sibling_tablets(tablet_id t) const {
+    if (tablet_count() == 1) {
+        return std::nullopt;
+    }
+    auto first_sibling = tablet_id(t.value() & ~0x1);
+    return std::make_pair(first_sibling, *next_tablet(first_sibling));
+}
+
 
 static
 write_replica_set_selector get_selector_for_writes(tablet_transition_stage stage) {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -540,6 +540,10 @@ bool tablet_map::needs_split() const {
     return std::holds_alternative<resize_decision::split>(_resize_decision.way);
 }
 
+bool tablet_map::needs_merge() const {
+    return std::holds_alternative<resize_decision::merge>(_resize_decision.way);
+}
+
 const locator::resize_decision& tablet_map::resize_decision() const {
     return _resize_decision;
 }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -580,6 +580,10 @@ resize_decision::seq_number_t resize_decision::next_sequence_number() const {
     return (sequence_number == std::numeric_limits<seq_number_t>::max()) ? 0 : sequence_number + 1;
 }
 
+bool resize_decision::initial_decision() const {
+    return sequence_number == 0;
+}
+
 table_load_stats& table_load_stats::operator+=(const table_load_stats& s) noexcept {
     size_in_bytes = size_in_bytes + s.size_in_bytes;
     split_ready_seq_number = std::min(split_ready_seq_number, s.split_ready_seq_number);

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -312,6 +312,8 @@ struct resize_decision {
     bool operator==(const resize_decision&) const;
     sstring type_name() const;
     seq_number_t next_sequence_number() const;
+    // Returns true if this is the initial decision, before split or merge was emitted.
+    bool initial_decision() const;
 };
 
 struct table_load_stats {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -171,8 +171,18 @@ struct tablet_info {
     db_clock::time_point repair_time;
     locator::tablet_task_info repair_task_info;
 
+    tablet_info() = default;
+    tablet_info(tablet_replica_set, db_clock::time_point, tablet_task_info);
+    tablet_info(tablet_replica_set);
+
     bool operator==(const tablet_info&) const = default;
 };
+
+// Merges tablet_info b into a, but with following constraints:
+//  - they cannot have active repair task, since each task has a different id
+//  - their replicas must be all co-located.
+// If tablet infos are mergeable, merged info is returned. Otherwise, nullopt.
+std::optional<tablet_info> merge_tablet_info(tablet_info a, tablet_info b);
 
 /// Represents states of the tablet migration state machine.
 ///

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -482,6 +482,7 @@ public:
     bool operator==(const tablet_map&) const = default;
 
     bool needs_split() const;
+    bool needs_merge() const;
 
     /// Returns the token_range in which the given token will belong to after a tablet split
     dht::token_range get_token_range_after_split(const token& t) const noexcept;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -62,7 +62,7 @@ struct tablet_replica {
     host_id host;
     shard_id shard;
 
-    bool operator==(const tablet_replica&) const = default;
+    auto operator<=>(const tablet_replica&) const = default;
 };
 
 using tablet_replica_set = utils::small_vector<tablet_replica, 3>;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -47,7 +47,7 @@ struct tablet_id {
     explicit tablet_id(size_t id) : id(id) {}
     size_t value() const { return id; }
     explicit operator size_t() const { return id; }
-    bool operator<=>(const tablet_id&) const = default;
+    auto operator<=>(const tablet_id&) const = default;
 };
 
 /// Identifies tablet (not be confused with tablet replica) in the scope of the whole cluster.
@@ -55,7 +55,7 @@ struct global_tablet_id {
     table_id table;
     tablet_id tablet;
 
-    bool operator<=>(const global_tablet_id&) const = default;
+    auto operator<=>(const global_tablet_id&) const = default;
 };
 
 struct tablet_replica {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -348,6 +348,12 @@ struct repair_scheduler_config {
 
 using load_stats_ptr = lw_shared_ptr<const load_stats>;
 
+struct tablet_desc {
+    tablet_id tid;
+    const tablet_info* info; // cannot be null.
+    const tablet_transition_info* transition; // null if there's no transition.
+};
+
 /// Stores information about tablets of a single table.
 ///
 /// The map contains a constant number of tablets, tablet_count().
@@ -452,6 +458,10 @@ public:
 
     /// Calls a given function for each tablet in the map in token ownership order.
     future<> for_each_tablet(seastar::noncopyable_function<future<>(tablet_id, const tablet_info&)> func) const;
+
+    /// Calls a given function for each sibling tablet in the map in token ownership order.
+    /// If tablet count == 1, then there will be only one call and 2nd tablet_desc is disengaged.
+    future<> for_each_sibling_tablets(seastar::noncopyable_function<future<>(tablet_desc, std::optional<tablet_desc>)> func) const;
 
     const auto& transitions() const {
         return _transitions;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -448,6 +448,11 @@ public:
         return tablet_id(size_t(t) + 1);
     }
 
+    // Returns the pair of sibling tablets for a given tablet id.
+    // For example, if id 1 is provided, a pair of 0 and 1 is returned.
+    // Returns disengaged optional when sibling pair cannot be found.
+    std::optional<std::pair<tablet_id, tablet_id>> sibling_tablets(tablet_id t) const;
+
     /// Returns true iff tablet has a given replica.
     /// If tablet is in transition, considers both previous and next replica set.
     bool has_replica(tablet_id, tablet_replica) const;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -11,6 +11,7 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
+#include <seastar/coroutine/switch_to.hh>
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/util/closeable.hh>
 #include <seastar/util/defer.hh>
@@ -635,7 +636,8 @@ const storage_group_map& storage_group_manager::storage_groups() const {
 }
 
 future<> storage_group_manager::stop_storage_groups() noexcept {
-    return parallel_for_each(_storage_groups | std::views::values, [] (auto sg) { return sg->stop("table removal"); });
+    co_await parallel_for_each(_storage_groups | std::views::values, [] (auto sg) { return sg->stop("table removal"); });
+    co_await stop();
 }
 
 void storage_group_manager::clear_storage_groups() {
@@ -684,6 +686,10 @@ public:
         _single_sg = sg.get();
         r[0] = std::move(sg);
         _storage_groups = std::move(r);
+    }
+
+    future<> stop() override {
+        return make_ready_future<>();
     }
 
     future<> update_effective_replication_map(const locator::effective_replication_map& erm, noncopyable_function<void()> refresh_mutation_source) override { return make_ready_future(); }
@@ -737,6 +743,8 @@ class tablet_storage_group_manager final : public storage_group_manager {
     // current split, and not a previously revoked (stale) decision.
     // The minimum value, which is a negative number, is not used by coordinator for first decision.
     locator::resize_decision::seq_number_t _split_ready_seq_number = std::numeric_limits<locator::resize_decision::seq_number_t>::min();
+    future<> _merge_completion_fiber;
+    condition_variable _merge_completion_event;
 private:
     const schema_ptr& schema() const {
         return _t.schema();
@@ -761,6 +769,12 @@ private:
     // the new tablet id (X >> 1). In practice, that means storage groups for X and X+1
     // are merged into a new storage group with id (X >> 1).
     future<> handle_tablet_merge_completion(const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap);
+
+    // When merge completes, compaction groups of sibling tablets are added to same storage
+    // group, but they're not merged yet into one, since the merge completion handler happens
+    // inside the erm updater which must complete ASAP. Therefore, those groups will be merged
+    // into a single one (main) in background.
+    future<> merge_completion_fiber();
 
     storage_group& storage_group_for_id(size_t i) const {
         return storage_group_manager::storage_group_for_id(schema(), i);
@@ -800,6 +814,7 @@ public:
         : _t(t)
         , _my_host_id(erm.get_token_metadata().get_my_id())
         , _tablet_map(&erm.get_token_metadata().tablets().get_tablet_map(schema()->id()))
+        , _merge_completion_fiber(merge_completion_fiber())
     {
         storage_group_map ret;
 
@@ -815,6 +830,11 @@ public:
             }
         }
         _storage_groups = std::move(ret);
+    }
+
+    future<> stop() override {
+        _merge_completion_event.signal();
+        return std::exchange(_merge_completion_fiber, make_ready_future<>());
     }
 
     future<> update_effective_replication_map(const locator::effective_replication_map& erm, noncopyable_function<void()> refresh_mutation_source) override;
@@ -934,6 +954,17 @@ void storage_group::add_merging_group(compaction_group_ptr cg) {
     _merging_groups.push_back(std::move(cg));
 }
 
+const std::vector<compaction_group_ptr>& storage_group::merging_groups() const {
+    return _merging_groups;
+}
+
+future<> storage_group::remove_empty_merging_groups() {
+    for (auto& group : _merging_groups | std::views::filter(std::mem_fn(&compaction_group::empty))) {
+        co_await group->stop("tablet merge");
+    }
+    std::erase_if(_merging_groups, std::mem_fn(&compaction_group::empty));
+}
+
 future<> storage_group::split(sstables::compaction_type_options::split opt) {
     if (set_split_mode()) {
         co_return;
@@ -944,6 +975,9 @@ future<> storage_group::split(sstables::compaction_type_options::split opt) {
         co_return;
     }
     for (auto cg : split_unready_groups()) {
+        if (cg->async_gate().is_closed()) {
+            continue;
+        }
         auto holder = cg->async_gate().hold();
         co_await cg->flush();
         // Waits on sstables produced by repair to be integrated into main set; off-strategy is usually a no-op with tablets.
@@ -1170,7 +1204,9 @@ future<> table::parallel_foreach_compaction_group(std::function<future<>(compact
 void table::for_each_compaction_group(std::function<void(compaction_group&)> action) {
     _sg_manager->for_each_storage_group([&] (size_t, storage_group& sg) {
         sg.for_each_compaction_group([&] (const compaction_group_ptr& cg) {
-           action(*cg);
+            if (auto holder = try_hold_gate(cg->async_gate())) {
+                action(*cg);
+            }
        });
     });
 }
@@ -1178,7 +1214,9 @@ void table::for_each_compaction_group(std::function<void(compaction_group&)> act
 void table::for_each_compaction_group(std::function<void(const compaction_group&)> action) const {
     _sg_manager->for_each_storage_group([&] (size_t, storage_group& sg) {
         sg.for_each_compaction_group([&] (const compaction_group_ptr& cg) {
-            action(*cg);
+            if (auto holder = try_hold_gate(cg->async_gate())) {
+                action(*cg);
+            }
         });
     });
 }
@@ -1832,6 +1870,35 @@ compaction_group::delete_unused_sstables(sstables::compaction_completion_desc de
     return delete_sstables_atomically(std::move(sstables_to_remove));
 }
 
+std::vector<sstables::shared_sstable> compaction_group::all_sstables() const {
+    std::vector<sstables::shared_sstable> all;
+    auto main_sstables = _main_sstables->all();
+    auto maintenance_sstables = _maintenance_sstables->all();
+    all.reserve(main_sstables->size() + maintenance_sstables->size());
+    std::ranges::copy(*main_sstables, std::back_inserter(all));
+    std::ranges::copy(*maintenance_sstables, std::back_inserter(all));
+    return all;
+}
+
+future<>
+compaction_group::merge_sstables_from(compaction_group& group) {
+    auto& cs = _t.get_compaction_strategy();
+    auto permit = co_await seastar::get_units(_t._sstable_set_mutation_sem, 1);
+    table::sstable_list_builder builder(std::move(permit));
+
+    auto sstables_to_merge = group.all_sstables();
+    // re-build new list for this group with sstables of the group being merged.
+    auto res = co_await builder.build_new_list(*main_sstables(), cs.make_sstable_set(_t.schema()), sstables_to_merge, {});
+    // execute:
+    std::invoke([&] noexcept {
+        set_main_sstables(std::move(res.new_sstable_set));
+        group.clear_sstables();
+        // FIXME: backlog adjustment is not exception safe.
+        backlog_tracker_adjust_charges({}, sstables_to_merge);
+    });
+    _t.rebuild_statistics();
+}
+
 future<>
 compaction_group::update_sstable_sets_on_compaction_completion(sstables::compaction_completion_desc desc) {
     // Build a new list of _sstables: We remove from the existing list the
@@ -2457,6 +2524,34 @@ future<> tablet_storage_group_manager::handle_tablet_split_completion(const loca
     return stop_fut;
 }
 
+future<> tablet_storage_group_manager::merge_completion_fiber() {
+    co_await coroutine::switch_to(_t.get_config().streaming_scheduling_group);
+
+    while (!_t.async_gate().is_closed()) {
+        try {
+            co_await for_each_storage_group_gently([] (storage_group& sg) -> future<> {
+                auto main_group = sg.main_compaction_group();
+                for (auto& group : sg.merging_groups()) {
+                    // Synchronize with ongoing writes that might be blocked waiting for memory.
+                    // Also, disabling compaction provides stability on the sstable set.
+                    co_await group->stop("tablet merge");
+                    // Flushes memtable, so all the data can be moved.
+                    co_await group->flush();
+                    co_await main_group->merge_sstables_from(*group);
+                }
+                co_await sg.remove_empty_merging_groups();
+            });
+        } catch (...) {
+            tlogger.error("Failed to merge compaction groups for table {}.{}", schema()->ks_name(), schema()->cf_name());
+        }
+        utils::get_local_injector().inject("replica_merge_completion_wait", [] () {
+            tlogger.info("Merge completion fiber finished, about to sleep");
+        });
+        co_await _merge_completion_event.wait();
+        tlogger.debug("Merge completion fiber woke up for {}.{}", schema()->ks_name(), schema()->cf_name());
+    }
+}
+
 future<> tablet_storage_group_manager::handle_tablet_merge_completion(const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap) {
     auto table_id = schema()->id();
     size_t old_tablet_count = old_tmap.tablet_count();
@@ -2493,12 +2588,12 @@ future<> tablet_storage_group_manager::handle_tablet_merge_completion(const loca
                 cg->update_id(new_tid);
                 new_sg->add_merging_group(cg);
             });
-            // FIXME: we MUST schedule a background action to flush memtable and move sstables of merging groups into the main one.
         }
 
         new_storage_groups[new_tid] = std::move(new_sg);
     }
     _storage_groups = std::move(new_storage_groups);
+    _merge_completion_event.signal();
     return make_ready_future<>();
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5453,7 +5453,11 @@ future<> storage_service::process_tablet_split_candidate(table_id table) noexcep
             sleep = true;
         }
         if (sleep) {
-            co_await split_retry.retry(_group0_as);
+            try {
+                co_await split_retry.retry(_group0_as);
+            } catch (...) {
+                slogger.warn("Sleep in split monitor failed with {}", std::current_exception());
+            }
         }
     }
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -756,7 +756,7 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
                     [[fallthrough]];
                 case topology::transition_state::tablet_migration:
                     [[fallthrough]];
-                case topology::transition_state::tablet_split_finalization:
+                case topology::transition_state::tablet_resize_finalization:
                     [[fallthrough]];
                 case topology::transition_state::commit_cdc_generation:
                     [[fallthrough]];

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -621,6 +621,12 @@ private:
         return trinfo ? trinfo->next : ti.replicas;
     }
 
+    tablet_replica_set sorted_replicas_for_tablet_load(const tablet_info& ti, const tablet_transition_info* trinfo) const {
+        auto set = get_replicas_for_tablet_load(ti, trinfo);
+        std::ranges::sort(set, std::less<tablet_replica>());
+        return set;
+    }
+
     // Whether to count the tablet as putting streaming load on the system.
     // Tablets which are streaming or are yet-to-stream are counted.
     bool is_streaming(const tablet_transition_info* trinfo) {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -348,6 +348,8 @@ class load_balancer {
     // It's an average per-shard load in terms of tablet count.
     using load_type = double;
 
+    using table_candidates_map = std::unordered_map<table_id, std::unordered_set<global_tablet_id>>;
+
     struct shard_load {
         size_t tablet_count = 0;
 
@@ -362,7 +364,7 @@ class load_balancer {
         // Tablets which still have a replica on this shard which are candidates for migrating away from this shard.
         // Grouped by table. Used when _use_table_aware_balancing == true.
         // The set of candidates per table may be empty.
-        std::unordered_map<table_id, std::unordered_set<global_tablet_id>> candidates;
+        table_candidates_map candidates;
         // For all tables. Used when _use_table_aware_balancing == false.
         std::unordered_set<global_tablet_id> candidates_all_tables;
 
@@ -1041,7 +1043,7 @@ public:
         return rand_int() % shard_count;
     }
 
-    table_id pick_table(const std::unordered_map<table_id, std::unordered_set<global_tablet_id>>& candidates) {
+    table_id pick_table(const table_candidates_map& candidates) {
         if (!_use_table_aware_balancing) {
             on_internal_error(lblogger, "pick_table() called when table-aware balancing is disabled");
         }

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -712,7 +712,8 @@ public:
         // Make plans for repair jobs
         plan.set_repair_plan(co_await make_repair_plan(plan));
 
-        plan.set_resize_plan(co_await make_resize_plan());
+        // Merge table-wide resize decisions, may emit new decisions, revoke or finalize ongoing ones.
+        plan.merge_resize_plan(co_await make_resize_plan());
 
         lblogger.info("Prepared {} migration plans, out of which there were {} tablet migration(s) and {} resize decision(s) and {} tablet repair(s)",
                 plan.size(), plan.tablet_migration_count(), plan.resize_decision_count(), plan.tablet_repair_count());

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -2252,6 +2252,7 @@ public:
                         throw std::runtime_error(fmt::format("Unable to find new replica for tablet {} on {} when draining {}. Consider adding new nodes or reducing replication factor. (nodes {}, replicas {})",
                                                         tablet, src, nodes_to_drain, nodes_by_load_dst, replicas));
                     }
+                    lblogger.debug("Adding replica {} of candidate {} to skipped list with the viable targets {}", src, candidate, skip.viable_targets);
                     src_node_info.skipped_candidates.emplace_back(src, tablets, std::move(skip.viable_targets));
                 };
 

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -172,8 +172,8 @@ public:
 
     const table_resize_plan& resize_plan() const { return _resize_plan; }
 
-    void set_resize_plan(table_resize_plan resize_plan) {
-        _resize_plan = std::move(resize_plan);
+    void merge_resize_plan(table_resize_plan resize_plan) {
+        _resize_plan.merge(std::move(resize_plan));
     }
 
     const tablet_repair_plan& repair_plan() const { return _repair_plan; }

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -153,6 +153,12 @@ public:
         _migrations.emplace_back(std::move(info));
     }
 
+    void add(migrations_vector migrations) {
+        for (auto&& mig : migrations) {
+            add(std::move(mig));
+        }
+    }
+
     void merge(migration_plan&& other) {
         std::move(other._migrations.begin(), other._migrations.end(), std::back_inserter(_migrations));
         _has_nodes_to_drain |= other._has_nodes_to_drain;

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -234,7 +234,7 @@ public:
 
     void set_use_table_aware_balancing(bool);
 
-    future<locator::tablet_map> split_tablets(locator::token_metadata_ptr, table_id);
+    future<locator::tablet_map> resize_tablets(locator::token_metadata_ptr, table_id);
 
     /// Should be called when the node is no longer a leader.
     void on_leadership_lost();

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -106,6 +106,7 @@ struct table_resize_plan {
                 resize[id] = std::move(other_resize);
             }
         }
+
         finalize_resize.merge(std::move(other.finalize_resize));
     }
 };

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1464,7 +1464,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
         co_await update_topology_state(std::move(guard), std::move(updates), "Finished tablet migration");
     }
 
-    future<> handle_tablet_split_finalization(group0_guard g) {
+    future<> handle_tablet_resize_finalization(group0_guard g) {
         // Executes a global barrier to guarantee that any process (e.g. repair) holding stale version
         // of token metadata will complete before we update topology.
         auto guard = co_await global_tablet_token_metadata_barrier(std::move(g));
@@ -1477,7 +1477,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
 
         for (auto& table_id : plan.resize_plan().finalize_resize) {
             auto s = _db.find_schema(table_id);
-            auto new_tablet_map = co_await _tablet_allocator.split_tablets(tm, table_id);
+            auto new_tablet_map = co_await _tablet_allocator.resize_tablets(tm, table_id);
             updates.emplace_back(co_await replica::tablet_map_to_mutation(
                 new_tablet_map,
                 table_id,
@@ -2095,8 +2095,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             case topology::transition_state::tablet_migration:
                 co_await handle_tablet_migration(std::move(guard), false);
                 break;
-            case topology::transition_state::tablet_split_finalization:
-                co_await handle_tablet_split_finalization(std::move(guard));
+            case topology::transition_state::tablet_resize_finalization:
+                co_await handle_tablet_resize_finalization(std::move(guard));
                 break;
             case topology::transition_state::left_token_ring: {
                 auto node = get_node_to_work_on(std::move(guard));
@@ -2544,8 +2544,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
     // Returns true if the state machine was transitioned into tablet migration path.
     future<bool> maybe_start_tablet_migration(group0_guard);
 
-    // Returns true if the state machine was transitioned into tablet split finalization path.
-    future<bool> maybe_start_tablet_split_finalization(group0_guard, const table_resize_plan& plan);
+    // Returns true if the state machine was transitioned into tablet resize finalization path.
+    future<bool> maybe_start_tablet_resize_finalization(group0_guard, const table_resize_plan& plan);
 
     future<locator::load_stats> refresh_tablet_load_stats();
     future<> start_tablet_load_stats_refresher();
@@ -2638,10 +2638,10 @@ future<bool> topology_coordinator::maybe_start_tablet_migration(group0_guard gua
 
     co_await generate_migration_updates(updates, guard, plan);
 
-    // We only want to consider transitioning into tablet split finalization path, if there's no other work
+    // We only want to consider transitioning into tablet resize finalization path, if there's no other work
     // to be done (e.g. start migration or/and emit split decision).
     if (updates.empty()) {
-        co_return co_await maybe_start_tablet_split_finalization(std::move(guard), plan.resize_plan());
+        co_return co_await maybe_start_tablet_resize_finalization(std::move(guard), plan.resize_plan());
     }
 
     updates.emplace_back(
@@ -2654,7 +2654,7 @@ future<bool> topology_coordinator::maybe_start_tablet_migration(group0_guard gua
     co_return true;
 }
 
-future<bool> topology_coordinator::maybe_start_tablet_split_finalization(group0_guard guard, const table_resize_plan& plan) {
+future<bool> topology_coordinator::maybe_start_tablet_resize_finalization(group0_guard guard, const table_resize_plan& plan) {
     if (plan.finalize_resize.empty()) {
         co_return false;
     }
@@ -2666,11 +2666,11 @@ future<bool> topology_coordinator::maybe_start_tablet_split_finalization(group0_
 
     updates.emplace_back(
         topology_mutation_builder(guard.write_timestamp())
-            .set_transition_state(topology::transition_state::tablet_split_finalization)
+            .set_transition_state(topology::transition_state::tablet_resize_finalization)
             .set_version(_topo_sm._topology.version + 1)
             .build());
 
-    co_await update_topology_state(std::move(guard), std::move(updates), "Started tablet split finalization");
+    co_await update_topology_state(std::move(guard), std::move(updates), "Started tablet resize finalization");
     co_return true;
 }
 

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -147,10 +147,15 @@ static std::unordered_map<topology::transition_state, sstring> transition_state_
     {topology::transition_state::write_both_read_old, "write both read old"},
     {topology::transition_state::write_both_read_new, "write both read new"},
     {topology::transition_state::tablet_migration, "tablet migration"},
-    {topology::transition_state::tablet_split_finalization, "tablet split finalization"},
+    {topology::transition_state::tablet_resize_finalization, "tablet resize finalization"},
     {topology::transition_state::tablet_draining, "tablet draining"},
     {topology::transition_state::left_token_ring, "left token ring"},
     {topology::transition_state::rollback_to_normal, "rollback to normal"},
+};
+
+// Allows old deprecated names to be recognized and point to the correct transition.
+static std::unordered_map<sstring, topology::transition_state> deprecated_name_to_transition_state = {
+    {"tablet split finalization", topology::transition_state::tablet_resize_finalization},
 };
 
 topology::transition_state transition_state_from_string(const sstring& s) {
@@ -158,6 +163,10 @@ topology::transition_state transition_state_from_string(const sstring& s) {
         if (e.second == s) {
             return e.first;
         }
+    }
+    auto it = deprecated_name_to_transition_state.find(s);
+    if (it != deprecated_name_to_transition_state.end()) {
+        return it->second;
     }
     on_internal_error(tsmlogger, format("cannot map name {} to transition_state", s));
 }

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -110,7 +110,7 @@ struct topology {
         write_both_read_old,
         write_both_read_new,
         tablet_migration,
-        tablet_split_finalization,
+        tablet_resize_finalization,
         left_token_ring,
         rollback_to_normal,
     };

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -33,6 +33,7 @@
 #include "utils/error_injection.hh"
 #include "utils/to_string.hh"
 #include "service/topology_coordinator.hh"
+#include "service/topology_state_machine.hh"
 
 #include <boost/regex.hpp>
 
@@ -3315,4 +3316,11 @@ SEASTAR_TEST_CASE(test_explicit_tablets_disable) {
     // Tablets can also be explicitly enabled for a new keyspace
     co_await test_create_keyspace("test_explictly_enabled_0", true, cfg, 0);
     co_await test_create_keyspace("test_explictly_enabled_128", true, cfg, 128);
+}
+
+SEASTAR_TEST_CASE(test_recognition_of_deprecated_name_for_resize_transition) {
+    using transition_state = service::topology::transition_state;
+    BOOST_REQUIRE_EQUAL(service::transition_state_from_string("tablet split finalization"), transition_state::tablet_resize_finalization);
+    BOOST_REQUIRE_EQUAL(service::transition_state_from_string("tablet resize finalization"), transition_state::tablet_resize_finalization);
+    return make_ready_future<>();
 }

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1380,6 +1380,7 @@ void apply_plan(token_metadata& tm, const migration_plan& plan) {
     for (auto&& mig : plan.migrations()) {
         tm.tablets().mutate_tablet_map(mig.tablet.table, [&] (tablet_map& tmap) {
             auto tinfo = tmap.get_tablet_info(mig.tablet.tablet);
+            testlog.trace("Replacing tablet {} replica from {} to {}", mig.tablet.tablet, mig.src, mig.dst);
             tinfo.replicas = replace_replica(tinfo.replicas, mig.src, mig.dst);
             tmap.set_tablet(mig.tablet.tablet, tinfo);
         });
@@ -1410,6 +1411,9 @@ size_t get_tablet_count(const tablet_metadata& tm) {
     }
     return count;
 }
+
+static
+void check_tablet_invariants(const tablet_metadata& tmeta);
 
 static
 void rebalance_tablets(tablet_allocator& talloc, shared_token_metadata& stm, locator::load_stats_ptr load_stats = {}, std::unordered_set<host_id> skiplist = {}) {
@@ -2421,11 +2425,35 @@ void check_tablet_invariants(const tablet_metadata& tmeta) {
             std::unordered_set<host_id> hosts;
             // Uniqueness of hosts
             for (const auto& replica: tinfo.replicas) {
-                BOOST_REQUIRE(hosts.insert(replica.host).second);
+                auto ret = hosts.insert(replica.host).second;
+                if (!ret) {
+                    testlog.error("Failed tablet invariant check for tablet {}: {}", tid, tinfo.replicas);
+                }
+                BOOST_REQUIRE(ret);
             }
             return make_ready_future<>();
         }).get();
     }
+}
+
+static
+std::vector<host_id>
+allocate_replicas_in_racks(const std::vector<endpoint_dc_rack>& racks, int rf,
+                           const std::unordered_map<sstring, std::vector<host_id>>& hosts_by_rack) {
+    // Choose replicas randomly while loading racks evenly.
+    std::vector<host_id> replica_hosts;
+    for (int i = 0; i < rf; ++i) {
+        auto rack = racks[i % racks.size()];
+        auto& rack_hosts = hosts_by_rack.at(rack.rack);
+        while (true) {
+            auto candidate_host = rack_hosts[tests::random::get_int<shard_id>(0, rack_hosts.size() - 1)];
+            if (std::find(replica_hosts.begin(), replica_hosts.end(), candidate_host) == replica_hosts.end()) {
+                replica_hosts.push_back(candidate_host);
+                break;
+            }
+        }
+    }
+    return replica_hosts;
 }
 
 SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
@@ -2481,18 +2509,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
                 tablet_map tmap(1 << log2_tablets);
                 for (auto tid : tmap.tablet_ids()) {
                     // Choose replicas randomly while loading racks evenly.
-                    std::vector<host_id> replica_hosts;
-                    for (int i = 0; i < rf; ++i) {
-                        auto rack = racks[i % racks.size()];
-                        auto& rack_hosts = hosts_by_rack[rack.rack];
-                        while (true) {
-                            auto candidate_host = rack_hosts[tests::random::get_int<shard_id>(0, rack_hosts.size() - 1)];
-                            if (std::find(replica_hosts.begin(), replica_hosts.end(), candidate_host) == replica_hosts.end()) {
-                                replica_hosts.push_back(candidate_host);
-                                break;
-                            }
-                        }
-                    }
+                    std::vector<host_id> replica_hosts = allocate_replicas_in_racks(racks, rf, hosts_by_rack);
                     tablet_replica_set replicas;
                     for (auto h : replica_hosts) {
                         auto shard_count = tm.get_topology().find_node(h)->get_shard_count();
@@ -2605,6 +2622,205 @@ SEASTAR_THREAD_TEST_CASE(basic_tablet_storage_splitting_test) {
             return make_ready_future<bool>(table.all_storage_groups_split());
         }, bool(false), std::logical_or<bool>()).get(), true);
     }, std::move(cfg)).get();
+}
+
+using rack_vector = std::vector<endpoint_dc_rack>;
+using hosts_by_rack_map = std::unordered_map<sstring, std::vector<host_id>>;
+
+// runs in seastar thread.
+static void do_test_load_balancing_merge_colocation(cql_test_env& e, const int n_racks, const int rf, const int n_hosts,
+                                                    const unsigned shard_count, const unsigned initial_tablets,
+                                                    std::function<void(token_metadata&, tablet_map&, const rack_vector&, const hosts_by_rack_map&)> set_tablets) {
+    rack_vector racks;
+    for (int i = 0; i < n_racks; i++) {
+        racks.push_back(endpoint_dc_rack{"dc1", format("rack-{}", i + 1)});
+    }
+
+    testlog.info("merge colocation test - hosts={}, racks={}, rf={}, shard_count={}, initial_tablets={}", n_hosts, racks.size(), rf, shard_count, initial_tablets);
+
+    std::vector<host_id> hosts;
+    for (int i = 0; i < n_hosts; ++i) {
+        hosts.push_back(host_id(next_uuid()));
+    }
+
+    auto table1 = add_table(e).get();
+
+    hosts_by_rack_map hosts_by_rack;
+    semaphore sem(1);
+    shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
+        locator::topology::config{
+            .this_endpoint = inet_address("192.168.0.1"),
+            .this_host_id = hosts[0],
+            .local_dc_rack = racks[std::min(1, n_racks - 1)]
+        }
+    });
+
+    stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
+        tablet_metadata tmeta;
+
+        int i = 0;
+        for (auto h : hosts) {
+            auto ip = inet_address(format("192.168.0.{}", ++i));
+            tm.update_host_id(h, ip);
+            auto rack = racks[i % racks.size()];
+            hosts_by_rack[rack.rack].push_back(h);
+            tm.update_topology(h, rack, node::state::normal, shard_count);
+            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(float(i) / hosts.size()))}, h);
+            testlog.debug("adding host {}, ip {}, rack {}, token {}", h, ip, rack.rack, token(tests::d2t(1. / hosts.size())));
+        }
+
+        tablet_map tmap(initial_tablets);
+        locator::resize_decision decision;
+        // leaves growing mode, allowing for merge decision.
+        decision.sequence_number = decision.next_sequence_number();
+        tmap.set_resize_decision(std::move(decision));
+        set_tablets(tm, tmap, racks, hosts_by_rack);
+        tmeta.set_tablet_map(table1, std::move(tmap));
+        tm.set_tablets(std::move(tmeta));
+    }).get();
+
+    auto tablet_count = [&] {
+        return stm.get()->tablets().get_tablet_map(table1).tablet_count();
+    };
+    auto do_rebalance_tablets = [&] (locator::load_stats load_stats) {
+        rebalance_tablets(e.get_tablet_allocator().local(), stm, make_lw_shared(std::move(load_stats)));
+    };
+
+    const uint64_t target_tablet_size = service::default_target_tablet_size;
+    auto merge_threshold = [&] () -> uint64_t {
+        return (target_tablet_size * 0.5f) * tablet_count();
+    };
+
+    while (tablet_count() > 1) {
+        locator::load_stats load_stats = {
+            .tables = {
+                { table1, table_load_stats{ .size_in_bytes = merge_threshold() - 1 }},
+            }
+        };
+
+        auto old_tablet_count = tablet_count();
+        check_tablet_invariants(stm.get()->tablets());
+        do_rebalance_tablets(std::move(load_stats));
+        check_tablet_invariants(stm.get()->tablets());
+        BOOST_REQUIRE_LT(tablet_count(), old_tablet_count);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_load_balancing_merge_colocation_with_random_load) {
+    do_with_cql_env_thread([] (auto& e) {
+        auto seed = tests::random::get_int<int32_t>();
+        std::mt19937 random_engine{seed};
+
+        testlog.info("test_load_balancing_merge_colocation - seed {}", seed);
+
+        for (auto i = 0; i < 10; i++) {
+            const int rf = tests::random::get_int<int>(3, 3);
+            const int n_racks = rf;
+            const int n_hosts = tests::random::get_int<unsigned>(n_racks * rf, n_racks * rf * 2);
+            const unsigned shard_count = tests::random::get_int<unsigned>(2, 12);
+            const unsigned total_shard_count = n_hosts * shard_count;
+            const unsigned initial_tablets = std::bit_ceil<unsigned>(tests::random::get_int<unsigned>(total_shard_count, total_shard_count * 10));
+
+            auto set_tablets = [rf, shard_count] (token_metadata&, tablet_map& tmap, const rack_vector& racks, const hosts_by_rack_map& hosts_by_rack) {
+                for (auto tid : tmap.tablet_ids()) {
+                    testlog.debug("allocating replica in racks with rf {}", rf);
+                    std::vector<host_id> replica_hosts = allocate_replicas_in_racks(racks, rf, hosts_by_rack);
+                    tablet_replica_set replicas;
+                    replicas.reserve(replica_hosts.size());
+                    for (auto h : replica_hosts) {
+                        replicas.push_back(tablet_replica {h, tests::random::get_int<shard_id>(0, shard_count - 1)});
+                    }
+                    testlog.debug("allocating replicas for tablet {}: {}", tid, replicas);
+                    tmap.set_tablet(tid, tablet_info {std::move(replicas)});
+                }
+            };
+
+            do_test_load_balancing_merge_colocation(e, n_racks, rf, n_hosts, shard_count, initial_tablets, set_tablets);
+        }
+    }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_load_balancing_merge_colocation_with_single_rack) {
+    do_with_cql_env_thread([] (auto& e) {
+        const int rf = 2;
+        const int n_racks = 1;
+        const int n_hosts = 2;
+        const unsigned shard_count = 2;
+        const unsigned initial_tablets = 2;
+
+        auto set_tablets = [] (token_metadata&, tablet_map& tmap, const rack_vector& racks, const hosts_by_rack_map& hosts_by_rack) {
+            auto& hosts = hosts_by_rack.at(racks.front().rack);
+            auto host1 = hosts[0];
+            auto host2 = hosts[1];
+            tmap.set_tablet(tablet_id(0), tablet_info {
+                tablet_replica_set {
+                    tablet_replica {host1, shard_id(0)},
+                    tablet_replica {host2, shard_id(0)},
+                }
+            });
+            tmap.set_tablet(tablet_id(1), tablet_info {
+                tablet_replica_set {
+                    tablet_replica {host2, shard_id(0)},
+                    tablet_replica {host1, shard_id(0)},
+                }
+            });
+        };
+
+        do_test_load_balancing_merge_colocation(e, n_racks, rf, n_hosts, shard_count, initial_tablets, set_tablets);
+    }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_load_balancing_merge_colocation_with_decomission) {
+    do_with_cql_env_thread([] (auto& e) {
+        const int rf = 3;
+        const int n_racks = 1;
+        const int n_hosts = 4;
+        const unsigned shard_count = 2;
+        const unsigned initial_tablets = 2;
+
+        auto set_tablets = [&] (token_metadata& tm, tablet_map& tmap, const rack_vector& racks, const hosts_by_rack_map& hosts_by_rack) {
+            auto& rack = racks.front();
+            auto& hosts = hosts_by_rack.at(rack.rack);
+            BOOST_REQUIRE(hosts.size() == 4);
+            auto a = hosts[0];
+            auto b = hosts[1];
+            auto c = hosts[2];
+            auto d = hosts[3];
+
+            // nodes   = {A, B, C, D}
+            // tablet1 = {A, B, C}
+            // tablet2 = {A, B, D}
+            // viable target for {tablet1, B} is D.
+            // viable target for {tablet2, B} is C.
+            //
+            // Decomission should succeed by migrating away even co-located replicas of sibling tablets that don't share viable targets.
+            // That should produce:
+            // tablet1 = {A, D, C}
+            // tablet2 = {A, C, D}
+
+            auto decision = tmap.resize_decision();
+            decision.way = locator::resize_decision::merge{};
+            tmap.set_resize_decision(std::move(decision));
+            tm.update_topology(b, rack, node::state::being_decommissioned, shard_count);
+
+            tmap.set_tablet(tablet_id(0), tablet_info {
+                tablet_replica_set {
+                    tablet_replica {a, shard_id(0)},
+                    tablet_replica {b, shard_id(0)},
+                    tablet_replica {c, shard_id(0)},
+                }
+            });
+            tmap.set_tablet(tablet_id(1), tablet_info {
+                tablet_replica_set {
+                    tablet_replica {a, shard_id(0)},
+                    tablet_replica {b, shard_id(0)},
+                    tablet_replica {d, shard_id(0)},
+                }
+            });
+        };
+
+        do_test_load_balancing_merge_colocation(e, n_racks, rf, n_hosts, shard_count, initial_tablets, set_tablets);
+    }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -37,6 +37,10 @@ async def inject_error_on(manager, error_name, servers):
     errs = [manager.api.enable_injection(s.ip_addr, error_name, False) for s in servers]
     await asyncio.gather(*errs)
 
+async def disable_injection_on(manager, error_name, servers):
+    errs = [manager.api.disable_injection(s.ip_addr, error_name) for s in servers]
+    await asyncio.gather(*errs)
+
 async def repair_on_node(manager: ManagerClient, server: ServerInfo, servers: list[ServerInfo], ranges: str = ''):
     node = server.ip_addr
     await manager.servers_see_each_other(servers)

--- a/test/topology_experimental_raft/test_tablets_merge.py
+++ b/test/topology_experimental_raft/test_tablets_merge.py
@@ -1,0 +1,303 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from cassandra.query import SimpleStatement, ConsistencyLevel
+
+from test.pylib.internal_types import ServerInfo
+from test.pylib.manager_client import ManagerClient
+from test.pylib.rest_client import inject_error_one_shot, HTTPError, read_barrier
+from test.topology.conftest import skip_mode
+
+import pytest
+import asyncio
+import logging
+import time
+import random
+
+logger = logging.getLogger(__name__)
+
+async def inject_error_one_shot_on(manager, error_name, servers):
+    errs = [inject_error_one_shot(manager.api, s.ip_addr, error_name) for s in servers]
+    await asyncio.gather(*errs)
+
+
+async def inject_error_on(manager, error_name, servers):
+    errs = [manager.api.enable_injection(s.ip_addr, error_name, False) for s in servers]
+    await asyncio.gather(*errs)
+
+async def disable_injection_on(manager, error_name, servers):
+    errs = [manager.api.disable_injection(s.ip_addr, error_name) for s in servers]
+    await asyncio.gather(*errs)
+
+
+async def get_tablet_count(manager: ManagerClient, server: ServerInfo, keyspace_name: str, table_name: str):
+    host = manager.cql.cluster.metadata.get_host(server.ip_addr)
+
+    # read_barrier is needed to ensure that local tablet metadata on the queried node
+    # reflects the finalized tablet movement.
+    await read_barrier(manager.api, server.ip_addr)
+
+    table_id = await manager.get_table_id(keyspace_name, table_name)
+    rows = await manager.cql.run_async(f"SELECT tablet_count FROM system.tablets where "
+                                       f"table_id = {table_id}", host=host)
+    return rows[0].tablet_count
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_tablet_merge_simple(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    cmdline = [
+        '--logger-log-level', 'storage_service=debug',
+        '--logger-log-level', 'table=debug',
+        '--logger-log-level', 'load_balancer=debug',
+        '--target-tablet-size-in-bytes', '30000',
+    ]
+    servers = [await manager.server_add(config={
+        'error_injections_at_startup': ['short_tablet_stats_refresh_interval']
+    }, cmdline=cmdline)]
+
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1;")
+
+    # Initial average table size of 400k (1 tablet), so triggers some splits.
+    total_keys = 200
+    keys = range(total_keys)
+    insert = cql.prepare(f"INSERT INTO test.test(pk, c) VALUES(?, ?)")
+    for pk in keys:
+        value = random.randbytes(2000)
+        cql.execute(insert, [pk, value])
+
+    async def check():
+        logger.info("Checking table")
+        cql = manager.get_cql()
+        rows = await cql.run_async("SELECT * FROM test.test BYPASS CACHE;")
+        assert len(rows) == len(keys)
+
+    await check()
+
+    await manager.api.flush_keyspace(servers[0].ip_addr, "test")
+
+    tablet_count = await get_tablet_count(manager, servers[0], 'test', 'test')
+    assert tablet_count == 1
+
+    logger.info("Adding new server")
+    servers.append(await manager.server_add(cmdline=cmdline))
+
+    # Increases the chance of tablet migration concurrent with split
+    await inject_error_one_shot_on(manager, "tablet_allocator_shuffle", servers)
+    await inject_error_on(manager, "tablet_load_stats_refresh_before_rebalancing", servers)
+
+    s1_log = await manager.server_open_log(servers[0].server_id)
+    s1_mark = await s1_log.mark()
+
+    # Now there's a split and migration need, so they'll potentially run concurrently.
+    await manager.api.enable_tablet_balancing(servers[0].ip_addr)
+
+    await check()
+    time.sleep(2) # Give load balancer some time to do work
+
+    await s1_log.wait_for('Detected tablet split for table', from_mark=s1_mark)
+
+    await check()
+
+    tablet_count = await get_tablet_count(manager, servers[0], 'test', 'test')
+    assert tablet_count > 1
+
+    # Allow shuffling of tablet replicas to make co-location work harder
+    async def shuffle():
+        await inject_error_on(manager, "tablet_allocator_shuffle", servers)
+        time.sleep(2)
+        await disable_injection_on(manager, "tablet_allocator_shuffle", servers)
+
+    await shuffle()
+
+    # This will allow us to simulate some balancing after co-location with shuffling, to make sure that
+    # balancer won't break co-location.
+    await inject_error_on(manager, "tablet_merge_completion_bypass", servers)
+
+    # Shrinks table significantly, forcing merge.
+    delete_keys = range(total_keys - 1)
+    await asyncio.gather(*[cql.run_async(f"DELETE FROM test.test WHERE pk={k};") for k in delete_keys])
+    keys = range(total_keys - 1, total_keys)
+
+    # To avoid race of major with migration
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    for server in servers:
+        await manager.api.flush_keyspace(server.ip_addr, "test")
+        await manager.api.keyspace_compaction(server.ip_addr, "test")
+    await manager.api.enable_tablet_balancing(servers[0].ip_addr)
+
+    await s1_log.wait_for("Emitting resize decision of type merge", from_mark=s1_mark)
+    # Waits for balancer to co-locate sibling tablets
+    await s1_log.wait_for("All sibling tablets are co-located")
+    # Do some shuffling to make sure balancer works with co-located tablets
+    await shuffle()
+
+    old_tablet_count = await get_tablet_count(manager, servers[0], 'test', 'test')
+
+    await inject_error_on(manager, "replica_merge_completion_wait", servers)
+    await disable_injection_on(manager, "tablet_merge_completion_bypass", servers)
+
+    await s1_log.wait_for('Detected tablet merge for table', from_mark=s1_mark)
+    await s1_log.wait_for('Merge completion fiber finished', from_mark=s1_mark)
+
+    tablet_count = await get_tablet_count(manager, servers[0], 'test', 'test')
+    assert tablet_count < old_tablet_count
+    await check()
+
+    for server in servers:
+        await manager.api.flush_keyspace(server.ip_addr, "test")
+        await manager.api.keyspace_compaction(server.ip_addr, "test")
+    await check()
+
+# Multiple cycles of split and merge, with topology changes in parallel and RF > 1.
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_tablet_split_and_merge_with_concurrent_topology_changes(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    cmdline = [
+        '--logger-log-level', 'storage_service=info',
+        '--logger-log-level', 'table=info',
+        '--logger-log-level', 'raft_topology=info',
+        '--logger-log-level', 'group0_raft_sm=info',
+        '--logger-log-level', 'load_balancer=info',
+        '--target-tablet-size-in-bytes', '30000',
+    ]
+    config = {
+        'error_injections_at_startup': ['short_tablet_stats_refresh_interval']
+    }
+    servers = [await manager.server_add(config=config, cmdline=cmdline),
+               await manager.server_add(config=config, cmdline=cmdline),
+               await manager.server_add(config=config, cmdline=cmdline)]
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1;")
+
+    async def perform_topology_ops():
+        logger.info("Topology ops in background")
+        server_id_to_decommission = servers[-1].server_id
+        logger.info("Decommissioning old server with id {}".format(server_id_to_decommission))
+        await manager.decommission_node(server_id_to_decommission)
+        servers.pop()
+        logger.info("Adding new server")
+        servers.append(await manager.server_add(cmdline=cmdline))
+        logger.info("Completed topology ops")
+
+    for cycle in range(2):
+        logger.info("Running split-merge cycle #{}".format(cycle))
+
+        await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+        logger.info("Inserting data")
+        # Initial average table size of (400k + metadata_overhead). Enough to trigger a few splits.
+        total_keys = 200
+        keys = range(total_keys)
+        insert = cql.prepare(f"INSERT INTO test.test(pk, c) VALUES(?, ?)")
+        for pk in keys:
+            value = random.randbytes(2000)
+            cql.execute(insert, [pk, value])
+
+        async def check():
+            logger.info("Checking table")
+            cql = manager.get_cql()
+            rows = await cql.run_async("SELECT * FROM test.test BYPASS CACHE;")
+            assert len(rows) == len(keys)
+
+        await check()
+
+        logger.info("Flushing keyspace")
+        for server in servers:
+            await manager.api.flush_keyspace(server.ip_addr, "test")
+
+        tablet_count = await get_tablet_count(manager, servers[0], 'test', 'test')
+
+        # Increases the chance of tablet migration concurrent with split
+        await inject_error_on(manager, "tablet_allocator_shuffle", servers)
+        await inject_error_on(manager, "tablet_load_stats_refresh_before_rebalancing", servers)
+
+        s1_log = await manager.server_open_log(servers[0].server_id)
+        s1_mark = await s1_log.mark()
+
+        logger.info("Enabling balancing")
+        # Now there's a split and migration need, so they'll potentially run concurrently.
+        await manager.api.enable_tablet_balancing(servers[0].ip_addr)
+
+        topology_ops_task = asyncio.create_task(perform_topology_ops())
+
+        await check()
+
+        logger.info("Waiting for split")
+        await disable_injection_on(manager, "tablet_allocator_shuffle", servers)
+        await s1_log.wait_for('Detected tablet split for table', from_mark=s1_mark)
+
+        logger.info("Waiting for topology ops")
+        await topology_ops_task
+
+        await check()
+
+        old_tablet_count = tablet_count
+        tablet_count = await get_tablet_count(manager, servers[0], 'test', 'test')
+        assert tablet_count > old_tablet_count
+        logger.info("Split increased number of tablets from {} to {}".format(old_tablet_count, tablet_count))
+
+        # Allow shuffling of tablet replicas to make co-location work harder
+        await inject_error_on(manager, "tablet_allocator_shuffle", servers)
+        # This will allow us to simulate some balancing after co-location with shuffling, to make sure that
+        # balancer won't break co-location.
+        await inject_error_on(manager, "tablet_merge_completion_bypass", servers)
+
+        logger.info("Deleting data")
+        # Delete almost all keys, enough to trigger a few merges.
+        delete_keys = range(total_keys - 1)
+        await asyncio.gather(*[cql.run_async(f"DELETE FROM test.test WHERE pk={k};") for k in delete_keys])
+        keys = range(total_keys - 1, total_keys)
+
+        await disable_injection_on(manager, "tablet_allocator_shuffle", servers)
+
+        # To avoid race of major with migration
+        await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+        logger.info("Flushing keyspace and performing major")
+        for server in servers:
+            await manager.api.flush_keyspace(server.ip_addr, "test")
+            await manager.api.keyspace_compaction(server.ip_addr, "test")
+        await manager.api.enable_tablet_balancing(servers[0].ip_addr)
+
+        logger.info("Waiting for merge decision")
+        await s1_log.wait_for("Emitting resize decision of type merge", from_mark=s1_mark)
+        # Waits for balancer to co-locate sibling tablets
+        await s1_log.wait_for("All sibling tablets are co-located")
+        # Do some shuffling to make sure balancer works with co-located tablets
+        await inject_error_on(manager, "tablet_allocator_shuffle", servers)
+
+        old_tablet_count = await get_tablet_count(manager, servers[0], 'test', 'test')
+
+        topology_ops_task = asyncio.create_task(perform_topology_ops())
+
+        await inject_error_on(manager, "replica_merge_completion_wait", servers)
+        await disable_injection_on(manager, "tablet_merge_completion_bypass", servers)
+        await disable_injection_on(manager, "tablet_allocator_shuffle", servers)
+
+        await s1_log.wait_for('Detected tablet merge for table', from_mark=s1_mark)
+        await s1_log.wait_for('Merge completion fiber finished', from_mark=s1_mark)
+
+        logger.info("Waiting for topology ops")
+        await topology_ops_task
+
+        tablet_count = await get_tablet_count(manager, servers[0], 'test', 'test')
+        assert tablet_count < old_tablet_count
+        logger.info("Merge decreased number of tablets from {} to {}".format(old_tablet_count, tablet_count))
+        await check()
+
+        logger.info("Flushing keyspace and performing major")
+        for server in servers:
+            await manager.api.flush_keyspace(server.ip_addr, "test")
+            await manager.api.keyspace_compaction(server.ip_addr, "test")
+        await check()


### PR DESCRIPTION
The goal of merge is to reduce the tablet count for a shrinking table. Similar to how split increases the count while the table is growing. The load balancer decision to merge is implemented today (came with infrastructure introduced for split), but it wasn't handled until now.

Initial tablet count is respected while the table is in "growing mode". For example, the table leaves it if there was a need to split above the initial tablet count. After the table leaves the mode, the average size can be trusted to determine that the table is shrinking. Merge decision is emitted if the average tablet size is 50% of the target. Hysteresis is applied to avoid oscillations between split and merges.

Similar to split, the decision to merge is recorded in tablet map's resize_type field with the string "merge". This is important in case of coordinator failover, so new coordinator continues from where the old left off.

Unlike split, the preparation phase during merge is not done by the replica (with split compactions), but rather by the coordinator by co-locating sibling tablets in the same node's shard. We can define sibling tablets as tablets that have contiguous range and will become one after merge. The concept is based on the power-of-two constraint and token contiguity. For example, in a table with 4 tablets, tablets of ids 0 and 1 are siblings, 2 and 3 are also siblings.

The algorithm for co-locating sibling tablets is very simple. The balancer is responsible for it, and it will emit migrations so that "odd" tablet will follow the "even" one. For example, tablet 1 will be migrated to where tablet 0 lives. Co-location is low in priority, it's not the end of the world to delay merge, but it's not ideal to delay e.g. decommission or even regular load balancing as that can translate into temporary unbalancing, impacting the user activities. So co-location migrations will happen when there is no more important work to do.
While regular balancing is higher in priority, it will not undo the co-location work done so far. It does that by treating co-located tablets as if they were already merged. The load inversion convergence check was adjusted so balancer understand when two tablets are being migrated instead of one, to avoid oscillations.

When balancer completes co-location work for a table undergoing merge, it will put the id of the table into the resize_plan, which is about communicating with the topology coordinator that a table is ready for it. With all sibling tablets co-located, the coordinator can resize the tablet map (reduce it by a factor of 2) and record the new map into group0. All the replicas will react to it (on token metadata update) by merging the storage (memtable(s) + sstables) of sibling tablets into one.

Fixes #18181.

system test details:

test: https://github.com/pehala/scylla-cluster-tests/blob/tablets_split_merge/tablets_split_merge_test.py
yaml file: https://github.com/pehala/scylla-cluster-tests/blob/tablets_split_merge/test-cases/features/tablets/tablets-split-merge-test.yaml

instance type: i3.8xlarge
nodes: 3
target tablet size: 0.5G (scaled down by 10, to make it easier to trigger splits and merges)
description: multiple cycles of growing and shrinking the data set in order to trigger splits and merges.
data_set_size: ~100G
initial_tablets: 64, so it grew to 128 tablets on split, and back to 64 on merge.

latency of reads and writes that happened in parallel to split and merge:
```
$ for i in scylla-bench*; do cat $i | grep "Mode\|99th:\|99\.9th:"; done
Mode:			 write
  99.9th:	 3.145727ms 
  99th:		 1.998847ms 
  99.9th:	 3.145727ms 
  99th:		 2.031615ms 
Mode:			 read
  99.9th:	 3.145727ms 
  99th:		 2.031615ms 
  99.9th:	 3.145727ms 
  99th:		 2.031615ms 
Mode:			 write
  99.9th:	 3.047423ms 
  99th:		 1.933311ms 
  99.9th:	 3.047423ms 
  99th:		 1.933311ms 
Mode:			 read
  99.9th:	 3.145727ms 
  99th:		 1.900543ms 
  99.9th:	 3.145727ms 
  99th:		 1.900543ms 
Mode:			 write
  99.9th:	 5.079039ms 
  99th:		 3.604479ms 
  99.9th:	 35.389439ms 
  99th:		 25.624575ms 
Mode:			 write
  99.9th:	 3.047423ms 
  99th:		 1.998847ms 
  99.9th:	 3.047423ms 
  99th:		 1.998847ms 
Mode:			 read
  99.9th:	 3.080191ms 
  99th:		 2.031615ms 
  99.9th:	 3.112959ms 
  99th:		 2.031615ms 
```