### PR TITLE
treewide: replace boost::irange with std::views::iota where possible

### DIFF
--- a/api/collectd.cc
+++ b/api/collectd.cc
@@ -11,6 +11,7 @@
 #include <seastar/core/scollectd.hh>
 #include <seastar/core/scollectd_api.hh>
 #include <boost/range/irange.hpp>
+#include <ranges>
 #include <regex>
 #include "api/api_init.hh"
 
@@ -61,7 +62,7 @@ void set_collectd(http_context& ctx, routes& r) {
 
         return do_with(std::vector<cd::collectd_value>(), [id] (auto& vec) {
             vec.resize(smp::count);
-            return parallel_for_each(boost::irange(0u, smp::count), [&vec, id] (auto cpu) {
+            return parallel_for_each(std::views::iota(0u, smp::count), [&vec, id] (auto cpu) {
                 return smp::submit_to(cpu, [id = *id] {
                     return scollectd::get_collectd_value(id);
                 }).then([&vec, cpu] (auto res) {

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1714,7 +1714,7 @@ public:
                 _estimation_per_shard[s].estimated_partitions += std::max(uint64_t(1), uint64_t(ceil(double(estimated_partitions) / shards.size())));
             }
         }
-        for (auto i : boost::irange(0u, smp::count)) {
+        for (auto i : std::views::iota(0u, smp::count)) {
             _run_identifiers[i] = run_id::create_random_id();
         }
     }

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -3121,7 +3121,7 @@ update_backlog node_update_backlog::fetch() {
 
 future<std::optional<update_backlog>> node_update_backlog::fetch_if_changed() {
     _last_update.store(clock::now(), std::memory_order_relaxed);
-    auto [np, max] = co_await map_reduce(boost::irange(0u, smp::count),
+    auto [np, max] = co_await map_reduce(std::views::iota(0u, smp::count),
             [this] (shard_id shard) {
                 return smp::submit_to(shard, [this, shard] {
                     // Even if the shard's backlog didn't change, we still need to take it into account when calculating the new max.

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -433,7 +433,7 @@ private:
     template <typename T>
     future<T> map_reduce_shards(std::function<T()> map, std::function<T(T, T)> reduce = std::plus<T>{}, T initial = {}) {
         co_return co_await map_reduce(
-                boost::irange(0u, smp::count),
+                std::views::iota(0u, smp::count),
                 [map] (shard_id shard) {
                     return smp::submit_to(shard, [map] {
                         return map();

--- a/dht/token.cc
+++ b/dht/token.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <limits>
 #include <ostream>
+#include <ranges>
 #include <boost/lexical_cast.hpp>
 
 #include "dht/token.hh"
@@ -130,7 +131,7 @@ init_zero_based_shard_start(unsigned shards, unsigned sharding_ignore_msb_bits) 
         return std::vector<uint64_t>(1, uint64_t(0));
     }
     auto ret = std::vector<uint64_t>(shards);
-    for (auto s : boost::irange<unsigned>(0, shards)) {
+    for (auto s : std::views::iota(0u, shards)) {
         uint64_t token = (uint128_t(s) << 64) / shards;
         token >>= sharding_ignore_msb_bits;   // leftmost bits are ignored by zero_based_shard_of
         // token is the start of the next shard, and can be slightly before due to rounding errors; adjust

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -679,7 +679,7 @@ future<> global_vnode_effective_replication_map::get_keyspace_erms(sharded<repli
         auto erm = db.find_keyspace(keyspace_name).get_vnode_effective_replication_map();
         auto ring_version = erm->get_token_metadata().get_ring_version();
         _erms[0] = make_foreign(std::move(erm));
-        co_await coroutine::parallel_for_each(boost::irange(1u, smp::count), [this, &sharded_db, keyspace_name, ring_version] (unsigned shard) -> future<> {
+        co_await coroutine::parallel_for_each(std::views::iota(1u, smp::count), [this, &sharded_db, keyspace_name, ring_version] (unsigned shard) -> future<> {
             _erms[shard] = co_await sharded_db.invoke_on(shard, [keyspace_name, ring_version] (const replica::database& db) {
                 const auto& ks = db.find_keyspace(keyspace_name);
                 auto erm = ks.get_vnode_effective_replication_map();

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -19,7 +19,7 @@
 #include "utils/chunked_vector.hh"
 #include "utils/hash.hh"
 
-#include <boost/range/adaptor/transformed.hpp>
+#include <ranges>
 #include <seastar/core/reactor.hh>
 #include <seastar/util/log.hh>
 #include <seastar/core/coroutine.hh>
@@ -407,7 +407,7 @@ public:
 
     /// Returns an iterable range over tablet_id:s which includes all tablets in token ring order.
     auto tablet_ids() const {
-        return boost::irange<size_t>(0, tablet_count()) | boost::adaptors::transformed([] (size_t i) {
+        return std::views::iota(0u, tablet_count()) | std::views::transform([] (size_t i) {
             return tablet_id(i);
         });
     }

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -620,7 +620,7 @@ future<> read_context::save_readers(mutation_reader::tracked_buffer unconsumed_b
         tracing::trace(_trace_state, "No compaction state to dismantle, partition exhausted", cs_stats);
     }
 
-    co_await parallel_for_each(boost::irange(0u, smp::count), [this, &last_pos] (shard_id shard) {
+    co_await parallel_for_each(std::views::iota(0u, smp::count), [this, &last_pos] (shard_id shard) {
         auto& rm = _readers[shard];
         if (rm.state == reader_state::successful_lookup || rm.state == reader_state::saving) {
             return save_reader(shard, last_pos);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1388,7 +1388,7 @@ future<> repair::user_requested_repair_task_impl::run() {
 
         auto ranges_parallelism = _ranges_parallelism;
         bool small_table_optimization = _small_table_optimization;
-        for (auto shard : boost::irange(unsigned(0), smp::count)) {
+        for (auto shard : std::views::iota(0u, smp::count)) {
             auto f = rs.container().invoke_on(shard, [keyspace, table_ids, id, ranges, hints_batchlog_flushed, ranges_parallelism, small_table_optimization,
                     data_centers, hosts, ignore_nodes, parent_data = get_repair_uniq_id().task_info, germs] (repair_service& local_repair) mutable -> future<> {
                 local_repair.get_metrics().repair_total_ranges_sum += ranges.size();
@@ -1506,7 +1506,7 @@ future<> repair::data_sync_repair_task_impl::run() {
         if (rs.get_repair_module().is_aborted(id.uuid())) {
             throw abort_requested_exception();
         }
-        for (auto shard : boost::irange(unsigned(0), smp::count)) {
+        for (auto shard : std::views::iota(0u, smp::count)) {
             auto f = rs.container().invoke_on(shard, [keyspace, table_ids, id, ranges, neighbors, reason, germs, parent_data = get_repair_uniq_id().task_info] (repair_service& local_repair) mutable -> future<> {
                 auto data_centers = std::vector<sstring>();
                 auto hosts = std::vector<sstring>();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2417,7 +2417,7 @@ future<> database::truncate_table_on_all_shards(sharded<database>& sharded_db, s
     std::vector<foreign_ptr<std::unique_ptr<table_truncate_state>>> table_states;
     table_states.resize(smp::count);
 
-    co_await coroutine::parallel_for_each(boost::irange(0u, smp::count), [&] (unsigned shard) -> future<> {
+    co_await coroutine::parallel_for_each(std::views::iota(0u, smp::count), [&] (unsigned shard) -> future<> {
         table_states[shard] = co_await smp::submit_to(shard, [&] () -> future<foreign_ptr<std::unique_ptr<table_truncate_state>>> {
             auto& cf = *table_shards;
             auto st = std::make_unique<table_truncate_state>();

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2411,7 +2411,7 @@ future<> tablet_storage_group_manager::handle_tablet_split_completion(const loca
         }
 
         tlogger.debug("Remapping tablet {} of table {} into new tablets [{}].",
-                      id, table_id, fmt::join(boost::irange(first_new_id, first_new_id+split_size), ", "));
+                      id, table_id, fmt::join(std::views::iota(first_new_id, first_new_id+split_size), ", "));
     }
 
     _storage_groups = std::move(new_storage_groups);

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -131,10 +131,10 @@ auto fmt::formatter<column_mapping>::format(const column_mapping& cm, fmt::forma
         return fmt::format("{{id={}, name=0x{}, type={}}}", i, e.name(), e.type()->name());
     };
     return fmt::format_to(ctx.out(), "{{static=[{}], regular=[{}]}}",
-               fmt::join(boost::irange<column_id>(0, n_static) |
-                         boost::adaptors::transformed([&] (column_id i) { return pr_entry(i, cm.static_column_at(i)); }), ", "),
-               fmt::join(boost::irange<column_id>(0, n_regular) |
-                         boost::adaptors::transformed([&] (column_id i) { return pr_entry(i, cm.regular_column_at(i)); }), ", "));
+               fmt::join(std::views::iota(column_id(0), n_static) |
+                         std::views::transform([&] (column_id i) { return pr_entry(i, cm.static_column_at(i)); }), ", "),
+               fmt::join(std::views::iota(column_id(0), n_regular) |
+                         std::views::transform([&] (column_id i) { return pr_entry(i, cm.regular_column_at(i)); }), ", "));
 }
 
 thread_local std::map<sstring, std::unique_ptr<dht::i_partitioner>> partitioners;

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -432,7 +432,7 @@ future<> sstable_directory::sstables_registry_components_lister::garbage_collect
 
 future<>
 sstable_directory::move_foreign_sstables(sharded<sstable_directory>& source_directory) {
-    return parallel_for_each(boost::irange(0u, smp::count), [this, &source_directory] (unsigned shard_id) mutable {
+    return parallel_for_each(std::views::iota(0u, smp::count), [this, &source_directory] (unsigned shard_id) mutable {
         auto info_vec = std::exchange(_unshared_remote_sstables[shard_id], {});
         if (info_vec.empty()) {
             return make_ready_future<>();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -469,7 +469,7 @@ parse(const schema& schema, sstable_version_types v, random_access_reader& in, d
 
     key_type nr_elements;
     co_await parse(schema, v, in, nr_elements);
-    for ([[maybe_unused]] auto _ : boost::irange<key_type>(0, nr_elements)) {
+    for ([[maybe_unused]] auto _ : std::views::iota(key_type(0), nr_elements)) {
         key_type new_key;
         unsigned new_size;
         co_await parse(schema, v, in, new_key);

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -400,7 +400,7 @@ public:
     template<typename T>
     static future<T> invoke_on_task(sharded<task_manager>& tm, task_id id, std::function<future<T> (task_manager::task_variant)> func) {
         std::optional<T> res;
-        co_await coroutine::parallel_for_each(boost::irange(0u, smp::count), [&tm, id, &res, &func] (unsigned shard) -> future<> {
+        co_await coroutine::parallel_for_each(std::views::iota(0u, smp::count), [&tm, id, &res, &func] (unsigned shard) -> future<> {
             auto local_res = co_await tm.invoke_on(shard, [id, func] (const task_manager& local_tm) -> future<std::optional<T>> {
                 const auto& all_tasks = local_tm.get_local_tasks();
                 if (auto it = all_tasks.find(id); it != all_tasks.end()) {

--- a/test/boost/chunked_managed_vector_test.cc
+++ b/test/boost/chunked_managed_vector_test.cc
@@ -11,6 +11,7 @@
 
 #include <deque>
 #include <random>
+#include <ranges>
 #include <algorithm>
 
 #include "utils/lsa/chunked_managed_vector.hh"
@@ -19,7 +20,6 @@
 
 #include <boost/range/algorithm/equal.hpp>
 #include <boost/range/algorithm/reverse.hpp>
-#include <boost/range/irange.hpp>
 
 using namespace logalloc;
 
@@ -51,7 +51,7 @@ SEASTAR_TEST_CASE(test_random_walk) {
             }
             case 1: {
                 auto nr_pushes = nr_dist(rand);
-                for (auto i : boost::irange(size_t(0), nr_pushes)) {
+                for (auto i : std::views::iota(size_t(0), nr_pushes)) {
                     (void)i;
                     auto n = rand();
                     c.push_back(n);

--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -8,6 +8,7 @@
 
 #define BOOST_TEST_MODULE core
 
+#include <ranges>
 #include <stdexcept>
 #include <optional>
 #include <variant>
@@ -46,7 +47,7 @@ BOOST_AUTO_TEST_CASE(test_random_walk) {
         }
         case 1: {
             auto nr_pushes = nr_dist(rand);
-            for (auto i : boost::irange(size_t(0), nr_pushes)) {
+            for (auto i : std::views::iota(size_t(0), nr_pushes)) {
                 (void)i;
                 auto n = rand();
                 c.push_back(n);

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -171,7 +171,7 @@ SEASTAR_TEST_CASE(test_truncate_without_snapshot_during_writes) {
         int count = 0;
 
         auto insert_data = [&] (uint32_t begin, uint32_t end) {
-            return parallel_for_each(boost::irange(begin, end), [&] (auto i) {
+            return parallel_for_each(std::views::iota(begin, end), [&] (auto i) {
                 auto pkey = partition_key::from_single_value(*s, to_bytes(fmt::format("key-{}", tests::random::get_int<uint64_t>())));
                 mutation m(s, pkey);
                 m.set_clustered_cell(clustering_key_prefix::make_empty(), "v", int32_t(42), {});

--- a/test/boost/dynamic_bitset_test.cc
+++ b/test/boost/dynamic_bitset_test.cc
@@ -13,6 +13,7 @@
 #include <boost/range/irange.hpp>
 #include <vector>
 #include <random>
+#include <ranges>
 
 #include "utils/dynamic_bitset.hh"
 
@@ -168,18 +169,18 @@ static void test_random_ops(size_t size, std::default_random_engine& re ) {
                 auto bit = bit_dist(re);
                 auto next = db.find_next_set(bit);
                 if (next == db.npos) {
-                    require(!boost::algorithm::any_of(boost::irange<size_t>(bit+1, size), is_set));
+                    require(!std::ranges::any_of(std::views::iota(bit+1, size), is_set));
                 } else {
-                    require(!boost::algorithm::any_of(boost::irange<size_t>(bit+1, next), is_set));
+                    require(!std::ranges::any_of(std::views::iota(bit+1, next), is_set));
                     require(is_set(next));
                 }
                 break;            }
             case 4: {
                 auto next = db.find_first_set();
                 if (next == db.npos) {
-                    require(!boost::algorithm::any_of(boost::irange<size_t>(0, size), is_set));
+                    require(!std::ranges::any_of(std::views::iota(0u, size), is_set));
                 } else {
-                    require(!boost::algorithm::any_of(boost::irange<size_t>(0, next), is_set));
+                    require(!std::ranges::any_of(std::views::iota(0u, next), is_set));
                     require(is_set(next));
                 }
                 break;
@@ -187,9 +188,9 @@ static void test_random_ops(size_t size, std::default_random_engine& re ) {
             case 5: {
                 auto next = db.find_last_set();
                 if (next == db.npos) {
-                    require(!boost::algorithm::any_of(boost::irange<size_t>(0, size), is_set));
+                    require(!std::ranges::any_of(std::views::iota(0u, size), is_set));
                 } else {
-                    require(!boost::algorithm::any_of(boost::irange<size_t>(next + 1, size), is_set));
+                    require(!std::ranges::any_of(std::views::iota(next + 1, size), is_set));
                     require(is_set(next));
                 }
                 break;

--- a/test/boost/flush_queue_test.cc
+++ b/test/boost/flush_queue_test.cc
@@ -9,6 +9,7 @@
 
 #include <random>
 #include <bitset>
+#include <ranges>
 #include <boost/test/unit_test.hpp>
 #include <boost/range/irange.hpp>
 #include <seastar/core/semaphore.hh>
@@ -30,7 +31,7 @@ SEASTAR_TEST_CASE(test_queue_ordering_random_ops) {
         std::vector<int> result;
     };
 
-    auto r = boost::irange(0, 100);
+    auto r = std::views::iota(0, 100);
 
     return do_for_each(r, [](int) {
         constexpr size_t num_ops = 1000;
@@ -83,7 +84,7 @@ SEASTAR_TEST_CASE(test_queue_ordering_multi_ops) {
         size_t n = 0;
     };
 
-    auto r = boost::irange(0, 100);
+    auto r = std::views::iota(0, 100);
 
     return do_for_each(r, [](int) {
         constexpr size_t num_ops = 1000;

--- a/test/boost/group0_test.cc
+++ b/test/boost/group0_test.cc
@@ -204,7 +204,7 @@ SEASTAR_TEST_CASE(test_concurrent_group0_modifications) {
         size_t M = 4;
 
         // Run N concurrent tasks, each performing M schema changes in sequence.
-        auto successes = co_await map_reduce(boost::irange(size_t{0}, N), std::bind_front(perform_schema_changes, std::ref(e), M), 0, std::plus{});
+        auto successes = co_await map_reduce(std::views::iota(size_t{0}, N), std::bind_front(perform_schema_changes, std::ref(e), M), 0, std::plus{});
 
         // The number of new entries that appeared in group 0 history table should be exactly equal
         // to the number of successful schema changes.
@@ -215,7 +215,7 @@ SEASTAR_TEST_CASE(test_concurrent_group0_modifications) {
 
         // Run N concurrent tasks, each performing M schema changes in sequence.
         // (use different range of task_ids so the new tasks' statements don't conflict with existing keyspaces from previous tasks)
-        successes = co_await map_reduce(boost::irange(N, 2*N), std::bind_front(perform_schema_changes, std::ref(e), M), 0, std::plus{});
+        successes = co_await map_reduce(std::views::iota(N, 2*N), std::bind_front(perform_schema_changes, std::ref(e), M), 0, std::plus{});
 
         // Each task performs M schema changes. There are N tasks.
         // Thus, for each task, all other tasks combined perform (N-1) * M schema changes.
@@ -231,7 +231,7 @@ SEASTAR_TEST_CASE(test_concurrent_group0_modifications) {
         rclient.operation_mutex().consume(1337);
         mm.set_concurrent_ddl_retries(0);
 
-        successes = co_await map_reduce(boost::irange(2*N, 3*N), std::bind_front(perform_schema_changes, std::ref(e), M), 0, std::plus{});
+        successes = co_await map_reduce(std::views::iota(2*N, 3*N), std::bind_front(perform_schema_changes, std::ref(e), M), 0, std::plus{});
 
         // Each execution should have succeeded on first attempt because the mutex serialized them all.
         BOOST_REQUIRE_EQUAL(successes, N*M);

--- a/test/boost/index_with_paging_test.cc
+++ b/test/boost/index_with_paging_test.cc
@@ -23,7 +23,7 @@ SEASTAR_TEST_CASE(test_index_with_paging) {
         // There should be enough rows to use multiple pages
         auto prepared_id = e.prepare("INSERT INTO tab (pk, ck, v, v2, v3) VALUES (?, ?, 1, ?, ?)").get();
         auto big_string_v = cql3::raw_value::make_value(serialized(big_string));
-        max_concurrent_for_each(boost::irange(0, 64 * 1024), 2, [&] (auto i) {
+        max_concurrent_for_each(std::views::iota(0, 64 * 1024), 2, [&] (auto i) {
             return e.execute_prepared(prepared_id, {
                 cql3::raw_value::make_value(serialized(i % 3)),                     // pk
                 cql3::raw_value::make_value(serialized(format("hello{}", i))),      // ck

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -1192,7 +1192,7 @@ SEASTAR_TEST_CASE(flushing_rate_is_reduced_if_compaction_doesnt_keep_up) {
                 replica::database& db = env.local_db();
                 replica::table& t = db.find_column_family(ks_name, cf_name);
 
-                for ([[maybe_unused]] int value : boost::irange<int>(0, num_flushes)) {
+                for ([[maybe_unused]] int value : std::views::iota(0, num_flushes)) {
                     ::usleep(sleep_ms * 1000);
                     co_await db.apply(t.schema(), freeze(gen()), tracing::trace_state_ptr(), db::commitlog::force_sync::yes, db::no_timeout);
                     co_await t.flush();
@@ -1203,7 +1203,7 @@ SEASTAR_TEST_CASE(flushing_rate_is_reduced_if_compaction_doesnt_keep_up) {
         };
 
         int sleep_ms = 2;
-        for ([[maybe_unused]] int i : boost::irange<int>(8)) {
+        for ([[maybe_unused]] int i : std::views::iota(0, 8)) {
             future<> f0 = smp::submit_to(0, flusher{.env=env, .num_flushes=100, .sleep_ms=0});
             future<> f1 = smp::submit_to(1, flusher{.env=env, .num_flushes=3, .sleep_ms=sleep_ms});
             co_await std::move(f0);

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -159,7 +159,7 @@ static std::pair<schema_ptr, std::vector<dht::decorated_key>> create_test_table(
 }
 
 static uint64_t aggregate_querier_cache_stat(distributed<replica::database>& db, uint64_t query::querier_cache::stats::*stat) {
-    return map_reduce(boost::irange(0u, smp::count), [stat, &db] (unsigned shard) {
+    return map_reduce(std::views::iota(0u, smp::count), [stat, &db] (unsigned shard) {
         return db.invoke_on(shard, [stat] (replica::database& local_db) {
             auto& stats = local_db.get_querier_cache_stats();
             return stats.*stat;
@@ -171,7 +171,7 @@ static void check_cache_population(distributed<replica::database>& db, size_t qu
         seastar::compat::source_location sl = seastar::compat::source_location::current()) {
     testlog.info("{}() called from {}() {}:{:d}", __FUNCTION__, sl.function_name(), sl.file_name(), sl.line());
 
-    parallel_for_each(boost::irange(0u, smp::count), [queriers, &db] (unsigned shard) {
+    parallel_for_each(std::views::iota(0u, smp::count), [queriers, &db] (unsigned shard) {
         return db.invoke_on(shard, [queriers] (replica::database& local_db) {
             auto& stats = local_db.get_querier_cache_stats();
             tests::require_equal(stats.population, queriers);

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -514,7 +514,7 @@ test_something_with_some_interesting_ranges_and_sharder(std::function<void (cons
 static
 void
 do_test_split_range_to_single_shard(const schema& s, const dht::static_sharder& sharder_, const dht::partition_range& pr) {
-    for (auto shard : boost::irange(0u, sharder_.shard_count())) {
+    for (auto shard : std::views::iota(0u, sharder_.shard_count())) {
         auto ranges = dht::split_range_to_single_shard(s, sharder_, pr, shard).get();
         auto sharder = dht::ring_position_range_sharder(sharder_, pr);
         auto x = sharder.next(s);
@@ -585,7 +585,7 @@ static
 void
 do_test_selective_token_range_sharder(const dht::sharder& input_sharder, const schema& s, const dht::token_range& range) {
     bool debug = false;
-    for (auto shard : boost::irange(0u, input_sharder.shard_count())) {
+    for (auto shard : std::views::iota(0u, input_sharder.shard_count())) {
         auto sharder = dht::selective_token_range_sharder(input_sharder, range, shard);
         auto range_shard = sharder.next();
         while (range_shard) {

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1445,7 +1445,7 @@ memory_limit_table create_memory_limit_table(cql_test_env& env, uint64_t target_
     const auto sstable_write_concurrency = 16;
 
     uint64_t num_sstables = 0;
-    parallel_for_each(boost::irange(0, sstable_write_concurrency), [&] (int i) {
+    parallel_for_each(std::views::iota(0, sstable_write_concurrency), [&] (int i) {
         return seastar::async([&] {
             while (num_sstables != target_num_sstables) {
                 ++num_sstables;
@@ -1502,7 +1502,7 @@ SEASTAR_TEST_CASE(test_reader_concurrency_semaphore_memory_limit_no_oom) {
 
         auto read_id = env.prepare("SELECT value FROM ks.tbl WHERE pk = ? AND ck = ?").get();
 
-        parallel_for_each(boost::irange(0, num_reads), [&] (int i) {
+        parallel_for_each(std::views::iota(0, num_reads), [&] (int i) {
             return env.execute_prepared(read_id, {cql3::raw_value::make_value(tbl.pk.explode().front()), cql3::raw_value::make_value(tbl.ck.explode().front())}).then_wrapped(
                     [&] (future<shared_ptr<cql_transport::messages::result_message>> fut) {
                 if (fut.failed()) {
@@ -1564,7 +1564,7 @@ SEASTAR_TEST_CASE(test_reader_concurrency_semaphore_memory_limit_engages) {
         uint64_t successful_reads = 0;
         uint64_t failed_reads = 0;
 
-        parallel_for_each(boost::irange(0, num_reads), [&] (int i) {
+        parallel_for_each(std::views::iota(0, num_reads), [&] (int i) {
             return env.execute_prepared(read_id, {cql3::raw_value::make_value(tbl.pk.explode().front()), cql3::raw_value::make_value(tbl.ck.explode().front())}).then_wrapped(
                         [&] (future<shared_ptr<cql_transport::messages::result_message>> fut) {
                 if (fut.failed()) {

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -3376,7 +3376,7 @@ SEASTAR_TEST_CASE(test_concurrent_reads_and_eviction) {
         };
 
         bool done = false;
-        auto readers = parallel_for_each(boost::irange(0, n_readers), [&] (auto id) {
+        auto readers = parallel_for_each(std::views::iota(0, n_readers), [&] (auto id) {
             generations[id] = last_generation;
             return seastar::async([&, id] {
                 while (!done) {

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -11,6 +11,7 @@
 #include <iterator>
 #include <algorithm>
 
+#include <boost/range/irange.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <seastar/core/thread.hh>
@@ -477,14 +478,14 @@ SEASTAR_TEST_CASE(test_uncompressed_skip_using_index_rows) {
         r.produces_partition_start(to_key(1))
             .produces_static_row({{st_cdef, int32_type->decompose(int32_t(777))}});
 
-        for (auto idx: boost::irange(0, 1024)) {
+        for (auto idx: std::views::iota(0, 1024)) {
             r.produces_row(to_ck(idx), to_expected(format("{}{}", rc_base, idx)));
         }
         r.produces_partition_end();
 
         r.produces_partition_start(to_key(2))
             .produces_static_row({{st_cdef, int32_type->decompose(int32_t(999))}});
-        for (auto idx: boost::irange(0, 1024)) {
+        for (auto idx: std::views::iota(0, 1024)) {
             r.produces_row(to_ck(idx), to_expected(format("{}{}", rc_base, idx)));
         }
         r.produces_partition_end()
@@ -504,20 +505,20 @@ SEASTAR_TEST_CASE(test_uncompressed_skip_using_index_rows) {
         auto r = assert_that(std::move(rd));
         r.produces_partition_start(to_key(1))
             .produces_static_row({{st_cdef, int32_type->decompose(int32_t(777))}});
-        for (auto idx: boost::irange(70, 80)) {
+        for (auto idx: std::views::iota(70, 80)) {
             r.produces_row(to_ck(idx), to_expected(format("{}{}", rc_base, idx)));
         }
-        for (auto idx: boost::irange(1001, 1024)) {
+        for (auto idx: std::views::iota(1001, 1024)) {
             r.produces_row(to_ck(idx), to_expected(format("{}{}", rc_base, idx)));
         }
         r.produces_partition_end();
 
         r.produces_partition_start(to_key(2))
             .produces_static_row({{st_cdef, int32_type->decompose(int32_t(999))}});
-        for (auto idx: boost::irange(70, 80)) {
+        for (auto idx: std::views::iota(70, 80)) {
             r.produces_row(to_ck(idx), to_expected(format("{}{}", rc_base, idx)));
         }
-        for (auto idx: boost::irange(1001, 1024)) {
+        for (auto idx: std::views::iota(1001, 1024)) {
             r.produces_row(to_ck(idx), to_expected(format("{}{}", rc_base, idx)));
         }
 
@@ -536,7 +537,7 @@ SEASTAR_TEST_CASE(test_uncompressed_skip_using_index_rows) {
         r.produces_partition_start(to_key(1));
 
         r.fast_forward_to(to_ck(316), to_ck(379));
-        for (auto idx: boost::irange(316, 379)) {
+        for (auto idx: std::views::iota(316, 379)) {
             r.produces_row(to_ck(idx), to_expected(format("{}{}", rc_base, idx)));
         }
         r.produces_end_of_stream();
@@ -548,13 +549,13 @@ SEASTAR_TEST_CASE(test_uncompressed_skip_using_index_rows) {
                 .produces_end_of_stream();
 
         r.fast_forward_to(to_ck(442), to_ck(450));
-        for (auto idx: boost::irange(442, 450)) {
+        for (auto idx: std::views::iota(442, 450)) {
             r.produces_row(to_ck(idx), to_expected(format("{}{}", rc_base, idx)));
         }
         r.produces_end_of_stream();
 
         r.fast_forward_to(to_ck(1009), to_ck(1024));
-        for (auto idx: boost::irange(1009, 1024)) {
+        for (auto idx: std::views::iota(1009, 1024)) {
             r.produces_row(to_ck(idx), to_expected(format("{}{}", rc_base, idx)));
         }
         r.produces_end_of_stream();
@@ -576,7 +577,7 @@ SEASTAR_TEST_CASE(test_uncompressed_skip_using_index_rows) {
         r.produces_partition_start(to_key(1));
         r.fast_forward_to(to_ck(200), to_ck(250));
 
-        for (auto idx: boost::irange(210, 241)) {
+        for (auto idx: std::views::iota(210, 241)) {
             r.produces_row(to_ck(idx), to_expected(format("{}{}", rc_base, idx)));
         }
         r.produces_end_of_stream();
@@ -592,19 +593,19 @@ SEASTAR_TEST_CASE(test_uncompressed_skip_using_index_rows) {
             .produces_end_of_stream();
 
         r.fast_forward_to(to_ck(200), to_ck(250));
-        for (auto idx: boost::irange(210, 241)) {
+        for (auto idx: std::views::iota(210, 241)) {
             r.produces_row(to_ck(idx), to_expected(format("{}{}", rc_base, idx)));
         }
         r.produces_end_of_stream();
 
         r.fast_forward_to(to_ck(900), to_ck(1010));
-        for (auto idx: boost::irange(1000, 1010)) {
+        for (auto idx: std::views::iota(1000, 1010)) {
             r.produces_row(to_ck(idx), to_expected(format("{}{}", rc_base, idx)));
         }
         r.produces_end_of_stream();
 
         r.fast_forward_to(to_ck(1010), to_ck(1024));
-        for (auto idx: boost::irange(1010, 1024)) {
+        for (auto idx: std::views::iota(1010, 1024)) {
             r.produces_row(to_ck(idx), to_expected(format("{}{}", rc_base, idx)));
         }
         r.produces_end_of_stream();
@@ -726,7 +727,7 @@ SEASTAR_TEST_CASE(test_uncompressed_filtering_and_forwarding_range_tombstones_re
     {
         auto r = make_assertions(sst.make_reader());
         tombstone tomb = make_tombstone(1525385507816568, 1534898526);
-        for (auto pkey : boost::irange(1, 3)) {
+        for (auto pkey : std::views::iota(1, 3)) {
             r.produces_partition_start(to_pkey(pkey))
             .produces_static_row({{st_cdef, int32_type->decompose(static_row_values[pkey - 1])}});
 
@@ -747,7 +748,7 @@ SEASTAR_TEST_CASE(test_uncompressed_filtering_and_forwarding_range_tombstones_re
                                            tracing::trace_state_ptr(),
                                            streamed_mutation::forwarding::yes));
         std::array<int32_t, 2> rt_deletion_times {1534898600, 1534899416};
-        for (auto pkey : boost::irange(1, 3)) {
+        for (auto pkey : std::views::iota(1, 3)) {
             const tombstone tomb = make_tombstone(1525385507816568, rt_deletion_times[pkey - 1]);
             r.produces_partition_start(to_pkey(pkey));
             // First, fast-forward to a block that start with an end open marker set
@@ -814,7 +815,7 @@ SEASTAR_TEST_CASE(test_uncompressed_filtering_and_forwarding_range_tombstones_re
 
         auto r = make_assertions(sst.make_reader(query::full_partition_range, slice));
         std::array<int32_t, 2> rt_deletion_times {1534898600, 1534899416};
-        for (auto pkey : boost::irange(1, 3)) {
+        for (auto pkey : std::views::iota(1, 3)) {
             auto slices = slice.get_all_ranges();
             const tombstone tomb = make_tombstone(1525385507816568, rt_deletion_times[pkey - 1]);
             r.produces_partition_start(to_pkey(pkey))
@@ -867,7 +868,7 @@ SEASTAR_TEST_CASE(test_uncompressed_filtering_and_forwarding_range_tombstones_re
                                                       streamed_mutation::forwarding::yes));
 
         std::array<int32_t, 2> rt_deletion_times {1534898600, 1534899416};
-        for (auto pkey : boost::irange(1, 3)) {
+        for (auto pkey : std::views::iota(1, 3)) {
             auto slices = slice.get_all_ranges();
             const tombstone tomb = make_tombstone(1525385507816568, rt_deletion_times[pkey - 1]);
             r.produces_partition_start(to_pkey(pkey))
@@ -3468,7 +3469,7 @@ SEASTAR_TEST_CASE(test_write_wide_partitions) {
     mutation mut1{s, key1};
     {
         mut1.set_static_cell("st", data_value{"hello"}, ts);
-        for (auto idx: boost::irange(0, 1024)) {
+        for (auto idx: std::views::iota(0, 1024)) {
             clustering_key ckey = clustering_key::from_deeply_exploded(*s, {format("{}{}", ck_base, idx)});
             mut1.partition().apply_insert(*s, ckey, ts);
             mut1.set_cell(ckey, "rc", data_value{format("{}{}", rc_base, idx)}, ts);
@@ -3480,7 +3481,7 @@ SEASTAR_TEST_CASE(test_write_wide_partitions) {
     mutation mut2{s, key2};
     {
         mut2.set_static_cell("st", data_value{"goodbye"}, ts);
-        for (auto idx: boost::irange(0, 1024)) {
+        for (auto idx: std::views::iota(0, 1024)) {
             clustering_key ckey = clustering_key::from_deeply_exploded(*s, {format("{}{}", ck_base, idx)});
             mut2.partition().apply_insert(*s, ckey, ts);
             mut2.set_cell(ckey, "rc", data_value{format("{}{}", rc_base, idx)}, ts);
@@ -3665,7 +3666,7 @@ SEASTAR_TEST_CASE(test_write_multiple_partitions) {
     // INSERT INTO multiple_partitions (pk, rc2) VALUES (2, 20) USING TIMESTAMP 1525385507816578;
     // INSERT INTO multiple_partitions (pk, rc3) VALUES (3, 30) USING TIMESTAMP 1525385507816588;
     std::vector<mutation> muts;
-    for (auto i : boost::irange(1, 4)) {
+    for (auto i : std::views::iota(1, 4)) {
         auto key = partition_key::from_deeply_exploded(*s, {i});
         muts.emplace_back(s, key);
 
@@ -3688,7 +3689,7 @@ static future<> test_write_many_partitions(sstring table_name, tombstone partiti
     schema_ptr s = builder.build(schema_builder::compact_storage::no);
 
     std::vector<mutation> muts;
-    for (auto i : boost::irange(0, 65536)) {
+    for (auto i : std::views::iota(0, 65536)) {
         auto key = partition_key::from_deeply_exploded(*s, {i});
         muts.emplace_back(s, key);
         if (partition_tomb) {
@@ -3770,7 +3771,7 @@ SEASTAR_TEST_CASE(test_write_multiple_rows) {
     // INSERT INTO multiple_rows (pk, ck, rc1) VALUES (0, 1, 10) USING TIMESTAMP 1525385507816568;
     // INSERT INTO multiple_rows (pk, ck, rc2) VALUES (0, 2, 20) USING TIMESTAMP 1525385507816578;
     // INSERT INTO multiple_rows (pk, ck, rc3) VALUES (0, 3, 30) USING TIMESTAMP 1525385507816588;
-    for (auto i : boost::irange(1, 4)) {
+    for (auto i : std::views::iota(1, 4)) {
         clustering_key ckey = clustering_key::from_deeply_exploded(*s, { i });
         mut.partition().apply_insert(*s, ckey, ts);
         mut.set_cell(ckey, to_bytes(format("rc{}", i)), data_value{i * 10}, ts);
@@ -3790,7 +3791,7 @@ SEASTAR_TEST_CASE(test_write_missing_columns_large_set) {
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
     builder.with_column("ck", int32_type, column_kind::clustering_key);
-    for (auto idx: boost::irange(1, 65)) {
+    for (auto idx: std::views::iota(1, 65)) {
         builder.with_column(to_bytes(format("rc{}", idx)), int32_type);
     }
     builder.set_compressor_params(compression_parameters::no_compression());
@@ -3805,7 +3806,7 @@ SEASTAR_TEST_CASE(test_write_missing_columns_large_set) {
     {
         clustering_key ckey = clustering_key::from_deeply_exploded(*s, {0});
         mut.partition().apply_insert(*s, ckey, ts);
-        for (auto idx: boost::irange(1, 63)) {
+        for (auto idx: std::views::iota(1, 63)) {
             mut.set_cell(ckey, to_bytes(format("rc{}", idx)), data_value{idx}, ts);
         }
     }
@@ -3994,7 +3995,7 @@ SEASTAR_TEST_CASE(test_write_large_clustering_key) {
     // CREATE TABLE large_clustering_key (pk int, ck1 text, ck2 text, ..., ck35 text, rc int, PRIMARY KEY (pk, ck1, ck2, ..., ck35)) WITH compression = {'sstable_compression': ''};
     schema_builder builder("sst3", table_name);
     builder.with_column("pk", int32_type, column_kind::partition_key);
-    for (auto idx: boost::irange(1, 36)) {
+    for (auto idx: std::views::iota(1, 36)) {
         builder.with_column(to_bytes(format("ck{}", idx)), utf8_type, column_kind::clustering_key);
     }
     builder.with_column("rc", int32_type);
@@ -4009,7 +4010,7 @@ SEASTAR_TEST_CASE(test_write_large_clustering_key) {
     //    - "X" for odd X
     // INSERT INTO large_clustering_key (pk, ck1, ..., ck35, rc) VALUES (0, '1', '', '3',..., '', '35', 1) USING TIMESTAMP 1525385507816568;
     std::vector<data_value> clustering_values;
-    for (auto idx: boost::irange(1, 36)) {
+    for (auto idx: std::views::iota(1, 36)) {
         clustering_values.emplace_back((idx % 2 == 1) ? std::to_string(idx) : std::string{});
     }
     clustering_key ckey = clustering_key::from_deeply_exploded(*s, clustering_values);
@@ -4262,7 +4263,7 @@ SEASTAR_TEST_CASE(test_write_many_range_tombstones) {
     gc_clock::time_point tp = gc_clock::time_point{} + gc_clock::duration{1528226962};
     tombstone tomb{write_timestamp, tp};
     sstring ck_base(650, 'a');
-    for (auto idx: boost::irange(1000, 1100)) {
+    for (auto idx: std::views::iota(1000, 1100)) {
         range_tombstone rt{clustering_key_prefix::from_single_value(*s, to_bytes(format("{}{}", ck_base, idx * 2))), tomb,
                            bound_kind::excl_start,
                            clustering_key_prefix::from_single_value(*s, to_bytes(format("{}{}", ck_base, idx * 2 + 1))),

--- a/test/boost/transport_test.cc
+++ b/test/boost/transport_test.cc
@@ -60,15 +60,15 @@ SEASTAR_THREAD_TEST_CASE(test_response_request_reader) {
     res.write_value(bytes_opt(value));
 
     // Name and value list
-    auto names_and_values = boost::copy_range<std::vector<std::pair<sstring, bytes_opt>>>(
-        boost::irange<int16_t>(0, tests::random::get_int<int16_t>(16) + 16)
-        | boost::adaptors::transformed([] (int) {
+    auto names_and_values =
+        std::views::iota(0, tests::random::get_int<int>(16) + 16)
+        | std::views::transform([] (int) {
             return std::pair(
                 tests::random::get_sstring(),
                 !tests::random::get_int(4) ? bytes_opt() : bytes_opt(tests::random::get_bytes(tests::random::get_int<int16_t>(1024)))
             );
         })
-    );
+        | std::ranges::to<std::vector<std::pair<sstring, bytes_opt>>>();
     res.write_short(names_and_values.size());
     for (auto& [ name, value ] : names_and_values) {
         res.write_string(name);
@@ -76,21 +76,21 @@ SEASTAR_THREAD_TEST_CASE(test_response_request_reader) {
     }
 
     // String list
-    auto string_list = boost::copy_range<std::vector<sstring>>(
-        boost::irange<int16_t>(0, tests::random::get_int<int16_t>(16) + 16)
-        | boost::adaptors::transformed([] (int) {
+    auto string_list =
+        std::views::iota(0, tests::random::get_int<int>(16) + 16)
+        | std::views::transform([] (int) {
             return tests::random::get_sstring();
         })
-    );
+        | std::ranges::to<std::vector<sstring>>();
     res.write_string_list(string_list);
 
     // String map
-    auto string_map = boost::copy_range<std::map<sstring, sstring>>(
-        boost::irange<int16_t>(0, tests::random::get_int<int16_t>(16) + 16)
-        | boost::adaptors::transformed([] (int) {
+    auto string_map =
+        std::views::iota(0, tests::random::get_int<int>(16) + 16)
+        | std::views::transform([] (int) {
             return std::pair(tests::random::get_sstring(), tests::random::get_sstring());
         })
-    );
+        | std::ranges::to<std::map>();
     res.write_string_map(string_map);
     auto string_unordered_map = std::unordered_map<sstring, sstring>(string_map.begin(), string_map.end());
 

--- a/test/boost/user_types_test.cc
+++ b/test/boost/user_types_test.cc
@@ -188,12 +188,12 @@ SEASTAR_TEST_CASE(test_invalid_user_type_statements) {
                 "Non-frozen UDTs with nested non-frozen collections are not supported");
 
         // cannot have too many fields inside UDTs
-        REQUIRE_INVALID(e, format("create type ut4 ({})", boost::algorithm::join(
-                boost::irange(0, 1 << 15) | boost::adaptors::transformed([] (int i) { return format("a{} int", i); }), ", ")),
+        REQUIRE_INVALID(e, seastar::format("create type ut4 ({})", fmt::join(
+                std::views::iota(0, 1 << 15) | std::views::transform([] (int i) { return format("a{} int", i); }), ", ")),
                 format("A user type cannot have more than {} fields", (1 << 15) - 1));
 
-        e.execute_cql(format("create type ut4 ({})", boost::algorithm::join(
-                boost::irange(1, 1 << 15) | boost::adaptors::transformed([] (int i) { return format("a{} int", i); }), ", "))).discard_result().get();
+        e.execute_cql(seastar::format("create type ut4 ({})", fmt::join(
+                std::views::iota(1, 1 << 15) | std::views::transform([] (int i) { return format("a{} int", i); }), ", "))).discard_result().get();
         REQUIRE_INVALID(e, "alter type ut4 add b int",
                 "Cannot add new field to type ks.ut4: maximum number of fields reached");
 

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -220,7 +220,7 @@ SEASTAR_TEST_CASE(test_builder_across_tokens_with_large_partitions) {
         auto s = e.local_db().find_schema("ks", "cf");
 
         auto make_key = [&] (auto) { return to_hex(random_bytes(128, gen));  };
-        for (auto&& k : boost::irange(0, 4) | boost::adaptors::transformed(make_key)) {
+        for (auto&& k : std::views::iota(0, 4) | std::views::transform(make_key)) {
             for (auto i = 0; i < 1000; ++i) {
                 e.execute_cql(format("insert into cf (p, c, v) values (0x{}, {:d}, 0)", k, i)).get();
             }
@@ -262,7 +262,7 @@ SEASTAR_TEST_CASE(test_builder_across_tokens_with_small_partitions) {
         auto s = e.local_db().find_schema("ks", "cf");
 
         auto make_key = [&] (auto) { return to_hex(random_bytes(128, gen));  };
-        for (auto&& k : boost::irange(0, 1000) | boost::adaptors::transformed(make_key)) {
+        for (auto&& k : std::views::iota(0, 1000) | std::views::transform(make_key)) {
             for (auto i = 0; i < 4; ++i) {
                 e.execute_cql(format("insert into cf (p, c, v) values (0x{}, {:d}, 0)", k, i)).get();
             }
@@ -372,7 +372,7 @@ SEASTAR_TEST_CASE(test_builder_with_concurrent_drop) {
         e.execute_cql("create table cf (p blob, c int, v int, primary key (p, c))").get();
 
         auto make_key = [&] (auto) { return to_hex(random_bytes(128, gen));  };
-        for (auto&& k : boost::irange(0, 1000) | boost::adaptors::transformed(make_key)) {
+        for (auto&& k : std::views::iota(0, 1000) | std::views::transform(make_key)) {
             for (auto i = 0; i < 5; ++i) {
                 e.execute_cql(format("insert into cf (p, c, v) values (0x{}, {:d}, 0)", k, i)).get();
             }
@@ -801,7 +801,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
 
     const auto partition_size_sets = std::vector<std::vector<int>>{{12}, {8, 4}, {8, 16}, {22}, {8, 8, 8, 8}, {8, 8, 8, 16, 8}, {8, 20, 16, 16}, {50}, {21}, {21, 2}};
     const auto max_partition_set_size = std::ranges::max_element(partition_size_sets, [] (const std::vector<int>& a, const std::vector<int>& b) { return a.size() < b.size(); })->size();
-    auto pkeys = ranges::to<std::vector<dht::decorated_key>>(boost::irange(size_t{0}, max_partition_set_size) | boost::adaptors::transformed([schema] (int i) {
+    auto pkeys = ranges::to<std::vector<dht::decorated_key>>(std::views::iota(size_t{0}, max_partition_set_size) | std::views::transform([schema] (int i) {
         return dht::decorate_key(*schema, partition_key::from_single_value(*schema, int32_type->decompose(data_value(i))));
     }));
     std::ranges::sort(pkeys, dht::ring_position_less_comparator(*schema));

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -552,7 +552,7 @@ static void test_fast_forwarding_across_partitions_to_empty_range(tests::reader_
     for (auto&& key : keys) {
         mutation m(s, key);
         sstring val = make_random_string(1024);
-        for (auto i : boost::irange(0u, ckeys_per_part)) {
+        for (auto i : std::views::iota(0u, ckeys_per_part)) {
             table.add_row(m, table.make_ckey(next_ckey + i), val);
         }
         next_ckey += ckeys_per_part;

--- a/test/manual/sstable_scan_footprint_test.cc
+++ b/test/manual/sstable_scan_footprint_test.cc
@@ -156,7 +156,7 @@ void execute_reads(const schema_ptr& schema, reader_concurrency_semaphore& sem, 
             (void)with_gate(g, [reads, read, &n, concurrency] {
                 const auto start = n;
                 n = std::min(reads, n + concurrency);
-                return parallel_for_each(boost::irange(start, n), read);
+                return parallel_for_each(std::views::iota(start, n), read);
             }).handle_exception([&e, &sem, initial_res] (std::exception_ptr eptr) {
                 const auto res = sem.available_resources();
                 testlog.error("Read failed: {}", eptr);

--- a/test/perf/perf.hh
+++ b/test/perf/perf.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <ranges>
 #include <seastar/core/print.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/distributed.hh>
@@ -132,7 +133,7 @@ public:
         auto stats_start = executor_shard_stats_snapshot();
         _instructions_retired_counter.enable();
         _cpu_cycles_retired_counter.enable();
-        auto idx = boost::irange(0, (int)_n_workers);
+        auto idx = std::views::iota(0, (int)_n_workers);
         return parallel_for_each(idx.begin(), idx.end(), [this] (auto idx) mutable {
             return this->run_worker();
         }).then([this, stats_start] {

--- a/test/perf/perf_s3_client.cc
+++ b/test/perf/perf_s3_client.cc
@@ -99,7 +99,7 @@ private:
 
 public:
     future<> run() {
-        co_await coroutine::parallel_for_each(boost::irange(0u, _parallel), [this] (auto fnr) -> future<> {
+        co_await coroutine::parallel_for_each(std::views::iota(0u, _parallel), [this] (auto fnr) -> future<> {
             plog.debug("Running {} fiber", fnr);
             co_await seastar::sleep(std::chrono::milliseconds(fnr)); // make some discrepancy
             co_await do_run();

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -206,7 +206,7 @@ public:
     }
 
     future<> fill_memtable() {
-        auto idx = boost::irange(0, int(_cfg.partitions / _cfg.sstables));
+        auto idx = std::views::iota(0, int(_cfg.partitions / _cfg.sstables));
         auto local_keys = tests::generate_partition_keys(int(_cfg.partitions / _cfg.sstables), s, local_shard_only::yes, tests::key_size{_cfg.key_size, _cfg.key_size});
         return do_for_each(idx.begin(), idx.end(), [this, local_keys = std::move(local_keys)] (auto iteration) {
             auto mut = mutation(this->s, local_keys.at(iteration));
@@ -356,9 +356,9 @@ template <typename Func>
 future<> time_runs(unsigned iterations, unsigned parallelism, distributed<perf_sstable_test_env>& dt, Func func) {
     using namespace boost::accumulators;
     auto acc = make_lw_shared<accumulator_set<double, features<tag::mean, tag::error_of<tag::mean>>>>();
-    auto idx = boost::irange(0, int(iterations));
+    auto idx = std::views::iota(0, int(iterations));
     return do_for_each(idx.begin(), idx.end(), [parallelism, acc, &dt, func] (auto iter) {
-        auto idx = boost::irange(0, int(parallelism));
+        auto idx = std::views::iota(0, int(parallelism));
         return parallel_for_each(idx.begin(), idx.end(), [&dt, func, acc] (auto idx) {
             return dt.map_reduce(adder<double>(), func, std::move(idx)).then([acc] (double result) {
                 auto& a = *acc;

--- a/test/raft/failure_detector_test.cc
+++ b/test/raft/failure_detector_test.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <ranges>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/sleep.hh>
@@ -20,7 +21,7 @@ future<> ping_shards() {
         return seastar::yield();
     }
 
-    return parallel_for_each(boost::irange(0u, smp::count), [] (shard_id s) {
+    return parallel_for_each(std::views::iota(0u, smp::count), [] (shard_id s) {
         return smp::submit_to(s, [](){});
     });
 }

--- a/test/raft/raft_address_map_test.cc
+++ b/test/raft/raft_address_map_test.cc
@@ -10,6 +10,7 @@
 #include <seastar/testing/on_internal_error.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <chrono>
+#include <ranges>
 
 #include "raft/raft.hh"
 #include "service/raft/raft_address_map.hh"
@@ -34,7 +35,7 @@ future<> ping_shards() {
 
     // Submit an empty message to other shards 100 times to account for task reordering in debug mode.
     for (int i = 0; i < 100; ++i) {
-        co_await parallel_for_each(boost::irange(0u, smp::count), [] (shard_id s) {
+        co_await parallel_for_each(std::views::iota(0u, smp::count), [] (shard_id s) {
             return smp::submit_to(s, [](){});
         });
     }

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -2106,7 +2106,7 @@ future<> ping_shards() {
         return seastar::yield();
     }
 
-    return parallel_for_each(boost::irange(0u, smp::count), [] (shard_id s) {
+    return parallel_for_each(std::views::iota(0u, smp::count), [] (shard_id s) {
         return smp::submit_to(s, [](){});
     });
 }

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -945,7 +945,7 @@ template <typename Clock>
 future<> raft_cluster<Clock>::add_entries_concurrent(size_t n, std::optional<size_t> server) {
     const auto start = _next_val;
     _next_val += n;
-    return parallel_for_each(boost::irange(start, _next_val), [this, server](size_t v) { return add_entry(v, server); });
+    return parallel_for_each(std::views::iota(start, _next_val), [this, server](size_t v) { return add_entry(v, server); });
 }
 
 template <typename Clock>

--- a/test/unit/row_cache_stress_test.cc
+++ b/test/unit/row_cache_stress_test.cc
@@ -74,7 +74,7 @@ struct table {
     }
 
     size_t index_of_key(const dht::decorated_key& dk) {
-        for (auto i : boost::irange<size_t>(0, p_keys.size())) {
+        for (auto i : std::views::iota(0u, p_keys.size())) {
             if (p_keys[i].equal(*s.schema(), dk)) {
                 return i;
             }
@@ -111,7 +111,7 @@ struct table {
 
     void mutate_next_phase() {
         testlog.trace("mutating, phase={}", mutation_phase);
-        for (auto i : boost::irange<int>(0, p_keys.size())) {
+        for (auto i : std::views::iota(0u, p_keys.size())) {
             auto t = s.new_timestamp();
             auto tag = value_tag(i, mutation_phase);
             auto m = get_mutation(i, t, tag);
@@ -366,7 +366,7 @@ int main(int argc, char** argv) {
             // populate the initial phase, readers expect constant fragment count.
             t.mutate_next_phase();
 
-            auto readers = parallel_for_each(boost::irange(0u, concurrency), [&] (auto i) {
+            auto readers = parallel_for_each(std::views::iota(0u, concurrency), [&] (auto i) {
                 reader_id id{format("single-{:d}", i)};
                 return seastar::async([&, i, id] {
                     single_partition_reader(i, id);
@@ -375,7 +375,7 @@ int main(int argc, char** argv) {
                 });
             });
 
-            auto scanning_readers = parallel_for_each(boost::irange(0u, scan_concurrency), [&] (auto i) {
+            auto scanning_readers = parallel_for_each(std::views::iota(0u, scan_concurrency), [&] (auto i) {
                 reader_id id{format("scan-{:d}", i)};
                 return seastar::async([&, id] {
                     scanning_reader(id);

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1182,7 +1182,7 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
         tracing::begin(trace_state, "Execute batch of CQL3 queries", client_state.get_client_address());
     }
 
-    for ([[gnu::unused]] auto i : boost::irange(0u, n)) {
+    for ([[gnu::unused]] auto i : std::views::iota(0u, n)) {
         const auto kind = in.read_byte();
 
         std::unique_ptr<cql3::statements::prepared_statement> stmt_ptr;
@@ -1908,7 +1908,7 @@ public:
             r.write_string(udt->_keyspace);
             r.write_bytes_as_string(udt->_name);
             r.write_short(udt->size());
-            for (auto&& i : boost::irange<size_t>(0, udt->size())) {
+            for (auto&& i : std::views::iota(0u, udt->size())) {
                 r.write_bytes_as_string(udt->field_name(i));
                 encode(r, udt->field_type(i));
             }


### PR DESCRIPTION
when building scylla with the standard library from GCC-14.2, shipped by
fedora 41, we have following build failure:

```
/home/kefu/.local/bin/clang++ -DDEBUG -DDEBUG_LSA_SANITIZER -DFMT_SHARED -DSANITIZE -DSCYLLA_BUILD_MODE=debug -DSCYLLA_ENABLE_ERROR_INJECTION -DSEASTAR_API_LEVEL=7 -DSEASTAR_DEBUG -DSEASTAR_DEBUG_PROMISE -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_SSTRING -DSEASTAR_TYPE_ERASE_MORE -DXXH_PRIVATE_API -DCMAKE_INTDIR=\"Debug\" -I/home/kefu/dev/scylladb -I/home/kefu/dev/scylladb/build/gen -I/home/kefu/dev/scylladb/seastar/include -I/home/kefu/dev/scylladb/build/seastar/gen/include -I/home/kefu/dev/scylladb/build/seastar/gen/src -isystem /home/kefu/dev/scylladb/abseil -g -Og -g -gz -std=gnu++23 -fvisibility=hidden -Wall -Werror -Wextra -Wno-error=deprecated-declarations -Wimplicit-fallthrough -Wno-c++11-narrowing -Wno-deprecated-copy -Wno-mismatched-tags -Wno-missing-field-initializers -Wno-overloaded-virtual -Wno-unsupported-friend -Wno-unused-parameter -ffile-prefix-map=/home/kefu/dev/scylladb/build=. -march=x86-64-v3 -mpclmul -Xclang -fexperimental-assignment-tracking=disabled -Werror=unused-result -fstack-clash-protection -fsanitize=address -fsanitize=undefined -MD -MT CMakeFiles/scylla-main.dir/Debug/init.cc.o -MF CMakeFiles/scylla-main.dir/Debug/init.cc.o.d -o CMakeFiles/scylla-main.dir/Debug/init.cc.o -c /home/kefu/dev/scylladb/init.cc
In file included from /home/kefu/dev/scylladb/init.cc:12:
In file included from /home/kefu/dev/scylladb/db/config.hh:20:
In file included from /home/kefu/dev/scylladb/locator/abstract_replication_strategy.hh:26:
/home/kefu/dev/scylladb/locator/tablets.hh:410:30: error: unexpected type name 'size_t': expected expression
  410 |         return boost::irange<size_t>(0, tablet_count()) | boost::adaptors::transformed([] (size_t i) {
      |                              ^
/home/kefu/dev/scylladb/locator/tablets.hh:410:23: error: no member named 'irange' in namespace 'boost'
  410 |         return boost::irange<size_t>(0, tablet_count()) | boost::adaptors::transformed([] (size_t i) {
      |                ~~~~~~~^
/home/kefu/dev/scylladb/locator/tablets.hh:410:38: error: left operand of comma operator has no effect [-Werror,-Wunused-value]
  410 |         return boost::irange<size_t>(0, tablet_count()) | boost::adaptors::transformed([] (size_t i) {
      |                                      ^
3 errors generated.
[16/782] Building CXX object CMakeFiles/scylla-main.dir/Debug/keys.cc.o
[17/782] Building CXX object CMakeFiles/scylla-main.dir/Debug/counters.cc.o
[18/782] Building CXX object CMakeFiles/scylla-main.dir/Debug/partition_slice_builder.cc.o
[19/782] Building CXX object CMakeFiles/scylla-main.dir/Debug/mutation_query.cc.o
FAILED: CMakeFiles/scylla-main.dir/Debug/mutation_query.cc.o
/home/kefu/.local/bin/clang++ -DDEBUG -DDEBUG_LSA_SANITIZER -DFMT_SHARED -DSANITIZE -DSCYLLA_BUILD_MODE=debug -DSCYLLA_ENABLE_ERROR_INJECTION -DSEASTAR_API_LEVEL=7 -DSEASTAR_DEBUG -DSEASTAR_DEBUG_PROMISE -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_SSTRING -DSEASTAR_TYPE_ERASE_MORE -DXXH_PRIVATE_API -DCMAKE_INTDIR=\"Debug\" -I/home/kefu/dev/scylladb -I/home/kefu/dev/scylladb/build/gen -I/home/kefu/dev/scylladb/seastar/include -I/home/kefu/dev/scylladb/build/seastar/gen/include -I/home/kefu/dev/scylladb/build/seastar/gen/src -isystem /home/kefu/dev/scylladb/abseil -g -Og -g -gz -std=gnu++23 -fvisibility=hidden -Wall -Werror -Wextra -Wno-error=deprecated-declarations -Wimplicit-fallthrough -Wno-c++11-narrowing -Wno-deprecated-copy -Wno-mismatched-tags -Wno-missing-field-initializers -Wno-overloaded-virtual -Wno-unsupported-friend -Wno-unused-parameter -ffile-prefix-map=/home/kefu/dev/scylladb/build=. -march=x86-64-v3 -mpclmul -Xclang -fexperimental-assignment-tracking=disabled -Werror=unused-result -fstack-clash-protection -fsanitize=address -fsanitize=undefined -MD -MT CMakeFiles/scylla-main.dir/Debug/mutation_query.cc.o -MF CMakeFiles/scylla-main.dir/Debug/mutation_query.cc.o.d -o CMakeFiles/scylla-main.dir/Debug/mutation_query.cc.o -c /home/kefu/dev/scylladb/mutation_query.cc
In file included from /home/kefu/dev/scylladb/mutation_query.cc:12:
In file included from /home/kefu/dev/scylladb/schema/schema_registry.hh:17:
In file included from /home/kefu/dev/scylladb/replica/database.hh:11:
In file included from /home/kefu/dev/scylladb/locator/abstract_replication_strategy.hh:26:
/home/kefu/dev/scylladb/locator/tablets.hh:410:30: error: unexpected type name 'size_t': expected expression
  410 |         return boost::irange<size_t>(0, tablet_count()) | boost::adaptors::transformed([] (size_t i) {
      |                              ^
/home/kefu/dev/scylladb/locator/tablets.hh:410:23: error: no member named 'irange' in namespace 'boost'
  410 |         return boost::irange<size_t>(0, tablet_count()) | boost::adaptors::transformed([] (size_t i) {
      |                ~~~~~~~^
/home/kefu/dev/scylladb/locator/tablets.hh:410:38: error: left operand of comma operator has no effect [-Werror,-Wunused-value]
  410 |         return boost::irange<size_t>(0, tablet_count()) | boost::adaptors::transformed([] (size_t i) {
      |                                      ^
In file included from /home/kefu/dev/scylladb/mutation_query.cc:12:
In file included from /home/kefu/dev/scylladb/schema/schema_registry.hh:17:
In file included from /home/kefu/dev/scylladb/replica/database.hh:37:
In file included from /home/kefu/dev/scylladb/db/snapshot-ctl.hh:20:
/home/kefu/dev/scylladb/tasks/task_manager.hh:403:54: error: no member named 'irange' in namespace 'boost'
  403 |         co_await coroutine::parallel_for_each(boost::irange(0u, smp::count), [&tm, id, &res, &func] (unsigned shard) -> future<> {
      |                                               ~~~~~~~^
4 errors generated.
```
so let's take the opportunity to switch from `boost::irange` to
`std::views::iota`.

in this change, we:

- switch from boost::irange to std::views::iota for better standard library compatibility
- retain boost::irange where step parameter is used, as std::views::iota doesn't support it
- this change partially modernizes our range usage while maintaining
- existing functionality

---

it's a cleanup, hence no need to backport.