### PR TITLE
locator: token_metadata: replace boost range with std range

### DIFF
--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -310,21 +310,21 @@ public:
 
 thread_local long token_metadata_impl::_static_ring_version;
 
-token_metadata::tokens_iterator::tokens_iterator(const token& start, const token_metadata_impl* token_metadata)
+tokens_iterator::tokens_iterator(const token& start, const token_metadata_impl* token_metadata)
     : _token_metadata(token_metadata) {
     _cur_it = _token_metadata->sorted_tokens().begin() + _token_metadata->first_token_index(start);
     _remaining = _token_metadata->sorted_tokens().size();
 }
 
-bool token_metadata::tokens_iterator::operator==(const tokens_iterator& it) const {
+bool tokens_iterator::operator==(const tokens_iterator& it) const {
     return _remaining == it._remaining;
 }
 
-const token& token_metadata::tokens_iterator::operator*() const {
+const token& tokens_iterator::operator*() const {
     return *_cur_it;
 }
 
-token_metadata::tokens_iterator& token_metadata::tokens_iterator::operator++() {
+tokens_iterator& tokens_iterator::operator++() {
     ++_cur_it;
     if (_cur_it == _token_metadata->sorted_tokens().end()) {
         _cur_it = _token_metadata->sorted_tokens().begin();

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -127,9 +127,9 @@ public:
      *
      * @return The requested range (see the description above)
      */
-    boost::iterator_range<token_metadata::tokens_iterator> ring_range(const token& start) const;
+    std::ranges::subrange<token_metadata::tokens_iterator> ring_range(const token& start) const;
 
-    boost::iterator_range<token_metadata::tokens_iterator> ring_range(dht::ring_position_view pos) const;
+    std::ranges::subrange<token_metadata::tokens_iterator> ring_range(dht::ring_position_view pos) const;
 
     topology& get_topology() {
         return _topology;
@@ -338,11 +338,11 @@ host_id token_metadata::get_my_id() const {
 }
 
 inline
-boost::iterator_range<token_metadata::tokens_iterator>
+std::ranges::subrange<token_metadata::tokens_iterator>
 token_metadata_impl::ring_range(const token& start) const {
     auto begin = token_metadata::tokens_iterator(start, this);
     auto end = token_metadata::tokens_iterator();
-    return boost::make_iterator_range(begin, end);
+    return std::ranges::subrange(begin, end);
 }
 
 future<std::unique_ptr<token_metadata_impl>> token_metadata_impl::clone_async() const noexcept {
@@ -590,7 +590,7 @@ void token_metadata_impl::add_bootstrap_token(token t, host_id endpoint) {
     add_bootstrap_tokens(tokens, endpoint);
 }
 
-boost::iterator_range<token_metadata::tokens_iterator>
+std::ranges::subrange<token_metadata::tokens_iterator>
 token_metadata_impl::ring_range(const dht::ring_position_view start) const {
     return ring_range(start.token());
 }
@@ -962,24 +962,24 @@ token_metadata::update_topology(host_id ep, std::optional<endpoint_dc_rack> opt_
     _impl->update_topology(ep, std::move(opt_dr), std::move(opt_st), std::move(shard_count));
 }
 
-boost::iterator_range<token_metadata::tokens_iterator>
+std::ranges::subrange<token_metadata::tokens_iterator>
 token_metadata::ring_range(const token& start) const {
     return _impl->ring_range(start);
 }
 
-boost::iterator_range<token_metadata::tokens_iterator>
+std::ranges::subrange<token_metadata::tokens_iterator>
 token_metadata::ring_range(dht::ring_position_view start) const {
     return _impl->ring_range(start);
 }
 
 class token_metadata_ring_splitter : public locator::token_range_splitter {
     token_metadata_ptr _tmptr;
-    boost::iterator_range<token_metadata::tokens_iterator> _range;
+    std::ranges::subrange<token_metadata::tokens_iterator> _range;
 public:
     token_metadata_ring_splitter(token_metadata_ptr tmptr)
         : _tmptr(std::move(tmptr))
         , _range(_tmptr->sorted_tokens().empty() // ring_range() throws if the ring is empty
-                ? boost::make_iterator_range(token_metadata::tokens_iterator(), token_metadata::tokens_iterator())
+                ? std::ranges::subrange(token_metadata::tokens_iterator(), token_metadata::tokens_iterator())
                 : _tmptr->ring_range(dht::minimum_token()))
     { }
 
@@ -992,7 +992,7 @@ public:
             return std::nullopt;
         }
         auto t = *_range.begin();
-        _range.drop_front();
+        _range.advance(1);
         return t;
     }
 };

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -135,6 +135,7 @@ public:
 class tokens_iterator {
 public:
     using iterator_category = std::input_iterator_tag;
+    using iterator_concept = std::input_iterator_tag;
     using value_type = token;
     using difference_type = std::ptrdiff_t;
     using pointer = token*;
@@ -145,6 +146,11 @@ public:
     bool operator==(const tokens_iterator& it) const;
     const token& operator*() const;
     tokens_iterator& operator++();
+    tokens_iterator operator++(int) {
+        auto tmp = *this;
+        ++*this;
+        return tmp;
+    }
 private:
     std::vector<token>::const_iterator _cur_it;
     size_t _remaining = 0;

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -16,7 +16,6 @@
 #include "dht/ring_position.hh"
 #include <optional>
 #include <memory>
-#include <boost/range/iterator_range.hpp>
 #include <boost/icl/interval.hpp>
 #include "interval.hh"
 #include <seastar/core/shared_future.hh>
@@ -210,12 +209,12 @@ public:
      *
      * @return The requested range (see the description above)
      */
-    boost::iterator_range<tokens_iterator> ring_range(const token& start) const;
+    std::ranges::subrange<tokens_iterator> ring_range(const token& start) const;
 
     /**
      * Returns a range of tokens such that the first token t satisfies dht::ring_position_view::ending_at(t) >= start.
      */
-    boost::iterator_range<tokens_iterator> ring_range(dht::ring_position_view start) const;
+    std::ranges::subrange<tokens_iterator> ring_range(dht::ring_position_view start) const;
 
     topology& get_topology();
     const topology& get_topology() const;

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -132,31 +132,32 @@ public:
     }
 };
 
+class tokens_iterator {
+public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = token;
+    using difference_type = std::ptrdiff_t;
+    using pointer = token*;
+    using reference = token&;
+public:
+    tokens_iterator() = default;
+    tokens_iterator(const token& start, const token_metadata_impl* token_metadata);
+    bool operator==(const tokens_iterator& it) const;
+    const token& operator*() const;
+    tokens_iterator& operator++();
+private:
+    std::vector<token>::const_iterator _cur_it;
+    size_t _remaining = 0;
+    const token_metadata_impl* _token_metadata = nullptr;
+
+    friend class token_metadata_impl;
+};
+
 class token_metadata final {
     std::unique_ptr<token_metadata_impl> _impl;
 private:
     friend class token_metadata_ring_splitter;
-    class tokens_iterator {
-    public:
-        using iterator_category = std::input_iterator_tag;
-        using value_type = token;
-        using difference_type = std::ptrdiff_t;
-        using pointer = token*;
-        using reference = token&;
-    public:
-        tokens_iterator() = default;
-        tokens_iterator(const token& start, const token_metadata_impl* token_metadata);
-        bool operator==(const tokens_iterator& it) const;
-        const token& operator*() const;
-        tokens_iterator& operator++();
-    private:
-        std::vector<token>::const_iterator _cur_it;
-        size_t _remaining = 0;
-        const token_metadata_impl* _token_metadata = nullptr;
-
-        friend class token_metadata_impl;
-    };
-
+    using tokens_iterator = locator::tokens_iterator;
 public:
     struct config {
         topology::config topo_cfg;


### PR DESCRIPTION
Reduce dependency load by standardizing on std::ranges. This is a little
involved since a we use a custom iterator.

Code cleanup; no backport.