### PR TITLE
cql3: prepared_statement, prepare_context: streamline passing information

### DIFF
--- a/cql3/prepare_context.hh
+++ b/cql3/prepare_context.hh
@@ -56,6 +56,7 @@ private:
     // the function call results.
     bool _processing_pk_restrictions = false;
 
+    schema_ptr _schema;
 public:
 
     prepare_context() = default;
@@ -66,13 +67,16 @@ public:
 
     std::vector<lw_shared_ptr<column_specification>> get_variable_specifications() &&;
 
-    std::vector<uint16_t> get_partition_key_bind_indexes(const schema& schema) const;
+    std::vector<uint16_t> get_partition_key_bind_indexes() const;
 
     void add_variable_specification(int32_t bind_index, lw_shared_ptr<column_specification> spec);
 
     void set_bound_variables(const std::vector<shared_ptr<column_identifier>>& bind_variable_names);
 
     void clear_pk_function_calls_cache();
+
+    // Required if set_bound_variables() is used
+    void set_schema(schema_ptr s) { _schema = s; }
 
     // Record a new function call, which evaluates a partition key constraint.
     // Also automatically assigns an id to the AST node for caching purposes.

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -466,11 +466,7 @@ alter_table_statement::raw_statement::prepare(data_dictionary::database db, cql_
                 _renames,
                 std::move(prepared_attrs)
             ),
-            ctx,
-            // since alter table is `cql_statement_no_metadata` (it doesn't return any metadata when preparing)
-            // and bind markers cannot be a part of partition key,
-            // we can pass empty vector as partition_key_bind_indices
-            std::vector<uint16_t>()); 
+            ctx);
 }
 
 }

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -439,15 +439,14 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats) {
     auto&& prep_attrs = _attrs->prepare(db, "[batch]", "[batch]");
     prep_attrs->fill_prepare_context(meta);
 
+    if (!have_multiple_cfs && !statements.empty()) {
+        meta.set_schema(statements[0].statement->s);
+    }
+
     cql3::statements::batch_statement batch_statement_(meta.bound_variables_size(), _type, std::move(statements), std::move(prep_attrs), stats);
 
-    std::vector<uint16_t> partition_key_bind_indices;
-    if (!have_multiple_cfs && batch_statement_.get_statements().size() > 0) {
-        partition_key_bind_indices = meta.get_partition_key_bind_indexes(*batch_statement_.get_statements()[0].statement->s);
-    }
-    return std::make_unique<prepared_statement>(make_shared<cql3::statements::batch_statement>(std::move(batch_statement_)),
-                                                     meta.get_variable_specifications(),
-                                                     std::move(partition_key_bind_indices));
+
+    return std::make_unique<prepared_statement>(make_shared<cql3::statements::batch_statement>(std::move(batch_statement_)), meta);
 }
 
 }

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -504,13 +504,13 @@ modification_statement::prepare(data_dictionary::database db, cql_stats& stats) 
     schema_ptr schema = validation::validate_column_family(db, keyspace(), column_family());
     auto meta = get_prepare_context();
     auto statement = prepare_statement(db, meta, stats);
