### PR TITLE
service: raft: fix rpc error message

### DIFF
--- a/service/raft/raft_rpc.cc
+++ b/service/raft/raft_rpc.cc
@@ -77,7 +77,7 @@ raft_rpc::two_way_rpc(sloc loc, raft::server_id id,
     }
     return verb(&_messaging, netw::msg_addr(*ip_addr), db::no_timeout, _group_id, _my_id, id, std::forward<Args>(args)...)
         .handle_exception_type([loc= std::move(loc), id] (const seastar::rpc::closed_error& e) {;
-            const auto msg = fmt::format("Failed to execute {} on leader {}: {}", loc.function_name(), id, e);
+            const auto msg = fmt::format("Failed to execute {}, destination {}: {}", loc.function_name(), id, e);
             rlogger.trace("{}", msg);
             return make_exception_future<Ret>(raft::transport_error(msg));
     });


### PR DESCRIPTION
What it called "leader" is actually the destination of the RPC.

Trivial fix, should be backported to all affected versions.