### PR TITLE
api: Remove param field from req_param

### DIFF
--- a/api/api.hh
+++ b/api/api.hh
@@ -219,11 +219,10 @@ template <class T, class Base = T>
 class req_param {
 public:
     sstring name;
-    sstring param;
     T value;
 
     req_param(const request& req, sstring name, T default_val) : name(name) {
-        param = req.get_query_param(name);
+        sstring param = req.get_query_param(name);
         if (param.empty()) {
             value = default_val;
             return;

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -1109,7 +1109,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         api::req_param<unsigned> list_size(*req, "list_size", 10);
 
         apilog.info("toppartitions query: name={} duration={} list_size={} capacity={}",
-            name, duration.param, list_size.param, capacity.param);
+            name, duration.value, list_size.value, capacity.value);
 
         return seastar::do_with(db::toppartitions_query(ctx.db, {{ks, cf}}, {}, duration.value, list_size, capacity), [&ctx] (db::toppartitions_query& q) {
             return run_toppartitions_query(q, ctx, true);

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -611,7 +611,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         api::req_param<unsigned> list_size(*req, "list_size", 10);
 
         apilog.info("toppartitions query: #table_filters={} #keyspace_filters={} duration={} list_size={} capacity={}",
-            !table_filters.empty() ? std::to_string(table_filters.size()) : "all", !keyspace_filters.empty() ? std::to_string(keyspace_filters.size()) : "all", duration.param, list_size.param, capacity.param);
+            !table_filters.empty() ? std::to_string(table_filters.size()) : "all", !keyspace_filters.empty() ? std::to_string(keyspace_filters.size()) : "all", duration.value, list_size.value, capacity.value);
 
         return seastar::do_with(db::toppartitions_query(ctx.db, std::move(table_filters), std::move(keyspace_filters), duration.value, list_size, capacity), [&ctx] (db::toppartitions_query& q) {
             return run_toppartitions_query(q, ctx);


### PR DESCRIPTION
The req_param class is used to help parsing http request parameters from strings into exact types (typically some simple types like strings, integrals or boolean). On it there are three fields:

- name -- the parameter name
- param -- the parameter string value
- value -- the parameter value of desired type

The `param` thing is not really needed, it's only used by few places that print it into logs, but they may as well just print the `value` thing itself.

**Please replace this line with justification for the backport/\* labels added to this PR**