### PR TITLE
Node replace and  remove operations: Add deprecate IP addresses usage warning.

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -898,7 +898,8 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         auto host_id = validate_host_id(req->get_query_param("host_id"));
         std::vector<sstring> ignore_nodes_strs = utils::split_comma_separated_list(req->get_query_param("ignore_nodes"));
         apilog.info("remove_node: host_id={} ignore_nodes={}", host_id, ignore_nodes_strs);
-        auto ignore_nodes = std::list<locator::host_id_or_endpoint>();
+        locator::host_id_or_endpoint_list ignore_nodes;
+        ignore_nodes.reserve(ignore_nodes_strs.size());
         for (const sstring& n : ignore_nodes_strs) {
             try {
                 auto hoep = locator::host_id_or_endpoint(n);

--- a/db/config.cc
+++ b/db/config.cc
@@ -1526,18 +1526,19 @@ future<> update_relabel_config_from_file(const std::string& name) {
     co_return;
 }
 
-std::vector<sstring> split_comma_separated_list(sstring comma_separated_list) {
+std::vector<sstring> split_comma_separated_list(const std::string_view comma_separated_list) {
     std::vector<sstring> strs, trimmed_strs;
-    boost::split(strs, std::move(comma_separated_list), boost::is_any_of(","));
-    for (sstring n : strs) {
+    boost::split(strs, comma_separated_list, boost::is_any_of(","));
+    trimmed_strs.reserve(strs.size());
+    for (sstring& n : strs) {
         std::replace(n.begin(), n.end(), '\"', ' ');
         std::replace(n.begin(), n.end(), '\'', ' ');
         boost::trim_all(n);
         if (!n.empty()) {
-            trimmed_strs.push_back(n);
+            trimmed_strs.push_back(std::move(n));
         }
     }
     return trimmed_strs;
 }
 
-}
+} // namespace utils

--- a/db/config.hh
+++ b/db/config.hh
@@ -545,6 +545,6 @@ future<gms::inet_address> resolve(const config_file::named_value<sstring>&, gms:
  */
 future<> update_relabel_config_from_file(const std::string& name);
 
-std::vector<sstring> split_comma_separated_list(sstring comma_separated_list);
+std::vector<sstring> split_comma_separated_list(std::string_view comma_separated_list);
 
-}
+} // namespace utils

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -79,6 +79,10 @@ struct host_id_or_endpoint {
 
 using host_id_or_endpoint_list = std::vector<host_id_or_endpoint>;
 
+[[nodiscard]] inline bool check_host_ids_contain_only_uuid(const auto& host_ids) {
+    return std::ranges::none_of(host_ids, [](const auto& node_str) { return locator::host_id_or_endpoint{node_str}.has_endpoint(); });
+}
+
 class token_metadata_impl;
 struct topology_change_info;
 

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -77,6 +77,8 @@ struct host_id_or_endpoint {
     gms::inet_address resolve_endpoint(const token_metadata&) const;
 };
 
+using host_id_or_endpoint_list = std::vector<host_id_or_endpoint>;
+
 class token_metadata_impl;
 struct topology_change_info;
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -126,6 +126,27 @@ session_manager& get_topology_session_manager() {
     return topology_session_manager;
 }
 
+namespace {
+
+[[nodiscard]] locator::host_id_or_endpoint_list string_list_to_endpoint_list(const std::vector<sstring>& src_node_strings) {
+    locator::host_id_or_endpoint_list resulting_node_list;
+    resulting_node_list.reserve(src_node_strings.size());
+    for (const sstring& n : src_node_strings) {
+        try {
+            resulting_node_list.emplace_back(n);
+        } catch (...) {
+            throw std::runtime_error(::format("Failed to parse node list: {}: invalid node={}: {}", src_node_strings, n, std::current_exception()));
+        }
+    }
+    return resulting_node_list;
+}
+
+[[nodiscard]] locator::host_id_or_endpoint_list parse_node_list(const std::string_view comma_separated_list) {
+    return string_list_to_endpoint_list(utils::split_comma_separated_list(comma_separated_list));
+}
+
+} // namespace
+
 static constexpr std::chrono::seconds wait_for_live_nodes_timeout{30};
 
 storage_service::storage_service(abort_source& abort_source,
@@ -1175,7 +1196,7 @@ future<> storage_service::raft_state_monitor_fiber(raft::server& raft, sharded<d
     }
 }
 
-std::unordered_set<raft::server_id> storage_service::find_raft_nodes_from_hoeps(const std::list<locator::host_id_or_endpoint>& hoeps) {
+std::unordered_set<raft::server_id> storage_service::find_raft_nodes_from_hoeps(const locator::host_id_or_endpoint_list& hoeps) const {
     std::unordered_set<raft::server_id> ids;
     for (const auto& hoep : hoeps) {
         std::optional<raft::server_id> id;
@@ -1196,16 +1217,8 @@ std::unordered_set<raft::server_id> storage_service::find_raft_nodes_from_hoeps(
 }
 
 std::unordered_set<raft::server_id> storage_service::ignored_nodes_from_join_params(const join_node_request_params& params) {
-    std::unordered_set<raft::server_id> ignored_nodes;
-
-    if (!params.ignore_nodes.empty()) {
-        std::list<locator::host_id_or_endpoint> ignore_nodes_params;
-        for (const auto& n : params.ignore_nodes) {
-            ignore_nodes_params.emplace_back(n);
-        }
-
-        ignored_nodes = find_raft_nodes_from_hoeps(ignore_nodes_params);
-    }
+    const locator::host_id_or_endpoint_list ignore_nodes_params = string_list_to_endpoint_list(params.ignore_nodes);
+    std::unordered_set<raft::server_id> ignored_nodes{find_raft_nodes_from_hoeps(ignore_nodes_params)};
 
     if (params.replaced_id) {
         // insert node that should be replaced to ignore list so that other topology operations
@@ -2182,19 +2195,6 @@ future<> storage_service::track_upgrade_progress_to_topology_coordinator(sharded
         rtlogger.error("failed to start one of the raft-related background fibers: {}", std::current_exception());
         abort();
     }
-}
-
-std::list<locator::host_id_or_endpoint> storage_service::parse_node_list(sstring comma_separated_list) {
-    std::vector<sstring> ignore_nodes_strs = utils::split_comma_separated_list(std::move(comma_separated_list));
-    std::list<locator::host_id_or_endpoint> ignore_nodes;
-    for (const sstring& n : ignore_nodes_strs) {
-        try {
-            ignore_nodes.push_back(locator::host_id_or_endpoint(n));
-        } catch (...) {
-            throw std::runtime_error(::format("Failed to parse node list: {}: invalid node={}: {}", ignore_nodes_strs, n, std::current_exception()));
-        }
-    }
-    return ignore_nodes;
 }
 
 // Runs inside seastar::async context
@@ -3993,7 +3993,7 @@ void storage_service::run_replace_ops(std::unordered_set<token>& bootstrap_token
     }
 }
 
-future<> storage_service::raft_removenode(locator::host_id host_id, std::list<locator::host_id_or_endpoint> ignore_nodes_params) {
+future<> storage_service::raft_removenode(locator::host_id host_id, locator::host_id_or_endpoint_list ignore_nodes_params) {
     auto id = raft::server_id{host_id.uuid()};
     utils::UUID request_id;
 
@@ -4099,7 +4099,7 @@ future<> storage_service::raft_removenode(locator::host_id host_id, std::list<lo
     }
 }
 
-future<> storage_service::removenode(locator::host_id host_id, std::list<locator::host_id_or_endpoint> ignore_nodes_params) {
+future<> storage_service::removenode(locator::host_id host_id, locator::host_id_or_endpoint_list ignore_nodes_params) {
     return run_with_api_lock_conditionally(sstring("removenode"), !raft_topology_change_enabled(), [host_id, ignore_nodes_params = std::move(ignore_nodes_params)] (storage_service& ss) mutable {
         return seastar::async([&ss, host_id, ignore_nodes_params = std::move(ignore_nodes_params)] () mutable {
             ss.check_ability_to_perform_topology_operation("removenode");
@@ -7335,8 +7335,8 @@ bool storage_service::is_repair_based_node_ops_enabled(streaming::stream_reason 
         {"removenode", streaming::stream_reason::removenode},
         {"rebuild", streaming::stream_reason::rebuild},
     };
-    auto enabled_list_str = _db.local().get_config().allowed_repair_based_node_ops();
-    std::vector<sstring> enabled_list = utils::split_comma_separated_list(std::move(enabled_list_str));
+    const sstring& enabled_list_str = _db.local().get_config().allowed_repair_based_node_ops();
+    std::vector<sstring> enabled_list = utils::split_comma_separated_list(enabled_list_str);
     std::unordered_set<streaming::stream_reason> enabled_set;
     for (const sstring& op : enabled_list) {
         try {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -373,8 +373,6 @@ private:
 
 public:
 
-    static std::list<locator::host_id_or_endpoint> parse_node_list(sstring comma_separated_list);
-
     future<> check_for_endpoint_collision(std::unordered_set<gms::inet_address> initial_contact_nodes,
             const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features);
 
@@ -699,7 +697,7 @@ public:
      *
      * @param hostIdString token for the node
      */
-    future<> removenode(locator::host_id host_id, std::list<locator::host_id_or_endpoint> ignore_nodes);
+    future<> removenode(locator::host_id host_id, locator::host_id_or_endpoint_list ignore_nodes);
     future<node_ops_cmd_response> node_ops_cmd_handler(gms::inet_address coordinator, std::optional<locator::host_id> coordinator_host_id, node_ops_cmd_request req);
     void node_ops_cmd_check(gms::inet_address coordinator, const node_ops_cmd_request& req);
     future<> node_ops_cmd_heartbeat_updater(node_ops_cmd cmd, node_ops_id uuid, std::list<gms::inet_address> nodes, lw_shared_ptr<bool> heartbeat_updater_done);
@@ -865,13 +863,13 @@ private:
     // as well as the system.peers table.
     shared_ptr<raft_ip_address_updater> _raft_ip_address_updater;
 
-    std::unordered_set<raft::server_id> find_raft_nodes_from_hoeps(const std::list<locator::host_id_or_endpoint>& hoeps);
+    std::unordered_set<raft::server_id> find_raft_nodes_from_hoeps(const locator::host_id_or_endpoint_list& hoeps) const;
 
     future<raft_topology_cmd_result> raft_topology_cmd_handler(raft::term_t term, uint64_t cmd_index, const raft_topology_cmd& cmd);
 
     future<> raft_initialize_discovery_leader(const join_node_request_params& params);
     future<> raft_decommission();
-    future<> raft_removenode(locator::host_id host_id, std::list<locator::host_id_or_endpoint> ignore_nodes_params);
+    future<> raft_removenode(locator::host_id host_id, locator::host_id_or_endpoint_list ignore_nodes_params);
     future<> raft_rebuild(utils::optional_param source_dc);
     future<> raft_check_and_repair_cdc_streams();
     future<> update_topology_with_local_metadata(raft::server&);

--- a/test/nodetool/test_nodeops.py
+++ b/test/nodetool/test_nodeops.py
@@ -24,31 +24,31 @@ def test_rebuild_with_dc(nodetool):
 
 
 def test_removenode(nodetool):
-    nodetool("removenode", "675ed9f4-6564-6dbd-can8-43fddce952gy", expected_requests=[
+    nodetool("removenode", "ac9e2ad5-c6d7-4769-a64b-6e73173ccd86", expected_requests=[
         expected_request("POST", "/storage_service/remove_node",
-                         params={"host_id": "675ed9f4-6564-6dbd-can8-43fddce952gy"})])
+                         params={"host_id": "ac9e2ad5-c6d7-4769-a64b-6e73173ccd86"})])
 
 
 def test_removenode_ignore_nodes_one_node(nodetool):
     nodetool("removenode",
-             "675ed9f4-6564-6dbd-can8-43fddce952gy",
+             "ac9e2ad5-c6d7-4769-a64b-6e73173ccd86",
              "--ignore-dead-nodes",
-             "88eed9f4-6564-6dbd-can8-43fddce952gy",
+             "c0f4683f-61aa-43d4-98b5-99e2c5d27952",
              expected_requests=[
                  expected_request("POST", "/storage_service/remove_node", params={
-                     "host_id": "675ed9f4-6564-6dbd-can8-43fddce952gy",
-                     "ignore_nodes": "88eed9f4-6564-6dbd-can8-43fddce952gy"})])
+                     "host_id": "ac9e2ad5-c6d7-4769-a64b-6e73173ccd86",
+                     "ignore_nodes": "c0f4683f-61aa-43d4-98b5-99e2c5d27952"})])
 
 
 def test_removenode_ignore_nodes_two_nodes(nodetool):
     nodetool("removenode",
-             "675ed9f4-6564-6dbd-can8-43fddce952gy",
+             "ac9e2ad5-c6d7-4769-a64b-6e73173ccd86",
              "--ignore-dead-nodes",
-             "88eed9f4-6564-6dbd-can8-43fddce952gy,99eed9f4-6564-6dbd-can8-43fddce952gy",
+             "c0f4683f-61aa-43d4-98b5-99e2c5d27952,7f066eb5-b76c-4587-922f-d71e2d7c3b51",
              expected_requests=[
                  expected_request("POST", "/storage_service/remove_node", params={
-                     "host_id": "675ed9f4-6564-6dbd-can8-43fddce952gy",
-                     "ignore_nodes": "88eed9f4-6564-6dbd-can8-43fddce952gy,99eed9f4-6564-6dbd-can8-43fddce952gy"})])
+                     "host_id": "ac9e2ad5-c6d7-4769-a64b-6e73173ccd86",
+                     "ignore_nodes": "c0f4683f-61aa-43d4-98b5-99e2c5d27952,7f066eb5-b76c-4587-922f-d71e2d7c3b51"})])
 
 
 def test_removenode_status(nodetool):
@@ -67,7 +67,7 @@ def test_removenode_force(nodetool):
 def test_removenode_status_with_ignore_dead_nodes(nodetool, scylla_only):
     check_nodetool_fails_with(
             nodetool,
-            ("removenode", "status", "--ignore-dead-nodes", "675ed9f4-6564-6dbd-can8-43fddce952gy"),
+            ("removenode", "status", "--ignore-dead-nodes", "ac9e2ad5-c6d7-4769-a64b-6e73173ccd86"),
             {"expected_requests": []},
             ["error processing arguments: cannot use --ignore-dead-nodes with status or force"])
 
@@ -75,6 +75,6 @@ def test_removenode_status_with_ignore_dead_nodes(nodetool, scylla_only):
 def test_removenode_force_with_ignore_dead_nodes(nodetool, scylla_only):
     check_nodetool_fails_with(
             nodetool,
-            ("removenode", "force", "--ignore-dead-nodes", "675ed9f4-6564-6dbd-can8-43fddce952gy"),
+            ("removenode", "force", "--ignore-dead-nodes", "ac9e2ad5-c6d7-4769-a64b-6e73173ccd86"),
             {"expected_requests": []},
             ["error processing arguments: cannot use --ignore-dead-nodes with status or force"])

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -42,6 +42,7 @@
 
 #include "api/scrub_status.hh"
 #include "gms/application_state.hh"
+#include "db/config.hh"
 #include "db_clock.hh"
 #include "log.hh"
 #include "release.hh"
@@ -53,6 +54,7 @@
 #include "utils/pretty_printers.hh"
 #include "utils/rjson.hh"
 #include "utils/UUID.hh"
+#include "locator/token_metadata.hh"
 
 namespace bpo = boost::program_options;
 
@@ -1379,6 +1381,12 @@ void removenode_operation(scylla_rest_client& client, const bpo::variables_map& 
         std::unordered_map<sstring, sstring> params{{"host_id", op}};
         if (vm.contains("ignore-dead-nodes")) {
             params["ignore_nodes"] = vm["ignore-dead-nodes"].as<sstring>();
+            const auto str_ids  = utils::split_comma_separated_list(params["ignore_nodes"]);
+            if (!locator::check_host_ids_contain_only_uuid(str_ids)) {
+                fmt::print(std::cout, "\nWarning: Using IP addresses for '--ignore-dead-nodes' is deprecated and"
+                " will be disabled in a future release. Please use host IDs instead. Run \"nodetool status\" to list all"
+                " node IDs.\n\n");
+            }
         }
         client.post("/storage_service/remove_node", std::move(params));
     }
@@ -3806,7 +3814,7 @@ by any means!
 For more information, see: {}"
 )", doc_link("operating-scylla/nodetool-commands/removenode.html")),
                 {
-                    typed_option<sstring>("ignore-dead-nodes", "Comma-separated list of dead nodes to ignore during removenode"),
+                    typed_option<sstring>("ignore-dead-nodes", "Comma-separated list of dead node host IDs to ignore during removenode"),
                 },
                 {
                     typed_option<sstring>("remove-operation", "status|force|$HOST_ID - show status of current node removal, force completion of pending removal, or remove provided ID", 1),


### PR DESCRIPTION
- As part of deprecation of IP address usage, warning messages were added when IP addresses specified in the `ignore-dead-nodes` and `--ignore-dead-nodes-for-replace` options for scylla and nodetool. 
- Slight optimizations for `utils::split_comma_separated_list`, ` host_id_or_endpoint lists` and `storage_service` remove node operations, replacing `std::list` usage with `std::vector`. 

Fixes scylladb/scylladb#19218

Backport: 6.2 as it's not yet released. 