### PR TITLE
doc: fix redundant references to version 6.2

### DIFF
--- a/docs/getting-started/install-scylla/install-on-linux.rst
+++ b/docs/getting-started/install-scylla/install-on-linux.rst
@@ -156,8 +156,8 @@ Install ScyllaDB
 (Optional) Install scylla-jmx
 -------------------------------
 
-    scylla-jmx becomes optional package from ScyllaDB 6.2, not installed by default.
-    If you need JMX server, see :doc:`Install scylla-jmx Package </getting-started/installation-common/install-jmx>`
+    scylla-jmx is an optional package and is not installed by default.
+    If you need JMX server, see :doc:`Install scylla-jmx Package </getting-started/installation-common/install-jmx>`.
 
 
 

--- a/docs/getting-started/installation-common/install-jmx.rst
+++ b/docs/getting-started/installation-common/install-jmx.rst
@@ -3,8 +3,8 @@
 Install scylla-jmx Package
 ======================================
 
-scylla-jmx becomes optional package from ScyllaDB 6.2, not installed by default.
-If you need JMX server you can still install it from scylla-jmx GitHub page.
+scylla-jmx is an optional package and is not installed by default.
+If you need JMX server, you can still install it from scylla-jmx GitHub page.
 
 .. tabs::
 

--- a/docs/getting-started/installation-common/unified-installer.rst
+++ b/docs/getting-started/installation-common/unified-installer.rst
@@ -50,8 +50,8 @@ Download and Install
 
 #. (Optional) Install scylla-jmx
 
-    scylla-jmx becomes optional package from ScyllaDB 6.2, not installed by default.
-    If you need JMX server, see :doc:`Install scylla-jmx Package </getting-started/installation-common/install-jmx>`
+    scylla-jmx is an optional package and is not installed by default.
+    If you need JMX server, see :doc:`Install scylla-jmx Package </getting-started/installation-common/install-jmx>`.
 
 Configure and Run ScyllaDB
 ----------------------------


### PR DESCRIPTION
This PR removes mentions of version 6.2 that were introduced with https://github.com/scylladb/scylladb/pull/17969.

Now that the documentation is versioned, there should be no reference to specific versions.

Fixes https://github.com/scylladb/scylladb/issues/21276

This PR should be backported to branch-6.2 as it's related to the code update in version 6.2 (it's a follow-up to https://github.com/scylladb/scylladb/pull/17969).