### PR TITLE
build: cmake: s/idle_compiler/idl_compiler/

### DIFF
--- a/idl/CMakeLists.txt
+++ b/idl/CMakeLists.txt
@@ -17,7 +17,7 @@ function(compile_idl input)
   add_custom_command(
     OUTPUT ${output}
     COMMAND ${Python3_EXECUTABLE} ${idl_compiler} --ns ser -f ${input} -o ${output}
-    DEPENDS ${idle_compiler} ${input})
+    DEPENDS ${idl_compiler} ${input})
   set(${parsed_args_SOURCES} ${output} PARENT_SCOPE)
 endfunction(compile_idl)
 


### PR DESCRIPTION
before this change, the header files generated with `idl-compiler.py` are not regenerated if `idl-compiler.py` is updated. but they should, as the change to the script could in turn change the generated header files. because we have a typo in the `DEPENDS` argument, `${idle_compiler}` is expanded to an empty string.

in this change, the typo is corrected, and the dependency from the generated headers to the script is correctly reflected in the building rules.

---

cmake related change, hence no need to backport.