### PR TITLE
Make restore task abortable

### DIFF
--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -15,6 +15,10 @@
 #include "schema/schema_fwd.hh"
 #include "seastarx.hh"
 
+namespace seastar {
+    class abort_source;
+}
+
 namespace data_dictionary {
 
 struct storage_options {
@@ -30,6 +34,7 @@ struct storage_options {
         sstring bucket;
         sstring endpoint;
         std::variant<sstring, table_id> location;
+        seastar::abort_source* abort_source = nullptr;
         static constexpr std::string_view name = "S3";
 
         static s3 from_map(const std::map<sstring, sstring>&);

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -22,6 +22,10 @@
 #include "db/system_keyspace.hh"
 #include "sstables/sstable_directory.hh"
 
+namespace seastar {
+    class abort_source;
+}
+
 namespace replica {
 class database;
 class table;
@@ -89,7 +93,7 @@ public:
     static future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
             get_sstables_from_upload_dir(distributed<replica::database>& db, sstring ks, sstring cf, sstables::sstable_open_config cfg);
     static future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
-            get_sstables_from_object_store(distributed<replica::database>& db, sstring ks, sstring cf, std::vector<sstring> sstables, sstring endpoint, sstring bucket, sstring prefix, sstables::sstable_open_config cfg);
+            get_sstables_from_object_store(distributed<replica::database>& db, sstring ks, sstring cf, std::vector<sstring> sstables, sstring endpoint, sstring bucket, sstring prefix, sstables::sstable_open_config cfg, std::function<seastar::abort_source*()> = {});
     static future<> process_upload_dir(distributed<replica::database>& db, sharded<db::view::view_builder>& vb, sstring ks_name, sstring cf_name);
 };
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -495,6 +495,11 @@ public:
     virtual tasks::is_user_task is_user_task() const noexcept override {
         return tasks::is_user_task::yes;
     }
+
+    tasks::is_abortable is_abortable() const noexcept override {
+        return tasks::is_abortable::yes;
+    }
+
     virtual future<tasks::task_manager::task::progress> get_progress() const override {
         llog.debug("get_progress: {}", _num_sstables_processed);
         unsigned processed = co_await _loader.map_reduce(adder<unsigned>(), [this] (auto&) {
@@ -514,14 +519,50 @@ future<> sstables_loader::download_task_impl::run() {
         .load_bloom_filter = false,
     };
     llog.debug("Loading sstables from {}({}/{})", _endpoint, _bucket, _prefix);
-    auto [ table_id, sstables_on_shards ] = co_await replica::distributed_loader::get_sstables_from_object_store(_loader.local()._db, _ks, _cf, _sstables, _endpoint, _bucket, _prefix, cfg);
-    llog.debug("Streaming sstables from {}({}/{})", _endpoint, _bucket, _prefix);
-    co_await _loader.invoke_on_all([this, &sstables_on_shards, table_id] (sstables_loader& loader) mutable -> future<> {
-        co_await loader.load_and_stream(_ks, _cf, table_id, std::move(sstables_on_shards[this_shard_id()]), false, false,
-                                        [this] (unsigned num_streamed) {
-            _num_sstables_processed[this_shard_id()] += num_streamed;
-        });
+
+    std::vector<seastar::abort_source> shard_aborts(smp::count);
+    auto [ table_id, sstables_on_shards ] = co_await replica::distributed_loader::get_sstables_from_object_store(_loader.local()._db, _ks, _cf, _sstables, _endpoint, _bucket, _prefix, cfg, [&] {
+        return &shard_aborts[this_shard_id()];
     });
+    llog.debug("Streaming sstables from {}({}/{})", _endpoint, _bucket, _prefix);
+    std::exception_ptr ex;
+    gate g;
+    try {
+        _as.check();
+
+        auto s = _as.subscribe([&]() noexcept {
+            try {
+                auto h = g.hold();
+                (void)smp::invoke_on_all([&shard_aborts, ex = _as.abort_requested_exception_ptr()] {
+                    shard_aborts[this_shard_id()].request_abort_ex(ex);
+                }).finally([h = std::move(h)] {});
+            } catch (...) {
+            }
+        });
+
+        co_await _loader.invoke_on_all([this, &sstables_on_shards, table_id] (sstables_loader& loader) mutable -> future<> {
+            co_await loader.load_and_stream(_ks, _cf, table_id, std::move(sstables_on_shards[this_shard_id()]), false, false, [this] (unsigned num_streamed) {
+                _num_sstables_processed[this_shard_id()] += num_streamed;
+            });
+        });
+    } catch (...) {
+        ex = std::current_exception();
+    }
+
+    co_await g.close();
+
+    if (_as.abort_requested()) {
+        if (!ex) {
+            ex = _as.abort_requested_exception_ptr();
+        }
+    }
+
+    if (ex) {
+        co_await _loader.invoke_on_all([&sstables_on_shards] (sstables_loader&) {
+            sstables_on_shards[this_shard_id()] = {}; // clear on correct shard
+        });
+        co_await coroutine::return_exception_ptr(std::move(ex));
+    }
 }
 
 sstables_loader::sstables_loader(sharded<replica::database>& db,
@@ -551,6 +592,7 @@ future<tasks::task_id> sstables_loader::download_new_sstables(sstring ks_name, s
         throw std::invalid_argument(format("endpoint {} not found", endpoint));
     }
     llog.info("Restore sstables from {}({}) to {}", endpoint, prefix, ks_name);
+
     auto task = co_await _task_manager_module->make_and_start_task<download_task_impl>({}, container(), std::move(endpoint), std::move(bucket), std::move(ks_name), std::move(cf_name), std::move(prefix), std::move(sstables));
     co_return task->id();
 }

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -106,7 +106,7 @@ public:
     future<> put_object(sstring object_name, ::memory_data_sink_buffers bufs, seastar::abort_source* = nullptr);
     future<> delete_object(sstring object_name, seastar::abort_source* = nullptr);
 
-    file make_readable_file(sstring object_name);
+    file make_readable_file(sstring object_name, seastar::abort_source* = nullptr);
     data_sink make_upload_sink(sstring object_name, seastar::abort_source* = nullptr);
     data_sink make_upload_jumbo_sink(sstring object_name, std::optional<unsigned> max_parts_per_piece = {}, seastar::abort_source* = nullptr);
     /// upload a file with specified path to s3


### PR DESCRIPTION
Fixes #20717

Enables abortable interface and propagates abort_source to all s3 objects used for reading the restore data.
    
Note: because restore is done on each shard, we have to maintain a per-shard abort source proxy for each, and do a background per-shard abort on abort call. This is synced at the end of "run()".

Abort source is added as an optional parameter to s3 storage and the s3 path in distributed loader. 

There is no attempt to "clean up" an aborted restore. As we read on a mutation level from remote sstables, we should not cause incomplete sstables as such, even though we might end up of course with partial data restored. 