### PR TITLE
Use checksummed input streams in `validate_checksums()`

### DIFF
--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -599,7 +599,7 @@ The content is dumped in JSON, using the following schema:
     $RESULT := {
         "has_checksums": Bool,
         "has_digest": Bool,
-        "valid_checksums": Bool, // optional
+        "valid": Bool, // optional
     }
 
 decompress

--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -586,7 +586,8 @@ The digest and the per-chunk checksum of uncompressed SStables are currently not
 
 This operation reads the entire ``Data.db`` and validates both kinds of checksums against the data.
 Errors found are logged to stderr. The output contains an object for each SStable that indicates if the SStable has checksums (false only for uncompressed SStables
-for which ``CRC.db`` is not present in ``TOC.txt``), and if the SStable matches all checksums.
+for which ``CRC.db`` is not present in ``TOC.txt``), if the SStable has a digest, and if the SStable matches all checksums and the digest. If no digest is available,
+validation will proceed using only the per-chunk checksums.
 
 The content is dumped in JSON, using the following schema:
 
@@ -597,6 +598,7 @@ The content is dumped in JSON, using the following schema:
 
     $RESULT := {
         "has_checksums": Bool,
+        "has_digest": Bool,
         "valid_checksums": Bool, // optional
     }
 

--- a/sstables/checksummed_data_source.cc
+++ b/sstables/checksummed_data_source.cc
@@ -112,6 +112,9 @@ public:
                     _end_pos = actual_end;
                 }
             }
