### PR TITLE
utils: chunked_vector: various constructor improvements

### DIFF
--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -178,6 +178,19 @@ BOOST_AUTO_TEST_CASE(tests_constructor_exception_safety) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(tests_constructor_exception_safety_range) {
+    auto checker = exception_safety_checker();
+    auto v = std::vector<exception_safe_class>(100, exception_safe_class(checker));
+    checker.set_countdown(5);
+    try {
+        auto u = utils::chunked_vector<exception_safe_class, 128>(std::from_range, v);
+        BOOST_REQUIRE(false);
+    } catch (...) {
+        v.clear();
+        BOOST_REQUIRE(checker.ok());
+    }
+}
+
 BOOST_AUTO_TEST_CASE(tests_reserve_partial) {
     auto rand = std::default_random_engine();
     auto size_dist = std::uniform_int_distribution<unsigned>(1, 1 << 12);
@@ -427,6 +440,13 @@ BOOST_AUTO_TEST_CASE(test_initializer_list_ctor) {
         BOOST_REQUIRE(*it == *vit);
     }
     BOOST_REQUIRE(vit == vec.end());
+}
+
+
+BOOST_AUTO_TEST_CASE(test_range_ctor) {
+    auto range = std::views::iota(0, 12345);
+    auto vec = range | std::ranges::to<utils::chunked_vector<int, 512>>();
+    BOOST_REQUIRE(std::ranges::equal(range, vec));
 }
 
 BOOST_AUTO_TEST_CASE(test_value_default_init_ctor) {

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -374,9 +374,7 @@ chunked_vector<T, max_contiguous_allocation>::chunked_vector(Iterator begin, Ite
 
 template <typename T, size_t max_contiguous_allocation>
 chunked_vector<T, max_contiguous_allocation>::chunked_vector(std::initializer_list<T> x)
-        : chunked_vector() {
-    reserve(x.size());
-    std::copy(x.begin(), x.end(), std::back_inserter(*this));
+        : chunked_vector(std::begin(x), std::end(x)) {
 }
 
 template <typename T, size_t max_contiguous_allocation>

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -354,12 +354,12 @@ template <typename T, size_t max_contiguous_allocation>
 template <typename Iterator>
 chunked_vector<T, max_contiguous_allocation>::chunked_vector(Iterator begin, Iterator end)
         : chunked_vector() {
-    auto is_random_access = std::is_base_of<std::random_access_iterator_tag, typename std::iterator_traits<Iterator>::iterator_category>::value;
-    if (is_random_access) {
+    auto is_forward = std::is_base_of<std::forward_iterator_tag, typename std::iterator_traits<Iterator>::iterator_category>::value;
+    if (is_forward) {
         reserve(std::distance(begin, end));
     }
     std::copy(begin, end, std::back_inserter(*this));
-    if (!is_random_access) {
+    if (!is_forward) {
         shrink_to_fit();
     }
 }


### PR DESCRIPTION
Optimize the various constructors a little, and add an std::from_range_t
constructor.

Minor improvement, so no backports.