### PR TITLE
compaction: Perform integrity checks on compacting SSTables

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1160,7 +1160,8 @@ public:
                 mr_fwd,
                 unwrap_monitor_generator(),
                 default_sstable_predicate(),
-                &_reader_statistics);
+                &_reader_statistics,
+                integrity_check::yes);
     }
 
     std::string_view report_start_desc() const override {
@@ -1307,7 +1308,10 @@ public:
                 std::move(trace),
                 sm_fwd,
                 mr_fwd,
-                unwrap_monitor_generator());
+                unwrap_monitor_generator(),
+                default_sstable_predicate(),
+                nullptr,
+                integrity_check::yes);
     }
 
     std::string_view report_start_desc() const override {
@@ -1634,7 +1638,7 @@ public:
         if (!range.is_full()) {
             on_internal_error(clogger, fmt::format("Scrub compaction in mode {} expected full partition range, but got {} instead", _options.operation_mode, range));
         }
-        auto full_scan_reader = _compacting->make_full_scan_reader(std::move(s), std::move(permit), nullptr, unwrap_monitor_generator());
+        auto full_scan_reader = _compacting->make_full_scan_reader(std::move(s), std::move(permit), nullptr, unwrap_monitor_generator(), integrity_check::yes);
         return make_mutation_reader<reader>(std::move(full_scan_reader), _options.operation_mode, _validation_errors);
     }
 
@@ -1739,7 +1743,8 @@ public:
                 nullptr,
                 sm_fwd,
                 mr_fwd,
-                unwrap_monitor_generator());
+                unwrap_monitor_generator(),
+                integrity_check::yes);
 
     }
 

--- a/sstables/data_source_types.hh
+++ b/sstables/data_source_types.hh
@@ -14,6 +14,7 @@ namespace sstables {
 
 template<bool check_digest>
 struct digest_members {
+    bool can_calculate_digest;
     uint32_t expected_digest;
     uint32_t actual_digest;
 };

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -1344,7 +1344,7 @@ private:
 
         if (_single_partition_read) {
             _read_enabled = (begin != *end);
-            _context = data_consume_single_partition<DataConsumeRowsContext>(*_schema, _sst, _consumer, { begin, *end });
+            _context = data_consume_single_partition<DataConsumeRowsContext>(*_schema, _sst, _consumer, { begin, *end }, integrity_check::no);
         } else {
             sstable::disk_read_range drr{begin, *end};
             auto last_end = _fwd_mr ? _sst->data_size() : drr.end;

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -1349,7 +1349,7 @@ private:
             sstable::disk_read_range drr{begin, *end};
             auto last_end = _fwd_mr ? _sst->data_size() : drr.end;
             _read_enabled = bool(drr);
-            _context = data_consume_rows<DataConsumeRowsContext>(*_schema, _sst, _consumer, std::move(drr), last_end, sstable::integrity_check::no);
+            _context = data_consume_rows<DataConsumeRowsContext>(*_schema, _sst, _consumer, std::move(drr), last_end, integrity_check::no);
         }
 
         _monitor.on_read_started(_context->reader_position());
@@ -1551,7 +1551,7 @@ public:
              reader_permit permit,
              tracing::trace_state_ptr trace_state,
              read_monitor& mon,
-             sstable::integrity_check integrity)
+             integrity_check integrity)
         : mp_row_consumer_reader_k_l(std::move(schema), permit, std::move(sst))
         , _consumer(this, _schema, std::move(permit), _schema->full_slice(), std::move(trace_state), streamed_mutation::forwarding::no, _sst)
         , _context(data_consume_rows<DataConsumeRowsContext>(*_schema, _sst, _consumer, integrity))
@@ -1598,7 +1598,7 @@ mutation_reader make_full_scan_reader(
         reader_permit permit,
         tracing::trace_state_ptr trace_state,
         read_monitor& monitor,
-        sstable::integrity_check integrity) {
+        integrity_check integrity) {
     return make_mutation_reader<sstable_full_scan_reader>(std::move(sstable), std::move(schema), std::move(permit),
             std::move(trace_state), monitor, integrity);
 }

