### PR TITLE
backup_task: track the first failure uploading sstables

### DIFF
--- a/db/snapshot/backup_task.cc
+++ b/db/snapshot/backup_task.cc
@@ -48,49 +48,69 @@ tasks::is_abortable backup_task_impl::is_abortable() const noexcept {
     return tasks::is_abortable::yes;
 }
 
-void backup_task_impl::do_backup() {
-    if (!file_exists(_snapshot_dir.native()).get()) {
+future<> backup_task_impl::do_backup() {
+    if (!co_await file_exists(_snapshot_dir.native())) {
         throw std::invalid_argument(fmt::format("snapshot does not exist at {}", _snapshot_dir.native()));
     }
 
+    std::exception_ptr ex;
     gate uploads;
-    auto wait = defer([&uploads] { uploads.close().get(); });
-
     auto snapshot_dir_lister = directory_lister(_snapshot_dir, lister::dir_entry_types::of<directory_entry_type::regular>());
-    auto close_snapshot_dir_lister = deferred_close(snapshot_dir_lister);
 
-    while (auto component_ent = snapshot_dir_lister.get().get()) {
+    for (;;) {
+        std::optional<directory_entry> component_ent;
+        try {
+            component_ent = co_await snapshot_dir_lister.get();
+        } catch (...) {
+            if (!ex) {
+                ex = std::current_exception();
+                break;
+            }
+        }
+        if (!component_ent.has_value()) {
+            break;
+        }
         auto gh = uploads.hold();
         auto component_name = _snapshot_dir / component_ent->name;
         auto destination = fmt::format("/{}/{}/{}", _bucket, _prefix, component_ent->name);
         snap_log.trace("Upload {} to {}", component_name.native(), destination);
         // Start uploading in the background. The caller waits for these fibers
-        // with the _uploads gate.
+        // with the uploads gate.
         // Parallelism is implicitly controlled in two ways:
         //  - s3::client::claim_memory semaphore
         //  - http::client::max_connections limitation
         // FIXME -- s3::client is not abortable yet, but when it will be, need to
         // propagate impl::_as abort requests into upload_file's fibers
-        std::ignore = _client->upload_file(component_name, destination).handle_exception([comp = component_name] (auto ex) {
-            snap_log.error("Error uploading {}: {}", comp.native(), ex);
-            std::rethrow_exception(ex);
+        std::ignore = _client->upload_file(component_name, destination).handle_exception([comp = component_name, &ex] (std::exception_ptr e) {
+            snap_log.error("Error uploading {}: {}", comp.native(), e);
+            // keep the first exception
+            if (!ex) {
+                ex = std::move(e);
+            }
         }).finally([gh = std::move(gh)] {});
-        thread::maybe_yield();
-        utils::get_local_injector().inject("backup_task_pause", [] (auto& handler) {
+        co_await coroutine::maybe_yield();
+        co_await utils::get_local_injector().inject("backup_task_pause", [] (auto& handler) {
             snap_log.info("backup task: waiting");
             return handler.wait_for_message(db::timeout_clock::now() + std::chrono::minutes(2));
-        }).get();
-        impl::_as.check();
+        });
+        if (impl::_as.abort_requested()) {
+            ex = impl::_as.abort_requested_exception_ptr();
+            break;
+        }
+    }
+
+    co_await snapshot_dir_lister.close();
+    co_await uploads.close();
+    if (ex) {
+        co_await coroutine::return_exception_ptr(std::move(ex));
     }
 }
 
 future<> backup_task_impl::run() {
     co_await _snap_ctl.run_snapshot_list_operation([this] {
-        return async([this] {
-            do_backup();
-            snap_log.info("Finished backup");
-        });
+        return do_backup();
     });
+    snap_log.info("Finished backup");
 }
 
 } // db::snapshot namespace

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -25,7 +25,7 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     sstring _bucket;
     sstring _prefix;
     std::filesystem::path _snapshot_dir;
-    void do_backup();
+    future<> do_backup();
 
 protected:
     virtual future<> run() override;


### PR DESCRIPTION
before this change, we only record the exception returned
by `upload_file()`, and rethrow the exception. but the exception
thrown by `update_file()` not populated to its caller. instead, the
exceptional future is ignored on pupose -- we need to perform
the uploads in parallel.  this is why the task is not marked fail
even if some of the uploads performed by it fail.

in this change, we

- coroutinize `backup_task_impl::do_backup()`. strictly speaking,
  this is not necessary to populate the exception. but, in order
  to ensure that the possible exception is captured before the
  gate is closed, and to reduce the intentation, the teardown
  steps are performed explicitly.
- in addition to noting down the exception in the logging message,
  we also store it in a local variable, which it rethrown
  before this function returns.

Fixes scylladb/scylladb#21248
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

"backup" API is a part of experimental feature, hence no need to backport.