### PR TITLE
alternator: fix "/localnodes" to not return down nodes

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -236,8 +236,8 @@ protected:
             }
             // Note that it's not enough for the node to be is_alive() - a
             // node joining the cluster is also "alive" but not responsive to
-            // requests. We need the node to be in normal state. See #19694.
-            if (_gossiper.is_normal(ip)) {
+            // requests. We alive *and* normal. See #19694, #21538.
+            if (_gossiper.is_alive(ip) && _gossiper.is_normal(ip)) {
                 // Use the gossiped broadcast_rpc_address if available instead
                 // of the internal IP address "ip". See discussion in #18711.
                 rjson::push_back(results, rjson::from_string(_gossiper.get_rpc_address(ip)));

--- a/test/topology_experimental_raft/test_alternator.py
+++ b/test/topology_experimental_raft/test_alternator.py
@@ -254,6 +254,50 @@ async def test_localnodes_drained_node(manager: ManagerClient):
             return False
     assert await wait_for(check_localnodes_one, time.time() + 60)
 
+
+@pytest.mark.asyncio
+async def test_localnodes_down_normal_node(manager: ManagerClient):
+    """Test that if in a cluster one node reaches "normal" state and then
+       brought down (so is now in "DN" state), a "/localnodes" request
+       should NOT return that node. Reproduces issue #21538.
+    """
+    # Start a cluster with two nodes and verify that at this point,
+    # "/localnodes" on the first node returns both nodes.
+    # We the retry loop below because the second node might take a
+    # bit of time to bootstrap after coming up, and only then will it
+    # appear on /localnodes (see #19694).
+    servers = await manager.servers_add(2, config=alternator_config)
+    localnodes_request = f"http://{servers[0].ip_addr}:{alternator_config['alternator_port']}/localnodes"
+    async def check_localnodes_two():
+        response = requests.get(localnodes_request)
+        j = json.loads(response.content.decode('utf-8'))
+        if set(j) == {servers[0].ip_addr, servers[1].ip_addr}:
+            return True
+        elif set(j).issubset({servers[0].ip_addr, servers[1].ip_addr}):
+            return None # try again
+        else:
+            return False
+    assert await wait_for(check_localnodes_two, time.time() + 60)
+    # Now stop the second node abruptly with server_stop(). The server will
+    # be down, the gossiper on the first node will soon realize it is down,
+    # but still consider it in a "normal" state - "DN" (down and normal).
+    # We then want to check that "/localnodes" handles this state correctly.
+    await manager.server_stop(servers[1].server_id)
+    # After that, "/localnodes" should no longer return the second node.
+    # It might take a short while until the first node learns what happened
+    # to the second, so we may need to retry for a while.
+    async def check_localnodes_one():
+        response = requests.get(localnodes_request)
+        j = json.loads(response.content.decode('utf-8'))
+        if set(j) == {servers[0].ip_addr, servers[1].ip_addr}:
+            return None # try again
+        elif set(j) == {servers[0].ip_addr}:
+            return True
+        else:
+            return False
+    assert await wait_for(check_localnodes_one, time.time() + 60)
+
+
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_localnodes_joining_nodes(manager: ManagerClient):


### PR DESCRIPTION
Alternator's "/localnodes" HTTP requests is supposed to return the list of nodes in the local DC to which the user can send requests.

Before commit bac7c3331377ad7bb85524d295e438230d61001e we used the gossiper is_alive() method to determine if a node should be returned. That commit changed the check to is_normal() - because a node can be alive but in non-normal (e.g., joining) state and not ready for requests.

However, it turns out that checking is_normal() is not enough, because if node is stopped abruptly, other nodes will still consider it "normal", but down (this is so-called "DN" state). So we need to check **both** is_alive() and is_normal().

This patch also adds a test reproducing this case, where a node is shut down abruptly. Before this patch, the test failed ("/localnodes" continued to return the dead node), and after it it passes.

Fixes #21538

This patch should be backported to all the live branches to which https://github.com/scylladb/scylladb/pull/19725 was backported.