### PR TITLE
cql3: respect PER PARTITION LIMIT for aggregate queries

### DIFF
--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -505,11 +505,12 @@ selection::collect_metadata(const schema& schema, const std::vector<prepared_sel
 
 result_set_builder::result_set_builder(const selection& s, gc_clock::time_point now,
                                        std::vector<size_t> group_by_cell_indices,
-                                       uint64_t limit)
+                                       uint64_t limit, uint64_t per_partition_limit)
     : _result_set(std::make_unique<result_set>(::make_shared<metadata>(*(s.get_result_metadata()))))
     , _selectors(s.new_selectors())
     , _group_by_cell_indices(std::move(group_by_cell_indices))
     , _limit(limit)
+    , _per_partition_limit(per_partition_limit)
     , _last_group(_group_by_cell_indices.size())
     , _group_began(false)
     , _now(now)

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -174,6 +174,7 @@ private:
     std::unique_ptr<selectors> _selectors;
     const std::vector<size_t> _group_by_cell_indices; ///< Indices in \c current of cells holding GROUP BY values.
     const uint64_t _limit; ///< Maximum number of rows to return.
+    const uint64_t _per_partition_limit; ///< Maximum number of rows to return per partition.
     std::vector<managed_bytes_opt> _last_group; ///< Previous row's group: all of GROUP BY column values.
     bool _group_began; ///< Whether a group began being formed.
 public:
@@ -238,7 +239,8 @@ public:
 
     result_set_builder(const selection& s, gc_clock::time_point now,
                        std::vector<size_t> group_by_cell_indices = {},
-                       uint64_t limit = std::numeric_limits<uint64_t>::max());
+                       uint64_t limit = std::numeric_limits<uint64_t>::max(),
+                       uint64_t per_partition_limit = std::numeric_limits<uint64_t>::max());
     void add_empty();
     void add(bytes_opt value);
     void add(const column_definition& def, const query::result_atomic_cell_view& c);

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -52,6 +52,8 @@ public:
     */
     virtual void add_input_row(result_set_builder& rs) = 0;
 
+    virtual std::uint64_t get_input_row_count() const = 0;
+
     virtual std::vector<managed_bytes_opt> get_output_row() = 0;
 
     // When not aggregating, each input row becomes one output row.

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -308,7 +308,7 @@ select_statement::make_partition_slice(const query_options& options) const
 }
 
 select_statement::get_limit_result select_statement::get_limit(
-    const query_options& options, const std::optional<expr::expression>& limit) const
+    const query_options& options, const std::optional<expr::expression>& limit, bool is_per_partition_limit) const
 {
     if (!limit.has_value()) {
         return bo::success(query::max_rows);
@@ -320,7 +320,8 @@ select_statement::get_limit_result select_statement::get_limit(
         }
         auto l = val.view().validate_and_deserialize<int32_t>(*int32_type);
         if (l <= 0) {
-            return bo::failure(exceptions::invalid_request_exception("LIMIT must be strictly positive"));
+            auto msg = is_per_partition_limit ? "PER PARTITION LIMIT must be strictly positive" : "LIMIT must be strictly positive";
+            return bo::failure(exceptions::invalid_request_exception(msg));
         }
         return bo::success(l);
     } catch (const marshal_exception& e) {

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -496,8 +496,10 @@ select_statement::execute_without_checking_exception_message_aggregate_or_paged(
     auto p = service::pager::query_pagers::pager(qp.proxy(), _query_schema, _selection,
             state, options, command, std::move(key_ranges), _restrictions_need_filtering ? _restrictions : nullptr);
 
+    auto per_partition_limit = get_limit(options, _per_partition_limit, true);
+
     if (aggregate || nonpaged_filtering) {
-        auto builder = cql3::selection::result_set_builder(*_selection, now, *_group_by_cell_indices, limit);
+        auto builder = cql3::selection::result_set_builder(*_selection, now, *_group_by_cell_indices, limit, per_partition_limit.value());
         coordinator_result<void> result_void = co_await utils::result_do_until(
                 [&p, &builder, limit] {
                     return p->is_exhausted() || (limit < builder.result_set_size());

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -154,7 +154,7 @@ public:
 
 protected:
     using get_limit_result = bo::result<uint64_t, exceptions::invalid_request_exception>;
-    get_limit_result get_limit(const query_options& options, const std::optional<expr::expression>& limit) const;
+    get_limit_result get_limit(const query_options& options, const std::optional<expr::expression>& limit, bool is_per_partition_limit = false) const;
     static uint64_t get_inner_loop_limit(const select_statement::get_limit_result& limit, bool is_aggregate);
 
     bool needs_post_query_ordering() const;

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
@@ -1259,7 +1259,7 @@ def testCompactStorage(cql, test_keyspace):
         assert_rows2(execute(cql, table, "INSERT INTO %s (partition, key, owner) VALUES ('a', 'c', 'x') IF NOT EXISTS"), [row(True)], [row(True,None,None,None)])
 
 # SelectGroupByTest
-@pytest.mark.xfail(reason="issue #4244, #5361, #5362, #5363")
+@pytest.mark.xfail(reason="issue #4244")
 def testGroupByWithoutPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, PRIMARY KEY (a, b, c, d)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, 1, 3, 6)")
@@ -1787,7 +1787,6 @@ def testGroupByWithoutPagingWithDeletions(cql, test_keyspace):
                    row(1, 2, 2, 3, 12),
                    row(1, 2, 3, 4, 12))
 
-@pytest.mark.xfail(reason="issue #5361, #5363")
 def testGroupByWithRangeNamesQueryWithoutPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, PRIMARY KEY (a, b, c)) WITH COMPACT STORAGE") as table:
         for i in range(1, 5):

--- a/test/cqlpy/cassandra_tests/validation/operations/select_group_by_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_group_by_test.py
@@ -7,7 +7,7 @@
 
 from cassandra_tests.porting import *
 
-@pytest.mark.xfail(reason="Issue #2060, #5361, #5362, #5363, #13109")
+@pytest.mark.xfail(reason="Issue #2060, #13109")
 def testGroupByWithoutPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, primary key (a, b, c, d))") as table:
 
@@ -533,7 +533,6 @@ def testGroupByWithoutPagingWithDeletions(cql, test_keyspace):
                    row(1, 2, 2, 3, 12),
                    row(1, 2, 3, 4, 12))
 
-@pytest.mark.xfail(reason="Issue #5361, #5363")
 def testGroupByWithRangeNamesQueryWithoutPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, primary key (a, b, c))") as table:
         for i in range(1,5):
