### PR TITLE
tasks: add comments about map_each_task safety

### DIFF
--- a/tasks/task_handler.cc
+++ b/tasks/task_handler.cc
@@ -41,6 +41,7 @@ static future<task_status> get_task_status(task_manager::task_ptr task) {
         .progress = co_await task->get_progress(),
         .children = co_await task->get_children().map_each_task<task_identity>(
             [broadcast_address] (const task_manager::foreign_task_ptr& task) {
+                // There is no race because id does not change for the whole task lifetime.
                 return task_identity{
                     .node = broadcast_address,
                     .task_id = task->id()

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -162,6 +162,7 @@ public:
             future<> for_each_task(std::function<future<>(const foreign_task_ptr&)> f_children,
                     std::function<future<>(const task_essentials&)> f_finished_children) const;
 
+            // Make sure there is no race between map_children and the child's owner shard.
             template<typename Res>
             future<std::vector<Res>> map_each_task(std::function<std::optional<Res>(const foreign_task_ptr&)> map_children,
                     std::function<std::optional<Res>(const task_essentials&)> map_finished_children) const {


### PR DESCRIPTION
No backport needed