### PR TITLE
RBAC: confirm that unprivileged users can't read the roles table

### DIFF
--- a/test/alternator/test_cql_rbac.py
+++ b/test/alternator/test_cql_rbac.py
@@ -955,3 +955,25 @@ def test_rbac_streams_autorevoke(dynamodb, cql):
                         shard_id = desc['StreamDescription']['Shards'][0]['ShardId']
                         iter = ds1.get_shard_iterator(StreamArn=arn, ShardId=shard_id, ShardIteratorType='LATEST')['ShardIterator']
                         unauthorized(lambda: ds1.get_records(ShardIterator=iter))
+
+# Test that the ability to read from *any* system table through Alternator
+# requires permissions for this specific table. This is different from the
+# logic in CQL where a table like system_schema.tables is readable to any
+# user (see test/cql-pytest/test_permissions.py::test_select_system_table).
+# Allowing unprivileged users to read from arbitrary system tables could
+# have opened many risks, the most serious of which being the ability to
+# read system.roles which contains the secret key of other, possibly more
+# privileged, users.
+def test_rbac_system_table(dynamodb, cql):
+    with new_role(cql) as (role, key):
+        with new_dynamodb(dynamodb, role, key) as d:
+            client = d.meta.client
+            internal_prefix = '.scylla.alternator.'
+            tbl1 = 'system_schema.tables'
+            # Without SELECT permissions, reading from the system table will
+            # fail:
+            unauthorized(lambda: client.scan(TableName=internal_prefix+tbl1))
+            # Adding SELECT permissions on this specific system table, the
+            # read will succeed:
+            with temporary_grant(cql, 'SELECT', tbl1, role):
+                authorized(lambda: client.scan(TableName=internal_prefix+tbl1))


### PR DESCRIPTION
A worry was raised that an unprivileged user might be able to read the system.roles table - which contains the Alternator secret keys (and also CQL's hashed passwords). This patch adds tests that show that this worry is unjustified - and acts as a regression test to ensure it never becomes justified. The tests show that an unprivileged user cannot read the system.roles table using either CQL or Alternator APIs.

More specifically, the two tests in this patch demonstrate that:

* The Alternator API does not allow an unprivileged user to read ANY system table, unless explicitly granted permissions for that table.

* The CQL API whitelists (see service::client_state::has_access) specific system tables - e.g., system_schema.tables - that are made readable to any unprivileged user. But the system.auth table is NOT whitelisted in this way - and is unreadable to unprivileged users unless explicitly granted permissions on that table.

The new tests passes on both Scylla and Casssandra.

Refs #5206 (that issue is about removing the Alternator secret keys from the roles table - but stealing CQL salted hashes is still pretty bad, so it's good to know that unprivileged users can't read them).

Test only, not need for backports.