### PR TITLE
[Backport 6.0] replica: Fix tombstone GC during tablet split preparation

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -171,7 +171,8 @@ static api::timestamp_type get_max_purgeable_timestamp(const table_state& table_
 }
 
 static std::vector<shared_sstable> get_uncompacting_sstables(const table_state& table_s, std::vector<shared_sstable> sstables) {
-    auto all_sstables = boost::copy_range<std::vector<shared_sstable>>(*table_s.main_sstable_set().all());
+    auto sstable_set = table_s.sstable_set_for_tombstone_gc();
+    auto all_sstables = boost::copy_range<std::vector<shared_sstable>>(*sstable_set->all());
     auto& compacted_undeleted = table_s.compacted_undeleted_sstables();
     all_sstables.insert(all_sstables.end(), compacted_undeleted.begin(), compacted_undeleted.end());
     boost::sort(all_sstables, [] (const shared_sstable& x, const shared_sstable& y) {

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -594,6 +594,8 @@ private:
     future<compaction_manager::compaction_stats_opt> compaction_done() noexcept {
         return _compaction_done.get_future();
     }
+
+    future<sstables::sstable_set> sstable_set_for_tombstone_gc(::compaction::table_state& t);
 public:
     bool stopping() const noexcept {
         return _compaction_data.abort.abort_requested();

--- a/compaction/table_state.hh
+++ b/compaction/table_state.hh
@@ -39,6 +39,7 @@ public:
     virtual bool compaction_enforce_min_threshold() const noexcept = 0;
     virtual const sstables::sstable_set& main_sstable_set() const = 0;
     virtual const sstables::sstable_set& maintenance_sstable_set() const = 0;
+    virtual lw_shared_ptr<const sstables::sstable_set> sstable_set_for_tombstone_gc() const = 0;
     virtual std::unordered_set<sstables::shared_sstable> fully_expired_sstables(const std::vector<sstables::shared_sstable>& sstables, gc_clock::time_point compaction_time) const = 0;
     virtual const std::vector<sstables::shared_sstable>& compacted_undeleted_sstables() const noexcept = 0;
     virtual sstables::compaction_strategy& get_compaction_strategy() const noexcept = 0;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -623,6 +623,12 @@ private:
     // can wait on compaction (backpressure) which in turn takes deletion guard on completion.
     future<> safe_foreach_sstable(const sstables::sstable_set&, noncopyable_function<future<>(const sstables::shared_sstable&)> action);
 
+    // Returns a sstable set that can be safely used for purging any expired tombstone in a compaction group.
+    // Only the sstables in the compaction group is not sufficient, since there might be other compaction
+    // groups during tablet split with overlapping token range, and we need to include them all in a single
+    // sstable set to allow safe tombstone gc.
+    lw_shared_ptr<const sstables::sstable_set> sstable_set_for_tombstone_gc(const compaction_group&) const;
+
     bool cache_enabled() const {
         return _config.enable_cache && _schema->caching_options().enabled();
     }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5231,9 +5231,9 @@ future<> storage_service::process_tablet_split_candidate(table_id table) noexcep
     };
 
     exponential_backoff_retry split_retry = exponential_backoff_retry(std::chrono::seconds(5), std::chrono::seconds(300));
-    bool sleep = false;
 
     while (!_async_gate.is_closed() && !_group0_as.abort_requested()) {
+        bool sleep = false;
         try {
             // Ensures that latest changes to tablet metadata, in group0, are visible
             auto guard = co_await _group0->client().start_operation(_group0_as);
@@ -5251,11 +5251,16 @@ future<> storage_service::process_tablet_split_candidate(table_id table) noexcep
                 release_guard(std::move(guard));
                 co_await split_all_compaction_groups();
             }
+        } catch (const seastar::abort_requested_exception& ex) {
+            slogger.warn("Failed to complete splitting of table {} due to {}", table, ex);
+            break;
+        } catch (raft::request_aborted& ex) {
+            slogger.warn("Failed to complete splitting of table {} due to {}", table, ex);
+            break;
         } catch (...) {
             slogger.error("Failed to complete splitting of table {} due to {}, retrying after {} seconds",
                           table, std::current_exception(), split_retry.sleep_time());
             sleep = true;
-            break;
         }
         if (sleep) {
             co_await split_retry.retry(_group0_as);

--- a/test/boost/compaction_group_test.cc
+++ b/test/boost/compaction_group_test.cc
@@ -102,6 +102,7 @@ public:
     virtual bool compaction_enforce_min_threshold() const noexcept override { return false; }
     virtual const sstables::sstable_set& main_sstable_set() const override { return _main_set; }
     virtual const sstables::sstable_set& maintenance_sstable_set() const override { return _maintenance_set; }
+    virtual lw_shared_ptr<const sstables::sstable_set> sstable_set_for_tombstone_gc() const override { return make_lw_shared<const sstables::sstable_set>(main_sstable_set()); }
     virtual std::unordered_set<sstables::shared_sstable> fully_expired_sstables(const std::vector<sstables::shared_sstable>& sstables, gc_clock::time_point compaction_time) const override { return {}; }
     virtual const std::vector<sstables::shared_sstable>& compacted_undeleted_sstables() const noexcept override { return _compacted_undeleted_sstables; }
     virtual sstables::compaction_strategy& get_compaction_strategy() const noexcept override { return _compaction_strategy; }

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -75,6 +75,9 @@ public:
     const sstables::sstable_set& maintenance_sstable_set() const override {
         return table().try_get_table_state_with_static_sharding().maintenance_sstable_set();
     }
+    lw_shared_ptr<const sstables::sstable_set> sstable_set_for_tombstone_gc() const override {
+        return make_lw_shared<const sstables::sstable_set>(main_sstable_set());
+    }
     std::unordered_set<sstables::shared_sstable> fully_expired_sstables(const std::vector<sstables::shared_sstable>& sstables, gc_clock::time_point query_time) const override {
         return sstables::get_fully_expired_sstables(*this, sstables, query_time);
     }

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -332,6 +332,11 @@ class ScyllaRESTAPIClient():
             params["cf"] = table
         await self.client.post(url, host=node_ip, params=params)
 
+    async def stop_compaction(self, node_ip: str, type: str) -> None:
+        """Stop compaction of a given type"""
+        url = f"/compaction_manager/stop_compaction?type={type}"
+        await self.client.post(url, host=node_ip)
+
     async def dump_llvm_profile(self, node_ip : str):
         """Dump llvm profile to disk that can later be used for PGO or coverage reporting.
            no-op if the scylla binary is not instrumented."""

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -1191,3 +1191,87 @@ async def test_tablet_storage_freeing(manager: ManagerClient):
     logger.info("Verify that the table's disk usage on first node shrunk by about half.")
     size_after = await manager.server_get_sstables_disk_usage(servers[0].server_id, "test", "test")
     assert size_before * 0.33 < size_after < size_before * 0.66
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_tombstone_gc_correctness_during_tablet_split(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    cmdline = [
+        '--logger-log-level', 'storage_service=debug',
+        '--logger-log-level', 'table=debug',
+        '--target-tablet-size-in-bytes', '5000',
+    ]
+    servers = [await manager.server_add(config={
+        'error_injections_at_startup': ['short_tablet_stats_refresh_interval']
+    }, cmdline=cmdline)]
+
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int) WITH gc_grace_seconds=0;")
+
+    await manager.api.disable_autocompaction(servers[0].ip_addr, "test")
+
+    keys = range(100)
+
+    logger.info("Generating sstable with shadowed data")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    await manager.api.flush_keyspace(servers[0].ip_addr, "test")
+
+    logger.info("Generating another sstable with tombstones")
+    await asyncio.gather(*[cql.run_async(f"DELETE FROM test.test WHERE pk={k};") for k in keys])
+    await manager.api.flush_keyspace(servers[0].ip_addr, "test")
+
+    async def assert_empty_table():
+        cql = manager.get_cql()
+        rows = await cql.run_async("SELECT * FROM test.test BYPASS CACHE;")
+        assert len(rows) == 0
+
+    await assert_empty_table()
+
+    await manager.api.flush_keyspace(servers[0].ip_addr, "test")
+
+    tablet_count = await get_tablet_count(manager, servers[0], 'test', 'test')
+    assert tablet_count == 1
+
+    await manager.api.enable_injection(servers[0].ip_addr, "tablet_load_stats_refresh_before_rebalancing", one_shot=False)
+    await manager.api.enable_injection(servers[0].ip_addr, "tablet_split_finalization_postpone", one_shot=False)
+
+    s1_log = await manager.server_open_log(servers[0].server_id)
+    s1_mark = await s1_log.mark()
+
+    # Waits for tombstones to be expired.
+    time.sleep(1)
+
+    await manager.api.enable_injection(servers[0].ip_addr, "split_sstable_rewrite", one_shot=False)
+
+    logger.info("Enable balancing so split will be emitted")
+    await manager.api.enable_tablet_balancing(servers[0].ip_addr)
+
+    logger.info("Waits for split of sstable containing expired tombstones")
+    await s1_log.wait_for(f"split_sstable_rewrite: waiting", from_mark=s1_mark)
+    s1_mark = await s1_log.mark()
+    await manager.api.message_injection(servers[0].ip_addr, "split_sstable_rewrite")
+    await s1_log.wait_for(f"split_sstable_rewrite: released", from_mark=s1_mark)
+
+    logger.info("Pause split of sstable containing deleted data")
+    await s1_log.wait_for(f"split_sstable_rewrite: waiting", from_mark=s1_mark)
+    s1_mark = await s1_log.mark()
+
+    logger.info("Force compaction of split sstable containing expired tombstone")
+    await manager.api.stop_compaction(servers[0].ip_addr, "SPLIT")
+    await manager.api.keyspace_compaction(servers[0].ip_addr, "test")
+
+    await s1_log.wait_for(f"split_sstable_rewrite: released", from_mark=s1_mark)
+
+    await manager.api.disable_injection(servers[0].ip_addr, "split_sstable_rewrite")
+
+    await manager.api.disable_injection(servers[0].ip_addr, "tablet_split_finalization_postpone")
+    await s1_log.wait_for('Detected tablet split for table', from_mark=s1_mark)
+
+    tablet_count = await get_tablet_count(manager, servers[0], 'test', 'test')
+    assert tablet_count > 1
+
+    logger.info("Verify data is not resurrected")
+    await assert_empty_table()

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -915,6 +915,7 @@ public:
     virtual bool compaction_enforce_min_threshold() const noexcept override { return false; }
     virtual const sstables::sstable_set& main_sstable_set() const override { return _main_set; }
     virtual const sstables::sstable_set& maintenance_sstable_set() const override { return _maintenance_set; }
+    lw_shared_ptr<const sstables::sstable_set> sstable_set_for_tombstone_gc() const override { return make_lw_shared<const sstables::sstable_set>(main_sstable_set()); }
     virtual std::unordered_set<sstables::shared_sstable> fully_expired_sstables(const std::vector<sstables::shared_sstable>& sstables, gc_clock::time_point compaction_time) const override { return {}; }
     virtual const std::vector<sstables::shared_sstable>& compacted_undeleted_sstables() const noexcept override { return _compacted_undeleted_sstables; }
     virtual sstables::compaction_strategy& get_compaction_strategy() const noexcept override { return _compaction_strategy; }


### PR DESCRIPTION
During split prepare phase, there will be more than 1 compaction group with
overlapping token range for a given replica.

Assume tablet 1 has sstable A containing deleted data, and sstable B containing
a tombstone that shadows data in A.

Then split starts:

sstable B is split first, and moved from main (unsplit) group to a
split-ready group
now compaction runs in split-ready group before sstable A is split
tombstone GC logic today only looks at underlying group, so compaction is step
2 will discard the deleted data in A, since it belongs to another group (the
unsplit one), and so the tombstone can be purged incorrectly.

To fix it, compaction will now work with all uncompacting sstables that belong
to the same replica, since tombstone GC requires all sstables that possibly
contain shadowed data to be available for correct decision to be made.

Fixes https://github.com/scylladb/scylladb/issues/20044.

Please replace this line with justification for the backport/* labels added to this PR
Branches 6.0, 6.1 and 6.2 are vulnerable, so backport is needed.

(cherry picked from commit https://github.com/scylladb/scylladb/commit/bcd358595f4afff05c3d1f2d64d8dd112895cd17)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/93815e064965325147b4da5c21b506485fff505f)

Refs https://github.com/scylladb/scylladb/pull/20939