### PR TITLE
tool/scylla-nodetool: check for positional argument passed to "restore"

### DIFF
--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1521,6 +1521,9 @@ void restore_operation(scylla_rest_client& client, const bpo::variables_map& vm)
         }
         params[required_param] = vm[required_param].as<sstring>();
     }
+    if (!vm.contains("sstables")) {
+      throw std::invalid_argument("missing required possitional argument: sstables");
+    }
     sstring sstables_body = std::invoke([&vm] {
         std::stringstream output;
         rjson::streaming_writer writer(output);


### PR DESCRIPTION
before this change, if no positional arguments are passed to "restore" subcommand, the tool fails with following error message:

```
error running operation: boost::wrapexcept<boost::bad_any_cast> (boost::bad_any_cast: failed conversion using boost::any_cast)
```

this is difficult to digest.

after this change, if no sstables are specified:

```
error processing arguments: missing required parameter: sstables
```

this is slightly better from user experience's perspective.

---

no need to backport, "nodetool restore" is not included by any LTS branches yet.