### PR TITLE
docs: nodetools-commands/restore: update to reflect the latest implementation

### DIFF
--- a/docs/operating-scylla/nodetool-commands/restore.rst
+++ b/docs/operating-scylla/nodetool-commands/restore.rst
@@ -11,16 +11,22 @@ Syntax
 
    nodetool [(-h <host> | --host <host>)] [(-p <port> | --port <port>)]
                --endpoint <endpoint> --bucket <bucket>
-               --snapshot <snapshot>
-               --keyspace <keyspace> [--table <table>]
+               --prefix <prefix>
+               --keyspace <keyspace>
+               --table <table>
                [--nowait]
+               <sstables>...
 
 Example
 -------
 
 .. code-block:: console
 
-   nodetool restore --endpoint s3.us-east-2.amazonaws.com  --bucket bucket-foo --snapshot ss --keyspace ks
+   nodetool restore --endpoint s3.us-east-2.amazonaws.com  --bucket bucket-foo --prefix ks/cf/24601 --keyspace ks --table cf \
+     scylla/ks/cf/34/me-3gdq_0bki_2dy4w2gqj6hoso4mw1-big-TOC.txt \
+     scylla/ks/cf/34/me-3gdq_0bki_2dipc1ysb2x2a3btgh-big-TOC.txt \
+     scylla/ks/cf/42/me-3gdq_0bki_2s3e829t3gyq994yjl-big-TOC.txt
+
 
 Options
 -------
@@ -28,10 +34,11 @@ Options
 * ``-h <host>`` or ``--host <host>`` - Node hostname or IP address.
 * ``--endpoint`` - ID of the configured object storage endpoint to load SSTables from
 * ``--bucket`` - Name of the bucket to load SSTables from
-* ``--snapshot`` - Name of a snapshot to load SSTables from
-* ``--keyspace`` - Name of a keyspace to load SSTables into
-* ``--table`` - Name of a table to load SSTables into
+* ``--prefix`` - The share prefix for object keys of backed up SSTables
+* ``--keyspace`` - Name of the keyspace to load SSTables into
+* ``--table`` - Name of the table to load SSTables into
 * ``--nowait`` - Don't wait on the restore process
+* ``<sstables>`` - Remainder of keys of the TOC (Table of Contents) components of SSTables to restore, relative to the specified prefix
 
 See also
 


### PR DESCRIPTION
in 787ea4b1d4, we added "sstables" argument to the "nodetool restore" command. but we failed to update the document to reflect the change.

in this change, we update the document for "restore" command to reflect the latest implementation changes introduced in commit 787ea4b1d4:

* Add information about the new "sstables" argument
* Update command line usage of "--table" argument -- it is now madatory
* Update the example accordingly.

---

no need to backport, "nodetool restore" is not included by any LTS branches yet.