### PR TITLE
replica/table: check memtable before discarding tombstone during read

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -78,6 +78,15 @@ private:
     // An input SSTable remains linked if it wasn't actually compacted, yet compaction manager wants
     // it to be moved from its original sstable set (e.g. maintenance) into a new one (e.g. main).
     future<> delete_unused_sstables(sstables::compaction_completion_desc desc);
+    // Tracks the maximum timestamp observed across all SSTables in this group.
+    // This is used by the compacting reader to determine if a memtable contains entries
+    // with timestamps that overlap with those in the SSTables of the compaction group.
+    // For this purpose, tracking the maximum seen timestamp is sufficient rather than the
+    // actual maximum across all SSTables. So, the variable is updated only when a new SSTable
+    // is added to the group. While `set_main_sstables` and `set_maintenance_sstables` can
+    // replace entire sstable sets, they are still called only by compaction, so the maximum
+    // seen timestamp remains the same and there is no need to update the variable in those cases.
+    api::timestamp_type _max_seen_timestamp = api::missing_timestamp;
 public:
     compaction_group(table& t, size_t gid, dht::token_range token_range);
     ~compaction_group();
@@ -139,6 +148,7 @@ public:
     void add_sstable(sstables::shared_sstable sstable);
     // Add sstable to maintenance set
     void add_maintenance_sstable(sstables::shared_sstable sst);
+    api::timestamp_type max_seen_timestamp() const { return _max_seen_timestamp; }
 
     // Update main sstable set based on info in completion descriptor, where input sstables
     // will be replaced by output ones, row cache ranges are possibly invalidated and

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -672,6 +672,7 @@ private:
     // Compound sstable set must be refreshed whenever any of its managed sets are changed
     void refresh_compound_sstable_set();
 
+    max_purgeable_fn get_max_purgeable_fn_for_cache_underlying_reader() const;
     snapshot_source sstables_as_snapshot_source();
     partition_presence_checker make_partition_presence_checker(lw_shared_ptr<const sstables::sstable_set>);
     std::chrono::steady_clock::time_point _sstable_writes_disabled_at;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -542,6 +542,7 @@ compaction_group::do_add_sstable(lw_shared_ptr<sstables::sstable_set> sstables, 
     if (backlog_tracker) {
         table::add_sstable_to_backlog_tracker(get_backlog_tracker(), sstable);
     }
+    _max_seen_timestamp = std::max(_max_seen_timestamp, sstable->get_stats_metadata().max_timestamp);
     return new_sstables;
 }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2531,6 +2531,32 @@ table::make_partition_presence_checker(lw_shared_ptr<const sstables::sstable_set
     };
 }
 
