### PR TITLE
serialization: replace boost::type with std::type_identity

### DIFF
--- a/cdc/cdc_extension.hh
+++ b/cdc/cdc_extension.hh
@@ -34,7 +34,7 @@ public:
         return ser::serialize_to_buffer<bytes>(_cdc_options.to_map());
     }
     static std::map<sstring, sstring> deserialize(const bytes_view& buffer) {
-        return ser::deserialize_from_buffer(buffer, boost::type<std::map<sstring, sstring>>());
+        return ser::deserialize_from_buffer(buffer, std::type_identity<std::map<sstring, sstring>>());
     }
     const options& get_options() const {
         return _cdc_options;

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <boost/type.hpp>
+#include <type_traits>
 #include <random>
 #include <unordered_set>
 #include <algorithm>

--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -193,7 +193,7 @@ future<> db::batchlog_manager::replay_all_failed_batches(post_replay_cleanup cle
         auto fms = make_lw_shared<std::deque<canonical_mutation>>();
         auto in = ser::as_input_stream(data);
         while (in.size()) {
-            fms->emplace_back(ser::deserialize(in, boost::type<canonical_mutation>()));
+            fms->emplace_back(ser::deserialize(in, std::type_identity<canonical_mutation>()));
         }
 
         auto size = data.size();

--- a/db/commitlog/commitlog_entry.cc
+++ b/db/commitlog/commitlog_entry.cc
@@ -37,7 +37,7 @@ void commitlog_entry_writer::write(ostream& out) const {
 commitlog_entry_reader::commitlog_entry_reader(const fragmented_temporary_buffer& buffer)
     : _ce([&] {
     auto in = seastar::fragmented_memory_input_stream(fragmented_temporary_buffer::view(buffer).begin(), buffer.size_bytes());
-    return ser::deserialize(in, boost::type<commitlog_entry>());
+    return ser::deserialize(in, std::type_identity<commitlog_entry>());
 }())
 {
 }

--- a/db/paxos_grace_seconds_extension.hh
+++ b/db/paxos_grace_seconds_extension.hh
@@ -60,7 +60,7 @@ public:
     }
 
     static int32_t deserialize(const bytes_view& buffer) {
-        return ser::deserialize_from_buffer(buffer, boost::type<int32_t>());
+        return ser::deserialize_from_buffer(buffer, std::type_identity<int32_t>());
     }
 
     int32_t get_paxos_grace_seconds() const {

--- a/db/per_partition_rate_limit_extension.hh
+++ b/db/per_partition_rate_limit_extension.hh
@@ -32,7 +32,7 @@ public:
         return ser::serialize_to_buffer<bytes>(_options.to_map());
     }
     static std::map<sstring, sstring> deserialize(const bytes_view& buffer) {
-        return ser::deserialize_from_buffer(buffer, boost::type<std::map<sstring, sstring>>());
+        return ser::deserialize_from_buffer(buffer, std::type_identity<std::map<sstring, sstring>>());
     }
     const per_partition_rate_limit_options& get_options() const {
         return _options;

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2620,7 +2620,7 @@ future<service::paxos::paxos_state> system_keyspace::load_paxos_state(partition_
         std::optional<service::paxos::proposal> accepted;
         if (row.has("proposal")) {
             accepted = service::paxos::proposal(row.get_as<utils::UUID>("proposal_ballot"),
-                    ser::deserialize_from_buffer<>(row.get_blob("proposal"),  boost::type<frozen_mutation>(), 0));
+                    ser::deserialize_from_buffer<>(row.get_blob("proposal"),  std::type_identity<frozen_mutation>(), 0));
         }
 
         std::optional<service::paxos::proposal> most_recent;
@@ -2628,7 +2628,7 @@ future<service::paxos::paxos_state> system_keyspace::load_paxos_state(partition_
             // the value can be missing if it was pruned, supply empty one since
             // it will not going to be used anyway
             auto fm = row.has("most_recent_commit") ?
-                     ser::deserialize_from_buffer<>(row.get_blob("most_recent_commit"), boost::type<frozen_mutation>(), 0) :
+                     ser::deserialize_from_buffer<>(row.get_blob("most_recent_commit"), std::type_identity<frozen_mutation>(), 0) :
                      freeze(mutation(s, key));
             most_recent = service::paxos::proposal(row.get_as<utils::UUID>("most_recent_commit_at"),
                     std::move(fm));

--- a/db/tags/extension.hh
+++ b/db/tags/extension.hh
@@ -27,7 +27,7 @@ public:
         return ser::serialize_to_buffer<bytes>(_tags);
     }
     static std::map<sstring, sstring> deserialize(bytes_view buffer) {
-        return ser::deserialize_from_buffer(buffer, boost::type<std::map<sstring, sstring>>());
+        return ser::deserialize_from_buffer(buffer, std::type_identity<std::map<sstring, sstring>>());
     }
     const std::map<sstring, sstring>& tags() const {
         return _tags;

--- a/frozen_schema.cc
+++ b/frozen_schema.cc
@@ -27,7 +27,7 @@ frozen_schema::frozen_schema(const schema_ptr& s)
 
 schema_ptr frozen_schema::unfreeze(const db::schema_ctxt& ctxt) const {
     auto in = ser::as_input_stream(_data);
-    auto sv = ser::deserialize(in, boost::type<ser::schema_view>());
+    auto sv = ser::deserialize(in, std::type_identity<ser::schema_view>());
     return sv.mutations().is_view()
          ? db::schema_tables::create_view_from_mutations(ctxt, sv.mutations(), sv.version())
          : db::schema_tables::create_table_from_mutations(ctxt, sv.mutations(), sv.version());

--- a/gms/inet_address_serializer.hh
+++ b/gms/inet_address_serializer.hh
@@ -38,9 +38,9 @@ template<>
 struct serializer<gms::inet_address> {
     template<typename Input>
     static gms::inet_address read(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         if (sz == std::numeric_limits<uint32_t>::max()) {
-            seastar::net::ipv6_address addr(deserialize(in, boost::type<net::ipv6_address::ipv6_bytes>()));
+            seastar::net::ipv6_address addr(deserialize(in, std::type_identity<net::ipv6_address::ipv6_bytes>()));
             return gms::inet_address(addr);
         }
         return gms::inet_address(sz);

--- a/message/rpc_protocol_impl.hh
+++ b/message/rpc_protocol_impl.hh
@@ -20,7 +20,7 @@ void write(serializer, Output& out, const T& data) {
     ser::serialize(out, data);
 }
 template <typename T, typename Input>
-T read(serializer, Input& in, boost::type<T> type) {
+T read(serializer, Input& in, std::type_identity<T> type) {
     return ser::deserialize(in, type);
 }
 
@@ -29,8 +29,8 @@ void write(serializer s, Output& out, const foreign_ptr<T>& v) {
     return write(s, out, *v);
 }
 template <typename Input, typename T>
-foreign_ptr<T> read(serializer s, Input& in, boost::type<foreign_ptr<T>>) {
-    return make_foreign(read(s, in, boost::type<T>()));
+foreign_ptr<T> read(serializer s, Input& in, std::type_identity<foreign_ptr<T>>) {
+    return make_foreign(read(s, in, std::type_identity<T>()));
 }
 
 template <typename Output, typename T>
@@ -38,8 +38,8 @@ void write(serializer s, Output& out, const lw_shared_ptr<T>& v) {
     return write(s, out, *v);
 }
 template <typename Input, typename T>
-lw_shared_ptr<T> read(serializer s, Input& in, boost::type<lw_shared_ptr<T>>) {
-    return make_lw_shared<T>(read(s, in, boost::type<T>()));
+lw_shared_ptr<T> read(serializer s, Input& in, std::type_identity<lw_shared_ptr<T>>) {
+    return make_lw_shared<T>(read(s, in, std::type_identity<T>()));
 }
 
 using rpc_protocol = rpc::protocol<serializer, messaging_verb>;

--- a/mutation/async_utils.cc
+++ b/mutation/async_utils.cc
@@ -70,7 +70,7 @@ future<> apply_gently(mutation& target, const mutation& m) {
 
 future<mutation> to_mutation_gently(const canonical_mutation& cm, schema_ptr s) {
     auto in = ser::as_input_stream(cm.representation());
-    auto mv = ser::deserialize(in, boost::type<ser::canonical_mutation_view>());
+    auto mv = ser::deserialize(in, std::type_identity<ser::canonical_mutation_view>());
 
     auto cf_id = mv.table_id();
     if (s->id() != cf_id) {

--- a/mutation/canonical_mutation.cc
+++ b/mutation/canonical_mutation.cc
@@ -35,19 +35,19 @@ canonical_mutation::canonical_mutation(const mutation& m)
 
 table_id canonical_mutation::column_family_id() const {
     auto in = ser::as_input_stream(_data);
-    auto mv = ser::deserialize(in, boost::type<ser::canonical_mutation_view>());
+    auto mv = ser::deserialize(in, std::type_identity<ser::canonical_mutation_view>());
     return mv.table_id();
 }
 
 partition_key canonical_mutation::key() const {
     auto in = ser::as_input_stream(_data);
-    auto mv = ser::deserialize(in, boost::type<ser::canonical_mutation_view>());
+    auto mv = ser::deserialize(in, std::type_identity<ser::canonical_mutation_view>());
     return mv.key();
 }
 
 mutation canonical_mutation::to_mutation(schema_ptr s) const {
     auto in = ser::as_input_stream(_data);
-    auto mv = ser::deserialize(in, boost::type<ser::canonical_mutation_view>());
+    auto mv = ser::deserialize(in, std::type_identity<ser::canonical_mutation_view>());
 
     auto cf_id = mv.table_id();
     if (s->id() != cf_id) {
@@ -83,7 +83,7 @@ auto fmt::formatter<canonical_mutation>::format(const canonical_mutation& cm, fm
         -> decltype(ctx.out()) {
     auto out = ctx.out();
     auto in = ser::as_input_stream(cm._data);
-    auto mv = ser::deserialize(in, boost::type<ser::canonical_mutation_view>());
+    auto mv = ser::deserialize(in, std::type_identity<ser::canonical_mutation_view>());
     column_mapping mapping = mv.mapping();
     auto partition_view = mutation_partition_view::from_view(mv.partition());
     out = fmt::format_to(out, "{{canonical_mutation: ");

--- a/mutation/frozen_mutation.cc
+++ b/mutation/frozen_mutation.cc
@@ -31,7 +31,7 @@ using namespace db;
 
 ser::mutation_view frozen_mutation::mutation_view() const {
     auto in = ser::as_input_stream(_bytes);
-    return ser::deserialize(in, boost::type<ser::mutation_view>());
+    return ser::deserialize(in, std::type_identity<ser::mutation_view>());
 }
 
 table_id

--- a/mutation/mutation_partition_view.cc
+++ b/mutation/mutation_partition_view.cc
@@ -188,7 +188,7 @@ template<typename Visitor>
 requires MutationViewVisitor<Visitor>
 void mutation_partition_view::do_accept(const column_mapping& cm, Visitor& visitor) const {
     auto in = _in;
-    auto mpv = ser::deserialize(in, boost::type<ser::mutation_partition_view>());
+    auto mpv = ser::deserialize(in, std::type_identity<ser::mutation_partition_view>());
 
     visitor.accept_partition_tombstone(mpv.tomb());
 
@@ -230,7 +230,7 @@ template<typename Visitor>
 requires MutationViewVisitor<Visitor>
 future<> mutation_partition_view::do_accept_gently(const column_mapping& cm, Visitor& visitor) const {
     auto in = _in;
-    auto mpv = ser::deserialize(in, boost::type<ser::mutation_partition_view>());
+    auto mpv = ser::deserialize(in, std::type_identity<ser::mutation_partition_view>());
 
     visitor.accept_partition_tombstone(mpv.tomb());
 
@@ -275,7 +275,7 @@ future<> mutation_partition_view::do_accept_gently(const column_mapping& cm, Vis
 template <bool is_preemptible>
 mutation_partition_view::accept_ordered_result mutation_partition_view::do_accept_ordered(const schema& s, mutation_partition_view_virtual_visitor& visitor, accept_ordered_cookie cookie) const {
     auto in = _in;
-    auto mpv = ser::deserialize(in, boost::type<ser::mutation_partition_view>());
+    auto mpv = ser::deserialize(in, std::type_identity<ser::mutation_partition_view>());
     const column_mapping& cm = s.get_column_mapping();
 
     if (!cookie.accepted_partition_tombstone) {
@@ -419,7 +419,7 @@ future<> mutation_partition_view::accept_gently_ordered(const schema& s, mutatio
 std::optional<clustering_key> mutation_partition_view::first_row_key() const
 {
     auto in = _in;
-    auto mpv = ser::deserialize(in, boost::type<ser::mutation_partition_view>());
+    auto mpv = ser::deserialize(in, std::type_identity<ser::mutation_partition_view>());
     auto rows = mpv.rows();
     if (rows.empty()) {
         return { };
@@ -430,7 +430,7 @@ std::optional<clustering_key> mutation_partition_view::first_row_key() const
 std::optional<clustering_key> mutation_partition_view::last_row_key() const
 {
     auto in = _in;
-    auto mpv = ser::deserialize(in, boost::type<ser::mutation_partition_view>());
+    auto mpv = ser::deserialize(in, std::type_identity<ser::mutation_partition_view>());
     auto rows = mpv.rows();
     if (rows.empty()) {
         return { };
@@ -451,7 +451,7 @@ mutation_partition_view mutation_partition_view::from_view(ser::mutation_partiti
 mutation_fragment frozen_mutation_fragment::unfreeze(const schema& s, reader_permit permit)
 {
     auto in = ser::as_input_stream(_bytes);
-    auto view = ser::deserialize(in, boost::type<ser::mutation_fragment_view>());
+    auto view = ser::deserialize(in, std::type_identity<ser::mutation_fragment_view>());
     return seastar::visit(view.fragment(),
         [&] (ser::clustering_row_view crv) {
             class clustering_row_builder {

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -765,7 +765,7 @@ std::ostream& operator<<(std::ostream& os, const schema& s) {
 std::string schema_extension::options_to_string() const {
     std::ostringstream ss;
     ss << '{';
-    map_as_cql_param(ss, ser::deserialize_from_buffer(serialize(), boost::type<default_map_type>(), 0));
+    map_as_cql_param(ss, ser::deserialize_from_buffer(serialize(), std::type_identity<default_map_type>(), 0));
     ss << '}';
     return ss.str();
 }

--- a/serialization_visitors.hh
+++ b/serialization_visitors.hh
@@ -74,7 +74,7 @@ inline frame<bytes_ostream> start_frame(bytes_ostream& out) {
 
 template<typename Input>
 size_type read_frame_size(Input& in) {
-    auto sz = deserialize(in, boost::type<size_type>());
+    auto sz = deserialize(in, std::type_identity<size_type>());
     if (sz < sizeof(size_type)) {
         throw std::runtime_error(fmt::format("IDL frame truncated: expected to have at least {} bytes, got {}", sizeof(size_type), sz));
     }

--- a/serializer.hh
+++ b/serializer.hh
@@ -19,7 +19,7 @@
 #include <variant>
 
 #include <boost/range/algorithm/for_each.hpp>
-#include <boost/type.hpp>
+#include <type_traits>
 
 namespace ser {
 
@@ -261,12 +261,12 @@ inline void serialize(Output& out, const std::reference_wrapper<T> v) {
 }
 
 template<typename T, typename Input>
-inline auto deserialize(Input& in, boost::type<T> t) {
+inline auto deserialize(Input& in, std::type_identity<T> t) {
     return serializer<T>::read(in);
 }
 
 template<typename T, typename Input>
-inline void skip(Input& v, boost::type<T>) {
+inline void skip(Input& v, std::type_identity<T>) {
     return serializer<T>::skip(v);
 }
 
@@ -283,19 +283,19 @@ template<typename Buffer, typename T>
 Buffer serialize_to_buffer(const T& v, size_t head_space = 0);
 
 template<typename T, typename Buffer>
-T deserialize_from_buffer(const Buffer&, boost::type<T>, size_t head_space = 0);
+T deserialize_from_buffer(const Buffer&, std::type_identity<T>, size_t head_space = 0);
 
 template<typename Output, typename ...T>
 void serialize(Output& out, const boost::variant<T...>& v);
 
 template<typename Input, typename ...T>
-boost::variant<T...> deserialize(Input& in, boost::type<boost::variant<T...>>);
+boost::variant<T...> deserialize(Input& in, std::type_identity<boost::variant<T...>>);
 
 template<typename Output, typename ...T>
 void serialize(Output& out, const std::variant<T...>& v);
 
 template<typename Input, typename ...T>
-std::variant<T...> deserialize(Input& in, boost::type<std::variant<T...>>);
+std::variant<T...> deserialize(Input& in, std::type_identity<std::variant<T...>>);
 
 struct unknown_variant_type {
     size_type index;
@@ -306,7 +306,7 @@ template<typename Output>
 void serialize(Output& out, const unknown_variant_type& v);
 
 template<typename Input>
-unknown_variant_type deserialize(Input& in, boost::type<unknown_variant_type>);
+unknown_variant_type deserialize(Input& in, std::type_identity<unknown_variant_type>);
 
 template <typename T>
 struct normalize {

--- a/serializer_impl.hh
+++ b/serializer_impl.hh
@@ -196,7 +196,7 @@ struct deserialize_array_helper<false, T> {
     static void doit(Input& in, Container& v, size_t sz) {
         typename container_traits<Container>::back_emplacer be(v);
         while (sz--) {
-            be(deserialize(in, boost::type<T>()));
+            be(deserialize(in, std::type_identity<T>()));
         }
     }
     template<typename Input>
@@ -224,7 +224,7 @@ struct vector_serializer {
     using value_type = typename Vector::value_type;
     template<typename Input>
     static Vector read(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         Vector v;
         v.reserve(sz);
         deserialize_array<value_type>(in, v, sz);
@@ -237,7 +237,7 @@ struct vector_serializer {
     }
     template<typename Input>
     static void skip(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         skip_array<value_type>(in, sz);
     }
 };
@@ -248,7 +248,7 @@ template<typename T>
 struct serializer<std::list<T>> {
     template<typename Input>
     static std::list<T> read(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         std::list<T> v;
         deserialize_array_helper<false, T>::doit(in, v, sz);
         return v;
@@ -260,7 +260,7 @@ struct serializer<std::list<T>> {
     }
     template<typename Input>
     static void skip(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         skip_array<T>(in, sz);
     }
 };
@@ -269,7 +269,7 @@ template<typename T>
 struct serializer<absl::btree_set<T>> {
     template<typename Input>
     static absl::btree_set<T> read(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         absl::btree_set<T> v;
         deserialize_array_helper<false, T>::doit(in, v, sz);
         return v;
@@ -281,7 +281,7 @@ struct serializer<absl::btree_set<T>> {
     }
     template<typename Input>
     static void skip(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         skip_array<T>(in, sz);
     }
 };
@@ -290,7 +290,7 @@ template<typename T, typename... Args>
 struct serializer<std::unordered_set<T, Args...>> {
     template<typename Input>
     static std::unordered_set<T, Args...> read(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         std::unordered_set<T, Args...> v;
         v.reserve(sz);
         deserialize_array_helper<false, T>::doit(in, v, sz);
@@ -303,7 +303,7 @@ struct serializer<std::unordered_set<T, Args...>> {
     }
     template<typename Input>
     static void skip(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         skip_array<T>(in, sz);
     }
 };
@@ -327,7 +327,7 @@ template<typename T, typename Ratio>
 struct serializer<std::chrono::duration<T, Ratio>> {
     template<typename Input>
     static std::chrono::duration<T, Ratio> read(Input& in) {
-        return std::chrono::duration<T, Ratio>(deserialize(in, boost::type<T>()));
+        return std::chrono::duration<T, Ratio>(deserialize(in, std::type_identity<T>()));
     }
     template<typename Output>
     static void write(Output& out, const std::chrono::duration<T, Ratio>& d) {
@@ -345,7 +345,7 @@ struct serializer<std::chrono::time_point<Clock, Duration>> {
 
     template<typename Input>
     static value_type read(Input& in) {
-        return typename Clock::time_point(Duration(deserialize(in, boost::type<uint64_t>())));
+        return typename Clock::time_point(Duration(deserialize(in, std::type_identity<uint64_t>())));
     }
     template<typename Output>
     static void write(Output& out, const value_type& v) {
@@ -379,11 +379,11 @@ template<typename K, typename V>
 struct serializer<std::map<K, V>> {
     template<typename Input>
     static std::map<K, V> read(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         std::map<K, V> m;
         while (sz--) {
-            K k = deserialize(in, boost::type<K>());
-            V v = deserialize(in, boost::type<V>());
+            K k = deserialize(in, std::type_identity<K>());
+            V v = deserialize(in, std::type_identity<V>());
             m[k] = v;
         }
         return m;
@@ -398,7 +398,7 @@ struct serializer<std::map<K, V>> {
     }
     template<typename Input>
     static void skip(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         while (sz--) {
             serializer<K>::skip(in);
             serializer<V>::skip(in);
@@ -410,12 +410,12 @@ template<typename K, typename V>
 struct serializer<std::unordered_map<K, V>> {
     template<typename Input>
     static std::unordered_map<K, V> read(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         std::unordered_map<K, V> m;
         m.reserve(sz);
         while (sz--) {
-            auto k = deserialize(in, boost::type<K>());
-            auto v = deserialize(in, boost::type<V>());
+            auto k = deserialize(in, std::type_identity<K>());
+            auto v = deserialize(in, std::type_identity<V>());
             m.emplace(std::move(k), std::move(v));
         }
         return m;
@@ -430,7 +430,7 @@ struct serializer<std::unordered_map<K, V>> {
     }
     template<typename Input>
     static void skip(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         while (sz--) {
             serializer<K>::skip(in);
             serializer<V>::skip(in);
@@ -442,7 +442,7 @@ template<typename Tag>
 struct serializer<bool_class<Tag>> {
     template<typename Input>
     static bool_class<Tag> read(Input& in) {
-        return bool_class<Tag>(deserialize(in, boost::type<bool>()));
+        return bool_class<Tag>(deserialize(in, std::type_identity<bool>()));
     }
 
     template<typename Output>
@@ -519,7 +519,7 @@ template<>
 struct serializer<temporary_buffer<char>> {
     template<typename Input>
     static temporary_buffer<char> read(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
 		auto v = temporary_buffer<char>(sz);
         in.read(reinterpret_cast<char*>(v.get_write()), sz);
         return v;
@@ -531,7 +531,7 @@ struct serializer<temporary_buffer<char>> {
     }
     template<typename Input>
     static void skip(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         in.skip(sz);
     }
 };
@@ -541,7 +541,7 @@ template<>
 struct serializer<bytes> {
     template<typename Input>
     static deserialized_bytes_proxy<Input> read(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         return deserialized_bytes_proxy<Input>(in.read_substream(sz));
     }
     template<typename Output>
@@ -577,7 +577,7 @@ struct serializer<bytes> {
     }
     template<typename Input>
     static void skip(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         in.skip(sz);
     }
 };
@@ -595,7 +595,7 @@ void serialize(Output& out, const bytes_ostream& v) {
     serializer<bytes>::write(out, v);
 }
 template<typename Input>
-bytes_ostream deserialize(Input& in, boost::type<bytes_ostream>) {
+bytes_ostream deserialize(Input& in, std::type_identity<bytes_ostream>) {
     return serializer<bytes>::read(in);
 }
 template<typename Output, typename FragmentedBuffer>
@@ -609,9 +609,9 @@ struct serializer<std::optional<T>> {
     template<typename Input>
     static std::optional<T> read(Input& in) {
         std::optional<T> v;
-        auto b = deserialize(in, boost::type<bool>());
+        auto b = deserialize(in, std::type_identity<bool>());
         if (b) {
-            v.emplace(deserialize(in, boost::type<T>()));
+            v.emplace(deserialize(in, std::type_identity<T>()));
         }
         return v;
     }
@@ -624,7 +624,7 @@ struct serializer<std::optional<T>> {
     }
     template<typename Input>
     static void skip(Input& in) {
-        auto present = deserialize(in, boost::type<bool>());
+        auto present = deserialize(in, std::type_identity<bool>());
         if (present) {
             serializer<T>::skip(in);
         }
@@ -638,7 +638,7 @@ template<typename T>
 struct serializer<seastar::lw_shared_ptr<T>> {
     template<typename Input>
     static seastar::lw_shared_ptr<T> read(Input& in) {
-        return seastar::make_lw_shared<T>(deserialize(in, boost::type<T>()));
+        return seastar::make_lw_shared<T>(deserialize(in, std::type_identity<T>()));
     }
     template<typename Output>
     static void write(Output& out, const seastar::lw_shared_ptr<T>& v) {
@@ -657,7 +657,7 @@ template<>
 struct serializer<sstring> {
     template<typename Input>
     static sstring read(Input& in) {
-        auto sz = deserialize(in, boost::type<uint32_t>());
+        auto sz = deserialize(in, std::type_identity<uint32_t>());
         sstring v = uninitialized_string(sz);
         in.read(v.data(), sz);
         return v;
@@ -669,7 +669,7 @@ struct serializer<sstring> {
     }
     template<typename Input>
     static void skip(Input& in) {
-        in.skip(deserialize(in, boost::type<size_type>()));
+        in.skip(deserialize(in, std::type_identity<size_type>()));
     }
 };
 
@@ -678,9 +678,9 @@ struct serializer<std::unique_ptr<T>> {
     template<typename Input>
     static std::unique_ptr<T> read(Input& in) {
         std::unique_ptr<T> v;
-        auto b = deserialize(in, boost::type<bool>());
+        auto b = deserialize(in, std::type_identity<bool>());
         if (b) {
-            v = std::make_unique<T>(deserialize(in, boost::type<T>()));
+            v = std::make_unique<T>(deserialize(in, std::type_identity<T>()));
         }
         return v;
     }
@@ -693,7 +693,7 @@ struct serializer<std::unique_ptr<T>> {
     }
     template<typename Input>
     static void skip(Input& in) {
-        auto present = deserialize(in, boost::type<bool>());
+        auto present = deserialize(in, std::type_identity<bool>());
         if (present) {
             serializer<T>::skip(in);
         }
@@ -704,7 +704,7 @@ template<typename Enum>
 struct serializer<enum_set<Enum>> {
     template<typename Input>
     static enum_set<Enum> read(Input& in) {
-        return enum_set<Enum>::from_mask(deserialize(in, boost::type<uint64_t>()));
+        return enum_set<Enum>::from_mask(deserialize(in, std::type_identity<uint64_t>()));
     }
     template<typename Output>
     static void write(Output& out, enum_set<Enum> v) {
@@ -751,7 +751,7 @@ Buffer serialize_to_buffer(const T& v, size_t head_space) {
 }
 
 template<typename T, typename Buffer>
-T deserialize_from_buffer(const Buffer& buf, boost::type<T> type, size_t head_space) {
+T deserialize_from_buffer(const Buffer& buf, std::type_identity<T> type, size_t head_space) {
     seastar::simple_input_stream in(reinterpret_cast<const char*>(buf.begin() + head_space), buf.size() - head_space);
     return deserialize(in, std::move(type));
 }
@@ -773,7 +773,7 @@ template<typename Output, typename ...T>
 void serialize(Output& out, const boost::variant<T...>& v) {}
 
 template<typename Input, typename ...T>
-boost::variant<T...> deserialize(Input& in, boost::type<boost::variant<T...>>) {
+boost::variant<T...> deserialize(Input& in, std::type_identity<boost::variant<T...>>) {
     return boost::variant<T...>();
 }
 
@@ -788,15 +788,15 @@ void serialize(Output& out, const std::variant<T...>& v) {
 }
 
 template<typename Input, typename T, size_t... I>
-T deserialize_std_variant(Input& in, boost::type<T> t,  size_t idx, std::index_sequence<I...>) {
+T deserialize_std_variant(Input& in, std::type_identity<T> t,  size_t idx, std::index_sequence<I...>) {
     T v;
-    (void)((I == idx ? v.template emplace<I>(deserialize(in, boost::type<std::variant_alternative_t<I, T>>())), true : false) || ...);
+    (void)((I == idx ? v.template emplace<I>(deserialize(in, std::type_identity<std::variant_alternative_t<I, T>>())), true : false) || ...);
     return v;
 }
 
 template<typename Input, typename ...T>
-std::variant<T...> deserialize(Input& in, boost::type<std::variant<T...>> v) {
-    size_t idx = deserialize(in, boost::type<uint8_t>());
+std::variant<T...> deserialize(Input& in, std::type_identity<std::variant<T...>> v) {
+    size_t idx = deserialize(in, std::type_identity<uint8_t>());
     return deserialize_std_variant(in, v, idx, std::make_index_sequence<sizeof...(T)>());
 }
 
@@ -805,10 +805,10 @@ void serialize(Output& out, const unknown_variant_type& v) {
     out.write(v.data.begin(), v.data.size());
 }
 template<typename Input>
-unknown_variant_type deserialize(Input& in, boost::type<unknown_variant_type>) {
+unknown_variant_type deserialize(Input& in, std::type_identity<unknown_variant_type>) {
     return seastar::with_serialized_stream(in, [] (auto& in) {
-        auto size = deserialize(in, boost::type<size_type>());
-        auto index = deserialize(in, boost::type<size_type>());
+        auto size = deserialize(in, std::type_identity<size_type>());
+        auto index = deserialize(in, std::type_identity<size_type>());
         auto sz = size - sizeof(size_type) * 2;
         sstring v = uninitialized_string(sz);
         in.read(v.data(), sz);
@@ -849,7 +849,7 @@ private:
             serializer<T>::skip(_in);
         }
         value_type deserialize_next() {
-            return deserialize(_in, boost::type<T>());
+            return deserialize(_in, std::type_identity<T>());
         }
     };
     struct reverse_iterator_data {
@@ -860,7 +860,7 @@ private:
         value_type deserialize_next() {
             input_stream is = *_substream_it;
             ++_substream_it;
-            return deserialize(is, boost::type<T>());
+            return deserialize(is, std::type_identity<T>());
         }
     };
 
@@ -873,7 +873,7 @@ public:
 
     explicit vector_deserializer(input_stream in)
         : _in(std::move(in))
-        , _size(deserialize(_in, boost::type<uint32_t>()))
+        , _size(deserialize(_in, std::type_identity<uint32_t>()))
     {
         if constexpr (!IsForward) {
             fill_substreams();

--- a/service/pager/paging_state.cc
+++ b/service/pager/paging_state.cc
@@ -71,7 +71,7 @@ lw_shared_ptr<service::pager::paging_state> service::pager::paging_state::deseri
     seastar::simple_input_stream in(reinterpret_cast<char*>(data.value().begin() + sizeof(uint32_t)), data.value().size() - sizeof(uint32_t));
 
     try {
-        return make_lw_shared<paging_state>(ser::deserialize(in, boost::type<paging_state>()));
+        return make_lw_shared<paging_state>(ser::deserialize(in, std::type_identity<paging_state>()));
     } catch (...) {
         std::throw_with_nested(
                 exceptions::protocol_exception(

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -259,7 +259,7 @@ future<> group0_state_machine::apply(std::vector<raft::command_cref> command) {
 
     for (auto&& c : command) {
         auto is = ser::as_input_stream(c);
-        auto cmd = ser::deserialize(is, boost::type<group0_command>{});
+        auto cmd = ser::deserialize(is, std::type_identity<group0_command>{});
 
 #ifndef SCYLLA_BUILD_MODE_RELEASE
         // Ensure that the schema of the mutations is a group0 schema.

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -106,7 +106,7 @@ future<raft::log_entries> raft_sys_table_storage::load_log() {
         auto raw_data = row.get_blob("data");
         auto in = ser::as_input_stream(raw_data);
         using data_variant_type = decltype(raft::log_entry::data);
-        data_variant_type data = ser::deserialize(in, boost::type<data_variant_type>());
+        data_variant_type data = ser::deserialize(in, std::type_identity<data_variant_type>());
 
         log.emplace_back(make_lw_shared<const raft::log_entry>(
             raft::log_entry{.term = term, .idx = idx, .data = std::move(data)}));

--- a/test/boost/bytes_ostream_test.cc
+++ b/test/boost/bytes_ostream_test.cc
@@ -30,7 +30,7 @@ void assert_sequence(bytes_ostream& buf, int count) {
     auto in = ser::as_input_stream(buf.linearize());
     SCYLLA_ASSERT(buf.size() == count * sizeof(int));
     for (int i = 0; i < count; i++) {
-        auto val = ser::deserialize(in, boost::type<int>());
+        auto val = ser::deserialize(in, std::type_identity<int>());
         BOOST_REQUIRE_EQUAL(val, i);
     }
 }
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(test_view) {
     BOOST_REQUIRE(buf.is_linearized());
 
     auto in = ser::as_input_stream(buf.view());
-    BOOST_REQUIRE_EQUAL(1, ser::deserialize(in, boost::type<int>()));
+    BOOST_REQUIRE_EQUAL(1, ser::deserialize(in, std::type_identity<int>()));
 }
 
 BOOST_AUTO_TEST_CASE(test_writing_blobs) {
@@ -205,8 +205,8 @@ BOOST_AUTO_TEST_CASE(test_retraction_to_the_same_chunk) {
     BOOST_REQUIRE(buf.size() == sizeof(int) * 2);
 
     auto in = ser::as_input_stream(buf.view());
-    BOOST_REQUIRE_EQUAL(ser::deserialize(in, boost::type<int>()), 1);
-    BOOST_REQUIRE_EQUAL(ser::deserialize(in, boost::type<int>()), 2);
+    BOOST_REQUIRE_EQUAL(ser::deserialize(in, std::type_identity<int>()), 1);
+    BOOST_REQUIRE_EQUAL(ser::deserialize(in, std::type_identity<int>()), 2);
     BOOST_REQUIRE(in.size() == 0);
 }
 
@@ -222,8 +222,8 @@ BOOST_AUTO_TEST_CASE(test_no_op_retraction) {
     BOOST_REQUIRE(buf.size() == sizeof(int) * 2);
 
     auto in = ser::as_input_stream(buf.view());
-    BOOST_REQUIRE_EQUAL(ser::deserialize(in, boost::type<int>()), 1);
-    BOOST_REQUIRE_EQUAL(ser::deserialize(in, boost::type<int>()), 2);
+    BOOST_REQUIRE_EQUAL(ser::deserialize(in, std::type_identity<int>()), 1);
+    BOOST_REQUIRE_EQUAL(ser::deserialize(in, std::type_identity<int>()), 2);
     BOOST_REQUIRE(in.size() == 0);
 }
 
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(test_retraction_discarding_chunks) {
     BOOST_REQUIRE(buf.size() == sizeof(int));
 
     auto in = ser::as_input_stream(buf.view());
-    BOOST_REQUIRE_EQUAL(ser::deserialize(in, boost::type<int>()), 1);
+    BOOST_REQUIRE_EQUAL(ser::deserialize(in, std::type_identity<int>()), 1);
     BOOST_REQUIRE(in.size() == 0);
 }
 
@@ -252,8 +252,8 @@ BOOST_AUTO_TEST_CASE(test_writing_placeholders) {
     ser::serialize(ph_stream, 1);
 
     auto in = ser::as_input_stream(buf.view());
-    BOOST_REQUIRE_EQUAL(ser::deserialize(in, boost::type<int>()), 1);
-    BOOST_REQUIRE_EQUAL(ser::deserialize(in, boost::type<int>()), 2);
+    BOOST_REQUIRE_EQUAL(ser::deserialize(in, std::type_identity<int>()), 1);
+    BOOST_REQUIRE_EQUAL(ser::deserialize(in, std::type_identity<int>()), 2);
     BOOST_REQUIRE(in.size() == 0);
 }
 

--- a/test/boost/idl_test.cc
+++ b/test/boost/idl_test.cc
@@ -182,12 +182,12 @@ BOOST_AUTO_TEST_CASE(test_simple_compound)
 
     auto bv1 = buf1.linearize();
     auto in1 = ser::as_input_stream(bv1);
-    auto deser_sc = ser::deserialize(in1, boost::type<simple_compound>());
+    auto deser_sc = ser::deserialize(in1, std::type_identity<simple_compound>());
     BOOST_REQUIRE_EQUAL(sc, deser_sc);
 
     auto bv2 = buf2.linearize();
     auto in2 = ser::as_input_stream(bv2);
-    auto sc_view = ser::deserialize(in2, boost::type<ser::writable_simple_compound_view>());
+    auto sc_view = ser::deserialize(in2, std::type_identity<ser::writable_simple_compound_view>());
     BOOST_REQUIRE_EQUAL(sc.foo, sc_view.foo());
     BOOST_REQUIRE_EQUAL(sc.bar, sc_view.bar());
 }
@@ -229,13 +229,13 @@ BOOST_AUTO_TEST_CASE(test_vector)
 
     auto bv1 = buf1.linearize();
     auto in1 = ser::as_input_stream(bv1);
-    auto deser_voc = ser::deserialize(in1, boost::type<vectors_of_compounds>());
+    auto deser_voc = ser::deserialize(in1, std::type_identity<vectors_of_compounds>());
     BOOST_REQUIRE_EQUAL(voc.first, deser_voc.first);
     BOOST_REQUIRE_EQUAL(voc.second, deser_voc.second);
 
     auto bv2 = buf2.linearize();
     auto in2 = ser::as_input_stream(bv2);
-    auto voc_view = ser::deserialize(in2, boost::type<ser::writable_vectors_of_compounds_view>());
+    auto voc_view = ser::deserialize(in2, std::type_identity<ser::writable_vectors_of_compounds_view>());
 
     auto first_range = voc_view.first();
     auto first_view = std::vector<ser::writable_simple_compound_view>(first_range.begin(), first_range.end());
@@ -280,7 +280,7 @@ BOOST_AUTO_TEST_CASE(test_variant)
 
     auto bv = buf.linearize();
     auto in = ser::as_input_stream(bv);
-    auto wv_view = ser::deserialize(in, boost::type<ser::writable_variants_view>());
+    auto wv_view = ser::deserialize(in, std::type_identity<ser::writable_variants_view>());
     BOOST_REQUIRE_EQUAL(wv_view.id(), 17);
 
     struct expect_compound : boost::static_visitor<simple_compound> {
@@ -353,7 +353,7 @@ BOOST_AUTO_TEST_CASE(test_compound_with_optional)
 
     auto bv1 = buf1.linearize();
     seastar::simple_input_stream in1(reinterpret_cast<const char*>(bv1.data()), bv1.size());
-    auto deser_one = ser::deserialize(in1, boost::type<compound_with_optional>());
+    auto deser_one = ser::deserialize(in1, std::type_identity<compound_with_optional>());
     BOOST_REQUIRE_EQUAL(one, deser_one);
 
     compound_with_optional two = { {}, foo };
@@ -364,7 +364,7 @@ BOOST_AUTO_TEST_CASE(test_compound_with_optional)
 
     auto bv2 = buf2.linearize();
     seastar::simple_input_stream in2(reinterpret_cast<const char*>(bv2.data()), bv2.size());
-    auto deser_two = ser::deserialize(in2, boost::type<compound_with_optional>());
+    auto deser_two = ser::deserialize(in2, std::type_identity<compound_with_optional>());
     BOOST_REQUIRE_EQUAL(two, deser_two);
 }
 
@@ -379,7 +379,7 @@ BOOST_AUTO_TEST_CASE(test_skip_does_not_deserialize)
         auto in = ser::as_input_stream(buf.linearize());
         auto prev = non_final_composite_test_object::construction_count;
 
-        ser::skip(in, boost::type<non_final_composite_test_object>());
+        ser::skip(in, std::type_identity<non_final_composite_test_object>());
 
         BOOST_REQUIRE(prev == non_final_composite_test_object::construction_count);
     }
@@ -393,7 +393,7 @@ BOOST_AUTO_TEST_CASE(test_skip_does_not_deserialize)
         auto in = ser::as_input_stream(buf.linearize());
         auto prev = final_composite_test_object::construction_count;
 
-        ser::skip(in, boost::type<final_composite_test_object>());
+        ser::skip(in, std::type_identity<final_composite_test_object>());
 
         BOOST_REQUIRE(prev == final_composite_test_object::construction_count);
     }
@@ -405,13 +405,13 @@ BOOST_AUTO_TEST_CASE(test_empty_struct)
     ser::serialize(buf1, empty_struct());
 
     auto in1 = ser::as_input_stream(buf1.linearize());
-    ser::deserialize(in1, boost::type<empty_struct>());
+    ser::deserialize(in1, std::type_identity<empty_struct>());
 
     bytes_ostream buf2;
     ser::serialize(buf2, empty_final_struct());
 
     auto in2 = ser::as_input_stream(buf2.linearize());
-    ser::deserialize(in2, boost::type<empty_final_struct>());
+    ser::deserialize(in2, std::type_identity<empty_final_struct>());
 }
 
 BOOST_AUTO_TEST_CASE(test_just_a_variant)
@@ -425,7 +425,7 @@ BOOST_AUTO_TEST_CASE(test_just_a_variant)
     .end_just_a_variant();
 
     auto in = ser::as_input_stream(buf);
-    auto view = ser::deserialize(in, boost::type<ser::just_a_variant_view>());
+    auto view = ser::deserialize(in, std::type_identity<ser::just_a_variant_view>());
     bool fired = false;
     seastar::visit(view.variant(), [&] (ser::writable_simple_compound_view v) {
             fired = true;
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE(test_just_a_variant)
     .end_just_a_variant();
 
     in = ser::as_input_stream(buf);
-    view = ser::deserialize(in, boost::type<ser::just_a_variant_view>());
+    view = ser::deserialize(in, std::type_identity<ser::just_a_variant_view>());
     fired = false;
     seastar::visit(view.variant(), [&] (simple_compound v) {
             fired = true;
@@ -462,7 +462,7 @@ BOOST_AUTO_TEST_CASE(test_fragmented_write)
         bytes_ostream buf;
         ser::serialize_fragmented(buf, fragment_generator(fragment_count, fragment_size));
         auto in = ser::as_input_stream(buf);
-        bytes deserialized = ser::deserialize(in, boost::type<bytes>());
+        bytes deserialized = ser::deserialize(in, std::type_identity<bytes>());
         BOOST_CHECK_EQUAL(deserialized, fragment_generator(fragment_count, fragment_size).to_bytes());
     }
 }
@@ -481,6 +481,6 @@ BOOST_AUTO_TEST_CASE(test_const_template_arg)
     BOOST_REQUIRE_EQUAL(buf.size(), 40);
 
     auto in = ser::as_input_stream(buf);
-    auto deser_obj = ser::deserialize(in, boost::type<const_template_arg_test_object>());
+    auto deser_obj = ser::deserialize(in, std::type_identity<const_template_arg_test_object>());
     BOOST_REQUIRE(obj == deser_obj);
 }

--- a/test/boost/keys_test.cc
+++ b/test/boost/keys_test.cc
@@ -144,7 +144,7 @@ inline
 T reserialize(const T& v) {
     auto buf = ser::serialize_to_buffer<bytes>(v);
     auto in = ser::as_input_stream(buf);
-    return ser::deserialize(in, boost::type<T>());
+    return ser::deserialize(in, std::type_identity<T>());
 }
 
 BOOST_AUTO_TEST_CASE(test_serialization) {

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -866,10 +866,10 @@ struct serializer<blob_header> {
     template <typename Input>
     static blob_header read(Input& in) {
         blob_header head;
-        head.size = ser::deserialize(in, boost::type<int>{});
-        head.includes_pk = ser::deserialize(in, boost::type<bool>{});
-        head.has_ck = ser::deserialize(in, boost::type<bool>{});
-        head.includes_ck = ser::deserialize(in, boost::type<bool>{});
+        head.size = ser::deserialize(in, std::type_identity<int>{});
+        head.includes_pk = ser::deserialize(in, std::type_identity<bool>{});
+        head.has_ck = ser::deserialize(in, std::type_identity<bool>{});
+        head.includes_ck = ser::deserialize(in, std::type_identity<bool>{});
         return head;
     }
     template <typename Output>
@@ -881,10 +881,10 @@ struct serializer<blob_header> {
     }
     template <typename Input>
     static void skip(Input& in) {
-        ser::skip(in, boost::type<int>{});
-        ser::skip(in, boost::type<bool>{});
-        ser::skip(in, boost::type<bool>{});
-        ser::skip(in, boost::type<bool>{});
+        ser::skip(in, std::type_identity<int>{});
+        ser::skip(in, std::type_identity<bool>{});
+        ser::skip(in, std::type_identity<bool>{});
+        ser::skip(in, std::type_identity<bool>{});
     }
 };
 

--- a/test/boost/serialization_test.cc
+++ b/test/boost/serialization_test.cc
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(inet_address) {
         BOOST_CHECK(ip.addr().is_ipv4());
         auto buf = ser::serialize_to_buffer<bytes>(ip);
         BOOST_CHECK_EQUAL(buf.size(), sizeof(uint32_t));
-        auto res = ser::deserialize_from_buffer(buf, boost::type<gms::inet_address>{});
+        auto res = ser::deserialize_from_buffer(buf, std::type_identity<gms::inet_address>{});
         uint32_t rip = res.addr().as_ipv4_address().ip;
         BOOST_CHECK_EQUAL(hip, rip);
     }
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(inet_address) {
         gms::inet_address ip("2001:6b0:8:2::232");
         BOOST_CHECK(ip.addr().is_ipv6());
         auto buf = ser::serialize_to_buffer<bytes>(ip);
-        auto res = ser::deserialize_from_buffer(buf, boost::type<gms::inet_address>{});
+        auto res = ser::deserialize_from_buffer(buf, std::type_identity<gms::inet_address>{});
         BOOST_CHECK_EQUAL(res, ip);
     }
 

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -136,8 +136,8 @@ public:
                 _gate.check();
 
                 auto is = ser::as_input_stream(cref);
-                auto cmd_id = ser::deserialize(is, boost::type<cmd_id_t>{});
-                auto input = ser::deserialize(is, boost::type<typename M::input_t>{});
+                auto cmd_id = ser::deserialize(is, std::type_identity<cmd_id_t>{});
+                auto input = ser::deserialize(is, std::type_identity<typename M::input_t>{});
                 auto [new_state, output] = M::delta(std::move(_val), std::move(input));
                 _val = std::move(new_state);
 

--- a/test/raft/replication.cc
+++ b/test/raft/replication.cc
@@ -65,7 +65,7 @@ size_t apply_changes(raft::server_id id, const std::vector<raft::command_cref>& 
 
     for (auto&& d : commands) {
         auto is = ser::as_input_stream(d);
-        int n = ser::deserialize(is, boost::type<int>());
+        int n = ser::deserialize(is, std::type_identity<int>());
         if (n != dummy_command) {
             entries++;
             hasher->update(n);      // running hash (values and snapshots)

--- a/tombstone_gc_extension.hh
+++ b/tombstone_gc_extension.hh
@@ -32,7 +32,7 @@ public:
         return ser::serialize_to_buffer<bytes>(_tombstone_gc_options.to_map());
     }
     static std::map<seastar::sstring, seastar::sstring> deserialize(const bytes_view& buffer) {
-        return ser::deserialize_from_buffer(buffer, boost::type<std::map<seastar::sstring, seastar::sstring>>());
+        return ser::deserialize_from_buffer(buffer, std::type_identity<std::map<seastar::sstring, seastar::sstring>>());
     }
     const tombstone_gc_options& get_options() const {
         return _tombstone_gc_options;


### PR DESCRIPTION
Recently, seastar rpc started accepting std::type_identity in addition to boost::type as a type marker (while labeling the latter with an ominous deprecation warning). Reduce our depedendency on boost by switching to std::type_identity.

Code cleanup; no backport needed.