### PR TITLE
build: Remove GCC ARM warning workaround (originally added in 193d1942)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1538,8 +1538,6 @@ def get_warning_options(cxx):
         '-Wno-unsupported-friend',
         '-Wno-missing-field-initializers',
         '-Wno-deprecated-copy',
-        # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77728
-        '-Wno-psabi',
         '-Wno-enum-constexpr-conversion',
     ]
 


### PR DESCRIPTION
The workaround was initially added to silence warnings on GCC < 6.4 for ARM platforms due to a compiler bug ( [gcc.gnu.org/bugzilla/show_bug.cgi?id=77728](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77728) ). Since our codebase now requires modern GCC versions for coroutine support, and the bug was fixed in GCC 6.4+, this workaround is no longer needed.

Refs 193d1942f22f399742b3fb15193b48e0ca3af2a5

---

it's a cleanup, hence no need to backport.