--- a/sstables/kl/reader.hh
+++ b/sstables/kl/reader.hh
@@ -11,7 +11,7 @@
 #include "readers/mutation_reader_fwd.hh"
 #include "readers/mutation_reader.hh"
 #include "sstables/progress_monitor.hh"
-#include "sstables/sstables.hh"
+#include "sstables/types_fwd.hh"
 
 namespace sstables {
 namespace kl {
@@ -47,7 +47,7 @@ mutation_reader make_full_scan_reader(
         reader_permit permit,
         tracing::trace_state_ptr trace_state,
         read_monitor& monitor,
-        sstable::integrity_check integrity);
+        integrity_check integrity);
 
 } // namespace kl
 } // namespace sstables

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1557,7 +1557,7 @@ private:
             sstable::disk_read_range drr{begin, *end};
             auto last_end = _fwd_mr ? _sst->data_size() : drr.end;
             _read_enabled = bool(drr);
-            _context = data_consume_rows<DataConsumeRowsContext>(*_schema, _sst, _consumer, std::move(drr), last_end, sstable::integrity_check::no);
+            _context = data_consume_rows<DataConsumeRowsContext>(*_schema, _sst, _consumer, std::move(drr), last_end, integrity_check::no);
         }
 
         _monitor.on_read_started(_context->reader_position());
@@ -1773,7 +1773,7 @@ public:
              reader_permit permit,
              tracing::trace_state_ptr trace_state,
              read_monitor& mon,
-             sstable::integrity_check integrity)
+             integrity_check integrity)
         : mp_row_consumer_reader_mx(std::move(schema), permit, std::move(sst))
         , _consumer(this, _schema, std::move(permit), _schema->full_slice(), std::move(trace_state), streamed_mutation::forwarding::no, _sst)
         , _context(data_consume_rows<DataConsumeRowsContext>(*_schema, _sst, _consumer, integrity))
@@ -1818,7 +1818,7 @@ mutation_reader make_full_scan_reader(
         reader_permit permit,
         tracing::trace_state_ptr trace_state,
         read_monitor& monitor,
-        sstable::integrity_check integrity) {
+        integrity_check integrity) {
     return make_mutation_reader<mx_sstable_full_scan_reader>(std::move(sstable), std::move(schema), std::move(permit),
             std::move(trace_state), monitor, integrity);
 }
@@ -2066,7 +2066,7 @@ future<uint64_t> validate(
         sstables::read_monitor& monitor) {
     auto schema = sstable->get_schema();
     validating_consumer consumer(schema, permit, sstable, std::move(error_handler));
-    auto context = data_consume_rows<data_consume_rows_context_m<validating_consumer>>(*schema, sstable, consumer, sstable::integrity_check::yes);
+    auto context = data_consume_rows<data_consume_rows_context_m<validating_consumer>>(*schema, sstable, consumer, integrity_check::yes);
 
     std::optional<sstables::index_reader> idx_reader;
     idx_reader.emplace(sstable, permit, tracing::trace_state_ptr{}, sstables::use_caching::no, false);

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1551,7 +1551,7 @@ private:
                 _context = std::move(reversed_context.the_context);
                 _reversed_read_sstable_position = &reversed_context.current_position_in_sstable;
             } else {
-                _context = data_consume_single_partition<DataConsumeRowsContext>(*_schema, _sst, _consumer, { begin, *end });
+                _context = data_consume_single_partition<DataConsumeRowsContext>(*_schema, _sst, _consumer, { begin, *end }, integrity_check::no);
             }
         } else {
             sstable::disk_read_range drr{begin, *end};

--- a/sstables/mx/reader.hh
+++ b/sstables/mx/reader.hh
@@ -28,7 +28,8 @@ mutation_reader make_reader(
         tracing::trace_state_ptr trace_state,
         streamed_mutation::forwarding fwd,
         mutation_reader::forwarding fwd_mr,
-        read_monitor& monitor);
+        read_monitor& monitor,
+        integrity_check integrity);
 
 // Same as above but the slice is moved and stored inside the reader.
 mutation_reader make_reader(
@@ -40,7 +41,8 @@ mutation_reader make_reader(
         tracing::trace_state_ptr trace_state,
         streamed_mutation::forwarding fwd,
         mutation_reader::forwarding fwd_mr,
-        read_monitor& monitor);
+        read_monitor& monitor,
+        integrity_check integrity);
 
 // A reader which doesn't use the index at all. It reads everything from the
 // sstable and it doesn't support skipping.

