### PR TITLE
node-exporter: Disable hwmon collector

### DIFF
--- a/dist/common/sysconfig/scylla-node-exporter
+++ b/dist/common/sysconfig/scylla-node-exporter
@@ -1,1 +1,1 @@
-SCYLLA_NODE_EXPORTER_ARGS="--collector.interrupts"
+SCYLLA_NODE_EXPORTER_ARGS="--collector.interrupts --no-collector.hwmon"


### PR DESCRIPTION
This collector reads nvme temperature sensor (e.g. `/sys/class/hwmon/hwmon0/temp1_min`), which was observed to cause bad performance on Azure cloud following the reading of the sensor (every time) for ~6 seconds. During the event, we can see elevated system time (up to 30%) and softirq time. CPU utilization is high, with nvme_queue_rq taking several orders of magnitude more time than normally. There are signs of contention, we can see `__pv_queued_spin_lock_slowpath` in the perf profile. 

This manifests as latency spikes and potentially also throughput drop due to reduced CPU capacity. By default, the monitoring stack queries it once every 60s.

Fixes https://github.com/scylladb/scylladb/issues/21163
