### PR TITLE
test_tablets: add rack decommission test cases

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1601,7 +1601,7 @@ public:
                 if (skip) {
                     if (src_node_info.drained && skip->viable_targets.empty()) {
                         auto replicas = tmap.get_tablet_info(source_tablet.tablet).replicas;
-                        throw std::runtime_error(fmt::format("Unable to find new replica for tablet {} on {} when draining {} (nodes {}, replicas {})",
+                        throw std::runtime_error(fmt::format("Unable to find new replica for tablet {} on {} when draining {}. Consider adding new nodes or reducing replication factor. (nodes {}, replicas {})",
                                                         source_tablet, src, nodes_to_drain, nodes_by_load_dst, replicas));
                     }
                     src_node_info.skipped_candidates.emplace_back(src, source_tablet, std::move(skip->viable_targets));

--- a/test/auth_cluster/test_auth_no_quorum.py
+++ b/test/auth_cluster/test_auth_no_quorum.py
@@ -6,7 +6,6 @@
 
 import asyncio
 import time
-from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 import pytest
 from cassandra.auth import PlainTextAuthProvider

--- a/test/auth_cluster/test_auth_v2_migration.py
+++ b/test/auth_cluster/test_auth_v2_migration.py
@@ -9,7 +9,6 @@ import logging
 import pytest
 import time
 
-from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import get_host_api_address, read_barrier
 from test.pylib.util import wait_for_cql_and_get_hosts, unique_name

--- a/test/auth_cluster/test_raft_service_levels.py
+++ b/test/auth_cluster/test_raft_service_levels.py
@@ -10,7 +10,6 @@ import logging
 from test.pylib.rest_client import get_host_api_address, read_barrier
 from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
 from test.pylib.manager_client import ManagerClient
-from test.pylib.internal_types import ServerInfo
 from test.topology.util import trigger_snapshot, wait_until_topology_upgrade_finishes, enter_recovery_state, reconnect_driver, \
         delete_raft_topology_state, delete_raft_data_and_upgrade_state, wait_until_upgrade_finishes
 from test.topology.conftest import skip_mode

--- a/test/pylib/internal_types.py
+++ b/test/pylib/internal_types.py
@@ -20,9 +20,14 @@ class ServerInfo(NamedTuple):
     server_id: ServerNum
     ip_addr: IPAddress
     rpc_address: IPAddress
+    datacenter: str
+    rack: str
 
     def __str__(self):
-        return f"Server({self.server_id}, {self.ip_addr}, {self.rpc_address})"
+        return f"Server({self.server_id}, {self.ip_addr}, {self.rpc_address}, {self.datacenter}, {self.rack})"
+    
+    def as_dict(self) -> dict[str, object]:
+        return {"server_id": self.server_id, "ip_addr": self.ip_addr, "rpc_address": self.rpc_address, "datacenter": self.datacenter, "rack": self.rack}
 
 
 class ServerUpState(Enum):

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -189,7 +189,7 @@ class ManagerClient():
         except RuntimeError as exc:
             raise Exception("Failed to get list of running servers") from exc
         assert isinstance(server_info_list, list), "running_servers got unknown data type"
-        return [ServerInfo(ServerNum(int(info[0])), IPAddress(info[1]), IPAddress(info[2]))
+        return [ServerInfo(ServerNum(int(info[0])), IPAddress(info[1]), IPAddress(info[2]), info[3], info[4])
                 for info in server_info_list]
 
     async def all_servers(self) -> list[ServerInfo]:
@@ -199,7 +199,7 @@ class ManagerClient():
         except RuntimeError as exc:
             raise Exception("Failed to get list of servers") from exc
         assert isinstance(server_info_list, list), "all_servers got unknown data type"
-        return [ServerInfo(ServerNum(int(info[0])), IPAddress(info[1]), IPAddress(info[2]))
+        return [ServerInfo(ServerNum(int(info[0])), IPAddress(info[1]), IPAddress(info[2]), info[3], info[4])
                 for info in server_info_list]
 
     async def mark_dirty(self) -> None:
@@ -355,7 +355,9 @@ class ManagerClient():
         try:
             s_info = ServerInfo(ServerNum(int(server_info["server_id"])),
                                 IPAddress(server_info["ip_addr"]),
-                                IPAddress(server_info["rpc_address"]))
+                                IPAddress(server_info["rpc_address"]),
+                                server_info["datacenter"],
+                                server_info["rack"])
         except Exception as exc:
             raise RuntimeError(f"server_add got invalid server data {server_info}") from exc
         logger.debug("ManagerClient added %s", s_info)
@@ -396,7 +398,9 @@ class ManagerClient():
             try:
                 s_info = ServerInfo(ServerNum(int(server_info["server_id"])),
                                     IPAddress(server_info["ip_addr"]),
-                                    IPAddress(server_info["rpc_address"]))
+                                    IPAddress(server_info["rpc_address"]),
+                                    server_info["datacenter"],
+                                    server_info["rack"])
                 s_infos.append(s_info)
             except Exception as exc:
                 raise RuntimeError(f"servers_add got invalid server data {server_info}") from exc

--- a/test/topology/test_automatic_cleanup.py
+++ b/test/topology/test_automatic_cleanup.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 from test.pylib.manager_client import ManagerClient
-from test.pylib.internal_types import ServerInfo
 from test.pylib.scylla_cluster import ReplaceConfig
 import pytest
 import logging

--- a/test/topology/test_change_ip.py
+++ b/test/topology/test_change_ip.py
@@ -116,7 +116,7 @@ async def test_change_two(manager, random_tables, mode):
         # and the mentioned above code is not exercised by this test.
         await manager.api.enable_injection(servers[0].ip_addr, 'ip-change-raft-sync-delay', one_shot=False)
     await manager.server_start(servers[1].server_id)
-    servers[1] = ServerInfo(servers[1].server_id, s1_new_ip, s1_new_ip)
+    servers[1] = ServerInfo(servers[1].server_id, s1_new_ip, s1_new_ip, servers[1].datacenter, servers[1].rack)
     if mode != 'release':
         s0_logs = await manager.server_open_log(servers[0].server_id)
         await s0_logs.wait_for('crash-before-prev-ip-removed hit, killing the node')
@@ -127,7 +127,7 @@ async def test_change_two(manager, random_tables, mode):
     await wait_proper_ips([servers[0], servers[1]])
 
     await manager.server_start(servers[2].server_id)
-    servers[2] = ServerInfo(servers[2].server_id, s2_new_ip, s2_new_ip)
+    servers[2] = ServerInfo(servers[2].server_id, s2_new_ip, s2_new_ip, servers[2].datacenter, servers[2].rack)
     await reconnect_driver(manager)
     await wait_proper_ips([servers[0], servers[1], servers[2]])
 

--- a/test/topology_custom/test_no_removed_node_event_on_ip_change.py
+++ b/test/topology_custom/test_no_removed_node_event_on_ip_change.py
@@ -48,7 +48,7 @@ async def test_no_removed_node_event_on_ip_change(manager: ManagerClient, caplog
         with test_cluster.connect() as test_cql:
             logger.info(f"starting the follower node {servers[1]}")
             await manager.server_start(servers[1].server_id)
-            servers[1] = ServerInfo(servers[1].server_id, s1_new_ip, s1_new_ip)
+            servers[1] = ServerInfo(servers[1].server_id, s1_new_ip, s1_new_ip, servers[1].datacenter, servers[1].rack)
 
             logger.info("waiting for cql and hosts")
             await wait_for_cql_and_get_hosts(test_cql, servers, time.time() + 30)

--- a/test/topology_custom/test_topology_failure_recovery.py
+++ b/test/topology_custom/test_topology_failure_recovery.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 from test.pylib.manager_client import ManagerClient
-from test.pylib.internal_types import ServerInfo
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.topology.conftest import skip_mode
 import pytest

--- a/test/topology_experimental_raft/test_mv_tablets_replace.py
+++ b/test/topology_experimental_raft/test_mv_tablets_replace.py
@@ -10,7 +10,7 @@ from cassandra.query import SimpleStatement
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.scylla_cluster import ReplaceConfig
-from test.pylib.internal_types import ServerInfo, HostID
+from test.pylib.internal_types import HostID
 
 import pytest
 import asyncio

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -1036,7 +1036,7 @@ async def get_tablet_tokens_from_host_on_shard(manager: ManagerClient, server: S
                 tokens.append(tablet_replica.last_token)
     return tokens
 
-async def get_tablet_count_per_shard_for_host(shards_count: int, manager: ManagerClient, server: ServerInfo, full_tables: dict[str: list[str]]) -> list[int]:
+async def get_tablet_count_per_shard_for_host(manager: ManagerClient, server: ServerInfo, full_tables: dict[str, list[str]], shards_count: int = 2) -> list[int]:
     host = await manager.get_host_id(server.server_id)
     result = [0] * shards_count
 
@@ -1073,10 +1073,10 @@ async def test_tablet_count_metric_per_shard(manager: ManagerClient):
 
     # Then tablet count metric for each shard depicts the actual state
     tables = { "testing": ["mytable1", "mytable2"] }
-    expected_count_per_shard_for_host_0 = await get_tablet_count_per_shard_for_host(shards_count, manager, servers[0], tables)
+    expected_count_per_shard_for_host_0 = await get_tablet_count_per_shard_for_host(manager, servers[0], tables, shards_count)
     await assert_tablet_count_metric_value_for_shards(manager, servers[0], expected_count_per_shard_for_host_0)
 
-    expected_count_per_shard_for_host_1 = await get_tablet_count_per_shard_for_host(shards_count, manager, servers[1], tables)
+    expected_count_per_shard_for_host_1 = await get_tablet_count_per_shard_for_host(manager, servers[1], tables, shards_count)
     await assert_tablet_count_metric_value_for_shards(manager, servers[1], expected_count_per_shard_for_host_1)
 
     # When third table is created
@@ -1084,10 +1084,10 @@ async def test_tablet_count_metric_per_shard(manager: ManagerClient):
 
     # Then tablet count metric for each shard depicts the actual state
     tables = { "testing": ["mytable1", "mytable2", "mytable3"] }
-    expected_count_per_shard_for_host_0 = await get_tablet_count_per_shard_for_host(shards_count, manager, servers[0], tables)
+    expected_count_per_shard_for_host_0 = await get_tablet_count_per_shard_for_host(manager, servers[0], tables, shards_count)
     await assert_tablet_count_metric_value_for_shards(manager, servers[0], expected_count_per_shard_for_host_0)
 
-    expected_count_per_shard_for_host_1 = await get_tablet_count_per_shard_for_host(shards_count, manager, servers[1], tables)
+    expected_count_per_shard_for_host_1 = await get_tablet_count_per_shard_for_host(manager, servers[1], tables, shards_count)
     await assert_tablet_count_metric_value_for_shards(manager, servers[1], expected_count_per_shard_for_host_1)
 
     # When one of tables is dropped
@@ -1095,10 +1095,10 @@ async def test_tablet_count_metric_per_shard(manager: ManagerClient):
 
     # Then tablet count metric for each shard depicts the actual state
     tables = { "testing": ["mytable1", "mytable3"] }
-    expected_count_per_shard_for_host_0 = await get_tablet_count_per_shard_for_host(shards_count, manager, servers[0], tables)
+    expected_count_per_shard_for_host_0 = await get_tablet_count_per_shard_for_host(manager, servers[0], tables, shards_count)
     await assert_tablet_count_metric_value_for_shards(manager, servers[0], expected_count_per_shard_for_host_0)
 
-    expected_count_per_shard_for_host_1 = await get_tablet_count_per_shard_for_host(shards_count, manager, servers[1], tables)
+    expected_count_per_shard_for_host_1 = await get_tablet_count_per_shard_for_host(manager, servers[1], tables, shards_count)
     await assert_tablet_count_metric_value_for_shards(manager, servers[1], expected_count_per_shard_for_host_1)
 
     # And when moving tablets from one shard of src_host to (dest_host, shard_3)

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -5,10 +5,10 @@
 #
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
-from test.pylib.internal_types import ServerInfo
+from test.pylib.internal_types import HostID, ServerInfo, ServerNum
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot, HTTPError, read_barrier
-from test.pylib.util import wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for_cql_and_get_hosts, unique_name
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
 from test.topology.conftest import skip_mode
 from test.topology.util import reconnect_driver
@@ -20,6 +20,9 @@ import time
 import random
 import os
 import glob
+from collections import defaultdict
+from collections.abc import Iterable
+from contextlib import asynccontextmanager
 
 
 logger = logging.getLogger(__name__)
@@ -1037,16 +1040,28 @@ async def get_tablet_tokens_from_host_on_shard(manager: ManagerClient, server: S
     return tokens
 
 async def get_tablet_count_per_shard_for_host(manager: ManagerClient, server: ServerInfo, full_tables: dict[str, list[str]], shards_count: int = 2) -> list[int]:
-    host = await manager.get_host_id(server.server_id)
-    result = [0] * shards_count
+    dict_result = await get_tablet_count_per_shard_for_hosts(manager, [server], full_tables, shards_count)
+    return dict_result[server.server_id]
+
+async def get_tablet_count_per_shard_for_hosts(manager: ManagerClient, servers: Iterable[ServerInfo], full_tables: dict[str, list[str]], shards_per_node: int = 2) -> dict[ServerNum, list[int]]:
+    result = dict[ServerNum, list[int]]()
+    hosts = dict[HostID, ServerNum]()
+    server1 = None
+
+    for server in servers:
+        if not server1:
+            server1 = server
+        result[server.server_id] = [0] * shards_per_node
+        hosts[await manager.get_host_id(server.server_id)] = server.server_id
 
     for keyspace, tables in full_tables.items():
         for table in tables:
-            table_tablets = await get_all_tablet_replicas(manager, server, keyspace, table)
+            table_tablets = await get_all_tablet_replicas(manager, server1, keyspace, table)
             for tablet_replica in table_tablets:
                 for host_id, shard_id in tablet_replica.replicas:
-                    if host_id == host:
-                        result[shard_id] += 1;
+                    if host_id in hosts:
+                        result[hosts[host_id]][shard_id] += 1
+
     return result
 
 def get_shard_that_has_tablets(tablet_count_per_shard: list[int]) -> int:
@@ -1497,3 +1512,200 @@ async def test_tombstone_gc_correctness_during_tablet_split(manager: ManagerClie
 
     logger.info("Verify data is not resurrected")
     await assert_empty_table()
+
+async def create_cluster(manager: ManagerClient, num_dcs: int, num_racks: int, nodes_per_rack: int) -> dict[ServerNum, ServerInfo]:
+    logger.debug(f"Creating cluster: num_dcs={num_dcs} num_racks={num_racks} nodes_per_rack={nodes_per_rack}")
+    servers: dict[ServerNum, ServerInfo] = dict()
+    for dc in range(1, num_dcs + 1):
+        for rack in range(1, num_racks + 1):
+            rack_servers = await manager.servers_add(nodes_per_rack, property_file={"dc": f"dc{dc}", "rack": f"rack{rack}"})
+            for s in rack_servers:
+                servers[s.server_id] = s
+    logger.debug(f"Created servers={list(servers.values())}")
+    return servers
+
+
+class TestContext:
+    def __init__(self, ks: str, table: str, rf: int, initial_tablets: int, num_keys: int):
+        self.ks = ks
+        self.table = table
+        self.rf = rf
+        self.initial_tablets = initial_tablets
+        self.num_keys = num_keys
+
+
+@asynccontextmanager
+async def create_and_populate_table(manager: ManagerClient, rf: int = 3, initial_tablets: int = 64, num_keys: int = 0):
+    ks = unique_name()
+    table = unique_name()
+    if not num_keys:
+        num_keys = initial_tablets * 4
+
+    logger.info(f"Creating table and populating data {ks}.{table}: rf={rf} initial_tablets={initial_tablets} num_keys={num_keys}")
+
+    cql = manager.get_cql()
+    try:
+        await cql.run_async(f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} AND tablets = {{'initial': {initial_tablets}}}")
+        await cql.run_async(f"CREATE TABLE {ks}.{table} (pk int PRIMARY KEY, c int)")
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.{table} (pk, c) VALUES ({k}, 1);") for k in range(num_keys)])
+        yield TestContext(ks, table, rf, initial_tablets, num_keys)
+    finally:
+        await cql.run_async(f"DROP KEYSPACE {ks}")
+
+
+def get_expected_replicas_per_server(live_servers: Iterable[ServerInfo], dead_servers: Iterable[ServerInfo], initial_tablets: int, rf: int) -> dict[ServerNum, float]:
+    total_replicas = initial_tablets * rf
+    nodes_per_rack: defaultdict[str, set[ServerNum]] = defaultdict(set)
+    for s in live_servers:
+        nodes_per_rack[s.rack].add(s.server_id)
+    replicas_per_rack = total_replicas / len(nodes_per_rack.keys())
+    result: dict[ServerNum, float] = dict()
+    for rack_servers in nodes_per_rack.values():
+        replicas_per_node = replicas_per_rack / len(rack_servers)
+        for id in rack_servers:
+            result[id] = replicas_per_node
+    for s in dead_servers:
+        result[s.server_id] = 0
+    return result
+
+
+def verify_replicas_per_server(desc: str, expected_replicas_per_server: dict[ServerNum, float], tablet_count: dict[ServerNum, list[int]], initial_tablets: int, rf: int, shards_per_node: int = 2):
+    logger.debug(f"{desc}: expected_replicas_per_server={expected_replicas_per_server} tablet_count={tablet_count}")
+    total = 0
+    for server_id, host_replicas in tablet_count.items():
+        expected_replicas_per_shard = expected_replicas_per_server[server_id] / shards_per_node
+        for i in host_replicas:
+            total += i
+            assert abs(i - expected_replicas_per_shard) <= 1
+    assert total == initial_tablets * rf
+
+
+@pytest.mark.asyncio
+async def test_decommission_rack_basic(manager: ManagerClient):
+    """
+    Test decommissioning of all nodes in a rack
+    when there are enough remaining racks to satisfy
+    the replication factor.
+    """
+    logger.info("Bootstrapping multi-rack cluster")
+    num_racks = 3
+    nodes_per_rack = 2
+    rf = num_racks - 1
+
+    all_servers = await create_cluster(manager, 1, num_racks, nodes_per_rack)
+    async with create_and_populate_table(manager, rf=rf) as ctx:
+        logger.info("Verify tablet replicas distribution")
+        tables = {ctx.ks: [ctx.table]}
+        expected_replicas_per_server = get_expected_replicas_per_server(all_servers.values(), [], ctx.initial_tablets, ctx.rf)
+        tablet_count = await get_tablet_count_per_shard_for_hosts(manager, all_servers.values(), tables)
+        verify_replicas_per_server("Before decommission", expected_replicas_per_server, tablet_count, ctx.initial_tablets, ctx.rf)
+
+        decommision_rack = f"rack{num_racks}"
+        logger.debug(f"Decommissioning rack={decommision_rack}")
+        live_servers: dict[ServerNum, ServerInfo] = dict()
+        dead_servers: dict[ServerNum, ServerInfo] = dict()
+        for id, s in all_servers.items():
+            if s.rack == decommision_rack:
+                logger.debug(f"Decommissioning server={s}")
+                await manager.decommission_node(s.server_id)
+                dead_servers[id] = s
+            else:
+                live_servers[id] = s
+
+        logger.info("Verify tablet replicas distribution")
+        expected_replicas_per_server = get_expected_replicas_per_server(live_servers.values(), dead_servers.values(), ctx.initial_tablets, ctx.rf)
+        tablet_count = await get_tablet_count_per_shard_for_hosts(manager, live_servers.values(), tables)
+        verify_replicas_per_server("After decommission", expected_replicas_per_server, tablet_count, ctx.initial_tablets, ctx.rf)
+
+@pytest.mark.asyncio
+async def test_decommission_rack_after_adding_new_rack(manager: ManagerClient):
+    """
+    Test decommissioning a rack, after a rack with new nodes is added
+    """
+    logger.info("Bootstrapping multi-rack cluster")
+    initial_num_racks = 3
+    num_racks = initial_num_racks + 1
+    nodes_per_rack = 2
+    rf = initial_num_racks
+
+    initial_servers = await create_cluster(manager, 1, initial_num_racks, nodes_per_rack)
+    async with create_and_populate_table(manager, rf=rf) as ctx:
+        logger.debug("Temporarily disable tablet load balancing")
+        node1 = sorted(initial_servers.values(), key=lambda s: s.server_id)[0]
+        await manager.api.disable_tablet_balancing(node1.ip_addr)
+
+        logger.info("Add a new rack")
+        new_rack = f"rack{num_racks}"
+        # copy initial_servers into all_servers, don't just assign it (by reference)
+        all_servers: list[ServerInfo] = list(initial_servers.values())
+        new_rack_servers = await manager.servers_add(nodes_per_rack, property_file={"dc": "dc1", "rack": new_rack})
+        all_servers.extend(new_rack_servers)
+
+        logger.info("Verify tablet replicas distribution")
+        tables = {ctx.ks: [ctx.table]}
+        expected_replicas_per_server = get_expected_replicas_per_server(initial_servers.values(), new_rack_servers, ctx.initial_tablets, ctx.rf)
+        tablet_count = await get_tablet_count_per_shard_for_hosts(manager, all_servers, tables)
+        verify_replicas_per_server("Before decommission", expected_replicas_per_server, tablet_count, ctx.initial_tablets, ctx.rf)
+
+        logger.debug("Reenable tablet load balancing")
+        await manager.api.enable_tablet_balancing(node1.ip_addr)
+
+        live_servers: dict[ServerNum, ServerInfo] = dict()
+        dead_servers: dict[ServerNum, ServerInfo] = dict()
+        decommision_rack = f"rack{initial_num_racks}"
+        logger.debug(f"Decommissioning rack={decommision_rack}")
+        for s in all_servers:
+            if s.rack == decommision_rack:
+                logger.debug(f"Decommissioning server={s}")
+                await manager.decommission_node(s.server_id)
+                dead_servers[s.server_id] = s
+            else:
+                live_servers[s.server_id] = s
+
+        logger.info("Verify tablet replicas distribution")
+        expected_replicas_per_server = get_expected_replicas_per_server(live_servers.values(), dead_servers.values(), ctx.initial_tablets, ctx.rf)
+        tablet_count = await get_tablet_count_per_shard_for_hosts(manager, all_servers, tables)
+        verify_replicas_per_server("After decommission", expected_replicas_per_server, tablet_count, ctx.initial_tablets, ctx.rf)
+
+@pytest.mark.asyncio
+async def test_decommission_not_enough_racks(manager: ManagerClient):
+    """
+    Test that decommissioning a rack fails if the number of rack is
+    insufficient to satisfy replication factor, even if the number of
+    nodes is sufficient.
+    Reproduces https://github.com/scylladb/scylladb/issues/19475
+    """
+    logger.info("Bootstrapping multi-rack cluster")
+    num_racks = 3
+    nodes_per_rack = 2
+    rf = num_racks
+
+    all_servers = await create_cluster(manager, 1, num_racks, nodes_per_rack)
+    async with create_and_populate_table(manager, rf=rf) as ctx:
+        logger.info("Verify tablet replicas distribution")
+        tables = {ctx.ks: [ctx.table]}
+        expected_replicas_per_server = get_expected_replicas_per_server(all_servers.values(), [], ctx.initial_tablets, ctx.rf)
+        tablet_count = await get_tablet_count_per_shard_for_hosts(manager, all_servers.values(), tables)
+        verify_replicas_per_server("Before decommission", expected_replicas_per_server, tablet_count, ctx.initial_tablets, ctx.rf)
+
+        live_servers: dict[ServerNum, ServerInfo] = dict()
+        dead_servers: dict[ServerNum, ServerInfo] = dict()
+        decommision_rack = f"rack{num_racks}"
+        decommision_count = 0
+        for s in all_servers.values():
+            if s.rack == decommision_rack:
+                logger.debug(f"Decommissioning server={s}")
+                decommision_count += 1
+                expected_error = "Unable to find new replica for tablet" if decommision_count == nodes_per_rack else None
+                await manager.decommission_node(s.server_id, expected_error=expected_error)
+                if not expected_error:
+                    dead_servers[s.server_id] = s
+                else:
+                    live_servers[s.server_id] = s
+            else:
+                live_servers[s.server_id] = s
+
+        logger.info("Verify tablet replicas distribution")
+        expected_replicas_per_server = get_expected_replicas_per_server(live_servers.values(), dead_servers.values(), ctx.initial_tablets, ctx.rf)
+        tablet_count = await get_tablet_count_per_shard_for_hosts(manager, all_servers.values(), tables)
+        verify_replicas_per_server("After decommission", expected_replicas_per_server, tablet_count, ctx.initial_tablets, ctx.rf)

--- a/test/topology_experimental_raft/test_tablets_intranode.py
+++ b/test/topology_experimental_raft/test_tablets_intranode.py
@@ -6,7 +6,6 @@
 from cassandra.query import SimpleStatement, ConsistencyLevel
 from cassandra.cluster import Session, ConsistencyLevel
 
-from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot, HTTPError
 from test.pylib.rest_client import inject_error


### PR DESCRIPTION
test_tablets: add rack decommission test cases

Test scenarios where decommissioing a compelte rack
should succeed, and reproduce scylladb/scylladb#19475
where decommissioning a rack would fail since the
number of remaining racks is insufficient to satisfy
the replication factor, even though the number of nodes
is sufficient, enshrining this behavior.

Refs scylladb/scylladb#19475

* This PR adds unit tests and improves an error message.  No backport required.