### PR TITLE
db: remove unused includes 

### DIFF
--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -9,7 +9,7 @@ env:
   BUILD_TYPE: RelWithDebInfo
   BUILD_DIR: build
   CLEANER_OUTPUT_PATH: build/clang-include-cleaner.log
-  CLEANER_DIRS: test/unit exceptions alternator api auth cdc compaction
+  CLEANER_DIRS: test/unit exceptions alternator api auth cdc compaction db
 
 permissions: {}
 

--- a/db/batchlog_manager.hh
+++ b/db/batchlog_manager.hh
@@ -11,9 +11,7 @@
 #pragma once
 
 #include <seastar/core/future.hh>
-#include <seastar/core/shared_future.hh>
-#include <seastar/core/distributed.hh>
-#include <seastar/core/timer.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/abort_source.hh>

--- a/db/chained_delegating_reader.hh
+++ b/db/chained_delegating_reader.hh
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <seastar/core/shared_future.hh>
-
 #include "readers/mutation_reader.hh"
 
 // A reader which allows to insert a deferring operation before reading.

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -12,9 +12,7 @@
 #include <memory>
 
 #include <seastar/core/future.hh>
-#include <seastar/core/shared_ptr.hh>
-#include <seastar/core/stream.hh>
-#include <seastar/core/file.hh>
+#include <seastar/core/simple-stream.hh>
 #include "replay_position.hh"
 #include "commitlog_entry.hh"
 #include "db/timeout_clock.hh"

