### PR TITLE
utils: small_vector: support from_range_t

### DIFF
--- a/utils/small_vector.hh
+++ b/utils/small_vector.hh
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <new>
 #include <utility>
+#include <ranges>
 #include <algorithm>
 #include <initializer_list>
 #include <memory>
@@ -141,6 +142,17 @@ public:
             _end = std::uninitialized_copy(first, last, _end);
         } else {
             std::copy(first, last, std::back_inserter(*this));
+        }
+    }
+
+    small_vector(std::from_range_t, std::ranges::range auto&& range) : small_vector() {
+        using Range = decltype(range);
+        if constexpr (std::ranges::sized_range<Range> || std::ranges::forward_range<Range>) {
+            auto n = std::ranges::distance(range);
+            reserve(n);
+            _end = std::ranges::uninitialized_copy(range, std::ranges::subrange(_end, _end + n)).out;
+        } else {
+            std::ranges::copy(range, std::back_inserter(*this));
         }
     }
 


### PR DESCRIPTION
std::ranges::to<>() has a little protocol with containers to allow them to optimize their construction from ranges. Implement it for small_vector. It optimizes ranges that can have their sized determined quickly, or that can be traversed twice to determine the size by reserving up front. Single-pass ranges (std::ranges::input_range) use the less efficient push_back method.

A unit test is added.

Small optimization, no backport needed.