### PR TITLE
cql3: warn when create keyspace/table/view/index already exists

### DIFF
--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -35,6 +35,8 @@ namespace cql3 {
 
 namespace statements {
 
+static logging::logger mylogger("create_index");
+
 create_index_statement::create_index_statement(cf_name name,
                                                ::shared_ptr<index_name> index_name,
                                                std::vector<::shared_ptr<index_target::raw>> raw_targets,
@@ -169,7 +171,9 @@ std::vector<::shared_ptr<index_target>> create_index_statement::validate_while_e
 
     if (db.existing_index_names(keyspace()).contains(_index_name)) {
         if (!_if_not_exists) {
-            throw exceptions::invalid_request_exception("Index already exists");
+            auto ex = std::make_exception_ptr(exceptions::invalid_request_exception(format("Index {}.{} already exists", keyspace(), _index_name)));
+            mylogger.warn("{}", ex);
+            std::rethrow_exception(std::move(ex));
         }
     }
 

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -39,6 +39,8 @@ namespace cql3 {
 
 namespace statements {
 
+static logging::logger mylogger("create_view");
+
 create_view_statement::create_view_statement(
         cf_name view_name,
         cf_name base_name,
@@ -380,7 +382,9 @@ create_view_statement::prepare_schema_mutations(query_processor& qp, const query
         m = co_await service::prepare_new_view_announcement(qp.proxy(), std::move(definition), ts);
     } catch (const exceptions::already_exists_exception& e) {
         if (!_if_not_exists) {
-            co_return coroutine::exception(std::current_exception());
+            auto ex = std::current_exception();
+            mylogger.warn("{}", ex);
+            co_return coroutine::exception(std::move(ex));
         }
     }
 


### PR DESCRIPTION
Before returning the error to the client, log a warning about it, to help analyze issues like scylladb/scylladb#21034

* Minor improvement in logging, no backport required