### PR TITLE
cql3/query_processor.cc: Add skip_when_empty to metrics

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -102,7 +102,7 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                 "queries",
                 _stats.queries_by_cl[cl],
                 sm::description("Counts queries by consistency level."),
-                {cl_label(clevel(cl))}));
+                {cl_label(clevel(cl))}).set_skip_when_empty());
     }
     _metrics.add_group("query_processor", qp_group);
 
@@ -122,7 +122,7 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                                         + _cql_stats.query_cnt(source_selector::USER, ks_selector::NONSYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::SELECT)
                                         + _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::SYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::SELECT)
                                         + _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::NONSYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::SELECT);
-                            }),
+                            }).set_skip_when_empty(),
 
                     sm::make_counter(
                             "inserts",
@@ -133,7 +133,7 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                                         + _cql_stats.query_cnt(source_selector::USER, ks_selector::NONSYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::INSERT)
                                         + _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::SYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::INSERT)
                                         + _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::NONSYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::INSERT);
-                            }),
+                            }).set_skip_when_empty(),
                     sm::make_counter(
                             "inserts",
                             sm::description("Counts the total number of CQL INSERT requests with/without conditions."),
@@ -154,7 +154,7 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                                         + _cql_stats.query_cnt(source_selector::USER, ks_selector::NONSYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::UPDATE)
                                         + _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::SYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::UPDATE)
                                         + _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::NONSYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::UPDATE);
-                            }),
+                            }).set_skip_when_empty(),
                     sm::make_counter(
                             "updates",
                             sm::description("Counts the total number of CQL UPDATE requests with/without conditions."),
@@ -175,7 +175,7 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                                         + _cql_stats.query_cnt(source_selector::USER, ks_selector::NONSYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::DELETE)
                                         + _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::SYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::DELETE)
                                         + _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::NONSYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::DELETE);
-                            }),
+                            }).set_skip_when_empty(),
                     sm::make_counter(
                             "deletes",
                             sm::description("Counts the total number of CQL DELETE requests with/without conditions."),
@@ -199,20 +199,20 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                             _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::SYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::SELECT),
                             sm::description("Counts the number of CQL SELECT requests executed on particular keyspaces. "
                                             "Label `who' indicates where the reqs come from (clients or DB internals)"),
-                            {internal_who_label_instance, system_ks_label_instance}),
+                            {internal_who_label_instance, system_ks_label_instance}).set_skip_when_empty(),
 
                     sm::make_counter(
                             "inserts_per_ks",
                             _cql_stats.query_cnt(source_selector::USER, ks_selector::SYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::INSERT),
                             sm::description("Counts the number of CQL INSERT requests executed on particular keyspaces. "
                                             "Label `who' indicates where the reqs come from (clients or DB internals)."),
-                            {user_who_label_instance, system_ks_label_instance, non_cas_label_instance}),
+                            {user_who_label_instance, system_ks_label_instance, non_cas_label_instance}).set_skip_when_empty(),
                     sm::make_counter(
                             "inserts_per_ks",
                             _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::SYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::INSERT),
                             sm::description("Counts the number of CQL INSERT requests executed on particular keyspaces. "
                                             "Label `who' indicates where the reqs come from (clients or DB internals)."),
-                            {internal_who_label_instance, system_ks_label_instance, non_cas_label_instance}),
+                            {internal_who_label_instance, system_ks_label_instance, non_cas_label_instance}).set_skip_when_empty(),
                     sm::make_counter(
                             "inserts_per_ks",
                             _cql_stats.query_cnt(source_selector::USER, ks_selector::SYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::INSERT),
@@ -231,13 +231,13 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                             _cql_stats.query_cnt(source_selector::USER, ks_selector::SYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::UPDATE),
                             sm::description("Counts the number of CQL UPDATE requests executed on particular keyspaces. "
                                             "Label `who' indicates where the reqs come from (clients or DB internals)"),
-                            {user_who_label_instance, system_ks_label_instance, non_cas_label_instance}),
+                            {user_who_label_instance, system_ks_label_instance, non_cas_label_instance}).set_skip_when_empty(),
                     sm::make_counter(
                             "updates_per_ks",
                             _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::SYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::UPDATE),
                             sm::description("Counts the number of CQL UPDATE requests executed on particular keyspaces. "
                                             "Label `who' indicates where the reqs come from (clients or DB internals)"),
