### PR TITLE
sstables: Avoid computing column_values_fixed_lengths on each read

### DIFF
--- a/sstables/column_translation.hh
+++ b/sstables/column_translation.hh
@@ -60,6 +60,7 @@ private:
                 const sstable_enabled_features& features,
                 bool is_static);
 
+        schema_ptr _schema;
         table_schema_version schema_uuid;
         std::vector<column_info> regular_schema_columns_from_sstable;
         std::vector<column_info> static_schema_columns_from_sstable;
@@ -73,7 +74,8 @@ private:
         state& operator=(state&&) = default;
 
         state(const schema& s, const serialization_header& header, const sstable_enabled_features& features)
-            : schema_uuid(s.version())
+            : _schema(s.shared_from_this())
+            , schema_uuid(s.version())
             , regular_schema_columns_from_sstable(build(s, header.regular_columns.elements, features, false))
             , static_schema_columns_from_sstable(build(s, header.static_columns.elements, features, true))
             , clustering_column_value_fix_lengths (get_clustering_values_fixed_lengths(header))

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -166,11 +166,13 @@ private:
     std::optional<deletion_time> _deletion_time;
 
     trust_promoted_index _trust_pi;
-    std::optional<column_values_fixed_lengths> _ck_values_fixed_lengths;
+    column_translation _ctr;
     tracing::trace_state_ptr _trace_state;
     const abort_source& _abort;
 
-    inline bool is_mc_format() const { return static_cast<bool>(_ck_values_fixed_lengths); }
+    inline bool is_mc_format() const {
+        return !_ctr.empty();
+    }
 
 public:
     void verify_end_state() const {
@@ -322,11 +324,12 @@ public:
 
     index_consume_entry_context(const sstable& sst, reader_permit permit, IndexConsumer& consumer, trust_promoted_index trust_pi,
             input_stream<char>&& input, uint64_t start, uint64_t maxlen,
-            std::optional<column_values_fixed_lengths> ck_values_fixed_lengths,
-            const abort_source& abort, tracing::trace_state_ptr trace_state = {})
+            column_translation ctr,
+            const abort_source& abort,
+            tracing::trace_state_ptr trace_state = {})
         : continuous_data_consumer(std::move(permit), std::move(input), start, maxlen)
         , _sst(sst), _consumer(consumer), _entry_offset(start), _trust_pi(trust_pi)
-        , _ck_values_fixed_lengths(std::move(ck_values_fixed_lengths))
+        , _ctr(std::move(ctr))
         , _trace_state(std::move(trace_state))
         , _abort(abort)
     {}
@@ -349,13 +352,7 @@ std::unique_ptr<clustered_index_cursor> promoted_index::make_cursor(shared_sstab
     file_input_stream_options options,
     use_caching caching)
 {
-    std::optional<column_values_fixed_lengths> ck_values_fixed_lengths;
-    if (sst->get_version() >= sstable_version_types::mc) {
-        ck_values_fixed_lengths = std::make_optional(
-            get_clustering_values_fixed_lengths(sst->get_serialization_header()));
-    }
-
-    if (sst->get_version() >= sstable_version_types::mc) {
+    if (sst->get_version() >= sstable_version_types::mc) [[likely]] {
         seastar::shared_ptr<cached_file> cached_file_ptr = caching
                 ? sst->_cached_index_file
                 : seastar::make_shared<cached_file>(make_tracked_index_file(*sst, permit, trace_state, caching),
@@ -366,13 +363,13 @@ std::unique_ptr<clustered_index_cursor> promoted_index::make_cursor(shared_sstab
         return std::make_unique<mc::bsearch_clustered_cursor>(*sst->get_schema(),
             _promoted_index_start, _promoted_index_size,
             promoted_index_cache_metrics, permit,
-            *ck_values_fixed_lengths, cached_file_ptr, _num_blocks, trace_state, sst->features());
+            sst->get_column_translation(), cached_file_ptr, _num_blocks, trace_state, sst->features());
     }
 
     auto file = make_tracked_index_file(*sst, permit, std::move(trace_state), caching);
     auto promoted_index_stream = make_file_input_stream(std::move(file), _promoted_index_start, _promoted_index_size,options);
     return std::make_unique<scanning_clustered_index_cursor>(*sst->get_schema(), permit,
-        std::move(promoted_index_stream), _promoted_index_size, _num_blocks, ck_values_fixed_lengths);
+        std::move(promoted_index_stream), _promoted_index_size, _num_blocks, std::nullopt);
 }
 
 // Less-comparator for lookups in the partition index.
@@ -472,11 +469,8 @@ class index_reader {
         auto input = make_file_input_stream(index_file, begin, (_single_page_read ? end : _sstable->index_size()) - begin,
                         get_file_input_stream_options());
         auto trust_pi = trust_promoted_index(_sstable->has_correct_promoted_index_entries());
-        auto ck_values_fixed_lengths = _sstable->get_version() >= sstable_version_types::mc
-                            ? std::make_optional(get_clustering_values_fixed_lengths(_sstable->get_serialization_header()))
-                            : std::optional<column_values_fixed_lengths>{};
         return std::make_unique<index_consume_entry_context<index_consumer>>(*_sstable, _permit, consumer, trust_pi, std::move(input),
-                            begin, end - begin, ck_values_fixed_lengths, _abort, _trace_state);
+                            begin, end - begin, _sstable->get_column_translation(), _abort, _trace_state);
     }
 
     future<> advance_context(index_bound& bound, uint64_t begin, uint64_t end, int quantity) {

--- a/sstables/mx/bsearch_clustered_cursor.hh
+++ b/sstables/mx/bsearch_clustered_cursor.hh
@@ -172,6 +172,7 @@ public:
     cached_file& _cached_file;
     data_consumer::primitive_consumer_impl<Buffer> _primitive_parser;
     u32_parser _u32_parser;
+    column_translation _ctr;
     clustering_parser<Buffer> _clustering_parser;
     promoted_index_block_parser<Buffer> _block_parser;
     reader_permit _permit;
@@ -268,7 +269,7 @@ public:
             uint64_t promoted_index_size,
             metrics& m,
             reader_permit permit,
-            column_values_fixed_lengths cvfl,
+            column_translation ctr,
             cached_file& f,
             pi_index_type blocks_count)
         : _blocks(block_comparator{s})
