### PR TITLE
sstables: generation_type: replace boost ranges with std ranges

### DIFF
--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -24,6 +24,7 @@
 #include <boost/range/algorithm/find.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 #include "size_tiered_compaction_strategy.hh"
 #include "leveled_compaction_strategy.hh"
 #include "time_window_compaction_strategy.hh"

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -16,6 +16,7 @@
 #include <boost/range/algorithm/find.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/algorithm/min_element.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 
 #include <ranges>
 

--- a/service/raft/group0_state_machine_merger.cc
+++ b/service/raft/group0_state_machine_merger.cc
@@ -9,6 +9,8 @@
 #include "db/system_keyspace.hh"
 #include "service/raft/group0_state_machine_merger.hh"
 
+#include <boost/range/adaptor/transformed.hpp>
+
 namespace service {
 
 static logging::logger slogger("group0_raft_sm_merger");

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -14,6 +14,8 @@
 #include "types/set.hh"
 #include "types/map.hh"
 
+#include <boost/range/adaptor/transformed.hpp>
+
 namespace db {
     extern thread_local data_type cdc_generation_ts_id_type;
 }

--- a/sstables/generation_type.hh
+++ b/sstables/generation_type.hh
@@ -14,11 +14,11 @@
 #include <cstdint>
 #include <compare>
 #include <limits>
+#include <ranges>
 #include <stdexcept>
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
-#include <boost/range/adaptor/transformed.hpp>
 #include "types/types.hh"
 #include "utils/assert.hh"
 #include "utils/UUID_gen.hh"
@@ -108,16 +108,16 @@ constexpr generation_type generation_from_value(generation_type::int_t value) {
 
 template <std::ranges::range Range, typename Target = std::vector<sstables::generation_type>>
 Target generations_from_values(const Range& values) {
-    return boost::copy_range<Target>(values | boost::adaptors::transformed([] (auto value) {
+    return values | std::views::transform([] (auto value) {
         return generation_type(value);
-    }));
+    }) | std::ranges::to<Target>();
 }
 
 template <typename Target = std::vector<sstables::generation_type>>
 Target generations_from_values(std::initializer_list<generation_type::int_t> values) {
-    return boost::copy_range<Target>(values | boost::adaptors::transformed([] (auto value) {
+    return values | std::views::transform([] (auto value) {
         return generation_type(value);
-    }));
+    }) | std::ranges::to<Target>();
 }
 
 using uuid_identifiers = bool_class<struct uuid_identifiers_tag>;


### PR DESCRIPTION
Reduce dependency load.

Cleanup; no backport.