### PR TITLE
TESTING _ please ignore [Backport 6.2] repair: Fix finished ranges metrics for removenode

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1732,7 +1732,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
             }
             auto nr_ranges = desired_ranges.size();
             sync_data_using_repair(keyspace_name, erm, std::move(desired_ranges), std::move(range_sources), reason, nullptr).get();
-            rlogger.info("bootstrap_with_repair: finished with keyspace={}, nr_ranges={}", keyspace_name, nr_ranges);
+            rlogger.info("bootstrap_with_repair: finished with keyspace={}, nr_ranges={}", keyspace_name, nr_ranges * nr_tables);
         }
         rlogger.info("bootstrap_with_repair: finished with keyspaces={}", ks_erms | boost::adaptors::map_keys);
     });
@@ -1914,12 +1914,12 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
             }
             temp.clear_gently().get();
             if (reason == streaming::stream_reason::decommission) {
-                container().invoke_on_all([nr_ranges_skipped] (repair_service& rs) {
-                    rs.get_metrics().decommission_finished_ranges += nr_ranges_skipped;
+                container().invoke_on_all([nr_ranges_skipped, nr_tables] (repair_service& rs) {
+                    rs.get_metrics().decommission_finished_ranges += nr_ranges_skipped * nr_tables;
                 }).get();
             } else if (reason == streaming::stream_reason::removenode) {
-                container().invoke_on_all([nr_ranges_skipped] (repair_service& rs) {
-                    rs.get_metrics().removenode_finished_ranges += nr_ranges_skipped;
+                container().invoke_on_all([nr_ranges_skipped, nr_tables] (repair_service& rs) {
+                    rs.get_metrics().removenode_finished_ranges += nr_ranges_skipped * nr_tables;
                 }).get();
             }
             if (is_removenode) {
@@ -1928,7 +1928,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
             auto nr_ranges_synced = ranges.size();
             sync_data_using_repair(keyspace_name, erm, std::move(ranges), std::move(range_sources), reason, ops).get();
             rlogger.info("{}: finished with keyspace={}, leaving_node={}, nr_ranges={}, nr_ranges_synced={}, nr_ranges_skipped={}",
-                op, keyspace_name, leaving_node, nr_ranges_total, nr_ranges_synced, nr_ranges_skipped);
+                op, keyspace_name, leaving_node, nr_ranges_total, nr_ranges_synced * nr_tables, nr_ranges_skipped * nr_tables);
         }
         rlogger.info("{}: finished with keyspaces={}, leaving_node={}", op, ks_erms | boost::adaptors::map_keys, leaving_node);
     });
@@ -2148,7 +2148,7 @@ future<> repair_service::do_rebuild_replace_with_repair(std::unordered_map<sstri
             }
             auto nr_ranges = ranges.size();
             sync_data_using_repair(keyspace_name, erm, std::move(ranges), std::move(range_sources), reason, nullptr).get();
-            rlogger.info("{}: finished with keyspace={}, source_dc={}, nr_ranges={}", op, keyspace_name, source_dc_for_keyspace, nr_ranges);
+            rlogger.info("{}: finished with keyspace={}, source_dc={}, nr_ranges={}", op, keyspace_name, source_dc_for_keyspace, nr_ranges * nr_tables);
         }
         rlogger.info("{}: finished with keyspaces={}, source_dc={}", op, ks_erms | boost::adaptors::map_keys, source_dc);
     });

--- a/test/topology_custom/test_node_ops_metrics.py
+++ b/test/topology_custom/test_node_ops_metrics.py
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+import asyncio
+import pytest
+import logging
+
+logger = logging.getLogger(__name__)
+
+@pytest.mark.asyncio
+async def test_bootstrap_removenode_metrics(manager):
+    cfg = {'enable_repair_based_node_ops': True}
+    servers = [await manager.server_add(config=cfg),
+               await manager.server_add(config=cfg),
+               await manager.server_add(config=cfg)]
+    await manager.server_stop_gracefully(servers[2].server_id)
+    await manager.remove_node(servers[0].server_id, servers[2].server_id)
+
+    def check_ops(metrics, ops):
+        metric_name = "scylla_node_ops_finished_percentage"
+        shard = 0
+        while True:
+            cnt = metrics.get(name=metric_name, labels={'ops': ops}, shard=str(shard))
+            if cnt == None:
+                break
+            logger.info(f"Checking {shard=} {cnt=}")
+            assert int(cnt) == 1
+            shard = shard + 1
+
+    for s in servers[:2]:
+        metrics = await manager.metrics.query(s.ip_addr)
+        check_ops(metrics, 'bootstrap')
+        check_ops(metrics, 'removenode')


### PR DESCRIPTION
The skipped ranges should be multiplied by the number of tables

Otherwise the finished ranges ratio will not reach 100%.

Fixes #21174


- (cherry picked from commit be70755f473ae4b840cedc65e5a073213292d289)

Parent PR: #21252