### PR TITLE
test: skip test_lwt_semaphore::test_cas_semaphore in aarch64 debug mode

### DIFF
--- a/test/topology_custom/test_lwt_semaphore.py
+++ b/test/topology_custom/test_lwt_semaphore.py
@@ -10,8 +10,10 @@ from test.pylib.rest_client import inject_error
 from test.pylib.util import wait_for_cql_and_get_hosts
 import pytest
 from cassandra.protocol import WriteTimeout
+from test.topology.conftest import skip_mode
 
 @pytest.mark.asyncio
+@skip_mode('debug', 'aarch64/debug is unpredictably slow', platform_key='aarch64')
 async def test_cas_semaphore(manager):
     """ This is a regression test for scylladb/scylladb#19698 """
     servers = await manager.servers_add(1, cmdline=['--smp', '1', '--write-request-timeout-in-ms', '500'])


### PR DESCRIPTION
The test configures write timeout to much smaller value to make the test run faster since for some writes sleep is inserted to hit the timeout, but it makes aarch64 debug flaky since timeout happens when it should not because of a natural slowness.

Fixes scylladb/scylladb#20515

Backport because the patch is safe and will make CI for affected branches less flaky.