### PR TITLE
mutation_writer,streaming: use reader_consumer_v2 type when appropriate

### DIFF
--- a/mutation_writer/multishard_writer.cc
+++ b/mutation_writer/multishard_writer.cc
@@ -25,12 +25,12 @@ private:
     schema_ptr _s;
     std::unique_ptr<reader_concurrency_semaphore> _semaphore;
     mutation_reader _reader;
-    std::function<future<> (mutation_reader reader)> _consumer;
+    reader_consumer_v2 _consumer;
 public:
     shard_writer(schema_ptr s,
         std::unique_ptr<reader_concurrency_semaphore> semaphore,
         mutation_reader reader,
-        std::function<future<> (mutation_reader reader)> consumer);
+        reader_consumer_v2 consumer);
     future<> consume();
     future<> close() noexcept;
 };
@@ -51,7 +51,7 @@ private:
     dht::shard_replica_set _current_shards;
     uint64_t _consumed_partitions = 0;
     mutation_reader _producer;
-    std::function<future<> (mutation_reader)> _consumer;
+    reader_consumer_v2 _consumer;
 private:
     dht::shard_replica_set shard_for_mf(const mutation_fragment_v2& mf) {
         auto token = mf.as_partition_start().key().token();
@@ -68,7 +68,7 @@ public:
         schema_ptr s,
         const dht::sharder& sharder,
         mutation_reader producer,
-        std::function<future<> (mutation_reader)> consumer);
+        reader_consumer_v2 consumer);
     future<uint64_t> operator()();
     future<> close() noexcept;
 };
@@ -76,7 +76,7 @@ public:
 shard_writer::shard_writer(schema_ptr s,
     std::unique_ptr<reader_concurrency_semaphore> semaphore,
     mutation_reader reader,
-    std::function<future<> (mutation_reader reader)> consumer)
+    reader_consumer_v2 consumer)
     : _s(s)
     , _semaphore(std::move(semaphore))
     , _reader(std::move(reader))
@@ -102,7 +102,7 @@ multishard_writer::multishard_writer(
     schema_ptr s,
     const dht::sharder& sharder,
     mutation_reader producer,
-    std::function<future<> (mutation_reader)> consumer)
+    reader_consumer_v2 consumer)
     : _s(std::move(s))
     , _sharder(sharder)
     , _queue_reader_handles(_sharder.shard_count())
@@ -221,7 +221,7 @@ future<uint64_t> multishard_writer::operator()() {
 future<uint64_t> distribute_reader_and_consume_on_shards(schema_ptr s,
     const dht::sharder& sharder,
     mutation_reader producer,
-    std::function<future<> (mutation_reader)> consumer,
+    reader_consumer_v2 consumer,
     utils::phased_barrier::operation&& op) {
     return do_with(multishard_writer(std::move(s), sharder, std::move(producer), std::move(consumer)), std::move(op), [] (multishard_writer& writer, utils::phased_barrier::operation&) {
         return writer().finally([&writer] {

--- a/mutation_writer/multishard_writer.hh
+++ b/mutation_writer/multishard_writer.hh
@@ -33,7 +33,7 @@ namespace mutation_writer {
 future<uint64_t> distribute_reader_and_consume_on_shards(schema_ptr s,
     const dht::sharder& sharder,
     mutation_reader producer,
-    std::function<future<> (mutation_reader)> consumer,
+    reader_consumer_v2 consumer,
     utils::phased_barrier::operation&& op = {});
 
 } // namespace mutation_writer

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -18,7 +18,7 @@
 
 namespace streaming {
 
-std::function<future<> (mutation_reader)> make_streaming_consumer(sstring origin,
+reader_consumer_v2 make_streaming_consumer(sstring origin,
         sharded<replica::database>& db,
         sharded<db::view::view_builder>& vb,
         uint64_t estimated_partitions,

--- a/streaming/consumer.hh
+++ b/streaming/consumer.hh
@@ -24,7 +24,7 @@ class view_builder;
 
 namespace streaming {
 
-std::function<future<>(mutation_reader)> make_streaming_consumer(sstring origin,
+reader_consumer_v2 make_streaming_consumer(sstring origin,
     sharded<replica::database>& db,
     sharded<db::view::view_builder>& vb,
     uint64_t estimated_partitions,

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -168,7 +168,7 @@ public:
 
     shared_ptr<stream_session> get_session(streaming::plan_id plan_id, gms::inet_address from, const char* verb, std::optional<table_id> cf_id = {});
 
-    std::function<future<>(mutation_reader)> make_streaming_consumer(
+    reader_consumer_v2 make_streaming_consumer(
             uint64_t estimated_partitions, stream_reason, service::frozen_topology_guard);
 public:
     virtual future<> on_join(inet_address endpoint, endpoint_state_ptr ep_state, gms::permit_id) override { return make_ready_future(); }

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -82,7 +82,7 @@ public:
     }
 };
 
-std::function<future<>(mutation_reader)>
+reader_consumer_v2
 stream_manager::make_streaming_consumer(uint64_t estimated_partitions, stream_reason reason, service::frozen_topology_guard topo_guard) {
     return streaming::make_streaming_consumer("streaming", _db, _view_builder, estimated_partitions, reason, is_offstrategy_supported(reason), topo_guard);
 }


### PR DESCRIPTION
The `reader_consumer_v2` type
(`std::function<future<> (mutation_reader)>`) is defined alongside `mutation_reader` in `mutation_reader.hh`.

before this change, we sometimes use
`std::function<future<> (mutation_reader)>` directly when defining a consumer parameter or a consumer variable.

in this change, we improve maintainability by:

- Reducing duplicate function type declarations
- Centralizing the consumer type definition
- Making future signature updates easier to implement

---

it's a cleanup, hence no need to backport.