### PR TITLE
sstables: scylla_metadata: add sstable identifier

### DIFF
--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -591,6 +591,7 @@ private:
     std::optional<scylla_metadata::large_data_stats> _large_data_stats;
     sstring _origin;
     std::optional<scylla_metadata::ext_timestamp_stats> _ext_timestamp_stats;
+    optimized_optional<sstable_id> _sstable_identifier;
 
     // Total reclaimable memory from all the components of the SSTable.
     // It is initialized to 0 to prevent the sstables manager from reclaiming memory
@@ -966,6 +967,11 @@ public:
 
     const sstring& get_origin() const noexcept {
         return _origin;
+    }
+
+    // sstable_id is null iff not present in scylla_metadata
+    const optimized_optional<sstable_id>& sstable_identifier() const noexcept {
+        return _sstable_identifier;
     }
 
     // Drops all evictable in-memory caches of on-disk content.

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1438,6 +1438,7 @@ const char* to_string(sstables::scylla_metadata_type t) {
         case sstables::scylla_metadata_type::ScyllaVersion: return "scylla_version";
         case sstables::scylla_metadata_type::ScyllaBuildId: return "scylla_build_id";
         case sstables::scylla_metadata_type::ExtTimestampStats: return "ext_timestamp_stats";
+        case sstables::scylla_metadata_type::SSTableIdentifier: return "sstable_identifier";
     }
     std::abort();
 }
@@ -1557,6 +1558,10 @@ public:
     void operator()(const sstables::disk_tagged_union_member<sstables::scylla_metadata_type, E, T>& m) const {
         _writer.Key(to_string(E));
         (*this)(m.value);
+    }
+
+    void operator()(const sstables::scylla_metadata::sstable_identifier& sid) const {
+        _writer.AsString(sid.value);
     }
 };
 


### PR DESCRIPTION
Keep a copy of the sstable uuid generation in a new
scylla_metadata sstable_identifier attribute.

If the SSTable happens to have a numerical generation
just create a new time-uuid and log a message about that.

Dump this new attribute in scylla sstable dump tool.

And add a unit test to verify that the written (and then
loaded) sstable identifier matches the sstable's generation.

The motivatrion for this change stems from backup
deduplication.  In essence, an sstable may already have been
backed up in a previous snapshot, and we don't want to
abck it up again if it's already present on external storage.

Today this is based on rclone that compares files checksums,
but once scylla will backup the sstables using the native
object-storage stack (#19890), we would like to use the sstable
globally-unique identifier for deduplication.  Although the
uuid-generation is encoded in the sstable path, the latter
may change, e.g. due to intra-node migration, so keep a copy
the original unique identifier in scylla-metadata, and that
attribute would survive file-based or intra-node migrations.

Fixes scylladb/scylladb#20459

* Optional enhancement.  no backport required