### PR TITLE
test: test_read_required_hosts: run with the raft-based topology

### DIFF
--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -271,10 +271,6 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
 }
 
 SEASTAR_TEST_CASE(test_read_required_hosts) {
-    // FIXME: the test fails without using force_gossip_topology_changes.
-    // Fix the test and remove force_gossip_topology_changes from config.
-    auto cfg = tablet_cql_test_config();
-    cfg.db_config->force_gossip_topology_changes(true);
     return do_with_cql_env_thread([] (cql_test_env& e) {
         auto h1 = host_id(utils::UUID_gen::get_time_UUID());
         auto h2 = host_id(utils::UUID_gen::get_time_UUID());
@@ -336,7 +332,7 @@ SEASTAR_TEST_CASE(test_read_required_hosts) {
         verify_tablet_metadata_persistence(e, tm, ts);
         BOOST_REQUIRE_EQUAL(std::unordered_set<locator::host_id>({h1, h2, h3}),
                             read_required_hosts(e.local_qp()).get());
-    }, cfg);
+    }, tablet_cql_test_config());
 }
 
 // Check that updating tablet-metadata and reloading only modified parts from


### PR DESCRIPTION
When we made the raft-based topology mandatory, all boost test
tests started using it. Then, `test_read_required_hosts` started
failing. We left investigating it for later and started running it
with `force-gossip-topology-changes` to make it pass.

Currently, the test doesn't fail with the raft-based topology
anymore. Hence, we remove the FIXME and run the test with a normal
config.

We don't know when and why the test stopped failing. Investigating
it wouldn't be easy, since we don't even know why it failed in the
first place. We suspect that there was some bug that is now fixed.

This patch only fixes a test, there is no need to backport it.

Fixes scylladb/scylladb#18463