### PR TITLE
virtual_tables: snapshots: include all snapshots

### DIFF
--- a/test/cql-pytest/nodetool.py
+++ b/test/cql-pytest/nodetool.py
@@ -124,6 +124,18 @@ def take_snapshot(cql, table, tag, skip_flush):
         args.append(ks)
         run_nodetool(cql, "snapshot", *args)
 
+def del_snapshot(cql, tag:str, keyspaces:list[str] = []):
+    if has_rest_api(cql):
+        params = {'tag': tag}
+        if keyspaces:
+            params["kn"] = ','.join(keyspaces)
+        requests.delete(f'{rest_api_url(cql)}/storage_service/snapshots/', params=params)
+    else:
+        args = ['--tag', tag]
+        if keyspaces:
+            args.extend(keyspaces)
+        run_nodetool(cql, "clearsnapshot", *args)
+
 def refreshsizeestimates(cql):
     if has_rest_api(cql):
         # The "nodetool refreshsizeestimates" is not available, or needed, in Scylla


### PR DESCRIPTION
Use database::get_snapshot_details to get the details
of all snapshots on disk, in particular those of
deleted tables.

Add test_snapshots_dropped_table to test listing
of snapshots of a deleted table.
And harden the existing test cases to use a unique
snapshot tag and to delete it when the test ends.

Fixes #18313

* No backport required at this time since this is rather minor UX issue that weren't hit in the field AFAIK