### PR TITLE
compaction: explain make_interpose_consumer() in compaction strategy

### DIFF
--- a/compaction/compaction_strategy_impl.hh
+++ b/compaction/compaction_strategy_impl.hh
@@ -70,6 +70,18 @@ public:
 
     virtual uint64_t adjust_partition_estimate(const mutation_source_metadata& ms_meta, uint64_t partition_estimate, schema_ptr schema) const;
 
+    /// Creates a decorated consumer that adds processing steps before the final consumer
+    ///
+    /// This factory function takes an end consumer functor and returns a new functor that
+    /// extends the processing pipeline. The returned functor "interposes" (inserts) additional
+    /// processing steps before delegating to the original end consumer. This enables building
+    /// layered processing pipelines where each layer can transform or filter the mutation
+    /// fragments before they reach their final destination.
+    ///
+    /// @param end_consumer The final consumer functor that processes mutation fragments
+    /// @return A new functor that wraps the end consumer with additional processing capabilities
+    /// @note The returned functor preserves the original consumer's semantics while allowing
+    ///       preprocessing of data
     virtual reader_consumer_v2 make_interposer_consumer(const mutation_source_metadata& ms_meta, reader_consumer_v2 end_consumer) const;
 
     virtual bool use_interposer_consumer() const {


### PR DESCRIPTION
Add documentation to clarify the purpose and behavior of make_interpose_consumer() in the compaction_strategy_impl class. This method is crucial for building layered processing pipelines but its semantics were previously undocumented.

The added documentation explains how:
- It decorates end consumers with additional processing steps
- It enables construction of processing pipelines
- The original consumer's semantics are preserved

This improves code maintainability by making the pipeline construction pattern more apparent to developers.

---

no need to backport, as this changejust adds a comment to source code.