### PR TITLE
Quiesce topology before dropping keyspace/table/view/index

### DIFF
--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -54,6 +54,11 @@ public:
         return false;
     }
 
+    // Returns true for statements that needs guard to be taken before the execution
+    virtual bool needs_topology_quiesce() const {
+        return false;
+    }
+
     explicit cql_statement(timeout_config_selector timeout_selector) : _timeout_config_selector(timeout_selector) {}
 
     virtual ~cql_statement()

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -538,6 +538,9 @@ future<::shared_ptr<cql_transport::messages::result_message>> query_processor::e
     size_t retries = remote_.get().mm.get_concurrent_ddl_retries();
     while (true)  {
         try {
+            if (statement->needs_topology_quiesce()) {
+                co_await remote_.get().ss.await_topology_quiesced();
+            }
             auto guard = co_await remote_.get().mm.start_group0_operation();
             co_return co_await fn(query_state, statement, options, std::move(guard));
         } catch (const service::group0_concurrent_modification& ex) {

--- a/cql3/statements/drop_index_statement.hh
+++ b/cql3/statements/drop_index_statement.hh
@@ -38,6 +38,11 @@ class drop_index_statement : public schema_altering_statement {
 public:
     drop_index_statement(::shared_ptr<index_name> index_name, bool if_exists);
 
+    // Prevent race between drop/truncate and tablet migration
+    virtual bool needs_topology_quiesce() const override {
+        return true;
+    }
+
     virtual const sstring& column_family() const override;
 
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;

--- a/cql3/statements/drop_keyspace_statement.hh
+++ b/cql3/statements/drop_keyspace_statement.hh
@@ -24,6 +24,11 @@ class drop_keyspace_statement : public schema_altering_statement {
 public:
     drop_keyspace_statement(const sstring& keyspace, bool if_exists);
 
+    // Prevent race between drop/truncate and tablet migration
+    virtual bool needs_topology_quiesce() const override {
+        return true;
+    }
+
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 
     virtual void validate(query_processor&, const service::client_state& state) const override;

--- a/cql3/statements/drop_table_statement.hh
+++ b/cql3/statements/drop_table_statement.hh
@@ -24,6 +24,11 @@ class drop_table_statement : public schema_altering_statement {
 public:
     drop_table_statement(cf_name cf_name, bool if_exists);
 
+    // Prevent race between drop/truncate and tablet migration
+    virtual bool needs_topology_quiesce() const override {
+        return true;
+    }
+
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const override;

--- a/cql3/statements/drop_view_statement.hh
+++ b/cql3/statements/drop_view_statement.hh
@@ -30,6 +30,11 @@ private:
 public:
     drop_view_statement(cf_name view_name, bool if_exists);
 
+    // Prevent race between drop/truncate and tablet migration
+    virtual bool needs_topology_quiesce() const override {
+        return true;
+    }
+
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -233,6 +233,13 @@ class ScyllaRESTAPIClient():
         await self.client.post(f"/v2/error_injection/injection/{injection}",
                                host=node_ip, params={"one_shot": str(one_shot)}, json={ key: str(value) for key, value in parameters.items() })
 
+    async def disable_injection(self, node_ip: str, injection: str) -> None:
+        """Enable error injection named `injection` on `node_ip`. Depending on `one_shot`,
+           the injection will be executed only once or every time the process passes the injection point.
+           Note: this only has an effect in specific build modes: debug,dev,sanitize.
+        """
+        await self.client.delete(f"/v2/error_injection/injection/{injection}", host=node_ip)
+
     async def get_injection(self, node_ip: str, injection: str) -> list[dict[str, Any]]:
         """Read the state of the error injection named `injection` on `node_ip`.
            The returned information includes whether the error injections is

--- a/test/topology_custom/test_topology_failure_recovery.py
+++ b/test/topology_custom/test_topology_failure_recovery.py
@@ -16,6 +16,11 @@ logger = logging.getLogger(__name__)
 async def inject_error_on(manager, error_name, servers):
     errs = [manager.api.enable_injection(s.ip_addr, error_name, True) for s in servers]
     await asyncio.gather(*errs)
+    try:
+        yield error_name
+    finally:
+        errs = [manager.api.disable_injection(s.ip_addr, error_name) for s in servers]
+        await asyncio.gather(*errs)
 
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
@@ -35,13 +40,12 @@ async def test_tablet_drain_failure_during_decommission(manager: ManagerClient):
     keys = range(256)
     await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
 
-    await inject_error_on(manager, "stream_tablet_fail_on_drain", servers)
+    async for e in inject_error_on(manager, "stream_tablet_fail_on_drain", servers):
+        await manager.decommission_node(servers[2].server_id, expected_error="Decommission failed. See earlier errors")
 
-    await manager.decommission_node(servers[2].server_id, expected_error="Decommission failed. See earlier errors")
-
-    matches = [await log.grep("raft_topology - rollback.*after decommissioning failure, moving transition state to rollback to normal",
-               from_mark=mark) for log, mark in zip(logs, marks)]
-    assert sum(len(x) for x in matches) == 1
+        matches = [await log.grep("raft_topology - rollback.*after decommissioning failure, moving transition state to rollback to normal",
+                from_mark=mark) for log, mark in zip(logs, marks)]
+        assert sum(len(x) for x in matches) == 1
 
     await cql.run_async("DROP KEYSPACE test;")
 


### PR DESCRIPTION
If the statement `needs_topology_quiesce`
call storage_service::await_topology_quiesced
to prevent a race between drop/truncate and tablet
migration.

Fixes scylladb/scylladb#20060

* Requires backport to all branches supporting tablets.
