### PR TITLE
docs: fix confgroup links

### DIFF
--- a/docs/_templates/db_config.tmpl
+++ b/docs/_templates/db_config.tmpl
@@ -2,7 +2,7 @@
 
 {% for group in data %}
 {% if group.value_status_count[value_status] > 0 %}
-.. _confgroup_{{ group.name }}:
+.. _confgroup_{{ group.name|lower|replace(" ", "_") }}:
 
 {{ group.name }}
 {{ '-' * (group.name|length) }}
@@ -13,7 +13,7 @@
 
 {% for item in group.properties %}
 {% if item.value_status == value_status %}
-.. _confprop_{{ item.name }}:
+.. _confprop_{{ item.name|lower|replace(" ", "_") }}:
 
 .. confval:: {{ item.name }}
 {% endif %}


### PR DESCRIPTION
It was not possible to link to configuration parameters groups in `docs/reference/configuration-parameters.rst` if the group name contained spaces.

## How to test

1. Add the following link to any RST page:

    ```
   :ref:`Link to param group <confgroup_ungrouped_properties>`
   ```
   
2. Build the docs.
3. Check the link renders without errors.


From @annastuchlik:
This is a fix to a feature introduced in version 6.2, so it requires backporting to branch-6.2.