### PR TITLE
docs: update theme 1.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: "pip"
+  directory: "/docs"
+  schedule:
+    interval: "daily"
+  ignore:
+  - dependency-name: "*"
+  allow:
+  - dependency-name: "sphinx-scylladb-theme"
+  - dependency-name: "sphinx-multiversion-scylla"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -43,7 +43,6 @@ pristine: clean
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf _data/*
-	rm -f poetry.lock
 
 # Generate output commands
 .PHONY: dirhtml

--- a/docs/_static/api/README.md
+++ b/docs/_static/api/README.md
@@ -1,6 +1,22 @@
-## README
+# README
 
-Static files and dependencies for the Swagger UI library are maintained independently in this directory. This ensures compatibility with Swagger 1.2 (deprecated), allowing for manual updates and customization as necessary.
+This directory contains static files and dependencies for the **Swagger UI library** to ensure compatibility with **Swagger 1.2** (deprecated). Files are managed for manual updates and customization.
 
-**Current Swagger UI Version:** 2.2.10
+## Configuration
 
+- **Swagger UI Version:** 2.2.10
+- **Source:** [Swagger UI Repository](https://github.com/swagger-api/swagger-ui/tree/v2.2.10/dist)
+- **Included Files:**
+  - `swagger-ui.min.js`
+  - Relevant dependencies from the [dist/lib directory](https://github.com/swagger-api/swagger-ui/tree/v2.2.10/dist/lib)
+
+## Rationale
+
+ Files are included directly to avoid adding `npm` as a build dependency. Deprecated libraries are not loaded from a CDN to maintain control over versions and be able to submit fixes if necessary.
+
+## Moving to OpenAPI 3
+
+When transitioning to **OpenAPI 3**, the current setup should be reevaluated. 
+
+- **Swagger 1.2** is deprecated, and using an outdated version may introduce maintenance overhead and compatibility issues.
+- **OpenAPI 3** provides improved functionality, broader tool support, and up-to-date best practices.

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,20 +1,19 @@
 [tool.poetry]
 name = "scylla"
-description = "Scylla Documentation"
-version = "4.3.0"
+description = "ScyllaDB Documentation"
+version = "0.1.0"
 authors = ["ScyllaDB Contributors"]
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.9"
-pyyaml = "6.0.1"
-pygments = "2.15.1"
-redirects_cli ="~0.1.2"
-sphinx-scylladb-theme = "^1.7.1"
-sphinx-sitemap = "2.5.1"
-sphinx-autobuild = "2021.3.14"
-Sphinx = "7.2.6"
-sphinx-multiversion-scylla = "~0.3.1"
+python = "^3.10"
+pygments = "^2.18.0"
+redirects_cli ="^0.1.3"
+sphinx-scylladb-theme = "^1.8.1"
+sphinx-sitemap = "^2.6.0"
+sphinx-autobuild = "^2024.4.19"
+Sphinx = "^7.3.7"
+sphinx-multiversion-scylla = "^0.3.1"
 sphinxcontrib-datatemplates = "^0.9.2"
 sphinx-scylladb-markdown = "^0.1.2"
 sphinx_collapse ="^0.1.3"


### PR DESCRIPTION
ScyllaDB Sphinx Theme 1.8 is out 🥳!  
![image](https://github.com/user-attachments/assets/64d8fc02-ea76-4128-b908-c79f8223b974)

Here's a summary of changes:
- Dark theme support for a fresh new look.
- Updated branding assets including new logos and mascots.
- Improved build process by recommending the inclusion of the `poetry.lock` file to ensure consistent dependencies in your CI/CD pipeline.
- New [tooltip component](https://sphinx-theme.scylladb.com/master/examples/tooltips.html) to add more context to glossary terms, configuration parameters, or any other elements without cluttering the page.

