### PR TITLE
node_exporter: use fewer collectors

### DIFF
--- a/dist/common/sysconfig/scylla-node-exporter
+++ b/dist/common/sysconfig/scylla-node-exporter
@@ -1,1 +1,1 @@
-SCYLLA_NODE_EXPORTER_ARGS="--collector.interrupts --no-collector.hwmon"
+SCYLLA_NODE_EXPORTER_ARGS="--collector.interrupts --no-collector.hwmon --no-collector.bcache --no-collector.btrfs --no-collector.fibrechannel --no-collector.infiniband --no-collector.ipvs --no-collector.nfs --no-collector.nfsd --no-collector.powersupplyclass --no-collector.rapl --no-collector.tapestats --no-collector.thermal_zone --no-collector.udp_queues --no-collector.zfs"


### PR DESCRIPTION
Remove unused / less useful collectors by default. While it doesn't seem to reduce memory usage, it may reduce potential performance or security issues in the future.
This is what we are left with (snippet of log when loading node exporter manually with the changed command line):

```
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:111 level=info msg="Enabled collectors" 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=arp 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=bonding 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=conntrack 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=cpu 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=cpufreq 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=diskstats 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=dmi 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=edac 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=entropy 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=filefd 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=filesystem 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=interrupts 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=loadavg 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=mdadm 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=meminfo 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=netclass 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=netdev 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=netstat 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=nvme 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=os 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=pressure 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=schedstat 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=selinux 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=sockstat 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=softnet 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=stat 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=textfile 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=time 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=timex 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=uname 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=vmstat 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=watchdog 
ts=2024-11-03T15:41:06.855Z caller=node_exporter.go:118 level=info collector=xfs
```
Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>

Improvement, no need to backport.
