### PR TITLE
raft: wait for the group0 upgrade to be finished before applying the group0 commands

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5503,6 +5503,10 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
     try {
         auto& raft_server = _group0->group0_server();
         auto group0_holder = _group0->hold_group0_gate();
+
+        // make sure any pending group0 upgrade is completed
+        co_await _group0->client().wait_until_group0_upgraded(_group0_as);
+
         // do barrier to make sure we always see the latest topology
         co_await raft_server.read_barrier(&_group0_as);
         if (raft_server.get_current_term() != term) {


### PR DESCRIPTION
There is a race condition in interaction between the raft-based topology and the group0 layer that can cause the group0 commands to be applied during the group0 upgrade procedure, causing the node startup to fail.

This patch fixes the issue by waiting for the group0 upgrade to be finished before applying the group0 commands.

Fixes: #20844

Backporting because it fixes a race condition in the product and also the associated test flakiness that can appear in CI runs of other branches too.