+            if (chunk_index >= _checksum.checksums.size()) {
+                throw malformed_sstable_exception(seastar::format("Chunk count mismatch between CRC and Data.db: expected {} but data file has more", _checksum.checksums.size()));
+            }
             auto expected_checksum = _checksum.checksums[chunk_index];
             auto actual_checksum = ChecksumType::checksum(buf.get(), buf.size());
             if (expected_checksum != actual_checksum) {

--- a/sstables/checksummed_data_source.cc
+++ b/sstables/checksummed_data_source.cc
@@ -17,6 +17,7 @@
 #include "exceptions.hh"
 #include "checksum_utils.hh"
 #include "data_source_types.hh"
+#include "checksummed_data_source.hh"
 
 namespace sstables {
 
@@ -29,6 +30,7 @@ class checksummed_file_data_source_impl : public data_source_impl {
     std::optional<input_stream<char>> _input_stream;
     const checksum& _checksum;
     [[no_unique_address]] digest_members<check_digest> _digests;
+    integrity_error_handler _error_handler;
     uint64_t _chunk_size_trailing_zeros;
     uint64_t _file_len;
     uint64_t _underlying_pos;
@@ -39,8 +41,10 @@ public:
     checksummed_file_data_source_impl(file f, uint64_t file_len,
                 const checksum& checksum, uint64_t pos, size_t len,
                 file_input_stream_options options,
-                std::optional<uint32_t> digest)
+                std::optional<uint32_t> digest,
+                integrity_error_handler error_handler)
             : _checksum(checksum)
+            , _error_handler(error_handler)
             , _file_len(file_len)
             , _pos(pos)
             , _beg_pos(pos)
@@ -118,7 +122,9 @@ public:
             auto expected_checksum = _checksum.checksums[chunk_index];
             auto actual_checksum = ChecksumType::checksum(buf.get(), buf.size());
             if (expected_checksum != actual_checksum) {
-                throw sstables::malformed_sstable_exception(format("Checksummed chunk of size {} at file offset {} failed checksum: expected={}, actual={}", buf.size(), _underlying_pos, expected_checksum, actual_checksum));
+                _error_handler(seastar::format(
+                        "Checksummed chunk of size {} at file offset {} failed checksum: expected={}, actual={}",
+                        buf.size(), _underlying_pos, expected_checksum, actual_checksum));
             }
 
             if constexpr (check_digest) {
@@ -133,7 +139,7 @@ public:
 
             if constexpr (check_digest) {
                 if (_digests.can_calculate_digest && _pos == _file_len && _digests.expected_digest != _digests.actual_digest) {
-                    throw malformed_sstable_exception(seastar::format("Digest mismatch: expected={}, actual={}", _digests.expected_digest, _digests.actual_digest));
+                    _error_handler(seastar::format("Digest mismatch: expected={}, actual={}", _digests.expected_digest, _digests.actual_digest));
                 }
             }
             return buf;
@@ -176,39 +182,48 @@ class checksummed_file_data_source : public data_source {
 public:
     checksummed_file_data_source(file f, uint64_t file_len, const checksum& checksum,
             uint64_t offset, size_t len, file_input_stream_options options,
-            std::optional<uint32_t> digest)
+            std::optional<uint32_t> digest, integrity_error_handler error_handler)
         : data_source(std::make_unique<checksummed_file_data_source_impl<ChecksumType, check_digest>>(
-                std::move(f), file_len, checksum, offset, len, std::move(options), digest))
+                std::move(f), file_len, checksum, offset, len, std::move(options), digest,
+                error_handler))
     {}
 };
 
 template <ChecksumUtils ChecksumType>
 inline input_stream<char> make_checksummed_file_input_stream(
         file f, uint64_t file_len, const checksum& checksum, uint64_t offset,
-        size_t len, file_input_stream_options options, std::optional<uint32_t> digest)
+        size_t len, file_input_stream_options options, std::optional<uint32_t> digest,
+        integrity_error_handler error_handler)
 {
     if (digest) {
         return input_stream<char>(checksummed_file_data_source<ChecksumType, true>(
-            std::move(f), file_len, checksum, offset, len, std::move(options), digest));
+            std::move(f), file_len, checksum, offset, len, std::move(options), digest,
+            error_handler));
     }
     return input_stream<char>(checksummed_file_data_source<ChecksumType, false>(
-        std::move(f), file_len, checksum, offset, len, std::move(options), digest));
+        std::move(f), file_len, checksum, offset, len, std::move(options), digest, error_handler));
 }
 
 input_stream<char> make_checksummed_file_k_l_format_input_stream(
         file f, uint64_t file_len, const checksum& checksum, uint64_t offset,
-        size_t len, file_input_stream_options options, std::optional<uint32_t> digest)
+        size_t len, file_input_stream_options options, std::optional<uint32_t> digest,
+        integrity_error_handler error_handler)
 {
     return make_checksummed_file_input_stream<adler32_utils>(std::move(f), file_len,
-            checksum, offset, len, std::move(options), digest);
+            checksum, offset, len, std::move(options), digest, error_handler);
 }
 
 input_stream<char> make_checksummed_file_m_format_input_stream(
         file f, uint64_t file_len, const checksum& checksum, uint64_t offset,
-        size_t len, file_input_stream_options options, std::optional<uint32_t> digest)
+        size_t len, file_input_stream_options options, std::optional<uint32_t> digest,
+        integrity_error_handler error_handler)
 {
     return make_checksummed_file_input_stream<crc32_utils>(std::move(f), file_len,
-            checksum, offset, len, std::move(options), digest);
+            checksum, offset, len, std::move(options), digest, error_handler);
 }
+
+void throwing_integrity_error_handler(sstring msg) {
+        throw sstables::malformed_sstable_exception(msg);
+};
 
 }

