### PR TITLE
Fix Replication Factor calculation for Tablets effective replication map.

### DIFF
--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -26,27 +26,25 @@ namespace db {
 
 logging::logger cl_logger("consistency");
 
-size_t quorum_for(const locator::effective_replication_map& erm) {
-    size_t replication_factor = erm.get_schema_replication_factor();
-    return replication_factor ? (replication_factor / 2) + 1 : 0;
+namespace {
+
+inline constexpr size_t quorum(const size_t replication_factor) {
+    return replication_factor > 0 ? replication_factor / 2 + 1 : 0;
 }
 
-size_t local_quorum_for(const locator::effective_replication_map& erm, const sstring& dc) {
-    using namespace locator;
+} // namespace
 
-    const auto& rs = erm.get_replication_strategy();
-
-    if (rs.get_type() == replication_strategy_type::network_topology) {
-        const network_topology_strategy* nrs =
-            static_cast<const network_topology_strategy*>(&rs);
-        size_t replication_factor = nrs->get_replication_factor(dc);
-        return replication_factor ? (replication_factor / 2) + 1 : 0;
-    }
-
-    return quorum_for(erm);
+size_t quorum_for(const locator::effective_replication_map& erm, const dht::token token_id) {
+    const size_t replication_factor = erm.get_replication_factor(token_id);
+    return quorum(replication_factor);
 }
 
-size_t block_for_local_serial(const locator::effective_replication_map& erm) {
+size_t local_quorum_for(const locator::effective_replication_map& erm, const sstring& dc, const dht::token token_id) {
+    const size_t replication_factor = erm.get_replication_factor(token_id, dc);
+    return quorum(replication_factor);
+}
+
+size_t block_for_local_serial(const locator::effective_replication_map& erm, const dht::token token_id) {
     using namespace locator;
 
     //
@@ -57,10 +55,10 @@ size_t block_for_local_serial(const locator::effective_replication_map& erm) {
     //
 
     const auto& topo = erm.get_topology();
-    return local_quorum_for(erm, topo.get_datacenter());
+    return local_quorum_for(erm, topo.get_datacenter(), token_id);
 }
 
-size_t block_for_each_quorum(const locator::effective_replication_map& erm) {
+size_t block_for_each_quorum(const locator::effective_replication_map& erm, const dht::token token_id) {
     using namespace locator;
 
     const auto& rs = erm.get_replication_strategy();
@@ -71,16 +69,16 @@ size_t block_for_each_quorum(const locator::effective_replication_map& erm) {
         size_t n = 0;
 
         for (auto& dc : nrs->get_datacenters()) {
-            n += local_quorum_for(erm, dc);
+            n += local_quorum_for(erm, dc, token_id);
         }
 
         return n;
     } else {
-        return quorum_for(erm);
+        return quorum_for(erm, token_id);
     }
 }
 
-size_t block_for(const locator::effective_replication_map& erm, consistency_level cl) {
+size_t block_for(const locator::effective_replication_map& erm, consistency_level cl, const dht::token token_id) {
     switch (cl) {
     case consistency_level::ONE:
         [[fallthrough]];
@@ -95,15 +93,15 @@ size_t block_for(const locator::effective_replication_map& erm, consistency_leve
     case consistency_level::QUORUM:
         [[fallthrough]];
     case consistency_level::SERIAL:
-        return quorum_for(erm);
+        return quorum_for(erm, token_id);
     case consistency_level::ALL:
-        return erm.get_schema_replication_factor();
+        return erm.get_replication_factor(token_id);
     case consistency_level::LOCAL_QUORUM:
         [[fallthrough]];
     case consistency_level::LOCAL_SERIAL:
-        return block_for_local_serial(erm);
+        return block_for_local_serial(erm, token_id);
     case consistency_level::EACH_QUORUM:
-        return block_for_each_quorum(erm);
+        return block_for_each_quorum(erm, token_id);
     default:
         abort();
     }
@@ -153,14 +151,15 @@ bool assure_sufficient_live_nodes_each_quorum(
         consistency_level cl,
         const locator::effective_replication_map& erm,
         const Range& live_endpoints,
-        const PendingRange& pending_endpoints) {
+        const PendingRange& pending_endpoints,
+        const dht::token token_id) {
     using namespace locator;
 
     auto& rs = erm.get_replication_strategy();
 
     if (rs.get_type() == replication_strategy_type::network_topology) {
         for (auto& entry : count_per_dc_endpoints(erm, live_endpoints, pending_endpoints)) {
-            auto dc_block_for = local_quorum_for(erm, entry.first);
+            auto dc_block_for = local_quorum_for(erm, entry.first, token_id);
             auto dc_live = entry.second.live;
             auto dc_pending = entry.second.pending;
 
@@ -180,8 +179,9 @@ void assure_sufficient_live_nodes(
         consistency_level cl,
         const locator::effective_replication_map& erm,
         const Range& live_endpoints,
+        const dht::token token_id,
         const PendingRange& pending_endpoints) {
-    size_t need = block_for(erm, cl);
+    size_t need = block_for(erm, cl, token_id);
 
     auto adjust_live_for_error = [] (size_t live, size_t pending) {
         // DowngradingConsistencyRetryPolicy uses alive replicas count from Unavailable
@@ -212,7 +212,7 @@ void assure_sufficient_live_nodes(
         break;
     }
     case consistency_level::EACH_QUORUM:
-        if (assure_sufficient_live_nodes_each_quorum(cl, erm, live_endpoints, pending_endpoints)) {
+        if (assure_sufficient_live_nodes_each_quorum(cl, erm, live_endpoints, pending_endpoints, token_id)) {
             break;
         }
     // Fallthrough on purpose for SimpleStrategy
@@ -228,9 +228,9 @@ void assure_sufficient_live_nodes(
     }
 }
 
-template void assure_sufficient_live_nodes(consistency_level, const locator::effective_replication_map&, const inet_address_vector_replica_set&, const std::array<gms::inet_address, 0>&);
-template void assure_sufficient_live_nodes(db::consistency_level, const locator::effective_replication_map&, const inet_address_vector_replica_set&, const utils::small_vector<gms::inet_address, 1ul>&);
-template void assure_sufficient_live_nodes(db::consistency_level, const locator::effective_replication_map&, const host_id_vector_replica_set&, const host_id_vector_topology_change&);
+template void assure_sufficient_live_nodes(consistency_level, const locator::effective_replication_map&, const inet_address_vector_replica_set&, dht::token token_id, const std::array<gms::inet_address, 0>&);
+template void assure_sufficient_live_nodes(db::consistency_level, const locator::effective_replication_map&, const inet_address_vector_replica_set&, dht::token token_id, const utils::small_vector<gms::inet_address, 1ul>&);
+template void assure_sufficient_live_nodes(db::consistency_level, const locator::effective_replication_map&, const host_id_vector_replica_set&, dht::token token_id, const host_id_vector_topology_change&);
 
 host_id_vector_replica_set
 filter_for_query(consistency_level cl,
@@ -240,7 +240,8 @@ filter_for_query(consistency_level cl,
                  read_repair_decision read_repair,
                  const gms::gossiper& g,
                  std::optional<locator::host_id>* extra,
-                 replica::column_family* cf) {
+                 replica::column_family* cf,
+                 const dht::token token_id) {
     size_t local_count;
 
     if (read_repair == read_repair_decision::GLOBAL) { // take RRD.GLOBAL out of the way
@@ -256,7 +257,7 @@ filter_for_query(consistency_level cl,
         }
     }
 
-    size_t bf = block_for(erm, cl);
+    size_t bf = block_for(erm, cl, token_id);
 
     if (read_repair == read_repair_decision::DC_LOCAL) {
         bf = std::max(bf, local_count);
@@ -356,7 +357,8 @@ filter_for_query(consistency_level cl,
 bool
 is_sufficient_live_nodes(consistency_level cl,
                          const locator::effective_replication_map& erm,
-                         const host_id_vector_replica_set& live_endpoints) {
+                         const host_id_vector_replica_set& live_endpoints,
+                         const dht::token token_id) {
     using namespace locator;
     const auto& topo = erm.get_topology();
 
@@ -367,14 +369,14 @@ is_sufficient_live_nodes(consistency_level cl,
     case consistency_level::LOCAL_ONE:
         return topo.count_local_endpoints(live_endpoints) >= 1;
     case consistency_level::LOCAL_QUORUM:
-        return topo.count_local_endpoints(live_endpoints) >= block_for(erm, cl);
+        return topo.count_local_endpoints(live_endpoints) >= block_for(erm, cl, token_id);
     case consistency_level::EACH_QUORUM:
     {
         auto& rs = erm.get_replication_strategy();
 
         if (rs.get_type() == replication_strategy_type::network_topology) {
             for (auto& entry : count_per_dc_endpoints(erm, live_endpoints)) {
-                if (entry.second.live < local_quorum_for(erm, entry.first)) {
+                if (entry.second.live < local_quorum_for(erm, entry.first, token_id)) {
                     return false;
                 }
             }
@@ -385,7 +387,7 @@ is_sufficient_live_nodes(consistency_level cl,
         [[fallthrough]];
         // Fallthrough on purpose for SimpleStrategy
     default:
-        return live_endpoints.size() >= block_for(erm, cl);
+        return live_endpoints.size() >= block_for(erm, cl, token_id);
     }
 }
 

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -27,7 +27,7 @@ namespace db {
 logging::logger cl_logger("consistency");
 
 size_t quorum_for(const locator::effective_replication_map& erm) {
-    size_t replication_factor = erm.get_replication_factor();
+    size_t replication_factor = erm.get_schema_replication_factor();
     return replication_factor ? (replication_factor / 2) + 1 : 0;
 }
 
@@ -97,7 +97,7 @@ size_t block_for(const locator::effective_replication_map& erm, consistency_leve
     case consistency_level::SERIAL:
         return quorum_for(erm);
     case consistency_level::ALL:
-        return erm.get_replication_factor();
+        return erm.get_schema_replication_factor();
     case consistency_level::LOCAL_QUORUM:
         [[fallthrough]];
     case consistency_level::LOCAL_SERIAL:

--- a/db/consistency_level.hh
+++ b/db/consistency_level.hh
@@ -12,6 +12,7 @@
 
 #include "db/consistency_level_type.hh"
 #include "db/read_repair_decision.hh"
+#include "dht/token.hh"
 #include "gms/inet_address.hh"
 #include "inet_address_vectors.hh"
 #include "utils/log.hh"
@@ -29,15 +30,15 @@ namespace db {
 
 extern logging::logger cl_logger;
 
-size_t quorum_for(const locator::effective_replication_map& erm);
+size_t quorum_for(const locator::effective_replication_map& erm, dht::token token_id);
 
-size_t local_quorum_for(const locator::effective_replication_map& erm, const sstring& dc);
+size_t local_quorum_for(const locator::effective_replication_map& erm, const sstring& dc, dht::token token_id);
 
-size_t block_for_local_serial(const locator::effective_replication_map& erm);
+size_t block_for_local_serial(const locator::effective_replication_map& erm, dht::token token_id);
 
-size_t block_for_each_quorum(const locator::effective_replication_map& erm);
+size_t block_for_each_quorum(const locator::effective_replication_map& erm, dht::token token_id);
 
-size_t block_for(const locator::effective_replication_map& erm, consistency_level cl);
+size_t block_for(const locator::effective_replication_map& erm, consistency_level cl, dht::token token_id);
 
 bool is_datacenter_local(consistency_level l);
 
@@ -49,7 +50,8 @@ filter_for_query(consistency_level cl,
                  read_repair_decision read_repair,
                  const gms::gossiper& g,
                  std::optional<locator::host_id>* extra,
-                 replica::column_family* cf);
+                 replica::column_family* cf,
+                 dht::token token_id);
 
 struct dc_node_count {
     size_t live = 0;
@@ -59,17 +61,19 @@ struct dc_node_count {
 bool
 is_sufficient_live_nodes(consistency_level cl,
                          const locator::effective_replication_map& erm,
-                         const host_id_vector_replica_set& live_endpoints);
+                         const host_id_vector_replica_set& live_endpoints,
+                         dht::token token_id);
 
 template<typename Range, typename PendingRange = std::array<gms::inet_address, 0>>
 void assure_sufficient_live_nodes(
         consistency_level cl,
         const locator::effective_replication_map& erm,
         const Range& live_endpoints,
+        dht::token token_id,
         const PendingRange& pending_endpoints = std::array<gms::inet_address, 0>());
 
-extern template void assure_sufficient_live_nodes(consistency_level, const locator::effective_replication_map&, const inet_address_vector_replica_set&, const std::array<gms::inet_address, 0>&);
-extern template void assure_sufficient_live_nodes(db::consistency_level, const locator::effective_replication_map&, const inet_address_vector_replica_set&, const utils::small_vector<gms::inet_address, 1ul>&);
-extern template void assure_sufficient_live_nodes(db::consistency_level, const locator::effective_replication_map&, const host_id_vector_replica_set&, const host_id_vector_topology_change&);
+extern template void assure_sufficient_live_nodes(consistency_level, const locator::effective_replication_map&, const inet_address_vector_replica_set&, dht::token token_id, const std::array<gms::inet_address, 0>&);
+extern template void assure_sufficient_live_nodes(db::consistency_level, const locator::effective_replication_map&, const inet_address_vector_replica_set&, dht::token token_id, const utils::small_vector<gms::inet_address, 1ul>&);
+extern template void assure_sufficient_live_nodes(db::consistency_level, const locator::effective_replication_map&, const host_id_vector_replica_set&, dht::token token_id, const host_id_vector_topology_change&);
 
 }

--- a/db/hints/internal/hint_sender.cc
+++ b/db/hints/internal/hint_sender.cc
@@ -259,9 +259,9 @@ void hint_sender::start() {
 future<> hint_sender::send_one_mutation(frozen_mutation_and_schema m) {
     auto ermp = _db.find_column_family(m.s).get_effective_replication_map();
     auto token = dht::get_token(*m.s, m.fm.key());
-    host_id_vector_replica_set natural_endpoints = ermp->get_natural_replicas(std::move(token));
+    host_id_vector_replica_set natural_endpoints = ermp->get_natural_replicas(token);
 
-    return futurize_invoke([this, m = std::move(m), ermp = std::move(ermp), &natural_endpoints] () mutable -> future<> {
+    return futurize_invoke([this, m = std::move(m), ermp = std::move(ermp), &natural_endpoints, token] () mutable -> future<> {
         // The fact that we send with CL::ALL in both cases below ensures that new hints are not going
         // to be generated as a result of hints sending.
         const auto& tm = ermp->get_token_metadata();
@@ -269,7 +269,7 @@ future<> hint_sender::send_one_mutation(frozen_mutation_and_schema m) {
 
         if (std::ranges::contains(natural_endpoints, dst) && !tm.is_leaving(dst)) {
             manager_logger.trace("Sending directly to {}", dst);
-            return _proxy.send_hint_to_endpoint(std::move(m), std::move(ermp), dst);
+            return _proxy.send_hint_to_endpoint(std::move(m), std::move(ermp), dst, token);
         } else {
             if (manager_logger.is_enabled(log_level::trace)) {
                 if (tm.is_leaving(end_point_key())) {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1820,7 +1820,8 @@ static future<> apply_to_remote_endpoints(service::storage_proxy& proxy, locator
             db::write_type::VIEW,
             std::move(tr_state),
             allow_hints,
-            service::is_cancellable::yes);
+            service::is_cancellable::yes,
+            view_token);
     while (utils::get_local_injector().enter("never_finish_remote_view_updates")) {
         co_await seastar::sleep(100ms);
     }

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -63,7 +63,7 @@ range_streamer::get_range_fetch_map(const std::unordered_map<dht::token_range, s
 
         if (!found_source) {
             auto& ks = _db.local().find_keyspace(keyspace);
-            auto rf = ks.get_vnode_effective_replication_map()->get_replication_factor();
+            auto rf = ks.get_vnode_effective_replication_map()->get_schema_replication_factor();
             // When a replacing node replaces a dead node with keyspace of RF
             // 1, it is expected that replacing node could not find a peer node
             // that contains data to stream from.
@@ -152,7 +152,7 @@ range_streamer::get_all_ranges_with_strict_sources_for(const sstring& keyspace_n
                 std::unordered_set<locator::host_id> new_endpoints(it->second.begin(), it->second.end());
                 //Due to CASSANDRA-5953 we can have a higher RF then we have endpoints.
                 //So we need to be careful to only be strict when endpoints == RF
-                if (old_endpoints.size() == erm->get_replication_factor()) {
+                if (old_endpoints.size() == erm->get_schema_replication_factor()) {
                     std::erase_if(old_endpoints,
                         [&new_endpoints] (locator::host_id ep) { return new_endpoints.contains(ep); });
                     if (old_endpoints.size() != 1) {
@@ -184,7 +184,7 @@ range_streamer::get_all_ranges_with_strict_sources_for(const sstring& keyspace_n
 }
 
 bool range_streamer::use_strict_sources_for_ranges(const sstring& keyspace_name, const locator::vnode_effective_replication_map_ptr& erm) {
-    auto rf = erm->get_replication_factor();
+    auto rf = erm->get_schema_replication_factor();
     auto nr_nodes_in_ring = get_token_metadata().get_normal_token_owners().size();
     bool everywhere_topology = erm->get_replication_strategy().get_type() == locator::replication_strategy_type::everywhere_topology;
     // Use strict when number of nodes in the ring is equal or more than RF

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -580,7 +580,7 @@ future<vnode_effective_replication_map_ptr> effective_replication_map_factory::c
     });
     mutable_vnode_effective_replication_map_ptr new_erm;
     if (ref_erm) {
-        auto rf = ref_erm->get_replication_factor();
+        auto rf = ref_erm->get_schema_replication_factor();
         auto local_data = co_await ref_erm->clone_data_gently();
         new_erm = make_effective_replication_map(std::move(rs), std::move(tmptr), std::move(local_data->replication_map),
             std::move(local_data->pending_endpoints), std::move(local_data->read_endpoints), std::move(local_data->dirty_endpoints), rf);

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -298,7 +298,7 @@ protected:
     }
 public:
     virtual ~per_table_replication_strategy() = default;
-    virtual effective_replication_map_ptr make_replication_map(table_id, token_metadata_ptr) const = 0;
+    virtual future<effective_replication_map_ptr> make_replication_map(table_id, token_metadata_ptr) const = 0;
 };
 
 // Holds the full replication_map resulting from applying the

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -96,7 +96,8 @@ public:
     using ptr_type = seastar::shared_ptr<abstract_replication_strategy>;
 
     // Check that the read replica set does not exceed what's allowed by the schema.
-    [[nodiscard]] virtual sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const = 0;
+    [[nodiscard]] virtual sstring sanity_check_read_replicas(
+            const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, dht::token token) const = 0;
 
     abstract_replication_strategy(
         replication_strategy_params params,

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -209,7 +209,7 @@ public:
     const token_metadata& get_token_metadata() const noexcept { return *_tmptr; }
     const token_metadata_ptr& get_token_metadata_ptr() const noexcept { return _tmptr; }
     const topology& get_topology() const noexcept { return _tmptr->get_topology(); }
-    size_t get_replication_factor() const noexcept { return _replication_factor; }
+    size_t get_schema_replication_factor() const noexcept { return _replication_factor; }
 
     void invalidate() const noexcept {
         _validity_abort_source->request_abort();

--- a/locator/everywhere_replication_strategy.cc
+++ b/locator/everywhere_replication_strategy.cc
@@ -41,7 +41,7 @@ void everywhere_replication_strategy::validate_options(const gms::feature_servic
 }
 
 sstring everywhere_replication_strategy::sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const {
-    const auto replication_factor = erm.get_replication_factor();
+    const auto replication_factor = erm.get_schema_replication_factor();
     if (read_replicas.size() > replication_factor) {
         return seastar::format("everywhere_replication_strategy: the number of replicas for everywhere_replication_strategy is {}, cannot be higher than replication factor {}", read_replicas.size(), replication_factor);
     }

--- a/locator/everywhere_replication_strategy.cc
+++ b/locator/everywhere_replication_strategy.cc
@@ -40,8 +40,9 @@ void everywhere_replication_strategy::validate_options(const gms::feature_servic
     }
 }
 
-sstring everywhere_replication_strategy::sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const {
-    const auto replication_factor = erm.get_schema_replication_factor();
+sstring everywhere_replication_strategy::sanity_check_read_replicas(
+        const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, const dht::token token) const {
+    const auto replication_factor = erm.get_replication_factor(token);
     if (read_replicas.size() > replication_factor) {
         return seastar::format("everywhere_replication_strategy: the number of replicas for everywhere_replication_strategy is {}, cannot be higher than replication factor {}", read_replicas.size(), replication_factor);
     }

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -33,6 +33,7 @@ public:
         return true;
     }
 
-    [[nodiscard]] sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const override;
+    [[nodiscard]] sstring sanity_check_read_replicas(
+            const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, dht::token token) const override;
 };
 }

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -38,7 +38,8 @@ size_t local_strategy::get_replication_factor(const token_metadata&) const {
     return 1;
 }
 
-sstring local_strategy::sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const {
+sstring local_strategy::sanity_check_read_replicas(
+        const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, const dht::token token) const {
     if (read_replicas.size() > 1) {
         return seastar::format("local_strategy: the number of replicas for local_strategy is {}, cannot be higher than 1", read_replicas.size());
     }

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -36,7 +36,8 @@ public:
         return false;
     }
 
-    [[nodiscard]] sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const override;
+    [[nodiscard]] sstring sanity_check_read_replicas(
+            const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, dht::token token) const override;
 };
 
 }

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -293,7 +293,7 @@ std::optional<std::unordered_set<sstring>> network_topology_strategy::recognized
     return opts;
 }
 
-effective_replication_map_ptr network_topology_strategy::make_replication_map(table_id table, token_metadata_ptr tm) const {
+future<effective_replication_map_ptr> network_topology_strategy::make_replication_map(table_id table, token_metadata_ptr tm) const {
     if (!uses_tablets()) {
         on_internal_error(rslogger, format("make_replication_map() called for table {} but replication strategy not configured to use tablets", table));
     }

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -42,7 +42,8 @@ public:
         return true;
     }
 
-    [[nodiscard]] sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const override;
+    [[nodiscard]] sstring sanity_check_read_replicas(
+            const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, dht::token token) const override;
 
 public: // tablet_aware_replication_strategy
     virtual future<effective_replication_map_ptr> make_replication_map(table_id, token_metadata_ptr) const override;

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -45,7 +45,7 @@ public:
     [[nodiscard]] sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const override;
 
 public: // tablet_aware_replication_strategy
-    virtual effective_replication_map_ptr make_replication_map(table_id, token_metadata_ptr) const override;
+    virtual future<effective_replication_map_ptr> make_replication_map(table_id, token_metadata_ptr) const override;
     virtual future<tablet_map> allocate_tablets_for_new_table(schema_ptr, token_metadata_ptr, unsigned initial_scale) const override;
     virtual future<tablet_map> reallocate_tablets(schema_ptr, token_metadata_ptr, tablet_map cur_tablets) const override;
 protected:

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -79,7 +79,8 @@ std::optional<std::unordered_set<sstring>>simple_strategy::recognized_options(co
     return {{ "replication_factor" }};
 }
 
-sstring simple_strategy::sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const {
+sstring simple_strategy::sanity_check_read_replicas(
+        const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, const dht::token token) const {
     if (read_replicas.size() > _replication_factor) {
         return seastar::format("ERM inconsistency, the read replica set for simple strategy has higher count of"
                                " read replicas [{}] than its replication factor [{}]",

--- a/locator/simple_strategy.hh
+++ b/locator/simple_strategy.hh
@@ -27,7 +27,9 @@ public:
 
     virtual future<host_id_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
 
-    [[nodiscard]] sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const override;
+    [[nodiscard]] sstring sanity_check_read_replicas(
+            const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, dht::token token) const override;
+
 private:
     size_t _replication_factor = 1;
 };

--- a/locator/tablet_replication_strategy.hh
+++ b/locator/tablet_replication_strategy.hh
@@ -30,7 +30,7 @@ protected:
     void process_tablet_options(abstract_replication_strategy&, replication_strategy_config_options&, replication_strategy_params);
     std::unordered_set<sstring> recognized_tablet_options() const;
     size_t get_initial_tablets() const { return _initial_tablets; }
-    effective_replication_map_ptr do_make_replication_map(table_id,
+    future<effective_replication_map_ptr> do_make_replication_map(table_id,
                                                           replication_strategy_ptr,
                                                           token_metadata_ptr,
                                                           size_t replication_factor) const;

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -811,7 +811,7 @@ private:
                     return info->next;
                 }
             }
-            on_internal_error(tablet_logger, format("Invalid replica selector", static_cast<int>(info->writes)));
+            on_internal_error(tablet_logger, format("Invalid replica selector {}", static_cast<int>(info->writes)));
         });
         tablet_logger.trace("get_replicas_for_write({}): table={}, tablet={}, replicas={}", search_token, _table, tablet, replicas);
         return replicas;

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1011,9 +1011,10 @@ std::unordered_set<sstring> tablet_aware_replication_strategy::recognized_tablet
     return opts;
 }
 
-effective_replication_map_ptr tablet_aware_replication_strategy::do_make_replication_map(
+future<effective_replication_map_ptr> tablet_aware_replication_strategy::do_make_replication_map(
         table_id table, replication_strategy_ptr rs, token_metadata_ptr tm, size_t replication_factor) const {
-    return seastar::make_shared<tablet_effective_replication_map>(table, std::move(rs), std::move(tm), replication_factor);
+    return make_ready_future<effective_replication_map_ptr>(
+            seastar::make_shared<tablet_effective_replication_map>(table, std::move(rs), std::move(tm), replication_factor));
 }
 
 void tablet_metadata_guard::check() noexcept {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -815,9 +815,26 @@ future<bool> check_tablet_replica_shards(const tablet_metadata& tm, host_id this
 }
 
 class tablet_effective_replication_map : public effective_replication_map {
+
+public:
+    using replication_factor_t = uint16_t;
+    using dc_index_type = uint16_t;
+    using replication_factor_list = utils::small_vector<replication_factor_t, 8>;
+    using datacenter_to_index_map = absl::flat_hash_map<sstring, dc_index_type>;
+    using tablet_to_datacenter_replication_factor_list_map = utils::chunked_vector<replication_factor_list>;
+
+private:
+
     table_id _table;
     tablet_sharder _sharder;
     mutable const tablet_map* _tmap = nullptr;
+    // The `_datacenter_map` stores the association between each data center
+    // and its index in the `replication_factor_list` in `_tablet_to_dc_replication_factor_map`.
+    const datacenter_to_index_map _datacenter_map;
+    // The `_tablet_to_dc_replication_factor_map` stores replication factors
+    // per data center for each Tablet.
+    const tablet_to_datacenter_replication_factor_list_map _tablet_to_dc_replication_factor_map;
+
 private:
     inet_address_vector_replica_set to_replica_set(const tablet_replica_set& replicas) const {
         inet_address_vector_replica_set result;
@@ -879,14 +896,53 @@ private:
     }
 
 public:
+
     tablet_effective_replication_map(table_id table,
                                      replication_strategy_ptr rs,
                                      token_metadata_ptr tmptr,
-                                     size_t replication_factor)
+                                     size_t replication_factor,
+                                     datacenter_to_index_map&& datacenter_map,
+                                     tablet_to_datacenter_replication_factor_list_map&& rf_map)
             : effective_replication_map(std::move(rs), std::move(tmptr), replication_factor)
             , _table(table)
             , _sharder(*_tmptr, table)
+            , _datacenter_map(std::move(datacenter_map))
+            , _tablet_to_dc_replication_factor_map(std::move(rf_map))
     { }
+
+    [[nodiscard]] size_t get_replication_factor(const dht::token id, const seastar::sstring& datacenter) const override {
+        tablet_logger.trace("Get RF for token {}, dc {}", id, datacenter);
+        const auto tablet = get_tablet_map().get_tablet_id(id);
+        if (tablet.id >= _tablet_to_dc_replication_factor_map.size()) [[unlikely]] {
+            on_internal_error(tablet_logger,
+                    format("tablet id index [{}] is out of range of replication factor map. Map size: [{}].", tablet.id, _tablet_to_dc_replication_factor_map.size()));
+        }
+
+        const auto& dc_rf_map = _tablet_to_dc_replication_factor_map[tablet.id];
+        const auto dc_it = _datacenter_map.find(datacenter);
+
+        if (dc_it == _datacenter_map.end()) [[unlikely]] {
+            on_internal_error(tablet_logger, format("Data center: [{}] does not exist in the datacenter map.", datacenter));
+        }
+        if (dc_it->second >= dc_rf_map.size()) [[unlikely]] {
+            on_internal_error(tablet_logger, format("Data center's: [{}] index: [{}] is out of range of the dc_rf_map. Map size: [{}].",
+                                                     datacenter, dc_it->second, dc_rf_map.size()));
+        }
+        return dc_rf_map[dc_it->second];
+    }
+
+    [[nodiscard]] size_t get_replication_factor(const dht::token id) const override {
+        tablet_logger.trace("Get RF for token {}", id);
+        const auto tablet = get_tablet_map().get_tablet_id(id);
+        if (tablet.id >= _tablet_to_dc_replication_factor_map.size()) [[unlikely]] {
+            on_internal_error(tablet_logger, format("Tablet id: [{}] index is out of range for"
+                                                    " _tablet_to_dc_replication_factor_map. Map size: [{}]",
+                                                     tablet.id, _tablet_to_dc_replication_factor_map.size()));
+        }
+        const auto& dc_rf_map = _tablet_to_dc_replication_factor_map[tablet.id];
+        const auto rf = std::accumulate(dc_rf_map.begin(), dc_rf_map.end(), 0);
+        return rf;
+    }
 
     virtual ~tablet_effective_replication_map() = default;
 
@@ -1026,10 +1082,65 @@ std::unordered_set<sstring> tablet_aware_replication_strategy::recognized_tablet
     return opts;
 }
 
+namespace {
+
+// Create a simple map [data center -> index]. This index is used as position index in the small vector
+// in the tablet_effective_replication_map::_tablet_to_dc_replication_factor_map.
+[[nodiscard]] tablet_effective_replication_map::datacenter_to_index_map build_datacenter_map(const auto& data_centers_list) {
+    uint32_t datacenter_index = 0;
+    tablet_effective_replication_map::datacenter_to_index_map datacenter_map;
+    datacenter_map.reserve(data_centers_list.size());
+    for (const sstring& datacenter : data_centers_list) {
+        datacenter_map.emplace(datacenter, datacenter_index);
+        ++datacenter_index;
+    }
+    return datacenter_map;
+}
+
+// Populate a map [tablet id -> replication factor list] with replication factors for each data center.
+// For each tablet index in the tablet map, it retrieves the current replica set using `get_endpoints_for_reading`
+// and counts replicas per data center.  Each data center's replication factor (RF) is saved under
+// its index according to the `datacenter_map`.
+future<tablet_effective_replication_map::tablet_to_datacenter_replication_factor_list_map> build_dc_replication_factor_map(const tablet_map& tablets,
+        const topology& topo, const tablet_effective_replication_map::datacenter_to_index_map& datacenter_map) {
+    tablet_effective_replication_map::tablet_to_datacenter_replication_factor_list_map tablet_to_dc_replication_factor_map;
+    tablet_to_dc_replication_factor_map.reserve(tablets.tablet_count());
+    for (size_t tablet_index = 0; tablet_index < tablets.tablet_count(); ++tablet_index) {
+        const tablet_replica_set& replicas = tablets.get_replicas_for_reading(tablet_id{tablet_index});
+        tablet_to_dc_replication_factor_map.emplace_back(datacenter_map.size(), 0);
+        auto& token_rf_list = tablet_to_dc_replication_factor_map.back();
+        for (const auto& node : replicas) {
+            const locator::node* node_ptr = topo.find_node(node.host);
+            if (node_ptr == nullptr) {
+                on_internal_error(tablet_logger, format("Could not find node: {} in topology.", node));
+            }
+            const sstring& datacenter = topo.get_datacenter(node.host);
+            const auto it = datacenter_map.find(datacenter);
+            if (it == datacenter_map.end()) {
+                on_internal_error(tablet_logger, format("Could not find datacenter: {} for node: {} ", datacenter, node));
+            }
+            const auto index = it->second;
+            assert(index < token_rf_list.size());
+            ++token_rf_list[index];
+        }
+        co_await seastar::maybe_yield();
+    }
+    tablet_logger.debug("Added: [{}] records to rf map.", tablet_to_dc_replication_factor_map.size());
+    co_return tablet_to_dc_replication_factor_map;
+}
+} // namespace
+
 future<effective_replication_map_ptr> tablet_aware_replication_strategy::do_make_replication_map(
         table_id table, replication_strategy_ptr rs, token_metadata_ptr tm, size_t replication_factor) const {
-    return make_ready_future<effective_replication_map_ptr>(
-            seastar::make_shared<tablet_effective_replication_map>(table, std::move(rs), std::move(tm), replication_factor));
+    tablet_logger.debug("Preparing ERM for table: [{}], topology {}", table,  fmt::ptr(&tm->get_topology()));
+    auto datacenter_map = build_datacenter_map(tm->get_topology().get_datacenters());
+
+    auto replication_factor_map = co_await build_dc_replication_factor_map(tm->tablets().get_tablet_map(table), tm->get_topology(), datacenter_map);
+
+    auto erm = seastar::make_shared<tablet_effective_replication_map>(
+            table, std::move(rs), std::move(tm), replication_factor, std::move(datacenter_map), std::move(replication_factor_map));
+
+    co_return erm;
 }
 
 void tablet_metadata_guard::check() noexcept {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -519,6 +519,13 @@ public:
 
     const locator::resize_decision& resize_decision() const;
     const locator::repair_scheduler_config& repair_scheduler_config() const;
+
+    const tablet_replica_set& get_replicas_for_reading(tablet_id tablet) const;
+
+    const tablet_replica_set& get_replicas_for_writing(tablet_id tablet) const;
+
+    const tablet_replica* get_pending_replica(tablet_id tablet) const;
+
 public:
     void set_tablet(tablet_id, tablet_info);
     void set_tablet_transition_info(tablet_id, tablet_transition_info);

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -234,7 +234,7 @@ const node& topology::add_node(node_holder nptr) {
             }
         }
 
-        tlogger.debug("topology[{}]: add_node: {}, at {}", fmt::ptr(this), node_printer(nptr.get()), lazy_backtrace());
+        tlogger.debug("topology[{}]: add_node: {}, at {}", fmt::ptr(this), node_printer(node), lazy_backtrace());
 
         index_node(*node);
     } catch (...) {

--- a/main.cc
+++ b/main.cc
@@ -1780,13 +1780,33 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 throw std::runtime_error("Detected a tablet with invalid replica shard, reducing shard count with tablet-enabled tables is not yet supported. Replace the node instead.");
             }
 
-            supervisor::notify("loading non-system sstables");
-            replica::distributed_loader::init_non_system_keyspaces(db, proxy, sys_ks).get();
-
-            sys_dist_ks.start(std::ref(qp), std::ref(mm), std::ref(proxy)).get();
-            auto stop_sdks = defer_verbose_shutdown("system distributed keyspace", [] {
-                sys_dist_ks.invoke_on_all(&db::system_distributed_keyspace::stop).get();
+            supervisor::notify("starting CDC Generation Management service");
+            /* This service uses the system distributed keyspace.
+             * It will only do that *after* the node has joined the token ring, and the token ring joining
+             * procedure (`storage_service::init_server`) is responsible for initializing sys_dist_ks.
+             * Hence the service will start using sys_dist_ks only after it was initialized.
+             *
+             * However, there is a problem with the service shutdown order: sys_dist_ks is stopped
+             * *before* CDC generation service is stopped (`storage_service::drain_on_shutdown` below),
+             * so CDC generation service takes sharded<db::sys_dist_ks> and must check local_is_initialized()
+             * every time it accesses it (because it may have been stopped already), then take local_shared()
+             * which will prevent sys_dist_ks from being destroyed while the service operates on it.
+             */
+            cdc::generation_service::config cdc_config;
+            cdc_config.ignore_msb_bits = cfg->murmur3_partitioner_ignore_msb_bits();
+            cdc_config.ring_delay = std::chrono::milliseconds(cfg->ring_delay_ms());
+            cdc_config.dont_rewrite_streams = cfg->cdc_dont_rewrite_streams();
+            cdc_generation_service.start(std::move(cdc_config), std::ref(gossiper), std::ref(sys_dist_ks), std::ref(sys_ks),
+                    std::ref(stop_signal.as_sharded_abort_source()), std::ref(token_metadata), std::ref(feature_service), std::ref(db),
+                    [&ss] () -> bool { return ss.local().raft_topology_change_enabled(); }).get();
+            auto stop_cdc_generation_service = defer_verbose_shutdown("CDC Generation Management service", [] {
+                cdc_generation_service.stop().get();
             });
+
+            utils::get_local_injector().inject("stop_after_starting_cdc_generation_service",
+                [] { std::raise(SIGSTOP); });
+
+            const auto generation_number = gms::generation_type(sys_ks.local().increment_and_get_generation().get());
 
             group0_service.start().get();
             auto stop_group0_service = defer_verbose_shutdown("group 0 service", [&group0_service] {
@@ -1799,6 +1819,33 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             // Set up group0 service earlier since it is needed by group0 setup just below
             ss.local().set_group0(group0_service);
+
+            // Load address_map from system.peers and subscribe to gossiper events to keep it updated.
+            ss.local().init_address_map(gossip_address_map.local()).get();
+            auto cancel_address_map_subscription = defer_verbose_shutdown("storage service uninit address map", [&ss] {
+                ss.local().uninit_address_map().get();
+            });
+
+            // Need to make sure storage service stopped using group0 before running group0_service.abort()
+            // Normally it is done in storage_service::do_drain(), but in case start up fail we need to do it
+            // here as well
+            auto stop_group0_usage_in_storage_service = defer_verbose_shutdown("group 0 usage in local storage", [&ss] {
+               ss.local().wait_for_group0_stop().get();
+            });
+
+            // Setup group0 early in case the node is bootstrapped already and the group exists.
+            // Need to do it before allowing incoming messaging service connections since
+            // storage proxy's and migration manager's verbs may access group0.
+            // This will also disable migration manager schema pulls if needed.
+            group0_service.setup_group0_if_exist(sys_ks.local(), ss.local(), qp.local(), mm.local()).get();
+
+            supervisor::notify("loading non-system sstables");
+            replica::distributed_loader::init_non_system_keyspaces(db, proxy, sys_ks).get();
+
+            sys_dist_ks.start(std::ref(qp), std::ref(mm), std::ref(proxy)).get();
+            auto stop_sdks = defer_verbose_shutdown("system distributed keyspace", [] {
+                sys_dist_ks.invoke_on_all(&db::system_distributed_keyspace::stop).get();
+            });
 
             supervisor::notify("starting view update generator");
             view_update_generator.start(std::ref(db), std::ref(proxy), std::ref(stop_signal.as_sharded_abort_source())).get();
@@ -1906,32 +1953,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             utils::get_local_injector().inject("stop_after_starting_repair",
-                [] { std::raise(SIGSTOP); });
-
-            supervisor::notify("starting CDC Generation Management service");
-            /* This service uses the system distributed keyspace.
-             * It will only do that *after* the node has joined the token ring, and the token ring joining
-             * procedure (`storage_service::init_server`) is responsible for initializing sys_dist_ks.
-             * Hence the service will start using sys_dist_ks only after it was initialized.
-             *
-             * However, there is a problem with the service shutdown order: sys_dist_ks is stopped
-             * *before* CDC generation service is stopped (`storage_service::drain_on_shutdown` below),
-             * so CDC generation service takes sharded<db::sys_dist_ks> and must check local_is_initialized()
-             * every time it accesses it (because it may have been stopped already), then take local_shared()
-             * which will prevent sys_dist_ks from being destroyed while the service operates on it.
-             */
-            cdc::generation_service::config cdc_config;
-            cdc_config.ignore_msb_bits = cfg->murmur3_partitioner_ignore_msb_bits();
-            cdc_config.ring_delay = std::chrono::milliseconds(cfg->ring_delay_ms());
-            cdc_config.dont_rewrite_streams = cfg->cdc_dont_rewrite_streams();
-            cdc_generation_service.start(std::move(cdc_config), std::ref(gossiper), std::ref(sys_dist_ks), std::ref(sys_ks),
-                    std::ref(stop_signal.as_sharded_abort_source()), std::ref(token_metadata), std::ref(feature_service), std::ref(db),
-                    [&ss] () -> bool { return ss.local().raft_topology_change_enabled(); }).get();
-            auto stop_cdc_generation_service = defer_verbose_shutdown("CDC Generation Management service", [] {
-                cdc_generation_service.stop().get();
-            });
-
-            utils::get_local_injector().inject("stop_after_starting_cdc_generation_service",
                 [] { std::raise(SIGSTOP); });
 
             auto get_cdc_metadata = [] (cdc::generation_service& svc) { return std::ref(svc.get_cdc_metadata()); };
@@ -2071,30 +2092,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
              */
             db.local().enable_autocompaction_toggle();
 
-            // Load address_map from system.peers and subscribe to gossiper events to keep it updated.
-            ss.local().init_address_map(gossip_address_map.local()).get();
-            auto cancel_address_map_subscription = defer_verbose_shutdown("storage service uninit address map", [&ss] {
-                ss.local().uninit_address_map().get();
-            });
-
-            // Need to make sure storage service stopped using group0 before running group0_service.abort()
-            // Normally it is done in storage_service::do_drain(), but in case start up fail we need to do it
-            // here as well
-            auto stop_group0_usage_in_storage_service = defer_verbose_shutdown("group 0 usage in local storage", [&ss] {
-               ss.local().wait_for_group0_stop().get();
-            });
-
-            // Setup group0 early in case the node is bootstrapped already and the group exists.
-            // Need to do it before allowing incoming messaging service connections since
-            // storage proxy's and migration manager's verbs may access group0.
-            // This will also disable migration manager schema pulls if needed.
-            group0_service.setup_group0_if_exist(sys_ks.local(), ss.local(), qp.local(), mm.local()).get();
-
             with_scheduling_group(maintenance_scheduling_group, [&] {
                 return messaging.invoke_on_all(&netw::messaging_service::start_listen, std::ref(token_metadata));
             }).get();
-
-            const auto generation_number = gms::generation_type(sys_ks.local().increment_and_get_generation().get());
 
             with_scheduling_group(maintenance_scheduling_group, [&] {
                 return ss.local().join_cluster(sys_dist_ks, proxy, service::start_hint_manager::yes, generation_number);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -629,7 +629,7 @@ repair::shard_repair_task_impl::shard_repair_task_impl(tasks::task_manager::modu
     , data_centers(data_centers_)
     , hosts(hosts_)
     , ignore_nodes(ignore_nodes_)
-    , total_rf(erm->get_replication_factor())
+    , total_rf(erm->get_schema_replication_factor())
     , _hints_batchlog_flushed(std::move(hints_batchlog_flushed))
     , _small_table_optimization(small_table_optimization)
     , _user_ranges_parallelism(ranges_parallelism ? std::optional<semaphore>(semaphore(*ranges_parallelism)) : std::nullopt)
@@ -1619,7 +1619,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
             dht::token_range_vector desired_ranges = strat.get_pending_address_ranges(tmptr, tokens, myid, myloc).get();
             bool find_node_in_local_dc_only = strat.get_type() == locator::replication_strategy_type::network_topology;
             bool everywhere_topology = strat.get_type() == locator::replication_strategy_type::everywhere_topology;
-            auto replication_factor = erm->get_replication_factor();
+            auto replication_factor = erm->get_schema_replication_factor();
 
             //Active ranges
             auto metadata_clone = tmptr->clone_only_token_map().get();

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -335,7 +335,7 @@ private:
             std::unique_ptr<mutation_holder> mh, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state,
             service_permit permit, db::allow_per_partition_rate_limit allow_limit, is_cancellable);
     result<response_id_type> create_write_response_handler(locator::effective_replication_map_ptr ermp, db::consistency_level cl, db::write_type type, std::unique_ptr<mutation_holder> m, host_id_vector_replica_set targets,
-            const host_id_vector_topology_change& pending_endpoints, host_id_vector_topology_change, tracing::trace_state_ptr tr_state, storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, is_cancellable);
+            const host_id_vector_topology_change& pending_endpoints, host_id_vector_topology_change, tracing::trace_state_ptr tr_state, storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, is_cancellable, dht::token);
     result<response_id_type> create_write_response_handler(const mutation&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit);
     result<response_id_type> create_write_response_handler(const hint_wrapper&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit);
     result<response_id_type> create_write_response_handler(const read_repair_mutation&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit);
@@ -357,9 +357,9 @@ private:
     db::hints::manager& hints_manager_for(db::write_type type);
     void sort_endpoints_by_proximity(const locator::effective_replication_map& erm, host_id_vector_replica_set& eps) const;
     host_id_vector_replica_set get_endpoints_for_reading(const sstring& ks_name, const locator::effective_replication_map& erm, const dht::token& token) const;
-    host_id_vector_replica_set filter_replicas_for_read(db::consistency_level, const locator::effective_replication_map&, host_id_vector_replica_set live_endpoints, const host_id_vector_replica_set& preferred_endpoints, db::read_repair_decision, std::optional<locator::host_id>* extra, replica::column_family*) const;
+    host_id_vector_replica_set filter_replicas_for_read(db::consistency_level, const locator::effective_replication_map&, host_id_vector_replica_set live_endpoints, const host_id_vector_replica_set& preferred_endpoints, db::read_repair_decision, std::optional<locator::host_id>* extra, replica::column_family*, dht::token) const;
     // As above with read_repair_decision=NONE, extra=nullptr.
-    host_id_vector_replica_set filter_replicas_for_read(db::consistency_level, const locator::effective_replication_map&, const host_id_vector_replica_set& live_endpoints, const host_id_vector_replica_set& preferred_endpoints, replica::column_family*) const;
+    host_id_vector_replica_set filter_replicas_for_read(db::consistency_level, const locator::effective_replication_map&, const host_id_vector_replica_set& live_endpoints, const host_id_vector_replica_set& preferred_endpoints, replica::column_family*, dht::token) const;
     bool is_alive(const gms::inet_address&) const;
     bool is_alive_id(const locator::effective_replication_map& erm, const locator::host_id&) const;
     result<::shared_ptr<abstract_read_executor>> get_read_executor(lw_shared_ptr<query::read_command> cmd,
@@ -453,7 +453,8 @@ private:
             tracing::trace_state_ptr tr_state,
             write_stats& stats,
             allow_hints,
-            is_cancellable);
+            is_cancellable,
+            dht::token token_id);
 
     void maybe_update_view_backlog_of(locator::host_id, std::optional<db::view::update_backlog>);
 
@@ -636,12 +637,12 @@ public:
     // hinted handoff support, and just one target. See also
     // send_to_live_endpoints() - another take on the same original function.
     future<> send_to_endpoint(frozen_mutation_and_schema fm_a_s, locator::effective_replication_map_ptr ermp, locator::host_id target, host_id_vector_topology_change pending_endpoints, db::write_type type,
-            tracing::trace_state_ptr tr_state, allow_hints, is_cancellable);
+            tracing::trace_state_ptr tr_state, allow_hints, is_cancellable, dht::token);
 
     // Send a mutation to a specific remote target as a hint.
     // Unlike regular mutations during write operations, hints are sent on the streaming connection
     // and use different RPC verb.
-    future<> send_hint_to_endpoint(frozen_mutation_and_schema fm_a_s, locator::effective_replication_map_ptr ermp, locator::host_id target);
+    future<> send_hint_to_endpoint(frozen_mutation_and_schema fm_a_s, locator::effective_replication_map_ptr ermp, locator::host_id target, dht::token);
 
     /**
      * Performs the truncate operatoin, which effectively deletes all data from

--- a/test/boost/small_vector_test.cc
+++ b/test/boost/small_vector_test.cc
@@ -492,3 +492,36 @@ BOOST_AUTO_TEST_CASE(from_range) {
     // Verify that copies are needed if the range is (only) an input_range.
     BOOST_REQUIRE_GT(do_test_from_range(stream_view, iota_view), 10);
 }
+
+// Constructor small_vector(size_t n, const T& value)
+BOOST_AUTO_TEST_CASE(fill_constructor) {
+    constexpr int64_t value = 42;
+
+    // Construct a vector filled with number of elements less than default capacity.
+    {
+        constexpr size_t NUM = 5;
+        constexpr size_t CAPACITY = 10;
+        utils::small_vector<size_t, CAPACITY> vec(NUM, value);
+        BOOST_CHECK_EQUAL(vec.size(), NUM);
+        BOOST_CHECK_EQUAL(vec.capacity(), CAPACITY);
+
+        // Check if all elements are initialized to 'value'
+        BOOST_CHECK(std::ranges::all_of(vec, [value](const auto& elem) {
+            return elem == value;
+        }));
+    }
+
+    // Construct a vector filled with number of elements higher than default capacity.
+    {
+        constexpr size_t NUM = 50;
+        constexpr size_t CAPACITY = 10;
+        utils::small_vector<size_t, CAPACITY> vec(NUM, value);
+        BOOST_CHECK_EQUAL(vec.size(), NUM);
+        BOOST_CHECK_EQUAL(vec.capacity(), NUM);
+
+        // Check if all elements are initialized to 'value'
+        BOOST_CHECK(std::ranges::all_of(vec, [value](const auto& elem) {
+            return elem == value;
+        }));
+    }
+}

--- a/test/topology_custom/test_change_replication_factor_1_to_0.py
+++ b/test/topology_custom/test_change_replication_factor_1_to_0.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
     "use_tablets",
     [
         pytest.param(False, id="vnodes"),
-        pytest.param(True, id="tablets", marks=pytest.mark.xfail(reason="issue #20282")),
+        pytest.param(True, id="tablets"),
     ],
 )
 @pytest.mark.asyncio

--- a/utils/small_vector.hh
+++ b/utils/small_vector.hh
@@ -198,6 +198,14 @@ public:
         _end = std::uninitialized_copy(other.begin(), other.end(), _end);
     }
 
+
+    small_vector(size_t n, const T& value) : small_vector() {
+        reserve(n);
+        auto nend = _begin + n;
+        std::uninitialized_fill(_end, nend, value);
+        _end = nend;
+    }
+
     // May invalidate iterators and references.
     small_vector& operator=(small_vector&& other) noexcept {
         clear();


### PR DESCRIPTION
Current implementation of replication factor calculation does not take into account Tablets migration. Since a table can be represented by multiple Tablets, during Tablets migration there are different Tablets could be in different states, thus there cannot be a single state for the table and previously used logic of taking the RF from the schema as it worked for VNodes, is not valid when tablets are in a migration state.

In this PR, the `effective_replication_map::get_replication_factor()` implementation was modified for Tablets. Instead of retrieving the replication factor from the schema, it now calculates the replication factor based on the actual replica set from the Tablets map. This change addresses potential inconsistencies between the schema and the state of individual tablets during migration.

Fixes scylladb/scylladb#20625 
Fixes scylladb/scylladb#20282

Since this fixes an important issue with Tablets, we need backports to 6.0, 6.1, 6.2.