### PR TITLE
code cleanup: remove "sstring_view" and replace its usages by std::string_view

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -3088,7 +3088,7 @@ update_item_operation::apply(std::unique_ptr<rjson::value> previous_item, api::t
         any_updates = true;
         if (_returnvalues == returnvalues::ALL_NEW) {
             rjson::replace_with_string_name(_return_attributes,
-                to_sstring_view(column_name), rjson::copy(json_value));
+                to_string_view(column_name), rjson::copy(json_value));
         } else if (_returnvalues == returnvalues::UPDATED_NEW) {
             rjson::value&& v = rjson::copy(json_value);
             if (h) {
@@ -3099,14 +3099,14 @@ update_item_operation::apply(std::unique_ptr<rjson::value> previous_item, api::t
                     // empty and the attribute names are unique, so we can
                     // use add().
                     rjson::add_with_string_name(_return_attributes,
-                        to_sstring_view(column_name), std::move(v));
+                        to_string_view(column_name), std::move(v));
                 }
             } else {
                 rjson::add_with_string_name(_return_attributes,
-                    to_sstring_view(column_name), std::move(v));
+                    to_string_view(column_name), std::move(v));
             }
         } else if (_returnvalues == returnvalues::UPDATED_OLD && previous_item) {
-            std::string_view cn =  to_sstring_view(column_name);
+            std::string_view cn =  to_string_view(column_name);
             const rjson::value* col = rjson::find(*previous_item, cn);
             if (col) {
                 rjson::value&& v = rjson::copy(*col);
@@ -3134,9 +3134,9 @@ update_item_operation::apply(std::unique_ptr<rjson::value> previous_item, api::t
     auto do_delete = [&] (bytes&& column_name) {
         any_deletes = true;
         if (_returnvalues == returnvalues::ALL_NEW) {
-            rjson::remove_member(_return_attributes, to_sstring_view(column_name));
+            rjson::remove_member(_return_attributes, to_string_view(column_name));
         } else if (_returnvalues == returnvalues::UPDATED_OLD && previous_item) {
-            std::string_view cn =  to_sstring_view(column_name);
+            std::string_view cn =  to_string_view(column_name);
             const rjson::value* col = rjson::find(*previous_item, cn);
             if (col) {
                 // In the UPDATED_OLD case the item starts empty and column
@@ -3239,7 +3239,7 @@ update_item_operation::apply(std::unique_ptr<rjson::value> previous_item, api::t
                     // check_needs_read_before_write_attribute_updates()
                     // returns true in this case, and previous_item is
                     // available to us when the item exists.
-                    const rjson::value* v1 = previous_item ? rjson::find(*previous_item, to_sstring_view(column_name)) : nullptr;
+                    const rjson::value* v1 = previous_item ? rjson::find(*previous_item, to_string_view(column_name)) : nullptr;
                     const rjson::value& v2 = (it->value)["Value"];
                     validate_value(v2, "AttributeUpdates");
                     std::string v2_type = get_item_type_string(v2);
@@ -3274,7 +3274,7 @@ update_item_operation::apply(std::unique_ptr<rjson::value> previous_item, api::t
                 // Note that check_needs_read_before_write_attribute_updates()
                 // made sure we retrieved previous_item (if exists) when there
                 // is an ADD action.
-                const rjson::value* v1 = previous_item ? rjson::find(*previous_item, to_sstring_view(column_name)) : nullptr;
+                const rjson::value* v1 = previous_item ? rjson::find(*previous_item, to_string_view(column_name)) : nullptr;
                 const rjson::value& v2 = (it->value)["Value"];
                 validate_value(v2, "AttributeUpdates");
                 // An ADD can be used to create a new attribute (when

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -70,7 +70,7 @@ enum class table_status {
     deleting
 };
 
-static sstring_view table_status_to_sstring(table_status tbl_status) {
+static std::string_view table_status_to_sstring(table_status tbl_status) {
     switch(tbl_status) {
         case table_status::active:
             return "ACTIVE";

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -395,7 +395,7 @@ static std::string_view truncated_content_view(const chunked_content& content, s
     }
 }
 
-static tracing::trace_state_ptr maybe_trace_query(service::client_state& client_state, std::string_view username, sstring_view op, const chunked_content& query) {
+static tracing::trace_state_ptr maybe_trace_query(service::client_state& client_state, std::string_view username, std::string_view op, const chunked_content& query) {
     tracing::trace_state_ptr trace_state;
     tracing::tracing& tracing_instance = tracing::tracing::get_local_tracing_instance();
     if (tracing_instance.trace_next_query() || tracing_instance.slow_query_tracing_enabled()) {

--- a/bytes.cc
+++ b/bytes.cc
@@ -33,7 +33,7 @@ static inline int8_t hex_to_int(unsigned char c) {
     }
 }
 
-bytes from_hex(sstring_view s) {
+bytes from_hex(std::string_view s) {
     if (s.length() % 2 == 1) {
         throw std::invalid_argument("An hex string representing bytes must have an even length");
     }

--- a/bytes.hh
+++ b/bytes.hh
@@ -20,8 +20,6 @@
 #include "utils/mutable_view.hh"
 #include "utils/simple_hashers.hh"
 
-using sstring_view = std::string_view;
-
 inline bytes to_bytes(bytes&& b) {
     return std::move(b);
 }

--- a/bytes.hh
+++ b/bytes.hh
@@ -26,11 +26,11 @@ inline bytes to_bytes(bytes&& b) {
     return std::move(b);
 }
 
-inline sstring_view to_sstring_view(bytes_view view) {
+inline std::string_view to_string_view(bytes_view view) {
     return {reinterpret_cast<const char*>(view.data()), view.size()};
 }
 
-inline bytes_view to_bytes_view(sstring_view view) {
+inline bytes_view to_bytes_view(std::string_view view) {
     return {reinterpret_cast<const int8_t*>(view.data()), view.size()};
 }
 
@@ -39,7 +39,7 @@ struct fmt_hex {
     fmt_hex(const bytes_view& v) noexcept : v(v) {}
 };
 
-bytes from_hex(sstring_view s);
+bytes from_hex(std::string_view s);
 sstring to_hex(bytes_view b);
 sstring to_hex(const bytes& b);
 sstring to_hex(const bytes_opt& b);

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -439,7 +439,7 @@ schema_ptr get_base_table(const replica::database& db, const schema& s) {
     return get_base_table(db, s.ks_name(), s.cf_name());
 }
 
-schema_ptr get_base_table(const replica::database& db, sstring_view ks_name,std::string_view table_name) {
+schema_ptr get_base_table(const replica::database& db, std::string_view ks_name, std::string_view table_name) {
     if (!is_log_name(table_name)) {
         return nullptr;
     }

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -104,7 +104,7 @@ enum class operation : int8_t {
 bool is_log_for_some_table(const replica::database& db, const sstring& ks_name, const std::string_view& table_name);
 
 schema_ptr get_base_table(const replica::database&, const schema&);
-schema_ptr get_base_table(const replica::database&, sstring_view, std::string_view);
+schema_ptr get_base_table(const replica::database&, std::string_view, std::string_view);
 
 seastar::sstring base_name(std::string_view log_name);
 seastar::sstring log_name(std::string_view table_name);

--- a/concrete_types.hh
+++ b/concrete_types.hh
@@ -80,17 +80,17 @@ struct duration_type_impl final : public concrete_type<cql_duration> {
 
 struct timestamp_type_impl final : public simple_type_impl<db_clock::time_point> {
     timestamp_type_impl();
-    static db_clock::time_point from_sstring(sstring_view s);
+    static db_clock::time_point from_string_view(std::string_view s);
 };
 
 struct simple_date_type_impl final : public simple_type_impl<uint32_t> {
     simple_date_type_impl();
-    static uint32_t from_sstring(sstring_view s);
+    static uint32_t from_string_view(std::string_view s);
 };
 
 struct time_type_impl final : public simple_type_impl<int64_t> {
     time_type_impl();
-    static int64_t from_sstring(sstring_view s);
+    static int64_t from_string_view(std::string_view s);
 };
 
 struct string_type_impl : public concrete_type<sstring> {
@@ -122,7 +122,7 @@ sstring timestamp_to_json_string(const timestamp_date_base_class& t, const bytes
 
 struct timeuuid_type_impl final : public concrete_type<utils::UUID> {
     timeuuid_type_impl();
-    static utils::UUID from_sstring(sstring_view s);
+    static utils::UUID from_string_view(std::string_view s);
 };
 
 struct varint_type_impl final : public concrete_type<utils::multiprecision_int> {
@@ -131,12 +131,12 @@ struct varint_type_impl final : public concrete_type<utils::multiprecision_int> 
 
 struct inet_addr_type_impl final : public concrete_type<seastar::net::inet_address> {
     inet_addr_type_impl();
-    static seastar::net::inet_address from_sstring(sstring_view s);
+    static seastar::net::inet_address from_string_view(std::string_view s);
 };
 
 struct uuid_type_impl final : public concrete_type<utils::UUID> {
     uuid_type_impl();
-    static utils::UUID from_sstring(sstring_view s);
+    static utils::UUID from_string_view(std::string_view s);
 };
 
 template <typename Func> using visit_ret_type = std::invoke_result_t<Func, const ascii_type_impl&>;

--- a/cql3/error_collector.hh
+++ b/cql3/error_collector.hh
@@ -34,7 +34,7 @@ class error_collector : public error_listener<RecognizerType, ExceptionBaseType>
     /**
      * The CQL query.
      */
-    const sstring_view _query;
+    const std::string_view _query;
 
     /**
      * An empty bitset to be used as a workaround for AntLR null dereference
@@ -50,7 +50,7 @@ public:
      *
      * @param query the CQL query that will be parsed
      */
-    error_collector(const sstring_view& query) : _query(query) {}
+    error_collector(const std::string_view& query) : _query(query) {}
 
     /**
      * Format and throw a new \c exceptions::syntax_exception.

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -605,7 +605,7 @@ untyped_constant_parsed_value(const untyped_constant uc, data_type validator)
 {
     try {
         if (uc.partial_type == untyped_constant::type_class::hex && validator == bytes_type) {
-            auto v = static_cast<sstring_view>(uc.raw_text);
+            auto v = static_cast<std::string_view>(uc.raw_text);
             v.remove_prefix(2);
             return validator->from_string(v);
         }

--- a/cql3/query_options.cc
+++ b/cql3/query_options.cc
@@ -26,7 +26,7 @@ thread_local query_options query_options::DEFAULT{default_cql_config,
 
 query_options::query_options(const cql_config& cfg,
                            db::consistency_level consistency,
-                           std::optional<std::vector<sstring_view>> names,
+                           std::optional<std::vector<std::string_view>> names,
                            std::vector<cql3::raw_value> values,
                            std::vector<cql3::raw_value_view> value_views,
                            cql3::unset_bind_variable_vector unset,
@@ -46,7 +46,7 @@ query_options::query_options(const cql_config& cfg,
 
 query_options::query_options(const cql_config& cfg,
                              db::consistency_level consistency,
-                             std::optional<std::vector<sstring_view>> names,
+                             std::optional<std::vector<std::string_view>> names,
                              cql3::raw_value_vector_with_unset values,
                              bool skip_metadata,
                              specific_options options
@@ -65,7 +65,7 @@ query_options::query_options(const cql_config& cfg,
 
 query_options::query_options(const cql_config& cfg,
                              db::consistency_level consistency,
-                             std::optional<std::vector<sstring_view>> names,
+                             std::optional<std::vector<std::string_view>> names,
                              cql3::raw_value_view_vector_with_unset value_views,
                              bool skip_metadata,
                              specific_options options

--- a/cql3/query_options.hh
+++ b/cql3/query_options.hh
@@ -78,7 +78,7 @@ public:
 private:
     const cql_config& _cql_config;
     const db::consistency_level _consistency;
-    const std::optional<std::vector<sstring_view>> _names;
+    const std::optional<std::vector<std::string_view>> _names;
     std::vector<cql3::raw_value> _values;
     std::vector<cql3::raw_value_view> _value_views;
     unset_bind_variable_vector _unset;
@@ -127,14 +127,14 @@ public:
 
     explicit query_options(const cql_config& cfg,
                            db::consistency_level consistency,
-                           std::optional<std::vector<sstring_view>> names,
+                           std::optional<std::vector<std::string_view>> names,
                            raw_value_vector_with_unset values,
                            bool skip_metadata,
                            specific_options options
                            );
     explicit query_options(const cql_config& cfg,
                            db::consistency_level consistency,
-                           std::optional<std::vector<sstring_view>> names,
+                           std::optional<std::vector<std::string_view>> names,
                            std::vector<cql3::raw_value> values,
                            std::vector<cql3::raw_value_view> value_views,
                            unset_bind_variable_vector unset,
@@ -143,7 +143,7 @@ public:
                            );
     explicit query_options(const cql_config& cfg,
                            db::consistency_level consistency,
-                           std::optional<std::vector<sstring_view>> names,
+                           std::optional<std::vector<std::string_view>> names,
                            raw_value_view_vector_with_unset value_views,
                            bool skip_metadata,
                            specific_options options
@@ -223,7 +223,7 @@ public:
     }
 
 
-    const std::optional<std::vector<sstring_view>>& get_names() const noexcept {
+    const std::optional<std::vector<std::string_view>>& get_names() const noexcept {
         return _names;
     }
 

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -565,7 +565,7 @@ query_processor::execute_maybe_with_guard(service::query_state& query_state, ::s
 }
 
 future<::shared_ptr<result_message>>
-query_processor::execute_direct_without_checking_exception_message(const sstring_view& query_string, service::query_state& query_state, dialect d, query_options& options) {
+query_processor::execute_direct_without_checking_exception_message(const std::string_view& query_string, service::query_state& query_state, dialect d, query_options& options) {
     log.trace("execute_direct: \"{}\"", query_string);
     tracing::trace(query_state.get_trace_state(), "Parsing a statement");
     auto p = get_statement(query_string, query_state.get_client_state(), d);
@@ -684,7 +684,7 @@ prepared_cache_key_type query_processor::compute_id(
 }
 
 std::unique_ptr<prepared_statement>
-query_processor::get_statement(const sstring_view& query, const service::client_state& client_state, dialect d) {
+query_processor::get_statement(const std::string_view& query, const service::client_state& client_state, dialect d) {
     std::unique_ptr<raw::parsed_statement> statement = parse_statement(query, d);
 
     // Set keyspace for statement that require login
@@ -699,12 +699,12 @@ query_processor::get_statement(const sstring_view& query, const service::client_
 }
 
 std::unique_ptr<raw::parsed_statement>
-query_processor::parse_statement(const sstring_view& query, dialect d) {
+query_processor::parse_statement(const std::string_view& query, dialect d) {
     try {
         {
             const char* error_injection_key = "query_processor-parse_statement-test_failure";
             utils::get_local_injector().inject(error_injection_key, [&]() {
-                if (query.find(error_injection_key) != sstring_view::npos) {
+                if (query.find(error_injection_key) != std::string_view::npos) {
                     throw std::runtime_error(error_injection_key);
                 }
             });

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -195,7 +195,7 @@ const auto deref = boost::adaptors::transformed([] (const managed_bytes_opt& b) 
 /// Returns possible values from t, which must be RHS of IN.
 value_list get_IN_values(
         const expression& e, const query_options& options, const serialized_compare& comparator,
-        sstring_view column_name) {
+        std::string_view column_name) {
     const cql3::raw_value in_list = evaluate(e, options);
     if (in_list.is_null()) {
         return value_list();

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2572,8 +2572,8 @@ future<> reset_internal_paging_size() {
 namespace util {
 
 std::unique_ptr<cql3::statements::raw::select_statement> build_select_statement(
-            const sstring_view& cf_name,
-            const sstring_view& where_clause,
+            const std::string_view& cf_name,
+            const std::string_view& where_clause,
             bool select_all_columns,
             const std::vector<column_definition>& selected_columns) {
     std::ostringstream out;

--- a/cql3/util.cc
+++ b/cql3/util.cc
@@ -23,7 +23,7 @@ void __sanitizer_finish_switch_fiber(void* fake_stack_save, const void** stack_b
 
 namespace cql3::util {
 
-static void do_with_parser_impl_impl(const sstring_view& cql, dialect d, noncopyable_function<void (cql3_parser::CqlParser& parser)> f) {
+static void do_with_parser_impl_impl(const std::string_view& cql, dialect d, noncopyable_function<void (cql3_parser::CqlParser& parser)> f) {
     cql3_parser::CqlLexer::collector_type lexer_error_collector(cql);
     cql3_parser::CqlParser::collector_type parser_error_collector(cql);
     cql3_parser::CqlLexer::InputStreamType input{reinterpret_cast<const ANTLR_UINT8*>(cql.begin()), ANTLR_ENC_UTF8, static_cast<ANTLR_UINT32>(cql.size()), nullptr};
@@ -38,7 +38,7 @@ static void do_with_parser_impl_impl(const sstring_view& cql, dialect d, noncopy
 
 #ifndef DEBUG
 
-void do_with_parser_impl(const sstring_view& cql, dialect d, noncopyable_function<void (cql3_parser::CqlParser& parser)> f) {
+void do_with_parser_impl(const std::string_view& cql, dialect d, noncopyable_function<void (cql3_parser::CqlParser& parser)> f) {
     return do_with_parser_impl_impl(cql, d, std::move(f));
 }
 
@@ -50,7 +50,7 @@ void do_with_parser_impl(const sstring_view& cql, dialect d, noncopyable_functio
 
 struct thunk_args {
     // arguments to do_with_parser_impl_impl
-    const sstring_view& cql;
+    const std::string_view& cql;
     dialect d;
     noncopyable_function<void (cql3_parser::CqlParser&)>&& func;
     // Exceptions can't be returned from another stack, so store
@@ -84,7 +84,7 @@ static void thunk(int p1, int p2) {
     setcontext(&args->caller_stack);
 };
 
-void do_with_parser_impl(const sstring_view& cql, dialect d, noncopyable_function<void (cql3_parser::CqlParser& parser)> f) {
+void do_with_parser_impl(const std::string_view& cql, dialect d, noncopyable_function<void (cql3_parser::CqlParser& parser)> f) {
     static constexpr size_t stack_size = 1 << 20;
     static thread_local std::unique_ptr<char[]> stack = std::make_unique<char[]>(stack_size);
     thunk_args args{
@@ -142,11 +142,11 @@ sstring relations_to_where_clause(const expr::expression& e) {
     return boost::algorithm::join(expressions, " AND ");
 }
 
-expr::expression where_clause_to_relations(const sstring_view& where_clause, dialect d) {
+expr::expression where_clause_to_relations(const std::string_view& where_clause, dialect d) {
     return do_with_parser(where_clause, d, std::mem_fn(&cql3_parser::CqlParser::whereClause));
 }
 
-sstring rename_column_in_where_clause(const sstring_view& where_clause, column_identifier::raw from, column_identifier::raw to, dialect d) {
+sstring rename_column_in_where_clause(const std::string_view& where_clause, column_identifier::raw from, column_identifier::raw to, dialect d) {
     std::vector<expr::expression> relations = boolean_factors(where_clause_to_relations(where_clause, d));
     std::vector<expr::expression> new_relations;
     new_relations.reserve(relations.size());

--- a/cql3/util.hh
+++ b/cql3/util.hh
@@ -25,10 +25,10 @@ namespace cql3 {
 namespace util {
 
 
-void do_with_parser_impl(const sstring_view& cql, dialect d, noncopyable_function<void (cql3_parser::CqlParser& p)> func);
+void do_with_parser_impl(const std::string_view& cql, dialect d, noncopyable_function<void (cql3_parser::CqlParser& p)> func);
 
 template <typename Func, typename Result = cql3_parser::unwrap_uninitialized_t<std::invoke_result_t<Func, cql3_parser::CqlParser&>>>
-Result do_with_parser(const sstring_view& cql, dialect d, Func&& f) {
+Result do_with_parser(const std::string_view& cql, dialect d, Func&& f) {
     std::optional<Result> ret;
     do_with_parser_impl(cql, d, [&] (cql3_parser::CqlParser& parser) {
         ret.emplace(f(parser));
@@ -38,16 +38,16 @@ Result do_with_parser(const sstring_view& cql, dialect d, Func&& f) {
 
 sstring relations_to_where_clause(const expr::expression& e);
 
-expr::expression where_clause_to_relations(const sstring_view& where_clause, dialect d);
+expr::expression where_clause_to_relations(const std::string_view& where_clause, dialect d);
 
-sstring rename_column_in_where_clause(const sstring_view& where_clause, column_identifier::raw from, column_identifier::raw to, dialect d);
+sstring rename_column_in_where_clause(const std::string_view& where_clause, column_identifier::raw from, column_identifier::raw to, dialect d);
 
 /// build a CQL "select" statement with the desired parameters.
 /// If select_all_columns==true, all columns are selected and the value of
 /// selected_columns is ignored.
 std::unique_ptr<cql3::statements::raw::select_statement> build_select_statement(
-        const sstring_view& cf_name,
-        const sstring_view& where_clause,
+        const std::string_view& cf_name,
+        const std::string_view& where_clause,
         bool select_all_columns,
         const std::vector<column_definition>& selected_columns);
 

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -169,7 +169,7 @@ database::existing_index_names(std::string_view ks_name, std::string_view cf_to_
 }
 
 schema_ptr
-database::get_cdc_base_table(sstring_view ks_name, std::string_view table_name) const {
+database::get_cdc_base_table(std::string_view ks_name, std::string_view table_name) const {
     return get_cdc_base_table(*find_table(ks_name, table_name).schema());
 }
 

--- a/data_dictionary/data_dictionary.hh
+++ b/data_dictionary/data_dictionary.hh
@@ -120,7 +120,7 @@ public:
     schema_ptr find_indexed_table(std::string_view ks_name, std::string_view index_name) const;
     sstring get_available_index_name(std::string_view ks_name, std::string_view table_name,
                                                std::optional<sstring> index_name_root) const;
-    schema_ptr get_cdc_base_table(sstring_view ks_name, std::string_view table_name) const;
+    schema_ptr get_cdc_base_table(std::string_view ks_name, std::string_view table_name) const;
     schema_ptr get_cdc_base_table(const schema&) const;
     const db::extensions& extensions() const;
     const gms::feature_service& features() const;

--- a/db/hints/sync_point.cc
+++ b/db/hints/sync_point.cc
@@ -89,19 +89,19 @@ static std::vector<sync_point::shard_rps> decode_one_type(uint16_t shard_count, 
     return ret;
 }
 
-static uint64_t calculate_checksum(const sstring_view s) {
+static uint64_t calculate_checksum(const std::string_view s) {
     xx_hasher h;
     h.update(s.data(), s.size());
     return h.finalize_uint64();
 }
 
-sync_point sync_point::decode(sstring_view s) {
+sync_point sync_point::decode(std::string_view s) {
     bytes raw = base64_decode(s);
     if (raw.empty()) {
         throw std::runtime_error("Could not decode the sync point - not a valid hex string");
     }
 
-    sstring_view raw_s(reinterpret_cast<const char*>(raw.data()), raw.size());
+    std::string_view raw_s(reinterpret_cast<const char*>(raw.data()), raw.size());
     seastar::simple_memory_input_stream in{raw_s.data(), raw_s.size()};
 
     uint8_t version = ser::serializer<uint8_t>::read(in);
@@ -195,7 +195,7 @@ sstring sync_point::encode() const {
     seastar::simple_memory_output_stream out{reinterpret_cast<char*>(serialized.data()), serialized.size()};
     ser::serializer<uint8_t>::write(out, 3);
     ser::serializer<sync_point_v3>::write(out, v3);
-    sstring_view serialized_s(reinterpret_cast<const char*>(serialized.data()), version_size + measure.size());
+    std::string_view serialized_s(reinterpret_cast<const char*>(serialized.data()), version_size + measure.size());
     uint64_t checksum = calculate_checksum(serialized_s);
     ser::serializer<uint64_t>::write(out, checksum);
 

--- a/db/hints/sync_point.hh
+++ b/db/hints/sync_point.hh
@@ -30,7 +30,7 @@ struct sync_point {
     std::vector<shard_rps> mv_per_shard_rps;
 
     /// \brief Decodes a sync point from an encoded, textual form (a hexadecimal string).
-    static sync_point decode(sstring_view s);
+    static sync_point decode(std::string_view s);
 
     /// \brief Encodes the sync point in a textual form (a hexadecimal string)
     sstring encode() const;

--- a/db/marshal/type_parser.cc
+++ b/db/marshal/type_parser.cc
@@ -31,20 +31,20 @@ namespace db {
 
 namespace marshal {
 
-type_parser::type_parser(sstring_view str, size_t idx)
+type_parser::type_parser(std::string_view str, size_t idx)
     : _str{str.begin(), str.end()}
     , _idx{idx}
 { }
 
-type_parser::type_parser(sstring_view str)
+type_parser::type_parser(std::string_view str)
     : type_parser{str, 0}
 { }
 
 data_type type_parser::parse(const sstring& str) {
-    return type_parser(sstring_view(str)).parse();
+    return type_parser(std::string_view(str)).parse();
 }
 
-data_type type_parser::parse(sstring_view str) {
+data_type type_parser::parse(std::string_view str) {
     return type_parser(str).parse();
 }
 

--- a/db/marshal/type_parser.hh
+++ b/db/marshal/type_parser.hh
@@ -31,15 +31,15 @@ class type_parser {
 
     public static final TypeParser EMPTY_PARSER = new TypeParser("", 0);
 #endif
-    type_parser(sstring_view str, size_t idx);
+    type_parser(std::string_view str, size_t idx);
 public:
-    explicit type_parser(sstring_view str);
+    explicit type_parser(std::string_view str);
 
     /**
      * Parse a string containing an type definition.
      */
     static data_type parse(const sstring& str);
-    static data_type parse(sstring_view str);
+    static data_type parse(std::string_view str);
 
 #if 0
     public static AbstractType<?> parse(CharSequence compareWith) throws SyntaxException, ConfigurationException

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -167,7 +167,7 @@ const std::vector<column_id>& db::view::base_dependent_view_info::base_regular_c
     if (use_only_for_reads) {
         on_internal_error(vlogger,
                 seastar::format("base_regular_columns_in_view_pk(): operation unsupported when initialized only for view reads. "
-                "Missing column in the base table: {}", to_sstring_view(_column_missing_in_base.value_or(bytes()))));
+                "Missing column in the base table: {}", to_string_view(_column_missing_in_base.value_or(bytes()))));
     }
     return _base_regular_columns_in_view_pk;
 }
@@ -176,7 +176,7 @@ const std::vector<column_id>& db::view::base_dependent_view_info::base_static_co
     if (use_only_for_reads) {
         on_internal_error(vlogger,
                 seastar::format("base_static_columns_in_view_pk(): operation unsupported when initialized only for view reads. "
-                "Missing column in the base table: {}", to_sstring_view(_column_missing_in_base.value_or(bytes()))));
+                "Missing column in the base table: {}", to_string_view(_column_missing_in_base.value_or(bytes()))));
     }
     return _base_static_columns_in_view_pk;
 }
@@ -185,7 +185,7 @@ const schema_ptr& db::view::base_dependent_view_info::base_schema() const {
     if (use_only_for_reads) {
         on_internal_error(vlogger,
                 seastar::format("base_schema(): operation unsupported when initialized only for view reads. "
-                "Missing column in the base table: {}", to_sstring_view(_column_missing_in_base.value_or(bytes()))));
+                "Missing column in the base table: {}", to_string_view(_column_missing_in_base.value_or(bytes()))));
     }
     return _base_schema;
 }
@@ -217,8 +217,8 @@ db::view::base_info_ptr view_info::make_base_dependent_view_info(const schema& b
             base_static_columns_in_view_pk.push_back(base_col->id);
         } else if (!base_col) {
             vlogger.error("Column {} in view {}.{} was not found in the base table {}.{}",
-                    to_sstring_view(view_col_name), _schema.ks_name(), _schema.cf_name(), base.ks_name(), base.cf_name());
-            if (to_sstring_view(view_col_name) == "idx_token") {
+                    to_string_view(view_col_name), _schema.ks_name(), _schema.cf_name(), base.ks_name(), base.cf_name());
+            if (to_string_view(view_col_name) == "idx_token") {
                 vlogger.warn("Missing idx_token column is caused by an incorrect upgrade of a secondary index. "
                         "Please recreate index {}.{} to avoid future issues.", _schema.ks_name(), _schema.cf_name());
             }

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -631,7 +631,7 @@ class db_config_table final : public streaming_virtual_table {
     future<> execute(reader_permit permit, result_collector& result, const query_restrictions& qr) override {
         struct config_entry {
             dht::decorated_key key;
-            sstring_view type;
+            std::string_view type;
             sstring source;
             sstring value;
         };

--- a/lang/lua.cc
+++ b/lang/lua.cc
@@ -542,7 +542,7 @@ struct simple_date_return_visitor {
         return uint32_t(v);
     }
     uint32_t operator()(const std::string_view& v) {
-        return simple_date_type_impl::from_sstring(v);
+        return simple_date_type_impl::from_string_view(v);
     }
     uint32_t operator()(const lua_table&);
 };
@@ -561,7 +561,7 @@ struct timestamp_return_visitor {
         throw exceptions::invalid_request_exception("timestamp value must fit in signed 64 bits");
     }
     db_clock::time_point operator()(const std::string_view& v) {
-        return timestamp_type_impl::from_sstring(v);
+        return timestamp_type_impl::from_string_view(v);
     }
     db_clock::time_point operator()(const lua_table&);
 };
@@ -774,15 +774,15 @@ struct from_lua_visitor {
     }
 
     data_value operator()(const inet_addr_type_impl& t) {
-        return t.from_sstring(get_string(l, -1));
+        return t.from_string_view(get_string(l, -1));
     }
 
     data_value operator()(const uuid_type_impl&) {
-        return uuid_type_impl::from_sstring(get_string(l, -1));
+        return uuid_type_impl::from_string_view(get_string(l, -1));
     }
 
     data_value operator()(const timeuuid_type_impl&) {
-        return timeuuid_native_type{timeuuid_type_impl::from_sstring(get_string(l, -1))};
+        return timeuuid_native_type{timeuuid_type_impl::from_string_view(get_string(l, -1))};
     }
 
     data_value operator()(const bytes_type_impl& t) {
@@ -839,7 +839,7 @@ struct from_lua_visitor {
                        throw exceptions::invalid_request_exception("time value must fit in signed 64 bits");
                    },
                    [] (const std::string_view& v) {
-                       return time_type_impl::from_sstring(v);
+                       return time_type_impl::from_string_view(v);
                    }
                ))};
     }

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -184,7 +184,7 @@ class natural_endpoints_tracker {
     //
     std::unordered_map<sstring, std::unordered_map<sstring, std::unordered_set<inet_address>>> _racks;
 
-    std::unordered_map<sstring_view, data_center_endpoints> _dcs;
+    std::unordered_map<std::string_view, data_center_endpoints> _dcs;
 
     size_t _dcs_to_fill;
 

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -1919,7 +1919,7 @@ bytes collection_column_computation::serialize() const {
             break;
     }
     rjson::add(serialized, "type", rjson::from_string(type));
-    rjson::add(serialized, "collection_name", rjson::from_string(to_sstring_view(_collection_name)));
+    rjson::add(serialized, "collection_name", rjson::from_string(to_string_view(_collection_name)));
     return to_bytes(rjson::print(serialized));
 }
 

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -1554,7 +1554,7 @@ void read_collections(schema_builder& builder, sstring comparator)
     // The format of collection entries in the comparator is:
     // org.apache.cassandra.db.marshal.ColumnToCollectionType(<name1>:<type1>, ...)
 
-    auto find_closing_parenthesis = [] (sstring_view str, size_t start) {
+    auto find_closing_parenthesis = [] (std::string_view str, size_t start) {
         auto pos = start;
         auto nest_level = 0;
         do {
@@ -1591,10 +1591,10 @@ void read_collections(schema_builder& builder, sstring comparator)
             throw marshal_exception("read_collections - colon not found");
         }
 
-        auto name = from_hex(sstring_view(comparator.c_str() + pos, colon - pos));
+        auto name = from_hex(std::string_view(comparator.c_str() + pos, colon - pos));
 
         colon++;
-        auto type_str = sstring_view(comparator.c_str() + colon, end - colon);
+        auto type_str = std::string_view(comparator.c_str() + colon, end - colon);
         auto type = db::marshal::type_parser::parse(type_str);
 
         builder.with_collection(name, type);

--- a/service/mapreduce_service.cc
+++ b/service/mapreduce_service.cc
@@ -434,7 +434,7 @@ future<query::mapreduce_result> mapreduce_service::execute_on_this_shard(
     auto query_options = make_lw_shared<cql3::query_options>(
         cql3::default_cql_config,
         req.cl,
-        std::optional<std::vector<sstring_view>>(), // Represents empty names.
+        std::optional<std::vector<std::string_view>>(), // Represents empty names.
         std::vector<cql3::raw_value>(), // Represents empty values.
         true, // Skip metadata.
         cql3::query_options::specific_options::DEFAULT

--- a/sstables/column_translation.hh
+++ b/sstables/column_translation.hh
@@ -26,7 +26,7 @@ inline column_values_fixed_lengths get_clustering_values_fixed_lengths(const ser
     column_values_fixed_lengths lengths;
     lengths.reserve(header.clustering_key_types_names.elements.size());
     for (auto&& t : header.clustering_key_types_names.elements) {
-        auto type = db::marshal::type_parser::parse(to_sstring_view(t.value));
+        auto type = db::marshal::type_parser::parse(to_string_view(t.value));
         lengths.push_back(type->value_length_if_fixed());
     }
 

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -178,7 +178,7 @@ public:
     void check_column_missing_in_current_schema(const column_translation::column_info& column_info,
                                                 api::timestamp_type timestamp) const {
         if (!column_info.id) {
-            sstring name = sstring(to_sstring_view(*column_info.name));
+            sstring name = sstring(to_string_view(*column_info.name));
             auto it = _schema->dropped_columns().find(name);
             if (it == _schema->dropped_columns().end() || timestamp > it->second.timestamp) {
                 throw malformed_sstable_exception(format("Column {} missing in current schema", name));

--- a/sstables/sstable_mutation_reader.cc
+++ b/sstables/sstable_mutation_reader.cc
@@ -131,7 +131,7 @@ std::vector<column_translation::column_info> column_translation::state::build(
         cols.reserve(src.size());
         for (auto&& desc : src) {
             const bytes& type_name = desc.type_name.value;
-            data_type type = db::marshal::type_parser::parse(to_sstring_view(type_name));
+            data_type type = db::marshal::type_parser::parse(to_string_view(type_name));
             if (!features.is_enabled(CorrectUDTsInCollections) && is_certainly_scylla_sstable(features)) {
                 // See #6130.
                 type = freeze_types_in_collections(std::move(type));

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1354,7 +1354,7 @@ future<> sstable::open_data(sstable_open_config cfg) noexcept {
     }
     auto* origin = _components->scylla_metadata->data.get<scylla_metadata_type::SSTableOrigin, scylla_metadata::sstable_origin>();
     if (origin) {
-        _origin = sstring(to_sstring_view(bytes_view(origin->value)));
+        _origin = sstring(to_string_view(bytes_view(origin->value)));
     }
     auto* ts_stats = _components->scylla_metadata->data.get<scylla_metadata_type::ExtTimestampStats, scylla_metadata::ext_timestamp_stats>();
     if (ts_stats) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1841,15 +1841,15 @@ sstable::write_scylla_metadata(shard_id shard, sstable_enabled_features features
     }
     if (!_origin.empty()) {
         scylla_metadata::sstable_origin o;
-        o.value = bytes(to_bytes_view(sstring_view(_origin)));
+        o.value = bytes(to_bytes_view(std::string_view(_origin)));
         _components->scylla_metadata->data.set<scylla_metadata_type::SSTableOrigin>(std::move(o));
     }
 
     scylla_metadata::scylla_version version;
-    version.value = bytes(to_bytes_view(sstring_view(scylla_version())));
+    version.value = bytes(to_bytes_view(std::string_view(scylla_version())));
     _components->scylla_metadata->data.set<scylla_metadata_type::ScyllaVersion>(std::move(version));
     scylla_metadata::scylla_build_id build_id;
-    build_id.value = bytes(to_bytes_view(sstring_view(get_build_id())));
+    build_id.value = bytes(to_bytes_view(std::string_view(get_build_id())));
     _components->scylla_metadata->data.set<scylla_metadata_type::ScyllaBuildId>(std::move(build_id));
     if (ts_stats) {
         if (sstlog.is_enabled(log_level::debug)) {

--- a/test/boost/UUID_test.cc
+++ b/test/boost/UUID_test.cc
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(test_UUID_comparison) {
 }
 
 BOOST_AUTO_TEST_CASE(test_from_string) {
-    auto check = [] (sstring_view sv) {
+    auto check = [] (std::string_view sv) {
         auto uuid = UUID(sv);
         BOOST_CHECK_EQUAL(uuid.version(), 4);
         BOOST_CHECK_EQUAL(fmt::to_string(uuid), sv);

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -361,7 +361,7 @@ SEASTAR_TEST_CASE(test_commitlog_reader){
                 auto&& [buf, rp] = buf_rp;
                 auto linearization_buffer = bytes_ostream();
                 auto in = buf.get_istream();
-                auto str = to_sstring_view(in.read_bytes_view(buf.size_bytes(), linearization_buffer));
+                auto str = to_string_view(in.read_bytes_view(buf.size_bytes(), linearization_buffer));
                 BOOST_CHECK_EQUAL(str, "hej bubba cow");
                 count++;
                 co_return;

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -3750,7 +3750,7 @@ SEASTAR_TEST_CASE(test_rf_expand) {
             auto row0 = rows[0];
             BOOST_REQUIRE_EQUAL(row0.size(), 1);
 
-            auto parsed = rjson::parse(to_sstring_view(to_bytes(*row0[0])));
+            auto parsed = rjson::parse(to_string_view(to_bytes(*row0[0])));
             return std::move(rjson::get(parsed, "replication"));
         };
 

--- a/test/boost/hint_test.cc
+++ b/test/boost/hint_test.cc
@@ -58,7 +58,7 @@ std::ostream& operator<<(std::ostream& out, const sync_point& sp) {
 static constexpr size_t version_size = sizeof(uint8_t);
 static constexpr size_t checksum_size = sizeof(uint64_t);
 
-static uint64_t calculate_checksum(const sstring_view s) {
+static uint64_t calculate_checksum(const std::string_view s) {
     xx_hasher h;
     h.update(s.data(), s.size());
     return h.finalize_uint64();
@@ -121,7 +121,7 @@ sstring encode_v1_or_v2(const sync_point& sp, encode_version v) {
     ser::serializer<sync_point_v1_or_v2>::write(out, v2);
 
     if (v == encode_version::v2) {
-        sstring_view serialized_s(reinterpret_cast<const char*>(serialized.data()), version_size + measure.size());
+        std::string_view serialized_s(reinterpret_cast<const char*>(serialized.data()), version_size + measure.size());
         uint64_t checksum = calculate_checksum(serialized_s);
         ser::serializer<uint64_t>::write(out, checksum);
     }

--- a/test/boost/query_processor_test.cc
+++ b/test/boost/query_processor_test.cc
@@ -218,7 +218,7 @@ SEASTAR_TEST_CASE(test_query_counters) {
         };
 
         // Executes a batch of (modifying) statements and waits for it to complete.
-        auto process_batch = [&e](const std::vector<sstring_view>& queries, clevel cl) mutable {
+        auto process_batch = [&e](const std::vector<std::string_view>& queries, clevel cl) mutable {
             e.execute_batch(queries, make_options(cl)).get();
         };
 

--- a/test/boost/restrictions_test.cc
+++ b/test/boost/restrictions_test.cc
@@ -28,7 +28,7 @@ using boost::adaptors::transformed;
 
 std::unique_ptr<cql3::query_options> to_options(
         const cql3::cql_config& cfg,
-        std::optional<std::vector<sstring_view>> names,
+        std::optional<std::vector<std::string_view>> names,
         std::vector<cql3::raw_value> values) {
     static auto& d = cql3::query_options::DEFAULT;
     return std::make_unique<cql3::query_options>(
@@ -40,7 +40,7 @@ std::unique_ptr<cql3::query_options> to_options(
 /// Asserts that e.execute_prepared(id, values) contains expected rows, in any order.
 void require_rows(cql_test_env& e,
                   cql3::prepared_cache_key_type id,
-                  std::optional<std::vector<sstring_view>> names,
+                  std::optional<std::vector<std::string_view>> names,
                   const std::vector<bytes_opt>& values,
                   const std::vector<std::vector<bytes_opt>>& expected,
                   const seastar::compat::source_location& loc = source_location::current()) {

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -1308,7 +1308,7 @@ SEASTAR_TEST_CASE(test_uncompressed_compound_static_row_read) {
     auto val_cdef = UNCOMPRESSED_COMPOUND_STATIC_ROW_SCHEMA->get_column_definition(to_bytes("val"));
     BOOST_REQUIRE(val_cdef);
 
-    auto generate = [&] (int int_val, sstring_view text_val, sstring_view inet_val) {
+    auto generate = [&] (int int_val, std::string_view text_val, std::string_view inet_val) {
         std::vector<flat_reader_assertions_v2::expected_column> columns;
 
         columns.push_back({s_int_cdef, int32_type->decompose(int_val)});
@@ -1669,8 +1669,8 @@ static future<> test_partition_key_with_values_of_different_types_read(const sst
     BOOST_REQUIRE(text_cdef);
 
     auto generate = [&] (bool bool_val, double double_val, float float_val, int int_val, long long_val,
-                         sstring_view timestamp_val, sstring_view timeuuid_val, sstring_view uuid_val,
-                         sstring_view text_val) {
+                         std::string_view timestamp_val, std::string_view timeuuid_val, std::string_view uuid_val,
+                         std::string_view text_val) {
         std::vector<flat_reader_assertions_v2::expected_column> columns;
 
         columns.push_back({bool_cdef, boolean_type->decompose(bool_val)});
@@ -1906,8 +1906,8 @@ SEASTAR_TEST_CASE(test_uncompressed_subset_of_columns_read) {
 
     auto generate = [&] (std::optional<bool> bool_val, std::optional<double> double_val,
                          std::optional<float> float_val, std::optional<int> int_val, std::optional<long> long_val,
-                         std::optional<sstring_view> timestamp_val, std::optional<sstring_view> timeuuid_val,
-                         std::optional<sstring_view> uuid_val, std::optional<sstring_view> text_val) {
+                         std::optional<std::string_view> timestamp_val, std::optional<std::string_view> timeuuid_val,
+                         std::optional<std::string_view> uuid_val, std::optional<std::string_view> text_val) {
         std::vector<flat_reader_assertions_v2::expected_column> columns;
 
         if (bool_val) {

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -46,7 +46,7 @@ query::clustering_row_ranges slice(
 /// Overload that parses the WHERE clause from string.  Named differently to disambiguate when where_clause is
 /// brace-initialized.
 query::clustering_row_ranges slice_parse(
-        sstring_view where_clause, cql_test_env& env,
+        std::string_view where_clause, cql_test_env& env,
         const sstring& table_name = "t", const sstring& keyspace_name = "ks") {
     return slice(boolean_factors(cql3::util::where_clause_to_relations(where_clause, cql3::dialect{})), env, table_name, keyspace_name);
 }

--- a/test/boost/transport_test.cc
+++ b/test/boost/transport_test.cc
@@ -121,13 +121,13 @@ SEASTAR_THREAD_TEST_CASE(test_response_request_reader) {
     BOOST_CHECK(v2.unset);
     BOOST_CHECK_EQUAL(to_bytes(req.read_value_view(version).value), value);
 
-    std::vector<sstring_view> names;
+    std::vector<std::string_view> names;
     std::vector<cql3::raw_value_view> values;
     cql3::unset_bind_variable_vector unset;
     req.read_name_and_value_list(version, names, values, unset);
     BOOST_CHECK(std::none_of(unset.begin(), unset.end(), std::identity()));
     BOOST_CHECK_EQUAL(names, names_and_values | boost::adaptors::transformed([] (auto& name_and_value) {
-        return sstring_view(name_and_value.first);
+        return std::string_view(name_and_value.first);
     }));
     BOOST_CHECK_EQUAL(values, names_and_values | boost::adaptors::transformed([] (auto& name_and_value) {
         if (!name_and_value.second) {

--- a/test/lib/cql_assertions.cc
+++ b/test/lib/cql_assertions.cc
@@ -191,7 +191,7 @@ rows_assertions rows_assertions::with_serialized_columns_count(size_t columns_co
 }
 
 shared_ptr<cql_transport::messages::result_message> cquery_nofail(
-        cql_test_env& env, sstring_view query, std::unique_ptr<cql3::query_options>&& qo, const seastar::compat::source_location& loc) {
+        cql_test_env& env, std::string_view query, std::unique_ptr<cql3::query_options>&& qo, const seastar::compat::source_location& loc) {
     try {
         if (qo) {
             return env.execute_cql(query, std::move(qo)).get();
@@ -206,7 +206,7 @@ shared_ptr<cql_transport::messages::result_message> cquery_nofail(
 }
 
 void require_rows(cql_test_env& e,
-                  sstring_view qstr,
+                  std::string_view qstr,
                   const std::vector<std::vector<bytes_opt>>& expected,
                   const seastar::compat::source_location& loc) {
     try {
@@ -218,7 +218,7 @@ void require_rows(cql_test_env& e,
     }
 }
 
-void eventually_require_rows(cql_test_env& e, sstring_view qstr, const std::vector<std::vector<bytes_opt>>& expected,
+void eventually_require_rows(cql_test_env& e, std::string_view qstr, const std::vector<std::vector<bytes_opt>>& expected,
                              const seastar::compat::source_location& loc) {
     try {
         eventually([&] {

--- a/test/lib/cql_assertions.hh
+++ b/test/lib/cql_assertions.hh
@@ -74,19 +74,19 @@ void assert_that_failed(future<T>&& f)
 /// \note Should be called from a seastar::thread context, as it awaits the CQL result.
 shared_ptr<cql_transport::messages::result_message> cquery_nofail(
         cql_test_env& env,
-        sstring_view query,
+        std::string_view query,
         std::unique_ptr<cql3::query_options>&& qo = nullptr,
         const seastar::compat::source_location& loc = seastar::compat::source_location::current());
 
 /// Asserts that cquery_nofail(e, qstr) contains expected rows, in any order.
 void require_rows(cql_test_env& e,
-                  sstring_view qstr,
+                  std::string_view qstr,
                   const std::vector<std::vector<bytes_opt>>& expected,
                   const seastar::compat::source_location& loc = seastar::compat::source_location::current());
 
 /// Like require_rows, but wraps assertions in \c eventually.
 void eventually_require_rows(
-        cql_test_env& e, sstring_view qstr, const std::vector<std::vector<bytes_opt>>& expected,
+        cql_test_env& e, std::string_view qstr, const std::vector<std::vector<bytes_opt>>& expected,
         const seastar::compat::source_location& loc = seastar::compat::source_location::current());
 
 /// Asserts that e.execute_prepared(id, values) contains expected rows, in any order.

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -220,7 +220,7 @@ public:
         adjust_rlimit();
     }
 
-    virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_cql(sstring_view text) override {
+    virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_cql(std::string_view text) override {
         testlog.trace("{}(\"{}\")", __FUNCTION__, text);
         auto qs = make_query_state();
         auto qo = make_shared<cql3::query_options>(cql3::query_options::DEFAULT);
@@ -230,7 +230,7 @@ public:
     }
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_cql(
-        sstring_view text,
+        std::string_view text,
         std::unique_ptr<cql3::query_options> qo) override
     {
         testlog.trace("{}(\"{}\")", __FUNCTION__, text);
@@ -1067,7 +1067,7 @@ private:
 
 public:
     future<::shared_ptr<cql_transport::messages::result_message>> execute_batch(
-        const std::vector<sstring_view>& queries, std::unique_ptr<cql3::query_options> qo) override {
+        const std::vector<std::string_view>& queries, std::unique_ptr<cql3::query_options> qo) override {
         using cql3::statements::batch_statement;
         using cql3::statements::modification_statement;
         std::vector<batch_statement::single_statement> modifications;

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -111,14 +111,14 @@ class cql_test_env {
 public:
     virtual ~cql_test_env() {};
 
-    virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_cql(sstring_view text) = 0;
+    virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_cql(std::string_view text) = 0;
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_cql(
-            sstring_view text, std::unique_ptr<cql3::query_options> qo) = 0;
+            std::string_view text, std::unique_ptr<cql3::query_options> qo) = 0;
 
     /// Processes queries (which must be modifying queries) as a batch.
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_batch(
-        const std::vector<sstring_view>& queries, std::unique_ptr<cql3::query_options> qo) = 0;
+        const std::vector<std::string_view>& queries, std::unique_ptr<cql3::query_options> qo) = 0;
 
     virtual future<cql3::prepared_cache_key_type> prepare(sstring query) = 0;
 

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -53,7 +53,7 @@ raw_value make_bigint_raw(int64_t val) {
     return make_raw(val);
 }
 
-raw_value make_text_raw(const sstring_view& text) {
+raw_value make_text_raw(const std::string_view& text) {
     return raw_value::make_value(utf8_type->decompose(text));
 }
 
@@ -95,7 +95,7 @@ constant make_bigint_const(int64_t val) {
     return make_const(val);
 }
 
-constant make_text_const(const sstring_view& text) {
+constant make_text_const(const std::string_view& text) {
     return constant(make_text_raw(text), utf8_type);
 }
 
@@ -353,7 +353,7 @@ tuple_constructor make_tuple_constructor(std::vector<expression> elements, std::
                              .type = tuple_type_impl::get_instance(std::move(element_types))};
 }
 
-usertype_constructor make_usertype_constructor(std::vector<std::pair<sstring_view, constant>> field_values) {
+usertype_constructor make_usertype_constructor(std::vector<std::pair<std::string_view, constant>> field_values) {
     usertype_constructor::elements_map_type elements_map;
     std::vector<bytes> field_names;
     std::vector<data_type> field_types;

--- a/test/lib/expr_test_utils.hh
+++ b/test/lib/expr_test_utils.hh
@@ -30,7 +30,7 @@ raw_value make_tinyint_raw(int8_t val);
 raw_value make_smallint_raw(int16_t val);
 raw_value make_int_raw(int32_t val);
 raw_value make_bigint_raw(int64_t val);
-raw_value make_text_raw(const sstring_view& text);
+raw_value make_text_raw(const std::string_view& text);
 raw_value make_float_raw(float val);
 raw_value make_double_raw(double val);
 
@@ -40,7 +40,7 @@ constant make_tinyint_const(int8_t val);
 constant make_smallint_const(int16_t val);
 constant make_int_const(int32_t val);
 constant make_bigint_const(int64_t val);
-constant make_text_const(const sstring_view& text);
+constant make_text_const(const std::string_view& text);
 constant make_float_const(float val);
 constant make_double_const(double val);
 
@@ -102,7 +102,7 @@ collection_constructor make_map_constructor(const std::vector<std::pair<expressi
                                             data_type key_type,
                                             data_type element_type);
 tuple_constructor make_tuple_constructor(std::vector<expression> elements, std::vector<data_type> element_types);
-usertype_constructor make_usertype_constructor(std::vector<std::pair<sstring_view, constant>> field_values);
+usertype_constructor make_usertype_constructor(std::vector<std::pair<std::string_view, constant>> field_values);
 
 ::lw_shared_ptr<column_specification> make_receiver(data_type receiver_type, sstring name = "receiver_name");
 

--- a/tools/scylla-types.cc
+++ b/tools/scylla-types.cc
@@ -141,7 +141,7 @@ void compare_handler(type_variant type, std::vector<bytes> values, const bpo::va
     } compare_visitor{values[0], values[1]};
 
     const auto res = std::visit(compare_visitor, type);
-    sstring_view res_str;
+    std::string_view res_str;
 
     if (res == 0) {
         res_str = "==";
@@ -399,7 +399,7 @@ $ scylla types {{action}} --help
         }
         type_variant type = [&app_config] () -> type_variant {
             auto types = boost::copy_range<std::vector<data_type>>(app_config["type"].as<std::vector<sstring>>()
-                    | boost::adaptors::transformed([] (const sstring_view type_name) { return db::marshal::type_parser::parse(type_name); }));
+                    | boost::adaptors::transformed([] (const std::string_view type_name) { return db::marshal::type_parser::parse(type_name); }));
             if (app_config.contains("prefix-compound")) {
                 return compound_type<allow_prefixes::yes>(std::move(types));
             } else if (app_config.contains("full-compound")) {

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -256,7 +256,7 @@ cql3::query_options trace_keyspace_helper::make_session_mutation_data(gms::inet_
     parameters_values_vector.reserve(record.parameters.size());
     std::for_each(record.parameters.begin(), record.parameters.end(), [&parameters_values_vector] (auto& val_pair) { parameters_values_vector.emplace_back(val_pair.first, val_pair.second); });
     auto my_map_type = map_type_impl::get_instance(utf8_type, utf8_type, true);
-    std::vector<sstring_view> names {
+    std::vector<std::string_view> names {
         "session_id",
         "command",
         "client",

--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -23,7 +23,7 @@ logging::logger trace_state_logger("trace_state");
 struct trace_state::params_values {
     struct prepared_statement_info {
         prepared_checked_weak_ptr statement;
-        std::optional<std::vector<sstring_view>> query_option_names;
+        std::optional<std::vector<std::string_view>> query_option_names;
         cql3::raw_value_view_vector_with_unset query_option_values;
         explicit prepared_statement_info(prepared_checked_weak_ptr statement) : statement(std::move(statement)) {}
     };
@@ -76,11 +76,11 @@ void trace_state::set_response_size(size_t s) noexcept {
     _records->session_rec.response_size = s;
 }
 
-void trace_state::add_query(sstring_view val) {
+void trace_state::add_query(std::string_view val) {
     _params_ptr->queries.emplace_back(std::move(val));
 }
 
-void trace_state::add_session_param(sstring_view key, sstring_view val) {
+void trace_state::add_session_param(std::string_view key, std::string_view val) {
     _records->session_rec.parameters.emplace(std::move(key), std::move(val));
 }
 
@@ -165,7 +165,7 @@ void trace_state::build_parameters_map() {
 }
 
 void trace_state::build_parameters_map_for_one_prepared(const prepared_checked_weak_ptr& prepared_ptr,
-        std::optional<std::vector<sstring_view>>& names_opt,
+        std::optional<std::vector<std::string_view>>& names_opt,
         cql3::raw_value_view_vector_with_unset& values, const sstring& param_name_prefix) {
     auto& params_map = _records->session_rec.parameters;
     size_t i = 0;

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -362,7 +362,7 @@ private:
      *
      * @param val the query string
      */
-    void add_query(sstring_view val);
+    void add_query(std::string_view val);
 
     /**
      * Store a custom session parameter.
@@ -372,7 +372,7 @@ private:
      * @param key the parameter key
      * @param val the parameter value
      */
-    void add_session_param(sstring_view key, sstring_view val);
+    void add_session_param(std::string_view key, std::string_view val);
 
     /**
      * Store a user provided timestamp.
@@ -428,7 +428,7 @@ private:
      * @param param_name_prefix prefix of the parameter key in the map, e.g. "param" or "param[1]"
      */
     void build_parameters_map_for_one_prepared(const prepared_checked_weak_ptr& prepared_ptr,
-            std::optional<std::vector<sstring_view>>& names_opt,
+            std::optional<std::vector<std::string_view>>& names_opt,
             cql3::raw_value_view_vector_with_unset& values, const sstring& param_name_prefix);
 
     /**
@@ -485,8 +485,8 @@ private:
     friend void set_batchlog_endpoints(const trace_state_ptr& p, const inet_address_vector_replica_set& val);
     friend void set_consistency_level(const trace_state_ptr& p, db::consistency_level val);
     friend void set_optional_serial_consistency_level(const trace_state_ptr& p, const std::optional<db::consistency_level>&val);
-    friend void add_query(const trace_state_ptr& p, sstring_view val);
-    friend void add_session_param(const trace_state_ptr& p, sstring_view key, sstring_view val);
+    friend void add_query(const trace_state_ptr& p, std::string_view val);
+    friend void add_session_param(const trace_state_ptr& p, std::string_view key, std::string_view val);
     friend void set_user_timestamp(const trace_state_ptr& p, api::timestamp_type val);
     friend void add_prepared_statement(const trace_state_ptr& p, prepared_checked_weak_ptr& prepared);
     friend void set_username(const trace_state_ptr& p, const std::optional<auth::authenticated_user>& user);
@@ -621,13 +621,13 @@ inline void set_optional_serial_consistency_level(const trace_state_ptr& p, cons
     }
 }
 
-inline void add_query(const trace_state_ptr& p, sstring_view val) {
+inline void add_query(const trace_state_ptr& p, std::string_view val) {
     if (p) {
         p->add_query(std::move(val));
     }
 }
 
-inline void add_session_param(const trace_state_ptr& p, sstring_view key, sstring_view val) {
+inline void add_session_param(const trace_state_ptr& p, std::string_view key, std::string_view val) {
     if (p) {
         p->add_session_param(std::move(key), std::move(val));
     }

--- a/transport/request.hh
+++ b/transport/request.hh
@@ -34,7 +34,7 @@ private:
             throw exceptions::protocol_exception(format("truncated frame: expected {:d} bytes, length is {:d}", attempted_read, actual_left));
         };
     };
-    static void validate_utf8(sstring_view s) {
+    static void validate_utf8(std::string_view s) {
         auto error_pos = utils::utf8::validate_with_error_position(to_bytes_view(s));
         if (error_pos) {
             throw exceptions::protocol_exception(format("Cannot decode string as UTF8, invalid character at byte offset {}", *error_pos));
@@ -99,18 +99,18 @@ public:
         return s;
     }
 
-    sstring_view read_string_view() {
+    std::string_view read_string_view() {
         auto n = read_short();
         auto bv = _in.read_bytes_view(n, *_linearization_buffer, exception_thrower());
-        auto s = sstring_view(reinterpret_cast<const char*>(bv.data()), bv.size());
+        auto s = std::string_view(reinterpret_cast<const char*>(bv.data()), bv.size());
         validate_utf8(s);
         return s;
     }
 
-    sstring_view read_long_string_view() {
+    std::string_view read_long_string_view() {
         auto n = read_int();
         auto bv = _in.read_bytes_view(n, *_linearization_buffer, exception_thrower());
-        auto s = sstring_view(reinterpret_cast<const char*>(bv.data()), bv.size());
+        auto s = std::string_view(reinterpret_cast<const char*>(bv.data()), bv.size());
         validate_utf8(s);
         return s;
     }
@@ -149,7 +149,7 @@ public:
         return cql3::raw_value_view::make_value(_in.read_view(len, exception_thrower()));
     }
 
-    void read_name_and_value_list(uint8_t version, std::vector<sstring_view>& names, std::vector<cql3::raw_value_view>& values,
+    void read_name_and_value_list(uint8_t version, std::vector<std::string_view>& names, std::vector<cql3::raw_value_view>& values,
             cql3::unset_bind_variable_vector& unset) {
         uint16_t size = read_short();
         names.reserve(size);
@@ -225,7 +225,7 @@ public:
         auto flags = enum_set<options_flag_enum>::from_mask(read_byte());
         std::vector<cql3::raw_value_view> values;
         cql3::unset_bind_variable_vector unset;
-        std::vector<sstring_view> names;
+        std::vector<std::string_view> names;
 
         if (flags.contains<options_flag::VALUES>()) {
             if (flags.contains<options_flag::NAMES_FOR_VALUES>()) {
@@ -261,7 +261,7 @@ public:
                 }
             }
 
-            std::optional<std::vector<sstring_view>> onames;
+            std::optional<std::vector<std::string_view>> onames;
             if (!names.empty()) {
                 onames = std::move(names);
             }

--- a/types/types.cc
+++ b/types/types.cc
@@ -171,7 +171,7 @@ template <typename T> static bytes decompose_value(T v) {
     return b;
 }
 
-template <typename T> static T parse_int(const integer_type_impl<T>& t, sstring_view s) {
+template <typename T> static T parse_int(const integer_type_impl<T>& t, std::string_view s) {
     try {
         auto value64 = boost::lexical_cast<int64_t>(s.begin(), s.size());
         auto value = static_cast<T>(value64);
@@ -264,7 +264,7 @@ static boost::posix_time::time_duration get_utc_offset(const std::string& s) {
     throw marshal_exception("Cannot get UTC offset for a timestamp");
 }
 
-int64_t timestamp_from_string(sstring_view s) {
+int64_t timestamp_from_string(std::string_view s) {
     try {
         std::string str;
         str.resize(s.size());
@@ -311,7 +311,7 @@ int64_t timestamp_from_string(sstring_view s) {
     }
 }
 
-db_clock::time_point timestamp_type_impl::from_sstring(sstring_view s) {
+db_clock::time_point timestamp_type_impl::from_string_view(std::string_view s) {
     return db_clock::time_point(db_clock::duration(timestamp_from_string(s)));
 }
 
@@ -327,7 +327,7 @@ static date::year_month_day get_simple_date_time(const boost::match_results<Cons
     auto day = boost::lexical_cast<unsigned>(sm[3]);
     return date::year_month_day{date::year{year}, date::month{month}, date::day{day}};
 }
-static uint32_t serialize(sstring_view input, int64_t days) {
+static uint32_t serialize(std::string_view input, int64_t days) {
     if (days < std::numeric_limits<int32_t>::min()) {
         throw marshal_exception(seastar::format("Input date {} is less than min supported date -5877641-06-23", input));
     }
@@ -337,13 +337,13 @@ static uint32_t serialize(sstring_view input, int64_t days) {
     days += 1UL << 31;
     return static_cast<uint32_t>(days);
 }
-uint32_t simple_date_type_impl::from_sstring(sstring_view s) {
+uint32_t simple_date_type_impl::from_string_view(std::string_view s) {
     char* end;
     errno = 0;
     auto v = std::strtoll(s.begin(), &end, 10);
     if(end != s.end()) {
         static const boost::regex date_re("^(-?\\d+)-(\\d+)-(\\d+)");
-        boost::match_results<sstring_view::const_iterator> dsm;
+        boost::match_results<std::string_view::const_iterator> dsm;
         if (!boost::regex_match(s.begin(), s.end(), dsm, date_re)) {
         throw marshal_exception(seastar::format("Unable to coerce '{}' to a formatted date (long)", s));
         }
@@ -361,7 +361,7 @@ uint32_t simple_date_type_impl::from_sstring(sstring_view s) {
 
 time_type_impl::time_type_impl() : simple_type_impl{kind::time, time_type_name, {}} {}
 
-int64_t time_type_impl::from_sstring(sstring_view s) {
+int64_t time_type_impl::from_string_view(std::string_view s) {
     static auto format_error = "Timestamp format must be hh:mm:ss[.fffffffff]";
     auto hours_end = s.find(':');
     if (hours_end == std::string::npos) {
@@ -2509,7 +2509,7 @@ bool abstract_type::equal(bytes_view v1, managed_bytes_view v2) const {
 }
 
 // Count number of ':' which are not preceded by '\'.
-static std::size_t count_segments(sstring_view v) {
+static std::size_t count_segments(std::string_view v) {
     std::size_t segment_count = 1;
     char prev_ch = '.';
     for (char ch : v) {
@@ -2522,11 +2522,11 @@ static std::size_t count_segments(sstring_view v) {
 }
 
 // Split on ':', unless it's preceded by '\'.
-static std::vector<sstring_view> split_field_strings(sstring_view v) {
+static std::vector<std::string_view> split_field_strings(std::string_view v) {
     if (v.empty()) {
-        return std::vector<sstring_view>();
+        return std::vector<std::string_view>();
     }
-    std::vector<sstring_view> result;
+    std::vector<std::string_view> result;
     result.reserve(count_segments(v));
     std::size_t prev = 0;
     char prev_ch = '.';
@@ -2542,12 +2542,12 @@ static std::vector<sstring_view> split_field_strings(sstring_view v) {
 }
 
 // Replace "\:" with ":" and "\@" with "@".
-static std::string unescape(sstring_view s) {
+static std::string unescape(std::string_view s) {
     return boost::regex_replace(std::string(s), boost::regex("\\\\([@:])"), "$1");
 }
 
 // Replace ":" with "\:" and "@" with "\@".
-static std::string escape(sstring_view s) {
+static std::string escape(std::string_view s) {
     return boost::regex_replace(std::string(s), boost::regex("[@:]"), "\\\\$0");
 }
 
@@ -2691,7 +2691,7 @@ static bytes serialize_value(const T& t, const typename T::native_type& v) {
     return b;
 }
 
-seastar::net::inet_address inet_addr_type_impl::from_sstring(sstring_view s) {
+seastar::net::inet_address inet_addr_type_impl::from_string_view(std::string_view s) {
     try {
         return inet_address(std::string(s.data(), s.size()));
     } catch (...) {
@@ -2699,7 +2699,7 @@ seastar::net::inet_address inet_addr_type_impl::from_sstring(sstring_view s) {
     }
 }
 
-utils::UUID uuid_type_impl::from_sstring(sstring_view s) {
+utils::UUID uuid_type_impl::from_string_view(std::string_view s) {
     static const boost::regex re("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$");
     if (!boost::regex_match(s.begin(), s.end(), re)) {
         throw marshal_exception(seastar::format("Cannot parse uuid from '{}'", s));
@@ -2707,7 +2707,7 @@ utils::UUID uuid_type_impl::from_sstring(sstring_view s) {
     return utils::UUID(s);
 }
 
-utils::UUID timeuuid_type_impl::from_sstring(sstring_view s) {
+utils::UUID timeuuid_type_impl::from_string_view(std::string_view s) {
     static const boost::regex re("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$");
     if (!boost::regex_match(s.begin(), s.end(), re)) {
         throw marshal_exception(seastar::format("Invalid UUID format ({})", s));
@@ -2721,7 +2721,7 @@ utils::UUID timeuuid_type_impl::from_sstring(sstring_view s) {
 
 namespace {
 struct from_string_visitor {
-    sstring_view s;
+    std::string_view s;
     bytes operator()(const reversed_type_impl& r) { return r.underlying_type()->from_string(s); }
     bytes operator()(const counter_type_impl&) { return long_type->from_string(s); }
     template <typename T> bytes operator()(const integer_type_impl<T>& t) { return decompose_value(parse_int(t, s)); }
@@ -2754,31 +2754,31 @@ struct from_string_visitor {
         if (s.empty()) {
             return bytes();
         }
-        return timeuuid_type_impl::from_sstring(s).serialize();
+        return timeuuid_type_impl::from_string_view(s).serialize();
     }
     bytes operator()(const timestamp_date_base_class& t) {
         if (s.empty()) {
             return bytes();
         }
-        return serialize_value(t, timestamp_type_impl::from_sstring(s));
+        return serialize_value(t, timestamp_type_impl::from_string_view(s));
     }
     bytes operator()(const simple_date_type_impl& t) {
         if (s.empty()) {
             return bytes();
         }
-        return serialize_value(t, simple_date_type_impl::from_sstring(s));
+        return serialize_value(t, simple_date_type_impl::from_string_view(s));
     }
     bytes operator()(const time_type_impl& t) {
         if (s.empty()) {
             return bytes();
         }
-        return serialize_value(t, time_type_impl::from_sstring(s));
+        return serialize_value(t, time_type_impl::from_string_view(s));
     }
     bytes operator()(const uuid_type_impl&) {
         if (s.empty()) {
             return bytes();
         }
-        return uuid_type_impl::from_sstring(s).serialize();
+        return uuid_type_impl::from_string_view(s).serialize();
     }
     template <typename T> bytes operator()(const floating_type_impl<T>& t) {
         if (s.empty()) {
@@ -2831,10 +2831,10 @@ struct from_string_visitor {
         if (s.empty()) {
             return bytes();
         }
-        return serialize_value(t, t.from_sstring(s));
+        return serialize_value(t, t.from_string_view(s));
     }
     bytes operator()(const tuple_type_impl& t) {
-        std::vector<sstring_view> field_strings = split_field_strings(s);
+        std::vector<std::string_view> field_strings = split_field_strings(s);
         if (field_strings.size() > t.size()) {
             throw marshal_exception(
                     format("Invalid tuple literal: too many elements. Type {} expects {:d} but got {:d}",
@@ -2859,7 +2859,7 @@ struct from_string_visitor {
 };
 }
 
-bytes abstract_type::from_string(sstring_view s) const { return visit(*this, from_string_visitor{s}); }
+bytes abstract_type::from_string(std::string_view s) const { return visit(*this, from_string_visitor{s}); }
 
 static sstring tuple_to_string(const tuple_type_impl &t, const tuple_type_impl::native_type& b) {
     std::ostringstream out;

--- a/types/types.hh
+++ b/types/types.hh
@@ -51,7 +51,7 @@ class cql3_type;
 
 }
 
-int64_t timestamp_from_string(sstring_view s);
+int64_t timestamp_from_string(std::string_view s);
 
 struct runtime_exception : public std::exception {
     sstring _why;
@@ -435,7 +435,7 @@ public:
         return to_string(bytes_view(b));
     }
     sstring to_string_impl(const data_value& v) const;
-    bytes from_string(sstring_view text) const;
+    bytes from_string(std::string_view text) const;
     bool is_counter() const;
     bool is_string() const;
     bool is_collection() const;

--- a/utils/UUID.hh
+++ b/utils/UUID.hh
@@ -36,9 +36,9 @@ public:
         : most_sig_bits(most_sig_bits), least_sig_bits(least_sig_bits) {}
 
     // May throw marshal_exception is failed to parse uuid string.
-    explicit UUID(const sstring& uuid_string) : UUID(sstring_view(uuid_string)) { }
-    explicit UUID(const char * s) : UUID(sstring_view(s)) {}
-    explicit UUID(sstring_view uuid_string);
+    explicit UUID(const sstring& uuid_string) : UUID(std::string_view(uuid_string)) { }
+    explicit UUID(const char * s) : UUID(std::string_view(s)) {}
+    explicit UUID(std::string_view uuid_string);
 
     int64_t get_most_significant_bits() const noexcept {
         return most_sig_bits;

--- a/utils/UUID_gen.cc
+++ b/utils/UUID_gen.cc
@@ -122,8 +122,8 @@ UUID UUID_gen::get_name_UUID(bytes_view b) {
     return get_name_UUID(reinterpret_cast<const unsigned char*>(b.begin()), b.size());
 }
 
-UUID UUID_gen::get_name_UUID(sstring_view s) {
-    static_assert(sizeof(char) == sizeof(sstring_view::value_type), "Assumed that str.size() counts in chars");
+UUID UUID_gen::get_name_UUID(std::string_view s) {
+    static_assert(sizeof(char) == sizeof(std::string_view::value_type), "Assumed that str.size() counts in chars");
     return get_name_UUID(reinterpret_cast<const unsigned char*>(s.begin()), s.size());
 }
 

--- a/utils/UUID_gen.hh
+++ b/utils/UUID_gen.hh
@@ -246,7 +246,7 @@ public:
      * Creates a type 3 (name based) UUID based on the specified byte array.
      */
     static UUID get_name_UUID(bytes_view b);
-    static UUID get_name_UUID(sstring_view str);
+    static UUID get_name_UUID(std::string_view str);
     static UUID get_name_UUID(const unsigned char* s, size_t len);
 
     /** decomposes a uuid into raw bytes. */

--- a/utils/big_decimal.cc
+++ b/utils/big_decimal.cc
@@ -41,7 +41,7 @@ big_decimal::big_decimal() : big_decimal(0, 0) {}
 big_decimal::big_decimal(int32_t scale, boost::multiprecision::cpp_int unscaled_value)
     : _scale(scale), _unscaled_value(std::move(unscaled_value)) {}
 
-big_decimal::big_decimal(sstring_view text)
+big_decimal::big_decimal(std::string_view text)
 {
     size_t e_pos = text.find_first_of("eE");
     std::string_view base = text.substr(0, e_pos);

--- a/utils/big_decimal.hh
+++ b/utils/big_decimal.hh
@@ -26,7 +26,7 @@ public:
         HALF_EVEN,
     };
 
-    explicit big_decimal(sstring_view text);
+    explicit big_decimal(std::string_view text);
     big_decimal();
     big_decimal(int32_t scale, boost::multiprecision::cpp_int unscaled_value);
     big_decimal(std::integral auto v) : big_decimal(0, v) {}

--- a/utils/uuid.cc
+++ b/utils/uuid.cc
@@ -38,7 +38,7 @@ std::ostream& operator<<(std::ostream& out, const UUID& uuid) {
     return out;
 }
 
-UUID::UUID(sstring_view uuid) {
+UUID::UUID(std::string_view uuid) {
     sstring uuid_string(uuid.begin(), uuid.end());
     boost::erase_all(uuid_string, "-");
     auto size = uuid_string.size() / 2;


### PR DESCRIPTION
For historic reasons, we have (in bytes.hh) a type sstring_view which is an alias for std::string_view - since the same standard type can hold a pointer into both a seastar::sstring and std::string.
    
This alias in unnecessary and misleading to new developers, who might be misled to believe it is assume it is somehow different from std::string_view - when it isn't. 

This series removes all uses of sstring_view (changing them to use std::string_view), and in the last patch removes the alias itself. A few functions whose name referred to "sstring" but take a std::string_view were renamed.

The patches are fairly mechanical and trivial, with no functional changes intended. To ease the review the series was split to a few smaller patches that modify specific areas of the code.    

Fixes #4062.