### PR TITLE
test/test_view_build_status: properly wait for v2 in migration test

### DIFF
--- a/test/topology_custom/test_view_build_status.py
+++ b/test/topology_custom/test_view_build_status.py
@@ -235,7 +235,7 @@ async def test_view_build_status_migration_to_v2(request, manager: ManagerClient
 
     # Check that new writes are written to the v2 table
     await create_mv(cql, "vt2")
-    await wait_for_view_v2(cql, "ks", "vt2", 3)
+    await asyncio.gather(*(wait_for_view_v2(cql, "ks", "vt2", 3, host=h) for h in hosts))
 
     result = await cql.run_async("SELECT * FROM system.view_build_status_v2")
     assert len(result) == 6


### PR DESCRIPTION
The test_view_build_status_migration_to_v2 test case creates a new view (vt2) after peforming the view_build_status -> view_build_status_v2 migration and waits until it is built by `wait_for_view_v2` function. It works by waiting until a SELECT from view_build_status_v2 will return the expected number of rows for a given view.

However, if the host parameter is unspecified, it will query only one node on each attempt. Because `view_build_status_v2` is managed via raft, queries always return data from the queried node only. It might happen that `wait_for_view_v2` fetches expected results from one node while a different node might be lagging behind the group0 coordinator and might not have all data yet.

In case of test_view_build_status_migration_to_v2 this is a problem - it first uses `wait_for_view_v2` to wait for view, later it queries `view_build_status_v2` on a random node and asserts its state - and might fail because that node didn't have the newest state yet.

Fix the issue by issuing `wait_for_view_v2` in parallel for all nodes in the cluster and waiting until all nodes have the most recent state.

Fixes: scylladb/scylladb#21060

Suggest backporting it to 6.2 - even though we didn't observe the failure there yet, the test on that branch is prone to the same failure and the fix is very tiny, so IMO it's worth it.