### PR TITLE
test.py: make sure topology/ and topology_custom/ passes with tablets on.

### DIFF
--- a/test/pylib/random_tables.py
+++ b/test/pylib/random_tables.py
@@ -266,8 +266,13 @@ class RandomTables():
     """A list of managed random tables"""
 
     def __init__(self, test_name: str, manager: ManagerClient, keyspace: str,
-                 replication_factor: int, dc_replication_factor: dict[str, int] = None):
+                 replication_factor: int,
+                 dc_replication_factor: dict[str, int] = None,
+                 enable_tablets: None | bool = None):
         keyspace_query = f"CREATE KEYSPACE IF NOT EXISTS {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : {replication_factor}}}"
+        if enable_tablets is not None:
+            enable_tablets = str(enable_tablets).lower()
+            keyspace_query += f" AND TABLETS = {{'enabled': {enable_tablets} }}"
         self.test_name = test_name
         self.manager = manager
         self.keyspace = keyspace

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -8,6 +8,7 @@ markers =
     slow: tests that take more than 30 seconds to run
     replication_factor: replication factor for RandomTables
     without_scylla: run without attaching to a scylla process
+    enable_tablets: create keyspace with tablets enabled or disabled
 norecursedirs = manual perf lib
 # Ignore warnings about HTTPS requests without certificate verification
 # (see issue #15287). Pytest breaks urllib3.disable_warnings() in conftest.py,

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -230,7 +230,10 @@ def cql(manager):
 async def random_tables(request, manager):
     rf_marker = request.node.get_closest_marker("replication_factor")
     replication_factor = rf_marker.args[0] if rf_marker is not None else 3  # Default 3
-    tables = RandomTables(request.node.name, manager, unique_name(), replication_factor)
+    enable_tablets = request.node.get_closest_marker("enable_tablets")
+    enable_tablets = enable_tablets.args[0] if enable_tablets is not None else None
+    tables = RandomTables(request.node.name, manager, unique_name(),
+                          replication_factor, None, enable_tablets)
     yield tables
 
     # Don't drop tables at the end if we failed or the cluster is dirty - it may be impossible

--- a/test/topology/test_mutation_schema_change.py
+++ b/test/topology/test_mutation_schema_change.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
+@pytest.mark.enable_tablets(False)                       # uses lightweight transactions
 async def test_mutation_schema_change(manager, random_tables):
     """
         Cluster A, B, C
@@ -81,6 +82,7 @@ async def test_mutation_schema_change(manager, random_tables):
 
 
 @pytest.mark.asyncio
+@pytest.mark.enable_tablets(False)                       # uses lightweight transactions
 async def test_mutation_schema_change_restart(manager, random_tables):
     """
         Cluster A, B, C

--- a/test/topology/test_mv.py
+++ b/test/topology/test_mv.py
@@ -16,6 +16,8 @@ import pytest
 
 from test.topology.util import new_test_keyspace, new_test_table, new_materialized_view
 
+ksdef = "WITH REPLICATION = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 3 } AND TABLETS = {'enabled': false }"
+
 logger = logging.getLogger(__name__)
 
 @pytest.mark.asyncio
@@ -32,7 +34,7 @@ async def test_mv_tombstone_gc_setting(manager):
     be here and not in the single-node cqlpy.
     """
     cql = manager.cql
-    async with new_test_keyspace(cql, "WITH REPLICATION = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 3 }") as keyspace:
+    async with new_test_keyspace(cql, ksdef) as keyspace:
         async with new_test_table(cql, keyspace, "p int primary key, x int") as table:
             # Adding "WITH tombstone_gc = ..." In the CREATE MATERIALIZED VIEW:
             async with new_materialized_view(cql, table, "*", "p, x", "p is not null and x is not null", "WITH tombstone_gc = {'mode': 'repair'}") as mv:
@@ -55,7 +57,7 @@ async def test_mv_tombstone_gc_not_inherited(manager):
     demonstrates the existing behavior.
     """
     cql = manager.cql
-    async with new_test_keyspace(cql, "WITH REPLICATION = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 3 }") as keyspace:
+    async with new_test_keyspace(cql, ksdef) as keyspace:
         async with new_test_table(cql, keyspace, "p int primary key, x int", "WITH tombstone_gc = {'mode': 'repair'}") as table:
             s = list(cql.execute(f"DESC {table}"))[0].create_statement
             assert "'mode': 'repair'" in s

