### PR TITLE
treewide: trade boost's any_of and all_of for std's any_of and all_of

### DIFF
--- a/alternator/conditions.cc
+++ b/alternator/conditions.cc
@@ -15,7 +15,6 @@
 #include "utils/base64.hh"
 #include "utils/rjson.hh"
 #include <stdexcept>
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include "utils/overloaded_functor.hh"
 
 #include "expressions.hh"
@@ -744,7 +743,7 @@ bool verify_condition_expression(
             case '&':
                 return std::ranges::all_of(list.conditions, verify_condition);
             case '|':
-                return boost::algorithm::any_of(list.conditions, verify_condition);
+                return std::ranges::any_of(list.conditions, verify_condition);
             default:
                 // Shouldn't happen unless we have a bug in the parser
                 throw std::logic_error("bad operator in condition_list");

--- a/alternator/conditions.cc
+++ b/alternator/conditions.cc
@@ -15,7 +15,6 @@
 #include "utils/base64.hh"
 #include "utils/rjson.hh"
 #include <stdexcept>
-#include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
 #include "utils/overloaded_functor.hh"
 
@@ -743,7 +742,7 @@ bool verify_condition_expression(
             };
             switch (list.op) {
             case '&':
-                return boost::algorithm::all_of(list.conditions, verify_condition);
+                return std::ranges::all_of(list.conditions, verify_condition);
             case '|':
                 return boost::algorithm::any_of(list.conditions, verify_condition);
             default:

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -37,7 +37,6 @@
 #include "utils/assert.hh"
 #include "utils/overloaded_functor.hh"
 #include <seastar/json/json_elements.hh>
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include "collection_mutation.hh"
 #include "schema/schema.hh"
 #include "db/tags/extension.hh"
@@ -2709,7 +2708,7 @@ static bool check_needs_read_before_write(const parsed::value& v) {
             return false;
         },
         [&] (const parsed::value::function_call& f) -> bool {
-            return boost::algorithm::any_of(f._parameters, [&] (const parsed::value& param) {
+            return std::ranges::any_of(f._parameters, [&] (const parsed::value& param) {
                 return check_needs_read_before_write(param);
             });
         },
@@ -2720,7 +2719,7 @@ static bool check_needs_read_before_write(const parsed::value& v) {
 }
 
 static bool check_needs_read_before_write(const attribute_path_map<parsed::update_expression::action>& update_expression) {
-    return boost::algorithm::any_of(update_expression, [](const auto& p) {
+    return std::ranges::any_of(update_expression, [](const auto& p) {
         if (!p.second.has_value()) {
             // If the action is not on the top-level attribute, we need to
             // read the old item: we change only a part of the top-level

--- a/alternator/expressions.cc
+++ b/alternator/expressions.cc
@@ -20,9 +20,6 @@
 #include <seastar/core/print.hh>
 #include <seastar/util/log.hh>
 
-#include <boost/algorithm/cxx11/any_of.hpp>
-#include <boost/algorithm/cxx11/all_of.hpp>
-
 #include <functional>
 #include <unordered_map>
 

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -14,7 +14,6 @@
 #include <string_view>
 #include <optional>
 
-#include <boost/algorithm/cxx11/all_of.hpp>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sleep.hh>
 #include <variant>

--- a/auth/roles-metadata.cc
+++ b/auth/roles-metadata.cc
@@ -8,7 +8,6 @@
 
 #include "auth/roles-metadata.hh"
 
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include <seastar/core/print.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
@@ -79,7 +78,7 @@ future<bool> any_nondefault_role_row_satisfies(
     }
     static const sstring col_name = sstring(meta::roles_table::role_col_name);
 
-    co_return boost::algorithm::any_of(*results, [&](const cql3::untyped_result_set_row& row) {
+    co_return std::ranges::any_of(*results, [&](const cql3::untyped_result_set_row& row) {
         auto superuser = rolename ? std::string_view(*rolename) : meta::DEFAULT_SUPERUSER_NAME;
         const bool is_nondefault = row.get_as<sstring>(col_name) != superuser;
         return is_nondefault && p(row);

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -18,7 +18,6 @@
 
 #include <boost/range/algorithm.hpp>
 #include <boost/range/join.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/algorithm/string/join.hpp>
 
 #include <seastar/core/future-util.hh>
@@ -1937,7 +1936,7 @@ get_fully_expired_sstables(const table_state& table_s, const std::vector<sstable
         // Get ancestors from sstable which is empty after restart. It works for this purpose because
         // we only need to check that a sstable compacted *in this instance* hasn't an ancestor undeleted.
         // Not getting it from sstable metadata because mc format hasn't it available.
-        return boost::algorithm::any_of(candidate->compaction_ancestors(), [&compacted_undeleted_gens] (const generation_type& gen) {
+        return std::ranges::any_of(candidate->compaction_ancestors(), [&compacted_undeleted_gens] (const generation_type& gen) {
             return compacted_undeleted_gens.contains(gen);
         });
     };

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -27,7 +27,6 @@
 #include "utils/UUID_gen.hh"
 #include "db/system_keyspace.hh"
 #include <cmath>
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
 
 static logging::logger cmlog("compaction_manager");
@@ -2026,7 +2025,7 @@ future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_range
 
 future<> compaction_manager::try_perform_cleanup(owned_ranges_ptr sorted_owned_ranges, table_state& t, tasks::task_info info) {
     auto check_for_cleanup = [this, &t] {
-        return boost::algorithm::any_of(_tasks, [&t] (auto& task) {
+        return std::ranges::any_of(_tasks, [&t] (auto& task) {
             return task.compacting_table() == &t && task.compaction_type() == sstables::compaction_type::Cleanup;
         });
     };

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -23,7 +23,6 @@
 #include "schema/schema.hh"
 #include <boost/range/algorithm/find.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include "size_tiered_compaction_strategy.hh"
 #include "leveled_compaction_strategy.hh"

--- a/compaction/size_tiered_compaction_strategy.hh
+++ b/compaction/size_tiered_compaction_strategy.hh
@@ -10,7 +10,6 @@
 
 #include "compaction_strategy_impl.hh"
 #include "sstables/shared_sstable.hh"
-#include <boost/algorithm/cxx11/any_of.hpp>
 
 class size_tiered_backlog_tracker;
 
@@ -65,7 +64,7 @@ class size_tiered_compaction_strategy : public compaction_strategy_impl {
     }
 
     bool is_any_bucket_interesting(const std::vector<std::vector<sstables::shared_sstable>>& buckets, int min_threshold) const {
-        return boost::algorithm::any_of(buckets, [&] (const auto& bucket) {
+        return std::ranges::any_of(buckets, [&] (const auto& bucket) {
             return this->is_bucket_interesting(bucket, min_threshold);
         });
     }

--- a/cql3/functions/as_json_function.hh
+++ b/cql3/functions/as_json_function.hh
@@ -18,8 +18,6 @@
 #include "bytes_ostream.hh"
 #include "types/types.hh"
 
-#include <boost/algorithm/cxx11/any_of.hpp>
-
 namespace cql3 {
 
 namespace functions {
@@ -52,7 +50,7 @@ public:
             if (i > 0) {
                 encoded_row.write(", ", 2);
             }
-            bool has_any_upper = boost::algorithm::any_of(_selector_names[i], [](unsigned char c) { return std::isupper(c); });
+            bool has_any_upper = std::ranges::any_of(_selector_names[i], [](unsigned char c) { return std::isupper(c); });
             encoded_row.write("\"", 1);
             if (has_any_upper) {
                 encoded_row.write("\\\"", 2);

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -8,8 +8,6 @@
  */
 
 #include <algorithm>
-#include <boost/algorithm/cxx11/all_of.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/map.hpp>
@@ -574,8 +572,8 @@ bool has_supporting_index(
         allow_local_index allow_local) {
     const auto indexes = index_manager.list_indexes();
     const auto support = std::bind(is_supported_by, std::ref(expr), std::placeholders::_1);
-    return allow_local ? boost::algorithm::any_of(indexes, support)
-            : boost::algorithm::any_of(
+    return allow_local ? std::ranges::any_of(indexes, support)
+            : std::ranges::any_of(
                     indexes | filtered([] (const secondary_index::index& i) { return !i.metadata().local(); }),
                     support);
 }
@@ -600,7 +598,7 @@ bool is_on_collection(const binary_operator& b) {
         return true;
     }
     if (auto tuple = expr::as_if<tuple_constructor>(&b.lhs)) {
-        return boost::algorithm::any_of(tuple->elements, [] (const expression& v) { return expr::is<subscript>(v); });
+        return std::ranges::any_of(tuple->elements, [] (const expression& v) { return expr::is<subscript>(v); });
     }
     return false;
 }

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -12,7 +12,6 @@
 #include <boost/range/algorithm/transform.hpp>
 #include <boost/range/adaptor/reversed.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
-#include <boost/algorithm/cxx11/all_of.hpp>
 
 #include "cql3/selection/selection.hh"
 #include "cql3/selection/raw_selector.hh"
@@ -256,7 +255,7 @@ public:
     }
 
     virtual bool is_reducible() const override {
-        return boost::algorithm::all_of(
+        return std::ranges::all_of(
                 _selectors,
                [] (const expr::expression& e) {
                     auto fc = expr::as_if<expr::function_call>(&e);
@@ -272,7 +271,7 @@ public:
                         return false;
                     }
                     // We only support transforming columns directly for parallel queries
-                    if (!boost::algorithm::all_of(fc->args, expr::is<expr::column_value>)) {
+                    if (!std::ranges::all_of(fc->args, expr::is<expr::column_value>)) {
                         return false;
                     }
                     return true;

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -11,7 +11,6 @@
 #include <boost/range/algorithm/equal.hpp>
 #include <boost/range/algorithm/transform.hpp>
 #include <boost/range/adaptor/reversed.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
 
 #include "cql3/selection/selection.hh"
 #include "cql3/selection/raw_selector.hh"
@@ -349,7 +348,7 @@ protected:
         explicit selectors_with_processing(const selection_with_processing& sel)
             : _sel(sel)
             , _temporaries(_sel._initial_values_for_temporaries)
-            , _requires_thread(boost::algorithm::any_of(sel._selectors, [] (const expr::expression& e) {
+            , _requires_thread(std::ranges::any_of(sel._selectors, [] (const expr::expression& e) {
                 return expr::find_in_expression<expr::function_call>(e, [] (const expr::function_call& fc) {
                     return std::get<shared_ptr<functions::function>>(fc.func)->requires_thread();
                 });

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -20,7 +20,6 @@
 #include "tracing/trace_state.hh"
 
 #include <boost/algorithm/cxx11/any_of.hpp>
-#include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/range/adaptor/uniqued.hpp>
 
 template<typename T = void>
@@ -110,7 +109,7 @@ void batch_statement::validate()
     }
 
     bool has_counters = boost::algorithm::any_of(_statements, [] (auto&& s) { return s.statement->is_counter(); });
-    bool has_non_counters = !boost::algorithm::all_of(_statements, [] (auto&& s) { return s.statement->is_counter(); });
+    bool has_non_counters = !std::ranges::all_of(_statements, [] (auto&& s) { return s.statement->is_counter(); });
     if (timestamp_set && has_counters) {
         throw exceptions::invalid_request_exception("Cannot provide custom timestamp for a BATCH containing counters");
     }

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -19,7 +19,6 @@
 #include "service/storage_proxy.hh"
 #include "tracing/trace_state.hh"
 
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/adaptor/uniqued.hpp>
 
 template<typename T = void>
@@ -49,7 +48,7 @@ batch_statement::batch_statement(int bound_terms, type type_,
     : cql_statement_opt_metadata(timeout_for_type(type_))
     , _bound_terms(bound_terms), _type(type_), _statements(std::move(statements))
     , _attrs(std::move(attrs))
-    , _has_conditions(boost::algorithm::any_of(_statements, [] (auto&& s) { return s.statement->has_conditions(); }))
+    , _has_conditions(std::ranges::any_of(_statements, [] (auto&& s) { return s.statement->has_conditions(); }))
     , _stats(stats)
 {
     validate();
@@ -73,7 +72,7 @@ batch_statement::batch_statement(type type_,
 
 bool batch_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const
 {
-    return boost::algorithm::any_of(_statements, [&ks_name, &cf_name] (auto&& s) { return s.statement->depends_on(ks_name, cf_name); });
+    return std::ranges::any_of(_statements, [&ks_name, &cf_name] (auto&& s) { return s.statement->depends_on(ks_name, cf_name); });
 }
 
 uint32_t batch_statement::get_bound_terms() const
@@ -108,12 +107,12 @@ void batch_statement::validate()
         }
     }
 
-    bool has_counters = boost::algorithm::any_of(_statements, [] (auto&& s) { return s.statement->is_counter(); });
+    bool has_counters = std::ranges::any_of(_statements, [] (auto&& s) { return s.statement->is_counter(); });
     bool has_non_counters = !std::ranges::all_of(_statements, [] (auto&& s) { return s.statement->is_counter(); });
     if (timestamp_set && has_counters) {
         throw exceptions::invalid_request_exception("Cannot provide custom timestamp for a BATCH containing counters");
     }
-    if (timestamp_set && boost::algorithm::any_of(_statements, [] (auto&& s) { return s.statement->is_timestamp_set(); })) {
+    if (timestamp_set && std::ranges::any_of(_statements, [] (auto&& s) { return s.statement->is_timestamp_set(); })) {
         throw exceptions::invalid_request_exception("Timestamp must be set either on BATCH or individual statements");
     }
     if (_type == type::COUNTER && has_non_counters) {

--- a/cql3/statements/delete_statement.cc
+++ b/cql3/statements/delete_statement.cc
@@ -9,7 +9,6 @@
  */
 
 #include "utils/assert.hh"
-#include <boost/algorithm/cxx11/all_of.hpp>
 
 #include "data_dictionary/data_dictionary.hh"
 #include "delete_statement.hh"

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -51,7 +51,6 @@
 #include "replica/database.hh"
 #include "replica/mutation_dump.hh"
 
-#include <boost/algorithm/cxx11/all_of.hpp>
 
 template<typename T = void>
 using coordinator_result = cql3::statements::select_statement::coordinator_result<T>;
@@ -2033,7 +2032,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
     prepared_attrs->fill_prepare_context(ctx);
 
     auto all_aggregates = [] (const std::vector<selection::prepared_selector>& prepared_selectors) {
-        return boost::algorithm::all_of(
+        return std::ranges::all_of(
             prepared_selectors | boost::adaptors::transformed(std::mem_fn(&selection::prepared_selector::expr)),
             [] (const expr::expression& e) {
                 auto fn_expr = expr::as_if<expr::function_call>(&e);

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -43,7 +43,6 @@
 #include "db/consistency_level_validations.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include "test/lib/select_statement_utils.hh"
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include "gms/feature_service.hh"
 #include "utils/assert.hh"
 #include "utils/result_combinators.hh"
@@ -1944,7 +1943,7 @@ select_statement::maybe_jsonize_select_clause(std::vector<selection::prepared_se
 static
 bool
 group_by_references_clustering_keys(const selection::selection& sel, const std::vector<size_t>& group_by_cell_indices) {
-    return boost::algorithm::any_of(group_by_cell_indices, [&] (size_t idx) {
+    return std::ranges::any_of(group_by_cell_indices, [&] (size_t idx) {
         return sel.get_columns()[idx]->kind == column_kind::clustering_key;
     });
 }

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -15,7 +15,6 @@
 #include "cql3/expr/expr-utils.hh"
 
 #include <boost/range/adaptor/transformed.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
 
 #include "mutation/mutation.hh"
 #include "types/user.hh"

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -21,8 +21,6 @@
 #include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/algorithm/transform.hpp>
 #include <boost/range/algorithm/copy.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
-#include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/algorithm/string/join.hpp>
 
 #include <fmt/ranges.h>
@@ -102,7 +100,7 @@ cql3::statements::select_statement& view_info::select_statement(data_dictionary:
            }
         }
 
-        if (legacy_token_column || boost::algorithm::any_of(_schema.all_columns(), std::mem_fn(&column_definition::is_computed))) {
+        if (legacy_token_column || std::ranges::any_of(_schema.all_columns(), std::mem_fn(&column_definition::is_computed))) {
             auto real_columns = _schema.all_columns() | boost::adaptors::filtered([legacy_token_column] (const column_definition& cdef) {
                 return &cdef != legacy_token_column && !cdef.is_computed();
             });
@@ -3149,7 +3147,7 @@ update_backlog node_update_backlog::fetch_shard(unsigned shard) {
 future<bool> view_builder::check_view_build_ongoing(const locator::token_metadata& tm, const sstring& ks_name, const sstring& cf_name) {
     using view_statuses_type = std::unordered_map<locator::host_id, sstring>;
     return view_status(ks_name, cf_name).then([&tm] (view_statuses_type&& view_statuses) {
-        return boost::algorithm::any_of(view_statuses, [&tm] (const view_statuses_type::value_type& view_status) {
+        return std::ranges::any_of(view_statuses, [&tm] (const view_statuses_type::value_type& view_status) {
             // Only consider status of known hosts.
             return view_status.second == "STARTED" && tm.get_endpoint_for_host_id_if_known(view_status.first);
         });

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -8,7 +8,6 @@
 
 #include <algorithm>
 
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/algorithm/string.hpp>
 #include <seastar/core/coroutine.hh>
@@ -575,7 +574,7 @@ public:
         });
         co_await add_partition(mutation_sink, "incremental_backup_enabled", [this] () {
             return _db.map_reduce0([] (replica::database& db) {
-                return boost::algorithm::any_of(db.get_keyspaces(), [] (const auto& id_and_ks) {
+                return std::ranges::any_of(db.get_keyspaces(), [] (const auto& id_and_ks) {
                     return id_and_ks.second.incremental_backups_enabled();
                 });
             }, false, std::logical_or{}).then([] (bool res) -> sstring {

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -21,7 +21,6 @@
 #include "db/tags/extension.hh"
 
 #include <boost/range/adaptor/map.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 namespace secondary_index {

--- a/partition_snapshot_row_cursor.hh
+++ b/partition_snapshot_row_cursor.hh
@@ -12,7 +12,6 @@
 #include "row_cache.hh"
 #include "utils/assert.hh"
 #include "utils/small_vector.hh"
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/range/algorithm/heap_algorithm.hpp>
 #include <fmt/core.h>

--- a/redis/keyspace_utils.cc
+++ b/redis/keyspace_utils.cc
@@ -26,7 +26,6 @@
 #include <seastar/core/print.hh>
 #include "db/config.hh"
 #include "data_dictionary/keyspace_metadata.hh"
-#include <boost/algorithm/cxx11/all_of.hpp>
 
 using namespace seastar;
 
@@ -167,7 +166,7 @@ future<> create_keyspace_if_not_exists_impl(seastar::sharded<service::storage_pr
             auto check = [&] (table t) {
                 return db.has_schema(ks_name, t.name);
             };
-            return db.has_keyspace(ks_name) && boost::algorithm::all_of(tables, check);
+            return db.has_keyspace(ks_name) && std::ranges::all_of(tables, check);
         });
 
         if (schema_ok) {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -27,7 +27,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/range/algorithm_ext.hpp>
 #include <boost/range/adaptor/map.hpp>

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -34,7 +34,6 @@
 #include "sstables/sstables.hh"
 #include "sstables/sstables_manager.hh"
 #include <boost/range/adaptor/map.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/range/algorithm/min_element.hpp>
 #include <boost/container/static_vector.hpp>

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -23,7 +23,6 @@
 #include "mutation_writer/multishard_writer.hh"
 #include "sstables/sstable_set.hh"
 #include "db/view/view_update_checks.hh"
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include "replica/database.hh"
 #include "streaming/stream_mutation_fragments_cmd.hh"

--- a/test/boost/dynamic_bitset_test.cc
+++ b/test/boost/dynamic_bitset_test.cc
@@ -9,8 +9,6 @@
 #define BOOST_TEST_MODULE core
 
 #include <boost/test/unit_test.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
-#include <boost/range/irange.hpp>
 #include <vector>
 #include <random>
 #include <ranges>

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -8,7 +8,6 @@
 
 #include <limits>
 
-#include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/range/combine.hpp>
 #include <boost/test/tools/old/interface.hpp>
 #include <fmt/ranges.h>

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -11,7 +11,6 @@
 #include <seastar/core/sleep.hh>
 #include <seastar/util/backtrace.hh>
 #include <seastar/util/alloc_failure_injector.hh>
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include <seastar/util/closeable.hh>
 
 #include "test/lib/scylla_test_case.hh"
@@ -3407,7 +3406,7 @@ SEASTAR_TEST_CASE(test_concurrent_reads_and_eviction) {
 
                     auto n_to_consider = last_generation - oldest_generation + 1;
                     auto possible_versions = boost::make_iterator_range(versions.end() - n_to_consider, versions.end());
-                    if (!boost::algorithm::any_of(possible_versions, [&] (const mutation& m) {
+                    if (!std::ranges::any_of(possible_versions, [&] (const mutation& m) {
                         auto m2 = m.sliced(fwd_ranges);
                         if (reversed) {
                             m2 = reverse(std::move(m2));

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4448,7 +4448,7 @@ SEASTAR_TEST_CASE(twcs_reshape_with_disjoint_set_test) {
                 auto ret = get_reshaping_job(cs, sstables, s, mode);
                 BOOST_REQUIRE_EQUAL(ret.sstables.size(), uint64_t(s->max_compaction_threshold()));
                 // fail if any file doesn't belong to set of small files
-                bool has_big_sized_files = boost::algorithm::any_of(ret.sstables, [&] (const sstables::shared_sstable& sst) {
+                bool has_big_sized_files = std::ranges::any_of(ret.sstables, [&] (const sstables::shared_sstable& sst) {
                     return !generations_for_small_files.contains(sst->generation());
                 });
                 BOOST_REQUIRE(!has_big_sized_files);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -57,7 +57,6 @@
 #include <ftw.h>
 #include <unistd.h>
 #include <boost/range/algorithm/find_if.hpp>
-#include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/icl/interval_map.hpp>
 #include <seastar/testing/test_case.hh>
 #include "test/lib/test_services.hh"
@@ -840,7 +839,7 @@ SEASTAR_TEST_CASE(leveled_invariant_fix) {
     auto candidate = manifest.get_compaction_candidates(last_compacted_keys, compaction_counter);
     BOOST_REQUIRE(candidate.level == 1);
     BOOST_REQUIRE(candidate.sstables.size() == size_t(sstables_no-1));
-    BOOST_REQUIRE(boost::algorithm::all_of(candidate.sstables, [&] (auto& sst) {
+    BOOST_REQUIRE(std::ranges::all_of(candidate.sstables, [&] (auto& sst) {
         return expected.erase(sst);
     }));
     BOOST_REQUIRE(expected.empty());
@@ -883,7 +882,7 @@ SEASTAR_TEST_CASE(leveled_stcs_on_L0) {
         auto candidate = manifest.get_compaction_candidates(last_compacted_keys, compaction_counter);
         BOOST_REQUIRE(candidate.level == 0);
         BOOST_REQUIRE(candidate.sstables.size() == size_t(l0_sstables_no));
-        BOOST_REQUIRE(boost::algorithm::all_of(candidate.sstables, [&] (auto& sst) {
+        BOOST_REQUIRE(std::ranges::all_of(candidate.sstables, [&] (auto& sst) {
             return expected.erase(sst);
         }));
         BOOST_REQUIRE(expected.empty());
@@ -4708,7 +4707,7 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
             // wait for submitted jobs to finish.
             auto end = [&cm, &tables, expected_after] {
                 return cm.get_stats().pending_tasks == 0 && cm.get_stats().active_tasks == 0
-                    && boost::algorithm::all_of(tables, [expected_after] (auto& t) { return t->sstables_count() == expected_after; });
+                    && std::ranges::all_of(tables, [expected_after] (auto& t) { return t->sstables_count() == expected_after; });
             };
             while (!end()) {
                 if (!cm.get_stats().pending_tasks && !cm.get_stats().active_tasks) {

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -43,7 +43,6 @@
 #include <ftw.h>
 #include <unistd.h>
 #include <boost/range/algorithm/find_if.hpp>
-#include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/algorithm/cxx11/is_sorted.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/icl/interval_map.hpp>
@@ -2057,7 +2056,7 @@ SEASTAR_TEST_CASE(sstable_owner_shards) {
             SCYLLA_ASSERT(expected_owners.size() <= smp_count);
             auto sst = make_shared_sstable(expected_owners, ignore_msb, smp_count);
             auto owners = boost::copy_range<std::unordered_set<unsigned>>(sst->get_shards_for_this_sstable());
-            BOOST_REQUIRE(boost::algorithm::all_of(expected_owners, [&] (unsigned expected_owner) {
+            BOOST_REQUIRE(std::ranges::all_of(expected_owners, [&] (unsigned expected_owner) {
                 return owners.contains(expected_owner);
             }));
         };


### PR DESCRIPTION
now that we are allowed to use C++23. we now have the luxury of using
`std::ranges::all_of` and `std::ranges::any_of` 

in this change, we replace `boost::algorithm::all_of` and `boost::algorithm::any_of` with
`std::ranges::all_of` and `std::ranges::any_of` respectively.

to reduce the dependency to boost for better maintainability, and leverage standard library features for better long-term support.

this change is part of our ongoing effort to modernize our codebase and reduce external dependencies where possible.

---

it's a cleanup, hence no need to backport.