### PR TITLE
main,cql_test_env: start group0_service before view_builder

### DIFF
--- a/api/raft.cc
+++ b/api/raft.cc
@@ -103,8 +103,8 @@ void set_raft(http_context&, httpd::routes& r, sharded<service::raft_group_regis
 
         if (!req->query_parameters.contains("group_id")) {
             // Read barrier on group 0 by default
-            co_await raft_gr.invoke_on(0, [timeout] (service::raft_group_registry& raft_gr) {
-                return raft_gr.group0_with_timeouts().read_barrier(nullptr, timeout);
+            co_await raft_gr.invoke_on(0, [timeout] (service::raft_group_registry& raft_gr) -> future<> {
+                co_await raft_gr.group0_with_timeouts().read_barrier(nullptr, timeout);
             });
             co_return json_void{};
         }
@@ -112,12 +112,12 @@ void set_raft(http_context&, httpd::routes& r, sharded<service::raft_group_regis
         raft::group_id gid{utils::UUID{req->get_query_param("group_id")}};
 
         std::atomic<bool> found_srv{false};
-        co_await raft_gr.invoke_on_all([gid, timeout, &found_srv] (service::raft_group_registry& raft_gr) {
+        co_await raft_gr.invoke_on_all([gid, timeout, &found_srv] (service::raft_group_registry& raft_gr) -> future<> {
             if (!raft_gr.find_server(gid)) {
-                return make_ready_future<>();
+                co_return;
             }
             found_srv = true;
-            return raft_gr.get_server_with_timeouts(gid).read_barrier(nullptr, timeout);
+            co_await raft_gr.get_server_with_timeouts(gid).read_barrier(nullptr, timeout);
         });
 
         if (!found_srv) {

--- a/main.cc
+++ b/main.cc
@@ -1672,6 +1672,18 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 sys_dist_ks.invoke_on_all(&db::system_distributed_keyspace::stop).get();
             });
 
+            group0_service.start().get();
+            auto stop_group0_service = defer_verbose_shutdown("group 0 service", [&group0_service] {
+                sl_controller.local().abort_group0_operations();
+                group0_service.abort().get();
+            });
+
+            utils::get_local_injector().inject("stop_after_starting_group0_service",
+                [] { std::raise(SIGSTOP); });
+
+            // Set up group0 service earlier since it is needed by group0 setup just below
+            ss.local().set_group0(group0_service);
+
             supervisor::notify("starting view update generator");
             view_update_generator.start(std::ref(db), std::ref(proxy), std::ref(stop_signal.as_sharded_abort_source())).get();
             auto stop_view_update_generator = defer_verbose_shutdown("view update generator", [] {
@@ -1942,18 +1954,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
              * the system keyspace started and nobody seemed to have any troubles.
              */
             db.local().enable_autocompaction_toggle();
-
-            group0_service.start().get();
-            auto stop_group0_service = defer_verbose_shutdown("group 0 service", [&group0_service] {
-                sl_controller.local().abort_group0_operations();
-                group0_service.abort().get();
-            });
-
-            utils::get_local_injector().inject("stop_after_starting_group0_service",
-                [] { std::raise(SIGSTOP); });
-
-            // Set up group0 service earlier since it is needed by group0 setup just below
-            ss.local().set_group0(group0_service);
 
             const auto generation_number = gms::generation_type(sys_ks.local().increment_and_get_generation().get());
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -909,6 +909,13 @@ private:
                 _group0_registry.invoke_on_all(&service::raft_group_registry::drain_on_shutdown).get();
             });
 
+            group0_service.start().get();
+            auto stop_group0_service = defer([&group0_service] {
+                group0_service.abort().get();
+            });
+
+            _ss.local().set_group0(group0_service);
+
             _view_update_generator.start(std::ref(_db), std::ref(_proxy), std::ref(abort_sources)).get();
             _view_update_generator.invoke_on_all(&db::view::view_update_generator::start).get();
             auto stop_view_update_generator = defer([this] {
@@ -957,13 +964,6 @@ private:
             auto stop_cdc_service = defer([this] {
                 _cdc.stop().get();
             });
-
-            group0_service.start().get();
-            auto stop_group0_service = defer([&group0_service] {
-                group0_service.abort().get();
-            });
-
-            _ss.local().set_group0(group0_service);
 
             const auto generation_number = gms::generation_type(_sys_ks.local().increment_and_get_generation().get());
 


### PR DESCRIPTION
In scylladb/scylladb#19745, view_builder was migrated to group0 and since then it is dependant on group0_service.
Because of this, group0_service should be initialized/destroyed before/after view_builder.

This patch also adds error injection to `raft_server_with_timeouts::read_barrier`, which does 1s sleep before doing the read barrier. There is a new test which reproduces the use after free bug using the error injection.

Fixes scylladb/scylladb#20772

scylladb/scylladb#19745 is present in 6.2, so this fix should be backported to it.