### PR TITLE
tasks: add api_task_ttl for tasks started with API

### DIFF
--- a/api/api-doc/task_manager.json
+++ b/api/api-doc/task_manager.json
@@ -198,7 +198,7 @@
                "parameters":[
                   {
                      "name":"ttl",
-                     "description":"The number of seconds for which the tasks will be kept in memory after it finishes",
+                     "description":"The number of seconds for which the task started internally will be kept in memory after it finishes",
                      "required":true,
                      "allowMultiple":false,
                      "type":"long",
@@ -211,6 +211,41 @@
                "summary":"Get current ttl value",
                "type":"long",
                "nickname":"get_ttl",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+               ]
+            }
+         ]
+      },
+      {
+         "path":"/task_manager/user_ttl",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Set user task ttl in seconds and get last value",
+               "type":"long",
+               "nickname":"get_and_update_user_ttl",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"user_ttl",
+                     "description":"The number of seconds for which the task started by user will be kept in memory after it finishes",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"long",
+                     "paramType":"query"
+                  }
+               ]
+            },
+            {
+               "method":"GET",
+               "summary":"Get current user task ttl value",
+               "type":"long",
+               "nickname":"get_user_ttl",
                "produces":[
                   "application/json"
                ],

--- a/api/api-doc/task_manager_test.json
+++ b/api/api-doc/task_manager_test.json
@@ -93,6 +93,14 @@
                      "allowMultiple":false,
                      "type":"string",
                      "paramType":"query"
+                  },
+                  {
+                     "name":"user_task",
+                     "description":"A flag indicating whether a task was started by user (false by default)",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"boolean",
+                     "paramType":"query"
                   }
                ]
             },

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -792,7 +792,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
 
         auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
         auto task = co_await compaction_module.make_and_start_task<cleanup_keyspace_compaction_task_impl>(
-            {}, std::move(keyspace), db, table_infos, flush_mode::all_tables);
+            {}, std::move(keyspace), db, table_infos, flush_mode::all_tables, tasks::is_user_task::yes);
         try {
             co_await task->done();
         } catch (...) {

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -217,6 +217,21 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         uint32_t ttl = cfg.task_ttl_seconds();
         co_return json::json_return_type(ttl);
     });
