### PR TITLE
build: build seastar as an external project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ target_link_libraries(scylla PRIVATE
     utils)
 
 target_link_libraries(scylla PRIVATE
-    seastar
+    Seastar::seastar
     absl::headers
     Boost::program_options)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ find_package(libxcrypt REQUIRED)
 find_package(Snappy REQUIRED)
 find_package(RapidJSON REQUIRED)
 find_package(xxHash REQUIRED)
+find_package(yaml-cpp REQUIRED)
 find_package(zstd REQUIRED)
 
 set(scylla_gen_build_dir "${CMAKE_BINARY_DIR}/gen")
@@ -276,6 +277,7 @@ target_link_libraries(scylla PRIVATE
 target_link_libraries(scylla PRIVATE
     Seastar::seastar
     absl::headers
+    yaml-cpp::yaml-cpp
     Boost::program_options)
 
 target_include_directories(scylla PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,16 +47,56 @@ set(CMAKE_CXX_EXTENSIONS ON CACHE INTERNAL "")
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF CACHE INTERNAL "")
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
-set(Seastar_TESTING ON CACHE BOOL "" FORCE)
-set(Seastar_API_LEVEL 7 CACHE STRING "" FORCE)
-set(Seastar_DEPRECATED_OSTREAM_FORMATTERS OFF CACHE BOOL "" FORCE)
-set(Seastar_APPS ON CACHE BOOL "" FORCE)
-set(Seastar_EXCLUDE_APPS_FROM_ALL ON CACHE BOOL "" FORCE)
-set(Seastar_EXCLUDE_TESTS_FROM_ALL ON CACHE BOOL "" FORCE)
-set(Seastar_IO_URING OFF CACHE BOOL "" FORCE)
-set(Seastar_SCHEDULING_GROUPS_COUNT 16 CACHE STRING "" FORCE)
-set(Seastar_UNUSED_RESULT_ERROR ON CACHE BOOL "" FORCE)
-add_subdirectory(seastar)
+get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(is_multi_config)
+    find_package(Seastar)
+    # this is atypical compared to standard ExternalProject usage:
+    # - Seastar's build system should already be configured at this point.
+    # - We maintain separate project variants for each configuration type.
+    #
+    # Benefits of this approach:
+    # - Allows the parent project to consume the compile options exposed by
+    #   .pc file. as the compile options vary from one config to another.
+    # - Allows application of config-specific settings
+    # - Enables building Seastar within the parent project's build system
+    # - Facilitates linking of artifacts with the external project target,
+    #   establishing proper dependencies between them
+    include(ExternalProject)
+
+    ExternalProject_Add(Seastar
+        SOURCE_DIR "${PROJECT_SOURCE_DIR}/seastar"
+        BINARY_DIR "${CMAKE_BINARY_DIR}/$<CONFIG>/seastar"
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR>
+          --target seastar
+          --target seastar_testing
+          --target seastar_perf_testing
+          --target app_iotune
+        BUILD_ALWAYS ON
+        BUILD_BYPRODUCTS
+          <BINARY_DIR>/libseastar.$<IF:$<CONFIG:Debug,Dev>,so,a>
+          <BINARY_DIR>/libseastar_testing.$<IF:$<CONFIG:Debug,Dev>,so,a>
+          <BINARY_DIR>/libseastar_perf_testing.$<IF:$<CONFIG:Debug,Dev>,so,a>
+          <BINARY_DIR>/apps/iotune/iotune
+          <BINARY_DIR>/gen/include/seastar/http/chunk_parsers.hh
+          <BINARY_DIR>/gen/include/seastar/http/request_parser.hh
+          <BINARY_DIR>/gen/include/seastar/http/response_parser.hh
+        INSTALL_COMMAND "")
+    add_dependencies(Seastar::seastar Seastar)
+    add_dependencies(Seastar::seastar_testing Seastar)
+else()
+    set(Seastar_TESTING ON CACHE BOOL "" FORCE)
+    set(Seastar_API_LEVEL 7 CACHE STRING "" FORCE)
+    set(Seastar_DEPRECATED_OSTREAM_FORMATTERS OFF CACHE BOOL "" FORCE)
+    set(Seastar_APPS ON CACHE BOOL "" FORCE)
+    set(Seastar_EXCLUDE_APPS_FROM_ALL ON CACHE BOOL "" FORCE)
+    set(Seastar_EXCLUDE_TESTS_FROM_ALL ON CACHE BOOL "" FORCE)
+    set(Seastar_IO_URING OFF CACHE BOOL "" FORCE)
+    set(Seastar_SCHEDULING_GROUPS_COUNT 16 CACHE STRING "" FORCE)
+    set(Seastar_UNUSED_RESULT_ERROR ON CACHE BOOL "" FORCE)
+    add_subdirectory(seastar)
+endif()
+
 set(ABSL_PROPAGATE_CXX_STD ON CACHE BOOL "" FORCE)
 
 find_package(Sanitizers QUIET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,8 @@ if(DEFINED CMAKE_BUILD_TYPE)
 endif(DEFINED CMAKE_BUILD_TYPE)
 
 include(mode.common)
-if(CMAKE_CONFIGURATION_TYPES)
+get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(is_multi_config)
     foreach(config ${CMAKE_CONFIGURATION_TYPES})
         include(mode.${config})
         list(APPEND scylla_build_modes ${scylla_build_mode_${config}})
@@ -47,7 +48,6 @@ set(CMAKE_CXX_EXTENSIONS ON CACHE INTERNAL "")
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF CACHE INTERNAL "")
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
-get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(is_multi_config)
     find_package(Seastar)
     # this is atypical compared to standard ExternalProject usage:

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -1,4 +1,29 @@
 # Generate C++ sources from Swagger definitions
+
+function(generate_swagger)
+  set(one_value_args TARGET VAR IN_FILE OUT_DIR)
+  cmake_parse_arguments(args "" "${one_value_args}" "" ${ARGN})
+  get_filename_component(in_file_name ${args_IN_FILE} NAME)
+  set(generator ${PROJECT_SOURCE_DIR}/seastar/scripts/seastar-json2code.py)
+  set(header_out ${args_OUT_DIR}/${in_file_name}.hh)
+  set(source_out ${args_OUT_DIR}/${in_file_name}.cc)
+
+  add_custom_command(
+    DEPENDS
+      ${args_IN_FILE}
+      ${generator}
+    OUTPUT ${header_out} ${source_out}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${args_OUT_DIR}
+    COMMAND ${generator} --create-cc -f ${args_IN_FILE} -o ${header_out})
+
+  add_custom_target(${args_TARGET}
+    DEPENDS
+      ${header_out}
+      ${source_out})
+
+  set(${args_VAR} ${header_out} ${source_out} PARENT_SCOPE)
+endfunction()
+
 set(swagger_files
   api-doc/authorization_cache.json
   api-doc/cache_service.json
@@ -29,7 +54,7 @@ set(swagger_files
 foreach(f ${swagger_files})
   get_filename_component(fname "${f}" NAME_WE)
   get_filename_component(dir "${f}" DIRECTORY)
-  seastar_generate_swagger(
+  generate_swagger(
     TARGET scylla_swagger_gen_${fname}
     VAR scylla_swagger_gen_${fname}_files
     IN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${f}"

--- a/cmake/FindSeastar.cmake
+++ b/cmake/FindSeastar.cmake
@@ -1,0 +1,115 @@
+#
+# Copyright 2024-present ScyllaDB
+#
+
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+find_package(PkgConfig QUIET REQUIRED)
+
+set(saved_pkg_config_path "$ENV{PKG_CONFIG_PATH}")
+foreach(config ${CMAKE_CONFIGURATION_TYPES})
+  # this path should be consistent with the path used by configure.py, which configures
+  # seastar's building system for each enabled build mode / configuration type
+  set(binary_dir "${CMAKE_BINARY_DIR}/${config}/seastar")
+  set(ENV{PKG_CONFIG_PATH} "${saved_pkg_config_path}:${CMAKE_BINARY_DIR}/${config}/seastar")
+
+  pkg_search_module(seastar-${config}
+    REQUIRED QUIET
+    NO_CMAKE_PATH
+    IMPORTED_TARGET GLOBAL
+    seastar)
+  find_path(seastar_INCLUDE_DIR
+    NAMES seastar/core/seastar.hh
+    HINTS
+      ${seastar-${config}_INCLUDE_DIRS})
+  pkg_search_module(seastar_testing-${config}
+    REQUIRED QUIET
+    NO_CMAKE_PATH
+    IMPORTED_TARGET GLOBAL
+    seastar-testing)
+  find_path(seastar_testing_INCLUDE_DIR
+    NAMES seastar/testing/seastar_test.hh
+    HINTS
+      ${seastar_testing-${config}_INCLUDE_DIRS})
+
+  mark_as_advanced(
+    seastar_INCLUDE_DIR
+    seastar_testing_INCLUDE_DIR)
+endforeach(config ${CMAKE_CONFIGURATION_TYPES})
+set(ENV{PKG_CONFIG_PATH} "${saved_pkg_config_path}")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Seastar
+  REQUIRED_VARS
+    seastar_INCLUDE_DIR
+    seastar_testing_INCLUDE_DIR)
+
+foreach(config ${CMAKE_CONFIGURATION_TYPES})
+  # this directory is created when building Seastar, but we create it manually.
+  # otherwise CMake would complain when configuring targets which link against the
+  # "Seastar::seastar" library. it is imported library. and CMake assures that
+  # all INTERFACE_INCLUDE_DIRECTORIES of an imported library should exist.
+  file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${config}/seastar/gen/include)
+endforeach()
+
+foreach(component "seastar" "seastar_testing" "seastar_perf_testing")
+  if(NOT TARGET Seastar::${component})
+    add_library(Seastar::${component} UNKNOWN IMPORTED)
+    foreach(config ${CMAKE_CONFIGURATION_TYPES})
+      set_property(TARGET Seastar::${component} APPEND
+        PROPERTY
+          IMPORTED_CONFIGURATIONS ${config})
+      string (TOUPPER ${config} CONFIG)
+      if(config MATCHES "Debug|Dev")
+        set_property(TARGET Seastar::${component}
+          PROPERTY
+            IMPORTED_LOCATION_${CONFIG} "${CMAKE_BINARY_DIR}/${config}/seastar/lib${component}.so")
+        set(prefix ${component}-${config})
+      else()
+        set_property(TARGET Seastar::${component}
+          PROPERTY
+            IMPORTED_LOCATION_${CONFIG} "${CMAKE_BINARY_DIR}/${config}/seastar/lib${component}.a")
+        set(prefix ${component}-${config}_STATIC)
+      endif()
+      # these two libraries provide .pc, so set the properties retrieved with
+      # pkg-config.
+      if(component MATCHES "^(seastar|seastar_testing)$")
+        set_property(TARGET Seastar::${component} APPEND
+          PROPERTY
+            INTERFACE_INCLUDE_DIRECTORIES $<$<CONFIG:${config}>:${${prefix}_INCLUDE_DIRS}>)
+        set_property(TARGET Seastar::${component} APPEND
+          PROPERTY
+            INTERFACE_LINK_LIBRARIES $<$<CONFIG:${config}>:${${prefix}_LINK_LIBRARIES}>)
+        set_property(TARGET Seastar::${component} APPEND
+          PROPERTY
+            INTERFACE_LINK_OPTIONS $<$<CONFIG:${config}>:${${prefix}_LDFLAGS}>)
+        set_property(TARGET Seastar::${component} APPEND
+          PROPERTY
+            INTERFACE_COMPILE_OPTIONS $<$<CONFIG:${config}>:${${prefix}_CFLAGS_OTHER}>)
+      endif()
+    endforeach()
+
+    # seastar_perf_testing does not provide its .pc, so let's just hardwire its
+    # properties
+    if(component STREQUAL "seastar_perf_testing")
+      set_target_properties(Seastar::seastar_perf_testing PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${Seastar_INCLUDE_DIR}"
+        INTERFACE_LINK_LIBRARIES Seastar::seastar)
+    endif()
+  endif()
+endforeach()
+
+if(NOT TARGET Seastar::iotune)
+  add_executable(Seastar::iotune IMPORTED)
+  foreach(config ${CMAKE_CONFIGURATION_TYPES})
+    set_property(TARGET Seastar::iotune APPEND
+      PROPERTY
+        IMPORTED_CONFIGURATIONS ${config})
+    string (TOUPPER ${config} CONFIG)
+    set_property(TARGET Seastar::iotune
+      PROPERTY
+        IMPORTED_LOCATION_${CONFIG} ${CMAKE_BINARY_DIR}/$<CONFIG>/seastar/apps/iotune/iotune)
+  endforeach()
+endif()

--- a/configure.py
+++ b/configure.py
@@ -2528,6 +2528,10 @@ def configure_using_cmake(args):
     source_dir = os.path.realpath(os.path.dirname(__file__))
     build_dir = os.path.join(source_dir, 'build')
 
+    if not args.dist_only:
+        for mode in selected_modes:
+            configure_seastar(build_dir, build_modes[mode].cmake_build_type, modes[mode])
+
     cmake_command = ['cmake']
     cmake_command += [f'-D{var}={value}' for var, value in settings.items()]
     cmake_command += ['-G', 'Ninja Multi-Config',

--- a/configure.py
+++ b/configure.py
@@ -1722,7 +1722,7 @@ def configure_seastar(build_dir, mode, mode_config):
         seastar_cmake_args += ['-DSeastar_ALLOC_FAILURE_INJECTION=ON']
     if args.seastar_debug_allocations:
         seastar_cmake_args += ['-DSeastar_DEBUG_ALLOCATIONS=ON']
-    if modes[mode]['build_seastar_shared_libs']:
+    if mode_config['build_seastar_shared_libs']:
         seastar_cmake_args += ['-DBUILD_SHARED_LIBS=ON']
 
     seastar_cmd = ['cmake', '-G', 'Ninja', real_relpath(args.seastar_path, seastar_build_dir)] + seastar_cmake_args

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -45,12 +45,17 @@ endfunction()
 add_stripped("${CMAKE_BINARY_DIR}/$<CONFIG>/scylla")
 
 # app_iotune is located in seastar/apps/iotune
-set(iotune_path "${CMAKE_BINARY_DIR}/$<CONFIG>/iotune")
+if(TARGET Seastar::iotune)
+  set(iotune_src "$<TARGET_PROPERTY:Seastar::iotune,IMPORTED_LOCATION>")
+else()
+  set(iotune_src "$<TARGET_FILE:app_iotune>")
+endif()
+set(iotune_dst "${CMAKE_BINARY_DIR}/$<CONFIG>/iotune")
 add_custom_command(
-  OUTPUT "${iotune_path}"
-  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:app_iotune> "${iotune_path}"
-  DEPENDS $<OUTPUT_CONFIG:$<TARGET_FILE:app_iotune>>)
-add_stripped("${iotune_path}")
+  OUTPUT "${iotune_dst}"
+  COMMAND ${CMAKE_COMMAND} -E copy "${iotune_src}" "${iotune_dst}"
+  DEPENDS $<OUTPUT_CONFIG:${iotune_src}>)
+add_stripped("${iotune_dst}")
 
 find_program(TAR_COMMAND tar
   REQUIRED)

--- a/redis/CMakeLists.txt
+++ b/redis/CMakeLists.txt
@@ -1,5 +1,26 @@
 # Generate C++ sources from ragel grammar files
-seastar_generate_ragel(
+
+find_package(ragel 6.10 REQUIRED)
+
+function(generate_ragel)
+  set(one_value_args TARGET VAR IN_FILE OUT_FILE)
+  cmake_parse_arguments(args "" "${one_value_args}" "" ${ARGN})
+  get_filename_component(out_dir ${args_OUT_FILE} DIRECTORY)
+
+  add_custom_command(
+    DEPENDS ${args_IN_FILE}
+    OUTPUT ${args_OUT_FILE}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${out_dir}
+    COMMAND ${ragel_RAGEL_EXECUTABLE} -G2 -o ${args_OUT_FILE} ${args_IN_FILE}
+    COMMAND sed -i -e "'1h;2,$$H;$$!d;g'" -re "'s/static const char _nfa[^;]*;//g'" ${args_OUT_FILE})
+
+  add_custom_target(${args_TARGET}
+    DEPENDS ${args_OUT_FILE})
+
+  set(${args_VAR} ${args_OUT_FILE} PARENT_SCOPE)
+endfunction()
+
+generate_ragel(
     TARGET scylla_ragel_gen_protocol_parser
     VAR scylla_ragel_gen_protocol_parser_file
     IN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/protocol_parser.rl"

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -13,7 +13,7 @@ function(add_perf_test name)
     PRIVATE
       perf-lib
       test-lib
-      seastar_perf_testing
+      Seastar::seastar_perf_testing
       Seastar::seastar
       xxHash::xxhash)
   if(parsed_args_LIBRARIES)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(cryptopp REQUIRED)
 find_package(rapidxml REQUIRED)
-
+find_package(GnuTLS 3.3.26 REQUIRED)
 add_library(utils STATIC)
 target_sources(utils
   PRIVATE
@@ -60,7 +60,8 @@ target_link_libraries(utils
     Boost::regex
     cryptopp::cryptopp
     rapidxml::rapidxml
-    yaml-cpp::yaml-cpp)
+    yaml-cpp::yaml-cpp
+    GnuTLS::gnutls)
 
 check_headers(check-headers utils
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -59,7 +59,8 @@ target_link_libraries(utils
   PRIVATE
     Boost::regex
     cryptopp::cryptopp
-    rapidxml::rapidxml)
+    rapidxml::rapidxml
+    yaml-cpp::yaml-cpp)
 
 check_headers(check-headers utils
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)


### PR DESCRIPTION
before this change, scylla's CMake-based system consumes Seastar
library by including it directly. but this failed to address the needs
of linking against Seastar shared libraries in Debug and Dev builds, while
linking against the static libraries in other builds. because Seastar
uses `BUILD_SHARED_LIBS` CMake variable to determine if it builds
shared libraries. and we cannot assign different values to this
CMake variable based on current configure type -- CMake does not
support. see https://gitlab.kitware.com/cmake/cmake/-/issues/19467

in order to address this problem, we have a couple possible
solutions:

- to enable Seastar to build both shared and static libraries in a
  pass. without sacrificing the performance, we have to build
  all object files twice: once with -fPIC, once without. in order
  to accompolish this goal, we need to develop a machinary to
  populate the same settings to these two builds. this would
  complicate the design of Seastar's building system further.
- to build Seastar libraries twice in scylla, we could use
  the ExternalProject module to implement this. but it'd be
  complicate to extract the compile options, and link options
  previously populated by Seastar's targets with CMake --
  we would have to replicate all of them in scylla. this is
  out of the question.
- to build Seastar libraries twice before building scylla,
  and let scylla to consume them using CMake config files or
  .pc files. this is a compromise. it enables scylla to
  drive the build of Seastar libraries and to consume
  the compile options and link options. the downside is:

  * the generated compilation database (compile_commands.json)
    does not include the commands building Seastar anymore.
  * the building system of scylla does not have finer graind
    control on the building process of seastar. for instance,
    we cannot specify the build dependency to a certain seastar
    library, and just build it instead of building the whole
    seastar project.

turns out the last approach is the best one we can have
at this moment. this is also the approach used by the existing
`configure.py`.

in this change, we

- add FindSeastar.cmake to

  * detect the preconfigured Seastar builds, and
  * extract the build options from .pc files
  * expose library targets to be consumed by parent project
- add Seastar as an external project, so we can build it from
  the parent project.

  this is atypical compared to standard ExternalProject usage:
  - Seastar's build system should already be configured at this point.
  - We maintain separate project variants for each configuration type.

  Benefits of this approach:
  - Allows the parent project to consume the compile options exposed by
    .pc file. as the compile options vary from one config to another.
  - Allows application of config-specific settings
  - Enables building Seastar within the parent project's build system
  - Facilitates linking of artifacts with the external project target,
    establishing proper dependencies between them

we will update `configure.py` to merge the compilation database
of scylla and seastar.

Refs scylladb/scylladb#2717

---

this is a CMake-related change, hence no need to backport. 