### PR TITLE
test.py: Add option to fail after number of failures

### DIFF
--- a/test.py
+++ b/test.py
@@ -56,7 +56,7 @@ all_modes = {'debug': 'Debug',
              'dev': 'Dev',
              'sanitize': 'Sanitize',
              'coverage': 'Coverage'}
-debug_modes = set(['debug', 'sanitize'])
+debug_modes = {'debug', 'sanitize'}
 
 def create_formatter(*decorators) -> Callable[[Any], str]:
     """Return a function which decorates its argument with the given
@@ -220,8 +220,8 @@ class TestSuite(ABC):
 
     @staticmethod
     def all_tests() -> Iterable['Test']:
-        return itertools.chain(*[suite.tests for suite in
-                                 TestSuite.suites.values()])
+        return itertools.chain(*(suite.tests for suite in
+                                 TestSuite.suites.values()))
 
     @property
     @abstractmethod
@@ -1505,7 +1505,7 @@ async def find_tests(options: argparse.Namespace) -> None:
 async def run_all_tests(signaled: asyncio.Event, options: argparse.Namespace) -> None:
     console = TabularConsoleOutput(options.verbose, TestSuite.test_count())
     signaled_task = asyncio.create_task(signaled.wait())
-    pending = set([signaled_task])
+    pending = {signaled_task}
 
     async def cancel(pending):
         for task in pending:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1252,6 +1252,8 @@ class ScyllaClusterManager:
         # The currently running test case with self.test_uname prepended, e.g.
         # test_topology.1::test_add_server_add_column
         self.current_test_case_full_name: str = ''
+        self.cluster: ScyllaCluster | None = None
+        self.site: aiohttp.web.UnixSite | None = None
         self.clusters: Pool[ScyllaCluster] = clusters
         self.is_running: bool = False
         self.is_before_test_ok: bool = False
@@ -1313,17 +1315,18 @@ class ScyllaClusterManager:
     async def stop(self) -> None:
         """Stop, cycle last cluster if not dirty and present"""
         self.logger.info("ScyllaManager stopping for test %s", self.test_uname)
-        if hasattr(self, "site"):
+        if self.site:
             await self.site.stop()
-            del self.site
-        if not self.cluster.is_dirty:
-            self.logger.info("Returning Scylla cluster %s for test %s", self.cluster, self.test_uname)
-            await self.clusters.put(self.cluster, is_dirty=False)
-        else:
-            self.logger.info("ScyllaManager: Scylla cluster %s is dirty after %s, stopping it",
-                            self.cluster, self.test_uname)
-            await self.clusters.put(self.cluster, is_dirty=True)
-        del self.cluster
+            self.site = None
+        if self.cluster:
+            if not self.cluster.is_dirty:
+                self.logger.info("Returning Scylla cluster %s for test %s", self.cluster, self.test_uname)
+                await self.clusters.put(self.cluster, is_dirty=False)
+            else:
+                self.logger.info("ScyllaManager: Scylla cluster %s is dirty after %s, stopping it",
+                                self.cluster, self.test_uname)
+                await self.clusters.put(self.cluster, is_dirty=True)
+            self.cluster = None
         if os.path.exists(self.manager_dir):
             await async_rmtree(self.manager_dir)
         self.is_running = False


### PR DESCRIPTION
### Overview

* Add `--max-failures` flag to test.py, which will stop the execution after number of failures
   * Helps with "fails-fast" approach and can be used to improve CI speed, especially the 100times run
   * Adds the number of cancelled tests to both summary and junit xml. I did not include them in boost, since it does not contain any statistics.
* Removes unnecessary list creation in test.py
   * Completely unrelated change, but it is small enough that I feel it can be included as part of this one. If this is an issue I can create separate PR for it

### Changes
*  Add `Test.started` property
   * Helps with determining the current status of the Test and differentiating cancelled/not started tests. 
* Add `Test.failed` and `Test.did_not_run` read-only computed properties   
   * Helper methods to determine status, instead of using `Test.success`, which does not tell the entire story
* Fix `ScyllaClusterManager.stop()` method, so it doesn't fail when ran multiple times
   * This happens when tasks are cancelled, not sure yet why, it almost certainly non-wanted behaviour but this behaviour was already there and with this fix it no longer causes errors 


### Backport
I will use backport/None for now as it is a new feature.

Fixes https://github.com/scylladb/qa-tasks/issues/1714