### PR TITLE
test/topology_experimental_raft: fix flaky test

### DIFF
--- a/test/topology_experimental_raft/test_alternator.py
+++ b/test/topology_experimental_raft/test_alternator.py
@@ -64,19 +64,6 @@ def full_query(table, ConsistentRead=True, **kwargs):
 # implement an async wrapper to the boto3 functions ourselves (e.g., run them
 # in a separate thread) ourselves.
 
-@pytest.fixture(scope="module")
-async def alternator3(manager_internal):
-    """A fixture with a 3-node Alternator cluster that can be shared between
-       multiple tests. These test should not modify the cluster's topology,
-       and should each use unique table names and/or unique keys to avoid
-       being confused by other tests.
-       Returns the manager object and 3 boto3 resource objects for making
-       DynamoDB API requests to each of the nodes in the Alternator cluster.
-    """
-    manager = manager_internal()
-    servers = await manager.servers_add(3, config=alternator_config)
-    yield [manager] + [get_alternator(server.ip_addr) for server in servers]
-    await manager.stop()
 
 test_table_prefix = 'alternator_Test_'
 def unique_table_name():
@@ -89,7 +76,7 @@ def unique_table_name():
 unique_table_name.last_ms = 0
 
 
-async def test_alternator_ttl_scheduling_group(alternator3):
+async def test_alternator_ttl_scheduling_group(manager: ManagerClient):
     """A reproducer for issue #18719: The expiration scans and deletions
        initiated by the Alternator TTL feature are supposed to run entirely in
        the "streaming" scheduling group. But because of a bug in inheritance
@@ -102,7 +89,8 @@ async def test_alternator_ttl_scheduling_group(alternator3):
        in the wrong scheduling group. We can assume this because we don't
        run multiple tests in parallel on the same cluster.
     """
-    manager, alternator, *_ = alternator3
+    servers = await manager.servers_add(3, config=alternator_config)
+    alternator = get_alternator(servers[0].ip_addr)
     table = alternator.create_table(TableName=unique_table_name(),
         BillingMode='PAY_PER_REQUEST',
         KeySchema=[


### PR DESCRIPTION
Today, each test function in test/topology_experimental_raft creates a cluster in the beginning of the test and drops it at the end of the function. This is very inefficient if you hope (like I do) to write many small and pinpointed test functions instead of large test functions that test 20 unrelated things.

Trying to propose a way to change this sad state of affairs, in test_alternator.py I created a fixture "alternator3" which I hoped could be used in multiple tests that need a 3-node Alternator cluster. Currently only one test uses this fixture.

Unfortunately, it turns out the alternator3 fixture is broken, and led to flaky test runs (sometimes the test using alternator3 picked up an existing cluster instead of starting with an empty cluster, and failed). These problems cannot be *completely* fixed at the current state of the framework. The framework does not currently allow keeping a 3-node cluster between test functions, while also allowing other test functions to create different clusters. The specific flakiness we saw could be fixed by adding a missing before_test() call, but in the future we would need to ensure that all the test functions that use it are contiguous in the test file, and I don't see how we can (or want to) ensure this. So at this point I am giving up and withdrawing this proposal until the developers of the topology test framework make this one of their design goals.

Since there was only one test using this fixture, removing it should make no performance or correctness difference - it should just fix the flakiness.

Fixes #21322.

Although this is a test-only patch, it makes sense to backport it because it fixes a potential test flakiness that can bother us in CI runs of other branches too. Please note that we never actually saw CI runs fail on this specific test flakiness (it was only reproduced locally), so the backport is of fairly low priority.