### PR TITLE
sstables: storage: Don't keep base directory in base class

### DIFF
--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -41,6 +41,7 @@ namespace sstables {
 // cannot define these classes in an anonymous namespace, as we need to
 // declare these storage classes as "friend" of class sstable
 class filesystem_storage final : public sstables::storage {
+    mutable opened_directory _base_dir;
     mutable opened_directory _dir;
     std::optional<std::filesystem::path> _temp_dir; // Valid while the sstable is being created, until sealed
 
@@ -68,7 +69,7 @@ private:
 
 public:
     explicit filesystem_storage(sstring dir, sstable_state state)
-        : storage(dir)
+        : _base_dir(dir)
         , _dir(make_path(dir, state))
     {}
 
@@ -477,7 +478,7 @@ future<> filesystem_storage::wipe(const sstable& sst, sync_dir sync) noexcept {
 }
 
 future<atomic_delete_context> filesystem_storage::atomic_delete_prepare(const std::vector<shared_sstable>& ssts) const {
-    co_return co_await sstable_directory::create_pending_deletion_log(base_dir(), ssts);
+    co_return co_await sstable_directory::create_pending_deletion_log(_base_dir, ssts);
 }
 
 future<> filesystem_storage::atomic_delete_complete(atomic_delete_context ctx) const {
@@ -504,6 +505,7 @@ future<> filesystem_storage::remove_by_registry_entry(entry_descriptor desc) {
 class s3_storage : public sstables::storage {
     shared_ptr<s3::client> _client;
     sstring _bucket;
+    sstring _location;
 
     static constexpr auto status_creating = "creating";
     static constexpr auto status_sealed = "sealed";
@@ -513,9 +515,9 @@ class s3_storage : public sstables::storage {
 
 public:
     s3_storage(shared_ptr<s3::client> client, sstring bucket, sstring dir)
-        : storage(std::move(dir))
-        , _client(std::move(client))
+        : _client(std::move(client))
         , _bucket(std::move(bucket))
+        , _location(std::move(dir))
     {
     }
 
@@ -539,7 +541,7 @@ public:
         return make_ready_future<uint64_t>(std::numeric_limits<uint64_t>::max());
     }
 
-    virtual sstring prefix() const override { return base_dir().native(); }
+    virtual sstring prefix() const override { return _location; }
 };
 
 sstring s3_storage::make_s3_object_name(const sstable& sst, component_type type) const {
@@ -554,7 +556,7 @@ sstring s3_storage::make_s3_object_name(const sstable& sst, component_type type)
 
 void s3_storage::open(sstable& sst) {
     entry_descriptor desc(sst._generation, sst._version, sst._format, component_type::TOC);
-    sst.manager().sstables_registry().create_entry(prefix(), status_creating, sst._state, std::move(desc)).get();
+    sst.manager().sstables_registry().create_entry(_location, status_creating, sst._state, std::move(desc)).get();
 
     memory_data_sink_buffers bufs;
     sst.write_toc(
@@ -584,7 +586,7 @@ future<data_sink> s3_storage::make_component_sink(sstable& sst, component_type t
 }
 
 future<> s3_storage::seal(const sstable& sst) {
-    co_await sst.manager().sstables_registry().update_entry_status(prefix(), sst.generation(), status_sealed);
+    co_await sst.manager().sstables_registry().update_entry_status(_location, sst.generation(), status_sealed);
 }
 
 future<> s3_storage::change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) {
@@ -594,19 +596,19 @@ future<> s3_storage::change_state(const sstable& sst, sstable_state state, gener
         // is moved from upload directory and this is another issue for S3 (#13018)
         co_await coroutine::return_exception(std::runtime_error("Cannot change state and generation of an S3 object"));
     }
-    co_await sst.manager().sstables_registry().update_entry_state(prefix(), sst.generation(), state);
+    co_await sst.manager().sstables_registry().update_entry_state(_location, sst.generation(), state);
 }
 
 future<> s3_storage::wipe(const sstable& sst, sync_dir) noexcept {
     auto& sstables_registry = sst.manager().sstables_registry();
 
-    co_await sstables_registry.update_entry_status(prefix(), sst.generation(), status_removing);
+    co_await sstables_registry.update_entry_status(_location, sst.generation(), status_removing);
 
     co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (auto type) -> future<> {
         co_await _client->delete_object(make_s3_object_name(sst, type));
     });
 
-    co_await sstables_registry.delete_entry(prefix(), sst.generation());
+    co_await sstables_registry.delete_entry(_location, sst.generation());
 }
 
 future<atomic_delete_context> s3_storage::atomic_delete_prepare(const std::vector<shared_sstable>&) const {

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -75,8 +75,6 @@ public:
 class storage {
     friend class test;
 
-    mutable opened_directory _base_dir;    // Local base directory (of table)
-
     // Internal, but can also be used by tests
     virtual future<> change_dir_for_test(sstring nd) {
         SCYLLA_ASSERT(false && "Changing directory not implemented");
@@ -89,15 +87,10 @@ class storage {
     }
 
 public:
-    explicit storage(std::string_view base_dir) : _base_dir(base_dir) {}
     virtual ~storage() {}
 
     using absolute_path = bool_class<class absolute_path_tag>; // FIXME -- should go away eventually
     using sync_dir = bool_class<struct sync_dir_tag>; // meaningful only to filesystem storage
-
-    opened_directory& base_dir() const {
-        return _base_dir;
-    }
 
     virtual future<> seal(const sstable& sst) = 0;
     virtual future<> snapshot(const sstable& sst, sstring dir, absolute_path abs, std::optional<generation_type> gen = {}) const = 0;


### PR DESCRIPTION
This reverts commit 44bd18318710b598b4579f6bc840b872e4e75416 and moves the base directory back on filesystem_storage. The mentioned commit says

>    so we can use the base (table) directory for
>    e.g. pending_delete logs, in the next patch.

but "next patch" doesn't use it outside of the filesystem-storage anyway.

This field doesn't make sense for S3 backend. Its "location" is not location, but a key in the system.sstables, which should rather be schema ID, not /var/lib/.../keyspace/table-uuid string.

refs: #19555