### PR TITLE
sstables: Fix use-after-free on page cache buffer when parsing promoted index entries across pages

### DIFF
--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -35,8 +35,6 @@
 #include <span>
 #include <unordered_map>
 
-class fragmented_temporary_buffer;
-
 namespace utils {
 class directories;
 } // namespace utils

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -1110,7 +1110,7 @@ public:
             _consumer.consume_row_end();
             return;
         }
-        if (_state != state::ROW_START || primitive_consumer::active()) {
+        if (_state != state::ROW_START || data_consumer::primitive_consumer::active()) {
             throw malformed_sstable_exception("end of input, but not end of row");
         }
     }

--- a/sstables/mx/bsearch_clustered_cursor.hh
+++ b/sstables/mx/bsearch_clustered_cursor.hh
@@ -372,6 +372,7 @@ inline
 future<cached_promoted_index::pi_offset_type>
 cached_promoted_index::read_block_offset(pi_index_type idx, tracing::trace_state_ptr trace_state) {
     return read(_promoted_index_start + get_offset_entry_pos(idx), trace_state, _u32_parser).then([idx, this] {
+        sstlog.trace("cached_promoted_index {}: read_block_offset: idx: {}, offset: {}", fmt::ptr(this), idx, _u32_parser.value());
         return _u32_parser.value();
     });
 }
@@ -381,6 +382,7 @@ future<> cached_promoted_index::read_block_start(promoted_index_block& block, tr
     return read(_promoted_index_start + block.offset, trace_state, _clustering_parser).then([this, &block] {
         auto mem_before = block.memory_usage();
         block.start.emplace(_clustering_parser.get_and_reset());
+        sstlog.trace("cached_promoted_index {}: read_block_start: {}", fmt::ptr(this), block);
         _metrics.used_bytes += block.memory_usage() - mem_before;
     });
 }
@@ -395,6 +397,7 @@ future<> cached_promoted_index::read_block(promoted_index_block& block, tracing:
         block.data_file_offset = _block_parser.offset();
         block.width = _block_parser.width();
         _metrics.used_bytes += block.memory_usage() - mem_before;
+        sstlog.trace("cached_promoted_index {}: read_block: {}", fmt::ptr(this), block);
     });
 }
 

--- a/sstables/mx/bsearch_clustered_cursor.hh
+++ b/sstables/mx/bsearch_clustered_cursor.hh
@@ -194,7 +194,14 @@ private:
                         throw retry_exception();
                     }
                     retry = true;
-                    return stop_iteration(c.consume(page) == data_consumer::read_status::ready);
+
+                    auto status = c.consume(page);
+
+                    utils::get_local_injector().inject("cached_promoted_index_parsing_invalidate_buf_across_page", [&page] {
+                        page.release_and_scramble();
+                    });
+
+                    return stop_iteration(status == data_consumer::read_status::ready);
                 });
             }).handle_exception_type([this, pos, trace_state, &c] (const retry_exception& e) {
                 _stream = _cached_file.read(pos, _permit, trace_state);
@@ -241,6 +248,7 @@ private:
         });
     }
 
+public:
     /// \brief Returns a pointer to promoted_index_block entry which has at least offset and index fields valid.
     future<promoted_index_block*> get_block_only_offset(pi_index_type idx, tracing::trace_state_ptr trace_state) {
         auto i = _blocks.lower_bound(idx);
@@ -258,6 +266,7 @@ private:
         });
     }
 
+private:
     void erase_range(block_set_type::iterator begin, block_set_type::iterator end) {
         while (begin != end) {
             --_metrics.block_count;
@@ -476,6 +485,8 @@ public:
             blocks_count)
         , _trace_state(std::move(trace_state))
     { }
+
+    cached_promoted_index& promoted_index() { return _promoted_index; }
 
     future<std::optional<skip_info>> advance_to(position_in_partition_view pos) override {
         position_in_partition::less_compare less(_s);

--- a/sstables/mx/bsearch_clustered_cursor.hh
+++ b/sstables/mx/bsearch_clustered_cursor.hh
@@ -176,6 +176,33 @@ private:
         });
     }
 
