### PR TITLE
test/auth_cluster/test_raft_service_levels: match enterprise SL limit

### DIFF
--- a/test/auth_cluster/test_raft_service_levels.py
+++ b/test/auth_cluster/test_raft_service_levels.py
@@ -34,7 +34,7 @@ async def test_service_levels_snapshot(manager: ManagerClient):
     await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
     await manager.servers_see_each_other(servers)
 
-    sls = ["sl" + unique_name() for _ in range(10)]
+    sls = ["sl" + unique_name() for _ in range(5)]
     for sl in sls:
         await cql.run_async(f"CREATE SERVICE LEVEL {sl}")
 
@@ -81,7 +81,7 @@ async def test_service_levels_upgrade(request, manager: ManagerClient):
         status = await manager.api.raft_topology_upgrade_status(host.address)
         assert status == "not_upgraded"
 
-    sls = ["sl" + unique_name() for _ in range(10)]
+    sls = ["sl" + unique_name() for _ in range(5)]
     for sl in sls:
         await cql.run_async(f"CREATE SERVICE LEVEL {sl}")
 
@@ -113,7 +113,7 @@ async def test_service_levels_work_during_recovery(manager: ManagerClient):
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
     logging.info("Creating a bunch of service levels")
-    sls = ["sl" + unique_name() for _ in range(10)]
+    sls = ["sl" + unique_name() for _ in range(5)]
     for sl in sls:
         await cql.run_async(f"CREATE SERVICE LEVEL {sl}")
     


### PR DESCRIPTION
Despite OSS doesn't limit number of created service levels, match the enterprise limit to decrease divergence in the test between OSS and enterprise.

Because we want to fix service levels limit in 2024.2, which is based on 6.0, backporting this to 6.0 and later branches.

Fixes scylladb/scylladb#21044

