### PR TITLE
test/alternator: move bizarre code next to the comment that explained it

### DIFF
--- a/test/alternator/test_number.py
+++ b/test/alternator/test_number.py
@@ -28,17 +28,17 @@
 import decimal
 from decimal import Decimal
 
-# Monkey-patch the boto3 library to stop doing its own error-checking on
-# numbers. This works around a bug https://github.com/boto/boto3/issues/2500
-# of incorrect checking of responses, and we also need to get boto3 to not do
-# its own error checking of requests, to allow us to check the server's
-# handling of such errors.
 import boto3.dynamodb.types
 import pytest
 from botocore.exceptions import ClientError
 
 from test.alternator.util import random_string, client_no_transform
 
+# Monkey-patch the boto3 library to stop doing its own error-checking on
+# numbers. This works around a bug https://github.com/boto/boto3/issues/2500
+# of incorrect checking of responses, and we also need to get boto3 to not do
+# its own error checking of requests, to allow us to check the server's
+# handling of such errors.
 boto3.dynamodb.types.DYNAMODB_CONTEXT = decimal.Context(prec=100)
 
 # Test that numbers of allowed magnitudes - between to 1e-130 and 1e125 -


### PR DESCRIPTION
In commit 9ff9cd37c3ece80c58f26fae6e2cd5bd0a88ebdb we added in test/alternator/test_number.py a workaround for a boto3 bug that prevented us (and still prevents us) from testing numbers with high precision. Because the workaround was so bizarre, the three lines it requires - two imports and an assignment - were preceded by a 5-line comment explaining it.

Unfortunately, a later commit 93b9b85c12a2dbcff1344dc23b381756337550dc went and arbitrarily moved import lines around, resulting in the comment being separated from the lines it was supposed to explain.

This patch moves the lines around again so the comment is next to the three lines it describes. No functionality of the test was changed.

Test code beautification only - no need to backport.