### PR TITLE
treewide: remove dependency on boost asio address_v4

### DIFF
--- a/seastarx.hh
+++ b/seastarx.hh
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <boost/asio/ip/address_v4.hpp>  // avoid conflict between ::socket and seastar::socket
-
 namespace seastar {
 
 template <typename T>

--- a/test/boost/types_test.cc
+++ b/test/boost/types_test.cc
@@ -10,7 +10,6 @@
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/net/inet_address.hh>
 #include "utils/UUID_gen.hh"
-#include <boost/asio/ip/address_v4.hpp>
 #include <seastar/net/ip.hh>
 #include <boost/multiprecision/cpp_int.hpp>
 #include "types/types.hh"


### PR DESCRIPTION
It's not used. There's a comment mentioning it prevents some type conflict, but apparently that was fixed some time ago.

Code cleanup, no backport.