### PR TITLE
doc: set 6.2 as the latest stable version

### DIFF
--- a/docs/_utils/redirects.yaml
+++ b/docs/_utils/redirects.yaml
@@ -1,30 +1,30 @@
 ### a dictionary of redirections
 #old path: new path
 
-# THESE REDIRECTIOSN SHOULD BE UNCOMMENTED WHEN 6.2 IS RELEASED
-# Before 6.2 documentation is available, these redirections result in 404
 
-#/stable/troubleshooting/nodetool-memory-read-timeout.html: /stable/troubleshooting/index.html
+# Remove an oudated article
+
+/stable/troubleshooting/nodetool-memory-read-timeout.html: /stable/troubleshooting/index.html
 
 # Move up the Features section
 
-#/stable/using-scylla/features.html: /stable/features/index.html
-#/stable/using-scylla/lwt.html: /stable/features/lwt.html
-#/stable/using-scylla/secondary-indexes.html: /stable/features/secondary-indexes.html
-#/stable/using-scylla/local-secondary-indexes.html: /stable/features/local-secondary-indexes.html
-#/stable/using-scylla/materialized-views.html: /stable/features/materialized-views.html
-#/stable/using-scylla/counters.html: /stable/features/counters.html
-#/stable/using-scylla/workload-attributes.html: /stable/features/workload-attributes.html
-#/stable/using-scylla/cdc/index.html: /stable/features/cdc/index.html
-#/stable/using-scylla/cdc/cdc-intro.html: /stable/features/cdc/cdc-intro.html
-#/stable/using-scylla/cdc/cdc-log-table.html: /stable/features/cdc/cdc-log-table.html
-#/stable/using-scylla/cdc/cdc-basic-operations.html: /stable/features/cdc/cdc-basic-operations.html
-#/stable/using-scylla/cdc/cdc-streams.html: /stable/features/cdc/cdc-streams.html
-#/stable/using-scylla/cdc/cdc-stream-generations.html: /stable/features/cdc/cdc-stream-generations.html
-#/stable/using-scylla/cdc/cdc-querying-streams.html: /stable/features/cdc/cdc-querying-streams.html
-#/stable/using-scylla/cdc/cdc-advanced-types.html: /stable/features/cdc/cdc-advanced-types.html
-#/stable/using-scylla/cdc/cdc-preimages.html: /stable/features/cdc/cdc-preimages.html
-#/stable/using-scylla/cdc/cdc-consistency.html: /stable/features/cdc/cdc-consistency.html
+/stable/using-scylla/features.html: /stable/features/index.html
+/stable/using-scylla/lwt.html: /stable/features/lwt.html
+/stable/using-scylla/secondary-indexes.html: /stable/features/secondary-indexes.html
+/stable/using-scylla/local-secondary-indexes.html: /stable/features/local-secondary-indexes.html
+/stable/using-scylla/materialized-views.html: /stable/features/materialized-views.html
+/stable/using-scylla/counters.html: /stable/features/counters.html
+/stable/using-scylla/workload-attributes.html: /stable/features/workload-attributes.html
+/stable/using-scylla/cdc/index.html: /stable/features/cdc/index.html
+/stable/using-scylla/cdc/cdc-intro.html: /stable/features/cdc/cdc-intro.html
+/stable/using-scylla/cdc/cdc-log-table.html: /stable/features/cdc/cdc-log-table.html
+/stable/using-scylla/cdc/cdc-basic-operations.html: /stable/features/cdc/cdc-basic-operations.html
+/stable/using-scylla/cdc/cdc-streams.html: /stable/features/cdc/cdc-streams.html
+/stable/using-scylla/cdc/cdc-stream-generations.html: /stable/features/cdc/cdc-stream-generations.html
+/stable/using-scylla/cdc/cdc-querying-streams.html: /stable/features/cdc/cdc-querying-streams.html
+/stable/using-scylla/cdc/cdc-advanced-types.html: /stable/features/cdc/cdc-advanced-types.html
+/stable/using-scylla/cdc/cdc-preimages.html: /stable/features/cdc/cdc-preimages.html
+/stable/using-scylla/cdc/cdc-consistency.html: /stable/features/cdc/cdc-consistency.html
 
 # Remove the Cluster membership changes and LWT consistency page
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,9 +18,9 @@ BASE_URL = 'https://opensource.docs.scylladb.com'
 TAGS = []
 BRANCHES = ["master", "branch-5.1", "branch-5.2", "branch-5.4", "branch-6.0", "branch-6.1", "branch-6.2"]
 # Set the latest version. 
-LATEST_VERSION = "branch-6.1"
+LATEST_VERSION = "branch-6.2"
 # Set which versions are not released yet.
-UNSTABLE_VERSIONS = ["master", "branch-6.2"]
+UNSTABLE_VERSIONS = ["master"]
 # Set which versions are deprecated.
 DEPRECATED_VERSIONS = [""]
 


### PR DESCRIPTION
This PR updates the configuration for ScyllaDB documentation so that:
- 6.2 is the latest version.
- 6.2 is removed from the list of unstable versions.

It must be merged when ScyllaDB 6.2 is released.

In addition, this commit uncomments the redirections that should be applied when version 6.2 is the latest stable version (which will happen when this commit is merged).

I've converted this PR to a draft so that it's not merged prematurely. It must be merged when ScyllaDB 6.2 is released so that version 6.2 is the default in the docs.

NOTE: Before 6.2 is released, the build will be failing because there's no AWS, Azure, and GCP image information available yet to be downloaded and displayed in the docs. Upon release, these issues will be fixed automatically.

No backport is required.

Fixes https://github.com/scylladb/scylladb/issues/21294