### PR TITLE
unified: drop scylla-tools from unified package

### DIFF
--- a/unified/build_unified.sh
+++ b/unified/build_unified.sh
@@ -63,7 +63,7 @@ if [ -z "$UNIFIED_PKG" ]; then
 fi
 UNIFIED_PKG="$(realpath -s $UNIFIED_PKG)"
 if [ -z "$PKGS" ]; then
-    PKGS="$BUILD_DIR/dist/tar/$PRODUCT-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-python3-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-tools-$VERSION-$RELEASE.noarch.tar.gz $BUILD_DIR/dist/tar/$PRODUCT-cqlsh-$VERSION-$RELEASE.$(arch).tar.gz"
+    PKGS="$BUILD_DIR/dist/tar/$PRODUCT-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-python3-$VERSION-$RELEASE.$(arch).tar.gz $BUILD_DIR/dist/tar/$PRODUCT-cqlsh-$VERSION-$RELEASE.$(arch).tar.gz"
 fi
 BASEDIR="$BUILD_DIR/unified/$PRODUCT-$VERSION"
 

--- a/unified/install.sh
+++ b/unified/install.sh
@@ -160,8 +160,6 @@ fi
 
 (cd $(readlink -f scylla-python3); ./install.sh --root "$root" --prefix "$prefix" ${args[@]})
 
-(cd $(readlink -f scylla-tools); ./install.sh --root "$root" --prefix "$prefix" ${args[@]})
-
 (cd $(readlink -f scylla-cqlsh); ./install.sh --root "$root" --prefix "$prefix" ${args[@]})
 
 install -m755 uninstall.sh -Dt "$rprefix"


### PR DESCRIPTION
On b8634fb, we dropped scylla-tools from rpm and deb, we should drop it from unified package as well.

Closes #20739