--- a/test/topology_custom/test_change_rpc_address.py
+++ b/test/topology_custom/test_change_rpc_address.py
@@ -27,16 +27,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+N_SERVERS = 2
 
 @pytest.fixture
 async def two_nodes_cluster(manager: ManagerClient) -> list[ServerNum]:
     logger.info(f"Booting initial 2-nodes cluster")
-    servers = [srv.server_id for srv in await manager.servers_add(2)]
+    servers = [srv.server_id for srv in await manager.servers_add(N_SERVERS)]
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
     return servers
 
 
 @pytest.mark.asyncio
+@pytest.mark.replication_factor(N_SERVERS)
 async def test_change_rpc_address(two_nodes_cluster: list[ServerNum],
                                   manager: ManagerClient,
                                   random_tables: RandomTables) -> None:

--- a/test/topology_custom/test_group0_schema_versioning.py
+++ b/test/topology_custom/test_group0_schema_versioning.py
@@ -124,7 +124,8 @@ async def test_schema_versioning_with_recovery(manager: ManagerClient):
     Verify that schema versions are in sync after each schema change.
     """
     cfg = {'enable_user_defined_functions': False,
-           'force_gossip_topology_changes': True}
+           'force_gossip_topology_changes': True,
+           'enable_tablets': False}
     logger.info("Booting cluster")
     servers = [await manager.server_add(config=cfg) for _ in range(3)]
     cql = manager.get_cql()
@@ -292,7 +293,8 @@ async def test_upgrade(manager: ManagerClient):
     # So we do the same here: start a cluster in Raft mode, then enter recovery
     # to simulate a non-Raft cluster.
     cfg = {'enable_user_defined_functions': False,
-           'force_gossip_topology_changes': True}
+           'force_gossip_topology_changes': True,
+           'enable_tablets': False}
     logger.info("Booting cluster")
     servers = [await manager.server_add(config=cfg) for _ in range(2)]
     cql = manager.get_cql()

--- a/test/topology_custom/test_multidc.py
+++ b/test/topology_custom/test_multidc.py
@@ -31,7 +31,7 @@ async def test_multidc(request: pytest.FixtureRequest, manager: ManagerClient) -
             property_file={'dc': f'dc{i}', 'rack': 'myrack1'}
         )
         logger.info(s_info)
-    random_tables = RandomTables(request.node.name, manager, unique_name(), 3)
+    random_tables = RandomTables(request.node.name, manager, unique_name(), 1)
     logger.info("Creating new tables")
     await random_tables.add_tables(ntables=3, ncolumns=3)
     await random_tables.verify_schema()

--- a/test/topology_custom/test_mv_topology_change.py
+++ b/test/topology_custom/test_mv_topology_change.py
@@ -29,7 +29,9 @@ logger = logging.getLogger(__name__)
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_mv_topology_change(manager: ManagerClient):
-    cfg = {'force_gossip_topology_changes': True, 'error_injections_at_startup': ['delay_before_get_view_natural_endpoint']}
+    cfg = {'force_gossip_topology_changes': True,
+           'enable_tablets': False,
+           'error_injections_at_startup': ['delay_before_get_view_natural_endpoint']}
 
     servers = [await manager.server_add(config=cfg, timeout=60) for _ in range(3)]
 

--- a/test/topology_custom/test_raft_fix_broken_snapshot.py
+++ b/test/topology_custom/test_raft_fix_broken_snapshot.py
@@ -34,6 +34,7 @@ async def test_raft_fix_broken_snapshot(manager: ManagerClient):
 
     cfg = {'enable_user_defined_functions': False,
            'force_gossip_topology_changes': True,
+           'enable_tablets': False,
            'error_injections_at_startup': ['raft_sys_table_storage::bootstrap/init_index_0']}
     srv = await manager.server_add(config=cfg)
     cql = manager.get_cql()

--- a/test/topology_custom/test_raft_recovery_basic.py
+++ b/test/topology_custom/test_raft_recovery_basic.py
@@ -20,7 +20,8 @@ from test.topology.util import reconnect_driver, enter_recovery_state, \
 @log_run_time
 async def test_raft_recovery_basic(request, manager: ManagerClient):
     cfg = {'enable_user_defined_functions': False,
-           'force_gossip_topology_changes': True}
+           'force_gossip_topology_changes': True,
+           'enable_tablets': False}
     cmd = ['--logger-log-level', 'raft=trace']
 
     servers = [await manager.server_add(config=cfg, cmdline=cmd) for _ in range(3)]

--- a/test/topology_custom/test_raft_recovery_majority_loss.py
+++ b/test/topology_custom/test_raft_recovery_majority_loss.py
@@ -29,7 +29,8 @@ async def test_recovery_after_majority_loss(request, manager: ManagerClient):
     about the schema changes.
     """
     cfg = {'enable_user_defined_functions': False,
-           'force_gossip_topology_changes': True}
+           'force_gossip_topology_changes': True,
+           'enable_tablets': False}
     servers = [await manager.server_add(config=cfg) for _ in range(3)]
 
     logging.info("Waiting until driver connects to every server")

