### PR TITLE
locator: Always preserve balancing_enabled in tablet_metadata::copy()

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -200,9 +200,6 @@ future<> tablet_metadata::mutate_tablet_map_async(table_id id, noncopyable_funct
 }
 
 future<tablet_metadata> tablet_metadata::copy() const {
-    if (_tablets.empty()) {
-        co_return tablet_metadata{};
-    }
     tablet_metadata copy;
     for (const auto& e : _tablets) {
         copy._tablets.emplace(e.first, co_await e.second.copy());


### PR DESCRIPTION
When there are zero tablets, tablet_metadata::_balancing_enabled is ignored in the copy.

The property not being preserved can result in balancer not respecting user's wish to disable balancing when a replica is created later on.

Fixes #21175.
