### PR TITLE
Update seastar submodule

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2070,7 +2070,12 @@ def write_build_file(f,
         ragels = {}
         antlr3_grammars = set()
         rust_headers = {}
-        seastar_lib_ext = 'so' if modeval['build_seastar_shared_libs'] else 'a'
+        if modeval['build_seastar_shared_libs']:
+            seastar_lib_type = 'shared'
+            seastar_lib_ext = 'so'
+        else:
+            seastar_lib_type = 'static'
+            seastar_lib_ext = 'a'
         seastar_dep = f'$builddir/{mode}/seastar/libseastar.{seastar_lib_ext}'
         seastar_testing_dep = f'$builddir/{mode}/seastar/libseastar_testing.{seastar_lib_ext}'
         abseil_dep = ' '.join(f'$builddir/{mode}/abseil/{lib}' for lib in abseil_libs)
@@ -2244,12 +2249,12 @@ def write_build_file(f,
                 .format(**locals()))
         f.write('  pool = submodule_pool\n')
         f.write('  subdir = $builddir/{mode}/seastar\n'.format(**locals()))
-        f.write('  target = seastar\n'.format(**locals()))
+        f.write('  target = seastar-{seastar_lib_type}\n'.format(**locals()))
         f.write('build {seastar_testing_dep}: ninja $builddir/{mode}/seastar/build.ninja | always\n'
                 .format(**locals()))
         f.write('  pool = submodule_pool\n')
         f.write('  subdir = $builddir/{mode}/seastar\n'.format(**locals()))
-        f.write('  target = seastar_testing\n'.format(**locals()))
+        f.write('  target = seastar_testing-{seastar_lib_type}\n'.format(**locals()))
         f.write('build $builddir/{mode}/seastar/apps/iotune/iotune: ninja $builddir/{mode}/seastar/build.ninja\n'
                 .format(**locals()))
         f.write('  pool = submodule_pool\n')


### PR DESCRIPTION
* seastar 3c9c2696...54e25a9d (40):
  > build: enable Seastar to build shared and static libs in a single build
  > build: include -fno-semantic-interposition in CXXFLAGS
  > loop: add Sentinel iterator support to parallel_for_each()
  > dns: use ARES_LIB_INIT_NONE instead of a magic number
  > dns: use struct typedef for `_channel`
  > doc/testing.md: explain seastar + boost test colocation
  > build: extract c-ares version from header file
  > dns: replace deprecated ares_process() with ares_process_fd()
  > build: do not support c-ares >= 1.33
  > http: fix indentation
  > http: Add non-owning `make_request` to http client
  > treewide: replace boost::irange with std::views::iota where possible
  > Added unit test for "http_content_length_data_sink_impl"
  > sharded.hh: migrate to concepts
  > file, scheduling: remove non-unified I/O and CPU scheduling
  > http: Add more HTTP response codes
  > http: add constness to `response_line`
  > http: refactor response_line to use `seastar::format`
  > httpd/file_handler: Always close stream
  > build: add compiler and C++ standard compatibility checks
  > rpc: rpc_types: replace boost::any with std::any
  > tls: drop dependency on boost::any
  > rpc: drop unnecessaty includes to boost libraries
  > rpc: compressor factory: deinline some boost-using functions
  > sharded: replace boost ranges with <ranges>
  > scheduling_specific: drop dependency on boost range adaptors
  > prefetch: drop dependency on boost::mpl
  > resource: drop unused dependency on boost::any
  > smp: drop dependency on boost ranges
  > reactor: remove unnecessary boost includes
  > execution_stage: remove unnecessary boost includes
  > sharded.hh: add invoke_on variant for a shard range
  > shared_ptr: remove deprecated lw_shared_ptr assignment operator
  > seastar-addr2line: add --debug arg
  > addr2line: add type checking
  > warnings: fix unused result warnings
  > thread_pool: fix includes
  > signal: remove trailing spaces
  > tests/unit: chmod -x signal_test.cc
  > iostream/http: Fix output_stream::write(temporary_buffer) overload

---

no critical fixes included, hence no need to backport.