### PR TITLE
doc: enable publishing docs for branch-6.2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,11 +16,11 @@ sys.path.insert(0, os.path.abspath(".."))
 BASE_URL = 'https://opensource.docs.scylladb.com'
 # Build documentation for the following tags and branches.
 TAGS = []
-BRANCHES = ["master", "branch-5.1", "branch-5.2", "branch-5.4", "branch-6.0", "branch-6.1"]
+BRANCHES = ["master", "branch-5.1", "branch-5.2", "branch-5.4", "branch-6.0", "branch-6.1", "branch-6.2"]
 # Set the latest version. 
 LATEST_VERSION = "branch-6.1"
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = ["master"]
+UNSTABLE_VERSIONS = ["master", "branch-6.2"]
 # Set which versions are deprecated.
 DEPRECATED_VERSIONS = [""]
 


### PR DESCRIPTION
This PR enables publishing documentation from branch-6.2. The docs will be published as UNSTABLE (the warning about version 6.1 being unstable will be displayed).

Fixes https://github.com/scylladb/scylladb/issues/20643

No backport is required.