### PR TITLE
Enhance load-and-stream with "scope"

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -881,6 +881,15 @@
                           "allowMultiple":false,
                           "type":"string",
                           "paramType":"query"
+                      },
+                      {
+                          "name":"scope",
+                          "description":"Defines the set of nodes to which mutations can be streamed",
+                          "required":false,
+                          "allowMultiple":false,
+                          "type":"string",
+                          "paramType":"query",
+                          "enum": ["all", "dc", "rack", "node"]
                       }
                   ]
               }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -479,7 +479,7 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
         return sst_loader.invoke_on(coordinator,
                 [ks = std::move(ks), cf = std::move(cf),
                 load_and_stream, primary_replica_only] (sstables_loader& loader) {
-            return loader.load_new_sstables(ks, cf, load_and_stream, primary_replica_only);
+            return loader.load_new_sstables(ks, cf, load_and_stream, primary_replica_only, sstables_loader::stream_scope::all);
         }).then_wrapped([] (auto&& f) {
             if (f.failed()) {
                 auto msg = fmt::format("Failed to load new sstables: {}", f.get_exception());
@@ -505,7 +505,7 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
         auto sstables = parsed.GetArray() |
             std::views::transform([] (const auto& s) { return sstring(rjson::to_string_view(s)); }) |
             std::ranges::to<std::vector>();
-        auto task_id = co_await sst_loader.local().download_new_sstables(keyspace, table, prefix, std::move(sstables), endpoint, bucket);
+        auto task_id = co_await sst_loader.local().download_new_sstables(keyspace, table, prefix, std::move(sstables), endpoint, bucket, sstables_loader::stream_scope::all);
         co_return json::json_return_type(fmt::to_string(task_id));
     });
 

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -463,6 +463,22 @@ void unset_repair(http_context& ctx, routes& r) {
     ss::force_terminate_all_repair_sessions_new.unset(r);
 }
 
+static sstables_loader::stream_scope parse_stream_scope(const sstring& scope_str) {
+    using namespace ss::ns_start_restore;
+    auto sc = scope_str.empty() ? scope::all : str2scope(scope_str);
+
+    switch (sc) {
+    case scope::all: return sstables_loader::stream_scope::all;
+    case scope::dc: return sstables_loader::stream_scope::dc;
+    case scope::rack: return sstables_loader::stream_scope::rack;
+    case scope::node: return sstables_loader::stream_scope::node;
+    case scope::NUM_ITEMS:
+        break;
+    }
+
+    throw httpd::bad_param_exception("invalid scope parameter value");
+}
+
 void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>& sst_loader) {
     ss::load_new_ss_tables.set(r, [&ctx, &sst_loader](std::unique_ptr<http::request> req) {
         auto ks = validate_keyspace(ctx, req);
@@ -495,6 +511,7 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
         auto table = req->get_query_param("table");
         auto bucket = req->get_query_param("bucket");
         auto prefix = req->get_query_param("prefix");
+        auto scope = parse_stream_scope(req->get_query_param("scope"));
 
         // TODO: the http_server backing the API does not use content streaming
         // should use it for better performance
@@ -505,7 +522,7 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
         auto sstables = parsed.GetArray() |
             std::views::transform([] (const auto& s) { return sstring(rjson::to_string_view(s)); }) |
             std::ranges::to<std::vector>();
-        auto task_id = co_await sst_loader.local().download_new_sstables(keyspace, table, prefix, std::move(sstables), endpoint, bucket, sstables_loader::stream_scope::all);
+        auto task_id = co_await sst_loader.local().download_new_sstables(keyspace, table, prefix, std::move(sstables), endpoint, bucket, scope);
         co_return json::json_return_type(fmt::to_string(task_id));
     });
 

--- a/docs/operating-scylla/nodetool-commands/restore.rst
+++ b/docs/operating-scylla/nodetool-commands/restore.rst
@@ -19,6 +19,7 @@ Syntax
                --keyspace <keyspace>
                --table <table>
                [--nowait]
+               [--scope <scope>]
                <sstables>...
 
 Example
@@ -43,7 +44,21 @@ Options
 * ``--keyspace`` - Name of the keyspace to load SSTables into
 * ``--table`` - Name of the table to load SSTables into
 * ``--nowait`` - Don't wait on the restore process
+* ``--scope <scope>`` - Use specified load-and-stream scope
 * ``<sstables>`` - Remainder of keys of the TOC (Table of Contents) components of SSTables to restore, relative to the specified prefix
+
+The `scope` parameter describes the subset of cluster nodes where you want to load data:
+
+* `node` - On the local node.
+* `rack` - On the local rack.
+* `dc` - In the datacenter (DC) where the local node lives.
+* `all` (default) - Everywhere across the cluster.
+
+To fully restore a cluster, you should combine the ``scope`` parameter with the correct list of
+SStables to restore to each node.
+On one extreme, one node is given all SStables with the scope ``all``; on the other extreme, all
+nodes are restoring only their own SStables with the scope ``node``. In between, you can choose
+a subset of nodes to restore only SStables that belong to the rack or DC.
 
 See also
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -162,6 +162,8 @@ public:
 protected:
     virtual host_id_vector_replica_set get_primary_endpoints(const dht::token& token) const;
     future<> stream_sstables(const dht::partition_range&, std::vector<sstables::shared_sstable>, std::function<void(unsigned)> on_streamed);
+private:
+    host_id_vector_replica_set get_all_endpoints(const dht::token& token) const;
 };
 
 class tablet_sstable_streamer : public sstable_streamer {
@@ -192,6 +194,10 @@ private:
 };
 
 host_id_vector_replica_set sstable_streamer::get_endpoints(const dht::token& token) const {
+    return get_all_endpoints(token);
+}
+
+host_id_vector_replica_set sstable_streamer::get_all_endpoints(const dht::token& token) const {
     if (_primary_replica_only) {
         return get_primary_endpoints(token);
     }

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -146,6 +146,9 @@ public:
             , _unlink_sstables(unlink)
             , _stream_scope(stream_scope::all)
     {
+        if (_primary_replica_only && _stream_scope != stream_scope::all) {
+            throw std::runtime_error("Scoped streaming of primary replica only is not supported yet");
+        }
         // By sorting SSTables by their primary key, we allow SSTable runs to be
         // incrementally streamed.
         // Overlapping run fragments can have their content deduplicated, reducing

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -35,6 +35,7 @@ class view_builder;
 // system. Built on top of the distributed_loader functionality.
 class sstables_loader : public seastar::peering_sharded_service<sstables_loader> {
 public:
+    enum class stream_scope { all, dc, rack, node };
     class task_manager_module : public tasks::task_manager::module {
         public:
             task_manager_module(tasks::task_manager& tm) noexcept : tasks::task_manager::module(tm, "sstables_loader") {}

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -59,7 +59,7 @@ private:
 
     future<> load_and_stream(sstring ks_name, sstring cf_name,
             table_id, std::vector<sstables::shared_sstable> sstables,
-            bool primary_replica_only, bool unlink_sstables,
+            bool primary_replica_only, bool unlink_sstables, stream_scope scope,
             std::function<void(unsigned)> on_streamed);
 
 public:
@@ -85,14 +85,14 @@ public:
      * @return a future<> when the operation finishes.
      */
     future<> load_new_sstables(sstring ks_name, sstring cf_name,
-            bool load_and_stream, bool primary_replica_only);
+            bool load_and_stream, bool primary_replica_only, stream_scope scope);
 
     /**
      * Download new SSTables not currently tracked by the system from object store
      */
     future<tasks::task_id> download_new_sstables(sstring ks_name, sstring cf_name,
             sstring prefix, std::vector<sstring> sstables,
-            sstring endpoint, sstring bucket);
+            sstring endpoint, sstring bucket, stream_scope scope);
 
     class download_task_impl;
 };

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -328,13 +328,15 @@ class ScyllaRESTAPIClient():
                   "snapshot": tag}
         return await self.client.post_json(f"/storage_service/backup", host=node_ip, params=params)
 
