### PR TITLE
docs: explain task status retention and one-time query behavior

### DIFF
--- a/docs/operating-scylla/nodetool-commands/tasks/index.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/index.rst
@@ -17,6 +17,16 @@ Nodetool tasks
 Task manager is an API-based tool for tracking long-running background operations, such as repair or compaction,
 which makes them observable and controllable. Task manager operates per node.
 
+Task Status Retention
+---------------------
+
+* When a task completes, its status is temporarily stored on the executing node
+* Status information is retained for up to :confval:`task_ttl_in_seconds` seconds
+* The status information of a completed task is automatically removed after being queried with ``tasks status`` or ``tasks tree``
+* ``tasks wait`` returns the status, but it does not remove the task information of the queried task
+
+.. note:: Multiple status queries using ``tasks status`` and ``tasks tree`` for the same completed task will only receive a response for the first query, since the status is removed after being retrieved.
+
 Supported tasks suboperations
 -----------------------------
 


### PR DESCRIPTION
Task status information from nodetool commands is not retained permanently:

- Status of completed tasks is only kept for `task_ttl_in_seconds`
- Status is removed after being queried, making it a one-time operation

This behavior is important for users to understand since subsequent queries for the same completed task will not return any information. Add documentation to make this clear to users.

---

the "status" subcommands are a part of user-facing interface, the change introducing the document was 20fffcdcf536aabe7409abf39e28c9034fee3598, which was in turn included by 6.2, so in order to clear the confusing, i think we should backport this change to 6.2 branch.