### PR TITLE
Squash some sstables::test helpers

### DIFF
--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -167,8 +167,7 @@ static future<sstable_ptr> do_write_sst(test_env& env, schema_ptr schema, sstrin
     auto sst = co_await env.reusable_sst(std::move(schema), load_dir, generation);
     sstable_generation_generator gen(generation.as_int());
     sstables::test(sst).change_generation_number(gen());
-    co_await sstables::test(sst).change_dir(write_dir);
-    co_await sstables::test(sst).store();
+    co_await sstables::test(sst).store(write_dir);
     co_return sst;
 }
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -166,8 +166,7 @@ SEASTAR_TEST_CASE(missing_summary_first_last_sane) {
 static future<sstable_ptr> do_write_sst(test_env& env, schema_ptr schema, sstring load_dir, sstring write_dir, sstables::generation_type generation) {
     auto sst = co_await env.reusable_sst(std::move(schema), load_dir, generation);
     sstable_generation_generator gen(generation.as_int());
-    sstables::test(sst).change_generation_number(gen());
-    co_await sstables::test(sst).store(write_dir);
+    co_await sstables::test(sst).store(write_dir, gen());
     co_return sst;
 }
 

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -122,7 +122,7 @@ public:
     future<> store() {
         _sst->_recognized_components.erase(component_type::Index);
         _sst->_recognized_components.erase(component_type::Data);
-        return seastar::async([sst = _sst] {
+        co_await seastar::async([sst = _sst] {
             sst->open_sstable("test");
             sst->write_statistics();
             sst->write_compression();

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -99,10 +99,6 @@ public:
         return _sst->_recognized_components;
     }
 
-    void change_generation_number(sstables::generation_type generation) {
-        _sst->_generation = generation;
-    }
-
     void set_data_file_size(uint64_t size) {
         _sst->_data_file_size = size;
     }
@@ -115,7 +111,8 @@ public:
         _sst->_run_identifier = identifier;
     }
 
-    future<> store(sstring dir) {
+    future<> store(sstring dir, sstables::generation_type generation) {
+        _sst->_generation = generation;
         co_await _sst->_storage->change_dir_for_test(dir);
         _sst->_recognized_components.erase(component_type::Index);
         _sst->_recognized_components.erase(component_type::Data);

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -103,10 +103,6 @@ public:
         _sst->_generation = generation;
     }
 
-    future<> change_dir(sstring dir) {
-        return _sst->_storage->change_dir_for_test(dir);
-    }
-
     void set_data_file_size(uint64_t size) {
         _sst->_data_file_size = size;
     }
@@ -119,7 +115,8 @@ public:
         _sst->_run_identifier = identifier;
     }
 
-    future<> store() {
+    future<> store(sstring dir) {
+        co_await _sst->_storage->change_dir_for_test(dir);
         _sst->_recognized_components.erase(component_type::Index);
         _sst->_recognized_components.erase(component_type::Data);
         co_await seastar::async([sst = _sst] {


### PR DESCRIPTION
There's a `missing_summary_first_last_sane` test case that uses some very specific way of modifying an sstable -- it loads one from resources, then tries to "write" the loaded stuff elsewhere. For that it uses a special purpose test::store() helper and a bunch of auxiliary ones from the same class. Those aux helpers are not used anywhere else and are also very special for this test case, so it make sense to keep this whole functionality in a single helper.