### PR TITLE
build: enable CMAKE_CXX_EXTENSIONS explicitly

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1699,6 +1699,7 @@ def configure_seastar(build_dir, mode, mode_config):
         '-DCMAKE_CXX_COMPILER={}'.format(args.cxx),
         '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON',
         '-DCMAKE_CXX_STANDARD=23',
+        '-DCMAKE_CXX_EXTENSIONS=ON',
         '-DSeastar_CXX_FLAGS=SHELL:{}'.format(mode_config['lib_cflags']),
         '-DSeastar_LD_FLAGS={}'.format(semicolon_separated(mode_config['lib_ldflags'], seastar_cxx_ld_flags)),
         '-DSeastar_API_LEVEL=7',


### PR DESCRIPTION
before this change, Seastar enables CXX_EXTENSIONS in its own build rules. but it does not expose it to the parent project. but scylladb's CMake building system respect seastar's .pc file and includes the cflags exposed by it. without this change, scylladb included "-std=c++23" from seastar, and "-std=gnu++23" from itself. this is both confusing and inconsistent with the build rules generated by `configure.py`.

in this change, we explicitly set `CMAKE_CXX_EXTENSIONS` when creating Seastar's building rules, so that it can populate this setting to its .pc file. in this way, we don't have two different options for specifying the C++ standard when building scylladb with CMake.

---

this is a cmake related change, hence no need to backport.