### PR TITLE
test.py: add run_in_unshare option 

### DIFF
--- a/test.py
+++ b/test.py
@@ -1116,15 +1116,12 @@ class ToolTest(Test):
 
     def __init__(self, test_no: int, shortname: str, suite) -> None:
         super().__init__(test_no, shortname, suite)
-        launcher = self.suite.cfg.get("launcher", "pytest")
-        self.path = launcher.split(maxsplit=1)[0]
+        self.path = "pytest"
         self.xmlout = os.path.join(self.suite.options.tmpdir, self.mode, "xml", self.uname + ".xunit.xml")
         ToolTest._reset(self)
 
     def _prepare_pytest_params(self, options: argparse.Namespace):
-        launcher = self.suite.cfg.get("launcher", "pytest")
-        self.args = launcher.split()[1:]
-        self.args += [
+        self.args = [
             "-s",  # don't capture print() output inside pytest
             "--log-level=DEBUG",   # Capture logs
             "-o",

--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -42,10 +42,10 @@ class ServerAddress(NamedTuple):
 
 
 @pytest.fixture(scope="session")
-def server_address(request):
+def server_address():
     # unshare(1) -rn drops us in a new network namespace in which the "lo" is
     # not up yet, so let's set it up first.
-    if request.config.getoption('--run-within-unshare'):
+    if os.environ.get('RUN_IN_UNSHARE'):
         try:
             args = "ip link set lo up".split()
             subprocess.run(args, check=True)

--- a/test/nodetool/suite.yaml
+++ b/test/nodetool/suite.yaml
@@ -1,3 +1,4 @@
 type: Tool
 coverage: false
-launcher: unshare -rn pytest --run-within-unshare
+run_in_unshare:
+  - '*'


### PR DESCRIPTION
it turns out we have more tests which require an isolated network
namespace. so instead of using launcher. let's introduce a more specific
`run_in_unshare` option, which accepts a list of string, each of which
is a glob pattern to match tests, so if a test is matched by any of
these glob pattern, it is launched in a `unshare` environment, which
has `RUN_IN_UNSHARE` environmental variable set.

this allows more tests to run in `unshare`, without worrying about
the already-used-port problem.

in this changeset, "launcher" option is dropped, as it does not 
have any users now.

---

no need to backport, as this change only enhances the testing harness, and has no impacts on the production.