### PR TITLE
Sanitize compaction manager API endpoints

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -274,8 +274,10 @@ future<> unset_hinted_handoff(http_context& ctx) {
     return ctx.http_server.set_routes([&ctx] (routes& r) { unset_hinted_handoff(ctx, r); });
 }
 
-future<> set_server_compaction_manager(http_context& ctx) {
-    return register_api(ctx, "compaction_manager", "The Compaction manager API", set_compaction_manager);
+future<> set_server_compaction_manager(http_context& ctx, sharded<compaction_manager>& cm) {
+    return register_api(ctx, "compaction_manager", "The Compaction manager API", [&cm] (http_context& ctx, routes& r) {
+        set_compaction_manager(ctx, r, cm);
+    });
 }
 
 future<> unset_server_compaction_manager(http_context& ctx) {

--- a/api/api.cc
+++ b/api/api.cc
@@ -278,6 +278,10 @@ future<> set_server_compaction_manager(http_context& ctx) {
     return register_api(ctx, "compaction_manager", "The Compaction manager API", set_compaction_manager);
 }
 
+future<> unset_server_compaction_manager(http_context& ctx) {
+    return ctx.http_server.set_routes([&ctx] (routes& r) { unset_compaction_manager(ctx, r); });
+}
+
 future<> set_server_done(http_context& ctx) {
     auto rb = std::make_shared < api_registry_builder > (ctx.api_doc);
 

--- a/api/api.cc
+++ b/api/api.cc
@@ -275,13 +275,7 @@ future<> unset_hinted_handoff(http_context& ctx) {
 }
 
 future<> set_server_compaction_manager(http_context& ctx) {
-    auto rb = std::make_shared < api_registry_builder > (ctx.api_doc);
-
-    return ctx.http_server.set_routes([rb, &ctx](routes& r) {
-        rb->register_function(r, "compaction_manager",
-                "The Compaction manager API");
-        set_compaction_manager(ctx, r);
-    });
+    return register_api(ctx, "compaction_manager", "The Compaction manager API", set_compaction_manager);
 }
 
 future<> set_server_done(http_context& ctx) {

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -121,6 +121,7 @@ future<> unset_hinted_handoff(http_context& ctx);
 future<> set_server_cache(http_context& ctx);
 future<> unset_server_cache(http_context& ctx);
 future<> set_server_compaction_manager(http_context& ctx);
+future<> unset_server_compaction_manager(http_context& ctx);
 future<> set_server_done(http_context& ctx);
 future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>& tm, lw_shared_ptr<db::config> cfg);
 future<> unset_server_task_manager(http_context& ctx);

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -17,6 +17,8 @@
 using request = http::request;
 using reply = http::reply;
 
+class compaction_manager;
+
 namespace service {
 
 class load_meter;
@@ -120,7 +122,7 @@ future<> set_hinted_handoff(http_context& ctx, sharded<service::storage_proxy>& 
 future<> unset_hinted_handoff(http_context& ctx);
 future<> set_server_cache(http_context& ctx);
 future<> unset_server_cache(http_context& ctx);
-future<> set_server_compaction_manager(http_context& ctx);
+future<> set_server_compaction_manager(http_context& ctx, sharded<compaction_manager>& cm);
 future<> unset_server_compaction_manager(http_context& ctx);
 future<> set_server_done(http_context& ctx);
 future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>& tm, lw_shared_ptr<db::config> cfg);

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -13,6 +13,7 @@
 #include "compaction/compaction_manager.hh"
 #include "api/api.hh"
 #include "api/api-doc/compaction_manager.json.hh"
+#include "api/api-doc/storage_service.json.hh"
 #include "db/system_keyspace.hh"
 #include "column_family.hh"
 #include "unimplemented.hh"
@@ -23,6 +24,7 @@
 namespace api {
 
 namespace cm = httpd::compaction_manager_json;
+namespace ss = httpd::storage_service_json;
 using namespace json;
 using namespace seastar::httpd;
 
@@ -201,6 +203,18 @@ void set_compaction_manager(http_context& ctx, routes& r) {
         return make_ready_future<json::json_return_type>(res);
     });
 
+    ss::get_compaction_throughput_mb_per_sec.set(r, [&ctx](std::unique_ptr<http::request> req) {
+        int value = ctx.db.local().get_compaction_manager().throughput_mbs();
+        return make_ready_future<json::json_return_type>(value);
+    });
+
+    ss::set_compaction_throughput_mb_per_sec.set(r, [](std::unique_ptr<http::request> req) {
+        //TBD
+        unimplemented();
+        auto value = req->get_query_param("value");
+        return make_ready_future<json::json_return_type>(json_void());
+    });
+
 }
 
 void unset_compaction_manager(http_context& ctx, routes& r) {
@@ -215,6 +229,8 @@ void unset_compaction_manager(http_context& ctx, routes& r) {
     cm::get_bytes_compacted.unset(r);
     cm::get_compaction_history.unset(r);
     cm::get_compaction_info.unset(r);
+    ss::get_compaction_throughput_mb_per_sec.unset(r);
+    ss::set_compaction_throughput_mb_per_sec.unset(r);
 }
 
 }

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -46,7 +46,7 @@ static std::unordered_map<std::pair<sstring, sstring>, uint64_t, utils::tuple_ha
     return std::move(a);
 }
 
-void set_compaction_manager(http_context& ctx, routes& r) {
+void set_compaction_manager(http_context& ctx, routes& r, sharded<compaction_manager>& cm) {
     cm::get_compactions.set(r, [&ctx] (std::unique_ptr<http::request> req) {
         return ctx.db.map_reduce0([](replica::database& db) {
             std::vector<cm::summary> summaries;

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -47,10 +47,9 @@ static std::unordered_map<std::pair<sstring, sstring>, uint64_t, utils::tuple_ha
 }
 
 void set_compaction_manager(http_context& ctx, routes& r, sharded<compaction_manager>& cm) {
-    cm::get_compactions.set(r, [&ctx] (std::unique_ptr<http::request> req) {
-        return ctx.db.map_reduce0([](replica::database& db) {
+    cm::get_compactions.set(r, [&cm] (std::unique_ptr<http::request> req) {
+        return cm.map_reduce0([](compaction_manager& cm) {
             std::vector<cm::summary> summaries;
-            const compaction_manager& cm = db.get_compaction_manager();
 
             for (const auto& c : cm.get_compactions()) {
                 cm::summary s;
@@ -102,10 +101,9 @@ void set_compaction_manager(http_context& ctx, routes& r, sharded<compaction_man
         return make_ready_future<json::json_return_type>(json_void());
     });
 
-    cm::stop_compaction.set(r, [&ctx] (std::unique_ptr<http::request> req) {
+    cm::stop_compaction.set(r, [&cm] (std::unique_ptr<http::request> req) {
         auto type = req->get_query_param("type");
-        return ctx.db.invoke_on_all([type] (replica::database& db) {
-            auto& cm = db.get_compaction_manager();
+        return cm.invoke_on_all([type] (compaction_manager& cm) {
             return cm.stop_compaction(type);
         }).then([] {
             return make_ready_future<json::json_return_type>(json_void());
@@ -155,14 +153,14 @@ void set_compaction_manager(http_context& ctx, routes& r, sharded<compaction_man
         return make_ready_future<json::json_return_type>(0);
     });
 
-    cm::get_compaction_history.set(r, [&ctx] (std::unique_ptr<http::request> req) {
-        std::function<future<>(output_stream<char>&&)> f = [&ctx] (output_stream<char>&& out) -> future<> {
+    cm::get_compaction_history.set(r, [&cm] (std::unique_ptr<http::request> req) {
+        std::function<future<>(output_stream<char>&&)> f = [&cm] (output_stream<char>&& out) -> future<> {
             auto s = std::move(out);
             bool first = true;
             std::exception_ptr ex;
             try {
                 co_await s.write("[");
-                co_await ctx.db.local().get_compaction_manager().get_compaction_history([&s, &first](const db::compaction_history_entry& entry) mutable -> future<> {
+                co_await cm.local().get_compaction_history([&s, &first](const db::compaction_history_entry& entry) mutable -> future<> {
                         cm::history h;
                         h.id = fmt::to_string(entry.id);
                         h.ks = std::move(entry.ks);
@@ -203,8 +201,8 @@ void set_compaction_manager(http_context& ctx, routes& r, sharded<compaction_man
         return make_ready_future<json::json_return_type>(res);
     });
 
-    ss::get_compaction_throughput_mb_per_sec.set(r, [&ctx](std::unique_ptr<http::request> req) {
-        int value = ctx.db.local().get_compaction_manager().throughput_mbs();
+    ss::get_compaction_throughput_mb_per_sec.set(r, [&cm](std::unique_ptr<http::request> req) {
+        int value = cm.local().throughput_mbs();
         return make_ready_future<json::json_return_type>(value);
     });
 

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -203,5 +203,19 @@ void set_compaction_manager(http_context& ctx, routes& r) {
 
 }
 
+void unset_compaction_manager(http_context& ctx, routes& r) {
+    cm::get_compactions.unset(r);
+    cm::get_pending_tasks_by_table.unset(r);
+    cm::force_user_defined_compaction.unset(r);
+    cm::stop_compaction.unset(r);
+    cm::stop_keyspace_compaction.unset(r);
+    cm::get_pending_tasks.unset(r);
+    cm::get_completed_tasks.unset(r);
+    cm::get_total_compactions_completed.unset(r);
+    cm::get_bytes_compacted.unset(r);
+    cm::get_compaction_history.unset(r);
+    cm::get_compaction_info.unset(r);
+}
+
 }
 

--- a/api/compaction_manager.hh
+++ b/api/compaction_manager.hh
@@ -15,5 +15,6 @@ class routes;
 namespace api {
 struct http_context;
 void set_compaction_manager(http_context& ctx, seastar::httpd::routes& r);
+void unset_compaction_manager(http_context& ctx, seastar::httpd::routes& r);
 
 }

--- a/api/compaction_manager.hh
+++ b/api/compaction_manager.hh
@@ -7,14 +7,17 @@
  */
 
 #pragma once
+#include <seastar/core/sharded.hh>
 
 namespace seastar::httpd {
 class routes;
 }
 
+class compaction_manager;
+
 namespace api {
 struct http_context;
-void set_compaction_manager(http_context& ctx, seastar::httpd::routes& r);
+void set_compaction_manager(http_context& ctx, seastar::httpd::routes& r, seastar::sharded<compaction_manager>& cm);
 void unset_compaction_manager(http_context& ctx, seastar::httpd::routes& r);
 
 }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1062,18 +1062,6 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         return make_ready_future<json::json_return_type>(0);
     });
 
-    ss::get_compaction_throughput_mb_per_sec.set(r, [&ctx](std::unique_ptr<http::request> req) {
-        int value = ctx.db.local().get_compaction_manager().throughput_mbs();
-        return make_ready_future<json::json_return_type>(value);
-    });
-
-    ss::set_compaction_throughput_mb_per_sec.set(r, [](std::unique_ptr<http::request> req) {
-        //TBD
-        unimplemented();
-        auto value = req->get_query_param("value");
-        return make_ready_future<json::json_return_type>(json_void());
-    });
-
     ss::is_incremental_backups_enabled.set(r, [&ctx](std::unique_ptr<http::request> req) {
         // If this is issued in parallel with an ongoing change, we may see values not agreeing.
         // Reissuing is asking for trouble, so we will just return true upon seeing any true value.
@@ -1615,8 +1603,6 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::is_joined.unset(r);
     ss::set_stream_throughput_mb_per_sec.unset(r);
     ss::get_stream_throughput_mb_per_sec.unset(r);
-    ss::get_compaction_throughput_mb_per_sec.unset(r);
-    ss::set_compaction_throughput_mb_per_sec.unset(r);
     ss::is_incremental_backups_enabled.unset(r);
     ss::set_incremental_backups_enabled.unset(r);
     ss::rebuild.unset(r);

--- a/main.cc
+++ b/main.cc
@@ -1616,6 +1616,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             // making compaction manager api available, after system keyspace has already been established.
             api::set_server_compaction_manager(ctx).get();
+            auto stop_cm_api = defer_verbose_shutdown("compaction manager API", [&ctx] {
+                api::unset_server_compaction_manager(ctx).get();
+            });
 
             cm.invoke_on_all([&](compaction_manager& cm) {
                 auto cl = db.local().commitlog();

--- a/main.cc
+++ b/main.cc
@@ -1615,7 +1615,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             db::schema_tables::recalculate_schema_version(sys_ks, proxy, feature_service.local()).get();
 
             // making compaction manager api available, after system keyspace has already been established.
-            api::set_server_compaction_manager(ctx).get();
+            api::set_server_compaction_manager(ctx, cm).get();
             auto stop_cm_api = defer_verbose_shutdown("compaction manager API", [&ctx] {
                 api::unset_server_compaction_manager(ctx).get();
             });


### PR DESCRIPTION
Endpoints are registered next to the service they use, and the unregistration deferred action is created right after it. When registered, the service in question is passed as argument and then captured by enpoints lambdas. This makes sure that service is not used by endpoints after being stopped.

That's not quite the case for compaction manager. Its endpoints can be registered in several places, and compaction_manager "function" is not unregistered on stop. This patch fixes some of this misbehavior, in particular:
- adds unregistration of compaction_manager API function
- uses sharded<compaction_manager>& argument in endpoints instead of ctx.db.local().get_compaction_manager() chain
- moves some endpoints from storage_service.cc to compaction_manager.cc