### PR TITLE
api: Remove foreach_column_family() helper

### DIFF
--- a/api/column_family.hh
+++ b/api/column_family.hh
@@ -23,8 +23,6 @@ void set_column_family(http_context& ctx, httpd::routes& r, sharded<db::system_k
 void unset_column_family(http_context& ctx, httpd::routes& r);
 
 table_id get_uuid(const sstring& name, const replica::database& db);
-future<> foreach_column_family(http_context& ctx, const sstring& name, std::function<void(replica::column_family&)> f);
-
 
 template<class Mapper, class I, class Reducer>
 future<I> map_reduce_cf_raw(http_context& ctx, const sstring& name, I init,


### PR DESCRIPTION
There's a whole lot of helpers and wrappers in api/ that help handlers manipulate keyspaces and tables. One of those is foreach_column_family which calls the provided callable on a table on each shard. There's exactly the same (but a bit more flexible) helper nearby. While at it, this helper gets a better name.
