### PR TITLE
raft_group0_client: place on a #include diet

### DIFF
--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -23,6 +23,8 @@
 #include "utils/rjson.hh"
 #include "utils/updateable_value.hh"
 
+#include "tracing/trace_state.hh"
+
 namespace db {
     class system_distributed_keyspace;
 }
@@ -49,6 +51,8 @@ namespace gms {
 class gossiper;
 
 }
+
+class schema_builder;
 
 namespace alternator {
 

--- a/alternator/rmw_operation.hh
+++ b/alternator/rmw_operation.hh
@@ -12,6 +12,8 @@
 #include "service/paxos/cas_request.hh"
 #include "utils/rjson.hh"
 #include "executor.hh"
+#include "tracing/trace_state.hh"
+#include "keys.hh"
 
 namespace alternator {
 

--- a/auth/certificate_authenticator.hh
+++ b/auth/certificate_authenticator.hh
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "auth/authenticator.hh"
+#include <boost/regex.hpp>
 
 namespace cql3 {
 

--- a/auth/common.cc
+++ b/auth/common.cc
@@ -25,6 +25,7 @@
 #include "service/raft/group0_state_machine.hh"
 #include "timeout_config.hh"
 #include "utils/error_injection.hh"
+#include "db/system_keyspace.hh"
 
 namespace auth {
 
@@ -40,7 +41,7 @@ constinit const std::string_view AUTH_PACKAGE_NAME("org.apache.cassandra.auth.")
 static logging::logger auth_log("auth");
 
 bool legacy_mode(cql3::query_processor& qp) {
-    return qp.auth_version < db::system_keyspace::auth_version_t::v2;
+    return qp.auth_version < db::auth_version_t::v2;
 }
 
 std::string_view get_auth_ks_name(cql3::query_processor& qp) {

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -32,6 +32,7 @@
 #include "utils/observable.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "types/types.hh"
+#include "db/auth_version.hh"
 
 
 namespace lang { class manager; }
@@ -175,7 +176,7 @@ public:
 
     lang::manager& lang() { return _lang_manager; }
 
-    db::system_keyspace::auth_version_t auth_version;
+    db::auth_version_t auth_version;
 
     statements::prepared_statement::checked_weak_ptr get_prepared(const std::optional<auth::authenticated_user>& user, const prepared_cache_key_type& key) {
         if (user) {

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -11,6 +11,7 @@
 #include "types/set.hh"
 #include "cql3/expr/evaluate.hh"
 #include "cql3/expr/expr-utils.hh"
+#include "mutation/mutation.hh"
 
 namespace cql3 {
 void

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -17,6 +17,7 @@
 #include "cas_request.hh"
 #include "cql3/query_processor.hh"
 #include "service/storage_proxy.hh"
+#include "tracing/trace_state.hh"
 
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/algorithm/cxx11/all_of.hpp>

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -14,6 +14,7 @@
 #include "log.hh"
 #include "service_permit.hh"
 #include "exceptions/coordinator_result.hh"
+#include "tracing/trace_state.hh"
 
 namespace cql_transport::messages {
     class result_message;

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -32,6 +32,7 @@
 #include "types/user.hh"
 #include "concrete_types.hh"
 #include "validation.hh"
+#include "dht/i_partitioner.hh"
 #include <optional>
 
 namespace cql3 {

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -16,6 +16,7 @@
 #include "gms/feature_service.hh"
 #include <fmt/core.h>
 #include <fmt/ranges.h>
+#include <fmt/std.h>
 #include <ios>
 #include <ostream>
 #include <boost/range/adaptor/map.hpp>

--- a/db/auth_version.hh
+++ b/db/auth_version.hh
@@ -1,0 +1,15 @@
+// Copyright (C) 2024-present ScyllaDB
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+#include <cstdint>
+
+namespace db {
+
+enum class auth_version_t: int64_t {
+    v1 = 1,
+    v2 = 2,
+};
+
+}

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -27,6 +27,7 @@
 #include "locator/host_id.hh"
 #include "virtual_tables.hh"
 #include "types/types.hh"
+#include "auth_version.hh"
 
 namespace sstables {
     struct entry_descriptor;
@@ -608,10 +609,7 @@ public:
     // returns the corresponding mutation. Otherwise returns nullopt.
     future<std::optional<mutation>> get_group0_schema_version();
 
-    enum class auth_version_t: int64_t {
-        v1 = 1,
-        v2 = 2,
-    };
+    using auth_version_t = db::auth_version_t;
 
     // If the `auth_version` key in `system.scylla_local` is present (either live or tombstone),
     // returns the corresponding mutation. Otherwise returns nullopt.

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -23,6 +23,7 @@
 #include "utils/serialized_action.hh"
 #include "service/raft/raft_group_registry.hh"
 #include "service/raft/raft_group0_client.hh"
+#include "db/timeout_clock.hh"
 
 #include <vector>
 

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -36,6 +36,12 @@ namespace service {
     class storage_service;
 }
 
+namespace locator {
+
+class shared_token_metadata;
+
+}
+
 namespace qos {
 /**
  *  a structure to hold a service level

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -24,6 +24,7 @@
 #include "replica/database.hh"
 #include "utils/assert.hh"
 #include "utils/to_string.hh"
+#include "db/system_keyspace.hh"
 
 
 namespace service {

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -498,6 +498,16 @@ template group0_command raft_group0_client::prepare_command(broadcast_table_quer
 template group0_command raft_group0_client::prepare_command(write_mutations change, std::string_view description);
 template group0_command raft_group0_client::prepare_command(mixed_change change, group0_guard& guard, std::string_view description);
 
+group0_batch::group0_batch(::service::group0_guard&& g)
+        : _guard(std::move(g)) {
+}
+
+group0_batch::group0_batch(std::optional<::service::group0_guard> g)
+        : _guard(std::move(g)) {
+}
+
+group0_batch::~group0_batch() = default;
+
 api::timestamp_type group0_batch::write_timestamp() const {
     if (!_guard) {
         on_internal_error(logger, "group0_batch: write_timestamp without guard taken");

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -11,6 +11,7 @@
 #include <optional>
 #include <seastar/core/coroutine.hh>
 #include "raft_group0_client.hh"
+#include "raft_group_registry.hh"
 #include <boost/algorithm/string/join.hpp>
 
 #include "frozen_schema.hh"

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -25,9 +25,10 @@
 #include "utils/UUID.hh"
 #include "timestamp.hh"
 #include "gc_clock.hh"
-#include "mutation/mutation.hh"
 #include "service/raft/group0_state_machine.hh"
 #include "service/maintenance_mode.hh"
+
+class mutation;
 
 namespace db {
 
@@ -221,11 +222,13 @@ private:
 
     future<> materialize_mutations();
 public:
-    explicit group0_batch(::service::group0_guard&& g) : _guard(std::move(g)) {}
+    explicit group0_batch(::service::group0_guard&& g);
     // Constructor with optional guard used to handle both legacy and current code.
     // There is no guard for legacy code but the whole class may be passed
     // through to simplify the flow.
-    explicit group0_batch(std::optional<::service::group0_guard> g) : _guard(std::move(g)) {}
+    explicit group0_batch(std::optional<::service::group0_guard> g);
+
+    ~group0_batch();
 
     // Annotation helper for cases where we need collector (e.g. some interface)
     // but the code is fully legacy and the collector won't be used.

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -20,8 +20,8 @@
 #include <string>
 
 #include "service/broadcast_tables/experimental/query_result.hh"
-#include "service/raft/raft_group_registry.hh"
 #include "service/raft/group0_fwd.hh"
+#include "service/raft/raft_timeout.hh"
 #include "utils/UUID.hh"
 #include "timestamp.hh"
 #include "gc_clock.hh"
@@ -37,6 +37,9 @@ class system_keyspace;
 }
 
 namespace service {
+
+class raft_group_registry;
+
 // Obtaining this object means that all previously finished operations on group 0 are visible on this node.
 
 // It is also required in order to perform group 0 changes

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -16,6 +16,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/rwlock.hh>
 #include <seastar/core/condition-variable.hh>
+#include <seastar/coroutine/generator.hh>
 #include <string>
 
 #include "service/broadcast_tables/experimental/query_result.hh"
@@ -24,9 +25,15 @@
 #include "utils/UUID.hh"
 #include "timestamp.hh"
 #include "gc_clock.hh"
+#include "mutation/mutation.hh"
 #include "service/raft/group0_state_machine.hh"
-#include "db/system_keyspace.hh"
 #include "service/maintenance_mode.hh"
+
+namespace db {
+
+class system_keyspace;
+
+}
 
 namespace service {
 // Obtaining this object means that all previously finished operations on group 0 are visible on this node.

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -14,6 +14,7 @@
 #include "message/messaging_service_fwd.hh"
 #include "raft/raft.hh"
 #include "raft/server.hh"
+#include "raft_timeout.hh"
 #include "utils/recent_entries_map.hh"
 #include "direct_failure_detector/failure_detector.hh"
 #include "service/raft/group0_fwd.hh"
@@ -52,11 +53,6 @@ struct raft_server_for_group {
     raft_sys_table_storage& persistence;
     std::optional<seastar::future<>> aborted;
     std::optional<lowres_clock::duration> default_op_timeout;
-};
-
-struct raft_timeout {
-    seastar::compat::source_location loc = seastar::compat::source_location::current();
-    std::optional<lowres_clock::time_point> value;
 };
 
 class raft_operation_timeout_error : public std::runtime_error {

--- a/service/raft/raft_timeout.hh
+++ b/service/raft/raft_timeout.hh
@@ -1,0 +1,20 @@
+// Copyright (C) 2024-present ScyllaDB
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#pragma once
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/util/source_location-compat.hh>
+
+#include "seastarx.hh"
+
+#include <optional>
+
+namespace service {
+
+struct raft_timeout {
+    seastar::compat::source_location loc = seastar::compat::source_location::current();
+    std::optional<lowres_clock::time_point> value;
+};
+
+}

--- a/test/boost/commitlog_cleanup_test.cc
+++ b/test/boost/commitlog_cleanup_test.cc
@@ -12,6 +12,7 @@
 #include "db/commitlog/commitlog_replayer.hh"
 #include "db/commitlog/commitlog.hh"
 #include "db/config.hh"
+#include "db/system_keyspace.hh"
 
 // Test that `canonical_token_range(tr)` contains the same tokens as `tr`.
 SEASTAR_TEST_CASE(test_canonical_token_range) {

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -15,6 +15,7 @@
 #include <boost/multiprecision/cpp_int.hpp>
 
 #include <fmt/ranges.h>
+#include <fmt/std.h>
 
 #include <seastar/net/inet_address.hh>
 

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -43,6 +43,7 @@
 #include "test/lib/tmpdir.hh"
 #include "db/data_listeners.hh"
 #include "multishard_mutation_query.hh"
+#include "mutation_query.hh"
 #include "transport/messages/result_message.hh"
 #include "compaction/compaction_manager.hh"
 #include "db/snapshot-ctl.hh"

--- a/test/boost/group0_cmd_merge_test.cc
+++ b/test/boost/group0_cmd_merge_test.cc
@@ -12,6 +12,7 @@
 #include "test/lib/cql_test_env.hh"
 
 #include "db/config.hh"
+#include "db/system_keyspace.hh"
 #include "service/migration_manager.hh"
 #include "service/raft/raft_group_registry.hh"
 #include "service/raft/group0_state_machine.hh"

--- a/test/boost/transport_test.cc
+++ b/test/boost/transport_test.cc
@@ -9,6 +9,7 @@
 #include "test/lib/scylla_test_case.hh"
 
 #include <fmt/ranges.h>
+#include <fmt/std.h>
 
 #include "transport/request.hh"
 #include "transport/response.hh"


### PR DESCRIPTION
Reduce compile time and unnecessary compilations by reducing #include load.

Minor refactoring, no backport.