### PR TITLE
serializer: drop dependency on boost ranges

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -25,6 +25,8 @@
 #include "utils/human_readable.hh"
 #include "utils/memory_limit_reached.hh"
 
+#include <boost/range/algorithm/for_each.hpp>
+
 logger rcslog("reader_concurrency_semaphore");
 
 struct reader_concurrency_semaphore::inactive_read {

--- a/serializer.hh
+++ b/serializer.hh
@@ -18,7 +18,6 @@
 #include "utils/fragment_range.hh"
 #include <variant>
 
-#include <boost/range/algorithm/for_each.hpp>
 #include <boost/type.hpp>
 
 namespace ser {
@@ -155,11 +154,10 @@ public:
 
     bytes linearize() const {
         bytes b(bytes::initialized_later(), size_bytes());
-        using boost::range::for_each;
         auto dst = b.begin();
-        for_each(*this, [&] (bytes_view fragment) {
+        for (bytes_view fragment : *this) {
             dst = std::copy(fragment.begin(), fragment.end(), dst);
-        });
+        }
         return b;
     }
 

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -17,6 +17,7 @@
 #include <boost/range/algorithm_ext.hpp>
 #include <boost/range/adaptor/indexed.hpp>
 #include <boost/range/adaptor/filtered.hpp>
+#include <boost/range/algorithm/for_each.hpp>
 #include <json/json.h>
 #include <fmt/ranges.h>
 #include "test/lib/cql_test_env.hh"

--- a/test/perf/perf_mutation_readers.cc
+++ b/test/perf/perf_mutation_readers.cc
@@ -13,6 +13,7 @@
 
 #include <boost/range/adaptor/sliced.hpp>
 #include <boost/range/adaptor/strided.hpp>
+#include <boost/range/algorithm/for_each.hpp>
 
 #include "test/lib/simple_schema.hh"
 #include "test/lib/simple_position_reader_queue.hh"


### PR DESCRIPTION
The call to boost::range::for_each is easily replaced with ranged for.

Code cleanup; no backport.