### PR TITLE
compaction: run cleanup under maintenance scheduling group

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1833,7 +1833,7 @@ protected:
     }
 private:
     future<> run_cleanup_job(sstables::compaction_descriptor descriptor) {
-        co_await coroutine::switch_to(_cm.compaction_sg());
+        co_await coroutine::switch_to(_cm.maintenance_sg());
 
         // Releases reference to cleaned files such that respective used disk space can be freed.
         using update_registration = compacting_sstable_registration::update_me;
@@ -1853,9 +1853,6 @@ private:
         };
         release_exhausted on_replace{_compacting, descriptor};
         for (;;) {
-            compaction_backlog_tracker user_initiated(std::make_unique<user_initiated_backlog_tracker>(_cm._compaction_controller.backlog_of_shares(200), _cm.available_memory()));
-            _cm.register_backlog_tracker(user_initiated);
-
             std::exception_ptr ex;
             try {
                 setup_new_compaction(descriptor.run_identifier);


### PR DESCRIPTION
The cleanup compaction task is a maintenance operation that runs after topology changes. So, run it under the maintenance scheduling group to avoid interference with regular compaction tasks. Also remove the share allocations done by the cleanup task, as they are unnecessary when running under the maintenance group.

Improvement; Backport not needed.