### PR TITLE
utils: cached_file: Mark permit as awaiting on page miss

### DIFF
--- a/utils/cached_file.hh
+++ b/utils/cached_file.hh
@@ -157,7 +157,8 @@ private:
     // Returns (page, true) if the page was cached, and (page, false) if the page was uncached.
     future<std::pair<cached_page::ptr_type, bool>> get_page_ptr(page_idx_type idx,
             page_count_type read_ahead,
-            tracing::trace_state_ptr trace_state) {
+            tracing::trace_state_ptr trace_state,
+            std::optional<reader_permit> permit = {}) {
         auto i = _cache.lower_bound(idx);
         if (i != _cache.end() && i->idx == idx) {
             ++_metrics.page_hits;
@@ -170,8 +171,14 @@ private:
         size_t size = (idx + read_ahead) > _last_page
                 ? (_last_page_size + (_last_page - idx) * page_size)
                 : read_ahead * page_size;
+
+        std::optional<reader_permit::resource_units> units;
+        if (permit) {
+            units = permit->consume_memory(size);
+        }
+
         return _file.dma_read_exactly<char>(idx * page_size, size)
-            .then([this, idx] (temporary_buffer<char>&& buf) mutable {
+            .then([this, units = std::move(units), idx] (temporary_buffer<char>&& buf) mutable {
                 cached_page::ptr_type first_page;
                 while (buf.size()) {
                     auto this_size = std::min(page_size, buf.size());
@@ -204,9 +211,16 @@ private:
     // Returns (page, true) if the page was cached, and (page, false) if the page was uncached.
     future<std::pair<temporary_buffer<char>, bool>> get_page(page_idx_type idx,
                                             page_count_type count,
-                                            tracing::trace_state_ptr trace_state) {
-        return get_page_ptr(idx, count, std::move(trace_state)).then([] (std::pair<cached_page::ptr_type, bool> cp) {
-            return std::make_pair(cp.first->get_buf(), cp.second);
+                                            tracing::trace_state_ptr trace_state,
+                                            std::optional<reader_permit> permit = {}) {
+        return get_page_ptr(idx, count, std::move(trace_state), permit).then([permit] (std::pair<cached_page::ptr_type, bool> cp) mutable {
+            auto buf = cp.first->get_buf();
+            if (permit) {
+                auto units = permit->consume_memory(buf.size());
+                buf = temporary_buffer<char>(buf.get_write(), buf.size(),
+                                             make_object_deleter(buf.release(), std::move(units)));
+            }
+            return std::make_pair(std::move(buf), cp.second);
         });
     }
 public:
@@ -345,18 +359,12 @@ public:
             if (!_cached_file || _page_idx > _cached_file->_last_page) {
                 return make_ready_future<temporary_buffer<char>>(temporary_buffer<char>());
             }
-            auto units = get_page_units(_size_hint);
             page_count_type readahead = div_ceil(_size_hint, page_size);
-            return _cached_file->get_page(_page_idx, readahead, _trace_state).then(
-                    [units = std::move(units), this] (std::pair<temporary_buffer<char>, bool> read_result) mutable {
+            return _cached_file->get_page(_page_idx, readahead, _trace_state, _permit).then(
+                    [this] (std::pair<temporary_buffer<char>, bool> read_result) mutable {
                 auto page = std::move(read_result.first);
                 if (_page_idx == _cached_file->_last_page) {
                     page.trim(_cached_file->_last_page_size);
-                }
-                if (units) {
-                    units = get_page_units();
-                    page = temporary_buffer<char>(page.get_write(), page.size(),
-                                                  make_object_deleter(page.release(), std::move(*units)));
                 }
                 page.trim_front(_offset_in_page);
                 _offset_in_page = 0;
@@ -374,16 +382,14 @@ public:
             if (!_cached_file || _page_idx > _cached_file->_last_page) {
                 return make_ready_future<page_view>(page_view());
             }
-            auto units = get_page_units(_size_hint);
             page_count_type readahead = div_ceil(_size_hint, page_size);
-            return _cached_file->get_page_ptr(_page_idx, readahead, _trace_state).then(
-                    [this, units = std::move(units)] (std::pair<cached_page::ptr_type, bool> read_result) mutable {
+            return _cached_file->get_page_ptr(_page_idx, readahead, _trace_state, _permit).then(
+                    [this] (std::pair<cached_page::ptr_type, bool> read_result) mutable {
                 auto page = std::move(read_result.first);
                 size_t size = _page_idx == _cached_file->_last_page
                         ? _cached_file->_last_page_size
                         : page_size;
-                units = get_page_units(page_size);
-                page_view buf(_offset_in_page, size - _offset_in_page, std::move(page), std::move(units));
+                page_view buf(_offset_in_page, size - _offset_in_page, std::move(page), get_page_units());
                 _offset_in_page = 0;
                 ++_page_idx;
                 shrink_size_hint(read_result.second);

--- a/utils/cached_file.hh
+++ b/utils/cached_file.hh
@@ -173,12 +173,14 @@ private:
                 : read_ahead * page_size;
 
         std::optional<reader_permit::resource_units> units;
+        std::optional<reader_permit::awaits_guard> await_guard;
         if (permit) {
             units = permit->consume_memory(size);
+            await_guard.emplace(*permit);
         }
 
         return _file.dma_read_exactly<char>(idx * page_size, size)
-            .then([this, units = std::move(units), idx] (temporary_buffer<char>&& buf) mutable {
+            .then([this, ag = std::move(await_guard), units = std::move(units), idx] (temporary_buffer<char>&& buf) mutable {
                 cached_page::ptr_type first_page;
                 while (buf.size()) {
                     auto this_size = std::min(page_size, buf.size());


### PR DESCRIPTION
Otherwise, the read will be considered as on-cpu during promoted index
search, which will severely underutlize the disk because by default
on-cpu concurrency is 1.

I verified this patch on the worst case scenario, where the workload
reads missing rows from a large partition. So partition index is
cached (no IO) and there is no data file IO (relies on https://github.com/scylladb/scylladb/pull/20522). 
But there is IO during promoted index search (via cached_file). 

Before the patch this workload was doing 4k req/s, after the patch it does 30k req/s.

The problem is much less pronounced if there is data file or partition index IO involved
because that IO will signal read concurrency semaphore to invite more concurrency.

Fixes #21325