### PR TITLE
docs: align tablestats documentation with actual output

### DIFF
--- a/docs/operating-scylla/nodetool-commands/_common/stats-output.rst
+++ b/docs/operating-scylla/nodetool-commands/_common/stats-output.rst
@@ -72,7 +72,7 @@ Off heap memory used (total)                      The memory used by memtable, b
 ------------------------------------------------  ---------------------------------------------------------------------------------
 SSTable Compression Ratio                         The ratio of the SSTable compression
 ------------------------------------------------  ---------------------------------------------------------------------------------
-Number of keys (estimate)                         The estimated row count (based on the estimated histogram)
+Number of partitions (estimate)                   The estimated partition count (based on the estimated histogram)
 ------------------------------------------------  ---------------------------------------------------------------------------------
 Memtable cell count                               memtable column count
 ------------------------------------------------  ---------------------------------------------------------------------------------


### PR DESCRIPTION
Update the tablestats documentation to correctly describe the "Number of partitions" metric. The previous documentation incorrectly referred to "estimated row count" when the command actually shows estimated partition count.

Before:

```
Number of keys (estimate) | The estimated row count
```

After:

```
Number of partitions (estimate) | The estimated partition count
```

This distinction is important since a partition (identified by its partition key) can contain multiple rows in ScyllaDB. The updated format also matches Cassandra's nodetool output for better compatibility.

Fixes scylladb/scylladb#21586

---

this addresses an issue in user-facing document, so should be backported to all LTS branches.