### PR TITLE
cql3: index_target: forward declare boost::regex

### DIFF
--- a/cql3/statements/index_target.hh
+++ b/cql3/statements/index_target.hh
@@ -13,7 +13,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include "cql3/column_identifier.hh"
 #include <variant>
-#include <boost/regex.hpp>
+#include <boost/regex_fwd.hpp>
 
 namespace cql3 {
 


### PR DESCRIPTION
No need to burden everyone with the full boost::regex code.

code cleanup; no backport.