### PR TITLE
utils/to_string: do not include fmt/ostream.h

### DIFF
--- a/utils/to_string.hh
+++ b/utils/to_string.hh
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <fmt/format.h>
-#include <fmt/ostream.h>
 #if FMT_VERSION >= 100000
 #include <fmt/std.h>
 #else


### PR DESCRIPTION
to_string.hh does not use this header, neither is it obliged to expose the content of this header. so, let's remove this include.

---

it's a cleanup, hence no need to backport.