### PR TITLE
cql3: statement_restrictions: adapt to functional style

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -2164,5 +2164,19 @@ const std::unordered_set<const column_definition*> statement_restrictions::get_n
     return _not_null_columns;
 }
 
+statement_restrictions
+analyze_statement_restrictions(
+        data_dictionary::database db,
+        schema_ptr schema,
+        statements::statement_type type,
+        const expr::expression& where_clause,
+        prepare_context& ctx,
+        bool selects_only_static_columns,
+        bool for_view,
+        bool allow_filtering,
+        check_indexes do_check_indexes) {
+    return statement_restrictions(db, std::move(schema), type, where_clause, ctx, selects_only_static_columns, for_view, allow_filtering, do_check_indexes);
+}
+
 } // namespace restrictions
 } // namespace cql3

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -121,6 +121,8 @@ private:
     check_indexes _check_indexes = check_indexes::yes;
     std::vector<const column_definition*> _column_defs_for_filtering;
     schema_ptr _view_schema;
+    std::optional<secondary_index::index> _idx_opt;
+    expr::expression _idx_restrictions = expr::conjunction({});
 public:
     /**
      * Creates a new empty <code>StatementRestrictions</code>.
@@ -260,6 +262,7 @@ public:
 
     schema_ptr get_view_schema() const { return _view_schema; }
 private:
+    std::pair<std::optional<secondary_index::index>, expr::expression> do_find_idx(const secondary_index::secondary_index_manager& sim) const;
     void add_restriction(const expr::binary_operator& restr, schema_ptr schema, bool allow_filtering, bool for_view);
     void add_is_not_restriction(const expr::binary_operator& restr, schema_ptr schema, bool for_view);
     void add_single_column_parition_key_restriction(const expr::binary_operator& restr, schema_ptr schema, bool allow_filtering, bool for_view);

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -132,6 +132,18 @@ public:
      */
     statement_restrictions(schema_ptr schema, bool allow_filtering);
 
+    friend statement_restrictions analyze_statement_restrictions(
+        data_dictionary::database db,
+        schema_ptr schema,
+        statements::statement_type type,
+        const expr::expression& where_clause,
+        prepare_context& ctx,
+        bool selects_only_static_columns,
+        bool for_view,
+        bool allow_filtering,
+        check_indexes do_check_indexes);
+
+private:
     statement_restrictions(data_dictionary::database db,
         schema_ptr schema,
         statements::statement_type type,
@@ -141,6 +153,7 @@ public:
         bool for_view,
         bool allow_filtering,
         check_indexes do_check_indexes);
+public:
 
     const std::vector<expr::expression>& index_restrictions() const;
 
@@ -396,6 +409,18 @@ public:
     /// Checks that the primary key restrictions don't contain null values, throws invalid_request_exception otherwise.
     void validate_primary_key(const query_options& options) const;
 };
+
+statement_restrictions analyze_statement_restrictions(
+        data_dictionary::database db,
+        schema_ptr schema,
+        statements::statement_type type,
+        const expr::expression& where_clause,
+        prepare_context& ctx,
+        bool selects_only_static_columns,
+        bool for_view,
+        bool allow_filtering,
+        check_indexes do_check_indexes);
+
 
 }
 

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -120,6 +120,7 @@ private:
 
     check_indexes _check_indexes = check_indexes::yes;
     std::vector<const column_definition*> _column_defs_for_filtering;
+    schema_ptr _view_schema;
 public:
     /**
      * Creates a new empty <code>StatementRestrictions</code>.
@@ -256,6 +257,8 @@ public:
      * @return the <code>column_definition</code> for the unrestricted column.
      */
     const column_definition& unrestricted_column(column_kind kind) const;
+
+    schema_ptr get_view_schema() const { return _view_schema; }
 private:
     void add_restriction(const expr::binary_operator& restr, schema_ptr schema, bool allow_filtering, bool for_view);
     void add_is_not_restriction(const expr::binary_operator& restr, schema_ptr schema, bool for_view);
@@ -314,7 +317,7 @@ public:
      */
     bool need_filtering() const;
 
