### PR TITLE
utils/small_vector: refactor expansion condition in reserve*()

### DIFF
--- a/utils/small_vector.hh
+++ b/utils/small_vector.hh
@@ -105,7 +105,7 @@ private:
     }
 
     void reserve_at_least(size_t n) {
-        if (__builtin_expect(_begin + n > _capacity_end, false)) {
+        if (__builtin_expect(n > capacity(), false)) {
             expand(std::max(n, capacity() * 2));
         }
     }
@@ -245,7 +245,7 @@ public:
     }
 
     void reserve(size_t n) {
-        if (__builtin_expect(_begin + n > _capacity_end, false)) {
+        if (__builtin_expect(n > capacity(), false)) {
             expand(n);
         }
     }


### PR DESCRIPTION
~~~
utils/small_vector: refactor expansion condition in reserve*()

Rewrite

  _begin + n > _capacity_end

as

  n > _capacity_end - _begin

and then as

  n > capacity()

for two reasons:

- The last form is easier to read than the first form.

- Per N4950 (the final C++23 working draft), [expr.add] paragraph 4, the
  expression

    _begin + n                            (i.e., P + J)

  is defined only if

    0 ≤ 0 + n ≤ _capacity_end - _begin    (i.e., 0 ≤ i + j ≤ n)

  equivalently, only if

    _begin ≤ _begin + n ≤ _capacity_end

  Therefore, the expression

    _begin + n

  invokes undefined behavior exactly when we'd expect our check

    _begin + n > _capacity_end

  to evaluate to true.

gcc and clang have been aggressively equating undefined behavior to "never
happens"; let's prevent that here.
~~~

No backports needed.
