### PR TITLE
replica: Fix schema change during migration cleanup

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -246,6 +246,9 @@ public:
     bool no_compacted_sstable_undeleted() const;
 
     future<> stop(sstring reason = "table removal") noexcept;
+
+    // Clear sstable sets
+    void clear_sstables();
 };
 
 using storage_group_ptr = lw_shared_ptr<storage_group>;
@@ -305,6 +308,7 @@ public:
     const storage_group_map& storage_groups() const;
 
     future<> stop_storage_groups() noexcept;
+    void clear_storage_groups();
     void remove_storage_group(size_t id);
     storage_group& storage_group_for_id(const schema_ptr&, size_t i) const;
     storage_group* maybe_storage_group_for_id(const schema_ptr&, size_t i) const;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -627,7 +627,9 @@ future<> storage_group_manager::for_each_storage_group_gently(std::function<futu
 
 void storage_group_manager::for_each_storage_group(std::function<void(size_t, storage_group&)> f) const {
     for (auto& [id, sg]: _storage_groups) {
-        f(id, *sg);
+        if (auto holder = try_hold_gate(sg->async_gate())) {
+            f(id, *sg);
+        }
     }
 }
 
@@ -637,6 +639,12 @@ const storage_group_map& storage_group_manager::storage_groups() const {
 
 future<> storage_group_manager::stop_storage_groups() noexcept {
     return parallel_for_each(_storage_groups | boost::adaptors::map_values, [] (auto sg) { return sg->stop("table removal"); });
+}
+
+void storage_group_manager::clear_storage_groups() {
+    for (auto& [id, sg]: _storage_groups) {
+        sg->clear_sstables();
+    }
 }
 
 void storage_group_manager::remove_storage_group(size_t id) {
@@ -1576,9 +1584,7 @@ table::stop() {
     co_await _sstable_deletion_gate.close();
     co_await std::move(gate_closed_fut);
     co_await get_row_cache().invalidate(row_cache::external_updater([this] {
-        for_each_compaction_group([] (compaction_group& cg) {
-            cg.clear_sstables();
-        });
+        _sg_manager->clear_storage_groups();
         _sstables = make_compound_sstable_set();
     }));
     _cache.refresh_snapshot();
@@ -2286,6 +2292,12 @@ bool compaction_group::empty() const noexcept {
 void compaction_group::clear_sstables() {
     _main_sstables = make_lw_shared<sstables::sstable_set>(_t._compaction_strategy.make_sstable_set(_t._schema));
     _maintenance_sstables = _t.make_maintenance_sstable_set();
+}
+
+void storage_group::clear_sstables() {
+    for (auto cg : compaction_groups()) {
+        cg->clear_sstables();
+    }
 }
 
 table::table(schema_ptr schema, config config, lw_shared_ptr<const storage_options> sopts, compaction_manager& compaction_manager,
@@ -3755,6 +3767,7 @@ future<> table::cleanup_tablet(database& db, db::system_keyspace& sys_ks, locato
     co_await clear_inactive_reads_for_tablet(db, sg);
     // compaction_group::stop takes care of flushing.
     co_await stop_compaction_groups(sg);
+    co_await utils::get_local_injector().inject("delay_tablet_compaction_groups_cleanup", std::chrono::seconds(5));
     co_await cleanup_compaction_groups(db, sys_ks, tid, sg);
     _sg_manager->remove_storage_group(tid.value());
 }


### PR DESCRIPTION
During migration cleanup, there's a small window in which the storage group was stopped but not yet removed from the list. So concurrent operations traversing the list could work with stopped groups.

During a test which emitted schema changes during migrations, a failure happened when updating the compaction strategy of a table, but since the group was stopped, the compaction manager was unable to find the state for that group.

In order to fix it, we'll skip stopped groups when traversing the list since they're unused at this stage of migration and going away soon.

Fixes #20699.
