### PR TITLE
build: cmake: remove "#pragma  once" as well

### DIFF
--- a/cmake/check_headers.cmake
+++ b/cmake/check_headers.cmake
@@ -46,7 +46,7 @@ function (check_headers check_headers_target target)
       DEPENDS ${CMAKE_SOURCE_DIR}/${fn}
       # silence "-Wpragma-once-outside-header"
       COMMAND sed
-            -e "s/^#pragma once//"
+            -e "s/^#pragma \\+once//"
             "${fn}" > "${src}"
       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
       VERBATIM)


### PR DESCRIPTION
in check_headers.cmake, we remove the `#pragma once` directive in the header to be checked, so the compiler does not fail with the error like:

```
error: #pragma once in main file [-Werror,-Wpragma-once-outside-header]
```

but there are chances we have multiple spaces between `#pragma` and `once`. this is also a valid `#pragma` directive. so let's be more tolerant and detect this case as well.

---


cmake related change, hence no need to backport.