### PR TITLE
build: populate --enable-dist --disable-dist to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,10 @@ include(check_headers)
 check_headers(check-headers scylla-main
   GLOB ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)
 
+option(Scylla_DIST
+  "Build dist targets"
+  ON)
+
 add_custom_target(compiler-training)
 
 add_subdirectory(api)
@@ -329,4 +333,6 @@ add_custom_target(maybe-scylla
 add_dependencies(compiler-training
   maybe-scylla)
 
-add_subdirectory(dist)
+if(Scylla_DIST)
+  add_subdirectory(dist)
+endif()

--- a/configure.py
+++ b/configure.py
@@ -2517,6 +2517,7 @@ def configure_using_cmake(args):
         'CMAKE_EXE_LINKER_FLAGS': semicolon_separated(args.user_ldflags),
         'CMAKE_EXPORT_COMPILE_COMMANDS': 'ON',
         'Scylla_CHECK_HEADERS': 'ON',
+        'Scylla_DIST': 'ON' if args.enable_dist in (None, True) else 'OFF',
         'Scylla_TEST_TIMEOUT': args.test_timeout,
         'Scylla_TEST_REPEAT': args.test_repeat,
     }

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -50,4 +50,6 @@ build_submodule(python3 python3
 check_headers(check-headers tools
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)
 
-add_subdirectory(testing/dist-check)
+if(Scylla_DIST)
+  add_subdirectory(testing/dist-check)
+endif()


### PR DESCRIPTION
before this change, the "dist" targets are always enabled in the CMake-based building system. but the build rules generated by `configure.py` does respect `--enable-dist` and `--disable-dist` command line options, and enable/distable the dist targets respectively.

in this change, we

- add a CMake option named "Scylla_DIST". the "dist" subdirectory in CMake only if this option is ON.
- pouplate the `--enable-dist` and `--disable-dist` option down to cmake by setting the `Scylla_DIST` option, when creating the build system using CMake.

this enables the CMake-based build system to be functionality wise more closer to the legacy building system.

Refs scylladb/scylladb#2717

---

this is a cmake-related change, hence no need to backport.