### PR TITLE
test.py: pass "count" to re.sub() with kwarg

### DIFF
--- a/test.py
+++ b/test.py
@@ -1468,7 +1468,7 @@ def parse_cmd_line() -> argparse.Namespace:
     try:
         out = ninja('unit_test_list')
         # [1/1] List configured unit tests
-        args.tests = set(re.sub(r'.* List configured unit tests\n(.*)\n', r'\1', out, 1, re.DOTALL).split("\n"))
+        args.tests = set(re.sub(r'.* List configured unit tests\n(.*)\n', r'\1', out, count=1, flags=re.DOTALL).split("\n"))
     except Exception:
         print(palette.fail("Failed to read output of `ninja unit_test_list`: please run ./configure.py first"))
         raise


### PR DESCRIPTION
since Python 3.13, passing count to `re.sub()` as positional argument has been deprecated. and when runnint `test.py` with Python 3.13, we have following warning:

```
/home/kefu/dev/scylladb/./test.py:1477: DeprecationWarning: 'count' is passed as positional argument
  args.tests = set(re.sub(r'.* List configured unit tests\n(.*)\n', r'\1', out, 1, re.DOTALL).split("\n"))
```

see also https://github.com/python/cpython/issues/56166

in order to silence this distracting warning, let's pass `count` using kwarg.

---

it's a cleanup, hence no need to backport.