### PR TITLE
message: do not include unused headers

### DIFF
--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -11,7 +11,7 @@ env:
   CLEANER_OUTPUT_PATH: build/clang-include-cleaner.log
   # the "idl" subdirectory does not contain C++ source code. the .hh files in it are
   # supposed to be processed by idl-compiler.py, so we don't check them using the cleaner
-  CLEANER_DIRS: test/unit exceptions alternator api auth cdc compaction db dht gms index lang
+  CLEANER_DIRS: test/unit exceptions alternator api auth cdc compaction db dht gms index lang message
 
 permissions: {}
 

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -11,8 +11,7 @@
 #include "db/config.hh"
 #include "messaging_service_fwd.hh"
 #include "msg_addr.hh"
-#include <seastar/core/seastar.hh>
-#include <seastar/core/distributed.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/sstring.hh>
 #include "gms/inet_address.hh"
 #include <seastar/rpc/rpc_types.hh>

--- a/message/messaging_service_fwd.hh
+++ b/message/messaging_service_fwd.hh
@@ -8,8 +8,9 @@
 
 #pragma once
 
-#include <boost/signals2.hpp>
+#include <boost/signals2/connection.hpp>
 #include <boost/signals2/dummy_mutex.hpp>
+#include <boost/signals2/signal_type.hpp>
 
 namespace gms { class inet_address; }
 


### PR DESCRIPTION
these unused includes are identified by clang-include-cleaner. after auditing the source files, all of the reports have been confirmed.

also, update the workflow to prevent future regressions of including unused headers in this subdirectory.

---

it's a cleanup, hence no need to backport.