### PR TITLE
cql3: respect the user-defined page size in aggregate queries

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -421,7 +421,7 @@ select_statement::do_execute(query_processor& qp,
     const bool aggregate = _selection->is_aggregate() || has_group_by();
     const bool nonpaged_filtering = _restrictions_need_filtering && page_size <= 0;
     if (aggregate || nonpaged_filtering) {
-        page_size = page_size <= 0 ? internal_paging_size : std::min(page_size, internal_paging_size);
+        page_size = page_size <= 0 ? internal_paging_size : page_size;
     }
 
     auto key_ranges = _restrictions->get_partition_key_ranges(options);


### PR DESCRIPTION
This change allows the user to fully set the page size for the query. There's still an internal hard-limit of 1MB anyway, so there's no need to limit it to our default value (because using a larger page size might be a query optimization sometimes)

Fixes #20612

There's no need for backports, as it's a quality of life improvement and not a regression (or, it's a regression introduced in 2018, as per #20612 )