### PR TITLE
test.py: Disable gathering metrics by default

### DIFF
--- a/test.py
+++ b/test.py
@@ -1353,7 +1353,7 @@ def parse_cmd_line() -> argparse.Namespace:
         help="""Path to temporary test data and log files. The data is
         further segregated per build mode. Default: ./testlog.""",
     )
-    parser.add_argument("--gather-metrics", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--gather-metrics", action=argparse.BooleanOptionalAction, default=False)
     parser.add_argument("--max-failures", type=int, default=-1, help="Maximum number of failures to tolerate before cancelling rest of tests.")
     parser.add_argument('--mode', choices=all_modes.keys(), action="append", dest="modes",
                         help="Run only tests for given build mode(s)")


### PR DESCRIPTION
Currently, gathering metrics are switched on by default. But this functionality requires specific configuration of the host system. We cannot adapt to all possible variants, so it's better to set them to off by default and switch on only when necessary.

Fixes: https://github.com/scylladb/scylladb/issues/20763