--- a/sstables/mx/reader.hh
+++ b/sstables/mx/reader.hh
@@ -11,7 +11,7 @@
 #include "readers/mutation_reader_fwd.hh"
 #include "readers/mutation_reader.hh"
 #include "sstables/progress_monitor.hh"
-#include "sstables/sstables.hh"
+#include "sstables/types_fwd.hh"
 
 namespace sstables {
 namespace mx {
@@ -50,7 +50,7 @@ mutation_reader make_full_scan_reader(
         reader_permit permit,
         tracing::trace_state_ptr trace_state,
         read_monitor& monitor,
-        sstable::integrity_check integrity);
+        integrity_check integrity);
 
 // Validate the content of the sstable with the mutation_fragment_stream_valdiator,
 // additionally cross checking that the content is laid out as expected by the

--- a/sstables/sstable_mutation_reader.hh
+++ b/sstables/sstable_mutation_reader.hh
@@ -110,7 +110,7 @@ position_in_partition_view get_slice_lower_bound(const schema& s, const query::p
 // heuristics which learn from the usefulness of previous read aheads.
 template <typename DataConsumeRowsContext>
 inline std::unique_ptr<DataConsumeRowsContext> data_consume_rows(const schema& s, shared_sstable sst, typename DataConsumeRowsContext::consumer& consumer,
-        sstable::disk_read_range toread, uint64_t last_end, sstable::integrity_check integrity) {
+        sstable::disk_read_range toread, uint64_t last_end, integrity_check integrity) {
     // Although we were only asked to read until toread.end, we'll not limit
     // the underlying file input stream to this end, but rather to last_end.
     // This potentially enables read-ahead beyond end, until last_end, which
@@ -158,7 +158,7 @@ inline std::unique_ptr<DataConsumeRowsContext> data_consume_single_partition(con
 // Like data_consume_rows() with bounds, but iterates over whole range
 template <typename DataConsumeRowsContext>
 inline std::unique_ptr<DataConsumeRowsContext> data_consume_rows(const schema& s, shared_sstable sst, typename DataConsumeRowsContext::consumer& consumer,
-        sstable::integrity_check integrity) {
+        integrity_check integrity) {
     auto data_size = sst->data_size();
     return data_consume_rows<DataConsumeRowsContext>(s, std::move(sst), consumer, {0, data_size}, data_size, integrity);
 }

--- a/sstables/sstable_mutation_reader.hh
+++ b/sstables/sstable_mutation_reader.hh
@@ -149,9 +149,10 @@ inline reversed_context<DataConsumeRowsContext> data_consume_reversed_partition(
 }
 
 template <typename DataConsumeRowsContext>
-inline std::unique_ptr<DataConsumeRowsContext> data_consume_single_partition(const schema& s, shared_sstable sst, typename DataConsumeRowsContext::consumer& consumer, sstable::disk_read_range toread) {
+inline std::unique_ptr<DataConsumeRowsContext> data_consume_single_partition(const schema& s, shared_sstable sst, typename DataConsumeRowsContext::consumer& consumer,
+        sstable::disk_read_range toread, integrity_check integrity) {
     auto input = sst->data_stream(toread.start, toread.end - toread.start,
-            consumer.permit(), consumer.trace_state(), sst->_single_partition_history);
+            consumer.permit(), consumer.trace_state(), sst->_single_partition_history, sstable::raw_stream::no, integrity);
     return std::make_unique<DataConsumeRowsContext>(s, std::move(sst), consumer, std::move(input), toread.start, toread.end - toread.start);
 }
 

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -229,7 +229,8 @@ public:
         tracing::trace_state_ptr,
         streamed_mutation::forwarding,
         mutation_reader::forwarding,
-        read_monitor_generator& rmg = default_read_monitor_generator()) const;
+        read_monitor_generator& rmg = default_read_monitor_generator(),
+        integrity_check integrity = integrity_check::no) const;
 
     // Filters out mutations that don't belong to the current shard.
     mutation_reader make_local_shard_sstable_reader(
@@ -242,13 +243,15 @@ public:
         mutation_reader::forwarding,
         read_monitor_generator& rmg = default_read_monitor_generator(),
         const sstable_predicate& p = default_sstable_predicate(),
-        combined_reader_statistics* statistics = nullptr) const;
+        combined_reader_statistics* statistics = nullptr,
+        integrity_check integrity = integrity_check::no) const;
 
     mutation_reader make_full_scan_reader(
             schema_ptr,
             reader_permit,
             tracing::trace_state_ptr,
-            read_monitor_generator& rmg = default_read_monitor_generator()) const;
+            read_monitor_generator& rmg = default_read_monitor_generator(),
+            integrity_check integrity = integrity_check::no) const;
 
     friend class compound_sstable_set;
 };

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -186,7 +186,6 @@ public:
     using format_types = sstable_format_types;
     using manager_list_link_type = bi::list_member_hook<bi::link_mode<bi::auto_unlink>>;
     using manager_set_link_type = bi::set_member_hook<bi::link_mode<bi::auto_unlink>>;
