### PR TITLE
utils: replace dependency on boost ranges with <ranges>

### DIFF
--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -9,7 +9,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
-#include <boost/range/adaptor/reversed.hpp>
 #include "mutation_partition.hh"
 #include "clustering_interval_set.hh"
 #include "converting_mutation_partition_applier.hh"
@@ -607,13 +606,13 @@ mutation_partition::upper_bound(const schema& schema, const query::clustering_ra
     return _rows.lower_bound(position_in_partition_view::for_range_end(r), rows_entry::tri_compare(schema));
 }
 
-boost::iterator_range<mutation_partition::rows_type::const_iterator>
+std::ranges::subrange<mutation_partition::rows_type::const_iterator>
 mutation_partition::range(const schema& schema, const query::clustering_range& r) const {
     check_schema(schema);
-    return boost::make_iterator_range(lower_bound(schema, r), upper_bound(schema, r));
+    return std::ranges::subrange(lower_bound(schema, r), upper_bound(schema, r));
 }
 
-boost::iterator_range<mutation_partition::rows_type::iterator>
+std::ranges::subrange<mutation_partition::rows_type::iterator>
 mutation_partition::range(const schema& schema, const query::clustering_range& r) {
     return unconst(_rows, static_cast<const mutation_partition*>(this)->range(schema, r));
 }
