### PR TITLE
doc: remove the Cassandra references from notedool

### DIFF
--- a/docs/operating-scylla/nodetool.rst
+++ b/docs/operating-scylla/nodetool.rst
@@ -61,7 +61,7 @@ Nodetool
    nodetool-commands/viewbuildstatus
    nodetool-commands/version
 
-The ``nodetool`` utility provides a simple command-line interface to the following exposed operations and attributes. ScyllaDB’s nodetool is a fork of `the Apache Cassandra nodetool <https://cassandra.apache.org/doc/latest/tools/nodetool/nodetool.html>`_ with the same syntax and a subset of the operations.
+The ``nodetool`` utility provides a simple command-line interface to the following exposed operations and attributes.
 
 .. _nodetool-generic-options:
 
@@ -133,4 +133,4 @@ Operations that are not listed below are currently not available.
 * :doc:`viewbuildstatus </operating-scylla/nodetool-commands/viewbuildstatus/>` - Shows the progress of a materialized view build.
 * :doc:`version </operating-scylla/nodetool-commands/version>` - Print the DB version.
 
-.. include:: /rst_include/apache-copyrights.rst
+


### PR DESCRIPTION
This PR removes the reference to Cassandra from the nodetool index, as the native nodetool is no longer a fork.

In addition, it removes the Apache copyright.

Fixes https://github.com/scylladb/scylladb/issues/21238

This PR needs to be backported to branch-6.2 affects ScyllaDB 6.2.