### PR TITLE
.github/scripts/label_promoted_commits.py: only match the Close tag in the last line in the commit message

### DIFF
--- a/.github/scripts/label_promoted_commits.py
+++ b/.github/scripts/label_promoted_commits.py
@@ -54,7 +54,8 @@ def main():
     # Print commit information
     for commit in commits:
         print(f'Commit sha is: {commit.sha}')
-        match = pr_pattern.search(commit.commit.message)
+        pr_last_line = commit.commit.message.splitlines()[-1]
+        match = pr_pattern.search(pr_last_line)
         if match:
             pr_number = int(match.group(1))
             if pr_number in processed_prs:


### PR DESCRIPTION
When a backport PR is promoted to the release branch, we automatically close the backport PR (since GitHub will only close the one based on the default branch) and update the labels in the original PRs

In a situation when we have multiple `closes` prefixes, the script will use the first one (which is not the correct one), see https://github.com/scylladb/scylladb/commit/3ddb61c90ee1259d352ec90ee215c23f06801b04

Fixing this by always using the last line with the `closes` prefix

**Backport process fix, no need to backport since we always running this from the `master` branch**