### PR TITLE
Populate raft address map from gossiper on raft configuration change

### DIFF
--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -102,16 +102,27 @@ static const auto raft_manual_recovery_doc = "https://docs.scylladb.com/master/a
 
 class group0_rpc: public service::raft_rpc {
     direct_failure_detector::failure_detector& _direct_fd;
+    gms::gossiper& _gossiper;
 public:
     explicit group0_rpc(direct_failure_detector::failure_detector& direct_fd,
             raft_state_machine& sm, netw::messaging_service& ms,
-            raft_address_map& address_map, shared_ptr<raft::failure_detector> raft_fd, raft::group_id gid, raft::server_id srv_id)
+            raft_address_map& address_map, shared_ptr<raft::failure_detector> raft_fd, raft::group_id gid, raft::server_id srv_id, gms::gossiper& gossiper)
         : raft_rpc(sm, ms, address_map, std::move(raft_fd), gid, srv_id)
-        , _direct_fd(direct_fd)
+        , _direct_fd(direct_fd), _gossiper(gossiper)
     {}
 
     virtual void on_configuration_change(raft::server_address_set add, raft::server_address_set del) override {
         for (const auto& addr: add) {
+            auto ip_for_id = _address_map.find(addr.id);
+            if (!ip_for_id) {
+                // Make sure that the addresses of new nodes in the configuration are in the address map
+                auto ips = _gossiper.get_nodes_with_host_id(locator::host_id(addr.id.uuid()));
+                for (auto ip : ips) {
+                    if (_gossiper.is_normal(ip)) {
+                        _address_map.add_or_update_entry(addr.id, ip);
+                    }
+                }
+            }
             // Entries explicitly managed via `rpc::on_configuration_change() should NOT be
             // expirable.
             _address_map.set_nonexpiring(addr.id);
@@ -204,7 +215,7 @@ const raft::server_id& raft_group0::load_my_id() {
 raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, raft::server_id my_id, service::storage_service& ss, cql3::query_processor& qp,
                                                             service::migration_manager& mm, bool topology_change_enabled) {
     auto state_machine = std::make_unique<group0_state_machine>(_client, mm, qp.proxy(), ss, _raft_gr.address_map(), _feat, topology_change_enabled);
-    auto rpc = std::make_unique<group0_rpc>(_raft_gr.direct_fd(), *state_machine, _ms.local(), _raft_gr.address_map(), _raft_gr.failure_detector(), gid, my_id);
+    auto rpc = std::make_unique<group0_rpc>(_raft_gr.direct_fd(), *state_machine, _ms.local(), _raft_gr.address_map(), _raft_gr.failure_detector(), gid, my_id, _gossiper);
     // Keep a reference to a specific RPC class.
     auto& rpc_ref = *rpc;
     auto storage = std::make_unique<raft_sys_table_storage>(qp, gid, my_id);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6650,6 +6650,10 @@ future<join_node_response_result> storage_service::join_node_response_handler(jo
         co_return join_node_response_result{};
     }
 
+    if (utils::get_local_injector().enter("join_node_response_drop_expiring")) {
+        _group0->modifiable_address_map().force_drop_expiring_entries();
+    }
+
     try {
         co_return co_await std::visit(overloaded_functor {
             [&] (const join_node_response_params::accepted& acc) -> future<join_node_response_result> {

--- a/test/topology_custom/test_long_join.py
+++ b/test/topology_custom/test_long_join.py
@@ -27,16 +27,20 @@ async def test_long_join(manager: ManagerClient) -> None:
     await asyncio.gather(task)
 
 @pytest.mark.asyncio
-async def test_long_join_drop_wntries_on_bootstrapping(manager: ManagerClient) -> None:
+async def test_long_join_drop_entries_on_bootstrapping(manager: ManagerClient) -> None:
     """The test checks that join works even if expiring entries are dropped
        on the joining node between placement of the join request and its processing"""
-    s1 = await manager.server_add()
+    servers = await manager.servers_add(2)
     inj = 'topology_coordinator_pause_before_processing_backlog'
-    await manager.api.enable_injection(s1.ip_addr, inj, one_shot=True)
-    s2 = await manager.server_add(start=False,  config={
+    [await manager.api.enable_injection(s.ip_addr, inj, one_shot=True) for s in servers]
+    s = await manager.server_add(start=False,  config={
         'error_injections_at_startup': ['pre_server_start_drop_expiring']
     })
-    task = asyncio.create_task(manager.server_start(s2.server_id))
-    await manager.server_sees_other_server(s1.ip_addr, s2.ip_addr, interval=300)
-    await manager.api.message_injection(s1.ip_addr, inj)
+    task = asyncio.create_task(manager.server_start(s.server_id))
+    log = await manager.server_open_log(s.server_id)
+    await log.wait_for("init - starting gossiper")
+    servers.append(s)
+    await manager.servers_see_each_other(servers, interval=300)
+    await manager.api.enable_injection(s.ip_addr, 'join_node_response_drop_expiring', one_shot=True)
+    [await manager.api.message_injection(s.ip_addr, inj) for s in servers[:-1]]
     await asyncio.gather(task)


### PR DESCRIPTION
For each new node added to the raft config populate it's ID to IP mapping in raft address map from the gossiper. The mapping may have expired if a node is added to the raft configuration long after it first appears in the gossiper.


Fixes scylladb/scylladb#20600

Backport to all supported versions since the bug may cause bootstrapping failure.