--- a/sstables/checksummed_data_source.hh
+++ b/sstables/checksummed_data_source.hh
@@ -15,15 +15,21 @@
 
 namespace sstables {
 
+using integrity_error_handler = std::function<void(sstring)>;
+
+void throwing_integrity_error_handler(sstring msg);
+
 input_stream<char> make_checksummed_file_k_l_format_input_stream(file f,
                 uint64_t file_len, const sstables::checksum& checksum,
                 uint64_t offset, size_t len,
                 class file_input_stream_options options,
-                std::optional<uint32_t> digest);
+                std::optional<uint32_t> digest,
+                integrity_error_handler error_handler = throwing_integrity_error_handler);
 
 input_stream<char> make_checksummed_file_m_format_input_stream(file f,
                 uint64_t file_len, const sstables::checksum& checksum,
                 uint64_t offset, size_t len,
                 class file_input_stream_options options,
-                std::optional<uint32_t> digest);
+                std::optional<uint32_t> digest,
+                integrity_error_handler error_handler = throwing_integrity_error_handler);
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2462,7 +2462,7 @@ component_type sstable::component_from_sstring(version_types v, const sstring &s
 
 input_stream<char> sstable::data_stream(uint64_t pos, size_t len,
         reader_permit permit, tracing::trace_state_ptr trace_state, lw_shared_ptr<file_input_stream_history> history, raw_stream raw,
-        integrity_check integrity) {
+        integrity_check integrity, integrity_error_handler error_handler) {
     file_input_stream_options options;
     options.buffer_size = sstable_buffer_size;
     options.read_ahead = 4;
@@ -2492,10 +2492,10 @@ input_stream<char> sstable::data_stream(uint64_t pos, size_t len,
         auto file_len = data_size();
         if (_version >= sstable_version_types::mc) {
              return make_checksummed_file_m_format_input_stream(f, file_len,
-                *checksum, pos, len, std::move(options), digest);
+                *checksum, pos, len, std::move(options), digest, error_handler);
         } else {
             return make_checksummed_file_k_l_format_input_stream(f, file_len,
-                *checksum, pos, len, std::move(options), digest);
+                *checksum, pos, len, std::move(options), digest, error_handler);
         }
     }
     return make_file_input_stream(f, pos, len, std::move(options));

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -37,6 +37,7 @@
 #include "sstables/storage.hh"
 #include "sstables/generation_type.hh"
 #include "sstables/types.hh"
+#include "sstables/checksummed_data_source.hh"
 #include "mutation/mutation_fragment_stream_validator.hh"
 #include "readers/mutation_reader_fwd.hh"
 #include "readers/mutation_reader.hh"
@@ -731,10 +732,16 @@ public:
     //
     // When created with `integrity_check::yes`, the integrity mechanisms
     // of the underlying data streams will be enabled.
+    //
+    // The `error_handler` parameter allows to customize the error handling
+    // logic when a checksum or digest mismatch is detected on an
+    // integrity-checked stream with no compression. The parameter is ignored
+    // if integrity checking is disabled or the SSTable is compressed.
     using raw_stream = bool_class<class raw_stream_tag>;
     input_stream<char> data_stream(uint64_t pos, size_t len,
             reader_permit permit, tracing::trace_state_ptr trace_state, lw_shared_ptr<file_input_stream_history> history,
-            raw_stream raw = raw_stream::no, integrity_check integrity = integrity_check::no);
+            raw_stream raw = raw_stream::no, integrity_check integrity = integrity_check::no,
+            integrity_error_handler error_handler = throwing_integrity_error_handler);
 
     // Read exactly the specific byte range from the data file (after
     // uncompression, if the file is compressed). This can be used to read

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -1059,10 +1059,14 @@ public:
 // Returns `no_checksum` if the sstable is uncompressed and does not have
 // a CRC component (CRC.db is missing from TOC.txt).
 // Validation errors are logged individually.