@@ -280,8 +281,9 @@ public:
         , _cached_file(f)
         , _primitive_parser(permit)
         , _u32_parser(_primitive_parser)
-        , _clustering_parser(s, permit, cvfl, true)
-        , _block_parser(s, permit, std::move(cvfl))
+        , _ctr(std::move(ctr))
+        , _clustering_parser(s, permit, _ctr.clustering_column_value_fix_legths(), true)
+        , _block_parser(s, permit, _ctr.clustering_column_value_fix_legths())
         , _permit(std::move(permit))
     { }
 
@@ -513,7 +515,7 @@ public:
             uint64_t promoted_index_size,
             cached_promoted_index::metrics& metrics,
             reader_permit permit,
-            column_values_fixed_lengths cvfl,
+            column_translation ctr,
             seastar::shared_ptr<cached_file> f,
             pi_index_type blocks_count,
             tracing::trace_state_ptr trace_state,
@@ -526,7 +528,7 @@ public:
             promoted_index_size,
             metrics,
             std::move(permit),
-            std::move(cvfl),
+            std::move(ctr),
             *_cached_file,
             blocks_count)
         , _trace_state(std::move(trace_state))

--- a/sstables/mx/parsers.hh
+++ b/sstables/mx/parsers.hh
@@ -30,7 +30,7 @@ template <ContiguousSharedBuffer Buffer>
 class clustering_parser {
     using FragmentedBuffer = basic_fragmented_buffer<Buffer>;
     const schema& _s;
-    column_values_fixed_lengths _clustering_values_fixed_lengths;
+    const column_values_fixed_lengths& _clustering_values_fixed_lengths;
     bool _parsing_start_key;
     boost::iterator_range<column_values_fixed_lengths::const_iterator> ck_range;
 
@@ -95,9 +95,9 @@ class clustering_parser {
 public:
     using read_status = data_consumer::read_status;
 
-    clustering_parser(const schema& s, reader_permit permit, column_values_fixed_lengths cvfl, bool parsing_start_key)
+    clustering_parser(const schema& s, reader_permit permit, const column_values_fixed_lengths& cvfl, bool parsing_start_key)
         : _s(s)
-        , _clustering_values_fixed_lengths(std::move(cvfl))
+        , _clustering_values_fixed_lengths(cvfl)
         , _parsing_start_key(parsing_start_key)
         , _primitive(std::move(permit))
     { }
@@ -237,8 +237,8 @@ class promoted_index_block_parser {
 public:
     using read_status = data_consumer::read_status;
 
-    promoted_index_block_parser(const schema& s, reader_permit permit, column_values_fixed_lengths cvfl)
-        : _clustering(s, permit, std::move(cvfl), true)
+    promoted_index_block_parser(const schema& s, reader_permit permit, const column_values_fixed_lengths& cvfl)
+        : _clustering(s, permit, cvfl, true)
         , _primitive(permit)
     { }
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -899,6 +899,19 @@ public:
             const schema& s, const serialization_header& h, const sstable_enabled_features& f) {
         return _column_translation.get_for_schema(s, h, f);
     }
+    column_translation get_column_translation(const schema& s) {
+        if (get_version() >= sstable_version_types::mc) [[likely]] {
+            return _column_translation.get_for_schema(s, get_serialization_header(), features());
+        } else {
+            return _column_translation.get_for_schema(s);
+        }
+    }
+    column_translation get_column_translation() {
+        if (!_column_translation.version()) {
+            return get_column_translation(*_schema);
+        }
+        return _column_translation;
+    }
     const std::vector<unsigned>& get_shards_for_this_sstable() const {
         return _shards;
     }

--- a/test/boost/index_reader_test.cc
+++ b/test/boost/index_reader_test.cc
@@ -38,7 +38,7 @@ SEASTAR_TEST_CASE(test_abort_during_index_read) {
         index_consume_entry_context<dummy_index_consumer> consumer_ctx(
             *sst, env.make_reader_permit(), consumer, trust_promoted_index::no,
             make_file_input_stream(index_file, 0, index_file_size), 0, index_file_size,
-            std::make_optional(get_clustering_values_fixed_lengths(sst->get_serialization_header())),
+            sst->get_column_translation(),
             sst->manager().get_abort_source());
 
         // request abort before starting to consume index, so that the consumer throws an exception as soon as it starts


### PR DESCRIPTION
Reads which need sstable index were computing
column_values_fixed_lengths each time. This showed up in perf profile
for a sstable-read heavy workload, and amounted to about 1-2% of time.

Computing it involves type name parsing. 

Avoid by using cached per-sstable mapping. There is already
sstable::_column_translation which can be used for this. It caches the
mapping for the least-recently used schema. Since the cursor uses the
mapping only for primary key columns, which are stable, any schema
will do, so we can use the last _column_translation. We only need to
make sure that it's always armed, so sstable loading is augmented with
arming with sstable's schema.

Also, fixes a potential use-after-free on schema in column_translation.
