### PR TITLE
scripts: fix bin/cqlsh shortcut

### DIFF
--- a/bin/cqlsh
+++ b/bin/cqlsh
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 here=$(dirname "$0")
-exec "$here/../tools/cqlsh/bin/cqlsh" "$@"
+exec "$here/../tools/cqlsh/bin/cqlsh.py" "$@"
 


### PR DESCRIPTION
Since 3c7af287253e0, the cqlsh submodule no longer contains a bin/cqlsh shell script. This broke the supermodule's bin/cqlsh shortcut.

Fix it by invoking cqlsh.py directly.

No backport needed; developer helper script.