### PR TITLE
replica,sstables: track download progress of download_task_impl

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -155,10 +155,10 @@ public:
 
     virtual future<> stream();
     inet_address_vector_replica_set get_endpoints(const dht::token& token) const;
+    future<> stream_sstable_mutations(const dht::partition_range&, std::vector<sstables::shared_sstable>);
 protected:
     virtual inet_address_vector_replica_set get_primary_endpoints(const dht::token& token) const;
     future<> stream_sstables(const dht::partition_range&, std::vector<sstables::shared_sstable>);
-    future<> stream_sstable_mutations(const dht::partition_range&, std::vector<sstables::shared_sstable>);
 };
 
 class tablet_sstable_streamer : public sstable_streamer {

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -58,7 +58,8 @@ private:
 
     future<> load_and_stream(sstring ks_name, sstring cf_name,
             table_id, std::vector<sstables::shared_sstable> sstables,
-            bool primary_replica_only, bool unlink_sstables);
+            bool primary_replica_only, bool unlink_sstables,
+            std::function<void(unsigned)> on_streamed);
 
 public:
     sstables_loader(sharded<replica::database>& db,

--- a/test/object_store/suite.yaml
+++ b/test/object_store/suite.yaml
@@ -5,3 +5,4 @@ cluster:
 extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer
+    enable_tablets: true

--- a/test/object_store/test_backup.py
+++ b/test/object_store/test_backup.py
@@ -271,7 +271,12 @@ async def test_simple_backup_and_restore(manager: ManagerClient, s3_server):
     print('Try to restore')
     tid = await manager.api.restore(server.ip_addr, ks, cf, s3_server.address, s3_server.bucket_name, prefix, toc_names)
     status = await manager.api.wait_task(server.ip_addr, tid)
-    assert (status is not None) and (status['state'] == 'done')
+    assert status is not None
+    assert status['state'] == 'done'
+    assert status['progress_units'] == "sstables"
+    assert status['progress_completed'] == len(toc_names)
+    assert status['progress_total'] == len(toc_names)
+
     print('Check that sstables came back')
     files = list_sstables()
     assert len(files) > 0


### PR DESCRIPTION
Previously, the progress of download_task_impl launched by the "restore" API
was not tracked. Since restore operations can involve large data transfers,
this makes it difficult for users to monitor progress.

The restore process happens in two sequential steps:
1. Open specified SSTables from object storage
2. Download and stream mutation fragments from the opened SSTables to
   mapped destinations

While both steps contribute to overall progress, they use different units
of measurement, making a unified progress metric challenging. Because
the load-and-stream step (step 2) is the largest time-consuming part of the
restore. This change implements progress tracking for this step as an
initial improvement to provide users with partial visibility into the
restore operation.

Fixes scylladb/scylladb#21427
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

this a part of experimental feature, hence no need to backport.