### PR TITLE
build: cmake: explicitly mark convenience libraries as STATIC

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -62,7 +62,7 @@ foreach(f ${swagger_files})
   list(APPEND swagger_gen_files "${scylla_swagger_gen_${fname}_files}")
 endforeach()
 
-add_library(api)
+add_library(api STATIC)
 target_sources(api
   PRIVATE
     api.cc

--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -69,7 +69,7 @@ generate_cxxbridge(wasmtime_bindings
 set_target_properties(Rust::rust_combined PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}")
 
-add_library(wasmtime_bindings)
+add_library(wasmtime_bindings STATIC)
 target_sources(wasmtime_bindings
   PRIVATE
     ${cxx_header}
@@ -87,7 +87,7 @@ generate_cxxbridge(inc
   OUTPUT_DIR "${binding_gen_build_dir}"
   SOURCES inc_sources)
 
-add_library(inc)
+add_library(inc STATIC)
 target_sources(inc
   PRIVATE
     ${cxx_header}

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(test-lib)
+add_library(test-lib STATIC)
 target_sources(test-lib
   PRIVATE
     cql_assertions.cc

--- a/test/raft/CMakeLists.txt
+++ b/test/raft/CMakeLists.txt
@@ -6,7 +6,7 @@ target_link_libraries(test-raft-helper
   test-lib
   Seastar::seastar_testing)
 
-add_library(test-raft)
+add_library(test-raft STATIC)
 target_sources(test-raft
   PRIVATE
     replication.cc)


### PR DESCRIPTION
before this change, these
[convenience libraries](https://www.gnu.org/software/automake/manual/html_node/Libtool-Convenience-Libraries.html) were implicitly built as static libraries by default, but weren't explicitly marked as STATIC in CMake. While this worked with default settings, it could cause issues if `BUILD_SHARED_LIBS` is enabled.

So before we are ready for building these components as shared libraries, let's mark all convenience libraries as STATIC for consistency and to prevent potential issues before we properly support shared library builds.

---

it's a cleanup, hence no need to backport.