### PR TITLE
.github/scripts/auto-backport.py: update method to get closed prs

### DIFF
--- a/.github/scripts/auto-backport.py
+++ b/.github/scripts/auto-backport.py
@@ -150,7 +150,10 @@ def main():
         start_commit, end_commit = args.commits.split('..')
         commits = repo.compare(start_commit, end_commit).commits
         for commit in commits:
-            for pr in commit.get_pulls():
+            match = re.search(rf"Closes .*#([0-9]+)", commit.commit.message, re.IGNORECASE)
+            if match:
+                pr_number = int(match.group(1))
+                pr = repo.get_pull(pr_number)
                 closed_prs.append(pr)
     if args.pull_request:
         start_commit = args.head_commit


### PR DESCRIPTION
`commit.get_pulls()` in PyGithub returns pull requests that are directly associated with the given commit

Since it closed PR., the relevant commit is an event type, and the backport automation didn't get the PR info for backporting

Ref: https://github.com/scylladb/scylladb/issues/18973

**Backport automation fix, need to be backported to all active releases**