### PR TITLE
repair: Fix stall in repair_get_row_diff_with_rpc_stream_process_op_slow_path

### DIFF
--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -26,6 +26,7 @@
 #include "mutation/frozen_mutation.hh"
 #include "utils/hash.hh"
 #include "repair/hash.hh"
+#include "utils/stall_free.hh"
 #include "repair/sync_boundary.hh"
 #include "tasks/types.hh"
 #include "schema/schema.hh"
@@ -209,6 +210,7 @@ public:
     partition_key& get_key() { return _key; }
     std::list<frozen_mutation_fragment>& get_mutation_fragments() { return _mfs; }
     void push_mutation_fragment(frozen_mutation_fragment mf) { _mfs.push_back(std::move(mf)); }
+    future<> clear_gently() { return utils::clear_gently(_mfs); };
 };
 
 using repair_row_on_wire = partition_key_and_mutation_fragments;

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2003,7 +2003,9 @@ static future<> repair_get_row_diff_with_rpc_stream_process_op_slow_path(
             co_await sink(repair_row_on_wire_with_cmd{repair_stream_cmd::end_of_current_rows, repair_row_on_wire()});
         } else {
             for (repair_row_on_wire& row : rows_on_wire) {
-                co_await sink(repair_row_on_wire_with_cmd{repair_stream_cmd::row_data, std::move(row)});
+                auto cmd = repair_row_on_wire_with_cmd{repair_stream_cmd::row_data, std::move(row)};
+                co_await sink(cmd);
+                co_await cmd.row.clear_gently();
             }
             co_await sink(repair_row_on_wire_with_cmd{repair_stream_cmd::end_of_current_rows, repair_row_on_wire()});
         }


### PR DESCRIPTION
Use clear_gently to avoid the following stalls.

```
~frozen_mutation_fragment at ././frozen_mutation.hh:268

std::destroy_at<frozen_mutation_fragment> at
/usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/stl_construct.h:88

std::allocator_traits<std::allocator<std::_List_node<frozen_mutation_fragment>
> >::destroy<frozen_mutation_fragment> at
/usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/alloc_traits.h:537

std::__cxx11::_List_base<frozen_mutation_fragment,
std::allocator<frozen_mutation_fragment> >::_M_clear at
/usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/list.tcc:77

~_List_base at /usr/lib/gcc/x86_64-redhat-linux/11/../../../../include/c++/11/bits/stl_list.h:499
~partition_key_and_mutation_fragments at ././repair/repair.hh:298
~repair_row_on_wire_with_cmd at ././repair/repair.hh:335
operator() at ./repair/row_level.cc:1881
```

Fixes #21016

Performance improvement only. No backport. 
