### PR TITLE
build: cmake: expose and use the path to iotune correctly

### DIFF
--- a/cmake/FindSeastar.cmake
+++ b/cmake/FindSeastar.cmake
@@ -110,6 +110,6 @@ if(NOT TARGET Seastar::iotune)
     string (TOUPPER ${config} CONFIG)
     set_property(TARGET Seastar::iotune
       PROPERTY
-        IMPORTED_LOCATION_${CONFIG} ${CMAKE_BINARY_DIR}/$<CONFIG>/seastar/apps/iotune/iotune)
+        IMPORTED_LOCATION_${CONFIG} ${CMAKE_BINARY_DIR}/${config}/seastar/apps/iotune/iotune)
   endforeach()
 endif()

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -46,7 +46,7 @@ add_stripped("${CMAKE_BINARY_DIR}/$<CONFIG>/scylla")
 
 # app_iotune is located in seastar/apps/iotune
 if(TARGET Seastar::iotune)
-  set(iotune_src "$<TARGET_PROPERTY:Seastar::iotune,IMPORTED_LOCATION>")
+  set(iotune_src "$<TARGET_FILE:Seastar::iotune>")
 else()
   set(iotune_src "$<TARGET_FILE:app_iotune>")
 endif()


### PR DESCRIPTION
in 415c83fa, we introduced a regression which broke the build of target of "package". because

- the IMPORT_LOCATION_<CONFIG> of the imported target of "Seastar::iotune" includes a literal `$<CONFIG>`
- we retrieve the property named "IMPORTED_LOCATION" from this target. but value of this property is empty.

so, when we copied this file, the "src" parameter passed to `cmake -E copy` is actually an empty string.

in this change, we

- set the `IMPORTED_LOCATION_${CONFIG}` property with a correct path.
- retrieve the property with the right approach -- to use `TARGET_FILE` generator expression.

---

this change is cmake related, and the fixed regression only exists in master, so no need to backport.