-    using integrity_check = bool_class<class integrity_check_tag>;
 public:
     sstable(schema_ptr schema,
             const data_dictionary::storage_options& storage,
@@ -1011,13 +1010,13 @@ public:
     friend class sstables_manager;
     template <typename DataConsumeRowsContext>
     friend std::unique_ptr<DataConsumeRowsContext>
-    data_consume_rows(const schema&, shared_sstable, typename DataConsumeRowsContext::consumer&, disk_read_range, uint64_t, sstable::integrity_check);
+    data_consume_rows(const schema&, shared_sstable, typename DataConsumeRowsContext::consumer&, disk_read_range, uint64_t, integrity_check);
     template <typename DataConsumeRowsContext>
     friend std::unique_ptr<DataConsumeRowsContext>
     data_consume_single_partition(const schema&, shared_sstable, typename DataConsumeRowsContext::consumer&, disk_read_range);
     template <typename DataConsumeRowsContext>
     friend std::unique_ptr<DataConsumeRowsContext>
-    data_consume_rows(const schema&, shared_sstable, typename DataConsumeRowsContext::consumer&, sstable::integrity_check);
+    data_consume_rows(const schema&, shared_sstable, typename DataConsumeRowsContext::consumer&, integrity_check);
     friend void lw_shared_ptr_deleter<sstables::sstable>::dispose(sstable* s);
     gc_clock::time_point get_gc_before_for_drop_estimation(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state, const schema_ptr& s) const;
     gc_clock::time_point get_gc_before_for_fully_expire(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state, const schema_ptr& s) const;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -1013,7 +1013,7 @@ public:
     data_consume_rows(const schema&, shared_sstable, typename DataConsumeRowsContext::consumer&, disk_read_range, uint64_t, integrity_check);
     template <typename DataConsumeRowsContext>
     friend std::unique_ptr<DataConsumeRowsContext>
-    data_consume_single_partition(const schema&, shared_sstable, typename DataConsumeRowsContext::consumer&, disk_read_range);
+    data_consume_single_partition(const schema&, shared_sstable, typename DataConsumeRowsContext::consumer&, disk_read_range, integrity_check);
     template <typename DataConsumeRowsContext>
     friend std::unique_ptr<DataConsumeRowsContext>
     data_consume_rows(const schema&, shared_sstable, typename DataConsumeRowsContext::consumer&, integrity_check);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -274,7 +274,8 @@ public:
             tracing::trace_state_ptr trace_state = {},
             streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
             mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes,
-            read_monitor& monitor = default_read_monitor());
+            read_monitor& monitor = default_read_monitor(),
+            integrity_check integrity = integrity_check::no);
 
     // A reader which doesn't use the index at all. It reads everything from the
     // sstable and it doesn't support skipping.

