### PR TITLE
Extend compaction_history table with additional compaction statistics

### DIFF
--- a/api/api-doc/compaction_manager.json
+++ b/api/api-doc/compaction_manager.json
@@ -246,6 +246,24 @@
             }
          }
       },
+      "sstableinfo":{
+         "id":"sstableinfo",
+         "description":"Compacted sstable information",
+         "properties":{
+            "generation":{
+               "type": "string",
+               "description":"Generation of the sstable"
+            },
+            "origin":{
+               "type":"string",
+               "description":"Origin of the sstable"
+            },
+            "size":{
+               "type":"long",
+               "description":"Size of the sstable"
+            }
+         }
+      },
       "compaction_info" :{
           "id": "compaction_info",
           "description":"A key value mapping",
@@ -327,6 +345,10 @@
                "type":"string",
                "description":"The UUID"
             },
+            "shard_id":{
+               "type":"int",
+               "description":"The shard id the compaction was executed on"
+            },
             "cf":{
                "type":"string",
                "description":"The column family name"
@@ -335,9 +357,17 @@
                "type":"string",
                "description":"The keyspace name"
             },
+            "compaction_type":{
+               "type":"string",
+               "description":"Type of compaction"
+            },
+            "started_at":{
+               "type":"long",
+               "description":"The time compaction started"
+            },
             "compacted_at":{
                "type":"long",
-               "description":"The time of compaction"
+               "description":"The time compaction completed"
             },
             "bytes_in":{
                "type":"long",
@@ -353,6 +383,32 @@
                   "type":"row_merged"
                },
                "description":"The merged rows"
+            },
+            "sstables_in": {
+               "type":"array",
+               "items":{
+                  "type":"sstableinfo"
+               },
+               "description":"List of input sstables for compaction"
+            },
+            "sstables_out": {
+               "type":"array",
+               "items":{
+                  "type":"sstableinfo"
+               },
+               "description":"List of output sstables from compaction"
+            },
+            "total_tombstone_purge_attempt":{
+               "type":"long",
+               "description":"Total number of tombstone purge attempts"
+            },
+            "total_tombstone_purge_failure_due_to_overlapping_with_memtable":{
+               "type":"long",
+               "description":"Number of tombstone purge failures due to data overlapping with memtables"
+            },
+            "total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable":{
+               "type":"long",
+               "description":"Number of tombstone purge failures due to data overlapping with non-compacting sstables"
             }
         }
       }

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -14,6 +14,7 @@
 #include "api/api.hh"
 #include "api/api-doc/compaction_manager.json.hh"
 #include "api/api-doc/storage_service.json.hh"
