### PR TITLE
fix(test.py): adjust break_manager method

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1482,7 +1482,6 @@ class ScyllaClusterManager:
         # make ScyllaClusterManager not operatable from client side
         self.logger.error(" %s, test case {test} BROKE ScyllaClusterManager", reason)
         self.server_broken_event.set()
-        self._mark_dirty(None)
 
     async def _mark_dirty(self, _request) -> None:
         """Mark current cluster dirty"""


### PR DESCRIPTION
remove unnecessary _mark_dirty call 

server_broken_event - stop the whole file execution (prevent the next tests from running because Pyhon server object is broken PR: https://github.com/scylladb/scylladb/pull/18236). and next file execution will create its new cluster
so _mark_dirty will not change anything
