### PR TITLE
locator: tablet_metadata_guard: forward declare database

### DIFF
--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -16,6 +16,7 @@
 #include "compaction/task_manager_module.hh"
 #include "service/storage_service.hh"
 #include "tasks/task_manager.hh"
+#include "replica/database.hh"
 
 using namespace seastar::httpd;
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -47,6 +47,7 @@
 #include "replica/query.hh"
 #include "types/types.hh"
 #include "service/raft/raft_group0_client.hh"
+#include "replica/database.hh"
 
 #include <unordered_map>
 

--- a/locator/tablet_metadata_guard.hh
+++ b/locator/tablet_metadata_guard.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "replica/database.hh"
+#include "replica/database_fwd.hh"
 #include "locator/tablets.hh"
 #include "locator/abstract_replication_strategy.hh"
 

--- a/node_ops/node_ops_ctl.cc
+++ b/node_ops/node_ops_ctl.cc
@@ -11,6 +11,7 @@
 #include "message/messaging_service.hh"
 #include "node_ops/node_ops_ctl.hh"
 #include "service/storage_service.hh"
+#include "replica/database.hh"
 
 #include <fmt/ranges.h>
 #include <seastar/core/sleep.hh>


### PR DESCRIPTION
No need to bring in a heavy databas.hh dependency.

Code cleanup; no backport.