### PR TITLE
repair: fix task_manager_module::abort_all_repairs

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -2464,6 +2464,8 @@ future<> repair::tablet_repair_task_impl::run() {
                     throw abort_requested_exception();
                 }
 
+                co_await utils::get_local_injector().inject("repair_tablet_repair_task_impl_run", utils::wait_for_message(10s));
+
                 std::unordered_map<dht::token_range, repair_neighbors> neighbors;
                 neighbors[m.range] = m.neighbors;
                 dht::token_range_vector ranges = {m.range};

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -554,12 +554,11 @@ bool repair::task_manager_module::is_aborted(const tasks::task_id& uuid) {
 
 void repair::task_manager_module::abort_all_repairs() {
     _aborted_pending_repairs = _pending_repairs;
-    for (auto& x : _repairs) {
-        auto it = get_local_tasks().find(x.second);
+    for (auto& id : _aborted_pending_repairs) {
+        auto it = get_local_tasks().find(id);
         if (it != get_local_tasks().end()) {
-            auto& impl = dynamic_cast<repair::shard_repair_task_impl&>(*it->second->_impl);
             // If the task is aborted, its state will change to failed. One can wait for this with task_manager::task::done().
-            impl.abort();
+            it->second->abort();
         }
     }
     rlogger.info0("Started to abort repair jobs={}, nr_jobs={}", _aborted_pending_repairs, _aborted_pending_repairs.size());

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -222,7 +222,6 @@ private:
     // Map repair id into repair_info.
     std::unordered_map<int, tasks::task_id> _repairs;
     std::unordered_set<tasks::task_id> _pending_repairs;
-    std::unordered_set<tasks::task_id> _aborted_pending_repairs;
     // The semaphore used to control the maximum
     // ranges that can be repaired in parallel.
     named_semaphore _range_parallelism_semaphore;

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -256,7 +256,7 @@ public:
     future<> run(repair_uniq_id id, std::function<void ()> func);
     future<repair_status> repair_await_completion(int id, std::chrono::steady_clock::time_point timeout);
     float report_progress();
-    bool is_aborted(const tasks::task_id& uuid);
+    future<bool> is_aborted(const tasks::task_id& uuid, shard_id shard);
 };
 
 }

--- a/test/topology_custom/test_repair.py
+++ b/test/topology_custom/test_repair.py
@@ -221,3 +221,41 @@ async def test_batchlog_flush_in_repair_with_cache(manager):
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_batchlog_flush_in_repair_without_cache(manager):
     await do_batchlog_flush_in_repair(manager, 0);
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_repair_abort(manager):
+    cfg = {'enable_tablets': True}
+    await manager.server_add(config=cfg)
+    await manager.server_add(config=cfg)
+    servers = await manager.running_servers()
+
+    cql = manager.get_cql()
+
+    cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
+    cql.execute("CREATE TABLE ks.tbl (pk int, ck int, PRIMARY KEY (pk, ck)) WITH tombstone_gc = {'mode': 'repair'}")
+
+    await manager.api.client.post(f"/task_manager/ttl", params={ "ttl": "100000" },
+                                                    host=servers[0].ip_addr)
+
+    await manager.api.enable_injection(servers[0].ip_addr, "repair_tablet_repair_task_impl_run", False, {})
+
+    # Start repair.
+    sequence_number = await manager.api.client.post_json(f"/storage_service/repair_async/ks", host=servers[0].ip_addr)
+
+    # Get repair id.
+    stats_list = await manager.api.client.get_json("/task_manager/list_module_tasks/repair", host=servers[0].ip_addr)
+    ids = [stats["task_id"] for stats in stats_list if stats["sequence_number"] == sequence_number]
+    assert len(ids) == 1
+    id = ids[0]
+
+    # Abort repair.
+    await manager.api.client.post("/storage_service/force_terminate_repair", host=servers[0].ip_addr)
+
+    await manager.api.message_injection(servers[0].ip_addr, "repair_tablet_repair_task_impl_run")
+    await manager.api.disable_injection(servers[0].ip_addr, "repair_tablet_repair_task_impl_run")
+
+    # Check if repair was aborted.
+    await manager.api.client.get_json(f"/task_manager/wait_task/{id}", host=servers[0].ip_addr)
+    statuses = await manager.api.client.get_json(f"/task_manager/task_status_recursive/{id}", host=servers[0].ip_addr)
+    assert all([status["state"] == "failed" for status in statuses])


### PR DESCRIPTION
Currently, task_manager_module::abort_all_repairs marks top-level repairs as aborted (but does not abort them) and aborts all existing shard tasks.

A running repair checks whether its id isn't contained in _aborted_pending_repairs and then proceeds to create shard tasks. If abort_all_repairs is executed after _aborted_pending_repairs is checked but before shard tasks are created, then those new tasks won't be aborted. The issue is the most severe for tablet_repair_task_impl that checks the _aborted_pending_repairs content from different shards, that do not see the top-level task. Hence the repair isn't stopped but it creates shard repair tasks on all shards but the one that initialized repair.

Abort top-level tasks in abort_all_repairs. Fix the shard on which the task abort is checked.

Fixes: #21612.

Needs backport to 6.1 and 6.2 as they contain the bug.