### PR TITLE
interval: replace boost ranges with std ranges

### DIFF
--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -135,14 +135,14 @@ static std::vector<sstring> get_keyspaces(const schema& s, const replica::databa
     auto keyspaces = db.get_non_system_keyspaces();
     auto cmp = keyspace_less_comparator(s);
     std::ranges::sort(keyspaces, cmp);
-    return boost::copy_range<std::vector<sstring>>(
-        range.slice(keyspaces, std::move(cmp)) | boost::adaptors::filtered([&s] (const auto& ks) {
+    return
+        range.slice(keyspaces, std::move(cmp)) | std::views::filter([&s] (const auto& ks) {
             // If this is a range query, results are divided between shards by the partition key (keyspace_name).
             return dht::static_shard_of(s, dht::get_token(s,
                         partition_key::from_single_value(s, utf8_type->decompose(ks))))
                 == this_shard_id();
         })
-    );
+        | std::ranges::to<std::vector<sstring>>();
 }
 
 /**

--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -64,19 +64,20 @@ public:
     using pointer = const virtual_row*;
     using reference = const virtual_row&;
 private:
-    std::reference_wrapper<const std::vector<bytes>> _cf_names;
-    std::reference_wrapper<const std::vector<token_range>> _ranges;
+    const std::vector<bytes>* _cf_names = nullptr;
+    const std::vector<token_range>* _ranges = nullptr;
     size_t _cf_names_idx = 0;
     size_t _ranges_idx = 0;
 public:
     struct end_iterator_tag {};
+    virtual_row_iterator() = default;
     virtual_row_iterator(const std::vector<bytes>& cf_names, const std::vector<token_range>& ranges)
-            : _cf_names(std::ref(cf_names))
-            , _ranges(std::ref(ranges))
+            : _cf_names(&cf_names)
+            , _ranges(&ranges)
     { }
     virtual_row_iterator(const std::vector<bytes>& cf_names, const std::vector<token_range>& ranges, end_iterator_tag)
-            : _cf_names(std::ref(cf_names))
-            , _ranges(std::ref(ranges))
+            : _cf_names(&cf_names)
+            , _ranges(&ranges)
             , _cf_names_idx(cf_names.size())
             , _ranges_idx(ranges.size())
     {
@@ -88,7 +89,7 @@ public:
         }
     }
     virtual_row_iterator& operator++() {
-        if (++_ranges_idx == _ranges.get().size() && ++_cf_names_idx < _cf_names.get().size()) {
+        if (++_ranges_idx == _ranges->size() && ++_cf_names_idx < _cf_names->size()) {
             _ranges_idx = 0;
         }
         return *this;
@@ -99,7 +100,7 @@ public:
         return i;
     }
     const value_type operator*() const {
-        return { _cf_names.get()[_cf_names_idx], _ranges.get()[_ranges_idx] };
+        return { (*_cf_names)[_cf_names_idx], (*_ranges)[_ranges_idx] };
     }
     bool operator==(const virtual_row_iterator& i) const {
         return _cf_names_idx == i._cf_names_idx


### PR DESCRIPTION
To reduce dependency load, replace use of boost ranges with std ranges.

Since std ranges are more particular about what iterators they accept, a custom iterator
in size_estimates_virtual_reader has to be fixed first.

No backport; code cleanup.