### PR TITLE
dht: do not include unused headers

### DIFF
--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -9,13 +9,10 @@
 
 #pragma once
 
-#include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/util/optimized_optional.hh>
 #include "keys.hh"
 #include <memory>
 #include <utility>
-#include <byteswap.h>
 #include "dht/token.hh"
 #include "dht/token-sharding.hh"
 #include "dht/decorated_key.hh"

--- a/dht/token-sharding.hh
+++ b/dht/token-sharding.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "utils/assert.hh"
 #include "dht/token.hh"
 #include <seastar/core/smp.hh>
 #include <boost/container/static_vector.hpp>


### PR DESCRIPTION
in 8d1b3223, we removed some unused "#include"s, but we failed to address all of them in "dht" subdirectory. and the unaddressed "#include"s are identified by the iwyu workflow.

in this change, we address the leftovers.

---

it's a cleanup, hence no need to backport.