### PR TITLE
[Backport 6.1] replica: ignore cleanup of deallocated storage group

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -301,6 +301,7 @@ public:
     future<> stop_storage_groups() noexcept;
     void remove_storage_group(size_t id);
     storage_group& storage_group_for_id(const schema_ptr&, size_t i) const;
+    storage_group* maybe_storage_group_for_id(const schema_ptr&, size_t i) const;
 
     // Caller must keep the current effective_replication_map_ptr valid
     // until the storage_group_manager finishes update_effective_replication_map

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -623,6 +623,11 @@ storage_group& storage_group_manager::storage_group_for_id(const schema_ptr& s, 
     return *it->second.get();
 }
 
+storage_group* storage_group_manager::maybe_storage_group_for_id(const schema_ptr& s, size_t i) const {
+    auto it = _storage_groups.find(i);
+    return it != _storage_groups.end() ? &*it->second.get() : nullptr;
+}
+
 class single_storage_group_manager final : public storage_group_manager {
     replica::table& _t;
     storage_group* _single_sg;
@@ -3681,8 +3686,14 @@ future<> table::cleanup_compaction_groups(database& db, db::system_keyspace& sys
 
 future<> table::cleanup_tablet(database& db, db::system_keyspace& sys_ks, locator::tablet_id tid) {
     auto holder = async_gate().hold();
-    auto& sg = storage_group_for_id(tid.value());
 
+    auto sgp = _sg_manager->maybe_storage_group_for_id(_schema, tid.value());
+    if (!sgp) {
+        tlogger.warn("Storage group for tablet {} is deallocated. Ignore cleanup.", tid);
+        co_return;
+    }
+
+    auto& sg = *sgp;
     co_await clear_inactive_reads_for_tablet(db, sg);
     // compaction_group::stop takes care of flushing.
     co_await stop_compaction_groups(sg);

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2748,3 +2748,27 @@ SEASTAR_THREAD_TEST_CASE(test_calculate_tablet_replicas_for_new_rf_default_rf_up
 
     execute_tablet_for_new_rf_test(config);
 }
+
+SEASTAR_TEST_CASE(test_cleanup_of_deallocated_tablet) {
+    auto cfg = tablet_cql_test_config();
+    cfg.initial_tablets = 1;
+
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        // Create a table.
+        e.execute_cql("create table ks.cf (pk int, ck int, primary key (pk, ck))").get();
+
+        size_t all_tablets = 0;
+        // Double cleanup the tablet.
+        e.db().invoke_on_all([&] (replica::database& db) -> future<> {
+            auto& cf = db.find_column_family("ks", "cf");
+            auto& sys_ks = e.get_system_keyspace().local();
+            auto tablet_count = cf.get_stats().tablet_count;
+            all_tablets += tablet_count;
+            if (tablet_count > 0) {
+                co_await cf.cleanup_tablet(db, sys_ks, locator::tablet_id(0));
+                co_await cf.cleanup_tablet(db, sys_ks, locator::tablet_id(0));
+            }
+        }).get();
+        assert(all_tablets);
+    }, cfg);
+}


### PR DESCRIPTION
Cleanup of a deallocated tablet throws an exception.
Since failed cleanup is retried, we end up in an infinite loop.

Ignore cleanup of deallocated storage groups.

Fixes: https://github.com/scylladb/scylladb/issues/19752.

Needs to be backported to all branches with tablets (6.0 and later)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/20d6cf55f25745a4326a3147139b302f5603e5b9)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/2c4b1d6b45095ce939f6953aedbfafa2152671e8)

Refs https://github.com/scylladb/scylladb/pull/20584