### PR TITLE
micro-updates to documentation development, on python-poetry

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,6 @@
 # Global variables
 # You can set these variables from the command line.
-POETRY        := poetry
+POETRY        := PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring poetry
 SPHINXOPTS    := -j auto
 SPHINXBUILD   := $(POETRY) run sphinx-build
 PAPER         :=

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ To create a new knowledge base article (KB):
 ### Prerequisites
 
 * Python 3. Check your version with `$ python --version`.
-* [poetry](https://python-poetry.org/) 1.12 or later
+* [poetry](https://python-poetry.org/) 1.8.1 or later
 * make
 
 #### Mac OS X


### PR DESCRIPTION
- `docs/Makefile`: work around python-poetry issue https://github.com/python-poetry/poetry/issues/8761
- `docs/README.md`: fix minimum poetry version

No backporting needed (docs development).