### PR TITLE
utils: hashers: include <memory>

### DIFF
--- a/utils/hashers.hh
+++ b/utils/hashers.hh
@@ -10,6 +10,7 @@
 
 #include "bytes.hh"
 #include "utils/hashing.hh"
+#include <memory>
 
 template<typename H>
 concept HasherReturningBytes = HasherReturning<H, bytes>;


### PR DESCRIPTION
hashers.hh uses std::unique_ptr, so include its header.

---
Small header cleanliness improvement, no backport.