### PR TITLE
compaction: remove unused "#include"

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -21,7 +21,6 @@
 #include "utils/updateable_value.hh"
 #include "utils/serialized_action.hh"
 #include <vector>
-#include <list>
 #include <functional>
 #include "compaction.hh"
 #include "compaction_backlog_manager.hh"


### PR DESCRIPTION
we don't use `std::list` in compaction/compaction_manager.hh, neither is this header responsible for exposing the declarations in `<list>`. so let's stop `#include` this header.

---

it's a cleanup, hence no need to backport.