### PR TITLE
compound_compat: replace use of boost ranges with std ranges

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -24,6 +24,8 @@
 #include "compaction/compaction_manager.hh"
 #include "unimplemented.hh"
 
+#include <boost/range/algorithm/copy.hpp>
+
 extern logging::logger apilog;
 
 namespace api {

--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -10,7 +10,7 @@
 
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/join.hpp>
+#include <ranges>
 #include <compare>
 #include "compound.hh"
 #include "schema/schema.hh"
@@ -346,8 +346,9 @@ public:
     static composite serialize_static(const schema& s, RangeOfSerializedComponents&& values) {
         // FIXME: Optimize
         auto b = bytes(size_t(2), bytes::value_type(0xff));
-        std::vector<bytes_view> sv(s.clustering_key_size());
-        b += composite::serialize_value(boost::range::join(sv, std::forward<RangeOfSerializedComponents>(values)), true).release_bytes();
+        std::vector<bytes_view> sv(s.clustering_key_size() + std::ranges::distance(values));
+        std::ranges::copy(values, sv.begin() + s.clustering_key_size());
+        b += composite::serialize_value(sv, true).release_bytes();
         return composite(std::move(b));
     }
 

--- a/compound_compat.hh
+++ b/compound_compat.hh
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <boost/range/algorithm/copy.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 #include <ranges>
 #include <compare>
 #include "compound.hh"
@@ -443,12 +441,12 @@ public:
         return iterator(iterator::end_iterator_tag());
     }
 
-    boost::iterator_range<iterator> components() const & {
+    std::ranges::subrange<iterator> components() const & {
         return { begin(), end() };
     }
 
     auto values() const & {
-        return components() | boost::adaptors::transformed([](auto&& c) { return c.first; });
+        return components() | std::views::transform(&component_view::first);
     }
 
     std::vector<component> components() const && {
@@ -461,7 +459,7 @@ public:
 
     std::vector<bytes> values() const && {
         std::vector<bytes> result;
-        boost::copy(components() | boost::adaptors::transformed([](auto&& c) { return to_bytes(c.first); }), std::back_inserter(result));
+        std::ranges::copy(components() | std::views::transform([](auto&& c) { return to_bytes(c.first); }), std::back_inserter(result));
         return result;
     }
 
@@ -586,7 +584,7 @@ public:
         return composite::iterator(composite::iterator::end_iterator_tag());
     }
 
-    boost::iterator_range<composite::iterator> components() const {
+    std::ranges::subrange<composite::iterator> components() const {
         return { begin(), end() };
     }
 
@@ -600,7 +598,7 @@ public:
     }
 
     auto values() const {
-        return components() | boost::adaptors::transformed([](auto&& c) { return c.first; });
+        return components() | std::views::transform(&composite::component_view::first);
     }
 
     size_t size() const {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -20,6 +20,7 @@
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/algorithm/transform.hpp>
+#include <boost/range/algorithm/copy.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/algorithm/cxx11/all_of.hpp>
 

--- a/gms/versioned_value.cc
+++ b/gms/versioned_value.cc
@@ -12,6 +12,7 @@
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 #include <charconv>
 
 namespace gms {

--- a/keys.cc
+++ b/keys.cc
@@ -12,6 +12,7 @@
 #include "dht/i_partitioner.hh"
 #include "clustering_bounds_comparator.hh"
 #include <boost/algorithm/string.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 
 logging::logger klog("keys");
 

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -9,6 +9,8 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
+#include <boost/range/adaptor/transformed.hpp>
+
 #include "mutation_partition.hh"
 #include "clustering_interval_set.hh"
 #include "converting_mutation_partition_applier.hh"

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -9,6 +9,8 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
+#include <boost/range/adaptor/transformed.hpp>
+
 #include "mutation_partition_v2.hh"
 #include "clustering_interval_set.hh"
 #include "converting_mutation_partition_applier.hh"

--- a/readers/mutation_reader.cc
+++ b/readers/mutation_reader.cc
@@ -8,6 +8,8 @@
 
 #include <seastar/util/lazy.hh>
 
+#include <boost/range/adaptor/transformed.hpp>
+
 #include "readers/mutation_reader.hh"
 #include "mutation/mutation_rebuilder.hh"
 #include "schema_upgrader.hh"

--- a/sstables/mx/parsers.hh
+++ b/sstables/mx/parsers.hh
@@ -15,6 +15,8 @@
 #include "sstables/mx/types.hh"
 #include "mutation/position_in_partition.hh"
 
+#include <boost/range/adaptor/transformed.hpp>
+
 namespace sstables {
 namespace mc {
 

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -14,6 +14,7 @@
 #include <boost/icl/interval_map.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
+#include <boost/range/algorithm/copy.hpp>
 
 #include "sstables.hh"
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -52,6 +52,7 @@
 #include "index_reader.hh"
 #include "downsampling.hh"
 #include <boost/algorithm/string.hpp>
+#include <boost/range/algorithm/copy.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/regex.hpp>

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -10,6 +10,7 @@
 
 #include <seastar/core/iostream.hh>
 #include <seastar/core/fstream.hh>
+#include <boost/range/adaptor/transformed.hpp>
 #include "sstables/types.hh"
 #include "checksum_utils.hh"
 #include "vint-serialization.hh"

--- a/test/boost/compound_test.cc
+++ b/test/boost/compound_test.cc
@@ -18,6 +18,8 @@
 #include "schema/schema_builder.hh"
 #include "dht/murmur3_partitioner.hh"
 
+#include <boost/range/adaptor/transformed.hpp>
+
 static std::vector<managed_bytes> to_bytes_vec(std::vector<sstring> values) {
     std::vector<managed_bytes> result;
     for (auto&& v : values) {

--- a/test/boost/counter_test.cc
+++ b/test/boost/counter_test.cc
@@ -14,6 +14,8 @@
 #include <seastar/core/thread.hh>
 #include <seastar/testing/random.hh>
 
+#include <boost/range/adaptor/transformed.hpp>
+
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/test_utils.hh"
 #include "schema/schema_builder.hh"

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -13,6 +13,8 @@
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/util/defer.hh>
 
+#include <boost/range/algorithm/copy.hpp>
+
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 #include "service/migration_manager.hh"

--- a/test/lib/data_model.cc
+++ b/test/lib/data_model.cc
@@ -12,6 +12,7 @@
 #include "test/lib/data_model.hh"
 
 #include <boost/algorithm/string/join.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 
 #include "schema/schema_builder.hh"
 #include "concrete_types.hh"

--- a/test/perf/perf_commitlog.cc
+++ b/test/perf/perf_commitlog.cc
@@ -12,6 +12,7 @@
 #include <boost/range/irange.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 #include <json/json.h>
 
 #include <seastar/core/app-template.hh>

--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 #include <chrono>
+#include <boost/range/adaptor/transformed.hpp>
 #include "cql3/statements/prepared_statement.hh"
 #include "tracing/trace_state.hh"
 #include "timestamp.hh"


### PR DESCRIPTION
Replace use of boost::ranges::join() with another construct, as it
has no std replacement, and replace other uses with their std
equivalent, in order to reduce dependency load.

Code cleanup - no backport.