### PR TITLE
Add ScyllaDB Manager Agent REST API port to networking administration page

### DIFF
--- a/docs/operating-scylla/_common/networking-ports.rst
+++ b/docs/operating-scylla/_common/networking-ports.rst
@@ -14,7 +14,9 @@ Port    Description                                   Protocol
 ------  --------------------------------------------  --------
 7001    SSL inter-node communication (RPC)            TCP
 ------  --------------------------------------------  --------
-10000   ScyllaDB REST API                               TCP
+10000   ScyllaDB REST API                             TCP
+------  --------------------------------------------  --------
+10001   ScyllaDB Manager Agent REST API               TCP
 ------  --------------------------------------------  --------
 9180    Prometheus API                                TCP
 ------  --------------------------------------------  --------
@@ -25,4 +27,4 @@ Port    Description                                   Protocol
 19142   Native shard-aware transport port  (ssl)         TCP
 ======  ============================================  ========
 
-.. note:: For ScyllaDB Manager ports, see the `ScyllaDB Manager <https://manager.docs.scylladb.com/>`_ documentation.
+.. note:: For more details about ScyllaDB Manager ports, see the `ScyllaDB Manager <https://manager.docs.scylladb.com/>`_ documentation.


### PR DESCRIPTION
In addition to linking to the ScyllaDB Manager documentation, we could also list the ScyllaDB Manager Agent REST API port in the table here. What do you think?