### PR TITLE
test/unit: remove unused #include

### DIFF
--- a/test/unit/lsa_async_eviction_test.cc
+++ b/test/unit/lsa_async_eviction_test.cc
@@ -14,8 +14,6 @@
 
 #include "utils/managed_bytes.hh"
 #include "utils/logalloc.hh"
-#include "utils/managed_ref.hh"
-#include "test/perf/perf.hh"
 #include "log.hh"
 
 void print_stats() {


### PR DESCRIPTION
following headers are no longer used by this compilation unit:

- "utils/managed_ref.hh"
- "test/perf/perf.hh"

this was identified by clang-include-cleaner. As the code is audited, we can safely remove the #include directive.

---

it's a cleanup, hence no need to backport.