### PR TITLE
materialized view: make flow-control maximum delay configurable

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1179,6 +1179,11 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , error_injections_at_startup(this, "error_injections_at_startup", error_injection_value_status, {}, "List of error injections that should be enabled on startup.")
     , topology_barrier_stall_detector_threshold_seconds(this, "topology_barrier_stall_detector_threshold_seconds", value_status::Used, 2, "Report sites blocking topology barrier if it takes longer than this.")
     , enable_tablets(this, "enable_tablets", value_status::Used, false, "Enable tablets for newly created keyspaces.")
+    , view_flow_control_delay_limit_in_ms(this, "view_flow_control_delay_limit_in_ms", liveness::LiveUpdate, value_status::Used, 1000,
+        "The maximal amount of that materialized-view update flow control may delay responses "
+        "to try to slow down the client and prevent buildup of unfinished view updates. "
+        "To be effective, this maximal delay should be larger than the typical latencies. "
+        "Setting view_flow_control_delay_limit_in_ms to 0 disables view-update flow control.")
     , default_log_level(this, "default_log_level", value_status::Used, seastar::log_level::info, "Default log level for log messages")
     , logger_log_level(this, "logger_log_level", value_status::Used, {}, "Map of logger name to log level. Valid log levels are 'error', 'warn', 'info', 'debug' and 'trace'")
     , log_to_stdout(this, "log_to_stdout", value_status::Used, true, "Send log output to stdout")

--- a/db/config.hh
+++ b/db/config.hh
@@ -496,6 +496,7 @@ public:
     named_value<std::vector<error_injection_at_startup>> error_injections_at_startup;
     named_value<double> topology_barrier_stall_detector_threshold_seconds;
     named_value<bool> enable_tablets;
+    named_value<uint32_t> view_flow_control_delay_limit_in_ms;
 
     static const sstring default_tls_priority;
 private:

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -3284,12 +3284,12 @@ void delete_ghost_rows_visitor::accept_new_row(const clustering_key& ck, const q
 }
 
 std::chrono::microseconds calculate_view_update_throttling_delay(db::view::update_backlog backlog,
-                                                                 db::timeout_clock::time_point timeout) {
-    constexpr auto delay_limit_us = 1000000;
+                                                                 db::timeout_clock::time_point timeout,
+                                                                 uint32_t view_flow_control_delay_limit_in_ms) {
     auto adjust = [] (float x) { return x * x * x; };
     auto budget = std::max(service::storage_proxy::clock_type::duration(0),
         timeout - service::storage_proxy::clock_type::now());
-    std::chrono::microseconds ret(uint32_t(adjust(backlog.relative_size()) * delay_limit_us));
+    std::chrono::microseconds ret(uint32_t(adjust(backlog.relative_size()) * view_flow_control_delay_limit_in_ms * 1000));
     // "budget" has millisecond resolution and can potentially be long
     // in the future so converting it to microseconds may overflow.
     // So to compare buget and ret we need to convert both to the lower

--- a/db/view/view_update_backlog.hh
+++ b/db/view/view_update_backlog.hh
@@ -82,5 +82,6 @@ public:
 // See: https://www.scylladb.com/2018/12/04/worry-free-ingestion-flow-control/
 std::chrono::microseconds calculate_view_update_throttling_delay(
     update_backlog backlog,
-    db::timeout_clock::time_point timeout);
+    db::timeout_clock::time_point timeout,
+    uint32_t view_flow_control_delay_limit_in_ms);
 }

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -22,6 +22,7 @@
 #include "utils/pretty_printers.hh"
 #include "readers/from_mutations_v2.hh"
 #include "service/storage_proxy.hh"
+#include "db/config.hh"
 
 static logging::logger vug_logger("view_update_generator");
 
@@ -450,7 +451,7 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
         // the one which limits the number of incoming client requests by delaying the response to the client.
         if (batch_num > 0) {
             update_backlog local_backlog = _db.get_view_update_backlog();
-            std::chrono::microseconds throttle_delay =  calculate_view_update_throttling_delay(local_backlog, timeout);
+            std::chrono::microseconds throttle_delay =  calculate_view_update_throttling_delay(local_backlog, timeout, _db.get_config().view_flow_control_delay_limit_in_ms());
 
             co_await seastar::sleep(throttle_delay);
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1599,7 +1599,7 @@ public:
     template<typename Func>
     void delay(tracing::trace_state_ptr trace, Func&& on_resume) {
         auto backlog = max_backlog();
-        auto delay = db::view::calculate_view_update_throttling_delay(backlog, _expire_timer.get_timeout());
+        auto delay = db::view::calculate_view_update_throttling_delay(backlog, _expire_timer.get_timeout(), _proxy->data_dictionary().get_config().view_flow_control_delay_limit_in_ms());
         stats().last_mv_flow_control_delay = delay;
         stats().mv_flow_control_delay += delay.count();
         if (delay.count() == 0) {


### PR DESCRIPTION
Until this patch, the materialized view flow-control algorithm (https://www.scylladb.com/2018/12/04/worry-free-ingestion-flow-control/) used a constant delay_limit_us hard-coded to one second, which means that when the size of view-update backlog reached the maximum (10% of memory), we delay every request by an additional second - while smaller amounts of backlog will result in smaller delays.

This hard-coded one maximum second delay was considered *huge* - it will slow down a client with concurrency 1000 to just 1000 requests per second - but we already saw some workloads where it was not enough - such as a test workload running very slow reads at high concurrency on a slow machine, where a latency of over one second was expected for each read, so adding a one second latecy for writes wasn't having any noticable affect on slowing down the client.

So this patch replaces the hard-coded default with a live-updateable configuration parameter, `view_flow_control_delay_limit_in_ms`, which defaults to 1000ms as before.

Another useful way in which the new `view_flow_control_delay_limit_in_ms` can be used is to set it to 0. In that case, the view-update flow control always adds zero delay, and in effect - does absolutely nothing. This setting can be used in emergency situations where it is suspected that the MV flow control is not behaving properly, and the user wants to disable it.

The new parameter's help string mentions both these use cases of the parameter.

Fixes #18187

**Please replace this line with justification for the backport/\* labels added to this PR**