### PR TITLE
Sanitize commitlog API endpoints

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -291,12 +291,16 @@ future<> set_server_done(http_context& ctx) {
         rb->register_function(r, "lsa", "Log-structured allocator API");
         set_lsa(ctx, r);
 
-        rb->register_function(r, "commitlog",
-                "The commit log API");
-        set_commitlog(ctx,r);
         rb->register_function(r, "collectd",
                 "The collectd API");
         set_collectd(ctx, r);
+    });
+}
+
+future<> set_server_commitlog(http_context& ctx, sharded<replica::database>& db) {
+    return register_api(ctx, "commitlog", "The commit log API", [&db] (http_context& ctx, routes& r) {
+        (void)db;
+        set_commitlog(ctx, r);
     });
 }
 

--- a/api/api.cc
+++ b/api/api.cc
@@ -304,6 +304,10 @@ future<> set_server_commitlog(http_context& ctx, sharded<replica::database>& db)
     });
 }
 
+future<> unset_server_commitlog(http_context& ctx) {
+    return ctx.http_server.set_routes([&ctx] (routes& r) { unset_commitlog(ctx, r); });
+}
+
 future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>& tm, lw_shared_ptr<db::config> cfg) {
     auto rb = std::make_shared < api_registry_builder > (ctx.api_doc);
 

--- a/api/api.cc
+++ b/api/api.cc
@@ -299,8 +299,7 @@ future<> set_server_done(http_context& ctx) {
 
 future<> set_server_commitlog(http_context& ctx, sharded<replica::database>& db) {
     return register_api(ctx, "commitlog", "The commit log API", [&db] (http_context& ctx, routes& r) {
-        (void)db;
-        set_commitlog(ctx, r);
+        set_commitlog(ctx, r, db);
     });
 }
 

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -135,5 +135,6 @@ future<> unset_load_meter(http_context& ctx);
 future<> set_server_cql_server_test(http_context& ctx, cql_transport::controller& ctl);
 future<> unset_server_cql_server_test(http_context& ctx);
 future<> set_server_commitlog(http_context& ctx, sharded<replica::database>&);
+future<> unset_server_commitlog(http_context& ctx);
 
 }

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -134,5 +134,6 @@ future<> set_load_meter(http_context& ctx, service::load_meter& lm);
 future<> unset_load_meter(http_context& ctx);
 future<> set_server_cql_server_test(http_context& ctx, cql_transport::controller& ctl);
 future<> unset_server_cql_server_test(http_context& ctx);
+future<> set_server_commitlog(http_context& ctx, sharded<replica::database>&);
 
 }

--- a/api/commitlog.cc
+++ b/api/commitlog.cc
@@ -68,4 +68,13 @@ void set_commitlog(http_context& ctx, routes& r) {
     });
 }
 
+void unset_commitlog(http_context& ctx, routes& r) {
+    httpd::commitlog_json::get_active_segment_names.unset(r);
+    httpd::commitlog_json::get_archiving_segment_names.unset(r);
+    httpd::commitlog_json::get_completed_tasks.unset(r);
+    httpd::commitlog_json::get_pending_tasks.unset(r);
+    httpd::commitlog_json::get_total_commit_log_size.unset(r);
+    httpd::commitlog_json::get_max_disk_size.unset(r);
+}
+
 }

--- a/api/commitlog.cc
+++ b/api/commitlog.cc
@@ -32,7 +32,7 @@ static auto acquire_cl_metric(http_context& ctx, std::function<T (const db::comm
     });
 }
 
-void set_commitlog(http_context& ctx, routes& r) {
+void set_commitlog(http_context& ctx, routes& r, sharded<replica::database>& db) {
     httpd::commitlog_json::get_active_segment_names.set(r,
             [&ctx](std::unique_ptr<request> req) {
         auto res = make_shared<std::vector<sstring>>();

--- a/api/commitlog.hh
+++ b/api/commitlog.hh
@@ -15,5 +15,6 @@ class routes;
 namespace api {
 struct http_context;
 void set_commitlog(http_context& ctx, seastar::httpd::routes& r);
+void unset_commitlog(http_context& ctx, seastar::httpd::routes& r);
 
 }

--- a/api/commitlog.hh
+++ b/api/commitlog.hh
@@ -8,13 +8,17 @@
 
 #pragma once
 
+#include <seastar/core/sharded.hh>
+
 namespace seastar::httpd {
 class routes;
 }
 
+namespace replica { class database; }
+
 namespace api {
 struct http_context;
-void set_commitlog(http_context& ctx, seastar::httpd::routes& r);
+void set_commitlog(http_context& ctx, seastar::httpd::routes& r, seastar::sharded<replica::database>&);
 void unset_commitlog(http_context& ctx, seastar::httpd::routes& r);
 
 }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -30,7 +30,6 @@
 #include "service/raft/raft_group0_client.hh"
 #include "service/storage_service.hh"
 #include "service/load_meter.hh"
-#include "db/commitlog/commitlog.hh"
 #include "gms/gossiper.hh"
 #include "db/system_keyspace.hh"
 #include <seastar/http/exception.hh>
@@ -544,10 +543,6 @@ static future<json::json_return_type> describe_ring_as_json_for_table(const shar
 }
 
 void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_service>& ss, service::raft_group0_client& group0_client) {
-    ss::get_commitlog.set(r, [&ctx](const_req req) {
-        return ctx.db.local().commitlog()->active_config().commit_log_location;
-    });
-
     ss::get_token_endpoint.set(r, [&ctx, &ss] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         const auto keyspace_name = req->get_query_param("keyspace");
         const auto table_name = req->get_query_param("cf");
@@ -1578,7 +1573,6 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
 }
 
 void unset_storage_service(http_context& ctx, routes& r) {
-    ss::get_commitlog.unset(r);
     ss::get_token_endpoint.unset(r);
     ss::toppartitions_generic.unset(r);
     ss::get_release_version.unset(r);

--- a/main.cc
+++ b/main.cc
@@ -1879,6 +1879,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             api::set_server_commitlog(ctx, db).get();
+            auto stop_commitlog_api = defer_verbose_shutdown("commitlog API", [&ctx] {
+                api::unset_server_commitlog(ctx).get();
+            });
 
             if (cfg->maintenance_mode()) {
                 startlog.info("entering maintenance mode.");

--- a/main.cc
+++ b/main.cc
@@ -1878,6 +1878,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 api::unset_server_cache(ctx).get();
             });
 
+            api::set_server_commitlog(ctx, db).get();
+
             if (cfg->maintenance_mode()) {
                 startlog.info("entering maintenance mode.");
 


### PR DESCRIPTION
Endpoints are registered next to the service they use, and the unregistration deferred action is created right after it. When registered, the service in question is passed as argument and then captured by enpoints lambdas. This makes sure that service is not used by endpoints after being stopped.

That's not so for commitlog endpoints. These are registered in several places, and /commitlog "function" is not unregistered on stop. This patch fixes some of this misbehavior, in particular:

 -  adds unregistration of commitlog API function
 -  uses sharded<database>& argument in endpoints instead of ctx.db
 -  moves some endpoints from storage_service.cc to commitlog.cc

