### PR TITLE
cql3: remove unused request_validations methods

### DIFF
--- a/cql3/statements/request_validations.hh
+++ b/cql3/statements/request_validations.hh
@@ -13,8 +13,6 @@
 #include "exceptions/exceptions.hh"
 #include <seastar/core/print.hh>
 
-#include <boost/range/algorithm/count_if.hpp>
-
 #include <set>
 
 namespace cql3 {
@@ -49,37 +47,6 @@ invalid_request(fmt::format_string<MessageArgs...> message_template, MessageArgs
     }
 
     /**
-     * Checks that the specified list does not contains duplicates.
-     *
-     * @param list the list to test
-     * @param message The error message
-     * @throws InvalidRequestException if the specified list contains duplicates.
-     */
-    template <typename T>
-    void check_contains_no_duplicates(const std::vector<T>& list, fmt::format_string<> message) {
-        if (std::set<T>(list.begin(), list.end()).size() != list.size()) {
-            throw invalid_request(message);
-        }
-    }
-
-    /**
-     * Checks that the specified list contains only the specified elements.
-     *
-     * @param list the list to test
-     * @param expected_elements the expected elements
-     * @param message the error message
-     * @throws InvalidRequestException if the specified list contains duplicates.
-     */
-    template <typename E>
-    void check_contains_only(const std::vector<E>& list,
-                             const std::vector<E>& expected_elements,
-                             fmt::format_string<> message) {
-        if (boost::count_if(list, [&] (const E& e) { return !boost::count_if(expected_elements, e); })) {
-            throw invalid_request(message);
-        }
-    }
-
-    /**
      * Checks that the specified expression is <code>false</code>. If not an <code>InvalidRequestException</code> will
      * be thrown.
      *
@@ -108,22 +75,6 @@ invalid_request(fmt::format_string<MessageArgs...> message_template, MessageArgs
     template <typename T, typename... MessageArgs>
     T check_not_null(T object, fmt::format_string<MessageArgs...> message_template, MessageArgs&... message_args) {
         check_true(bool(object), message_template, std::forward<MessageArgs>(message_args)...);
-        return object;
-    }
-
-    /**
-     * Checks that the specified object is <code>null</code>.
-     * If it is not an <code>InvalidRequestException</code> will be throws.
-     *
-     * @param object the object to test
-     * @param message_template the template used to build the error message
-     * @param message_args the message arguments
-     * @return the object
-     * @throws InvalidRequestException if the specified object is not <code>null</code>.
-     */
-    template <typename T, typename... MessageArgs>
-    T check_null(T object, fmt::format_string<MessageArgs...> message_template, MessageArgs&&... message_args) {
-        check_true(!bool(object), message_template, std::forward<MessageArgs>(message_args)...);
         return object;
     }
 


### PR DESCRIPTION
These methods are not used and therefore removed.

Code cleanup - no backport.