-enum class validate_checksums_result {
+enum class validate_checksums_status {
     invalid = 0,
     valid = 1,
     no_checksum = 2
+};
+struct validate_checksums_result {
+    validate_checksums_status status;
+    bool has_digest;
 };
 future<validate_checksums_result> validate_checksums(shared_sstable sst, reader_permit permit);
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2950,7 +2950,8 @@ SEASTAR_TEST_CASE(sstable_validate_test) {
         f.close().get();
 
         auto res = sstables::validate_checksums(sst, permit).get();
-        BOOST_REQUIRE(res == validate_checksums_result::invalid);
+        BOOST_REQUIRE(res.status == validate_checksums_status::invalid);
+        BOOST_REQUIRE(res.has_digest);
 
 
         const auto errors = sst->validate(permit, abort, error_handler{count}).get();

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2863,12 +2863,20 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                 BOOST_REQUIRE(res.status == validate_checksums_status::invalid);
                 BOOST_REQUIRE(res.has_digest);
 
+                testlog.info("Validating with no digest {}", sst->get_filename());
+
+                sstables::test(sst).set_digest(std::nullopt);
+                sstables::test(sst).rewrite_toc_without_component(component_type::Digest);
+                res = sstables::validate_checksums(sst, permit).get();
+                BOOST_REQUIRE(res.status == validate_checksums_status::invalid);
+                BOOST_REQUIRE(!res.has_digest);
+
                 if (compression_params == no_compression_params) {
                     testlog.info("Validating with no checksums {}", sst->get_filename());
                     sstables::test(sst).rewrite_toc_without_component(component_type::CRC);
                     auto res = sstables::validate_checksums(sst, permit).get();
                     BOOST_REQUIRE(res.status == validate_checksums_status::no_checksum);
-                    BOOST_REQUIRE(res.has_digest);
+                    BOOST_REQUIRE(!res.has_digest);
                 }
 
                 { // truncate the sstable

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -206,6 +206,10 @@ public:
     const utils::filter_ptr& get_filter() const {
         return _sst->_components->filter;
     }
+
+    void set_digest(std::optional<uint32_t> digest) {
+        _sst->_components->digest = digest;
+    }
 };
 
 inline auto replacer_fn_no_op() {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1620,11 +1620,11 @@ void validate_checksums_operation(schema_ptr schema, reader_permit permit, const
         writer.Bool(res.has_digest);
         switch (res.status) {
         case validate_checksums_status::valid:
-            writer.Key("valid_checksums");
+            writer.Key("valid");
             writer.Bool(true);
             break;
         case validate_checksums_status::invalid:
-            writer.Key("valid_checksums");
+            writer.Key("valid");
             writer.Bool(false);
             break;
         case validate_checksums_status::no_checksum:

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1608,20 +1608,26 @@ void validate_checksums_operation(schema_ptr schema, reader_permit permit, const
         writer.Key(sst->get_filename());
         writer.StartObject();
         writer.Key("has_checksums");
-        switch (res) {
-        case validate_checksums_result::valid:
+        switch (res.status) {
+        case validate_checksums_status::valid:
+        case validate_checksums_status::invalid:
             writer.Bool(true);
+            break;
+        case validate_checksums_status::no_checksum:
+            writer.Bool(false);
+        }
+        writer.Key("has_digest");
+        writer.Bool(res.has_digest);
+        switch (res.status) {
+        case validate_checksums_status::valid:
             writer.Key("valid_checksums");
             writer.Bool(true);
             break;
-        case validate_checksums_result::invalid:
-            writer.Bool(true);
+        case validate_checksums_status::invalid:
             writer.Key("valid_checksums");
             writer.Bool(false);
             break;
-        case validate_checksums_result::no_checksum:
-            writer.Bool(false);
-            break;
+        case validate_checksums_status::no_checksum:
         }
         writer.EndObject();
     }


### PR DESCRIPTION
With commits ed7d352e7d and bb1867c7c7, we now have input streams for both compressed and uncompressed SSTables that provide seamless checksum and digest checking. The code for these was based on `validate_checksums()`, which implements its own validation logic over raw streams. This has led to some duplicate code.

This PR deduplicates the uncompressed case by modifying `validate_checksums()` to use a checksummed input stream instead of a raw stream. The same cannot be done for compressed SSTables though. The reason is that `validate_checksums()` needs to examine the whole data file, even if an invalid chunk is encountered. In the checksummed case we support that by offloading the error handling logic from the data source via a function parameter. In the compressed data source we cannot do that because it needs to return decompressed data and decompression may fail if the data are invalid.

This PR also enables `validate_checksums()` to partially verify SSTables with just the per-chunk checksums if the digest is missing. 

In more detail, this PR consists of:
* Port of some integrity checks from `do_validate_uncompressed()` to the checksummed data source. It should now be able to detect corruption due to truncated or appended chunks (expected number of chunks is retrieved from the CRC component).
* Introduction of `error_handler` parameter in checksummed data source and `data_stream()`.
* Refactoring of `validate_checksums()`. The JSON response of `sstable validate-checksums` was also modified to report a missing digest.
*  Tests for `validate_checksums()` against SSTables with truncated data, appended data, invalid digests, or no digest.

Refs #19058.

This PR is a hybrid of cleanup and feature. No backport is needed.