-    async def restore(self, node_ip: str, ks: str, cf: str, dest: str, bucket: str, prefix: str, sstables: list[str]) -> str:
+    async def restore(self, node_ip: str, ks: str, cf: str, dest: str, bucket: str, prefix: str, sstables: list[str], scope: str = None) -> str:
         """Restore keyspace:table from backup"""
         params = {"keyspace": ks,
                   "table": cf,
                   "endpoint": dest,
                   "bucket": bucket,
                   "prefix": prefix}
+        if scope is not None:
+            params['scope'] = scope
         return await self.client.post_json(f"/storage_service/restore", host=node_ip, params=params, json=sstables)
 
     async def take_snapshot(self, node_ip: str, ks: str, tag: str) -> None:

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1536,6 +1536,9 @@ void restore_operation(scylla_rest_client& client, const bpo::variables_map& vm)
     if (!vm.contains("sstables")) {
       throw std::invalid_argument("missing required possitional argument: sstables");
     }
+    if (vm.contains("scope")) {
+        params["scope"] = vm["scope"].as<sstring>();
+    }
     sstring sstables_body = std::invoke([&vm] {
         std::stringstream output;
         rjson::streaming_writer writer(output);
@@ -3943,6 +3946,7 @@ For more information, see: {}"
                     typed_option<sstring>("keyspace", "Name of a keyspace to copy SSTables to"),
                     typed_option<sstring>("table", "Name of a table to copy SSTables to"),
                     typed_option<>("nowait", "Don't wait on the restore process"),
+                    typed_option<sstring>("scope", "Load-and-stream scope (node, rack or dc)"),
                 },
                 {
                     typed_option<std::vector<sstring>>("sstables", "The object keys of the TOC component of the SSTables to be restored", -1),


### PR DESCRIPTION
The main purpose of this change is to enhance the restore from object storage usage.

Currently, restore uses the load-and-stream facility. When triggered, the restoring task opens the provided list of sstables directory from the remote bucket and then feeds the list of sstables to load_and_stream() method. The method, in turn, iterates over this list, reads mutations and for each mutation decides where to send one by checking the replication map (it's pretty much the same for both vnodes and tablets, but for tablets that are "fully contained" by a range there's the plan to stream faster).

As described above, restore is governed by a single node and this single node reads all sstables from the object store, which can be very slow. This PR allows speeding things up. For that, the load-and-stream code is equipped with the "scope" filter which limits where mutations can be streamed to. There are four options for that -- all, dc, rack and node. The "all" is how things work currently, "dc" and "rack" filter out target nodes that don't belong to this node's dc/rack respectively. The "node" scope only streams mutations to local node.

With the "node" scope it's possible to make all nodes in the cluster load mutations that belong to them in parallel, without re-sending them to peers. The last patch in this PR is the test that shows how it can be possible.