### PR TITLE
streaming: stream-session: switch to tracking permit

### DIFF
--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -127,7 +127,7 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
                     _db.local().get_token_metadata().get_topology().my_address())));
         }
         return _mm.local().get_schema_for_write(schema_id, from, _ms.local(), as).then([this, from, estimated_partitions, plan_id, cf_id, source, reason, topo_guard, &as] (schema_ptr s) mutable {
-          return _db.local().obtain_reader_permit(s, "stream-session", db::no_timeout, {}).then([this, from, estimated_partitions, plan_id, cf_id, source, reason, topo_guard, s, &as] (reader_permit permit) mutable {
+            auto permit = _db.local().get_reader_concurrency_semaphore().make_tracking_only_permit(s, "stream-session", db::no_timeout, {});
             struct stream_mutation_fragments_cmd_status {
                 bool got_cmd = false;
                 bool got_end_of_stream = false;
@@ -249,7 +249,6 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
             });
           }
             return make_ready_future<rpc::sink<int>>(sink);
-        });
       });
     });
     ms.register_stream_mutation_done([this] (const rpc::client_info& cinfo, streaming::plan_id plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id) {


### PR DESCRIPTION
The stream-session is the receiving end of streaming, it reads the mutation fragment stream from an RPC stream and writes it onto the disk. As such, this part does no disk IO and therefore, using a permit with count resources is superfluous. Furthermore, after d98708013cc076d28688cdd999d01ea8062a7f8d, the count resources on this permit can cause a deadlock on the receiver end, via the `db::view::check_view_update_path()`, which wants to read the content of a system table and therefore has to obtain a permit of its own.

Switch to a tracking-only permit, primarily to resolve the deadlock, but also because admission is not necessary for a read which does no IO.

Refs: #20885 (partial fix, solves only one of the deadlocks)
Fixes: https://github.com/scylladb/scylladb/issues/21264

This fixes a regression introduced by https://github.com/scylladb/scylladb/commit/d98708013cc076d28688cdd999d01ea8062a7f8d so it has to be backported to 6.2