--- a/sstables/types_fwd.hh
+++ b/sstables/types_fwd.hh
@@ -8,10 +8,13 @@
 
 #pragma once
 
+#include <seastar/util/bool_class.hh>
+
 #include "utils/UUID.hh"
 
 namespace sstables {
 
 using run_id = utils::tagged_uuid<struct run_id_tag>;
+using integrity_check = bool_class<class integrity_check_tag>;
 
 } // namespace sstables


### PR DESCRIPTION
This PR enables compaction tasks to verify the integrity of the input data through checksum and digest checks. The mechanism for integrity checking was introduced in previous PRs (#20207, #20720) as a built-in functionality of the input streams. This PR integrates this mechanism with compaction. The change applies to all compaction types and covers both compressed and uncompressed SSTables adhering to the 3.x format. If a compaction task reads only part of an SSTable, then only the per-chunk checksums are verified, not the digest.

The PR consists of:
* Changes to mx readers to support integrity checking. The kl readers, considered as compatibility-only, were left unchanged. Also, integrity checking on single-partition reversed reads (`data_consume_reversed_partition()`) remains unsupported by mx readers as this is not used in compaction.
* Changes to `sstable` and `sstable_set` APIs to allow toggling integrity checks for mx readers.
* Activation of integrity checking for all compaction types.
* Tests for all compaction types with corrupted SSTables.

Integrity checks come at a cost. For uncompressed SSTables, the cost is the loading of the CRC and Digest components from disk, and the calculation of checksums and digest from the actual data. For compressed SSTables, checksums are stored in-place and they are being checked already on all reads, so the only extra cost is the loading and calculation of the digest. The measurements show a ~5% regression in compaction performance for uncompressed SSTables, and a negligible regression for compressed SSTables.

Command: `perf-sstable --smp=1 --cpuset=1 --poll-mode --mode=compaction --iterations=1000 --partitions 10000 --sstables=1 --key_size=4096 --num_columns=15 --column_size={32, 1024, 3500, 7000, 14500}`

Uncompressed SSTables:
```
+--------------+-----------------------+----------------------+------------+
| SSTable Size | No Integrity (p/sec)  | Integrity (p/sec)    | Regression |
+--------------+-----------------------+----------------------+------------+
| 50  MiB      | 65175.59 +- 80.82     | 61814.63 +- 72.88    | 5.16%      |
| 200 MiB      | 41795.10 +- 60.39     | 39686.28 +- 45.05    | 5.05%      |
| 500 MiB      | 21087.41 +- 30.72     | 20092.93 +- 25.05    | 4.72%      |
| 1   GiB      | 12781.64 +- 21.77     | 12233.94 +- 21.71    | 4.29%      |
| 2   GiB      |  6629.99 +-  9.40     |  6377.13 +-  8.28    | 3.81%      |
+--------------+-----------------------+----------------------+------------+
```
Compressed SSTables:
```
+--------------+-----------------------+----------------------+------------+
| SSTable Size | No Integrity (p/sec)  | Integrity (p/sec)    | Regression |
+--------------+-----------------------+----------------------+------------+
| 50  MiB      | 53975.05 +- 63.18     | 53825.93 +- 62.28    |  0.28%     |
| 200 MiB      | 28687.94 +- 26.58     | 28689.41 +- 26.91    |  0%        |
| 500 MiB      | 13865.35 +- 15.50     | 13790.41 +- 14.88    |  0.54%     |
| 1   GiB      |  7858.10 +-  7.71     |  7829.75 +-  9.66    |  0.36%     |
| 2   GiB      |  4023.11 +-  2.43     |  4010.54 +-  2.55    |  0.31%     |
+--------------+-----------------------+----------------------+------------+
(p/sec = partitions/sec)
```

Refs #19071.

New feature, no backport is needed.