### PR TITLE
proxy: Don't keep truncate timeout as optional argument

### DIFF
--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -643,9 +643,9 @@ public:
      * the column family cfname
      * @param keyspace
      * @param cfname
-     * @param timeout (default: use truncate_request_timeout_in_ms config)
+     * @param timeout
      */
-    future<> truncate_blocking(sstring keyspace, sstring cfname, std::optional<std::chrono::milliseconds> timeout_in_ms = std::nullopt);
+    future<> truncate_blocking(sstring keyspace, sstring cfname, std::chrono::milliseconds timeout_in_ms);
 
     /*
      * Executes data query on the whole cluster.


### PR DESCRIPTION
Because it is never such -- the only caller of truncate_blocking() always knows the timeout it want this method to use.
