### PR TITLE
gms: inet_address: drop unused raw_addr method and modernize comperators

### DIFF
--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -58,10 +58,6 @@ public:
     bytes_view bytes() const noexcept {
         return bytes_view(reinterpret_cast<const int8_t*>(_addr.data()), _addr.size());
     }
-    // TODO remove
-    uint32_t raw_addr() const {
-        return addr().as_ipv4_address().ip;
-    }
     friend inline bool operator==(const inet_address& x, const inet_address& y) noexcept = default;
     friend inline bool operator<(const inet_address& x, const inet_address& y) noexcept {
         return x.bytes() < y.bytes();

--- a/gms/inet_address.hh
+++ b/gms/inet_address.hh
@@ -58,9 +58,9 @@ public:
     bytes_view bytes() const noexcept {
         return bytes_view(reinterpret_cast<const int8_t*>(_addr.data()), _addr.size());
     }
-    friend inline bool operator==(const inet_address& x, const inet_address& y) noexcept = default;
-    friend inline bool operator<(const inet_address& x, const inet_address& y) noexcept {
-        return x.bytes() < y.bytes();
+    constexpr bool operator==(const inet_address&) const noexcept = default;
+    constexpr auto operator<=>(const inet_address& o) const noexcept {
+        return bytes() <=> o.bytes();
     }
     friend struct std::hash<inet_address>;
 


### PR DESCRIPTION
Drop the unused `gms::inet_address::raw_addr` method
and modernize operator== and operator< as class methods 

* Cleanup only, no backport needed