### PR TITLE
treewide: s/boost::transform/std::ranges::transform/

### DIFF
--- a/api/cql_server_test.cc
+++ b/api/cql_server_test.cc
@@ -9,7 +9,6 @@
 #ifndef SCYLLA_BUILD_MODE_RELEASE
 
 #include <seastar/core/coroutine.hh>
-#include <boost/range/algorithm/transform.hpp>
 
 #include "api/api-doc/cql_server_test.json.hh"
 #include "cql_server_test.hh"
@@ -50,7 +49,7 @@ void set_cql_server_test(http_context& ctx, seastar::httpd::routes& r, cql_trans
         auto sl_params = co_await ctl.get_connections_service_level_params();
 
         std::vector<connection_sl_params> result;
-        boost::transform(std::move(sl_params), std::back_inserter(result), [] (const cql_transport::connection_service_level_params& params) {
+        std::ranges::transform(std::move(sl_params), std::back_inserter(result), [] (const cql_transport::connection_service_level_params& params) {
             auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(params.timeout_config.read_timeout).count();
             return connection_sl_params(
                     std::move(params.role_name), 

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -33,7 +33,7 @@ tm::task_status make_status(tasks::task_status status) {
     ::gmtime_r(&start_time, &st);
 
     std::vector<tm::task_identity> tis{status.children.size()};
-    boost::transform(status.children, tis.begin(), [] (const auto& child) {
+    std::ranges::transform(status.children, tis.begin(), [] (const auto& child) {
         tm::task_identity ident;
         ident.task_id = child.task_id.to_sstring();
         ident.node = fmt::format("{}", child.node);

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -560,7 +560,7 @@ void result_set_builder::add_collection(const column_definition& def, bytes_view
 
 void result_set_builder::update_last_group() {
     _group_began = true;
-    boost::transform(_group_by_cell_indices, _last_group.begin(), [this](size_t i) { return current[i]; });
+    std::ranges::transform(_group_by_cell_indices, _last_group.begin(), [this](size_t i) { return current[i]; });
 }
 
 bool result_set_builder::last_group_ended() const {

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -8,7 +8,6 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
-#include <boost/range/algorithm.hpp>
 #include <fmt/format.h>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/on_internal_error.hh>
@@ -229,7 +228,7 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
             service::topology_change change{{builder.build()}};
 
             auto topo_schema = qp.db().find_schema(db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY);
-            boost::transform(change.mutations, std::back_inserter(muts), [topo_schema] (const canonical_mutation& cm) {
+            std::ranges::transform(change.mutations, std::back_inserter(muts), [topo_schema] (const canonical_mutation& cm) {
                 return cm.to_mutation(topo_schema);
             });
 
@@ -239,7 +238,7 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
             service::topology_change req_change{{rtbuilder.build()}};
 
             auto topo_req_schema = qp.db().find_schema(db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY_REQUESTS);
-            boost::transform(req_change.mutations, std::back_inserter(muts), [topo_req_schema] (const canonical_mutation& cm) {
+            std::ranges::transform(req_change.mutations, std::back_inserter(muts), [topo_req_schema] (const canonical_mutation& cm) {
                 return cm.to_mutation(topo_req_schema);
             });
         } else {

--- a/test/boost/mutation_fragment_test.cc
+++ b/test/boost/mutation_fragment_test.cc
@@ -29,7 +29,6 @@
 #include "test/lib/fragment_scatterer.hh"
 #include "test/lib/test_utils.hh"
 
-#include <boost/range/algorithm/transform.hpp>
 #include "readers/from_mutations_v2.hh"
 
 SEASTAR_TEST_CASE(test_mutation_merger_conforms_to_mutation_source) {
@@ -86,7 +85,7 @@ SEASTAR_TEST_CASE(test_range_tombstones_stream) {
         auto pk = partition_key::from_single_value(*s, int32_type->decompose(0));
         auto create_ck = [&] (std::vector<int> v) {
             std::vector<bytes> vs;
-            boost::transform(v, std::back_inserter(vs), [] (int x) { return int32_type->decompose(x); });
+            std::ranges::transform(v, std::back_inserter(vs), [] (int x) { return int32_type->decompose(x); });
             return clustering_key_prefix::from_exploded(*s, std::move(vs));
         };
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <boost/range/algorithm/transform.hpp>
 #include <iterator>
 #include <random>
 #include <seastar/core/thread.hh>
@@ -1068,7 +1067,7 @@ public:
         using cql3::statements::batch_statement;
         using cql3::statements::modification_statement;
         std::vector<batch_statement::single_statement> modifications;
-        boost::transform(queries, back_inserter(modifications), [this](const auto& query) {
+        std::ranges::transform(queries, back_inserter(modifications), [this](const auto& query) {
             auto stmt = local_qp().get_statement(query, _core_local.local().client_state, test_dialect());
             if (!dynamic_cast<modification_statement*>(stmt->statement.get())) {
                 throw exceptions::invalid_request_exception(


### PR DESCRIPTION
now that we are allowed to use C++23. we now have the luxury of using
`std::ranges::transform`.

in this change, we:

- replace `boost::adaptors::map_values` with `std::ranges::transform`
- update affected code to work with `std::ranges::transform`

to reduce the dependency to boost for better maintainability, and
leverage standard library features for better long-term support.

this change is part of our ongoing effort to modernize our codebase
and reduce external dependencies where possible.

---

it's a cleanup, hence no need to backport.