### PR TITLE
compaction: make drain wait for compactions to stop during shutdown

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -448,6 +448,13 @@ future<> compaction_task_executor::update_history(table_state& t, const sstables
         // cannot be accessed until we make combined_reader more generic,
         // for example, by adding a reducer method.
         auto sys_ks = _cm._sys_ks; // hold pointer on sys_ks
+
+        co_await utils::get_local_injector().inject("update_history_wait", [](auto& handler) -> future<> {
+            cmlog.info("update_history_wait: waiting");
+            co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::seconds{120});
+            cmlog.info("update_history_wait: released");
+        });
+
         co_await sys_ks->update_compaction_history(cdata.compaction_uuid, t.schema()->ks_name(), t.schema()->cf_name(),
                 ended_at.count(), res.stats.start_size, res.stats.end_size, std::unordered_map<int32_t, int64_t>{});
     }
@@ -1097,10 +1104,13 @@ future<> compaction_manager::stop_ongoing_compactions(sstring reason, table_stat
 
 future<> compaction_manager::drain() {
     cmlog.info("Asked to drain");
-    if (*_early_abort_subscription) {
+    if (_state == state::enabled) {
+        // This is a drain request and not a shutdown request.
+        // Disable the state so that it can be enabled later if requested.
         _state = state::disabled;
-        co_await stop_ongoing_compactions("drain");
     }
+    // Stop ongoing compactions, if the request has not been sent already and wait for them to stop.
+    co_await stop_ongoing_compactions("drain");
     cmlog.info("Drained");
 }
 


### PR DESCRIPTION
During shutdown, the compaction_manager starts stopping ongoing compaction tasks through `really_do_stop()` method as soon as it receives a signal from the abort source. Later, when the database object shuts down, it calls `compaction_manager::drain` to ensure that all compaction tasks have stopped. However, `compaction_manager::drain` is currently implemented in such a way that, during shutdown, it effectively becomes a no-op because the compaction_manager has already initiated the stopping of tasks. As a result the caller assumes that all the compaction tasks have stopped and proceeds to close all the tables. This can lead to race conditions where table closures overlap with compaction tasks that are still running, resulting in exceptions like :

```
exception during mutation write to 127.0.0.1:
utils::internal::nested_exception<std::runtime_error> (Could not write
mutation system:compaction_history
(pk{0010b70d31705e0411efb2edf6467f094c8b}) to commitlog):
seastar::gate_closed_exception (gate closed)
```

This commit fixes the issue by updating `compaction_manager::drain` to invoke `stop_ongoing_compactions` even during shutdown to ensure that it waits for the ongoing compaction tasks to complete. The `stop_ongoing_compactions` method will also send a stop request to these tasks before waiting, but the request will be ignored by the tasks as they would have already received one earlier from `really_do_stop()`.

Fixes #20197

Fixes a benign exception that occurs during shutdown. No backport needed.