### PR TITLE
directories: cleanups to silence clang-tidy false alarms

### DIFF
--- a/utils/directories.cc
+++ b/utils/directories.cc
@@ -99,6 +99,7 @@ future<> directories::create_and_verify(directories::set dir_set, recursive recu
 }
 
 template <typename... Args>
+[[noreturn]]
 static inline
 void verification_error(const fs::path& path, const char* fstr, Args&&... args) {
     auto emsg = fmt::format(fmt::runtime(fstr), std::forward<Args>(args)...);


### PR DESCRIPTION
clang-tidy warns:

```
Warning: /__w/scylladb/scylladb/utils/directories.cc:132:52: warning: 'path' used after it was moved [bugprone-use-after-move]
  132 |         bool can_access = co_await file_accessible(path.string(), access_flags::read | access_flags::write | access_flags::execute);
      |                                                    ^
/__w/scylladb/scylladb/utils/directories.cc:121:28: note: move occurred here
  121 |         verification_error(std::move(path), "File not owned by current euid: {}. Owner is: {}", geteuid(), sd.uid);
      |                            ^
```

because we pass `std::move(path)` to `verification_error()`, and "then" use this variable again in this same function.
this is a false alarm, but we could make it very clear to convince this tool that it's safe to do so.

---

it's a cleanup, hence no need to backport.