### PR TITLE
test: fix flaky test_multidc_alter_tablets_rf

### DIFF
--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -207,7 +207,7 @@ async def test_multidc_alter_tablets_rf(request: pytest.FixtureRequest, manager:
     await manager.servers_add(2, config=config, property_file={'dc': f'dc2', 'rack': 'myrack'})
 
     cql = manager.get_cql()
-    await cql.run_async("create keyspace ks with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}")
+    await cql.run_async("create keyspace if not exists ks with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}")
     # need to create a table to not change only the schema, but also tablets replicas
     await cql.run_async("create table ks.t (pk int primary key)")
     with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):


### PR DESCRIPTION
The testcase is flaky due to a known python driver issue:
https://github.com/scylladb/python-driver/issues/317.
This issue causes the `CREATE KEYSPACE` statement to be sometimes
executed twice in a row, and the 2nd CREATE statement causes the test to
fail.
In order to work around it, it's enough to add `if not exists` when
creating a ks.

Fixes: https://github.com/scylladb/scylladb/issues/21034

Needs to be backported to all 6.x branches, as the PR introducing this flakiness is backported to every 6.x branch.