### PR TITLE
lang, .github: remove unused includes, add more directories to CLEANER_DIR

### DIFF
--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -9,7 +9,9 @@ env:
   BUILD_TYPE: RelWithDebInfo
   BUILD_DIR: build
   CLEANER_OUTPUT_PATH: build/clang-include-cleaner.log
-  CLEANER_DIRS: test/unit exceptions alternator api auth cdc compaction db dht gms
+  # the "idl" subdirectory does not contain C++ source code. the .hh files in it are
+  # supposed to be processed by idl-compiler.py, so we don't check them using the cleaner
+  CLEANER_DIRS: test/unit exceptions alternator api auth cdc compaction db dht gms index lang
 
 permissions: {}
 

--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -45,6 +45,7 @@
 #include "cql3/functions/user_function.hh"
 #include "cql3/functions/user_aggregate.hh"
 #include "utils/overloaded_functor.hh"
+#include "db/config.hh"
 #include "db/system_keyspace.hh"
 #include "db/extensions.hh"
 #include "utils/sorting.hh"

--- a/lang/wasm.hh
+++ b/lang/wasm.hh
@@ -15,7 +15,6 @@
 #include "rust/wasmtime_bindings.hh"
 #include "lang/wasm_instance_cache.hh"
 #include "lang/wasm_alien_thread_runner.hh"
-#include "db/config.hh"
 
 namespace wasm {
 


### PR DESCRIPTION
in this series:

- remove unused `#include` in "lang" subdirectory
- add index and lang to CLEANER_DIR

---

cleanup and improvements in the CI, hence no need to backport.