### PR TITLE
test.py: Enables debugging inside pytest subprocesses

### DIFF
--- a/test.py
+++ b/test.py
@@ -617,6 +617,8 @@ class Test:
         self.id = test_no
         self.path = ""
         self.args: List[str] = []
+        # Arguments which are required by a program regardless of additional test specific arguments
+        self.core_args : List[str] = []
         self.valid_exit_codes = [0]
         # Name with test suite name
         self.name = os.path.join(suite.name, shortname.split('.')[0])
@@ -968,7 +970,8 @@ class PythonTest(Test):
 
     def __init__(self, test_no: int, shortname: str, casename: str, suite) -> None:
         super().__init__(test_no, shortname, suite)
-        self.path = "pytest"
+        self.path = "python"
+        self.core_args = ["-m", "pytest"]
         self.casename = casename
         self.xmlout = os.path.join(self.suite.options.tmpdir, self.mode, "xml", self.uname + ".xunit.xml")
         self.server_log: Optional[str] = None
@@ -1244,10 +1247,10 @@ async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, e
             test.time_end = 0
 
             path = test.path
-            args = test.args
+            args = test.core_args + test.args
             if options.cpus:
                 path = 'taskset'
-                args = ['-c', options.cpus, test.path, *test.args]
+                args = ['-c', options.cpus, test.path, *args]
 
             test_running_event = asyncio.Event()
             test_resource_watcher = resource_gather.cgroup_monitor(test_event=test_running_event)


### PR DESCRIPTION
### What it does
Enables debugging inside pytest subprocesses. It seems that pydev automatically attaches itself also to all python subprocesses. Since we call "pytest" wrapper the debugger did not attach to subprocess and we debug individual tests and both server (`ScyllaClusterManager._cluster_running_servers`) and client (`ManagerClient,running_servers`) functions (in local env only)

### How it does that
Replaces "pytest" invocation in `PythonTest` with `python -m pytest`. These are virtually equivalent calls, only difference is that `python -m pytest` also includes adds the current directory to `sys.path`, which I do not think we care about (https://docs.pytest.org/en/stable/how-to/usage.html#calling-pytest-through-python-m-pytest)

### Implementation details
We use `self.path` and `self.args` to specifiy what program to run in Tests, since `python -m args` is not only a path but an argument that always needs to be at the first index I choose to add a new property called `self.core_args` to `Test` class, which are special arguments that will be always added as first.

I could not use `self.args` directly, because we often insert at 0 position in subclasses and in general, we mess with that argument a lot, new argument, even if used only for once type of test, seemed like an easier and smaller solution.

### How to test
* Add breakpoints to any test function in topology/test_change_ip.py
* Start debug said test as usual (`test.py topology/test_change_ip`)
     *  I used Pycharm, i.e. pydev, but should work with other debuggers as well
* See that it stop at your breakpoint

### Backports
Since this is an improvement only, I will mark it as `backport/none`.