### PR TITLE
test.py: Add pytest-xdist to the toolchain

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -141,6 +141,7 @@ declare -A pip_packages=(
     [scylla-api-client]=
     [treelib]=
     [allure-pytest]=
+    [pytest-xdist]=
 )
 
 pip_symlinks=(

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-40-20240925
+docker.io/scylladb/scylla-toolchain:fedora-40-20241022


### PR DESCRIPTION
Add new dependency pytest-xdist to the toolchain. This will allow executing boost and unit tests from pytest in parallel, reducing the time needed for the run.

