### PR TITLE
[Backport 6.1] cql/tablets: fix retrying ALTER tablets KEYSPACE

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -764,80 +764,80 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             break;
         case global_topology_request::keyspace_rf_change: {
             rtlogger.info("keyspace_rf_change requested");
-                sstring ks_name = *_topo_sm._topology.new_keyspace_rf_change_ks_name;
-                std::unordered_map<sstring, sstring> saved_ks_props = *_topo_sm._topology.new_keyspace_rf_change_data;
-                cql3::statements::ks_prop_defs new_ks_props{std::map<sstring, sstring>{saved_ks_props.begin(), saved_ks_props.end()}};
+            sstring ks_name = *_topo_sm._topology.new_keyspace_rf_change_ks_name;
+            std::unordered_map<sstring, sstring> saved_ks_props = *_topo_sm._topology.new_keyspace_rf_change_data;
+            cql3::statements::ks_prop_defs new_ks_props{std::map<sstring, sstring>{saved_ks_props.begin(), saved_ks_props.end()}};
 
-                auto repl_opts = new_ks_props.get_replication_options();
-                repl_opts.erase(cql3::statements::ks_prop_defs::REPLICATION_STRATEGY_CLASS_KEY);
-                utils::UUID req_uuid = *_topo_sm._topology.global_request_id;
-                std::vector<canonical_mutation> updates;
-                sstring error;
-                if (_db.has_keyspace(ks_name)) {
-                    auto& ks = _db.find_keyspace(ks_name);
-                    auto tmptr = get_token_metadata_ptr();
-                    size_t unimportant_init_tablet_count = 2; // must be a power of 2
-                    locator::tablet_map new_tablet_map{unimportant_init_tablet_count};
+            auto repl_opts = new_ks_props.get_replication_options();
+            repl_opts.erase(cql3::statements::ks_prop_defs::REPLICATION_STRATEGY_CLASS_KEY);
+            utils::UUID req_uuid = *_topo_sm._topology.global_request_id;
+            std::vector<canonical_mutation> updates;
+            sstring error;
+            if (_db.has_keyspace(ks_name)) {
+                auto& ks = _db.find_keyspace(ks_name);
+                auto tmptr = get_token_metadata_ptr();
+                size_t unimportant_init_tablet_count = 2; // must be a power of 2
+                locator::tablet_map new_tablet_map{unimportant_init_tablet_count};
 
-                    auto tables_with_mvs = ks.metadata()->tables();
-                    auto views = ks.metadata()->views();
-                    tables_with_mvs.insert(tables_with_mvs.end(), views.begin(), views.end());
-                    for (const auto& table_or_mv : tables_with_mvs) {
-                        try {
-                            locator::tablet_map old_tablets = tmptr->tablets().get_tablet_map(table_or_mv->id());
-                            locator::replication_strategy_params params{repl_opts, old_tablets.tablet_count()};
-                            auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params);
-                            new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table_or_mv, tmptr, old_tablets);
-                        } catch (const std::exception& e) {
-                            error = e.what();
-                            rtlogger.error("Couldn't process global_topology_request::keyspace_rf_change, error: {},"
-                                           "desired new ks opts: {}", error, new_ks_props.get_replication_options());
-                            updates.clear(); // remove all tablets mutations ...
-                            break;           // ... and only create mutations deleting the global req
-                        }
-
-                        replica::tablet_mutation_builder tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id());
-                        co_await new_tablet_map.for_each_tablet([&](locator::tablet_id tablet_id, const locator::tablet_info& tablet_info) -> future<> {
-                            auto last_token = new_tablet_map.get_last_token(tablet_id);
-                            updates.emplace_back(co_await make_canonical_mutation_gently(
-                                    replica::tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id())
-                                            .set_new_replicas(last_token, tablet_info.replicas)
-                                            .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
-                                            .set_transition(last_token, locator::tablet_transition_kind::rebuild)
-                                            .build()
-                            ));
-                            co_await coroutine::maybe_yield();
-                        });
+                auto tables_with_mvs = ks.metadata()->tables();
+                auto views = ks.metadata()->views();
+                tables_with_mvs.insert(tables_with_mvs.end(), views.begin(), views.end());
+                for (const auto& table_or_mv : tables_with_mvs) {
+                    try {
+                        locator::tablet_map old_tablets = tmptr->tablets().get_tablet_map(table_or_mv->id());
+                        locator::replication_strategy_params params{repl_opts, old_tablets.tablet_count()};
+                        auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params);
+                        new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table_or_mv, tmptr, old_tablets);
+                    } catch (const std::exception& e) {
+                        error = e.what();
+                        rtlogger.error("Couldn't process global_topology_request::keyspace_rf_change, error: {},"
+                                       "desired new ks opts: {}", error, new_ks_props.get_replication_options());
+                        updates.clear(); // remove all tablets mutations ...
+                        break;           // ... and only create mutations deleting the global req
                     }