--- a/db/commitlog/commitlog_extensions.hh
+++ b/db/commitlog/commitlog_extensions.hh
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <tuple>
-#include <optional>
 #include <seastar/core/seastar.hh>
 
 namespace db {

--- a/db/commitlog/replay_position.hh
+++ b/db/commitlog/replay_position.hh
@@ -10,11 +10,10 @@
 #pragma once
 
 #include <stdint.h>
-#include <seastar/core/shared_ptr.hh>
 #include "schema/schema_fwd.hh"
 #include "utils/hash.hh"
 #include "sstables/version.hh"
-
+#include "seastarx.hh"
 
 namespace db {
 

--- a/db/config.hh
+++ b/db/config.hh
@@ -9,11 +9,10 @@
 
 #pragma once
 
-#include <boost/program_options.hpp>
+#include <boost/program_options/options_description.hpp>
 #include <unordered_map>
 
 #include <seastar/core/sstring.hh>
-#include <seastar/core/shared_ptr.hh>
 #include <seastar/util/program-options.hh>
 #include <seastar/util/log.hh>
 
@@ -21,7 +20,6 @@
 #include "seastarx.hh"
 #include "utils/config_file.hh"
 #include "utils/enum_option.hh"
-#include "locator/host_id.hh"
 #include "gms/inet_address.hh"
 #include "db/hints/host_filter.hh"
 #include "utils/updateable_value.hh"

--- a/db/consistency_level.hh
+++ b/db/consistency_level.hh
@@ -12,15 +12,10 @@
 
 #include "db/consistency_level_type.hh"
 #include "db/read_repair_decision.hh"
-#include "exceptions/exceptions.hh"
 #include "gms/inet_address.hh"
 #include "inet_address_vectors.hh"
 #include "log.hh"
 #include "replica/database_fwd.hh"
-
-#include <iosfwd>
-#include <vector>
-#include <unordered_set>
 
 namespace gms {
 class gossiper;

--- a/db/cql_type_parser.hh
+++ b/db/cql_type_parser.hh
@@ -11,7 +11,6 @@
 
 #include <vector>
 #include <seastar/core/sstring.hh>
-#include <seastar/core/shared_ptr.hh>
 
 #include "types/types.hh"
 

--- a/db/data_listeners.hh
+++ b/db/data_listeners.hh
@@ -9,8 +9,7 @@
 #pragma once
 
 #include <seastar/core/distributed.hh>
-#include <seastar/core/future.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/future.hh>  // IWYU pragma: keep
 #include <seastar/core/weak_ptr.hh>
 
 #include "utils/hash.hh"
@@ -19,7 +18,6 @@
 #include "utils/top_k.hh"
 #include "schema/schema_registry.hh"
 
-#include <vector>
 #include <set>
 
 class frozen_mutation;

--- a/db/extensions.hh
+++ b/db/extensions.hh
@@ -19,7 +19,7 @@
 
 #include <seastar/core/sstring.hh>
 
-#include "bytes.hh"
+#include "bytes_fwd.hh"
 #include "schema/schema_fwd.hh"
 
 namespace sstables {

--- a/db/functions/aggregate_function.hh
+++ b/db/functions/aggregate_function.hh
@@ -12,7 +12,6 @@
 
 #include "function.hh"
 #include "stateless_aggregate_function.hh"
-#include <optional>
 
 namespace db {
 namespace functions {

--- a/db/functions/scalar_function.hh
+++ b/db/functions/scalar_function.hh
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "bytes.hh"
+#include "bytes_fwd.hh"
 #include "function.hh"
 #include <span>
 

--- a/db/heat_load_balance.hh
+++ b/db/heat_load_balance.hh
@@ -30,7 +30,7 @@
 #include "utils/assert.hh"
 #include <vector>
 #include <cassert>
-#include <fmt/ranges.h>
+#include <fmt/ranges.h>  // IWYU pragma: keep
 #include <boost/range/adaptor/map.hpp>
 #include "log.hh"
 

--- a/db/hints/internal/hint_endpoint_manager.hh
+++ b/db/hints/internal/hint_endpoint_manager.hh
@@ -13,7 +13,6 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/shared_mutex.hh>
 #include <seastar/core/shared_ptr.hh>
-#include <seastar/core/smp.hh>
 #include <seastar/util/noncopyable_function.hh>
 
 // Scylla includes.
@@ -22,15 +21,11 @@
 #include "db/hints/internal/hint_sender.hh"
 #include "db/hints/internal/hint_storage.hh"
 #include "db/hints/resource_manager.hh"
-#include "utils/runtime.hh"
 #include "enum_set.hh"
 
 // STD.
 #include <cassert>
-#include <chrono>
 #include <filesystem>
-#include <memory>
-#include <unordered_map>
 
 namespace db::hints {
 

--- a/db/hints/internal/hint_sender.hh
+++ b/db/hints/internal/hint_sender.hh
@@ -22,7 +22,6 @@
 #include "db/commitlog/replay_position.hh"
 #include "db/hints/internal/common.hh"
 #include "db/hints/internal/hint_storage.hh"
-#include "gms/inet_address.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "mutation/frozen_mutation.hh"
 #include "schema/schema.hh"

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -13,10 +13,8 @@
 #include "utils/assert.hh"
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_mutex.hh>
-#include <seastar/core/timer.hh>
 #include <seastar/util/noncopyable_function.hh>
 
 // Scylla includes.

--- a/db/hints/resource_manager.hh
+++ b/db/hints/resource_manager.hh
@@ -12,8 +12,6 @@
 #include <filesystem>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/semaphore.hh>
-#include <seastar/core/gate.hh>
-#include <seastar/core/memory.hh>
 #include <seastar/core/future.hh>
 #include "seastarx.hh"
 #include <unordered_set>

--- a/db/rate_limiter.hh
+++ b/db/rate_limiter.hh
@@ -11,13 +11,8 @@
 #include <cstdint>
 #include <cstddef>
 #include <chrono>
-#include <limits>
-#include <concepts>
 #include <vector>
-#include <optional>
-#include <random>
 
-#include <seastar/core/future.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/metrics_registration.hh>

--- a/db/system_keyspace_view_types.hh
+++ b/db/system_keyspace_view_types.hh
@@ -8,9 +8,7 @@
 
 #pragma once
 
-#include <seastar/core/seastar.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/core/smp.hh>
 #include <utility>
 #include <optional>
 #include "dht/token.hh"

--- a/db/tags/utils.hh
+++ b/db/tags/utils.hh
@@ -16,7 +16,6 @@
 #include "seastarx.hh"
 
 #include "schema/schema.hh"
-#include "service/client_state.hh"
 #include "service/migration_manager.hh"
 
 namespace db {

--- a/db/view/build_progress_virtual_reader.hh
+++ b/db/view/build_progress_virtual_reader.hh
@@ -15,8 +15,6 @@
 #include "query-request.hh"
 #include "schema/schema_fwd.hh"
 
-#include <boost/range/iterator_range.hpp>
-
 #include <iterator>
 #include <memory>
 

--- a/db/view/node_view_update_backlog.hh
+++ b/db/view/node_view_update_backlog.hh
@@ -18,7 +18,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <new>
 
 namespace db::view {
 

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -17,7 +17,6 @@
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
-#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_future.hh>

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -10,9 +10,9 @@
 
 #include "sstables/shared_sstable.hh"
 #include "db/timeout_clock.hh"
-#include "db_clock.hh"
 #include "utils/chunked_vector.hh"
 #include "schema/schema_fwd.hh"
+#include "gc_clock.hh"
 
 #include <seastar/core/sharded.hh>
 #include <seastar/core/metrics_registration.hh>

--- a/utils/hashers.hh
+++ b/utils/hashers.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <memory>
 #include "bytes.hh"
 #include "utils/hashing.hh"
 

--- a/utils/i_filter.hh
+++ b/utils/i_filter.hh
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "bytes.hh"
+#include <memory>
 
 namespace utils {
 


### PR DESCRIPTION
these unused includes are identified by clang-include-cleaner.
after auditing the source files, all of the reports have been
confirmed.

please note, since we have `using seastar::shared_ptr` in
`seastarx.h`, this renders `#include <seastar/core/shared_ptr.hh>`
unnecessary if we don't need the full definition of `seastar::shared_ptr`.

so, in this change, all the unused includes are removed.

---

it's a cleanup, hence no need to backport.