### PR TITLE
Use table id as system.sstables partition key

### DIFF
--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -12,6 +12,7 @@
 #include <map>
 #include <variant>
 #include <seastar/core/sstring.hh>
+#include "schema/schema_fwd.hh"
 #include "seastarx.hh"
 
 namespace data_dictionary {
@@ -28,7 +29,7 @@ struct storage_options {
     struct s3 {
         sstring bucket;
         sstring endpoint;
-        sstring prefix;
+        std::variant<sstring, table_id> location;
         static constexpr std::string_view name = "S3";
 
         static s3 from_map(const std::map<sstring, sstring>&);

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1120,7 +1120,7 @@ schema_ptr system_keyspace::sstables_registry() {
     static thread_local auto schema = [] {
         auto id = generate_legacy_id(NAME, SSTABLES_REGISTRY);
         return schema_builder(NAME, SSTABLES_REGISTRY, id)
-            .with_column("location", utf8_type, column_kind::partition_key)
+            .with_column("location", uuid_type, column_kind::partition_key) // will be renamed to "owner" soon
             .with_column("generation", timeuuid_type, column_kind::clustering_key)
             .with_column("status", utf8_type)
             .with_column("state", utf8_type)
@@ -3276,32 +3276,37 @@ system_keyspace::read_cdc_generation_opt(utils::UUID id) {
     co_return cdc::topology_description{std::move(entries)};
 }
 
-future<> system_keyspace::sstables_registry_create_entry(sstring location, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) {
+future<> system_keyspace::sstables_registry_create_entry(table_id owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) {
+    utils::UUID location = owner.id;
     static const auto req = format("INSERT INTO system.{} (location, generation, status, state, version, format) VALUES (?, ?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
     slogger.trace("Inserting {}.{} into {}", location, desc.generation, SSTABLES_REGISTRY);
     co_await execute_cql(req, location, desc.generation, status, sstables::state_to_dir(state), fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
 }
 
-future<> system_keyspace::sstables_registry_update_entry_status(sstring location, sstables::generation_type gen, sstring status) {
+future<> system_keyspace::sstables_registry_update_entry_status(table_id owner, sstables::generation_type gen, sstring status) {
+    utils::UUID location = owner.id;
     static const auto req = format("UPDATE system.{} SET status = ? WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
     slogger.trace("Updating {}.{} -> status={} in {}", location, gen, status, SSTABLES_REGISTRY);
     co_await execute_cql(req, status, location, gen).discard_result();
 }
 
-future<> system_keyspace::sstables_registry_update_entry_state(sstring location, sstables::generation_type gen, sstables::sstable_state state) {
+future<> system_keyspace::sstables_registry_update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state) {
+    utils::UUID location = owner.id;
     static const auto req = format("UPDATE system.{} SET state = ? WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
     auto new_state = sstables::state_to_dir(state);
     slogger.trace("Updating {}.{} -> state={} in {}", location, gen, new_state, SSTABLES_REGISTRY);
     co_await execute_cql(req, new_state, location, gen).discard_result();
 }
 
-future<> system_keyspace::sstables_registry_delete_entry(sstring location, sstables::generation_type gen) {
+future<> system_keyspace::sstables_registry_delete_entry(table_id owner, sstables::generation_type gen) {
+    utils::UUID location = owner.id;
     static const auto req = format("DELETE FROM system.{} WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
     slogger.trace("Removing {}.{} from {}", location, gen, SSTABLES_REGISTRY);
     co_await execute_cql(req, location, gen).discard_result();
 }
 
-future<> system_keyspace::sstables_registry_list(sstring location, sstable_registry_entry_consumer consumer) {
+future<> system_keyspace::sstables_registry_list(table_id owner, sstable_registry_entry_consumer consumer) {
+    utils::UUID location = owner.id;
     static const auto req = format("SELECT status, state, generation, version, format FROM system.{} WHERE location = ?", SSTABLES_REGISTRY);
     slogger.trace("Listing {} entries from {}", location, SSTABLES_REGISTRY);
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1120,7 +1120,7 @@ schema_ptr system_keyspace::sstables_registry() {
     static thread_local auto schema = [] {
         auto id = generate_legacy_id(NAME, SSTABLES_REGISTRY);
         return schema_builder(NAME, SSTABLES_REGISTRY, id)
-            .with_column("location", uuid_type, column_kind::partition_key) // will be renamed to "owner" soon
+            .with_column("owner", uuid_type, column_kind::partition_key)
             .with_column("generation", timeuuid_type, column_kind::clustering_key)
             .with_column("status", utf8_type)
             .with_column("state", utf8_type)
@@ -3277,40 +3277,36 @@ system_keyspace::read_cdc_generation_opt(utils::UUID id) {
 }
 
 future<> system_keyspace::sstables_registry_create_entry(table_id owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) {
-    utils::UUID location = owner.id;
-    static const auto req = format("INSERT INTO system.{} (location, generation, status, state, version, format) VALUES (?, ?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
-    slogger.trace("Inserting {}.{} into {}", location, desc.generation, SSTABLES_REGISTRY);
-    co_await execute_cql(req, location, desc.generation, status, sstables::state_to_dir(state), fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
+    static const auto req = format("INSERT INTO system.{} (owner, generation, status, state, version, format) VALUES (?, ?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
+    slogger.trace("Inserting {}.{} into {}", owner, desc.generation, SSTABLES_REGISTRY);
+    co_await execute_cql(req, owner.id, desc.generation, status, sstables::state_to_dir(state), fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
 }
 
 future<> system_keyspace::sstables_registry_update_entry_status(table_id owner, sstables::generation_type gen, sstring status) {
-    utils::UUID location = owner.id;
-    static const auto req = format("UPDATE system.{} SET status = ? WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
-    slogger.trace("Updating {}.{} -> status={} in {}", location, gen, status, SSTABLES_REGISTRY);
-    co_await execute_cql(req, status, location, gen).discard_result();
+    static const auto req = format("UPDATE system.{} SET status = ? WHERE owner = ? AND generation = ?", SSTABLES_REGISTRY);
+    slogger.trace("Updating {}.{} -> status={} in {}", owner, gen, status, SSTABLES_REGISTRY);
+    co_await execute_cql(req, status, owner.id, gen).discard_result();
 }
 
 future<> system_keyspace::sstables_registry_update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state) {
-    utils::UUID location = owner.id;
-    static const auto req = format("UPDATE system.{} SET state = ? WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
+    static const auto req = format("UPDATE system.{} SET state = ? WHERE owner = ? AND generation = ?", SSTABLES_REGISTRY);
     auto new_state = sstables::state_to_dir(state);
-    slogger.trace("Updating {}.{} -> state={} in {}", location, gen, new_state, SSTABLES_REGISTRY);
-    co_await execute_cql(req, new_state, location, gen).discard_result();
+    slogger.trace("Updating {}.{} -> state={} in {}", owner, gen, new_state, SSTABLES_REGISTRY);
+    co_await execute_cql(req, new_state, owner.id, gen).discard_result();
 }
 
 future<> system_keyspace::sstables_registry_delete_entry(table_id owner, sstables::generation_type gen) {
-    utils::UUID location = owner.id;
-    static const auto req = format("DELETE FROM system.{} WHERE location = ? AND generation = ?", SSTABLES_REGISTRY);
-    slogger.trace("Removing {}.{} from {}", location, gen, SSTABLES_REGISTRY);
-    co_await execute_cql(req, location, gen).discard_result();
+    static const auto req = format("DELETE FROM system.{} WHERE owner = ? AND generation = ?", SSTABLES_REGISTRY);
+    slogger.trace("Removing {}.{} from {}", owner, gen, SSTABLES_REGISTRY);
+    co_await execute_cql(req, owner.id, gen).discard_result();
+
 }
 
 future<> system_keyspace::sstables_registry_list(table_id owner, sstable_registry_entry_consumer consumer) {
-    utils::UUID location = owner.id;
-    static const auto req = format("SELECT status, state, generation, version, format FROM system.{} WHERE location = ?", SSTABLES_REGISTRY);
-    slogger.trace("Listing {} entries from {}", location, SSTABLES_REGISTRY);
+    static const auto req = format("SELECT status, state, generation, version, format FROM system.{} WHERE owner = ?", SSTABLES_REGISTRY);
+    slogger.trace("Listing {} entries from {}", owner, SSTABLES_REGISTRY);
 
-    co_await _qp.query_internal(req, db::consistency_level::ONE, { location }, 1000, [ consumer = std::move(consumer) ] (const cql3::untyped_result_set::row& row) -> future<stop_iteration> {
+    co_await _qp.query_internal(req, db::consistency_level::ONE, { owner.id }, 1000, [ consumer = std::move(consumer) ] (const cql3::untyped_result_set::row& row) -> future<stop_iteration> {
         auto status = row.get_as<sstring>("status");
         auto state = sstables::state_from_dir(row.get_as<sstring>("state"));
         auto gen = sstables::generation_type(row.get_as<utils::UUID>("generation"));

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -627,12 +627,12 @@ public:
     future<mutation> make_view_builder_version_mutation(api::timestamp_type ts, view_builder_version_t version);
     future<view_builder_version_t> get_view_builder_version();
 
-    future<> sstables_registry_create_entry(sstring location, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc);
-    future<> sstables_registry_update_entry_status(sstring location, sstables::generation_type gen, sstring status);
-    future<> sstables_registry_update_entry_state(sstring location, sstables::generation_type gen, sstables::sstable_state state);
-    future<> sstables_registry_delete_entry(sstring location, sstables::generation_type gen);
+    future<> sstables_registry_create_entry(table_id owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc);
+    future<> sstables_registry_update_entry_status(table_id owner, sstables::generation_type gen, sstring status);
+    future<> sstables_registry_update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state);
+    future<> sstables_registry_delete_entry(table_id owner, sstables::generation_type gen);
     using sstable_registry_entry_consumer = sstables::sstables_registry::entry_consumer;
-    future<> sstables_registry_list(sstring location, sstable_registry_entry_consumer consumer);
+    future<> sstables_registry_list(table_id owner, sstable_registry_entry_consumer consumer);
 
     future<std::optional<sstring>> load_group0_upgrade_state();
     future<> save_group0_upgrade_state(sstring);

--- a/db/system_keyspace_sstables_registry.hh
+++ b/db/system_keyspace_sstables_registry.hh
@@ -15,23 +15,23 @@ class system_keyspace_sstables_registry : public sstables::sstables_registry {
 public:
     system_keyspace_sstables_registry(system_keyspace& keyspace) : _keyspace(keyspace.shared_from_this()) {}
 
-    virtual seastar::future<> create_entry(sstring location, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) override {
+    virtual seastar::future<> create_entry(table_id location, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) override {
         return _keyspace->sstables_registry_create_entry(location, status, state, desc);
     }
 
-    virtual seastar::future<> update_entry_status(sstring location, sstables::generation_type gen, sstring status) override {
+    virtual seastar::future<> update_entry_status(table_id location, sstables::generation_type gen, sstring status) override {
         return _keyspace->sstables_registry_update_entry_status(location, gen, status);
     }
 
-    virtual seastar::future<> update_entry_state(sstring location, sstables::generation_type gen, sstables::sstable_state state) override {
+    virtual seastar::future<> update_entry_state(table_id location, sstables::generation_type gen, sstables::sstable_state state) override {
         return _keyspace->sstables_registry_update_entry_state(location, gen, state);
     }
 
-    virtual seastar::future<> delete_entry(sstring location, sstables::generation_type gen) override {
+    virtual seastar::future<> delete_entry(table_id location, sstables::generation_type gen) override {
         return _keyspace->sstables_registry_delete_entry(location, gen);
     }
 
-    virtual seastar::future<> sstables_registry_list(sstring location, entry_consumer consumer) override {
+    virtual seastar::future<> sstables_registry_list(table_id location, entry_consumer consumer) override {
         return _keyspace->sstables_registry_list(location, std::move(consumer));
     }
 };

--- a/db/system_keyspace_sstables_registry.hh
+++ b/db/system_keyspace_sstables_registry.hh
@@ -15,24 +15,24 @@ class system_keyspace_sstables_registry : public sstables::sstables_registry {
 public:
     system_keyspace_sstables_registry(system_keyspace& keyspace) : _keyspace(keyspace.shared_from_this()) {}
 
-    virtual seastar::future<> create_entry(table_id location, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) override {
-        return _keyspace->sstables_registry_create_entry(location, status, state, desc);
+    virtual seastar::future<> create_entry(table_id owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) override {
+        return _keyspace->sstables_registry_create_entry(owner, status, state, desc);
     }
 
-    virtual seastar::future<> update_entry_status(table_id location, sstables::generation_type gen, sstring status) override {
-        return _keyspace->sstables_registry_update_entry_status(location, gen, status);
+    virtual seastar::future<> update_entry_status(table_id owner, sstables::generation_type gen, sstring status) override {
+        return _keyspace->sstables_registry_update_entry_status(owner, gen, status);
     }
 
-    virtual seastar::future<> update_entry_state(table_id location, sstables::generation_type gen, sstables::sstable_state state) override {
-        return _keyspace->sstables_registry_update_entry_state(location, gen, state);
+    virtual seastar::future<> update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state) override {
+        return _keyspace->sstables_registry_update_entry_state(owner, gen, state);
     }
 
-    virtual seastar::future<> delete_entry(table_id location, sstables::generation_type gen) override {
-        return _keyspace->sstables_registry_delete_entry(location, gen);
+    virtual seastar::future<> delete_entry(table_id owner, sstables::generation_type gen) override {
+        return _keyspace->sstables_registry_delete_entry(owner, gen);
     }
 
-    virtual seastar::future<> sstables_registry_list(table_id location, entry_consumer consumer) override {
-        return _keyspace->sstables_registry_list(location, std::move(consumer));
+    virtual seastar::future<> sstables_registry_list(table_id owner, entry_consumer consumer) override {
+        return _keyspace->sstables_registry_list(owner, std::move(consumer));
     }
 };
 

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -55,7 +55,7 @@ sstable_directory::filesystem_components_lister::filesystem_components_lister(st
 {
 }
 
-sstable_directory::sstables_registry_components_lister::sstables_registry_components_lister(sstables::sstables_registry& sstables_registry, sstring location)
+sstable_directory::sstables_registry_components_lister::sstables_registry_components_lister(sstables::sstables_registry& sstables_registry, table_id location)
         : _sstables_registry(sstables_registry)
         , _location(std::move(location))
 {
@@ -89,7 +89,7 @@ sstable_directory::make_components_lister() {
                 // collect and process them is by listing the bucket
                 return std::make_unique<sstable_directory::filesystem_components_lister>(fs::path(std::get<sstring>(os.location)), _manager, os);
             }
-            return std::make_unique<sstable_directory::sstables_registry_components_lister>(_manager.sstables_registry(), std::get<sstring>(os.location));
+            return std::make_unique<sstable_directory::sstables_registry_components_lister>(_manager.sstables_registry(), std::get<table_id>(os.location));
         }
     }, _storage_opts->value);
 }

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -131,12 +131,12 @@ public:
 
     class sstables_registry_components_lister final : public components_lister {
         sstables_registry& _sstables_registry;
-        sstring _location;
+        table_id _location;
 
         future<> garbage_collect(storage&);
 
     public:
-        sstables_registry_components_lister(sstables::sstables_registry& sstables_registry, sstring location);
+        sstables_registry_components_lister(sstables::sstables_registry& sstables_registry, table_id owner);
 
         virtual future<> process(sstable_directory& directory, process_flags flags) override;
         virtual future<> commit() override;

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -131,7 +131,7 @@ public:
 
     class sstables_registry_components_lister final : public components_lister {
         sstables_registry& _sstables_registry;
-        table_id _location;
+        table_id _owner;
 
         future<> garbage_collect(storage&);
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -508,6 +508,10 @@ public:
 private:
     sstring filename(component_type f) const {
         auto dir = _storage->prefix();
+        return filename(f, std::move(dir));
+    }
+
+    sstring filename(component_type f, sstring dir) const {
         return filename(dir, _schema->ks_name(), _schema->cf_name(), _version, _generation, _format, f);
     }
 

--- a/sstables/sstables_registry.hh
+++ b/sstables/sstables_registry.hh
@@ -7,6 +7,7 @@
 
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future.hh>
+#include "schema/schema_fwd.hh"
 #include "seastarx.hh"
 
 namespace sstables {
@@ -18,12 +19,12 @@ namespace sstables {
 class sstables_registry {
 public:
     virtual ~sstables_registry();
-    virtual future<> create_entry(sstring location, sstring status, sstable_state state, sstables::entry_descriptor desc) = 0;
-    virtual future<> update_entry_status(sstring location, sstables::generation_type gen, sstring status) = 0;
-    virtual future<> update_entry_state(sstring location, sstables::generation_type gen, sstables::sstable_state state) = 0;
-    virtual future<> delete_entry(sstring location, sstables::generation_type gen) = 0;
+    virtual future<> create_entry(table_id owner, sstring status, sstable_state state, sstables::entry_descriptor desc) = 0;
+    virtual future<> update_entry_status(table_id owner, sstables::generation_type gen, sstring status) = 0;
+    virtual future<> update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state) = 0;
+    virtual future<> delete_entry(table_id owner, sstables::generation_type gen) = 0;
     using entry_consumer = noncopyable_function<future<>(sstring status, sstables::sstable_state state, sstables::entry_descriptor desc)>;
-    virtual future<> sstables_registry_list(sstring location, entry_consumer consumer) = 0;
+    virtual future<> sstables_registry_list(table_id owner, entry_consumer consumer) = 0;
 };
 
 } // namespace sstables

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -352,7 +352,7 @@ test_env::make_sstable(schema_ptr schema, sstring dir, sstables::generation_type
     auto storage = _impl->storage;
     std::visit(overloaded_functor {
         [&dir] (data_dictionary::storage_options::local& o) { o.dir = dir; },
-        [&dir] (data_dictionary::storage_options::s3& o) { o.prefix = dir; },
+        [&dir] (data_dictionary::storage_options::s3& o) { o.location = dir; },
     }, storage.value);
     return _impl->mgr.make_sstable(std::move(schema), storage, generation, sstables::sstable_state::normal, v, f, now, default_io_error_handler_gen(), buffer_size);
 }
@@ -488,7 +488,7 @@ test_env::make_table_for_tests(schema_ptr s, sstring dir) {
     auto storage = _impl->storage;
     std::visit(overloaded_functor {
         [&dir] (data_dictionary::storage_options::local& o) { o.dir = dir; },
-        [&dir] (data_dictionary::storage_options::s3& o) { o.prefix = dir; },
+        [&dir] (data_dictionary::storage_options::s3& o) { o.location = dir; },
     }, storage.value);
     return table_for_tests(manager(), _impl->cmgr->get_compaction_manager(), s, std::move(cfg), std::move(storage));
 }

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -274,12 +274,12 @@ class mock_sstables_registry : public sstables::sstables_registry {
     };
     std::map<std::pair<table_id, generation_type>, entry> _entries;
 public:
-    virtual future<> create_entry(table_id location, sstring status, sstable_state state, sstables::entry_descriptor desc) override {
-        _entries.emplace(std::make_pair(location, desc.generation), entry { status, state, desc });
+    virtual future<> create_entry(table_id owner, sstring status, sstable_state state, sstables::entry_descriptor desc) override {
+        _entries.emplace(std::make_pair(owner, desc.generation), entry { status, state, desc });
         co_return;
     };
-    virtual future<> update_entry_status(table_id location, sstables::generation_type gen, sstring status) override {
-        auto it = _entries.find(std::make_pair(location, gen));
+    virtual future<> update_entry_status(table_id owner, sstables::generation_type gen, sstring status) override {
+        auto it = _entries.find(std::make_pair(owner, gen));
         if (it != _entries.end()) {
             it->second.status = status;
         } else {
@@ -287,8 +287,8 @@ public:
         }
         co_return;
     }
-    virtual future<> update_entry_state(table_id location, sstables::generation_type gen, sstables::sstable_state state) override {
-        auto it = _entries.find(std::make_pair(location, gen));
+    virtual future<> update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state) override {
+        auto it = _entries.find(std::make_pair(owner, gen));
         if (it != _entries.end()) {
             it->second.state = state;
         } else {
@@ -296,8 +296,8 @@ public:
         }
         co_return;
     }
-    virtual future<> delete_entry(table_id location, sstables::generation_type gen) override {
-        auto it = _entries.find(std::make_pair(location, gen));
+    virtual future<> delete_entry(table_id owner, sstables::generation_type gen) override {
+        auto it = _entries.find(std::make_pair(owner, gen));
         if (it != _entries.end()) {
             _entries.erase(it);
         } else {
@@ -305,9 +305,9 @@ public:
         }
         co_return;
     }
-    virtual future<> sstables_registry_list(table_id location, entry_consumer consumer) override {
+    virtual future<> sstables_registry_list(table_id owner, entry_consumer consumer) override {
         for (auto& [loc_and_gen, e] : _entries) {
-            if (loc_and_gen.first == location) {
+            if (loc_and_gen.first == owner) {
                 co_await consumer(e.status, e.state, e.desc);
             }
         }


### PR DESCRIPTION
The system.sstables (a.k.a. sstables registry) primary key is "string location" as partition key and "uuid generation" as clustering one. The "location" part was taken from table.config.datadir value which, in turn, a string containing path to on-disk files if the table was located locally, e.g. /var/lib/scylla/data/ks/cf-abc123 one. Recently [1] the datadir was moved from table config onto storage options, but this string is still used as registry key.

Other than being owned by a table with ID, sstables are accessed by restore-from-object-storage code [2]. To make it work, both storage driver and sstable_directory helper class maintain two formats of object prefixes for sstables components. For S3-backed sstables having a record in registry, the path used is s3://bucket/generation/component. For restore code there are user-provided prefixes that do not match the aforementioned pattern. The selection between those two is now made by checking sstable state, which is not obvious and may cause troubles for tiered storage driver.

This patch changes  the registry schema so that partition key becomes "uuid owner" and is set to be table.id() value. This is to stop using the local path by S3 backed sstables. Also this change makes it possible for storage driver and sstable directory to rely on the storage options only to tell different bucket prefixes formats from each other.

As a side effect, the make_s3_object_name() helper, that generates the proper object name, becomes explicit for restore-from-S3 usage. Now it relies on the sstable::filename() calling this->prefix() behind the scenes and the latter to return the user-provided prefix, which is pretty fragile construction.

No need to backport (and it's not going to be easy to do it), storage options feature is still experimental

Refs #20675 [1]
Refs #20305 [2]