### PR TITLE
cql3: Print arguments and return type without frozen when describing UDF

### DIFF
--- a/cql3/functions/user_function.cc
+++ b/cql3/functions/user_function.cc
@@ -75,7 +75,7 @@ description user_function::describe(with_create_statement with_stmt) const {
             return std::nullopt;
         }
 
-        auto arg_type_range = _arg_types | std::views::transform(std::mem_fn(&abstract_type::cql3_type_name));
+        auto arg_type_range = _arg_types | std::views::transform(std::mem_fn(&abstract_type::cql3_type_name_without_frozen));
         auto arg_range = std::views::zip(_arg_names, arg_type_range)
                 | std::views::transform([] (std::tuple<std::string_view, std::string_view> arg) {
                     const auto [name, type] = arg;
@@ -89,7 +89,7 @@ description user_function::describe(with_create_statement with_stmt) const {
                 "AS $${}$$;",
                 cql3::util::maybe_quote(name().keyspace), cql3::util::maybe_quote(name().name), fmt::join(arg_range, ", "),
                 _called_on_null_input ? "CALLED" : "RETURNS NULL",
-                _return_type->cql3_type_name(),
+                _return_type->cql3_type_name_without_frozen(),
                 _language,
                 _body);
     });


### PR DESCRIPTION
Scylla doesn't allow for the types of arguments or the return type of a UDF
to be frozen. As a result, before these changes, create statements
produced to restore UDFs as part of `DESCRIBE` statements could not
be executed.

Fixes scylladb/scylladb#20256

Backport: necessary as the restore process may not work correctly without these changes. The affected versions span from 5.2 to the current master, but we only want to apply the fix to the live versions, so 6.0, 6.1, and 6.2.