### PR TITLE
treewide: replace boost::find_if with std::ranges::find_if

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -4677,7 +4677,7 @@ future<executor::request_return_type> executor::list_tables(client_state& client
     // is an implicit order of elements that Dynamo imposes.
     auto table_names_it = [&table_names, &exclusive_start] {
         if (!exclusive_start.empty()) {
-            auto it = boost::find_if(table_names, [&exclusive_start] (const sstring& table_name) { return table_name == exclusive_start; });
+            auto it = std::ranges::find_if(table_names, [&exclusive_start] (const sstring& table_name) { return table_name == exclusive_start; });
             return std::next(it, it != table_names.end());
         } else {
             return table_names.begin();

--- a/combine.hh
+++ b/combine.hh
@@ -25,8 +25,8 @@ combine(InputIterator1 begin1, InputIterator1 end1,
         Compare compare,
         Merge merge) {
     while (begin1 != end1 && begin2 != end2) {
-        auto& e1 = *begin1;
-        auto& e2 = *begin2;
+        std::iter_const_reference_t<InputIterator1> e1 = *begin1;
+        std::iter_const_reference_t<InputIterator2> e2 = *begin2;
         if (compare(e1, e2)) {
             *out++ = e1;
             ++begin1;

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -320,7 +320,7 @@ static value_set possible_lhs_values(const column_definition* cdef,
                             if (!cdef) {
                                 return unbounded_value_set;
                             }
-                            const auto found = boost::find_if(
+                            const auto found = std::ranges::find_if(
                                     tuple.elements, [&] (const expression& c) { return expr::as<column_value>(c).col == cdef; });
                             if (found == tuple.elements.end()) {
                                 return unbounded_value_set;

--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -14,7 +14,6 @@
 #include <boost/range/adaptor/indirected.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/algorithm/find_if.hpp>
 
 #include "clustering_bounds_comparator.hh"
 #include "replica/database_fwd.hh"
@@ -197,10 +196,10 @@ static future<std::vector<token_range>> get_local_ranges(replica::database& db, 
         // We merge the ranges to be compatible with how Cassandra shows it's size estimates table.
         // All queries will be on that table, where all entries are text and there's no notion of
         // token ranges form the CQL point of view.
-        auto left_inf = boost::find_if(ranges, [] (auto&& r) {
+        auto left_inf = std::ranges::find_if(ranges, [] (auto&& r) {
             return r.end() && (!r.start() || r.start()->value().is_minimum());
         });
-        auto right_inf = boost::find_if(ranges, [] (auto&& r) {
+        auto right_inf = std::ranges::find_if(ranges, [] (auto&& r) {
             return r.start() && (!r.end() || r.end()->value().is_maximum());
         });
         if (left_inf != right_inf && left_inf != ranges.end() && right_inf != ranges.end()) {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -17,7 +17,6 @@
 #include <vector>
 #include <algorithm>
 
-#include <boost/range/algorithm/find_if.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/algorithm/transform.hpp>
 #include <boost/range/algorithm/copy.hpp>
@@ -2498,7 +2497,7 @@ void view_builder::on_update_view(const sstring& ks_name, const sstring& view_na
         if (step_it == _base_to_build_step.end()) {
             return;// In case all the views for this CF have finished building already.
         }
-        auto status_it = boost::find_if(step_it->second.build_status, [view] (const view_build_status& bs) {
+        auto status_it = std::ranges::find_if(step_it->second.build_status, [view] (const view_build_status& bs) {
             return bs.view->id() == view->id();
         });
         if (status_it != step_it->second.build_status.end()) {

--- a/index/secondary_index.cc
+++ b/index/secondary_index.cc
@@ -13,7 +13,6 @@
 #include "cql3/statements/index_target.hh"
 
 #include <boost/regex.hpp>
-#include <boost/range/algorithm/find_if.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <seastar/util/log.hh>
 

--- a/locator/util.cc
+++ b/locator/util.cc
@@ -129,10 +129,10 @@ describe_ring(const replica::database& db, const gms::gossiper& gossiper, const 
         co_await coroutine::maybe_yield();
     }
     // Convert to wrapping ranges
-    auto left_inf = boost::find_if(ranges, [] (const dht::token_range_endpoints& tr) {
+    auto left_inf = std::ranges::find_if(ranges, [] (const dht::token_range_endpoints& tr) {
         return tr._start_token.empty();
     });
-    auto right_inf = boost::find_if(ranges, [] (const dht::token_range_endpoints& tr) {
+    auto right_inf = std::ranges::find_if(ranges, [] (const dht::token_range_endpoints& tr) {
         return tr._end_token.empty();
     });
     using set = std::unordered_set<sstring>;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -34,7 +34,6 @@
 #include "sstables/sstables.hh"
 #include "sstables/sstables_manager.hh"
 #include <boost/range/adaptor/map.hpp>
-#include <boost/range/algorithm/find_if.hpp>
 #include <boost/range/algorithm/min_element.hpp>
 #include <boost/container/static_vector.hpp>
 #include "mutation/frozen_mutation.hh"
@@ -173,7 +172,7 @@ phased_barrier_top_10_counts(const database::tables_metadata& tables_metadata, s
             return;
         }
 
-        auto it = boost::find_if(res, [count] (const count_and_tables& x) {
+        auto it = std::ranges::find_if(res, [count] (const count_and_tables& x) {
             return x.first == count;
         });
         if (it != res.end()) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5717,7 +5717,7 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                     case node_state::normal: {
                         // If asked to stream a node in normal state it means that remove operation is running
                         // Find the node that is been removed
-                        auto it = boost::find_if(_topology_state_machine._topology.transition_nodes, [] (auto& e) { return e.second.state == node_state::removing; });
+                        auto it = std::ranges::find_if(_topology_state_machine._topology.transition_nodes, [] (auto& e) { return e.second.state == node_state::removing; });
                         if (it == _topology_state_machine._topology.transition_nodes.end()) {
                             rtlogger.warn("got stream_ranges request while my state is normal but cannot find a node that is been removed");
                             break;

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <boost/range/algorithm/find_if.hpp>
 #include <iostream>
 #include <unordered_set>
 #include <unordered_map>

--- a/sstables/compress.cc
+++ b/sstables/compress.cc
@@ -9,7 +9,6 @@
 #include <stdexcept>
 #include <cstdlib>
 
-#include <boost/range/algorithm/find_if.hpp>
 #include <seastar/core/align.hh>
 #include <seastar/core/bitops.hh>
 #include <seastar/core/byteorder.hh>
@@ -76,7 +75,7 @@ inline bit_displacement displacement_for(uint64_t prefix_bits, uint8_t size_bits
 std::pair<bucket_info, segment_info> params_for_chunk_size(uint32_t chunk_size) {
     const uint8_t chunk_size_log2 = log2ceil(chunk_size);
 
-    auto it = boost::find_if(bucket_infos, [&] (const bucket_info& bi) {
+    auto it = std::ranges::find_if(bucket_infos, [&] (const bucket_info& bi) {
         return bi.chunk_size_log2 == chunk_size_log2;
     });
 
@@ -89,7 +88,7 @@ std::pair<bucket_info, segment_info> params_for_chunk_size(uint32_t chunk_size) 
     }
 
     auto b = *it;
-    auto s = *boost::find_if(segment_infos, [&] (const segment_info& si) {
+    auto s = *std::ranges::find_if(segment_infos, [&] (const segment_info& si) {
         return si.data_size_log2 == b.best_data_size_log2 && si.chunk_size_log2 == b.chunk_size_log2;
     });
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -56,7 +56,6 @@
 #include <stdio.h>
 #include <ftw.h>
 #include <unistd.h>
-#include <boost/range/algorithm/find_if.hpp>
 #include <boost/icl/interval_map.hpp>
 #include <seastar/testing/test_case.hh>
 #include "test/lib/test_services.hh"
@@ -3613,7 +3612,7 @@ SEASTAR_TEST_CASE(partial_sstable_run_filtered_out_test) {
 
         auto generation_exists = [&cf] (sstables::generation_type generation) {
             auto sstables = cf->get_sstables();
-            auto entry = boost::range::find_if(*sstables, [generation] (shared_sstable sst) { return generation == sst->generation(); });
+            auto entry = std::ranges::find_if(*sstables, [generation] (shared_sstable sst) { return generation == sst->generation(); });
             return entry != sstables->end();
         };
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -42,7 +42,6 @@
 #include <stdio.h>
 #include <ftw.h>
 #include <unistd.h>
-#include <boost/range/algorithm/find_if.hpp>
 #include <boost/algorithm/cxx11/is_sorted.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/icl/interval_map.hpp>
@@ -2167,7 +2166,7 @@ SEASTAR_TEST_CASE(test_wrong_counter_shard_order) {
                     auto acv = ac_o_c.as_atomic_cell(s->regular_column_at(id));
                     counter_cell_view ccv(acv);
                     counter_shard_view::less_compare_by_id cmp;
-                    BOOST_REQUIRE_MESSAGE(boost::algorithm::is_sorted(ccv.shards(), cmp),
+                    BOOST_REQUIRE_MESSAGE(std::ranges::is_sorted(ccv.shards(), cmp),
                                           fmt::format("{} is expected to be sorted", ccv));
                     BOOST_REQUIRE_EQUAL(ccv.total_value(), expected_value);
                     n++;

--- a/test/lib/data_model.cc
+++ b/test/lib/data_model.cc
@@ -41,7 +41,7 @@ mutation_description::row_marker::row_marker(api::timestamp_type timestamp, gc_c
 { }
 
 void mutation_description::remove_column(row& r, const sstring& name) {
-    auto it = boost::range::find_if(r, [&] (const cell& c) {
+    auto it = std::ranges::find_if(r, [&] (const cell& c) {
         return c.column_name == name;
     });
     if (it != r.end()) {
@@ -226,7 +226,7 @@ mutation mutation_description::build(schema_ptr s) const {
 }
 
 std::vector<table_description::column>::iterator table_description::find_column(std::vector<column>& columns, const sstring& name) {
-    return boost::range::find_if(columns, [&] (const column& c) {
+    return std::ranges::find_if(columns, [&] (const column& c) {
         return std::get<sstring>(c) == name;
     });
 }

--- a/test/manual/enormous_table_scan_test.cc
+++ b/test/manual/enormous_table_scan_test.cc
@@ -19,7 +19,6 @@
 #include <boost/range/adaptor/indirected.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/algorithm/find_if.hpp>
 
 #include "dht/i_partitioner.hh"
 #include "mutation/mutation_fragment.hh"

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -603,7 +603,7 @@ schema_ptr load_system_schema(const db::config& cfg, std::string_view keyspace, 
     if (ks_it == schemas.end()) {
         throw std::invalid_argument(fmt::format("unknown system keyspace: {}", keyspace));
     }
-    auto tb_it = boost::find_if(ks_it->second, [&] (const schema_ptr& s) {
+    auto tb_it = std::ranges::find_if(ks_it->second, [&] (const schema_ptr& s) {
         return s->cf_name() == table;
     });
     if (tb_it == ks_it->second.end()) {

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -23,7 +23,6 @@
 #include <boost/make_shared.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/reversed.hpp>
-#include <boost/range/algorithm/find_if.hpp>
 #include <fmt/chrono.h>
 #include <fmt/ranges.h>
 #include <seastar/core/sleep.hh>

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -997,7 +997,7 @@ void scrub_operation(schema_ptr schema, reader_permit permit, const std::vector<
             throw std::invalid_argument("missing mandatory command-line argument --scrub-mode");
         }
         const auto mode_name = vm["scrub-mode"].as<std::string>();
-        auto mode_it = boost::find_if(scrub_modes, [&mode_name] (const std::pair<std::string, compaction_type_options::scrub::mode>& v) {
+        auto mode_it = std::ranges::find_if(scrub_modes, [&mode_name] (const std::pair<std::string, compaction_type_options::scrub::mode>& v) {
             return v.first == mode_name;
         });
         if (mode_it == scrub_modes.end()) {
@@ -2551,7 +2551,7 @@ void write_operation(schema_ptr schema, reader_permit permit, const std::vector<
     mutation_fragment_stream_validation_level validation_level;
     {
         const auto vl_name = vm["validation-level"].as<std::string>();
-        auto vl_it = boost::find_if(valid_validation_levels, [&vl_name] (const std::pair<std::string, mutation_fragment_stream_validation_level>& v) {
+        auto vl_it = std::ranges::find_if(valid_validation_levels, [&vl_name] (const std::pair<std::string, mutation_fragment_stream_validation_level>& v) {
             return v.first == vl_name;
         });
         if (vl_it == valid_validation_levels.end()) {


### PR DESCRIPTION
now that we are allowed to use C++23. we now have the luxury of using `std::ranges::find_if`.

in this change, we:

- replace `boost::find_if` with `std::ranges::find_if`
- remove all `#include <boost/range/algorithm/find_if.hpp>`

to reduce the dependency to boost for better maintainability, and leverage standard library features for better long-term support.

this change is part of our ongoing effort to modernize our codebase and reduce external dependencies where possible.

---

it's a cleanup, hence no need to backport.