### PR TITLE
treewide: accept list of sstables in "restore" API 

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -847,12 +847,24 @@
                           "paramType":"query"
                       },
                       {
-                          "name":"snapshot",
-                          "description":"Name of a snapshot to copy SSTables from",
+                          "name":"prefix",
+                          "description":"The prefix of the object keys for the backuped SSTables",
                           "required":true,
                           "allowMultiple":false,
                           "type":"string",
                           "paramType":"query"
+                      },
+                      {
+                          "in": "body",
+                          "name": "sstables",
+                          "description": "The list of the object keys of the TOC component of the SSTables to be restored",
+                          "required":true,
+                          "schema" :{
+                              "type": "array",
+                              "items": {
+                                  "type": "string"
+                              }
+                          }
                       },
                       {
                           "name":"keyspace",
@@ -865,7 +877,7 @@
                       {
                           "name":"table",
                           "description":"Name of a table to copy SSTables to",
-                          "required":false,
+                          "required":true,
                           "allowMultiple":false,
                           "type":"string",
                           "paramType":"query"

--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -47,6 +47,8 @@ struct storage_options {
     bool can_update_to(const storage_options& new_options);
 
     static value_type from_map(std::string_view type, std::map<sstring, sstring> values);
+
+    storage_options append_to_s3_prefix(const sstring& s) const;
 };
 
 inline storage_options make_local_options(std::filesystem::path dir) {

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -234,14 +234,16 @@ distributed_loader::get_sstables_from_upload_dir(distributed<replica::database>&
 }
 
 future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
-distributed_loader::get_sstables_from_object_store(distributed<replica::database>& db, sstring ks, sstring cf, sstring endpoint, sstring bucket, sstring prefix, sstables::sstable_open_config cfg) {
-    return get_sstables_from(db, ks, cf, cfg, [bucket, endpoint, prefix] (auto& global_table, auto& directory) {
+distributed_loader::get_sstables_from_object_store(distributed<replica::database>& db, sstring ks, sstring cf, std::vector<sstring> sstables, sstring endpoint, sstring bucket, sstring prefix, sstables::sstable_open_config cfg) {
+    return get_sstables_from(db, ks, cf, cfg, [bucket, endpoint, prefix, sstables=std::move(sstables)] (auto& global_table, auto& directory) {
         return directory.start(global_table.as_sharded_parameter(),
             sharded_parameter([bucket, endpoint, prefix] {
                 data_dictionary::storage_options opts;
                 opts.value = data_dictionary::storage_options::s3{bucket, endpoint, prefix};
                 return make_lw_shared<const data_dictionary::storage_options>(std::move(opts));
-            }), &error_handler_gen_for_upload_dir);
+            }),
+            sstables,
+            &error_handler_gen_for_upload_dir);
     });
 }
 

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -89,7 +89,7 @@ public:
     static future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
             get_sstables_from_upload_dir(distributed<replica::database>& db, sstring ks, sstring cf, sstables::sstable_open_config cfg);
     static future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
-            get_sstables_from_object_store(distributed<replica::database>& db, sstring ks, sstring cf, sstring endpoint, sstring bucket, sstring prefix, sstables::sstable_open_config cfg);
+            get_sstables_from_object_store(distributed<replica::database>& db, sstring ks, sstring cf, std::vector<sstring> sstables, sstring endpoint, sstring bucket, sstring prefix, sstables::sstable_open_config cfg);
     static future<> process_upload_dir(distributed<replica::database>& db, sharded<db::view::view_builder>& vb, sstring ks_name, sstring cf_name);
 };
 

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -183,9 +183,13 @@ private:
 private:
     std::unique_ptr<sstable_directory::components_lister> make_components_lister();
 
-    future<> process_descriptor(sstables::entry_descriptor desc, process_flags flags);
+    future<> process_descriptor(sstables::entry_descriptor desc,
+            process_flags flags,
+            noncopyable_function<data_dictionary::storage_options()>&& get_storage_options);
     void validate(sstables::shared_sstable sst, process_flags flags) const;
-    future<sstables::shared_sstable> load_sstable(sstables::entry_descriptor desc, sstables::sstable_open_config cfg = {}) const;
+    future<sstables::shared_sstable> load_sstable(sstables::entry_descriptor desc,
+            noncopyable_function<data_dictionary::storage_options()>&& get_storage_options,
+            sstables::sstable_open_config cfg = {}) const;
 
     future<> load_foreign_sstables(sstable_entry_descriptor_vector info_vec);
 

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -143,6 +143,15 @@ public:
         virtual future<> prepare(sstable_directory&, process_flags, storage&) override;
     };
 
+    class restore_components_lister final : public components_lister {
+        std::vector<sstring> _toc_filenames;
+    public:
+        restore_components_lister(const data_dictionary::storage_options::value_type& options, std::vector<sstring> toc_filenames);
+        virtual future<> process(sstable_directory& directory, process_flags flags) override;
+        virtual future<> commit() override;
+        virtual future<> prepare(sstable_directory&, process_flags, storage&) override;
+    };
+
 private:
 
     // prevents an object that respects a phaser (usually a table) from disappearing in the middle of the operation.
@@ -205,6 +214,10 @@ public:
             io_error_handler_gen error_handler_gen);
     sstable_directory(replica::table& table,
             lw_shared_ptr<const data_dictionary::storage_options> storage_opts,
+            io_error_handler_gen error_handler_gen);
+    sstable_directory(replica::table& table,
+            lw_shared_ptr<const data_dictionary::storage_options> storage_opts,
+            std::vector<sstring> sstables,
             io_error_handler_gen error_handler_gen);
     sstable_directory(sstables_manager& manager,
             schema_ptr schema,

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <vector>
 #include <seastar/core/sharded.hh>
 #include "schema/schema_fwd.hh"
 #include "sstables/shared_sstable.hh"
@@ -88,7 +89,8 @@ public:
      * Download new SSTables not currently tracked by the system from object store
      */
     future<tasks::task_id> download_new_sstables(sstring ks_name, sstring cf_name,
-            sstring endpoint, sstring bucket, sstring snapshot);
+            sstring prefix, std::vector<sstring> sstables,
+            sstring endpoint, sstring bucket);
 
     class download_task_impl;
 };

