### PR TITLE
data_dictionary: compose the location with "/"

### DIFF
--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -362,10 +362,16 @@ storage_options storage_options::append_to_s3_prefix(const sstring& s) const {
     //     desc: me-3gdq_0bki_2cvk02wubgncy8qd41-big
     SCYLLA_ASSERT(!is_local_type());
     storage_options ret = *this;
+    if (s.empty()) {
+        // scylla-manager should always pass sstables with non-empty dirname,
+        // but still..
+        return ret;
+    }
+
     s3 s3_options = std::get<s3>(value);
     SCYLLA_ASSERT(std::holds_alternative<sstring>(s3_options.location));
     sstring prefix = std::get<sstring>(s3_options.location);
-    s3_options.location = prefix + s;
+    s3_options.location = seastar::format("{}/{}", prefix, s);
     ret.value = std::move(s3_options);
     return ret;
 }


### PR DESCRIPTION
in 787ea4b1, we construct a new `storage_options` for each sstable to be restored. the `location` of the new `storage_option` instances is composed of the configured `prefix` and the dirname of each toc component. but instead of separating them with "/", we just concatenate them. this breaks the test if the specified key representing toc components includes "dirname" in them.

in this change

- data_directory: instead of using "{prefix}{dirname}", we use "{prefix}/{dirname}".
- test/object_store: update the existing test to add a suffix in the keys of the toc objects to mimic the typical use case.

---

the "restore" API is not included by any LTS branches, so no need to backport.