### PR TITLE
raft: remove the group0 state id handler stop check

### DIFF
--- a/service/raft/group0_state_id_handler.cc
+++ b/service/raft/group0_state_id_handler.cc
@@ -116,19 +116,9 @@ group0_state_id_handler::group0_state_id_handler(
     , _refresh_interval(get_refresh_interval(local_db)) {
 }
 
-group0_state_id_handler::~group0_state_id_handler() {
-    if (!_stopped) {
-        on_fatal_internal_error(slogger, "group0_state_id_handler is being destroyed without being stopped");
-    }
-}
-
-void group0_state_id_handler::start() {
+void group0_state_id_handler::run() {
     if (this_shard_id() != 0) {
         on_fatal_internal_error(slogger, "group0_state_id_handler must be started on shard 0");
-    }
-
-    if (_stopped) {
-        return;
     }
 
     _timer.set_callback([this] {
@@ -141,11 +131,6 @@ void group0_state_id_handler::start() {
     // after that send every _refresh_interval.
 
     _timer.arm(2 * gms::gossiper::INTERVAL);
-}
-
-void group0_state_id_handler::stop() {
-    _timer.cancel();
-    _stopped = true;
 }
 
 future<> group0_state_id_handler::advertise_state_id(utils::UUID state_id) {

--- a/service/raft/group0_state_id_handler.hh
+++ b/service/raft/group0_state_id_handler.hh
@@ -53,7 +53,6 @@ class group0_state_id_handler {
     lowres_clock::duration _refresh_interval;
 
     timer<> _timer;
-    bool _stopped = false;
 
     utils::UUID _state_id_last_advertised;
     utils::UUID _state_id_last_reconcile;
@@ -65,10 +64,7 @@ class group0_state_id_handler {
 public:
     group0_state_id_handler(replica::database& local_db, gms::gossiper& gossiper, const raft_address_map& address_map, group0_server_accessor server_accessor);
 
-    ~group0_state_id_handler();
-
-    void start();
-    void stop();
+    void run();
 
     future<> advertise_state_id(utils::UUID state_id);
 };

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -76,7 +76,7 @@ group0_state_machine::group0_state_machine(raft_group0_client& client, migration
         // node doesn't support it yet.
         _topology_change_enabled = true;
     })) {
-    _state_id_handler.start();
+    _state_id_handler.run();
 }
 
 static mutation extract_history_mutation(std::vector<canonical_mutation>& muts, const data_dictionary::database db) {
@@ -400,7 +400,6 @@ future<> group0_state_machine::transfer_snapshot(raft::server_id from_id, raft::
 }
 
 future<> group0_state_machine::abort() {
-    _state_id_handler.stop();
     _abort_source.request_abort();
     return _gate.close();
 }


### PR DESCRIPTION
The stop assertion check in the group0 state id handler was triggering under some circumstances (stopping server during restart). In that case it might be that the stop is initiated before the server is fully initialized, and then the handler destructor is being called without calling to the `stop()` method first. This is a valid scenario.

The whole `stop()` in the group0 state id handler is not necessary, as the only operation being done is cancelling the timer which is done by the timer destructor automatically anyway.

There is the concern of a currently running timer callback, but it is currently synchronous so the timer shouldn't be destroyed before the callback finishes.

Fixes: scylladb/scylladb#21074

No backport: Fixes an issue that is currently only present in master