### PR TITLE
build: cmake: disable Seastar exception hack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,9 @@ else()
     set(Seastar_SCHEDULING_GROUPS_COUNT 16 CACHE STRING "" FORCE)
     set(Seastar_UNUSED_RESULT_ERROR ON CACHE BOOL "" FORCE)
     add_subdirectory(seastar)
+    target_compile_definitions (seastar
+      PRIVATE
+        SEASTAR_NO_EXCEPTION_HACK)
 endif()
 
 set(ABSL_PROPAGATE_CXX_STD ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
in cc3953e5, we disabled Seastar exception hack in configure.py. this change disabled the Seastar exception hack in the following two builds:

- build generated directly by configure.py
- build configured with multi-config generator using CMake

but we also have non-multi-config build using CMake. to be more consistent, let's apply the equivalent change to non-multi-config build of CMake.

---

it's a cmake-related change, hence no need to backport.