### PR TITLE
docs: correct the storage size for n2-highmem-32 to 9000GB

### DIFF
--- a/docs/getting-started/cloud-instance-recommendations.rst
+++ b/docs/getting-started/cloud-instance-recommendations.rst
@@ -175,7 +175,7 @@ Recommended instances types are `n1-highmem <https://cloud.google.com/compute/do
    * - n2-highmem-32
      - 32
      - 256
-     - 6,000
+     - 9,000
    * - n2-highmem-48
      - 48
      - 384


### PR DESCRIPTION
updated storage size for n2-highmem-32 to 9000GB as this is default in SC

---

this change impacts the user-visible document, and should be backported to all LTS branches.