### PR TITLE
Put sstables::test class on a diet

### DIFF
--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -109,7 +109,7 @@ SEASTAR_TEST_CASE(datafile_generation_09) {
         BOOST_REQUIRE(sst1_s.first_key.value == sst2_s.first_key.value);
         BOOST_REQUIRE(sst1_s.last_key.value == sst2_s.last_key.value);
 
-        sstables::test(sst2).read_toc().get();
+        sst2->read_toc().get();
         auto& sst1_c = sstables::test(sst).get_components();
         auto& sst2_c = sstables::test(sst2).get_components();
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -100,8 +100,8 @@ SEASTAR_TEST_CASE(datafile_generation_09) {
         auto sst2 = env.reusable_sst(sst).get();
 
         sstables::test(sst2).read_summary().get();
-        summary& sst1_s = sstables::test(sst).get_summary();
-        summary& sst2_s = sstables::test(sst2).get_summary();
+        const summary& sst1_s = sst->get_summary();
+        const summary& sst2_s = sst2->get_summary();
 
         BOOST_REQUIRE(::memcmp(&sst1_s.header, &sst2_s.header, sizeof(summary::header)) == 0);
         BOOST_REQUIRE(sst1_s.positions == sst2_s.positions);
@@ -2115,7 +2115,7 @@ SEASTAR_TEST_CASE(test_summary_entry_spanning_more_keys_than_min_interval) {
 
         auto sst = make_sstable_containing(env.make_sstable(s), mutations);
 
-        summary& sum = sstables::test(sst).get_summary();
+        const summary& sum = sst->get_summary();
         BOOST_REQUIRE(sum.entries.size() == 1);
 
         std::set<mutation, mutation_decorated_key_less_comparator> merged;
@@ -2319,7 +2319,7 @@ SEASTAR_TEST_CASE(summary_rebuild_sanity) {
 
         sstables::test(sst).remove_component(component_type::Summary).get();
         sst = env.reusable_sst(sst).get();
-        summary& s2 = sstables::test(sst).get_summary();
+        const summary& s2 = sst->get_summary();
 
         BOOST_REQUIRE(::memcmp(&s1.header, &s2.header, sizeof(summary::header)) == 0);
         BOOST_REQUIRE(s1.positions == s2.positions);

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2314,7 +2314,8 @@ SEASTAR_TEST_CASE(summary_rebuild_sanity) {
 
         auto sst = make_sstable_containing(env.make_sstable(s), mutations);
 
-        summary s1 = sstables::test(sst).move_summary();
+        summary s1 = std::move(sstables::test(sst)._summary());
+        BOOST_REQUIRE(!(bool)sstables::test(sst)._summary()); // make sure std::move above took place
         BOOST_REQUIRE(s1.entries.size() > 1);
 
         sstables::test(sst).remove_component(component_type::Summary).get();

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -153,7 +153,7 @@ SEASTAR_TEST_CASE(missing_summary_interval_1_query_ok) {
 
 SEASTAR_TEST_CASE(missing_summary_first_last_sane) {
     return test_using_reusable_sst(uncompressed_schema(), uncompressed_dir(), 2, [] (test_env& env, shared_sstable ptr) {
-        auto& summary = sstables::test(ptr).get_summary();
+        const auto& summary = ptr->get_summary();
         BOOST_REQUIRE(summary.header.size == 1);
         BOOST_REQUIRE(summary.positions.size() == 1);
         BOOST_REQUIRE(summary.entries.size() == 1);
@@ -205,8 +205,8 @@ SEASTAR_TEST_CASE(check_summary_func) {
     return write_and_validate_sst(std::move(s), "test/resource/sstables/compressed", [] (shared_sstable sst1, shared_sstable sst2) {
         sstables::test(sst2).read_summary().get();
 
-        summary& sst1_s = sstables::test(sst1).get_summary();
-        summary& sst2_s = sstables::test(sst2).get_summary();
+        const summary& sst1_s = sst1->get_summary();
+        const summary& sst2_s = sst2->get_summary();
 
         BOOST_REQUIRE(::memcmp(&sst1_s.header, &sst2_s.header, sizeof(summary::header)) == 0);
         BOOST_REQUIRE(sst1_s.positions == sst2_s.positions);

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -250,7 +250,7 @@ SEASTAR_TEST_CASE(check_toc_func) {
 
 SEASTAR_TEST_CASE(uncompressed_random_access_read) {
     return test_using_reusable_sst(uncompressed_schema(), uncompressed_dir(), 1, [] (auto& env, auto sstp) {
-        temporary_buffer<char> buf = sstables::test(sstp).data_read(env.make_reader_permit(), 97, 6).get();
+        temporary_buffer<char> buf = sstp->data_read(97, 6, env.make_reader_permit()).get();
         BOOST_REQUIRE(sstring(buf.get(), buf.size()) == "gustaf");
     });
 }
@@ -258,7 +258,7 @@ SEASTAR_TEST_CASE(uncompressed_random_access_read) {
 SEASTAR_TEST_CASE(compressed_random_access_read) {
     auto s = make_schema_for_compressed_sstable();
     return test_using_reusable_sst(std::move(s), "test/resource/sstables/compressed", 1, [] (auto& env, auto sstp) {
-        temporary_buffer<char> buf = sstables::test(sstp).data_read(env.make_reader_permit(), 97, 6).get();
+        temporary_buffer<char> buf = sstp->data_read(97, 6, env.make_reader_permit()).get();
         BOOST_REQUIRE(sstring(buf.get(), buf.size()) == "gustaf");
     });
 }

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -31,6 +31,7 @@
 #include "test/lib/tmpdir.hh"
 #include "partition_slice_builder.hh"
 #include "sstables/sstable_mutation_reader.hh"
+#include "sstables/binary_search.hh"
 
 #include <boost/range/combine.hpp>
 
@@ -281,7 +282,7 @@ SEASTAR_TEST_CASE(find_key_map) {
         kk.push_back(make_map_value(map_type, map));
 
         auto key = sstables::key::from_deeply_exploded(*s, kk);
-        BOOST_REQUIRE(sstables::test(sstp).binary_search(s->get_partitioner(), summary.entries, key) == 0);
+        BOOST_REQUIRE(sstables::binary_search(s->get_partitioner(), summary.entries, key) == 0);
     });
 }
 
@@ -302,7 +303,7 @@ SEASTAR_TEST_CASE(find_key_set) {
         kk.push_back(make_set_value(set_type, set));
 
         auto key = sstables::key::from_deeply_exploded(*s, kk);
-        BOOST_REQUIRE(sstables::test(sstp).binary_search(s->get_partitioner(), summary.entries, key) == 0);
+        BOOST_REQUIRE(sstables::binary_search(s->get_partitioner(), summary.entries, key) == 0);
     });
 }
 
@@ -323,7 +324,7 @@ SEASTAR_TEST_CASE(find_key_list) {
         kk.push_back(make_list_value(list_type, list));
 
         auto key = sstables::key::from_deeply_exploded(*s, kk);
-        BOOST_REQUIRE(sstables::test(sstp).binary_search(s->get_partitioner(), summary.entries, key) == 0);
+        BOOST_REQUIRE(sstables::binary_search(s->get_partitioner(), summary.entries, key) == 0);
     });
 }
 
@@ -341,7 +342,7 @@ SEASTAR_TEST_CASE(find_key_composite) {
         kk.push_back(data_value(b2));
 
         auto key = sstables::key::from_deeply_exploded(*s, kk);
-        BOOST_REQUIRE(sstables::test(sstp).binary_search(s->get_partitioner(), summary.entries, key) == 0);
+        BOOST_REQUIRE(sstables::binary_search(s->get_partitioner(), summary.entries, key) == 0);
     });
 }
 
@@ -352,7 +353,7 @@ SEASTAR_TEST_CASE(all_in_place) {
         int idx = 0;
         for (auto& e: summary.entries) {
             auto key = sstables::key::from_bytes(bytes(e.key));
-            BOOST_REQUIRE(sstables::test(sstp).binary_search(sstp->get_schema()->get_partitioner(), summary.entries, key) == idx++);
+            BOOST_REQUIRE(sstables::binary_search(sstp->get_schema()->get_partitioner(), summary.entries, key) == idx++);
         }
     });
 }
@@ -363,7 +364,7 @@ SEASTAR_TEST_CASE(full_index_search) {
         int idx = 0;
         for (auto& e : index_list) {
             auto key = key::from_partition_key(*sstp->get_schema(), e.key);
-            BOOST_REQUIRE(sstables::test(sstp).binary_search(sstp->get_schema()->get_partitioner(), index_list, key) == idx++);
+            BOOST_REQUIRE(sstables::binary_search(sstp->get_schema()->get_partitioner(), index_list, key) == idx++);
         }
     });
 }
@@ -382,7 +383,7 @@ SEASTAR_TEST_CASE(not_find_key_composite_bucket0) {
 
         auto key = sstables::key::from_deeply_exploded(*s, kk);
         // (result + 1) * -1 -1 = 0
-        BOOST_REQUIRE(sstables::test(sstp).binary_search(s->get_partitioner(), summary.entries, key) == -2);
+        BOOST_REQUIRE(sstables::binary_search(s->get_partitioner(), summary.entries, key) == -2);
     });
 }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -240,7 +240,7 @@ SEASTAR_TEST_CASE(check_statistics_func) {
 SEASTAR_TEST_CASE(check_toc_func) {
     auto s = make_schema_for_compressed_sstable();
     return write_and_validate_sst(std::move(s), "test/resource/sstables/compressed", [] (shared_sstable sst1, shared_sstable sst2) {
-        sstables::test(sst2).read_toc().get();
+        sst2->read_toc().get();
         auto& sst1_c = sstables::test(sst1).get_components();
         auto& sst2_c = sstables::test(sst2).get_components();
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -224,8 +224,8 @@ SEASTAR_TEST_CASE(check_statistics_func) {
     auto s = make_schema_for_compressed_sstable();
     return write_and_validate_sst(std::move(s), "test/resource/sstables/compressed", [] (shared_sstable sst1, shared_sstable sst2) {
         sstables::test(sst2).read_statistics().get();
-        statistics& sst1_s = sstables::test(sst1).get_statistics();
-        statistics& sst2_s = sstables::test(sst2).get_statistics();
+        const statistics& sst1_s = sst1->get_statistics();
+        const statistics& sst2_s = sst2->get_statistics();
 
         BOOST_REQUIRE(sst1_s.offsets.elements.size() == sst2_s.offsets.elements.size());
         BOOST_REQUIRE(sst1_s.contents.size() == sst2_s.contents.size());

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -96,10 +96,6 @@ public:
         return _sst->read_summary_entry(i);
     }
 
-    summary& get_summary() {
-        return _sst->_components->summary;
-    }
-
     summary move_summary() {
         return std::move(_sst->_components->summary);
     }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -100,10 +100,6 @@ public:
         return std::move(_sst->_components->summary);
     }
 
-    future<> read_toc() noexcept {
-        return _sst->read_toc();
-    }
-
     auto& get_components() {
         return _sst->_recognized_components;
     }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -96,10 +96,6 @@ public:
         return _sst->read_summary_entry(i);
     }
 
-    summary move_summary() {
-        return std::move(_sst->_components->summary);
-    }
-
     auto& get_components() {
         return _sst->_recognized_components;
     }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -13,7 +13,6 @@
 #include "sstables/sstables.hh"
 #include "sstables/shared_sstable.hh"
 #include "sstables/index_reader.hh"
-#include "sstables/binary_search.hh"
 #include "sstables/writer.hh"
 #include "compaction/compaction_manager.hh"
 #include "replica/memtable-sstable.hh"
@@ -98,11 +97,6 @@ public:
 
     auto& get_components() {
         return _sst->_recognized_components;
-    }
-
-    template <typename T>
-    int binary_search(const dht::i_partitioner& p, const T& entries, const key& sk) {
-        return sstables::binary_search(p, entries, sk);
     }
 
     void change_generation_number(sstables::generation_type generation) {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -47,10 +47,6 @@ public:
         return _sst->_components->summary;
     }
 
-    future<temporary_buffer<char>> data_read(reader_permit permit, uint64_t pos, size_t len) {
-        return _sst->data_read(pos, len, std::move(permit));
-    }
-
     std::unique_ptr<index_reader> make_index_reader(reader_permit permit) {
         return std::make_unique<index_reader>(_sst, std::move(permit));
     }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -88,10 +88,6 @@ public:
         return _sst->read_statistics();
     }
 
-    statistics& get_statistics() {
-        return _sst->_components->statistics;
-    }
-
     future<> read_summary() noexcept {
         return _sst->read_summary();
     }


### PR DESCRIPTION
This one is aimed at giving tests the ability to call private methods of class sstable. Some of the wrappers in the test class wrap public methods and can be removed.