### PR TITLE
compaction: fix the indent

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -2122,20 +2122,19 @@ compaction_manager::maybe_split_sstable(sstables::shared_sstable sst, table_stat
     }
     std::vector<sstables::shared_sstable> ret;
 
-        // FIXME: indentation.
-        auto gate = get_compaction_state(&t).gate.hold();
-        sstables::compaction_progress_monitor monitor;
-        sstables::compaction_data info = create_compaction_data();
-        sstables::compaction_descriptor desc = split_compaction_task_executor::make_descriptor(sst, opt);
-        desc.creator = [&t] (shard_id _) {
-            return t.make_sstable();
-        };
-        desc.replacer = [&] (sstables::compaction_completion_desc d) {
-            std::move(d.new_sstables.begin(), d.new_sstables.end(), std::back_inserter(ret));
-        };
+    auto gate = get_compaction_state(&t).gate.hold();
+    sstables::compaction_progress_monitor monitor;
+    sstables::compaction_data info = create_compaction_data();
+    sstables::compaction_descriptor desc = split_compaction_task_executor::make_descriptor(sst, opt);
+    desc.creator = [&t] (shard_id _) {
+        return t.make_sstable();
+    };
+    desc.replacer = [&] (sstables::compaction_completion_desc d) {
+        std::move(d.new_sstables.begin(), d.new_sstables.end(), std::back_inserter(ret));
+    };
 
-        co_await sstables::compact_sstables(std::move(desc), info, t, monitor);
-        co_await sst->unlink();
+    co_await sstables::compact_sstables(std::move(desc), info, t, monitor);
+    co_await sst->unlink();
 
     co_return ret;
 }


### PR DESCRIPTION
in 38ce2c605dc97d0ed13a7fc241e086c768e03d35, we left a TODO for reindent the code.

in this change, we reindent the code to address this TODO.

Refs 38ce2c605dc97d0ed13a7fc241e086c768e03d35
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

it's a cleanup, hence no need to backport.