### PR TITLE
Update seastar submodule

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1170,7 +1170,7 @@ static future<executor::request_return_type> create_table_on_shard0(service::cli
     }
 
     if (!unused_attribute_definitions.empty()) {
-        co_return api_error::validation(format(
+        co_return api_error::validation(fmt::format(
             "AttributeDefinitions defines spurious attributes not used by any KeySchema: {}",
             unused_attribute_definitions));
     }

--- a/exceptions/exceptions.cc
+++ b/exceptions/exceptions.cc
@@ -45,7 +45,7 @@ const std::unordered_map<exception_code, sstring>& exception_map() {
 }
 
 template<typename... Args>
-static inline sstring prepare_message(const char* fmt, Args&&... args) noexcept {
+static inline sstring prepare_message(fmt::format_string<Args...> fmt, Args&&... args) noexcept {
     try {
         return seastar::format(fmt, std::forward<Args>(args)...);
     } catch (...) {

--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -197,9 +197,9 @@ mutation_reader make_foreign_reader(schema_ptr schema,
 }
 
 template <typename... Arg>
-static void require(bool condition, const char* msg, const Arg&... arg) {
+static void require(bool condition, fmt::format_string<Arg...> fmt, Arg&&... arg) {
     if (!condition) {
-        on_internal_error(mrlog, seastar::format(msg, arg...));
+        on_internal_error(mrlog, seastar::format(fmt, std::forward<Arg>(arg)...)) ;
     }
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1925,7 +1925,7 @@ future<uint64_t> sstable::validate(reader_permit permit, abort_source& abort,
     auto handle_sstable_exception = [&error_handler](const malformed_sstable_exception& e, uint64_t& errors) -> std::exception_ptr {
         std::exception_ptr ex;
         try {
-            error_handler(format("unrecoverable error: {}", e));
+            error_handler(seastar::format("unrecoverable error: {}", e));
             ++errors;
         } catch (...) {
             ex = std::current_exception();

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -376,8 +376,8 @@ std::pair<evaluation_inputs, std::unique_ptr<evaluation_inputs_data>> make_evalu
     const schema_ptr& table_schema,
     const column_values& column_vals,
     const std::vector<raw_value>& bind_marker_values) {
-    auto throw_error = [&](const auto&... fmt_args) -> sstring {
-        sstring error_msg = seastar::format(fmt_args...);
+    auto throw_error = [&]<typename... Args>(fmt::format_string<Args...> fmt, Args&&... args) -> sstring {
+        sstring error_msg = seastar::format(fmt, std::forward<Args>(args)...);
         sstring final_msg = seastar::format("make_evaluation_inputs error: {}. (table_schema: {}, column_vals: {})", error_msg,
                                    *table_schema, column_vals);
         throw std::runtime_error(final_msg);

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -278,7 +278,7 @@ private:
     template <std::size_t... Is>
     inline sstring_vec stats_values_to_strings_impl(const stats_values& values, std::index_sequence<Is...> seq) {
         static_assert(stats_formats.size() == seq.size());
-        sstring_vec result {seastar::format(stats_formats[Is].c_str(), std::get<Is>(values))...};
+        sstring_vec result {seastar::format(fmt::runtime(stats_formats[Is].c_str()), std::get<Is>(values))...};
         return result;
     }
 

--- a/utils/http.hh
+++ b/utils/http.hh
@@ -64,7 +64,7 @@ public:
     {
     }
 
-    virtual future<connected_socket> make() override {
+    virtual future<connected_socket> make(abort_source*) override {
         if (!_state->initialized) {
             _logger.debug("Waiting for factory to initialize");
             co_await _done.get_future();


### PR DESCRIPTION
* seastar ec5da7a6...d90a3b6a (32):
  > rpc: conditionally use fmt::runtime() based on SEASTAR_LOGGER_COMPILE_TIME_FMT
  > build: check the combination of Sanitizers
  > tls: clear session ticket before releasing
  > print: remove dead code
  > doc/lambda-coroutine-fiasco: reword for better readability
  > rpc: fix compilation error caused by fmt::runtime()
  > tutorial: explain the use case of rethrow_exception and coroutine::exception
  > reactor: print more informative error when io_submit fails
  > README.md: note GitHub discussions
  > prometheus: `fmt::print` to stringstream directly
  > doc: add document for testing with seastar
  > seastar/testing: only include used headers
  > test: Add abortable http client test cases
  > http/client: Add abortable make_request() API method
  > http/client: Abort established connections
  > http/client: Handle abort source in pool wait
  > http/client: Add abort source to factory::make() method
  > http/client: Pass abort_source here and there
  > http/client: Idnentation fix after previous patch
  > http/client: Merge some continuations explicitly
  > signal: add seastar signal api
  > httpd: remove unused prometheus structs
  > print: use fmtlib's fmt::format_string in format()
  > rpc: do not use seastar::format() in rpc logger
  > treewide: s/format/seastar::format/
  > prometheus: sanitize label value for text protocol
  > tests: unit test prometheus wire format
  > io-tester: Introduce batches to rate-based submission
  > io-tester: Generalize issueing request and collecting its result
  > io-tester: Cancel intent once
  > io-tester: Dont carry rps/parallelism variables over lambdas
  > io-tester: Simplify in-flight management

The breaking changes in the seastar submodule necessitate corresponding modifications in our code. These changes must be implemented together in a single commit to maintain consistency. So that each commit is buildable.

following changes are included in addition to seastar submodule update:
* instead of passing a `const char*` for the format string, pass a templated `fmt::format_string<...>`, this depends on the `seastar::format()` change in seastar.
* explicitly call `fmt::runtime()` if the format string is not a consteval expression. this depends on the `seastar::format()` change in seastar. as `seastar::format()` does not accept a plain `const char*` which is not constexpr anymore.
* pass abort_source to `dns_connection_factory::make()`. this depends on the change in seastar, which added a `abort_source*` argument to the pure virtual member function of `connection_factory::make()`.
* call call {fmt,seastar}::format() explicitly. this is a follow up of 3e84d43f, which takes care of all places where we should call `fmt::format()` and `seastar::format()` explicitly to disambiguate the `format()` call. but more `format()` call made their way into the source tree after 3e84d43f. so we need fix them as well.

---

the bump in seastar does not include critical fixes impacting production, so no need to backport