### PR TITLE
[Backport 6.0] mv: skip building view updates on a pending replica

### DIFF
--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -14,6 +14,7 @@
 #include "readers/flat_mutation_reader_v2.hh"
 #include "mutation/frozen_mutation.hh"
 #include "data_dictionary/data_dictionary.hh"
+#include "locator/abstract_replication_strategy.hh"
 
 class frozen_mutation_and_schema;
 
@@ -314,6 +315,10 @@ future<query::clustering_row_ranges> calculate_affected_clustering_ranges(
         const std::vector<view_and_base>& views);
 
 bool needs_static_row(const mutation_partition& mp, const std::vector<view_and_base>& views);
+
+// Whether this node and shard should generate and send view updates for the given token.
+// Checks that the node is one of the replicas (not a pending replicas), and is ready for reads.
+bool should_generate_view_updates_on_this_shard(const schema_ptr& base, const locator::effective_replication_map_ptr& ermp, dht::token token);
 
 size_t memory_usage_of(const frozen_mutation_and_schema& mut);
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -624,6 +624,9 @@ database::setup_metrics() {
 
         sm::make_total_operations("total_view_updates_failed_remote", _cf_stats.total_view_updates_failed_remote,
                 sm::description("Total number of view updates generated for tables and failed to be sent to remote replicas.")),
+
+        sm::make_total_operations("total_view_updates_on_wrong_node", _cf_stats.total_view_updates_on_wrong_node,
+                sm::description("Total number of view updates which are computed on the wrong node.")).set_skip_when_empty(),
     });
     if (this_shard_id() == 0) {
         _metrics.add_group("database", {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -320,6 +320,9 @@ struct cf_stats {
     uint64_t total_view_updates_pushed_remote = 0;
     uint64_t total_view_updates_failed_local = 0;
     uint64_t total_view_updates_failed_remote = 0;
+
+    // How many times we build view updates only to realize it's the wrong node and drop the update
+    uint64_t total_view_updates_on_wrong_node = 0;
 };
 
 class table;

--- a/test/topology_custom/test_mv_topology_change.py
+++ b/test/topology_custom/test_mv_topology_change.py
@@ -7,11 +7,15 @@ import asyncio
 import pytest
 import time
 import logging
+import requests
+import re
 
 from cassandra.cluster import ConnectionException, NoHostAvailable  # type: ignore
 
 from test.pylib.manager_client import ManagerClient
+from test.pylib.tablets import get_tablet_replica
 from test.topology.conftest import skip_mode
+from test.pylib.util import wait_for
 
 
 logger = logging.getLogger(__name__)
@@ -76,6 +80,90 @@ async def test_mv_topology_change(manager: ManagerClient):
 
     stop_event.set()
     await asyncio.gather(*tasks)
+
+# Reproduces #19152
+# Verify a pending replica is not doing unnecessary work of building and sending view updates.
+# 1) we have a table with a materialized view with RF=1.
+#    the base and view tablets start on node 1.
+# 2) start migrating a base-table tablet from node 1 to node 2
+# 3) while node 2 is a pending replica, write to the table
+# 4) complete migration
+# 5) verify node 2 did not build view updates
+# With the parameter intranode=True it's the same except the tablet
+# is migrating between two shards on the same node.
+@pytest.mark.parametrize("intranode", [True, False])
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_mv_update_on_pending_replica(manager: ManagerClient, intranode):
+    cfg = {'enable_tablets': True}
+    cmd = ['--smp', '2']
+    servers = [await manager.server_add(config=cfg, cmdline=cmd)]
+
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+    await cql.run_async("CREATE MATERIALIZED VIEW test.mv1 AS SELECT * FROM test.test WHERE pk IS NOT NULL AND c IS NOT NULL PRIMARY KEY (c, pk);")
+
+    table_id = await manager.get_table_id('test', 'test')
+
+    servers.append(await manager.server_add(config=cfg, cmdline=cmd))
+
+    key = 7 # Whatever
+    tablet_token = 0 # Doesn't matter since there is one tablet
+    await cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({key}, 0)")
+
+    replica = await get_tablet_replica(manager, servers[0], 'test', 'test', tablet_token)
+    s0_host_id = await manager.get_host_id(servers[0].server_id)
+    s1_host_id = await manager.get_host_id(servers[1].server_id)
+    src_shard = replica[1]
+    dst_shard = 1-replica[1]
+    assert replica[0] == s0_host_id
+
+    if intranode:
+        dst_host = s0_host_id
+        dst_ip = servers[0].ip_addr
+        streaming_wait_injection = "intranode_migration_streaming_wait"
+    else:
+        dst_host = s1_host_id
+        dst_ip = servers[1].ip_addr
+        streaming_wait_injection = "stream_mutation_fragments"
+
+    await manager.api.enable_injection(dst_ip, streaming_wait_injection, one_shot=True)
+
+    migration_task = asyncio.create_task(
+        manager.api.move_tablet(servers[0].ip_addr, "test", "test", s0_host_id, src_shard, dst_host, dst_shard, tablet_token))
+
+    async def tablet_is_streaming():
+        res = await cql.run_async(f"SELECT stage FROM system.tablets WHERE table_id={table_id}")
+        stage = res[0].stage
+        return stage == 'streaming' or None
+
+    await wait_for(tablet_is_streaming, time.time() + 60)
+
+    await cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({key}, {1})")
+
+    # Release abandoned streaming
+    await manager.api.message_injection(dst_ip, streaming_wait_injection)
+
+    logger.info("Waiting for migration to finish")
+    await migration_task
+    logger.info("Migration done")
+
+    def get_view_updates_on_wrong_node_count(server):
+        metrics = requests.get(f"http://{server.ip_addr}:9180/metrics").text
+        pattern = re.compile("^scylla_database_total_view_updates_on_wrong_node")
+        for metric in metrics.split('\n'):
+            if pattern.match(metric) is not None:
+                return int(float(metric.split()[1]))
+
+    assert all(map(lambda x: x is None or x == 0, [get_view_updates_on_wrong_node_count(server) for server in servers]))
+
+    res = await cql.run_async(f"SELECT c FROM test.test WHERE pk={key}")
+    assert [1] == [x.c for x in res]
+    res = await cql.run_async(f"SELECT c FROM test.mv1 WHERE pk={key} ALLOW FILTERING")
+    assert [1] == [x.c for x in res]
 
 # Reproduces issue #19529
 # Write to a table with MV while one node is stopped, and verify


### PR DESCRIPTION
Currently, a pending replica that applies a write on a table that has materialized views, will build all the view updates as a normal replica, only to realize at a late point, in db::view::get_view_natural_endpoint(), that it doesn't have a paired view replica to send the updates to. It will then either drop the view updates, or send them to a pending view replica, if such exists.

This work is unnecessary since it may be dropped, and even if there is a pending view replica to send the updates to, the updates that are built by the pending replica may be wrong since it may have incomplete information.

This commit fixes the inefficiency by skipping the view update building step when applying an update on a pending replica.

The metric total_view_updates_on_wrong_node is added to count the cases that a view update is determined to be unnecessary.

The test reproduces the scenario of writing to a table and applying the update on a pending replica, and verifies that the pending replica doesn't try to build view updates.

Fixes scylladb/scylladb#19152

Closes scylladb/scylladb#19488

Fixes scylladb/scylladb#20787

(cherry picked from commit 08b29460fc9578ce3d998d9dd96ea260f1c8dc5f)