### PR TITLE
config: do not provide default value for set_value() and friends

### DIFF
--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -149,9 +149,9 @@ public:
         bool matches(std::string_view name) const;
         virtual void add_command_line_option(bpo::options_description_easy_init&) = 0;
         virtual void set_value(const YAML::Node&) = 0;
-        virtual bool set_value(sstring, config_source = config_source::Internal) = 0;
+        virtual bool set_value(sstring, config_source) = 0;
         virtual future<> set_value_on_all_shards(const YAML::Node&) = 0;
-        virtual future<bool> set_value_on_all_shards(sstring, config_source = config_source::Internal) = 0;
+        virtual future<bool> set_value_on_all_shards(sstring, config_source) = 0;
         virtual value_status status() const noexcept = 0;
         virtual config_source source() const noexcept = 0;
         sstring source_name() const noexcept;
@@ -258,12 +258,12 @@ public:
 
         void add_command_line_option(bpo::options_description_easy_init&) override;
         void set_value(const YAML::Node&) override;
-        bool set_value(sstring, config_source = config_source::Internal) override;
+        bool set_value(sstring, config_source) override;
         // For setting a single value on all shards,
         // without having to call broadcast_to_all_shards
         // that broadcasts all values to all shards.
         future<> set_value_on_all_shards(const YAML::Node&) override;
-        future<bool> set_value_on_all_shards(sstring, config_source = config_source::Internal) override;
+        future<bool> set_value_on_all_shards(sstring, config_source) override;
     };
 
     typedef std::reference_wrapper<config_src> cfg_ref;


### PR DESCRIPTION
before this change, `config_file::set_value()` and `config_file::set_value_on_all_shards()` provide default value for `config_source`. but the default value is never used -- we alway specify the `source_source` when calling `set_value_on_all_shards()`.

so in hope to improve the readability, the default value is removed. so, for example, one can figure out when `config_source::Internal` is used with less efforts. despite that `config_file::set_value()` is not used in the tree. for the sake of completeness, its default value is also dropped.

---

it's a cleanup, hence no need to backport.