### PR TITLE
database: drop_table_on_all_shards: stop table in truncate_table_on_all_shards

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -1043,6 +1043,7 @@ future<> query_processor::announce_schema_statement(const statements::schema_alt
         co_await remote_.get().mm.announce<service::topology_change>(std::move(m), std::move(guard), description);
         // TODO: eliminate timeout from alter ks statement on the cqlsh/driver side
         auto error = co_await remote_.get().ss.wait_for_topology_request_completion(request_id);
+        //co_await remote_.get().ss.set_tablet_balancing_fenced_tables(stmt.fenced_tables(), false);
         co_await remote_.get().ss.wait_for_topology_not_busy();
         if (!error.empty()) {
             log.error("CQL statement \"{}\" with topology request_id \"{}\" failed with error: \"{}\"", stmt.raw_cql_statement, request_id, error);

--- a/cql3/statements/drop_table_statement.cc
+++ b/cql3/statements/drop_table_statement.cc
@@ -16,6 +16,7 @@
 #include "service/storage_proxy.hh"
 #include "mutation/mutation.hh"
 #include "cdc/log.hh"
+#include "replica/database.hh"
 
 namespace cql3 {
 
@@ -43,6 +44,8 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_w
     }
 
     try {
+        auto s = qp.db().find_schema(keyspace(), column_family());
+        _fenced_tables.insert(s->id());
         auto muts = co_await service::prepare_column_family_drop_announcement(qp.proxy(), keyspace(), column_family(), mc.write_timestamp());
         mc.add_mutations(std::move(muts));
 

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -38,6 +38,8 @@ private:
     const bool _is_column_family_level;
 
 protected:
+    mutable std::unordered_set<table_id> _fenced_tables;
+
     explicit schema_altering_statement(timeout_config_selector timeout_selector = &timeout_config::other_timeout);
 
     schema_altering_statement(cf_name name, timeout_config_selector timeout_selector = &timeout_config::other_timeout);
@@ -65,6 +67,8 @@ public:
     using event_t = cql_transport::event::schema_change;
     virtual future<std::tuple<::shared_ptr<event_t>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const;
     virtual future<std::tuple<::shared_ptr<event_t>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const;
+
+    const std::unordered_set<table_id>& fenced_tables() const noexcept { return _fenced_tables; };
 };
 
 }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -209,6 +209,7 @@ future<tablet_metadata> tablet_metadata::copy() const {
     }
 
     copy._balancing_enabled = _balancing_enabled;
+    copy._fenced_tables = _fenced_tables;
 
     co_return copy;
 }

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -26,6 +26,7 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+#include <unordered_set>
 
 namespace locator {
 
@@ -466,8 +467,10 @@ private:
 
     // When false, tablet load balancer will not try to rebalance tablets.
     bool _balancing_enabled = true;
+    std::unordered_set<table_id> _fenced_tables;
 public:
     bool balancing_enabled() const { return _balancing_enabled; }
+    const std::unordered_set<table_id>& fenced_tables() const { return _fenced_tables; }
     const tablet_map& get_tablet_map(table_id id) const;
     const table_to_tablet_map& all_tables() const { return _tablets; }
     size_t external_memory_usage() const;
@@ -482,7 +485,10 @@ public:
     tablet_metadata(tablet_metadata&&) = default;
     tablet_metadata& operator=(tablet_metadata&&) = default;
 
-    void set_balancing_enabled(bool value) { _balancing_enabled = value; }
+    void set_balancing_enabled(bool value, std::unordered_set<table_id> fenced_tables = {}) {
+        _balancing_enabled = value;
+        _fenced_tables = std::move(fenced_tables);
+    }
     void set_tablet_map(table_id, tablet_map);
     void drop_tablet_map(table_id);
 

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -246,6 +246,9 @@ public:
     bool no_compacted_sstable_undeleted() const;
 
     future<> stop(sstring reason = "table removal") noexcept;
+    bool is_stopped() const noexcept {
+        return _async_gate.is_closed();
+    }
 
     // Clear sstable sets
     void clear_sstables();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2416,94 +2416,94 @@ future<> database::truncate_table_on_all_shards(sharded<database>& sharded_db, s
     table_states.resize(smp::count);
 
     std::exception_ptr ex;
-  try {
-    co_await coroutine::parallel_for_each(std::views::iota(0u, smp::count), [&] (unsigned shard) -> future<> {
-        table_states[shard] = co_await smp::submit_to(shard, [&] () -> future<foreign_ptr<std::unique_ptr<table_truncate_state>>> {
-            auto& cf = *table_shards;
-            auto st = std::make_unique<table_truncate_state>();
+    try {
+        co_await coroutine::parallel_for_each(std::views::iota(0u, smp::count), [&] (unsigned shard) -> future<> {
+            table_states[shard] = co_await smp::submit_to(shard, [&] () -> future<foreign_ptr<std::unique_ptr<table_truncate_state>>> {
+                auto& cf = *table_shards;
+                auto st = std::make_unique<table_truncate_state>();
 
-            st->holder = cf.async_gate().hold();
+                st->holder = cf.async_gate().hold();
 
-            // Force mutations coming in to re-acquire higher rp:s
-            // This creates a "soft" ordering, in that we will guarantee that
-            // any sstable written _after_ we issue the flush below will
-            // only have higher rp:s than we will get from the discard_sstable
-            // call.
-            st->low_mark_at = db_clock::now();
-            st->low_mark = cf.set_low_replay_position_mark();
+                // Force mutations coming in to re-acquire higher rp:s
+                // This creates a "soft" ordering, in that we will guarantee that
+                // any sstable written _after_ we issue the flush below will
+                // only have higher rp:s than we will get from the discard_sstable
+                // call.
+                st->low_mark_at = db_clock::now();
+                st->low_mark = cf.set_low_replay_position_mark();
 
-            st->cres.reserve(1 + cf.views().size());
-            auto& db = sharded_db.local();
-            auto& cm = db.get_compaction_manager();
+                st->cres.reserve(1 + cf.views().size());
+                auto& db = sharded_db.local();
+                auto& cm = db.get_compaction_manager();
 
-          if (do_stop) {
-                st->stop_future = cf.stop();
-          } else {
-            co_await cf.parallel_foreach_table_state([&cm, &st] (compaction::table_state& ts) -> future<> {
-                st->cres.emplace_back(co_await cm.stop_and_disable_compaction(ts));
+                if (do_stop) {
+                    st->stop_future = cf.stop();
+                } else {
+                    co_await cf.parallel_foreach_table_state([&cm, &st] (compaction::table_state& ts) -> future<> {
+                        st->cres.emplace_back(co_await cm.stop_and_disable_compaction(ts));
+                    });
+                }
+                co_await coroutine::parallel_for_each(cf.views(), [&] (view_ptr v) -> future<> {
+                    auto& vcf = db.find_column_family(v);
+                    if (do_stop) {
+                        st->stop_future = st->stop_future.then([&vcf] {
+                            return vcf.stop();
+                        });
+                    } else {
+                        co_await vcf.parallel_foreach_table_state([&cm, &st] (compaction::table_state& ts) -> future<> {
+                            st->cres.emplace_back(co_await cm.stop_and_disable_compaction(ts));
+                        });
+                    }
+                });
+
+                co_return make_foreign(std::move(st));
             });
-          }
+        });
+
+        const auto should_flush = with_snapshot && cf.can_flush();
+        dblog.trace("{} {}.{} and views on all shards", should_flush ? "Flushing" : "Clearing", s->ks_name(), s->cf_name());
+        std::function<future<>(replica::table&)> flush_or_clear = should_flush ?
+                [] (replica::table& cf) {
+                    // TODO:
+                    // this is not really a guarantee at all that we've actually
+                    // gotten all things to disk. Again, need queue-ish or something.
+                    return cf.flush();
+                } :
+                [] (replica::table& cf) {
+                    return cf.clear();
+                };
+        co_await sharded_db.invoke_on_all([&] (replica::database& db) -> future<> {
+            unsigned shard = this_shard_id();
+            auto& cf = *table_shards;
+            auto& st = *table_states[shard];
+
+            co_await flush_or_clear(cf);
             co_await coroutine::parallel_for_each(cf.views(), [&] (view_ptr v) -> future<> {
                 auto& vcf = db.find_column_family(v);
-              if (do_stop) {
-                    st->stop_future = st->stop_future.then([&vcf] {
-                        return vcf.stop();
-                    });
-              } else {
-                co_await vcf.parallel_foreach_table_state([&cm, &st] (compaction::table_state& ts) -> future<> {
-                    st->cres.emplace_back(co_await cm.stop_and_disable_compaction(ts));
-                });
-              }
+                co_await flush_or_clear(vcf);
             });
-
-            co_return make_foreign(std::move(st));
+            st.did_flush = should_flush;
         });
-    });
 
-    const auto should_flush = with_snapshot && cf.can_flush();
-    dblog.trace("{} {}.{} and views on all shards", should_flush ? "Flushing" : "Clearing", s->ks_name(), s->cf_name());
-    std::function<future<>(replica::table&)> flush_or_clear = should_flush ?
-            [] (replica::table& cf) {
-                // TODO:
-                // this is not really a guarantee at all that we've actually
-                // gotten all things to disk. Again, need queue-ish or something.
-                return cf.flush();
-            } :
-            [] (replica::table& cf) {
-                return cf.clear();
-            };
-    co_await sharded_db.invoke_on_all([&] (replica::database& db) -> future<> {
-        unsigned shard = this_shard_id();
-        auto& cf = *table_shards;
-        auto& st = *table_states[shard];
+        auto truncated_at = truncated_at_opt.value_or(db_clock::now());
 
-        co_await flush_or_clear(cf);
-        co_await coroutine::parallel_for_each(cf.views(), [&] (view_ptr v) -> future<> {
-            auto& vcf = db.find_column_family(v);
-            co_await flush_or_clear(vcf);
+        if (with_snapshot) {
+            auto name = snapshot_name_opt.value_or(
+                format("{:d}-{}", truncated_at.time_since_epoch().count(), cf.schema()->cf_name()));
+            co_await table::snapshot_on_all_shards(sharded_db, table_shards, name);
+        }
+
+        co_await sharded_db.invoke_on_all([&] (database& db) {
+            auto shard = this_shard_id();
+            auto& cf = *table_shards;
+            auto& st = *table_states[shard];
+
+            return db.truncate(sys_ks.local(), cf, st, truncated_at);
         });
-        st.did_flush = should_flush;
-    });
-
-    auto truncated_at = truncated_at_opt.value_or(db_clock::now());
-
-    if (with_snapshot) {
-        auto name = snapshot_name_opt.value_or(
-            format("{:d}-{}", truncated_at.time_since_epoch().count(), cf.schema()->cf_name()));
-        co_await table::snapshot_on_all_shards(sharded_db, table_shards, name);
+        dblog.info("Truncated {}.{}", s->ks_name(), s->cf_name());
+    } catch (...) {
+        ex = std::current_exception();
     }
-
-    co_await sharded_db.invoke_on_all([&] (database& db) {
-        auto shard = this_shard_id();
-        auto& cf = *table_shards;
-        auto& st = *table_states[shard];
-
-        return db.truncate(sys_ks.local(), cf, st, truncated_at);
-    });
-    dblog.info("Truncated {}.{}", s->ks_name(), s->cf_name());
-  } catch (...) {
-    ex = std::current_exception();
-  }
 
     if (do_stop) {
         co_await sharded_db.invoke_on_all([&] (database& db) {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1827,7 +1827,7 @@ private:
 
     struct table_truncate_state;
 
-    static future<> truncate_table_on_all_shards(sharded<database>& db, sharded<db::system_keyspace>& sys_ks, const global_table_ptr&, std::optional<db_clock::time_point> truncated_at_opt, bool with_snapshot, std::optional<sstring> snapshot_name_opt);
+    static future<> truncate_table_on_all_shards(sharded<database>& db, sharded<db::system_keyspace>& sys_ks, const global_table_ptr&, std::optional<db_clock::time_point> truncated_at_opt, bool with_snapshot, std::optional<sstring> snapshot_name_opt, bool do_stop);
     future<> truncate(db::system_keyspace& sys_ks, column_family& cf, const table_truncate_state&, db_clock::time_point truncated_at);
 public:
     /** Truncates the given column family */

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -924,6 +924,7 @@ public:
     future<> add_tablet_replica(table_id, dht::token, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> del_tablet_replica(table_id, dht::token, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> set_tablet_balancing_enabled(bool);
+    future<> set_tablet_balancing_fenced_tables(const std::unordered_set<table_id>& tables, bool enabled);
     future<> await_topology_quiesced();
 
     // In the maintenance mode, other nodes won't be available thus we disabled joining

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -195,6 +195,17 @@ topology_mutation_builder& topology_mutation_builder::set_tablet_balancing_enabl
     return *this;
 }
 
+topology_mutation_builder& topology_mutation_builder::add_tablet_balancing_fenced_tables(const std::unordered_set<table_id>& value) {
+    return apply_set("tablet_balancing_fenced_tables", collection_apply_mode::update, value | boost::adaptors::transformed([] (const auto& id) { return id.uuid(); }));
+}
+
+topology_mutation_builder& topology_mutation_builder::set_tablet_balancing_fenced_tables(const std::unordered_set<table_id>& value) {
+    if (!value.empty()) {
+        return apply_set("tablet_balancing_fenced_tables", collection_apply_mode::overwrite, value | boost::adaptors::transformed([] (const auto& id) { return id.uuid(); }));
+    }
+    return del("tablet_balancing_fenced_tables");
+}
+
 topology_mutation_builder& topology_mutation_builder::del_transition_state() {
     return del("transition_state");
 }

--- a/service/topology_mutation.hh
+++ b/service/topology_mutation.hh
@@ -112,6 +112,8 @@ public:
     topology_mutation_builder& set_fence_version(topology::version_t);
     topology_mutation_builder& set_session(session_id);
     topology_mutation_builder& set_tablet_balancing_enabled(bool);
+    topology_mutation_builder& add_tablet_balancing_fenced_tables(const std::unordered_set<table_id>&);
+    topology_mutation_builder& set_tablet_balancing_fenced_tables(const std::unordered_set<table_id>&);
     topology_mutation_builder& set_new_cdc_generation_data_uuid(const utils::UUID& value);
     topology_mutation_builder& set_committed_cdc_generations(const std::vector<cdc::generation_id_v2>& values);
     topology_mutation_builder& set_new_keyspace_rf_change_data(const sstring &ks_name, const std::map<sstring, sstring> &rf_per_dc);

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -183,6 +183,9 @@ struct topology {
     // When false, tablet load balancer will not try to rebalance tablets.
     bool tablet_balancing_enabled = true;
 
+    // Set of fenced tables
+    std::unordered_set<table_id> tablet_balancing_fenced_tables;
+
     // The set of nodes that should be considered dead during topology operations
     std::unordered_set<raft::server_id> ignored_nodes;
 


### PR DESCRIPTION
There is a race between truncate_table_on_all_shards, when called from drop_table_on_all_shards, and tablet migration that may trip the internal error in `table::discard_sstables` that verifies that compaction is disabled on all storage_groups.

This change moves the call to table::stop to truncate_table_on_all_shards in this code path, so to stop all storage_groups rather than stop_and_disable_compaction.

Correspondingly, change the internal error to check that all storage groups are either closed or disabled compaction.

Fixes scylladb/scylladb#20060

* Needs backport to all branches that support tablets
