### PR TITLE
interval: include used header

### DIFF
--- a/interval.hh
+++ b/interval.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "utils/assert.hh"
+#include <algorithm>
 #include <list>
 #include <vector>
 #include <optional>


### PR DESCRIPTION
when building the tree with Clang-20 and libstdc++ shippped with GCC-14.2, we have following build failure:

```
/home/kefu/dev/scylladb/interval.hh:638:14: error: no member named 'sort' in namespace 'std'
  638 |         std::sort(intervals.begin(), intervals.end(), [&](auto&& r1, auto&& r2) {
      |         ~~~~~^
/home/kefu/dev/scylladb/interval.hh:691:21: error: no member named 'upper_bound' in namespace 'std'
  691 |         return std::upper_bound(r.begin(), r.end(), value, std::forward<LessComparator>(cmp));
      |                ~~~~~^
/home/kefu/dev/scylladb/interval.hh:723:18: error: no member named 'minmax' in namespace 'std'; did you mean 'fminmag'?
  723 |         auto p = std::minmax(_interval, other._interval, [&cmp] (auto&& a, auto&& b) {
      |                  ^~~~~~~~~~~
      |                  fminmag
```

it turns out we failed to include the used header.

in this change, we include `<algorithm>` so that this header is self-contained.

after this change, the build passes.

---

this addresses a build failure with the toolchain composed of clang built from git main HEAD and gcc from fedora 41, but our frozen toolchain is based on fedora 40, hence no need to backport.