### PR TITLE
utils: unconst: wean away from boost range library

### DIFF
--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -9,7 +9,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
-#include <boost/range/adaptor/reversed.hpp>
 #include "mutation_partition.hh"
 #include "clustering_interval_set.hh"
 #include "converting_mutation_partition_applier.hh"
@@ -607,13 +606,13 @@ mutation_partition::upper_bound(const schema& schema, const query::clustering_ra
     return _rows.lower_bound(position_in_partition_view::for_range_end(r), rows_entry::tri_compare(schema));
 }
 
-boost::iterator_range<mutation_partition::rows_type::const_iterator>
+std::ranges::subrange<mutation_partition::rows_type::const_iterator>
 mutation_partition::range(const schema& schema, const query::clustering_range& r) const {
     check_schema(schema);
-    return boost::make_iterator_range(lower_bound(schema, r), upper_bound(schema, r));
+    return std::ranges::subrange(lower_bound(schema, r), upper_bound(schema, r));
 }
 
-boost::iterator_range<mutation_partition::rows_type::iterator>
+std::ranges::subrange<mutation_partition::rows_type::iterator>
 mutation_partition::range(const schema& schema, const query::clustering_range& r) {
     return unconst(_rows, static_cast<const mutation_partition*>(this)->range(schema, r));
 }
@@ -640,7 +639,7 @@ void mutation_partition::for_each_row(const schema& schema, const query::cluster
             }
         }
     } else {
-        for (const auto& e : r | boost::adaptors::reversed) {
+        for (const auto& e : r | std::views::reverse) {
             if (func(e) == stop_iteration::yes) {
                 break;
             }

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -10,12 +10,13 @@
 
 #include <iosfwd>
 #include <boost/intrusive/set.hpp>
-#include <boost/range/iterator_range.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/intrusive/parent_from_member.hpp>
 
 #include <seastar/core/bitset-iter.hh>
 #include <seastar/util/optimized_optional.hh>
+
+#include <ranges>
 
 #include "schema/schema_fwd.hh"
 #include "tombstone.hh"
@@ -1451,12 +1452,12 @@ public:
     row_tombstone tombstone_for_row(const schema& schema, const clustering_key& key) const;
     // Can be called only for non-dummy entries
     row_tombstone tombstone_for_row(const schema& schema, const rows_entry& e) const;
-    boost::iterator_range<rows_type::const_iterator> range(const schema& schema, const query::clustering_range& r) const;
+    std::ranges::subrange<rows_type::const_iterator> range(const schema& schema, const query::clustering_range& r) const;
     rows_type::const_iterator lower_bound(const schema& schema, const query::clustering_range& r) const;
     rows_type::const_iterator upper_bound(const schema& schema, const query::clustering_range& r) const;
     rows_type::iterator lower_bound(const schema& schema, const query::clustering_range& r);
     rows_type::iterator upper_bound(const schema& schema, const query::clustering_range& r);
-    boost::iterator_range<rows_type::iterator> range(const schema& schema, const query::clustering_range& r);
+    std::ranges::subrange<rows_type::iterator> range(const schema& schema, const query::clustering_range& r);
     // Returns an iterator range of rows_entry, with only non-dummy entries.
     auto non_dummy_rows() const {
         return boost::make_iterator_range(_rows.begin(), _rows.end())

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -9,7 +9,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
-#include <boost/range/adaptor/reversed.hpp>
 #include "mutation_partition_v2.hh"
 #include "clustering_interval_set.hh"
 #include "converting_mutation_partition_applier.hh"
@@ -715,13 +714,13 @@ mutation_partition_v2::upper_bound(const schema& schema, const query::clustering
     return _rows.lower_bound(position_in_partition_view::for_range_end(r), rows_entry::tri_compare(schema));
 }
 
-boost::iterator_range<mutation_partition_v2::rows_type::const_iterator>
+std::ranges::subrange<mutation_partition_v2::rows_type::const_iterator>
 mutation_partition_v2::range(const schema& schema, const query::clustering_range& r) const {
     check_schema(schema);
-    return boost::make_iterator_range(lower_bound(schema, r), upper_bound(schema, r));
+    return std::ranges::subrange(lower_bound(schema, r), upper_bound(schema, r));
 }
 
-boost::iterator_range<mutation_partition_v2::rows_type::iterator>
+std::ranges::subrange<mutation_partition_v2::rows_type::iterator>
 mutation_partition_v2::range(const schema& schema, const query::clustering_range& r) {
     return unconst(_rows, static_cast<const mutation_partition_v2*>(this)->range(schema, r));
 }
@@ -748,7 +747,7 @@ void mutation_partition_v2::for_each_row(const schema& schema, const query::clus
             }
         }
     } else {
-        for (const auto& e : r | boost::adaptors::reversed) {
+        for (const auto& e : r | std::views::reverse) {
             if (func(e) == stop_iteration::yes) {
                 break;
             }

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -243,12 +243,12 @@ public:
     rows_type& mutable_clustered_rows() noexcept { return _rows; }
 
     const row* find_row(const schema& s, const clustering_key& key) const;
-    boost::iterator_range<rows_type::const_iterator> range(const schema& schema, const query::clustering_range& r) const;
+    std::ranges::subrange<rows_type::const_iterator> range(const schema& schema, const query::clustering_range& r) const;
     rows_type::const_iterator lower_bound(const schema& schema, const query::clustering_range& r) const;
     rows_type::const_iterator upper_bound(const schema& schema, const query::clustering_range& r) const;
     rows_type::iterator lower_bound(const schema& schema, const query::clustering_range& r);
     rows_type::iterator upper_bound(const schema& schema, const query::clustering_range& r);
-    boost::iterator_range<rows_type::iterator> range(const schema& schema, const query::clustering_range& r);
+    std::ranges::subrange<rows_type::iterator> range(const schema& schema, const query::clustering_range& r);
     // Returns an iterator range of rows_entry, with only non-dummy entries.
     auto non_dummy_rows() const {
         return boost::make_iterator_range(_rows.begin(), _rows.end())

--- a/utils/unconst.hh
+++ b/utils/unconst.hh
@@ -8,12 +8,12 @@
 
 #pragma once
 
-#include <boost/range/iterator_range.hpp>
+#include <ranges>
 
 template <typename Container>
-boost::iterator_range<typename Container::iterator>
-unconst(Container& c, boost::iterator_range<typename Container::const_iterator> r) {
-    return boost::make_iterator_range(
+std::ranges::range auto
+unconst(Container& c, std::ranges::range auto&& r) {
+    return std::ranges::subrange(
             c.erase(r.begin(), r.begin()),
             c.erase(r.end(), r.end())
     );


### PR DESCRIPTION
As part of the effort to standardize on a single range library, convert the unconst helper
and its only user to \<ranges>.

The only user, mutation_partitions, happens to use intrusive_btree::iterator as the payload. That
iterator wasn't fully conform to iterator requirements, so it's fixed in a preliminary patch.

Code cleanup; no backport.