### PR TITLE
test: route S3 Proxy server messages through logger

### DIFF
--- a/test/pylib/s3_proxy.py
+++ b/test/pylib/s3_proxy.py
@@ -92,26 +92,6 @@ class InjectingHandler(BaseHTTPRequestHandler):
         super().__init__(*args, **kwargs)
         self.close_connection = False
 
-    def log_error(self, format, *args):
-        if self.logger:
-            self.logger.info("%s - - [%s] %s\n" %
-                             (self.client_address[0],
-                              self.log_date_time_string(),
-                              format % args))
-        else:
-            sys.stderr.write("%s - - [%s] %s\n" %
-                             (self.address_string(),
-                              self.log_date_time_string(),
-                              format % args))
-
-    def log_message(self, format, *args):
-        # Just don't be too verbose
-        if not self.logger:
-            sys.stderr.write("%s - - [%s] %s\n" %
-                             (self.address_string(),
-                              self.log_date_time_string(),
-                              format % args))
-
     def parsed_qs(self):
         parsed_url = urlparse(self.path)
         query_components = parse_qs(parsed_url.query)

--- a/test/pylib/start_s3_proxy.py
+++ b/test/pylib/start_s3_proxy.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
-import asyncio
-import signal
 import argparse
+import asyncio
+import logging
+import signal
 import time
 
 from s3_proxy import S3ProxyServer
@@ -11,11 +12,16 @@ async def run():
     parser = argparse.ArgumentParser(description="Start S3 proxy server")
     parser.add_argument('--host', default='127.0.0.1')
     parser.add_argument('--port', type=int, default=9002)
+    parser.add_argument('--log-level', default=logging.WARNING,
+                        choices=logging.getLevelNamesMapping().keys(),
+                        help="Set log level")
     parser.add_argument('--minio-uri', default="http://127.0.0.1:9000")
     parser.add_argument('--max-retries', type=int, default=5)
     parser.add_argument('--rnd-seed', type=int, default=int(time.time()))
     args = parser.parse_args()
-    server = S3ProxyServer(args.host, args.port, args.minio_uri, args.max_retries, args.rnd_seed)
+    logging.basicConfig(level=args.log_level)
+    server = S3ProxyServer(args.host, args.port, args.minio_uri, args.max_retries, args.rnd_seed,
+                           logging.getLogger('s3-proxy'))
 
     print('Starting S3 proxy server')
     await server.start()


### PR DESCRIPTION
This change was created in the same spirit of https://github.com/scylladb/scylladb/commit/f8221b960f9150f088787aa9a9baf4a04de583cf.
The S3ProxyServer (introduced in https://github.com/scylladb/scylladb/commit/8919e0ababaea180f6100d8cc2daaf4378ab2602) currently prints its
status directly to stdout, which can be distracting when reviewing test
results. For example:

```console
$ ./test.py --mode release object_store/test_backup::test_simple_backup_and_restore
Found 1 tests.
Setting minio proxy random seed to 1731924995
Starting S3 proxy server on ('127.193.179.2', 9002)
================================================================================
[N/TOTAL]   SUITE    MODE   RESULT   TEST
------------------------------------------------------------------------------
[1/1]      object_store release [ PASS ] object_store.test_backup.1
Stopping S3 proxy server
------------------------------------------------------------------------------
CPU utilization: 3.1%
```

Move these messages to use proper logging to give developers more control
over their visibility:

- Make logger parameter mandatory in S3ProxyServer constructor
- Route "Stopping S3 proxy" message through the provided logger
- Add --log-level option to the standalone proxy server launcher

The message is now hidden:

```console
$ ./test.py --mode release object_store/test_backup::test_simple_backup_and_restore
Found 1 tests.
================================================================================
[N/TOTAL]   SUITE    MODE   RESULT   TEST
------------------------------------------------------------------------------
[1/1]      object_store release [ PASS ] object_store.test_backup.1
------------------------------------------------------------------------------
CPU utilization: 4.1%
```

---

this change improves the developer experience, hence no need to backport.