### PR TITLE
github: use GithubException when appropriate

### DIFF
--- a/.github/scripts/auto-backport.py
+++ b/.github/scripts/auto-backport.py
@@ -97,7 +97,7 @@ def backport(repo, pr, version, commits, backport_base_branch, user):
             repo_local.git.checkout(b=new_branch_name)
             try:
                 fork_repo = pr.user.get_repo(repo.name)
-            except Exception as e:
+            except GithubException as e:
                 print(f"Error retrieving repository: {e}")
                 # Since Scylla core repo was modified a few years ago to ScyllaDB,
                 # some developers may have forks based on the original name `scylla`


### PR DESCRIPTION
`Exception` could be too general, what we really care about is `GithubException`. so let's catch the latter instead for better readability.

---

it's a cleanup, hence no need to backport.