### PR TITLE
[Backport 6.1] compaction_manager: compaction_disabled: return true if not in compaction_state

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -2229,7 +2229,15 @@ bool compaction_manager::has_table_ongoing_compaction(const table_state& t) cons
 };
 
 bool compaction_manager::compaction_disabled(table_state& t) const {
-    return _compaction_state.contains(&t) && _compaction_state.at(&t).compaction_disabled();
+    if (auto it = _compaction_state.find(&t); it != _compaction_state.end()) {
+        return it->second.compaction_disabled();
+    } else {
+        cmlog.debug("compaction_disabled: {}:{} not in compaction_state", t.schema()->id(), t.get_group_id());
+        // Compaction is not strictly disabled, but it is not enabled either.
+        // The callers actually care about if it's enabled or not, not about the actual state of
+        // compaction_state::compaction_disabled()
+        return true;
+    }
 }
 
 future<> compaction_manager::stop_compaction(sstring type, table_state* table) {


### PR DESCRIPTION
When a compaction_group is removed via `compaction_manager::remove`, it is erase from `_compaction_state`, and therefore compaction is definitely not enabled on it.

This triggers an internal error if tablets are cleaned up during drop/truncate, which checks that compaction is disabled in all compaction groups.

Note that the callers of `compaction_disabled` aren't really interested in compaction being actively disabled on the compaction_group, but rather if it's enabled or not. A follow-up patch can be consider to reverse the logic and expose `compaction_enabled` rather than `compaction_disabled`.

Fixes scylladb/scylladb#20060

* Needs backport to all branches that support tablets

- (cherry picked from commit 78ceaeabcab6902da80f238a5f982ebc00f3bd68)

Parent PR: #21378