### PR TITLE
De-duplicate validation of tables in some column_family API endpoints

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -921,15 +921,13 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
 
     cf::enable_auto_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) {
         apilog.info("column_family/enable_auto_compaction: name={}", req->get_path_param("name"));
-        auto [ks, cf] = parse_fully_qualified_cf_name(req->get_path_param("name"));
-        auto ti = table_info{ .name = cf, .id = get_uuid(ks, cf, ctx.db.local()) };
+        auto ti = parse_table_info(req->get_path_param("name"), ctx.db.local());
         return set_tables_autocompaction(ctx, {std::move(ti)}, true);
     });
 
     cf::disable_auto_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) {
         apilog.info("column_family/disable_auto_compaction: name={}", req->get_path_param("name"));
-        auto [ks, cf] = parse_fully_qualified_cf_name(req->get_path_param("name"));
-        auto ti = table_info{ .name = cf, .id = get_uuid(ks, cf, ctx.db.local()) };
+        auto ti = parse_table_info(req->get_path_param("name"), ctx.db.local());
         return set_tables_autocompaction(ctx, {std::move(ti)}, false);
     });
 
@@ -957,15 +955,13 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
 
     cf::enable_tombstone_gc.set(r, [&ctx](std::unique_ptr<http::request> req) {
         apilog.info("column_family/enable_tombstone_gc: name={}", req->get_path_param("name"));
-        auto [ks, cf] = parse_fully_qualified_cf_name(req->get_path_param("name"));
-        auto ti = table_info{ .name = cf, .id = get_uuid(ks, cf, ctx.db.local()) };
+        auto ti = parse_table_info(req->get_path_param("name"), ctx.db.local());
         return set_tables_tombstone_gc(ctx, {std::move(ti)}, true);
     });
 
     cf::disable_tombstone_gc.set(r, [&ctx](std::unique_ptr<http::request> req) {
         apilog.info("column_family/disable_tombstone_gc: name={}", req->get_path_param("name"));
-        auto [ks, cf] = parse_fully_qualified_cf_name(req->get_path_param("name"));
-        auto ti = table_info{ .name = cf, .id = get_uuid(ks, cf, ctx.db.local()) };
+        auto ti = parse_table_info(req->get_path_param("name"), ctx.db.local());
         return set_tables_tombstone_gc(ctx, {std::move(ti)}, false);
     });
 
