### PR TITLE
Update report-scylla-problem.rst removing references to old Health Check Report

### DIFF
--- a/docs/troubleshooting/report-scylla-problem.rst
+++ b/docs/troubleshooting/report-scylla-problem.rst
@@ -279,17 +279,12 @@ Once you have collected and compressed your reports, send them to ScyllaDB for a
    curl -X PUT https://upload.scylladb.com/$report_uuid/yourfile -T yourfile
 
 
-For example with the health check report and node health check report:
-
-
-.. code-block:: shell
-
-   curl -X PUT https://upload.scylladb.com/$report_uuid/output_files.tgz -T output_files.tgz
+For example with the Scylla Doctor's vitals:
 
   
 .. code-block:: shell
  
-   curl -X PUT https://upload.scylladb.com/$report_uuid/192.0.2.0-health-check-report.txt -T 192.0.2.0-health-check-report.txt
+   curl -X PUT https://upload.scylladb.com/$report_uuid/my_cluster_123_vitals.tgz -T my_cluster_123_vitals.tgz
 
 
 The **UUID** you generated replaces the variable ``$report_uuid`` at runtime. ``yourfile`` is any file you need to send to ScyllaDB support.


### PR DESCRIPTION
The health check report is the old method for gathering troubleshooting information. It was replaced by Scylla Doctor vitals and this was already updated in the documentation. This PR just removes the remaining Health Check references in the page. 