### PR TITLE
build: cmake: improve source generated for check_header

### DIFF
--- a/cmake/check_headers.cmake
+++ b/cmake/check_headers.cmake
@@ -35,7 +35,6 @@ function (check_headers check_headers_target target)
 
   foreach(fn ${sources})
     get_filename_component(file_dir ${fn} DIRECTORY)
-    list(APPEND includes "${CMAKE_SOURCE_DIR}/${file_dir}")
     set(src_dir "${CMAKE_BINARY_DIR}/check-headers/${file_dir}")
     file(MAKE_DIRECTORY "${src_dir}")
     get_filename_component(file_name ${fn} NAME)
@@ -44,10 +43,7 @@ function (check_headers check_headers_target target)
     add_custom_command(
       OUTPUT ${src}
       DEPENDS ${CMAKE_SOURCE_DIR}/${fn}
-      # silence "-Wpragma-once-outside-header"
-      COMMAND sed
-            -e "s/^#pragma once//"
-            "${fn}" > "${src}"
+      COMMAND ${CMAKE_COMMAND} -E echo "#include \"${fn}\"" > "${src}"
       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
       VERBATIM)
     list(APPEND srcs "${src}")


### PR DESCRIPTION
in check_headers.cmake, we verify the self containness of a header file by replicating it and remove `#pragma once` directive in this header. but this approach failed to compile headers which includes a header file with the same name in the root source directory, as we add `-I<directory-of-original-header>` in the cflags when building the generated source file, so that it can include the headers in the same directory. but this confuses the compiler, as, assuming we have "log.hh" in current directory, and under the root source directory, the compiler would always include the "log.hh" in the current directory even it should have included "log.hh" under the root source directory.

in this change, instead of adding `-I<directory-of-original-header>` to cflags, we just include the header under test in a new .cc file created for testing. this should address this problem.

---

this is a cmake-related change, hence no need to backport.