-                            {internal_who_label_instance, system_ks_label_instance, non_cas_label_instance}),
+                            {internal_who_label_instance, system_ks_label_instance, non_cas_label_instance}).set_skip_when_empty(),
                     sm::make_counter(
                             "updates_per_ks",
                             _cql_stats.query_cnt(source_selector::USER, ks_selector::SYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::UPDATE),
@@ -256,13 +256,13 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                             _cql_stats.query_cnt(source_selector::USER, ks_selector::SYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::DELETE),
                             sm::description("Counts the number of CQL DELETE requests executed on particular keyspaces. "
                                             "Label `who' indicates where the reqs come from (clients or DB internals)"),
-                            {user_who_label_instance, system_ks_label_instance, non_cas_label_instance}),
+                            {user_who_label_instance, system_ks_label_instance, non_cas_label_instance}).set_skip_when_empty(),
                     sm::make_counter(
                             "deletes_per_ks",
                             _cql_stats.query_cnt(source_selector::INTERNAL, ks_selector::SYSTEM, cond_selector::NO_CONDITIONS, stm::statement_type::DELETE),
                             sm::description("Counts the number of CQL DELETE requests executed on particular keyspaces. "
                                             "Label `who' indicates where the reqs come from (clients or DB internals)"),
-                            {internal_who_label_instance, system_ks_label_instance, non_cas_label_instance}),
+                            {internal_who_label_instance, system_ks_label_instance, non_cas_label_instance}).set_skip_when_empty(),
                     sm::make_counter(
                             "deletes_per_ks",
                             _cql_stats.query_cnt(source_selector::USER, ks_selector::SYSTEM, cond_selector::WITH_CONDITIONS, stm::statement_type::DELETE),
@@ -280,59 +280,59 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                             "batches",
                             _cql_stats.batches,
                             sm::description("Counts the total number of CQL BATCH requests without conditions."),
-                            {non_cas_label_instance}),
+                            {non_cas_label_instance}).set_skip_when_empty(),
 
                     sm::make_counter(
                             "batches",
                             _cql_stats.cas_batches,
                             sm::description("Counts the total number of CQL BATCH requests with conditions."),
-                            {cas_label_instance}),
+                            {cas_label_instance}).set_skip_when_empty(),
 
                     sm::make_counter(
                             "statements_in_batches",
                             _cql_stats.statements_in_batches,
                             sm::description("Counts the total number of sub-statements in CQL BATCH requests without conditions."),
-                            {non_cas_label_instance}),
+                            {non_cas_label_instance}).set_skip_when_empty(),
 
                     sm::make_counter(
                             "statements_in_batches",
                             _cql_stats.statements_in_cas_batches,
                             sm::description("Counts the total number of sub-statements in CQL BATCH requests with conditions."),
-                            {cas_label_instance}),
+                            {cas_label_instance}).set_skip_when_empty(),
 
                     sm::make_counter(
                             "batches_pure_logged",
                             _cql_stats.batches_pure_logged,
                             sm::description(
-                                    "Counts the total number of LOGGED batches that were executed as LOGGED batches.")),
+                                    "Counts the total number of LOGGED batches that were executed as LOGGED batches.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "batches_pure_unlogged",
                             _cql_stats.batches_pure_unlogged,
                             sm::description(
                                     "Counts the total number of UNLOGGED batches that were executed as UNLOGGED "
-                                    "batches.")),
+                                    "batches.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "batches_unlogged_from_logged",
                             _cql_stats.batches_unlogged_from_logged,
                             sm::description("Counts the total number of LOGGED batches that were executed as UNLOGGED "
-                                            "batches.")),
+                                            "batches.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "rows_read",
                             _cql_stats.rows_read,
