### PR TITLE
doc: add metric updates from 6.1 to 6.2

### DIFF
--- a/docs/upgrade/upgrade-opensource/upgrade-guide-from-6.1-to-6.2/metric-update-6.1-to-6.2.rst
+++ b/docs/upgrade/upgrade-opensource/upgrade-guide-from-6.1-to-6.2/metric-update-6.1-to-6.2.rst
@@ -21,8 +21,8 @@ The following metrics are new in ScyllaDB |NEW_VERSION|:
 
    * - Metric
      - Description
-   * -
-     - 
+   * - scylla_alternator_batch_item_count 
+     - The total number of items processed across all batches
 
   
 


### PR DESCRIPTION
This PR specifies metrics that are new in version 6.2 compared to 6.1, as specified in https://github.com/scylladb/scylladb/issues/20176 (=> there's just one new metric).

Fixes https://github.com/scylladb/scylladb/issues/20176

This PR must be backported to branch-6.2 as the update is part of the 6.2 upgrade guide.