--- a/test/object_store/test_backup.py
+++ b/test/object_store/test_backup.py
@@ -153,6 +153,8 @@ async def test_simple_backup_and_restore(manager: ManagerClient, s3_server):
     orig_res = cql.execute(f"SELECT * FROM {ks}.{cf}")
     orig_rows = { x.name: x.value for x in orig_res }
 
+    toc_names = [entry.name for entry in list_sstables() if entry.name.endswith('TOC.txt')]
+
     prefix = f'{cf}/{snap_name}'
     tid = await manager.api.backup(server.ip_addr, ks, cf, snap_name, s3_server.address, s3_server.bucket_name, prefix)
     status = await manager.api.wait_task(server.ip_addr, tid)
@@ -166,7 +168,7 @@ async def test_simple_backup_and_restore(manager: ManagerClient, s3_server):
     assert not res
 
     print(f'Try to restore')
-    tid = await manager.api.restore(server.ip_addr, ks, cf, snap_name, s3_server.address, s3_server.bucket_name)
+    tid = await manager.api.restore(server.ip_addr, ks, cf, s3_server.address, s3_server.bucket_name, prefix, toc_names)
     status = await manager.api.wait_task(server.ip_addr, tid)
     assert (status is not None) and (status['state'] == 'done')
     print(f'Check that sstables came back')

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -317,14 +317,14 @@ class ScyllaRESTAPIClient():
                   "snapshot": tag}
         return await self.client.post_json(f"/storage_service/backup", host=node_ip, params=params)
 
-    async def restore(self, node_ip: str, ks: str, cf: str, tag: str, dest: str, bucket: str) -> str:
+    async def restore(self, node_ip: str, ks: str, cf: str, dest: str, bucket: str, prefix: str, sstables: list[str]) -> str:
         """Restore keyspace:table from backup"""
         params = {"keyspace": ks,
                   "table": cf,
                   "endpoint": dest,
                   "bucket": bucket,
-                  "snapshot": tag}
-        return await self.client.post_json(f"/storage_service/restore", host=node_ip, params=params)
+                  "prefix": prefix}
+        return await self.client.post_json(f"/storage_service/restore", host=node_ip, params=params, json=sstables)
 
     async def take_snapshot(self, node_ip: str, ks: str, tag: str) -> None:
         """Take keyspace snapshot"""


### PR DESCRIPTION
before this change, we enumerate the sstables tracked by the
system.sstables table, and restore them when serving
requests to "storage_service/restore" API. this works fine with
"storage_service/backup" API. but this "restore" API cannot be
used as a drop-in replacement of the rclone based API currently
used by scylla-manager.

in order to fill the gap, in this change:

* add the "prefix" parameter for specifying the shared prefix of
  sstables
* add the "sstables" parameter for specifying the list of  TOC
  components of sstables
* remove the "snapshot" parameter, as we don't encode the prefix
  on scylla's end anymore.
* make the "table" parameter mandatory.

Fixes https://github.com/scylladb/scylladb/issues/20461

----

this change is a part of the efforts to bring the native backup/restore to scylla, no need to backprt.