### PR TITLE
Remove all_datadirs vector of strings from table::config

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -31,7 +31,6 @@
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/metrics.hh>
-#include <boost/algorithm/string/erase.hpp>
 #include "sstables/sstables.hh"
 #include "sstables/sstables_manager.hh"
 #include <boost/range/adaptor/map.hpp>
@@ -2553,12 +2552,6 @@ std::pair<sstring, table_id> parse_table_directory_name(const sstring& directory
         on_internal_error(dblog, format("table directory entry name '{}' is invalid: no '-' separator found at pos {}", directory_name, pos));
     }
     return std::make_pair(directory_name.substr(0, pos), table_id(utils::UUID(directory_name.substr(pos + 1))));
-}
-
-sstring format_table_directory_name(sstring name, table_id id) {
-    auto uuid_sstring = id.to_sstring();
-    boost::erase_all(uuid_sstring, "-");
-    return format("{}-{}", name, uuid_sstring);
 }
 
 future<std::unordered_map<sstring, database::snapshot_details>> database::get_snapshot_details() {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1231,9 +1231,6 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     column_family::config cfg;
     const db::config& db_config = db.get_config();
 
-    for (auto& extra : db_config.data_file_directories()) {
-        cfg.all_datadirs.push_back(format("{}/{}/{}", extra, s.ks_name(), format_table_directory_name(s.cf_name(), s.id())));
-    }
     cfg.enable_disk_reads = _config.enable_disk_reads;
     cfg.enable_disk_writes = _config.enable_disk_writes;
     cfg.enable_commitlog = _config.enable_commitlog;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -394,7 +394,6 @@ class table : public enable_lw_shared_from_this<table>
             , public weakly_referencable<table> {
 public:
     struct config {
-        std::vector<sstring> all_datadirs;
         bool enable_disk_writes = true;
         bool enable_disk_reads = true;
         bool enable_cache = true;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1891,10 +1891,8 @@ public:
     future<> clear_inactive_reads_for_tablet(table_id table, dht::token_range tablet_range);
 };
 
-// A pair of helper functions to make directory name for a table
-// out of its name and uuid, and to parse the directory name back
-// into name and uuid of the table
-sstring format_table_directory_name(sstring name, table_id id);
+// A helper function to parse the directory name back
+// into name and uuid of the table (see format_table_directory_name())
 std::pair<sstring, table_id> parse_table_directory_name(const sstring&);
 
 } // namespace replica

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1892,7 +1892,7 @@ public:
 };
 
 // A helper function to parse the directory name back
