### PR TITLE
utils: i_filter: include <memory>

### DIFF
--- a/utils/i_filter.hh
+++ b/utils/i_filter.hh
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "bytes.hh"
+#include <memory>
 
 namespace utils {
 


### PR DESCRIPTION
i_filter uses std::unique_ptr, so include its header.

---
Small header cleanliness improvement, no backport.