### PR TITLE
treewide: include seastar/core/format.hh instead of seastar/core/print.hh

### DIFF
--- a/alternator/expressions.cc
+++ b/alternator/expressions.cc
@@ -17,7 +17,7 @@
 
 #include "seastarx.hh"
 
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/util/log.hh>
 
 #include <functional>

--- a/auth/authentication_options.hh
+++ b/auth/authentication_options.hh
@@ -14,7 +14,7 @@
 #include <unordered_set>
 #include <variant>
 
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/sstring.hh>
 
 #include "seastarx.hh"

--- a/auth/role_manager.hh
+++ b/auth/role_manager.hh
@@ -14,7 +14,7 @@
 #include <unordered_set>
 
 #include <seastar/core/future.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/sstring.hh>
 
 #include "auth/resource.hh"

--- a/auth/roles-metadata.cc
+++ b/auth/roles-metadata.cc
@@ -8,7 +8,7 @@
 
 #include "auth/roles-metadata.hh"
 
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
 

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -15,7 +15,7 @@
 #include <boost/algorithm/string/join.hpp>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/on_internal_error.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>

--- a/bytes.cc
+++ b/bytes.cc
@@ -8,7 +8,7 @@
 
 #include "bytes.hh"
 #include <fmt/ostream.h>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 static inline int8_t hex_to_int(unsigned char c) {
     switch (c) {

--- a/cql3/functions/bytes_conversion_fcts.hh
+++ b/cql3/functions/bytes_conversion_fcts.hh
@@ -12,7 +12,7 @@
 
 #include "native_scalar_function.hh"
 #include "exceptions/exceptions.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/util/log.hh>
 #include "cql3/cql3_type.hh"
 

--- a/cql3/functions/castas_fcts.hh
+++ b/cql3/functions/castas_fcts.hh
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "cql3/functions/function.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 namespace cql3 {
 namespace functions {

--- a/cql3/statements/index_prop_defs.cc
+++ b/cql3/statements/index_prop_defs.cc
@@ -9,7 +9,7 @@
  */
 
 #include <set>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include "index_prop_defs.hh"
 #include "index/secondary_index.hh"
 #include "exceptions/exceptions.hh"

--- a/cql3/statements/property_definitions.cc
+++ b/cql3/statements/property_definitions.cc
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include "cql3/statements/property_definitions.hh"
 #include "exceptions/exceptions.hh"
 

--- a/cql3/statements/request_validations.hh
+++ b/cql3/statements/request_validations.hh
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "exceptions/exceptions.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 #include <set>
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -19,7 +19,7 @@
 #include <fmt/ranges.h>
 
 #include <seastar/core/coroutine.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/log-cli.hh>
 #include <seastar/net/tls.hh>

--- a/db/hints/internal/hint_sender.cc
+++ b/db/hints/internal/hint_sender.cc
@@ -17,7 +17,7 @@
 #include <seastar/core/file-types.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sleep.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/seastar.hh>
 
 // Boost features.

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -7,7 +7,7 @@
  */
 
 #include "utils/assert.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/coroutine.hh>
 #include "db/system_keyspace.hh"
 #include "db/large_data_handler.hh"

--- a/duration.cc
+++ b/duration.cc
@@ -9,7 +9,7 @@
 #include "duration.hh"
 
 #include <boost/lexical_cast.hpp>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 #include <cctype>
 #include <optional>

--- a/exceptions/exceptions.cc
+++ b/exceptions/exceptions.cc
@@ -11,7 +11,7 @@
 #include "exceptions.hh"
 
 #include "bytes.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/util/log.hh>
 
 namespace exceptions {

--- a/gms/inet_address.cc
+++ b/gms/inet_address.cc
@@ -11,7 +11,7 @@
 #include <boost/io/ios_state.hpp>
 #include <seastar/net/inet_address.hh>
 #include <seastar/net/dns.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/future.hh>
 #include "inet_address.hh"
 

--- a/gms/version_generator.cc
+++ b/gms/version_generator.cc
@@ -11,7 +11,7 @@
 #include <seastar/util/modules.hh>
 #include <seastar/core/shard_id.hh>
 #include <seastar/core/on_internal_error.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include "utils/log.hh"
 #include "seastarx.hh"
 #include "version_generator.hh"

--- a/mutation/range_tombstone_assembler.hh
+++ b/mutation/range_tombstone_assembler.hh
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <exception>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 #include "mutation/mutation_fragment_v2.hh"
 

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -7,7 +7,7 @@
  */
 
 #include <seastar/core/seastar.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/file.hh>
 #include <seastar/util/lazy.hh>
 #include <seastar/util/log.hh>

--- a/redis/exceptions.hh
+++ b/redis/exceptions.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 #include "bytes.hh"
 

--- a/redis/keyspace_utils.cc
+++ b/redis/keyspace_utils.cc
@@ -23,7 +23,7 @@
 #include "db/system_keyspace.hh"
 #include "schema/schema.hh"
 #include "gms/gossiper.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include "db/config.hh"
 #include "data_dictionary/keyspace_metadata.hh"
 #include "replica/database.hh"

--- a/redis/mutation_utils.cc
+++ b/redis/mutation_utils.cc
@@ -10,7 +10,7 @@
 #include "types/types.hh"
 #include "service/storage_proxy.hh"
 #include "schema/schema.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include "redis/keyspace_utils.hh"
 #include "redis/options.hh"
 #include "mutation/mutation.hh"

--- a/redis/options.cc
+++ b/redis/options.cc
@@ -9,7 +9,7 @@
 #include "redis/options.hh"
 #include "service/storage_proxy.hh"
 #include "data_dictionary/data_dictionary.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include "redis/keyspace_utils.hh"
 
 using namespace seastar;

--- a/redis/reply.hh
+++ b/redis/reply.hh
@@ -11,7 +11,7 @@
 #include "bytes.hh"
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/scattered_message.hh>
 #include "redis/exceptions.hh"
 #include "utils/fmt-compat.hh"

--- a/release.cc
+++ b/release.cc
@@ -13,7 +13,7 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 static const char scylla_product_str[] = SCYLLA_PRODUCT;
 static const char scylla_version_str[] = SCYLLA_VERSION;

--- a/replica/exceptions.hh
+++ b/replica/exceptions.hh
@@ -13,7 +13,7 @@
 #include <variant>
 
 #include <seastar/core/abort_source.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/timed_out_error.hh>
 

--- a/service/qos/qos_common.hh
+++ b/service/qos/qos_common.hh
@@ -11,7 +11,7 @@
 #include "db/consistency_level_type.hh"
 #include "seastarx.hh"
 #include <seastar/core/sstring.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <map>
 #include <stdexcept>
 #include <string_view>

--- a/sstables/exceptions.hh
+++ b/sstables/exceptions.hh
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <concepts>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 #include "seastarx.hh"
 

--- a/sstables/integrity_checked_file_impl.cc
+++ b/sstables/integrity_checked_file_impl.cc
@@ -8,7 +8,7 @@
 
 #include "integrity_checked_file_impl.hh"
 #include <seastar/core/do_with.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <boost/algorithm/cxx11/all_of.hpp>
 #include "bytes.hh"
 

--- a/supervisor.hh
+++ b/supervisor.hh
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <seastar/core/sstring.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/util/log.hh>
 #include "seastarx.hh"
 #include <systemd/sd-daemon.h>

--- a/test/boost/checksum_utils_test.cc
+++ b/test/boost/checksum_utils_test.cc
@@ -11,7 +11,7 @@
 #include <boost/test/unit_test.hpp>
 #include "sstables/checksum_utils.hh"
 #include "test/lib/make_random_string.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 template<typename ReferenceImpl, typename Impl>
 static

--- a/test/boost/crc_test.cc
+++ b/test/boost/crc_test.cc
@@ -12,7 +12,7 @@
 #include "utils/crc.hh"
 #include "utils/clmul.hh"
 #include "utils/gz/barrett.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 constexpr uint32_t input_32_1_c = 0x12345678;
 uint32_t input_32_1 = input_32_1_c; // NOT constexpr

--- a/test/boost/dirty_memory_manager_test.cc
+++ b/test/boost/dirty_memory_manager_test.cc
@@ -14,7 +14,7 @@
 
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/core/sleep.hh>

--- a/test/boost/double_decker_test.cc
+++ b/test/boost/double_decker_test.cc
@@ -10,7 +10,7 @@
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <fmt/core.h>
 #include <string>
 

--- a/test/boost/flush_queue_test.cc
+++ b/test/boost/flush_queue_test.cc
@@ -19,7 +19,7 @@
 
 #include "seastarx.hh"
 #include "test/lib/scylla_test_case.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include "utils/flush_queue.hh"
 
 SEASTAR_TEST_CASE(test_queue_ordering_random_ops) {

--- a/test/boost/logalloc_test.cc
+++ b/test/boost/logalloc_test.cc
@@ -12,7 +12,7 @@
 #include <algorithm>
 
 #include <seastar/core/circular_buffer.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/core/sleep.hh>

--- a/test/boost/murmur_hash_test.cc
+++ b/test/boost/murmur_hash_test.cc
@@ -12,7 +12,7 @@
 
 #include "utils/murmur_hash.hh"
 #include "bytes.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 static const bytes full_sequence("012345678901234567890123456789012345678901234567890123456789");
 

--- a/test/lib/test_utils.cc
+++ b/test/lib/test_utils.cc
@@ -10,7 +10,7 @@
 
 #include <seastar/util/file.hh>
 #include <boost/range/adaptor/map.hpp>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/util/backtrace.hh>
 #include "test/lib/log.hh"
 #include "test/lib/simple_schema.hh"

--- a/test/manual/streaming_histogram_test.cc
+++ b/test/manual/streaming_histogram_test.cc
@@ -10,7 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include "utils/streaming_histogram.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <map>
 #include <cmath>
 

--- a/test/perf/perf.hh
+++ b/test/perf/perf.hh
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <ranges>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/distributed.hh>
 #include <seastar/core/weak_ptr.hh>

--- a/tracing/traced_file.cc
+++ b/tracing/traced_file.cc
@@ -7,7 +7,7 @@
  */
 
 #include <seastar/core/future.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 #include "tracing/traced_file.hh"
 

--- a/transport/cql_protocol_extension.cc
+++ b/transport/cql_protocol_extension.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include "transport/cql_protocol_extension.hh"
 #include "cql3/result_set.hh"
 #include "exceptions/exceptions.hh"

--- a/transport/messages/result_message.cc
+++ b/transport/messages/result_message.cc
@@ -10,7 +10,7 @@
 #include "result_message.hh"
 #include "cql3/cql_statement.hh"
 #include "utils/to_string.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 namespace cql_transport::messages {
 

--- a/types/types.cc
+++ b/types/types.cc
@@ -17,7 +17,7 @@
 #include "concrete_types.hh"
 #include <exception>
 #include <iterator>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/shared_ptr.hh>
 #include "types/types.hh"
 #include "utils/assert.hh"

--- a/unimplemented.hh
+++ b/unimplemented.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/enum.hh>
 

--- a/utils/UUID.hh
+++ b/utils/UUID.hh
@@ -17,7 +17,7 @@
 #include <compare>
 
 #include <seastar/core/sstring.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/net/byteorder.hh>
 #include "bytes.hh"
 #include "utils/assert.hh"

--- a/utils/base64.cc
+++ b/utils/base64.cc
@@ -8,7 +8,7 @@
 
 #include "base64.hh"
 
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 // Arrays for quickly converting to and from an integer between 0 and 63,
 // and the character used in base64 encoding to represent it.

--- a/utils/big_decimal.cc
+++ b/utils/big_decimal.cc
@@ -10,7 +10,7 @@
 #include "big_decimal.hh"
 #include <cassert>
 #include "marshal_exception.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 #ifdef __clang__
 

--- a/utils/bloom_calculations.hh
+++ b/utils/bloom_calculations.hh
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "utils/assert.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include "exceptions/exceptions.hh"
 
 namespace utils {

--- a/utils/config_file.cc
+++ b/utils/config_file.cc
@@ -20,7 +20,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/fstream.hh>
 #include <seastar/core/do_with.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/util/defer.hh>
 

--- a/utils/estimated_histogram.hh
+++ b/utils/estimated_histogram.hh
@@ -17,7 +17,7 @@
 #include <chrono>
 #include <fmt/ostream.h>
 #include <seastar/core/metrics_types.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include "seastarx.hh"
 #include <seastar/core/bitops.hh>
 #include <limits>

--- a/utils/exceptions.cc
+++ b/utils/exceptions.cc
@@ -5,7 +5,7 @@
 /* SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/rpc/rpc.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/backtrace.hh>

--- a/utils/fragment_range.hh
+++ b/utils/fragment_range.hh
@@ -12,7 +12,7 @@
 #include <compare>
 #include <algorithm>
 #include <seastar/net/byteorder.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/util/backtrace.hh>
 
 #include "marshal_exception.hh"

--- a/utils/fragmented_temporary_buffer.hh
+++ b/utils/fragmented_temporary_buffer.hh
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include <seastar/core/iostream.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/simple-stream.hh>
 

--- a/utils/int_range.hh
+++ b/utils/int_range.hh
@@ -10,7 +10,7 @@
 
 #include "utils/assert.hh"
 #include "interval.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 
 #include "seastarx.hh"
 

--- a/utils/lister.cc
+++ b/utils/lister.cc
@@ -1,5 +1,5 @@
 #include <seastar/core/coroutine.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/util/log.hh>

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -14,7 +14,7 @@
 
 #include <seastar/core/memory.hh>
 #include <seastar/core/align.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/coroutine.hh>

--- a/utils/rjson.cc
+++ b/utils/rjson.cc
@@ -7,7 +7,7 @@
  */
 
 #include "rjson.hh"
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/iostream.hh>

--- a/version.hh
+++ b/version.hh
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <seastar/core/sstring.hh>
-#include <seastar/core/print.hh>
+#include <seastar/core/format.hh>
 #include <tuple>
 
 namespace version {


### PR DESCRIPTION
The later includes the former and in addition to `seastar::format()`, `print.hh` also provides helpers like `seastar::fprint()` and `seastar::print()`, which are deprecated and not used by scylladb.

Previously, we include `seastar/core/print.hh` for using `seastar::format()`. and in seastar 5b04939e, we extracted `seastar::format()` into `seastar/core/format.hh`. this allows us to include a much smaller header.

In this change, we just include `seastar/core/format.hh` in place of `seastar/core/print.hh`.

---

it's a cleanup, hence no need to backport.