### PR TITLE
alternator: add "dc" and "rack" options to "/localnodes" request

### DIFF
--- a/test/alternator/test_scylla.py
+++ b/test/alternator/test_scylla.py
@@ -28,3 +28,55 @@ def test_localnodes(scylla_only, dynamodb):
     # We have a separate test, test_localnodes_broadcast_rpc_address, on how
     # this changes if "broadcast_rpc_address" is configured.
     assert urllib.parse.urlparse(url).hostname in j
+
+# The "this_dc" fixture figures out the name of Scylla DC to which "dynamodb"
+# is connected. Any test using this fixture automatically becomes scylla_only.
+@pytest.fixture(scope="session")
+def this_dc(dynamodb, scylla_only):
+    tbl = dynamodb.Table('.scylla.alternator.system.local')
+    dc = tbl.scan(AttributesToGet=['data_center'])['Items'][0]['data_center']
+    yield dc
+
+# The "this_rack" fixture figures out the name of Scylla rack to which "dynamodb"
+# is connected. Any test using this fixture automatically becomes scylla_only.
+@pytest.fixture(scope="session")
+def this_rack(dynamodb, scylla_only):
+    tbl = dynamodb.Table('.scylla.alternator.system.local')
+    rack = tbl.scan(AttributesToGet=['rack'])['Items'][0]['rack']
+    yield rack
+
+# Minimal test for the "dc" option in /localnodes request. In this test framework
+# we can't test multiple data centers, but we can test that dc={this_dc} returns
+# a node, while dc=nonexistent_dc doesn't.
+def test_localnodes_option_dc(scylla_only, dynamodb, this_dc):
+    url = dynamodb.meta.client._endpoint.host
+    # Using dc={this_dc} should work and return at least this node:
+    response = requests.get(url + f'/localnodes?dc={this_dc}', verify=False)
+    assert response.ok
+    j = json.loads(response.content.decode('utf-8'))
+    assert isinstance(j, list)
+    assert len(j) >= 1
+    # Using dc=nonexistent_dc should return an empty list (not an error)
+    response = requests.get(url + f'/localnodes?dc=nonexistent_dc', verify=False)
+    assert response.ok
+    j = json.loads(response.content.decode('utf-8'))
+    assert isinstance(j, list)
+    assert len(j) == 0
+
+# Minimal test for the "rack" option in /localnodes request. In this test framework
+# we can't test multiple racks, but we can test that rack={this_rack} returns a node,
+# and rack=nonexistent_rack doesn't.
+def test_localnodes_option_rack(scylla_only, dynamodb, this_rack):
+    url = dynamodb.meta.client._endpoint.host
+    # Using rack={this_rack} should work and return at least this node:
+    response = requests.get(url + f'/localnodes?rack={this_rack}', verify=False)
+    assert response.ok
+    j = json.loads(response.content.decode('utf-8'))
+    assert isinstance(j, list)
+    assert len(j) >= 1
+    # Using rack=nonexistent_rack should return an empty list (not an error)
+    response = requests.get(url + f'/localnodes?rack=nonexistent_rack', verify=False)
+    assert response.ok
+    j = json.loads(response.content.decode('utf-8'))
+    assert isinstance(j, list)
+    assert len(j) == 0


### PR DESCRIPTION
Before this patch, the "/localnodes" HTTP request to the Alternator server lists all the live nodes of the current DC. This patch adds two optional parameters to this query:

  dc: allows to list the live nodes of a specific named DC instead of the
      current DC of the server.

  rack: allows to restrict the results to just the nodes belonging to a
      specific named rack.

For both options, if no live node exists in the given dc or rack (in particular, if such a dc or rack doesn't even exist), an empty list is returned - it's not an error.

The default, if dc or rack is not specified - remains exactly as it is today - look at the current DC (the one of the node being request), and do not restrict the list to any specific rack.

We expect the new options that we added here to be useful for two use cases:

1. A client that knows of *some* Scylla node (belonging to an unknown DC), but wants to list the nodes in *its* DC, which it knows by name.

2. A client in a multi-rack DC (e.g., multi-AZ region in AWS) that wants to send requests to nodes in its own rack (which it knows by name), to avoid cross-rack networking costs.

Note that in both cases, this requires clients to know the names of DCs and AZs via some out-of-band means. The client can also get a list of DCs and racks using the system.local system table, as the tests included in this patch demonstrate.

This patch includes tests for these new options. These tests use the test/alternator framework so can't set up a multi-dc multi-rack cluster, but we can still check that requests with the one correct dc or rack work, and requests asking for the wrong dc or rack return an empty list.

Fixes #12147

This is a new feature, so no backports needed.