@@ -1049,8 +1045,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
     });
 
     cf::set_compaction_strategy_class.set(r, [&ctx](std::unique_ptr<http::request> req) {
-        auto [ks, cf] = parse_fully_qualified_cf_name(req->get_path_param("name"));
-        auto ti = table_info{ .name = cf, .id = get_uuid(ks, cf, ctx.db.local()) };
+        auto ti = parse_table_info(req->get_path_param("name"), ctx.db.local());
         sstring strategy = req->get_query_param("class_name");
         apilog.info("column_family/set_compaction_strategy_class: name={} strategy={}", req->get_path_param("name"), strategy);
         return for_tables_on_all_shards(ctx, {std::move(ti)}, [strategy] (replica::table& cf) {

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -943,7 +943,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         auto tables = table_infos | std::views::transform([] (auto& ti) { return ti.name; }) | std::ranges::to<std::vector>();
 
         apilog.info("enable_auto_compaction: keyspace={} tables={}", keyspace, tables);
-        return set_tables_autocompaction(ctx, keyspace, tables, true);
+        return set_tables_autocompaction(ctx, keyspace, std::move(tables), true);
     });
 
     ss::disable_auto_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) {
@@ -952,7 +952,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         auto tables = table_infos | std::views::transform([] (auto& ti) { return ti.name; }) | std::ranges::to<std::vector>();
 
         apilog.info("disable_auto_compaction: keyspace={} tables={}", keyspace, tables);
-        return set_tables_autocompaction(ctx, keyspace, tables, false);
+        return set_tables_autocompaction(ctx, keyspace, std::move(tables), false);
     });
 
     cf::get_tombstone_gc.set(r, [&ctx] (const_req req) {
@@ -981,7 +981,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         auto tables = table_infos | std::views::transform([] (auto& ti) { return ti.name; }) | std::ranges::to<std::vector>();
 
         apilog.info("enable_tombstone_gc: keyspace={} tables={}", keyspace, tables);
-        return set_tables_tombstone_gc(ctx, keyspace, tables, true);
+        return set_tables_tombstone_gc(ctx, keyspace, std::move(tables), true);
     });
 
     ss::disable_tombstone_gc.set(r, [&ctx](std::unique_ptr<http::request> req) {
@@ -990,7 +990,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         auto tables = table_infos | std::views::transform([] (auto& ti) { return ti.name; }) | std::ranges::to<std::vector>();
 
         apilog.info("disable_tombstone_gc: keyspace={} tables={}", keyspace, tables);
-        return set_tables_tombstone_gc(ctx, keyspace, tables, false);
+        return set_tables_tombstone_gc(ctx, keyspace, std::move(tables), false);
     });
 
     cf::get_built_indexes.set(r, [&ctx, &sys_ks](std::unique_ptr<http::request> req) {

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -1058,6 +1058,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
 
     cf::set_compaction_strategy_class.set(r, [&ctx](std::unique_ptr<http::request> req) {
         auto [ks, cf] = parse_fully_qualified_cf_name(req->get_path_param("name"));
+        auto ti = table_info{ .name = cf, .id = get_uuid(ks, cf, ctx.db.local()) };
         sstring strategy = req->get_query_param("class_name");
         apilog.info("column_family/set_compaction_strategy_class: name={} strategy={}", req->get_path_param("name"), strategy);
         return for_tables_on_all_shards(ctx, ks, {std::move(cf)}, [strategy] (replica::table& cf) {

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -926,14 +926,14 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
     cf::enable_auto_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) {
         apilog.info("column_family/enable_auto_compaction: name={}", req->get_path_param("name"));
         auto [ks, cf] = parse_fully_qualified_cf_name(req->get_path_param("name"));
-        validate_table(ctx, ks, cf);
+        auto ti = table_info{ .name = cf, .id = get_uuid(ks, cf, ctx.db.local()) };
         return set_tables_autocompaction(ctx, ks, {std::move(cf)}, true);
     });
 
     cf::disable_auto_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) {
         apilog.info("column_family/disable_auto_compaction: name={}", req->get_path_param("name"));
         auto [ks, cf] = parse_fully_qualified_cf_name(req->get_path_param("name"));
-        validate_table(ctx, ks, cf);
+        auto ti = table_info{ .name = cf, .id = get_uuid(ks, cf, ctx.db.local()) };
         return set_tables_autocompaction(ctx, ks, {std::move(cf)}, false);
     });
 
@@ -964,14 +964,14 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
     cf::enable_tombstone_gc.set(r, [&ctx](std::unique_ptr<http::request> req) {
         apilog.info("column_family/enable_tombstone_gc: name={}", req->get_path_param("name"));
         auto [ks, cf] = parse_fully_qualified_cf_name(req->get_path_param("name"));
-        validate_table(ctx, ks, cf);
+        auto ti = table_info{ .name = cf, .id = get_uuid(ks, cf, ctx.db.local()) };
         return set_tables_tombstone_gc(ctx, ks, {std::move(cf)}, true);
     });
 
     cf::disable_tombstone_gc.set(r, [&ctx](std::unique_ptr<http::request> req) {
         apilog.info("column_family/disable_tombstone_gc: name={}", req->get_path_param("name"));
         auto [ks, cf] = parse_fully_qualified_cf_name(req->get_path_param("name"));
-        validate_table(ctx, ks, cf);
+        auto ti = table_info{ .name = cf, .id = get_uuid(ks, cf, ctx.db.local()) };
         return set_tables_tombstone_gc(ctx, ks, {std::move(cf)}, false);
     });
 

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -939,7 +939,8 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
 
     ss::enable_auto_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) {
         auto keyspace = validate_keyspace(ctx, req);
-        auto tables = parse_tables(keyspace, ctx, req->query_parameters, "cf");
+        auto table_infos = parse_table_infos(keyspace, ctx, req->query_parameters, "cf");
+        auto tables = table_infos | std::views::transform([] (auto& ti) { return ti.name; }) | std::ranges::to<std::vector>();
 
         apilog.info("enable_auto_compaction: keyspace={} tables={}", keyspace, tables);
         return set_tables_autocompaction(ctx, keyspace, tables, true);
@@ -947,7 +948,8 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
 
     ss::disable_auto_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) {
         auto keyspace = validate_keyspace(ctx, req);
-        auto tables = parse_tables(keyspace, ctx, req->query_parameters, "cf");
+        auto table_infos = parse_table_infos(keyspace, ctx, req->query_parameters, "cf");
+        auto tables = table_infos | std::views::transform([] (auto& ti) { return ti.name; }) | std::ranges::to<std::vector>();
 
         apilog.info("disable_auto_compaction: keyspace={} tables={}", keyspace, tables);
         return set_tables_autocompaction(ctx, keyspace, tables, false);
@@ -975,7 +977,8 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
 
     ss::enable_tombstone_gc.set(r, [&ctx](std::unique_ptr<http::request> req) {
         auto keyspace = validate_keyspace(ctx, req);
-        auto tables = parse_tables(keyspace, ctx, req->query_parameters, "cf");
+        auto table_infos = parse_table_infos(keyspace, ctx, req->query_parameters, "cf");
+        auto tables = table_infos | std::views::transform([] (auto& ti) { return ti.name; }) | std::ranges::to<std::vector>();
 
         apilog.info("enable_tombstone_gc: keyspace={} tables={}", keyspace, tables);
         return set_tables_tombstone_gc(ctx, keyspace, tables, true);
@@ -983,7 +986,8 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
 
     ss::disable_tombstone_gc.set(r, [&ctx](std::unique_ptr<http::request> req) {
         auto keyspace = validate_keyspace(ctx, req);
-        auto tables = parse_tables(keyspace, ctx, req->query_parameters, "cf");
+        auto table_infos = parse_table_infos(keyspace, ctx, req->query_parameters, "cf");
+        auto tables = table_infos | std::views::transform([] (auto& ti) { return ti.name; }) | std::ranges::to<std::vector>();
 
         apilog.info("disable_tombstone_gc: keyspace={} tables={}", keyspace, tables);
         return set_tables_tombstone_gc(ctx, keyspace, tables, false);

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -79,10 +79,6 @@ future<json::json_return_type>  get_cf_stats(http_context& ctx,
 }
 
 static future<json::json_return_type> for_tables_on_all_shards(http_context& ctx, const sstring& keyspace, std::vector<sstring> tables, std::function<future<>(replica::table&)> set) {
-    if (tables.empty()) {
-        tables = map_keys(ctx.db.local().find_keyspace(keyspace).metadata().get()->cf_meta_data());
-    }
-
     return do_with(keyspace, std::move(tables), [&ctx, set] (const sstring& keyspace, const std::vector<sstring>& tables) {
         return ctx.db.invoke_on_all([&keyspace, &tables, set] (replica::database& db) {
             return parallel_for_each(tables, [&db, &keyspace, set] (const sstring& table) {

--- a/api/column_family.hh
+++ b/api/column_family.hh
@@ -22,12 +22,12 @@ namespace api {
 void set_column_family(http_context& ctx, httpd::routes& r, sharded<db::system_keyspace>& sys_ks);
 void unset_column_family(http_context& ctx, httpd::routes& r);
 
-table_id get_uuid(const sstring& name, const replica::database& db);
+table_info parse_table_info(const sstring& name, const replica::database& db);
 
 template<class Mapper, class I, class Reducer>
 future<I> map_reduce_cf_raw(http_context& ctx, const sstring& name, I init,
         Mapper mapper, Reducer reducer) {
-    auto uuid = get_uuid(name, ctx.db.local());
+    auto uuid = parse_table_info(name, ctx.db.local()).id;
     using mapper_type = std::function<std::unique_ptr<std::any>(replica::database&)>;
     using reducer_type = std::function<std::unique_ptr<std::any>(std::unique_ptr<std::any>, std::unique_ptr<std::any>)>;
     return ctx.db.map_reduce0(mapper_type([mapper, uuid](replica::database& db) {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -84,7 +84,7 @@ sstring validate_keyspace(const http_context& ctx, const http::request& req) {
     return validate_keyspace(ctx, req.get_path_param("keyspace"));
 }
 
-void validate_table(const http_context& ctx, sstring ks_name, sstring table_name) {
+static void validate_table(const http_context& ctx, sstring ks_name, sstring table_name) {
     auto& db = ctx.db.local();
     try {
         db.find_column_family(ks_name, table_name);

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -132,7 +132,7 @@ int64_t validate_int(const sstring& param) {
 // splits a request parameter assumed to hold a comma-separated list of table names
 // verify that the tables are found, otherwise a bad_param_exception exception is thrown
 // containing the description of the respective no_such_column_family error.
-std::vector<sstring> parse_tables(const sstring& ks_name, const http_context& ctx, sstring value) {
+static std::vector<sstring> parse_tables(const sstring& ks_name, const http_context& ctx, sstring value) {
     if (value.empty()) {
         return map_keys(ctx.db.local().find_keyspace(ks_name).metadata().get()->cf_meta_data());
     }
@@ -147,7 +147,7 @@ std::vector<sstring> parse_tables(const sstring& ks_name, const http_context& ct
     return names;
 }
 
-std::vector<sstring> parse_tables(const sstring& ks_name, const http_context& ctx, const std::unordered_map<sstring, sstring>& query_params, sstring param_name) {
+static std::vector<sstring> parse_tables(const sstring& ks_name, const http_context& ctx, const std::unordered_map<sstring, sstring>& query_params, sstring param_name) {
     auto it = query_params.find(param_name);
     if (it == query_params.end()) {
         return {};

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -43,10 +43,6 @@ sstring validate_keyspace(const http_context& ctx, sstring ks_name);
 // containing the description of the respective keyspace error.
 sstring validate_keyspace(const http_context& ctx, const std::unique_ptr<http::request>& req);
 
-// verify that the table parameter is found, otherwise a bad_param_exception exception is thrown
-// containing the description of the respective table error.
-void validate_table(const http_context& ctx, sstring ks_name, sstring table_name);
-
 // splits a request parameter assumed to hold a comma-separated list of table names
 // verify that the tables are found, otherwise a bad_param_exception exception is thrown
 // containing the description of the respective no_such_column_family error.

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -46,13 +46,6 @@ sstring validate_keyspace(const http_context& ctx, const std::unique_ptr<http::r
 // splits a request parameter assumed to hold a comma-separated list of table names
 // verify that the tables are found, otherwise a bad_param_exception exception is thrown
 // containing the description of the respective no_such_column_family error.
-// Returns an empty vector if no parameter was found.
-// If the parameter is found and empty, returns a list of all table names in the keyspace.
-std::vector<sstring> parse_tables(const sstring& ks_name, const http_context& ctx, const std::unordered_map<sstring, sstring>& query_params, sstring param_name);
-
-// splits a request parameter assumed to hold a comma-separated list of table names
-// verify that the tables are found, otherwise a bad_param_exception exception is thrown
-// containing the description of the respective no_such_column_family error.
 // Returns a vector of all table infos given by the parameter, or
 // if the parameter is not found or is empty, returns a list of all table infos in the keyspace.
 std::vector<table_info> parse_table_infos(const sstring& ks_name, const http_context& ctx, const std::unordered_map<sstring, sstring>& query_params, sstring param_name);


### PR DESCRIPTION
In column_family.cc and storage_service.cc there exist a bunch of helpers that parse and/or validate ks/cf names, and different endpoints use different combinations of those, duplicating the functionality of each other and generating some mess. This PR cleans the endpoints from column_family.cc that parse and validate fully qualified table name (the '$ks:$cf' string).

A visible "improvement" is that `validate_table()` helper usage in the api/ directory is narrowed down to storage_service.cc file only (with the intent to remove that helper completely), and the aforementioned `for_tables_on_all_shards()` helper becomes shorter and tiny bit faster, because it doesn't perform some re-lookups of tables, that had been performed by validation sanity checks before it.

There's more to be done in those helpers, this PR wraps only one part of this mess.

Below is the list of endpoints this PR affects and the tests that validate the changes:

|endpoint|test|
|-|-|
|column_family/autocompaction|rest_api/test_column_family::test_column_family_auto_compaction_table|
|column_family/tombstone_gc|rest_api/test_column_family::test_column_family_tombstone_gc_api|
|column_family/compaction_strategy|rest_api/test_column_family/test_column_family_compaction_strategy|
|compaction_manager/stop_keyspace_compaction/|rest_api/test_compaction_manager::{test_compaction_manager_stop_keyspace_compaction,test_compaction_manager_stop_keyspace_compaction_tables}|
