### PR TITLE
[Backport 6.1] replica: Fix schema change during migration cleanup

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -250,6 +250,9 @@ public:
     bool no_compacted_sstable_undeleted() const;
 
     future<> stop() noexcept;
+
+    // Clear sstable sets
+    void clear_sstables();
 };
 
 using storage_group_ptr = lw_shared_ptr<storage_group>;
@@ -309,6 +312,7 @@ public:
     const storage_group_map& storage_groups() const;
 
     future<> stop_storage_groups() noexcept;
+    void clear_storage_groups();
     void remove_storage_group(size_t id);
     storage_group& storage_group_for_id(const schema_ptr&, size_t i) const;
     storage_group* maybe_storage_group_for_id(const schema_ptr&, size_t i) const;

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -1349,3 +1349,53 @@ async def test_tombstone_gc_correctness_during_tablet_split(manager: ManagerClie
 
     logger.info("Verify data is not resurrected")
     await assert_empty_table()
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_schema_change_during_cleanup(manager: ManagerClient):
+    logger.info("Start first node")
+    servers = [await manager.server_add()]
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+    cql = manager.get_cql()
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+
+    logger.info("Populating table")
+
+    keys = range(256)
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+
+    async def check():
+        logger.info("Checking table")
+        rows = await cql.run_async("SELECT * FROM test.test;")
+        assert rows == expected_rows
+        assert len(rows) == len(keys)
+        for r in rows:
+            assert r.c == r.pk
+
+    s1_log = await manager.server_open_log(servers[0].server_id)
+    s1_mark = await s1_log.mark()
+
+    logger.info("Start second node.")
+    servers.append(await manager.server_add())
+    s1_host_id = await manager.get_host_id(servers[1].server_id)
+
+    await inject_error_on(manager, "delay_tablet_compaction_groups_cleanup", servers)
+
+    logger.info("Read system.tablets.")
+    tablet_replicas = await get_all_tablet_replicas(manager, servers[0], 'test', 'test')
+    assert len(tablet_replicas) == 1
+
+    logger.info("Migrating one tablet to another node.")
+    t = tablet_replicas[0]
+    migration_task = asyncio.create_task(
+        manager.api.move_tablet(servers[0].ip_addr, "test", "test", *t.replicas[0], *(s1_host_id, 0), t.last_token))
+
+    logger.info("Waiting for log")
+    await s1_log.wait_for('Initiating tablet cleanup of', from_mark=s1_mark, timeout=120)
+    time.sleep(1)
+    await cql.run_async("ALTER TABLE test.test WITH gc_grace_seconds = 0;")
+    await migration_task


### PR DESCRIPTION
During migration cleanup, there's a small window in which the storage group was stopped but not yet removed from the list. So concurrent operations traversing the list could work with stopped groups.

During a test which emitted schema changes during migrations, a failure happened when updating the compaction strategy of a table, but since the group was stopped, the compaction manager was unable to find the state for that group.

In order to fix it, we'll skip stopped groups when traversing the list since they're unused at this stage of migration and going away soon.

Fixes #20699.

Signed-off-by: Raphael S. Carvalho <raphaelsc@scylladb.com>
(cherry picked from commit b8d6f864bcd2e4cfa9e62408f1aee260cd2c3b64)
