### PR TITLE
Fix gossiper orphan node floating problem by adding a remover fiber

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -389,6 +389,7 @@ future<> gossiper::do_send_ack2_msg(msg_addr from, utils::chunked_vector<gossip_
     gms::gossip_digest_ack2 ack2_msg(std::move(delta_ep_state_map));
     logger.debug("Calling do_send_ack2_msg to node {}, ack_msg_digest={}, ack2_msg={}", from, ack_msg_digest, ack2_msg);
     co_await ser::gossip_rpc_verbs::send_gossip_digest_ack2(&_messaging, from, std::move(ack2_msg));
+    logger.debug("finished do_send_ack2_msg to node {}, ack_msg_digest={}, ack2_msg={}", from, ack_msg_digest, ack2_msg);
 }
 
 // Depends on

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -13,6 +13,7 @@
 #include "compaction/task_manager_module.hh"
 #include "gc_clock.hh"
 #include "raft/raft.hh"
+#include <seastar/core/sleep.hh>
 #include "service/qos/raft_service_level_distributed_data_accessor.hh"
 #include "service/qos/service_level_controller.hh"
 #include "service/qos/standard_service_level_distributed_data_accessor.hh"
@@ -20,6 +21,7 @@
 #include "service/topology_guard.hh"
 #include "service/session.hh"
 #include "dht/boot_strapper.hh"
+#include <chrono>
 #include <exception>
 #include <optional>
 #include <fmt/ranges.h>
@@ -109,6 +111,8 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/join.hpp>
+#include <stdexcept>
+#include <unistd.h>
 
 using token = dht::token;
 using UUID = utils::UUID;
@@ -1264,6 +1268,11 @@ public:
     future<> pre_server_start(const group0_info& g0_info) override {
         rtlogger.info("join: sending the join request to {}", g0_info.ip_addr);
 
+        co_await utils::get_local_injector().inject("crash_before_group0_join", [](auto& handler) -> future<> {
+            // This wait ensures that node gossips its state before crashing.
+            co_await handler.wait_for_message(db::timeout_clock::now() + std::chrono::minutes(5));
+            throw std::runtime_error("deliberately crashed for orphan remover test");
+        });
         auto result = co_await ser::join_node_rpc_verbs::send_join_node_request(
                 &_ss._messaging.local(), netw::msg_addr(g0_info.ip_addr), g0_info.id, _req);
         std::visit(overloaded_functor {

--- a/test/topology_custom/test_gossiper_orphan_remover.py
+++ b/test/topology_custom/test_gossiper_orphan_remover.py
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+import asyncio
+import time
+import pytest
+import logging
+from test.pylib.manager_client import ManagerClient
+from test.topology.conftest import skip_mode
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_crashed_node_substitution(manager: ManagerClient):
+    servers = await manager.servers_add(3, config={
+        'error_injections_at_startup': ['fast_orphan_removal_fiber']
+    })
+
+    cmdline = [
+        '--logger-log-level', 'gossip=debug',
+    ]
+    failed_server = await manager.server_add(start=False, config={
+        'error_injections_at_startup': ['crash_before_group0_join']}, cmdline=cmdline)
+    task = asyncio.create_task(manager.server_start(failed_server.server_id, expected_error="deliberately crashed for orphan remover test"))
+
+    log = await manager.server_open_log(failed_server.server_id)
+    await log.wait_for("finished do_send_ack2_msg")
+    await manager.api.message_injection(failed_server.ip_addr, 'crash_before_group0_join')
+    
+    await task
+    
+    live_eps = await manager.api.client.get_json("/gossiper/endpoint/live", host=servers[0].ip_addr)
+    down_eps = await manager.api.client.get_json("/gossiper/endpoint/down", host=servers[0].ip_addr)
+
+    gossiper_eps = live_eps + down_eps
+    post_crash_servers = await manager.running_servers()
+    server_eps = [s.ip_addr for s in post_crash_servers]
+
+    assert len(gossiper_eps) == (len(server_eps)+1)
+
+    orphan_ip = [ip for ip in gossiper_eps if ip not in server_eps][0]
+    assert failed_server.ip_addr == orphan_ip 
+
+    [await manager.api.enable_injection(s.ip_addr, 'speedup_orphan_removal', one_shot=False) for s in servers]
+    [await manager.api.message_injection(s.ip_addr, 'fast_orphan_removal_fiber') for s in servers]
+
+    log = await manager.server_open_log(servers[0].server_id)
+    await log.wait_for(f"Finished to force remove node {orphan_ip}")
+
+    post_wait_live_eps = await manager.api.client.get_json("/gossiper/endpoint/live", host=servers[0].ip_addr)
+    post_wait_down_eps = await manager.api.client.get_json("/gossiper/endpoint/down", host=servers[0].ip_addr)
+
+    assert len(post_wait_live_eps + post_wait_down_eps) == len(server_eps)
+    assert orphan_ip not in (post_wait_live_eps + post_wait_down_eps)


### PR DESCRIPTION
In the current scenario, if during startup, a node crashes after initiating gossip and before joining group0, then it keeps floating in the gossiper forever because the raft based gossiper purging logic is only effective once node joins group0. This orphan node hinders the successor node from same ip to join cluster since it collides with it during gossiper shadow round.

This pr intends to fix this issue by adding a background thread which periodically checks for such orphan entries in gossiper and removes them.

A test is also added in to verify this logic. This test fails without this background thread enabled, hence verifying the behavior.

This PR fixes a bug. Hence we need to backport it.

Fixes: #20082