-    auto partition_key_bind_indices = meta.get_partition_key_bind_indexes(*schema);
-    return std::make_unique<prepared_statement>(std::move(statement), meta, std::move(partition_key_bind_indices));
+    return std::make_unique<prepared_statement>(std::move(statement), meta);
 }
 
 ::shared_ptr<cql3::statements::modification_statement>
 modification_statement::prepare(data_dictionary::database db, prepare_context& ctx, cql_stats& stats) const {
     schema_ptr schema = validation::validate_column_family(db, keyspace(), column_family());
+    ctx.set_schema(schema);
 
     auto prepared_attributes = _attrs->prepare(db, keyspace(), column_family());
     prepared_attributes->fill_prepare_context(ctx);
@@ -539,7 +539,7 @@ modification_statement::prepare(data_dictionary::database db, prepare_context& c
     if (!prepared_stmt->has_conditions() && prepared_stmt->_restrictions.has_value()) {
         ctx.clear_pk_function_calls_cache();
     }
-    prepared_stmt->_may_use_token_aware_routing = ctx.get_partition_key_bind_indexes(*schema).size() != 0;
+    prepared_stmt->_may_use_token_aware_routing = ctx.get_partition_key_bind_indexes().size() != 0;
     return prepared_stmt;
 }
 

--- a/cql3/statements/prepared_statement.hh
+++ b/cql3/statements/prepared_statement.hh
@@ -41,13 +41,8 @@ public:
     const std::vector<uint16_t> partition_key_bind_indices;
     const std::vector<sstring> warnings;
 
-    prepared_statement(seastar::shared_ptr<cql_statement> statement_, std::vector<seastar::lw_shared_ptr<column_specification>> bound_names_,
-                       std::vector<uint16_t> partition_key_bind_indices, std::vector<sstring> warnings = {});
-
-    prepared_statement(seastar::shared_ptr<cql_statement> statement_, const prepare_context& ctx, const std::vector<uint16_t>& partition_key_bind_indices,
+    prepared_statement(seastar::shared_ptr<cql_statement> statement_, const prepare_context& ctx,
                        std::vector<sstring> warnings = {});
-
-    prepared_statement(seastar::shared_ptr<cql_statement> statement_, prepare_context&& ctx, std::vector<uint16_t>&& partition_key_bind_indices);
 
     prepared_statement(seastar::shared_ptr<cql_statement>&& statement_);
 

--- a/cql3/statements/raw/parsed_statement.cc
+++ b/cql3/statements/raw/parsed_statement.cc
@@ -38,26 +38,17 @@ void parsed_statement::set_bound_variables(const std::vector<::shared_ptr<column
 }
 
 prepared_statement::prepared_statement(
-        ::shared_ptr<cql_statement> statement_, std::vector<lw_shared_ptr<column_specification>> bound_names_,
-        std::vector<uint16_t> partition_key_bind_indices, std::vector<sstring> warnings)
+        ::shared_ptr<cql_statement> statement_,
+        const prepare_context& ctx,
+        std::vector<sstring> warnings)
     : statement(std::move(statement_))
-    , bound_names(std::move(bound_names_))
-    , partition_key_bind_indices(std::move(partition_key_bind_indices))
+    , bound_names(ctx.get_variable_specifications())
+    , partition_key_bind_indices(ctx.get_partition_key_bind_indexes())
     , warnings(std::move(warnings))
 { }
 
-prepared_statement::prepared_statement(
-        ::shared_ptr<cql_statement> statement_, const prepare_context& ctx,
-        const std::vector<uint16_t>& partition_key_bind_indices, std::vector<sstring> warnings)
-    : prepared_statement(statement_, ctx.get_variable_specifications(), partition_key_bind_indices, std::move(warnings))
-{ }
-
-prepared_statement::prepared_statement(::shared_ptr<cql_statement> statement_, prepare_context&& ctx, std::vector<uint16_t>&& partition_key_bind_indices)
-    : prepared_statement(statement_, std::move(ctx).get_variable_specifications(), std::move(partition_key_bind_indices))
-{ }
-
 prepared_statement::prepared_statement(::shared_ptr<cql_statement>&& statement_)
-    : prepared_statement(statement_, std::vector<lw_shared_ptr<column_specification>>(), std::vector<uint16_t>())
+    : statement(statement_)
 { }
 
 }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2157,9 +2157,10 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
                 std::move(prepared_attrs));
     }
 
-    auto partition_key_bind_indices = ctx.get_partition_key_bind_indexes(*schema);
+    ctx.set_schema(schema);
+    auto partition_key_bind_indices = ctx.get_partition_key_bind_indexes();
     stmt->_may_use_token_aware_routing = partition_key_bind_indices.size() != 0;
-    return make_unique<prepared_statement>(std::move(stmt), ctx, std::move(partition_key_bind_indices), std::move(warnings));
+    return make_unique<prepared_statement>(std::move(stmt), ctx, std::move(warnings));
 }
 
 ::shared_ptr<restrictions::statement_restrictions>


### PR DESCRIPTION
The prepare_context class is used to collect information about the statement being prepared. This collected information is later transferred to the prepared_statement class via its constructors.

There are however many such constructors, and it's up to the callers to extract the information from prepare_context and pass it to prepared_statement.

Streamline the process by having the prepared_statement constructor do the work.

There are two small points to consider:
 - Extracting the routing key requires the schema; we add an optional prepare_context::set_schema() to enable this.
 - for batch statements, we previously only created the routing key for the first statement; now it's called for the entire batch. To compensate, we stop processing a partition key column once we have a match.

The intent is to increase use of this method of passing information.

Refactoring, so no backport