### PR TITLE
sstables/mx/reader: release column value buffer after consumed

### DIFF
--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1033,6 +1033,8 @@ private:
         column_label:
             if (_subcolumns_to_read == 0) {
                 if (no_more_columns()) {
+                    // Release buffer used to read column values.
+                    _column_value = fragmented_temporary_buffer();
                     _state = state::FLAGS;
                     if (_consumer.consume_row_end() == data_consumer::proceed::no) {
                         co_yield data_consumer::proceed::no;

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1543,7 +1543,7 @@ SEASTAR_TEST_CASE(test_reader_concurrency_semaphore_memory_limit_engages) {
     db_cfg.reader_concurrency_semaphore_kill_limit_multiplier.set(4, utils::config_file::config_source::CommandLine);
 
     return do_with_cql_env_thread([] (cql_test_env& env) {
-        auto tbl = create_memory_limit_table(env, 32);
+        auto tbl = create_memory_limit_table(env, 64);
 
         auto& db = env.local_db();
         auto& semaphore = db.get_reader_concurrency_semaphore();


### PR DESCRIPTION
data_consume_rows_context_m has a _column_value buffer it uses to read key and column values into, preparing for parsing and consuming them.
This buffer is reset (released) in a few different cases:
* When using it for key - after consuming its content
* When using it for column value - when a colum has no value

However, the buffer is not released when used for a column value and the column is consumed. This means that if a large column is read from the sstable, this buffer can potentially linger and keep consuming memory until either one of the other release scenarios is hit, or the reader is destroyed.
Add a third release scenario, releasing the buffer after the row end was consumed. This allows the buffer to be re-used between columns of the same row, at the same time ensuring that a large buffer will not linger.

This patch can almost halve the memory consumption of reads in certain circumstances. Point in case: the test test_reader_concurrency_semaphore_memory_limit_engages starts to fail after this fix, because the read doesn't trigger the OOM limit anymore and needs doubling of the concurrency to keep passing.

This issue was found in a dtest (`test_ics_refresh_with_big_sstable_files`), which writes some large cells of up to 7MiB. After reading the row containing this large cell, the reader holds on to the 7MiB buffer causing the semaphore's OOM protection to kick in down the line.

Fixes: https://github.com/scylladb/scylladb/issues/21160