### PR TITLE
node_ops: fix task_manager_module::get_nodes()

### DIFF
--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -199,6 +199,8 @@ std::set<gms::inet_address> task_manager_module::get_nodes() const noexcept {
             _ss._topology_state_machine._topology.transition_nodes
         ) | boost::adaptors::transformed([&ss = _ss] (auto& node) {
             return ss.host2ip(locator::host_id{node.first.uuid()});
+        }) | boost::adaptors::filtered([&ss = _ss] (auto& ip) {
+            return ss._gossiper.is_alive(ip);
         })
     );
 }


### PR DESCRIPTION
Currently, node ops virtual task gathers its children from all nodes contained in a sum of service::topology::normal_nodes and service::topology::transition_nodes. The maps may contain nodes that are down but weren't removed yet. So, if a user requests the status of a node ops virtual task, the task's attempt to retrieve its children list may fail with seastar::rpc::closed_error.

Filter out the tasks that are down in node_ops::task_manager_module::get_nodes.

Fixes: #20843.

Needs backport to 6.2 as it contains virtual tasks