### PR TITLE
build: cmake: drop scylla-jmx from the build

### DIFF
--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -110,8 +110,6 @@ set(dist_pkgs
 dist_submodule(cqlsh cqlsh dist_pkgs)
 dist_submodule(tools java dist_pkgs
   NOARCH)
-dist_submodule(jmx jmx dist_pkgs
-  NOARCH)
 dist_submodule(python3 python3 dist_pkgs)
 set(unified_dist_pkg
   "${CMAKE_BINARY_DIR}/$<CONFIG>/dist/tar/${Scylla_PRODUCT}-unified-${Scylla_VERSION}-${Scylla_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}.tar.gz")
@@ -134,7 +132,6 @@ add_custom_target(dist)
 add_dependencies(dist
   dist-cqlsh
   dist-tools
-  dist-jmx
   dist-python3
   dist-server)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -26,8 +26,6 @@ include(build_submodule)
 build_submodule(cqlsh cqlsh)
 build_submodule(tools java
   NOARCH)
-build_submodule(jmx jmx
-  NOARCH)
 
 execute_process(
   COMMAND "${CMAKE_SOURCE_DIR}/install-dependencies.sh" --print-python3-runtime-packages

--- a/tools/testing/dist-check/CMakeLists.txt
+++ b/tools/testing/dist-check/CMakeLists.txt
@@ -13,6 +13,5 @@ add_custom_target(dist-check
 add_dependencies(dist-check
   dist-server-rpm
   dist-python3-rpm
-  dist-jmx-rpm
   dist-tools-rpm
   dist-cqlsh-rpm)


### PR DESCRIPTION
in 3cd2a6173668c5a13b6e674f912ff597f76422f5, we dropped scylla-jmx from the build. but didn't update the CMake building system accordingly, this broke the CMake build, as the dependencies pointing to jmx cannot be found or fulfilled.

in this change, we remove all references to jmx in the CMake build.

---

no need to backport, as CMake is not used in any of the LTS branches.