### PR TITLE
bytes, utils: include fmt/iostream.h and iostream when appropriate

### DIFF
--- a/bytes.cc
+++ b/bytes.cc
@@ -7,6 +7,7 @@
  */
 
 #include "bytes.hh"
+#include <fmt/ostream.h>
 #include <seastar/core/print.hh>
 
 static inline int8_t hex_to_int(unsigned char c) {

--- a/utils/estimated_histogram.hh
+++ b/utils/estimated_histogram.hh
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <vector>
 #include <chrono>
+#include <fmt/ostream.h>
 #include <seastar/core/metrics_types.hh>
 #include <seastar/core/print.hh>
 #include "seastarx.hh"

--- a/utils/rjson.hh
+++ b/utils/rjson.hh
@@ -26,6 +26,7 @@
  * or calling Size() on a non-array value.
  */
 
+#include <iostream>
 #include <string>
 #include <string_view>
 #include <type_traits>

--- a/utils/uuid.cc
+++ b/utils/uuid.cc
@@ -13,6 +13,7 @@
 #include <boost/iterator/function_input_iterator.hpp>
 #include <boost/algorithm/string.hpp>
 #include <string>
+#include <fmt/ostream.h>
 #include <seastar/core/sstring.hh>
 #include "marshal_exception.hh"
 


### PR DESCRIPTION
in seastar e96932b05f394b27cd0101e24f0584736795b50f, we stopped including unused `fmt/ostream.h`. this helped to reduce the header dependency. but this also broke the build of scylladb, as we rely on the `fmt/ostream.h` indirectly included by seastar's header project.

in this change, we include `fmt/iostream.h` and `iostream` explictly when we are using the declarations in them. this enables us to

- bump up the seastar submodule
- potentially reduce the header dependency as we will be able to include seastar/core/format.hh instead of a more bloated seastar/core/print.hh after bumping up seastar submodule

---

it's a cleanup, hence no need to backport.