### PR TITLE
topology coordinator: take a copy of a replication state in raft_topo…

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5633,7 +5633,7 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
             break;
             case raft_topology_cmd::command::stream_ranges: {
                 co_await with_scheduling_group(_db.local().get_streaming_scheduling_group(), coroutine::lambda([&] () -> future<> {
-                    const auto& rs = _topology_state_machine._topology.find(id)->second;
+                    const auto rs = _topology_state_machine._topology.find(id)->second;
                     auto tstate = _topology_state_machine._topology.tstate;
                     if (!rs.ring || rs.ring->tokens.empty()) {
                         rtlogger.warn("got {} request but the node does not own any tokens and is in the {} state", cmd.cmd, rs.state);


### PR DESCRIPTION
…logy_cmd_handler

Current code takes a reference and holds it past preemption points. And while the state itself is not suppose to change the reference may become stale because the state is re-created on each raft topology command.

Fix it by taking a copy instead. This is a slow path anyway.

Fixes: scylladb/scylladb#21220

Backport to all supported branches since this is a use after free