### PR TITLE
utils/s3: include used header

### DIFF
--- a/utils/s3/aws_error.cc
+++ b/utils/s3/aws_error.cc
@@ -12,6 +12,7 @@
 #include <rapidxml/rapidxml.hpp>
 #endif
 
+#include <memory>
 #include "utils/s3/aws_error.hh"
 
 namespace aws {


### PR DESCRIPTION
when building the tree with clang-19 and libstdc++ shipped along with GCC 14.2.1, we have

```
clang++ -MD -MT build/release/utils/s3/aws_error.o -MF build/release/utils/s3/aws_error.o.d -std=c++23 -I/home/kefu/dev/scylladb/master/seastar/include -I/home/kefu/dev/scylladb/master/build/release/seastar/gen/include -Werror=unused-result -DSEASTAR_API_LEVEL=7 -DSEASTAR_SSTRING -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_LOGGER_TYPE_STDOUT -DFMT_SHARED -I/usr/include/p11-kit-1 -DWITH_GZFILEOP -ffile-prefix-map=/home/kefu/dev/scylladb/master=. -march=westmere -ffunction-sections -fdata-sections  -O3 -mllvm -inline-threshold=2500 -fno-slp-vectorize -DSCYLLA_BUILD_MODE=release -g -gz -Xclang -fexperimental-assignment-tracking=disabled -iquote. -iquote build/release/gen -std=gnu++23  -ffile-prefix-map=/home/kefu/dev/scylladb/master=. -march=westmere -DBOOST_ALL_DYN_LINK    -fvisibility=hidden -isystem abseil -Wall -Werror -Wextra -Wimplicit-fallthrough -Wno-mismatched-tags -Wno-c++11-narrowing -Wno-overloaded-virtual -Wno-unused-parameter -Wno-unsupported-friend -Wno-missing-field-initializers -Wno-deprecated-copy -Wno-psabi -Wno-error=deprecated-declarations -DXXH_PRIVATE_API -DSEASTAR_TESTING_MAIN  -c -o build/release/utils/s3/aws_error.o utils/s3/aws_error.cc
utils/s3/aws_error.cc:33:21: error: no member named 'make_unique' in namespace 'std'
   33 |     auto doc = std::make_unique<rapidxml::xml_document<>>();
      |                ~~~~~^
utils/s3/aws_error.cc:33:57: error: expected '(' for function-style cast or type construction
   33 |     auto doc = std::make_unique<rapidxml::xml_document<>>();
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~^
utils/s3/aws_error.cc:33:59: error: expected expression
   33 |     auto doc = std::make_unique<rapidxml::xml_document<>>();
      |                                                           ^
3 errors generated.
ninja: build stopped: subcommand failed.
```

in order to address the build failure, let's include the used header.

---

it addresses a build failure which only surfaces with libstdc++-14.2.1. and the involved source file does not exist in any LTS branches, so no need to backport.