-                            sm::description("Counts the total number of rows read during CQL requests.")),
+                            sm::description("Counts the total number of rows read during CQL requests.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "prepared_cache_evictions",
                             [] { return prepared_statements_cache::shard_stats().prepared_cache_evictions; },
-                            sm::description("Counts the number of prepared statements cache entries evictions.")),
+                            sm::description("Counts the number of prepared statements cache entries evictions.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "unprivileged_entries_evictions_on_size",
                             [] { return prepared_statements_cache::shard_stats().unprivileged_entries_evictions_on_size; },
-                            sm::description("Counts a number of evictions of prepared statements from the prepared statements cache after they have been used only once. An increasing counter suggests the user may be preparing a different statement for each request instead of reusing the same prepared statement with parameters.")),
+                            sm::description("Counts a number of evictions of prepared statements from the prepared statements cache after they have been used only once. An increasing counter suggests the user may be preparing a different statement for each request instead of reusing the same prepared statement with parameters.")).set_skip_when_empty(),
 
                     sm::make_gauge(
                             "prepared_cache_size",
@@ -347,88 +347,88 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                     sm::make_counter(
                             "secondary_index_creates",
                             _cql_stats.secondary_index_creates,
-                            sm::description("Counts the total number of CQL CREATE INDEX requests.")),
+                            sm::description("Counts the total number of CQL CREATE INDEX requests.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "secondary_index_drops",
                             _cql_stats.secondary_index_drops,
-                            sm::description("Counts the total number of CQL DROP INDEX requests.")),
+                            sm::description("Counts the total number of CQL DROP INDEX requests.")).set_skip_when_empty(),
 
                     // secondary_index_reads total count is also included in all cql reads
                     sm::make_counter(
                             "secondary_index_reads",
                             _cql_stats.secondary_index_reads,
-                            sm::description("Counts the total number of CQL read requests performed using secondary indexes.")),
+                            sm::description("Counts the total number of CQL read requests performed using secondary indexes.")).set_skip_when_empty(),
 
                     // secondary_index_rows_read total count is also included in all cql rows read
                     sm::make_counter(
                             "secondary_index_rows_read",
                             _cql_stats.secondary_index_rows_read,
-                            sm::description("Counts the total number of rows read during CQL requests performed using secondary indexes.")),
+                            sm::description("Counts the total number of rows read during CQL requests performed using secondary indexes.")).set_skip_when_empty(),
 
                     // read requests that required ALLOW FILTERING
                     sm::make_counter(
                             "filtered_read_requests",
                             _cql_stats.filtered_reads,
-                            sm::description("Counts the total number of CQL read requests that required ALLOW FILTERING. See filtered_rows_read_total to compare how many rows needed to be filtered.")),
+                            sm::description("Counts the total number of CQL read requests that required ALLOW FILTERING. See filtered_rows_read_total to compare how many rows needed to be filtered.")).set_skip_when_empty(),
 
                     // rows read with filtering enabled (because ALLOW FILTERING was required)
                     sm::make_counter(
                             "filtered_rows_read_total",
                             _cql_stats.filtered_rows_read_total,
-                            sm::description("Counts the total number of rows read during CQL requests that required ALLOW FILTERING. See filtered_rows_matched_total and filtered_rows_dropped_total for information how accurate filtering queries are.")),
+                            sm::description("Counts the total number of rows read during CQL requests that required ALLOW FILTERING. See filtered_rows_matched_total and filtered_rows_dropped_total for information how accurate filtering queries are.")).set_skip_when_empty(),
 
                     // rows read with filtering enabled and accepted by the filter
                     sm::make_counter(
                             "filtered_rows_matched_total",
                             _cql_stats.filtered_rows_matched_total,
-                            sm::description("Counts the number of rows read during CQL requests that required ALLOW FILTERING and accepted by the filter. Number similar to filtered_rows_read_total indicates that filtering is accurate.")),
+                            sm::description("Counts the number of rows read during CQL requests that required ALLOW FILTERING and accepted by the filter. Number similar to filtered_rows_read_total indicates that filtering is accurate.")).set_skip_when_empty(),
 
                     // rows read with filtering enabled and rejected by the filter
                     sm::make_counter(
                             "filtered_rows_dropped_total",
                             [this]() {return _cql_stats.filtered_rows_read_total - _cql_stats.filtered_rows_matched_total;},
-                            sm::description("Counts the number of rows read during CQL requests that required ALLOW FILTERING and dropped by the filter. Number similar to filtered_rows_read_total indicates that filtering is not accurate and might cause performance degradation.")),
+                            sm::description("Counts the number of rows read during CQL requests that required ALLOW FILTERING and dropped by the filter. Number similar to filtered_rows_read_total indicates that filtering is not accurate and might cause performance degradation.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "select_bypass_caches",
                             _cql_stats.select_bypass_caches,
-                            sm::description("Counts the number of SELECT query executions with BYPASS CACHE option.")),
+                            sm::description("Counts the number of SELECT query executions with BYPASS CACHE option.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "select_allow_filtering",
                             _cql_stats.select_allow_filtering,
-                            sm::description("Counts the number of SELECT query executions with ALLOW FILTERING option.")),
+                            sm::description("Counts the number of SELECT query executions with ALLOW FILTERING option.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "select_partition_range_scan",
                             _cql_stats.select_partition_range_scan,
-                            sm::description("Counts the number of SELECT query executions requiring partition range scan.")),
+                            sm::description("Counts the number of SELECT query executions requiring partition range scan.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "select_partition_range_scan_no_bypass_cache",
                             _cql_stats.select_partition_range_scan_no_bypass_cache,
-                            sm::description("Counts the number of SELECT query executions requiring partition range scan without BYPASS CACHE option.")),
+                            sm::description("Counts the number of SELECT query executions requiring partition range scan without BYPASS CACHE option.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "select_parallelized",
                             _cql_stats.select_parallelized,
-                            sm::description("Counts the number of parallelized aggregation SELECT query executions.")),
+                            sm::description("Counts the number of parallelized aggregation SELECT query executions.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "authorized_prepared_statements_cache_evictions",
                             [] { return authorized_prepared_statements_cache::shard_stats().authorized_prepared_statements_cache_evictions; },
-                            sm::description("Counts the number of authenticated prepared statements cache entries evictions.")),
+                            sm::description("Counts the number of authenticated prepared statements cache entries evictions.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "authorized_prepared_statements_privileged_entries_evictions_on_size",
                             [] { return authorized_prepared_statements_cache::shard_stats().authorized_prepared_statements_privileged_entries_evictions_on_size; },
-                            sm::description("Counts a number of evictions of prepared statements from the authorized prepared statements cache after they have been used more than once.")),
+                            sm::description("Counts a number of evictions of prepared statements from the authorized prepared statements cache after they have been used more than once.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "authorized_prepared_statements_unprivileged_entries_evictions_on_size",
                             [] { return authorized_prepared_statements_cache::shard_stats().authorized_prepared_statements_unprivileged_entries_evictions_on_size; },
-                            sm::description("Counts a number of evictions of prepared statements from the authorized prepared statements cache after they have been used only once. An increasing counter suggests the user may be preparing a different statement for each request instead of reusing the same prepared statement with parameters.")),
+                            sm::description("Counts a number of evictions of prepared statements from the authorized prepared statements cache after they have been used only once. An increasing counter suggests the user may be preparing a different statement for each request instead of reusing the same prepared statement with parameters.")).set_skip_when_empty(),
 
                     sm::make_gauge(
                             "authorized_prepared_statements_cache_size",
@@ -443,7 +443,7 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                     sm::make_counter(
                             "reverse_queries",
                             _cql_stats.reverse_queries,
-                            sm::description("Counts the number of CQL SELECT requests with reverse ORDER BY order.")),
+                            sm::description("Counts the number of CQL SELECT requests with reverse ORDER BY order.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "unpaged_select_queries",
@@ -451,49 +451,49 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                                 return _cql_stats.unpaged_select_queries(ks_selector::NONSYSTEM)
                                         + _cql_stats.unpaged_select_queries(ks_selector::SYSTEM);
                             },
-                            sm::description("Counts the total number of unpaged CQL SELECT requests.")),
+                            sm::description("Counts the total number of unpaged CQL SELECT requests.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "unpaged_select_queries_per_ks",
                             _cql_stats.unpaged_select_queries(ks_selector::SYSTEM),
                             sm::description("Counts the number of unpaged CQL SELECT requests against particular keyspaces."),
-                            {system_ks_label_instance}),
+                            {system_ks_label_instance}).set_skip_when_empty(),
 
                     sm::make_counter(
                             "minimum_replication_factor_fail_violations",
                             _cql_stats.minimum_replication_factor_fail_violations,
                             sm::description("Counts the number of minimum_replication_factor_fail_threshold guardrail violations, "
-                                            "i.e. attempts to create a keyspace with RF on one of the DCs below the set guardrail.")),
+                                            "i.e. attempts to create a keyspace with RF on one of the DCs below the set guardrail.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "minimum_replication_factor_warn_violations",
                             _cql_stats.minimum_replication_factor_warn_violations,
                             sm::description("Counts the number of minimum_replication_factor_warn_threshold guardrail violations, "
-                                            "i.e. attempts to create a keyspace with RF on one of the DCs below the set guardrail.")),
+                                            "i.e. attempts to create a keyspace with RF on one of the DCs below the set guardrail.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "maximum_replication_factor_warn_violations",
                             _cql_stats.maximum_replication_factor_warn_violations,
                             sm::description("Counts the number of maximum_replication_factor_warn_threshold guardrail violations, "
-                                            "i.e. attempts to create a keyspace with RF on one of the DCs above the set guardrail.")),
+                                            "i.e. attempts to create a keyspace with RF on one of the DCs above the set guardrail.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "maximum_replication_factor_fail_violations",
                             _cql_stats.maximum_replication_factor_fail_violations,
                             sm::description("Counts the number of maximum_replication_factor_fail_threshold guardrail violations, "
-                                            "i.e. attempts to create a keyspace with RF on one of the DCs above the set guardrail.")),
+                                            "i.e. attempts to create a keyspace with RF on one of the DCs above the set guardrail.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "replication_strategy_warn_list_violations",
                             _cql_stats.replication_strategy_warn_list_violations,
                             sm::description("Counts the number of replication_strategy_warn_list guardrail violations, "
-                                            "i.e. attempts to set a discouraged replication strategy in a keyspace via CREATE/ALTER KEYSPACE.")),
+                                            "i.e. attempts to set a discouraged replication strategy in a keyspace via CREATE/ALTER KEYSPACE.")).set_skip_when_empty(),
 
                     sm::make_counter(
                             "replication_strategy_fail_list_violations",
                             _cql_stats.replication_strategy_fail_list_violations,
                             sm::description("Counts the number of replication_strategy_fail_list guardrail violations, "
-                                            "i.e. attempts to set a forbidden replication strategy in a keyspace via CREATE/ALTER KEYSPACE.")),
+                                            "i.e. attempts to set a forbidden replication strategy in a keyspace via CREATE/ALTER KEYSPACE.")).set_skip_when_empty(),
             });
 
     _mnotifier.register_listener(_migration_subscriber.get());


### PR DESCRIPTION
This patch introduces the skip_when_empty flag to all CQL counters that previously lacked this setting.

The skip_when_empty flag is a metric optimization that prevents reporting on counters that have never been used. Once a counter has been used (i.e., it holds a positive value), it will continue to be reported consistently from that point onward.

Fixes #21046

Enhancement, no need to backport