### PR TITLE
Collect and report backup progress

### DIFF
--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -10,9 +10,8 @@
 #pragma once
 
 #include <filesystem>
+#include "utils/s3/client_fwd.hh"
 #include "tasks/task_manager.hh"
-
-namespace s3 { class client; }
 
 namespace db {
 class snapshot_ctl;

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -24,6 +24,8 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     sstring _bucket;
     sstring _prefix;
     std::filesystem::path _snapshot_dir;
+    s3::upload_progress _progress = {};
+
     future<> do_backup();
 
 protected:
@@ -41,6 +43,7 @@ public:
     virtual std::string type() const override;
     virtual tasks::is_internal is_internal() const noexcept override;
     virtual tasks::is_abortable is_abortable() const noexcept override;
+    virtual future<tasks::task_manager::task::progress> get_progress() const override;
 };
 
 } // snapshot namespace

--- a/test/object_store/test_backup.py
+++ b/test/object_store/test_backup.py
@@ -69,6 +69,7 @@ async def test_simple_backup(manager: ManagerClient, s3_server):
     print(f'Status: {status}, waiting to finish')
     status = await manager.api.wait_task(server.ip_addr, tid)
     assert (status is not None) and (status['state'] == 'done')
+    assert (status['progress_total'] > 0) and (status['progress_completed'] == status['progress_total'])
 
     objects = set([ o.key for o in get_s3_resource(s3_server).Bucket(s3_server.bucket_name).objects.all() ])
     for f in files:

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -913,6 +913,7 @@ data_sink client::make_upload_jumbo_sink(sstring object_name, std::optional<unsi
 class client::do_upload_file : private multipart_upload {
     const std::filesystem::path _path;
     size_t _part_size;
+    upload_progress& _progress;
 
     // each time, we read up to transmit size from disk.
     // this is also an option which limits the number of multipart upload tasks.
@@ -934,7 +935,8 @@ class client::do_upload_file : private multipart_upload {
     // transmit data from input to output in chunks sized up to unit_size
     static future<> copy_to(input_stream<char> input,
                             output_stream<char> output,
-                            size_t unit_size) {
+                            size_t unit_size,
+                            upload_progress& progress) {
         std::exception_ptr ex;
         try {
             for (;;) {
@@ -967,10 +969,10 @@ class client::do_upload_file : private multipart_upload {
         req.query_parameters.emplace("partNumber", to_sstring(part_number + 1));
         req.query_parameters.emplace("uploadId", _upload_id);
         s3l.trace("PUT part {}, {} bytes (upload id {})", part_number, part_size, _upload_id);
-        req.write_body("bin", part_size, [f=std::move(f), mem_units=std::move(mem_units), offset, part_size] (output_stream<char>&& out_) {
+        req.write_body("bin", part_size, [f=std::move(f), mem_units=std::move(mem_units), offset, part_size, &progress = _progress] (output_stream<char>&& out_) {
             auto input = make_file_input_stream(f, offset, part_size, input_stream_options());
             auto output = std::move(out_);
-            return copy_to(std::move(input), std::move(output), _transmit_size);
+            return copy_to(std::move(input), std::move(output), _transmit_size, progress);
         });
         // upload the parts in the background for better throughput
         auto gh = _bg_flushes.hold();
@@ -1039,10 +1041,10 @@ class client::do_upload_file : private multipart_upload {
         if (_tag) {
             req._headers["x-amz-tagging"] = seastar::format("{}={}", _tag->key, _tag->value);
         }
-        req.write_body("bin", len, [f = std::move(f)] (output_stream<char>&& out_) mutable {
+        req.write_body("bin", len, [f = std::move(f), &progress = _progress] (output_stream<char>&& out_) mutable {
             auto input = make_file_input_stream(std::move(f), input_stream_options());
             auto output = std::move(out_);
-            return copy_to(std::move(input), std::move(output), _transmit_size);
+            return copy_to(std::move(input), std::move(output), _transmit_size, progress);
         });
         co_await _client->make_request(std::move(req), [len, start = s3_clock::now()] (group_client& gc, const auto& rep, auto&& in) {
             gc.write_stats.update(len, s3_clock::now() - start);
@@ -1055,10 +1057,12 @@ public:
                    std::filesystem::path path,
                    sstring object_name,
                    std::optional<tag> tag,
-                   size_t part_size)
+                   size_t part_size,
+                   upload_progress& up)
         : multipart_upload(std::move(cln), std::move(object_name), std::move(tag))
         , _path{std::move(path)}
         , _part_size(part_size)
+        , _progress(up)
     {
     }
 
@@ -1081,13 +1085,25 @@ public:
 
 future<> client::upload_file(std::filesystem::path path,
                               sstring object_name,
+                              upload_progress& up) {
+    do_upload_file do_upload{shared_from_this(),
+                             std::move(path),
+                             std::move(object_name),
+                             {}, 0, up};
+    co_await do_upload.upload();
+}
+
+future<> client::upload_file(std::filesystem::path path,
+                              sstring object_name,
                               std::optional<tag> tag,
                               std::optional<size_t> part_size) {
+    upload_progress noop;
     do_upload_file do_upload{shared_from_this(),
                              std::move(path),
                              std::move(object_name),
                              std::move(tag),
-                             part_size.value_or(0)};
+                             part_size.value_or(0),
+                             noop};
     co_await do_upload.upload();
 }
 

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -945,6 +945,7 @@ class client::do_upload_file : private multipart_upload {
                     break;
                 }
                 co_await output.write(buf.get(), buf.size());
+                progress.uploaded += buf.size();
             }
             co_await output.flush();
         } catch (...) {
@@ -1070,6 +1071,7 @@ public:
         auto f = co_await open_file_dma(_path.native(), open_flags::ro);
         const auto stat = co_await f.stat();
         const uint64_t file_size = stat.st_size;
+        _progress.total += file_size;
         // use multipart upload when possible in order to transmit parts in
         // parallel to improve throughput
         if (file_size > aws_minimum_part_size) {

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -117,6 +117,9 @@ public:
                          sstring object_name,
                          std::optional<tag> tag = {},
                          std::optional<size_t> max_part_size = {});
+    future<> upload_file(std::filesystem::path path,
+                         sstring object_name,
+                         upload_progress& up);
 
     void update_config(endpoint_config_ptr);
 

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -17,6 +17,7 @@
 #include <filesystem>
 #include "utils/lister.hh"
 #include "utils/s3/creds.hh"
+#include "utils/s3/client_fwd.hh"
 
 using namespace seastar;
 class memory_data_sink_buffers;

--- a/utils/s3/client_fwd.hh
+++ b/utils/s3/client_fwd.hh
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+#include <cstddef>
+
+namespace s3 {
+class client;
+}

--- a/utils/s3/client_fwd.hh
+++ b/utils/s3/client_fwd.hh
@@ -11,4 +11,9 @@
 
 namespace s3 {
 class client;
+
+struct upload_progress {
+    size_t total;
+    size_t uploaded;
+};
 }


### PR DESCRIPTION
Task manager GET /status method returns two counters that reflect task progress -- total and completed. To make caller reason about their meaning, additionally there's progress_units field next to those counters.

This patch implements this progress report for backup task. The units are bytes, the total counter is total size of files that are being uploaded, and the completed counter is total amount of bytes successfully sent with PUT requests. To get the counters, the client::upload_file() is extended to calculate those.

fixes #20653 