### PR TITLE
test.py: Increase workers for cluster cleaning

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -50,7 +50,7 @@ from cassandra.policies import WhiteListRoundRobinPolicy  # type: ignore
 from cassandra.connection import UnixSocketEndPoint
 
 
-io_executor = concurrent.futures.ThreadPoolExecutor(max_workers=8)
+io_executor = concurrent.futures.ThreadPoolExecutor(max_workers=20)
 
 async def async_rmtree(directory, *args, **kwargs):
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
Increase workers for that used in method async_rmtree() that is used for cleaning directories. This should help to reduce flakiness.
Increasing the workers count was introduced in https://github.com/scylladb/scylladb/commit/f54b7f5427246f2c592c8c57d751c0ddbc3a40bc but there is no need to backport the whole commit.