@@ -603,7 +602,7 @@ def testGroupByWithRangeNamesQueryWithoutPaging(cql, test_keyspace):
                    row(1, 1, 2, 2, 2),
                    row(2, 1, 3, 2, 3))
 
-@pytest.mark.xfail(reason="Issue #5361, #5362, #5363, #13109")
+@pytest.mark.xfail(reason="Issue #13109")
 def testGroupByWithStaticColumnsWithoutPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, s int static, d int, primary key (a, b, c))") as table:
         # ------------------------------------
@@ -1081,7 +1080,6 @@ def testGroupByWithStaticColumnsWithoutPaging(cql, test_keyspace):
                    row(4, 8, None, 1, 0),
                    row(1, 4, 1, 2, 2))
 
-@pytest.mark.xfail(reason="Issue #5361, #5362, #5363")
 def testGroupByWithPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, e int, primary key (a, b, c, d))") as table:
         execute(cql, table, "INSERT INTO %s (a, b, c, d, e) VALUES (1, 2, 1, 3, 6)")
@@ -1499,7 +1497,6 @@ def testGroupByWithPaging(cql, test_keyspace):
                                                pageSize),
                           row(1, 3))
 
-@pytest.mark.xfail(reason="Issue #5361, #5363")
 def testGroupByWithRangeNamesQueryWithPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, d int, primary key (a, b, c))") as table:
         for i in range(1,5):
@@ -1570,7 +1567,7 @@ def testGroupByWithRangeNamesQueryWithPaging(cql, test_keyspace):
                           row(1, 1, 2, 2, 2),
                           row(2, 1, 3, 2, 3))
 
-@pytest.mark.xfail(reason="Issue #5361, #5362, #5363")
+@pytest.mark.xfail(reason="Issue #21267")
 def testGroupByWithStaticColumnsWithPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, s int static, d int, primary key (a, b, c))") as table:
         # ------------------------------------
@@ -1778,6 +1775,7 @@ def testGroupByWithStaticColumnsWithPaging(cql, test_keyspace):
 
         for pageSize in range(1,10):
             # Range queries
+            # Reproduces #21267
             assertRowsNet(execute_with_paging(cql, table, "SELECT a, b, s, count(b), count(s) FROM %s GROUP BY a", pageSize),
                           row(1, 2, 1, 4, 4),
                           row(2, 2, 2, 2, 2),

--- a/test/cqlpy/test_group_by.py
+++ b/test/cqlpy/test_group_by.py
@@ -131,7 +131,6 @@ def test_group_by_clustering_prefix_with_limit_and_paging(cql, table1):
 
 # Adding a PER PARTITION LIMIT should be honored
 # Reproduces #5363 - fewer results than the limit were generated
-@pytest.mark.xfail(reason="issue #5363")
 def test_group_by_clustering_prefix_with_pplimit(cql, table1):
     # Without per-partition limit we get 4 results, 2 from each partition:
     assert {(0,0,0,1), (0,1,0,3), (1,0,0,5), (1,1,0,7)} == set(cql.execute(f'SELECT p,c1,c2,v FROM {table1} GROUP BY p,c1'))
@@ -189,7 +188,6 @@ def test_group_by_count_with_limit(cql, table1):
 
 # Adding a PER PARTITION LIMIT should be honored
 # Reproduces #5363 - more results than the limit were generated
-@pytest.mark.xfail(reason="issue #5363")
 def test_group_by_count_with_pplimit(cql, table1):
     # Without per-partition limit we get 4 results, 2 from each partition:
     assert {(0,0,2), (0,1,2), (1,0,2), (1,1,2)} == set(cql.execute(f'SELECT p,c1,count(*) FROM {table1} GROUP BY p,c1'))


### PR DESCRIPTION
Currently, PER PARTITION LIMIT is not implemented for aggregates and queries can result in more rows than expected from the same partition. 

Instrument the result_set_builder class so that it can enforce PER PARTITION LIMIT for aggregate queries, specifically:
- add per_partition_limit to the result_set_builder
- expose the number of input rows in the selector

result_set_builder gets two new functions handling partition start and end:
- accept_partition_end for notifying that a partition has been finished. This is also called when a page ends, so we cannot simply flush here, as a naive implementation could do.
- accept_new_partition, where we flush_selectors() if it's indeed a new partition (and not a continuation of the previous) and the query has a grouping: we don't want to flush on new partition in a query like SELECT COUNT(*) FROM foo;

Fixes #5363 