### PR TITLE
bytes_ostream: replace boost ranges with std ranges

### DIFF
--- a/bytes_ostream.hh
+++ b/bytes_ostream.hh
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <boost/range/iterator_range.hpp>
-
 #include "bytes.hh"
 #include "utils/assert.hh"
 #include "utils/managed_bytes.hh"
@@ -17,11 +15,13 @@
 #include <seastar/core/loop.hh>
 #include <bit>
 #include <concepts>
+#include <ranges>
 
 
 class bytes_ostream_fragment_iterator {
 public:
     using iterator_category = std::input_iterator_tag;
+    using iterator_concept = std::input_iterator_tag;
     using value_type = bytes_view;
     using difference_type = std::ptrdiff_t;
     using pointer = bytes_view*;
@@ -362,7 +362,7 @@ public:
 
     output_iterator write_begin() { return output_iterator(*this); }
 
-    boost::iterator_range<fragment_iterator> fragments() const {
+    std::ranges::subrange<fragment_iterator> fragments() const {
         return { begin(), end() };
     }
 

--- a/bytes_ostream.hh
+++ b/bytes_ostream.hh
@@ -18,6 +18,49 @@
 #include <bit>
 #include <concepts>
 
+
+class bytes_ostream_fragment_iterator {
+public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = bytes_view;
+    using difference_type = std::ptrdiff_t;
+    using pointer = bytes_view*;
+    using reference = bytes_view&;
+public:
+    using chunk = multi_chunk_blob_storage;
+    struct implementation {
+        chunk* current_chunk;
+    };
+private:
+    chunk* _current = nullptr;
+public:
+    bytes_ostream_fragment_iterator() = default;
+    bytes_ostream_fragment_iterator(chunk* current) : _current(current) {}
+    bytes_ostream_fragment_iterator(const bytes_ostream_fragment_iterator&) = default;
+    bytes_ostream_fragment_iterator& operator=(const bytes_ostream_fragment_iterator&) = default;
+    bytes_view operator*() const {
+        return { _current->data, _current->frag_size };
+    }
+    bytes_view operator->() const {
+        return *(*this);
+    }
+    bytes_ostream_fragment_iterator& operator++() {
+        _current = _current->next;
+        return *this;
+    }
+    bytes_ostream_fragment_iterator operator++(int) {
+        bytes_ostream_fragment_iterator tmp(*this);
+        ++(*this);
+        return tmp;
+    }
+    bool operator==(const bytes_ostream_fragment_iterator&) const = default;
+    implementation extract_implementation() const {
+        return implementation {
+            .current_chunk = _current,
+        };
+    }
+};
+
 /**
  * Utility for writing data into a buffer when its final size is not known up front.
  *
@@ -46,46 +89,7 @@ private:
     size_type _size;
     size_type _initial_chunk_size = default_chunk_size;
 public:
-    class fragment_iterator {
-    public:
-        using iterator_category = std::input_iterator_tag;
-        using value_type = bytes_view;
-        using difference_type = std::ptrdiff_t;
-        using pointer = bytes_view*;
-        using reference = bytes_view&;
-
-        struct implementation {
-            chunk* current_chunk;
-        };
-    private:
-        chunk* _current = nullptr;
-    public:
-        fragment_iterator() = default;
-        fragment_iterator(chunk* current) : _current(current) {}
-        fragment_iterator(const fragment_iterator&) = default;
-        fragment_iterator& operator=(const fragment_iterator&) = default;
-        bytes_view operator*() const {
-            return { _current->data, _current->frag_size };
-        }
-        bytes_view operator->() const {
-            return *(*this);
-        }
-        fragment_iterator& operator++() {
-            _current = _current->next;
-            return *this;
-        }
-        fragment_iterator operator++(int) {
-            fragment_iterator tmp(*this);
-            ++(*this);
-            return tmp;
-        }
-        bool operator==(const fragment_iterator&) const = default;
-        implementation extract_implementation() const {
-            return implementation {
-                .current_chunk = _current,
-            };
-        }
-    };
+    using fragment_iterator = bytes_ostream_fragment_iterator;
     using const_iterator = fragment_iterator;
 
     class output_iterator {


### PR DESCRIPTION
To reduce the dependency load, replace boost ranges with std::ranges.

Cleanup; no backport.