### PR TITLE
treewide: s/boost::adaptors::map_values/std::views::values/

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -439,7 +439,7 @@ struct compaction_read_monitor_generator final : public read_monitor_generator {
         : _table_s(table_s), _use_backlog_tracker(use_backlog_tracker) {}
 
     uint64_t compacted() const {
-        return boost::accumulate(_generated_monitors | boost::adaptors::map_values | boost::adaptors::transformed([](auto& monitor) { return monitor.compacted(); }), uint64_t(0));
+        return std::ranges::fold_left(_generated_monitors | std::views::values | std::views::transform([](auto& monitor) { return monitor.compacted(); }), uint64_t(0), std::plus());
     }
 
     void remove_exhausted_sstables(const std::vector<sstables::shared_sstable>& exhausted_sstables) {

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1141,7 +1141,7 @@ future<> compaction_manager::really_do_stop() {
     // Reset the metrics registry
     _metrics.clear();
     co_await stop_ongoing_compactions("shutdown");
-    co_await coroutine::parallel_for_each(_compaction_state | boost::adaptors::map_values, [] (compaction_state& cs) -> future<> {
+    co_await coroutine::parallel_for_each(_compaction_state | std::views::values, [] (compaction_state& cs) -> future<> {
         if (!cs.gate.is_closed()) {
             co_await cs.gate.close();
         }

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -161,7 +161,7 @@ void functions::remove_function(const function_name& name, const std::vector<dat
 }
 
 std::optional<function_name> functions::used_by_user_aggregate(shared_ptr<user_function> func) const {
-    for (const shared_ptr<function>& fptr : _declared | boost::adaptors::map_values) {
+    for (const shared_ptr<function>& fptr : _declared | std::views::values) {
         auto aggregate = dynamic_pointer_cast<user_aggregate>(fptr);
         if (aggregate && (same_signature(aggregate->sfunc(), func)
             || (same_signature(aggregate->finalfunc(), func))
@@ -174,7 +174,7 @@ std::optional<function_name> functions::used_by_user_aggregate(shared_ptr<user_f
 }
 
 std::optional<function_name> functions::used_by_user_function(const ut_name& user_type) const {
-    for (const shared_ptr<function>& fptr : _declared | boost::adaptors::map_values) {
+    for (const shared_ptr<function>& fptr : _declared | std::views::values) {
         for (auto& arg_type : fptr->arg_types()) {
             if (arg_type->references_user_type(user_type.get_keyspace(), user_type.get_user_type_name())) {
                 return fptr->name();

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -956,7 +956,7 @@ static std::vector<expr::expression> extract_partition_range(
         return {std::move(*v.tokens)};
     }
     if (v.single_column.size() == schema->partition_key_size()) {
-        return boost::copy_range<std::vector<expression>>(v.single_column | boost::adaptors::map_values);
+        return v.single_column | std::views::values | std::ranges::to<std::vector>();
     }
     return {};
 }
@@ -2834,7 +2834,7 @@ unsigned int statement_restrictions::num_clustering_prefix_columns_that_need_not
     // 3. a SLICE restriction isn't on a last place
     column_id position = 0;
     unsigned int count = 0;
-    for (const auto& restriction : column_restrictions | boost::adaptors::map_values) {
+    for (const auto& restriction : column_restrictions | std::views::values) {
         if (find_needs_filtering(restriction)
             || position != get_the_only_column(restriction).col->id) {
             return count;

--- a/cql3/statements/alter_type_statement.cc
+++ b/cql3/statements/alter_type_statement.cc
@@ -57,7 +57,7 @@ future<std::vector<mutation>> alter_type_statement::prepare_announcement_mutatio
         throw exceptions::invalid_request_exception(format("No user type named {} exists.", _name.to_cql_string()));
     }
 
-    for (auto&& schema : ks.metadata()->cf_meta_data() | boost::adaptors::map_values) {
+    for (auto&& schema : ks.metadata()->cf_meta_data() | std::views::values) {
         for (auto&& column : schema->partition_key_columns()) {
             if (column.type->references_user_type(_name.get_keyspace(), _name.get_user_type_name())) {
                 throw exceptions::invalid_request_exception(format("Cannot add new field to type {} because it is used in the partition key column {} of table {}.{}",
@@ -72,7 +72,7 @@ future<std::vector<mutation>> alter_type_statement::prepare_announcement_mutatio
     auto res = co_await service::prepare_update_type_announcement(sp, updated, ts);
     std::move(res.begin(), res.end(), std::back_inserter(m));
 
-    for (auto&& schema : ks.metadata()->cf_meta_data() | boost::adaptors::map_values) {
+    for (auto&& schema : ks.metadata()->cf_meta_data() | std::views::values) {
         auto cfm = schema_builder(schema);
         bool modified = false;
         for (auto&& column : schema->all_columns()) {
@@ -137,7 +137,7 @@ user_type alter_type_statement::add_or_alter::do_add(data_dictionary::database d
 
     if (_field_type->is_duration()) {
         auto&& ks = db.find_keyspace(keyspace());
-        for (auto&& schema : ks.metadata()->cf_meta_data() | boost::adaptors::map_values) {
+        for (auto&& schema : ks.metadata()->cf_meta_data() | std::views::values) {
             for (auto&& column : schema->clustering_key_columns()) {
                 if (column.type->references_user_type(_name.get_keyspace(), _name.get_user_type_name())) {
                     throw exceptions::invalid_request_exception(format("Cannot add new field to type {} because it is used in the clustering key column {} of table {}.{} where durations are not allowed",

--- a/cql3/statements/drop_type_statement.cc
+++ b/cql3/statements/drop_type_statement.cc
@@ -90,7 +90,7 @@ bool drop_type_statement::validate_while_executing(query_processor& qp) const {
         auto&& keyspace = type->_keyspace;
         auto&& name = type->_name;
 
-        for (auto&& ut : all_types | boost::adaptors::map_values) {
+        for (auto&& ut : all_types | std::views::values) {
             if (ut->_keyspace == keyspace && ut->_name == name) {
                 continue;
             }
@@ -100,7 +100,7 @@ bool drop_type_statement::validate_while_executing(query_processor& qp) const {
             }
         }
 
-        for (auto&& cfm : ks.metadata()->cf_meta_data() | boost::adaptors::map_values) {
+        for (auto&& cfm : ks.metadata()->cf_meta_data() | std::views::values) {
             for (auto&& col : cfm->all_columns()) {
                 if (col.type->references_user_type(keyspace, name)) {
                     throw exceptions::invalid_request_exception(format("Cannot drop user type {}.{} as it is still used by table {}.{}", keyspace, type->get_name_as_string(), cfm->ks_name(), cfm->cf_name()));

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -2146,7 +2146,7 @@ void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
         return;
     }
     // defensive copy.
-    auto callbacks = boost::copy_range<std::vector<flush_handler>>(_flush_handlers | boost::adaptors::map_values);
+    auto callbacks = _flush_handlers | std::views::values | std::ranges::to<std::vector>();
     auto& active = _segments.back();
 
     // RP at "start" of segment we leave untouched.
@@ -2269,7 +2269,7 @@ void db::commitlog::segment_manager::check_no_data_older_than_allowed() {
     }
 
     if (!ids.empty()) {
-        auto callbacks = boost::copy_range<std::vector<flush_handler>>(_flush_handlers | boost::adaptors::map_values);
+        auto callbacks = _flush_handlers | std::views::values | std::ranges::to<std::vector>();
         // For each CF id: for each callback c: call c(id, high)
         for (auto& f : callbacks) {
             for (auto& id : ids) {

--- a/db/extensions.cc
+++ b/db/extensions.cc
@@ -22,19 +22,19 @@ db::extensions::~extensions()
 std::vector<sstables::file_io_extension*>
 db::extensions::sstable_file_io_extensions() const {
     using etype = sstables::file_io_extension;
-    return boost::copy_range<std::vector<etype*>>(
-            _sstable_file_io_extensions
-            | boost::adaptors::map_values
-            | boost::adaptors::transformed(std::mem_fn(&std::unique_ptr<etype>::get)));
+    return _sstable_file_io_extensions
+            | std::views::values
+            | std::views::transform(std::mem_fn(&std::unique_ptr<etype>::get))
+            | std::ranges::to<std::vector>();
 }
 
 std::vector<db::commitlog_file_extension*>
 db::extensions::commitlog_file_extensions() const {
     using etype = db::commitlog_file_extension;
-    return boost::copy_range<std::vector<etype*>>(
-            _commitlog_file_extensions
-            | boost::adaptors::map_values
-            | boost::adaptors::transformed(std::mem_fn(&std::unique_ptr<etype>::get)));
+    return _commitlog_file_extensions
+            | std::views::values
+            | std::views::transform(std::mem_fn(&std::unique_ptr<etype>::get))
+            | std::ranges::to<std::vector>();
 }
 
 std::set<sstring>

--- a/db/hints/internal/hint_storage.cc
+++ b/db/hints/internal/hint_storage.cc
@@ -177,10 +177,10 @@ future<> rebalance_segments(const fs::path& hint_directory, hints_segments_map& 
     std::unordered_map<sstring, size_t> per_ep_hints;
 
     for (const auto& [ep, ep_hint_segments] : segments_map) {
-        per_ep_hints[ep] = boost::accumulate(ep_hint_segments
-                | boost::adaptors::map_values
-                | boost::adaptors::transformed(std::mem_fn(&segment_list::size)),
-                size_t(0));
+        per_ep_hints[ep] = std::ranges::fold_left(ep_hint_segments
+                | std::views::values
+                | std::views::transform(std::mem_fn(&segment_list::size)),
+                size_t(0), std::plus());
         manager_logger.trace("{}: total files: {}", ep, per_ep_hints[ep]);
     }
 

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -223,7 +223,7 @@ future<> manager::stop() {
     return _migrating_done.finally([this] {
         return _draining_eps_gate.close();
     }).finally([this] {
-        return parallel_for_each(_ep_managers | boost::adaptors::map_values, [] (hint_endpoint_manager& ep_man) {
+        return parallel_for_each(_ep_managers | std::views::values, [] (hint_endpoint_manager& ep_man) {
             return ep_man.stop();
         }).finally([this] {
             _ep_managers.clear();
@@ -690,7 +690,7 @@ future<> manager::drain_for(endpoint_id host_id, gms::inet_address ip) noexcept 
         set_draining_all();
 
         try {
-            co_await coroutine::parallel_for_each(_ep_managers | boost::adaptors::map_values,
+            co_await coroutine::parallel_for_each(_ep_managers | std::views::values,
                     [&drain_ep_manager] (hint_endpoint_manager& ep_man) {
                 return drain_ep_manager(ep_man);
             });

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -133,7 +133,7 @@ void space_watchdog::on_timer() {
     //    |  |- ...
     //
 
-    for (auto& per_device_limits : _per_device_limits_map | boost::adaptors::map_values) {
+    for (auto& per_device_limits : _per_device_limits_map | std::views::values) {
         _total_size = 0;
         for (manager& shard_manager : per_device_limits.managers) {
             shard_manager.clear_eps_with_pending_hints();

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1255,7 +1255,7 @@ std::vector<mutation> make_create_keyspace_mutations(schema_features features, l
         for (const auto& kv : keyspace->user_types().get_all_types()) {
             add_type_to_schema_mutation(kv.second, timestamp, mutations);
         }
-        for (auto&& s : keyspace->cf_meta_data() | boost::adaptors::map_values) {
+        for (auto&& s : keyspace->cf_meta_data() | std::views::values) {
             add_table_or_view_to_schema_mutation(s, timestamp, true, mutations);
         }
     }

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -399,8 +399,8 @@ public:
 
     bool check_if_matches(const clustering_key& key, const query::result_row_view& static_row, const query::result_row_view& row) const {
         std::vector<bytes> ck = key.explode();
-        return boost::algorithm::all_of(
-            _view.select_statement(_db).get_restrictions()->get_non_pk_restriction() | boost::adaptors::map_values,
+        return std::ranges::all_of(
+            _view.select_statement(_db).get_restrictions()->get_non_pk_restriction() | std::views::values,
             [&] (auto&& r) {
                 // FIXME: move outside all_of(). However, crashes.
                 auto static_and_regular_columns = cql3::expr::get_non_pk_values(*_selection, static_row, &row);

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -91,7 +91,7 @@ public:
 
     uint64_t sstables_pending_work() const noexcept {
         return _inactive_pending_work +
-            boost::accumulate(_monitors | boost::adaptors::map_values | boost::adaptors::transformed(std::mem_fn(&read_monitor::pending_work)), uint64_t(0));
+            std::ranges::fold_left(_monitors | std::views::values | std::views::transform(std::mem_fn(&read_monitor::pending_work)), uint64_t(0), std::plus());
     }
 };
 

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -368,7 +368,7 @@ future<> persistent_feature_enabler::enable_features() {
     // The key itself is maintained as an `unordered_set<string>` and serialized via `to_string`
     // function to preserve readability.
     std::set<sstring> feats_set = co_await _sys_ks.load_local_enabled_features();
-    for (feature& f : _feat.registered_features() | boost::adaptors::map_values) {
+    for (feature& f : _feat.registered_features() | std::views::values) {
         if (!f && features.contains(f.name())) {
             feats_set.emplace(f.name());
         }
@@ -384,7 +384,7 @@ future<> persistent_feature_enabler::enable_features() {
 future<> feature_service::enable(std::set<std::string_view> list) {
     // `gms::feature::enable` should be run within a seastar thread context
     return seastar::async([this, list = std::move(list)] {
-        for (gms::feature& f : _registered_features | boost::adaptors::map_values) {
+        for (gms::feature& f : _registered_features | std::views::values) {
             if (list.contains(f.name())) {
                 f.enable();
             }

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -318,14 +318,15 @@ view_ptr secondary_index_manager::create_view_for_index(const index_metadata& im
 }
 
 std::vector<index_metadata> secondary_index_manager::get_dependent_indices(const column_definition& cdef) const {
-    return boost::copy_range<std::vector<index_metadata>>(_indices
-           | boost::adaptors::map_values
-           | boost::adaptors::filtered([&] (auto& index) { return index.depends_on(cdef); })
-           | boost::adaptors::transformed([&] (auto& index) { return index.metadata(); }));
+    return _indices
+           | std::views::values
+           | std::views::filter([&] (auto& index) { return index.depends_on(cdef); })
+           | std::views::transform([&] (auto& index) { return index.metadata(); })
+           | std::ranges::to<std::vector>();
 }
 
 std::vector<index> secondary_index_manager::list_indexes() const {
-    return boost::copy_range<std::vector<index>>(_indices | boost::adaptors::map_values);
+    return _indices | std::views::values | std::ranges::to<std::vector>();
 }
 
 bool secondary_index_manager::is_index(view_ptr view) const {
@@ -333,13 +334,13 @@ bool secondary_index_manager::is_index(view_ptr view) const {
 }
 
 bool secondary_index_manager::is_index(const schema& s) const {
-    return boost::algorithm::any_of(_indices | boost::adaptors::map_values, [&s] (const index& i) {
+    return std::ranges::any_of(_indices | std::views::values, [&s] (const index& i) {
         return s.cf_name() == index_table_name(i.metadata().name());
     });
 }
 
 bool secondary_index_manager::is_global_index(const schema& s) const {
-    return boost::algorithm::any_of(_indices | boost::adaptors::map_values, [&s] (const index& i) {
+    return std::ranges::any_of(_indices | std::views::values, [&s] (const index& i) {
         return !i.metadata().local() && s.cf_name() == index_table_name(i.metadata().name());
     });
 }

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -149,7 +149,7 @@ public:
         : all(std::move(a)) {
     }
     explicit repair_neighbors(const std::unordered_map<locator::host_id, gms::inet_address>& a)
-        : all(boost::copy_range<std::vector<gms::inet_address>>(a | boost::adaptors::map_values)) {
+        : all(a | std::views::values | std::ranges::to<std::vector<gms::inet_address>>()) {
     }
     repair_neighbors(std::vector<gms::inet_address> a, std::vector<gms::inet_address> m)
         : all(std::move(a))

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3364,8 +3364,8 @@ future<>
 repair_service::remove_repair_meta() {
     rlogger.debug("Remove all repair_meta for all nodes");
     auto repair_metas = make_lw_shared<utils::chunked_vector<repair_meta_ptr>>(
-            boost::copy_range<utils::chunked_vector<repair_meta_ptr>>(repair_meta_map()
-            | boost::adaptors::map_values));
+            repair_meta_map()
+            | std::views::values | std::ranges::to<utils::chunked_vector<repair_meta_ptr>>());
     repair_meta_map().clear();
     co_await coroutine::parallel_for_each(*repair_metas, [&] (auto& rm) -> future<> {
         co_await rm->stop();

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -442,7 +442,7 @@ future<> distributed_loader::populate_keyspace(distributed<replica::database>& d
 {
     dblog.info("Populating Keyspace {}", ks_name);
 
-    co_await coroutine::parallel_for_each(ks.metadata()->cf_meta_data() | boost::adaptors::map_values, [&] (schema_ptr s) -> future<> {
+    co_await coroutine::parallel_for_each(ks.metadata()->cf_meta_data() | std::views::values, [&] (schema_ptr s) -> future<> {
         auto uuid = s->id();
         sstring cfname = s->cf_name();
         auto gtable = co_await get_table_on_all_shards(db, ks_name, cfname);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4556,7 +4556,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
             });
         } else if (req.cmd == node_ops_cmd::replace_prepare_mark_alive) {
             // Wait for local node has marked replacing node as alive
-            auto nodes = boost::copy_range<std::vector<inet_address>>(req.replace_nodes| boost::adaptors::map_values);
+            auto nodes = req.replace_nodes| std::views::values | std::ranges::to<std::vector>();
             try {
                 _gossiper.wait_alive(nodes, std::chrono::milliseconds(120 * 1000)).get();
             } catch (...) {
@@ -6156,7 +6156,7 @@ static bool increases_replicas_per_rack(const locator::topology& topology, const
     for (auto& replica: tinfo.replicas) {
         m[topology.get_rack(replica.host)]++;
     }
-    auto max = *boost::max_element(m | boost::adaptors::map_values);
+    auto max = *std::ranges::max_element(m | std::views::values);
     return m[dst_rack] + 1 > max;
 }
 

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -110,15 +110,15 @@ std::set<sstring> calculate_not_yet_enabled_features(const std::set<sstring>& en
 std::set<sstring> topology_features::calculate_not_yet_enabled_features() const {
     return ::service::calculate_not_yet_enabled_features(
             enabled_features,
-            normal_supported_features | boost::adaptors::map_values);
+            normal_supported_features | std::views::values);
 }
 
 std::set<sstring> topology::calculate_not_yet_enabled_features() const {
     return ::service::calculate_not_yet_enabled_features(
             enabled_features,
             normal_nodes
-            | boost::adaptors::map_values
-            | boost::adaptors::transformed([] (const replica_state& rs) -> const std::set<sstring>& {
+            | std::views::values
+            | std::views::transform([] (const replica_state& rs) -> const std::set<sstring>& {
                 return rs.supported_features;
             }));
 }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -409,7 +409,7 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
     // If scylla was supposed to have generated this SSTable, this is not okay and
     // we refuse to proceed. If this coming from, say, an import, then we just delete,
     // log and proceed.
-    for (auto& path : _state->generations_found | boost::adaptors::map_values) {
+    for (auto& path : _state->generations_found | std::views::values) {
         if (flags.throw_on_missing_toc) {
             throw sstables::malformed_sstable_exception(seastar::format("At directory: {}: no TOC found for SSTable {}!. Refusing to boot", _directory.native(), path.native()));
         } else {

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -157,7 +157,7 @@ sstable_set::all_sstable_runs() const {
 
 std::vector<frozen_sstable_run>
 partitioned_sstable_set::all_sstable_runs() const {
-    return boost::copy_range<std::vector<frozen_sstable_run>>(_all_runs | boost::adaptors::map_values);
+    return _all_runs | std::views::values | std::ranges::to<std::vector<frozen_sstable_run>>();
 }
 
 lw_shared_ptr<const sstable_list>
@@ -508,11 +508,11 @@ std::unique_ptr<sstable_set_impl> time_series_sstable_set::clone() const {
 }
 
 std::vector<shared_sstable> time_series_sstable_set::select(const dht::partition_range& range) const {
-    return boost::copy_range<std::vector<shared_sstable>>(*_sstables | boost::adaptors::map_values);
+    return *_sstables | std::views::values | std::ranges::to<std::vector>();
 }
 
 lw_shared_ptr<const sstable_list> time_series_sstable_set::all() const {
-    return make_lw_shared<const sstable_list>(boost::copy_range<const sstable_list>(*_sstables | boost::adaptors::map_values));
+    return make_lw_shared<const sstable_list>(*_sstables | std::views::values | std::ranges::to<sstable_list>());
 }
 
 size_t

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -674,10 +674,11 @@ const task_manager::tasks_collection& task_manager::get_tasks_collection() const
 
 future<std::vector<task_id>> task_manager::get_virtual_task_children(task_id parent_id) {
     return container().map_reduce0([parent_id] (task_manager& tm) {
-        return boost::copy_range<std::vector<task_id>>(tm.get_local_tasks() |
-            boost::adaptors::map_values |
-            boost::adaptors::filtered([parent_id] (const auto& task) { return task->get_parent_id() == parent_id; }) |
-            boost::adaptors::transformed([] (const auto& task) { return task->id(); }));
+        return tm.get_local_tasks() |
+            std::views::values |
+            std::views::filter([parent_id] (const auto& task) { return task->get_parent_id() == parent_id; }) |
+            std::views::transform([] (const auto& task) { return task->id(); }) |
+            std::ranges::to<std::vector>();
     }, std::vector<task_id>{}, concat<task_id>);
 }
 

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -1139,7 +1139,7 @@ SEASTAR_THREAD_TEST_CASE(test_list_logging) {
             }
         }, [&](data_value v) {
             auto map = value_cast<map_type_impl::native_type>(std::move(v));
-            auto cpy = boost::copy_range<std::vector<data_value>>(map | boost::adaptors::map_values);
+            auto cpy = map | std::views::values | std::ranges::to<std::vector>();
             // verify key is timeuuid
             for (auto& key : map | std::views::keys) {
                 value_cast<utils::UUID>(key);

--- a/test/boost/multishard_combining_reader_as_mutation_source_test.cc
+++ b/test/boost/multishard_combining_reader_as_mutation_source_test.cc
@@ -50,7 +50,7 @@ static auto make_populate(bool evict_paused_readers, bool single_fragment_buffer
 
         dummy_sharder sharder(s->get_sharder(), mutations_by_token);
 
-        auto merged_mutations = boost::copy_range<std::vector<std::vector<frozen_mutation>>>(mutations_by_token | boost::adaptors::map_values);
+        auto merged_mutations = mutations_by_token | std::views::values | std::ranges::to<std::vector>();
 
         auto remote_memtables = make_lw_shared<std::vector<foreign_ptr<lw_shared_ptr<replica::memtable>>>>();
         for (unsigned shard = 0; shard < sharder.shard_count(); ++shard) {

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -1901,7 +1901,7 @@ multishard_reader_for_read_ahead prepare_multishard_reader_for_read_ahead_test(s
 
     auto shard_pkeys = std::vector<std::vector<uint32_t>>(smp::count, std::vector<uint32_t>{});
     auto i = unsigned(0);
-    for (auto pkey : pkeys_by_tokens | boost::adaptors::map_values) {
+    for (auto pkey : pkeys_by_tokens | std::views::values) {
         shard_pkeys[i++ % smp::count].push_back(pkey);
     }
 

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -2833,5 +2833,5 @@ std::vector<mutation> squash_mutations(std::vector<mutation> mutations) {
             it->second.apply(mut);
         }
     }
-    return boost::copy_range<std::vector<mutation>>(merged_muts | boost::adaptors::map_values);
+    return merged_muts | std::views::values | std::ranges::to<std::vector>();
 }


### PR DESCRIPTION
now that we are allowed to use C++23. we now have the luxury of using `std::views::values`.

in this change, we:

- replace `boost::adaptors::map_values` with `std::views::values`
- update affected code to work with `std::views::values`
- the places where we use `boost::join()` are not changed, because we cannot use `std::views::concat` yet. this helper is only available in C++26.

to reduce the dependency to boost for better maintainability, and leverage standard library features for better long-term support.

this change is part of our ongoing effort to modernize our codebase and reduce external dependencies where possible.

---

it's a cleanup, hence no need to backport.