### PR TITLE
docs: update admin-tools docs with deprecation and removal notice for java tools

### DIFF
--- a/docs/operating-scylla/_common/tools_index.rst
+++ b/docs/operating-scylla/_common/tools_index.rst
@@ -8,8 +8,6 @@
 * :doc:`cassandra-stress </operating-scylla/admin-tools/cassandra-stress/>` A tool for benchmarking and load testing a ScyllaDB and Cassandra clusters.
 * :doc:`SSTabledump </operating-scylla/admin-tools/sstabledump>`
 * :doc:`SSTableMetadata </operating-scylla/admin-tools/sstablemetadata>`
-* sstablelevelreset - Reset level to 0 on a selected set of SSTables that use LeveledCompactionStrategy (LCS).
-* sstablerepairedset - Mark specific SSTables as repaired or unrepaired.
 * `scyllatop <https://www.scylladb.com/2016/03/22/scyllatop/>`_ - A terminal base top-like tool for scylladb collectd/prometheus metrics.
 * :doc:`scylla_dev_mode_setup</getting-started/installation-common/dev-mod>` - run ScyllaDB in Developer Mode.
 * :doc:`perftune</operating-scylla/admin-tools/perftune>` - performance configuration.

--- a/docs/operating-scylla/admin-tools/sstabledump.rst
+++ b/docs/operating-scylla/admin-tools/sstabledump.rst
@@ -1,7 +1,7 @@
 SSTabledump
 ============
 
-.. warning:: SSTabledump is deprecated since ScyllaDB 5.4, and will be removed in a future release.
+.. warning:: SSTabledump is deprecated since ScyllaDB 5.4, and will be removed in the next release.
              Please consider switching to :doc:`ScyllaDB SSTable </operating-scylla/admin-tools/scylla-sstable>`.
 
 This tool allows you to converts SSTable into a JSON format file.

--- a/docs/operating-scylla/admin-tools/sstableloader.rst
+++ b/docs/operating-scylla/admin-tools/sstableloader.rst
@@ -3,6 +3,11 @@ SSTableLoader
 
 Bulk loads SSTables from a directory to a ScyllaDB cluster via the **CQL API**.
 
+.. warning::
+
+    SSTableLoader is deprecated since ScyllaDB 6.2 and will be removed in the next release.
+    Please consider switching to :doc:`nodetool refresh --load-and-stream </operating-scylla/nodetool-commands/refresh>`.
+
 .. note::
 
    This tool is **different than Apache Cassandra's sstableloader**, which uses an internal RPC protocol to load data.

--- a/docs/operating-scylla/admin-tools/sstablemetadata.rst
+++ b/docs/operating-scylla/admin-tools/sstablemetadata.rst
@@ -1,7 +1,7 @@
 SSTableMetadata
 ===============
 
-.. warning:: SSTableMetadata is deprecated since ScyllaDB 5.4, and will be removed in a future release.
+.. warning:: SSTableMetadata is deprecated since ScyllaDB 5.4, and will be removed in the next release.
              Please consider switching to :ref:`scylla sstable dump-statistics` and :ref:`scylla sstable dump-summary`.
 
 SSTableMetadata prints metadata in ``Statistics.db`` and ``Summary.db`` about the specified SSTables to the console.


### PR DESCRIPTION
Java tools are deprecated and slated for removal in the next ScyllaDB release.
Update the admin-tools docs and make sure all java tool documentation pages have a notice reflecting this fact.

Fixes: https://github.com/scylladb/scylladb/issues/21149

Should be backported to 6.2, so users of the latest stable version can see the notice.