### PR TITLE
treewide: s/boost::adaptors::map_keys/std::views::keys/

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -2192,7 +2192,7 @@ static future<> do_batch_write(service::storage_proxy& proxy,
     // likely that a batch will contain both tables which always demand LWT and ones
     // that don't - it's fragile to split a batch into multiple storage proxy requests though.
     // Hence, the decision is conservative - if any table enforces LWT,the whole batch will use it.
-    const bool needs_lwt = boost::algorithm::any_of(mutation_builders | boost::adaptors::map_keys, [] (const schema_ptr& schema) {
+    const bool needs_lwt = std::ranges::any_of(mutation_builders | std::views::keys, [] (const schema_ptr& schema) {
         return rmw_operation::get_write_isolation_for_schema(schema) == rmw_operation::write_isolation::LWT_ALWAYS;
     });
     if (!needs_lwt) {

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -80,7 +80,7 @@ tm::task_stats make_stats(tasks::task_stats stats) {
 
 void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>& tm, db::config& cfg) {
     tm::get_modules.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        std::vector<std::string> v = boost::copy_range<std::vector<std::string>>(tm.local().get_modules() | boost::adaptors::map_keys);
+        std::vector<std::string> v = tm.local().get_modules() | std::views::keys | std::ranges::to<std::vector>();
         co_return v;
     });
 

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -344,7 +344,7 @@ std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepa
         } else {
             if (stmt->_columns.size() > 1) {
                 throw exceptions::invalid_request_exception(seastar::format("COMPACT STORAGE with composite PRIMARY KEY allows no more than one column not part of the PRIMARY KEY (got: {})",
-                    fmt::join(stmt->_columns | boost::adaptors::map_keys, ", ")));
+                    fmt::join(stmt->_columns | std::views::keys, ", ")));
             }
 #if 0
             Map.Entry<ColumnIdentifier, AbstractType> lastEntry = stmt.columns.entrySet().iterator().next();

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -294,7 +294,7 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     } else if (!non_pk_restrictions.empty()) {
         throw exceptions::invalid_request_exception(seastar::format("Non-primary key columns cannot be restricted in the SELECT statement used for materialized view {} creation (got restrictions on: {})",
                 column_family(),
-                fmt::join(non_pk_restrictions | boost::adaptors::map_keys | boost::adaptors::transformed(std::mem_fn(&column_definition::name_as_text)), ", ")));
+                fmt::join(non_pk_restrictions | std::views::keys | std::views::transform(std::mem_fn(&column_definition::name_as_text)), ", ")));
     }
 
     // IS NOT NULL restrictions are handled separately from other restrictions.

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -498,9 +498,10 @@ modification_statement::process_where_clause(data_dictionary::database db, expr:
     if (!_restrictions->get_non_pk_restriction().empty()) {
         throw exceptions::invalid_request_exception(seastar::format("Invalid where clause contains non PRIMARY KEY columns: {}",
                                                                     fmt::join(_restrictions->get_non_pk_restriction()
-                                         | boost::adaptors::map_keys
-                                         | boost::adaptors::indirected
-                                         | boost::adaptors::transformed(std::mem_fn(&column_definition::name_as_text)), ", ")));
+                                         | std::views::keys
+                                         | std::views::transform([](const column_definition* c) {
+                                             return c->name_as_text();
+                                         }), ", ")));
     }
     const expr::expression& ck_restrictions = _restrictions->get_clustering_columns_restrictions();
     if (has_slice(ck_restrictions) && !allow_clustering_key_slices()) {

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -296,8 +296,8 @@ storage_options::s3 storage_options::s3::from_map(const std::map<sstring, sstrin
     }
     if (values.size() > allowed_options.size()) {
         throw std::runtime_error(fmt::format("Extraneous options for S3: {}; allowed: {}",
-            boost::algorithm::join(values | boost::adaptors::map_keys, ","),
-            boost::algorithm::join(allowed_options | boost::adaptors::map_keys, ",")));
+            fmt::join(values | std::views::keys, ","),
+            fmt::join(allowed_options | std::views::keys, ",")));
     }
     return options;
 }

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -2183,7 +2183,7 @@ void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
 
         flushing += size - waste;
 
