### PR TITLE
paxos_state: release semaphore units before checking if a semaphore c…

### DIFF
--- a/service/paxos/paxos_state.hh
+++ b/service/paxos/paxos_state.hh
@@ -56,6 +56,7 @@ private:
         guard(key_lock_map& map, const dht::token& key, clock_type::time_point timeout) : _map(map), _key(key), _timeout(timeout) {};
         guard(guard&& o) = default;
         ~guard() {
+            _units.return_all();
             _map.release_semaphore_for_key(_key);
         }
     };


### PR DESCRIPTION
…an be dropped

To drop a semaphore it should not be held by anyone, so we need to release out units before checking if a semaphore can be dropped.

Fixes: scylladb/scylladb#20602

Backport to all versions since it is a memory leak.