### PR TITLE
treewide: de-static namespace scope functions in headers

### DIFF
--- a/cartesian_product.hh
+++ b/cartesian_product.hh
@@ -76,7 +76,7 @@ public:
 };
 
 template<typename T>
-static inline
+inline
 size_t cartesian_product_size(const std::vector<std::vector<T>>& vec_of_vecs) {
     size_t r = 1;
     for (auto&& vec : vec_of_vecs) {
@@ -86,7 +86,7 @@ size_t cartesian_product_size(const std::vector<std::vector<T>>& vec_of_vecs) {
 }
 
 template<typename T>
-static inline
+inline
 bool cartesian_product_is_empty(const std::vector<std::vector<T>>& vec_of_vecs) {
     for (auto&& vec : vec_of_vecs) {
         if (vec.empty()) {
@@ -97,7 +97,7 @@ bool cartesian_product_is_empty(const std::vector<std::vector<T>>& vec_of_vecs) 
 }
 
 template<typename T>
-static inline
+inline
 cartesian_product<T> make_cartesian_product(const std::vector<std::vector<T>>& vec_of_vecs) {
     return cartesian_product<T>(vec_of_vecs);
 }

--- a/clocks-impl.hh
+++ b/clocks-impl.hh
@@ -16,13 +16,13 @@
 extern std::atomic<int64_t> clocks_offset;
 
 template<typename Duration>
-static inline void forward_jump_clocks(Duration delta)
+inline void forward_jump_clocks(Duration delta)
 {
     auto d = std::chrono::duration_cast<std::chrono::seconds>(delta).count();
     clocks_offset.fetch_add(d, std::memory_order_relaxed);
 }
 
-static inline std::chrono::seconds get_clocks_offset()
+inline std::chrono::seconds get_clocks_offset()
 {
     auto off = clocks_offset.load(std::memory_order_relaxed);
     return std::chrono::seconds(off);

--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -185,7 +185,7 @@ public:
 // Converts compound_type<> representation to legacy representation
 // @packed is assumed to be serialized using supplied @type.
 template <typename CompoundType>
-static inline
+inline
 bytes to_legacy(CompoundType& type, managed_bytes_view packed) {
     legacy_compound_view<CompoundType> lv(type, packed);
     bytes legacy_form(bytes::initialized_later(), lv.size());

--- a/concrete_types.hh
+++ b/concrete_types.hh
@@ -174,7 +174,7 @@ template <typename Func> concept CanHandleAllTypes = requires(Func f) {
 
 template<typename Func>
 requires CanHandleAllTypes<Func>
-static inline visit_ret_type<Func> visit(const abstract_type& t, Func&& f) {
+inline visit_ret_type<Func> visit(const abstract_type& t, Func&& f) {
     switch (t.get_kind()) {
     case abstract_type::kind::ascii:
         return f(*static_cast<const ascii_type_impl*>(&t));

--- a/cql3/column_identifier.hh
+++ b/cql3/column_identifier.hh
@@ -88,12 +88,12 @@ public:
     friend std::hash<column_identifier_raw>;
 };
 
-static inline
+inline
 const column_definition* get_column_definition(const schema& schema, const column_identifier& id) {
     return schema.get_column_definition(id.bytes_);
 }
 
-static inline
+inline
 ::shared_ptr<column_identifier> to_identifier(const column_definition& def) {
     return def.column_specification->name;
 }

--- a/cql3/statements/bound.hh
+++ b/cql3/statements/bound.hh
@@ -18,22 +18,22 @@ namespace statements {
 
 enum class bound : int32_t { START = 0, END };
 
-static inline
+inline
 int32_t get_idx(bound b) {
     return (int32_t)b;
 }
 
-static inline
+inline
 bound reverse(bound b) {
     return bound((int32_t)b ^ 1);
 }
 
-static inline
+inline
 bool is_start(bound b) {
     return b == bound::START;
 }
 
-static inline
+inline
 bool is_end(bound b) {
     return b == bound::END;
 }

--- a/db_clock.hh
+++ b/db_clock.hh
@@ -39,7 +39,7 @@ public:
     }
 };
 
-static inline
+inline
 gc_clock::time_point to_gc_clock(db_clock::time_point tp) noexcept {
     // Converting time points through `std::time_t` means that we don't have to make any assumptions about the epochs
     // of `gc_clock` and `db_clock`, though we require that that the period of `gc_clock` is also 1 s like

--- a/mutation/canonical_mutation.hh
+++ b/mutation/canonical_mutation.hh
@@ -49,7 +49,7 @@ template <> struct fmt::formatter<canonical_mutation> : fmt::formatter<string_vi
     auto format(const canonical_mutation&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-static inline std::ostream& operator<<(std::ostream& os, const canonical_mutation& cm) {
+inline std::ostream& operator<<(std::ostream& os, const canonical_mutation& cm) {
     fmt::print(os, "{}", cm);
     return os;
 }

--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -18,7 +18,7 @@
 
 extern logging::logger mclog;
 
-static inline bool has_ck_selector(const query::clustering_row_ranges& ranges) {
+inline bool has_ck_selector(const query::clustering_row_ranges& ranges) {
     // Like PK range, an empty row range, should be considered an "exclude all" restriction
     return ranges.empty() || std::any_of(ranges.begin(), ranges.end(), [](auto& r) {
         return !r.is_full();

--- a/mutation/tombstone.hh
+++ b/mutation/tombstone.hh
@@ -78,7 +78,7 @@ struct fmt::formatter<tombstone> : fmt::formatter<string_view> {
      }
 };
 
-static inline std::ostream& operator<<(std::ostream& out, const tombstone& t) {
+inline std::ostream& operator<<(std::ostream& out, const tombstone& t) {
     fmt::print(out, "{}", t);
     return out;
 }

--- a/serializer_impl.hh
+++ b/serializer_impl.hh
@@ -75,7 +75,7 @@ struct serialize_array_helper<false, T> {
 };
 
 template<typename T, typename Container, typename Output>
-static inline void serialize_array(Output& out, const Container& v) {
+inline void serialize_array(Output& out, const Container& v) {
     serialize_array_helper<can_serialize_fast<T>(), T>::doit(out, v);
 }
 
@@ -208,12 +208,12 @@ struct deserialize_array_helper<false, T> {
 };
 
 template<typename T, typename Input, typename Container>
-static inline void deserialize_array(Input& in, Container& v, size_t sz) {
+inline void deserialize_array(Input& in, Container& v, size_t sz) {
     deserialize_array_helper<can_serialize_fast<T>(), T>::doit(in, v, sz);
 }
 
 template<typename T, typename Input>
-static inline void skip_array(Input& in, size_t sz) {
+inline void skip_array(Input& in, size_t sz) {
     deserialize_array_helper<can_serialize_fast<T>(), T>::skip(in, sz);
 }
 

--- a/sstables/consumer.hh
+++ b/sstables/consumer.hh
@@ -24,7 +24,7 @@
 #include <variant>
 
 template<typename T>
-static inline T consume_be(temporary_buffer<char>& p) {
+inline T consume_be(temporary_buffer<char>& p) {
     T i = read_be<T>(p.get());
     p.trim_front(sizeof(T));
     return i;

--- a/sstables/hyperloglog.hh
+++ b/sstables/hyperloglog.hh
@@ -66,7 +66,7 @@ static constexpr double pow_2_32 = 4294967296.0; ///< 2^32
 static constexpr double neg_pow_2_32 = -4294967296.0; ///< -(2^32)
 
 
-static inline size_t size_unsigned_var_int(unsigned int value) {
+inline size_t size_unsigned_var_int(unsigned int value) {
     size_t size = 0;
     while ((value & 0xFFFFFF80) != 0L) {
         size++;
@@ -76,7 +76,7 @@ static inline size_t size_unsigned_var_int(unsigned int value) {
     return size;
 }
 
-static inline size_t write_unsigned_var_int(unsigned int value, uint8_t* to) {
+inline size_t write_unsigned_var_int(unsigned int value, uint8_t* to) {
     size_t size = 0;
     while ((value & 0xFFFFFF80) != 0L) {
         *to = (value & 0x7F) | 0x80;

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -31,7 +31,7 @@
 
 // While the sstable code works with char, bytes_view works with int8_t
 // (signed char). Rather than change all the code, let's do a cast.
-static inline bytes_view to_bytes_view(const temporary_buffer<char>& b) {
+inline bytes_view to_bytes_view(const temporary_buffer<char>& b) {
     using byte = bytes_view::value_type;
     return bytes_view(reinterpret_cast<const byte*>(b.get()), b.size());
 }

--- a/test/lib/mutation_assertions.hh
+++ b/test/lib/mutation_assertions.hh
@@ -108,12 +108,12 @@ public:
     }
 };
 
-static inline
+inline
 mutation_partition_assertion assert_that(schema_ptr s, const mutation_partition& mp) {
     return {std::move(s), mp};
 }
 
-static inline
+inline
 mutation_partition_assertion assert_that(schema_ptr s, const mutation_partition_v2& mp) {
     return {s, mp.as_mutation_partition(*s)};
 }
@@ -184,7 +184,7 @@ public:
     }
 };
 
-static inline
+inline
 mutation_assertion assert_that(mutation m) {
     return { std::move(m) };
 }
@@ -208,7 +208,7 @@ public:
     }
 };
 
-static inline
+inline
 mutation_opt_assertions assert_that(mutation_opt mo) {
     return { std::move(mo) };
 }

--- a/test/lib/mutation_reader_assertions.hh
+++ b/test/lib/mutation_reader_assertions.hh
@@ -28,7 +28,7 @@ inline bool trim_range_tombstone(const schema& s, range_tombstone& rt, const que
     return relevant;
 }
 
-static inline void match_compacted_mutation(const mutation_opt& mo, const mutation& m, gc_clock::time_point query_time,
+inline void match_compacted_mutation(const mutation_opt& mo, const mutation& m, gc_clock::time_point query_time,
                                             const std::optional<query::clustering_row_ranges>& ck_ranges = {}) {
     // If the passed in mutation is empty, allow for the reader to produce an empty or no partition.
     if (m.partition().empty() && !mo) {

--- a/timestamp.hh
+++ b/timestamp.hh
@@ -39,7 +39,7 @@ public:
     }
 };
 
-static inline
+inline
 timestamp_type new_timestamp() {
     return timestamp_clock::now().time_since_epoch().count();
 }

--- a/types/types.hh
+++ b/types/types.hh
@@ -570,7 +570,7 @@ bool operator==(const data_value& x, const data_value& y);
 using bytes_view_opt = std::optional<bytes_view>;
 using managed_bytes_view_opt = std::optional<managed_bytes_view>;
 
-static inline
+inline
 std::strong_ordering tri_compare(data_type t, managed_bytes_view e1, managed_bytes_view e2) {
     return t->compare(e1, e2);
 }
@@ -585,7 +585,7 @@ tri_compare_opt(data_type t, managed_bytes_view_opt v1, managed_bytes_view_opt v
     }
 }
 
-static inline
+inline
 bool equal(data_type t, managed_bytes_view e1, managed_bytes_view e2) {
     return t->equal(e1, e2);
 }
@@ -876,7 +876,7 @@ less_unsigned(bytes_view v1, bytes_view v2) {
 }
 
 template<typename Type>
-static inline
+inline
 typename Type::value_type deserialize_value(Type& t, bytes_view v) {
     return t.deserialize_value(v);
 }

--- a/utils/array-search.hh
+++ b/utils/array-search.hh
@@ -29,7 +29,7 @@ static constexpr int64_t simple_key_unused_value = std::numeric_limits<int64_t>:
  */
 int array_search_gt(int64_t val, const int64_t* array, const int capacity, const int size);
 
-static inline unsigned array_search_4_eq(uint8_t val, const uint8_t* array) {
+inline unsigned array_search_4_eq(uint8_t val, const uint8_t* array) {
     // Unrolled loop is few %s faster
     if (array[0] == val) {
         return 0;
@@ -44,7 +44,7 @@ static inline unsigned array_search_4_eq(uint8_t val, const uint8_t* array) {
     }
 }
 
-static inline unsigned array_search_8_eq(uint8_t val, const uint8_t* array) {
+inline unsigned array_search_8_eq(uint8_t val, const uint8_t* array) {
     for (unsigned i = 0; i < 8; i++) {
         if (array[i] == val) {
             return i;

--- a/utils/aws_sigv4.hh
+++ b/utils/aws_sigv4.hh
@@ -37,9 +37,9 @@ std::string get_signature(std::string_view access_key_id, std::string_view secre
         const std::vector<temporary_buffer<char>>* body_content, std::string_view region, std::string_view service, std::string_view query_string);
 
 // Convenience alias not to pass obscure nullptr argument to get_signature()
-static inline constexpr std::vector<temporary_buffer<char>>* unsigned_content = nullptr;
+inline constexpr std::vector<temporary_buffer<char>>* unsigned_content = nullptr;
 // Same for datestamp checking
-static inline auto omit_datestamp_expiration_check = std::nullopt;
+inline auto omit_datestamp_expiration_check = std::nullopt;
 
 std::string format_time_point(db_clock::time_point tp);
 

--- a/utils/crc.hh
+++ b/utils/crc.hh
@@ -22,19 +22,19 @@
 #elif defined(__aarch64__)
 #include <arm_acle.h>
 /* Implement x86-64 intrinsics with according aarch64 ones */
-static inline uint32_t _mm_crc32_u8(uint32_t crc, uint8_t in)
+inline uint32_t _mm_crc32_u8(uint32_t crc, uint8_t in)
 {
     return __crc32cb(crc, in);
 }
-static inline uint32_t _mm_crc32_u16(uint32_t crc, uint16_t in)
+inline uint32_t _mm_crc32_u16(uint32_t crc, uint16_t in)
 {
     return __crc32ch(crc, in);
 }
-static inline uint32_t _mm_crc32_u32(uint32_t crc, uint32_t in)
+inline uint32_t _mm_crc32_u32(uint32_t crc, uint32_t in)
 {
     return __crc32cw(crc, in);
 }
-static inline uint32_t _mm_crc32_u64(uint32_t crc, uint64_t in)
+inline uint32_t _mm_crc32_u64(uint32_t crc, uint64_t in)
 {
     return __crc32cd(crc, in);
 }

--- a/utils/fragment_range.hh
+++ b/utils/fragment_range.hh
@@ -388,7 +388,7 @@ T read_simple_exactly(View v) {
 }
 
 template<typename T, FragmentedMutableView Out>
-static inline
+inline
 void write(Out& out, std::type_identity_t<T> val) {
     auto v = net::ntoh(val);
     auto p = reinterpret_cast<const bytes_view::value_type*>(&v);
@@ -401,7 +401,7 @@ void write(Out& out, std::type_identity_t<T> val) {
 }
 
 template<typename T, FragmentedMutableView Out>
-static inline
+inline
 void write_native(Out& out, std::type_identity_t<T> v) {
     auto p = reinterpret_cast<const bytes_view::value_type*>(&v);
     if (out.current_fragment().size() >= sizeof(v)) [[likely]] {

--- a/utils/lister.hh
+++ b/utils/lister.hh
@@ -216,18 +216,18 @@ public:
     future<> close() noexcept override;
 };
 
-static inline fs::path operator/(const fs::path& lhs, const char* rhs) {
+inline fs::path operator/(const fs::path& lhs, const char* rhs) {
     return lhs / fs::path(rhs);
 }
 
-static inline fs::path operator/(const fs::path& lhs, const sstring& rhs) {
+inline fs::path operator/(const fs::path& lhs, const sstring& rhs) {
     return lhs / fs::path(rhs);
 }
 
-static inline fs::path operator/(const fs::path& lhs, std::string_view rhs) {
+inline fs::path operator/(const fs::path& lhs, std::string_view rhs) {
     return lhs / fs::path(rhs);
 }
 
-static inline fs::path operator/(const fs::path& lhs, const std::string& rhs) {
+inline fs::path operator/(const fs::path& lhs, const std::string& rhs) {
     return lhs / fs::path(rhs);
 }

--- a/utils/murmur_hash.hh
+++ b/utils/murmur_hash.hh
@@ -45,7 +45,7 @@ uint64_t read_block(InputIterator& in) {
            (((uint64_t) tmp[6] & 0xff) << 48) + (((uint64_t) tmp[7] & 0xff) << 56);
 }
 
-static inline
+inline
 uint64_t fmix(uint64_t k) {
     k ^= (uint64_t)k >> 33;
     k *= 0xff51afd7ed558ccdL;

--- a/utils/serialization.hh
+++ b/utils/serialization.hh
@@ -138,7 +138,7 @@ size_t serialize_string_size(const sstring& s) {;
 }
 
 template<typename T, typename CharOutputIterator>
-static inline
+inline
 void write(CharOutputIterator& out, const T& val) {
     auto v = net::ntoh(val);
     out = std::copy_n(reinterpret_cast<char*>(&v), sizeof(v), out);

--- a/utils/vle.hh
+++ b/utils/vle.hh
@@ -22,13 +22,13 @@ static constexpr uint32_t uleb64_express_supreme = 1 << uleb64_express_bits;
 
 // Returns the number of bytes needed to encode the value
 // The value cannot be 0 (not checked)
-static inline size_t uleb64_encoded_size(uint32_t val) noexcept {
+inline size_t uleb64_encoded_size(uint32_t val) noexcept {
     return seastar::log2floor(val) / 6 + 1;
 }
 
 template <typename Poison, typename Unpoison>
 requires std::is_invocable<Poison, const char*, size_t>::value && std::is_invocable<Unpoison, const char*, size_t>::value
-static inline void uleb64_encode(char*& pos, uint32_t val, Poison&& poison, Unpoison&& unpoison) noexcept {
+inline void uleb64_encode(char*& pos, uint32_t val, Poison&& poison, Unpoison&& unpoison) noexcept {
     uint64_t b = 64;
     auto start = pos;
     do {
@@ -46,7 +46,7 @@ static inline void uleb64_encode(char*& pos, uint32_t val, Poison&& poison, Unpo
 
 template <typename Poison, typename Unpoison>
 requires std::is_invocable<Poison, const char*, size_t>::value && std::is_invocable<Unpoison, const char*, size_t>::value
-static inline void uleb64_encode(char*& pos, uint32_t val, size_t encoded_size, Poison&& poison, Unpoison&& unpoison) noexcept {
+inline void uleb64_encode(char*& pos, uint32_t val, size_t encoded_size, Poison&& poison, Unpoison&& unpoison) noexcept {
     uint64_t b = 64;
     auto start = pos;
     unpoison(start, encoded_size);
@@ -63,7 +63,7 @@ static inline void uleb64_encode(char*& pos, uint32_t val, size_t encoded_size, 
 }
 
 #if !defined(SEASTAR_ASAN_ENABLED)
-static inline void uleb64_express_encode_impl(char*& pos, uint64_t val, size_t size) noexcept {
+inline void uleb64_express_encode_impl(char*& pos, uint64_t val, size_t size) noexcept {
     static_assert(uleb64_express_bits == 12);
 
     if (size > sizeof(uint64_t)) {
@@ -77,7 +77,7 @@ static inline void uleb64_express_encode_impl(char*& pos, uint64_t val, size_t s
 
 template <typename Poison, typename Unpoison>
 requires std::is_invocable<Poison, const char*, size_t>::value && std::is_invocable<Unpoison, const char*, size_t>::value
-static inline void uleb64_express_encode(char*& pos, uint32_t val, size_t encoded_size, size_t gap, Poison&& poison, Unpoison&& unpoison) noexcept {
+inline void uleb64_express_encode(char*& pos, uint32_t val, size_t encoded_size, size_t gap, Poison&& poison, Unpoison&& unpoison) noexcept {
     if (encoded_size + gap > sizeof(uint64_t)) {
         uleb64_express_encode_impl(pos, val, encoded_size);
     } else {
@@ -87,14 +87,14 @@ static inline void uleb64_express_encode(char*& pos, uint32_t val, size_t encode
 #else
 template <typename Poison, typename Unpoison>
 requires std::is_invocable<Poison, const char*, size_t>::value && std::is_invocable<Unpoison, const char*, size_t>::value
-static inline void uleb64_express_encode(char*& pos, uint32_t val, size_t encoded_size, size_t gap, Poison&& poison, Unpoison&& unpoison) noexcept {
+inline void uleb64_express_encode(char*& pos, uint32_t val, size_t encoded_size, size_t gap, Poison&& poison, Unpoison&& unpoison) noexcept {
     uleb64_encode(pos, val, encoded_size, poison, unpoison);
 }
 #endif
 
 template <typename Poison, typename Unpoison>
 requires std::is_invocable<Poison, const char*, size_t>::value && std::is_invocable<Unpoison, const char*, size_t>::value
-static inline uint32_t uleb64_decode_forwards(const char*& pos, Poison&& poison, Unpoison&& unpoison) noexcept {
+inline uint32_t uleb64_decode_forwards(const char*& pos, Poison&& poison, Unpoison&& unpoison) noexcept {
     uint32_t n = 0;
     unsigned shift = 0;
     auto p = pos; // avoid aliasing; p++ doesn't touch memory
@@ -115,7 +115,7 @@ static inline uint32_t uleb64_decode_forwards(const char*& pos, Poison&& poison,
 
 template <typename Poison, typename Unpoison>
 requires std::is_invocable<Poison, const char*, size_t>::value && std::is_invocable<Unpoison, const char*, size_t>::value
-static inline uint32_t uleb64_decode_bacwards(const char*& pos, Poison&& poison, Unpoison&& unpoison) noexcept {
+inline uint32_t uleb64_decode_bacwards(const char*& pos, Poison&& poison, Unpoison&& unpoison) noexcept {
     uint32_t n = 0;
     uint8_t b;
     auto p = pos; // avoid aliasing; --p doesn't touch memory


### PR DESCRIPTION
'static inline' is always wrong in headers - if the same header is included multiple times, and the function happens not to be inlined, then multiple copies of it will be generated.

Fix by mechanically changing '^static inline' to 'inline'.

Code cleanup; no backport necessary.