-        for (auto& id : s->_cf_dirty | boost::adaptors::map_keys) {
+        for (auto& id : s->_cf_dirty |  std::views::keys) {
             ids.insert(id);
         }
 
@@ -2244,7 +2244,7 @@ void db::commitlog::segment_manager::check_no_data_older_than_allowed() {
                 // There is data in this segment that has lived longer than allowed (might be flushed actually
                 // but can still affect compaction/resurrect stuff on replay). Collect all dirty 
                 // id:s (stuff keeping this segment alive), and ask for them to be memtable flushed
-                for (auto& id : s->_cf_dirty | boost::adaptors::map_keys) {
+                for (auto& id : s->_cf_dirty | std::views::keys) {
                     ids.insert(id);
                 }
 
@@ -2572,7 +2572,7 @@ struct fmt::formatter<db::commitlog::segment::cf_mark> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     template <typename FormatContext>
     auto format(const db::commitlog::segment::cf_mark& m, FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "{}", fmt::join(m.s._cf_dirty | boost::adaptors::map_keys, ", "));
+        return fmt::format_to(ctx.out(), "{}", fmt::join(m.s._cf_dirty | std::views::keys, ", "));
     }
 };
 

--- a/db/extensions.cc
+++ b/db/extensions.cc
@@ -39,8 +39,7 @@ db::extensions::commitlog_file_extensions() const {
 
 std::set<sstring>
 db::extensions::schema_extension_keywords() const {
-    return boost::copy_range<std::set<sstring>>(
-            _schema_extensions | boost::adaptors::map_keys);
+    return _schema_extensions | std::views::keys | std::ranges::to<std::set>();
 }
 
 void db::extensions::add_sstable_file_io_extension(sstring n, sstable_file_io_extension f) {

--- a/db/heat_load_balance.cc
+++ b/db/heat_load_balance.cc
@@ -8,6 +8,7 @@
 #include <vector>
 #include <list>
 #include <random>
+#include <ranges>
 #include <fmt/ranges.h>
 #include "heat_load_balance.hh"
 
@@ -298,7 +299,7 @@ redistribute(const std::vector<float>& p, unsigned me, unsigned k) {
                 sorted_deficits.insert(it, std::make_pair(i, deficit[i]));
             }
         }
-        hr_logger.trace("sorted_deficits={}{}", sorted_deficits | boost::adaptors::map_keys, sorted_deficits | boost::adaptors::map_values);
+        hr_logger.trace("sorted_deficits={}{}", sorted_deficits | std::views::keys, sorted_deficits | std::views::values);
         float s = 0;
         int count = mixed_count;
         for (auto& d : sorted_deficits) {

--- a/db/heat_load_balance.hh
+++ b/db/heat_load_balance.hh
@@ -30,8 +30,8 @@
 #include "utils/assert.hh"
 #include <vector>
 #include <cassert>
+#include <ranges>
 #include <fmt/ranges.h>  // IWYU pragma: keep
-#include <boost/range/adaptor/map.hpp>
 #include "log.hh"
 
 extern logging::logger hr_logger;
@@ -126,7 +126,7 @@ miss_equalizing_combination(
     clip_probabilities(p, 1.0f / bf);
 
 
-    hr_logger.trace("desired probabilities: {}, {}", node_hit_rate | boost::adaptors::map_keys, p);
+    hr_logger.trace("desired probabilities: {}, {}", node_hit_rate | std::views::keys, p);
 
     // If me >= rf, this node is NOT one of the replicas, and we just need
     // to use the probabilities for these replicas, without doing the

--- a/db/per_partition_rate_limit_options.cc
+++ b/db/per_partition_rate_limit_options.cc
@@ -45,7 +45,7 @@ per_partition_rate_limit_options::per_partition_rate_limit_options(std::map<sstr
     if (!map.empty()) {
         throw exceptions::configuration_exception(seastar::format(
                 "Unknown keys in map for per_partition_rate_limit extension: {}",
-                fmt::join(map | boost::adaptors::map_keys, ", ")));
+                fmt::join(map | std::views::keys, ", ")));
     }
 }
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1980,7 +1980,7 @@ static void make_drop_table_or_view_mutations(schema_ptr schema_table,
             drop_column_from_schema_mutation(computed_columns(), table_or_view, column.name_as_text(), timestamp, mutations);
         }
     }
-    for (auto& column : table_or_view->dropped_columns() | boost::adaptors::map_keys) {
+    for (auto& column : table_or_view->dropped_columns() | std::views::keys) {
         drop_column_from_schema_mutation(dropped_columns(), table_or_view, column, timestamp, mutations);
     }
     mutation m1{scylla_tables(), pkey};

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -10,6 +10,7 @@
  * Copyright (C) 2020-present ScyllaDB
  */
 
+#include <algorithm>
 #include <stdexcept>
 #include <boost/range/adaptors.hpp>
 #include <seastar/core/coroutine.hh>
@@ -71,7 +72,7 @@ future<> snapshot_ctl::take_snapshot(sstring tag, std::vector<sstring> keyspace_
     }
 
     if (keyspace_names.size() == 0) {
-        boost::copy(_db.local().get_keyspaces() | boost::adaptors::map_keys, std::back_inserter(keyspace_names));
+        std::ranges::copy(_db.local().get_keyspaces() | std::views::keys, std::back_inserter(keyspace_names));
     };
 
     return run_snapshot_modify_operation([tag = std::move(tag), keyspace_names = std::move(keyspace_names), sf, this] () mutable {

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -87,7 +87,7 @@ std::unique_ptr<dht::i_partitioner> make_partitioner(sstring partitioner_name) {
                 partitioner_name,
                 fmt::join(
                     class_registry<i_partitioner>::classes() |
-                    boost::adaptors::map_keys,
+                    std::views::keys,
                     ", "),
                 e.what()));
     }

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -253,7 +253,7 @@ future<> range_streamer::stream_async() {
     return do_for_each(_to_stream, [this, description = _description] (auto& stream) {
         const auto& keyspace = stream.first;
         auto& ip_range_vec = stream.second;
-        auto ips = boost::copy_range<std::list<inet_address>>(ip_range_vec | boost::adaptors::map_keys);
+        auto ips = ip_range_vec | std::views::keys | std::ranges::to<std::list>();
         // Fetch from or send to peer node in parallel
         logger.info("{} with {} for keyspace={} started, nodes_to_stream={}", description, ips, keyspace, ip_range_vec.size());
         return parallel_for_each(ip_range_vec, [this, description, keyspace] (auto& ip_range) {

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -678,7 +678,7 @@ future<> gossiper::apply_state_locally_without_listener_notification(std::unorde
 
 future<> gossiper::apply_state_locally(std::map<inet_address, endpoint_state> map) {
     auto start = std::chrono::steady_clock::now();
-    auto endpoints = boost::copy_range<utils::chunked_vector<inet_address>>(map | boost::adaptors::map_keys);
+    auto endpoints = map | std::views::keys | std::ranges::to<utils::chunked_vector<inet_address>>();
     std::shuffle(endpoints.begin(), endpoints.end(), _random_engine);
     auto node_is_seed = [this] (gms::inet_address ip) { return is_seed(ip); };
     boost::partition(endpoints, node_is_seed);
@@ -1562,7 +1562,7 @@ const std::unordered_map<inet_address, endpoint_state_ptr>& gms::gossiper::get_e
 }
 
 std::vector<inet_address> gossiper::get_endpoints() const {
-    return boost::copy_range<std::vector<inet_address>>(_endpoint_state_map | boost::adaptors::map_keys);
+    return _endpoint_state_map | std::views::keys | std::ranges::to<std::vector>();
 }
 
 stop_iteration gossiper::for_each_endpoint_state_until(std::function<stop_iteration(const inet_address&, const endpoint_state&)> func) const {
@@ -2731,7 +2731,7 @@ int gossiper::get_down_endpoint_count() const noexcept {
 }
 
 int gossiper::get_up_endpoint_count() const noexcept {
-    return boost::count_if(_endpoint_state_map | boost::adaptors::map_keys, [this] (const inet_address& ep) {
+    return std::ranges::count_if(_endpoint_state_map | std::views::keys, [this] (const inet_address& ep) {
         return is_alive(ep);
     });
 }

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -515,11 +515,9 @@ tasks::task_manager::task_ptr repair::task_manager_module::get_shard_task_ptr(in
 }
 
 std::vector<int> repair::task_manager_module::get_active() const {
-    std::vector<int> res;
-    boost::push_back(res, _status | boost::adaptors::filtered([] (auto& x) {
+    return _status | std::views::filter([] (auto& x) {
         return x.second == repair_status::RUNNING;
-    }) | boost::adaptors::map_keys);
-    return res;
+    }) | std::views::keys | std::ranges::to<std::vector>();
 }
 
 size_t repair::task_manager_module::nr_running_repair_jobs() {
@@ -1587,7 +1585,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
             rs.get_metrics().bootstrap_finished_ranges = 0;
             rs.get_metrics().bootstrap_total_ranges = nr_ranges_total;
         }).get();
-        rlogger.info("bootstrap_with_repair: started with keyspaces={}, nr_ranges_total={}", ks_erms | boost::adaptors::map_keys, nr_ranges_total);
+        rlogger.info("bootstrap_with_repair: started with keyspaces={}, nr_ranges_total={}", ks_erms | std::views::keys, nr_ranges_total);
         for (const auto& [keyspace_name, erm] : ks_erms) {
             if (!db.has_keyspace(keyspace_name)) {
                 rlogger.info("bootstrap_with_repair: keyspace={} does not exist any more, ignoring it", keyspace_name);
@@ -1734,7 +1732,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
             sync_data_using_repair(keyspace_name, erm, std::move(desired_ranges), std::move(range_sources), reason, nullptr).get();
             rlogger.info("bootstrap_with_repair: finished with keyspace={}, nr_ranges={}", keyspace_name, nr_ranges);
         }
-        rlogger.info("bootstrap_with_repair: finished with keyspaces={}", ks_erms | boost::adaptors::map_keys);
+        rlogger.info("bootstrap_with_repair: finished with keyspaces={}", ks_erms | std::views::keys);
     });
 }
 
@@ -1772,7 +1770,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
             static std::list<gms::inet_address> no_ignore_nodes;
             return ops ? ops->ignore_nodes : no_ignore_nodes;
         };
-        rlogger.info("{}: started with keyspaces={}, leaving_node={}, ignore_nodes={}", op, ks_erms | boost::adaptors::map_keys, leaving_node, get_ignore_nodes());
+        rlogger.info("{}: started with keyspaces={}, leaving_node={}, ignore_nodes={}", op, ks_erms | std::views::keys, leaving_node, get_ignore_nodes());
         for (const auto& [keyspace_name, erm] : ks_erms) {
             if (!db.has_keyspace(keyspace_name)) {
                 rlogger.info("{}: keyspace={} does not exist any more, ignoring it", op, keyspace_name);
@@ -1930,7 +1928,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
             rlogger.info("{}: finished with keyspace={}, leaving_node={}, nr_ranges={}, nr_ranges_synced={}, nr_ranges_skipped={}",
                 op, keyspace_name, leaving_node, nr_ranges_total, nr_ranges_synced, nr_ranges_skipped);
         }
-        rlogger.info("{}: finished with keyspaces={}, leaving_node={}", op, ks_erms | boost::adaptors::map_keys, leaving_node);
+        rlogger.info("{}: finished with keyspaces={}, leaving_node={}", op, ks_erms | std::views::keys, leaving_node);
     });
 }
 
@@ -2019,7 +2017,7 @@ future<> repair_service::do_rebuild_replace_with_repair(std::unordered_map<sstri
                 source_dc.reset();
             }
         }
-        rlogger.info("{}: started with keyspaces={}, source_dc={}, nr_ranges_total={}, ignore_nodes={} replaced_node={}", op, ks_erms | boost::adaptors::map_keys, source_dc, nr_ranges_total, ignore_nodes, replaced_node);
+        rlogger.info("{}: started with keyspaces={}, source_dc={}, nr_ranges_total={}, ignore_nodes={} replaced_node={}", op, ks_erms | std::views::keys, source_dc, nr_ranges_total, ignore_nodes, replaced_node);
         for (const auto& [keyspace_name, erm] : ks_erms) {
             size_t nr_ranges_skipped = 0;
             if (!db.has_keyspace(keyspace_name)) {
@@ -2150,7 +2148,7 @@ future<> repair_service::do_rebuild_replace_with_repair(std::unordered_map<sstri
             sync_data_using_repair(keyspace_name, erm, std::move(ranges), std::move(range_sources), reason, nullptr).get();
             rlogger.info("{}: finished with keyspace={}, source_dc={}, nr_ranges={}", op, keyspace_name, source_dc_for_keyspace, nr_ranges);
         }
-        rlogger.info("{}: finished with keyspaces={}, source_dc={}", op, ks_erms | boost::adaptors::map_keys, source_dc);
+        rlogger.info("{}: finished with keyspaces={}, source_dc={}", op, ks_erms | std::views::keys, source_dc);
     });
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -677,7 +677,7 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
 #endif
 
     rtlogger.debug("reload raft topology state");
-    std::unordered_set<raft::server_id> prev_normal = boost::copy_range<std::unordered_set<raft::server_id>>(_topology_state_machine._topology.normal_nodes | boost::adaptors::map_keys);
+    std::unordered_set<raft::server_id> prev_normal = _topology_state_machine._topology.normal_nodes | std::views::keys | std::ranges::to<std::unordered_set>();
 
     std::unordered_set<locator::host_id> tablet_hosts;
     if (_db.local().get_config().enable_tablets()) {
@@ -1940,7 +1940,7 @@ future<> storage_service::join_topology(sharded<db::system_distributed_keyspace>
 
         std::unordered_set<inet_address> ips;
         const auto& am = _group0->address_map();
-        for (auto id : _topology_state_machine._topology.normal_nodes | boost::adaptors::map_keys) {
+        for (auto id : _topology_state_machine._topology.normal_nodes | std::views::keys) {
             auto ip = am.find(id);
             if (ip) {
                 ips.insert(*ip);
@@ -2996,7 +2996,7 @@ future<> storage_service::join_cluster(sharded<db::system_distributed_keyspace>&
         }));
     auto loaded_peer_features = co_await _sys_ks.local().load_peer_features();
     slogger.info("initial_contact_nodes={}, loaded_endpoints={}, loaded_peer_features={}",
-            initial_contact_nodes, loaded_endpoints | boost::adaptors::map_keys, loaded_peer_features.size());
+            initial_contact_nodes, loaded_endpoints | std::views::keys, loaded_peer_features.size());
     for (auto& x : loaded_peer_features) {
         slogger.info("peer={}, supported_features={}", x.first, x.second);
     }
@@ -4286,7 +4286,7 @@ public:
 };
 
 void storage_service::node_ops_cmd_check(gms::inet_address coordinator, const node_ops_cmd_request& req) {
-    auto ops_uuids = boost::copy_range<std::vector<node_ops_id>>(_node_ops| boost::adaptors::map_keys);
+    auto ops_uuids = _node_ops | std::views::keys | std::ranges::to<std::vector>();
     std::string msg;
     if (req.cmd == node_ops_cmd::removenode_prepare || req.cmd == node_ops_cmd::replace_prepare ||
             req.cmd == node_ops_cmd::decommission_prepare || req.cmd == node_ops_cmd::bootstrap_prepare) {
@@ -4347,7 +4347,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
 
         if (req.cmd == node_ops_cmd::query_pending_ops) {
             bool ok = true;
-            auto ops_uuids = boost::copy_range<std::list<node_ops_id>>(_node_ops| boost::adaptors::map_keys);
+            auto ops_uuids = _node_ops| std::views::keys | std::ranges::to<std::list>();
             node_ops_cmd_response resp(ok, ops_uuids);
             slogger.debug("node_ops_cmd_handler: Got query_pending_ops request from {}, pending_ops={}", coordinator, ops_uuids);
             return resp;

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -383,7 +383,7 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
             _directory, _state->descriptors.size(), _state->generations_found.size());
 
     if (!_state->generations_found.empty()) {
-        directory._max_generation_seen =  boost::accumulate(_state->generations_found | boost::adaptors::map_keys, sstables::generation_type{}, [] (generation_type a, generation_type b) {
+        directory._max_generation_seen = std::ranges::fold_left(_state->generations_found | std::views::keys, sstables::generation_type{}, [] (generation_type a, generation_type b) {
             return std::max<generation_type>(a, b);
         });
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1698,7 +1698,7 @@ static
 void
 populate_statistics_offsets(sstable_version_types v, statistics& s) {
     // copy into a sorted vector to guarantee consistent order
-    auto types = boost::copy_range<std::vector<metadata_type>>(s.contents | boost::adaptors::map_keys);
+    auto types = s.contents | std::views::keys | std::ranges::to<std::vector>();
     std::ranges::sort(types);
 
     // populate the hash with garbage so we can calculate its size
@@ -2240,7 +2240,7 @@ void sstable::validate_originating_host_id() const {
 
 std::vector<sstring> sstable::component_filenames() const {
     std::vector<sstring> res;
-    for (auto c : sstable_version_constants::get_component_map(_version) | boost::adaptors::map_keys) {
+    for (auto c : sstable_version_constants::get_component_map(_version) | std::views::keys) {
         if (has_component(c)) {
             res.emplace_back(filename(c));
         }

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -1141,7 +1141,7 @@ SEASTAR_THREAD_TEST_CASE(test_list_logging) {
             auto map = value_cast<map_type_impl::native_type>(std::move(v));
             auto cpy = boost::copy_range<std::vector<data_value>>(map | boost::adaptors::map_values);
             // verify key is timeuuid
-            for (auto& key : map | boost::adaptors::map_keys) {
+            for (auto& key : map | std::views::keys) {
                 value_cast<utils::UUID>(key);
             }
             return ::make_list_value(list_type, std::move(cpy));
@@ -1678,7 +1678,7 @@ static void test_pre_post_image(cql_test_env& e, const std::vector<image_persist
         }
 
         // Register new encountered timestamps so that we won't repeat them in next run
-        for (const auto& time : groups | boost::adaptors::map_keys) {
+        for (const auto& time : groups | std::views::keys) {
             processed_times.insert(time);
         }
 

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -396,7 +396,7 @@ SEASTAR_TEST_CASE(test_commitlog_reader){
         auto segments = log.get_active_segment_names();
         BOOST_REQUIRE(segments.size() > 1);
 
-        auto ids = boost::copy_range<std::vector<segment_id_type>>(set.usage() | boost::adaptors::map_keys);
+        auto ids = set.usage() | std::views::keys | std::ranges::to<std::vector>();
         std::sort(ids.begin(), ids.end());
         auto id = ids.front();
         auto i = std::find_if(segments.begin(), segments.end(), [id](sstring filename) {

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -386,7 +386,7 @@ SEASTAR_THREAD_TEST_CASE(test_timestamp_based_splitting_mutation_writer) {
 
     segregate_by_timestamp(make_mutation_reader_from_mutations_v2(random_schema.schema(), semaphore.make_permit(), muts), classify_fn, std::move(consumer)).get();
 
-    testlog.debug("Data split into {} buckets: {}", buckets.size(), boost::copy_range<std::vector<int64_t>>(buckets | boost::adaptors::map_keys));
+    testlog.debug("Data split into {} buckets: {}", buckets.size(), buckets | std::views::keys | std::ranges::to<std::vector>());
 
     assert_that_segregator_produces_correct_data(buckets, muts, semaphore.make_permit(), random_schema);
 }
@@ -585,7 +585,7 @@ SEASTAR_THREAD_TEST_CASE(test_token_group_based_splitting_mutation_writer) {
 
     segregate_by_token_group(make_mutation_reader_from_mutations_v2(random_schema.schema(), semaphore.make_permit(), muts), classify_fn, std::move(consumer)).get();
 
-    testlog.info("Data split into {} buckets: {}", buckets.size(), boost::copy_range<std::vector<int64_t>>(buckets | boost::adaptors::map_keys));
+    testlog.info("Data split into {} buckets: {}", buckets.size(), buckets | std::views::keys | std::ranges::to<std::vector>());
 
     assert_that_segregator_produces_correct_data(buckets, muts, semaphore.make_permit(), random_schema);
 }

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -491,7 +491,7 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
             .build();
 
         auto make_random_options = [&] () {
-            auto option_dcs = boost::copy_range<std::vector<sstring>>(node_count_per_dc | boost::adaptors::map_keys);
+            auto option_dcs = node_count_per_dc | std::views::keys | std::ranges::to<std::vector>();
             std::map<sstring, sstring> options;
             std::shuffle(option_dcs.begin(), option_dcs.end(), random_engine);
             size_t num_option_dcs = 1 + tests::random::get_int(option_dcs.size() - 1);
@@ -688,7 +688,7 @@ static bool has_sufficient_replicas(
                 const std::unordered_map<sstring, std::unordered_set<inet_address>>& all_endpoints,
                 const std::unordered_map<sstring, size_t>& datacenters) noexcept {
 
-    for (auto& dc : datacenters | boost::adaptors::map_keys) {
+    for (auto& dc : datacenters | std::views::keys) {
         if (!has_sufficient_replicas(dc, dc_replicas, all_endpoints,
                         datacenters)) {
             return false;

--- a/test/lib/dummy_sharder.hh
+++ b/test/lib/dummy_sharder.hh
@@ -25,7 +25,7 @@ public:
     template <typename T>
     dummy_sharder(const dht::static_sharder& sharding, const std::map<dht::token, T>& something_by_token)
         : dht::static_sharder(sharding)
-        , _tokens(boost::copy_range<std::vector<dht::token>>(something_by_token | boost::adaptors::map_keys)) {
+        , _tokens(something_by_token | std::views::keys | std::ranges::to<std::vector>()) {
     }
 
     virtual unsigned shard_of(const dht::token& t) const override;

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -1909,11 +1909,12 @@ int scylla_fast_forward_main(int argc, char** argv) {
                 ),
             "Test groups to run")
         ("datasets", bpo::value<std::vector<std::string>>()->default_value(
-                boost::copy_range<std::vector<std::string>>(datasets
-                    | boost::adaptors::filtered([] (auto&& e) {
+                datasets
+                    | std::views::filter([] (auto&& e) {
                         return e.second->enabled_by_default();
                     })
-                    | boost::adaptors::map_keys)),
+                    | std::views::keys
+                    | std::ranges::to<std::vector<std::string>>()),
             "Use only the following datasets")
         ("list-tests", "Show available test groups")
         ("list-datasets", "Show available datasets")

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1280,7 +1280,7 @@ void help_operation(const tool_app_template::config& cfg, const bpo::variables_m
     if (vm.contains("command")) {
         const auto command = vm["command"].as<std::vector<sstring>>();
         const auto& ops = get_operations_with_func();
-        auto keys = ops | boost::adaptors::map_keys;
+        auto keys = ops | std::views::keys;
         auto it = std::ranges::find_if(keys, [&] (const operation& op) { return op.name() == command[0]; });
         if (it == keys.end()) {
             throw std::invalid_argument(fmt::format("unknown command {}", get_command_name(command)));
@@ -4508,7 +4508,7 @@ Supported Nodetool operations:
 
 For more information, see: {})";
 
-    const auto operations = boost::copy_range<std::vector<operation>>(get_operations_with_func() | boost::adaptors::map_keys);
+    const auto operations = get_operations_with_func() | std::views::keys | std::ranges::to<std::vector>();
     tool_app_template::config app_cfg{
             .name = app_name,
             .description = seastar::format(description_template, app_name, nlog.name(), boost::algorithm::join(operations | boost::adaptors::transformed([] (const auto& op) {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -3092,7 +3092,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
 
 )";
 
-    const auto operations = boost::copy_range<std::vector<operation>>(operations_with_func | boost::adaptors::map_keys);
+    const auto operations = operations_with_func | std::views::keys | std::ranges::to<std::vector>();
     tool_app_template::config app_cfg{
             .name = app_name,
             .description = seastar::format(description_template, app_name, sst_log.name(), boost::algorithm::join(operations | boost::adaptors::transformed([] (const auto& op) {

--- a/tools/scylla-types.cc
+++ b/tools/scylla-types.cc
@@ -382,7 +382,7 @@ For more information about individual actions, see their specific help:
 $ scylla types {{action}} --help
 )";
 
-    const auto operations = boost::copy_range<std::vector<operation>>(operations_with_func | boost::adaptors::map_keys);
+    const auto operations = operations_with_func | std::views::keys | std::ranges::to<std::vector>();
     tool_app_template::config app_cfg{
         .name = app_name,
         .description = seastar::format(description_template, app_name, app_name, boost::algorithm::join(operations | boost::adaptors::transformed(


### PR DESCRIPTION
now that we are allowed to use C++23. we now have the luxury of using `std::views::keys`.

in this change, we:

- replace `boost::adaptors::map_keys` with `std::views::keys`
- update affected code to work with `std::views::keys`

to reduce the dependency to boost for better maintainability, and leverage standard library features for better long-term support.

this change is part of our ongoing effort to modernize our codebase and reduce external dependencies where possible.

---

it's a cleanup, hence no need to backport.