+max_purgeable_fn table::get_max_purgeable_fn_for_cache_underlying_reader() const {
+    return [this](const dht::decorated_key& dk, ::is_shadowable is_shadowable) {
+        auto& sg = storage_group_for_token(dk.token());
+        auto max_purgeable_timestamp = api::max_timestamp;
+
+        sg.for_each_compaction_group([&dk, is_shadowable, &max_purgeable_timestamp] (const compaction_group_ptr& cg) {
+            const auto& mt = cg->memtables()->active_memtable();
+            // see get_max_purgeable_timestamp() in compaction.cc for comments on choosing min timestamp
+            api::timestamp_type memtable_min_timestamp = is_shadowable ? mt.get_min_live_row_marker_timestamp() : mt.get_min_live_timestamp();
+            if (memtable_min_timestamp > cg->max_seen_timestamp()) {
+                // All the entries in the memtable are newer than the entries in the
+                // SSTable within this compaction group. So, no need to check further.
+                return;
+            }
+
+            // If a memtable with a minimum timestamp lower than the current maximum
+            // purgeable timestamp has the given key, the tombstone should not be purged.
+            if (memtable_min_timestamp < max_purgeable_timestamp && mt.contains_partition(dk)) {
+                max_purgeable_timestamp = memtable_min_timestamp;
+            }
+        });
+
+        return max_purgeable_timestamp;
+    };
+}
+
 snapshot_source
 table::sstables_as_snapshot_source() {
     return snapshot_source([this] () {
@@ -2546,7 +2572,7 @@ table::sstables_as_snapshot_source() {
             return make_compacting_reader(
                 std::move(reader),
                 gc_clock::now(),
-                can_always_purge,
+                get_max_purgeable_fn_for_cache_underlying_reader(),
                 _compaction_manager.get_tombstone_gc_state(),
                 fwd);
         }, [this, sst_set] {

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -307,6 +307,10 @@ class ScyllaRESTAPIClient():
         """Flush keyspace"""
         await self.client.post(f"/storage_service/keyspace_flush/{ks}", host=node_ip)
 
+    async def flush_all_keyspaces(self, node_ip: str) -> None:
+        """Flush all keyspaces"""
+        await self.client.post(f"/storage_service/flush", host=node_ip)
+
     async def backup(self, node_ip: str, ks: str, table: str, tag: str, dest: str, bucket: str, prefix: str) -> str:
         """Backup keyspace's snapshot"""
         params = {"keyspace": ks,

--- a/test/topology_custom/test_compacting_reader_tombstone_gc.py
+++ b/test/topology_custom/test_compacting_reader_tombstone_gc.py
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from test.pylib.manager_client import ManagerClient
+
+import pytest
+import asyncio
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+# Reproducer for https://github.com/scylladb/scylladb/issues/20916.
+@pytest.mark.asyncio
+async def test_compacting_reader_tombstone_gc_with_data_in_memtable(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    cmdline = [
+        '--logger-log-level', 'table=debug',
+        '--logger-log-level', 'mutation_compactor=debug',
+    ]
+    servers = [await manager.server_add(cmdline=cmdline)]
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int) WITH gc_grace_seconds = 0;")
+
+    await manager.api.disable_autocompaction(servers[0].ip_addr, "test")
+
+    key = 7 # Whatever
+
+    # Simulates scenario where node missed tombstone and has it written to sstable directly
+    # after repair, whereas the deleted data remains on memtable due to low write activity.
+
+    # write a expiring tombstone into a sstable (flushed below)
+    await cql.run_async(f'DELETE FROM test.test USING timestamp 10 WHERE pk = {key}')
+
+    # waits for tombstone to expire
+    time.sleep(1)
+
+    # system-wide flush to prevent CL segment from blocking tombstone GC in the read path.
+    await manager.api.flush_all_keyspaces(servers[0].ip_addr)
+
+    # write into memtable data shadowed by the tombstone now living in the sstable
+    await cql.run_async(f'INSERT INTO test.test (pk, c) VALUES ({key}, 0) USING timestamp 9')
+
+    await manager.api.drop_sstable_caches(servers[0].ip_addr)
+
+    # Without cache, the compacting reader is bypassed; Verify that the data in memtable is discarded
+    bypass_cache_rows = cql.execute(f'SELECT pk, c FROM test.test WHERE pk = {key} BYPASS CACHE;')
+    assert len(list(bypass_cache_rows)) == 0
+
+    # With the cache, the compacting reader is involved;
+    # Verify that the tombstone is not purged, allowing it to shadow the data in memtable
+    through_cache_rows = cql.execute(f'SELECT pk, c FROM test.test WHERE pk = {key};')
+    assert len(list(through_cache_rows)) == 0


### PR DESCRIPTION
On the read path, the compacting reader is applied only to the sstable
reader. This can cause an expired tombstone from an sstable to be purged
from the request before it has a chance to merge with deleted data in
the memtable leading to data resurrection.

Fix this by checking the memtables before deciding to purge tombstones
from the request on the read path. A tombstone will not be purged if a
key exists in any of the table's memtables with a minimum live timestamp
that is lower than the maximum purgeable timestamp.

Fixes #20916

`perf-simple-query` stats before and after this fix :

`build/Dev/scylla perf-simple-query --smp=1 --flush` :
```
// Before this Fix
// ---------------
94941.79 tps ( 71.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   59393 insns/op,   24029 cycles/op,        0 errors)
97551.14 tps ( 71.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   59376 insns/op,   23966 cycles/op,        0 errors)
96599.92 tps ( 71.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   59367 insns/op,   23998 cycles/op,        0 errors)
97774.91 tps ( 71.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   59370 insns/op,   23968 cycles/op,        0 errors)
97796.13 tps ( 71.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   59368 insns/op,   23947 cycles/op,        0 errors)

         throughput: mean=96932.78 standard-deviation=1215.71 median=97551.14 median-absolute-deviation=842.13 maximum=97796.13 minimum=94941.79
instructions_per_op: mean=59374.78 standard-deviation=10.78 median=59369.59 median-absolute-deviation=6.36 maximum=59393.12 minimum=59367.02
  cpu_cycles_per_op: mean=23981.67 standard-deviation=32.29 median=23967.76 median-absolute-deviation=16.33 maximum=24029.38 minimum=23947.19

// After this Fix
// --------------
95313.53 tps ( 71.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   59392 insns/op,   24058 cycles/op,        0 errors)
97311.48 tps ( 71.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   59375 insns/op,   24005 cycles/op,        0 errors)
98043.10 tps ( 71.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   59381 insns/op,   23941 cycles/op,        0 errors)
96750.31 tps ( 71.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   59396 insns/op,   24025 cycles/op,        0 errors)
93381.21 tps ( 71.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   59390 insns/op,   24097 cycles/op,        0 errors)

         throughput: mean=96159.93 standard-deviation=1847.88 median=96750.31 median-absolute-deviation=1151.55 maximum=98043.10 minimum=93381.21
instructions_per_op: mean=59386.60 standard-deviation=8.78 median=59389.55 median-absolute-deviation=6.02 maximum=59396.40 minimum=59374.73
  cpu_cycles_per_op: mean=24025.13 standard-deviation=58.39 median=24025.17 median-absolute-deviation=32.67 maximum=24096.66 minimum=23941.22
```

This PR fixes a regression introduced in ce96b472d3 and should be backported to older versions.