### PR TITLE
schema_registry: stop includeing replica/database.hh

### DIFF
--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -12,6 +12,7 @@
 #include <seastar/json/json_elements.hh>
 #include "api/api_init.hh"
 #include "db/data_listeners.hh"
+#include "compaction/compaction_descriptor.hh"
 
 namespace cql_transport { class controller; }
 namespace db {

--- a/mutation/frozen_mutation.cc
+++ b/mutation/frozen_mutation.cc
@@ -7,6 +7,7 @@
  */
 
 #include <seastar/core/coroutine.hh>
+#include <boost/range/adaptor/transformed.hpp>
 #include "frozen_mutation.hh"
 #include "schema/schema_registry.hh"
 #include "mutation_partition.hh"

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -13,6 +13,7 @@
 #include "utils/log.hh"
 #include "db/schema_tables.hh"
 #include "view_info.hh"
+#include "replica/database.hh"
 
 static logging::logger slogger("schema_registry");
 

--- a/schema/schema_registry.hh
+++ b/schema/schema_registry.hh
@@ -14,7 +14,7 @@
 #include <seastar/core/shared_future.hh>
 #include "schema_fwd.hh"
 #include "frozen_schema.hh"
-#include "replica/database.hh"
+#include "replica/database_fwd.hh"
 
 namespace db {
 class schema_ctxt;

--- a/test/boost/mutation_fragment_test.cc
+++ b/test/boost/mutation_fragment_test.cc
@@ -31,6 +31,8 @@
 
 #include "readers/from_mutations_v2.hh"
 
+#include <boost/range/join.hpp>
+
 SEASTAR_TEST_CASE(test_mutation_merger_conforms_to_mutation_source) {
     return seastar::async([] {
         tests::reader_concurrency_semaphore_wrapper semaphore;

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -23,6 +23,8 @@
 #include "test/lib/key_utils.hh"
 #include "mutation/atomic_cell_or_collection.hh"
 
+#include <boost/range/adaptor/transformed.hpp>
+
 // Helper for working with the following table:
 //
 //   CREATE TABLE ks.cf (pk text, ck text, v text, s1 text static, PRIMARY KEY (pk, ck));


### PR DESCRIPTION
database.hh is a hotspot that changes often (or its dependencies do). Avoid including it to reduce recompilations.

Code cleanup; no backport.