+    template <typename Consumer>
+    future<> read(cached_file::offset_type pos, tracing::trace_state_ptr trace_state, Consumer& c) {
+        struct retry_exception : std::exception {};
+        _stream = _cached_file.read(pos, _permit, trace_state);
+        c.reset();
+        return repeat([this, pos, trace_state, &c] {
+            return _stream.next_page_view().then([this, &c] (cached_file::page_view&& page) {
+                if (!page) {
+                    on_internal_error(sstlog, "End of stream while parsing");
+                }
+                bool retry = false;
+                return _as(_cached_file.region(), [&] {
+                    if (retry) {
+                        throw retry_exception();
+                    }
+                    retry = true;
+                    auto buf = page.get_buf();
+                    return stop_iteration(c.consume(buf) == data_consumer::read_status::ready);
+                });
+            }).handle_exception_type([this, pos, trace_state, &c] (const retry_exception& e) {
+                _stream = _cached_file.read(pos, _permit, trace_state);
+                c.reset();
+                return stop_iteration::no;
+            });
+        });
+    }
+
     // Returns offset of the entry in the offset map for the promoted index block of the index idx.
     // The offset is relative to the promoted index start in the index file.
     // idx must be in the range 0..(_blocks_count-1)
@@ -200,9 +227,7 @@ private:
     // Postconditions:
     //   - block.start is engaged and valid.
     future<> read_block_start(promoted_index_block& block, tracing::trace_state_ptr trace_state) {
-        _stream = _cached_file.read(_promoted_index_start + block.offset, _permit, trace_state);
-        _clustering_parser.reset();
-        return consume_stream(_stream, _clustering_parser).then([this, &block] {
+        return read(_promoted_index_start + block.offset, trace_state, _clustering_parser).then([this, &block] {
             auto mem_before = block.memory_usage();
             block.start.emplace(_clustering_parser.get_and_reset());
             _metrics.used_bytes += block.memory_usage() - mem_before;
@@ -212,9 +237,7 @@ private:
     // Postconditions:
     //   - block.end is engaged, all fields in the block are valid
     future<> read_block(promoted_index_block& block, tracing::trace_state_ptr trace_state) {
-        _stream = _cached_file.read(_promoted_index_start + block.offset, _permit, trace_state);
-        _block_parser.reset();
-        return consume_stream(_stream, _block_parser).then([this, &block] {
+        return read(_promoted_index_start + block.offset, trace_state, _block_parser).then([this, &block] {
             auto mem_before = block.memory_usage();
             block.start.emplace(std::move(_block_parser.start()));
             block.end.emplace(std::move(_block_parser.end()));

--- a/sstables/mx/bsearch_clustered_cursor.hh
+++ b/sstables/mx/bsearch_clustered_cursor.hh
@@ -145,6 +145,22 @@ private:
     //
     using block_set_type = std::set<promoted_index_block, block_comparator>;
     block_set_type _blocks;
+private:
+    struct u32_parser {
+        data_consumer::primitive_consumer& parser;
+
+        void reset() {
+            parser.read_32();
+        }
+
+        data_consumer::read_status consume(temporary_buffer<char>& buf) {
+            return parser.consume_u32(buf);
+        }
+
+        uint32_t value() const {
+            return parser._u32;
+        }
+    };
 public:
     const schema& _s;
     uint64_t _promoted_index_start;
@@ -153,28 +169,13 @@ public:
     const pi_index_type _blocks_count;
     cached_file& _cached_file;
     data_consumer::primitive_consumer _primitive_parser;
+    u32_parser _u32_parser;
     clustering_parser _clustering_parser;
     promoted_index_block_parser _block_parser;
     reader_permit _permit;
     cached_file::stream _stream;
     logalloc::allocating_section _as;
 private:
-    // Feeds the stream into the consumer until the consumer is satisfied.
-    // Does not give unconsumed data back to the stream.
-    template <typename Consumer>
-    future<> consume_stream(cached_file::stream& s, Consumer& c) {
-        return repeat([&] {
-            return s.next_page_view().then([&] (cached_file::page_view&& page) {
-                if (!page) {
-                    on_internal_error(sstlog, "End of stream while parsing");
-                }
-                return _as(_cached_file.region(), [&] {
-                    auto buf = page.get_buf();
-                    return stop_iteration(c.consume(buf) == data_consumer::read_status::ready);
-                });
-            });
-        });
-    }
 
     template <typename Consumer>
     future<> read(cached_file::offset_type pos, tracing::trace_state_ptr trace_state, Consumer& c) {
@@ -211,16 +212,8 @@ private:
     }
 
     future<pi_offset_type> read_block_offset(pi_index_type idx, tracing::trace_state_ptr trace_state) {
-        _stream = _cached_file.read(_promoted_index_start + get_offset_entry_pos(idx), _permit, trace_state);
-        return _stream.next_page_view().then([this] (cached_file::page_view page) {
-            temporary_buffer<char> buf = page.get_buf();
-            static_assert(noexcept(std::declval<data_consumer::primitive_consumer>().read_32(buf)));
-            if (__builtin_expect(_primitive_parser.read_32(buf) == data_consumer::read_status::ready, true)) {
-                return make_ready_future<pi_offset_type>(_primitive_parser._u32);
-            }
-            return consume_stream(_stream, _primitive_parser).then([this] {
-                return _primitive_parser._u32;
-            });
+        return read(_promoted_index_start + get_offset_entry_pos(idx), trace_state, _u32_parser).then([this] {
+            return _u32_parser.value();
         });
     }
 
@@ -290,6 +283,7 @@ public:
         , _blocks_count(blocks_count)
         , _cached_file(f)
         , _primitive_parser(permit)
+        , _u32_parser(_primitive_parser)
         , _clustering_parser(s, permit, cvfl, true)
         , _block_parser(s, permit, std::move(cvfl))
         , _permit(std::move(permit))

--- a/sstables/mx/bsearch_clustered_cursor.hh
+++ b/sstables/mx/bsearch_clustered_cursor.hh
@@ -146,14 +146,16 @@ private:
     using block_set_type = std::set<promoted_index_block, block_comparator>;
     block_set_type _blocks;
 private:
+    using Buffer = cached_file::page_view;
+
     struct u32_parser {
-        data_consumer::primitive_consumer& parser;
+        data_consumer::primitive_consumer_impl<Buffer>& parser;
 
         void reset() {
             parser.read_32();
         }
 
-        data_consumer::read_status consume(temporary_buffer<char>& buf) {
+        data_consumer::read_status consume(Buffer& buf) {
             return parser.consume_u32(buf);
         }
 
@@ -168,15 +170,14 @@ public:
     metrics& _metrics;
     const pi_index_type _blocks_count;
     cached_file& _cached_file;
-    data_consumer::primitive_consumer _primitive_parser;
+    data_consumer::primitive_consumer_impl<Buffer> _primitive_parser;
     u32_parser _u32_parser;
-    clustering_parser _clustering_parser;
-    promoted_index_block_parser _block_parser;
+    clustering_parser<Buffer> _clustering_parser;
+    promoted_index_block_parser<Buffer> _block_parser;
     reader_permit _permit;
     cached_file::stream _stream;
     logalloc::allocating_section _as;
 private:
-
     template <typename Consumer>
     future<> read(cached_file::offset_type pos, tracing::trace_state_ptr trace_state, Consumer& c) {
         struct retry_exception : std::exception {};
@@ -193,8 +194,7 @@ private:
                         throw retry_exception();
                     }
                     retry = true;
-                    auto buf = page.get_buf();
-                    return stop_iteration(c.consume(buf) == data_consumer::read_status::ready);
+                    return stop_iteration(c.consume(page) == data_consumer::read_status::ready);
                 });
             }).handle_exception_type([this, pos, trace_state, &c] (const retry_exception& e) {
                 _stream = _cached_file.read(pos, _permit, trace_state);

--- a/sstables/mx/parsers.hh
+++ b/sstables/mx/parsers.hh
@@ -26,20 +26,22 @@ namespace mc {
 //   while (cp.consume(next_buf()) == read_status::waiting) {}
 //   position_in_partition pos = cp.get();
 //
+template <ContiguousSharedBuffer Buffer>
 class clustering_parser {
+    using FragmentedBuffer = basic_fragmented_buffer<Buffer>;
     const schema& _s;
     column_values_fixed_lengths _clustering_values_fixed_lengths;
     bool _parsing_start_key;
     boost::iterator_range<column_values_fixed_lengths::const_iterator> ck_range;
 
-    std::vector<fragmented_temporary_buffer> clustering_key_values;
+    std::vector<FragmentedBuffer> clustering_key_values;
     bound_kind_m kind{};
 
-    fragmented_temporary_buffer column_value;
+    FragmentedBuffer column_value;
     uint64_t ck_blocks_header = 0;
     uint32_t ck_blocks_header_offset = 0;
     std::optional<position_in_partition> _pos;
-    data_consumer::primitive_consumer _primitive;
+    data_consumer::primitive_consumer_impl<Buffer> _primitive;
 
     enum class state {
         CLUSTERING_START,
@@ -79,7 +81,7 @@ class clustering_parser {
 
     position_in_partition make_position() {
         auto key = clustering_key_prefix::from_range(clustering_key_values | boost::adaptors::transformed(
-            [] (const fragmented_temporary_buffer& b) { return fragmented_temporary_buffer::view(b); }));
+            [] (const FragmentedBuffer & b) { return typename FragmentedBuffer::view(b); }));
 
         if (kind == bound_kind_m::clustering) {
             return position_in_partition::for_key(std::move(key));
@@ -108,7 +110,7 @@ public:
 
     // Feeds the data into the state machine.
     // Returns read_status::ready when !active() after the call.
-    read_status consume(temporary_buffer<char>& data) {
+    read_status consume(Buffer& data) {
         if (_primitive.consume(data) == read_status::waiting) {
             return read_status::waiting;
         }
@@ -208,8 +210,9 @@ public:
     }
 };
 
+template <ContiguousSharedBuffer Buffer>
 class promoted_index_block_parser {
-    clustering_parser _clustering;
+    clustering_parser<Buffer> _clustering;
 
     std::optional<position_in_partition> _start_pos;
     std::optional<position_in_partition> _end_pos;
@@ -230,7 +233,7 @@ class promoted_index_block_parser {
         DONE,
     } _state = state::START;
 
-    data_consumer::primitive_consumer _primitive;
+    data_consumer::primitive_consumer_impl<Buffer> _primitive;
 public:
     using read_status = data_consumer::read_status;
 
@@ -248,7 +251,7 @@ public:
     // Feeds the data into the state machine.
     // Returns read_status::ready when whole block was parsed.
     // If returns read_status::waiting then data.empty() after the call.
-    read_status consume(temporary_buffer<char>& data) {
+    read_status consume(Buffer& data) {
         static constexpr size_t width_base = 65536;
         if (_primitive.consume(data) == read_status::waiting) {
             return read_status::waiting;

--- a/sstables/mx/parsers.hh
+++ b/sstables/mx/parsers.hh
@@ -202,7 +202,9 @@ public:
     }
 
     void reset() {
+        _parsing_start_key = true;
         _state = state::CLUSTERING_START;
+        _primitive.reset();
     }
 };
 
@@ -318,7 +320,7 @@ public:
 
     void reset() {
         _end_open_marker.reset();
-        _clustering.set_parsing_start_key(true);
+        _clustering.reset();
         _state = state::START;
     }
 };

--- a/sstables/promoted_index_blocks_reader.hh
+++ b/sstables/promoted_index_blocks_reader.hh
@@ -71,7 +71,7 @@ private:
     };
 
     struct m_parser_context {
-        mc::promoted_index_block_parser block_parser;
+        mc::promoted_index_block_parser<temporary_buffer<char>> block_parser;
 
         m_parser_context(const schema& s, reader_permit permit, column_values_fixed_lengths cvfl)
             : block_parser(s, std::move(permit), std::move(cvfl))

--- a/test/boost/cached_file_test.cc
+++ b/test/boost/cached_file_test.cc
@@ -453,3 +453,52 @@ SEASTAR_THREAD_TEST_CASE(test_invalidation) {
     BOOST_REQUIRE_EQUAL(2, metrics.page_populations);
     BOOST_REQUIRE_EQUAL(0, metrics.page_hits);
 }
+
+SEASTAR_THREAD_TEST_CASE(test_page_view_as_contiguous_shared_buffer) {
+    auto page_size = cached_file::page_size;
+    test_file tf = make_test_file(page_size);
+
+    cached_file_stats metrics;
+    logalloc::region region;
+    cached_file cf(tf.f, metrics, cf_lru, region, page_size);
+
+    auto s = cf.read(1, std::nullopt);
+    cached_file::page_view p = s.next_page_view().get();
+    BOOST_REQUIRE_EQUAL(tf.contents.substr(1, page_size - 1), sstring(p.begin(), p.end()));
+    BOOST_REQUIRE_EQUAL(p.size(), page_size - 1);
+    BOOST_REQUIRE(!p.empty());
+
+    p.trim(10);
+    BOOST_REQUIRE_EQUAL(tf.contents.substr(1, 10), sstring(p.begin(), p.end()));
+    BOOST_REQUIRE_EQUAL(tf.contents.substr(1, 10), sstring(p.get_write(), p.end()));
+
+    p.trim_front(1);
+    BOOST_REQUIRE_EQUAL(tf.contents.substr(2, 9), sstring(p.begin(), p.end()));
+
+    // Check movability
+    {
+        auto p_cpy = p.share();
+        auto p1 = std::move(p_cpy);
+        BOOST_REQUIRE_EQUAL(tf.contents.substr(2, 9), sstring(p1.begin(), p1.end()));
+        BOOST_REQUIRE(p_cpy.empty());
+        BOOST_REQUIRE(p_cpy.size() == 0);
+        BOOST_REQUIRE(!p_cpy);
+    }
+
+    auto p2 = p.share(2, 3);
+    BOOST_REQUIRE_EQUAL(tf.contents.substr(4, 3), sstring(p2.begin(), p2.end()));
+    p2.trim_front(1); // should not affect p
+
+    p.trim_front(9);
+    BOOST_REQUIRE_EQUAL(p.size(), 0);
+    BOOST_REQUIRE(p.begin() == p.end());
+
+    p = {};
+    BOOST_REQUIRE_EQUAL(p.size(), 0);
+    BOOST_REQUIRE(p.begin() == p.end());
+    BOOST_REQUIRE(!p);
+    BOOST_REQUIRE_EQUAL(sstring(p.begin(), p.end()), sstring());
+
+    // p should not affect p2
+    BOOST_REQUIRE_EQUAL(tf.contents.substr(5, 2), sstring(p2.begin(), p2.end()));
+}

--- a/test/boost/index_reader_test.cc
+++ b/test/boost/index_reader_test.cc
@@ -11,6 +11,7 @@
 #include "test/lib/simple_schema.hh"
 #include "test/lib/sstable_test_env.hh"
 #include "test/lib/sstable_utils.hh"
+#include "test/lib/make_random_string.hh"
 
 #include "readers/from_mutations_v2.hh"
 
@@ -44,5 +45,85 @@ SEASTAR_TEST_CASE(test_abort_during_index_read) {
         env.request_abort();
         BOOST_CHECK_THROW(consumer_ctx.consume_input().get(), seastar::abort_requested_exception);
         consumer_ctx.close().get();
+    });
+}
+
+SEASTAR_TEST_CASE(test_promoted_index_parsing_page_crossing_and_retries) {
+    return test_env::do_with_async([](test_env& env) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+        testlog.info("Skipped because error injection is not enabled");
+#else
+        simple_schema ss;
+        auto s = ss.schema();
+
+        auto pk = ss.make_pkey();
+        auto mut = mutation(s, pk);
+
+        // enough to have same index block whose clustering key is split across pages
+        std::vector<clustering_key> keys;
+        const auto n_keys = 100;
+        auto key_size = cached_file::page_size / 3; // guarantees that index blocks are not congruent with page size.
+        keys.reserve(n_keys);
+        for (int i = 0; i < n_keys; ++i) {
+            keys.push_back(ss.make_ckey(make_random_string(key_size)));
+            ss.add_row(mut, keys[i], "v");
+        }
+
+        clustering_key::less_compare less(*s);
+        std::sort(keys.begin(), keys.end(), less);
+
+        env.manager().set_promoted_index_block_size(1); // force entry for each row
+        auto mut_reader = make_mutation_reader_from_mutations_v2(s, env.make_reader_permit(), std::move(mut));
+        auto sst = make_sstable_easy(env, std::move(mut_reader), env.manager().configure_writer());
+
+        tests::reader_concurrency_semaphore_wrapper semaphore;
+        auto permit = semaphore.make_permit();
+        tracing::trace_state_ptr trace = nullptr;
+
+        auto index = std::make_unique<index_reader>(sst, permit, trace, use_caching::yes, true);
+        auto close_index = deferred_close(*index);
+
+        index->advance_to(dht::ring_position_view(pk)).get();
+        index->read_partition_data().get();
+
+        auto cur = dynamic_cast<mc::bsearch_clustered_cursor*>(index->current_clustered_cursor());
+        BOOST_REQUIRE(cur);
+
+        std::optional<cached_file::offset_type> prev_offset;
+        int crossed_page = 0;
+
+        utils::get_local_injector().enable("cached_promoted_index_parsing_invalidate_buf_across_page", false);
+
+        for (int i = 0; i < n_keys - 1; ++i) {
+            auto block_offset = cur->promoted_index().get_block_only_offset(i, trace).get()->offset;
+            auto next_block_offset = cur->promoted_index().get_block_only_offset(i + 1, trace).get()->offset;
+
+            auto start_page = block_offset / cached_file::page_size;
+            auto end_page = (next_block_offset - 1) / cached_file::page_size;
+            if (start_page != end_page) {
+                auto pos = position_in_partition::for_key(keys[i]);
+                position_in_partition::equal_compare eq(*s);
+
+                testlog.info("Crossed page at block {}, offset [{}, {})", i, block_offset, next_block_offset);
+                crossed_page++;
+
+                auto* block = cur->promoted_index().get_block(i, trace).get();
+
+                testlog.debug("key   : {}", pos);
+                testlog.debug("start : {}", *block->start);
+                testlog.debug("end   : {}", *block->end);
+
+                BOOST_REQUIRE(eq(*block->start, pos));
+                BOOST_REQUIRE(eq(*block->end, pos));
+                if (prev_offset) {
+                    BOOST_REQUIRE_LT(*prev_offset, block->data_file_offset);
+                }
+
+                prev_offset = block->data_file_offset;
+            }
+        }
+
+        BOOST_REQUIRE_GE(crossed_page, 6); // If not, increase n_keys
+#endif
     });
 }

--- a/test/boost/index_reader_test.cc
+++ b/test/boost/index_reader_test.cc
@@ -119,6 +119,19 @@ SEASTAR_TEST_CASE(test_promoted_index_parsing_page_crossing_and_retries) {
                     BOOST_REQUIRE_LT(*prev_offset, block->data_file_offset);
                 }
 
+                cur->promoted_index().clear();
+
+                utils::get_local_injector().enable("cached_promoted_index_bad_alloc_parsing_across_page", true);
+                block = cur->promoted_index().get_block(i, trace).get();
+
+                testlog.debug("start : {}", *block->start);
+                testlog.debug("end   : {}", *block->end);
+                BOOST_REQUIRE(eq(*block->start, pos));
+                BOOST_REQUIRE(eq(*block->end, pos));
+                if (prev_offset) {
+                    BOOST_REQUIRE_LT(*prev_offset, block->data_file_offset);
+                }
+
                 prev_offset = block->data_file_offset;
             }
         }

--- a/utils/cached_file.hh
+++ b/utils/cached_file.hh
@@ -115,13 +115,6 @@ private:
             return temporary_buffer<char>(_buf.get_write(), _buf.size(), make_deleter([self = std::move(self)] {}));
         }
 
-        // Returns a buffer which reflects contents of this page.
-        // The buffer will not prevent eviction.
-        // The buffer is invalidated when the page is evicted or when the owning LSA region invalidates references.
-        temporary_buffer<char> get_buf_weak() {
-            return temporary_buffer<char>(_lsa_buf.get(), _lsa_buf.size(), deleter());
-        }
-
         // Returns a pointer to the contents of the page.
         // The buffer is invalidated when the page is evicted or when the owning LSA region invalidates references.
         char* begin() {
@@ -239,14 +232,6 @@ public:
             _size = std::exchange(o._size, 0);
             _units = std::move(o._units);
             return *this;
-        }
-
-        // The returned buffer is valid only until the LSA region associated with cached_file invalidates references.
-        temporary_buffer<char> get_buf() {
-            auto buf = _page->get_buf_weak();
-            buf.trim_front(_offset);
-            buf.trim(_size);
-            return buf;
         }
 
         operator bool() const { return bool(_page) && _size; }

--- a/utils/cached_file.hh
+++ b/utils/cached_file.hh
@@ -222,8 +222,8 @@ public:
         // The returned buffer is valid only until the LSA region associated with cached_file invalidates references.
         temporary_buffer<char> get_buf() {
             auto buf = _page->get_buf_weak();
-            buf.trim(_size);
             buf.trim_front(_offset);
+            buf.trim(_size);
             return buf;
         }
 
@@ -306,7 +306,7 @@ public:
                         ? _cached_file->_last_page_size
                         : page_size;
                 units = get_page_units(page_size);
-                page_view buf(_offset_in_page, size, std::move(page), std::move(units));
+                page_view buf(_offset_in_page, size - _offset_in_page, std::move(page), std::move(units));
                 _offset_in_page = 0;
                 ++_page_idx;
                 return buf;

--- a/utils/cached_file.hh
+++ b/utils/cached_file.hh
@@ -79,6 +79,10 @@ private:
             }
             return std::unique_ptr<cached_page, cached_page_del>(this);
         }
+
+        bool only_ref() const {
+            return _use_count <= 1;
+        }
     public:
         explicit cached_page(cached_file* parent, page_idx_type idx, temporary_buffer<char> buf)
             : parent(parent)
@@ -232,6 +236,24 @@ public:
             _size = std::exchange(o._size, 0);
             _units = std::move(o._units);
             return *this;
+        }
+
+        // Fills the page with garbage, releases the pointer and evicts the page so that it's no longer in cache.
+        // For testing use-after-free on the buffer space.
+        // After the call, the object is the same state as after being moved-from.
+        void release_and_scramble() noexcept {
+            if (_page->only_ref()) {
+                std::memset(_page->_lsa_buf.get(), 0xfe, _page->_lsa_buf.size());
+                cached_page& cp = *_page;
+                _page = nullptr;
+                cp.parent->_lru.remove(cp);
+                cp.on_evicted();
+            } else {
+                _page = nullptr;
+            }
+            _size = 0;
+            _offset = 0;
+            _units = std::nullopt;
         }
 
         operator bool() const { return bool(_page) && _size; }

--- a/utils/contiguous_shared_buffer.hh
+++ b/utils/contiguous_shared_buffer.hh
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <concepts>
+#include <memory>
+
+// A contiguous buffer of char objects which can be trimmed and
+// supports zero-copy sharing of its underlying memory.
+template<typename T>
+concept ContiguousSharedBuffer = std::movable<T>
+    && std::default_initializable<T>
+    && requires(T& obj, size_t pos, size_t len) {
+
+        // Creates a new buffer that shares the memory of the original buffer.
+        // The lifetime of the new buffer is independent of the original buffer.
+        { obj.share() } -> std::same_as<T>;
+
+        // Like share() but the new buffer represents a sub-range of the original buffer.
+        { obj.share(pos, len) } -> std::same_as<T>;
+
+        // Trims the suffix of a buffer so that 'len' is the index of the first removed byte.
+        { obj.trim(len) } -> std::same_as<void>;
+
+        // Trims the prefix of the buffer so that `pos` is the index of the first byte after the trim.
+        { obj.trim_front(pos) } -> std::same_as<void>;
+
+        { obj.begin() } -> std::same_as<const char*>;
+        { obj.get() } -> std::same_as<const char*>;
+        { obj.get_write() } -> std::same_as<char*>;
+        { obj.end() } -> std::same_as<const char*>;
+        { obj.size() } -> std::same_as<size_t>;
+        { obj.empty() } -> std::same_as<bool>;
+};


### PR DESCRIPTION
This fixes a use-after-free bug when parsing clustering key across
pages.

Also includes a fix for allocating section retry, which is potentially not safe (not in practice yet).

Details of the first problem:

Clustering key index lookup is based on the index file page cache. We
do a binary search within the index, which involves parsing index
blocks touched by the algorithm. Index file pages are 4 KB chunks
which are stored in LSA.

To parse the first key of the block, we reuse clustering_parser, which
is also used when parsing the data file. The parser is stateful and
accepts consecutive chunks as temporary_buffers. The parser is
supposed to keep its state across chunks.

In 93482439, the promoted index cursor was optimized to avoid 
fully page copy when parsing index blocks. Instead, parser is
given a temporary_buffer which is a view on the page.

A bit earlier, in b1b5bda, the parser was changed to keep shared 
fragments of the buffer passed to the parser in its internal state (across pages)
rather than copy the fragments into a new buffer. This is problematic 
when buffers come from page cache because LSA buffers may be moved
around or evicted. So the temporary_buffer which is a view on the LSA
buffer is valid only around the duration of a single consume() call to
the parser.

If the blob which is parsed (e.g. variable-length clustering key
component) spans pages, the fragments stored in the parser may be
invalidated before the component is fully parsed. As a result, the
parsed clustering key may have incorrect component values. This never
causes parsing errors because the "length" field is always parsed from
the current buffer, which is valid, and component parsing will end at
the right place in the next (valid) buffer.

The problematic path for clustering_key parsing is the one which calls
primitive_consumer::read_bytes(), which is called for example for text
components. Fixed-size components are not parsed like this, they store
the intermediate state by copying data.

This may cause incorrect clustering keys to be parsed when doing
binary search in the index, diverting the search to an incorrect
block.

Details of the solution:

We adapt page_view to a temporary_buffer-like API. For this, a new concept 
is introduced called ContiguousSharedBuffer. We also change parsers so that
they can be templated on the type of the buffer they work with (page_view vs
temporary_buffer). This way we don't introduce indirection to existing algorithms.

We use page_view instead of temporary_buffer in the promoted
index parser which works with page cache buffers. page_view can be safely
shared via share() and stored across allocating sections. It keeps hold to the
LSA buffer even across allocating sections by the means of cached_file::page_ptr.

Fixes #20766
