### PR TITLE
test/pylib: scylla_cluster: set endpoint_snitch in scylla conf

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -299,6 +299,9 @@ class ScyllaServer:
         self.resources_certificate_file = self.resourcesdir / "scylla.crt"
         self.resources_keyfile_file = self.resourcesdir / "scylla.key"
 
+        if property_file and not "endpoint_snitch" in config_options:
+            config_options["endpoint_snitch"] = "GossipingPropertyFileSnitch"
+
         # Sum of basic server configuration and the user-provided config options.
         self.config = make_scylla_conf(
                 mode = mode,
@@ -788,7 +791,7 @@ class ScyllaCluster:
         cluster_name: str
         ip_addr: IPAddress
         seeds: List[str]
-        property_file: dict[str, Any]
+        property_file: dict[str, Any] | None
         config_from_test: dict[str, Any]
         cmdline_from_test: List[str]
         server_encryption: str

--- a/test/topology_custom/test_snitch_change.py
+++ b/test/topology_custom/test_snitch_change.py
@@ -19,8 +19,8 @@ logger = logging.getLogger(__name__)
 async def test_snitch_change(manager: ManagerClient) -> None:
     """ The test changes snitch from simple to GossipingPropertyFileSnitch one and checks
         that DC and rack names change accordingly"""
-    s1 = await manager.server_add(property_file = {'dc': 'DC1', 'rack' : 'R1'})
-    s2 = await manager.server_add(property_file = {'dc': 'DC1', 'rack' : 'R1'})
+    s1 = await manager.server_add(config = {"endpoint_snitch": "SimpleSnitch"}, property_file = {'dc': 'DC1', 'rack' : 'R1'})
+    s2 = await manager.server_add(config = {"endpoint_snitch": "SimpleSnitch"}, property_file = {'dc': 'DC1', 'rack' : 'R1'})
     cql = manager.get_cql()
     res = await cql.run_async(f"SELECT data_center,rack From system.peers")
     assert res[0].data_center == "datacenter1" and res[0].rack == "rack1"


### PR DESCRIPTION
When `property_file` is provided, we generate a
`cassandra-rackdc.properties` file, but to actually use it, `endpoint_snitch` must be set to `GossipingPropertyFileSnitch`.

* No backport required at this point
