### PR TITLE
Fix sstables registry mock

### DIFF
--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -304,7 +304,7 @@ public:
     }
     virtual future<> sstables_registry_list(sstring location, entry_consumer consumer) override {
         for (auto& [loc, e] : _entries) {
-            co_await consumer(loc, e.state, e.desc);
+            co_await consumer(e.status, e.state, e.desc);
         }
     }
 };


### PR DESCRIPTION
There are two issues in it. First, listing the registry with a consumer callback passes wrong argument to the consumer. Second, the primary key of the registry is wrong. Both issues don't show up, because existing tests that use mock don't read from it, only write. Tests that read from registry are python tests that start scylla and thus use real registry.