### PR TITLE
build: do not pass Seastar_CXX_DIALECT=gnu++23 when building Seastar

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1698,7 +1698,6 @@ def configure_seastar(build_dir, mode, mode_config):
         '-DCMAKE_CXX_STANDARD=23',
         '-DSeastar_CXX_FLAGS=SHELL:{}'.format(mode_config['lib_cflags']),
         '-DSeastar_LD_FLAGS={}'.format(semicolon_separated(mode_config['lib_ldflags'], seastar_cxx_ld_flags)),
-        '-DSeastar_CXX_DIALECT=gnu++23',
         '-DSeastar_API_LEVEL=7',
         '-DSeastar_DEPRECATED_OSTREAM_FORMATTERS=OFF',
         '-DSeastar_UNUSED_RESULT_ERROR=ON',


### PR DESCRIPTION
Seastar now respect CMAKE_CXX_STANDARD in favor of Seastar_CXX_DIALECT, which has been dropped in Seastar's commit of
60bc8603bd438232614e9b3dcd7537dc83c85206 .

---

it's a cleanup, hence no need to backport.