--- a/test/topology_custom/test_raft_recovery_stuck.py
+++ b/test/topology_custom/test_raft_recovery_stuck.py
@@ -30,7 +30,8 @@ async def test_recover_stuck_raft_recovery(request, manager: ManagerClient):
     remaining nodes will restart the procedure, establish a new group 0 and finish upgrade.
     """
     cfg = {'enable_user_defined_functions': False,
-           'force_gossip_topology_changes': True}
+           'force_gossip_topology_changes': True,
+           'enable_tablets': False}
     servers = [await manager.server_add(config=cfg) for _ in range(3)]
     srv1, *others = servers
 

--- a/test/topology_custom/test_view_build_status.py
+++ b/test/topology_custom/test_view_build_status.py
@@ -192,7 +192,7 @@ async def test_view_build_status_snapshot(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_view_build_status_migration_to_v2(request, manager: ManagerClient):
     # First, force the first node to start in legacy mode
-    cfg = {'force_gossip_topology_changes': True}
+    cfg = {'force_gossip_topology_changes': True, 'enable_tablets': False}
 
     servers = [await manager.server_add(config=cfg)]
     # Enable raft-based node operations for subsequent nodes - they should fall back to
@@ -246,7 +246,7 @@ async def test_view_build_status_migration_to_v2(request, manager: ManagerClient
 @pytest.mark.asyncio
 async def test_view_build_status_migration_to_v2_with_write_during_migration(request, manager: ManagerClient):
     # First, force the first node to start in legacy mode
-    cfg = {'force_gossip_topology_changes': True}
+    cfg = {'force_gossip_topology_changes': True, 'enable_tablets': False}
 
     servers = [await manager.server_add(config=cfg)]
     # Enable raft-based node operations for subsequent nodes - they should fall back to
@@ -304,7 +304,7 @@ async def test_view_build_status_migration_to_v2_with_write_during_migration(req
 @pytest.mark.asyncio
 async def test_view_build_status_migration_to_v2_barrier(request, manager: ManagerClient):
     # First, force the first node to start in legacy mode
-    cfg = {'force_gossip_topology_changes': True}
+    cfg = {'force_gossip_topology_changes': True, 'enable_tablets': False}
 
     servers = [await manager.server_add(config=cfg)]
     # Enable raft-based node operations for subsequent nodes - they should fall back to
@@ -429,7 +429,7 @@ async def test_view_build_status_with_replace_node(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_view_build_status_migration_to_v2_with_cleanup(request, manager: ManagerClient):
     # First, force the first node to start in legacy mode
-    cfg = {'force_gossip_topology_changes': True}
+    cfg = {'force_gossip_topology_changes': True, 'enable_tablets': False}
 
     servers = [await manager.server_add(config=cfg)]
     # Enable raft-based node operations for subsequent nodes - they should fall back to

--- a/test/topology_custom/test_writes_to_previous_cdc_generations.py
+++ b/test/topology_custom/test_writes_to_previous_cdc_generations.py
@@ -21,6 +21,7 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+keyspace_cql = "CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false }"
 
 async def wait_for_publishing_generations(cql: Session, servers: list[ServerInfo]) -> Optional[set[datetime]]:
     query_gen_timestamps = SimpleStatement(
@@ -71,7 +72,7 @@ async def test_writes_to_recent_previous_cdc_generations(request, manager: Manag
     gen_timestamps = await wait_for_publishing_generations(cql, servers)
 
     logger.info("Creating a test table")
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
+    await cql.run_async(keyspace_cql)
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int) WITH cdc = {'enabled': true}")
 
     async def do_write(timestamp: int):
@@ -121,7 +122,7 @@ async def test_writes_to_old_previous_cdc_generation(request, manager: ManagerCl
     gen_timestamps = await wait_for_publishing_generations(cql, servers)
 
     logger.info("Creating a test table")
-    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
+    await cql.run_async(keyspace_cql)
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int) WITH cdc = {'enabled': true}")
 
     ts2 = max(gen_timestamps)


### PR DESCRIPTION
Explicitly disable tablets in a few tests that rely on features not yet supported with tablets.