### PR TITLE
Add tablet repair scheduler support

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2853,6 +2853,46 @@
          ]
       },
       {
+         "path":"/storage_service/tablets/repair",
+         "operations":[
+            {
+               "nickname":"repair_tablet",
+               "method":"POST",
+               "summary":"Repair a tablet",
+               "type":"void",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"ks",
+                     "description":"Keyspace name to repair",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"table",
+                     "description":"Table name to repair",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"tokens",
+                     "description":"Tokens owned by the tablets to repair. Multiple tokens can be provided using a comma-separated list. When set to the special word 'all', all tablets will be repaired",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  }
+               ]
+            }
+         ]
+      },
+      {
          "path":"/storage_service/tablets/balancing",
          "operations":[
             {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2321,6 +2321,7 @@ future<> system_keyspace::make(
         co_await db.create_local_system_table(table, maybe_write_in_user_memory(table), erm_factory);
         co_await db.find_column_family(table).init_storage();
     }
+    replica::tablet_add_repair_scheduler_user_types(NAME, db);
 }
 
 void system_keyspace::mark_writable() {

--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -209,7 +209,23 @@ CREATE TABLE system.tablets (
     tablet_count int static,
     resize_type text static,
     resize_seq_number bigint static,
+    repair_scheduler_config frozen<repair_scheduler_config> static,
+    repair_task_info frozen<tablet_task_info>,
+    repair_time timestamp,
     PRIMARY KEY ((keyspace_name, table_id), last_token)
+)
+
+CREATE TYPE system.repair_scheduler_config (
+    auto_repair_enabled boolean,
+    auto_repair_threshold bigint
+)
+
+CREATE TYPE system.tablet_task_info (
+    request_type text,
+    tablet_task_id uuid,
+    request_time timestamp,
+    sched_nr bigint,
+    sched_time timestamp
 )
 ~~~
 
@@ -231,6 +247,19 @@ Only tables which use tablet-based replication strategy have an entry here.
    (last_token(i-1), last_token(i)] for i > 0
 ```
 
+`repair_time` is the last time the tablet has been repaired.
+
+`repair_task_info` contains the metadata for the task manager. It contains the following values:
+  * `request_type` - The type of the request. It could be user_repair and auto_repair.
+  * `tablet_task_id` - The UUID of the task.
+  * `request_time` - The time the request is created.
+  * `sched_nr` - Number of times the request has been scheduled by the repair scheduler.
+  * `sched_time` - The time the request has been scheduled by the repair scheduler.
+
+`repair_scheduler_config` contains configuration for the repair scheduler. It contains the following values:
+  * `auto_repair_enabled` - When set to true, auto repair is enabled. Disabled by default.
+  * `auto_repair_threshold` -  If the time since last repair is longer than auto_repair_threshold seconds, the tablet is eligible for auto repair.
+
 Each tablet is represented by a single row. `replicas` holds the set of shard-replicas of the tablet.
 It's a list of tuples where the first element is `host_id` of the replica and the second element is the `shard_id` of the replica.
 
@@ -242,6 +271,7 @@ During tablet splitting, the load balancer sets `resize_type` column with `split
 The `transition` column can have the following values:
   * `migration` - One tablet replica is moving from one shard to another.
   * `rebuild` - New tablet replica is created from the remaining replicas.
+  * `repair` - Tablet replicas are being repaired.
 
 # Virtual tables in the system keyspace
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -144,6 +144,8 @@ public:
     gms::feature fragmented_commitlog_entries { *this, "FRAGMENTED_COMMITLOG_ENTRIES"sv };
     gms::feature maintenance_tenant { *this, "MAINTENANCE_TENANT"sv };
 
+    gms::feature tablet_repair_scheduler { *this, "TABLET_REPAIR_SCHEDULER"sv };
+
     // A feature just for use in tests. It must not be advertised unless
     // the "features_enable_test_feature" injection is enabled.
     // This feature MUST NOT be advertised in release mode!

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -64,4 +64,5 @@ verb [[cancellable]] raft_pull_snapshot (raft::server_id dst_id, service::raft_s
 verb [[cancellable]] tablet_stream_data (raft::server_id dst_id, locator::global_tablet_id);
 verb [[cancellable]] tablet_cleanup (raft::server_id dst_id, locator::global_tablet_id);
 verb [[cancellable]] table_load_stats (raft::server_id dst_id) -> locator::load_stats;
+verb [[cancellable]] tablet_repair(raft::server_id dst_id, locator::global_tablet_id);
 }

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -353,8 +353,9 @@ future<tablet_map> network_topology_strategy::reallocate_tablets(schema_ptr s, t
     tablet_logger.debug("Allocating tablets for {}.{} ({}): dc_rep_factor={} tablet_count={}", s->ks_name(), s->cf_name(), s->id(), _dc_rep_factor, tablets.tablet_count());
 
     for (tablet_id tb : tablets.tablet_ids()) {
-        auto replicas = co_await reallocate_tablets(s, tm, load, tablets, tb);
-        tablets.set_tablet(tb, tablet_info{std::move(replicas)});
+        auto tinfo = tablets.get_tablet_info(tb);
+        tinfo.replicas = co_await reallocate_tablets(s, tm, load, tablets, tb);
+        tablets.set_tablet(tb, std::move(tinfo));
     }
 
     tablet_logger.debug("Allocated tablets for {}.{} ({}): dc_rep_factor={}: {}", s->ks_name(), s->cf_name(), s->id(), _dc_rep_factor, tablets);

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -14,10 +14,12 @@
 #include "db/system_keyspace.hh"
 #include "replica/database.hh"
 #include "utils/stall_free.hh"
+#include "utils/rjson.hh"
 #include "gms/feature_service.hh"
 
 #include <algorithm>
 #include <iterator>
+#include <chrono>
 
 #include <fmt/ranges.h>
 
@@ -38,6 +40,10 @@ write_replica_set_selector get_selector_for_writes(tablet_transition_stage stage
             return write_replica_set_selector::both;
         case tablet_transition_stage::streaming:
             return write_replica_set_selector::both;
+        case tablet_transition_stage::repair:
+            return write_replica_set_selector::previous;
+        case tablet_transition_stage::end_repair:
+            return write_replica_set_selector::previous;
         case tablet_transition_stage::write_both_read_new:
             return write_replica_set_selector::both;
         case tablet_transition_stage::use_new:
@@ -62,6 +68,10 @@ read_replica_set_selector get_selector_for_reads(tablet_transition_stage stage) 
         case tablet_transition_stage::write_both_read_old:
             return read_replica_set_selector::previous;
         case tablet_transition_stage::streaming:
+            return read_replica_set_selector::previous;
+        case tablet_transition_stage::repair:
+            return read_replica_set_selector::previous;
+        case tablet_transition_stage::end_repair:
             return read_replica_set_selector::previous;
         case tablet_transition_stage::write_both_read_new:
             return read_replica_set_selector::next;
@@ -121,9 +131,26 @@ tablet_migration_streaming_info get_migration_streaming_info(const locator::topo
             });
 
             return result;
+        case tablet_transition_kind::repair:
+            auto s = std::unordered_set<tablet_replica>(tinfo.replicas.begin(), tinfo.replicas.end());
+            result.stream_weight = locator::tablet_migration_stream_weight_repair;
+            result.read_from = s;
+            result.written_to = std::move(s);
+            return result;
     }
     on_internal_error(tablet_logger, format("Invalid tablet transition kind: {}", static_cast<int>(trinfo.transition)));
 }
+
+bool tablet_has_excluded_node(const locator::topology& topo, const tablet_info& tinfo) {
+    for (const auto& r : tinfo.replicas) {
+        auto* n = topo.find_node(r.host);
+        if (!n || n->is_excluded()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 
 std::optional<tablet_replica> get_leaving_replica(const tablet_info& tinfo, const tablet_transition_info& trinfo) {
     auto leaving = substract_sets(tinfo.replicas, trinfo.next);
@@ -362,6 +389,10 @@ void tablet_map::set_resize_decision(locator::resize_decision decision) {
     _resize_decision = std::move(decision);
 }
 
+void tablet_map::set_repair_scheduler_config(locator::repair_scheduler_config config) {
+    _repair_scheduler_config = std::move(config);
+}
+
 void tablet_map::clear_tablet_transition_info(tablet_id id) {
     check_tablet_id(id);
     _transitions.erase(id);
@@ -409,6 +440,8 @@ static const std::unordered_map<tablet_transition_stage, sstring> tablet_transit
     {tablet_transition_stage::write_both_read_old, "write_both_read_old"},
     {tablet_transition_stage::write_both_read_new, "write_both_read_new"},
     {tablet_transition_stage::streaming, "streaming"},
+    {tablet_transition_stage::repair, "repair"},
+    {tablet_transition_stage::end_repair, "end_repair"},
     {tablet_transition_stage::use_new, "use_new"},
     {tablet_transition_stage::cleanup, "cleanup"},
     {tablet_transition_stage::cleanup_target, "cleanup_target"},
@@ -441,6 +474,7 @@ static const std::unordered_map<tablet_transition_kind, sstring> tablet_transiti
         {tablet_transition_kind::migration, "migration"},
         {tablet_transition_kind::intranode_migration, "intranode_migration"},
         {tablet_transition_kind::rebuild, "rebuild"},
+        {tablet_transition_kind::repair, "repair"},
 };
 
 static const std::unordered_map<sstring, tablet_transition_kind> tablet_transition_kind_from_name = std::invoke([] {
@@ -463,6 +497,33 @@ tablet_transition_kind tablet_transition_kind_from_string(const sstring& name) {
     return tablet_transition_kind_from_name.at(name);
 }
 
+// The names are persisted in system tables so should not be changed.
+static const std::unordered_map<tablet_task_type, sstring> tablet_task_type_to_name = {
+    {locator::tablet_task_type::none, "none"},
+    {locator::tablet_task_type::user_repair, "user_repair"},
+    {locator::tablet_task_type::auto_repair, "auto_repair"},
+};
+
+static const std::unordered_map<sstring, tablet_task_type> tablet_task_type_from_name = std::invoke([] {
+    std::unordered_map<sstring, tablet_task_type> result;
+    for (auto&& [v, s] : tablet_task_type_to_name) {
+        result.emplace(s, v);
+    }
+    return result;
+});
+
+sstring tablet_task_type_to_string(tablet_task_type kind) {
+    auto i = tablet_task_type_to_name.find(kind);
+    if (i == tablet_task_type_to_name.end()) {
+        on_internal_error(tablet_logger, format("Invalid repair task type: {}", static_cast<int>(kind)));
+    }
+    return i->second;
+}
+
+tablet_task_type tablet_task_type_from_string(const sstring& name) {
+    return tablet_task_type_from_name.at(name);
+}
+
 size_t tablet_map::external_memory_usage() const {
     size_t result = _tablets.external_memory_usage();
     for (auto&& tablet : _tablets) {
@@ -481,6 +542,10 @@ bool tablet_map::needs_split() const {
 
 const locator::resize_decision& tablet_map::resize_decision() const {
     return _resize_decision;
+}
+
+const locator::repair_scheduler_config& tablet_map::repair_scheduler_config() const {
+    return _repair_scheduler_config;
 }
 
 static auto to_resize_type(sstring decision) {
@@ -926,6 +991,11 @@ auto fmt::formatter<locator::tablet_transition_kind>::format(const locator::tabl
     return fmt::format_to(ctx.out(), "{}", locator::tablet_transition_kind_to_string(kind));
 }
 
+auto fmt::formatter<locator::tablet_task_type>::format(const locator::tablet_task_type& kind, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", locator::tablet_task_type_to_string(kind));
+}
+
 auto fmt::formatter<locator::tablet_map>::format(const locator::tablet_map& r, fmt::format_context& ctx) const
         -> decltype(ctx.out()) {
     auto out = ctx.out();
@@ -980,4 +1050,45 @@ auto fmt::formatter<locator::tablet_metadata_change_hint>::format(const locator:
         first = false;
     }
     return fmt::format_to(out, "\n}}");
+}
+
+auto fmt::formatter<locator::repair_scheduler_config>::format(const locator::repair_scheduler_config& config, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    std::map<sstring, sstring> ret{
+        {"auto_repair_enabled", config.auto_repair_enabled ? "true" : "false"},
+        {"auto_repair_threshold", std::to_string(config.auto_repair_threshold.count())},
+    };
+    return fmt::format_to(ctx.out(), "{}", rjson::print(rjson::from_string_map(ret)));
+};
+
+auto fmt::formatter<locator::tablet_task_info>::format(const locator::tablet_task_info& info, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    std::map<sstring, sstring> ret{
+        {"request_type", fmt::to_string(info.request_type)},
+        {"tablet_task_id", fmt::to_string(info.tablet_task_id)},
+        {"request_time", fmt::to_string(db_clock::to_time_t(info.request_time))},
+        {"sched_nr", fmt::to_string(info.sched_nr)},
+        {"sched_time", fmt::to_string(db_clock::to_time_t(info.sched_time))},
+    };
+    return fmt::format_to(ctx.out(), "{}", rjson::print(rjson::from_string_map(ret)));
+};
+
+bool locator::tablet_task_info::is_valid() const {
+    return request_type != locator::tablet_task_type::none;
+}
+
+bool locator::tablet_task_info::is_user_request() const {
+    return request_type == locator::tablet_task_type::user_repair;
+}
+
+locator::tablet_task_info locator::tablet_task_info::make_auto_request() {
+    long sched_nr = 0;
+    auto tablet_task_id = locator::tablet_task_id(utils::UUID_gen::get_time_UUID());
+    return locator::tablet_task_info{locator::tablet_task_type::auto_repair, tablet_task_id, db_clock::now(), sched_nr, db_clock::time_point()};
+}
+
+locator::tablet_task_info locator::tablet_task_info::make_user_request() {
+    long sched_nr = 0;
+    auto tablet_task_id = locator::tablet_task_id(utils::UUID_gen::get_time_UUID());
+    return locator::tablet_task_info{locator::tablet_task_type::user_repair, tablet_task_id, db_clock::now(), sched_nr, db_clock::time_point()};
 }

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -236,9 +236,15 @@ tablet_replica_set get_primary_replicas(const tablet_info&, const tablet_transit
 tablet_transition_info migration_to_transition_info(const tablet_info&, const tablet_migration_info&);
 
 /// Describes streaming required for a given tablet transition.
+constexpr int tablet_migration_stream_weight_default = 1;
+constexpr int tablet_migration_stream_weight_repair = 2;
 struct tablet_migration_streaming_info {
     std::unordered_set<tablet_replica> read_from;
     std::unordered_set<tablet_replica> written_to;
+    // The stream_weight for repair migration is set to 2, because it requires
+    // more work than just moving the tablet around. The stream_weight for all
+    // other migrations are set to 1.
+    int stream_weight = tablet_migration_stream_weight_default;
 };
 
 tablet_migration_streaming_info get_migration_streaming_info(const locator::topology&, const tablet_info&, const tablet_transition_info&);

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -18,6 +18,7 @@
 #include "schema/schema_fwd.hh"
 #include "utils/chunked_vector.hh"
 #include "utils/hash.hh"
+#include "utils/UUID.hh"
 
 #include <ranges>
 #include <seastar/core/reactor.hh>
@@ -34,6 +35,8 @@ class topology;
 extern seastar::logger tablet_logger;
 
 using token = dht::token;
+
+using tablet_task_id = utils::tagged_uuid<struct tablet_task_id_tag>;
 
 // Identifies tablet within the scope of a single tablet_map,
 // which has a scope of (table_id, token metadata version).
@@ -141,9 +144,34 @@ bool contains(const tablet_replica_set& rs, const tablet_replica& r) {
     return std::ranges::any_of(rs, [&] (auto&& r_) { return r_ == r; });
 }
 
+
+enum class tablet_task_type {
+    none,
+    user_repair,
+    auto_repair,
+};
+
+sstring tablet_task_type_to_string(tablet_task_type);
+tablet_task_type tablet_task_type_from_string(const sstring&);
+
+struct tablet_task_info {
+    tablet_task_type request_type = tablet_task_type::none;
+    locator::tablet_task_id tablet_task_id;
+    db_clock::time_point request_time;
+    int64_t sched_nr = 0;
+    db_clock::time_point sched_time;
+    bool operator==(const tablet_task_info&) const = default;
+    bool is_valid() const;
+    bool is_user_request() const;
+    static tablet_task_info make_user_request();
+    static tablet_task_info make_auto_request();
+};
+
 /// Stores information about a single tablet.
 struct tablet_info {
     tablet_replica_set replicas;
+    db_clock::time_point repair_time;
+    locator::tablet_task_info repair_task_info;
 
     bool operator==(const tablet_info&) const = default;
 };
@@ -171,6 +199,8 @@ enum class tablet_transition_stage {
     cleanup_target,
     revert_migration,
     end_migration,
+    repair,
+    end_repair,
 };
 
 enum class tablet_transition_kind {
@@ -186,6 +216,9 @@ enum class tablet_transition_kind {
     // The new replica is (tablet_transition_info::next - tablet_info::replicas).
     // The leaving replica is (tablet_info::replicas - tablet_transition_info::next).
     rebuild,
+
+    // Repair the tablet replicas
+    repair,
 };
 
 sstring tablet_transition_stage_to_string(tablet_transition_stage);
@@ -249,6 +282,7 @@ struct tablet_migration_streaming_info {
 
 tablet_migration_streaming_info get_migration_streaming_info(const locator::topology&, const tablet_info&, const tablet_transition_info&);
 tablet_migration_streaming_info get_migration_streaming_info(const locator::topology&, const tablet_info&, const tablet_migration_info&);
+bool tablet_has_excluded_node(const locator::topology& topo, const tablet_info& tinfo);
 
 // Describes if a given token is located at either left or right side of a tablet's range
 enum tablet_range_side {
@@ -304,6 +338,14 @@ struct load_stats {
     }
 };
 
+struct repair_scheduler_config {
+    bool auto_repair_enabled = false;
+    // If the time since last repair is bigger than auto_repair_threshold
+    // seconds, the tablet is eligible for auto repair.
+    std::chrono::seconds auto_repair_threshold{10 * 24 * 3600};
+    bool operator==(const repair_scheduler_config&) const = default;
+};
+
 using load_stats_ptr = lw_shared_ptr<const load_stats>;
 
 /// Stores information about tablets of a single table.
@@ -333,6 +375,7 @@ private:
     size_t _log2_tablets; // log_2(_tablets.size())
     std::unordered_map<tablet_id, tablet_transition_info> _transitions;
     resize_decision _resize_decision;
+    repair_scheduler_config _repair_scheduler_config;
 
     /// Returns the largest token owned by tablet_id when the tablet_count is `1 << log2_tablets`.
     dht::token get_last_token(tablet_id id, size_t log2_tablets) const;
@@ -444,10 +487,12 @@ public:
     dht::token_range get_token_range_after_split(const token& t) const noexcept;
 
     const locator::resize_decision& resize_decision() const;
+    const locator::repair_scheduler_config& repair_scheduler_config() const;
 public:
     void set_tablet(tablet_id, tablet_info);
     void set_tablet_transition_info(tablet_id, tablet_transition_info);
     void set_resize_decision(locator::resize_decision);
+    void set_repair_scheduler_config(locator::repair_scheduler_config config);
     void clear_tablet_transition_info(tablet_id);
     void clear_transitions();
 
@@ -608,4 +653,19 @@ struct fmt::formatter<locator::tablet_metadata> : fmt::formatter<string_view> {
 template <>
 struct fmt::formatter<locator::tablet_metadata_change_hint> : fmt::formatter<string_view> {
     auto format(const locator::tablet_metadata_change_hint&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<locator::repair_scheduler_config> : fmt::formatter<string_view> {
+    auto format(const locator::repair_scheduler_config&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<locator::tablet_task_info> : fmt::formatter<string_view> {
+    auto format(const locator::tablet_task_info&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<locator::tablet_task_type> : fmt::formatter<string_view> {
+    auto format(const locator::tablet_task_type&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -622,6 +622,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::TABLET_STREAM_FILES:
     case messaging_verb::TABLET_STREAM_DATA:
     case messaging_verb::TABLET_CLEANUP:
+    case messaging_verb::TABLET_REPAIR:
     case messaging_verb::TABLE_LOAD_STATS:
         return 1;
     case messaging_verb::CLIENT_ID:

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -201,7 +201,8 @@ enum class messaging_verb : int32_t {
     TABLE_LOAD_STATS = 72,
     JOIN_NODE_QUERY = 73,
     TASKS_GET_CHILDREN = 74,
-    LAST = 75,
+    TABLET_REPAIR = 75,
+    LAST = 76,
 };
 
 } // namespace netw

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -20,6 +20,7 @@
 #include <seastar/util/bool_class.hh>
 #include "service/raft/raft_address_map.hh"
 #include "utils/user_provided_param.hh"
+#include "locator/tablet_metadata_guard.hh"
 
 using namespace seastar;
 
@@ -178,6 +179,7 @@ private:
 public:
     future<> repair_tablets(repair_uniq_id id, sstring keyspace_name, std::vector<sstring> table_names, host2ip_t host2ip, bool primary_replica_only = true, dht::token_range_vector ranges_specified = {}, std::vector<sstring> dcs = {}, std::unordered_set<gms::inet_address> hosts = {}, std::unordered_set<gms::inet_address> ignore_nodes = {}, std::optional<int> ranges_parallelism = std::nullopt);
 
+    future<> repair_tablet(locator::tablet_metadata_guard& guard, locator::global_tablet_id gid);
 private:
 
     future<repair_update_system_table_response> repair_update_system_table_handler(

--- a/replica/tablet_mutation_builder.hh
+++ b/replica/tablet_mutation_builder.hh
@@ -40,6 +40,10 @@ public:
     tablet_mutation_builder& del_session(dht::token last_token);
     tablet_mutation_builder& del_transition(dht::token last_token);
     tablet_mutation_builder& set_resize_decision(locator::resize_decision);
+    tablet_mutation_builder& set_repair_scheduler_config(locator::repair_scheduler_config);
+    tablet_mutation_builder& set_repair_time(dht::token last_token, db_clock::time_point repair_time);
+    tablet_mutation_builder& set_repair_task_info(dht::token last_token, locator::tablet_task_info info);
+    tablet_mutation_builder& del_repair_task_info(dht::token last_token);
 
     mutation build() {
         return std::move(_m);

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -27,6 +27,12 @@ namespace replica {
 
 using namespace locator;
 
+static thread_local auto repair_scheduler_config_type = user_type_impl::get_instance(
+        "system", "repair_scheduler_config", {"auto_repair_enabled", "auto_repair_threshold"},
+        {boolean_type, long_type}, false);
+static thread_local auto tablet_task_info_type = user_type_impl::get_instance(
+        "system", "tablet_task_info", {"request_type", "tablet_task_id", "request_time", "sched_nr", "sched_time"},
+        {utf8_type, uuid_type, timestamp_type, long_type, timestamp_type}, false);
 static thread_local auto replica_type = tuple_type_impl::get_instance({uuid_type, int32_type});
 static thread_local auto replica_set_type = list_type_impl::get_instance(replica_type, false);
 static thread_local auto tablet_info_type = tuple_type_impl::get_instance({long_type, long_type, replica_set_type});
@@ -39,11 +45,18 @@ data_type get_tablet_info_type() {
     return tablet_info_type;
 }
 
+void tablet_add_repair_scheduler_user_types(const sstring& ks, replica::database& db) {
+    db.find_keyspace(ks).add_user_type(repair_scheduler_config_type);
+    db.find_keyspace(ks).add_user_type(tablet_task_info_type);
+}
+
 schema_ptr make_tablets_schema() {
     // FIXME: Allow UDTs in system keyspace:
     // CREATE TYPE tablet_replica (replica_id uuid, shard int);
     // replica_set_type = frozen<list<tablet_replica>>
     auto id = generate_legacy_id(db::system_keyspace::NAME, db::system_keyspace::TABLETS);
+    // Bump the schema version offset for tablet repair scheduler columns
+    constexpr uint16_t schema_version_offset = 1;
     return schema_builder(db::system_keyspace::NAME, db::system_keyspace::TABLETS, id)
             .with_column("table_id", uuid_type, column_kind::partition_key)
             .with_column("tablet_count", int32_type, column_kind::static_column)
@@ -57,7 +70,10 @@ schema_ptr make_tablets_schema() {
             .with_column("session", uuid_type)
             .with_column("resize_type", utf8_type, column_kind::static_column)
             .with_column("resize_seq_number", long_type, column_kind::static_column)
-            .with_version(db::system_keyspace::generate_schema_version(id))
+            .with_column("repair_time", timestamp_type)
+            .with_column("repair_task_info", tablet_task_info_type)
+            .with_column("repair_scheduler_config", repair_scheduler_config_type, column_kind::static_column)
+            .with_version(db::system_keyspace::generate_schema_version(id, schema_version_offset))
             .build();
 }
 
@@ -70,6 +86,25 @@ std::vector<data_value> replicas_to_data_value(const tablet_replica_set& replica
                 data_value(int(replica.shard))
         }));
     }
+    return result;
+};
+
+data_value tablet_task_info_to_data_value(const locator::tablet_task_info& info) {
+    data_value result = make_user_value(tablet_task_info_type, {
+        data_value(locator::tablet_task_type_to_string(info.request_type)),
+        data_value(info.tablet_task_id.uuid()),
+        data_value(info.request_time),
+        data_value(info.sched_nr),
+        data_value(info.sched_time)
+    });
+    return result;
+};
+
+data_value repair_scheduler_config_to_data_value(const locator::repair_scheduler_config& config) {
+    data_value result = make_user_value(repair_scheduler_config_type, {
+        data_value(config.auto_repair_enabled),
+        data_value(int64_t(config.auto_repair_threshold.count())),
+    });
     return result;
 };
 
@@ -89,6 +124,7 @@ tablet_map_to_mutation(const tablet_map& tablets, table_id id, const sstring& ke
     m.set_static_cell("table_name", data_value(table_name), ts);
     m.set_static_cell("resize_type", data_value(tablets.resize_decision().type_name()), ts);
     m.set_static_cell("resize_seq_number", data_value(int64_t(tablets.resize_decision().sequence_number)), ts);
+    m.set_static_cell("repair_scheduler_config", repair_scheduler_config_to_data_value(tablets.repair_scheduler_config()), ts);
 
     tablet_id tid = tablets.first_tablet();
     for (auto&& tablet : tablets.tablets()) {
@@ -167,6 +203,31 @@ tablet_mutation_builder::set_resize_decision(locator::resize_decision resize_dec
     return *this;
 }
 
+tablet_mutation_builder&
+tablet_mutation_builder::set_repair_scheduler_config(locator::repair_scheduler_config config) {
+    _m.set_static_cell("repair_scheduler_config", repair_scheduler_config_to_data_value(config), _ts);
+    return *this;
+}
+
+tablet_mutation_builder&
+tablet_mutation_builder::set_repair_time(dht::token last_token, db_clock::time_point repair_time) {
+    _m.set_clustered_cell(get_ck(last_token), "repair_time", data_value(repair_time), _ts);
+    return *this;
+}
+
+tablet_mutation_builder&
+tablet_mutation_builder::set_repair_task_info(dht::token last_token, locator::tablet_task_info repair_task_info) {
+    _m.set_clustered_cell(get_ck(last_token), "repair_task_info", tablet_task_info_to_data_value(repair_task_info), _ts);
+    return *this;
+}
+
+tablet_mutation_builder&
+tablet_mutation_builder::del_repair_task_info(dht::token last_token) {
+    auto col = _s->get_column_definition("repair_task_info");
+    _m.set_clustered_cell(get_ck(last_token), *col, atomic_cell::make_dead(_ts, gc_clock::now()));
+    return *this;
+}
+
 mutation make_drop_tablet_map_mutation(table_id id, api::timestamp_type ts) {
     auto s = db::system_keyspace::tablets();
     mutation m(s, partition_key::from_single_value(*s,
@@ -194,6 +255,39 @@ static
 tablet_replica_set deserialize_replica_set(cql3::untyped_result_set_row::view_type raw_value) {
     return tablet_replica_set_from_cell(
             replica_set_type->deserialize_value(raw_value));
+}
+
+locator::tablet_task_info tablet_task_info_from_cell(const data_value& v) {
+    std::vector<data_value> dv = value_cast<user_type_impl::native_type>(v);
+    auto result = locator::tablet_task_info{
+        locator::tablet_task_type_from_string(value_cast<sstring>(dv[0])),
+        locator::tablet_task_id(value_cast<utils::UUID>(dv[1])),
+        value_cast<db_clock::time_point>(dv[2]),
+        value_cast<int64_t>(dv[3]),
+        value_cast<db_clock::time_point>(dv[4]),
+    };
+    return result;
+}
+
+static
+locator::tablet_task_info deserialize_tablet_task_info(cql3::untyped_result_set_row::view_type raw_value) {
+    return tablet_task_info_from_cell(
+            tablet_task_info_type->deserialize_value(raw_value));
+}
+
+locator::repair_scheduler_config repair_scheduler_config_from_cell(const data_value& v) {
+    std::vector<data_value> dv = value_cast<user_type_impl::native_type>(v);
+    auto result = locator::repair_scheduler_config{
+        value_cast<bool>(dv[0]),
+        std::chrono::seconds(value_cast<int64_t>(dv[1])),
+    };
+    return result;
+}
+
+static
+locator::repair_scheduler_config deserialize_repair_scheduler_config(cql3::untyped_result_set_row::view_type raw_value) {
+    return repair_scheduler_config_from_cell(
+            repair_scheduler_config_type->deserialize_value(raw_value));
 }
 
 future<> save_tablet_metadata(replica::database& db, const tablet_metadata& tm, api::timestamp_type ts) {
@@ -343,6 +437,16 @@ tablet_id process_one_row(table_id table, tablet_map& map, tablet_id tid, const 
         new_tablet_replicas = deserialize_replica_set(row.get_view("new_replicas"));
     }
 
+    db_clock::time_point repair_time;
+    if (row.has("repair_time")) {
+        repair_time = row.get_as<db_clock::time_point>("repair_time");
+    }
+
+    locator::tablet_task_info repair_task_info;
+    if (row.has("repair_task_info")) {
+        repair_task_info = deserialize_tablet_task_info(row.get_view("repair_task_info"));
+    }
+
     if (row.has("stage")) {
         auto stage = tablet_transition_stage_from_string(row.get_as<sstring>("stage"));
         auto transition = tablet_transition_kind_from_string(row.get_as<sstring>("transition"));
@@ -364,7 +468,7 @@ tablet_id process_one_row(table_id table, tablet_map& map, tablet_id tid, const 
                 std::move(new_tablet_replicas), pending_replica, session_id});
     }
 
-    map.set_tablet(tid, tablet_info{std::move(tablet_replicas)});
+    map.set_tablet(tid, tablet_info{std::move(tablet_replicas), repair_time, repair_task_info});
 
     auto persisted_last_token = dht::token::from_int64(row.get_as<int64_t>("last_token"));
     auto current_last_token = map.get_last_token(tid);
@@ -404,6 +508,11 @@ struct tablet_metadata_builder {
 
                 locator::resize_decision resize_decision(std::move(resize_type_name), resize_seq_number);
                 current->map.set_resize_decision(std::move(resize_decision));
+            }
+
+            if (row.has("repair_scheduler_config")) {
+                auto config = deserialize_repair_scheduler_config(row.get_view("repair_scheduler_config"));
+                current->map.set_repair_scheduler_config(std::move(config));
             }
         }
 

--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -37,6 +37,8 @@ data_type get_tablet_info_type();
 
 schema_ptr make_tablets_schema();
 
+void tablet_add_repair_scheduler_user_types(const sstring& ks, replica::database& db);
+
 std::vector<data_value> replicas_to_data_value(const locator::tablet_replica_set& replicas);
 
 /// Converts information in tablet_map to mutations of system.tablets.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6175,6 +6175,154 @@ static bool increases_replicas_per_rack(const locator::topology& topology, const
     return m[dst_rack] + 1 > max;
 }
 
+future<service::group0_guard> storage_service::get_guard_for_tablet_update() {
+    auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
+    co_return guard;
+}
+
+future<bool> storage_service::exec_tablet_update(service::group0_guard guard, std::vector<canonical_mutation> updates, sstring reason) {
+    rtlogger.info("{}", reason);
+    rtlogger.trace("do update {} reason {}", updates, reason);
+    updates.emplace_back(topology_mutation_builder(guard.write_timestamp())
+            .set_version(_topology_state_machine._topology.version + 1)
+            .build());
+    topology_change change{std::move(updates)};
+    group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, reason);
+    try {
+        co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
+        co_return true;
+    } catch (group0_concurrent_modification&) {
+        rtlogger.debug("exec_tablet_update(): concurrent modification, retrying");
+    }
+    co_return false;
+}
+
+// Repair the tablets contain the tokens and wait for the repair to finish
+// This is used to run a manual repair requested by user from the restful API.
+future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_request(table_id table, std::variant<utils::chunked_vector<dht::token>, all_tokens_tag> tokens_variant) {
+    auto holder = _async_gate.hold();
+
+    if (this_shard_id() != 0) {
+        // group0 is only set on shard 0.
+        co_return co_await container().invoke_on(0, [&] (auto& ss) {
+            return ss.add_repair_tablet_request(table, std::move(tokens_variant));
+        });
+    }
+
+    bool all_tokens = std::holds_alternative<all_tokens_tag>(tokens_variant);
+    utils::chunked_vector<dht::token> tokens;
+    if (!all_tokens) {
+        tokens = std::get<utils::chunked_vector<dht::token>>(tokens_variant);
+    }
+
+    if (!_feature_service.tablet_repair_scheduler) {
+        throw std::runtime_error("The TABLET_REPAIR_SCHEDULER feature is not enabled on the cluster yet");
+    }
+
+    auto repair_task_info = locator::tablet_task_info::make_user_request();
+    auto res = std::unordered_map<sstring, sstring>{{sstring("tablet_task_id"), repair_task_info.tablet_task_id.to_sstring()}};
+
+    auto start = std::chrono::steady_clock::now();
+    slogger.info("Starting tablet repair by API request table_id={} tokens={} all_tokens={} tablet_task_id={}", table, tokens, all_tokens, repair_task_info.tablet_task_id);
+
+    while (true) {
+        auto guard = co_await get_guard_for_tablet_update();
+
+        auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
+        std::vector<canonical_mutation> updates;
+
+        if (all_tokens) {
+            tokens.clear();
+            co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& info) -> future<> {
+                auto last_token = tmap.get_last_token(tid);
+                tokens.push_back(last_token);
+                co_return;
+            });
+        }
+
+        for (const auto& token : tokens) {
+            auto tid = tmap.get_tablet_id(token);
+            auto& tinfo = tmap.get_tablet_info(tid);
+            auto& req_id = tinfo.repair_task_info.tablet_task_id;
+            if (req_id) {
+                throw std::runtime_error(fmt::format("Tablet {} is already in repair by tablet_task_id={}",
+                        locator::global_tablet_id{table, tid}, req_id));
+            }
+            auto last_token = tmap.get_last_token(tid);
+            updates.emplace_back(
+                replica::tablet_mutation_builder(guard.write_timestamp(), table)
+                    .set_repair_task_info(last_token, repair_task_info)
+                    .build());
+        }
+
+        sstring reason = format("Repair tablet by API request tokens={} tablet_task_id={}", tokens, repair_task_info.tablet_task_id);
+        if (co_await exec_tablet_update(std::move(guard), std::move(updates), std::move(reason))) {
+            break;
+        }
+    }
+
+    co_await _topology_state_machine.event.wait([&] {
+        auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
+        return std::all_of(tokens.begin(), tokens.end(), [&] (const dht::token& token) {
+            auto id = tmap.get_tablet_id(token);
+            return tmap.get_tablet_info(id).repair_task_info.tablet_task_id != repair_task_info.tablet_task_id;
+        });
+    });
+
+    auto duration = std::chrono::duration<float>(std::chrono::steady_clock::now() - start);
+    slogger.info("Finished tablet repair by API request table_id={} tokens={} all_tokens={} tablet_task_id={} duration={}",
+            table, tokens, all_tokens, repair_task_info.tablet_task_id, duration);
+
+    co_return res;
+}
+
+
+// Delete a tablet repair request by the given tablet_task_id
+future<> storage_service::del_repair_tablet_request(table_id table, locator::tablet_task_id tablet_task_id) {
+    auto holder = _async_gate.hold();
+
+    if (this_shard_id() != 0) {
+        // group0 is only set on shard 0.
+        co_return co_await container().invoke_on(0, [&] (auto& ss) {
+            return ss.del_repair_tablet_request(table, tablet_task_id);
+        });
+    }
+
+    if (!_feature_service.tablet_repair_scheduler) {
+        throw std::runtime_error("The TABLET_REPAIR_SCHEDULER feature is not enabled on the cluster yet");
+    }
+
+    slogger.info("Deleting tablet repair request by API request table_id={} tablet_task_id={}", table, tablet_task_id);
+    while (true) {
+        auto guard = co_await get_guard_for_tablet_update();
+
+        auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
+        std::vector<canonical_mutation> updates;
+
+        co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& info) -> future<> {
+            auto& tinfo = tmap.get_tablet_info(tid);
+            auto& req_id = tinfo.repair_task_info.tablet_task_id;
+            if (req_id != tablet_task_id) {
+                co_return;
+            }
+            auto last_token = tmap.get_last_token(tid);
+            auto* trinfo = tmap.get_tablet_transition_info(tid);
+            auto update = replica::tablet_mutation_builder(guard.write_timestamp(), table)
+                            .del_repair_task_info(last_token);
+            if (trinfo && trinfo->transition == locator::tablet_transition_kind::repair) {
+                update.del_session(last_token);
+            }
+            updates.emplace_back(update.build());
+        });
+
+        sstring reason = format("Deleting tablet repair request by API request tablet_id={} tablet_task_id={}", table, tablet_task_id);
+        if (co_await exec_tablet_update(std::move(guard), std::move(updates), std::move(reason))) {
+            break;
+        }
+    }
+    slogger.info("Deleted tablet repair request by API request table_id={} tablet_task_id={}", table, tablet_task_id);
+}
+
 future<> storage_service::move_tablet(table_id table, dht::token token, locator::tablet_replica src, locator::tablet_replica dst, loosen_constraints force) {
     auto holder = _async_gate.hold();
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -194,6 +194,7 @@ private:
     future<> do_tablet_operation(locator::global_tablet_id tablet,
                                  sstring op_name,
                                  std::function<future<>(locator::tablet_metadata_guard&)> op);
+    future<> repair_tablet(locator::global_tablet_id);
     future<> stream_tablet(locator::global_tablet_id);
     // Clones storage of leaving tablet into pending one. Done in the context of intra-node migration,
     // when both of which sit on the same node. So all the movement is local.

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -717,12 +717,12 @@ public:
     void apply_load(node_load_map& nodes, const tablet_migration_streaming_info& info) {
         for (auto&& replica : info.read_from) {
             if (nodes.contains(replica.host)) {
-                nodes[replica.host].shards[replica.shard].streaming_read_load += 1;
+                nodes[replica.host].shards[replica.shard].streaming_read_load += info.stream_weight;
             }
         }
         for (auto&& replica : info.written_to) {
             if (nodes.contains(replica.host)) {
-                nodes[replica.host].shards[replica.shard].streaming_write_load += 1;
+                nodes[replica.host].shards[replica.shard].streaming_write_load += info.stream_weight;
             }
         }
     }
@@ -733,7 +733,7 @@ public:
                 continue;
             }
             auto load = nodes[r.host].shards[r.shard].streaming_read_load;
-            if (load >= max_read_streaming_load) {
+            if (load + info.stream_weight > max_read_streaming_load) {
                 lblogger.debug("Migration skipped because of read load limit on {} ({})", r, load);
                 return false;
             }
@@ -743,7 +743,7 @@ public:
                 continue;
             }
             auto load = nodes[r.host].shards[r.shard].streaming_write_load;
-            if (load >= max_write_streaming_load) {
+            if (load + info.stream_weight > max_write_streaming_load) {
                 lblogger.debug("Migration skipped because of write load limit on {} ({})", r, load);
                 return false;
             }

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -110,22 +110,44 @@ struct table_resize_plan {
     }
 };
 
+struct tablet_repair_plan {
+    std::unordered_set<locator::global_tablet_id> _repairs;
+
+    const std::unordered_set<locator::global_tablet_id>& repairs() const {
+        return _repairs;
+    }
+
+    size_t size() const { return _repairs.size(); };
+
+    void merge(tablet_repair_plan&& other) {
+        for (auto& r : other._repairs) {
+            _repairs.insert(r);
+        }
+    }
+
+    void add(const locator::global_tablet_id& gid) {
+        _repairs.insert(gid);
+    }
+};
+
 class migration_plan {
 public:
     using migrations_vector = utils::chunked_vector<tablet_migration_info>;
 private:
     migrations_vector _migrations;
     table_resize_plan _resize_plan;
+    tablet_repair_plan _repair_plan;
     bool _has_nodes_to_drain = false;
 public:
     /// Returns true iff there are decommissioning nodes which own some tablet replicas.
     bool has_nodes_to_drain() const { return _has_nodes_to_drain; }
 
     const migrations_vector& migrations() const { return _migrations; }
-    bool empty() const { return _migrations.empty() && !_resize_plan.size(); }
-    size_t size() const { return _migrations.size() + _resize_plan.size(); }
+    bool empty() const { return _migrations.empty() && !_resize_plan.size() && !_repair_plan.size();}
+    size_t size() const { return _migrations.size() + _resize_plan.size() + _repair_plan.size(); }
     size_t tablet_migration_count() const { return _migrations.size(); }
     size_t resize_decision_count() const { return _resize_plan.size(); }
+    size_t tablet_repair_count() const { return _repair_plan.size(); }
 
     void add(tablet_migration_info info) {
         _migrations.emplace_back(std::move(info));
@@ -135,6 +157,7 @@ public:
         std::move(other._migrations.begin(), other._migrations.end(), std::back_inserter(_migrations));
         _has_nodes_to_drain |= other._has_nodes_to_drain;
         _resize_plan.merge(std::move(other._resize_plan));
+        _repair_plan.merge(std::move(other._repair_plan));
     }
 
     void set_has_nodes_to_drain(bool b) {
@@ -146,6 +169,14 @@ public:
     void set_resize_plan(table_resize_plan resize_plan) {
         _resize_plan = std::move(resize_plan);
     }
+
+    const tablet_repair_plan& repair_plan() const { return _repair_plan; }
+
+    void set_repair_plan(tablet_repair_plan repair) {
+        _repair_plan = std::move(repair);
+    }
+
+    future<std::unordered_set<locator::global_tablet_id>> get_migration_tablet_ids() const;
 };
 
 class migration_notifier;

--- a/test/pylib/repair.py
+++ b/test/pylib/repair.py
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from test.pylib.util import wait_for_cql_and_get_hosts
+
+import asyncio
+import time
+import logging
+import json
+
+async def load_tablet_repair_time(cql, hosts, table_id):
+    all_rows = []
+    repair_time_map = {}
+
+    for host in hosts:
+        logging.debug(f'Query hosts={host}');
+        rows = await cql.run_async(f"SELECT last_token, repair_time from system.tablets where table_id = {table_id}", host=host)
+        all_rows += rows
+    for row in all_rows:
+        logging.debug(f"Got system.tablets={row}")
+
+    for row in all_rows:
+        key = str(row[0])
+        repair_time_map[key] = row[1]
+
+    return repair_time_map
+
+async def create_table_insert_data_for_repair(manager, rf = 3 , tablets = 8, fast_stats_refresh = True, nr_keys = 256):
+    if fast_stats_refresh:
+        config = {'error_injections_at_startup': ['short_tablet_stats_refresh_interval']}
+    else:
+        config = {}
+    servers = [await manager.server_add(config=config), await manager.server_add(config=config), await manager.server_add(config=config)]
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {{'class': 'NetworkTopologyStrategy', "
+                  "'replication_factor': {}}} AND tablets = {{'initial': {}}};".format(rf, tablets))
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int) WITH tombstone_gc = {'mode':'repair'};")
+    keys = range(nr_keys)
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    logging.info(f'Got hosts={hosts}');
+    table_id = await manager.get_table_id("test", "test")
+    return (servers, cql, hosts, table_id)

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -273,6 +273,13 @@ class ScyllaRESTAPIClient():
             "token": str(token)
         })
 
+    async def tablet_repair(self, node_ip: str, ks: str, table: str, token : int) -> None:
+        await self.client.post(f"/storage_service/tablets/repair", host=node_ip, params={
+            "ks": ks,
+            "table": table,
+            "tokens": str(token)
+        })
+
     async def enable_tablet_balancing(self, node_ip: str) -> None:
         await self.client.post(f"/storage_service/tablets/balancing", host=node_ip, params={"enabled": "true"})
 

--- a/test/topology_experimental_raft/test_tablet_repair_scheduler.py
+++ b/test/topology_experimental_raft/test_tablet_repair_scheduler.py
@@ -1,0 +1,114 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from test.pylib.manager_client import ManagerClient
+from test.topology.conftest import skip_mode
+from test.pylib.repair import load_tablet_repair_time, create_table_insert_data_for_repair
+from test.pylib.rest_client import inject_error_one_shot
+
+import pytest
+import asyncio
+import logging
+import time
+import datetime
+
+logger = logging.getLogger(__name__)
+
+
+async def inject_error_one_shot_on(manager, error_name, servers):
+    errs = [inject_error_one_shot(manager.api, s.ip_addr, error_name) for s in servers]
+    await asyncio.gather(*errs)
+
+async def inject_error_on(manager, error_name, servers, params = {}):
+    errs = [manager.api.enable_injection(s.ip_addr, error_name, False, params) for s in servers]
+    await asyncio.gather(*errs)
+
+async def inject_error_off(manager, error_name, servers):
+    errs = [manager.api.disable_injection(s.ip_addr, error_name) for s in servers]
+    await asyncio.gather(*errs)
+
+@pytest.mark.asyncio
+async def test_tablet_manual_repair(manager: ManagerClient):
+    servers, cql, hosts, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=False)
+    token = -1
+
+    start = time.time()
+    await manager.api.tablet_repair(servers[0].ip_addr, "test", "test", token)
+    duration = time.time() - start
+    map1 = await load_tablet_repair_time(cql, hosts[0:1], table_id)
+    logging.info(f'map1={map1} duration={duration}')
+
+    # The repair time granularity is seconds. This makes sure the second repair time
+    # is different than the previous one.
+    await asyncio.sleep(1)
+
+    start = time.time()
+    await manager.api.tablet_repair(servers[0].ip_addr, "test", "test", token)
+    duration = time.time() - start
+    map2 = await load_tablet_repair_time(cql, hosts[0:1], table_id)
+    logging.info(f'map2={map2} duration={duration}')
+
+    t1 = map1[str(token)]
+    t2 = map2[str(token)]
+    logging.info(f't1={t1} t2={t2}')
+
+    assert t2 > t1
+
+@pytest.mark.asyncio
+async def test_tablet_manual_repair_all_tokens(manager: ManagerClient):
+    servers, cql, hosts, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=False)
+    token = "all"
+    now = datetime.datetime.utcnow()
+    map1 = await load_tablet_repair_time(cql, hosts[0:1], table_id)
+    await manager.api.tablet_repair(servers[0].ip_addr, "test", "test", token)
+    map2 = await load_tablet_repair_time(cql, hosts[0:1], table_id)
+    logging.info(f'{map1=} {map2=}')
+    assert len(map1) == len(map2)
+    for k, v in map1.items():
+        assert v == None
+    for k, v in map2.items():
+        assert v != None
+        assert v > now
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_tablet_manual_repair_reject_parallel_requests(manager: ManagerClient):
+    servers, cql, hosts, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=False)
+    token = -1
+
+    await inject_error_on(manager, "tablet_repair_add_delay_in_ms", servers, params={'value':'3000'})
+
+    class asyncState:
+        error = 0
+        ok = 0
+
+    state = asyncState()
+
+    async def run_repair(state):
+        try:
+            await manager.api.tablet_repair(servers[0].ip_addr, "test", "test", token)
+            state.ok = state.ok + 1
+        except Exception as e:
+            logging.info(f"Got exception as expected: {e}")
+            state.error = state.error + 1
+
+    await asyncio.gather(*[run_repair(state) for i in range(3)])
+
+    # A new tablet repair request can only be issued after the first one is
+    # finished.
+    assert state.ok == 1
+    assert state.error == 2
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_tablet_repair_error_and_retry(manager: ManagerClient):
+    servers, cql, hosts, table_id = await create_table_insert_data_for_repair(manager)
+
+    # Repair should finish with one time error injection
+    token = -1
+    await inject_error_one_shot_on(manager, "repair_tablet_fail_on_rpc_call", servers)
+    await manager.api.tablet_repair(servers[0].ip_addr, "test", "test", token)
+    await inject_error_off(manager, "repair_tablet_fail_on_rpc_call", servers)


### PR DESCRIPTION
This adds a new tablet migration kind: repair. It allows tablet repair
scheduler to use this migration kind to schedule repair jobs.

The current repair scheduler implementation does the following:

- A tablet is picked to be repaired when is requested by user

- The tablet repair can be scheduled along with tablet migration and
  rebuild. It runs in the tablet_migration track.

- Repair jobs are scheduled in a smart way so that at any point in time,
  there are no more than configured jobs per shard, which is similar to
  scylla manager's control.

New feature. No backport is needed.