### PR TITLE
sstables/sstables.hh: Remove unused forward declarations

### DIFF
--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -73,7 +73,6 @@ namespace fs = std::filesystem;
 extern logging::logger sstlog;
 class sstable_writer;
 class sstables_manager;
-class metadata_collector;
 
 struct foreign_sstable_open_info;
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -71,7 +71,6 @@ class writer;
 namespace fs = std::filesystem;
 
 extern logging::logger sstlog;
-class key;
 class sstable_writer;
 class sstable_writer_v2;
 class sstables_manager;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -59,8 +59,6 @@ class large_data_handler;
 
 namespace sstables {
 
-class random_access_reader;
-
 class sstable_directory;
 extern thread_local utils::updateable_value<bool> global_cache_index_pages;
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -96,7 +96,6 @@ class data_consume_context;
 
 class index_reader;
 class partition_index_cache;
-class sstables_manager;
 
 extern size_t summary_byte_cost(double summary_ratio);
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -72,7 +72,6 @@ namespace fs = std::filesystem;
 
 extern logging::logger sstlog;
 class sstable_writer;
-class sstable_writer_v2;
 class sstables_manager;
 class metadata_collector;
 


### PR DESCRIPTION
Code cleanup, no backport needed.