### PR TITLE
database: Also forced new schema commitlog segment on user initiated memtable flush

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2271,6 +2271,13 @@ future<> database::flush_table_on_all_shards(sharded<database>& sharded_db, std:
     return flush_table_on_all_shards(sharded_db, sharded_db.local().find_uuid(ks_name, table_name));
 }
 
+static future<> force_new_commitlog_segments(std::unique_ptr<db::commitlog>& cl1, std::unique_ptr<db::commitlog>& cl2) {
+    co_await cl1->force_new_active_segment();
+    if (cl2) {
+        co_await cl2->force_new_active_segment();
+    }
+}
+
 future<> database::flush_tables_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name, std::vector<sstring> table_names) {
     /**
      * #14870 
@@ -2281,7 +2288,7 @@ future<> database::flush_tables_on_all_shards(sharded<database>& sharded_db, std
      * as sstable-ish a universe as we can, as soon as we can.
     */
     return sharded_db.invoke_on_all([] (replica::database& db) {
-        return db._commitlog->force_new_active_segment();
+        return force_new_commitlog_segments(db._commitlog, db._schema_commitlog);
     }).then([&, ks_name, table_names = std::move(table_names)] {
         return parallel_for_each(table_names, [&, ks_name] (const auto& table_name) {
             return flush_table_on_all_shards(sharded_db, ks_name, table_name);
@@ -2292,7 +2299,7 @@ future<> database::flush_tables_on_all_shards(sharded<database>& sharded_db, std
 future<> database::flush_keyspace_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name) {
     // see above
     return sharded_db.invoke_on_all([] (replica::database& db) {
-        return db._commitlog->force_new_active_segment();
+        return force_new_commitlog_segments(db._commitlog, db._schema_commitlog);
     }).then([&, ks_name] {
         auto& ks = sharded_db.local().find_keyspace(ks_name);
         return parallel_for_each(ks.metadata()->cf_meta_data(), [&] (auto& pair) {


### PR DESCRIPTION
Refs #20686
Refs #15607

In #15060 we added forced new commitlog segment on user initated flush, mainly so that tests can verify tombstone gc and other compaction related things, without having to wait for "organic" segment deletion. Schema commitlog was not included, mainly because we did not have tests featuring compaction checks of schema related tables, but also because it was assumed to be lower general througput.
There is however no real reason to not include it, and it will make some testing much quicker and more predictable.

