### PR TITLE
docs: add documentation for scylla_identifier

### DIFF
--- a/docs/dev/sstable-scylla-format.md
+++ b/docs/dev/sstable-scylla-format.md
@@ -59,6 +59,15 @@ Scylla executable that created the sstable.
 `ext_timestamp_stats` (tag 9): a `map<ext_timestamp_stats_type, int64_t>` with statistics
 about timestamps in the sstable, like: `min_live_timestamp`, and `min_live_row_marker_timestamp`.
 
+`sstable_identifier` (tag 10): a uuid identifying the sstable for its whole lifetime.
+It is derived from the sstable uuid generation, upon creation (or uniquely generated
+if the sstable has numerical generation).  Yet, unlike the sstable that may
+change if the sstable is migrated to a different shard or node, the sstable
+identifier is stable and copied with the rest of the scylla metadata.
+
+The [scylla sstable dump-scylla-metadata](https://github.com/scylladb/scylladb/blob/master/docs/operating-scylla/admin-tools/scylla-sstable.rst#dump-scylla-metadata) tool
+can be used to dump the scylla metadata in JSON format.
+
 ## sharding_metadata subcomponent
 
     sharding_metadata = token_range_count token_range*

--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -500,6 +500,7 @@ The content is dumped in JSON, using the following schema:
         "scylla_build_id": String
         "scylla_version": String
         "ext_timestamp_stats": {"$key": int64, ...}
+        "sstable_identifier": String, // UUID
     }
 
     $SHARDING_METADATA := {


### PR DESCRIPTION
Commit 3a12ad96c7bd433a4f1b822397bd033d6e0b4a4f
added an sstable_identifier uuid to the SSTable
scylla_metadata component, however it was
under-documented and this patch adds the missing
documentation for the sstable component format,
and to the scylla sstable tool documentation.

* sstable_identifier is confined to master so no backport is needed