-    void validate_secondary_index_selections(bool selects_only_static_columns);
+    void validate_secondary_index_selections(bool selects_only_static_columns) const;
 
     /**
      * Checks if the query has some restrictions on the clustering columns.
@@ -363,6 +366,7 @@ public:
         return _clustering_row_level_filter;
     }
 
+private:
     /// Prepares internal data for evaluating index-table queries.  Must be called before
     /// get_local_index_clustering_ranges().
     void prepare_indexed_local(const schema& idx_tbl_schema);
@@ -371,6 +375,7 @@ public:
     /// get_global_index_clustering_ranges() or get_global_index_token_clustering_ranges().
     void prepare_indexed_global(const schema& idx_tbl_schema);
 
+public:
     /// Calculates clustering ranges for querying a global-index table.
     std::vector<query::clustering_range> get_global_index_clustering_ranges(
             const query_options& options, const schema& idx_tbl_schema) const;

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -415,7 +415,7 @@ void modification_statement::build_cas_result_set_metadata() {
 
 void
 modification_statement::process_where_clause(data_dictionary::database db, expr::expression where_clause, prepare_context& ctx) {
-    _restrictions = restrictions::statement_restrictions(db, s, type, where_clause, ctx,
+    _restrictions = restrictions::analyze_statement_restrictions(db, s, type, where_clause, ctx,
             applies_only_to_static_columns(), _selects_a_collection, false /* allow_filtering */, restrictions::check_indexes::no);
     /*
      * If there's no clustering columns restriction, we may assume that EXISTS

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -982,15 +982,7 @@ indexed_table_select_statement::prepare(data_dictionary::database db,
         throw std::runtime_error("No index found.");
     }
 
-    const auto& im = index_opt->metadata();
-    sstring index_table_name = im.name() + "_index";
-    schema_ptr view_schema = db.find_schema(schema->ks_name(), index_table_name);
-
-    if (im.local()) {
-        restrictions->prepare_indexed_local(*view_schema);
-    } else {
-        restrictions->prepare_indexed_global(*view_schema);
-    }
+    schema_ptr view_schema = restrictions->get_view_schema();
 
     return ::make_shared<cql3::statements::indexed_table_select_statement>(
             schema,

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2164,8 +2164,8 @@ select_statement::prepare_restrictions(data_dictionary::database db,
                                        restrictions::check_indexes do_check_indexes)
 {
     try {
-        return ::make_shared<restrictions::statement_restrictions>(db, schema, statement_type::SELECT, _where_clause, ctx,
-            selection->contains_only_static_columns(), for_view, allow_filtering, do_check_indexes);
+        return ::make_shared<restrictions::statement_restrictions>(restrictions::analyze_statement_restrictions(db, schema, statement_type::SELECT, _where_clause, ctx,
+            selection->contains_only_static_columns(), for_view, allow_filtering, do_check_indexes));
     } catch (const exceptions::unrecognized_entity_exception& e) {
         if (contains_alias(e.entity)) {
             throw exceptions::invalid_request_exception(format("Aliases aren't allowed in the WHERE clause (name: '{}')", e.entity));

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -30,7 +30,7 @@ query::clustering_row_ranges slice(
         const std::vector<expr::expression>& where_clause, cql_test_env& env,
         const sstring& table_name = "t", const sstring& keyspace_name = "ks") {
     prepare_context ctx;
-    return restrictions::statement_restrictions(
+    return restrictions::analyze_statement_restrictions(
             env.data_dictionary(),
             env.local_db().find_schema(keyspace_name, table_name),
             statements::statement_type::SELECT,


### PR DESCRIPTION
The statement_restrictions class started life in the object-oriented style - an
object that interacts with its environment via mutators and is observed via
observers.

This is however not suitable for its objective: to analyze the WHERE clause,
select a query plan, and partition the WHERE clause atoms to the various
parts demanded by the query plan (read_command and filters). Furthermore,
the object oriented style makes it hard to work with as you can only call some
observers after the related mutators were called.

Fix this by transforming the code info a more functional style: we call
a function that returns an immutable statement_restrictions object that
can only be observed. This makes it easier to further change in the future,
as changes will not have to consider interaction with the environment.

No backport as this is a refactoring