### PR TITLE
build: include subdirectory rules in compilation database merge

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2513,7 +2513,7 @@ def generate_compdb_for_cmake_build(source_dir, build_dir):
         # directory as relevant. Since CMake generates .o files in
         # "CMakeFiles" directories, we preserve the compilation rules for
         # these generated files.
-        prefix = "CMakeFiles"
+        prefix = ""
         subprocess.run([os.path.join(source_dir, 'scripts/merge-compdb.py'),
                         prefix,
                         scylla_compdb_path,


### PR DESCRIPTION
Previously in e65185ba, when merging Seastar's and ScyllaDB's compilation databases, the "prefix" parameter in merge-compdb.py was too restrictive. It only included build rules for files with "CMakeFiles" prefix, excluding source files in subdirectories like `apps/iotune/CMakeFiles/app_iotune.dir/iotune.cc.o`.

In this change, we change the prefix parameter to an empty string to include all source files whose object files are located under build directories, regardless of their path structure.

---

this is a cmake-related change, hence no need to backport.