### PR TITLE
test/cql-pytest: fix support for Cassandra 3

### DIFF
--- a/test/cql-pytest/conftest.py
+++ b/test/cql-pytest/conftest.py
@@ -261,8 +261,8 @@ def temp_workdir():
         yield workdir
 
 @pytest.fixture(scope="session")
-def has_tablets(cql):
-    with new_test_keyspace(cql, " WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor': 1}") as keyspace:
+def has_tablets(cql, this_dc):
+    with new_test_keyspace(cql, " WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "': 1}") as keyspace:
         return keyspace_has_tablets(cql, keyspace)
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
One of the design goals of the test/cql-pytest frameworks was to be able to run these tests against Cassandra. Preferably, we should be able to run most of the tests against any popular version of Cassandra, including Cassandra 3. This is admittingly a very old version, but was still maintained until just a year ago, it's the version that Scylla is most compatible with, and we can still be curious about how it worked.

Until recently cql-pytest indeed worked on Cassandra 3, but it broke on some change related to tablet detection that cause our most basic fixture - "text_keyspace" - to use the Cassandra 4 feature of "auto expand". This is trivial to fix - we should just use the this_dc fixture that we already had exactly for this purpose.

Fixes #20781