### PR TITLE
configure.py: deduplicate --out-final-name arg added in build.ninja

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -21,7 +21,7 @@ from shutil import which
 from typing import NamedTuple
 
 
-configure_args = str.join(' ', [shlex.quote(x) for x in sys.argv[1:] if not x.startswith('--out=')])
+configure_args = str.join(' ', [shlex.quote(x) for x in sys.argv[1:] if not x.startswith('--out=') and not x.startswith('--out-final-name=')])
 
 # distribution "internationalization", converting package names.
 # Fedora name is key, values is distro -> package name dict.


### PR DESCRIPTION
Every time the ninja buildfile decides it needs to be updates, it calls the configure.py script with roughly the same set of flags. However, the --out-final-name flag is improperly handled and, on each reconfigure, one more --out-final-name flag is appended to the rebuild command. This is harmless because each instance of the flag will specify the same parameter, but slightly annoying because it bloats the generated file and the duplicated flags show up in ninja's output when reconfigure runs.

Fix the problem by stripping the --out-final-name flags from the set of the flags passed to the configure.py before forwarding them to the reconfigure rule.

No need to backport. It's a slightly annoying but harmless bug that only affects the developer experience and not the behavior of Scylla itself.