### PR TITLE
compaction: use better partition estimate for split compaction

### DIFF
--- a/compaction/table_state.hh
+++ b/compaction/table_state.hh
@@ -59,6 +59,7 @@ public:
     virtual compaction_backlog_tracker& get_backlog_tracker() = 0;
     virtual const std::string get_group_id() const noexcept = 0;
     virtual seastar::condition_variable& get_staging_done_condition() noexcept = 0;
+    virtual dht::token_range get_token_range_after_split(const dht::token& t) const noexcept = 0;
 };
 
 } // namespace compaction

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -303,6 +303,14 @@ dht::token tablet_map::get_first_token(tablet_id id) const {
     }
 }
 
+dht::token_range tablet_map::get_token_range(tablet_id id, size_t log2_tablets) const {
+    if (id == first_tablet()) {
+        return dht::token_range::make({dht::minimum_token(), false}, {get_last_token(id, log2_tablets), true});
+    } else {
+        return dht::token_range::make({get_last_token(tablet_id(size_t(id) - 1), log2_tablets), false}, {get_last_token(id, log2_tablets), true});
+    }
+}
+
 dht::token_range tablet_map::get_token_range(tablet_id id) const {
     if (id == first_tablet()) {
         return dht::token_range::make({dht::minimum_token(), false}, {get_last_token(id), true});

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -316,6 +316,13 @@ dht::token_range tablet_map::get_token_range(tablet_id id) const {
     return get_token_range(id, _log2_tablets);
 }
 
+dht::token_range tablet_map::get_token_range_after_split(const token& t) const noexcept {
+    // when the tablets are split, the tablet count doubles, (i.e.) _log2_tablets increases by 1
+    const auto log2_tablets_after_split = _log2_tablets + 1;
+    auto id_after_split = tablet_id(dht::compaction_group_of(log2_tablets_after_split, t));
+    return get_token_range(id_after_split, log2_tablets_after_split);
+}
+
 tablet_replica tablet_map::get_primary_replica(tablet_id id) const {
     const auto& replicas = get_tablet_info(id).replicas;
     return replicas.at(size_t(id) % replicas.size());

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -286,9 +286,13 @@ std::pair<tablet_id, tablet_range_side> tablet_map::get_tablet_id_and_range_side
     return {tablet_id(current_id), tablet_range_side(id_after_split & 0x1)};
 }
 
+dht::token tablet_map::get_last_token(tablet_id id, size_t log2_tablets) const {
+    return dht::last_token_of_compaction_group(log2_tablets, size_t(id));
+}
+
 dht::token tablet_map::get_last_token(tablet_id id) const {
     check_tablet_id(id);
-    return dht::last_token_of_compaction_group(_log2_tablets, size_t(id));
+    return get_last_token(id, _log2_tablets);
 }
 
 dht::token tablet_map::get_first_token(tablet_id id) const {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -312,11 +312,8 @@ dht::token_range tablet_map::get_token_range(tablet_id id, size_t log2_tablets) 
 }
 
 dht::token_range tablet_map::get_token_range(tablet_id id) const {
-    if (id == first_tablet()) {
-        return dht::token_range::make({dht::minimum_token(), false}, {get_last_token(id), true});
-    } else {
-        return dht::token_range::make({get_last_token(tablet_id(size_t(id) - 1)), false}, {get_last_token(id), true});
-    }
+    check_tablet_id(id);
+    return get_token_range(id, _log2_tablets);
 }
 
 tablet_replica tablet_map::get_primary_replica(tablet_id id) const {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -330,6 +330,10 @@ private:
 
     /// Returns the largest token owned by tablet_id when the tablet_count is `1 << log2_tablets`.
     dht::token get_last_token(tablet_id id, size_t log2_tablets) const;
+
+    /// Returns token_range which contains all tokens owned by the specified tablet
+    /// when the tablet_count is `1 << log2_tablets`.
+    dht::token_range get_token_range(tablet_id id, size_t log2_tablets) const;
 public:
     /// Constructs a tablet map.
     ///

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -327,6 +327,9 @@ private:
     size_t _log2_tablets; // log_2(_tablets.size())
     std::unordered_map<tablet_id, tablet_transition_info> _transitions;
     resize_decision _resize_decision;
+
+    /// Returns the largest token owned by tablet_id when the tablet_count is `1 << log2_tablets`.
+    dht::token get_last_token(tablet_id id, size_t log2_tablets) const;
 public:
     /// Constructs a tablet map.
     ///

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -434,6 +434,9 @@ public:
 
     bool needs_split() const;
 
+    /// Returns the token_range in which the given token will belong to after a tablet split
+    dht::token_range get_token_range_after_split(const token& t) const noexcept;
+
     const locator::resize_decision& resize_decision() const;
 public:
     void set_tablet(tablet_id, tablet_info);

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -353,6 +353,7 @@ public:
     virtual future<> split_all_storage_groups() = 0;
     virtual future<> maybe_split_compaction_group_of(size_t idx) = 0;
     virtual future<std::vector<sstables::shared_sstable>> maybe_split_sstable(const sstables::shared_sstable& sst) = 0;
+    virtual dht::token_range get_token_range_after_split(const dht::token&) const noexcept = 0;
 
     virtual lw_shared_ptr<sstables::sstable_set> make_sstable_set() const = 0;
 };

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -580,6 +580,8 @@ public:
     // If split is required, then the compaction group of the given tablet is guaranteed to
     // be split once it returns.
     future<> maybe_split_compaction_group_of(locator::tablet_id);
+
+    dht::token_range get_token_range_after_split(const dht::token&) const noexcept;
 private:
     // If SSTable doesn't need split, the same input SSTable is returned as output.
     // If SSTable needs split, then output SSTables are returned and the input SSTable is deleted.

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2284,6 +2284,10 @@ public:
     seastar::condition_variable& get_staging_done_condition() noexcept override {
         return _cg.get_staging_done_condition();
     }
+
+    dht::token_range get_token_range_after_split(const dht::token& t) const noexcept override {
+        return _t.get_token_range_after_split(t);
+    }
 };
 
 compaction_group::compaction_group(table& t, size_t group_id, dht::token_range token_range)

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -726,6 +726,7 @@ public:
     future<std::vector<sstables::shared_sstable>> maybe_split_sstable(const sstables::shared_sstable& sst) override {
         return make_ready_future<std::vector<sstables::shared_sstable>>(std::vector<sstables::shared_sstable>{sst});
     }
+    dht::token_range get_token_range_after_split(const dht::token&) const noexcept override { return dht::token_range(); }
 
     lw_shared_ptr<sstables::sstable_set> make_sstable_set() const override {
         return get_compaction_group().make_sstable_set();
@@ -835,6 +836,9 @@ public:
     future<> split_all_storage_groups() override;
     future<> maybe_split_compaction_group_of(size_t idx) override;
     future<std::vector<sstables::shared_sstable>> maybe_split_sstable(const sstables::shared_sstable& sst) override;
+    dht::token_range get_token_range_after_split(const dht::token& token) const noexcept override {
+        return tablet_map().get_token_range_after_split(token);
+    }
 
     lw_shared_ptr<sstables::sstable_set> make_sstable_set() const override {
         // FIXME: avoid recreation of compound_set for groups which had no change. usually, only one group will be changed at a time.
@@ -1025,6 +1029,10 @@ future<> table::maybe_split_compaction_group_of(locator::tablet_id tablet_id) {
 future<std::vector<sstables::shared_sstable>> table::maybe_split_new_sstable(const sstables::shared_sstable& sst) {
     auto holder = async_gate().hold();
     co_return co_await _sg_manager->maybe_split_sstable(sst);
+}
+
+dht::token_range table::get_token_range_after_split(const dht::token& token) const noexcept {
+    return _sg_manager->get_token_range_after_split(token);
 }
 
 std::unique_ptr<storage_group_manager> table::make_storage_group_manager() {

--- a/test/boost/compaction_group_test.cc
+++ b/test/boost/compaction_group_test.cc
@@ -126,6 +126,7 @@ public:
     virtual compaction_backlog_tracker& get_backlog_tracker() override { return _backlog_tracker; }
     virtual const std::string get_group_id() const noexcept override { return "0"; }
     virtual seastar::condition_variable& get_staging_done_condition() noexcept override { return _staging_done_condition; }
+    dht::token_range get_token_range_after_split(const dht::token& t) const noexcept override { return dht::token_range(); }
 };
 
 SEASTAR_TEST_CASE(basic_compaction_group_splitting_test) {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -125,6 +125,9 @@ public:
     seastar::condition_variable& get_staging_done_condition() noexcept override {
         return _staging_condition;
     }
+    dht::token_range get_token_range_after_split(const dht::token& t) const noexcept override {
+        return table().get_token_range_after_split(t);
+    }
 };
 
 table_for_tests::data::data()

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -938,6 +938,7 @@ public:
     virtual compaction_backlog_tracker& get_backlog_tracker() override { return _backlog_tracker; }
     virtual const std::string get_group_id() const noexcept override { return _group_id; }
     virtual seastar::condition_variable& get_staging_done_condition() noexcept override { return _staging_done_condition; }
+    dht::token_range get_token_range_after_split(const dht::token& t) const noexcept override { return dht::token_range(); }
 };
 
 void validate_output_dir(std::filesystem::path output_dir, bool accept_nonempty_output_dir) {


### PR DESCRIPTION
Split compaction divides the partitions in an existing sstable into two groups and writes them into two new sstables, which replace the original one. The partition count from the original sstable is used as an estimate when writing the new ones, but this estimate is not accurate as the partitions are split between the two new sstables and each will contain only a portion of the original partition count. This also causes the bloom filters to be rebuilt at the end of compaction, as they were initially built with inaccurate estimates.

Fix this by using a better estimate for the output sstables, which is half the original partition count.

Fixes #20253

Improvement; No need to backport.