### PR TITLE
cql3: drop workaround for castas_fctn_simple()

### DIFF
--- a/cql3/functions/castas_fcts.cc
+++ b/cql3/functions/castas_fcts.cc
@@ -69,16 +69,6 @@ using bytes_opt = std::optional<bytes>;
 template<typename ToType, typename FromType>
 static data_value castas_fctn_simple(data_value from) {
     auto val_from = value_cast<FromType>(from);
-    // Workaround for https://github.com/boostorg/multiprecision/issues/553 (the additional bug discovered post-closing)
-    if constexpr (std::is_floating_point_v<ToType> && std::is_same_v<FromType, utils::multiprecision_int>) {
-        static auto min = utils::multiprecision_int(std::numeric_limits<ToType>::lowest());
-        static auto max = utils::multiprecision_int(std::numeric_limits<ToType>::max());
-        if (val_from < min) {
-            return -std::numeric_limits<ToType>::infinity();
-        } else if (val_from > max) {
-            return std::numeric_limits<ToType>::infinity();
-        }
-    }
     return static_cast<ToType>(val_from);
 }
 


### PR DESCRIPTION
now that https://src.fedoraproject.org/rpms/boost/c/e13a584ab74584d6f5a6c002fb10e11994b91f5b?branch=f40 has been merged, and our toolchain is based on the fedora 40 on 20240710, which should include this change.

so let's drop the workaround from 51d09e6a

Refs #18508
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

----

it's a cleanup, hence no need to backport.