-                } else {
-                    error = "Can't ALTER keyspace " + ks_name + ", keyspace doesn't exist";
-                }
 
-                updates.push_back(canonical_mutation(topology_mutation_builder(guard.write_timestamp())
-                                                             .set_transition_state(topology::transition_state::tablet_migration)
-                                                             .set_version(_topo_sm._topology.version + 1)
-                                                             .del_global_topology_request()
-                                                             .del_global_topology_request_id()
-                                                             .build()));
-                updates.push_back(canonical_mutation(topology_request_tracking_mutation_builder(req_uuid)
-                                                             .done(error)
-                                                             .build()));
-                if (error.empty()) {
-                    const sstring strategy_name = "NetworkTopologyStrategy";
-                    auto ks_md = keyspace_metadata::new_keyspace(ks_name, strategy_name, repl_opts,
-                                                                 new_ks_props.get_initial_tablets(std::nullopt),
-                                                                 new_ks_props.get_durable_writes(), new_ks_props.get_storage_options());
-                    auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
-                    for (auto& m: schema_muts) {
-                        updates.emplace_back(m);
-                    }
+                    replica::tablet_mutation_builder tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id());
+                    co_await new_tablet_map.for_each_tablet([&](locator::tablet_id tablet_id, const locator::tablet_info& tablet_info) -> future<> {
+                        auto last_token = new_tablet_map.get_last_token(tablet_id);
+                        updates.emplace_back(co_await make_canonical_mutation_gently(
+                                replica::tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id())
+                                        .set_new_replicas(last_token, tablet_info.replicas)
+                                        .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
+                                        .set_transition(last_token, locator::tablet_transition_kind::rebuild)
+                                        .build()
+                        ));
+                        co_await coroutine::maybe_yield();
+                    });
                 }
+            } else {
+                error = "Can't ALTER keyspace " + ks_name + ", keyspace doesn't exist";
+            }
 
-                sstring reason = format("ALTER tablets KEYSPACE called with options: {}", saved_ks_props);
-                rtlogger.trace("do update {} reason {}", updates, reason);
-                mixed_change change{std::move(updates)};
-                group0_command g0_cmd = _group0.client().prepare_command(std::move(change), guard, reason);
-                co_await _group0.client().add_entry(std::move(g0_cmd), std::move(guard), _as);
+            updates.push_back(canonical_mutation(topology_mutation_builder(guard.write_timestamp())
+                                                         .set_transition_state(topology::transition_state::tablet_migration)
+                                                         .set_version(_topo_sm._topology.version + 1)
+                                                         .del_global_topology_request()
+                                                         .del_global_topology_request_id()
+                                                         .build()));
+            updates.push_back(canonical_mutation(topology_request_tracking_mutation_builder(req_uuid)
+                                                         .done(error)
+                                                         .build()));
+            if (error.empty()) {
+                const sstring strategy_name = "NetworkTopologyStrategy";
+                auto ks_md = keyspace_metadata::new_keyspace(ks_name, strategy_name, repl_opts,
+                                                             new_ks_props.get_initial_tablets(std::nullopt),
+                                                             new_ks_props.get_durable_writes(), new_ks_props.get_storage_options());
+                auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
+                for (auto& m: schema_muts) {
+                    updates.emplace_back(m);
+                }
+            }
+
+            sstring reason = seastar::format("ALTER tablets KEYSPACE called with options: {}", saved_ks_props);
+            rtlogger.trace("do update {} reason {}", updates, reason);
+            mixed_change change{std::move(updates)};
+            group0_command g0_cmd = _group0.client().prepare_command(std::move(change), guard, reason);
+            co_await _group0.client().add_entry(std::move(g0_cmd), std::move(guard), _as);
         }
         break;
         }

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -837,6 +837,11 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             rtlogger.trace("do update {} reason {}", updates, reason);
             mixed_change change{std::move(updates)};
             group0_command g0_cmd = _group0.client().prepare_command(std::move(change), guard, reason);
+            co_await utils::get_local_injector().inject("wait-before-committing-rf-change-event", [] (auto& handler) -> future<> {
+                rtlogger.info("wait-before-committing-rf-change-event injection hit");
+                co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::seconds{30});
+                rtlogger.info("wait-before-committing-rf-change-event injection done");
+            });
             co_await _group0.client().add_entry(std::move(g0_cmd), std::move(guard), _as);
         }
         break;

