### PR TITLE
compaction: fix potential data resurrection with file-based migration

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -59,6 +59,7 @@ class compaction_group {
     seastar::condition_variable _staging_done_condition;
     // Gates async operations confined to a single group.
     seastar::gate _async_gate;
+    bool _tombstone_gc_enabled = true;
 private:
     // Adds new sstable to the set of sstables
     // Doesn't update the cache. The cache must be synchronized in order for reads to see
@@ -112,6 +113,14 @@ public:
 
     const dht::token_range& token_range() const noexcept {
         return _token_range;
+    }
+
+    void set_tombstone_gc_enabled(bool tombstone_gc_enabled) noexcept {
+        _tombstone_gc_enabled = tombstone_gc_enabled;
+    }
+
+    bool tombstone_gc_enabled() const noexcept {
+        return _tombstone_gc_enabled;
     }
 
     void set_compaction_strategy_state(compaction::compaction_strategy_state compaction_strategy_state) noexcept;

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -1299,6 +1299,73 @@ async def test_tablet_storage_freeing(manager: ManagerClient):
 
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
+async def test_tombstone_gc_disabled_on_pending_replica(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    servers = [await manager.server_add()]
+
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 4};")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int) WITH gc_grace_seconds = 0;")
+
+    servers.append(await manager.server_add())
+
+    key = 7 # Whatever
+    tablet_token = 0 # Doesn't matter since there is one tablet
+    await cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({key}, 1) USING timestamp 9")
+    rows = await cql.run_async("SELECT pk from test.test")
+    assert len(rows) == 1
+
+    replica = await get_tablet_replica(manager, servers[0], 'test', 'test', tablet_token)
+
+    s0_host_id = await manager.get_host_id(servers[0].server_id)
+    s1_host_id = await manager.get_host_id(servers[1].server_id)
+    dst_shard = 0
+
+    await manager.api.enable_injection(servers[1].ip_addr, "stream_mutation_fragments", one_shot=True)
+    s1_log = await manager.server_open_log(servers[1].server_id)
+    s1_mark = await s1_log.mark()
+
+    migration_task = asyncio.create_task(
+        manager.api.move_tablet(servers[0].ip_addr, "test", "test", replica[0], replica[1], s1_host_id, dst_shard, tablet_token))
+
+    await s1_log.wait_for('stream_mutation_fragments: waiting', from_mark=s1_mark)
+    s1_mark = await s1_log.mark()
+
+    # write a tombstone with timestamp X to DB
+    await cql.run_async(f'DELETE FROM test.test USING timestamp 10 WHERE pk = {key}')
+
+    # flush both servers
+    for s in servers:
+        await manager.api.flush_keyspace(s.ip_addr, "test")
+
+    await asyncio.sleep(1)
+
+    # major compact both servers
+    for s in servers:
+        await manager.api.keyspace_compaction(s.ip_addr, "test")
+
+    # write backdated data to test.test with timestamp X-1 with the same key as the tombstone
+    await cql.run_async(f'INSERT INTO test.test (pk, c) VALUES ({key}, 0) USING timestamp 9')
+
+    # release streaming
+    await manager.api.message_injection(servers[1].ip_addr, "stream_mutation_fragments")
+    await s1_log.wait_for('stream_mutation_fragments: done', from_mark=s1_mark)
+
+    logger.info("Waiting for migration to finish")
+    await migration_task
+    logger.info("Migration done")
+
+    for s in servers:
+        await manager.api.flush_keyspace(s.ip_addr, "test")
+
+    # verify result
+    rows = await cql.run_async(f'SELECT pk, c FROM test.test WHERE pk = {key};')
+    assert len(rows) == 0
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
 async def test_schema_change_during_cleanup(manager: ManagerClient):
     logger.info("Start first node")
     servers = [await manager.server_add()]


### PR DESCRIPTION
When tablets are migrated with file-based streaming, we can have a situation where a tombstone is garbage collected before the data it shadows lands. For instance, if we have a tablet replica with 3 sstables:

1. sstable containing an expired tombstone
2. sstable with additional data
3. sstable containing data which is shadowed by the expired tombstone in sstable 1

If this tablet is migrated, and the sstables are streamed in the order listed above, the first two sstables can be compacted before the third sstable arrives. In that case, the expired tombstone will be garbage collected, and data in the third sstable will be resurrected after it arrives to the pending replica.

This change fixes this problem by disabling tombstone garbage collection for pending replicas.

This fixes a problem in Enterprise, but the change is in OSS in order to have as few differences between OSS and Enterprise and to have a common infrastructure for disabling tombstone GC on pending replicas.

This change has to be backported to all active versions: 6.0, 6.1 and 6.2, as well as Enterprise 2024.2
