### PR TITLE
Alternator: a few RBAC fixes

### DIFF
--- a/alternator/controller.cc
+++ b/alternator/controller.cc
@@ -130,10 +130,10 @@ future<> controller::start_server() {
                 std::throw_with_nested(std::runtime_error("Failed to set up Alternator TLS credentials"));
             }
         }
-        bool alternator_enforce_authorization = _config.alternator_enforce_authorization();
         _server.invoke_on_all(
-                [this, addr, alternator_port, alternator_https_port, creds = std::move(creds), alternator_enforce_authorization] (server& server) mutable {
-            return server.init(addr, alternator_port, alternator_https_port, creds, alternator_enforce_authorization,
+                [this, addr, alternator_port, alternator_https_port, creds = std::move(creds)] (server& server) mutable {
+            return server.init(addr, alternator_port, alternator_https_port, creds,
+                    _config.alternator_enforce_authorization,
                     &_memory_limiter.local().get_semaphore(),
                     _config.max_concurrent_requests_per_shard);
         }).handle_exception([this, addr, alternator_port, alternator_https_port] (std::exception_ptr ep) {

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -561,7 +561,7 @@ future<> verify_permission(
     auth::permission permission_to_check) {
     auto resource = auth::make_data_resource(schema->ks_name(), schema->cf_name());
     if (!co_await client_state.check_has_permission(auth::command_desc(permission_to_check, resource))) {
-        sstring username = "anonymous";
+        sstring username = "<anonymous>";
         if (client_state.user() && client_state.user()->name) {
             username = client_state.user()->name.value();
         }
@@ -580,7 +580,7 @@ future<> verify_permission(
 future<> verify_create_permission(const service::client_state& client_state) {
     auto resource = auth::resource(auth::resource_kind::data);
     if (!co_await client_state.check_has_permission(auth::command_desc(auth::permission::CREATE, resource))) {
-        sstring username = "anonymous";
+        sstring username = "<anonymous>";
         if (client_state.user() && client_state.user()->name) {
             username = client_state.user()->name.value();
         }

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -137,6 +137,25 @@ std::string json_string::to_json() const {
     return _value;
 }
 
+executor::executor(gms::gossiper& gossiper,
+         service::storage_proxy& proxy,
+         service::migration_manager& mm,
+         db::system_distributed_keyspace& sdks,
+         cdc::metadata& cdc_metadata,
+         smp_service_group ssg,
+         utils::updateable_value<uint32_t> default_timeout_in_ms)
+    : _gossiper(gossiper),
+      _proxy(proxy),
+      _mm(mm),
+      _sdks(sdks),
+      _cdc_metadata(cdc_metadata),
+      _enforce_authorization(_proxy.data_dictionary().get_config().alternator_enforce_authorization()),
+      _ssg(ssg)
+{
+    s_default_timeout_in_ms = std::move(default_timeout_in_ms);
+}
+
+
 void executor::supplement_table_info(rjson::value& descr, const schema& schema, service::storage_proxy& sp) {
     rjson::add(descr, "CreationDateTime", rjson::value(std::chrono::duration_cast<std::chrono::seconds>(gc_clock::now().time_since_epoch()).count()));
     rjson::add(descr, "TableStatus", "ACTIVE");
@@ -556,9 +575,13 @@ future<executor::request_return_type> executor::describe_table(client_state& cli
 // SELECT, DROP, etc.) on the given table. When permission is denied an
 // appropriate user-readable api_error::access_denied is thrown.
 future<> verify_permission(
+    bool enforce_authorization,
     const service::client_state& client_state,
     const schema_ptr& schema,
     auth::permission permission_to_check) {
+    if (!enforce_authorization) {
+        co_return;
+    }
     auto resource = auth::make_data_resource(schema->ks_name(), schema->cf_name());
     if (!co_await client_state.check_has_permission(auth::command_desc(permission_to_check, resource))) {
         sstring username = "<anonymous>";
@@ -577,7 +600,10 @@ future<> verify_permission(
 // Similar to verify_permission() above, but just for CREATE operations.
 // Those do not operate on any specific table, so require permissions on
 // ALL KEYSPACES instead of any specific table.
-future<> verify_create_permission(const service::client_state& client_state) {
+future<> verify_create_permission(bool enforce_authorization, const service::client_state& client_state) {
+    if (!enforce_authorization) {
+        co_return;
+    }
     auto resource = auth::resource(auth::resource_kind::data);
     if (!co_await client_state.check_has_permission(auth::command_desc(auth::permission::CREATE, resource))) {
         sstring username = "<anonymous>";
@@ -604,7 +630,7 @@ future<executor::request_return_type> executor::delete_table(client_state& clien
 
     schema_ptr schema = get_table(_proxy, request);
     rjson::value table_description = fill_table_description(schema, table_status::deleting, _proxy);
-    co_await verify_permission(client_state, schema, auth::permission::DROP);
+    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::DROP);
     co_await _mm.container().invoke_on(0, [&, cs = client_state.move_to_other_shard()] (service::migration_manager& mm) -> future<> {
         // FIXME: the following needs to be in a loop. If mm.announce() below
         // fails, we need to retry the whole thing.
@@ -898,7 +924,7 @@ future<executor::request_return_type> executor::tag_resource(client_state& clien
     if (tags->Size() < 1) {
         co_return api_error::validation("The number of tags must be at least 1") ;
     }
-    co_await verify_permission(client_state, schema, auth::permission::ALTER);
+    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::ALTER);
     co_await db::modify_tags(_mm, schema->ks_name(), schema->cf_name(), [tags](std::map<sstring, sstring>& tags_map) {
         update_tags_map(*tags, tags_map, update_tags_action::add_tags);
     });
@@ -918,7 +944,7 @@ future<executor::request_return_type> executor::untag_resource(client_state& cli
     }
 
     schema_ptr schema = get_table_from_arn(_proxy, rjson::to_string_view(*arn));
-    co_await verify_permission(client_state, schema, auth::permission::ALTER);
+    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::ALTER);
     co_await db::modify_tags(_mm, schema->ks_name(), schema->cf_name(), [tags](std::map<sstring, sstring>& tags_map) {
         update_tags_map(*tags, tags_map, update_tags_action::delete_tags);
     });
@@ -1001,7 +1027,7 @@ static std::unordered_set<std::string> validate_attribute_definitions(const rjso
     return seen_attribute_names;
 }
 
-static future<executor::request_return_type> create_table_on_shard0(service::client_state&& client_state, tracing::trace_state_ptr trace_state, rjson::value request, service::storage_proxy& sp, service::migration_manager& mm, gms::gossiper& gossiper) {
+static future<executor::request_return_type> create_table_on_shard0(service::client_state&& client_state, tracing::trace_state_ptr trace_state, rjson::value request, service::storage_proxy& sp, service::migration_manager& mm, gms::gossiper& gossiper, bool enforce_authorization) {
     SCYLLA_ASSERT(this_shard_id() == 0);
 
     // We begin by parsing and validating the content of the CreateTable
@@ -1195,7 +1221,7 @@ static future<executor::request_return_type> create_table_on_shard0(service::cli
     }
     builder.add_extension(db::tags_extension::NAME, ::make_shared<db::tags_extension>(tags_map));
 
-    co_await verify_create_permission(client_state);
+    co_await verify_create_permission(enforce_authorization, client_state);
 
     schema_ptr schema = builder.build();
     for (auto& view_builder : view_builders) {
@@ -1290,9 +1316,9 @@ future<executor::request_return_type> executor::create_table(client_state& clien
     _stats.api_operations.create_table++;
     elogger.trace("Creating table {}", request);
 
-    co_return co_await _mm.container().invoke_on(0, [&, tr = tracing::global_trace_state_ptr(trace_state), request = std::move(request), &sp = _proxy.container(), &g = _gossiper.container(), client_state_other_shard = client_state.move_to_other_shard()]
+    co_return co_await _mm.container().invoke_on(0, [&, tr = tracing::global_trace_state_ptr(trace_state), request = std::move(request), &sp = _proxy.container(), &g = _gossiper.container(), client_state_other_shard = client_state.move_to_other_shard(), enforce_authorization = bool(_enforce_authorization)]
                                         (service::migration_manager& mm) mutable -> future<executor::request_return_type> {
-        co_return co_await create_table_on_shard0(client_state_other_shard.get(), tr, std::move(request), sp.local(), mm, g.local());
+        co_return co_await create_table_on_shard0(client_state_other_shard.get(), tr, std::move(request), sp.local(), mm, g.local(), enforce_authorization);
     });
 }
 
@@ -1317,7 +1343,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
         verify_billing_mode(request);
     }
 
-    co_return co_await _mm.container().invoke_on(0, [&p = _proxy.container(), request = std::move(request), gt = tracing::global_trace_state_ptr(std::move(trace_state)), client_state_other_shard = client_state.move_to_other_shard()]
+    co_return co_await _mm.container().invoke_on(0, [&p = _proxy.container(), request = std::move(request), gt = tracing::global_trace_state_ptr(std::move(trace_state)), enforce_authorization = bool(_enforce_authorization), client_state_other_shard = client_state.move_to_other_shard()]
                                                 (service::migration_manager& mm) mutable -> future<executor::request_return_type> {
         // FIXME: the following needs to be in a loop. If mm.announce() below
         // fails, we need to retry the whole thing.
@@ -1348,7 +1374,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
         }
 
         auto schema = builder.build();
-        co_await verify_permission(client_state_other_shard.get(), schema, auth::permission::ALTER);
+        co_await verify_permission(enforce_authorization, client_state_other_shard.get(), schema, auth::permission::ALTER);
         auto m = co_await service::prepare_column_family_update_announcement(p.local(), schema,  std::vector<view_ptr>(), group0_guard.write_timestamp());
 
         co_await mm.announce(std::move(m), std::move(group0_guard), format("alternator-executor: update {} table", tab->cf_name()));
@@ -1907,7 +1933,7 @@ future<executor::request_return_type> executor::put_item(client_state& client_st
     tracing::add_table_name(trace_state, op->schema()->ks_name(), op->schema()->cf_name());
     const bool needs_read_before_write = op->needs_read_before_write();
 
-    co_await verify_permission(client_state, op->schema(), auth::permission::MODIFY);
+    co_await verify_permission(_enforce_authorization, client_state, op->schema(), auth::permission::MODIFY);
 
     if (auto shard = op->shard_for_execute(needs_read_before_write); shard) {
         _stats.api_operations.put_item--; // uncount on this shard, will be counted in other shard
@@ -1999,7 +2025,7 @@ future<executor::request_return_type> executor::delete_item(client_state& client
     tracing::add_table_name(trace_state, op->schema()->ks_name(), op->schema()->cf_name());
     const bool needs_read_before_write = op->needs_read_before_write();
 
-    co_await verify_permission(client_state, op->schema(), auth::permission::MODIFY);
+    co_await verify_permission(_enforce_authorization, client_state, op->schema(), auth::permission::MODIFY);
 
     if (auto shard = op->shard_for_execute(needs_read_before_write); shard) {
         _stats.api_operations.delete_item--; // uncount on this shard, will be counted in other shard
@@ -2226,7 +2252,7 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
     }
 
     for (const auto& b : mutation_builders) {
-        co_await verify_permission(client_state, b.first, auth::permission::MODIFY);
+        co_await verify_permission(_enforce_authorization, client_state, b.first, auth::permission::MODIFY);
     }
 
     _stats.api_operations.batch_write_item_batch_total += batch_size;
@@ -3274,7 +3300,7 @@ future<executor::request_return_type> executor::update_item(client_state& client
     tracing::add_table_name(trace_state, op->schema()->ks_name(), op->schema()->cf_name());
     const bool needs_read_before_write = op->needs_read_before_write();
 
-    co_await verify_permission(client_state, op->schema(), auth::permission::MODIFY);
+    co_await verify_permission(_enforce_authorization, client_state, op->schema(), auth::permission::MODIFY);
 
     if (auto shard = op->shard_for_execute(needs_read_before_write); shard) {
         _stats.api_operations.update_item--; // uncount on this shard, will be counted in other shard
@@ -3373,7 +3399,7 @@ future<executor::request_return_type> executor::get_item(client_state& client_st
     auto attrs_to_get = calculate_attrs_to_get(request, used_attribute_names);
     const rjson::value* expression_attribute_names = rjson::find(request, "ExpressionAttributeNames");
     verify_all_are_used(expression_attribute_names, used_attribute_names, "ExpressionAttributeNames", "GetItem");
-    co_await verify_permission(client_state, schema, auth::permission::SELECT);
+    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::SELECT);
     co_return co_await _proxy.query(schema, std::move(command), std::move(partition_ranges), cl,
             service::storage_proxy::coordinator_query_options(executor::default_timeout(), std::move(permit), client_state, trace_state)).then(
             [this, schema, partition_slice = std::move(partition_slice), selection = std::move(selection), attrs_to_get = std::move(attrs_to_get), start_time = std::move(start_time)] (service::storage_proxy::coordinator_query_result qr) mutable {
@@ -3494,7 +3520,7 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     }
 
     for (const table_requests& tr : requests) {
-        co_await verify_permission(client_state, tr.schema, auth::permission::SELECT);
+        co_await verify_permission(_enforce_authorization, client_state, tr.schema, auth::permission::SELECT);
     }
 
     _stats.api_operations.batch_get_item_batch_total += requests.size();
@@ -3909,7 +3935,8 @@ static future<executor::request_return_type> do_query(service::storage_proxy& pr
         service::client_state& client_state,
         cql3::cql_stats& cql_stats,
         tracing::trace_state_ptr trace_state,
-        service_permit permit) {
+        service_permit permit,
+        bool enforce_authorization) {
     lw_shared_ptr<service::pager::paging_state> old_paging_state = nullptr;
 
     tracing::trace(trace_state, "Performing a database query");
@@ -3936,7 +3963,7 @@ static future<executor::request_return_type> do_query(service::storage_proxy& pr
         old_paging_state = make_lw_shared<service::pager::paging_state>(pk, pos, query::max_partitions, query_id::create_null_id(), service::pager::paging_state::replicas_per_token_range{}, std::nullopt, 0);
     }
 
-    co_await verify_permission(client_state, table_schema, auth::permission::SELECT);
+    co_await verify_permission(enforce_authorization, client_state, table_schema, auth::permission::SELECT);
 
     auto regular_columns = boost::copy_range<query::column_id_vector>(
             table_schema->regular_columns() | boost::adaptors::transformed([] (const column_definition& cdef) { return cdef.id; }));
@@ -4080,7 +4107,7 @@ future<executor::request_return_type> executor::scan(client_state& client_state,
     verify_all_are_used(expression_attribute_values, used_attribute_values, "ExpressionAttributeValues", "Scan");
 
     return do_query(_proxy, schema, exclusive_start_key, std::move(partition_ranges), std::move(ck_bounds), std::move(attrs_to_get), limit, cl,
-            std::move(filter), query::partition_slice::option_set(), client_state, _stats.cql_stats, trace_state, std::move(permit));
+            std::move(filter), query::partition_slice::option_set(), client_state, _stats.cql_stats, trace_state, std::move(permit), _enforce_authorization);
 }
 
 static dht::partition_range calculate_pk_bound(schema_ptr schema, const column_definition& pk_cdef, const rjson::value& comp_definition, const rjson::value& attrs) {
@@ -4560,7 +4587,7 @@ future<executor::request_return_type> executor::query(client_state& client_state
     query::partition_slice::option_set opts;
     opts.set_if<query::partition_slice::option::reversed>(!forward);
     return do_query(_proxy, schema, exclusive_start_key, std::move(partition_ranges), std::move(ck_bounds), std::move(attrs_to_get), limit, cl,
-            std::move(filter), opts, client_state, _stats.cql_stats, std::move(trace_state), std::move(permit));
+            std::move(filter), opts, client_state, _stats.cql_stats, std::move(trace_state), std::move(permit), _enforce_authorization);
 }
 
 future<executor::request_return_type> executor::list_tables(client_state& client_state, service_permit permit, rjson::value request) {

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -158,6 +158,7 @@ class executor : public peering_sharded_service<executor> {
     service::migration_manager& _mm;
     db::system_distributed_keyspace& _sdks;
     cdc::metadata& _cdc_metadata;
+    utils::updateable_value<bool> _enforce_authorization;
     // An smp_service_group to be used for limiting the concurrency when
     // forwarding Alternator request between shards - if necessary for LWT.
     smp_service_group _ssg;
@@ -176,10 +177,7 @@ public:
              db::system_distributed_keyspace& sdks,
              cdc::metadata& cdc_metadata,
              smp_service_group ssg,
-             utils::updateable_value<uint32_t> default_timeout_in_ms)
-        : _gossiper(gossiper), _proxy(proxy), _mm(mm), _sdks(sdks), _cdc_metadata(cdc_metadata), _ssg(ssg) {
-        s_default_timeout_in_ms = std::move(default_timeout_in_ms);
-    }
+             utils::updateable_value<uint32_t> default_timeout_in_ms);
 
     future<request_return_type> create_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
     future<request_return_type> describe_table(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request);
@@ -265,6 +263,6 @@ bool is_big(const rjson::value& val, int big_size = 100'000);
 // Check CQL's Role-Based Access Control (RBAC) permission (MODIFY,
 // SELECT, DROP, etc.) on the given table. When permission is denied an
 // appropriate user-readable api_error::access_denied is thrown.
-future<> verify_permission(const service::client_state&, const schema_ptr&, auth::permission);
+future<> verify_permission(bool enforce_authorization, const service::client_state&, const schema_ptr&, auth::permission);
 
 }

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -556,9 +556,9 @@ server::server(executor& exec, service::storage_proxy& proxy, gms::gossiper& gos
 }
 
 future<> server::init(net::inet_address addr, std::optional<uint16_t> port, std::optional<uint16_t> https_port, std::optional<tls::credentials_builder> creds,
-        bool enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests) {
+        utils::updateable_value<bool> enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests) {
     _memory_limiter = memory_limiter;
-    _enforce_authorization = enforce_authorization;
+    _enforce_authorization = std::move(enforce_authorization);
     _max_concurrent_requests = std::move(max_concurrent_requests);
     if (!port && !https_port) {
         return make_exception_future<>(std::runtime_error("Either regular port or TLS port"

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -39,7 +39,7 @@ class server {
     qos::service_level_controller& _sl_controller;
 
     key_cache _key_cache;
-    bool _enforce_authorization;
+    utils::updateable_value<bool> _enforce_authorization;
     utils::small_vector<std::reference_wrapper<seastar::httpd::http_server>, 2> _enabled_servers;
     gate _pending_requests;
     // In some places we will need a CQL updateable_timeout_config object even
@@ -76,7 +76,7 @@ public:
     server(executor& executor, service::storage_proxy& proxy, gms::gossiper& gossiper, auth::service& service, qos::service_level_controller& sl_controller);
 
     future<> init(net::inet_address addr, std::optional<uint16_t> port, std::optional<uint16_t> https_port, std::optional<tls::credentials_builder> creds,
-            bool enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests);
+            utils::updateable_value<bool> enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests);
     future<> stop();
 private:
     void set_routes(seastar::httpd::routes& r);

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -824,7 +824,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
 
     tracing::add_table_name(trace_state, schema->ks_name(), schema->cf_name());
 
-    co_await verify_permission(client_state, schema, auth::permission::SELECT);
+    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::SELECT);
 
     db::consistency_level cl = db::consistency_level::LOCAL_QUORUM;
     partition_key pk = iter.shard.id.to_partition_key(*schema);

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -99,7 +99,7 @@ future<executor::request_return_type> executor::update_time_to_live(client_state
     }
     sstring attribute_name(v->GetString(), v->GetStringLength());
 
-    co_await verify_permission(client_state, schema, auth::permission::ALTER);
+    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::ALTER);
     co_await db::modify_tags(_mm, schema->ks_name(), schema->cf_name(), [&](std::map<sstring, sstring>& tags_map) {
         if (enabled) {
             if (tags_map.contains(TTL_TAG_KEY)) {


### PR DESCRIPTION
The main goal of this PR is to fix a bug (#20619) in the alternator_enforce_authorization=false setting - which didn't do its job (i.e, _don't_ check permissions) when authorization is configured in CQL but not wanted in Alternator.

The series also a few smaller bugs in the code that were discovered while debugging the main issue:
1. A potential use-after-free (that didn't seem to hit us in practice) is fixed.
2. A confusing error message (that was also reported in #20619) is improved.
3. Make the alternator_enforce_authorization live-updatable. There was no reason why it shouldn't be, and as this series needs to make this flag available to more code, let's just do it properly and assume the flag is live-updatable.

Because the RBAC feature has not been backported to any open-source branches, neither should these fixes. But if some private branch received a backport of the RBAC feature, it should get these fixes too.

Fixes #20619.