--- a/test/topology_custom/test_tablets_cql.py
+++ b/test/topology_custom/test_tablets_cql.py
@@ -12,6 +12,7 @@ from cassandra.protocol import InvalidRequest
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot
 from test.topology.conftest import skip_mode
+from test.topology.util import disable_schema_agreement_wait
 
 logger = logging.getLogger(__name__)
 
@@ -66,3 +67,65 @@ async def test_alter_dropped_tablets_keyspace(manager: ManagerClient) -> None:
 
     with pytest.raises(InvalidRequest, match="Can't ALTER keyspace ks, keyspace doesn't exist") as e:
         await task
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_alter_tablets_keyspace_concurrent_modification(manager: ManagerClient) -> None:
+    config = {
+        'enable_tablets': 'true'
+    }
+
+    logger.info("starting a node (the leader)")
+    servers = [await manager.server_add(config=config)]
+
+    logger.info("starting a second node (the follower)")
+    servers += [await manager.server_add(config=config)]
+
+    await manager.get_cql().run_async("create keyspace ks with "
+                                      "replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} and "
+                                      "tablets = {'initial': 2}")
+    await manager.get_cql().run_async("create table ks.t (pk int primary key)")
+
+    logger.info(f"injecting wait-before-committing-rf-change-event into the leader node {servers[0]}")
+    injection_handler = await inject_error_one_shot(manager.api, servers[0].ip_addr,
+                                                    'wait-before-committing-rf-change-event')
+
+    # ALTER tablets KS only accepts a specific DC, it rejects the generic 'replication_factor' tag
+    res = await manager.get_cql().run_async("select data_center from system.local")
+    this_dc = res[0].data_center
+
+    async def alter_tablets_ks_without_waiting_to_complete():
+        logger.info("scheduling ALTER KS to change the RF from 1 to 2")
+        await manager.get_cql().run_async("alter keyspace ks "
+                                          f"with replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': 2}}")
+
+    # by creating a task this way we ensure it's immediately executed,
+    # but we don't want to wait until the task is completed here,
+    # because we want to do something else in the meantime
+    task = asyncio.create_task(alter_tablets_ks_without_waiting_to_complete())
+
+    logger.info(f"waiting for the leader node {servers[0]} to start handling the keyspace-rf-change request")
+    leader_log_file = await manager.server_open_log(servers[0].server_id)
+    await leader_log_file.wait_for("wait-before-committing-rf-change-event injection hit", timeout=10)
+
+    logger.info(f"creating another keyspace from the follower node {servers[1]} so that the leader, which hangs on injected sleep, "
+                f"wakes up with a changed schema")
+    host = manager.get_cql().cluster.metadata.get_host(servers[1].ip_addr)
+    with disable_schema_agreement_wait(manager.get_cql()):
+        await manager.get_cql().run_async("create keyspace ks2 with "
+                                          "replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} "
+                                          "and tablets = {'enabled': true}", host=host)
+
+    logger.info("waking up the leader to continue processing ALTER on a changed schema, which should cause a retry")
+    await injection_handler.message()
+
+    logger.info("waiting for ALTER to complete")
+    await task
+
+    # ensure that the concurrent modification error really did take place
+    matches = await leader_log_file.grep("topology change coordinator fiber got group0_concurrent_modification")
+    assert matches
+
+    # ensure that the ALTER has eventually succeeded and we changed RF from 1 to 2
+    res = manager.get_cql().execute(f"SELECT * FROM system_schema.keyspaces WHERE keyspace_name = 'ks'")
+    assert res[0].replication[this_dc] == '2'


### PR DESCRIPTION
ALTER tablets-enabled KEYSPACES (KS) may fail due to
group0_concurrent_modification, in which case it's repeated by a for
loop surrounding the code. But because raft's add_entry consumes the
raft's guard (by std::move'ing the guard object), retries of ALTER KS
will use a moved-from guard object, which is UB, potentially a crash.
The fix is to remove the before mentioned for loop altogether and rethrow the exception, as the rf_change event
will be repeated by the topology state machine if it receives the
concurrent modification exception, because the event will remain present
in the global requests queue, hence it's going to be executed as the
very next event.
Note: refactor is implemented in the follow-up commit.

Fixes: https://github.com/scylladb/scylladb/issues/21102

Should be backported to every 6.x branch, as it may lead to a crash.

(cherry picked from commit https://github.com/scylladb/scylladb/commit/de511f56acc7b09652a9f4033a6886e8fe4d7452)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/3f4c8a30e37effdfb906465aaf59517caed8945f)

(cherry picked from commit https://github.com/scylladb/scylladb/commit/522bede8ecfbf306e693ba8cdabe3ab69b059b59)

Refs https://github.com/scylladb/scylladb/pull/21121