### PR TITLE
commitlog_test: Up timeout for large entry tests

### DIFF
--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -1860,7 +1860,7 @@ static future<> do_test_oversized_entry(size_t max_size_mb) {
         }
 
         // this will create an oversized entry set.
-        auto res = co_await log.add_entries(writers, db::timeout_clock::now() + 60s);
+        auto res = co_await log.add_entries(writers, db::timeout_clock::now() + 200s);
 
         auto i = mutations.begin();
         for (auto& h : res) {


### PR DESCRIPTION
Fixes #21150

Apparently, on some CI, in debug, these tests can time out (large alloc) without actually failing what they do. Up the timeout (could consider removing as well, but...) so they hopefully pass.

Should not need backport, as the issue has not shown other than in enterprise master.