### PR TITLE
repair: implement tablet_repair_task_impl::release_resources

### DIFF
--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -108,6 +108,7 @@ private:
     std::vector<tablet_repair_task_meta> _metas;
     optimized_optional<abort_source::subscription> _abort_subscription;
     std::optional<int> _ranges_parallelism;
+    size_t _metas_size = 0;
 public:
     tablet_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, sstring keyspace, std::vector<sstring> tables, streaming::stream_reason reason, std::vector<tablet_repair_task_meta> metas, std::optional<int> ranges_parallelism)
         : repair_task_impl(module, id.uuid(), id.id, "keyspace", keyspace, "", "", tasks::task_id::create_null_id(), reason)
@@ -121,6 +122,10 @@ public:
     virtual tasks::is_abortable is_abortable() const noexcept override {
         return tasks::is_abortable(!_abort_subscription);
     }
+
+    virtual void release_resources() noexcept override;
+private:
+    size_t get_metas_size() const noexcept;
 protected:
     future<> run() override;
 

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -395,6 +395,7 @@ async def test_tablet_repair(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cmdline = [
         '--logger-log-level', 'repair=trace',
+        '--task-ttl-in-seconds', '3600',    # Make sure the test passes with non-zero task_ttl.
     ]
     servers = await manager.servers_add(3, cmdline=cmdline)
 


### PR DESCRIPTION
tablet_repair_task_impl keeps a vector of tablet_repair_task_meta, each of which keeps an effective_replication_map_ptr. So, after the task completes, the token metadata version will not change for task_ttl seconds.

Implement tablet_repair_task_impl::release_resources method that clears tablet_repair_task_meta vector when the task finishes.

Set task_ttl to 1h in test_tablet_repair to check whether the test won't time out.

Fixes: #21503.

Requires backport to 6.0 that introduces tablet_repair_task_impl and all later releases