### PR TITLE
test: route S3 mock server messages through logger

### DIFF
--- a/test/pylib/start_s3_mock.py
+++ b/test/pylib/start_s3_mock.py
@@ -3,6 +3,7 @@ import asyncio
 import sys
 import signal
 import argparse
+import logging
 from s3_server_mock import MockS3Server
 
 
@@ -10,8 +11,12 @@ async def run():
     parser = argparse.ArgumentParser(description="Start S3 mock server")
     parser.add_argument('--host', default='127.0.0.1')
     parser.add_argument('--port', type=int, default=2012)
+    parser.add_argument('--log-level', default=logging.WARNING,
+                        choices=logging.getLevelNamesMapping().keys(),
+                        help="Set log level")
     args = parser.parse_args()
-    server = MockS3Server(args.host, args.port)
+    logging.basicConfig(level=args.log_level)
+    server = MockS3Server(args.host, args.port, logging.getLogger('s3-server'))
 
     print('Starting S3 mock server')
     await server.start()


### PR DESCRIPTION
The S3 mock server (introduced in 5a96549c) currently prints its status messages directly to stdout, which can be distracting when reviewing test results. For example:

```console
$ ./test.py --verbose --mode debug object_store/test_backup::test_simple_backup
Found 1 tests.
Starting S3 mock server on ('127.226.51.1', 2012)
================================================================================
[N/TOTAL]   SUITE    MODE   RESULT   TEST
------------------------------------------------------------------------------
[1/1]      object_store  debug  [ PASS ] object_store.test_backup.1 5.99s
Stopping S3 mock server
-------------------------
CPU utilization: 6.5%
```

Move these messages to use proper logging to give developers more control over their visibility:

- Make logger parameter mandatory in MockS3Server constructor
- Route "Stopping S3 mock server" message through the provided logger
- Add --log-level option to the standalone mock server launcher

The message is now hidden:

```console
$ ./test.py --verbose --mode debug --save-log-on-success object_store/test_backup::test_simple_backup
Found 1 tests.
================================================================================
[N/TOTAL]   SUITE    MODE   RESULT   TEST
------------------------------------------------------------------------------

[1/1]      object_store  debug  [ PASS ] object_store.test_backup.1 6.25s
------------------------------------------------------------------------------
CPU utilization: 5.5%
```

---

this change improves the developer's experience, hence no need to backport.