### PR TITLE
treewide: add storage_hints to reader_consumer_v2

### DIFF
--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -41,7 +41,7 @@ struct compaction_completion_desc {
 };
 
 // creates a new SSTable for a given shard
-using compaction_sstable_creator_fn = std::function<shared_sstable(shard_id shard)>;
+using compaction_sstable_creator_fn = std::function<shared_sstable(shard_id shard, storage_hints)>;
 // Replaces old sstable(s) by new one(s) which contain all non-expired data.
 using compaction_sstable_replacer_fn = std::function<void(compaction_completion_desc)>;
 

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -408,8 +408,8 @@ future<sstables::compaction_result> compaction_task_executor::compact_sstables(s
     if (can_purge) {
         descriptor.enable_garbage_collection(co_await sstable_set_for_tombstone_gc(t));
     }
-    descriptor.creator = [&t] (shard_id) {
-        return t.make_sstable();
+    descriptor.creator = [&t] (shard_id, storage_hints hints) {
+        return t.make_sstable(hints);
     };
     descriptor.replacer = [this, &t, &on_replace, offstrategy] (sstables::compaction_completion_desc desc) {
         t.get_compaction_strategy().notify_completion(t, desc.old_sstables, desc.new_sstables);
@@ -2128,8 +2128,8 @@ compaction_manager::maybe_split_sstable(sstables::shared_sstable sst, table_stat
     sstables::compaction_progress_monitor monitor;
     sstables::compaction_data info = create_compaction_data();
     sstables::compaction_descriptor desc = split_compaction_task_executor::make_descriptor(sst, opt);
-    desc.creator = [&t] (shard_id _) {
-        return t.make_sstable();
+    desc.creator = [&t] (shard_id, storage_hints hints) {
+        return t.make_sstable(hints);
     };
     desc.replacer = [&] (sstables::compaction_completion_desc d) {
         std::move(d.new_sstables.begin(), d.new_sstables.end(), std::back_inserter(ret));

--- a/compaction/table_state.hh
+++ b/compaction/table_state.hh
@@ -46,7 +46,7 @@ public:
     virtual compaction_strategy_state& get_compaction_strategy_state() noexcept = 0;
     virtual reader_permit make_compaction_reader_permit() const = 0;
     virtual sstables::sstables_manager& get_sstables_manager() noexcept = 0;
-    virtual sstables::shared_sstable make_sstable() const = 0;
+    virtual sstables::shared_sstable make_sstable(storage_hints) const = 0;
     virtual sstables::sstable_writer_config configure_writer(sstring origin) const = 0;
     virtual api::timestamp_type min_memtable_timestamp() const = 0;
     virtual api::timestamp_type min_memtable_live_timestamp() const = 0;

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -218,7 +218,7 @@ reader_consumer_v2 time_window_compaction_strategy::make_interposer_consumer(con
             && get_window_for(_options, *ms_meta.min_timestamp) == get_window_for(_options, *ms_meta.max_timestamp)) {
         return end_consumer;
     }
-    return [options = _options, end_consumer = std::move(end_consumer)] (mutation_reader rd) mutable -> future<> {
+    return [options = _options, end_consumer = std::move(end_consumer)] (mutation_reader rd, storage_hints hints) mutable -> future<> {
         return mutation_writer::segregate_by_timestamp(
                 std::move(rd),
                 classify_by_timestamp(std::move(options)),

--- a/mutation_writer/feed_writers.cc
+++ b/mutation_writer/feed_writers.cc
@@ -10,14 +10,14 @@
 
 namespace mutation_writer {
 
-bucket_writer_v2::bucket_writer_v2(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle_v2> queue_reader, reader_consumer_v2& consumer)
+bucket_writer_v2::bucket_writer_v2(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle_v2> queue_reader, reader_consumer_v2& consumer, storage_hints hints)
     : _schema(schema)
     , _handle(std::move(queue_reader.second))
-    , _consume_fut(consumer(std::move(queue_reader.first)))
+    , _consume_fut(consumer(std::move(queue_reader.first), hints))
 { }
 
-bucket_writer_v2::bucket_writer_v2(schema_ptr schema, reader_permit permit, reader_consumer_v2& consumer)
-    : bucket_writer_v2(schema, make_queue_reader_v2(schema, std::move(permit)), consumer)
+bucket_writer_v2::bucket_writer_v2(schema_ptr schema, reader_permit permit, reader_consumer_v2& consumer, storage_hints hints)
+    : bucket_writer_v2(schema, make_queue_reader_v2(schema, std::move(permit)), consumer, std::move(hints))
 { }
 
 future<> bucket_writer_v2::consume(mutation_fragment_v2 mf) {

--- a/mutation_writer/feed_writers.hh
+++ b/mutation_writer/feed_writers.hh
@@ -19,10 +19,10 @@ class bucket_writer_v2 {
     future<> _consume_fut;
 
 private:
-    bucket_writer_v2(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle_v2> queue_reader_v2, reader_consumer_v2& consumer);
+    bucket_writer_v2(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle_v2> queue_reader_v2, reader_consumer_v2& consumer, storage_hints hints);
 
 public:
-    bucket_writer_v2(schema_ptr schema, reader_permit permit, reader_consumer_v2& consumer);
+    bucket_writer_v2(schema_ptr schema, reader_permit permit, reader_consumer_v2& consumer, storage_hints hints);
 
     future<> consume(mutation_fragment_v2 mf);
 

--- a/mutation_writer/multishard_writer.cc
+++ b/mutation_writer/multishard_writer.cc
@@ -86,7 +86,7 @@ shard_writer::shard_writer(schema_ptr s,
 future<> shard_writer::consume() {
     return _reader.peek().then([this] (mutation_fragment_v2* mf_ptr) {
         if (mf_ptr) {
-            return _consumer(std::move(_reader));
+            return _consumer(std::move(_reader), storage_hints{});
         }
         return make_ready_future<>();
     });

--- a/mutation_writer/partition_based_splitting_writer.cc
+++ b/mutation_writer/partition_based_splitting_writer.cc
@@ -41,7 +41,8 @@ private:
     }
 
     future<> flush_memtable() {
-        co_await _consumer(_memtable->make_flush_reader(_schema, _permit));
+        // scrub compaction does not support tiered storage
+        co_await _consumer(_memtable->make_flush_reader(_schema, _permit), storage_hints{});
         _memtable = make_lw_shared<replica::memtable>(_schema);
     }
 
@@ -76,7 +77,8 @@ public:
         , _permit(std::move(permit))
         , _consumer(std::move(consumer))
         , _max_memory(cfg.max_memory)
-        , _bucket_writer(_schema, _permit, _consumer)
+        // scrub compaction does not support tiered storage
+        , _bucket_writer(_schema, _permit, _consumer, storage_hints{})
         , _memtable(make_lw_shared<replica::memtable>(_schema))
         , _last_pos(position_in_partition::for_partition_start())
     { }

--- a/mutation_writer/shard_based_splitting_writer.cc
+++ b/mutation_writer/shard_based_splitting_writer.cc
@@ -41,7 +41,8 @@ public:
     future<> consume(partition_start&& ps) {
         _current_shard = dht::static_shard_of(*_schema, ps.key().token()); // FIXME: Use table sharder
         if (!_shards[_current_shard]) {
-            _shards[_current_shard] = shard_writer(_schema, _permit, _consumer);
+            // resharding compaction does not support tiered storage
+            _shards[_current_shard] = shard_writer(_schema, _permit, _consumer, storage_hints{});
         }
         return write_to_shard(mutation_fragment_v2(*_schema, _permit, std::move(ps)));
     }

--- a/mutation_writer/token_group_based_splitting_writer.cc
+++ b/mutation_writer/token_group_based_splitting_writer.cc
@@ -31,7 +31,8 @@ private:
 
     inline void allocate_new_writer_if_needed() {
         if (!_current_writer) [[unlikely]] {
-            _current_writer = bucket_writer_v2(_schema, _permit, _consumer);
+            // split compaction does not support tiered storage
+            _current_writer = bucket_writer_v2(_schema, _permit, _consumer, storage_hints{});
         }
     }
 

--- a/readers/mutation_reader.hh
+++ b/readers/mutation_reader.hh
@@ -760,7 +760,10 @@ future<> consume_partitions(mutation_reader& reader, Consumer consumer) {
     });
 }
 
+struct storage_hints {
+    int64_t bucket_id = -1;
+};
 /// A consumer function that is passed a mutation_reader to be consumed from
 /// and returns a future<> resolved when the reader is fully consumed, and closed.
 /// Note: the function assumes ownership of the reader and must close it in all cases.
-using reader_consumer_v2 = std::function<future<> (mutation_reader)>;
+using reader_consumer_v2 = std::function<future<> (mutation_reader, storage_hints)>;

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3116,7 +3116,7 @@ SEASTAR_THREAD_TEST_CASE(test_scrub_segregate_stack) {
     mutation_writer::segregate_by_partition(
             make_scrubbing_reader(make_mutation_reader_from_fragments(schema, permit, std::move(all_fragments)), sstables::compaction_type_options::scrub::mode::segregate, validation_errors),
             mutation_writer::segregate_config{100000},
-            [&schema, &segregated_fragment_streams] (mutation_reader rd) {
+            [&schema, &segregated_fragment_streams] (mutation_reader rd, storage_hints) {
         return async([&schema, &segregated_fragment_streams, rd = std::move(rd)] () mutable {
             auto close = deferred_close(rd);
             auto& fragments = segregated_fragment_streams.emplace_back();

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -110,7 +110,7 @@ shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::memtable>
 future<compaction_result> compact_sstables(test_env& env, sstables::compaction_descriptor descriptor, table_for_tests t,
                  std::function<shared_sstable()> creator, sstables::compaction_sstable_replacer_fn replacer, can_purge_tombstones can_purge) {
     auto& table_s = t.as_table_state();
-    descriptor.creator = [creator = std::move(creator)] (shard_id dummy) mutable {
+    descriptor.creator = [creator = std::move(creator)] (shard_id dummy, storage_hints) mutable {
         return creator();
     };
     descriptor.replacer = std::move(replacer);

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -87,7 +87,7 @@ public:
     sstables::sstables_manager& get_sstables_manager() noexcept override {
         return _sstables_manager;
     }
-    sstables::shared_sstable make_sstable() const override {
+    sstables::shared_sstable make_sstable(storage_hints) const override {
         return table().make_sstable();
     }
     sstables::sstable_writer_config configure_writer(sstring origin) const override {

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -279,7 +279,7 @@ public:
 
                 auto descriptor = sstables::compaction_descriptor(std::move(ssts));
                 descriptor.enable_garbage_collection(cf->get_sstable_set());
-                descriptor.creator = [sst_gen = std::move(sst_gen)] (unsigned dummy) mutable {
+                descriptor.creator = [sst_gen = std::move(sst_gen)] (shard_id, storage_hints) mutable {
                     return sst_gen();
                 };
                 descriptor.replacer = sstables::replacer_fn_no_op();

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -925,7 +925,7 @@ public:
     virtual compaction_strategy_state& get_compaction_strategy_state() noexcept override { return _compaction_strategy_state; }
     virtual reader_permit make_compaction_reader_permit() const override { return _permit; }
     virtual sstables::sstables_manager& get_sstables_manager() noexcept override { return _sst_man; }
-    virtual sstables::shared_sstable make_sstable() const override { return do_make_sstable(); }
+    virtual sstables::shared_sstable make_sstable(storage_hints) const override { return do_make_sstable(); }
     virtual sstables::sstable_writer_config configure_writer(sstring origin) const override { return do_configure_writer(std::move(origin)); }
     virtual api::timestamp_type min_memtable_timestamp() const override { return api::min_timestamp; }
     virtual api::timestamp_type min_memtable_live_timestamp() const override { return api::min_timestamp; }
@@ -1013,7 +1013,7 @@ void scrub_operation(schema_ptr schema, reader_permit permit, const std::vector<
 
     auto compaction_descriptor = sstables::compaction_descriptor(std::move(sstables));
     compaction_descriptor.options = sstables::compaction_type_options::make_scrub(scrub_mode, sstables::compaction_type_options::scrub::quarantine_invalid_sstables::no);
-    compaction_descriptor.creator = [&table_state] (shard_id) { return table_state.make_sstable(); };
+    compaction_descriptor.creator = [&table_state] (shard_id, storage_hints hints) { return table_state.make_sstable(hints); };
     compaction_descriptor.replacer = [] (sstables::compaction_completion_desc) { };
 
     auto compaction_data = sstables::compaction_data{};


### PR DESCRIPTION
Add `storage_hints` parameter to communicate per-SSTable storage preferences for optimizing data placement in tiered storage scenarios. This enhances `reader_consumer_v2`'s capability to influence how `compact_for_compaction_v2` creates new SSTables.

Previously:

- `reader_consumer_v2` only accepted mutation_reader parameter
- No way to specify storage preferences for individual SSTables
- Limited control over hot/cold data segregation

Now:
- Adds `storage_hints` parameter alongside `mutation_reader`
- Enables fine-grained control over SSTable creation and placement
- Preserves backward compatibility by passing hints throughout the stack

Initial focus:
- Primarily targets time_window_compaction_strategy
- Optimizes for predictable access patterns and data distribution
- Enables better hot/cold data segregation

Technical notes:
- `storage_hints` parameter flows through entire data path
- Parameter preserved even in code paths where tiered storage is not yet supported, simplifying future extensions
- Designed to improve data locality based on temperature patterns

This is a part of the tiered storage optimization initiative.

Fixes scylladb/scylladb#21512

---

no need to backport, it's a part of an experimental feature.