### PR TITLE
schema: add accessors for primary key columns and non-primary-key columns

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -845,7 +845,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
     static const bytes eor_column_name = cdc::log_meta_column_name_bytes("end_of_batch");
 
     std::optional<attrs_to_get> key_names =
-        std::views::join(std::array{base->partition_key_columns(), base->clustering_key_columns()})
+        base->primary_key_columns()
         | std::views::transform([&] (const column_definition& cdef) {
             return std::make_pair<std::string, attrs_to_get_node>(cdef.name_as_text(), {}); })
         | std::ranges::to<attrs_to_get>()

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -269,7 +269,7 @@ void alter_table_statement::drop_column(const query_options& options, const sche
             drop_timestamp = _attrs->get_timestamp(now, options);
         }
 
-        for (auto&& column_def : std::views::join(std::array{schema.static_columns(), schema.regular_columns()})) { // find
+        for (auto&& column_def : schema.static_and_regular_columns()) { // find
             if (column_def.name() == column_name.name()) {
                 cfm.remove_column(column_name.name(), drop_timestamp);
                 break;

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -399,7 +399,7 @@ void batch_statement::build_cas_result_set_metadata() {
             ::make_shared<cql3::column_identifier>("[applied]", false), boolean_type);
     columns.push_back(applied);
 
-    for (const auto& def : std::views::join(std::array{schema.partition_key_columns(), schema.clustering_key_columns()})) {
+    for (const auto& def : schema.primary_key_columns()) {
         _columns_of_cas_result_set.set(def.ordinal_id);
     }
     for (const auto& s : _statements) {

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -195,7 +195,7 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     auto restrictions = static_pointer_cast<statements::select_statement>(prepared->statement)->get_restrictions();
 
     auto base_primary_key_cols =
-            std::views::join(std::array{schema->partition_key_columns(), schema->clustering_key_columns()})
+            schema->primary_key_columns()
             | std::views::transform([](auto&& def) { return &def; })
             | std::ranges::to<std::unordered_set<const column_definition*>>();
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -983,7 +983,7 @@ future<> store_column_mapping(distributed<service::storage_proxy>& proxy, schema
     }
     // Use one timestamp for all mutations for the ease of debugging
     const auto ts = api::new_timestamp();
-    for (const auto& cdef : std::views::join(std::array{s->static_columns(), s->regular_columns()})) {
+    for (const auto& cdef : s->static_and_regular_columns()) {
         mutation m(history_tbl, pk);
         auto ckey = clustering_key::from_exploded(*history_tbl, {uuid_type->decompose(s->version().uuid()),
                                                                  utf8_type->decompose(cdef.name_as_text())});

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -201,7 +201,7 @@ db::view::base_info_ptr view_info::make_base_dependent_view_info(const schema& b
             })
         && _schema.partition_key_size() == base.partition_key_size();
 
-    for (auto&& view_col : std::views::join(std::array{_schema.partition_key_columns(), _schema.clustering_key_columns()})) {
+    for (auto&& view_col : _schema.primary_key_columns()) {
         if (view_col.is_computed()) {
             // we are not going to find it in the base table...
             if (view_col.get_computation().depends_on_non_primary_key_column()) {

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -1745,6 +1745,16 @@ schema::regular_columns() const {
 }
 
 schema::const_iterator_range_type
+schema::primary_key_columns() const {
+    return std::ranges::subrange(_raw._columns.begin(), _raw._columns.begin() + column_offset(column_kind::static_column));
+}
+
+schema::const_iterator_range_type
+schema::static_and_regular_columns() const {
+    return std::ranges::subrange(_raw._columns.begin() + column_offset(column_kind::static_column), _raw._columns.end());
+}
+
+schema::const_iterator_range_type
 schema::columns(column_kind kind) const {
     switch (kind) {
     case column_kind::partition_key:

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -840,6 +840,9 @@ public:
     const_iterator_range_type columns(column_kind) const;
     // Returns a range of column definitions
 
+    const_iterator_range_type primary_key_columns() const;
+    const_iterator_range_type static_and_regular_columns() const;
+
     std::ranges::range auto all_columns_in_select_order() const {
         return _all_columns_in_select_order | std::views::transform([] (const column_definition* def) -> const column_definition& { return *def; });
     }


### PR DESCRIPTION
It's somewhat common to ask for the partition key and clustering key columns, or for the static and regular columsn. Provide accessors for them rather than requiring the user to glue them.

Some callers are converted.

Small cleanup, no backport needed.