### PR TITLE
utils/rjson.cc: correct a comment about assert()

### DIFF
--- a/utils/rjson.hh
+++ b/utils/rjson.hh
@@ -29,7 +29,6 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
-#include "utils/assert.hh"
 #include "utils/base64.hh"
 
 #include <seastar/core/future.hh>
@@ -51,12 +50,12 @@ public:
 
 // rapidjson configuration macros
 #define RAPIDJSON_HAS_STDSTRING 1
-// Default rjson policy is to use SCYLLA_ASSERT() - which is dangerous for two reasons:
-// 1. SCYLLA_ASSERT() can be turned off with -DNDEBUG
-// 2. SCYLLA_ASSERT() crashes a program
+// Default rjson policy is to use assert() - which is dangerous for two reasons:
+// 1. assert() can be turned off with -DNDEBUG
+// 2. assert() crashes a program
 // Fortunately, the default policy can be overridden, and so rapidjson errors will
 // throw an rjson::error exception instead.
-#define RAPIDJSON_ASSERT(x) do { if (!(x)) throw rjson::error(fmt::format("JSON SCYLLA_ASSERT failed on condition '{}', at: {}", #x, current_backtrace_tasklocal())); } while (0)
+#define RAPIDJSON_ASSERT(x) do { if (!(x)) throw rjson::error(fmt::format("JSON assert failed on condition '{}', at: {}", #x, current_backtrace_tasklocal())); } while (0)
 // This macro is used for functions which are called for every json char making it
 // quite costly if not inlined, by default rapidjson only enables it if NDEBUG
 // is defined which isn't the case for us.


### PR DESCRIPTION
Commit aa1270a00c40af8dddb71b8b8d80d10957d92798 changed most uses of `assert` in the codebase to `SCYLLA_ASSERT`.

But the comment fixed in this patch is talking specifically about `assert`, and shouldn't have been changed. It doesn't make sense after the change.

Should be backported to 6.2, because why not.