### PR TITLE
raft: consider the gossiper state then sending the group0 state id

### DIFF
--- a/service/raft/group0_state_id_handler.cc
+++ b/service/raft/group0_state_id_handler.cc
@@ -149,6 +149,11 @@ void group0_state_id_handler::stop() {
 }
 
 future<> group0_state_id_handler::advertise_state_id(utils::UUID state_id) {
+    if (!_gossiper.is_enabled()) {
+        slogger.debug("Skipping advertisement of state id {} because gossiper is not active", state_id);
+        return make_ready_future();
+    }
+
     if (_state_id_last_advertised && utils::timeuuid_tri_compare(_state_id_last_advertised, state_id) > 0) {
         slogger.debug("Skipping advertisement of stale state id {}", state_id);
         return make_ready_future();

--- a/test/topology_experimental_raft/test_tombstone_gc.py
+++ b/test/topology_experimental_raft/test_tombstone_gc.py
@@ -13,6 +13,7 @@ import pytest
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from test.topology.conftest import skip_mode
 from test.topology.util import disable_schema_agreement_wait, new_test_keyspace, new_test_table
 
 logger = logging.getLogger(__name__)
@@ -198,3 +199,37 @@ async def test_group0_tombstone_gc(manager: ManagerClient):
 
             # test #3: the tombstones are cleaned up after the node is started again
             await verify_tombstone_gc(tombstone_mark)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(reason="Issue #21117")
+@skip_mode('release', "test only needs to run once - allowing only the 'dev' mode")
+@skip_mode('debug', "test only needs to run once - allowing only the 'dev' mode")
+async def test_group0_state_id_failure(manager: ManagerClient):
+    """
+    Issue #21117 regression test.
+
+    Make sure that the "endpoint_state_map does not contain endpoint" warning is not triggered when the state_id is updated.
+
+    Arrange:
+        - start 1 node
+    Act:
+        - restart the node
+    Assert:
+        - the "endpoint_state_map does not contain endpoint" didn't appear in the log
+    """
+
+    # Start the node
+
+    srv = await manager.server_add()
+
+    # Restart the node
+
+    await manager.server_restart(srv.server_id)
+
+    # Check the log
+
+    log = await manager.server_open_log(srv.server_id)
+    matches = await log.grep(r"Fail to apply application_state.*endpoint_state_map does not contain endpoint .* application_states = {GROUP0_STATE_ID")
+
+    assert not matches, "The 'endpoint_state_map does not contain endpoint' warning appeared in the log"

--- a/test/topology_experimental_raft/test_tombstone_gc.py
+++ b/test/topology_experimental_raft/test_tombstone_gc.py
@@ -202,7 +202,6 @@ async def test_group0_tombstone_gc(manager: ManagerClient):
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="Issue #21117")
 @skip_mode('release', "test only needs to run once - allowing only the 'dev' mode")
 @skip_mode('debug', "test only needs to run once - allowing only the 'dev' mode")
 async def test_group0_state_id_failure(manager: ManagerClient):


### PR DESCRIPTION
Skip the advertisement of the group0 state id in case the gossiper is
not active (ready).

Sending the application state when the gossiper is not active caused
a warning being shown in the log about the local endpoint not being
found in the gossiper endpoint state map on a (graceful) node restart.

The local endpoint is initialized on the gossiper startup, so we skip
the state id advertisement until the startup is finished.

Fixes: scylladb/scylladb#21117

No backport: Fixes an issue that is currently only present in master