### PR TITLE
utils: s3: include <memory> for aws_error.cc

### DIFF
--- a/utils/s3/aws_error.cc
+++ b/utils/s3/aws_error.cc
@@ -14,6 +14,8 @@
 
 #include "utils/s3/aws_error.hh"
 
+#include <memory>
+
 namespace aws {
 
 aws_error::aws_error(aws_error_type error_type, retryable is_retryable) : _type(error_type), _is_retryable(is_retryable) {


### PR DESCRIPTION
aws_error.cc uses std::make_unique, but doesn't include the right header.

Only needed for a future toolchain, so no backport needed.