+#include "db/compaction_history_entry.hh"
 #include "db/system_keyspace.hh"
 #include "column_family.hh"
 #include "unimplemented.hh"

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -160,8 +160,11 @@ void set_compaction_manager(http_context& ctx, routes& r, sharded<compaction_man
                 co_await cm.local().get_compaction_history([&s, &first](const db::compaction_history_entry& entry) mutable -> future<> {
                         cm::history h;
                         h.id = fmt::to_string(entry.id);
+                        h.shard_id = entry.shard_id;
                         h.ks = std::move(entry.ks);
                         h.cf = std::move(entry.cf);
+                        h.compaction_type = entry.compaction_type;
+                        h.started_at = entry.started_at;
                         h.compacted_at = entry.compacted_at;
                         h.bytes_in = entry.bytes_in;
                         h.bytes_out =  entry.bytes_out;
@@ -173,6 +176,24 @@ void set_compaction_manager(http_context& ctx, routes& r, sharded<compaction_man
                             e.value = it.second;
                             h.rows_merged.push(std::move(e));
                         }
+                        for (const auto& data : entry.sstables_in) {
+                            httpd::compaction_manager_json::sstableinfo sstable;
+                            sstable.generation = fmt::to_string(data.generation),
+                            sstable.origin = data.origin,
+                            sstable.size = data.size,
+                            h.sstables_in.push(std::move(sstable));
+                        }
+                        for (const auto& data : entry.sstables_out) {
+                            httpd::compaction_manager_json::sstableinfo sstable;
+                            sstable.generation = fmt::to_string(data.generation),
+                            sstable.origin = data.origin,
+                            sstable.size = data.size,
+                            h.sstables_out.push(std::move(sstable));
+                        }
+                        h.total_tombstone_purge_attempt = entry.total_tombstone_purge_attempt;
+                        h.total_tombstone_purge_failure_due_to_overlapping_with_memtable = entry.total_tombstone_purge_failure_due_to_overlapping_with_memtable;
+                        h.total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable = entry.total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable;
+
                         if (!first) {
                             co_await s.write(", ");
                         }

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -13,6 +13,7 @@
 #include "sstables/shared_sstable.hh"
 #include "sstables/generation_type.hh"
 #include "compaction/compaction_descriptor.hh"
+#include "mutation/mutation_tombstone_stats.hh"
 #include "gc_clock.hh"
 #include "utils/UUID.hh"
 #include "table_state.hh"
@@ -82,6 +83,7 @@ struct compaction_stats {
     // Bloom filter checks during max purgeable calculation
     uint64_t bloom_filter_checks = 0;
     combined_reader_statistics reader_statistics;
+    tombstone_purge_stats tombstone_purge_stats;
 
     compaction_stats& operator+=(const compaction_stats& r) {
         started_at = std::max(started_at, r.started_at);
@@ -90,6 +92,7 @@ struct compaction_stats {
         end_size += r.end_size;
         validation_errors += r.validation_errors;
         bloom_filter_checks += r.bloom_filter_checks;
+        tombstone_purge_stats += r.tombstone_purge_stats;
         return *this;
     }
     friend compaction_stats operator+(const compaction_stats& l, const compaction_stats& r) {

--- a/compaction/compaction_garbage_collector.hh
+++ b/compaction/compaction_garbage_collector.hh
@@ -22,7 +22,20 @@ using can_gc_fn = std::function<bool(tombstone, is_shadowable)>;
 extern can_gc_fn always_gc;
 extern can_gc_fn never_gc;
 
-using max_purgeable_fn = std::function<api::timestamp_type(const dht::decorated_key&, is_shadowable)>;
+struct max_purgeable {
+    enum class timestamp_source {
+        none,
+        memtable_possibly_shadowing_data,
+        other_sstables_possibly_shadowing_data
+    };
+
+    operator bool() const { return timestamp != api::missing_timestamp; }
+
+    api::timestamp_type timestamp { api::missing_timestamp };
+    timestamp_source source { timestamp_source::none };
+};
+
+using max_purgeable_fn = std::function<max_purgeable(const dht::decorated_key&, is_shadowable)>;
 
 extern max_purgeable_fn can_always_purge;
 extern max_purgeable_fn can_never_purge;

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -26,6 +26,7 @@
 #include "utils/assert.hh"
 #include "utils/error_injection.hh"
 #include "utils/UUID_gen.hh"
+#include "db/compaction_history_entry.hh"
 #include "db/system_keyspace.hh"
 #include "tombstone_gc-internals.hh"
 #include <cmath>

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -467,8 +467,17 @@ future<> compaction_task_executor::update_history(table_state& t, sstables::comp
             }
             rows_merged[id] = res.stats.reader_statistics.rows_merged_histogram[id];
         }
-        co_await sys_ks->update_compaction_history(cdata.compaction_uuid, t.schema()->ks_name(), t.schema()->cf_name(),
-                ended_at.count(), res.stats.start_size, res.stats.end_size, std::move(rows_merged));
+
+        db::compaction_history_entry entry {
+            .id = cdata.compaction_uuid,
+            .ks = t.schema()->ks_name(),
+            .cf = t.schema()->cf_name(),
+            .compacted_at = ended_at.count(),
+            .bytes_in = res.stats.start_size,
+            .bytes_out = res.stats.end_size,
+            .rows_merged = std::move(rows_merged)
+        };
+        co_await sys_ks->update_compaction_history(std::move(entry));
     }
 }
 

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -549,7 +549,7 @@ protected:
     future<sstables::compaction_result> compact_sstables(sstables::compaction_descriptor descriptor, sstables::compaction_data& cdata, on_replacement&,
                                 compaction_manager::can_purge_tombstones can_purge = compaction_manager::can_purge_tombstones::yes,
                                 sstables::offstrategy offstrategy = sstables::offstrategy::no);
-    future<> update_history(::compaction::table_state& t, const sstables::compaction_result& res, const sstables::compaction_data& cdata);
+    future<> update_history(::compaction::table_state& t, sstables::compaction_result&& res, const sstables::compaction_data& cdata);
     bool should_update_history(sstables::compaction_type ct) {
         return ct == sstables::compaction_type::Compaction;
     }

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -35,8 +35,8 @@
 #include "utils/pluggable.hh"
 
 namespace db {
-class system_keyspace;
 class compaction_history_entry;
+class system_keyspace;
 }
 
 namespace sstables { class test_env_compaction_manager; }

--- a/db/compaction_history_entry.hh
+++ b/db/compaction_history_entry.hh
@@ -5,24 +5,36 @@
 /*
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
+
 #pragma once
 
+#include <seastar/core/shard_id.hh>
 #include <seastar/core/sstring.hh>
+#include <vector>
 #include <unordered_map>
+#include "sstables/basic_info.hh"
 #include "utils/UUID.hh"
 
 namespace db {
 
 struct compaction_history_entry {
     utils::UUID id;
+    shard_id shard_id;
     sstring ks;
     sstring cf;
+    sstring compaction_type;
+    int64_t started_at = 0;
     int64_t compacted_at = 0;
     int64_t bytes_in = 0;
     int64_t bytes_out = 0;
     // Key: number of rows merged
     // Value: counter
     std::unordered_map<int32_t, int64_t> rows_merged;
+    std::vector<sstables::basic_info> sstables_in;
+    std::vector<sstables::basic_info> sstables_out;
+    int64_t total_tombstone_purge_attempt = 0;
+    int64_t total_tombstone_purge_failure_due_to_overlapping_with_memtable = 0;
+    int64_t total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable = 0;
 };
 
 }

--- a/db/compaction_history_entry.hh
+++ b/db/compaction_history_entry.hh
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+#pragma once
+
+#include <seastar/core/sstring.hh>
+#include <unordered_map>
+#include "utils/UUID.hh"
+
+namespace db {
+
+struct compaction_history_entry {
+    utils::UUID id;
+    sstring ks;
+    sstring cf;
+    int64_t compacted_at = 0;
+    int64_t bytes_in = 0;
+    int64_t bytes_out = 0;
+    // Key: number of rows merged
+    // Value: counter
+    std::unordered_map<int32_t, int64_t> rows_merged;
+};
+
+}

--- a/db/read_context.hh
+++ b/db/read_context.hh
@@ -198,7 +198,7 @@ public:
     void on_underlying_created() { ++_underlying_created; }
     bool digest_requested() const { return _slice.options.contains<query::partition_slice::option::with_digest>(); }
     const tombstone_gc_state* tombstone_gc_state() const { return _tombstone_gc_state; }
-    api::timestamp_type get_max_purgeable(const dht::decorated_key& dk, is_shadowable is) const { return _get_max_purgeable(dk, is); }
+    api::timestamp_type get_max_purgeable(const dht::decorated_key& dk, is_shadowable is) const { return _get_max_purgeable(dk, is).timestamp; }
 public:
     future<> ensure_underlying() {
         if (_underlying_snapshot) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -49,6 +49,7 @@
 #include "service/raft/raft_group0_client.hh"
 #include "utils/shared_dict.hh"
 #include "replica/database.hh"
+#include "db/compaction_history_entry.hh"
 
 #include <unordered_map>
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -389,8 +389,7 @@ public:
         DECOMMISSIONED
     };
 
-    future<> update_compaction_history(utils::UUID uuid, sstring ksname, sstring cfname, int64_t compacted_at, int64_t bytes_in, int64_t bytes_out,
-                                       std::unordered_map<int32_t, int64_t> rows_merged);
+    future<> update_compaction_history(compaction_history_entry);
     using compaction_history_consumer = noncopyable_function<future<>(const compaction_history_entry&)>;
     future<> get_compaction_history(compaction_history_consumer f);
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -110,18 +110,7 @@ class system_keyspace_view_build_progress;
 struct replay_position;
 typedef std::vector<db::replay_position> replay_positions;
 
-
-struct compaction_history_entry {
-    utils::UUID id;
-    sstring ks;
-    sstring cf;
-    int64_t compacted_at = 0;
-    int64_t bytes_in = 0;
-    int64_t bytes_out = 0;
-    // Key: number of rows merged
-    // Value: counter
-    std::unordered_map<int32_t, int64_t> rows_merged;
-};
+struct compaction_history_entry;
 
 class system_keyspace : public seastar::peering_sharded_service<system_keyspace>, public seastar::async_sharded_service<system_keyspace> {
     cql3::query_processor& _qp;

--- a/docs/operating-scylla/nodetool-commands/compactionhistory.rst
+++ b/docs/operating-scylla/nodetool-commands/compactionhistory.rst
@@ -13,31 +13,49 @@ Example output:
 
 .. code-block:: yaml
 
-   id                                     keyspace_name      columnfamily_name            compacted_at             bytes_in       bytes_out      rows_merged
-   17536e70-5358-11e6-9d5f-000000000000   keyspace1          standard1                    1469554849495             413966109      211273222
-   4e164760-5354-11e6-9d5f-000000000000   system             local                        1469553223382             12804          12639
-   17abc7a0-5358-11e6-9710-000000000001   keyspace1          standard1                    1469554850073             413967233      210742975
-   18537950-5358-11e6-be35-000000000002   keyspace1          standard1                    1469554851173             413973134      210595169
-   19452c50-5358-11e6-8491-000000000003   keyspace1          standard1                    1469554852756             413966390      210388634
+   id                                     shard_id keyspace_name columnfamily_name compaction_name started_at              compacted_at            bytes_in bytes_out rows_merged   sstables_in                                                                                                                                                              sstables_out                                                                          total_tombstone_purge_attempt total_tombstone_purge_failure_due_to_overlapping_with_memtable total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable
+   17536e70-5358-11e6-9d5f-000000000000          0 ks            test              Compact         2024-12-17T16:19:55.914 2024-12-17T16:39:55.914    11000      5583 {1: 78, 2: 6} [{generation: 2a5db691-bc8d-11ef-a5f9-bbbda77f5688, origin: memtable, size: 5468}, {generation: 28c58a60-bc8d-11ef-a5f9-bbbda77f5688, origin: memtable, size: 5532}]     [{generation: 2a5fb260-bc8d-11ef-a5f9-bbbda77f5688, origin: compaction, size: 5583}]  3                             0                                                              1
+   4e164760-5354-11e6-9d5f-000000000000          1 ks            test              Compact         2024-12-17T16:19:55.913 2024-12-17T16:39:55.913    10919      5490 {1: 56, 2: 2} [{generation: 2a5db691-bc8d-11ef-ad72-bbbca77f5688, origin: memtable, size: 5433}, {generation: 28c58a60-bc8d-11ef-ad72-bbbca77f5688, origin: memtable, size: 5486}]     [{generation: 2a5f8b50-bc8d-11ef-ad72-bbbca77f5688, origin: compaction, size: 5490}]  1                             0                                                              0
+   17abc7a0-5358-11e6-9710-000000000001          0 system        raft              Compact         2024-12-17T16:19:52.570 2024-12-17T16:39:52.570   102199     96181 {1: 20, 2: 3} [{generation: 285b08c0-bc8d-11ef-a5f9-bbbda77f5688, origin: memtable, size: 13683}, {generation: 2798ca30-bc8d-11ef-a5f9-bbbda77f5688, origin: compaction, size: 88516}] [{generation: 28614a50-bc8d-11ef-a5f9-bbbda77f5688, origin: compaction, size: 96181}] 1                             0                                                              0
+   18537950-5358-11e6-be35-000000000002          0 system_schema columns           Compact         2024-12-17T16:19:52.563 2024-12-17T16:39:52.563    25478     19882 {1: 506}      [{generation: 28545200-bc8d-11ef-a5f9-bbbda77f5688, origin: memtable, size: 5744}, {generation: 279a02b0-bc8d-11ef-a5f9-bbbda77f5688, origin: compaction, size: 19734}]  [{generation: 286011d0-bc8d-11ef-a5f9-bbbda77f5688, origin: compaction, size: 19882}] 15                            0                                                              0
+   19452c50-5358-11e6-8491-000000000003          0 system        topology          Compact         2024-12-17T16:19:52.555 2024-12-17T16:39:52.555    22197     14236 {2: 4}        [{generation: 00000000-0000-1000-0000-000000000002, origin: memtable, size: 9296}, {generation: 285ba501-bc8d-11ef-a5f9-bbbda77f5688, origin: memtable, size: 12901}]    [{generation: 285e3d10-bc8d-11ef-a5f9-bbbda77f5688, origin: compaction, size: 14236}] 0                             0                                                              0
 
 
 Explanation:
 
-================================================  =================================================================================
-Parameter                                         Description
-================================================  =================================================================================
-id                                                id of the compaction 
-------------------------------------------------  ---------------------------------------------------------------------------------
-keyspace_name                                     keyspace name that the compaction performed on
-------------------------------------------------  ---------------------------------------------------------------------------------
-columnfamily_name                                 columnfamily name that the compaction performed on
-------------------------------------------------  ---------------------------------------------------------------------------------
-compacted_at                                      timestamp when the compaction starts
-------------------------------------------------  ---------------------------------------------------------------------------------
-bytes_in                                          SSTable size before the compaction
-------------------------------------------------  ---------------------------------------------------------------------------------
-bytes_out                                         SSTable size after the compaction
-================================================  =================================================================================
+==========================================================================  ======================================================================================================
+Parameter                                                                   Description
+==========================================================================  ======================================================================================================
+id                                                                          id of the compaction
+--------------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------
+shard_id                                                                    id of the shard the compaction was executed on
+--------------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------
+keyspace_name                                                               keyspace name that the compaction performed on
+--------------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------
+columnfamily_name                                                           columnfamily name that the compaction performed on
+--------------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------
+compaction_type                                                             type of compaction, e.g. major, regular, reshard, cleanup, etc.
+--------------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------
+started_at                                                                  timestamp when the compaction started
+--------------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------
+compacted_at                                                                timestamp when the compaction completed
+--------------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------
+bytes_in                                                                    SSTable size before the compaction
+--------------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------
+bytes_out                                                                   SSTable size after the compaction
+--------------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------
+rows_merged                                                                 histogram of merged data (takes into account clustering rows, static rows, range tombstones, etc.)
+--------------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------
+sstables_in                                                                 list of sstables that were the input of the compaction
+--------------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------
+sstables_out                                                                list of sstables that were the output of the compaction (usually one; with ICS/LCS it can be more)
+--------------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------
+total_tombstone_purge_attempt                                               total amount of tombstones that were candidates for garbage-collection
+--------------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------
+total_tombstone_purge_failure_due_to_overlapping_with_memtable              purgeable tombstone which couldn't be collected because memtable contains possibly shadowed data
+--------------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------
+total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable  purgeable tombstone which couldn't be collected because other sstables contains possibly shadowed data
+==========================================================================  ======================================================================================================
 
 
 .. include:: nodetool-index.rst

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -137,6 +137,7 @@ public:
     gms::feature view_build_status_on_group0 { *this, "VIEW_BUILD_STATUS_ON_GROUP0"sv };
     gms::feature views_with_tablets { *this, "VIEWS_WITH_TABLETS"sv };
     gms::feature group0_limited_voters { *this, "GROUP0_LIMITED_VOTERS"sv };
+    gms::feature compaction_history_upgrade { *this, "COMPACTION_HISTORY_UPGRADE"};
 
     // Whether to allow fragmented commitlog entries. While this is a node-local feature as such, hide
     // behind a feature to ensure an upgrading cluster appears to be at least functional before using,

--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -11,6 +11,7 @@
 #include "compaction/compaction_garbage_collector.hh"
 #include "mutation_fragment.hh"
 #include "mutation_fragment_stream_validator.hh"
+#include "mutation_tombstone_stats.hh"
 #include "tombstone_gc.hh"
 #include "full_position.hh"
 #include <type_traits>
@@ -181,6 +182,7 @@ class compact_mutation_state {
     std::unique_ptr<mutation_compactor_garbage_collector> _collector;
 
     compaction_stats _stats;
+    tombstone_purge_stats* _tombstone_stats = nullptr;
 
     mutation_fragment_stream_validating_filter _validator;
 
@@ -249,14 +251,42 @@ private:
     }
 
     bool can_purge_tombstone(const tombstone& t, is_shadowable is_shadowable, const gc_clock::time_point deletion_time) {
+        bool purgeable = false;
+        auto timestamp_source = max_purgeable::timestamp_source::none;
+
         if (_tombstone_gc_state.cheap_to_get_gc_before(_schema)) {
             // if retrieval of grace period is cheap, can_gc() will only be
             // called for tombstones that are older than grace period, in
             // order to avoid unnecessary bloom filter checks when calculating
             // max purgeable timestamp.
-            return satisfy_grace_period(deletion_time) && can_gc(t, is_shadowable);
+            purgeable = satisfy_grace_period(deletion_time);
+            if (purgeable) {
+                std::tie(purgeable, timestamp_source) = can_gc(t, is_shadowable);
+            }
+        } else {
+            std::tie(purgeable, timestamp_source) = can_gc(t, is_shadowable);
+            if (purgeable) {
+                purgeable = satisfy_grace_period(deletion_time);
+            }
         }
-        return can_gc(t, is_shadowable) && satisfy_grace_period(deletion_time);
+
+        if constexpr (sstable_compaction()) {
+            if (!_tombstone_stats || !t) {
+                return purgeable;
+            }
+
+            ++_tombstone_stats->attempts;
+            if (!purgeable) {
+                static int64_t tombstone_purge_stats::*stats_table[] = {
+                    &tombstone_purge_stats::failures_other,
+                    &tombstone_purge_stats::failures_due_to_overlapping_with_memtable,
+                    &tombstone_purge_stats::failures_due_to_overlapping_with_uncompacting_sstable
+                };
+                ++(_tombstone_stats->*stats_table[static_cast<int>(timestamp_source)]);
+            }
+        }
+
+        return purgeable;
     }
 
     bool can_purge_tombstone(const tombstone& t) {
@@ -281,19 +311,19 @@ private:
         }
     }
 
-    bool can_gc(tombstone t, is_shadowable is_shadowable) {
+    std::pair<bool,max_purgeable::timestamp_source> can_gc(tombstone t, is_shadowable is_shadowable) {
         if (!sstable_compaction()) {
-            return true;
+            return std::make_pair(true, max_purgeable::timestamp_source::none);
         }
         if (!t) {
-            return false;
+            return std::make_pair(false, max_purgeable::timestamp_source::none);
         }
         if (!_max_purgeable) {
             _max_purgeable = _get_max_purgeable(*_dk, is_shadowable);
         }
         auto ret = t.timestamp < _max_purgeable.timestamp;
         mclog.debug("can_gc: t={} is_shadowable={} max_purgeable={}: ret={}", t, is_shadowable, _max_purgeable.timestamp, ret);
-        return ret;
+        return std::make_pair(ret, _max_purgeable.source);
     };
 
 public:
@@ -317,15 +347,17 @@ public:
 
     compact_mutation_state(const schema& s, gc_clock::time_point compaction_time,
             max_purgeable_fn get_max_purgeable,
-            const tombstone_gc_state& gc_state)
+            const tombstone_gc_state& gc_state,
+            tombstone_purge_stats* tombstone_stats = nullptr)
         : _schema(s)
         , _query_time(compaction_time)
         , _get_max_purgeable(std::move(get_max_purgeable))
-        , _can_gc([this] (tombstone t, is_shadowable is_shadowable) { return can_gc(t, is_shadowable); })
+        , _can_gc([this] (tombstone t, is_shadowable is_shadowable) { return can_gc(t, is_shadowable).first; })
         , _slice(s.full_slice())
         , _tombstone_gc_state(gc_state)
         , _last_pos(position_in_partition::for_partition_end())
         , _collector(std::make_unique<mutation_compactor_garbage_collector>(_schema))
+        , _tombstone_stats(tombstone_stats)
         // We already have a validator for compaction in the sstable writer, no need to validate twice
         , _validator("mutation_compactor for compaction", _schema, mutation_fragment_stream_validation_level::none)
     {
@@ -655,9 +687,10 @@ public:
     // Can only be used for compact_for_sstables::yes
     compact_mutation(const schema& s, gc_clock::time_point compaction_time,
             max_purgeable_fn get_max_purgeable,
+
             const tombstone_gc_state& gc_state,
-            Consumer consumer, GCConsumer gc_consumer = GCConsumer())
-        : _state(make_lw_shared<compact_mutation_state<SSTableCompaction>>(s, compaction_time, get_max_purgeable, gc_state))
+            Consumer consumer, GCConsumer gc_consumer = GCConsumer(), tombstone_purge_stats* tombstone_stats = nullptr)
+        : _state(make_lw_shared<compact_mutation_state<SSTableCompaction>>(s, compaction_time, get_max_purgeable, gc_state, tombstone_stats))
         , _consumer(std::move(consumer))
         , _gc_consumer(std::move(gc_consumer)) {
     }

--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -149,7 +149,7 @@ class compact_mutation_state {
     gc_clock::time_point _query_time;
     max_purgeable_fn _get_max_purgeable;
     can_gc_fn _can_gc;
-    api::timestamp_type _max_purgeable = api::missing_timestamp;
+    max_purgeable _max_purgeable;
     std::optional<gc_clock::time_point> _gc_before;
     const query::partition_slice& _slice;
     uint64_t _row_limit{};
@@ -288,11 +288,11 @@ private:
         if (!t) {
             return false;
         }
-        if (_max_purgeable == api::missing_timestamp) {
+        if (!_max_purgeable) {
             _max_purgeable = _get_max_purgeable(*_dk, is_shadowable);
         }
-        auto ret = t.timestamp < _max_purgeable;
-        mclog.debug("can_gc: t={} is_shadowable={} max_purgeable={}: ret={}", t, is_shadowable, _max_purgeable, ret);
+        auto ret = t.timestamp < _max_purgeable.timestamp;
+        mclog.debug("can_gc: t={} is_shadowable={} max_purgeable={}: ret={}", t, is_shadowable, _max_purgeable.timestamp, ret);
         return ret;
     };
 
@@ -347,7 +347,7 @@ public:
         _static_row_live = false;
         _partition_tombstone = {};
         _current_partition_limit = std::min(_row_limit, _partition_row_limit);
-        _max_purgeable = api::missing_timestamp;
+        _max_purgeable = {};
         _gc_before = std::nullopt;
         _last_static_row.reset();
         _last_pos = position_in_partition::for_partition_start();

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -2526,7 +2526,7 @@ future<> mutation_cleaner_impl::drain() {
 can_gc_fn always_gc = [] (tombstone, is_shadowable) { return true; };
 can_gc_fn never_gc = [] (tombstone, is_shadowable) { return false; };
 
-max_purgeable_fn can_always_purge = [] (const dht::decorated_key&, is_shadowable) { return api::max_timestamp; };
-max_purgeable_fn can_never_purge = [] (const dht::decorated_key&, is_shadowable) { return api::min_timestamp; };
+max_purgeable_fn can_always_purge = [] (const dht::decorated_key&, is_shadowable) -> max_purgeable { return { .timestamp = api::max_timestamp }; };
+max_purgeable_fn can_never_purge = [] (const dht::decorated_key&, is_shadowable) -> max_purgeable { return { .timestamp = api::min_timestamp }; };
 
 logging::logger compound_logger("compound");

--- a/mutation/mutation_tombstone_stats.hh
+++ b/mutation/mutation_tombstone_stats.hh
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <cstdint>
+
+struct tombstone_purge_stats {
+    int64_t attempts { 0 };
+    int64_t failures_due_to_overlapping_with_memtable { 0 };
+    int64_t failures_due_to_overlapping_with_uncompacting_sstable { 0 };
+    int64_t failures_other { 0 };
+
+    tombstone_purge_stats& operator+=(const tombstone_purge_stats& other) {
+        attempts += other.attempts;
+        failures_due_to_overlapping_with_memtable += other.failures_due_to_overlapping_with_memtable;
+        failures_due_to_overlapping_with_uncompacting_sstable += other.failures_due_to_overlapping_with_uncompacting_sstable;
+
+        return *this;
+    }
+};
+
+inline tombstone_purge_stats operator+(const tombstone_purge_stats& left, const tombstone_purge_stats& right) {
+    auto tmp = left;
+    tmp += right;
+    return tmp;
+}

--- a/readers/compacting.hh
+++ b/readers/compacting.hh
@@ -17,6 +17,7 @@ class decorated_key;
 }
 
 class tombstone_gc_state;
+struct tombstone_purge_stats;
 
 /// Creates a compacting reader.
 ///
@@ -36,4 +37,5 @@ class tombstone_gc_state;
 mutation_reader make_compacting_reader(mutation_reader source, gc_clock::time_point compaction_time,
         max_purgeable_fn get_max_purgeable,
         const tombstone_gc_state& gc_state,
-        streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no);
+        streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
+        tombstone_purge_stats* tombstone_stats = nullptr);

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -1470,10 +1470,11 @@ public:
     compacting_reader(mutation_reader source, gc_clock::time_point compaction_time,
             max_purgeable_fn get_max_purgeable,
             const tombstone_gc_state& gc_state,
-            streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no)
+            streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
+            tombstone_purge_stats* tombstone_stats = nullptr)
         : impl(source.schema(), source.permit())
         , _reader(std::move(source))
-        , _compactor(*_schema, compaction_time, get_max_purgeable, gc_state)
+        , _compactor(*_schema, compaction_time, get_max_purgeable, gc_state, tombstone_stats)
         , _last_uncompacted_partition_start(dht::decorated_key(dht::minimum_token(), partition_key::make_empty()), tombstone{})
         , _fwd(fwd) {
     }
@@ -1556,6 +1557,6 @@ public:
 
 mutation_reader make_compacting_reader(mutation_reader source, gc_clock::time_point compaction_time,
         max_purgeable_fn get_max_purgeable,
-        const tombstone_gc_state& gc_state, streamed_mutation::forwarding fwd) {
-    return make_mutation_reader<compacting_reader>(std::move(source), compaction_time, get_max_purgeable, gc_state, fwd);
+        const tombstone_gc_state& gc_state, streamed_mutation::forwarding fwd, tombstone_purge_stats* tombstone_stats) {
+    return make_mutation_reader<compacting_reader>(std::move(source), compaction_time, get_max_purgeable, gc_state, fwd, tombstone_stats);
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2802,7 +2802,7 @@ table::make_partition_presence_checker(lw_shared_ptr<const sstables::sstable_set
 }
 
 max_purgeable_fn table::get_max_purgeable_fn_for_cache_underlying_reader() const {
-    return [this](const dht::decorated_key& dk, ::is_shadowable is_shadowable) {
+    return [this](const dht::decorated_key& dk, ::is_shadowable is_shadowable) -> max_purgeable {
         auto& sg = storage_group_for_token(dk.token());
         auto max_purgeable_timestamp = api::max_timestamp;
 
@@ -2810,7 +2810,7 @@ max_purgeable_fn table::get_max_purgeable_fn_for_cache_underlying_reader() const
             max_purgeable_timestamp = std::min(cg->memtables()->min_live_timestamp(dk, is_shadowable, cg->max_seen_timestamp()), max_purgeable_timestamp);
         });
 
-        return max_purgeable_timestamp;
+        return { .timestamp = max_purgeable_timestamp };
     };
 }
 

--- a/sstables/basic_info.hh
+++ b/sstables/basic_info.hh
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <seastar/core/sstring.hh>
+#include "sstables/generation_type.hh"
+
+namespace sstables {
+
+struct basic_info {
+    generation_type generation;
+    sstring origin;
+    int64_t size;
+};
+
+}

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2738,7 +2738,7 @@ class basic_compacted_fragments_consumer_base {
     gc_clock::time_point _query_time;
     gc_clock::time_point _gc_before;
     max_purgeable_fn _get_max_purgeable;
-    api::timestamp_type _max_purgeable;
+    max_purgeable _max_purgeable;
 
     std::vector<mutation> _mutations;
     mutation_rebuilder_v2 _mutation;
@@ -2748,7 +2748,7 @@ private:
         if (!t) {
             return true;
         }
-        return t.timestamp < _max_purgeable;
+        return t.timestamp < _max_purgeable.timestamp;
     }
     bool is_tombstone_purgeable(const tombstone& t) {
         return t.deletion_time < _gc_before && can_gc(t);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3714,8 +3714,8 @@ SEASTAR_TEST_CASE(purged_tombstone_consumer_sstable_test) {
         };
 
         auto compact = [&] (std::vector<shared_sstable> all) -> std::pair<shared_sstable, shared_sstable> {
-            auto max_purgeable_func = [max_purgeable_ts] (const dht::decorated_key& dk, is_shadowable) {
-                return max_purgeable_ts;
+            auto max_purgeable_func = [max_purgeable_ts] (const dht::decorated_key& dk, is_shadowable) -> max_purgeable {
+                return { .timestamp = max_purgeable_ts };
             };
 
             auto non_purged = env.make_sstable(s);

--- a/test/cqlpy/test_compaction.py
+++ b/test/cqlpy/test_compaction.py
@@ -4,16 +4,8 @@
 
 import pytest
 import requests
-from .util import new_materialized_view, new_test_table, unique_name
+from .util import new_materialized_view, new_test_table, unique_name, sleep_till_whole_second
 from . import nodetool
-import time
-
-# sleep to let a ttl (of `seconds`) expire and
-# the commitlog minimum gc time, in seconds,
-# to be greater than the tombstone deletion time
-def sleep_till_whole_second(seconds=1):
-    t = time.time()
-    time.sleep(seconds - (t - int(t)))
 
 def test_tombstone_gc_with_conflict_in_memtable(scylla_only, cql, test_keyspace):
     """

--- a/test/cqlpy/util.py
+++ b/test/cqlpy/util.py
@@ -26,6 +26,13 @@ def random_string(length=10, chars=string.ascii_uppercase + string.digits):
 def random_bytes(length=10):
     return bytearray(random.getrandbits(8) for _ in range(length))
 
+# sleep to let a ttl (of `seconds`) expire and
+# the commitlog minimum gc time, in seconds,
+# to be greater than the tombstone deletion time
+def sleep_till_whole_second(seconds=1):
+    t = time.time()
+    time.sleep(seconds - (t - int(t)))
+
 # A function for picking a unique name for test keyspace or table.
 # This name doesn't need to be quoted in CQL - it only contains
 # lowercase letters, numbers, and underscores, and starts with a letter.

--- a/test/nodetool/test_compactionhistory.py
+++ b/test/nodetool/test_compactionhistory.py
@@ -23,65 +23,127 @@ def format_compacted_at(compacted_at: int):
 HISTORY_RESPONSE = [
         {
             "id": "edde9300-5e9c-11ee-a8f6-7d85dcfeb8f4",
+            "shard_id": 0,
             "cf": "peers",
             "ks": "system",
+            "compaction_type": "Compact",
+            "started_at": 1695973259380,
             "compacted_at": 1695973859380,
             "bytes_in": 11714,
             "bytes_out": 11808,
             "rows_merged": [{"key": 1, "value": 12}],
+            "sstables_in": [
+                {
+                    "generation": "3glx_0srx_1lvc01zhjn9048se29",
+                    "origin": "memtable",
+                    "size": 5466,
+                },
+                {
+                    "generation": "3glx_0sru_3zlr42ksepk902v8dt",
+                    "origin": "memtable",
+                    "size": 5519,
+                }],
+            "sstables_out": [
+                {
+                    "generation": "3glx_0srx_1o0hs1zhjn9048se29",
+                    "origin": "compaction",
+                    "size": 5457,
+                }],
+            "total_tombstone_purge_attempt": 14,
+            "total_tombstone_purge_failure_due_to_overlapping_with_memtable": 0,
+            "total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable": 0,
         },
         {
             "id": "edef82f0-5e9c-11ee-a8f6-7d85dcfeb8f4",
+            "shard_id": 0,
             "cf": "functions",
             "ks": "system_schema",
+            "compaction_type": "Compact",
+            "started_at": 1695973259491,
             "compacted_at": 1695973859491,
             "bytes_in": 5790,
             "bytes_out": 5944,
             "rows_merged": [{"key": 1, "value": 5}, {"key": 2, "value": 1}],
+            "sstables_in": [
+                {
+                    "generation": "3glx_0srx_1lvc02ksepk902v8dt",
+                    "origin": "memtable",
+                    "size": 5668,
+                },
+                {
+                    "generation": "3glx_0sru_3zlr42ksepk902v8dt",
+                    "origin": "memtable",
+                    "size": 5669,
+                }],
+            "sstables_out": [
+                {
+                    "generation": "3glx_0srx_1pasg2ksepk902v8dt",
+                    "origin": "compaction",
+                    "size": 5687,
+                }],
+            "total_tombstone_purge_attempt": 14,
+            "total_tombstone_purge_failure_due_to_overlapping_with_memtable": 5,
+            "total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable": 5,
         },
-        # "rows_merged" field missing on purpose
+        # "rows_merged", "sstables_in", "sstables_out" fields missing on purpose. It happens when dealing with
+        # moxed node clusters. In this case, the fields are not present in the response.
         {
             "id": "8b857440-0e35-11f0-9fcc-a895cfb212f2",
+            "shard_id": 0,
             "cf": "functions",
             "ks": "system_schema",
+            "compaction_type": "Compact",
+            "started_at": 1695973859492,
             "compacted_at": 1695973859492,
             "bytes_in": 579,
             "bytes_out": 594,
+            "total_tombstone_purge_attempt": 0,
+            "total_tombstone_purge_failure_due_to_overlapping_with_memtable": 0,
+            "total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable": 0,
         }]
 
 EXPECTED_REQUEST = expected_request("GET", "/compaction_manager/compaction_history", response=HISTORY_RESPONSE)
 
 
-def test_text(request, nodetool):
-    expected_res_cassandra = \
+def _test_text_nodetool_cassandra(nodetool):
+    expected_response = \
 """Compaction History:
 id                                   keyspace_name columnfamily_name compacted_at            bytes_in bytes_out rows_merged
 8b857440-0e35-11f0-9fcc-a895cfb212f2 system_schema functions         {} 579      594   {{}}
 edef82f0-5e9c-11ee-a8f6-7d85dcfeb8f4 system_schema functions         {} 5790     5944  {{1: 5, 2: 1}}
 edde9300-5e9c-11ee-a8f6-7d85dcfeb8f4 system        peers             {} 11714    11808 {{1: 12}}
-""".format(format_compacted_at(1695973859492), format_compacted_at(1695973859491), format_compacted_at(1695973859380))
+""".format(format_compacted_at(1695973859492), format_compacted_at(1695973859491), format_compacted_at(1695973259380))
 
-    # Scylla aligns number columns to the right except rows_merged column.
-    expected_res_scylla = "\n".join([
-"Compaction History:",
-"id                                   keyspace_name columnfamily_name compacted_at            bytes_in bytes_out rows_merged ",
-"8b857440-0e35-11f0-9fcc-a895cfb212f2 system_schema functions         {}      579       594 {{}}          ".format(format_compacted_at(1695973859492)),
-"edef82f0-5e9c-11ee-a8f6-7d85dcfeb8f4 system_schema functions         {}     5790      5944 {{1: 5, 2: 1}}".format(format_compacted_at(1695973859491)),
-"edde9300-5e9c-11ee-a8f6-7d85dcfeb8f4 system        peers             {}    11714     11808 {{1: 12}}     ".format(format_compacted_at(1695973859380)),
-""])
+    VALID_KEYS = ["id", "cf", "ks", "compaction_type", "compacted_at", "bytes_in", "bytes_out"]
+    CASSANDRA_HISTORY_RESPONSE = [{key: data[key] for key in VALID_KEYS} for data in HISTORY_RESPONSE]
+    CASSANDRA_EXPECTED_REQUEST = expected_request("GET", "/compaction_manager/compaction_history", response=CASSANDRA_HISTORY_RESPONSE)
+
+    for cmd in [("compactionhistory",), ("compactionhistory", "--format", "text")]:
+        response = nodetool(*cmd, expected_requests=[CASSANDRA_EXPECTED_REQUEST])
+        assert response.stdout == expected_response
+
+
+def _test_text_nodetool_scylla(nodetool):
+    # Scylla aligns number columns to the right.
+    expected_response = \
+"""Compaction History:
+id                                   shard_id keyspace_name columnfamily_name compaction_type started_at              compacted_at            bytes_in bytes_out rows_merged  sstables_in                                                                                                                                                          sstables_out                                                                         total_tombstone_purge_attempt total_tombstone_purge_failure_due_to_overlapping_with_memtable total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable 
+8b857440-0e35-11f0-9fcc-a895cfb212f2        0 system_schema functions         Compact         {} {}      579       594 {{}}           []                                                                                                                                                                   []                                                                                   0                             0                                                              0                                                                          
+edef82f0-5e9c-11ee-a8f6-7d85dcfeb8f4        0 system_schema functions         Compact         {} {}     5790      5944 {{1: 5, 2: 1}} [{{generation: 5d022760-b617-11ef-a97d-8438c36f0e31, origin: memtable, size: 5668}}, {{generation: 5b756ce0-b617-11ef-a97d-8438c36f0e31, origin: memtable, size: 5669}}] [{{generation: 5d049860-b617-11ef-a97d-8438c36f0e31, origin: compaction, size: 5687}}] 14                            5                                                              5                                                                          
+edde9300-5e9c-11ee-a8f6-7d85dcfeb8f4        0 system        peers             Compact         {} {}    11714     11808 {{1: 12}}      [{{generation: 5d022760-b617-11ef-8294-8437c36f0e31, origin: memtable, size: 5466}}, {{generation: 5b756ce0-b617-11ef-a97d-8438c36f0e31, origin: memtable, size: 5519}}] [{{generation: 5d03ae00-b617-11ef-8294-8437c36f0e31, origin: compaction, size: 5457}}] 14                            0                                                              0                                                                          
+""".format(format_compacted_at(1695973859492), format_compacted_at(1695973859492), format_compacted_at(1695973259491), format_compacted_at(1695973859491), format_compacted_at(1695973259380), format_compacted_at(1695973859380))
 
     assert "rows_merged" not in HISTORY_RESPONSE[-1]
     for cmd in [("compactionhistory",), ("compactionhistory", "--format", "text"), ("compactionhistory", "-F", "text")]:
-        if request.config.getoption("nodetool") != "scylla" and len(cmd) > 1:
-            # The -F text is a scylla-extension, cassandra-nodetool doesn't support it
-            continue
+        response = nodetool(*cmd, expected_requests=[EXPECTED_REQUEST])
+        assert response.stdout == expected_response
 
-        res = nodetool(*cmd, expected_requests=[EXPECTED_REQUEST])
 
-        if request.config.getoption("nodetool") == "scylla":
-            assert res.stdout == expected_res_scylla
-        else:
-            assert res.stdout == expected_res_cassandra
+def test_text(request, nodetool):
+    if request.config.getoption("nodetool") == "scylla":
+        _test_text_nodetool_scylla(nodetool)
+    else:
+        _test_text_nodetool_cassandra(nodetool)
 
 
 def test_json(nodetool):
@@ -89,17 +151,28 @@ def test_json(nodetool):
             "CompactionHistory": [
                 {
                     "id": "8b857440-0e35-11f0-9fcc-a895cfb212f2",
+                    "shard_id": 0,
                     "columnfamily_name": "functions",
                     "keyspace_name": "system_schema",
+                    "compaction_type": "Compact",
+                    "started_at": format_compacted_at(1695973859492),
                     "compacted_at": format_compacted_at(1695973859492),
                     "bytes_in": 579,
                     "bytes_out": 594,
                     "rows_merged": [],
+                    "sstables_in": [],
+                    "sstables_out": [],
+                    "total_tombstone_purge_attempt": 0,
+                    "total_tombstone_purge_failure_due_to_overlapping_with_memtable": 0,
+                    "total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable": 0,
                 },
                 {
                     "id": "edef82f0-5e9c-11ee-a8f6-7d85dcfeb8f4",
+                    "shard_id": 0,
                     "columnfamily_name": "functions",
                     "keyspace_name": "system_schema",
+                    "compaction_type": "Compact",
+                    "started_at": format_compacted_at(1695973259491),
                     "compacted_at": format_compacted_at(1695973859491),
                     "bytes_in": 5790,
                     "bytes_out": 5944,
@@ -113,11 +186,34 @@ def test_json(nodetool):
                             "value": 1
                         }
                     ],
+                    "sstables_in": [
+                        {
+                            "generation": "5d022760-b617-11ef-a97d-8438c36f0e31",
+                            "origin": "memtable",
+                            "size": 5668,
+                        },
+                        {
+                            "generation": "5b756ce0-b617-11ef-a97d-8438c36f0e31",
+                            "origin": "memtable",
+                            "size": 5669,
+                        }],
+                    "sstables_out": [
+                        {
+                            "generation": "5d049860-b617-11ef-a97d-8438c36f0e31",
+                            "origin": "compaction",
+                            "size": 5687,
+                        }],
+                    "total_tombstone_purge_attempt": 14,
+                    "total_tombstone_purge_failure_due_to_overlapping_with_memtable": 5,
+                    "total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable": 5,
                 },
                 {
                     "id": "edde9300-5e9c-11ee-a8f6-7d85dcfeb8f4",
+                    "shard_id": 0,
                     "columnfamily_name": "peers",
                     "keyspace_name": "system",
+                    "compaction_type": "Compact",
+                    "started_at": format_compacted_at(1695973259380),
                     "compacted_at": format_compacted_at(1695973859380),
                     "bytes_in": 11714,
                     "bytes_out": 11808,
@@ -127,6 +223,26 @@ def test_json(nodetool):
                             "value": 12
                         }
                     ],
+                    "sstables_in": [
+                        {
+                            "generation": "5d022760-b617-11ef-8294-8437c36f0e31",
+                            "origin": "memtable",
+                            "size": 5466,
+                        },
+                        {
+                            "generation": "5b756ce0-b617-11ef-a97d-8438c36f0e31",
+                            "origin": "memtable",
+                            "size": 5519,
+                        }],
+                    "sstables_out": [
+                        {
+                            "generation": "5d03ae00-b617-11ef-8294-8437c36f0e31",
+                            "origin": "compaction",
+                            "size": 5457,
+                        }],
+                    "total_tombstone_purge_attempt": 14,
+                    "total_tombstone_purge_failure_due_to_overlapping_with_memtable": 0,
+                    "total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable": 0,
                 }
             ]
         }
@@ -134,7 +250,6 @@ def test_json(nodetool):
     assert "rows_merged" not in HISTORY_RESPONSE[-1]
     for cmd in [("compactionhistory", "--format", "json"), ("compactionhistory", "-F", "json")]:
         res = nodetool(*cmd, expected_requests=[EXPECTED_REQUEST])
-
         assert json.loads(res.stdout) == expected_res
 
 
@@ -143,17 +258,28 @@ def test_yaml(nodetool):
             "CompactionHistory": [
                 {
                     "id": "8b857440-0e35-11f0-9fcc-a895cfb212f2",
+                    "shard_id": 0,
                     "columnfamily_name": "functions",
                     "keyspace_name": "system_schema",
+                    "compaction_type": "Compact",
+                    "started_at": format_compacted_at(1695973859492),
                     "compacted_at": format_compacted_at(1695973859492),
                     "bytes_in": 579,
                     "bytes_out": 594,
                     "rows_merged": [],
+                    "sstables_in": [],
+                    "sstables_out": [],
+                    "total_tombstone_purge_attempt": 0,
+                    "total_tombstone_purge_failure_due_to_overlapping_with_memtable": 0,
+                    "total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable": 0,
                 },
                 {
                     "id": "edef82f0-5e9c-11ee-a8f6-7d85dcfeb8f4",
+                    "shard_id": 0,
                     "columnfamily_name": "functions",
                     "keyspace_name": "system_schema",
+                    "compaction_type": "Compact",
+                    "started_at": format_compacted_at(1695973259491),
                     "compacted_at": format_compacted_at(1695973859491),
                     "bytes_in": 5790,
                     "bytes_out": 5944,
@@ -167,11 +293,34 @@ def test_yaml(nodetool):
                             "value": 1
                         }
                     ],
+                    "sstables_in": [
+                        {
+                            "generation": "5d022760-b617-11ef-a97d-8438c36f0e31",
+                            "origin": "memtable",
+                            "size": 5668,
+                        },
+                        {
+                            "generation": "5b756ce0-b617-11ef-a97d-8438c36f0e31",
+                            "origin": "memtable",
+                            "size": 5669,
+                        }],
+                    "sstables_out": [
+                        {
+                            "generation": "5d049860-b617-11ef-a97d-8438c36f0e31",
+                            "origin": "compaction",
+                            "size": 5687,
+                        }],
+                    "total_tombstone_purge_attempt": 14,
+                    "total_tombstone_purge_failure_due_to_overlapping_with_memtable": 5,
+                    "total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable": 5,
                 },
                 {
                     "id": "edde9300-5e9c-11ee-a8f6-7d85dcfeb8f4",
+                    "shard_id": 0,
                     "columnfamily_name": "peers",
                     "keyspace_name": "system",
+                    "compaction_type": "Compact",
+                    "started_at": format_compacted_at(1695973259380),
                     "compacted_at": format_compacted_at(1695973859380),
                     "bytes_in": 11714,
                     "bytes_out": 11808,
@@ -181,6 +330,26 @@ def test_yaml(nodetool):
                             "value": 12
                         }
                     ],
+                    "sstables_in": [
+                        {
+                            "generation": "5d022760-b617-11ef-8294-8437c36f0e31",
+                            "origin": "memtable",
+                            "size": 5466,
+                        },
+                        {
+                            "generation": "5b756ce0-b617-11ef-a97d-8438c36f0e31",
+                            "origin": "memtable",
+                            "size": 5519,
+                        }],
+                    "sstables_out": [
+                        {
+                            "generation": "5d03ae00-b617-11ef-8294-8437c36f0e31",
+                            "origin": "compaction",
+                            "size": 5457,
+                        }],
+                    "total_tombstone_purge_attempt": 14,
+                    "total_tombstone_purge_failure_due_to_overlapping_with_memtable": 0,
+                    "total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable": 0,
                 }
             ]
         }

--- a/test/rest_api/test_compactionhistory.py
+++ b/test/rest_api/test_compactionhistory.py
@@ -3,13 +3,70 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 import requests
-import sys
 import time
 from collections import defaultdict
+from dataclasses import dataclass, field
 
-# Use the util.py library from ../cqlpy:
-sys.path.insert(1, sys.path[0] + '/test/cqlpy')
-from ..cqlpy.util import new_test_table, new_test_keyspace
+from ..cqlpy.util import new_test_table, new_test_keyspace, sleep_till_whole_second
+
+@dataclass
+class TombstonePurgeStats:
+    attempts: int = 0
+    failures_due_to_memtables: int = 0
+    failures_due_to_other_sstables: int = 0
+
+
+@dataclass
+class SStablesStats:
+    input: list[dict] = field(default_factory=list)
+    output: list[dict] = field(default_factory=list)
+
+
+def waitAndGetCompleteCompactionHistory(rest_api, table):
+    # cql-pytest/run.py::run_scylla_cmd() passes "--smp 2" to scylla, so we
+    # use this value to ensure compaction results from all shards arrived
+    # to the table.
+    SCYLLA_SMP_COUNT = 2
+    ks, cf = table.split('.')
+    while True:
+        response = rest_api.send("GET", "compaction_manager/compaction_history")
+        assert response.status_code == requests.codes.ok
+
+        table_entry_count = sum(1 for data in response.json() if data["ks"] == ks and data["cf"] == cf)
+        if table_entry_count == SCYLLA_SMP_COUNT:
+            return response
+
+        assert table_entry_count < SCYLLA_SMP_COUNT
+        time.sleep(0.2)
+
+
+def extractTombstonePurgeStatistics(response, ks) -> TombstonePurgeStats:
+    '''
+    Extract compaction history statistics for a given keyspace ks from the response and squash
+    it as there will be as many items as the number of shards.
+    '''
+    stats = TombstonePurgeStats()
+    for data in response.json():
+        if data["ks"] == ks:
+            stats.attempts += data["total_tombstone_purge_attempt"]
+            stats.failures_due_to_memtables += data["total_tombstone_purge_failure_due_to_overlapping_with_memtable"]
+            stats.failures_due_to_other_sstables += data["total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable"]
+
+    return stats
+
+
+def extractSStablesStatistics(response, ks) -> SStablesStats:
+    '''
+    Extract compaction history statistics for a given keyspace ks from the response and squash
+    it as there will be as many items as the number of shards.
+    '''
+    stats = SStablesStats()
+    for data in response.json():
+        if data["ks"] == ks:
+            stats.input += data["sstables_in"]
+            stats.output += data["sstables_out"]
+
+    return stats
 
 
 def extractRowsMergedAsSortedList(response, ks):
@@ -27,77 +84,153 @@ def extractRowsMergedAsSortedList(response, ks):
     return [{"key": key, "value": value} for key, value in sorted(total.items())]
 
 
+def populateSomeData(cql, cf: str, pk_range: tuple[int], timestamp: int | None = None, step: int = 0):
+    stmt = cql.prepare(f"INSERT INTO {cf} (pk, ck, v) VALUES (?, ?, ?) {'USING TIMESTAMP ?' if timestamp else ''}")
+    for pk in range(*pk_range):
+        for ck in range(1, 6):
+            timestamp = timestamp + step if timestamp is not None else None
+            cql.execute(stmt, [pk, ck*11+100, 0], timestamp)
+
+
+def alterSomeData(cql, cf: str, timestamp: int | None = None):
+    using_timestamp = f"USING TIMESTAMP {timestamp}" if timestamp else ''
+
+    cql.execute(f"DELETE FROM {cf} {using_timestamp} WHERE pk=1 and ck=122")
+    cql.execute(f"DELETE FROM {cf} {using_timestamp} WHERE pk=5 and ck=155")
+    cql.execute(f"DELETE FROM {cf} {using_timestamp} WHERE pk=3 and ck>111 AND ck<144")
+    cql.execute(f"UPDATE {cf} {using_timestamp} SET v=100 WHERE pk=2 AND ck=122")
+    cql.execute(f"DELETE FROM {cf} {using_timestamp} WHERE pk=5")
+
+
 def test_compactionhistory_rows_merged_null_compaction_strategy(cql, rest_api):
     with new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         with new_test_table(cql, ks, "pk int, ck int, v int, PRIMARY KEY (pk, ck)", "WITH compaction = {'class': 'NullCompactionStrategy'};") as cf:
-            stmt = cql.prepare(f"INSERT INTO {cf} (pk, ck, v) VALUES (?, ?, ?)")
-            cql.execute(stmt, [1, 111, 0])
-            cql.execute(stmt, [1, 122, 0])
-            cql.execute(stmt, [1, 133, 0])
-            cql.execute(stmt, [2, 222, 0])
-            cql.execute(stmt, [3, 333, 0])
-            cql.execute(stmt, [3, 344, 0])
-            cql.execute(stmt, [3, 355, 0])
-            cql.execute(stmt, [3, 366, 0])
-            cql.execute(stmt, [3, 377, 0])
-            cql.execute(stmt, [4, 444, 0])
-            cql.execute(stmt, [5, 555, 0])
-
+            populateSomeData(cql, cf, (1, 6))
             response = rest_api.send("POST", f"storage_service/keyspace_flush/{ks}")
             assert response.status_code == requests.codes.ok
 
-            cql.execute(f"DELETE FROM {cf} WHERE pk=1 and ck=122")
-            cql.execute(f"DELETE FROM {cf} WHERE pk=5 and ck=555")
-            cql.execute(f"DELETE FROM {cf} WHERE pk=3 and ck>333 AND ck <366")
-            cql.execute(f"UPDATE {cf} SET v=100 WHERE pk=2 AND ck=222")
-            cql.execute(f"DELETE FROM {cf} WHERE pk=5")
+            alterSomeData(cql, cf)
             response = rest_api.send("POST", f"storage_service/keyspace_flush/{ks}")
             assert response.status_code == requests.codes.ok
 
-            response = rest_api.send("POST", "storage_service/compact")
+            response = rest_api.send("POST", f"storage_service/keyspace_compaction/{ks}")
             assert response.status_code == requests.codes.ok
 
-            response = rest_api.send("GET", "compaction_manager/compaction_history")
-            assert response.status_code == requests.codes.ok
-            assert extractRowsMergedAsSortedList(response, ks) == [{"key": 1, "value": 13}, {"key": 2, "value": 10}]
+            response = waitAndGetCompleteCompactionHistory(rest_api, cf)
+            assert extractRowsMergedAsSortedList(response, ks) == [{"key": 1, "value": 27}, {"key": 2, "value": 10}]
 
 
 def test_compactionhistory_rows_merged_time_window_compaction_strategy(cql, rest_api):
     with new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        with new_test_table(cql, ks, "pk int, ck int, v int, PRIMARY KEY (pk, ck)", "WITH compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_unit': 'MINUTES', 'compaction_window_size': 1};") as cf:
-            rest_api.send("POST", f"/column_family/autocompaction/{ks}:{cf.split('.')[-1]}")
-            current_time = int(time.time())
+        compaction_opt = "{'class': 'TimeWindowCompactionStrategy', 'compaction_window_unit': 'MINUTES', 'compaction_window_size': 1}"
+        with new_test_table(cql, ks, "pk int, ck int, v int, PRIMARY KEY (pk, ck)",
+                            f"WITH compaction = {compaction_opt};") as cf:
+            timestamp = int(time.time())
 
             # Spread data across 2 windows by simulating a write process. `USING TIMESTAMP` is
             # provided to distribute the writes in the first one-minute window while updates and
             # deletes are propagated into the second 1-minute window.
-            stmt = cql.prepare(f"INSERT INTO {cf} (pk, ck, v) VALUES (?, ?, ?) USING TIMESTAMP ?")
-            cql.execute(stmt, [1, 111, 0, current_time - 60 + 1])
-            cql.execute(stmt, [1, 122, 0, current_time - 60 + 2])
-            cql.execute(stmt, [1, 133, 0, current_time - 60 + 3])
-            cql.execute(stmt, [2, 222, 0, current_time - 60 + 4])
-            cql.execute(stmt, [3, 333, 0, current_time - 60 + 5])
-            cql.execute(stmt, [3, 344, 0, current_time - 60 + 6])
-            cql.execute(stmt, [3, 355, 0, current_time - 60 + 7])
-            cql.execute(stmt, [3, 366, 0, current_time - 60 + 8])
-            cql.execute(stmt, [3, 377, 0, current_time - 60 + 9])
-            cql.execute(stmt, [4, 444, 0, current_time - 60 + 10])
-            cql.execute(stmt, [5, 555, 0, current_time - 60 + 11])
-
+            populateSomeData(cql, cf, (1, 6), timestamp - 60, 1)
             response = rest_api.send("POST", f"storage_service/keyspace_flush/{ks}")
             assert response.status_code == requests.codes.ok
 
-            cql.execute(f"DELETE FROM {cf} WHERE pk=1 and ck=122")
-            cql.execute(f"DELETE FROM {cf} WHERE pk=5 AND ck=555")
-            cql.execute(f"DELETE FROM {cf} WHERE pk=3 and ck>333 AND ck <366")
-            cql.execute(f"UPDATE {cf} SET v=100 WHERE pk=2 AND ck=222")
-            cql.execute(f"DELETE FROM {cf} WHERE pk=5")
+            alterSomeData(cql, cf)
             response = rest_api.send("POST", f"storage_service/keyspace_flush/{ks}")
             assert response.status_code == requests.codes.ok
 
-            response = rest_api.send("POST", "storage_service/compact")
+            response = rest_api.send("POST", f"storage_service/keyspace_compaction/{ks}")
             assert response.status_code == requests.codes.ok
 
-            response = rest_api.send("GET", "compaction_manager/compaction_history")
+            response = waitAndGetCompleteCompactionHistory(rest_api, cf)
+            assert extractRowsMergedAsSortedList(response, ks) == [{"key": 1, "value": 27}, {"key": 2, "value": 10}]
+
+
+def test_compactionhistory_tombstone_purge_statistics(cql, rest_api):
+    with new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
+        with new_test_table(cql, ks, "pk int, ck int, v int, PRIMARY KEY (pk, ck)",
+                            "WITH compaction = {'class': 'NullCompactionStrategy'} AND tombstone_gc = {'mode': 'immediate'};") as cf:
+            timestamp = int(time.time())
+
+            populateSomeData(cql, cf, (1, 11), timestamp - 10)
+            response = rest_api.send("POST", "storage_service/flush")
             assert response.status_code == requests.codes.ok
-            assert extractRowsMergedAsSortedList(response, ks) == [{"key": 1, "value": 13}, {"key": 2, "value": 10}]
+
+            populateSomeData(cql, cf, (11, 21), timestamp - 5)
+            alterSomeData(cql, cf, timestamp - 5)
+            response = rest_api.send("POST", "storage_service/flush")
+            assert response.status_code == requests.codes.ok
+
+            # Sleep a second to let the commitlog minimum gc time, in seconds, be greater than the tombstone deletion time
+            sleep_till_whole_second(1)
+            response = rest_api.send("POST", f"storage_service/keyspace_compaction/{ks}")
+            assert response.status_code == requests.codes.ok
+
+            response = waitAndGetCompleteCompactionHistory(rest_api, cf)
+            stats = extractTombstonePurgeStatistics(response, ks)
+            assert stats == TombstonePurgeStats(5, 0, 0)
+
+            stats = extractSStablesStatistics(response, ks)
+            assert len(stats.input) == 4 and len(stats.output) == 2
+
+
+def test_compactionhistory_tombstone_purge_statistics_overlapping_with_memtable(cql, rest_api):
+    with new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
+        with new_test_table(cql, ks, "pk int, ck int, v int, PRIMARY KEY (pk, ck)",
+                            "WITH compaction = {'class': 'NullCompactionStrategy'} AND tombstone_gc = {'mode': 'immediate'};") as cf:
+            timestamp = int(time.time())
+
+            populateSomeData(cql, cf, (11, 21), timestamp - 5)
+            alterSomeData(cql, cf, timestamp - 5)
+            response = rest_api.send("POST", "storage_service/flush")
+            assert response.status_code == requests.codes.ok
+
+            # Sleep a second to let the commitlog minimum gc time, in seconds, be greater than the tombstone deletion time
+            sleep_till_whole_second(1)
+            populateSomeData(cql, cf, (1, 11), timestamp - 10)
+            response = rest_api.send("POST", "storage_service/flush")
+            assert response.status_code == requests.codes.ok
+
+            # Do not flush to keep it in memtable
+            cql.execute(f"UPDATE {cf} USING TIMESTAMP {timestamp - 7} SET v=100 WHERE pk=1 AND ck=122")
+            cql.execute(f"UPDATE {cf} USING TIMESTAMP {timestamp - 7} SET v=100 WHERE pk=7 AND ck=122")
+
+            response = rest_api.send("POST", f"storage_service/keyspace_compaction/{ks}", {"flush_memtables": "false"})
+            assert response.status_code == requests.codes.ok
+
+            response = waitAndGetCompleteCompactionHistory(rest_api, cf)
+            stats = extractTombstonePurgeStatistics(response, ks)
+            assert stats == TombstonePurgeStats(5, 1, 0)
+
+
+def test_compactionhistory_tombstone_purge_statistics_overlapping_with_other_sstables(cql, rest_api):
+    with new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
+        compaction_opt = "{'class': 'SizeTieredCompactionStrategy', 'min_threshold': 2, 'min_sstable_size': 0}"
+        with new_test_table(cql, ks, "pk int, ck int, v int, PRIMARY KEY (pk, ck)",
+                            f"WITH compaction = {compaction_opt} AND tombstone_gc = {{'mode': 'immediate'}};") as cf:
+            timestamp = int(time.time())
+
+            cql.execute(f"UPDATE {cf} USING TIMESTAMP {timestamp - 7} SET v=100 WHERE pk=1 AND ck=122")
+            cql.execute(f"UPDATE {cf} USING TIMESTAMP {timestamp - 7} SET v=100 WHERE pk=7 AND ck=122")
+            response = rest_api.send("POST", "storage_service/flush")
+            assert response.status_code == requests.codes.ok
+
+            # Now produce two additional sstable that will get into the same bucket
+            # and hence be compacted together but not with the sstable from above.
+            populateSomeData(cql, cf, (11, 21), timestamp - 5)
+            alterSomeData(cql, cf, timestamp - 5)
+            response = rest_api.send("POST", "storage_service/flush")
+            assert response.status_code == requests.codes.ok
+
+            # Sleep a second to let the commitlog minimum gc time, in seconds, be greater than the tombstone deletion time
+            sleep_till_whole_second(1)
+            populateSomeData(cql, cf, (1, 11), timestamp - 10)
+            response = rest_api.send("POST", "storage_service/flush")
+            assert response.status_code == requests.codes.ok
+
+            response = waitAndGetCompleteCompactionHistory(rest_api, cf)
+
+            stats = extractTombstonePurgeStatistics(response, ks)
+            assert stats == TombstonePurgeStats(5, 0, 1)
+
+            stats = extractSStablesStatistics(response, ks)
+            assert len(stats.input) == 4 and len(stats.output) == 2

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -39,6 +39,7 @@
 #include "api/scrub_status.hh"
 #include "gms/application_state.hh"
 #include "db/config.hh"
+#include "db/compaction_history_entry.hh"
 #include "db_clock.hh"
 #include "utils/log.hh"
 #include "release.hh"
@@ -105,11 +106,21 @@ struct fmt::formatter<file_size_printer> : fmt::formatter<string_view> {
     }
 };
 
+template <>
+struct fmt::formatter<sstables::basic_info> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const sstables::basic_info& sstable, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{{generation: {}, origin: {}, size: {}}}", data_value(sstable.generation), sstable.origin, sstable.size);
+    }
+};
+
 namespace {
 
 const auto app_name = "nodetool";
 
 logging::logger nlog(format("scylla-{}", app_name));
+
+using history_entry = db::compaction_history_entry;
 
 struct operation_failed_on_scylladb : public std::runtime_error {
     using std::runtime_error::runtime_error;
@@ -624,17 +635,47 @@ void print_compactionhistory(const std::vector<Entry>& history) {
     for (const auto& e : history) {
         auto output = seq->add_map();
         output->add_item("id", fmt::to_string(e.id));
-        output->add_item("columnfamily_name", e.table);
-        output->add_item("keyspace_name", e.keyspace);
+        output->add_item("shard_id", e.shard_id);
+        output->add_item("columnfamily_name", e.cf);
+        output->add_item("keyspace_name", e.ks);
+        output->add_item("compaction_type", e.compaction_type);
+        output->add_item("started_at", format_compacted_at(e.started_at));
         output->add_item("compacted_at", format_compacted_at(e.compacted_at));
         output->add_item("bytes_in", e.bytes_in);
         output->add_item("bytes_out", e.bytes_out);
-        auto seq = output->add_seq("rows_merged");
-        for (const auto& [key, value] : e.rows_merged) {
-            auto output = seq->add_map();
-            output->add_item("key", key);
-            output->add_item("value", value);
+        {
+            auto seq = output->add_seq("rows_merged");
+            for (const auto& [key, value] : std::map<int32_t, int64_t>(e.rows_merged.begin(), e.rows_merged.end())) {
+                auto output = seq->add_map();
+                output->add_item("key", key);
+                output->add_item("value", value);
+            }
         }
+        {
+            auto seq = output->add_seq("sstables_in");
+            for (const auto& sstable : e.sstables_in) {
+                auto output = seq->add_map();
+                output->add_item("generation", fmt::to_string(data_value(sstable.generation)));
+                output->add_item("origin", sstable.origin);
+                output->add_item("size", sstable.size);
+            }
+        }
+        {
+            auto seq = output->add_seq("sstables_out");
+            for (const auto& sstable : e.sstables_out) {
+                auto output = seq->add_map();
+                output->add_item("generation", fmt::to_string(data_value(sstable.generation)));
+                output->add_item("origin", sstable.origin);
+                output->add_item("size", sstable.size);
+            }
+        }
+        output->add_item("total_tombstone_purge_attempt", e.total_tombstone_purge_attempt);
+        output->add_item(
+                "total_tombstone_purge_failure_due_to_overlapping_with_memtable",
+                e.total_tombstone_purge_failure_due_to_overlapping_with_memtable);
+        output->add_item(
+                "total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable",
+                e.total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable);
     }
 }
 
@@ -647,22 +688,12 @@ void compactionhistory_operation(scylla_rest_client& client, const bpo::variable
     }
 
     const auto history_json = client.get("/compaction_manager/compaction_history");
-
-    struct history_entry {
-        utils::UUID id;
-        std::string table;
-        std::string keyspace;
-        int64_t compacted_at;
-        int64_t bytes_in;
-        int64_t bytes_out;
-        std::map<int32_t, int64_t> rows_merged;
-    };
     std::vector<history_entry> history;
 
     for (const auto& history_entry_json : history_json.GetArray()) {
         const auto& history_entry_json_object = history_entry_json.GetObject();
 
-        std::map<int32_t, int64_t> rows_merged;
+        std::unordered_map<int32_t, int64_t> rows_merged;
         if (history_entry_json_object.HasMember("rows_merged")) {
             for (const auto& rows_merged_json : history_entry_json_object["rows_merged"].GetArray()) {
                 const auto& rows_merged_json_object = rows_merged_json.GetObject();
@@ -670,45 +701,87 @@ void compactionhistory_operation(scylla_rest_client& client, const bpo::variable
             }
         }
 
+        std::vector<sstables::basic_info> sstables_in;
+        if (history_entry_json_object.HasMember("sstables_in")) {
+            sstables_in.reserve(history_entry_json_object["sstables_in"].GetArray().Size());
+            for (const auto& sstables_in_json : history_entry_json_object["sstables_in"].GetArray()) {
+                const auto& sstables_in_json_object = sstables_in_json.GetObject();
+                sstables_in.emplace_back(sstables::generation_type::from_string(std::string(rjson::to_string_view(sstables_in_json_object["generation"]))),
+                        sstring(rjson::to_string_view(sstables_in_json_object["origin"])),  sstables_in_json_object["size"].GetInt64());
+            }
+        }
+
+        std::vector<sstables::basic_info> sstables_out;
+        if (history_entry_json_object.HasMember("sstables_out")) {
+            sstables_out.reserve(history_entry_json_object["sstables_out"].GetArray().Size());
+            for (const auto& sstables_in_json : history_entry_json_object["sstables_out"].GetArray()) {
+                const auto& sstables_in_json_object = sstables_in_json.GetObject();
+                sstables_out.emplace_back(sstables::generation_type::from_string(std::string(rjson::to_string_view(sstables_in_json_object["generation"]))),
+                        sstring(rjson::to_string_view(sstables_in_json_object["origin"])),  sstables_in_json_object["size"].GetInt64());
+            }
+        }
+
         history.emplace_back(history_entry{
                 .id = utils::UUID(rjson::to_string_view(history_entry_json_object["id"])),
-                .table = std::string(rjson::to_string_view(history_entry_json_object["cf"])),
-                .keyspace = std::string(rjson::to_string_view(history_entry_json_object["ks"])),
+                .shard_id = history_entry_json_object["shard_id"].GetInt(),
+                .ks = sstring(rjson::to_string_view(history_entry_json_object["ks"])),
+                .cf = sstring(rjson::to_string_view(history_entry_json_object["cf"])),
+                .compaction_type = sstring(rjson::to_string_view(history_entry_json_object["compaction_type"])),
+                .started_at = history_entry_json_object["started_at"].GetInt64(),
                 .compacted_at = history_entry_json_object["compacted_at"].GetInt64(),
                 .bytes_in = history_entry_json_object["bytes_in"].GetInt64(),
                 .bytes_out = history_entry_json_object["bytes_out"].GetInt64(),
-                .rows_merged = std::move(rows_merged)});
+                .rows_merged = std::move(rows_merged),
+                .sstables_in = std::move(sstables_in),
+                .sstables_out = std::move(sstables_out),
+                .total_tombstone_purge_attempt = history_entry_json_object["total_tombstone_purge_attempt"].GetInt64(),
+                .total_tombstone_purge_failure_due_to_overlapping_with_memtable =
+                        history_entry_json_object["total_tombstone_purge_failure_due_to_overlapping_with_memtable"].GetInt64(),
+                .total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable =
+                        history_entry_json_object["total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable"].GetInt64()});
     }
 
     std::ranges::sort(history, [] (const history_entry& a, const history_entry& b) { return a.compacted_at > b.compacted_at; });
 
     if (format == "text") {
-        std::array<std::string, 7> header_row{"id", "keyspace_name", "columnfamily_name", "compacted_at", "bytes_in", "bytes_out", "rows_merged"};
-        std::array<size_t, 7> max_column_length{};
+        constexpr size_t column_count = 15;
+        std::array<std::string, column_count> header_row{"id", "shard_id", "keyspace_name", "columnfamily_name", "compaction_type", "started_at",
+                        "compacted_at", "bytes_in", "bytes_out", "rows_merged", "sstables_in", "sstables_out", "total_tombstone_purge_attempt",
+                        "total_tombstone_purge_failure_due_to_overlapping_with_memtable",
+                        "total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable"};
+        std::array<size_t, column_count> max_column_length{};
         for (size_t c = 0; c < header_row.size(); ++c) {
             max_column_length[c] = header_row[c].size();
         }
 
-        std::vector<std::array<std::string, 7>> rows;
+        std::vector<std::array<std::string, column_count>> rows;
         rows.reserve(history.size());
         for (const auto& e : history) {
-            rows.push_back({fmt::to_string(e.id), e.keyspace, e.table, format_compacted_at(e.compacted_at), fmt::to_string(e.bytes_in),
-                    fmt::to_string(e.bytes_out), fmt::to_string(e.rows_merged)});
+            rows.push_back({fmt::to_string(e.id), fmt::to_string(e.shard_id), e.ks, e.cf, e.compaction_type, format_compacted_at(e.started_at),
+                    format_compacted_at(e.compacted_at), fmt::to_string(e.bytes_in), fmt::to_string(e.bytes_out),
+                    fmt::to_string(std::map<int32_t, int64_t>(e.rows_merged.begin(), e.rows_merged.end())), fmt::to_string(e.sstables_in),
+                    fmt::to_string(e.sstables_out), fmt::to_string(e.total_tombstone_purge_attempt),
+                    fmt::to_string(e.total_tombstone_purge_failure_due_to_overlapping_with_memtable),
+                    fmt::to_string(e.total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable)});
             for (size_t c = 0; c < rows.back().size(); ++c) {
                 max_column_length[c] = std::max(max_column_length[c], rows.back()[c].size());
             }
         }
 
-        const auto header_row_format = fmt::format("{{:<{}}} {{:<{}}} {{:<{}}} {{:<{}}} {{:<{}}} {{:<{}}} {{:<{}}}\n", max_column_length[0],
-                max_column_length[1], max_column_length[2], max_column_length[3], max_column_length[4], max_column_length[5], max_column_length[6]);
-        const auto regular_row_format = fmt::format("{{:<{}}} {{:<{}}} {{:<{}}} {{:<{}}} {{:>{}}} {{:>{}}} {{:<{}}}\n", max_column_length[0],
-                max_column_length[1], max_column_length[2], max_column_length[3], max_column_length[4], max_column_length[5], max_column_length[6]);
+        const auto header_row_format =
+                fmt::format("{} \n", fmt::join(max_column_length | std::views::transform([](size_t value) { return fmt::format("{{:<{}}}", value); }), " "));
+
+        static auto regular_row_formatter = [] <typename... Args> (Args&&... args) {
+            return fmt::format("{{:<{}}} {{:>{}}} {{:<{}}} {{:<{}}} {{:<{}}} {{:<{}}} {{:<{}}} {{:>{}}} {{:>{}}} {{:<{}}} {{:<{}}} {{:<{}}} {{:<{}}} {{:<{}}} {{:<{}}} \n",
+                               std::forward<Args>(args)...);
+        };
+        const auto regular_row_format = std::apply(regular_row_formatter, max_column_length);
 
         fmt::print(std::cout, "Compaction History:\n");
-        fmt::print(std::cout, fmt::runtime(header_row_format.c_str()), header_row[0], header_row[1], header_row[2], header_row[3], header_row[4],
-                header_row[5], header_row[6]);
+        fmt::print(std::cout, fmt::runtime(header_row_format.c_str()), header_row[0], header_row[1], header_row[2], header_row[3], header_row[4], header_row[5],
+                header_row[6], header_row[7], header_row[8], header_row[9], header_row[10], header_row[11], header_row[12], header_row[13], header_row[14]);
         for (const auto& r : rows) {
-            fmt::print(std::cout, fmt::runtime(regular_row_format.c_str()), r[0], r[1], r[2], r[3], r[4], r[5], r[6]);
+            fmt::print(std::cout, fmt::runtime(regular_row_format.c_str()), r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12], r[13], r[14]);
         }
     } else if (format == "json") {
         print_compactionhistory<json_writer>(history);


### PR DESCRIPTION
Currently, the `system.compaction_history` table miss information like the type of compaction (cleanup, major, resharding, etc), the sstable generations involved (in and out), shard's id the compaction was triggered on and statistics on purged tombstones to be collected during compaction.

The series extends the table with the following columns:

-  "compaction_type" (text)
- "shard_id" (int)
- "sstables_in" (list<sstableinfo_type>)
- "sstables_out" (list<sstableinfo_type>)
- "total_tombstone_purge_attempt" (long)
- "total_tombstone_purge_failure_due_to_overlapping_with_memtable" (long)
- "total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable" (long)

with a user defined type `sstableinfo_type` that holds the information about sstable file

- generation (uuid)
- origin (text)
- size (long)

Additional statistics stored in the compaction_history have been incorporated in the API  `/compaction_manager/compaction_history` and the `nodetool compactionhistory` command.

No backport is required. It extends the existing compaction history output.

Fixes https://github.com/scylladb/scylladb/issues/3791