### PR TITLE
Documment using default loglevel with contianers

### DIFF
--- a/docs/dev/docker-hub.md
+++ b/docs/dev/docker-hub.md
@@ -314,6 +314,14 @@ For example, to disable developer mode:
 $ docker run --name some-scylla -d scylladb/scylla --developer-mode 0
 ```
 
+#### `--default-log-level arg (=info)``
+
+Default log level for log messages. Valid values are trace, debug, info, warn, error.
+
+```console
+$ docker run --name some-scylla -d scylladb/scylla --default-log-level debug
+```
+
 #### `--experimental ENABLE`
 
 The `--experimental` command line option enables ScyllaDB's experimental mode


### PR DESCRIPTION
**Please replace this line with justification for the backport/\* labels added to this PR**

This PR documents using `--default-log-level` with containers. Request by @tzach  in https://github.com/scylladb/scylladb/pull/19671#issuecomment-2366809033