### PR TITLE
replica: ignore cleanup of deallocated storage group

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -301,6 +301,7 @@ public:
     future<> stop_storage_groups() noexcept;
     void remove_storage_group(size_t id);
     storage_group& storage_group_for_id(const schema_ptr&, size_t i) const;
+    storage_group* maybe_storage_group_for_id(const schema_ptr&, size_t i) const;
 
     // Caller must keep the current effective_replication_map_ptr valid
     // until the storage_group_manager finishes update_effective_replication_map


### PR DESCRIPTION
Cleanup of a deallocated tablet throws an exception. 
Since failed cleanup is retried, we end up in an infinite loop.

Ignore cleanup of deallocated storage groups.

Fixes:  #19752.

Needs to be backported to all branches with tablets (6.0 and later)