### PR TITLE
mv: add a dedicated read concurrency semaphore for view update read before writes

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1033,6 +1033,12 @@ db::config::config(std::shared_ptr<db::extensions> exts)
             "Start killing reads after their collective memory consumption goes above $normal_limit * $multiplier.")
     , reader_concurrency_semaphore_cpu_concurrency(this, "reader_concurrency_semaphore_cpu_concurrency", liveness::LiveUpdate, value_status::Used, 1,
             "Admit new reads while there are less than this number of requests that need CPU.")
+    , view_update_reader_concurrency_semaphore_serialize_limit_multiplier(this, "view_update_reader_concurrency_semaphore_serialize_limit_multiplier", liveness::LiveUpdate, value_status::Used, 2,
+            "Start serializing view update reads after their collective memory consumption goes above $normal_limit * $multiplier.")
+    , view_update_reader_concurrency_semaphore_kill_limit_multiplier(this, "view_update_reader_concurrency_semaphore_kill_limit_multiplier", liveness::LiveUpdate, value_status::Used, 4,
+            "Start killing view update reads after their collective memory consumption goes above $normal_limit * $multiplier.")
+    , view_update_reader_concurrency_semaphore_cpu_concurrency(this, "view_update_reader_concurrency_semaphore_cpu_concurrency", liveness::LiveUpdate, value_status::Used, 1,
+            "Admit new view update reads while there are less than this number of requests that need CPU.")
     , maintenance_reader_concurrency_semaphore_count_limit(this, "maintenance_reader_concurrency_semaphore_count_limit", liveness::LiveUpdate, value_status::Used, 10,
             "Allow up to this many maintenance (e.g. streaming and repair) reads per shard to progress at the same time.")
     , twcs_max_window_count(this, "twcs_max_window_count", liveness::LiveUpdate, value_status::Used, 50,

--- a/db/config.hh
+++ b/db/config.hh
@@ -384,6 +384,9 @@ public:
     named_value<uint32_t> reader_concurrency_semaphore_serialize_limit_multiplier;
     named_value<uint32_t> reader_concurrency_semaphore_kill_limit_multiplier;
     named_value<uint32_t> reader_concurrency_semaphore_cpu_concurrency;
+    named_value<uint32_t> view_update_reader_concurrency_semaphore_serialize_limit_multiplier;
+    named_value<uint32_t> view_update_reader_concurrency_semaphore_kill_limit_multiplier;
+    named_value<uint32_t> view_update_reader_concurrency_semaphore_cpu_concurrency;
     named_value<int> maintenance_reader_concurrency_semaphore_count_limit;
     named_value<uint32_t> twcs_max_window_count;
     named_value<unsigned> initial_sstable_loading_concurrency;

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -9,6 +9,7 @@
  */
 
 #include <boost/range/adaptor/transformed.hpp>
+#include <chrono>
 #include <deque>
 #include <functional>
 #include <optional>
@@ -1385,6 +1386,9 @@ future<std::optional<utils::chunked_vector<frozen_mutation_and_schema>>> view_up
         co_await (do_advance_existings ? advance_all() : advance_updates());
     } else if (do_advance_existings) {
         co_await advance_existings();
+    }
+    if (utils::get_local_injector().enter("keep_mv_read_semaphore_units_10ms_longer") && _existing && _existing->is_clustering_row()) {
+        co_await seastar::sleep(std::chrono::milliseconds(10));
     }
 
     // If the partition tombstone update is applied to all the views and there are no other updates, we can skip going over

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1422,9 +1422,12 @@ public:
 private:
     replica::cf_stats _cf_stats;
     static constexpr size_t max_count_concurrent_reads{100};
+    static constexpr size_t max_count_concurrent_view_update_reads{50};
     size_t max_memory_concurrent_reads() { return _dbcfg.available_memory * 0.02; }
+    size_t max_memory_concurrent_view_update_reads() { return _dbcfg.available_memory * 0.01; }
     // Assume a queued read takes up 1kB of memory, and allow 2% of memory to be filled up with such reads.
     size_t max_inactive_queue_length() { return _dbcfg.available_memory * 0.02 / 1000; }
