### PR TITLE
build: cmake: link cql3 library to the service library

### DIFF
--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(service
     Seastar::seastar
     xxHash::xxhash
   PRIVATE
+    cql3
     mutation
     node_ops
     raft


### PR DESCRIPTION
After commit d16ea0af, compiling the server using cmake fails with the following error :

```
FAILED: service/CMakeFiles/service.dir/Dev/qos/service_level_controller.cc.o
...
/home/Scylla/scylladb/cql3/util.hh:21:10: fatal error: 'cql3/CqlParser.hpp' file not found
   21 | #include "cql3/CqlParser.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Fix it by linking the cql3 library to the service library.

Backport not required.

Fixes: #20821