### PR TITLE
tasks: improve task_manager::lookup_virtual_task

### DIFF
--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -101,15 +101,6 @@ tasks::task_manager::task_group node_ops_virtual_task::get_group() const noexcep
     return tasks::task_manager::task_group::topology_change_group;
 }
 
-future<std::set<tasks::task_id>> node_ops_virtual_task::get_ids() const {
-    db::system_keyspace& sys_ks = _ss._sys_ks.local();
-    service::topology& topology = _ss._topology_state_machine._topology;
-    co_return co_await get_entries(sys_ks, topology, get_task_manager().get_task_ttl())
-        | std::views::keys
-        | std::views::transform([](const utils::UUID& uuid) { return tasks::task_id(uuid); })
-        | std::ranges::to<std::set>();
-}
-
 future<bool> node_ops_virtual_task::contains(tasks::task_id task_id) const {
     if (!task_id.uuid().is_timestamp()) {
         // Task id of node ops operation is always a timestamp.

--- a/node_ops/task_manager_module.hh
+++ b/node_ops/task_manager_module.hh
@@ -28,7 +28,6 @@ public:
         , _ss(ss)
     {}
     virtual tasks::task_manager::task_group get_group() const noexcept override;
-    virtual future<std::set<tasks::task_id>> get_ids() const override;
     virtual future<bool> contains(tasks::task_id task_id) const override;
     virtual future<tasks::is_abortable> is_abortable() const override;
 

--- a/node_ops/task_manager_module.hh
+++ b/node_ops/task_manager_module.hh
@@ -29,6 +29,7 @@ public:
     {}
     virtual tasks::task_manager::task_group get_group() const noexcept override;
     virtual future<std::set<tasks::task_id>> get_ids() const override;
+    virtual future<bool> contains(tasks::task_id task_id) const override;
     virtual future<tasks::is_abortable> is_abortable() const override;
 
     virtual future<std::optional<tasks::task_status>> get_status(tasks::task_id id) override;

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -436,10 +436,6 @@ task_manager::virtual_task::virtual_task(virtual_task_impl_ptr&& impl) noexcept
     SCYLLA_ASSERT(this_shard_id() == 0);
 }
 
-future<std::set<task_id>> task_manager::virtual_task::get_ids() const {
-    return _impl->get_ids();
-}
-
 future<bool> task_manager::virtual_task::contains(tasks::task_id task_id) const {
     return _impl->contains(task_id);
 }

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -440,6 +440,10 @@ future<std::set<task_id>> task_manager::virtual_task::get_ids() const {
     return _impl->get_ids();
 }
 
+future<bool> task_manager::virtual_task::contains(tasks::task_id task_id) const {
+    return _impl->contains(task_id);
+}
+
 task_manager::module_ptr task_manager::virtual_task::get_module() const noexcept {
     return _impl->get_module();
 }
@@ -721,7 +725,7 @@ future<task_manager::foreign_task_ptr> task_manager::lookup_task_on_all_shards(s
 future<task_manager::virtual_task_ptr> task_manager::lookup_virtual_task(task_manager& tm, task_id id) {
     auto vts = tm.get_virtual_tasks();
     for (auto [_, vt]: tm.get_virtual_tasks()) {
-        if ((co_await vt->get_ids()).contains(id)) {
+        if (co_await vt->contains(id)) {
             co_return vt;
         }
     }

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -273,6 +273,7 @@ public:
         public:
             virtual task_group get_group() const noexcept = 0;
             virtual future<std::set<task_id>> get_ids() const = 0;
+            virtual future<bool> contains(tasks::task_id task_id) const = 0;
             module_ptr get_module() const noexcept;
             task_manager& get_task_manager() const noexcept;
             virtual future<tasks::is_abortable> is_abortable() const;
@@ -289,6 +290,7 @@ public:
         virtual_task(virtual_task_impl_ptr&& impl) noexcept;
 
         future<std::set<task_id>> get_ids() const;
+        future<bool> contains(tasks::task_id task_id) const;
         module_ptr get_module() const noexcept;
         task_group get_group() const noexcept;
         future<tasks::is_abortable> is_abortable() const;

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -272,7 +272,6 @@ public:
             static future<std::vector<task_identity>> get_children(module_ptr module, task_id parent_id);
         public:
             virtual task_group get_group() const noexcept = 0;
-            virtual future<std::set<task_id>> get_ids() const = 0;
             virtual future<bool> contains(tasks::task_id task_id) const = 0;
             module_ptr get_module() const noexcept;
             task_manager& get_task_manager() const noexcept;
@@ -289,7 +288,6 @@ public:
     public:
         virtual_task(virtual_task_impl_ptr&& impl) noexcept;
 
-        future<std::set<task_id>> get_ids() const;
         future<bool> contains(tasks::task_id task_id) const;
         module_ptr get_module() const noexcept;
         task_group get_group() const noexcept;


### PR DESCRIPTION
Currently, to find the operation with given id, all operations tracked by a virtual task are listed. This isn't necessary, since we only need info regarding one particular operation.

Add a method to check whether a virtual task tracks the operation with the given id.

No backport needed