### PR TITLE
treewide: add "table" parameter to "backup" API 

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -799,6 +799,14 @@
                           "paramType":"query"
                       },
                       {
+                          "name":"table",
+                          "description":"Name of a table to copy sstables from",
+                          "required":true,
+                          "allowMultiple":false,
+                          "type":"string",
+                          "paramType":"query"
+                      },
+                      {
                           "name":"snapshot",
                           "description":"Name of a snapshot to copy sstables from",
                           "required":false,

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1795,6 +1795,7 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
     ss::start_backup.set(r, [&snap_ctl] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto endpoint = req->get_query_param("endpoint");
         auto keyspace = req->get_query_param("keyspace");
+        auto table = req->get_query_param("table");
         auto bucket = req->get_query_param("bucket");
         auto prefix = req->get_query_param("prefix");
         auto snapshot_name = req->get_query_param("snapshot");
@@ -1804,7 +1805,7 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
         }
 
         auto& ctl = snap_ctl.local();
-        auto task_id = co_await ctl.start_backup(std::move(endpoint), std::move(bucket), std::move(prefix), std::move(keyspace), std::move(snapshot_name));
+        auto task_id = co_await ctl.start_backup(std::move(endpoint), std::move(bucket), std::move(prefix), std::move(keyspace), std::move(table), std::move(snapshot_name));
         co_return json::json_return_type(fmt::to_string(task_id));
     });
 

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -106,7 +106,7 @@ public:
      */
     future<> clear_snapshot(sstring tag, std::vector<sstring> keyspace_names, sstring cf_name);
 
-    future<tasks::task_id> start_backup(sstring endpoint, sstring bucket, sstring prefix, sstring keyspace, sstring snapshot_name);
+    future<tasks::task_id> start_backup(sstring endpoint, sstring bucket, sstring prefix, sstring keyspace, sstring table, sstring snapshot_name);
 
     future<std::unordered_map<sstring, db_snapshot_details>> get_snapshot_details();
 

--- a/db/snapshot/backup_task.cc
+++ b/db/snapshot/backup_task.cc
@@ -27,14 +27,13 @@ backup_task_impl::backup_task_impl(tasks::task_manager::module_ptr module,
                                    sstring bucket,
                                    sstring prefix,
                                    sstring ks,
-                                   sstring snapshot_name) noexcept
+                                   std::filesystem::path snapshot_dir) noexcept
     : tasks::task_manager::task::impl(module, tasks::task_id::create_random_id(), 0, "node", ks, "", "", tasks::task_id::create_null_id())
     , _snap_ctl(ctl)
     , _client(std::move(client))
     , _bucket(std::move(bucket))
     , _prefix(std::move(prefix))
