### PR TITLE
utils: UUID: make get_time_UUID() respect clock offset in tests

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1463,7 +1463,7 @@ deps['test/boost/bytes_ostream_test'] = [
     "test/lib/log.cc",
 ]
 deps['test/boost/input_stream_test'] = ['test/boost/input_stream_test.cc']
-deps['test/boost/UUID_test'] = ['utils/UUID_gen.cc', 'test/boost/UUID_test.cc', 'utils/uuid.cc', 'utils/dynamic_bitset.cc', 'utils/hashers.cc', 'utils/on_internal_error.cc']
+deps['test/boost/UUID_test'] = ['clocks-impl.cc', 'utils/UUID_gen.cc', 'test/boost/UUID_test.cc', 'utils/uuid.cc', 'utils/dynamic_bitset.cc', 'utils/hashers.cc', 'utils/on_internal_error.cc']
 deps['test/boost/murmur_hash_test'] = ['bytes.cc', 'utils/murmur_hash.cc', 'test/boost/murmur_hash_test.cc']
 deps['test/boost/allocation_strategy_test'] = ['test/boost/allocation_strategy_test.cc', 'utils/logalloc.cc', 'utils/dynamic_bitset.cc']
 deps['test/boost/log_heap_test'] = ['test/boost/log_heap_test.cc']

--- a/utils/UUID_gen.hh
+++ b/utils/UUID_gen.hh
@@ -19,6 +19,7 @@
 
 #include "UUID.hh"
 #include "on_internal_error.hh"
+#include "db_clock.hh"
 
 namespace utils {
 
@@ -96,8 +97,7 @@ private:
     // need monotonicity between time UUIDs created at different
     // shards and UUID code uses thread local state on each shard.
     int64_t create_time_safe() {
-        using std::chrono::system_clock;
-        auto millis = duration_cast<milliseconds>(system_clock::now().time_since_epoch());
+        auto millis = duration_cast<milliseconds>(db_clock::now().time_since_epoch());
         decimicroseconds when = from_unix_timestamp(millis);
         if (when > _last_used_time) {
             _last_used_time = when;


### PR DESCRIPTION
schema_change_test currently fails due to failure to start a cql test env in unit tests after the point where this is called (in one of the test cases):

```
   forward_jump_clocks(std::chrono::seconds(60*60*24*31));
```

The problem manifests with a failure to join the cluster due to missing_column exception ("missing_column: done") being thrown from system_keyspace::get_topology_request_state(). It's a symptom of join request being missing in system.topology_requests. It's missing because the row is expired.

When request is created, we insert the
mutations with intended TTL of 1 month. The actual TTL value is computed like this:

```
  ttl_opt topology_request_tracking_mutation_builder::ttl() const {
      return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::microseconds(_ts)) + std::chrono::months(1)
          - std::chrono::duration_cast<std::chrono::seconds>(gc_clock::now().time_since_epoch()); }
```

_ts comes from the request_id, which is supposed to be a timeuuid set from current time when request starts. It's set using utils::UUID_gen::get_time_UUID(). It reads the system clock without adding the clock offset, so after forward_jump_clocks(), _ts and gc_clock::now() may be far off. In some cases the accumulated offset is larger than 1month and the ttl becomes negative, causing the request row to expire immediately and failing the boot sequence.

The test doesn't fail in CI becuase there each test case runs in a separate process, so there is no bootstrap attempt (by new cql test env) after forward_jump_clocks().

Introduced in fba6877b3e5b82c992d25931d0d2fa943cb468f0 (probably). Hence backports to >= 6.1