### PR TITLE
schema/schema: break circular dependency with replica::database

### DIFF
--- a/replica/schema_describe_helper.hh
+++ b/replica/schema_describe_helper.hh
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "data_dictionary/data_dictionary.hh"
+#include "index/secondary_index_manager.hh"
+#include "schema/schema.hh"
+
+namespace replica {
+
+class schema_describe_helper : public ::schema_describe_helper {
+    data_dictionary::database _db;
+public:
+    explicit schema_describe_helper(data_dictionary::database db) : _db(db) { }
+
+    virtual bool is_global_index(const table_id& base_id, const schema& view_s) const override {
+        return  _db.find_column_family(base_id).get_index_manager().is_global_index(view_s);
+    }
+
+    virtual bool is_index(const table_id& base_id, const schema& view_s) const override {
+        return  _db.find_column_family(base_id).get_index_manager().is_index(view_s);
+    }
+
+    virtual schema_ptr find_schema(const table_id& id) const override {
+        return _db.find_schema(id);
+    }
+};
+
+} // namespace data_dictionary

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -61,6 +61,7 @@
 #include "readers/multi_range.hh"
 #include "readers/combined.hh"
 #include "readers/compacting.hh"
+#include "replica/schema_describe_helper.hh"
 
 namespace replica {
 
@@ -2598,7 +2599,8 @@ table::seal_snapshot(sstring jsondir, std::vector<snapshot_file_set> file_sets) 
 }
 
 future<> table::write_schema_as_cql(database& db, sstring dir) const {
-    auto schema_desc = this->schema()->describe(db, cql3::describe_option::STMTS);
+    replica::schema_describe_helper describe_helper{db.as_data_dictionary()};
+    auto schema_desc = this->schema()->describe(describe_helper, cql3::describe_option::STMTS);
 
     auto schema_description = std::move(*schema_desc.create_statement);
     auto schema_file_name = dir + "/schema.cql";

--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -27,6 +27,7 @@
 #include "utils/assert.hh"
 #include "utils/big_decimal.hh"
 #include "utils/UUID_gen.hh"
+#include "replica/schema_describe_helper.hh"
 
 namespace tests {
 
@@ -1147,7 +1148,8 @@ future<> random_schema::create_with_cql(cql_test_env& env) {
 
         auto& db = env.local_db();
 
-        auto schema_desc = _schema->describe(db, cql3::describe_option::STMTS);
+        replica::schema_describe_helper describe_helper{db.as_data_dictionary()};
+        auto schema_desc = _schema->describe(describe_helper, cql3::describe_option::STMTS);
 
         env.execute_cql(*schema_desc.create_statement).get();
         auto& tbl = db.find_column_family(ks_name, tbl_name);


### PR DESCRIPTION
The schema module (everything in schema/) is supposed to be towards the leafs in the ScyllaDB inter-module dependency graph. In other words, it should not depend on many other modules. On the other hand, almost the entire codebase depends on the schema module itself. Currently there is a circular dependency between schema and replica::database, as the latter is a required argument for schema::describe(). This is bad, not just because of the dependency mess it introduces, but also because now schema::describe() can only be used by code which has a reference to the database handy.

This patch breaks this circular dependency, by introducing the schema_describe_helper interface and providing an implementation for it in database.hh.

There is another circular dependency: schema <-> replica::table. This is not addressed by this patch.

Improvement, no backport needed.