### PR TITLE
treewide: Prefer bytes_fwd.hh over bytes.hh

### DIFF
--- a/auth/sasl_challenge.hh
+++ b/auth/sasl_challenge.hh
@@ -18,7 +18,7 @@
 #include <seastar/core/sstring.hh>
 
 #include "auth/authenticated_user.hh"
-#include "bytes.hh"
+#include "bytes_fwd.hh"
 #include "seastarx.hh"
 
 namespace auth {

--- a/cdc/cdc_extension.hh
+++ b/cdc/cdc_extension.hh
@@ -11,7 +11,7 @@
 
 #include <seastar/core/sstring.hh>
 
-#include "bytes.hh"
+#include "bytes_fwd.hh"
 #include "cdc/cdc_options.hh"
 #include "schema/schema.hh"
 #include "serializer_impl.hh"

--- a/cql3/error_collector.hh
+++ b/cql3/error_collector.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "bytes.hh"
 #include "cql3/error_listener.hh"
 #include "exceptions/exceptions.hh"
 

--- a/exceptions/exceptions.cc
+++ b/exceptions/exceptions.cc
@@ -9,6 +9,8 @@
  */
 
 #include "exceptions.hh"
+
+#include "bytes.hh"
 #include <seastar/core/print.hh>
 #include <seastar/util/log.hh>
 

--- a/exceptions/exceptions.hh
+++ b/exceptions/exceptions.hh
@@ -15,7 +15,7 @@
 #include "db/operation_type.hh"
 #include <stdexcept>
 #include <seastar/core/sstring.hh>
-#include "bytes.hh"
+#include "bytes_fwd.hh"
 
 namespace exceptions {
 


### PR DESCRIPTION
CI started reporting warnings about including `bytes.hh` in
several files. The reason is they actually only use code
introduced in `bytes_fwd.hh` (which is also included by `bytes.hh`).
Clang-include-cleaner suggests that we get rid of that indirection
and only include `bytes_fwd.hh`. That's what happens in this commit.

We include `bytes.hh` in `exceptions/exceptions.cc` because
it relies on the formatting utilities declared and defined
in `bytes.hh`.

Backport: no need as the PR fixes warnings in CI.