### PR TITLE
mutation: switch from boost ranges to std ranges

### DIFF
--- a/cql3/statements/prune_materialized_view_statement.cc
+++ b/cql3/statements/prune_materialized_view_statement.cc
@@ -13,6 +13,7 @@
 #include "service/storage_proxy.hh"
 #include <fmt/ranges.h>
 #include <seastar/core/coroutine.hh>
+#include <boost/range/adaptor/filtered.hpp>
 
 using namespace std::chrono_literals;
 

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1089,7 +1089,7 @@ bool mutation_partition::equal(const schema& this_schema, const mutation_partiti
         return false;
     }
 
-    if (!boost::equal(non_dummy_rows(), p.non_dummy_rows(),
+    if (!std::ranges::equal(non_dummy_rows(), p.non_dummy_rows(),
         [&] (const rows_entry& e1, const rows_entry& e2) {
             return e1.equal(this_schema, e2, p_schema);
         }

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -10,7 +10,6 @@
 
 #include <iosfwd>
 #include <boost/intrusive/set.hpp>
-#include <boost/range/adaptor/filtered.hpp>
 #include <boost/intrusive/parent_from_member.hpp>
 
 #include <seastar/core/bitset-iter.hh>
@@ -1460,8 +1459,8 @@ public:
     std::ranges::subrange<rows_type::iterator> range(const schema& schema, const query::clustering_range& r);
     // Returns an iterator range of rows_entry, with only non-dummy entries.
     auto non_dummy_rows() const {
-        return boost::make_iterator_range(_rows.begin(), _rows.end())
-            | boost::adaptors::filtered([] (const rows_entry& e) { return bool(!e.dummy()); });
+        return std::ranges::subrange(_rows.begin(), _rows.end())
+            | std::views::filter([] (const rows_entry& e) { return bool(!e.dummy()); });
     }
     void accept(const schema&, mutation_partition_visitor&) const;
 

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -851,7 +851,7 @@ bool mutation_partition_v2::equal(const schema& this_schema, const mutation_part
         return false;
     }
 
-    if (!boost::equal(non_dummy_rows(), p.non_dummy_rows(),
+    if (!std::ranges::equal(non_dummy_rows(), p.non_dummy_rows(),
         [&] (const rows_entry& e1, const rows_entry& e2) {
             return e1.equal(this_schema, e2, p_schema);
         }

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -11,14 +11,14 @@
 #include "utils/assert.hh"
 #include <iosfwd>
 #include <boost/intrusive/set.hpp>
-#include <boost/range/iterator_range.hpp>
-#include <boost/range/adaptor/filtered.hpp>
 #include <boost/intrusive/parent_from_member.hpp>
 
 #include <seastar/core/bitset-iter.hh>
 #include <seastar/util/optimized_optional.hh>
 
 #include "mutation_partition.hh"
+
+#include <ranges>
 
 // is_evictable::yes means that the object is part of an evictable snapshots in MVCC,
 // and non-evictable one otherwise.
@@ -252,8 +252,8 @@ public:
     std::ranges::subrange<rows_type::iterator> range(const schema& schema, const query::clustering_range& r);
     // Returns an iterator range of rows_entry, with only non-dummy entries.
     auto non_dummy_rows() const {
-        return boost::make_iterator_range(_rows.begin(), _rows.end())
-            | boost::adaptors::filtered([] (const rows_entry& e) { return bool(!e.dummy()); });
+        return std::ranges::subrange(_rows.begin(), _rows.end())
+            | std::views::filter([] (const rows_entry& e) { return bool(!e.dummy()); });
     }
     void accept(const schema&, mutation_partition_visitor&) const;
 

--- a/partition_snapshot_reader.hh
+++ b/partition_snapshot_reader.hh
@@ -15,7 +15,6 @@
 #include "clustering_key_filter.hh"
 #include "query-request.hh"
 #include "partition_snapshot_row_cursor.hh"
-#include <boost/range/algorithm/heap_algorithm.hpp>
 #include <any>
 
 extern seastar::logger mplog;

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -4408,7 +4408,7 @@ SEASTAR_TEST_CASE(test_populating_cache_with_expired_and_nonexpired_tombstones) 
         BOOST_REQUIRE_EQUAL(cp.clustered_row(*s, ck1).deleted_at(), row_tombstone(tombstone(1, dt_noexp))); // non-expired tombstone is in cache
         BOOST_REQUIRE(cp.find_row(*s, ck2) == nullptr); // expired tombstone isn't in cache
 
-        const auto rows = cp.non_dummy_rows();
+        auto rows = cp.non_dummy_rows();
         BOOST_REQUIRE(std::distance(rows.begin(), rows.end()) == 1); // cache contains non-expired row only
     });
 }


### PR DESCRIPTION
Wean the mutation code (at least the headers) from boost ranges to std ranges,
in order to reduce the dependency load. 

Cleanup, so no backport.