### PR TITLE
[Backport 6.0] database::get_all_tables_flushed_at: fix return value

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2363,6 +2363,7 @@ future<> database::flush_keyspace_on_all_shards(sharded<database>& sharded_db, s
 
 future<> database::flush_all_tables() {
     // see above
+    dblog.info("Forcing new commitlog segment and flushing all tables");
     co_await _commitlog->force_new_active_segment();
     co_await get_tables_metadata().parallel_for_each_table([] (table_id, lw_shared_ptr<table> t) {
         return t->flush();
@@ -2372,13 +2373,11 @@ future<> database::flush_all_tables() {
 }
 
 future<db_clock::time_point> database::get_all_tables_flushed_at(sharded<database>& sharded_db) {
-    db_clock::time_point min_all_tables_flushed_at;
-    co_await sharded_db.map_reduce0([&] (const database& db) {
+    return sharded_db.map_reduce0([&] (const database& db) {
         return db._all_tables_flushed_at;
     }, db_clock::now(), [] (db_clock::time_point l, db_clock::time_point r) {
         return std::min(l, r);
     });
-    co_return min_all_tables_flushed_at;
 }
 
 future<> database::drop_cache_for_keyspace_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name) {

--- a/test/topology_custom/test_major_compaction.py
+++ b/test/topology_custom/test_major_compaction.py
@@ -1,0 +1,72 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import pytest
+import logging
+import asyncio
+
+from test.pylib.manager_client import ManagerClient
+
+logger = logging.getLogger(__name__)
+
+async def disable_autocompaction_across_keyspaces(manager: ManagerClient, server_ip_addr: str, *keyspace_list):
+    """Disable autocompaction that might interfere with testing"""
+
+    logger.info("Disabling autocompaction across keyspaces")
+    for ks in (*keyspace_list, "system", "system_schema"):
+        await manager.api.disable_autocompaction(server_ip_addr, ks)
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("compaction_flush_all_tables_before_major_seconds", [0, 2, 10])
+async def test_major_compaction_flush_all_tables(manager: ManagerClient, compaction_flush_all_tables_before_major_seconds):
+    """
+    1. Start server with configured compaction_flush_all_tables_before_major_seconds value
+    2. Create table and insert few rows
+    3. Run major compaction and verify if all tables were flushed
+       - if compaction_flush_all_tables_before_major_seconds == 0, expect no flush to happen
+       - if compaction_flush_all_tables_before_major_seconds == 2 or 10, expect all tables to be flushed
+    4. Sleep for 2 seconds
+    3. Run major compaction again and verify if all tables were flushed
+       - if compaction_flush_all_tables_before_major_seconds == 0, expect no flush to happen
+       - if compaction_flush_all_tables_before_major_seconds == 2, expect all tables to be flushed as 2 seconds have elapsed already
+       - if compaction_flush_all_tables_before_major_seconds == 10, expect no flush to happen as only 2 seconds have elapsed
+    """
+    logger.info("Bootstrapping cluster")
+    cfg = {'compaction_flush_all_tables_before_major_seconds' : compaction_flush_all_tables_before_major_seconds}
+    server = (await manager.servers_add(1, config=cfg, cmdline=['--smp=1']))[0]
+
+    logger.info("Creating table")
+    ks = "test_flush_all_tables"
+    cf = "t1"
+    cql = manager.get_cql()
+    await cql.run_async(f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}")
+    await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY)")
+    await disable_autocompaction_across_keyspaces(manager, server.ip_addr, ks)
+
+    logger.info("Populating table")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.{cf} (pk) VALUES ({k});") for k in range(256)])
+    await manager.api.keyspace_flush(server.ip_addr, ks, cf)
+    log = await manager.server_open_log(server.server_id)
+
+    async def check_all_table_flush_in_major_compaction(expect_all_table_flush: bool):
+        mark = await log.mark()
+
+        logger.info("Start major compaction")
+        await manager.api.keyspace_compaction(server.ip_addr, ks, cf)
+
+        flush_log = await log.grep("Forcing new commitlog segment and flushing all tables", from_mark=mark)
+        assert len(flush_log) == (1 if expect_all_table_flush else 0)
+
+    # all tables should be flushed the first time unless compaction_flush_all_tables_before_major_seconds == 0
+    await check_all_table_flush_in_major_compaction(compaction_flush_all_tables_before_major_seconds != 0)
+
+    if compaction_flush_all_tables_before_major_seconds == 2:
+        # let 2 seconds pass before trying again
+        await asyncio.sleep(compaction_flush_all_tables_before_major_seconds)
+
+    # for the second time, all tables should be flushed only if
+    # compaction_flush_all_tables_before_major_seconds == 2 as only 2 seconds have passed
+    await check_all_table_flush_in_major_compaction(compaction_flush_all_tables_before_major_seconds == 2)


### PR DESCRIPTION
The `database::get_all_tables_flushed_at` method returns a variable without setting the computed all_tables_flushed_at value. This causes its caller, `maybe_flush_all_tables` to flush all the tables everytime regardless of when they were last flushed. Fix this by returning the computed value from `database::get_all_tables_flushed_at`.

Fixes #20301

Closes scylladb/scylladb#20471

* github.com:scylladb/scylladb:
  cql-pytest: add test to verify compaction_flush_all_tables_before_major_seconds config
  database::get_all_tables_flushed_at: fix return value

(cherry picked from commit 0e5b444777be0d76b6514458afbbafbd6cc36b06)

Backported from #20471 to 6.0.