### PR TITLE
Add tests for MVs and indexes representation in system. table(s) and API(s)

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -992,11 +992,13 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         auto ks_cf = parse_fully_qualified_cf_name(req->get_path_param("name"));
         auto&& ks = std::get<0>(ks_cf);
         auto&& cf_name = std::get<1>(ks_cf);
-        return sys_ks.local().load_view_build_progress().then([ks, cf_name, &ctx](const std::vector<db::system_keyspace_view_build_progress>& vb) mutable {
+        // Use of load_built_views() as filtering table should be in sync with
+        // built_indexes_virtual_reader filtering with BUILT_VIEWS table
+        return sys_ks.local().load_built_views().then([ks, cf_name, &ctx](const std::vector<db::system_keyspace::view_name>& vb) mutable {
             std::set<sstring> vp;
             for (auto b : vb) {
-                if (b.view.first == ks) {
-                    vp.insert(b.view.second);
+                if (b.first == ks) {
+                    vp.insert(b.second);
                 }
             }
             std::vector<sstring> res;
@@ -1004,7 +1006,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
             replica::column_family& cf = ctx.db.local().find_column_family(uuid);
             res.reserve(cf.get_index_manager().list_indexes().size());
             for (auto&& i : cf.get_index_manager().list_indexes()) {
-                if (!vp.contains(secondary_index::index_table_name(i.metadata().name()))) {
+                if (vp.contains(secondary_index::index_table_name(i.metadata().name()))) {
                     res.emplace_back(i.metadata().name());
                 }
             }

--- a/index/built_indexes_virtual_reader.hh
+++ b/index/built_indexes_virtual_reader.hh
@@ -221,6 +221,8 @@ public:
             tracing::trace_state_ptr trace_state,
             streamed_mutation::forwarding fwd,
             mutation_reader::forwarding fwd_mr) {
+        // Use of BUILT_VIEWS as filtering table should be in sync with
+        // cf::get_built_indexes's filtering with load_built_views()
         return make_mutation_reader<built_indexes_reader>(
                 _db,
                 s,

--- a/test/boost/virtual_reader_test.cc
+++ b/test/boost/virtual_reader_test.cc
@@ -212,31 +212,3 @@ SEASTAR_TEST_CASE(test_query_view_built_progress_virtual_table) {
         assert_that(rs).is_rows().with_size(0);
     });
 }
-
-SEASTAR_TEST_CASE(test_query_built_indexes_virtual_table) {
-    return do_with_cql_env_thread([] (cql_test_env& e) {
-        auto idx = secondary_index::index_table_name("idx");
-        e.execute_cql("create table cf(p int PRIMARY KEY, v int);").get();
-        auto f1 = e.local_view_builder().wait_until_built("ks", "vcf");
-        auto f2 = e.local_view_builder().wait_until_built("ks", idx);
-        e.execute_cql("create materialized view vcf as select * from cf "
-                      "where v is not null and p is not null "
-                      "primary key (v, p)").get();
-        e.execute_cql("create index idx on cf (v)").get();
-        f1.get();
-        f2.get();
-        auto rs = e.execute_cql("select * from system.built_views").get();
-        assert_that(rs).is_rows().with_rows_ignore_order({
-                { {utf8_type->decompose(sstring("ks"))}, {utf8_type->decompose(idx)} },
-                { {utf8_type->decompose(sstring("ks"))}, {"vcf"} },
-        });
-        rs = e.execute_cql("select * from system.\"IndexInfo\"").get();
-        assert_that(rs).is_rows().with_rows_ignore_order({
-                { {utf8_type->decompose(sstring("ks"))}, {utf8_type->decompose(sstring("idx"))} },
-        });
-        rs = e.execute_cql("select * from system.\"IndexInfo\" where table_name = 'ks' and index_name = 'idx'").get();
-        assert_that(rs).is_rows().with_size(1);
-        rs = e.execute_cql("select * from system.\"IndexInfo\" where table_name = 'ks' and index_name = 'vcf'").get();
-        assert_that(rs).is_rows().with_size(0);
-    });
-}

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -7,6 +7,7 @@
 import time
 import re
 import pytest
+import rest_api
 
 from util import new_test_table, unique_name, new_materialized_view, ScyllaMetrics, new_secondary_index
 from cassandra.protocol import ConfigurationException, InvalidRequest, SyntaxException
@@ -1579,3 +1580,17 @@ def test_view_in_system_tables(cql, test_keyspace):
             assert view in res
             res = [ f'{r.table_name}.{r.index_name}' for r in cql.execute('select * from system."IndexInfo"')]
             assert view not in res
+
+# Test view representation in REST API
+def test_view_in_API(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v int") as base:
+        with new_materialized_view(cql, base, '*', 'v,p', 'v is not null and p is not null') as view:
+            view_name = view.split('.')[1]
+            res = rest_api.get_request(cql, f"storage_service/view_build_statuses/{test_keyspace}/{view_name}")
+            assert len(res) == 1 and 'value' in res[0] and res[0]['value'] in [ 'STARTED', 'SUCCESS' ]
+            # Indexes are implemented on top of materialized-views, but even then no MVs
+            # should appear in the output of built_indexes API. And since this API only
+            # reports views that are built, check that view is built first.
+            wait_for_view_built(cql, view)
+            res = rest_api.get_request(cql, f"column_family/built_indexes/{base.replace('.',':')}")
+            assert view_name not in res

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -14,7 +14,7 @@ from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, C
 from cassandra.query import SimpleStatement
 from cassandra_tests.porting import assert_rows, assert_row_count, assert_rows_ignoring_order, assert_empty
 
-from util import new_test_table, unique_name, unique_key_int
+from util import new_test_table, unique_name, unique_key_int, is_scylla
 
 # A reproducer for issue #7443: Normally, when the entire table is SELECTed,
 # the partitions are returned sorted by the partitions' token. When there
@@ -1956,3 +1956,18 @@ def test_paging_and_drop_index_no_allow_filtering(cql, test_keyspace):
                 assert len(r.current_rows) <= page_size
                 got.extend(r.current_rows)
             assert expected == got
+
+
+# Test index representation in system.* tables
+def test_index_in_system_tables(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v int") as table:
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+        wait_for_index(cql, test_keyspace, index_name)
+        if is_scylla(cql):
+            res = [ f'{r.keyspace_name}.{r.view_name}' for r in cql.execute('select * from system.built_views')]
+            assert f'{test_keyspace}.{index_name}_index' in res
+        res = [ f'{r.table_name}::{r.index_name}' for r in cql.execute('select * from system."IndexInfo"')]
+        assert f'{test_keyspace}::{index_name}' in res
+        res = cql.execute(f'select * from system."IndexInfo" where table_name = \'{test_keyspace}\' AND index_name = \'{index_name}\'').one()
+        assert (test_keyspace, index_name) == (res.table_name, res.index_name)

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -10,6 +10,7 @@ import time
 import tempfile
 import pytest
 import os
+import rest_api
 from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException, ReadFailure, WriteFailure
 from cassandra.query import SimpleStatement
 from cassandra_tests.porting import assert_rows, assert_row_count, assert_rows_ignoring_order, assert_empty
@@ -1971,3 +1972,12 @@ def test_index_in_system_tables(cql, test_keyspace):
         assert f'{test_keyspace}::{index_name}' in res
         res = cql.execute(f'select * from system."IndexInfo" where table_name = \'{test_keyspace}\' AND index_name = \'{index_name}\'').one()
         assert (test_keyspace, index_name) == (res.table_name, res.index_name)
+
+# Test index representation in REST API
+def test_index_in_API(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v int") as table:
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+        wait_for_index(cql, test_keyspace, index_name)
+        res = rest_api.get_request(cql, f"column_family/built_indexes/{table.replace('.',':')}")
+        assert index_name in res


### PR DESCRIPTION
After MV or index is created, information about it can be obtained from system tables or API. In particular, there's system.IndexInfo table and /column_family/built_indexes endpoint that return very same info.

For the system table there's a boost/virtual_reader_test::test_query_built_indexes_virtual_table, but it only tests the table, not API endpoint. In order to have its API part, it's good to move the test from boost to cqlpy suite and extend. Other than extension ability this move has two other benefits.

First, in its new form it can be run against C* (this test actually would have failed against it, it was fixed and described in  af485f5226 (secondary index: fix index name in IndexInfo system table)).
Second, boost test wires up cql-test-env, which is weighty, while cqlpy one would run against already started scylla that can be faster.

This is to validate #21445 change.