### PR TITLE
compound: replace boost ranges with std ranges

### DIFF
--- a/compound.hh
+++ b/compound.hh
@@ -12,8 +12,7 @@
 #include <algorithm>
 #include <vector>
 #include <span>
-#include <boost/range/iterator_range.hpp>
-#include <boost/range/adaptor/transformed.hpp>
+#include <ranges>
 #include "utils/assert.hh"
 #include "utils/serialization.hh"
 #include <seastar/util/backtrace.hh>
@@ -95,10 +94,10 @@ private:
     }
 public:
     managed_bytes serialize_single(const managed_bytes& v) const {
-        return serialize_value(boost::make_iterator_range(&v, 1+&v));
+        return serialize_value(std::ranges::subrange(&v, 1+&v));
     }
     managed_bytes serialize_single(const bytes& v) const {
-        return serialize_value(boost::make_iterator_range(&v, 1+&v));
+        return serialize_value(std::ranges::subrange(&v, 1+&v));
     }
     template<typename RangeOfSerializedComponents>
     static managed_bytes serialize_value(RangeOfSerializedComponents&& values) {
@@ -112,10 +111,10 @@ public:
     }
     template<typename T>
     static managed_bytes serialize_value(std::initializer_list<T> values) {
-        return serialize_value(boost::make_iterator_range(values.begin(), values.end()));
+        return serialize_value(std::span(values));
     }
     managed_bytes serialize_optionals(std::span<const bytes_opt> values) const {
-        return serialize_value(boost::make_iterator_range(values.begin(), values.end()) | boost::adaptors::transformed([] (const bytes_opt& bo) -> bytes_view {
+        return serialize_value(values | std::views::transform([] (const bytes_opt& bo) -> bytes_view {
             if (!bo) {
                 throw std::logic_error("attempted to create key component from empty optional");
             }
@@ -123,7 +122,7 @@ public:
         }));
     }
     managed_bytes serialize_optionals(std::span<const managed_bytes_opt> values) const {
-        return serialize_value(boost::make_iterator_range(values.begin(), values.end()) | boost::adaptors::transformed([] (const managed_bytes_opt& bo) -> managed_bytes_view {
+        return serialize_value(values | std::views::transform([] (const managed_bytes_opt& bo) -> managed_bytes_view {
             if (!bo) {
                 throw std::logic_error("attempted to create key component from empty optional");
             }
@@ -195,8 +194,8 @@ public:
     static iterator end(managed_bytes_view v) {
         return iterator(typename iterator::end_iterator_tag(), v);
     }
-    static boost::iterator_range<iterator> components(managed_bytes_view v) {
-        return { begin(v), end(v) };
+    static std::ranges::subrange<iterator> components(managed_bytes_view v) {
+        return std::ranges::subrange(begin(v), end(v));
     }
     value_type deserialize_value(managed_bytes_view v) const {
         std::vector<bytes> result;

--- a/compound.hh
+++ b/compound.hh
@@ -146,11 +146,10 @@ public:
     }
     class iterator {
     public:
-        using iterator_category = std::input_iterator_tag;
+        using iterator_category = std::forward_iterator_tag;
+        using iterator_concept = std::forward_iterator_tag;
         using value_type = const managed_bytes_view;
         using difference_type = std::ptrdiff_t;
-        using pointer = const value_type*;
-        using reference = const value_type&;
     private:
         managed_bytes_view _v;
         managed_bytes_view _current;
@@ -187,8 +186,7 @@ public:
             ++(*this);
             return i;
         }
-        const value_type& operator*() const { return _current; }
-        const value_type* operator->() const { return &_current; }
+        value_type operator*() const { return _current; }
         bool operator==(const iterator& i) const { return _remaining == i._remaining; }
     };
     static iterator begin(managed_bytes_view v) {

--- a/cql3/statements/index_target.cc
+++ b/cql3/statements/index_target.cc
@@ -13,6 +13,7 @@
 #include "index_target.hh"
 #include "index/secondary_index.hh"
 #include <boost/algorithm/string/join.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 
 namespace cql3 {
 

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5133,7 +5133,7 @@ static void test_sstable_write_large_row_f(schema_ptr s, reader_permit permit, r
     auto f = [&i, &expected, &pk, &threshold](const schema& s, const sstables::key& partition_key,
                      const clustering_key_prefix* clustering_key, uint64_t row_size, uint64_t range_tombstones, uint64_t dead_rows,
                      const column_definition* cdef, uint64_t cell_size, uint64_t collection_elements) {
-        BOOST_REQUIRE_EQUAL(pk.components(s), partition_key.to_partition_key(s).components(s));
+        BOOST_REQUIRE(std::ranges::equal(pk.components(s), partition_key.to_partition_key(s).components(s)));
         BOOST_REQUIRE_LT(i, expected.size());
         BOOST_REQUIRE_GT(row_size, threshold);
         BOOST_REQUIRE_EQUAL(range_tombstones, 0);
@@ -5187,7 +5187,7 @@ static void test_sstable_write_large_cell_f(schema_ptr s, reader_permit permit, 
                      const clustering_key_prefix* clustering_key, uint64_t row_size, uint64_t range_tombstones, uint64_t dead_rows,
                      const column_definition* cdef, uint64_t cell_size, uint64_t collection_elements) {
         BOOST_TEST_MESSAGE(format("i={} ck={} cell_size={} threshold={}", i, clustering_key ? format("{}", *clustering_key) : "null", cell_size, threshold));
-        BOOST_REQUIRE_EQUAL(pk.components(s), partition_key.to_partition_key(s).components(s));
+        BOOST_REQUIRE(std::ranges::equal(pk.components(s), partition_key.to_partition_key(s).components(s)));
         BOOST_REQUIRE_LT(i, expected.size());
         BOOST_REQUIRE_GT(cell_size, threshold);
         BOOST_REQUIRE_EQUAL(range_tombstones, 0);
@@ -5256,7 +5256,7 @@ static void test_sstable_log_too_many_rows_f(int rows, int range_tombstones, uin
                      const clustering_key_prefix* clustering_key, uint64_t rows_count, uint64_t range_tombstones_count, uint64_t dead_rows,
                      const column_definition* cdef, uint64_t cell_size, uint64_t collection_elements) {
         BOOST_REQUIRE_GT(rows_count, threshold);
-        BOOST_REQUIRE_EQUAL(pk.components(sc), partition_key.to_partition_key(sc).components(sc));
+        BOOST_REQUIRE(std::ranges::equal(pk.components(sc), partition_key.to_partition_key(sc).components(sc)));
         BOOST_REQUIRE_EQUAL(dead_rows, 0);
 
         // Inserting one range tombstone creates two range tombstone marker rows
@@ -5374,7 +5374,7 @@ static void test_sstable_log_too_many_dead_rows_f(int rows, uint64_t threshold, 
         BOOST_REQUIRE_EQUAL(rows_count, rows);
         BOOST_REQUIRE_EQUAL(dead_rows, expected_dead_rows + expected_expired_rows + expected_rows_with_dead_cell);
         BOOST_REQUIRE_EQUAL(range_tombstones, expected_range_tombstones);
-        BOOST_REQUIRE_EQUAL(pk.components(sc), partition_key.to_partition_key(sc).components(sc));
+        BOOST_REQUIRE(std::ranges::equal(pk.components(sc), partition_key.to_partition_key(sc).components(sc)));
         logged = true;
     };
 
@@ -5423,7 +5423,7 @@ static void test_sstable_too_many_collection_elements_f(int elements, uint64_t t
                      const clustering_key_prefix* clustering_key, uint64_t rows_count, uint64_t range_tombstones, uint64_t dead_rows,
                      const column_definition* cdef, uint64_t cell_size, uint64_t collection_elements) {
         BOOST_REQUIRE_GT(collection_elements, threshold);
-        BOOST_REQUIRE_EQUAL(pk.components(sc), partition_key.to_partition_key(sc).components(sc));
+        BOOST_REQUIRE(std::ranges::equal(pk.components(sc), partition_key.to_partition_key(sc).components(sc)));
         BOOST_REQUIRE_EQUAL(range_tombstones, 0);
         BOOST_REQUIRE_EQUAL(dead_rows, 0);
         logged = true;

--- a/test/lib/key_utils.cc
+++ b/test/lib/key_utils.cc
@@ -42,7 +42,7 @@ std::vector<DecoratedKey> generate_keys(
         }
         auto raw_key = RawKey::from_deeply_exploded(*s, components);
         // discard empty keys on the off chance that we generate one
-        if (raw_key.is_empty() || (types.size() == 1 && raw_key.begin(*s)->empty())) {
+        if (raw_key.is_empty() || (types.size() == 1 && (*raw_key.begin(*s)).empty())) {
             continue;
         }
         if constexpr (std::is_same_v<RawKey, DecoratedKey>) {

--- a/test/lib/result_set_assertions.cc
+++ b/test/lib/result_set_assertions.cc
@@ -48,7 +48,7 @@ row_assertion::matches(const query::result_set_row& row) const {
 
 sstring
 row_assertion::describe(schema_ptr schema) const {
-    return seastar::format("{{{}}}", fmt::join(_expected_values | boost::adaptors::transformed([&schema] (auto&& e) {
+    return seastar::format("{{{}}}", fmt::join(_expected_values | std::views::transform([&schema] (auto&& e) {
         auto&& name = e.first;
         auto&& value = e.second;
         const column_definition* def = schema->get_column_definition(name);

--- a/validation.cc
+++ b/validation.cc
@@ -22,7 +22,7 @@ namespace validation {
 std::optional<sstring> is_cql_key_invalid(const schema& schema, partition_key_view key) {
     // C* validates here that the thrift key is not empty.
     // It can only be empty if it is not composite and its only component in CQL form is empty.
-    if (schema.partition_key_size() == 1 && key.begin(schema)->empty()) {
+    if (schema.partition_key_size() == 1 && (*key.begin(schema)).empty()) {
         return sstring("Key may not be empty");
     }
 


### PR DESCRIPTION
Continue standardization on std::ranges. Since compound contains a custom
iterator, we first have to upgrade it to C++20 iterator concepts.

Cleanup / minor refactoring, so no backport.