### PR TITLE
tablets: Process skipped candidates to fix imbalance with multiple racks

### DIFF
--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -223,7 +223,7 @@ public:
     // Returns 1 when shards are imbalanced, but it's not possible to balance them.
     load_type get_shard_imbalance(host_id node) const {
         auto minmax = get_shard_minmax(node);
-        return minmax.max() - minmax.max();
+        return minmax.max() - minmax.min();
     }
 
     min_max_tracker<load_type> get_shard_minmax(host_id node) const {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1468,8 +1468,7 @@ public:
             auto src_host = nodes_by_load.back();
             auto& src_node_info = nodes[src_host];
 
-            bool drain_skipped = src_node_info.shards_by_load.empty() && src_node_info.drained
-                    && !src_node_info.skipped_candidates.empty();
+            bool drain_skipped = src_node_info.shards_by_load.empty() && !src_node_info.skipped_candidates.empty();
 
             lblogger.debug("source node: {}, avg_load={:.2f}, skipped={}, drain_skipped={}", src_host,
                            src_node_info.avg_load, src_node_info.skipped_candidates.size(), drain_skipped);
@@ -1632,6 +1631,7 @@ public:
                 _stats.for_dc(dc).migrations_produced++;
                 plan.add(std::move(mig));
             } else {
+                lblogger.debug("Skipped migration: {}", mig);
                 // Shards are overloaded with streaming. Do not include the migration in the plan, but
                 // continue as if it was in the hope that we will find a migration which can be executed without
                 // violating the load. Next make_plan() invocation will notice that the migration was not executed.

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2438,7 +2438,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
         });
 
         size_t total_tablet_count = 0;
-        stm.mutate_token_metadata([&](token_metadata& tm) {
+        stm.mutate_token_metadata([&](token_metadata& tm) -> future<> {
             tablet_metadata tmeta;
 
             int i = 0;
@@ -2452,6 +2452,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
                     // Leave the first host empty by making it invisible to allocation algorithm.
                     hosts_by_rack[rack.rack].push_back(h);
                 }
+                co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(double(i) / hosts.size()))}, h);
             }
 
             size_t tablet_count_bits = 8;
@@ -2488,7 +2489,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
                 tmeta.set_tablet_map(table, std::move(tmap));
             }
             tm.set_tablets(std::move(tmeta));
-            return make_ready_future<>();
+            co_return;
         }).get();
 
         testlog.debug("tablet metadata: {}", stm.get()->tablets());


### PR DESCRIPTION
After fixing load_sketch::get_shard_imbalance(), a test caught a scenario with multiple racks where we end up with node and shard imbalance.

this is the configuration after balancer incorrectly thinks it converged.
```
Node 1714c700-*: rack=rack-1 avg_load=4.5, tablets=9, shards=2, state=normal
Node 167c3080-*: rack=rack-2 avg_load=5, tablets=10, shards=2, state=normal
Node 15e39a00-*: rack=rack-1 avg_load=4, tablets=8, shards=2, state=normal
Node 154b0380-*: rack=rack-2 avg_load=4, tablets=8, shards=2, state=normal
Node 14b26d00-*: rack=rack-1 avg_load=4.5, tablets=9, shards=2, state=normal
Node 1419d680-*: rack=rack-2 avg_load=4, tablets=8, shards=2, state=normal
```

however, it clearly shows rack-2 is imbalanced. Further inspection also showed shard imbalance. We could have migrated a tablet from node 167c3080-* to some other node on the same rack. After recent changes for balancer becoming table aware, a target on a different rack can be picked but it's pushed into skipped list since the target is not viable (since it doesn't meet replication constraints). For each skipped candidate in this list, there's also its viable targets.

This skipped list is never processed unless the context is node draining, so that's why we can end up with imbalance. To fix it, we'll allow processing of skipped list when the context is not drain, if we ran out of candidates in the most-loaded source. There's not guarantee viable targets will be on the least loaded nodes, but balancer looks for the best destination among them and also apply the convergence check to avoid oscillations. So it's an improvement. Also, the imbalance found by the test is fixed with this change.

can be reproduced with:
./test.py --mode=dev tablets_test --random-seed 4127388107
