### PR TITLE
cmake/check_headers: correct typos

### DIFF
--- a/cmake/check_headers.cmake
+++ b/cmake/check_headers.cmake
@@ -22,7 +22,7 @@ function (check_headers check_headers_target target)
     file(GLOB_RECURSE sources
       LIST_DIRECTORIES false
       RELATIVE ${CMAKE_SOURCE_DIR}
-      "${parsed_args_RECURSIVE}")
+      "${parsed_args_GLOB_RECURSE}")
   else()
     message(FATAL_ERROR "Please specify GLOB or GLOB_RECURSE.")
   endif()

--- a/node_ops/CMakeLists.txt
+++ b/node_ops/CMakeLists.txt
@@ -12,5 +12,5 @@ target_link_libraries(node_ops
   PRIVATE
     service)
 
-check_headers(check-headers api
+check_headers(check-headers node_ops
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/sstables/CMakeLists.txt
+++ b/sstables/CMakeLists.txt
@@ -36,5 +36,5 @@ target_link_libraries(sstables
     libdeflate::libdeflate
     ZLIB::ZLIB)
 
-check_headers(check-headers streaming
+check_headers(check-headers sstables
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)


### PR DESCRIPTION
Commit efd65aebb28d ("build: cmake: add check-header target", 2023-11-13) introduced three typos:

- In "cmake/check_headers.cmake", it checked whether the "parsed_args_GLOB_RECURSE" argument was defined, but then it referenced the same under the wrong name "parsed_args_RECURSIVE".

- The above error masked two further typos; namely the duplicate use of "api" and "streaming" each, as targets. With "parsed_args_GLOB_RECURSE" above fixed, CMake now reports these conflicting arguments (target names). They should have been "node_ops" and "sstables", respectively.

Correct the typos.

Developer-oriented build fix for CMake, which is currently not the default yet; no need to backport it.