### PR TITLE
[Backport 6.0] tablet: Fix single-sstable split when attaching new unsplit sstables

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -2055,8 +2055,10 @@ compaction_manager::maybe_split_sstable(sstables::shared_sstable sst, table_stat
     }
     std::vector<sstables::shared_sstable> ret;
 
-    co_await run_custom_job(t, sstables::compaction_type::Split, "Split SSTable",
-                            [&] (sstables::compaction_data& info, sstables::compaction_progress_monitor& monitor) -> future<> {
+        // FIXME: indentation.
+        auto gate = get_compaction_state(&t).gate.hold();
+        sstables::compaction_progress_monitor monitor;
+        sstables::compaction_data info = create_compaction_data();
         sstables::compaction_descriptor desc = split_compaction_task_executor::make_descriptor(sst, opt);
         desc.creator = [&t] (shard_id _) {
             return t.make_sstable();
@@ -2067,7 +2069,6 @@ compaction_manager::maybe_split_sstable(sstables::shared_sstable sst, table_stat
 
         co_await sstables::compact_sstables(std::move(desc), info, t, monitor);
         co_await sst->unlink();
-    }, tasks::task_info{}, throw_if_stopping::yes);
 
     co_return ret;
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -720,6 +720,15 @@ private:
     size_t tablet_id_for_token(dht::token t) const noexcept {
         return tablet_map().get_tablet_id(t).value();
     }
+
+    storage_group_ptr allocate_storage_group(const locator::tablet_map& tmap, locator::tablet_id tid, dht::token_range range) const {
+        auto cg = make_lw_shared<compaction_group>(_t, tid.value(), std::move(range));
+        auto sg = make_lw_shared<storage_group>(std::move(cg));
+        if (tmap.needs_split()) {
+            sg->set_split_mode();
+        }
+        return sg;
+    }
 public:
     tablet_storage_group_manager(table& t, const locator::effective_replication_map& erm)
         : _t(t)
@@ -736,8 +745,7 @@ public:
 
             if (tmap.has_replica(tid, local_replica)) {
                 tlogger.debug("Tablet with id {} and range {} present for {}.{}", tid, range, schema()->ks_name(), schema()->cf_name());
-                auto cg = make_lw_shared<compaction_group>(_t, tid.value(), std::move(range));
-                ret[tid.value()] = make_lw_shared<storage_group>(std::move(cg));
+                ret[tid.value()] = allocate_storage_group(tmap, tid, std::move(range));
             }
         }
         _storage_groups = std::move(ret);
@@ -859,6 +867,7 @@ future<> storage_group::split(sstables::compaction_type_options::split opt) {
     if (set_split_mode()) {
         co_return;
     }
+    co_await utils::get_local_injector().inject("delay_split_compaction", 5s);
 
     if (_main_cg->empty()) {
         co_return;
@@ -2291,8 +2300,7 @@ future<> tablet_storage_group_manager::update_effective_replication_map(const lo
         auto transition_info = transition.second;
         if (!_storage_groups.contains(tid.value()) && tablet_migrates_in(transition_info)) {
             auto range = new_tablet_map->get_token_range(tid);
-            auto cg = make_lw_shared<compaction_group>(_t, tid.value(), std::move(range));
-            _storage_groups[tid.value()] = make_lw_shared<storage_group>(std::move(cg));
+            _storage_groups[tid.value()] = allocate_storage_group(*new_tablet_map, tid, std::move(range));
             tablet_migrating_in = true;
         }
     }


### PR DESCRIPTION
To fix a race between split and repair here https://github.com/scylladb/scylladb/commit/c1de4859d815b3eb4aebef7b7e1c7998c6860f76, a new sstable
generated during streaming can be split before being attached to the sstable
set. That's to prevent an unsplit sstable from reaching the set after the
tablet map is resized.

So we can think this split is an extension of the sstable writer. A failure
during split means the new sstable won't be added. Also, the duration of split
is also adding to the time erm is held. For example, repair writer will only
release its erm once the split sstable is added into the set.

This single-sstable split is going through run_custom_job(), which serializes
with other maintenance tasks. That was a terrible decision, since the split may
have to wait for ongoing maintenance task to finish, which means holding erm
for longer. Additionally, if split monitor decides to run split on the entire
compaction group, it can cause single-sstable split to be aborted since the
former wants to select all sstables, propagating a failure to the streaming
writer.
That results in new sstable being leaked and may cause problems on restart,
since the underlying tablet may have moved elsewhere or multiple splits may
have happened. We have some fragility today in cleaning up leaked sstables on
streaming failure, but this single-sstable split made it worse since the
failure can happen during normal operation, when there's e.g. no I/O error.

It makes sense to kill run_custom_job() usage, since the single-sstable split
is offline and an extension of sstable writing, therefore it makes no sense to
serialize with maintenance tasks. It must also inherit the sched group of the
process writing the new sstable. The inheritance happens today, but is fragile.

Fixes https://github.com/scylladb/scylladb/issues/20626.

(cherry picked from commit https://github.com/scylladb/scylladb/commit/999f1f13185c13b950c1001e2b5e149701c3feb6)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/38ce2c605dc97d0ed13a7fc241e086c768e03d35)

Refs https://github.com/scylladb/scylladb/pull/20737