### PR TITLE
mutation_writer/feed_writer: remove redundant check

### DIFF
--- a/mutation_writer/feed_writers.hh
+++ b/mutation_writer/feed_writers.hh
@@ -40,7 +40,7 @@ future<> feed_writer(mutation_reader&& rd_ref, Writer wr) {
     auto rd = std::move(rd_ref);
     std::exception_ptr ex;
     try {
-        while (!rd.is_end_of_stream() || !rd.is_buffer_empty()) {
+        while (!rd.is_end_of_stream()) {
             co_await rd.fill_buffer();
             while (!rd.is_buffer_empty()) {
                 co_await rd.pop_mutation_fragment().consume(wr);


### PR DESCRIPTION
`mutation_reader::is_end_of_stream()` returns
`_impl->is_end_of_stream() && is_buffer_empty()`, so `!is_end_of_stream()` equals to 
`!_impl->is_end_of_stream() || !is_buffer_empty()`, which in turn always equals to
`!_impl->is_end_of_stream() || !is_buffer_empty() || !is_buffer_empty()`. hence there is no need to check `rd.is_buffer_empty()` again.

in this change, the redundant condition is dropped. simpler this way.

---

it's a cleanup, hence no need to backport.