### PR TITLE
treewide: drop includes of \<boost/range/adaptors.hpp>

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -45,7 +45,6 @@
 #include "replica/database.hh"
 #include "alternator/rmw_operation.hh"
 #include <seastar/core/coroutine.hh>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm/find_end.hpp>
 #include <unordered_set>
 #include "service/storage_proxy.hh"

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -18,7 +18,6 @@
 #include "utils/overloaded_functor.hh"
 
 #include <utility>
-#include <boost/range/adaptors.hpp>
 
 namespace api {
 

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -17,7 +17,6 @@
 #include <algorithm>
 
 #include <boost/range/algorithm.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/join.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/algorithm/string/join.hpp>

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -23,7 +23,6 @@
 #include "schema/schema.hh"
 #include <boost/range/algorithm/find.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include "size_tiered_compaction_strategy.hh"
 #include "leveled_compaction_strategy.hh"

--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -12,7 +12,7 @@
 #include "cql3/statements/property_definitions.hh"
 
 #include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/adaptors.hpp>
+#include <boost/range/adaptor/reversed.hpp>
 #include <boost/range/algorithm.hpp>
 
 namespace sstables {

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -23,7 +23,8 @@
 #include "user_aggregate.hh"
 #include "cql3/expr/expression.hh"
 #include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/adaptors.hpp>
+#include <boost/range/adaptor/filtered.hpp>
+#include <boost/range/adaptor/map.hpp>
 
 #include "error_injection_fcts.hh"
 

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -10,8 +10,9 @@
 #include <algorithm>
 #include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
+#include <boost/range/adaptor/filtered.hpp>
+#include <boost/range/adaptor/map.hpp>
 #include <functional>
 #include <ranges>
 #include <stdexcept>

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -8,9 +8,9 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm/equal.hpp>
 #include <boost/range/algorithm/transform.hpp>
+#include <boost/range/adaptor/reversed.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/algorithm/cxx11/all_of.hpp>
 

--- a/cql3/statements/delete_statement.cc
+++ b/cql3/statements/delete_statement.cc
@@ -10,7 +10,6 @@
 
 #include "utils/assert.hh"
 #include <boost/algorithm/cxx11/all_of.hpp>
-#include <boost/range/adaptors.hpp>
 
 #include "data_dictionary/data_dictionary.hh"
 #include "delete_statement.hh"

--- a/cql3/statements/prune_materialized_view_statement.cc
+++ b/cql3/statements/prune_materialized_view_statement.cc
@@ -11,7 +11,6 @@
 #include "cql3/restrictions/statement_restrictions.hh"
 #include "cql3/query_processor.hh"
 #include "service/storage_proxy.hh"
-#include <boost/range/adaptors.hpp>
 #include <fmt/ranges.h>
 #include <seastar/core/coroutine.hh>
 

--- a/cql3/statements/strongly_consistent_modification_statement.cc
+++ b/cql3/statements/strongly_consistent_modification_statement.cc
@@ -11,7 +11,6 @@
 
 #include "cql3/statements/strongly_consistent_modification_statement.hh"
 
-#include <boost/range/adaptors.hpp>
 #include <optional>
 
 #include <seastar/core/future.hh>

--- a/db/hints/internal/hint_storage.cc
+++ b/db/hints/internal/hint_storage.cc
@@ -20,7 +20,7 @@
 #include <seastar/core/sstring.hh>
 
 // Boost features.
-#include <boost/range/adaptors.hpp>
+#include <boost/range/adaptor/map.hpp>
 
 // Scylla includes.
 #include "db/hints/internal/hint_logger.hh"

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -28,7 +28,6 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 
 // Boost features.
-#include <boost/range/adaptors.hpp>
 
 // Scylla includes.
 #include "db/hints/internal/hint_logger.hh"

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -11,7 +11,6 @@
  */
 
 #include <stdexcept>
-#include <boost/range/adaptors.hpp>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/switch_to.hh>

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -19,7 +19,6 @@
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/algorithm/transform.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/algorithm/cxx11/all_of.hpp>
 

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -14,7 +14,6 @@
 #include "log.hh"
 #include "streaming/stream_plan.hh"
 #include "db/config.hh"
-#include <boost/range/adaptors.hpp>
 #include <fmt/ranges.h>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/sleep.hh>

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -34,9 +34,9 @@
 #include <chrono>
 #include "locator/host_id.hh"
 #include <boost/range/algorithm/set_algorithm.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm/count_if.hpp>
 #include <boost/range/algorithm/partition.hpp>
+#include <boost/range/adaptor/map.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <utility>

--- a/index/secondary_index.cc
+++ b/index/secondary_index.cc
@@ -15,7 +15,6 @@
 #include <boost/regex.hpp>
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/algorithm/string/join.hpp>
-#include <boost/range/adaptors.hpp>
 #include <seastar/util/log.hh>
 
 #include "exceptions/exceptions.hh"

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -22,7 +22,6 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <boost/algorithm/string.hpp>
-#include <boost/range/adaptors.hpp>
 #include "exceptions/exceptions.hh"
 #include "utils/assert.hh"
 #include "utils/class_registrator.hh"

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -19,7 +19,6 @@
 #include <boost/icl/interval_map.hpp>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
-#include <boost/range/adaptors.hpp>
 #include <seastar/core/smp.hh>
 #include "utils/assert.hh"
 #include "utils/stall_free.hh"

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -8,11 +8,12 @@
 
 #pragma once
 
+#include <boost/range/adaptor/map.hpp>
+
 #include <unordered_map>
 #include <exception>
 #include <absl/container/btree_set.h>
 #include <fmt/core.h>
-#include <boost/range/adaptors.hpp>
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/sstring.hh>

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -34,7 +34,6 @@
 #include <algorithm>
 #include <random>
 #include <optional>
-#include <boost/range/adaptors.hpp>
 #include <boost/intrusive/list.hpp>
 #include "gms/i_endpoint_state_change_subscriber.hh"
 #include "gms/gossiper.hh"

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -9,6 +9,7 @@
 #include "cql3/util.hh"
 #include "utils/assert.hh"
 #include <boost/algorithm/string/join.hpp>
+#include <boost/range/adaptor/reversed.hpp>
 #include <chrono>
 
 #include <seastar/core/sleep.hh>

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -61,7 +61,6 @@
 #include "utils/user_provided_param.hh"
 #include "version.hh"
 #include "dht/range_streamer.hh"
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
 #include "transport/server.hh"
 #include <seastar/core/rwlock.hh>

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -10,7 +10,7 @@
 #include "topology_state_machine.hh"
 #include "log.hh"
 
-#include <boost/range/adaptors.hpp>
+#include <boost/range/adaptor/map.hpp>
 
 namespace service {
 

--- a/sstables/generation_type.hh
+++ b/sstables/generation_type.hh
@@ -15,10 +15,10 @@
 #include <compare>
 #include <limits>
 #include <stdexcept>
-#include <boost/range/adaptors.hpp>
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
+#include <boost/range/adaptor/transformed.hpp>
 #include "types/types.hh"
 #include "utils/assert.hh"
 #include "utils/UUID_gen.hh"

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <boost/range/adaptors.hpp>
 
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
@@ -16,7 +15,6 @@
 #include <seastar/rpc/rpc_types.hh>
 #include <seastar/util/defer.hh>
 
-#include <boost/range/adaptors.hpp>
 
 #include "db/timeout_clock.hh"
 #include "message/messaging_service.hh"

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -9,7 +9,8 @@
 #pragma once
 
 #include <list>
-#include <boost/range/adaptors.hpp>
+#include <boost/range/adaptor/map.hpp>
+#include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/algorithm/transform.hpp>
 #include <boost/range/join.hpp>
 #include <seastar/core/on_internal_error.hh>

--- a/test/boost/aggregate_fcts_test.cc
+++ b/test/boost/aggregate_fcts_test.cc
@@ -8,7 +8,6 @@
 
 
 #include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>

--- a/test/boost/auth_test.cc
+++ b/test/boost/auth_test.cc
@@ -8,7 +8,6 @@
 
 
 #include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <stdint.h>

--- a/test/boost/batchlog_manager_test.cc
+++ b/test/boost/batchlog_manager_test.cc
@@ -8,7 +8,6 @@
 
 
 #include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <stdint.h>

--- a/test/boost/castas_fcts_test.cc
+++ b/test/boost/castas_fcts_test.cc
@@ -8,7 +8,6 @@
 
 
 #include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>

--- a/test/boost/cql_functions_test.cc
+++ b/test/boost/cql_functions_test.cc
@@ -9,8 +9,8 @@
 #include <algorithm>
 
 #include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
+#include <boost/range/adaptor/uniqued.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 

--- a/test/boost/cql_query_group_test.cc
+++ b/test/boost/cql_query_group_test.cc
@@ -8,7 +8,6 @@
 
 
 #include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -8,7 +8,6 @@
 
 
 #include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>

--- a/test/boost/cql_query_like_test.cc
+++ b/test/boost/cql_query_like_test.cc
@@ -8,7 +8,6 @@
 
 
 #include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -9,8 +9,8 @@
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
+#include <boost/range/adaptor/reversed.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 

--- a/test/boost/filtering_test.cc
+++ b/test/boost/filtering_test.cc
@@ -8,7 +8,6 @@
 
 
 #include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>

--- a/test/boost/json_cql_query_test.cc
+++ b/test/boost/json_cql_query_test.cc
@@ -8,7 +8,6 @@
 
 
 #include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -7,7 +7,6 @@
  */
 
 #include <boost/test/unit_test.hpp>
-#include <boost/range/adaptors.hpp>
 #include <fmt/ranges.h>
 #include "gms/inet_address.hh"
 #include "locator/types.hh"

--- a/test/boost/query_processor_test.cc
+++ b/test/boost/query_processor_test.cc
@@ -8,7 +8,6 @@
 
 
 #include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <fmt/ranges.h>

--- a/test/boost/restrictions_test.cc
+++ b/test/boost/restrictions_test.cc
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <boost/range/adaptors.hpp>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include "test/lib/scylla_test_case.hh"

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -34,6 +34,8 @@
 #include "utils/to_string.hh"
 #include "service/topology_coordinator.hh"
 
+#include <boost/regex.hpp>
+
 using namespace locator;
 using namespace replica;
 using namespace service;

--- a/test/boost/virtual_reader_test.cc
+++ b/test/boost/virtual_reader_test.cc
@@ -9,7 +9,6 @@
  */
 
 #include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <stdint.h>

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -8,6 +8,7 @@
 
 #include <set>
 #include <boost/range/adaptor/map.hpp>
+#include <boost/range/adaptor/sliced.hpp>
 #include <boost/test/unit_test.hpp>
 #include <fmt/ranges.h>
 #include "partition_slice_builder.hh"

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -20,6 +20,7 @@
 #include "utils/assert.hh"
 #include "utils/overloaded_functor.hh"
 #include <boost/program_options.hpp>
+#include <boost/range/adaptor/reversed.hpp>
 #include <iostream>
 #include <fmt/ranges.h>
 #include <seastar/util/defer.hh>

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -15,7 +15,8 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/range/irange.hpp>
 #include <boost/range/algorithm_ext.hpp>
-#include <boost/range/adaptors.hpp>
+#include <boost/range/adaptor/indexed.hpp>
+#include <boost/range/adaptor/filtered.hpp>
 #include <json/json.h>
 #include <fmt/ranges.h>
 #include "test/lib/cql_test_env.hh"

--- a/test/perf/perf_mutation_readers.cc
+++ b/test/perf/perf_mutation_readers.cc
@@ -6,11 +6,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <boost/range/adaptors.hpp>
 
 #include <seastar/core/sleep.hh>
 #include <seastar/testing/perf_tests.hh>
 #include <seastar/util/closeable.hh>
+
+#include <boost/range/adaptor/sliced.hpp>
+#include <boost/range/adaptor/strided.hpp>
 
 #include "test/lib/simple_schema.hh"
 #include "test/lib/simple_position_reader_queue.hh"

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -22,7 +22,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/range/adaptor/map.hpp>
-#include <boost/range/adaptors.hpp>
+#include <boost/range/adaptor/reversed.hpp>
 #include <boost/range/algorithm/find_if.hpp>
 #include <fmt/chrono.h>
 #include <fmt/ranges.h>

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -8,6 +8,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/join.hpp>
+#include <boost/range/adaptor/map.hpp>
 #include <filesystem>
 #include <set>
 #include <fmt/chrono.h>


### PR DESCRIPTION
This includes way too much, including \<boost/regex.hpp>, which is huge. Drop includes of adaptors.hpp and replace by what is needed.

Cleanup, no backport.