### PR TITLE
cql3: util: remove unneeded boost/range includes from header files

### DIFF
--- a/cql3/util.cc
+++ b/cql3/util.cc
@@ -8,6 +8,8 @@
 #include "util.hh"
 #include "cql3/expr/expr-utils.hh"
 
+#include <boost/algorithm/string/join.hpp>
+
 #ifdef DEBUG
 
 #include <ucontext.h>

--- a/cql3/util.hh
+++ b/cql3/util.hh
@@ -12,9 +12,6 @@
 
 #include <vector>
 
-#include <boost/algorithm/string/join.hpp>
-#include <boost/range/adaptor/transformed.hpp>
-
 #include <seastar/core/sstring.hh>
 
 #include "cql3/column_identifier.hh"

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -22,6 +22,7 @@
 #include <boost/range/algorithm/transform.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/algorithm/cxx11/all_of.hpp>
+#include <boost/algorithm/string/join.hpp>
 
 #include <fmt/ranges.h>
 


### PR DESCRIPTION
The includes are redistributed to the source files that need them.

code cleanup; no backport.