### PR TITLE
commitlog: Fix buffer_list_bytes not updated correctly

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1099,7 +1099,12 @@ public:
             write(out, uint64_t(0));
         }
 
-        buf.remove_suffix(buf.size_bytes() - size);
+        auto to_remove = buf.size_bytes() - size;
+        // #20862 - we decrement usage counter based on buf.size() below.
+        // Since we are shrinking buffer here, we need to also decrement
+        // counter already
+        buf.remove_suffix(to_remove);
+        _segment_manager->totals.buffer_list_bytes -= to_remove;
 
         // Build sector checksums.
         auto id = net::hton(_desc.id);
@@ -3236,6 +3241,10 @@ uint64_t db::commitlog::get_total_size() const {
         + _segment_manager->totals.wasted_size_on_disk
         + _segment_manager->totals.buffer_list_bytes
         ;
+}
+
+uint64_t db::commitlog::get_buffer_size() const {
+    return _segment_manager->totals.buffer_list_bytes;
 }
 
 uint64_t db::commitlog::get_completed_tasks() const {

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -297,6 +297,7 @@ public:
     future<> delete_segments(std::vector<sstring>) const;
 
     uint64_t get_total_size() const;
+    uint64_t get_buffer_size() const;
     uint64_t get_completed_tasks() const;
     uint64_t get_flush_count() const;
     uint64_t get_pending_tasks() const;


### PR DESCRIPTION
Fixes #20862

With the change in 60af2f3cb21914f855fd5cc1929629c113b7999b the bookkeep for buffer memory was changed subtly, the problem here that we would shrink buffer size before we after flush use said buffer's size to decrement the buffer_list_bytes value, previously inc:ed by the full, allocated size. I.e. we would slowly grow this value instead of adjusting properly to actual used bytes.

Test included.

(cherry picked from commit ee5e71172f12c215ec96a87cfd0c8ec8aa8e0d1d)

Manual backport, see mergify fail: #20904