### PR TITLE
test: lib: rest_client: use 'http' scheme even when connecting via a unix domain socket

### DIFF
--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -128,7 +128,7 @@ class UnixRESTClient(RESTClient):
     def __init__(self, sock_path: str):
         # NOTE: using Python requests style URI for Unix domain sockets to avoid using "localhost"
         #       host parameter is ignored but set to socket name as convention
-        self.uri_scheme: str = "http+unix"
+        self.uri_scheme: str = "http"
         self.default_host: str = f"{os.path.basename(sock_path)}"
         self.connector = UnixConnector(path=sock_path)
 


### PR DESCRIPTION
aiohttp 3.10.5 complains when 'unix+http' is used for a unix-domain socket. USe 'http', which work with 3.10.5 and the toolchain's 3.9.5.

Only needed for a future toolchain, so no backport needed.