### PR TITLE
github: add a trigger to retrigger clang-tidy with comment

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -10,6 +10,9 @@ on:
       - 'docs/**'
       - '.github/**'
   workflow_dispatch:
+  issue_comment:
+    types:
+      - created
 
 env:
   BUILD_TYPE: RelWithDebInfo
@@ -25,6 +28,7 @@ concurrency:
 
 jobs:
   read-toolchain:
+    if: github.event_name == 'pull_request' || (github.event.issue.pull_request && startsWith(github.event.comment.body, '/clang-tidy'))
     uses: ./.github/workflows/read-toolchain.yaml
   clang-tidy:
     name: Run clang-tidy


### PR DESCRIPTION
before this change, clang-tidy is triggered by a pull request. but there are chances that user wants to retrigger it. for jenkins jobs, user can rebuild a job manually. but for workflow, only the developers with write permission can retrigger a workflow. this is not convenient to regular contributors.

so, in this change, another trigger is added, so that user can trigger the clang-tidy workflow with "/clang-tidy" command. the syntax is inspired by IRC commands.

---

no need to backport, because it's an improvement of the CI.