### PR TITLE
test: btree: use BOOST_DATA_TEST_CASE() when appropriate

### DIFF
--- a/test/boost/btree_test.cc
+++ b/test/boost/btree_test.cc
@@ -185,7 +185,8 @@ BOOST_AUTO_TEST_CASE(test_find_all) {
     t.clear_and_dispose(key_deleter);
 }
 
-static void test_lower_bound_sz(int nkeys) {
+BOOST_DATA_TEST_CASE(test_lower_bound_sz,
+                     boost::unit_test::data::make({1, 3, 16}), nkeys) {
     test_tree t;
 
     for (int i = 0; i < nkeys; i++) {
@@ -222,12 +223,6 @@ static void test_lower_bound_sz(int nkeys) {
             BOOST_REQUIRE(!match && *it == i);
         }
     }
-}
-
-BOOST_AUTO_TEST_CASE(test_lower_bound_all) {
-    test_lower_bound_sz(1);
-    test_lower_bound_sz(3);
-    test_lower_bound_sz(16);
 }
 
 BOOST_AUTO_TEST_CASE(test_upper_bound_all) {


### PR DESCRIPTION
instead grouping tests with different parameters, let's parameterize them using `BOOST_DATA_TEST_CASE()`, simpler this way. and the tests can be more structured.

---

it's a cleanup, hence no need to backport.