### PR TITLE
build: cmake: correct some tests' KIND

### DIFF
--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -3,7 +3,7 @@ add_scylla_test(UUID_test
 add_scylla_test(aggregate_fcts_test
   KIND SEASTAR)
 add_scylla_test(allocation_strategy_test
-  KIND SEASTAR)
+  KIND BOOST)
 add_scylla_test(alternator_unit_test
   KIND BOOST
   LIBRARIES alternator)
@@ -32,7 +32,8 @@ add_scylla_test(broken_sstable_test
 add_scylla_test(btree_test
   KIND SEASTAR)
 add_scylla_test(bytes_ostream_test
-  KIND SEASTAR)
+  KIND BOOST
+  LIBRARIES Seastar::seastar_testing)
 add_scylla_test(cache_algorithm_test
   KIND SEASTAR)
 add_scylla_test(cache_mutation_reader_test
@@ -48,7 +49,8 @@ add_scylla_test(cartesian_product_test
 add_scylla_test(castas_fcts_test
   KIND SEASTAR)
 add_scylla_test(cdc_generation_test
-  KIND SEASTAR)
+  KIND BOOST
+  LIBRARIES Seastar::seastar_testing)
 add_scylla_test(cdc_test
   KIND SEASTAR)
 add_scylla_test(cell_locker_test
@@ -159,7 +161,8 @@ add_scylla_test(index_reader_test
 add_scylla_test(index_with_paging_test
   KIND SEASTAR)
 add_scylla_test(input_stream_test
-  KIND SEASTAR)
+  KIND BOOST
+  LIBRARIES Seastar::seastar_testing)
 add_scylla_test(intrusive_array_test
   KIND SEASTAR)
 add_scylla_test(json_cql_query_test
@@ -192,7 +195,8 @@ add_scylla_test(logalloc_standard_allocator_segment_pool_backend_test
 add_scylla_test(logalloc_test
   KIND SEASTAR)
 add_scylla_test(managed_bytes_test
-  KIND SEASTAR)
+  KIND BOOST
+  LIBRARIES Seastar::seastar_testing)
 add_scylla_test(managed_vector_test
   KIND SEASTAR)
 add_scylla_test(map_difference_test

--- a/test/manual/CMakeLists.txt
+++ b/test/manual/CMakeLists.txt
@@ -13,10 +13,11 @@ add_scylla_test(message_test
   SOURCES message.cc
   KIND SEASTAR)
 add_scylla_test(partition_data_test
-  KIND SEASTAR)
+  KIND BOOST
+  LIBRARIES Seastar::seastar_testing)
 add_scylla_test(row_locker_test
   KIND SEASTAR)
 add_scylla_test(sstable_scan_footprint_test
   KIND SEASTAR)
 add_scylla_test(streaming_histogram_test
-  KIND SEASTAR)
+  KIND BOOST)


### PR DESCRIPTION
before this change, we build some tests as if they are Seastar tests. but after 415c83fa, these tests failed to link. because the Seastar::seastar_testing does not expose `-DSEASTAR_TESTING_MAIN` in its cflags. the behavior of the Seastar::seastar_testing  is expected. because a test linking against this library is not necessarily driven by the `main()` provided by `testing/seastar_test.hh`.

so, in this change, we correct the `KIND` parameter of these tests, so that they use `KIND BOOST`, as these tests can be driven by the `main()` provided by Boost.Test's driver. `cdc_generation_test` is a use case where the test is driven by Boost.Test's `main()`, and in the meanwhile, it utilizes seastar_testing, so let's add `Seastar::seastar_testing` to its `LIBRARIES`.

---

this is a cmake-related change, hence no need to backport.