@@ -640,7 +639,7 @@ void mutation_partition::for_each_row(const schema& schema, const query::cluster
             }
         }
     } else {
-        for (const auto& e : r | boost::adaptors::reversed) {
+        for (const auto& e : r | std::views::reverse) {
             if (func(e) == stop_iteration::yes) {
                 break;
             }

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -10,12 +10,13 @@
 
 #include <iosfwd>
 #include <boost/intrusive/set.hpp>
-#include <boost/range/iterator_range.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/intrusive/parent_from_member.hpp>
 
 #include <seastar/core/bitset-iter.hh>
 #include <seastar/util/optimized_optional.hh>
+
+#include <ranges>
 
 #include "schema/schema_fwd.hh"
 #include "tombstone.hh"
@@ -1451,12 +1452,12 @@ public:
     row_tombstone tombstone_for_row(const schema& schema, const clustering_key& key) const;
     // Can be called only for non-dummy entries
     row_tombstone tombstone_for_row(const schema& schema, const rows_entry& e) const;
-    boost::iterator_range<rows_type::const_iterator> range(const schema& schema, const query::clustering_range& r) const;
+    std::ranges::subrange<rows_type::const_iterator> range(const schema& schema, const query::clustering_range& r) const;
     rows_type::const_iterator lower_bound(const schema& schema, const query::clustering_range& r) const;
     rows_type::const_iterator upper_bound(const schema& schema, const query::clustering_range& r) const;
     rows_type::iterator lower_bound(const schema& schema, const query::clustering_range& r);
     rows_type::iterator upper_bound(const schema& schema, const query::clustering_range& r);
-    boost::iterator_range<rows_type::iterator> range(const schema& schema, const query::clustering_range& r);
+    std::ranges::subrange<rows_type::iterator> range(const schema& schema, const query::clustering_range& r);
     // Returns an iterator range of rows_entry, with only non-dummy entries.
     auto non_dummy_rows() const {
         return boost::make_iterator_range(_rows.begin(), _rows.end())

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -9,7 +9,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
-#include <boost/range/adaptor/reversed.hpp>
 #include "mutation_partition_v2.hh"
 #include "clustering_interval_set.hh"
 #include "converting_mutation_partition_applier.hh"
@@ -715,13 +714,13 @@ mutation_partition_v2::upper_bound(const schema& schema, const query::clustering
     return _rows.lower_bound(position_in_partition_view::for_range_end(r), rows_entry::tri_compare(schema));
 }
 
-boost::iterator_range<mutation_partition_v2::rows_type::const_iterator>
+std::ranges::subrange<mutation_partition_v2::rows_type::const_iterator>
 mutation_partition_v2::range(const schema& schema, const query::clustering_range& r) const {
     check_schema(schema);
-    return boost::make_iterator_range(lower_bound(schema, r), upper_bound(schema, r));
+    return std::ranges::subrange(lower_bound(schema, r), upper_bound(schema, r));
 }
 
-boost::iterator_range<mutation_partition_v2::rows_type::iterator>
+std::ranges::subrange<mutation_partition_v2::rows_type::iterator>
 mutation_partition_v2::range(const schema& schema, const query::clustering_range& r) {
     return unconst(_rows, static_cast<const mutation_partition_v2*>(this)->range(schema, r));
 }
@@ -748,7 +747,7 @@ void mutation_partition_v2::for_each_row(const schema& schema, const query::clus
             }
         }
     } else {
-        for (const auto& e : r | boost::adaptors::reversed) {
+        for (const auto& e : r | std::views::reverse) {
             if (func(e) == stop_iteration::yes) {
                 break;
             }

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -243,12 +243,12 @@ public:
     rows_type& mutable_clustered_rows() noexcept { return _rows; }
 
     const row* find_row(const schema& s, const clustering_key& key) const;
-    boost::iterator_range<rows_type::const_iterator> range(const schema& schema, const query::clustering_range& r) const;
+    std::ranges::subrange<rows_type::const_iterator> range(const schema& schema, const query::clustering_range& r) const;
     rows_type::const_iterator lower_bound(const schema& schema, const query::clustering_range& r) const;
     rows_type::const_iterator upper_bound(const schema& schema, const query::clustering_range& r) const;
     rows_type::iterator lower_bound(const schema& schema, const query::clustering_range& r);
     rows_type::iterator upper_bound(const schema& schema, const query::clustering_range& r);
-    boost::iterator_range<rows_type::iterator> range(const schema& schema, const query::clustering_range& r);
+    std::ranges::subrange<rows_type::iterator> range(const schema& schema, const query::clustering_range& r);
     // Returns an iterator range of rows_entry, with only non-dummy entries.
     auto non_dummy_rows() const {
         return boost::make_iterator_range(_rows.begin(), _rows.end())

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -43,6 +43,7 @@
 #include <boost/range/algorithm/find.hpp>
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
+#include <boost/range/algorithm/remove.hpp>
 #include <boost/range/algorithm/heap_algorithm.hpp>
 #include <boost/range/numeric.hpp>
 #include <boost/range/empty.hpp>

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -42,8 +42,7 @@
 
 #include "utils/small_vector.hh"
 
-#include <boost/range/algorithm/equal.hpp>
-#include <boost/version.hpp>
+#include <ranges>
 #include <memory>
 #include <type_traits>
 #include <iterator>
@@ -315,7 +314,7 @@ public:
     std::reverse_iterator<const_iterator> crend() const { return std::reverse_iterator(cbegin()); }
 public:
     bool operator==(const chunked_vector& x) const {
-        return boost::equal(*this, x);
+        return std::ranges::equal(*this, x);
     }
 };
 

--- a/utils/class_registrator.hh
+++ b/utils/class_registrator.hh
@@ -9,9 +9,9 @@
 #pragma once
 
 #include <memory>
+#include <ranges>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
-#include <boost/range/algorithm/find_if.hpp>
 
 #include "seastarx.hh"
 
@@ -112,7 +112,7 @@ sstring nonstatic_class_registry<BaseType, Args...>::to_qualified_class_name(std
     } else {
         const auto& classes{nonstatic_class_registry<BaseType, Args...>::classes()};
 
-        const auto it = boost::find_if(classes, [class_name](const auto& registered_class) {
+        const auto it = std::ranges::find_if(classes, [class_name](const auto& registered_class) {
             // the fully qualified name contains the short name
             auto i = registered_class.first.find_last_of('.');
             return i != sstring::npos && registered_class.first.compare(i + 1, sstring::npos, class_name) == 0;

--- a/utils/config_file.cc
+++ b/utils/config_file.cc
@@ -13,7 +13,6 @@
 
 #include <boost/program_options.hpp>
 #include <boost/any.hpp>
-#include <boost/range/adaptor/filtered.hpp>
 
 #include <seastar/core/file.hh>
 #include <seastar/core/seastar.hh>
@@ -26,6 +25,8 @@
 #include <seastar/util/defer.hh>
 
 #include <seastar/json/json_elements.hh>
+
+#include <ranges>
 
 #include "config_file.hh"
 #include "config_file_impl.hh"
@@ -340,9 +341,9 @@ void utils::config_file::read_from_yaml(const char* yaml, error_handler h) {
 }
 
 utils::config_file::configs utils::config_file::set_values() const {
-    return boost::copy_range<configs>(_cfgs | boost::adaptors::filtered([] (const config_src& cfg) {
+    return _cfgs | std::views::filter([] (const config_src& cfg) {
         return cfg.status() > value_status::Used || cfg.source() > config_source::None;
-    }));
+    }) | std::ranges::to<configs>();
 }
 
 utils::config_file::configs utils::config_file::unset_values() const {

--- a/utils/crc.hh
+++ b/utils/crc.hh
@@ -15,8 +15,6 @@
 #include <seastar/net/byteorder.hh>
 #include <seastar/core/byteorder.hh>
 
-#include <boost/range/algorithm/for_each.hpp>
-
 #if defined(__x86_64__) || defined(__i386__)
 #include <smmintrin.h>
 #elif defined(__aarch64__)
@@ -209,10 +207,9 @@ public:
     template<typename FragmentedBuffer>
     requires FragmentRange<FragmentedBuffer>
     void process_fragmented(const FragmentedBuffer& buffer) {
-        using boost::range::for_each;
-        for_each(buffer, [this] (bytes_view bv) {
+        for (bytes_view bv : buffer) {
             process(reinterpret_cast<const uint8_t*>(bv.data()), bv.size());
-        });
+        }
     }
 
     uint32_t get() const {

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -20,14 +20,13 @@
 
 #include "log.hh"
 
+#include <ranges>
 #include <algorithm>
 #include <chrono>
 #include <type_traits>
 #include <optional>
 #include <unordered_map>
 
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/adaptor/filtered.hpp>
 #include <boost/lexical_cast.hpp>
 
 
@@ -354,9 +353,10 @@ public:
     }
 
     std::vector<sstring> enabled_injections() const {
-        return boost::copy_range<std::vector<sstring>>(_enabled | boost::adaptors::filtered([] (const auto& pair) {
-            return !pair.second.is_ongoing_oneshot();
-        }) | boost::adaptors::map_keys);
+        return _enabled
+                | std::views::filter([] (const auto& pair) { return !pair.second.is_ongoing_oneshot(); })
+                | std::views::keys
+                | std::ranges::to<std::vector<sstring>>();
     }
 
     // \brief Inject a lambda call

--- a/utils/fragment_range.hh
+++ b/utils/fragment_range.hh
@@ -10,7 +10,7 @@
 
 #include <concepts>
 #include <compare>
-#include <boost/range/algorithm/copy.hpp>
+#include <algorithm>
 #include <seastar/net/byteorder.hh>
 #include <seastar/core/print.hh>
 #include <seastar/util/backtrace.hh>
@@ -123,7 +123,7 @@ bytes linearized(const FragmentedBuffer& buffer)
     bytes b(bytes::initialized_later(), buffer.size_bytes());
     auto dst = b.begin();
     for (bytes_view fragment : buffer) {
-        dst = boost::copy(fragment, dst);
+        dst = std::ranges::copy(fragment, dst).out;
     }
     return b;
 }

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -6,14 +6,11 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <boost/range/algorithm/heap_algorithm.hpp>
-#include <boost/range/algorithm/remove.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/intrusive/list.hpp>
 #include <boost/intrusive/set.hpp>
 #include <boost/intrusive/slist.hpp>
-#include <boost/range/adaptors.hpp>
 #include <stack>
+#include <ranges>
 
 #include <seastar/core/memory.hh>
 #include <seastar/core/align.hh>
@@ -2666,10 +2663,10 @@ idle_cpu_handler_result tracker::impl::compact_on_idle(work_waiting_on_reactor c
         return c2->min_occupancy() < c1->min_occupancy();
     };
 
-    boost::range::make_heap(_regions, cmp);
+    std::ranges::make_heap(_regions, cmp);
 
     while (!check_for_work()) {
-        boost::range::pop_heap(_regions, cmp);
+        std::ranges::pop_heap(_regions, cmp);
         region::impl* r = _regions.back();
 
         if (!r->is_idle_compactible()) {
@@ -2678,7 +2675,7 @@ idle_cpu_handler_result tracker::impl::compact_on_idle(work_waiting_on_reactor c
 
         r->compact();
 
-        boost::range::push_heap(_regions, cmp);
+        std::ranges::push_heap(_regions, cmp);
     }
     return idle_cpu_handler_result::interrupted_by_higher_priority_task;
 }
@@ -2774,7 +2771,7 @@ size_t tracker::impl::compact_and_evict_locked(size_t reserve_segments, size_t m
         return c2->min_occupancy() < c1->min_occupancy();
     };
 
-    boost::range::make_heap(_regions, cmp);
+    std::ranges::make_heap(_regions, cmp);
 
     if (llogger.is_enabled(logging::log_level::debug)) {
         llogger.debug("Occupancy of regions:");
@@ -2790,7 +2787,7 @@ size_t tracker::impl::compact_and_evict_locked(size_t reserve_segments, size_t m
                               regions, evictable_regions, regions - evictable_regions);
         });
         while (_segment_pool->total_memory_in_use() > target_mem) {
-            boost::range::pop_heap(_regions, cmp);
+            std::ranges::pop_heap(_regions, cmp);
             region::impl* r = _regions.back();
 
             if (!r->is_compactible()) {
@@ -2810,7 +2807,7 @@ size_t tracker::impl::compact_and_evict_locked(size_t reserve_segments, size_t m
                 r->compact();
             }
 
-            boost::range::push_heap(_regions, cmp);
+            std::ranges::push_heap(_regions, cmp);
 
             if (preempt && need_preempt()) {
                 break;

--- a/utils/lsa/chunked_managed_vector.hh
+++ b/utils/lsa/chunked_managed_vector.hh
@@ -16,13 +16,12 @@
 #include "utils/logalloc.hh"
 #include "utils/managed_vector.hh"
 
-#include <boost/range/algorithm/equal.hpp>
-#include <boost/version.hpp>
 #include <type_traits>
 #include <iterator>
 #include <utility>
 #include <algorithm>
 #include <stdexcept>
+#include <ranges>
 
 namespace lsa {
 
@@ -263,7 +262,7 @@ public:
     std::reverse_iterator<const_iterator> crend() const { return std::reverse_iterator(cbegin()); }
 public:
     bool operator==(const chunked_managed_vector& x) const {
-        return boost::equal(*this, x);
+        return std::ranges::equal(*this, x);
     }
 
     // Returns the amount of external memory used to hold inserted items.

--- a/utils/observable.hh
+++ b/utils/observable.hh
@@ -10,8 +10,7 @@
 
 #include <seastar/util/noncopyable_function.hh>
 #include <vector>
-#include <boost/range/algorithm/replace.hpp>
-#include <boost/range/algorithm/remove.hpp>
+#include <algorithm>
 
 namespace utils {
 
@@ -85,10 +84,10 @@ public:
     friend class observer;
 private:
     void destroyed(observer* dead) {
-        _observers.erase(boost::remove(_observers, dead), _observers.end());
+        _observers.erase(std::ranges::remove(_observers, dead).begin(), _observers.end());
     }
     void moved(observer* from, observer* to) {
-        boost::replace(_observers, from, to);
+        std::ranges::replace(_observers, from, to);
     }
     void update_observers(observable* ob) {
         for (auto&& c : _observers) {

--- a/utils/unconst.hh
+++ b/utils/unconst.hh
@@ -8,12 +8,12 @@
 
 #pragma once
 
-#include <boost/range/iterator_range.hpp>
+#include <ranges>
 
 template <typename Container>
-boost::iterator_range<typename Container::iterator>
-unconst(Container& c, boost::iterator_range<typename Container::const_iterator> r) {
-    return boost::make_iterator_range(
+std::ranges::range auto
+unconst(Container& c, std::ranges::range auto&& r) {
+    return std::ranges::subrange(
             c.erase(r.begin(), r.begin()),
             c.erase(r.end(), r.end())
     );


### PR DESCRIPTION
To avoid depending on two similar libraries (boost ranges and std \<ranges), replace
uses of the former with the latter. This series tackles the utils/ directory.

Code cleanup, no backport.