### PR TITLE
reader_concurrency_semaphore: in stats, fix swapped count_resources and memory_resources

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1407,7 +1407,7 @@ reader_concurrency_semaphore::can_admit_read(const reader_permit::impl& permit) 
     }
 
     if (!has_available_units(permit.base_resources())) {
-        auto reason = _resources.memory >= permit.base_resources().memory ? reason::memory_resources : reason::count_resources;
+        auto reason = _resources.memory >= permit.base_resources().memory ? reason::count_resources : reason::memory_resources;
         if (_inactive_reads.empty()) {
             return {can_admit::no, reason};
         } else {


### PR DESCRIPTION
can_admit_read() returns reason::memory_resources when the permit is queued due to lack of count resources, and it returns reason::count_resources when the permit is queued due to lack of memory resources. It's supposed to be the other way around.

This bug is causing the two counts to be swapped in the stat dumps printed to the logs when semaphores time out.

This is a bug, so it should be backported to all affected releases.