### PR TITLE
schema: convert from boost ranges to std ranges

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -521,8 +521,9 @@ struct scan_ranges_context {
         // be good if we can read only the single item of the map - it
         // should be possible (and a must for issue #7751!).
         lw_shared_ptr<service::pager::paging_state> paging_state = nullptr;
-        auto regular_columns = boost::copy_range<query::column_id_vector>(
-            s->regular_columns() | boost::adaptors::transformed([] (const column_definition& cdef) { return cdef.id; }));
+        auto regular_columns =
+            s->regular_columns() | std::views::transform([] (const column_definition& cdef) { return cdef.id; })
+            | std::ranges::to<query::column_id_vector>();
         selection = cql3::selection::selection::wildcard(s);
         query::partition_slice::option_set opts = selection->get_query_options();
         opts.set<query::partition_slice::option::allow_short_read>();

--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -10,6 +10,7 @@
 
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/range/adaptor/transformed.hpp>
+#include <boost/range/join.hpp>
 #include <compare>
 #include "compound.hh"
 #include "schema/schema.hh"

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -24,6 +24,8 @@
 #include "cql3/functions/first_function.hh"
 #include "cql3/functions/aggregate_fcts.hh"
 
+#include <ranges>
+
 namespace cql3 {
 
 logger cql_logger("cql_logger");
@@ -443,14 +445,15 @@ std::vector<const column_definition*> selection::wildcard_columns(schema_ptr sch
     // filter out hidden columns, which should not be seen by the
     // user when doing "SELECT *". We also disallow selecting them
     // individually (see column_identifier::new_selector_factory()).
-    return boost::copy_range<std::vector<const column_definition*>>(
+    return
         columns |
-        boost::adaptors::filtered([](const column_definition& c) {
+        std::views::filter([](const column_definition& c) {
             return !c.is_hidden_from_cql();
         }) |
-        boost::adaptors::transformed([](const column_definition& c) {
+        std::views::transform([](const column_definition& c) {
             return &c;
-        }));
+        }) |
+        std::ranges::to<std::vector>();
 }
 
 ::shared_ptr<selection> selection::wildcard(schema_ptr schema) {

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -269,7 +269,7 @@ void alter_table_statement::drop_column(const query_options& options, const sche
             drop_timestamp = _attrs->get_timestamp(now, options);
         }
 
-        for (auto&& column_def : boost::range::join(schema.static_columns(), schema.regular_columns())) { // find
+        for (auto&& column_def : std::views::join(std::array{schema.static_columns(), schema.regular_columns()})) { // find
             if (column_def.name() == column_name.name()) {
                 cfm.remove_column(column_name.name(), drop_timestamp);
                 break;

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -399,7 +399,7 @@ void batch_statement::build_cas_result_set_metadata() {
             ::make_shared<cql3::column_identifier>("[applied]", false), boolean_type);
     columns.push_back(applied);
 
-    for (const auto& def : boost::range::join(schema.partition_key_columns(), schema.clustering_key_columns())) {
+    for (const auto& def : std::views::join(std::array{schema.partition_key_columns(), schema.clustering_key_columns()})) {
         _columns_of_cas_result_set.set(def.ordinal_id);
     }
     for (const auto& s : _statements) {

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -194,9 +194,10 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     auto prepared = raw_select.prepare(db, ignored, true);
     auto restrictions = static_pointer_cast<statements::select_statement>(prepared->statement)->get_restrictions();
 
-    auto base_primary_key_cols = boost::copy_range<std::unordered_set<const column_definition*>>(
-            boost::range::join(schema->partition_key_columns(), schema->clustering_key_columns())
-            | boost::adaptors::transformed([](auto&& def) { return &def; }));
+    auto base_primary_key_cols =
+            std::views::join(std::array{schema->partition_key_columns(), schema->clustering_key_columns()})
+            | std::views::transform([](auto&& def) { return &def; })
+            | std::ranges::to<std::unordered_set<const column_definition*>>();
 
     // Validate the primary key clause, ensuring only one non-PK base column is used in the view's PK.
     bool has_non_pk_column = false;

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1476,12 +1476,12 @@ indexed_table_select_statement::find_index_clustering_rows(query_processor& qp, 
         }
         for (size_t i = 0; i < rs.size(); i++) {
             const auto& row = rs.at(i);
-            auto pk_columns = _schema->partition_key_columns() | boost::adaptors::transformed([&] (auto& cdef) {
+            auto pk_columns = _schema->partition_key_columns() | std::views::transform([&] (auto& cdef) {
                 return row.get_blob(cdef.name_as_text());
             });
             auto pk = partition_key::from_range(pk_columns);
             auto dk = dht::decorate_key(*_schema, pk);
-            auto ck_columns = _schema->clustering_key_columns() | boost::adaptors::transformed([&] (auto& cdef) {
+            auto ck_columns = _schema->clustering_key_columns() | std::views::transform([&] (auto& cdef) {
                 return row.get_blob(cdef.name_as_text());
             });
             auto ck = clustering_key::from_range(ck_columns);

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -983,7 +983,7 @@ future<> store_column_mapping(distributed<service::storage_proxy>& proxy, schema
     }
     // Use one timestamp for all mutations for the ease of debugging
     const auto ts = api::new_timestamp();
-    for (const auto& cdef : boost::range::join(s->static_columns(), s->regular_columns())) {
+    for (const auto& cdef : std::views::join(std::array{s->static_columns(), s->regular_columns()})) {
         mutation m(history_tbl, pk);
         auto ckey = clustering_key::from_exploded(*history_tbl, {uuid_type->decompose(s->version().uuid()),
                                                                  utf8_type->decompose(cdef.name_as_text())});

--- a/partition_slice_builder.cc
+++ b/partition_slice_builder.cc
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/range/algorithm_ext/push_back.hpp>
 
@@ -44,16 +43,16 @@ partition_slice_builder::build() {
     if (_static_columns) {
         static_columns = std::move(*_static_columns);
     } else {
-        boost::range::push_back(static_columns,
-            _schema.static_columns() | boost::adaptors::transformed(std::mem_fn(&column_definition::id)));
+        static_columns =
+            _schema.static_columns() | std::views::transform(std::mem_fn(&column_definition::id)) | std::ranges::to<query::column_id_vector>();
     }
 
     query::column_id_vector regular_columns;
     if (_regular_columns) {
         regular_columns = std::move(*_regular_columns);
     } else {
-        boost::range::push_back(regular_columns,
-            _schema.regular_columns() | boost::adaptors::transformed(std::mem_fn(&column_definition::id)));
+        regular_columns = 
+            _schema.regular_columns() | std::views::transform(std::mem_fn(&column_definition::id)) | std::ranges::to<query::column_id_vector>();
     }
 
     return {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3548,10 +3548,10 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
     query::column_id_vector static_columns;
     query::column_id_vector regular_columns;
     if (need_regular) {
-        boost::copy(base->regular_columns() | boost::adaptors::transformed(std::mem_fn(&column_definition::id)), std::back_inserter(regular_columns));
+        std::ranges::copy(base->regular_columns() | std::views::transform(std::mem_fn(&column_definition::id)), std::back_inserter(regular_columns));
     }
     if (need_static) {
-        boost::copy(base->static_columns() | boost::adaptors::transformed(std::mem_fn(&column_definition::id)), std::back_inserter(static_columns));
+        std::ranges::copy(base->static_columns() | std::views::transform(std::mem_fn(&column_definition::id)), std::back_inserter(static_columns));
     }
     query::partition_slice::option_set opts;
     opts.set(query::partition_slice::option::send_partition_key);

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -13,6 +13,7 @@
 #include <functional>
 #include <optional>
 #include <unordered_map>
+#include <ranges>
 #include <boost/range/iterator_range.hpp>
 #include <boost/range/join.hpp>
 #include <boost/lexical_cast.hpp>
@@ -629,6 +630,8 @@ private:
     column_count_type _regular_column_count;
     column_count_type _static_column_count;
 
+    std::vector<const column_definition*> _all_columns_in_select_order;
+
     extensions_map& extensions() {
         return _raw._extensions;
     }
@@ -656,6 +659,7 @@ private:
 
     lw_shared_ptr<cql3::column_specification> make_column_specification(const column_definition& def) const;
     void rebuild();
+    void compute_all_columns_in_select_order();
     schema(const schema&, const std::function<void(schema&)>&);
     class private_tag{};
 public:
@@ -838,10 +842,9 @@ public:
     const_iterator_range_type columns(column_kind) const;
     // Returns a range of column definitions
 
-    typedef boost::range::joined_range<const_iterator_range_type, const_iterator_range_type>
-        select_order_range;
-
-    select_order_range all_columns_in_select_order() const;
+    std::ranges::range auto all_columns_in_select_order() const {
+        return _all_columns_in_select_order | std::views::transform([] (const column_definition* def) -> const column_definition& { return *def; });
+    }
     uint32_t position(const column_definition& column) const;
 
     const columns_type& all_columns() const {

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -14,8 +14,6 @@
 #include <optional>
 #include <unordered_map>
 #include <ranges>
-#include <boost/range/iterator_range.hpp>
-#include <boost/range/join.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/dynamic_bitset.hpp>
 
@@ -644,8 +642,8 @@ public:
     typedef std::vector<column_definition> columns_type;
     typedef typename columns_type::iterator iterator;
     typedef typename columns_type::const_iterator const_iterator;
-    typedef boost::iterator_range<iterator> iterator_range_type;
-    typedef boost::iterator_range<const_iterator> const_iterator_range_type;
+    typedef std::ranges::subrange<iterator> iterator_range_type;
+    typedef std::ranges::subrange<const_iterator> const_iterator_range_type;
 
     static constexpr int32_t NAME_LENGTH = 48;
 

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -367,8 +367,8 @@ static sstring pk_type_to_string(const schema& s) {
     } else {
         return seastar::format("org.apache.cassandra.db.marshal.CompositeType({})",
                                fmt::join(s.partition_key_columns()
-                                          | boost::adaptors::transformed(std::mem_fn(&column_definition::type))
-                                          | boost::adaptors::transformed(std::mem_fn(&abstract_type::name)),
+                                          | std::views::transform(std::mem_fn(&column_definition::type))
+                                          | std::views::transform(std::mem_fn(&abstract_type::name)),
                                         ","));
     }
 }

--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -894,8 +894,9 @@ std::vector<const user_type_impl*> dump_udts(const schema& schema) {
     udt_list udts;
 
     const auto cdefs_to_types = [] (const schema::const_iterator_range_type& cdefs) -> std::vector<data_type> {
-        return boost::copy_range<std::vector<data_type>>(cdefs |
-                boost::adaptors::transformed([] (const column_definition& cdef) { return cdef.type; }));
+        return cdefs
+               | std::views::transform([] (const column_definition& cdef) { return cdef.type; })
+               | std::ranges::to<std::vector>();
     };
 
     udts.merge(dump_udts(cdefs_to_types(schema.partition_key_columns())));


### PR DESCRIPTION
To reduce dependency load, change uses of boost ranges to std::ranges.

The first patch is preparation, replacing a construct that isn't easy to support with std ranges with something simpler.

No backport as this is a code cleanup.