### PR TITLE
auth: remove unused #include

### DIFF
--- a/auth/resource.hh
+++ b/auth/resource.hh
@@ -18,7 +18,6 @@
 #include <unordered_set>
 
 #include <fmt/core.h>
-#include <seastar/core/print.hh>
 #include <seastar/core/sstring.hh>
 
 #include "auth/permission.hh"


### PR DESCRIPTION
the `seastar/core/print.hh` header is no longer required by `auth/resource.hh`. this was identified by clang-include-cleaner. As the code is audited, wecan safely remove the #include directive.

---

it's a cleanup, hence no need to backport.