+    size_t max_inactive_view_update_queue_length() { return _dbcfg.available_memory * 0.01 / 1000; }
     // They're rather heavyweight, so limit more
     static constexpr size_t max_count_streaming_concurrent_reads{10};
     size_t max_memory_streaming_concurrent_reads() { return _dbcfg.available_memory * 0.02; }
@@ -1475,6 +1478,8 @@ private:
     reader_concurrency_semaphore _compaction_concurrency_sem;
     reader_concurrency_semaphore _system_read_concurrency_sem;
 
+    // The view update read concurrency semaphore used for view updates coming from user writes.
+    reader_concurrency_semaphore _view_update_read_concurrency_sem;
     db::timeout_semaphore _view_update_concurrency_sem{max_memory_pending_view_updates()};
 
     cache_tracker _row_cache_tracker;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3522,7 +3522,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
     const bool need_static = db::view::needs_static_row(m.partition(), views);
     if (!need_regular && !need_static) {
         tracing::trace(tr_state, "View updates do not require read-before-write");
-        co_await gen->generate_and_propagate_view_updates(*this, base, sem.make_tracking_only_permit(s, "push-view-updates-1", timeout, tr_state), std::move(views), std::move(m), { }, tr_state, now, timeout);
+        co_await gen->generate_and_propagate_view_updates(*this, base, sem.make_tracking_only_permit(s, "push-view-updates-no-read-before-write", timeout, tr_state), std::move(views), std::move(m), { }, tr_state, now, timeout);
         // In this case we are not doing a read-before-write, just a
         // write, so no lock is needed.
         co_return row_locker::lock_holder();
@@ -3555,7 +3555,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
     co_await utils::get_local_injector().inject("table_push_view_replica_updates_timeout", timeout);
     auto lock = co_await std::move(lockf);
     auto pk = dht::partition_range::make_singular(m.decorated_key());
-    auto permit = sem.make_tracking_only_permit(base, "push-view-updates-2", timeout, tr_state);
+    auto permit = co_await sem.obtain_permit(base, "push-view-updates-read-before-write", estimate_read_memory_cost(), timeout, tr_state);
     auto reader = source.make_reader_v2(base, permit, pk, slice, tr_state, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
     co_await gen->generate_and_propagate_view_updates(*this, base, std::move(permit), std::move(views), std::move(m), std::move(reader), tr_state, now, timeout);
     tracing::trace(tr_state, "View updates for {}.{} were generated and propagated", base->ks_name(), base->cf_name());

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -2330,10 +2330,11 @@ class scylla_memory(gdb.Command):
 
         database_typename = lookup_type(['replica::database', 'database'])[1].name
         gdb.write('Replica:\n')
-        gdb.write('  Read Concurrency Semaphores:\n    {}\n    {}\n    {}\n'.format(
+        gdb.write('  Read Concurrency Semaphores:\n    {}\n    {}\n    {}\n    {}\n'.format(
                 scylla_memory.format_semaphore_stats(db['_read_concurrency_sem']),
                 scylla_memory.format_semaphore_stats(db['_streaming_concurrency_sem']),
-                scylla_memory.format_semaphore_stats(db['_system_read_concurrency_sem'])))
+                scylla_memory.format_semaphore_stats(db['_system_read_concurrency_sem']),
+                scylla_memory.format_semaphore_stats(db['_view_update_read_concurrency_sem'])))
 
         gdb.write('  Execution Stages:\n')
         for es_path in [('_apply_stage',)]:
@@ -5835,6 +5836,11 @@ class scylla_read_stats(gdb.Command):
             db = find_db()
             semaphores = [db["_read_concurrency_sem"], db["_streaming_concurrency_sem"], db["_system_read_concurrency_sem"]]
             semaphores.append(db["_compaction_concurrency_sem"])
+            try:
+                semaphores.append(db["_view_update_read_concurrency_sem"])
+            except gdb.error:
+                # 6.2 compatibility
+                pass
 
         for semaphore in semaphores:
             scylla_read_stats.dump_reads_from_semaphore(semaphore)

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -469,6 +469,12 @@ private:
             if (!cfg->reader_concurrency_semaphore_kill_limit_multiplier.is_set()) {
                 cfg->reader_concurrency_semaphore_kill_limit_multiplier.set(std::numeric_limits<uint32_t>::max());
             }
+            if (!cfg->view_update_reader_concurrency_semaphore_serialize_limit_multiplier.is_set()) {
+                cfg->view_update_reader_concurrency_semaphore_serialize_limit_multiplier.set(std::numeric_limits<uint32_t>::max());
+            }
+            if (!cfg->view_update_reader_concurrency_semaphore_kill_limit_multiplier.is_set()) {
+                cfg->view_update_reader_concurrency_semaphore_kill_limit_multiplier.set(std::numeric_limits<uint32_t>::max());
+            }
             tmpdir data_dir;
             auto data_dir_path = data_dir.path().string();
             if (!cfg->data_file_directories.is_set()) {

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -125,6 +125,8 @@ def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addr
 
         'reader_concurrency_semaphore_serialize_limit_multiplier': 0,
         'reader_concurrency_semaphore_kill_limit_multiplier': 0,
+        'view_update_reader_concurrency_semaphore_serialize_limit_multiplier': 0,
+        'view_update_reader_concurrency_semaphore_kill_limit_multiplier': 0,
 
         'maintenance_socket': socket_path,
 

--- a/test/topology_custom/test_mv_read_concurrency.py
+++ b/test/topology_custom/test_mv_read_concurrency.py
@@ -1,0 +1,86 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from test.pylib.manager_client import ManagerClient
+
+import asyncio
+import pytest
+import logging
+
+from test.topology.conftest import skip_mode
+from test.pylib.util import wait_for_view
+from cassandra import ReadTimeout, WriteTimeout
+
+logger = logging.getLogger(__name__)
+
+# This test verifies that the writes causing view updates don't impact the latency of regular reads
+# due to contention on the read concurrency semaphore.
+# The test creates a table and a table with a materialized view, and then runs a large number of writes causing view updates
+# while concurrently running a small read workload on the other table.
+# The test fails if any of the reads times out.
+# Reproduces https://github.com/scylladb/scylladb/issues/8873
+@pytest.mark.asyncio
+@skip_mode('release', "error injections aren't enabled in release mode")
+async def test_mv_read_concurrency(manager: ManagerClient) -> None:
+    node_count = 1
+    # Disable cache to make reads use the read concurrency semaphore.
+    # Tests remove the rcs multiplier by default, here we use a slightly smaller one (1 instead of default 2) to hit the issue faster.
+    cfg = {
+        'enable_tablets': True,
+        'enable_cache': False,
+        'reader_concurrency_semaphore_serialize_limit_multiplier': 1,
+        'view_update_reader_concurrency_semaphore_serialize_limit_multiplier': 1,
+    }
+    servers = await manager.servers_add(node_count, config=cfg)
+
+    cql, _ = await manager.get_ready_cql(servers)
+    await cql.run_async(f"CREATE KEYSPACE ks WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}")
+    await cql.run_async(f"CREATE TABLE ks.tab (p int PRIMARY KEY, mvp int, v text)")
+    await cql.run_async(f"CREATE TABLE ks.tab2 (p int PRIMARY KEY, mvp int)")
+    await cql.run_async(f"CREATE MATERIALIZED VIEW IF NOT EXISTS ks.mv AS SELECT p, mvp FROM ks.tab \
+        WHERE p IS NOT NULL AND mvp IS NOT NULL PRIMARY KEY (mvp, p)")
+    await wait_for_view(cql, 'mv', node_count)
+
+    row_count = 300
+    for i in range(10):
+        await cql.run_async(f"INSERT INTO ks.tab2 (p, mvp) VALUES ({i}, {i})")
+
+    # The injection prolongs the time we hold the read concurrency semaphore resources during the rbw during a view update
+    await manager.api.enable_injection(servers[0].ip_addr, "keep_mv_read_semaphore_units_10ms_longer", one_shot=False)
+
+    failed = None
+    stop_event = asyncio.Event()
+    async def do_read(i: int):
+        read_stmt = cql.prepare(f"SELECT mvp FROM ks.tab2 WHERE p=? USING TIMEOUT 10s")
+        while not stop_event.is_set():
+            try:
+                await manager.cql.run_async(read_stmt, [i])
+                await asyncio.sleep(0.1)
+            except ReadTimeout as err:
+                stop_event.set()
+                # Fail the test after waiting for the other tasks to finish to avoid clogging the test logs with 100000*'a'
+                nonlocal failed
+                failed = err
+
+    async def do_mv_inserts(i: int):
+        insert_stmt = cql.prepare(f"INSERT INTO ks.tab(p, mvp, v) VALUES (?, ?, '{100000*'a'}') USING TIMEOUT 10s")
+        reps = 0
+        while not stop_event.is_set() and reps < 50:
+            try:
+                await manager.cql.run_async(insert_stmt, [i, i])
+                reps += 1
+            except WriteTimeout:
+                # The writes may timeout for the same reason as the reads, but this test is focused on the reads specifically, so don't fail
+                logger.info(f"Write timeout on {i}")
+
+    read_tasks = [asyncio.create_task(do_read(i)) for i in range(10)]
+    insert_tasks = [asyncio.create_task(do_mv_inserts(i)) for i in range(row_count)]
+
+    await asyncio.gather(*insert_tasks)
+    stop_event.set()
+    await asyncio.gather(*read_tasks)
+
+    if failed:
+        raise failed


### PR DESCRIPTION
When writing to some tables with materialized views, we need to read from the base table first to perform a delete of the old view row. When doing so, the memory used for the read is tracked by the user read concurrency semaphore. When we have a large number of such reads, we may use up all of the semaphore units, causing the following reads to be queued. When we have some user reads coming at the same time, these reads can have very high latency due to the write workload on the base table. We want to avoid this, so that the write workload doesn't have a high impact on the latency of the read workload.

This is fixed in this patch by adding a separate read concurrency semaphore just for view update read-before-writes. With the new semaphore, even if there are many view update read-before-writes, they will be queued on a different semaphore than the user reads, and they won't impact their latency.

The second issue fixed by this patch is the concurrency of the view updates that is currently unlimited. Because of that view updates may take up so much memory that they we may run out of memory.
    
This is fixed by using the read admission on the view update concurrency semaphore.
This limits the number of concurrent view update reads to
max_count_concurrent_view_update_reads, all other incoming view update reads are
queued using just a small chunk of memory. Without this, the reads would also get
queued after exceeding view_update_reader_concurrency_semaphore_serialize_limit_multiplier, but they would take much more memory while staying in the queue.

The new semaphore has half the capacity of the regular user read concurrency semahpore and is currently used only for user writes - is't used independently of the scheduling group on which we base the read semaphore selection, but we use a different code path for streaming (not database::do_apply) and we shouldn't have view updates in system writes or during compaction.

This patch also adds a test to confirm that the view update workload doesn't impact the read latency, as well as a test which confirms that we do not run out of memory even under heavy view udpate workload.

The issue of view updates causing increased latencies most often occurs in the following scenario:
* we have a medium to high write workload to a table with a materialized view which requires reading from the base table before sending the update to delete the old rows
* we have any read workload
* one replica is slower or is handling more writes due to an imbalance of data distribution
* we write with a cl<ALL, the mentioned replica is replying to write requests slower while new ones keep being sent to it. 
* each write performs a read first taking resources from the user read concurrency semaphore, so when enough writes accumulate the reads using the semaphore start getting queued
* the queue is shared by regular reads and view update reads. When there's enough view update reads in the queue, regular reads start getting increased latencies

An sct test (perf-regression-latency-mv-read-concurrency) was prepared to somewhat resemble this scenario:
* the tables were prepared satisfying the conditions above
* we use a medium write workload and a very low read workload
* the imbalance is achieved by writing to just a few (10) partitions - some replicas (and shards) can have twice or more used partitions than others. We also keep writing to a limited (though high) number of rows, to cause overwrites which require reading before sending the view update
* to minimize the test case, we use a cluster of 3 nodes and rf=2, we write with cl=ONE to have background replica writes and read with cl=ALL to wait for the slower replica to respond.

In the test above:
* without the fix, the latency of reads increases over 50s
* with the fix, the latency of reads stays below 20ms

Fixes https://github.com/scylladb/scylladb/issues/8873
Fixes https://github.com/scylladb/scylladb/issues/15805

The patch is not that small and it isn't fixing a regression, so no backports