### PR TITLE
repair: Enable small table optimization for RBNO bootstrap and decommission

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -985,6 +985,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , repair_multishard_reader_enable_read_ahead(this, "repair_multishard_reader_enable_read_ahead", liveness::LiveUpdate, value_status::Used, false,
         "The multishard reader has a read-ahead feature to improve latencies of range-scans. This feature can be detrimental when the multishard reader is used under repair, as is the case in repair in mixed-shard clusters."
         " This know allows disabling this read-ahead (default), this can help the performance of mixed-shard repair (including RBNO).")
+    , enable_small_table_optimization_for_rbno(this, "enable_small_table_optimization_for_rbno", liveness::LiveUpdate, value_status::Used, false, "Set true to enable small table optimization for repair based node operations")
     , ring_delay_ms(this, "ring_delay_ms", value_status::Used, 30 * 1000, "Time a node waits to hear from other nodes before joining the ring in milliseconds. Same as -Dcassandra.ring_delay_ms in cassandra.")
     , shadow_round_ms(this, "shadow_round_ms", value_status::Used, 300 * 1000, "The maximum gossip shadow round time. Can be used to reduce the gossip feature check time during node boot up.")
     , fd_max_interval_ms(this, "fd_max_interval_ms", value_status::Used, 2 * 1000, "The maximum failure_detector interval time in milliseconds. Interval larger than the maximum will be ignored. Larger cluster may need to increase the default.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -344,6 +344,7 @@ public:
     named_value<uint32_t> repair_hints_batchlog_flush_cache_time_in_ms;
     named_value<uint64_t> repair_multishard_reader_buffer_hint_size;
     named_value<uint64_t> repair_multishard_reader_enable_read_ahead;
+    named_value<bool> enable_small_table_optimization_for_rbno;
     named_value<uint32_t> ring_delay_ms;
     named_value<uint32_t> shadow_round_ms;
     named_value<uint32_t> fd_max_interval_ms;

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -277,4 +277,4 @@ future<> repair_cf_range_row_level(repair::shard_repair_task_impl& shard_task,
 future<std::list<repair_row>> to_repair_rows_list(repair_rows_on_wire rows,
         schema_ptr s, uint64_t seed, repair_master is_master,
         reader_permit permit, repair_hasher hasher);
-void flush_rows(schema_ptr s, std::list<repair_row>& rows, lw_shared_ptr<repair_writer>& writer, locator::effective_replication_map_ptr erm = {}, bool small_table_optimization = false);
+void flush_rows(schema_ptr s, std::list<repair_row>& rows, lw_shared_ptr<repair_writer>& writer, locator::effective_replication_map_ptr erm = {}, bool small_table_optimization = false, repair_meta* rm = nullptr);

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -158,6 +158,7 @@ public:
     bool _hints_batchlog_flushed = false;
     std::unordered_set<gms::inet_address> nodes_down;
     bool _small_table_optimization = false;
+    size_t small_table_optimization_ranges_reduced_factor = 1;
 private:
     bool _aborted = false;
     std::optional<sstring> _failed_because;


### PR DESCRIPTION
The non local strategy system keyspaces usually contain very litte data.
All the tables within them have to be repaired for all the token ranges,
which could be large in clusters with a large number of nodes. In multiple
DC setup, the repair in RBNO is dominated by the network latency. As a
result, it takes a long time to repair those tables even if they are
almost empty.

To speed up the RBNO bootstrap, especially for starting empty clusters,
this patch enables small table optimization for RBNO for system tables.
We could enable it for small user tables as a follow up.

Tests:

1) A 5ms latency is added to simulate cross dc network delay, 256 tokens
per node, 10 nodes:

- Before

  topology_custom dev topology_custom.test_boot_time.1 1287.06s

- After

  topology_custom dev topology_custom.test_boot_time.1 12.48s

The test shows 100X boot time improvement

2) A SCT test to bootstrap 3 DCs, 3 nodes in each DC.

- Before

  Time to bootstrap = 1h23m

- After

  Time to bootstrap = 13m

The test shows 6X bootstrap time improvement

Fixes #19131

New feature.  No backport is needed.
