### PR TITLE
fix regressions of building tests with cmake

### DIFF
--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -25,7 +25,7 @@ add_scylla_test(big_decimal_test
 add_scylla_test(bloom_filter_test
   KIND SEASTAR)
 add_scylla_test(bptree_test
-  KIND BOOST
+  KIND SEASTAR
   LIBRARIES utils)
 add_scylla_test(broken_sstable_test
   KIND SEASTAR)

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -15,7 +15,8 @@ add_scylla_test(auth_passwords_test
 add_scylla_test(auth_resource_test
   KIND BOOST)
 add_scylla_test(auth_test
-  KIND SEASTAR)
+  KIND SEASTAR
+  LIBRARIES cql3)
 add_scylla_test(batchlog_manager_test
   KIND SEASTAR)
 add_scylla_test(big_decimal_test


### PR DESCRIPTION
Fix two recent regressions of the cmake build -- found this time in the test suite.

We (presumably) don't build stable releases (and their tests) with CMake, so backporting these fixes appears unnecessary, even if the regressions have been ported to stable branches.

@xemul @dawmd @tchaikov @tgrabiec @scylladb/scylla-maint