### PR TITLE
mergify: add support for branch-6.2

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,6 +15,31 @@ pull_request_rules:
         - closed
     actions:
       delete_head_branch:
+  - name: Automate backport pull request 6.2
+    conditions:
+      - or:
+        - closed
+        - merged
+      - or:
+          - base=master
+          - base=next
+      - label=backport/6.2 # The PR must have this label to trigger the backport
+      - label=promoted-to-master
+    actions:
+      copy:
+        title: "[Backport 6.2] {{ title }}"
+        body: |
+          {{ body }}
+
+          {% for c in commits %}
+          (cherry picked from commit {{ c.sha }})
+          {% endfor %}
+
+          Refs #{{number}}
+        branches:
+          - branch-6.2
+        assignees:
+          - "{{ author }}"
   - name: Automate backport pull request 6.1
     conditions:
       - or:
@@ -38,31 +63,6 @@ pull_request_rules:
            Refs #{{number}}
         branches:
           - branch-6.1
-        assignees:
-          - "{{ author }}"
-  - name: Automate backport pull request 5.4
-    conditions:
-      - or:
-        - closed
-        - merged
-      - or:
-          - base=master
-          - base=next
-      - label=backport/5.4 # The PR must have this label to trigger the backport
-      - label=promoted-to-master
-    actions:
-      copy:
-        title: "[Backport 5.4] {{ title }}"
-        body: |
-          {{ body }}
-
-          {% for c in commits %}
-          (cherry picked from commit {{ c.sha }})
-          {% endfor %}
-
-          Refs #{{number}}
-        branches:
-          - branch-5.4
         assignees:
           - "{{ author }}"
   - name: Automate backport pull request 6.0


### PR DESCRIPTION
branch-6.2 is already available, adding support for it in mergify to allow backport to this new branch.
in addition, since branch 5.4 reached EOL - removing it