### PR TITLE
test: include fmt/iostream.h and iostream when appropriate

### DIFF
--- a/test/boost/bptree_validation.hh
+++ b/test/boost/bptree_validation.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <iostream>
 #include "utils/bptree.hh"
 
 namespace bplus {


### PR DESCRIPTION
this change was created in the same spirit of aebb5329, which included the fmt/iostream.h and iostream when appropriate so that the tree can build with seastar submodule including e96932b0. in the seastar change, we stopped including unused `fmt/ostream.h` in a public header in seastar, so the parent projects relying on the header to indirectly include fmt/ostream.h and iostream would have to include these headers explicitly.

---

this change prepares the seastar submodule bump up, hence no need to backport.