### PR TITLE
storage_proxy: make sure there is no end iterator in _live_iterators …

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1726,10 +1726,16 @@ public:
         // handler is being removed from the b::list, so if any live iterator points at it,
         // move it to the next object (this requires that the list is traversed in the forward
         // direction).
+        bool drop_end = false;
         for (auto& itp : _live_iterators) {
             if (&**itp == handler) {
                 ++*itp;
+                drop_end |= (*itp == end());
             }
+        }
+        if (drop_end) {
+            const auto [first, last] = std::ranges::remove_if(_live_iterators, [this] (iterator* pit) { return *pit == end(); });
+            _live_iterators.erase(first, last);
         }
     }
     class iterator_guard {
@@ -6780,7 +6786,7 @@ void storage_proxy::cancel_write_handlers(noncopyable_function<bool(const abstra
             it->timeout_cb();
         }
         ++it;
-        if (need_preempt()) {
+        if (need_preempt() && it != _cancellable_write_handlers_list->end()) {
             cancellable_write_handlers_list::iterator_guard ig{*_cancellable_write_handlers_list, it};
             seastar::thread::yield();
         }


### PR DESCRIPTION
…array

storage_proxy::cancellable_write_handlers_list::update_live_iterators assumes that iterators in _live_iterators can be dereferenced, but the code does not make any attempt to make sure this is the case. The iterator can be the end iterator which cannot be dereferenced.

The patch makes sure that there is no end iterator in _live_iterators.

Fixes scylladb/scylladb#20874

Backport because without the patch there is a UB in the code. Looks benign but UBSan complain and makes CI flaky.