### PR TITLE
test: move a materialized-view test from boost to cqlpy

### DIFF
--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -4536,48 +4536,6 @@ SEASTAR_TEST_CASE(test_time_uuid_fcts_result) {
     });
 }
 
-// Test that tombstones with future timestamps work correctly
-// when a write with lower timestamp arrives - in such case,
-// if the base row is covered by such a tombstone, a view update
-// needs to take it into account. Refs #5793
-SEASTAR_TEST_CASE(test_views_with_future_tombstones) {
-    return do_with_cql_env_thread([] (auto& e) {
-        cquery_nofail(e, "CREATE TABLE t (a int, b int, c int, d int, e int, PRIMARY KEY (a,b,c));");
-        cquery_nofail(e, "CREATE MATERIALIZED VIEW tv AS SELECT * FROM t"
-                " WHERE a IS NOT NULL AND b IS NOT NULL AND c IS NOT NULL PRIMARY KEY (b,a,c);");
-
-        // Partition tombstone
-        cquery_nofail(e, "delete from t using timestamp 10 where a=1;");
-        auto msg = cquery_nofail(e, "select * from t;");
-        assert_that(msg).is_rows().with_size(0);
-        cquery_nofail(e, "insert into t (a,b,c,d,e) values (1,2,3,4,5) using timestamp 8;");
-        msg = cquery_nofail(e, "select * from t;");
-        assert_that(msg).is_rows().with_size(0);
-        msg = cquery_nofail(e, "select * from tv;");
-        assert_that(msg).is_rows().with_size(0);
-
-        // Range tombstone
-        cquery_nofail(e, "delete from t using timestamp 16 where a=2 and b > 1 and b < 4;");
-        msg = cquery_nofail(e, "select * from t;");
-        assert_that(msg).is_rows().with_size(0);
-        cquery_nofail(e, "insert into t (a,b,c,d,e) values (2,3,4,5,6) using timestamp 12;");
-        msg = cquery_nofail(e, "select * from t;");
-        assert_that(msg).is_rows().with_size(0);
-        msg = cquery_nofail(e, "select * from tv;");
-        assert_that(msg).is_rows().with_size(0);
-
-        // Row tombstone
-        cquery_nofail(e, "delete from t using timestamp 24 where a=3 and b=4 and c=5;");
-        msg = cquery_nofail(e, "select * from t;");
-        assert_that(msg).is_rows().with_size(0);
-        cquery_nofail(e, "insert into t (a,b,c,d,e) values (3,4,5,6,7) using timestamp 18;");
-        msg = cquery_nofail(e, "select * from t;");
-        assert_that(msg).is_rows().with_size(0);
-        msg = cquery_nofail(e, "select * from tv;");
-        assert_that(msg).is_rows().with_size(0);
-    });
-}
-
 static std::unique_ptr<cql3::query_options> q_serial_opts(
         std::vector<cql3::raw_value> values,
         db::consistency_level cl) {

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -1538,3 +1538,34 @@ def test_alter_table_add_select_star(cql, test_keyspace):
             cql.execute(f'INSERT INTO {base} (p,a,b,c) VALUES (0,1,2,3)')
             assert {(0,1,2,3),(1,2,3,None)} == set(cql.execute(f"SELECT p,a,b,c FROM {base}"))
             assert {(0,1,2,3),(1,2,3,None)} == set(cql.execute(f"SELECT p,a,b,c FROM {mv}"))
+
+# Test that tombstones with future timestamps work correctly
+# when a write with lower timestamp arrives - in such case,
+# if the base row is covered by such a tombstone, a view update
+# needs to take it into account.
+# Reproduces issue #5793
+def test_views_with_future_tombstones(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, 'a int, b int, c int, d int, e int, primary key (a, b, c)') as table:
+        with new_materialized_view(cql, table, '*', 'b, a, c', 'a is not null and b is not null and c is not null') as mv:
+            # Partition tombstone
+            cql.execute(f'delete from {table} using timestamp 10 where a=1')
+            assert [] == list(cql.execute(f'select * from {table}'))
+            cql.execute(f'insert into {table} (a,b,c,d,e) values (1,2,3,4,5) using timestamp 8')
+            assert [] == list(cql.execute(f'select * from {table}'))
+            # On a single-node test, the update will be synchronous so no
+            # need for retry.
+            assert [] == list(cql.execute(f'select * from {mv}'))
+
+            # Range tombstone
+            cql.execute(f'delete from {table} using timestamp 16 where a=2 and b > 1 and b < 4')
+            assert [] == list(cql.execute(f'select * from {table}'))
+            cql.execute(f'insert into {table} (a,b,c,d,e) values (2,3,4,5,6) using timestamp 12')
+            assert [] == list(cql.execute(f'select * from {table}'))
+            assert [] == list(cql.execute(f'select * from {mv}'))
+
+            # Row tombstone
+            cql.execute(f'delete from {table} using timestamp 24 where a=3 and b=4 and c=5')
+            assert [] == list(cql.execute(f'select * from {table}'))
+            cql.execute(f'insert into {table} (a,b,c,d,e) values (3,4,5,6,7) using timestamp 18')
+            assert [] == list(cql.execute(f'select * from {table}'))
+            assert [] == list(cql.execute(f'select * from {mv}'))


### PR DESCRIPTION
This patch moves (after straightforward translation) the test "test_views_with_future_tombstone", a regression test for #5793, from the C++ boost framework to the Python cqlpy framework.

The main motivation this move is the ease of debugging failures: During the work on a patch for #20679 (eliminating read-before-write) this test began to fail, and understanding where the C++ failed was near impossible: the Boost test framework reports that the test failed, but not in which line or why, and adding printouts to this huge source file require a ridiculous amount of time for recompilation every time. In contrast, the new pytest-based version shows exactly where the error is, beautifully:

```
>               assert [] == list(cql.execute(f'select * from {mv}'))
E               assert [] == [Row(b=2, a=1, c=3, d=4, e=5)]
test_materialized_view.py:1614: AssertionError
```

It shows exactly which assertion failed, and exactly what were the values that were compared. Beautiful and super helpful for debugging.

Beyond the ease of debugging, moving this (and later, other) test to the cql-pytest framework has additional advantages:

1. The test was misplaced, in the cql_test source file, and it belongs with materialized views tests so let's use this opportunity to move it to the right place.
2. Can easily run the same test on multiple versions of Scylla, and also on Cassandra. It's a good way to confirm the test is correct.
3. No need to recompile the test after every attempt to fix the bug. The cql_query_test.cc is huge - over 6,000 lines - and takes over a minute to compile after every attempt to fix a bug.

Refs #16134 (the issue asks to move all MV tests to cql-pytest)

Test movement only, no need for backports.