### PR TITLE
docs: update command

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,6 +32,9 @@ setupenv:
 .PHONY: setup
 setup:
 	$(POETRY) install
+
+.PHONY: update
+update:
 	$(POETRY) update
 
 # Clean commands


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/849

Separates the update command from the setup command.

This is required because versions now are not strictly pinned in the `pyproject.toml` file since Sphinx ScyllaDB Theme 1.8. This change makes sure that the versions defined in the ``poetry.lock`` file committed to the repository are the ones used for production builds.

## How to test

1. Build the docs locally with ``make preview``.
2. Check ``poetry.lock`` dependencies are not updated.