### PR TITLE
repair: disable the multishard reader's read-ahead

### DIFF
--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -1051,7 +1051,7 @@ future<> multishard_combining_reader_v2::handle_empty_reader_buffer() {
         // If we crossed shards and the next reader has an empty buffer we
         // double concurrency so the next time we cross shards we will have
         // more chances of hitting the reader's buffer.
-        if (_crossed_shards) {
+        if (_crossed_shards && _read_ahead == read_ahead::yes) {
             _concurrency = std::min(_concurrency * 2, _sharder.shard_count());
 
             // Read ahead shouldn't change the min selection heap so we work on a local copy.

--- a/readers/multishard.hh
+++ b/readers/multishard.hh
@@ -103,6 +103,8 @@ public:
             tracing::trace_state_ptr trace_ptr) = 0;
 };
 
+using read_ahead = bool_class<struct read_ahead_tag>;
+
 /// Make a multishard_combining_reader.
 ///
 /// multishard_combining_reader takes care of reading a range from all shards
@@ -117,8 +119,9 @@ public:
 /// has to move between shards often. When concurrency is > 1, the reader
 /// issues background read-aheads to the next shards so that by the time it
 /// needs to move to them they have the data ready.
-/// For dense tables (where we rarely cross shards) we rely on the
-/// foreign_reader to issue sufficient read-aheads on its own to avoid blocking.
+/// Read-ahead can be disabled to reduce the multishard reader's footprint.
+/// Useful when the reader operates in the context of a possibly congested
+/// semaphore, and the avoidance of evictions is more important than low latencies.
 ///
 /// The readers' life-cycles are managed through the supplied lifecycle policy.
 mutation_reader make_multishard_combining_reader_v2(
@@ -129,7 +132,8 @@ mutation_reader make_multishard_combining_reader_v2(
         const dht::partition_range& pr,
         const query::partition_slice& ps,
         tracing::trace_state_ptr trace_state = nullptr,
-        mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::no);
+        mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::no,
+        read_ahead ra = read_ahead::yes);
 
 mutation_reader make_multishard_combining_reader_v2_for_tests(
         const dht::sharder& sharder,

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2912,7 +2912,7 @@ mutation_reader make_multishard_streaming_reader(distributed<replica::database>&
             mutation_reader::forwarding fwd_mr) {
         auto table_id = s->id();
         return make_multishard_combining_reader_v2(seastar::make_shared<streaming_reader_lifecycle_policy>(db, table_id, compaction_time),
-                std::move(s), erm, std::move(permit), pr, ps, std::move(trace_state), fwd_mr);
+                std::move(s), erm, std::move(permit), pr, ps, std::move(trace_state), fwd_mr, read_ahead::no);
     });
     auto&& full_slice = schema->full_slice();
     return make_flat_multi_range_reader(schema, std::move(permit), std::move(ms),
@@ -2931,7 +2931,10 @@ mutation_reader make_multishard_streaming_reader(distributed<replica::database>&
         std::move(erm),
         std::move(permit),
         range,
-        full_slice);
+        full_slice,
+        {},
+        mutation_reader::forwarding::no,
+        read_ahead::no);
 }
 
 auto fmt::formatter<gc_clock::time_point>::format(gc_clock::time_point tp, fmt::format_context& ctx) const


### PR DESCRIPTION
The multishard reader employs read-ahead to reduce the amount of times its consumer is blocked due to the multishard reader having to create a new reader on the next shard. For this reason, the multishard reader will kick-off new read-aheads on the next shards, with increasing concurrency, every time it hits such a cold shard.
This was designed to reduce the latency of range scans. But in the case of repair, read-ahead is suspected to contribute significant extra load on the congested streaming semaphore and thus contribute to the subsequent trashing (excessive reader eviction).
First off, read-ahead was designed with pages of limited size in mind. Repair can read much more, even for a single repair buffer. This can lead to read-ahead concurrency to continue ramping up, creating and using more and more readers.
Secondly, repair is not latency sensitive, so even when working well and there is no congestion, the benefits are negligible.

Refs: https://github.com/scylladb/scylladb/issues/18269

This can improve mixed-shard repairs significantly, so we should backport to all live releases.