### PR TITLE
auth: include boost/regex_fwd.hpp in header 

### DIFF
--- a/auth/certificate_authenticator.cc
+++ b/auth/certificate_authenticator.cc
@@ -9,7 +9,7 @@
 
 #include "auth/certificate_authenticator.hh"
 
-#include <regex>
+#include <boost/regex.hpp>
 #include <fmt/ranges.h>
 
 #include "utils/class_registrator.hh"

--- a/auth/certificate_authenticator.hh
+++ b/auth/certificate_authenticator.hh
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "auth/authenticator.hh"
-#include <boost/regex.hpp>
+#include <boost/regex_fwd.hpp>
 
 namespace cql3 {
 

--- a/auth/certificate_authenticator.hh
+++ b/auth/certificate_authenticator.hh
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "auth/authenticator.hh"
-#include <boost/regex_fwd.hpp>
+#include <boost/regex_fwd.hpp>  // IWYU pragma: keep
 
 namespace cql3 {
 


### PR DESCRIPTION
since we only need the full definition of boost::regex in the .cc
file, where we

- define the constructor and destructor
- and actually use the regex.

there is no need to include boost/regex.hpp in the header, in order
to keep the preprocessed header smaller. let's use a header only
contains forward declarations in header, and include the full
definition in the .cc file.

---

it's a cleanup, hence no need to backport.