### PR TITLE
build: disable Seastar exception hack

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1662,6 +1662,9 @@ user_ldflags = forced_ldflags + ' ' + args.user_ldflags
 curdir = os.getcwd()
 user_cflags = args.user_cflags + f" -ffile-prefix-map={curdir}=."
 
+# Since gcc 13, libgcc doesn't need the exception workaround
+user_cflags += ' -DSEASTAR_NO_EXCEPTION_HACK'
+
 if args.target != '':
     user_cflags += ' -march=' + args.target
 


### PR DESCRIPTION
In [1], Seastar started to bypass a lock in libgcc's exception throwing mechanism to allow scalability on large machines. The problem is documented in [2] and reported as fixed.

In [3], testing results on a 2s96c192t machine are reported. The problem appears indeed fixed with gcc 14's runtime (which we use, even though we build with clang).

Given the new results, we can safely drop the exception scalability hack. As [1] states that the hack causes the loss of a translation cache, we may gain some performance this way.

With that, we disable the cache by defining some random macros.

[1] https://github.com/scylladb/seastar/commit/464f5e3ae43b366b05573018fc46321863bf2fae
[2] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71744
[3] https://github.com/scylladb/seastar/issues/2479#issuecomment-2427098413

No backport: not a regression.