+
+    tm::get_and_update_user_ttl.set(r, [&cfg] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        uint32_t user_ttl = cfg.user_task_ttl_seconds();
+        try {
+            co_await cfg.user_task_ttl_seconds.set_value_on_all_shards(req->query_parameters["user_ttl"], utils::config_file::config_source::API);
+        } catch (...) {
+            throw bad_param_exception(fmt::format("{}", std::current_exception()));
+        }
+        co_return json::json_return_type(user_ttl);
+    });
+
+    tm::get_user_ttl.set(r, [&cfg] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        uint32_t user_ttl = cfg.user_task_ttl_seconds();
+        co_return json::json_return_type(user_ttl);
+    });
 }
 
 void unset_task_manager(http_context& ctx, routes& r) {

--- a/api/task_manager_test.cc
+++ b/api/task_manager_test.cc
@@ -21,6 +21,17 @@ namespace tmt = httpd::task_manager_test_json;
 using namespace json;
 using namespace seastar::httpd;
 
+static future<tasks::task_id> make_test_task(tasks::task_manager& task_manager, sstring module_name, unsigned shard, tasks::task_id id, std::string keyspace,
+                                      std::string table, std::string entity, tasks::task_info parent_d) {
+    return task_manager.container().invoke_on(shard, [id, module = std::move(module_name), keyspace = std::move(keyspace), table = std::move(table), entity = std::move(entity), parent_d] (tasks::task_manager& tm) {
+        auto module_ptr = tm.find_module(module);
+        auto task_impl_ptr = seastar::make_shared<tasks::test_task_impl>(module_ptr, id ? id : tasks::task_id::create_random_id(), parent_d ? 0 : module_ptr->new_sequence_number(), std::move(keyspace), std::move(table), std::move(entity), parent_d.id);
+        return module_ptr->make_task(std::move(task_impl_ptr), parent_d).then([] (auto task) {
+            return task->id();
+        });
+    });
+}
+
 void set_task_manager_test(http_context& ctx, routes& r, sharded<tasks::task_manager>& tm) {
     tmt::register_test_module.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         co_await tm.invoke_on_all([] (tasks::task_manager& tm) {
@@ -60,7 +71,7 @@ void set_task_manager_test(http_context& ctx, routes& r, sharded<tasks::task_man
         }
 
         auto module = tms.local().find_module("test");
-        id = co_await module->make_task<tasks::test_task_impl>(shard, id, keyspace, table, entity, data);
+        id = co_await make_test_task(module->get_task_manager(), module->get_name(), shard, id, keyspace, table, entity, data);
         co_await tms.invoke_on(shard, [id] (tasks::task_manager& tm) {
             auto it = tm.get_local_tasks().find(id);
             if (it != tm.get_local_tasks().end()) {

--- a/api/task_manager_test.cc
+++ b/api/task_manager_test.cc
@@ -11,6 +11,7 @@
 #include <seastar/core/coroutine.hh>
 
 #include "task_manager_test.hh"
+#include "api/api.hh"
 #include "api/api-doc/task_manager_test.json.hh"
 #include "tasks/test_module.hh"
 #include "utils/overloaded_functor.hh"
@@ -22,10 +23,10 @@ using namespace json;
 using namespace seastar::httpd;
 
 static future<tasks::task_id> make_test_task(tasks::task_manager& task_manager, sstring module_name, unsigned shard, tasks::task_id id, std::string keyspace,
-                                      std::string table, std::string entity, tasks::task_info parent_d) {
-    return task_manager.container().invoke_on(shard, [id, module = std::move(module_name), keyspace = std::move(keyspace), table = std::move(table), entity = std::move(entity), parent_d] (tasks::task_manager& tm) {
+                                      std::string table, std::string entity, tasks::task_info parent_d, tasks::is_user_task user_task) {
+    return task_manager.container().invoke_on(shard, [id, module = std::move(module_name), keyspace = std::move(keyspace), table = std::move(table), entity = std::move(entity), parent_d, user_task] (tasks::task_manager& tm) {
         auto module_ptr = tm.find_module(module);
-        auto task_impl_ptr = seastar::make_shared<tasks::test_task_impl>(module_ptr, id ? id : tasks::task_id::create_random_id(), parent_d ? 0 : module_ptr->new_sequence_number(), std::move(keyspace), std::move(table), std::move(entity), parent_d.id);
+        auto task_impl_ptr = seastar::make_shared<tasks::test_task_impl>(module_ptr, id ? id : tasks::task_id::create_random_id(), parent_d ? 0 : module_ptr->new_sequence_number(), std::move(keyspace), std::move(table), std::move(entity), parent_d.id, user_task);
         return module_ptr->make_task(std::move(task_impl_ptr), parent_d).then([] (auto task) {
             return task->id();
         });
@@ -69,9 +70,10 @@ void set_task_manager_test(http_context& ctx, routes& r, sharded<tasks::task_man
             auto parent_ptr = co_await tasks::task_manager::lookup_task_on_all_shards(tm, data.id);
             data.shard = parent_ptr->get_status().shard;
         }
+        auto user_task = tasks::is_user_task{req_param<bool>(*req, "user_task", false)};
 
         auto module = tms.local().find_module("test");
-        id = co_await make_test_task(module->get_task_manager(), module->get_name(), shard, id, keyspace, table, entity, data);
+        id = co_await make_test_task(module->get_task_manager(), module->get_name(), shard, id, keyspace, table, entity, data, user_task);
         co_await tms.invoke_on(shard, [id] (tasks::task_manager& tm) {
             auto it = tm.get_local_tasks().find(id);
             if (it != tm.get_local_tasks().end()) {

--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -73,7 +73,7 @@ void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<service::
         }
 
         auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
-        auto task = co_await compaction_module.make_and_start_task<cleanup_keyspace_compaction_task_impl>({}, std::move(keyspace), db, table_infos, flush_mode::all_tables);
+        auto task = co_await compaction_module.make_and_start_task<cleanup_keyspace_compaction_task_impl>({}, std::move(keyspace), db, table_infos, flush_mode::all_tables, tasks::is_user_task::yes);
 
         co_return json::json_return_type(task->get_status().id.to_sstring());
     });

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -94,6 +94,8 @@ public:
                 fm.value_or(flush_mode::all_tables), consider_only_existing_data)
         , _db(db)
     {}
+
+    tasks::is_user_task is_user_task() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -125,6 +127,8 @@ public:
         , _cv(cv)
         , _current_task(current_task)
     {}
+
+    tasks::is_user_task is_user_task() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -204,17 +208,22 @@ private:
     sharded<replica::database>& _db;
     std::vector<table_info> _table_infos;
     const flush_mode _flush_mode;
+    tasks::is_user_task _is_user_task;
 public:
     cleanup_keyspace_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
             sharded<replica::database>& db,
             std::vector<table_info> table_infos,
-            flush_mode mode) noexcept
+            flush_mode mode,
+            tasks::is_user_task is_user_task) noexcept
         : cleanup_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "keyspace", std::move(keyspace), "", "", tasks::task_id::create_null_id())
         , _db(db)
         , _table_infos(std::move(table_infos))
         , _flush_mode(mode)
+        , _is_user_task(is_user_task)
     {}
+
+    tasks::is_user_task is_user_task() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -231,6 +240,8 @@ public:
     std::string type() const final {
         return "global cleanup compaction";
     }
+
+    tasks::is_user_task is_user_task() const noexcept override;
 private:
     future<> run() final;
 };
@@ -316,6 +327,8 @@ public:
         , _table_infos(std::move(table_infos))
         , _needed(needed)
     {}
+
+    tasks::is_user_task is_user_task() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -411,6 +424,8 @@ public:
     virtual std::string type() const override {
         return "upgrade " + sstables_compaction_task_impl::type();
     }
+
+    tasks::is_user_task is_user_task() const noexcept override;
 protected:
     virtual future<> run() override;
 };
@@ -495,6 +510,8 @@ public:
     virtual std::string type() const override {
         return "scrub " + sstables_compaction_task_impl::type();
     }
+
+    tasks::is_user_task is_user_task() const noexcept override;
 protected:
     virtual future<> run() override;
 };

--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -543,8 +543,11 @@ murmur3_partitioner_ignore_msb_bits: 12
 # Set to `false` to fall-back to the old algorithm.
 # enable_parallelized_aggregation: true
 
-# Time for which task manager task is kept in memory after it completes.
+# Time for which task manager task started internally is kept in memory after it completes.
 # task_ttl_in_seconds: 0
+
+# Time for which task manager task started by user is kept in memory after it completes.
+# user_task_ttl_in_seconds: 3600
 
 # In materialized views, restrictions are allowed only on the view's primary key columns.
 # In old versions Scylla mistakenly allowed IS NOT NULL restrictions on columns which were not part

--- a/db/config.cc
+++ b/db/config.cc
@@ -1139,7 +1139,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Ignore truncation record stored in system tables as if tables were never truncated.")
     , force_schema_commit_log(this, "force_schema_commit_log", value_status::Deprecated, false,
         "Use separate schema commit log unconditionally rater than after restart following discovery of cluster-wide support for it.")
-    , task_ttl_seconds(this, "task_ttl_in_seconds", liveness::LiveUpdate, value_status::Used, 0, "Time for which information about finished task stays in memory.")
+    , task_ttl_seconds(this, "task_ttl_in_seconds", liveness::LiveUpdate, value_status::Used, 0, "Time for which information about finished task started internally stays in memory.")
+    , user_task_ttl_seconds(this, "user_task_ttl_in_seconds", liveness::LiveUpdate, value_status::Used, 3600, "Time for which information about finished task started by user stays in memory.")
     , nodeops_watchdog_timeout_seconds(this, "nodeops_watchdog_timeout_seconds", liveness::LiveUpdate, value_status::Used, 120, "Time in seconds after which node operations abort when not hearing from the coordinator.")
     , nodeops_heartbeat_interval_seconds(this, "nodeops_heartbeat_interval_seconds", liveness::LiveUpdate, value_status::Used, 10, "Period of heartbeat ticks in node operations.")
     , cache_index_pages(this, "cache_index_pages", liveness::LiveUpdate, value_status::Used, true,

--- a/db/config.hh
+++ b/db/config.hh
@@ -441,6 +441,7 @@ public:
     named_value<bool> force_schema_commit_log;
 
     named_value<uint32_t> task_ttl_seconds;
+    named_value<uint32_t> user_task_ttl_seconds;
     named_value<uint32_t> nodeops_watchdog_timeout_seconds;
     named_value<uint32_t> nodeops_heartbeat_interval_seconds;
 

--- a/db/snapshot/backup_task.cc
+++ b/db/snapshot/backup_task.cc
@@ -56,6 +56,10 @@ future<tasks::task_manager::task::progress> backup_task_impl::get_progress() con
     };
 }
 
+tasks::is_user_task backup_task_impl::is_user_task() const noexcept {
+    return tasks::is_user_task::yes;
+}
+
 future<> backup_task_impl::do_backup() {
     if (!co_await file_exists(_snapshot_dir.native())) {
         throw std::invalid_argument(fmt::format("snapshot does not exist at {}", _snapshot_dir.native()));

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -44,6 +44,7 @@ public:
     virtual tasks::is_internal is_internal() const noexcept override;
     virtual tasks::is_abortable is_abortable() const noexcept override;
     virtual future<tasks::task_manager::task::progress> get_progress() const override;
+    virtual tasks::is_user_task is_user_task() const noexcept override;
 };
 
 } // snapshot namespace

--- a/docs/dev/task_manager.md
+++ b/docs/dev/task_manager.md
@@ -20,9 +20,11 @@ tasks - global, cluster-wide operations.
 # Time to live of a task
 
 Regular root tasks are kept in task manager for `task_ttl` time after
-they are finished. `task_ttl` value can be set in node configuration
-with `--task-ttl-in-seconds` option or changed with task manager API
-(`/task_manager/ttl`).
+they are finished or for `user_task_ttl` if they were started by user.
+`task_ttl` or `user_task_ttl` value can be set in node configuration
+with respectively `--task-ttl-in-seconds` or `--user-task-ttl-in-seconds`
+option or changed with task manager API (`/task_manager/ttl` or
+`/task_manager/user_ttl`).
 
 A task which isn't a root is unregistered immediately after it is
 finished and its status is folded into its parent. When a task
@@ -72,6 +74,8 @@ Briefly:
         order, unregisters the task;
 - `/task_manager/ttl` -
         gets or sets new ttl.
+- `/task_manager/user_ttl` -
+        gets or sets new user ttl.
 
 # Virtual tasks
 
@@ -99,6 +103,6 @@ are kept only on shard 0.
 # Group traits of virtual tasks
 
 - `topology_change_group`:
-    - tasks are listed for `task_ttl` after they are finished,
+    - tasks are listed for `user_task_ttl` after they are finished,
       but their statuses can be viewed as long as they are kept
       in topology_requests table.

--- a/docs/operating-scylla/admin-tools/task-manager.rst
+++ b/docs/operating-scylla/admin-tools/task-manager.rst
@@ -20,9 +20,10 @@ If a task is internal, it is unregistered from task manager immediately after it
 parent, the task's status is folded into its parent and accessible only through the parent. You won't see the statuses
 of indirect descendants (e.g. children of children) of a finished task unless they have failed.
 
-Other non-cluster tasks stay in task manager for *task_ttl* second after they are finished. task_ttl value can be set
-with ``task_ttl_in_seconds`` param or through ``/task_manager/ttl`` api. The time for which cluster tasks are visible
-in task manager isn't specified.
+Other non-cluster tasks stay in task manager for *task_ttl* seconds after they are finished or *user_task_ttl* seconds if they
+were started by user. task_ttl value can be set with ``task_ttl_in_seconds`` param or through ``/task_manager/ttl`` api.
+user_task_ttl value can be set with ``user_task_ttl_in_seconds`` param or through ``/task_manager/user_ttl`` api. The time
+for which cluster tasks are visible in task manager isn't specified.
 
 
 Task manager API
@@ -83,6 +84,10 @@ API calls
 * ``/task_manager/ttl`` - gets or sets new ttl; query params (if setting):
 
 	- *ttl* - new ttl value.
+
+* ``/task_manager/user_ttl`` - gets or sets new user ttl; query params (if setting):
+
+	- *user_ttl* - new user ttl value.
 
 Cluster tasks are not unregistered from task manager with API calls.
 

--- a/docs/operating-scylla/nodetool-commands/backup.rst
+++ b/docs/operating-scylla/nodetool-commands/backup.rst
@@ -4,6 +4,10 @@ Nodetool backup
 
 **backup** - Copy SSTables from a specified keyspace's snapshot to a designated bucket in object storage
 
+Note that status of backup can be checked for ``user_task_ttl`` seconds after the operation is done.
+You can set the ttl using :doc:`nodetool tasks user-ttl </operating-scylla/nodetool-commands/tasks/user-ttl>`.
+If ``--nowait`` flag is not set, the command relies on ``user_task_ttl`` internally.
+
 Syntax
 ------
 

--- a/docs/operating-scylla/nodetool-commands/restore.rst
+++ b/docs/operating-scylla/nodetool-commands/restore.rst
@@ -4,6 +4,10 @@ Nodetool restore
 
 **restore** - Load SSTables from a designated bucket in object store into a specified keyspace or table
 
+Note that status of restore can be checked for ``user_task_ttl`` seconds after the operation is done.
+You can set the ttl using :doc:`nodetool tasks user-ttl </operating-scylla/nodetool-commands/tasks/user-ttl>`.
+If ``--nowait`` flag is not set, the command relies on ``user_task_ttl`` internally.
+
 Syntax
 ------
 

--- a/docs/operating-scylla/nodetool-commands/tasks/index.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/index.rst
@@ -5,6 +5,7 @@ Nodetool tasks
    :hidden:
 
    abort <abort>
+   user-ttl <user-ttl>
    list <list>
    modules <modules>
    status <status>
@@ -21,6 +22,7 @@ Supported tasks suboperations
 -----------------------------
 
 * :doc:`abort </operating-scylla/nodetool-commands/tasks/abort>` - Aborts the task.
+* :doc:`user-ttl </operating-scylla/nodetool-commands/tasks/user-ttl>` - Gets or sets user_task_ttl value.
 * :doc:`list </operating-scylla/nodetool-commands/tasks/list>` - Lists tasks in the module.
 * :doc:`modules </operating-scylla/nodetool-commands/tasks/modules>` - Lists supported modules.
 * :doc:`status </operating-scylla/nodetool-commands/tasks/status>` - Gets status of the task.

--- a/docs/operating-scylla/nodetool-commands/tasks/user-ttl.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/user-ttl.rst
@@ -1,0 +1,34 @@
+Nodetool tasks user-ttl
+=======================
+**tasks user-ttl** - Gets or sets user_task_ttl value in seconds, i.e. time for which tasks started by user are kept
+in task manager after they are finished.
+
+The new value is set only in memory. To change the configuration, modify ``user_task_ttl_in_seconds`` in ``scylla.yaml``.
+You can also run Scylla with ``--user-task-ttl-in-seconds`` parameter.
+
+If user_task_ttl == 0, tasks are unregistered from task manager immediately after they are finished.
+
+Syntax
+-------
+.. code-block:: console
+
+   nodetool tasks user-ttl [--set <time_in_seconds>]
+
+Options
+-------
+
+* ``--set`` - sets user_task_ttl to the specified value.
+
+For example:
+
+Gets user_task_ttl value:
+
+.. code-block:: shell
+
+   > nodetool tasks user-ttl
+
+Sets user_task_ttl value to 10 seconds:
+
+.. code-block:: shell
+
+   > nodetool tasks user-ttl --set 10

--- a/main.cc
+++ b/main.cc
@@ -1054,6 +1054,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto get_tm_cfg = sharded_parameter([&] {
                 return tasks::task_manager::config {
                     .task_ttl = cfg->task_ttl_seconds,
+                    .user_task_ttl = cfg->user_task_ttl_seconds,
                     .broadcast_address = broadcast_addr
                 };
             });

--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -143,7 +143,7 @@ future<> node_ops_virtual_task::abort(tasks::task_id id) noexcept {
 future<std::vector<tasks::task_stats>> node_ops_virtual_task::get_stats() {
     db::system_keyspace& sys_ks = _ss._sys_ks.local();
     service::topology& topology = _ss._topology_state_machine._topology;
-    co_return boost::copy_range<std::vector<tasks::task_stats>>(co_await get_entries(sys_ks, topology, get_task_manager().get_task_ttl())
+    co_return boost::copy_range<std::vector<tasks::task_stats>>(co_await get_entries(sys_ks, topology, get_task_manager().get_user_task_ttl())
             | boost::adaptors::transformed([] (const auto& e) {
         auto id = e.first;
         auto& entry = e.second;

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1333,6 +1333,10 @@ future<int> repair_service::do_repair_start(sstring keyspace, std::unordered_map
     co_return id.id;
 }
 
+tasks::is_user_task repair::user_requested_repair_task_impl::is_user_task() const noexcept {
+    return tasks::is_user_task::yes;
+}
+
 future<> repair::user_requested_repair_task_impl::run() {
     auto module = dynamic_pointer_cast<repair::task_manager_module>(_module);
     auto& rs = module->get_repair_service();
@@ -2444,6 +2448,10 @@ future<> repair_service::repair_tablet(locator::tablet_metadata_guard& guard, lo
     auto duration = std::chrono::duration<float>(std::chrono::steady_clock::now()- start);
     rlogger.info("repair[{}]: Finished tablet repair for table={}.{} range={} duration={} replicas={} global_tablet_id={}",
             id.uuid(), keyspace_name, table_name, range, duration, replicas, gid);
+}
+
+tasks::is_user_task repair::tablet_repair_task_impl::is_user_task() const noexcept {
+    return tasks::is_user_task::yes;
 }
 
 void repair::tablet_repair_task_impl::release_resources() noexcept {

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -65,6 +65,8 @@ public:
     virtual tasks::is_abortable is_abortable() const noexcept override {
         return tasks::is_abortable::yes;
     }
+
+    tasks::is_user_task is_user_task() const noexcept override;
 protected:
     future<> run() override;
 
@@ -123,6 +125,7 @@ public:
         return tasks::is_abortable(!_abort_subscription);
     }
 
+    tasks::is_user_task is_user_task() const noexcept override;
     virtual void release_resources() noexcept override;
 private:
     size_t get_metas_size() const noexcept;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1065,7 +1065,7 @@ future<> storage_service::sstable_cleanup_fiber(raft::server& server, gate::hold
                 auto& compaction_module = _db.local().get_compaction_manager().get_task_manager_module();
                 // we flush all tables before cleanup the keyspaces individually, so skip the flush-tables step here
                 auto task = co_await compaction_module.make_and_start_task<cleanup_keyspace_compaction_task_impl>(
-                    {}, ks_name, _db, table_infos, flush_mode::skip);
+                    {}, ks_name, _db, table_infos, flush_mode::skip, tasks::is_user_task::no);
                 try {
                     co_return co_await task->done();
                 } catch (...) {

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -488,6 +488,10 @@ public:
     virtual tasks::is_internal is_internal() const noexcept override {
         return tasks::is_internal::no;
     }
+
+    virtual tasks::is_user_task is_user_task() const noexcept override {
+        return tasks::is_user_task::yes;
+    }
 };
 
 future<> sstables_loader::download_task_impl::run() {

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -621,9 +621,7 @@ future<task_manager::task_ptr> task_manager::module::make_task(task::task_impl_p
 
 task_manager::task_manager(config cfg, class abort_source& as) noexcept
     : _cfg(std::move(cfg))
-    , _update_task_ttl_action([this] { return update_task_ttl(); })
-    , _task_ttl_observer(_cfg.task_ttl.observe(_update_task_ttl_action.make_observer()))
-    , _task_ttl(_cfg.task_ttl.get())
+    , _task_ttl(_cfg.task_ttl)
     , _user_task_ttl(_cfg.user_task_ttl)
 {
     _abort_subscription = as.subscribe([this] () noexcept {
@@ -633,9 +631,7 @@ task_manager::task_manager(config cfg, class abort_source& as) noexcept
 }
 
 task_manager::task_manager() noexcept
-    : _update_task_ttl_action([this] { return update_task_ttl(); })
-    , _task_ttl_observer(_cfg.task_ttl.observe(_update_task_ttl_action.make_observer()))
-    , _task_ttl(0)
+    : _task_ttl(0)
     , _user_task_ttl(0)
 {}
 

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -624,17 +624,19 @@ task_manager::task_manager(config cfg, class abort_source& as) noexcept
     , _update_task_ttl_action([this] { return update_task_ttl(); })
     , _task_ttl_observer(_cfg.task_ttl.observe(_update_task_ttl_action.make_observer()))
     , _task_ttl(_cfg.task_ttl.get())
+    , _user_task_ttl(_cfg.user_task_ttl)
 {
     _abort_subscription = as.subscribe([this] () noexcept {
         _as.request_abort();
     });
-    tmlogger.debug("Started task manager (TTL={})", get_task_ttl());
+    tmlogger.debug("Started task manager (TTL={}) (USER TTL={})", get_task_ttl(), get_user_task_ttl());
 }
 
 task_manager::task_manager() noexcept
     : _update_task_ttl_action([this] { return update_task_ttl(); })
     , _task_ttl_observer(_cfg.task_ttl.observe(_update_task_ttl_action.make_observer()))
     , _task_ttl(0)
+    , _user_task_ttl(0)
 {}
 
 gms::inet_address task_manager::get_broadcast_address() const noexcept {
@@ -740,6 +742,10 @@ abort_source& task_manager::abort_source() noexcept {
 
 std::chrono::seconds task_manager::get_task_ttl() const noexcept {
     return std::chrono::seconds(_task_ttl);
+}
+
+std::chrono::seconds task_manager::get_user_task_ttl() const noexcept {
+    return std::chrono::seconds(_user_task_ttl);
 }
 
 void task_manager::register_module(std::string name, module_ptr module) {

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -157,6 +157,10 @@ is_internal task_manager::task::impl::is_internal() const noexcept {
     return tasks::is_internal(bool(_parent_id));
 }
 
+tasks::is_user_task task_manager::task::impl::is_user_task() const noexcept {
+    return tasks::is_user_task::no;
+}
+
 static future<> abort_children(task_manager::module_ptr module, task_id parent_id) noexcept {
     co_await utils::get_local_injector().inject("tasks_abort_children", utils::wait_for_message(10s));
 
@@ -350,6 +354,10 @@ is_abortable task_manager::task::is_abortable() const noexcept {
 
 is_internal task_manager::task::is_internal() const noexcept {
     return _impl->is_internal();
+}
+
+is_user_task task_manager::task::is_user_task() const noexcept {
+    return _impl->is_user_task();
 }
 
 void task_manager::task::abort() noexcept {

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -39,6 +39,7 @@ namespace tasks {
 
 using is_abortable = bool_class <struct abortable_tag>;
 using is_internal = bool_class<struct internal_tag>;
+using is_user_task = bool_class<struct user_task_tag>;
 
 extern logging::logger tmlogger;
 
@@ -202,6 +203,7 @@ public:
             virtual future<task_manager::task::progress> get_progress() const;
             virtual tasks::is_abortable is_abortable() const noexcept;
             virtual tasks::is_internal is_internal() const noexcept;
+            virtual tasks::is_user_task is_user_task() const noexcept;
             virtual void abort() noexcept;
             bool is_complete() const noexcept;
             bool is_done() const noexcept;
@@ -242,6 +244,7 @@ public:
         future<progress> get_progress() const;
         tasks::is_abortable is_abortable() const noexcept;
         tasks::is_internal is_internal() const noexcept;
+        tasks::is_user_task is_user_task() const noexcept;
         void abort() noexcept;
         bool abort_requested() const noexcept;
         future<> done() const noexcept;

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -59,6 +59,7 @@ public:
     enum class task_group;
     struct config {
         utils::updateable_value<uint32_t> task_ttl;
+        utils::updateable_value<uint32_t> user_task_ttl;
         gms::inet_address broadcast_address;
     };
     using task_ptr = lw_shared_ptr<task_manager::task>;
@@ -84,6 +85,7 @@ private:
     serialized_action _update_task_ttl_action;
     utils::observer<uint32_t> _task_ttl_observer;
     uint32_t _task_ttl;
+    utils::updateable_value<uint32_t> _user_task_ttl;
     netw::messaging_service* _messaging = nullptr;
 public:
     class task_not_found : public std::exception {
@@ -434,6 +436,7 @@ public:
     seastar::abort_source& abort_source() noexcept;
 public:
     std::chrono::seconds get_task_ttl() const noexcept;
+    std::chrono::seconds get_user_task_ttl() const noexcept;
 private:
     future<> update_task_ttl() noexcept {
         _task_ttl = _cfg.task_ttl.get();

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -336,18 +336,6 @@ public:
         void unregister_task(task_id id) noexcept;
         virtual future<> stop() noexcept;
     public:
-        template<typename T>
-        requires std::is_base_of_v<task_manager::task::impl, T>
-        future<task_id> make_task(unsigned shard, task_id id, std::string keyspace, std::string table, std::string entity, task_info parent_d) {
-            return _tm.container().invoke_on(shard, [id, module = _name, keyspace = std::move(keyspace), table = std::move(table), entity = std::move(entity), parent_d] (task_manager& tm) {
-                auto module_ptr = tm.find_module(module);
-                auto task_impl_ptr = seastar::make_shared<T>(module_ptr, id ? id : task_id::create_random_id(), parent_d ? 0 : module_ptr->new_sequence_number(), std::move(keyspace), std::move(table), std::move(entity), parent_d.id);
-                return module_ptr->make_task(std::move(task_impl_ptr), parent_d).then([] (auto task) {
-                    return task->id();
-                });
-            });
-        }
-
         // Must be called on target shard.
         // If task has a parent, data concerning its children is updated and sequence number is inherited
         // from a parent and set. Otherwise, it must be set by caller.

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -82,9 +82,7 @@ private:
     config _cfg;
     seastar::abort_source _as;
     optimized_optional<seastar::abort_source::subscription> _abort_subscription;
-    serialized_action _update_task_ttl_action;
-    utils::observer<uint32_t> _task_ttl_observer;
-    uint32_t _task_ttl;
+    utils::updateable_value<uint32_t> _task_ttl;
     utils::updateable_value<uint32_t> _user_task_ttl;
     netw::messaging_service* _messaging = nullptr;
 public:
@@ -437,11 +435,6 @@ public:
 public:
     std::chrono::seconds get_task_ttl() const noexcept;
     std::chrono::seconds get_user_task_ttl() const noexcept;
-private:
-    future<> update_task_ttl() noexcept {
-        _task_ttl = _cfg.task_ttl.get();
-        return make_ready_future<>();
-    }
 protected:
     void unregister_module(std::string name) noexcept;
     void register_task(task_ptr task);

--- a/tasks/test_module.hh
+++ b/tasks/test_module.hh
@@ -23,9 +23,11 @@ class test_task_impl : public task_manager::task::impl {
 private:
     promise<> _finish_run;
     bool _finished = false;
+    tasks::is_user_task _user_task;
 public:
-    test_task_impl(task_manager::module_ptr module, task_id id, uint64_t sequence_number = 0, std::string keyspace = "", std::string table = "", std::string entity = "", task_id parent_id = task_id::create_null_id()) noexcept
+    test_task_impl(task_manager::module_ptr module, task_id id, uint64_t sequence_number = 0, std::string keyspace = "", std::string table = "", std::string entity = "", task_id parent_id = task_id::create_null_id(), tasks::is_user_task user_task = tasks::is_user_task::no) noexcept
         : task_manager::task::impl(module, id, sequence_number, "test", std::move(keyspace), std::move(table), std::move(entity), parent_id)
+        , _user_task(user_task)
     {}
 
     virtual std::string type() const override {
@@ -34,6 +36,10 @@ public:
 
     future<> run() override {
         return _finish_run.get_future();
+    }
+
+    tasks::is_user_task is_user_task() const noexcept override {
+        return _user_task;
     }
 
     friend class test_task;

--- a/test/nodetool/test_tasks.py
+++ b/test/nodetool/test_tasks.py
@@ -29,6 +29,14 @@ def test_abort_failure(nodetool, scylla_only):
             {"expected_requests": []},
             ["required parameter is missing"])
 
+def test_user_ttl(nodetool, scylla_only):
+    nodetool("tasks", "user-ttl", expected_requests=[
+        expected_request("GET", "/task_manager/user_ttl")])
+
+    params = { "user_ttl": "10" }
+    nodetool("tasks", "user-ttl", "--set", params["user_ttl"], expected_requests=[
+        expected_request("POST", "/task_manager/user_ttl", params)])
+
 def test_list(nodetool, scylla_only):
     nodetool("tasks", "list", "repair", expected_requests=[
         expected_request("GET", "/task_manager/list_module_tasks/repair", response=[])])

--- a/test/rest_api/rest_util.py
+++ b/test/rest_api/rest_util.py
@@ -86,6 +86,17 @@ def set_tmp_task_ttl(rest_api, seconds):
         resp = rest_api.send("POST", "task_manager/ttl", { "ttl" : old_ttl })
         resp.raise_for_status()
 
+@contextmanager
+def set_tmp_user_task_ttl(rest_api, seconds):
+    resp = rest_api.send("POST", "task_manager/user_ttl", { "user_ttl" : seconds })
+    resp.raise_for_status()
+    old_ttl = resp.json()
+    try:
+        yield old_ttl
+    finally:
+        resp = rest_api.send("POST", "task_manager/user_ttl", { "user_ttl" : old_ttl })
+        resp.raise_for_status()
+
 # Unfortunately by default Python threads print their exceptions
 # (e.g., assertion failures) but don't propagate them to the join(),
 # so the overall test doesn't fail. The following Thread wrapper

--- a/test/topology_tasks/task_manager_client.py
+++ b/test/topology_tasks/task_manager_client.py
@@ -58,6 +58,12 @@ class TaskManagerClient():
         assert(type(old_ttl) == int)
         return old_ttl
 
+    async def set_user_task_ttl(self, node_ip: IPAddress, ttl: int) -> int:
+        """Set task ttl and get old value."""
+        old_ttl = await self.api.client.post_json("/task_manager/user_ttl", params={ "user_ttl": str(ttl) }, host=node_ip)
+        assert(type(old_ttl) == int)
+        return old_ttl
+
     async def get_task_status_recursively(self, node_ip: IPAddress, task_id: TaskID) -> list[TaskStatus]:
         """Get status of a task and all its descendants."""
         status_list = await self.api.client.get_json(f"/task_manager/task_status_recursive/{task_id}", host=node_ip)

--- a/test/topology_tasks/test_node_ops_tasks.py
+++ b/test/topology_tasks/test_node_ops_tasks.py
@@ -222,7 +222,7 @@ async def test_node_ops_tasks_ttl(manager: ManagerClient):
     tm = TaskManagerClient(manager.api)
 
     servers = [await manager.server_add() for _ in range(2)]
-    [await tm.set_task_ttl(server.ip_addr, 3) for server in servers]
+    [await tm.set_user_task_ttl(server.ip_addr, 3) for server in servers]
     time.sleep(3)
     await get_new_virtual_tasks_statuses(tm, module_name, servers, [], expected_task_num=0)
 

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -2911,6 +2911,18 @@ void tasks_abort_operation(scylla_rest_client& client, const bpo::variables_map&
     }
 }
 
+void tasks_user_ttl_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    if (!vm.contains("set")) {
+        auto res = client.get("/task_manager/user_ttl");
+        fmt::print("Current user ttl: {}\n", res);
+        return;
+    }
+    auto new_ttl = vm["set"].as<uint32_t>();
+    std::unordered_map<sstring, sstring> params = {{ "user_ttl", fmt::to_string(new_ttl) }};
+
+    auto res = client.post("/task_manager/user_ttl", std::move(params));
+}
+
 void tasks_list_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     if (!vm.contains("module")) {
         throw std::invalid_argument("required parameter is missing: module");
@@ -4219,6 +4231,20 @@ For more information, see: {}"
                             },
                         },
                         {
+                            "user-ttl",
+                            "Gets or sets user task ttl",
+fmt::format(R"(
+Gets or sets the time in seconds for which tasks started by user will be kept in task manager after
+they are finished.
+
+For more information, see: {}"
+)", doc_link("operating-scylla/nodetool-commands/tasks/user-ttl.html")),
+                            {
+                                typed_option<uint32_t>("set", "New user_task_ttl value", -1),
+                            },
+                            { },
+                        },
+                        {
                             "list",
                             "Gets a list of tasks in a given module",
 fmt::format(R"(
@@ -4317,6 +4343,9 @@ For more information, see: {}"
                 {
                     {
                         "abort", { tasks_abort_operation }
+                    },
+                    {
+                        "user-ttl", { tasks_user_ttl_operation }
                     },
                     {
                         "list", { tasks_list_operation }


### PR DESCRIPTION
When users start an operation asynchronously with API, they are expected to check the operation's status. Hence, the status should be kept in task manager for reasonable time after the operation is done. The operations that are started internally usually don't need to stay in task manager for that long.

Add api_task_ttl that will be used for tasks started with API. By default it's 1 hour. The time for which non-API tasks stay in task manager isn't changed.

Fixes: #21499.
Refs: #21425.

No backport needed - previous versions may use task_ttl