### PR TITLE
test/boost/view_schema_test.cc: Wait for views to build in test_view_update_generating_writetime

### DIFF
--- a/test/boost/view_schema_test.cc
+++ b/test/boost/view_schema_test.cc
@@ -3071,7 +3071,7 @@ SEASTAR_TEST_CASE(test_view_update_generating_writetime) {
 
         // Updating column value with TTL will propagate for virtual columns
         e.execute_cql("UPDATE t USING TIMESTAMP 7 SET g=40 WHERE k=1 AND c=1;").get();
-        e.execute_cql("UPDATE t USING TTL 10 AND TIMESTAMP 8 SET g=40 WHERE k=1 AND c=1;").get();
+        e.execute_cql("UPDATE t USING TTL 300 AND TIMESTAMP 8 SET g=40 WHERE k=1 AND c=1;").get();
         eventually([&] {
             msg = e.execute_cql("SELECT WRITETIME(g) FROM t").get();
             assert_that(msg).is_rows().with_row({long_type->decompose(int64_t(8))});

--- a/test/boost/view_schema_test.cc
+++ b/test/boost/view_schema_test.cc
@@ -3002,6 +3002,9 @@ SEASTAR_TEST_CASE(test_view_update_generating_writetime) {
         e.execute_cql("CREATE MATERIALIZED VIEW mv2 AS SELECT k,c,a,b FROM t "
                          "WHERE k IS NOT NULL AND c IS NOT NULL AND a IS NOT NULL PRIMARY KEY (c, k, a)").get();
 
+        e.local_view_builder().wait_until_built("ks", "mv1").get();
+        e.local_view_builder().wait_until_built("ks", "mv2").get();
+
         auto total_t_view_updates = [&] {
             return e.db().map_reduce0([] (replica::database& local_db) {
                 const db::view::stats& local_stats = local_db.find_column_family("ks", "t").get_view_stats();


### PR DESCRIPTION
Before these changes, we didn't wait for the materialized views to
finish building before writing to the base table. That led to generating
an additional view update, which, in turn, led to test failures.

The scenario corresponding to the summary above looked like this:

1. The test creates an empty table and MVs on it.
2. The view builder starts, but it doesn't finish immediately.
3. The test performs mutations to the base table. Since the views
   already exist, view updates are generated.
4. Finally, the view builder finishes. It notices that the base
   table has a row, so it generates a view update for it because
   it doesn't notice that we already have data in the view.

We solve it by explicitly waiting for both views to finish building
and only then start writing to the base table.

Additionally, we also fix a lifetime issue of the row the test revolves
around, further stabilizing CI.

Fixes https://github.com/scylladb/scylladb/issues/20889

Backport: These changes have no semantic effect on the codebase,
but they stabilize CI, so we want to backport them to the maintained
versions of Scylla.