### PR TITLE
tablets_allocator: get_viable_targets: allow increasing max_rack_load if all racks are equally loaded

### DIFF
--- a/test.py
+++ b/test.py
@@ -478,7 +478,8 @@ class PythonTestSuite(TestSuite):
                 config_options=config_options,
                 property_file=create_cfg.property_file,
                 append_env=self.base_env,
-                server_encryption=create_cfg.server_encryption)
+                server_encryption=create_cfg.server_encryption,
+                endpoint_snitch=create_cfg.endpoint_snitch)
 
             return server
 

--- a/test/topology_custom/test_snitch_change.py
+++ b/test/topology_custom/test_snitch_change.py
@@ -19,8 +19,8 @@ logger = logging.getLogger(__name__)
 async def test_snitch_change(manager: ManagerClient) -> None:
     """ The test changes snitch from simple to GossipingPropertyFileSnitch one and checks
         that DC and rack names change accordingly"""
-    s1 = await manager.server_add(property_file = {'dc': 'DC1', 'rack' : 'R1'})
-    s2 = await manager.server_add(property_file = {'dc': 'DC1', 'rack' : 'R1'})
+    s1 = await manager.server_add(property_file = {'dc': 'DC1', 'rack' : 'R1'}, endpoint_snitch = "SimpleSnitch")
+    s2 = await manager.server_add(property_file = {'dc': 'DC1', 'rack' : 'R1'}, endpoint_snitch = "SimpleSnitch")
     cql = manager.get_cql()
     res = await cql.run_async(f"SELECT data_center,rack From system.peers")
     assert res[0].data_center == "datacenter1" and res[0].rack == "rack1"


### PR DESCRIPTION
When a rack is decommissioned, allow migrating to other racks
when they have the same load, even though that will increase
the maximum rack load.

Fixes scylladb/scylladb#19475

* Requires backport to 6.2 (since 99d0aaa7d27040541a323501ef4e9d501f72fac7)