### PR TITLE
Atomic schema changes

### DIFF
--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -102,6 +102,12 @@ const functions& instance();
 
 class change_batch : public functions {
 public:
+    struct func_name_and_args {
+        function_name name;
+        std::vector<data_type> arg_types;
+    };
+    std::vector<func_name_and_args> removed_functions;
+
     // Skip init as we copy data from static instance.
     change_batch() : functions(skip_init{}) {
         _declared = instance()._declared;
@@ -112,6 +118,11 @@ public:
 
     // Used only by unittest.
     void clear_functions() noexcept;
+
+    void remove_function(function_name& name, std::vector<data_type>& arg_types) {
+        removed_functions.emplace_back(name, arg_types);
+        functions::remove_function(name, arg_types);
+    };
 };
 
 }

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -260,13 +260,13 @@ static future<affected_keyspaces> merge_keyspaces(distributed<service::storage_p
     auto& sharded_db = proxy.local().get_db();
     for (auto& name : affected.created) {
         slogger.info("Creating keyspace {}", name);
-        auto ksm = co_await create_keyspace_from_schema_partition(proxy,
+        auto ksm = co_await create_keyspace_metadata(proxy,
                 schema_result_value_type{name, after.at(name)});
         co_await replica::database::create_keyspace_on_all_shards(sharded_db, proxy, *ksm);
     }
     for (auto& name : affected.altered) {
         slogger.info("Altering keyspace {}", name);
-        auto tmp_ksm = co_await create_keyspace_from_schema_partition(proxy,
+        auto tmp_ksm = co_await create_keyspace_metadata(proxy,
                 schema_result_value_type{name, after.at(name)});
         co_await replica::database::update_keyspace_on_all_shards(sharded_db, *tmp_ksm);
     }

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -251,24 +251,29 @@ static future<affected_keyspaces> merge_keyspaces(distributed<service::storage_p
      */
     auto diff = difference(before, after, indirect_equal_to<lw_shared_ptr<query::result_set>>());
 
+    auto created = std::move(diff.entries_only_on_right);
+    auto altered = std::move(diff.entries_differing);
+
     affected_keyspaces affected{
-        .created = std::move(diff.entries_only_on_right),
-        .altered = std::move(diff.entries_differing),
         .dropped = std::move(diff.entries_only_on_left),
     };
 
     auto& sharded_db = proxy.local().get_db();
-    for (auto& name : affected.created) {
+    for (auto& name : created) {
         slogger.info("Creating keyspace {}", name);
         auto ksm = co_await create_keyspace_metadata(proxy,
                 schema_result_value_type{name, after.at(name)});
-        co_await replica::database::create_keyspace_on_all_shards(sharded_db, proxy, *ksm);
+        affected.created.push_back(
+                co_await replica::database::prepare_create_keyspace_on_all_shards(
+                        sharded_db, proxy, *ksm));
     }
-    for (auto& name : affected.altered) {
+    for (auto& name : altered) {
         slogger.info("Altering keyspace {}", name);
         auto tmp_ksm = co_await create_keyspace_metadata(proxy,
                 schema_result_value_type{name, after.at(name)});
-        co_await replica::database::update_keyspace_on_all_shards(sharded_db, *tmp_ksm);
+        affected.altered.push_back(
+                co_await replica::database::prepare_update_keyspace_on_all_shards(
+                        sharded_db, *tmp_ksm));
     }
     for (auto& key : affected.dropped) {
         slogger.info("Dropping keyspace {}", key);
@@ -789,16 +794,38 @@ future<> schema_applier::update(const std::vector<mutation>& muts) {
             _before.scylla_aggregates, _after.scylla_aggregates);
 
     co_await drop_types(_proxy, _affected_user_types);
-
-    auto& sharded_db = _proxy.local().get_db();
-    // it is safe to drop a keyspace only when all nested ColumnFamilies where deleted
-    for (auto& name : _affected_keyspaces.dropped) {
-        co_await replica::database::drop_keyspace_on_all_shards(sharded_db, name);
-    }
 }
 
-void schema_applier::commit() {
-    // TODO: add copy on write to schema changes
+void schema_applier::commit_on_shard(replica::database& db) {
+    // commit keyspace operations
+    for (auto& ks_per_shard : _affected_keyspaces.created) {
+        auto& ks = ks_per_shard[this_shard_id()];
+        db.insert_keyspace(std::move(ks));
+    }
+    for (auto& ks_change_per_shard : _affected_keyspaces.altered) {
+        auto& ks_change = ks_change_per_shard[this_shard_id()];
+        db.update_keyspace(std::move(ks_change));
+    }
+    for (auto& ks_name : _affected_keyspaces.dropped) {
+        db.drop_keyspace(ks_name);
+    }
+    // TODO: move code for all schema modifications
+}
+
+// TODO: move per shard logic directly to raft so that all subsystems can be updated together
+future<> schema_applier::commit() {
+    auto& sharded_db = _proxy.local().get_db();
+    // Run func first on shard 0
+    // to allow "seeding" of the effective_replication_map
+    // with a new e_r_m instance.
+    co_await sharded_db.invoke_on(0, [this] (replica::database& db) { return commit_on_shard(db); });
+    co_await sharded_db.invoke_on_all([this] (replica::database& db) {
+        if (this_shard_id() == 0) {
+            return make_ready_future<>();
+        }
+        commit_on_shard(db);
+        return make_ready_future<>();
+    });
 }
 
 future<> schema_applier::notify() {
@@ -806,10 +833,12 @@ future<> schema_applier::notify() {
     co_await sharded_db.invoke_on_all([&] (replica::database& db) -> future<> {
         auto& notifier = db.get_notifier();
         // notify about keyspaces
-        for (auto& name : _affected_keyspaces.created) {
+        for (auto& ks : _affected_keyspaces.created) {
+            auto& name = ks[this_shard_id()]->metadata()->name();
             co_await notifier.create_keyspace(name);
         }
-        for (auto& name : _affected_keyspaces.altered) {
+        for (auto& change : _affected_keyspaces.altered) {
+            auto& name = change[this_shard_id()].keyspace_name();
             co_await notifier.update_keyspace(name);
         }
         for (auto& name : _affected_keyspaces.dropped) {
@@ -851,7 +880,7 @@ static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, shar
     co_await ap.adjust(mutations);
     co_await proxy.local().get_db().local().apply(freeze(mutations), db::no_timeout);
     co_await ap.update(mutations);
-    ap.commit();
+    co_await ap.commit();
     co_await ap.notify();
 }
 

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -32,7 +32,6 @@
 #include "db/system_keyspace.hh"
 #include "cql3/expr/expression.hh"
 #include "types/types.hh"
-#include "db/schema_tables.hh"
 #include "service/migration_manager.hh"
 #include "service/storage_proxy.hh"
 #include "gms/feature_service.hh"
@@ -54,13 +53,10 @@
 #include "types/list.hh"
 #include "types/set.hh"
 #include "mutation/async_utils.hh"
-#include "db/schema_tables.hh"
 
 namespace db {
 
 namespace schema_tables {
-
-enum class table_kind { table, view };
 
 static constexpr std::initializer_list<table_kind> all_table_kinds = {
     table_kind::table,
@@ -73,6 +69,24 @@ static schema_ptr get_table_holder(table_kind k) {
         case table_kind::view: return views();
     }
     abort();
+}
+
+table_selector& table_selector::operator+=(table_selector&& o) {
+    all_in_keyspace |= o.all_in_keyspace;
+    for (auto t : all_table_kinds) {
+        tables[t].merge(std::move(o.tables[t]));
+    }
+    return *this;
+}
+
+void table_selector::add(table_kind t, sstring name) {
+    tables[t].emplace(std::move(name));
+}
+
+void table_selector::add(sstring name) {
+    for (auto t : all_table_kinds) {
+        add(t, name);
+    }
 }
 
 }
@@ -96,29 +110,6 @@ template <> struct fmt::formatter<db::schema_tables::table_kind> {
 namespace db {
 
 namespace schema_tables {
-
-struct table_selector {
-    bool all_in_keyspace = false; // If true, selects all existing tables in a keyspace plus what's in "tables";
-    std::unordered_map<table_kind, std::unordered_set<sstring>> tables;
-
-    table_selector& operator+=(table_selector&& o) {
-        all_in_keyspace |= o.all_in_keyspace;
-        for (auto t : all_table_kinds) {
-            tables[t].merge(std::move(o.tables[t]));
-        }
-        return *this;
-    }
-
-    void add(table_kind t, sstring name) {
-        tables[t].emplace(std::move(name));
-    }
-
-    void add(sstring name) {
-        for (auto t : all_table_kinds) {
-            add(t, name);
-        }
-    }
-};
 
 static std::optional<table_id> table_id_from_mutations(const schema_mutations& sm) {
     auto table_rs = query::result_set(sm.columnfamilies_mutation());
@@ -737,47 +728,49 @@ static future<> merge_aggregates(distributed<service::storage_proxy>& proxy, con
     });
 }
 
-static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks, std::vector<mutation> mutations, bool reload)
-{
-    slogger.trace("do_merge_schema: {}", mutations);
+future<schema_complete_view> schema_applier::get_schema_complete_view() {
+    schema_complete_view v;
+    v.keyspaces = co_await read_schema_for_keyspaces(_proxy, KEYSPACES, _keyspaces);
+    v.tables = co_await read_tables_for_keyspaces(_proxy, _keyspaces, table_kind::table, _affected_tables);
+    v.types = co_await read_schema_for_keyspaces(_proxy, TYPES, _keyspaces);
+    v.views = co_await read_tables_for_keyspaces(_proxy, _keyspaces, table_kind::view, _affected_tables);
+    v.functions = co_await read_schema_for_keyspaces(_proxy, FUNCTIONS, _keyspaces);
+    v.aggregates = co_await read_schema_for_keyspaces(_proxy, AGGREGATES, _keyspaces);
+    v.scylla_aggregates = co_await read_schema_for_keyspaces(_proxy, SCYLLA_AGGREGATES, _keyspaces);
+
+    co_return std::move(v);
+}
+
+future<> schema_applier::prepare(const std::vector<mutation>& muts) {
     schema_ptr s = keyspaces();
-    // compare before/after schemas of the affected keyspaces only
-    std::set<sstring> keyspaces;
-    using keyspace_name = sstring;
-    std::unordered_map<keyspace_name, table_selector> affected_tables;
-    locator::tablet_metadata_change_hint tablet_hint;
-    for (auto&& mutation : mutations) {
+    for (auto& mutation : muts) {
         sstring keyspace_name = value_cast<sstring>(utf8_type->deserialize(mutation.key().get_component(*s, 0)));
 
         if (schema_tables_holding_schema_mutations().contains(mutation.schema()->id())) {
-            affected_tables[keyspace_name] += get_affected_tables(keyspace_name, mutation);
+            _affected_tables[keyspace_name] += get_affected_tables(keyspace_name, mutation);
         }
 
-        replica::update_tablet_metadata_change_hint(tablet_hint, mutation);
+        replica::update_tablet_metadata_change_hint(_tablet_hint, mutation);
 
-        keyspaces.emplace(std::move(keyspace_name));
-        // We must force recalculation of schema version after the merge, since the resulting
-        // schema may be a mix of the old and new schemas, with the exception of entries
-        // that originate from group 0.
-        maybe_delete_schema_version(mutation);
+        _keyspaces.emplace(std::move(keyspace_name));
     }
 
-    if (reload) {
-        for (auto&& ks : proxy.local().get_db().local().get_non_system_keyspaces()) {
-            keyspaces.emplace(ks);
+    if (_reload) {
+        for (auto&& ks : _proxy.local().get_db().local().get_non_system_keyspaces()) {
+            _keyspaces.emplace(ks);
             table_selector sel;
             sel.all_in_keyspace = true;
-            affected_tables[ks] = sel;
+            _affected_tables[ks] = sel;
         }
     }
 
     // Resolve sel.all_in_keyspace == true to the actual list of tables and views.
-    for (auto&& [keyspace_name, sel] : affected_tables) {
+    for (auto&& [keyspace_name, sel] : _affected_tables) {
         if (sel.all_in_keyspace) {
             // FIXME: Obtain from the database object
             slogger.trace("Reading table list for keyspace {}", keyspace_name);
             for (auto k : all_table_kinds) {
-                for (auto&& n : co_await read_table_names_of_keyspace(proxy, keyspace_name, get_table_holder(k))) {
+                for (auto&& n : co_await read_table_names_of_keyspace(_proxy, keyspace_name, get_table_holder(k))) {
                     sel.add(k, std::move(n));
                 }
             }
@@ -785,40 +778,59 @@ static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, shar
         slogger.debug("Affected tables for keyspace {}: {}", keyspace_name, sel.tables);
     }
 
-    // current state of the schema
-    auto&& old_keyspaces = co_await read_schema_for_keyspaces(proxy, KEYSPACES, keyspaces);
-    auto&& old_column_families = co_await read_tables_for_keyspaces(proxy, keyspaces, table_kind::table, affected_tables);
-    auto&& old_types = co_await read_schema_for_keyspaces(proxy, TYPES, keyspaces);
-    auto&& old_views = co_await read_tables_for_keyspaces(proxy, keyspaces, table_kind::view, affected_tables);
-    auto old_functions = co_await read_schema_for_keyspaces(proxy, FUNCTIONS, keyspaces);
-    auto old_aggregates = co_await read_schema_for_keyspaces(proxy, AGGREGATES, keyspaces);
-    auto old_scylla_aggregates = co_await read_schema_for_keyspaces(proxy, SCYLLA_AGGREGATES, keyspaces);
+    _before = co_await get_schema_complete_view();
+}
 
-    co_await proxy.local().get_db().local().apply(freeze(mutations), db::no_timeout);
+future<> schema_applier::adjust(std::vector<mutation>& muts) {
+    for (auto& mut : muts) {
+        // We must force recalculation of schema version after the merge, since the resulting
+        // schema may be a mix of the old and new schemas, with the exception of entries
+        // that originate from group 0.
+        maybe_delete_schema_version(mut);
+    }
+    return make_ready_future<>();
+}
 
-    // with new data applied
-    auto&& new_keyspaces = co_await read_schema_for_keyspaces(proxy, KEYSPACES, keyspaces);
-    auto&& new_column_families = co_await read_tables_for_keyspaces(proxy, keyspaces, table_kind::table, affected_tables);
-    auto&& new_types = co_await read_schema_for_keyspaces(proxy, TYPES, keyspaces);
-    auto&& new_views = co_await read_tables_for_keyspaces(proxy, keyspaces, table_kind::view, affected_tables);
-    auto new_functions = co_await read_schema_for_keyspaces(proxy, FUNCTIONS, keyspaces);
-    auto new_aggregates = co_await read_schema_for_keyspaces(proxy, AGGREGATES, keyspaces);
-    auto new_scylla_aggregates = co_await read_schema_for_keyspaces(proxy, SCYLLA_AGGREGATES, keyspaces);
+future<> schema_applier::update(const std::vector<mutation>& muts) {
+    _after = co_await get_schema_complete_view();
 
-    std::set<sstring> keyspaces_to_drop = co_await merge_keyspaces(proxy, std::move(old_keyspaces), std::move(new_keyspaces));
-    auto types_to_drop = co_await merge_types(proxy, std::move(old_types), std::move(new_types));
-    co_await merge_tables_and_views(proxy, sys_ks,
-        std::move(old_column_families), std::move(new_column_families),
-        std::move(old_views), std::move(new_views), reload, std::move(tablet_hint));
-    co_await merge_functions(proxy, std::move(old_functions), std::move(new_functions));
-    co_await merge_aggregates(proxy, std::move(old_aggregates), std::move(new_aggregates), std::move(old_scylla_aggregates), std::move(new_scylla_aggregates));
+    std::set<sstring> keyspaces_to_drop = co_await merge_keyspaces(_proxy, _before.keyspaces, _after.keyspaces);
+    auto types_to_drop = co_await merge_types(_proxy, _before.types, _after.types);
+    co_await merge_tables_and_views(_proxy, _sys_ks,
+            _before.tables, _after.tables,
+            _before.views, _after.views,
+            _reload, _tablet_hint);
+    co_await merge_functions(_proxy, _before.functions, _after.functions);
+    co_await merge_aggregates(_proxy, _before.aggregates, _after.aggregates,
+            _before.scylla_aggregates, _after.scylla_aggregates);
     co_await types_to_drop.drop();
 
-    auto& sharded_db = proxy.local().get_db();
+    auto& sharded_db = _proxy.local().get_db();
     // it is safe to drop a keyspace only when all nested ColumnFamilies where deleted
     for (auto keyspace_to_drop : keyspaces_to_drop) {
         co_await replica::database::drop_keyspace_on_all_shards(sharded_db, keyspace_to_drop);
     }
+}
+
+void schema_applier::commit() {
+    // TODO: add copy on write to schema changes
+}
+
+future<> schema_applier::notify() {
+    // TODO: pull out notifications code from update() and place here
+    co_return;
+}
+
+static future<> do_merge_schema(distributed<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks, std::vector<mutation> mutations, bool reload)
+{
+    slogger.trace("do_merge_schema: {}", mutations);
+    schema_applier ap(proxy, sys_ks, reload);
+    co_await ap.prepare(mutations);
+    co_await ap.adjust(mutations);
+    co_await proxy.local().get_db().local().apply(freeze(mutations), db::no_timeout);
+    co_await ap.update(mutations);
+    ap.commit();
+    co_await ap.notify();
 }
 
 /**

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -237,7 +237,7 @@ static void maybe_delete_schema_version(mutation& m) {
     }
 }
 
-static future<std::set<sstring>> merge_keyspaces(distributed<service::storage_proxy>& proxy, const schema_result& before, const schema_result& after)
+static future<affected_keyspaces> merge_keyspaces(distributed<service::storage_proxy>& proxy, const schema_result& before, const schema_result& after)
 {
     /*
      * - we don't care about entriesOnlyOnLeft() or entriesInCommon(), because only the changes are of interest to us
@@ -251,27 +251,29 @@ static future<std::set<sstring>> merge_keyspaces(distributed<service::storage_pr
      */
     auto diff = difference(before, after, indirect_equal_to<lw_shared_ptr<query::result_set>>());
 
-    auto& created = diff.entries_only_on_right;
-    auto& altered = diff.entries_differing;
-    auto& dropped = diff.entries_only_on_left;
+    affected_keyspaces affected{
+        .created = std::move(diff.entries_only_on_right),
+        .altered = std::move(diff.entries_differing),
+        .dropped = std::move(diff.entries_only_on_left),
+    };
 
     auto& sharded_db = proxy.local().get_db();
-    for (auto& name : created) {
+    for (auto& name : affected.created) {
         slogger.info("Creating keyspace {}", name);
         auto ksm = co_await create_keyspace_from_schema_partition(proxy,
                 schema_result_value_type{name, after.at(name)});
         co_await replica::database::create_keyspace_on_all_shards(sharded_db, proxy, *ksm);
     }
-    for (auto& name : altered) {
+    for (auto& name : affected.altered) {
         slogger.info("Altering keyspace {}", name);
         auto tmp_ksm = co_await create_keyspace_from_schema_partition(proxy,
                 schema_result_value_type{name, after.at(name)});
         co_await replica::database::update_keyspace_on_all_shards(sharded_db, *tmp_ksm);
     }
-    for (auto& key : dropped) {
+    for (auto& key : affected.dropped) {
         slogger.info("Dropping keyspace {}", key);
     }
-    co_return dropped;
+    co_return affected;
 }
 
 static std::vector<const query::result_set_row*> collect_rows(const std::set<sstring>& keys, const schema_result& result) {
@@ -794,7 +796,7 @@ future<> schema_applier::adjust(std::vector<mutation>& muts) {
 future<> schema_applier::update(const std::vector<mutation>& muts) {
     _after = co_await get_schema_complete_view();
 
-    std::set<sstring> keyspaces_to_drop = co_await merge_keyspaces(_proxy, _before.keyspaces, _after.keyspaces);
+    _affected_keyspaces = co_await merge_keyspaces(_proxy, _before.keyspaces, _after.keyspaces);
     auto types_to_drop = co_await merge_types(_proxy, _before.types, _after.types);
     co_await merge_tables_and_views(_proxy, _sys_ks,
             _before.tables, _after.tables,
@@ -807,8 +809,8 @@ future<> schema_applier::update(const std::vector<mutation>& muts) {
 
     auto& sharded_db = _proxy.local().get_db();
     // it is safe to drop a keyspace only when all nested ColumnFamilies where deleted
-    for (auto keyspace_to_drop : keyspaces_to_drop) {
-        co_await replica::database::drop_keyspace_on_all_shards(sharded_db, keyspace_to_drop);
+    for (auto& name : _affected_keyspaces.dropped) {
+        co_await replica::database::drop_keyspace_on_all_shards(sharded_db, name);
     }
 }
 
@@ -817,6 +819,22 @@ void schema_applier::commit() {
 }
 
 future<> schema_applier::notify() {
+    auto& sharded_db = _proxy.local().get_db();
+    co_await sharded_db.invoke_on_all([&] (replica::database& db) -> future<> {
+        auto& notifier = db.get_notifier();
+        // notify about keyspaces
+        for (auto& name : _affected_keyspaces.created) {
+            const auto& ks = db.find_keyspace(name);
+            co_await notifier.create_keyspace(ks.metadata());
+        }
+        for (auto& name : _affected_keyspaces.altered) {
+            const auto& ks = db.find_keyspace(name);
+            co_await notifier.update_keyspace(ks.metadata());
+        }
+        for (auto& name : _affected_keyspaces.dropped) {
+            co_await notifier.drop_keyspace(name);
+        }
+    });
     // TODO: pull out notifications code from update() and place here
     co_return;
 }

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -663,11 +663,12 @@ static void drop_cached_func(replica::database& db, const query::result_set_row&
     }
 }
 
-static future<> merge_functions(distributed<service::storage_proxy>& proxy, schema_result before, schema_result after) {
+static future<functions_change_batch_all_shards> merge_functions(distributed<service::storage_proxy>& proxy, schema_result before, schema_result after) {
     auto diff = diff_rows(before, after);
 
+    functions_change_batch_all_shards batches(smp::count);
     co_await proxy.local().get_db().invoke_on_all(coroutine::lambda([&] (replica::database& db) -> future<> {
-        cql3::functions::change_batch batch;
+        auto& batch = batches[this_shard_id()];
         for (const auto& val : diff.created) {
             batch.add_function(co_await create_func(db, *val));
         }
@@ -691,14 +692,16 @@ static future<> merge_functions(distributed<service::storage_proxy>& proxy, sche
         batch.commit();
         co_await std::move(events);
     }));
+    co_return batches;
 }
 
-static future<> merge_aggregates(distributed<service::storage_proxy>& proxy, const schema_result& before, const schema_result& after,
+static future<functions_change_batch_all_shards> merge_aggregates(distributed<service::storage_proxy>& proxy, const schema_result& before, const schema_result& after,
         const schema_result& scylla_before, const schema_result& scylla_after) {
     auto diff = diff_aggregates_rows(before, after, scylla_before, scylla_after);
 
+    functions_change_batch_all_shards batches(smp::count);
     co_await proxy.local().get_db().invoke_on_all([&] (replica::database& db)-> future<> {
-        cql3::functions::change_batch batch;
+        auto& batch = batches[this_shard_id()];
         for (const auto& val : diff.created) {
             batch.add_function(create_aggregate(db, *val.first, val.second, batch));
         }
@@ -715,6 +718,7 @@ static future<> merge_aggregates(distributed<service::storage_proxy>& proxy, con
         batch.commit();
         co_await std::move(events);
     });
+    co_return batches;
 }
 
 future<schema_complete_view> schema_applier::get_schema_complete_view() {
@@ -789,8 +793,8 @@ future<> schema_applier::update(const std::vector<mutation>& muts) {
             _before.tables, _after.tables,
             _before.views, _after.views,
             _reload, _tablet_hint);
-    co_await merge_functions(_proxy, _before.functions, _after.functions);
-    co_await merge_aggregates(_proxy, _before.aggregates, _after.aggregates,
+    _functions_batch = co_await merge_functions(_proxy, _before.functions, _after.functions);
+    _aggregates_batch = co_await merge_aggregates(_proxy, _before.aggregates, _after.aggregates,
             _before.scylla_aggregates, _after.scylla_aggregates);
 
     co_await drop_types(_proxy, _affected_user_types);

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -604,25 +604,11 @@ static future<affected_tables_and_views> merge_tables_and_views(distributed<serv
         });
     });
     co_await db.invoke_on_all([&](replica::database& db) -> future<> {
-        std::vector<bool> columns_changed;
-        columns_changed.reserve(diff.tables.altered.size() + diff.views.altered.size());
+        diff.columns_changed.reserve(diff.tables.altered.size() + diff.views.altered.size());
         for (auto&& altered : boost::range::join(diff.tables.altered, diff.views.altered)) {
-            columns_changed.push_back(db.update_column_family(altered.new_schema));
+            diff.columns_changed.push_back(db.update_column_family(altered.new_schema));
             co_await coroutine::maybe_yield();
         }
-        auto it = columns_changed.begin();
-        auto notify = [&] (auto& r, auto&& f) -> future<> {
-            co_await max_concurrent_for_each(r, max_concurrent, std::move(f));
-        };
-        // View drops are notified first, because a table can only be dropped if its views are already deleted
-        co_await notify(diff.views.dropped, [&] (auto&& dt) { return db.get_notifier().drop_view(view_ptr(dt.schema)); });
-        co_await notify(diff.tables.dropped, [&] (auto&& dt) { return db.get_notifier().drop_column_family(dt.schema); });
-        // Table creations are notified first, in case a view is created right after the table
-        co_await notify(diff.tables.created, [&] (auto&& gs) { return db.get_notifier().create_column_family(gs); });
-        co_await notify(diff.views.created, [&] (auto&& gs) { return db.get_notifier().create_view(view_ptr(gs)); });
-        // Table altering is notified first, in case new base columns appear
-        co_await notify(diff.tables.altered, [&] (auto&& altered) { return db.get_notifier().update_column_family(altered.new_schema, *it++); });
-        co_await notify(diff.views.altered, [&] (auto&& altered) { return db.get_notifier().update_view(view_ptr(altered.new_schema), *it++); });
     });
 
     // Insert column_mapping into history table for altered and created tables.
@@ -649,6 +635,22 @@ static future<affected_tables_and_views> merge_tables_and_views(distributed<serv
     });
 
     co_return diff;
+}
+
+static future<> notify_tables_and_views(service::migration_notifier& notifier, const affected_tables_and_views& diff) {
+    auto it = diff.columns_changed.begin();
+    auto notify = [&] (auto& r, auto&& f) -> future<> {
+        co_await max_concurrent_for_each(r, max_concurrent, std::move(f));
+    };
+    // View drops are notified first, because a table can only be dropped if its views are already deleted
+    co_await notify(diff.views.dropped, [&] (auto&& dt) { return notifier.drop_view(view_ptr(dt.schema)); });
+    co_await notify(diff.tables.dropped, [&] (auto&& dt) { return notifier.drop_column_family(dt.schema); });
+    // Table creations are notified first, in case a view is created right after the table
+    co_await notify(diff.tables.created, [&] (auto&& gs) { return notifier.create_column_family(gs); });
+    co_await notify(diff.views.created, [&] (auto&& gs) { return notifier.create_view(view_ptr(gs)); });
+    // Table altering is notified first, in case new base columns appear
+    co_await notify(diff.tables.altered, [&] (auto&& altered) { return notifier.update_column_family(altered.new_schema, *it++); });
+    co_await notify(diff.views.altered, [&] (auto&& altered) { return notifier.update_view(view_ptr(altered.new_schema), *it++); });
 }
 
 static void drop_cached_func(replica::database& db, const query::result_set_row& row) {
@@ -829,6 +831,8 @@ future<> schema_applier::notify() {
         for (auto& type : types.dropped) {
             co_await notifier.drop_user_type(type);
         }
+
+        co_await notify_tables_and_views(notifier, _affected_tables_and_views);
     });
     // TODO: pull out notifications code from update() and place here
     co_return;

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -26,6 +26,7 @@
 
 #include <fmt/ranges.h>
 
+#include "seastar/core/shard_id.hh"
 #include "view_info.hh"
 #include "replica/database.hh"
 #include "lang/manager.hh"
@@ -425,41 +426,42 @@ static aggregate_diff diff_aggregates_rows(const schema_result& aggr_before, con
     return {std::move(created), std::move(dropped)};
 }
 
-struct [[nodiscard]] user_types_to_drop final {
-    seastar::noncopyable_function<future<> ()> drop;
-};
-
 // see the comments for merge_keyspaces()
-static future<user_types_to_drop> merge_types(distributed<service::storage_proxy>& proxy, schema_result before, schema_result after)
+static future<affected_user_types> merge_types(distributed<service::storage_proxy>& proxy, schema_result before, schema_result after)
 {
     auto diff = diff_rows(before, after);
+    affected_user_types affected(smp::count);
 
-    // Create and update user types before any tables/views are created that potentially
-    // use those types. Similarly, defer dropping until after tables/views that may use
-    // some of these user types are dropped.
-
-    co_await proxy.local().get_db().invoke_on_all([&] (replica::database& db) -> future<> {
-        auto created_types = co_await create_types(db, diff.created);
-        for (auto&& user_type : created_types) {
+    co_await proxy.local().get_db().invoke_on_all([&] (replica::database& db) mutable -> future<> {
+        // Create and update user types before any tables/views are created that potentially
+        // use those types.
+        auto created = co_await create_types(db, diff.created);
+        for (auto&& user_type : created) {
             db.find_keyspace(user_type->_keyspace).add_user_type(user_type);
-            co_await db.get_notifier().create_user_type(user_type);
+            affected[this_shard_id()].created.push_back(user_type);
         }
-        auto altered_types = co_await create_types(db, diff.altered);
-        for (auto&& user_type : altered_types) {
+        auto altered = co_await create_types(db, diff.altered);
+        for (auto&& user_type : altered) {
             db.find_keyspace(user_type->_keyspace).add_user_type(user_type);
-            co_await db.get_notifier().update_user_type(user_type);
+            affected[this_shard_id()].altered.push_back(user_type);
+        }
+        auto dropped = co_await create_types(proxy.local().get_db().local(), diff.dropped);
+        for (auto&& user_type : dropped) {
+            // Just add to affected, defers dropping until after tables/views that may use
+            // some of these user types are dropped.
+            affected[this_shard_id()].dropped.push_back(user_type);
         }
     });
+    co_return affected;
+}
 
-    co_return user_types_to_drop{[&proxy, before = std::move(before), rows = std::move(diff.dropped)] () mutable -> future<> {
-        co_await proxy.local().get_db().invoke_on_all([&] (replica::database& db) -> future<> {
-            auto dropped = co_await create_types(db, rows);
-            for (auto& user_type : dropped) {
-                db.find_keyspace(user_type->_keyspace).remove_user_type(user_type);
-                co_await db.get_notifier().drop_user_type(user_type);
-            }
-        });
-    }};
+static future<> drop_types(distributed<service::storage_proxy>& proxy, affected_user_types& types) {
+    co_await proxy.local().get_db().invoke_on_all([&] (replica::database& db) -> future<> {
+        for (auto& user_type : types[this_shard_id()].dropped) {
+            db.find_keyspace(user_type->_keyspace).remove_user_type(user_type);
+        }
+        co_return;
+    });
 }
 
 struct schema_diff {
@@ -797,7 +799,7 @@ future<> schema_applier::update(const std::vector<mutation>& muts) {
     _after = co_await get_schema_complete_view();
 
     _affected_keyspaces = co_await merge_keyspaces(_proxy, _before.keyspaces, _after.keyspaces);
-    auto types_to_drop = co_await merge_types(_proxy, _before.types, _after.types);
+    _affected_user_types = co_await merge_types(_proxy, _before.types, _after.types);
     co_await merge_tables_and_views(_proxy, _sys_ks,
             _before.tables, _after.tables,
             _before.views, _after.views,
@@ -805,7 +807,8 @@ future<> schema_applier::update(const std::vector<mutation>& muts) {
     co_await merge_functions(_proxy, _before.functions, _after.functions);
     co_await merge_aggregates(_proxy, _before.aggregates, _after.aggregates,
             _before.scylla_aggregates, _after.scylla_aggregates);
-    co_await types_to_drop.drop();
+
+    co_await drop_types(_proxy, _affected_user_types);
 
     auto& sharded_db = _proxy.local().get_db();
     // it is safe to drop a keyspace only when all nested ColumnFamilies where deleted
@@ -831,6 +834,17 @@ future<> schema_applier::notify() {
         }
         for (auto& name : _affected_keyspaces.dropped) {
             co_await notifier.drop_keyspace(name);
+        }
+        // notify about user types
+        auto& types = _affected_user_types[this_shard_id()];
+        for (auto& type : types.created) {
+            co_await notifier.create_user_type(type);
+        }
+        for (auto& type : types.altered) {
+            co_await notifier.update_user_type(type);
+        }
+        for (auto& type : types.dropped) {
+            co_await notifier.drop_user_type(type);
         }
     });
     // TODO: pull out notifications code from update() and place here

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -44,7 +44,6 @@
 #include <seastar/coroutine/all.hh>
 #include "log.hh"
 #include "frozen_schema.hh"
-#include "schema/schema_registry.hh"
 #include "system_keyspace.hh"
 #include "system_distributed_keyspace.hh"
 #include "cql3/query_processor.hh"
@@ -464,25 +463,6 @@ static future<> drop_types(distributed<service::storage_proxy>& proxy, affected_
     });
 }
 
-struct schema_diff {
-    struct dropped_schema {
-        global_schema_ptr schema;
-    };
-
-    struct altered_schema {
-        global_schema_ptr old_schema;
-        global_schema_ptr new_schema;
-    };
-
-    std::vector<global_schema_ptr> created;
-    std::vector<altered_schema> altered;
-    std::vector<dropped_schema> dropped;
-
-    size_t size() const {
-        return created.size() + altered.size() + dropped.size();
-    }
-};
-
 // Which side of the diff this schema is on?
 // Helps ensuring that when creating schema for altered views, we match "before"
 // version of view to "before" version of base table and "after" to "after"
@@ -538,7 +518,7 @@ constexpr size_t max_concurrent = 8;
 // that when a base schema and a subset of its views are modified together (i.e.,
 // upon an alter table or alter type statement), then they are published together
 // as well, without any deferring in-between.
-static future<> merge_tables_and_views(distributed<service::storage_proxy>& proxy,
+static future<affected_tables_and_views> merge_tables_and_views(distributed<service::storage_proxy>& proxy,
     sharded<db::system_keyspace>& sys_ks,
     const std::map<table_id, schema_mutations>& tables_before,
     const std::map<table_id, schema_mutations>& tables_after,
@@ -547,10 +527,11 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
     bool reload,
     locator::tablet_metadata_change_hint tablet_hint)
 {
-    auto tables_diff = diff_table_or_view(proxy, std::move(tables_before), std::move(tables_after), reload, [&] (schema_mutations sm, schema_diff_side) {
+    affected_tables_and_views diff;
+    diff.tables = diff_table_or_view(proxy, std::move(tables_before), std::move(tables_after), reload, [&] (schema_mutations sm, schema_diff_side) {
         return create_table_from_mutations(proxy, std::move(sm));
     });
-    auto views_diff = diff_table_or_view(proxy, std::move(views_before), std::move(views_after), reload, [&] (schema_mutations sm, schema_diff_side side) {
+    diff.views = diff_table_or_view(proxy, std::move(views_before), std::move(views_after), reload, [&] (schema_mutations sm, schema_diff_side side) {
         // The view schema mutation should be created with reference to the base table schema because we definitely know it by now.
         // If we don't do it we are leaving a window where write commands to this schema are illegal.
         // There are 3 possibilities:
@@ -560,7 +541,7 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
         //    the database object.
         view_ptr vp = create_view_from_mutations(proxy, std::move(sm));
         schema_ptr base_schema;
-        for (auto&& altered : tables_diff.altered) {
+        for (auto&& altered : diff.tables.altered) {
             // Chose the appropriate version of the base table schema: old -> old, new -> new.
             schema_ptr s = side == schema_diff_side::left ? altered.old_schema : altered.new_schema;
             if (s->ks_name() == vp->ks_name() && s->cf_name() == vp->view_info()->base_name() ) {
@@ -569,7 +550,7 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
             }
         }
         if (!base_schema) {
-            for (auto&& s : tables_diff.created) {
+            for (auto&& s : diff.tables.created) {
                 if (s.get()->ks_name() == vp->ks_name() && s.get()->cf_name() == vp->view_info()->base_name() ) {
                     base_schema = s;
                     break;
@@ -593,11 +574,11 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
     // to a mv not finding its schema when snapshotting since the main table
     // was already dropped (see https://github.com/scylladb/scylla/issues/5614)
     auto& db = proxy.local().get_db();
-    co_await max_concurrent_for_each(views_diff.dropped, max_concurrent, [&db, &sys_ks] (schema_diff::dropped_schema& dt) {
+    co_await max_concurrent_for_each(diff.views.dropped, max_concurrent, [&db, &sys_ks] (schema_diff::dropped_schema& dt) {
         auto& s = *dt.schema.get();
         return replica::database::drop_table_on_all_shards(db, sys_ks, s.ks_name(), s.cf_name());
     });
-    co_await max_concurrent_for_each(tables_diff.dropped, max_concurrent, [&db, &sys_ks] (schema_diff::dropped_schema& dt) -> future<> {
+    co_await max_concurrent_for_each(diff.tables.dropped, max_concurrent, [&db, &sys_ks] (schema_diff::dropped_schema& dt) -> future<> {
         auto& s = *dt.schema.get();
         return replica::database::drop_table_on_all_shards(db, sys_ks, s.ks_name(), s.cf_name());
     });
@@ -615,17 +596,17 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
     co_await db.invoke_on_all([&] (replica::database& db) -> future<> {
         // In order to avoid possible races we first create the tables and only then the views.
         // That way if a view seeks information about its base table it's guaranteed to find it.
-        co_await max_concurrent_for_each(tables_diff.created, max_concurrent, [&] (global_schema_ptr& gs) -> future<> {
+        co_await max_concurrent_for_each(diff.tables.created, max_concurrent, [&] (global_schema_ptr& gs) -> future<> {
             co_await db.add_column_family_and_make_directory(gs, replica::database::is_new_cf::yes);
         });
-        co_await max_concurrent_for_each(views_diff.created, max_concurrent, [&] (global_schema_ptr& gs) -> future<> {
+        co_await max_concurrent_for_each(diff.views.created, max_concurrent, [&] (global_schema_ptr& gs) -> future<> {
             co_await db.add_column_family_and_make_directory(gs, replica::database::is_new_cf::yes);
         });
     });
     co_await db.invoke_on_all([&](replica::database& db) -> future<> {
         std::vector<bool> columns_changed;
-        columns_changed.reserve(tables_diff.altered.size() + views_diff.altered.size());
-        for (auto&& altered : boost::range::join(tables_diff.altered, views_diff.altered)) {
+        columns_changed.reserve(diff.tables.altered.size() + diff.views.altered.size());
+        for (auto&& altered : boost::range::join(diff.tables.altered, diff.views.altered)) {
             columns_changed.push_back(db.update_column_family(altered.new_schema));
             co_await coroutine::maybe_yield();
         }
@@ -634,14 +615,14 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
             co_await max_concurrent_for_each(r, max_concurrent, std::move(f));
         };
         // View drops are notified first, because a table can only be dropped if its views are already deleted
-        co_await notify(views_diff.dropped, [&] (auto&& dt) { return db.get_notifier().drop_view(view_ptr(dt.schema)); });
-        co_await notify(tables_diff.dropped, [&] (auto&& dt) { return db.get_notifier().drop_column_family(dt.schema); });
+        co_await notify(diff.views.dropped, [&] (auto&& dt) { return db.get_notifier().drop_view(view_ptr(dt.schema)); });
+        co_await notify(diff.tables.dropped, [&] (auto&& dt) { return db.get_notifier().drop_column_family(dt.schema); });
         // Table creations are notified first, in case a view is created right after the table
-        co_await notify(tables_diff.created, [&] (auto&& gs) { return db.get_notifier().create_column_family(gs); });
-        co_await notify(views_diff.created, [&] (auto&& gs) { return db.get_notifier().create_view(view_ptr(gs)); });
+        co_await notify(diff.tables.created, [&] (auto&& gs) { return db.get_notifier().create_column_family(gs); });
+        co_await notify(diff.views.created, [&] (auto&& gs) { return db.get_notifier().create_view(view_ptr(gs)); });
         // Table altering is notified first, in case new base columns appear
-        co_await notify(tables_diff.altered, [&] (auto&& altered) { return db.get_notifier().update_column_family(altered.new_schema, *it++); });
-        co_await notify(views_diff.altered, [&] (auto&& altered) { return db.get_notifier().update_view(view_ptr(altered.new_schema), *it++); });
+        co_await notify(diff.tables.altered, [&] (auto&& altered) { return db.get_notifier().update_column_family(altered.new_schema, *it++); });
+        co_await notify(diff.views.altered, [&] (auto&& altered) { return db.get_notifier().update_view(view_ptr(altered.new_schema), *it++); });
     });
 
     // Insert column_mapping into history table for altered and created tables.
@@ -654,18 +635,20 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
     //
     // Drop column mapping entries for dropped tables since these will not be TTLed automatically
     // and will stay there forever if we don't clean them up manually
-    co_await max_concurrent_for_each(tables_diff.created, max_concurrent, [&proxy] (global_schema_ptr& gs) -> future<> {
+    co_await max_concurrent_for_each(diff.tables.created, max_concurrent, [&proxy] (global_schema_ptr& gs) -> future<> {
         co_await store_column_mapping(proxy, gs.get(), false);
     });
-    co_await max_concurrent_for_each(tables_diff.altered, max_concurrent, [&proxy] (schema_diff::altered_schema& altered) -> future<> {
+    co_await max_concurrent_for_each(diff.tables.altered, max_concurrent, [&proxy] (schema_diff::altered_schema& altered) -> future<> {
         co_await when_all_succeed(
             store_column_mapping(proxy, altered.old_schema.get(), true),
             store_column_mapping(proxy, altered.new_schema.get(), false));
     });
-    co_await max_concurrent_for_each(tables_diff.dropped, max_concurrent, [&sys_ks] (schema_diff::dropped_schema& dropped) -> future<> {
+    co_await max_concurrent_for_each(diff.tables.dropped, max_concurrent, [&sys_ks] (schema_diff::dropped_schema& dropped) -> future<> {
         schema_ptr s = dropped.schema.get();
         co_await drop_column_mapping(sys_ks.local(), s->id(), s->version());
     });
+
+    co_return diff;
 }
 
 static void drop_cached_func(replica::database& db, const query::result_set_row& row) {
@@ -800,7 +783,7 @@ future<> schema_applier::update(const std::vector<mutation>& muts) {
 
     _affected_keyspaces = co_await merge_keyspaces(_proxy, _before.keyspaces, _after.keyspaces);
     _affected_user_types = co_await merge_types(_proxy, _before.types, _after.types);
-    co_await merge_tables_and_views(_proxy, _sys_ks,
+    _affected_tables_and_views = co_await merge_tables_and_views(_proxy, _sys_ks,
             _before.tables, _after.tables,
             _before.views, _after.views,
             _reload, _tablet_hint);

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -672,7 +672,6 @@ static future<functions_change_batch_all_shards> merge_functions(distributed<ser
         for (const auto& val : diff.created) {
             batch.add_function(co_await create_func(db, *val));
         }
-        auto events = make_ready_future<>();
         for (const auto& val : diff.dropped) {
             cql3::functions::function_name name{
                 val->get_nonnull<sstring>("keyspace_name"), val->get_nonnull<sstring>("function_name")};
@@ -681,16 +680,12 @@ static future<functions_change_batch_all_shards> merge_functions(distributed<ser
             // change there is no window between cache removal and declaration removal
             drop_cached_func(db, *val);
             batch.remove_function(name, arg_types);
-            events = events.then([&db, name, arg_types] () {
-                return db.get_notifier().drop_function(std::move(name), std::move(arg_types));
-            });
         }
         for (const auto& val : diff.altered) {
             drop_cached_func(db, *val);
             batch.replace_function(co_await create_func(db, *val));
         }
         batch.commit();
-        co_await std::move(events);
     }));
     co_return batches;
 }
@@ -705,18 +700,14 @@ static future<functions_change_batch_all_shards> merge_aggregates(distributed<se
         for (const auto& val : diff.created) {
             batch.add_function(create_aggregate(db, *val.first, val.second, batch));
         }
-        auto events = make_ready_future<>();
         for (const auto& val : diff.dropped) {
             cql3::functions::function_name name{
                 val.first->get_nonnull<sstring>("keyspace_name"), val.first->get_nonnull<sstring>("aggregate_name")};
             auto arg_types = read_arg_types(db, *val.first, name.keyspace);
             batch.remove_function(name, arg_types);
-            events = events.then([&db, name, arg_types] () {
-                return db.get_notifier().drop_aggregate(std::move(name), std::move(arg_types));
-            });
         }
         batch.commit();
-        co_await std::move(events);
+        co_return;
     });
     co_return batches;
 }
@@ -837,6 +828,16 @@ future<> schema_applier::notify() {
         }
 
         co_await notify_tables_and_views(notifier, _affected_tables_and_views);
+
+        // notify about user functions and aggregates
+        auto& funcs_batch = _functions_batch[this_shard_id()];
+        for (auto& func : funcs_batch.removed_functions) {
+            co_await notifier.drop_function(func.name, func.arg_types);
+        }
+        auto& aggrs_batch = _aggregates_batch[this_shard_id()];
+        for (auto& aggr : aggrs_batch.removed_functions) {
+            co_await notifier.drop_aggregate(aggr.name, aggr.arg_types);
+        }
     });
     // TODO: pull out notifications code from update() and place here
     co_return;

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -690,7 +690,6 @@ static future<functions_change_batch_all_shards> merge_functions(distributed<ser
             drop_cached_func(db, *val);
             batch.replace_function(co_await create_func(db, *val));
         }
-        batch.commit();
     }));
     co_return batches;
 }
@@ -711,7 +710,6 @@ static future<functions_change_batch_all_shards> merge_aggregates(distributed<se
             auto arg_types = read_arg_types(db, *val.first, name.keyspace);
             batch.remove_function(name, arg_types);
         }
-        batch.commit();
         co_return;
     });
     co_return batches;
@@ -809,6 +807,12 @@ void schema_applier::commit_on_shard(replica::database& db) {
     for (auto& ks_name : _affected_keyspaces.dropped) {
         db.drop_keyspace(ks_name);
     }
+    // commit user functions and aggregates
+    auto& funcs_change_batch = _functions_batch[this_shard_id()];
+    funcs_change_batch.commit();
+    auto& aggrs_change_batch = _aggregates_batch[this_shard_id()];
+    aggrs_change_batch.commit();
+
     // TODO: move code for all schema modifications
 }
 

--- a/db/schema_applier.cc.orig
+++ b/db/schema_applier.cc.orig
@@ -822,12 +822,16 @@ future<> schema_applier::notify() {
     auto& sharded_db = _proxy.local().get_db();
     co_await sharded_db.invoke_on_all([&] (replica::database& db) -> future<> {
         auto& notifier = db.get_notifier();
-        // notify about keyspaces
         for (auto& name : _affected_keyspaces.created) {
             co_await notifier.create_keyspace(name);
         }
         for (auto& name : _affected_keyspaces.altered) {
-            co_await notifier.update_keyspace(name);
+<<<<<<< HEAD
+            const auto& ks = db.find_keyspace(name);
+            co_await notifier.update_keyspace(ks.metadata());
+=======
+            co_await db.get_notifier().update_keyspace(name);
+>>>>>>> 40592830b1 (service: unify keyspace notification functions arguments)
         }
         for (auto& name : _affected_keyspaces.dropped) {
             co_await notifier.drop_keyspace(name);

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -44,6 +44,13 @@ struct schema_complete_view {
     schema_tables::schema_result scylla_aggregates;
 };
 
+// groups keyspaces based on what is happening to them during schema change
+struct affected_keyspaces {
+    std::set<sstring> created;
+    std::set<sstring> altered;
+    std::set<sstring> dropped;
+};
+
 class schema_applier {
     using keyspace_name = sstring;
 
@@ -57,6 +64,8 @@ class schema_applier {
 
     schema_complete_view _before;
     schema_complete_view _after;
+
+    affected_keyspaces _affected_keyspaces;
 
     future<schema_complete_view> get_schema_complete_view();
 public:

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -84,6 +84,7 @@ struct schema_diff {
 struct affected_tables_and_views {
     schema_diff tables;
     schema_diff views;
+    std::vector<bool> columns_changed;
 };
 
 class schema_applier {

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -14,6 +14,7 @@
 #include "service/storage_proxy.hh"
 #include "query-result-set.hh"
 #include "db/schema_tables.hh"
+#include "schema/schema_registry.hh"
 
 #include <seastar/core/distributed.hh>
 
@@ -60,6 +61,31 @@ struct affected_user_types_per_shard {
 // groups UDTs based on what is happening to them during schema change
 using affected_user_types = std::vector<affected_user_types_per_shard>;
 
+// schema_diff represents what is happening with tables or views during schema merge
+struct schema_diff {
+    struct dropped_schema {
+        global_schema_ptr schema;
+    };
+
+    struct altered_schema {
+        global_schema_ptr old_schema;
+        global_schema_ptr new_schema;
+    };
+
+    std::vector<global_schema_ptr> created;
+    std::vector<altered_schema> altered;
+    std::vector<dropped_schema> dropped;
+
+    size_t size() const {
+        return created.size() + altered.size() + dropped.size();
+    }
+};
+
+struct affected_tables_and_views {
+    schema_diff tables;
+    schema_diff views;
+};
+
 class schema_applier {
     using keyspace_name = sstring;
 
@@ -76,6 +102,7 @@ class schema_applier {
 
     affected_keyspaces _affected_keyspaces;
     affected_user_types _affected_user_types;
+    affected_tables_and_views _affected_tables_and_views;
 
     future<schema_complete_view> get_schema_complete_view();
 public:

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -51,6 +51,15 @@ struct affected_keyspaces {
     std::set<sstring> dropped;
 };
 
+struct affected_user_types_per_shard {
+    std::vector<user_type> created;
+    std::vector<user_type> altered;
+    std::vector<user_type> dropped;
+};
+
+// groups UDTs based on what is happening to them during schema change
+using affected_user_types = std::vector<affected_user_types_per_shard>;
+
 class schema_applier {
     using keyspace_name = sstring;
 
@@ -66,6 +75,7 @@ class schema_applier {
     schema_complete_view _after;
 
     affected_keyspaces _affected_keyspaces;
+    affected_user_types _affected_user_types;
 
     future<schema_complete_view> get_schema_complete_view();
 public:

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -87,6 +87,8 @@ struct affected_tables_and_views {
     std::vector<bool> columns_changed;
 };
 
+using functions_change_batch_all_shards = std::vector<cql3::functions::change_batch>;
+
 class schema_applier {
     using keyspace_name = sstring;
 
@@ -104,6 +106,9 @@ class schema_applier {
     affected_keyspaces _affected_keyspaces;
     affected_user_types _affected_user_types;
     affected_tables_and_views _affected_tables_and_views;
+
+    functions_change_batch_all_shards _functions_batch;
+    functions_change_batch_all_shards _aggregates_batch;
 
     future<schema_complete_view> get_schema_complete_view();
 public:

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -13,6 +13,7 @@
 #include "seastar/core/future.hh"
 #include "service/storage_proxy.hh"
 #include "query-result-set.hh"
+#include "db/schema_tables.hh"
 
 #include <seastar/core/distributed.hh>
 
@@ -21,6 +22,71 @@ namespace db {
 namespace schema_tables {
 
 future<> merge_schema(sharded<db::system_keyspace>& sys_ks, distributed<service::storage_proxy>& proxy, gms::feature_service& feat, std::vector<mutation> mutations, bool reload = false);
+
+enum class table_kind { table, view };
+
+struct table_selector {
+    bool all_in_keyspace = false; // If true, selects all existing tables in a keyspace plus what's in "tables";
+    std::unordered_map<table_kind, std::unordered_set<sstring>> tables;
+
+    table_selector& operator+=(table_selector&& o);
+    void add(table_kind t, sstring name);
+    void add(sstring name);
+};
+
+struct schema_complete_view {
+    schema_tables::schema_result keyspaces;
+    std::map<table_id, schema_mutations> tables;
+    schema_tables::schema_result types;
+    std::map<table_id, schema_mutations> views;
+    schema_tables::schema_result functions;
+    schema_tables::schema_result aggregates;
+    schema_tables::schema_result scylla_aggregates;
+};
+
+class schema_applier {
+    using keyspace_name = sstring;
+
+    sharded<service::storage_proxy>& _proxy;
+    sharded<db::system_keyspace>& _sys_ks;
+    bool _reload;
+
+    std::set<sstring> _keyspaces;
+    std::unordered_map<keyspace_name, table_selector> _affected_tables;
+    locator::tablet_metadata_change_hint _tablet_hint;
+
+    schema_complete_view _before;
+    schema_complete_view _after;
+
+    future<schema_complete_view> get_schema_complete_view();
+public:
+    schema_applier(
+            sharded<service::storage_proxy>& proxy,
+            sharded<db::system_keyspace>& sys_ks,
+            bool reload = false)
+            : _proxy(proxy), _sys_ks(sys_ks), _reload(reload) {};
+
+    // Gets called before mutations are applied,
+    // preferably no work should be done here but subsystem
+    // may do some snapshot of 'before' data.
+    future<> prepare(const std::vector<mutation>& muts);
+    // Allows to modify mutations before they are applied,
+    // preferably no work is done here but sometimes we need to adjust
+    // for legacy things.
+    future<> adjust(std::vector<mutation>& muts);
+    // Update is called after mutations are applied, it should create
+    // all updates but not yet commit them to a subsystem (i.e. copy on write style).
+    // All changes should be visible only to schema_applier object but not to other subsystems.
+    future<> update(const std::vector<mutation>& muts);
+    // Makes updates visible. Before calling this function in memory state as observed by other
+    // components should not yet change. The function atomically switches current state with
+    // new state (the one built in update function).
+    void commit();
+    // Notify is called after commit and allows to trigger code which can't provide
+    // atomicity either for legacy reasons or causes side effects to an external system
+    // (e.g. informing client's driver).
+    future<> notify();
+};
 
 }
 

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -47,8 +47,8 @@ struct schema_complete_view {
 
 // groups keyspaces based on what is happening to them during schema change
 struct affected_keyspaces {
-    std::set<sstring> created;
-    std::set<sstring> altered;
+    std::vector<replica::database::created_keyspace_per_shard> created;
+    std::vector<replica::database::keyspace_change_per_shard> altered;
     std::set<sstring> dropped;
 };
 
@@ -133,11 +133,14 @@ public:
     // Makes updates visible. Before calling this function in memory state as observed by other
     // components should not yet change. The function atomically switches current state with
     // new state (the one built in update function).
-    void commit();
+    future<> commit();
     // Notify is called after commit and allows to trigger code which can't provide
     // atomicity either for legacy reasons or causes side effects to an external system
     // (e.g. informing client's driver).
     future<> notify();
+
+private:
+    void commit_on_shard(replica::database& db);
 };
 
 }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1294,7 +1294,7 @@ std::vector<mutation> make_drop_keyspace_mutations(schema_features features, lw_
  *
  * @param partition Keyspace attributes in serialized form
  */
-future<lw_shared_ptr<keyspace_metadata>> create_keyspace_from_schema_partition(distributed<service::storage_proxy>& proxy, const schema_result_value_type& result)
+future<lw_shared_ptr<keyspace_metadata>> create_keyspace_metadata(distributed<service::storage_proxy>& proxy, const schema_result_value_type& result)
 {
     auto scylla_specific_rs = co_await extract_scylla_specific_keyspace_info(proxy, result);
 

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -237,7 +237,7 @@ std::vector<mutation> make_create_keyspace_mutations(schema_features features, l
 
 std::vector<mutation> make_drop_keyspace_mutations(schema_features features, lw_shared_ptr<keyspace_metadata> keyspace, api::timestamp_type timestamp);
 
-future<lw_shared_ptr<keyspace_metadata>> create_keyspace_from_schema_partition(distributed<service::storage_proxy>& proxy, const schema_result_value_type& partition);
+future<lw_shared_ptr<keyspace_metadata>> create_keyspace_metadata(distributed<service::storage_proxy>& proxy, const schema_result_value_type& partition);
 
 std::vector<mutation> make_create_type_mutations(lw_shared_ptr<keyspace_metadata> keyspace, user_type type, api::timestamp_type timestamp);
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -686,7 +686,7 @@ do_parse_schema_tables(distributed<service::storage_proxy>& proxy, const sstring
 future<> database::parse_system_tables(distributed<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks) {
     using namespace db::schema_tables;
     co_await do_parse_schema_tables(proxy, db::schema_tables::KEYSPACES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
-        auto ksm = co_await create_keyspace_from_schema_partition(proxy, v);
+        auto ksm = co_await create_keyspace_metadata(proxy, v);
         co_return co_await create_keyspace(ksm, proxy.local().get_erm_factory(), system_keyspace::no);
     }));
     co_await do_parse_schema_tables(proxy, db::schema_tables::TYPES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -782,7 +782,7 @@ database::init_commitlog() {
     });
 }
 
-future<> database::modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func, std::function<future<>(replica::database&)> notifier) {
+future<> database::modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func) {
     // Run func first on shard 0
     // to allow "seeding" of the effective_replication_map
     // with a new e_r_m instance.
@@ -793,7 +793,6 @@ future<> database::modify_keyspace_on_all_shards(sharded<database>& sharded_db, 
         }
         return func(db);
     });
-    co_await sharded_db.invoke_on_all(notifier);
 }
 
 future<> database::update_keyspace(const keyspace_metadata& tmp_ksm) {
@@ -816,9 +815,6 @@ future<> database::update_keyspace(const keyspace_metadata& tmp_ksm) {
 future<> database::update_keyspace_on_all_shards(sharded<database>& sharded_db, const keyspace_metadata& ksm) {
     return modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) {
         return db.update_keyspace(ksm);
-    }, [&] (replica::database& db) {
-        const auto& ks = db.find_keyspace(ksm.name());
-        return db.get_notifier().update_keyspace(ks.metadata());
     });
 }
 
@@ -830,8 +826,6 @@ future<> database::drop_keyspace_on_all_shards(sharded<database>& sharded_db, co
     return modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) {
         db.drop_keyspace(name);
         return make_ready_future<>();
-    }, [&] (replica::database& db) {
-        return db.get_notifier().drop_keyspace(name);
     });
 }
 
@@ -1346,9 +1340,6 @@ future<> database::create_keyspace_on_all_shards(sharded<database>& sharded_db, 
     co_await modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) -> future<> {
         auto ksm = keyspace_metadata::new_keyspace(ks_metadata);
         co_await db.create_keyspace(ksm, proxy.local().get_erm_factory(), system_keyspace::no);
-    }, [&] (replica::database& db) -> future<> {
-        const auto& ks = db.find_keyspace(ks_metadata.name());
-        co_await db.get_notifier().create_keyspace(ks.metadata());
     });
 }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -10,6 +10,7 @@
 #include <fmt/std.h>
 #include "log.hh"
 #include "replica/database_fwd.hh"
+#include "seastar/core/shard_id.hh"
 #include "utils/assert.hh"
 #include "utils/lister.hh"
 #include "replica/database.hh"
@@ -820,27 +821,22 @@ void database::update_keyspace(keyspace_change change) {
     ks.apply(std::move(change));
 }
 
-future<> database::update_keyspace_on_all_shards(sharded<database>& sharded_db, const keyspace_metadata& ksm) {
-    return modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) -> future<> {
+future<database::keyspace_change_per_shard> database::prepare_update_keyspace_on_all_shards(sharded<database>& sharded_db, const keyspace_metadata& ksm) {
+    keyspace_change_per_shard changes(smp::count);
+    co_await modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) -> future<> {
         auto& ks = db.find_keyspace(ksm.name());
         auto new_ksm = ::make_lw_shared<keyspace_metadata>(ksm.name(), ksm.strategy_name(), ksm.strategy_options(), ksm.initial_tablets(), ksm.durable_writes(),
                 boost::copy_range<std::vector<schema_ptr>>(ks.metadata()->cf_meta_data() | boost::adaptors::map_values), std::move(ks.metadata()->user_types()), ksm.get_storage_options());
 
         auto change = co_await db.prepare_update_keyspace(ks, new_ksm);
-        db.update_keyspace(std::move(change));
+        changes[this_shard_id()] = std::move(change);
         co_return;
     });
+    co_return changes;
 }
 
 void database::drop_keyspace(const sstring& name) {
     _keyspaces.erase(name);
-}
-
-future<> database::drop_keyspace_on_all_shards(sharded<database>& sharded_db, const sstring& name) {
-    return modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) {
-        db.drop_keyspace(name);
-        return make_ready_future<>();
-    });
 }
 
 static bool is_system_table(const schema& s) {
@@ -1356,12 +1352,14 @@ void database::insert_keyspace(std::unique_ptr<keyspace> ks) {
     _keyspaces.emplace(name, std::move(*ks));
 }
 
-future<> database::create_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ks_metadata) {
+future<database::created_keyspace_per_shard> database::prepare_create_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ks_metadata) {
+    created_keyspace_per_shard created(smp::count);
     co_await modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) -> future<> {
         auto ksm = keyspace_metadata::new_keyspace(ks_metadata);
         auto ks = co_await db.create_keyspace(ksm, proxy.local().get_erm_factory(), system_keyspace::no);
-        db.insert_keyspace(std::move(ks));
+        created[this_shard_id()] = std::move(ks);
     });
+    co_return created;
 }
 
 future<>

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -13,6 +13,7 @@
 #include "utils/assert.hh"
 #include "utils/lister.hh"
 #include "replica/database.hh"
+#include <memory>
 #include <seastar/core/future-util.hh>
 #include "db/system_keyspace.hh"
 #include "db/system_keyspace_sstables_registry.hh"
@@ -687,7 +688,9 @@ future<> database::parse_system_tables(distributed<service::storage_proxy>& prox
     using namespace db::schema_tables;
     co_await do_parse_schema_tables(proxy, db::schema_tables::KEYSPACES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
         auto ksm = co_await create_keyspace_metadata(proxy, v);
-        co_return co_await create_keyspace(ksm, proxy.local().get_erm_factory(), system_keyspace::no);
+        auto ks = co_await create_keyspace(ksm, proxy.local().get_erm_factory(), system_keyspace::no);
+        insert_keyspace(std::move(ks));
+        co_return;
     }));
     co_await do_parse_schema_tables(proxy, db::schema_tables::TYPES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
         auto& ks = this->find_keyspace(v.first);
@@ -880,7 +883,8 @@ future<> database::create_local_system_table(
                 std::nullopt,
                 durable
                 );
-        co_await create_keyspace(ksm, erm_factory, replica::database::system_keyspace::yes);
+        auto ks = co_await create_keyspace(ksm, erm_factory, replica::database::system_keyspace::yes);
+        insert_keyspace(std::move(ks));
     }
     auto& ks = find_keyspace(ks_name);
     auto cfg = ks.make_column_family_config(*table, *this);
@@ -1309,7 +1313,7 @@ std::vector<view_ptr> database::get_views() const {
             | boost::adaptors::transformed([] (auto& cf) { return view_ptr(cf->schema()); }));
 }
 
-future<> database::create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, system_keyspace system) {
+future<keyspace> database::create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, system_keyspace system) {
     auto kscfg = make_keyspace_config(*ksm);
     if (system == system_keyspace::yes) {
         kscfg.enable_disk_reads = kscfg.enable_disk_writes = kscfg.enable_commitlog = !_cfg.volatile_system_keyspace_for_testing();
@@ -1323,23 +1327,29 @@ future<> database::create_in_memory_keyspace(const lw_shared_ptr<keyspace_metada
     }
     keyspace ks(ksm, std::move(kscfg), erm_factory);
     co_await ks.create_replication_strategy(get_shared_token_metadata());
-    _keyspaces.emplace(ksm->name(), std::move(ks));
+    co_return ks;
 }
 
-future<>
+future<std::unique_ptr<keyspace>>
 database::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, system_keyspace system) {
-    if (_keyspaces.contains(ksm->name())) {
-        co_return;
-    }
-
-    co_await create_in_memory_keyspace(ksm, erm_factory, system);
     co_await get_sstables_manager(system).init_keyspace_storage(ksm->get_storage_options(), ksm->name());
+    co_return std::make_unique<keyspace>(
+            co_await create_in_memory_keyspace(ksm, erm_factory, system));
+}
+
+void database::insert_keyspace(std::unique_ptr<keyspace> ks) {
+    auto& name = ks->metadata()->name();
+    if (_keyspaces.contains(name)) {
+        return;
+    }
+    _keyspaces.emplace(name, std::move(*ks));
 }
 
 future<> database::create_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ks_metadata) {
     co_await modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) -> future<> {
         auto ksm = keyspace_metadata::new_keyspace(ks_metadata);
-        co_await db.create_keyspace(ksm, proxy.local().get_erm_factory(), system_keyspace::no);
+        auto ks = co_await db.create_keyspace(ksm, proxy.local().get_erm_factory(), system_keyspace::no);
+        db.insert_keyspace(std::move(ks));
     });
 }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -97,9 +97,8 @@ make_flush_controller(const db::config& cfg, backlog_controller::scheduling_grou
     return flush_controller(sg, cfg.memtable_flush_static_shares(), 50ms, cfg.unspooled_dirty_soft_limit(), std::move(fn));
 }
 
-keyspace::keyspace(lw_shared_ptr<keyspace_metadata> metadata, config cfg, locator::effective_replication_map_factory& erm_factory)
-    : _metadata(std::move(metadata))
-    , _config(std::move(cfg))
+keyspace::keyspace(config cfg, locator::effective_replication_map_factory& erm_factory)
+    : _config(std::move(cfg))
     , _erm_factory(erm_factory)
 {}
 
@@ -798,26 +797,38 @@ future<> database::modify_keyspace_on_all_shards(sharded<database>& sharded_db, 
     });
 }
 
-future<> database::update_keyspace(const keyspace_metadata& tmp_ksm) {
-    auto& ks = find_keyspace(tmp_ksm.name());
-    auto new_ksm = ::make_lw_shared<keyspace_metadata>(tmp_ksm.name(), tmp_ksm.strategy_name(), tmp_ksm.strategy_options(), tmp_ksm.initial_tablets(), tmp_ksm.durable_writes(),
-                    boost::copy_range<std::vector<schema_ptr>>(ks.metadata()->cf_meta_data() | boost::adaptors::map_values), std::move(ks.metadata()->user_types()), tmp_ksm.get_storage_options());
+future<keyspace_change> database::prepare_update_keyspace(const keyspace& ks, lw_shared_ptr<keyspace_metadata> metadata) const {
+    auto strategy = keyspace::create_replication_strategy(metadata);
+    co_return keyspace_change{
+        .metadata = metadata,
+        .strategy = std::move(strategy),
+        .erm = co_await ks.create_effective_replication_map(strategy,
+                get_shared_token_metadata()),
+    };
+}
 
+void database::update_keyspace(keyspace_change change) {
+    auto& ks = find_keyspace(change.metadata->name());
     bool old_durable_writes = ks.metadata()->durable_writes();
-    bool new_durable_writes = new_ksm->durable_writes();
+    bool new_durable_writes = change.metadata->durable_writes();
     if (old_durable_writes != new_durable_writes) {
-        for (auto& [cf_name, cf_schema] : new_ksm->cf_meta_data()) {
+        for (auto& [cf_name, cf_schema] : change.metadata->cf_meta_data()) {
             auto& cf = find_column_family(cf_schema);
             cf.set_durable_writes(new_durable_writes);
         }
     }
-
-    co_await ks.update_from(get_shared_token_metadata(), std::move(new_ksm));
+    ks.apply(std::move(change));
 }
 
 future<> database::update_keyspace_on_all_shards(sharded<database>& sharded_db, const keyspace_metadata& ksm) {
-    return modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) {
-        return db.update_keyspace(ksm);
+    return modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) -> future<> {
+        auto& ks = db.find_keyspace(ksm.name());
+        auto new_ksm = ::make_lw_shared<keyspace_metadata>(ksm.name(), ksm.strategy_name(), ksm.strategy_options(), ksm.initial_tablets(), ksm.durable_writes(),
+                boost::copy_range<std::vector<schema_ptr>>(ks.metadata()->cf_meta_data() | boost::adaptors::map_values), std::move(ks.metadata()->user_types()), ksm.get_storage_options());
+
+        auto change = co_await db.prepare_update_keyspace(ks, new_ksm);
+        db.update_keyspace(std::move(change));
+        co_return;
     });
 }
 
@@ -1193,19 +1204,17 @@ bool database::column_family_exists(const table_id& uuid) const {
     return _tables_metadata.contains(uuid);
 }
 
-future<>
-keyspace::create_replication_strategy(const locator::shared_token_metadata& stm) {
+locator::replication_strategy_ptr
+keyspace::create_replication_strategy(lw_shared_ptr<keyspace_metadata> metadata) {
     using namespace locator;
-
-    locator::replication_strategy_params params(_metadata->strategy_options(), _metadata->initial_tablets());
-    _replication_strategy =
-            abstract_replication_strategy::create_replication_strategy(_metadata->strategy_name(), params);
+    replication_strategy_params params(metadata->strategy_options(), metadata->initial_tablets());
     rslogger.debug("replication strategy for keyspace {} is {}, opts={}",
-            _metadata->name(), _metadata->strategy_name(), _metadata->strategy_options());
-    if (!_replication_strategy->is_per_table()) {
-        auto erm = co_await _erm_factory.create_effective_replication_map(_replication_strategy, stm.get());
-        update_effective_replication_map(std::move(erm));
-    }
+            metadata->name(), metadata->strategy_name(), metadata->strategy_options());
+    return abstract_replication_strategy::create_replication_strategy(metadata->strategy_name(), params);
+}
+
+future<locator::vnode_effective_replication_map_ptr> keyspace::create_effective_replication_map(locator::replication_strategy_ptr strategy, const locator::shared_token_metadata& stm) const {
+    co_return co_await _erm_factory.create_effective_replication_map(strategy, stm.get());
 }
 
 void
@@ -1218,9 +1227,10 @@ keyspace::get_replication_strategy() const {
     return *_replication_strategy;
 }
 
-future<> keyspace::update_from(const locator::shared_token_metadata& stm, ::lw_shared_ptr<keyspace_metadata> ksm) {
-    _metadata = std::move(ksm);
-   return create_replication_strategy(stm);
+void keyspace::apply(keyspace_change kc) {
+    _metadata = std::move(kc.metadata);
+    _replication_strategy = std::move(kc.strategy);
+    _effective_replication_map = std::move(kc.erm);
 }
 
 column_family::config
@@ -1325,8 +1335,9 @@ future<keyspace> database::create_in_memory_keyspace(const lw_shared_ptr<keyspac
         // don't make internal keyspaces write wait for user writes (if under pressure), and also to avoid possible deadlocks.
         kscfg.dirty_memory_manager = &_system_dirty_memory_manager;
     }
-    keyspace ks(ksm, std::move(kscfg), erm_factory);
-    co_await ks.create_replication_strategy(get_shared_token_metadata());
+    keyspace ks(std::move(kscfg), erm_factory);
+    auto change = co_await prepare_update_keyspace(ks, ksm);
+    ks.apply(std::move(change));
     co_return ks;
 }
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1251,6 +1251,13 @@ using user_types_metadata = data_dictionary::user_types_metadata;
 
 using keyspace_metadata = data_dictionary::keyspace_metadata;
 
+// Encapsulates objects needed to update keyspace schema
+struct keyspace_change {
+    lw_shared_ptr<keyspace_metadata> metadata;
+    locator::replication_strategy_ptr strategy;
+    locator::vnode_effective_replication_map_ptr erm;
+};
+
 class keyspace {
 public:
     struct config {
@@ -1282,14 +1289,14 @@ private:
     locator::effective_replication_map_factory& _erm_factory;
 
 public:
-    explicit keyspace(lw_shared_ptr<keyspace_metadata> metadata, config cfg, locator::effective_replication_map_factory& erm_factory);
+    explicit keyspace(config cfg, locator::effective_replication_map_factory& erm_factory);
     keyspace(const keyspace&) = delete;
     void operator=(const keyspace&) = delete;
     keyspace(keyspace&&) = default;
 
     future<> shutdown() noexcept;
 
-    future<> update_from(const locator::shared_token_metadata& stm, lw_shared_ptr<keyspace_metadata>);
+    void apply(keyspace_change kc);
 
     future<> init_storage();
 
@@ -1298,7 +1305,12 @@ public:
      * boom, it is replaced.
      */
     lw_shared_ptr<keyspace_metadata> metadata() const;
-    future<> create_replication_strategy(const locator::shared_token_metadata& stm);
+
+    static locator::replication_strategy_ptr create_replication_strategy(
+            lw_shared_ptr<keyspace_metadata> metadata);
+    future<locator::vnode_effective_replication_map_ptr> create_effective_replication_map(
+            locator::replication_strategy_ptr strategy,
+            const locator::shared_token_metadata& stm) const;
     void update_effective_replication_map(locator::vnode_effective_replication_map_ptr erm);
 
     /**
@@ -1569,7 +1581,8 @@ private:
     void insert_keyspace(std::unique_ptr<keyspace> ks);
     future<> remove(table&) noexcept;
     void drop_keyspace(const sstring& name);
-    future<> update_keyspace(const keyspace_metadata& tmp_ksm);
+    future<keyspace_change> prepare_update_keyspace(const keyspace& ks, lw_shared_ptr<keyspace_metadata> metadata) const;
+    void update_keyspace(keyspace_change change);
     static future<> modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func);
 
     future<> foreach_reader_concurrency_semaphore(std::function<future<>(reader_concurrency_semaphore&)> func);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1578,15 +1578,16 @@ private:
     Future update_write_metrics(Future&& f);
     void update_write_metrics_for_timed_out_write();
     future<std::unique_ptr<keyspace>> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
-    void insert_keyspace(std::unique_ptr<keyspace> ks);
     future<> remove(table&) noexcept;
-    void drop_keyspace(const sstring& name);
     future<keyspace_change> prepare_update_keyspace(const keyspace& ks, lw_shared_ptr<keyspace_metadata> metadata) const;
-    void update_keyspace(keyspace_change change);
     static future<> modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func);
 
     future<> foreach_reader_concurrency_semaphore(std::function<future<>(reader_concurrency_semaphore&)> func);
 public:
+    void insert_keyspace(std::unique_ptr<keyspace> ks);
+    void update_keyspace(keyspace_change change);
+    void drop_keyspace(const sstring& name);
+
     static table_schema_version empty_version;
 
     query::result_memory_limiter& get_result_memory_limiter() {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1569,7 +1569,7 @@ private:
     future<> remove(table&) noexcept;
     void drop_keyspace(const sstring& name);
     future<> update_keyspace(const keyspace_metadata& tmp_ksm);
-    static future<> modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func, std::function<future<>(replica::database&)> notifier);
+    static future<> modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func);
 
     future<> foreach_reader_concurrency_semaphore(std::function<future<>(reader_concurrency_semaphore&)> func);
 public:

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1551,7 +1551,7 @@ private:
     future<> flush_system_column_families();
 
     using system_keyspace = bool_class<struct system_keyspace_tag>;
-    future<> create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
+    future<keyspace> create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
     void setup_metrics();
     void setup_scylla_memory_diagnostics_producer();
 
@@ -1565,7 +1565,8 @@ private:
     template<typename Future>
     Future update_write_metrics(Future&& f);
     void update_write_metrics_for_timed_out_write();
-    future<> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
+    future<std::unique_ptr<keyspace>> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
+    void insert_keyspace(std::unique_ptr<keyspace> ks);
     future<> remove(table&) noexcept;
     void drop_keyspace(const sstring& name);
     future<> update_keyspace(const keyspace_metadata& tmp_ksm);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1256,6 +1256,10 @@ struct keyspace_change {
     lw_shared_ptr<keyspace_metadata> metadata;
     locator::replication_strategy_ptr strategy;
     locator::vnode_effective_replication_map_ptr erm;
+
+    const sstring& keyspace_name() const {
+        return metadata->name();
+    }
 };
 
 class keyspace {
@@ -1661,20 +1665,22 @@ public:
     table_id find_uuid(std::string_view ks, std::string_view cf) const;
     table_id find_uuid(const schema_ptr&) const;
 
+    using created_keyspace_per_shard = std::vector<std::unique_ptr<keyspace>>;
+    using keyspace_change_per_shard = std::vector<keyspace_change>;
+
     /**
      * Creates a keyspace for a given metadata if it still doesn't exist.
      *
      * @return ready future when the operation is complete
      */
-    static future<> create_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ksm);
+    static future<created_keyspace_per_shard> prepare_create_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ksm);
     /* below, find_keyspace throws no_such_<type> on fail */
     keyspace& find_keyspace(std::string_view name);
     const keyspace& find_keyspace(std::string_view name) const;
     bool has_keyspace(std::string_view name) const;
     void validate_keyspace_update(keyspace_metadata& ksm);
     void validate_new_keyspace(keyspace_metadata& ksm);
-    static future<> update_keyspace_on_all_shards(sharded<database>& sharded_db, const keyspace_metadata& ksm);
-    static future<> drop_keyspace_on_all_shards(sharded<database>& sharded_db, const sstring& name);
+    static future<keyspace_change_per_shard> prepare_update_keyspace_on_all_shards(sharded<database>& sharded_db, const keyspace_metadata& ksm);
     std::vector<sstring> get_non_system_keyspaces() const;
     std::vector<sstring> get_user_keyspaces() const;
     std::vector<sstring> get_all_keyspaces() const;

--- a/service/migration_listener.hh
+++ b/service/migration_listener.hh
@@ -131,16 +131,16 @@ public:
     /// Unregister a migration listener on current shard.
     future<> unregister_listener(migration_listener* listener);
 
-    future<> create_keyspace(lw_shared_ptr<keyspace_metadata> ksm);
+    future<> create_keyspace(const sstring& ks_name);
     future<> create_column_family(schema_ptr cfm);
     future<> create_user_type(user_type type);
     future<> create_view(view_ptr view);
-    future<> update_keyspace(lw_shared_ptr<keyspace_metadata> ksm);
+    future<> update_keyspace(const sstring& ks_name);
     future<> update_column_family(schema_ptr cfm, bool columns_changed);
     future<> update_user_type(user_type type);
     future<> update_view(view_ptr view, bool columns_changed);
     future<> update_tablet_metadata(locator::tablet_metadata_change_hint);
-    future<> drop_keyspace(sstring ks_name);
+    future<> drop_keyspace(const sstring& ks_name);
     future<> drop_column_family(schema_ptr cfm);
     future<> drop_user_type(user_type type);
     future<> drop_view(view_ptr view);

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -436,12 +436,11 @@ future<> migration_notifier::on_schema_change(std::function<void(migration_liste
     });
 }
 
-future<> migration_notifier::create_keyspace(lw_shared_ptr<keyspace_metadata> ksm) {
-    const auto& name = ksm->name();
+future<> migration_notifier::create_keyspace(const sstring& ks_name) {
     co_await on_schema_change([&] (migration_listener* listener) {
-        listener->on_create_keyspace(name);
+        listener->on_create_keyspace(ks_name);
     }, [&] (std::exception_ptr ex) {
-        return fmt::format("Create keyspace notification failed {}: {}", name, ex);
+        return fmt::format("Create keyspace notification failed {}: {}", ks_name, ex);
     });
 }
 
@@ -475,12 +474,11 @@ future<> migration_notifier::create_view(view_ptr view) {
     });
 }
 
-future<> migration_notifier::update_keyspace(lw_shared_ptr<keyspace_metadata> ksm) {
-    const auto& name = ksm->name();
+future<> migration_notifier::update_keyspace(const sstring& ks_name) {
     co_await on_schema_change([&] (migration_listener* listener) {
-        listener->on_update_keyspace(name);
+        listener->on_update_keyspace(ks_name);
     }, [&] (std::exception_ptr ex) {
-        return fmt::format("Update keyspace notification failed {}: {}", name, ex);
+        return fmt::format("Update keyspace notification failed {}: {}", ks_name, ex);
     });
 }
 
@@ -522,7 +520,7 @@ future<> migration_notifier::update_tablet_metadata(locator::tablet_metadata_cha
     });
 }
 
-future<> migration_notifier::drop_keyspace(sstring ks_name) {
+future<> migration_notifier::drop_keyspace(const sstring& ks_name) {
     co_await on_schema_change([&] (migration_listener* listener) {
         listener->on_drop_keyspace(ks_name);
     }, [&] (std::exception_ptr ex) {


### PR DESCRIPTION
TODO: add cover letter

TODO: move all schema entities, currently only keyspaces and functions/aggregates are fully moved

TODO: extract the interface and move it to raft code