### PR TITLE
error_injection: Remove unused inject(sleep, then invoke) overload

### DIFF
--- a/test/boost/error_injection_test.cc
+++ b/test/boost/error_injection_test.cc
@@ -130,23 +130,6 @@ SEASTAR_TEST_CASE(test_inject_sleep_deadline_manual_clock) {
     });
 }
 
-SEASTAR_TEST_CASE(test_inject_sleep_deadline_manual_clock_lambda) {
-    return do_with_cql_env_thread([] (cql_test_env& e) {
-        utils::error_injection<true> errinj;
-
-        // Inject sleep, deadline short-circuit
-        auto deadline = seastar::manual_clock::now() + sleep_msec;
-        errinj.enable("future_deadline");
-        auto f = errinj.inject("future_deadline", deadline, [deadline] {
-            BOOST_REQUIRE_GE(seastar::manual_clock::now() - deadline,
-                             seastar::manual_clock::duration::zero());
-            return make_ready_future<>();
-        });
-        manual_clock::advance(sleep_msec);
-        f.get();
-    });
-}
-
 SEASTAR_TEST_CASE(test_inject_sleep_deadline_db_clock) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         utils::error_injection<true> errinj;

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -394,22 +394,6 @@ public:
         return seastar::sleep<Clock>(duration);
     }
 
-    // \brief Inject a sleep to deadline with lambda(timeout)
-    // Avoid adding a sleep continuation in the chain for disabled error injection
-    template <typename Clock, typename Duration, typename Func>
-    [[gnu::always_inline]]
-    std::invoke_result_t<Func> inject(const std::string_view& name, std::chrono::time_point<Clock, Duration> deadline,
-                Func&& func) {
-        if (enter(name)) {
-            std::chrono::milliseconds duration = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - Clock::now());
-            errinj_logger.debug("Triggering sleep injection \"{}\" ({}ms)", name, duration.count());
-            return seastar::sleep<Clock>(duration).then([func = std::move(func)] {
-                    return func(); });
-        } else {
-            return func();
-        }
-    }
-
     // \brief Inject exception
     // \param exception_factory function returning an exception pointer
     template <typename Func>
@@ -578,15 +562,6 @@ public:
     [[gnu::always_inline]]
     future<> inject(const std::string_view& name, std::chrono::time_point<Clock, Duration> deadline) {
         return make_ready_future<>();
-    }
-
-    // \brief Inject a sleep to deadline (timeout) with lambda
-    // Avoid adding a continuation in the chain for disabled error injections
-    template <typename Clock, typename Duration, typename Func>
-    [[gnu::always_inline]]
-    std::invoke_result_t<Func> inject(const std::string_view& name, std::chrono::time_point<Clock, Duration> deadline,
-                Func&& func) {
-        return func();
     }
 
     // Inject exception


### PR DESCRIPTION
The overload was introduced by a8b14b0227 (utils: add timeout error injection with lambda), but is only used by the test nowadays.
