### PR TITLE
test/scylla_gdb: get table::_schema raw pointer with lw_shared_ptr

### DIFF
--- a/test/scylla_gdb/suite.yaml
+++ b/test/scylla_gdb/suite.yaml
@@ -1,5 +1,3 @@
 type: Run
-disable: # https://github.com/scylladb/scylladb/issues/20741
-    - run
 run_in_release:
     - run

--- a/test/scylla_gdb/test_misc.py
+++ b/test/scylla_gdb/test_misc.py
@@ -123,8 +123,8 @@ def test_timers(gdb):
 def schema(gdb, scylla_gdb):
     db = scylla_gdb.sharded(gdb.parse_and_eval('::debug::the_database')).local()
     table = next(scylla_gdb.for_each_table(db))
-    gdb.set_convenience_variable('schema', 
-        table['_schema']['_p'].reinterpret_cast(gdb.lookup_type('schema').pointer()))
+    gdb.set_convenience_variable('schema',
+        scylla_gdb.seastar_lw_shared_ptr(table['_schema']).get())
     yield '$schema'
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This commit addresses an issue where accessing the raw pointer of the schema instance within `table::_schema` using `table.schema._p` was unreliable.

before this change, `_p` was of type `lw_shared_ptr_counter_base*`, a type-erased smart pointer, preventing direct casting to the underlying schema pointer. but we still cast it to `schema*` anyway. this led to a gdb.MemoryError when dereferencing the deduced pointer: but the type of `_p` is `lw_shared_ptr_counter_base*`, which is a type erased smart pointer, and it cannot be casted directly to the under pointer pointing to a `schema` instance. this results in:

```
Traceback (most recent call last):
  File "/home/avi/scylla/test/scylla_gdb/../../scylla-gdb.py", line 5554, in invoke
    self.print_key_type(seastar_lw_shared_ptr(schema['_clustering_key_type']).get().dereference(), 'clustering')
  File "/home/avi/scylla/test/scylla_gdb/../../scylla-gdb.py", line 5533, in print_key_type
    key_type = seastar_shared_ptr(key_type).get().dereference()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gdb.MemoryError: Cannot access memory at address 0x4000079656b0078
```

when we are dereferencing the raw pointer deduced this way.

in this change

* we use the wrapper of `seastar_lw_shared_ptr` to safely obtain the raw pointer.
* reenable this test previously disabled by 3d781c4f

tested using
```console
$ SCYLLA=/home/kefu/dev/scylladb/master/build/release/scylla \
  test/scylla_gdb/run -o junit_suite_name=scylla_gdb test_misc.py::test_schema
```

on an up-to-date fedora 40 installation.

Fixes scylladb/scylladb#20741
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

no need to backport, as this change corrects a bug in the testing harness. no impact to the production.