### PR TITLE
sstable_loader: Remove unused _snapshot_name from download_task_impl

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -456,7 +456,6 @@ class sstables_loader::download_task_impl : public tasks::task_manager::task::im
     sstring _cf;
     sstring _prefix;
     std::vector<sstring> _sstables;
-    sstring _snapshot_name;
 
 protected:
     virtual future<> run() override;


### PR DESCRIPTION
in 787ea4b1, we introduced `_prefix` and `_sstables` member  variables to `sstables_loader::download_task_impl`, replacing the functionality of `_snapshot_name`. However, we overlooked removing the now-obsolete `_snapshot_name` variable.

this commit removes the unused `_snapshot_name` member variable to improve code cleanliness and prevent potential confusion.

---

it's a cleanup of a recently introduced feature, hence no need to backport.