### PR TITLE
cql3: Rename `SALTED HASH` to `HASHED PASSWORD`

### DIFF
--- a/auth/authentication_options.hh
+++ b/auth/authentication_options.hh
@@ -23,7 +23,7 @@ namespace auth {
 
 enum class authentication_option {
     password,
-    salted_hash,
+    hashed_password,
     options
 };
 
@@ -37,8 +37,8 @@ struct fmt::formatter<auth::authentication_option> : fmt::formatter<string_view>
         switch (a) {
         case password:
             return formatter<string_view>::format("PASSWORD", ctx);
-        case salted_hash:
-            return formatter<string_view>::format("SALTED HASH", ctx);
+        case hashed_password:
+            return formatter<string_view>::format("HASHED PASSWORD", ctx);
         case options:
             return formatter<string_view>::format("OPTIONS", ctx);
         }
@@ -57,12 +57,12 @@ struct password_option {
 };
 
 /// Used exclusively for restoring roles.
-struct salted_hash_option {
-    sstring salted_hash;
+struct hashed_password_option {
+    sstring hashed_password;
 };
 
 struct authentication_options final {
-    std::optional<std::variant<password_option, salted_hash_option>> credentials;
+    std::optional<std::variant<password_option, hashed_password_option>> credentials;
     std::optional<custom_options> options;
 };
 

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -181,7 +181,7 @@ public:
     /// Produces descriptions that can be used to restore the state of auth. That encompasses
     /// roles, role grants, and permission grants.
     ///
-    future<std::vector<cql3::description>> describe_auth(bool with_salted_hashes);
+    future<std::vector<cql3::description>> describe_auth(bool with_hashed_passwords);
 
     authenticator& underlying_authenticator() const {
         return *_authenticator;
@@ -207,7 +207,7 @@ private:
     future<> create_legacy_keyspace_if_missing(::service::migration_manager& mm) const;
     future<bool> has_superuser(std::string_view role_name, const role_set& roles) const;
 
-    future<std::vector<cql3::description>> describe_roles(bool with_salted_hashes);
+    future<std::vector<cql3::description>> describe_roles(bool with_hashed_passwords);
     future<std::vector<cql3::description>> describe_permissions() const;
 };
 

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -1340,7 +1340,7 @@ roleOptions[cql3::role_options& opts]
 
 roleOption[cql3::role_options& opts]
     : K_PASSWORD '=' v=STRING_LITERAL { opts.password = $v.text; }
-    | K_SALTED K_HASH '=' v=STRING_LITERAL { opts.salted_hash = $v.text; }
+    | K_HASHED K_PASSWORD '=' v=STRING_LITERAL { opts.hashed_password = $v.text; }
     | K_OPTIONS '=' m=mapLiteral { opts.options = convert_property_map(m); }
     | K_SUPERUSER '=' b=BOOLEAN { opts.is_superuser = convert_boolean_literal($b.text); }
     | K_LOGIN '=' b=BOOLEAN { opts.can_login = convert_boolean_literal($b.text); }
@@ -1470,7 +1470,7 @@ describeStatement returns [std::unique_ptr<cql3::statements::raw::describe_state
         bool only = false;
         std::optional<sstring> keyspace;
         sstring generic_name = "";
-        bool with_salted_hashes = false;
+        bool with_hashed_passwords = false;
     }
     : ( K_DESCRIBE | K_DESC )
     ( (K_CLUSTER) => K_CLUSTER                      { $stmt = cql3::statements::raw::describe_statement::cluster();                }
@@ -1497,8 +1497,8 @@ describeStatement returns [std::unique_ptr<cql3::statements::raw::describe_state
         | tK=unreserved_keyword                     { generic_name = tK; } )
                                                     { $stmt = cql3::statements::raw::describe_statement::generic(keyspace, generic_name); }
     )
-    ( K_WITH K_INTERNALS (K_AND K_PASSWORDS { with_salted_hashes = true; })?
-        { $stmt->with_internals_details(with_salted_hashes); } )?
+    ( K_WITH K_INTERNALS (K_AND K_PASSWORDS { with_hashed_passwords = true; })?
+        { $stmt->with_internals_details(with_hashed_passwords); } )?
     ;
 
 /** DEFINITIONS **/
@@ -2075,8 +2075,7 @@ basic_unreserved_keyword returns [sstring str]
         | K_OPTIONS
         | K_PASSWORD
         | K_PASSWORDS
-        | K_SALTED
-        | K_HASH
+        | K_HASHED
         | K_EXISTS
         | K_CUSTOM
         | K_TRIGGER
@@ -2238,8 +2237,7 @@ K_SUPERUSER:   S U P E R U S E R;
 K_NOSUPERUSER: N O S U P E R U S E R;
 K_PASSWORD:    P A S S W O R D;
 K_PASSWORDS:   P A S S W O R D S;
-K_SALTED:      S A L T E D;
-K_HASH:        H A S H;
+K_HASHED:      H A S H E D;
 K_LOGIN:       L O G I N;
 K_NOLOGIN:     N O L O G I N;
 K_OPTIONS:     O P T I O N S;

--- a/cql3/role_options.hh
+++ b/cql3/role_options.hh
@@ -13,7 +13,7 @@ struct role_options final {
     std::optional<bool> is_superuser{};
     std::optional<bool> can_login{};
     std::optional<sstring> password{};
-    std::optional<sstring> salted_hash{};
+    std::optional<sstring> hashed_password{};
 
     // The parser makes a `std::map`, not a `std::unordered_map`.
     std::optional<std::map<sstring, sstring>> options{};

--- a/cql3/statements/describe_statement.hh
+++ b/cql3/statements/describe_statement.hh
@@ -75,7 +75,7 @@ public:
 class schema_describe_statement : public describe_statement {
     struct schema_desc {
         bool full_schema;
-        bool with_salted_hashes;
+        bool with_hashed_passwords;
     };
     struct keyspace_desc {
         std::optional<sstring> keyspace;
@@ -91,7 +91,7 @@ protected:
     virtual seastar::future<std::vector<std::vector<bytes_opt>>> describe(cql3::query_processor& qp, const service::client_state& client_state) const override;
 
 public:
-    schema_describe_statement(bool full_schema, bool with_salted_hashes, bool with_internals);
+    schema_describe_statement(bool full_schema, bool with_hashed_passwords, bool with_internals);
     schema_describe_statement(std::optional<sstring> keyspace, bool only, bool with_internals);
 };
 

--- a/cql3/statements/raw/describe_statement.hh
+++ b/cql3/statements/raw/describe_statement.hh
@@ -44,7 +44,7 @@ private:
     struct describe_cluster {};
     struct describe_schema {
         bool full_schema = false;
-        bool with_salted_hashes = false;
+        bool with_hashed_passwords = false;
     };
     struct describe_keyspace {
         std::optional<sstring> keyspace;
@@ -77,7 +77,7 @@ private:
 
 public:
     explicit describe_statement(describe_config config);
-    void with_internals_details(bool with_salted_hashes);
+    void with_internals_details(bool with_hashed_passwords);
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats) override;
 

--- a/cql3/statements/role-management-statements.cc
+++ b/cql3/statements/role-management-statements.cc
@@ -37,8 +37,8 @@ using result_message = cql_transport::messages::result_message;
 using result_message_ptr = ::shared_ptr<result_message>;
 
 static auth::authentication_options extract_authentication_options(const cql3::role_options& options) {
-    if (options.password && options.salted_hash) {
-        throw exceptions::syntax_exception("Only one of the options: PASSWORD, SALTED HASH can be provided");
+    if (options.password && options.hashed_password) {
+        throw exceptions::syntax_exception("Only one of the options: PASSWORD, HASHED PASSWORD can be provided");
     }
 
     auth::authentication_options authen_options;
@@ -47,8 +47,8 @@ static auth::authentication_options extract_authentication_options(const cql3::r
         authen_options.options = std::unordered_map<sstring, sstring>(options.options->begin(), options.options->end());
     }
 
-    if (options.salted_hash) {
-        authen_options.credentials = auth::salted_hash_option {.salted_hash = *options.salted_hash};
+    if (options.hashed_password) {
+        authen_options.credentials = auth::hashed_password_option {.hashed_password = *options.hashed_password};
     }
     if (options.password) {
         authen_options.credentials = auth::password_option {.password = *options.password};
@@ -85,14 +85,14 @@ future<> create_role_statement::check_access(query_processor& qp, const service:
     return async([this, &state] {
         state.ensure_has_permission({auth::permission::CREATE, auth::root_role_resource()}).get();
 
-        if (!_options.is_superuser && !_options.salted_hash) {
+        if (!_options.is_superuser && !_options.hashed_password) {
             return;
         }
 
         const bool has_superuser = auth::has_superuser(*state.get_auth_service(), *state.user()).get();
 
-        if (_options.salted_hash && !has_superuser) {
-            throw exceptions::unauthorized_exception("Only superusers can create a role with a salted hash.");
+        if (_options.hashed_password && !has_superuser) {
+            throw exceptions::unauthorized_exception("Only superusers can create a role with a hashed password.");
         }
 
         if (_options.is_superuser.value_or(false) && !has_superuser) {

--- a/docs/cql/cql-extensions.md
+++ b/docs/cql/cql-extensions.md
@@ -416,6 +416,6 @@ For more details, check [Service Levels docs](https://github.com/scylladb/scylla
 
 We extended the semantics of `DESCRIBE SCHEMA WITH INTERNALS`: aside from describing the elements of the schema,
 it also describes authentication/authorization and service levels. Additionally, we introduced a new tier of the
-statement: `DESCRIBE SCHEMA WITH INTERNALS AND PASSWORDS`, which also includes the information about salted hashes of the roles.
+statement: `DESCRIBE SCHEMA WITH INTERNALS AND PASSWORDS`, which also includes the information about hashed passwords of the roles.
 
 For more details, see [the article on DESCRIBE SCHEMA](./describe-schema.rst).

--- a/docs/cql/describe-schema.rst
+++ b/docs/cql/describe-schema.rst
@@ -30,7 +30,7 @@ Syntax and semantics
 
 * ``DESCRIBE [FULL] SCHEMA WITH INTERNALS AND PASSWORDS``: aside from the information retrieved as part of the
   previous tier, the statements corresponding to restoring roles *do* contain information about their
-  passwords; namely—their salted hashes. For more information regarding salted hashes, see the relevant section
+  passwords; namely—their hashed passwords. For more information regarding hashed passwords, see the relevant section
   below.
 
 Instead of ``DESCRIBE``, you can use its shortened form: ``DESC``.
@@ -64,7 +64,7 @@ Relation to authentication and authorization
 
 It's important to note that the information returned by ``DESCRIBE [FULL] SCHEMA WITH INTERNALS [AND PASSWORDS]``
 depends on the currently used authenticator and authorizer. If the used authenticator doesn't use passwords to
-authenticate a role, the salted hashes won't be returned even if they're present in the database. That scenario
+authenticate a role, the hashed passwords won't be returned even if they're present in the database. That scenario
 may happen if, for example, you start using `AllowAllAuthenticator`.
 
 Similarly, permission grants may not be returned if they're not used, e.g. when ScyllaDB is configured to use
@@ -95,17 +95,17 @@ cqlsh support
     | ``DESCRIBE [FULL] SCHEMA WITH INTERNALS AND PASSWORDS`` | 6.0.23                    |
     +---------------------------------------------------------+---------------------------+
 
-Appendix I, salted hashes
--------------------------
+Appendix I, hashed passwords
+----------------------------
 
-A salted hash is an encrypted form of a password stored by ScyllaDB to authenticate roles. The statements returned
+A hashed password is an encrypted form of a password stored by ScyllaDB to authenticate roles. The statements returned
 by ``DESCRIBE [FULL] SCHEMA WITH INTERNALS AND PASSWORDS`` corresponding to recreating the roles will be of the
 following form:
 
 .. code-block:: cql
 
-    CREATE ROLE [IF NOT EXISTS] <role_name> WITH SALTED HASH = '<salted_hash>' AND LOGIN = <boolean> AND SUPERUSER = <boolean>
+    CREATE ROLE [IF NOT EXISTS] <role_name> WITH HASHED PASSWORD = '<hashed_password>' AND LOGIN = <boolean> AND SUPERUSER = <boolean>
 
 The semantics of this statement is analogous to the regular ``CREATE ROLE`` statement except that it circumvents
-the encryption phase of the execution and inserts the salted hash directly into ``system.roles``. You should not use
+the encryption phase of the execution and inserts the hashed password directly into ``system.roles``. You should not use
 this statement unless it was returned by ``DESCRIBE SCHEMA``.

--- a/docs/cql/non-reserved-keywords.rst
+++ b/docs/cql/non-reserved-keywords.rst
@@ -30,7 +30,7 @@ Non-reserved keywords only have meaning in their particular area of context and 
 * FROZEN	
 * FUNCTION	
 * FUNCTIONS	
-* HASH
+* HASHED
 * INET	
 * INITCOND	
 * INPUT	
@@ -53,7 +53,6 @@ Non-reserved keywords only have meaning in their particular area of context and 
 * RETURNS	
 * ROLE	
 * ROLES	
-* SALTED
 * SFUNC	
 * SMALLINT	
 * STATIC	

--- a/docs/dev/describe_schema.md
+++ b/docs/dev/describe_schema.md
@@ -83,10 +83,10 @@ Taking all of this into consideration is crucial when designing the semantics of
 that is unused in the output of the statement, like permission grants? Or should we not?
 
 The conclusion we reached is to rely on the current configuration and on it only. That means that if some data cannot be accessed
-via the API, it won't be included. For example, if we use `AllowAllAuthenticator`, no salted hashes will be printed
-when executing `DESCRIBE SCHEMA WITH INTERNALS AND PASSWORDS` because salted hashes are not used by the authenticator.
+via the API, it won't be included. For example, if we use `AllowAllAuthenticator`, no hashed passwords will be printed
+when executing `DESCRIBE SCHEMA WITH INTERNALS AND PASSWORDS` because hashed passwords are not used by the authenticator.
 
-The rationale for that decision is the fact that we want to backup the current state of Scylla. Restoring salted hashes, permission grants, etc.
+The rationale for that decision is the fact that we want to backup the current state of Scylla. Restoring hashed passwords, permission grants, etc.
 would require changing the configuration to be even able to insert the data. That's something we want to avoid.
 
 For that reason, the user should be aware of this fact and make sure they are prepared for possible "data loss".
@@ -104,7 +104,7 @@ Scylla doesn't store the passwords of the roles; instead, it stores salted hashe
 To restore a role with its password, we want utilize that salted hash. We introduce a new form of the `CREATE ROLE` statement:
 
 ```sql
-CREATE ROLE [ IF NOT EXISTS ] `role_name` WITH SALTED HASH = '`salted_hash`' ( AND `role_option` )*
+CREATE ROLE [ IF NOT EXISTS ] `role_name` WITH HASHED PASSWORD = '`hashed_password`' ( AND `role_option` )*
 ```
 
 where
@@ -114,7 +114,7 @@ role_option: LOGIN '=' `string`
            :| SUPERUSER '=' `boolean`
 ```
 
-Performing that query will result in creating a new role whose salted hash stored in the database is exactly the same as the one provided by the user. If the specified role already exists, the query will fail and no side effect will be observed—in short, we follow the semantics of the "normal" version of `CREATE ROLE`.
+Performing that query will result in creating a new role whose hashed password stored in the database is exactly the same as the one provided by the user. If the specified role already exists, the query will fail and no side effect will be observed—in short, we follow the semantics of the "normal" version of `CREATE ROLE`.
 
 The user executing that statement is required to be a superuser.
 

--- a/test/boost/auth_test.cc
+++ b/test/boost/auth_test.cc
@@ -358,32 +358,32 @@ SEASTAR_TEST_CASE(test_alter_with_workload_type) {
     }, auth_on(false));
 }
 
-SEASTAR_TEST_CASE(test_try_to_create_role_with_salted_hash_and_password) {
+SEASTAR_TEST_CASE(test_try_to_create_role_with_hashed_password_and_password) {
     return do_with_cql_env_thread([] (cql_test_env& env) {
         BOOST_REQUIRE_THROW(
-            env.execute_cql("CREATE ROLE jane WITH SALTED HASH = 'something' AND PASSWORD = 'something'").get(),
+            env.execute_cql("CREATE ROLE jane WITH HASHED PASSWORD = 'something' AND PASSWORD = 'something'").get(),
             exceptions::syntax_exception);
     }, auth_on(false));
 }
 
-SEASTAR_TEST_CASE(test_try_to_create_role_with_password_and_salted_hash) {
+SEASTAR_TEST_CASE(test_try_to_create_role_with_password_and_hashed_password) {
     return do_with_cql_env_thread([] (cql_test_env& env) {
         BOOST_REQUIRE_THROW(
-            env.execute_cql("CREATE ROLE jane WITH PASSWORD = 'something' AND SALTED HASH = 'something'").get(),
+            env.execute_cql("CREATE ROLE jane WITH PASSWORD = 'something' AND HASHED PASSWORD = 'something'").get(),
             exceptions::syntax_exception);
     }, auth_on(false));
 }
 
-SEASTAR_TEST_CASE(test_try_create_role_with_salted_hash_as_anonymous_user) {
+SEASTAR_TEST_CASE(test_try_create_role_with_hashed_password_as_anonymous_user) {
     return do_with_cql_env_thread([] (cql_test_env& env) {
         env.local_client_state().set_login(auth::anonymous_user());
         env.refresh_client_state().get();
         BOOST_REQUIRE(auth::is_anonymous(*env.local_client_state().user()));
-        BOOST_REQUIRE_THROW(env.execute_cql("CREATE ROLE my_new_role WITH SALTED HASH = 'myhash'").get(), exceptions::unauthorized_exception);
+        BOOST_REQUIRE_THROW(env.execute_cql("CREATE ROLE my_new_role WITH HASHED PASSWORD = 'myhash'").get(), exceptions::unauthorized_exception);
     }, auth_on(true));
 }
 
-SEASTAR_TEST_CASE(test_try_login_after_creating_roles_with_salted_hash) {
+SEASTAR_TEST_CASE(test_try_login_after_creating_roles_with_hashed_password) {
     return do_with_cql_env_thread([] (cql_test_env& env) {
         // Note: crypt(5) specifies:
         //
@@ -391,8 +391,8 @@ SEASTAR_TEST_CASE(test_try_login_after_creating_roles_with_salted_hash) {
         //     or the characters `:`, `;`, `*`, `!`, or `\`.   (These  characters  are
         //     used as delimiters and special markers in the passwd(5) and shadow(5) files.)"
 
-        env.execute_cql("CREATE ROLE invalid_role WITH SALTED HASH = ';' AND LOGIN = true").get();
-        env.execute_cql("CREATE ROLE valid_role WITH SALTED HASH = 'salted_hash' AND LOGIN = true").get();
+        env.execute_cql("CREATE ROLE invalid_role WITH HASHED PASSWORD = ';' AND LOGIN = true").get();
+        env.execute_cql("CREATE ROLE valid_role WITH HASHED PASSWORD = 'hashed_password' AND LOGIN = true").get();
         BOOST_REQUIRE_EXCEPTION(authenticate(env, "invalid_role", "pwd").get(), exceptions::authentication_exception,
                 exception_predicate::message_equals("Could not verify password"));
         BOOST_REQUIRE_EXCEPTION(authenticate(env, "valid_role", "pwd").get(), exceptions::authentication_exception,

--- a/test/boost/cql_auth_syntax_test.cc
+++ b/test/boost/cql_auth_syntax_test.cc
@@ -321,19 +321,19 @@ BOOST_AUTO_TEST_CASE(revoke_role) {
     test_valid("REVOKE soldier FROM boromir;");
 }
 
-BOOST_AUTO_TEST_CASE(create_role_with_salted_hash) {
-    test_valid("CREATE ROLE adam WITH SALTED HASH = 'something';");
+BOOST_AUTO_TEST_CASE(create_role_with_hashed_password) {
+    test_valid("CREATE ROLE adam WITH HASHED PASSWORD = 'something';");
 }
 
-BOOST_AUTO_TEST_CASE(create_role_with_salted) {
+BOOST_AUTO_TEST_CASE(create_role_with_hashed) {
     BOOST_REQUIRE_THROW(
-        cql3::util::do_with_parser("CREATE ROLE jane WITH SALTED = 'something';", cql3::dialect{}, std::mem_fn(&cql3_parser::CqlParser::query)),
+        cql3::util::do_with_parser("CREATE ROLE jane WITH HASHED = 'something';", cql3::dialect{}, std::mem_fn(&cql3_parser::CqlParser::query)),
         exceptions::syntax_exception);
 }
 
-BOOST_AUTO_TEST_CASE(create_role_with_salted_underscore_hash) {
+BOOST_AUTO_TEST_CASE(create_role_with_hashed_underscore_password) {
     BOOST_REQUIRE_THROW(
-        cql3::util::do_with_parser("CREATE ROLE jane WITH SALTED_HASH = 'something';", cql3::dialect{}, std::mem_fn(&cql3_parser::CqlParser::query)),
+        cql3::util::do_with_parser("CREATE ROLE jane WITH HASHED_PASSWORD = 'something';", cql3::dialect{}, std::mem_fn(&cql3_parser::CqlParser::query)),
         exceptions::syntax_exception);
 }
 
@@ -343,14 +343,14 @@ BOOST_AUTO_TEST_CASE(create_role_with_hash) {
         exceptions::syntax_exception);
 }
 
-BOOST_AUTO_TEST_CASE(create_role_with_salted_hash_double_quotation_marks) {
+BOOST_AUTO_TEST_CASE(create_role_with_hashed_password_double_quotation_marks) {
     BOOST_REQUIRE_THROW(
-        cql3::util::do_with_parser("CREATE ROLE jane WITH SALTED HASH = \"something\";", cql3::dialect{}, std::mem_fn(&cql3_parser::CqlParser::query)),
+        cql3::util::do_with_parser("CREATE ROLE jane WITH HASHED PASSWORD = \"something\";", cql3::dialect{}, std::mem_fn(&cql3_parser::CqlParser::query)),
         exceptions::syntax_exception);
 }
 
-BOOST_AUTO_TEST_CASE(create_role_with_salted_no_quotation_marks) {
+BOOST_AUTO_TEST_CASE(create_role_with_hashed_no_quotation_marks) {
     BOOST_REQUIRE_THROW(
-        cql3::util::do_with_parser("CREATE ROLE jane WITH SALTED = something;", cql3::dialect{}, std::mem_fn(&cql3_parser::CqlParser::query)),
+        cql3::util::do_with_parser("CREATE ROLE jane WITH HASHED = something;", cql3::dialect{}, std::mem_fn(&cql3_parser::CqlParser::query)),
         exceptions::syntax_exception);
 }


### PR DESCRIPTION
Cassandra 4.1 announced a new option to create a role with: `HASHED PASSWORD`. Example:

```
CREATE ROLE bob WITH HASHED PASSWORD = 'hashed_password';
```

We've already introduced another option following the same semantics: `SALTED HASH`; example:

```
CREATE ROLE bob WITH SALTED HASH = 'salted_hash';
```

The change hasn't made it to any release yet, so in this commit we rename it to `HASHED PASSWORD` to be compatible with Cassandra.

Additionally, we adjust existing tests to work against Cassandra too.

Fixes scylladb/scylladb#21350

Backport: not needed. The changes didn't make it to any released version.