-// into name and uuid of the table (see format_table_directory_name())
+// into name and uuid of the table (see init_table_storage())
 std::pair<sstring, table_id> parse_table_directory_name(const sstring&);
 
 } // namespace replica

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -340,9 +340,7 @@ future<> table_populator::stop() {
 }
 
 future<> table_populator::collect_subdirs(const data_dictionary::storage_options::local& so, sstables::sstable_state state) {
-    auto datadirs = _global_table->get_config().all_datadirs
-            | std::views::transform([] (const sstring& d) { return std::filesystem::path(d); })
-            | std::ranges::to<std::vector<std::filesystem::path>>();
+    auto datadirs = _global_table->get_sstables_manager().get_local_directories(so);
     co_await coroutine::parallel_for_each(datadirs, [&] (const std::filesystem::path& datadir) -> future<> {
         auto dptr = make_lw_shared<sharded<sstables::sstable_directory>>();
         co_await dptr->start(_global_table.as_sharded_parameter(), state,

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -340,11 +340,14 @@ future<> table_populator::stop() {
 }
 
 future<> table_populator::collect_subdirs(const data_dictionary::storage_options::local& so, sstables::sstable_state state) {
-    co_await coroutine::parallel_for_each(_global_table->get_config().all_datadirs, [&] (const sstring& datadir) -> future<> {
+    auto datadirs = _global_table->get_config().all_datadirs
+            | std::views::transform([] (const sstring& d) { return std::filesystem::path(d); })
+            | std::ranges::to<std::vector<std::filesystem::path>>();
+    co_await coroutine::parallel_for_each(datadirs, [&] (const std::filesystem::path& datadir) -> future<> {
         auto dptr = make_lw_shared<sharded<sstables::sstable_directory>>();
         co_await dptr->start(_global_table.as_sharded_parameter(), state,
                         sharded_parameter([datadir] {
-                            auto opts = data_dictionary::make_local_options(std::filesystem::path(datadir));
+                            auto opts = data_dictionary::make_local_options(datadir);
                             return make_lw_shared<const data_dictionary::storage_options>(std::move(opts));
                         }), default_io_error_handler_gen());
         _sstable_directories.push_back(std::move(dptr));

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2748,9 +2748,7 @@ future<std::unordered_map<sstring, table::snapshot_details>> table::get_snapshot
             return all_snapshots;
         }
 
-        auto datadirs = _config.all_datadirs
-                | std::views::transform([] (const sstring& d) { return fs::path(d); })
-                | std::ranges::to<std::vector<fs::path>>();
+        auto datadirs = _sstables_manager.get_local_directories(*so);
         for (auto& datadir : datadirs) {
             fs::path snapshots_dir = datadir / sstables::snapshots_dir;
             auto file_exists = io_check([&snapshots_dir] { return seastar::file_exists(snapshots_dir.native()); }).get();

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2743,6 +2743,10 @@ future<bool> table::snapshot_exists(sstring tag) {
 future<std::unordered_map<sstring, table::snapshot_details>> table::get_snapshot_details() {
     return seastar::async([this] {
         std::unordered_map<sstring, snapshot_details> all_snapshots;
+        auto* so = std::get_if<storage_options::local>(&_storage_opts->value);
+        if (so == nullptr || so->dir.empty()) {
+            return all_snapshots;
+        }
         for (auto& datadir : _config.all_datadirs) {
             fs::path snapshots_dir = fs::path(datadir) / sstables::snapshots_dir;
             auto file_exists = io_check([&snapshots_dir] { return seastar::file_exists(snapshots_dir.native()); }).get();

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -325,6 +325,10 @@ void sstables_manager::validate_new_keyspace_storage_options(const data_dictiona
     }, so.value);
 }
 
+std::vector<std::filesystem::path> sstables_manager::get_local_directories(const data_dictionary::storage_options::local& so) const {
+    return sstables::get_local_directories(_db_config, so);
+}
+
 void sstables_manager::on_unlink(sstable* sst) {
     // Remove the sst from manager's reclaimed list to prevent any attempts to reload its components.
     _reclaimed.erase(*sst);

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -197,6 +197,8 @@ public:
     // To be called by the sstable to signal its unlinking
     void on_unlink(sstable* sst);
 
+    std::vector<std::filesystem::path> get_local_directories(const data_dictionary::storage_options::local& so) const;
+
 private:
     void add(sstable* sst);
     // Transition the sstable to the "inactive" state. It has no

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -681,16 +681,12 @@ std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const
     }, s_opts.value);
 }
 
-static sstring format_table_directory_name(sstring name, table_id id) {
-    auto uuid_sstring = id.to_sstring();
-    boost::erase_all(uuid_sstring, "-");
-    return format("{}-{}", name, uuid_sstring);
-}
-
 future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage(const sstables_manager& mgr, const schema& s, const data_dictionary::storage_options::local& so) {
     std::vector<sstring> dirs;
     for (const auto& dd : mgr.config().data_file_directories()) {
-        auto dir = format("{}/{}/{}", dd, s.ks_name(), format_table_directory_name(s.cf_name(), s.id()));
+        auto uuid_sstring = s.id().to_sstring();
+        boost::erase_all(uuid_sstring, "-");
+        auto dir = format("{}/{}/{}-{}", dd, s.ks_name(), s.cf_name(), uuid_sstring);
         dirs.emplace_back(std::move(dir));
     }
     co_await coroutine::parallel_for_each(dirs, [] (sstring dir) -> future<> {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -700,6 +700,16 @@ future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage
     co_return make_lw_shared<const data_dictionary::storage_options>(std::move(nopts));
 }
 
+std::vector<std::filesystem::path> get_local_directories(const db::config& db, const data_dictionary::storage_options::local& so) {
+    // see how this path is formatted by init_table_storage() above
+    auto table_dir = so.dir.parent_path().filename() / so.dir.filename();
+    return db.data_file_directories()
+            | std::views::transform([&table_dir] (const auto& datadir) {
+                return std::filesystem::path(datadir) / table_dir;
+            })
+            | std::ranges::to<std::vector<std::filesystem::path>>();
+}
+
 future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage(const sstables_manager& mgr, const schema& s, const data_dictionary::storage_options::s3& so) {
     data_dictionary::storage_options nopts;
     nopts.value = data_dictionary::storage_options::s3 {

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -120,4 +120,6 @@ future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage
 future<> destroy_table_storage(const data_dictionary::storage_options& so);
 future<> init_keyspace_storage(const sstables_manager&, const data_dictionary::storage_options& so, sstring ks_name);
 
+std::vector<std::filesystem::path> get_local_directories(const db::config& db, const data_dictionary::storage_options::local& so);
+
 } // namespace sstables


### PR DESCRIPTION
The all_datadirs keeps paths to directories where local sstables can be. In fact, Scylla doesn't put sstables there, but can try to find them on boot and when checking snapshots. The 0th element of this vector, called datadir, had recently been removed by #20675, now it's time to drop all_datadirs as well. The needed paths can be obtained from table's storage options (see #20542) and db::config::data_file_directories option.