-    , _ks(std::move(ks))
-    , _snapshot_name(std::move(snapshot_name)) {
+    , _snapshot_dir(std::move(snapshot_dir)) {
 }
 
 std::string backup_task_impl::type() const {
@@ -49,97 +48,49 @@ tasks::is_abortable backup_task_impl::is_abortable() const noexcept {
     return tasks::is_abortable::yes;
 }
 
-future<> backup_task_impl::run(sstring data_dir) {
-    return async([this, data_dir = std::move(data_dir)] {
-        gate uploads;
-        auto wait = defer([&uploads] { uploads.close().get(); });
-        std::exception_ptr ex;
-        //
-        // The keyspace data directories and their snapshots are arranged as follows:
-        //
-        //  <data dir>
-        //  |- <keyspace name1>
-        //  |  |- <column family name1>
-        //  |     |- snapshots
-        //  |        |- <snapshot name1>
-        //  |          |- <snapshot file1>
-        //  |          |- <snapshot file2>
-        //  |          |- ...
-        //  |        |- <snapshot name2>
-        //  |        |- ...
-        //  |  |- <column family name2>
-        //  |  |- ...
-        //  |- <keyspace name2>
-        //  |- ...
-        //
-        auto ks_dir = fs::path(data_dir) / _ks;
-        auto ks_dir_lister = directory_lister(ks_dir, lister::dir_entry_types::of<directory_entry_type::directory>());
-        auto close_ks_dir_lister = deferred_close(ks_dir_lister);
+void backup_task_impl::do_backup() {
+    if (!file_exists(_snapshot_dir.native()).get()) {
+        throw std::invalid_argument(fmt::format("snapshot does not exist at {}", _snapshot_dir.native()));
+    }
 
-        snap_log.trace("Scan keyspace dir {}", ks_dir.native());
-        while (auto table_ent = ks_dir_lister.get().get()) {
-            auto snapshot_dir = ks_dir / table_ent->name / sstables::snapshots_dir / _snapshot_name;
-            auto has_snapshot = file_exists(snapshot_dir.native()).get();
+    gate uploads;
+    auto wait = defer([&uploads] { uploads.close().get(); });
 
-            snap_log.trace("Check table snapshot dir {} (exists={})", snapshot_dir.native(), has_snapshot);
-            if (!has_snapshot) {
-                continue;
-            }
-
-            auto cf_name_and_uuid = replica::parse_table_directory_name(table_ent->name);
-            auto snapshot_dir_lister = directory_lister(snapshot_dir, lister::dir_entry_types::of<directory_entry_type::regular>());
+            auto snapshot_dir_lister = directory_lister(_snapshot_dir, lister::dir_entry_types::of<directory_entry_type::regular>());
             auto close_snapshot_dir_lister = deferred_close(snapshot_dir_lister);
 
             while (auto component_ent = snapshot_dir_lister.get().get()) {
                 auto gh = uploads.hold();
-                auto component_name = snapshot_dir / component_ent->name;
+                auto component_name = _snapshot_dir / component_ent->name;
                 auto destination = fmt::format("/{}/{}/{}", _bucket, _prefix, component_ent->name);
                 snap_log.trace("Upload {} to {}", component_name.native(), destination);
                 // Start uploading in the background. The caller waits for these fibers
                 // with the _uploads gate.
-                // Parallelizm is implicitly controlled in two ways:
+                // Parallelism is implicitly controlled in two ways:
                 //  - s3::client::claim_memory semaphore
                 //  - http::client::max_connections limitation
                 // FIXME -- s3::client is not abortable yet, but when it will be, need to
                 // propagate impl::_as abort requests into upload_file's fibers
-                std::ignore = _client->upload_file(component_name, destination).handle_exception([this, comp = component_name] (auto ex) {
+                std::ignore = _client->upload_file(component_name, destination).handle_exception([comp = component_name] (auto ex) {
                     snap_log.error("Error uploading {}: {}", comp.native(), ex);
-                    _ex = std::move(ex);
+                    std::rethrow_exception(ex);
                 }).finally([gh = std::move(gh)] {});
                 thread::maybe_yield();
-                if (_ex) {
-                    break;
-                }
                 utils::get_local_injector().inject("backup_task_pause", [] (auto& handler) {
                     snap_log.info("backup task: waiting");
                     return handler.wait_for_message(db::timeout_clock::now() + std::chrono::minutes(2));
                 }).get();
-                if (impl::_as.abort_requested()) {
-                    _ex = impl::_as.abort_requested_exception_ptr();
-                    break;
-                }
+                impl::_as.check();
             }
-        }
-    });
 }
 
 future<> backup_task_impl::run() {
-    co_await _snap_ctl.run_snapshot_list_operation(coroutine::lambda([this] -> future<> {
-        std::vector<sstring> data_dirs = _snap_ctl._db.local().get_config().data_file_directories();
-        co_await coroutine::parallel_for_each(data_dirs, [this] (auto& d) -> future<> {
-            try {
-                co_await run(d);
-            } catch (...) {
-                _ex = std::current_exception();
-                snap_log.warn("Error walking snapshots in {}: {}", d, _ex);
-            }
+    co_await _snap_ctl.run_snapshot_list_operation([this] {
+        return async([this] {
+            do_backup();
+            snap_log.info("Finished backup");
         });
-        if (_ex) {
-            snap_log.error("Backup finished with error");
-            std::rethrow_exception(_ex);
-        }
-    }));
-    snap_log.info("Finished backup");
+    });
 }
 
 } // db::snapshot namespace

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include "tasks/task_manager.hh"
 
 namespace s3 { class client; }
@@ -23,11 +24,9 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     shared_ptr<s3::client> _client;
     sstring _bucket;
     sstring _prefix;
-    sstring _ks;
-    sstring _snapshot_name;
+    std::filesystem::path _snapshot_dir;
     std::exception_ptr _ex;
-
-    future<> run(sstring data_dir);
+    void do_backup();
 
 protected:
     virtual future<> run() override;
@@ -39,7 +38,7 @@ public:
                      sstring bucket,
                      sstring prefix,
                      sstring ks,
-                     sstring snapshot_name) noexcept;
+                     std::filesystem::path snapshot_dir) noexcept;
 
     virtual std::string type() const override;
     virtual tasks::is_internal is_internal() const noexcept override;

--- a/docs/dev/object_storage.md
+++ b/docs/dev/object_storage.md
@@ -102,6 +102,7 @@ The API endpoint name is `/storage_service/backup` and its Swagger description c
 found [here](./api/api-doc/storage_service.json). Accepted parameters are
 
 * *keyspace*: the keyspace to copy sstables from
+* *table*: the table to copy sstables from
 * *snapshot*: the snapshot name to copy sstables from
 * *endpoint*: the key in the object storage configuration file
 * *bucket*: bucket name to put sstables' files in

--- a/docs/operating-scylla/nodetool-commands/backup.rst
+++ b/docs/operating-scylla/nodetool-commands/backup.rst
@@ -9,9 +9,10 @@ Syntax
 
 .. code-block:: console
 
-   nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
-               --keyspace <keyspace> [--snapshot <snapshot>]
-               --endpoint <endpoint> --bucket <bucket>
+   nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)] backup
+               --keyspace <keyspace> --table <table>
+               [--snapshot <snapshot>]
+               --endpoint <endpoint> --bucket <bucket> --prefix <prefix>
                [--nowait]
 
 Example
@@ -19,13 +20,14 @@ Example
 
 .. code-block:: console
 
-    nodetool backup --endpoint s3.us-east-2.amazonaws.com  --bucket bucket-foo --prefix foo/bar/baz --keyspace ks --snapshot ss
+    nodetool backup --endpoint s3.us-east-2.amazonaws.com  --bucket bucket-foo --prefix foo/bar/baz --keyspace ks --table table --snapshot ss
 
 Options
 -------
 
 * ``-h <host>`` or ``--host <host>`` - Node hostname or IP address.
 * ``--keyspace`` - Name of a keyspace to copy SSTables from
+* ``--table`` - Name of a table to copy SSTables from
 * ``--snapshot`` - Name of a snapshot to copy sstables from
 * ``--endpoint`` - ID of the configured object storage endpoint to copy SSTables to
 * ``--bucket`` - Name of the bucket to backup SSTables to

--- a/test/nodetool/test_backup.py
+++ b/test/nodetool/test_backup.py
@@ -37,11 +37,13 @@ def test_backup(nodetool, scylla_only, nowait, task_state, task_error):
     bucket = "bucket-foo"
     prefix = "foo/bar/baz"
     keyspace = "ks"
+    table = "cf"
     snapshot = "ss"
     params = {"endpoint": endpoint,
               "bucket": bucket,
               "prefix": prefix,
               "keyspace": keyspace,
+              "table": table,
               "snapshot": snapshot}
     task_id = "2c4a3e5f"
     start_time = "2024-08-08T14:29:25Z"
@@ -74,6 +76,7 @@ def test_backup(nodetool, scylla_only, nowait, task_state, task_error):
             "--bucket", bucket,
             "--prefix", prefix,
             "--keyspace", keyspace,
+            "--table", table,
             "--snapshot", snapshot]
     if nowait:
         args.append("--nowait")

--- a/test/object_store/test_backup.py
+++ b/test/object_store/test_backup.py
@@ -63,7 +63,7 @@ async def test_simple_backup(manager: ManagerClient, s3_server):
 
     print('Backup snapshot')
     prefix = f'{cf}/backup'
-    tid = await manager.api.backup(server.ip_addr, ks, 'backup', s3_server.address, s3_server.bucket_name, prefix)
+    tid = await manager.api.backup(server.ip_addr, ks, cf, 'backup', s3_server.address, s3_server.bucket_name, prefix)
     print(f'Started task {tid}')
     status = await manager.api.get_task_status(server.ip_addr, tid)
     print(f'Status: {status}, waiting to finish')
@@ -106,7 +106,7 @@ async def test_backup_is_abortable(manager: ManagerClient, s3_server):
 
     print('Backup snapshot')
     prefix = f'{cf}/backup'
-    tid = await manager.api.backup(server.ip_addr, ks, 'backup', s3_server.address, s3_server.bucket_name, prefix)
+    tid = await manager.api.backup(server.ip_addr, ks, cf, 'backup', s3_server.address, s3_server.bucket_name, prefix)
 
     print(f'Started task {tid}, aborting it early')
     await log.wait_for('backup task: waiting', from_mark=mark)
@@ -154,7 +154,7 @@ async def test_simple_backup_and_restore(manager: ManagerClient, s3_server):
     orig_rows = { x.name: x.value for x in orig_res }
 
     prefix = f'{cf}/{snap_name}'
-    tid = await manager.api.backup(server.ip_addr, ks, snap_name, s3_server.address, s3_server.bucket_name, prefix)
+    tid = await manager.api.backup(server.ip_addr, ks, cf, snap_name, s3_server.address, s3_server.bucket_name, prefix)
     status = await manager.api.wait_task(server.ip_addr, tid)
     assert (status is not None) and (status['state'] == 'done')
 

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -307,9 +307,10 @@ class ScyllaRESTAPIClient():
         """Flush keyspace"""
         await self.client.post(f"/storage_service/keyspace_flush/{ks}", host=node_ip)
 
-    async def backup(self, node_ip: str, ks: str, tag: str, dest: str, bucket: str, prefix: str) -> str:
+    async def backup(self, node_ip: str, ks: str, table: str, tag: str, dest: str, bucket: str, prefix: str) -> str:
         """Backup keyspace's snapshot"""
         params = {"keyspace": ks,
+                  "table": table,
                   "endpoint": dest,
                   "bucket": bucket,
                   "prefix": prefix,

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -390,7 +390,7 @@ const std::map<operation, operation_action>& get_operations_with_func();
 
 void backup_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     std::unordered_map<sstring, sstring> params;
-    for (auto required_param : {"endpoint", "bucket", "prefix", "keyspace"}) {
+    for (auto required_param : {"endpoint", "bucket", "prefix", "keyspace", "table"}) {
         if (!vm.contains(required_param)) {
             throw std::invalid_argument(fmt::format("missing required parameter: {}", required_param));
         }
@@ -3244,6 +3244,7 @@ For more information, see: {}"
 )", doc_link("operating-scylla/nodetool-commands/backup.html")),
                 {
                     typed_option<sstring>("keyspace", "Name of a keyspace to copy SSTables from"),
+                    typed_option<sstring>("table", "Name of a table to copy SSTables from"),
                     typed_option<sstring>("snapshot", "Name of a snapshot to copy SSTables from"),
                     typed_option<sstring>("endpoint", "ID of the configured object storage endpoint to copy SSTables to"),
                     typed_option<sstring>("bucket", "Name of the bucket to backup SSTables to"),


### PR DESCRIPTION
with this parameter, "backup" API can backup the given table, this
enables it to be a drop-in replacement of existing rclone API used by
scylla manager.

Fixes https://github.com/scylladb/scylladb/issues/20636

---

this change is a part of the efforts to bring the native backup/restore to scylla, no need to backprt.