### PR TITLE
service: remove extraneous space in `#pragma  once`

### DIFF
--- a/service/cache_hitrate_calculator.hh
+++ b/service/cache_hitrate_calculator.hh
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#pragma  once
+#pragma once
 
 #include "replica/database_fwd.hh"
 #include "schema/schema_fwd.hh"

--- a/service/load_meter.hh
+++ b/service/load_meter.hh
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#pragma  once
+#pragma once
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/distributed.hh>


### PR DESCRIPTION
to be more consistent with the rest of the tree.

---

it's a cleanup, hence no need to backport.