### PR TITLE
memtable: ensure _flushed_memory doesn't grow above total_memory

### DIFF
--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -124,8 +124,7 @@ memtable::memtable(schema_ptr schema, dirty_memory_manager& dmm,
     memtable_list* memtable_list, seastar::scheduling_group compaction_scheduling_group)
         : dirty_memory_manager_logalloc::size_tracked_region()
         , _dirty_mgr(dmm)
-        , _cleaner(*this, no_cache_tracker, table_stats.memtable_app_stats, compaction_scheduling_group,
-                   [this] (size_t freed) { remove_flushed_memory(freed); })
+        , _cleaner(*this, no_cache_tracker, table_stats.memtable_app_stats, compaction_scheduling_group)
         , _memtable_list(memtable_list)
         , _schema(std::move(schema))
         , _table_shared_data(table_shared_data)
@@ -149,23 +148,17 @@ memtable::~memtable() {
     logalloc::region::unlisten();
 }
 
-uint64_t memtable::dirty_size() const {
-    return occupancy().total_space();
-}
-
 void memtable::evict_entry(memtable_entry& e, mutation_cleaner& cleaner) noexcept {
     e.partition().evict(cleaner);
     nr_partitions--;
 }
 
 void memtable::clear() noexcept {
-    auto dirty_before = dirty_size();
     with_allocator(allocator(), [this] {
         partitions.clear_and_dispose([this] (memtable_entry* e) noexcept {
             evict_entry(*e, _cleaner);
         });
     });
-    remove_flushed_memory(dirty_before - dirty_size());
 }
 
 future<> memtable::clear_gently() noexcept {
@@ -176,7 +169,6 @@ future<> memtable::clear_gently() noexcept {
             auto p = std::move(partitions);
             nr_partitions = 0;
             while (!p.empty()) {
-                auto dirty_before = dirty_size();
                 with_allocator(alloc, [&] () noexcept {
                     while (!p.empty()) {
                         if (p.begin()->clear_gently() == stop_iteration::no) {
@@ -188,7 +180,6 @@ future<> memtable::clear_gently() noexcept {
                         }
                     }
                 });
-                remove_flushed_memory(dirty_before - dirty_size());
                 seastar::thread::yield();
             }
 
@@ -525,13 +516,16 @@ public:
 
 void memtable::add_flushed_memory(uint64_t delta) {
     _flushed_memory += delta;
-    _dirty_mgr.account_potentially_cleaned_up_memory(this, delta);
+    if (_flushed_memory > 0) {
+        _dirty_mgr.account_potentially_cleaned_up_memory(this, std::min<int64_t>(delta, _flushed_memory));
+    }
 }
 
 void memtable::remove_flushed_memory(uint64_t delta) {
-    delta = std::min(_flushed_memory, delta);
+    if (_flushed_memory > 0) {
+        _dirty_mgr.revert_potentially_cleaned_up_memory(this, std::min<int64_t>(delta, _flushed_memory));
+    }
     _flushed_memory -= delta;
-    _dirty_mgr.revert_potentially_cleaned_up_memory(this, delta);
 }
 
 void memtable::on_detach_from_region_group() noexcept {
@@ -540,8 +534,11 @@ void memtable::on_detach_from_region_group() noexcept {
 }
 
 void memtable::revert_flushed_memory() noexcept {
-    _dirty_mgr.revert_potentially_cleaned_up_memory(this, _flushed_memory);
+    if (_flushed_memory > 0) {
+        _dirty_mgr.revert_potentially_cleaned_up_memory(this, _flushed_memory);
+    }
     _flushed_memory = 0;
+    _total_memory_low_watermark_during_flush = _total_memory;
 }
 
 class flush_memory_accounter {
@@ -554,7 +551,7 @@ public:
         : _mt(mt)
 	{}
     ~flush_memory_accounter() {
-        SCYLLA_ASSERT(_mt._flushed_memory <= _mt.occupancy().total_space());
+        SCYLLA_ASSERT(_mt._flushed_memory <= static_cast<int64_t>(_mt.occupancy().total_space()));
     }
     uint64_t compute_size(memtable_entry& e, partition_snapshot& snp) {
         return e.size_in_allocator_without_rows(_mt.allocator())
@@ -747,6 +744,7 @@ memtable::make_flat_reader_opt(schema_ptr query_schema,
 mutation_reader
 memtable::make_flush_reader(schema_ptr s, reader_permit permit) {
     if (!_merged_into_cache) {
+        revert_flushed_memory();
         return make_mutation_reader<flush_reader>(std::move(s), std::move(permit), shared_from_this());
     } else {
         auto& full_slice = s->full_slice();
@@ -873,8 +871,10 @@ auto fmt::formatter<replica::memtable>::format(replica::memtable& mt,
 }
 
 void replica::memtable::increase_usage(logalloc::region* r, ssize_t delta) {
+    SCYLLA_ASSERT(delta >= 0);
     _dirty_mgr.region_group().increase_usage(r);
     _dirty_mgr.region_group().update_unspooled(delta);
+    _total_memory += delta;
 }
 
 void replica::memtable::decrease_evictable_usage(logalloc::region* r) {
@@ -882,8 +882,14 @@ void replica::memtable::decrease_evictable_usage(logalloc::region* r) {
 }
 
 void replica::memtable::decrease_usage(logalloc::region* r, ssize_t delta) {
+    SCYLLA_ASSERT(delta <= 0);
     _dirty_mgr.region_group().decrease_usage(r);
     _dirty_mgr.region_group().update_unspooled(delta);
+    _total_memory += delta;
+    if (_total_memory < _total_memory_low_watermark_during_flush) {
+        remove_flushed_memory(_total_memory_low_watermark_during_flush - _total_memory);
+        _total_memory_low_watermark_during_flush = _total_memory;
+    }
 }
 
 void replica::memtable::add(logalloc::region* r) {

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -131,7 +131,7 @@ memtable::memtable(schema_ptr schema, dirty_memory_manager& dmm,
         , _table_shared_data(table_shared_data)
         , partitions(dht::raw_token_less_comparator{})
         , _table_stats(table_stats) {
-    logalloc::region::listen(&dmm.region_group());
+    logalloc::region::listen(this);
 }
 
 static thread_local dirty_memory_manager mgr_for_tests;
@@ -870,4 +870,28 @@ auto fmt::formatter<replica::memtable>::format(replica::memtable& mt,
                                         fmt::format_context& ctx) const -> decltype(ctx.out()) {
     logalloc::reclaim_lock rl(mt);
     return fmt::format_to(ctx.out(), "{{memtable: [{}]}}", fmt::join(mt.partitions, ",\n"));
+}
+
+void replica::memtable::increase_usage(logalloc::region* r, ssize_t delta) {
+    _dirty_mgr.region_group().increase_usage(r);
+    _dirty_mgr.region_group().update_unspooled(delta);
+}
+
+void replica::memtable::decrease_evictable_usage(logalloc::region* r) {
+    _dirty_mgr.region_group().decrease_usage(r);
+}
+
+void replica::memtable::decrease_usage(logalloc::region* r, ssize_t delta) {
+    _dirty_mgr.region_group().decrease_usage(r);
+    _dirty_mgr.region_group().update_unspooled(delta);
+}
+
+void replica::memtable::add(logalloc::region* r) {
+    _dirty_mgr.region_group().add(r);
+}
+void replica::memtable::del(logalloc::region* r) {
+    _dirty_mgr.region_group().del(r);
+}
+void replica::memtable::moved(logalloc::region* old_address, logalloc::region* new_address) {
+    _dirty_mgr.region_group().moved(old_address, new_address);
 }

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -104,7 +104,7 @@ class dirty_memory_manager;
 struct table_stats;
 
 // Managed by lw_shared_ptr<>.
-class memtable final : public enable_lw_shared_from_this<memtable>, private dirty_memory_manager_logalloc::size_tracked_region {
+class memtable final : public enable_lw_shared_from_this<memtable>, private dirty_memory_manager_logalloc::size_tracked_region, public logalloc::region_listener {
 public:
     using partitions_type = double_decker<int64_t, memtable_entry,
                             dht::raw_token_less_comparator, dht::ring_position_comparator,
@@ -325,6 +325,14 @@ public:
     dirty_memory_manager& get_dirty_memory_manager() noexcept {
         return _dirty_mgr;
     }
+
+    // Implementation of region_listener.
+    virtual void increase_usage(logalloc::region* r, ssize_t delta) override;
+    virtual void decrease_evictable_usage(logalloc::region* r) override;
+    virtual void decrease_usage(logalloc::region* r, ssize_t delta) override;
+    virtual void add(logalloc::region* r) override;
+    virtual void del(logalloc::region* r) override;
+    virtual void moved(logalloc::region* old_address, logalloc::region* new_address) override;
 
     friend fmt::formatter<memtable>;
 };

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -126,7 +126,24 @@ private:
     // mutation_source is necessary for the combined mutation source to be
     // monotonic. That combined source in this case is cache + memtable.
     mutation_source_opt _underlying;
-    uint64_t _flushed_memory = 0;
+    // Tracks the difference between the amount of memory "spooled" during the flush
+    // and the memory freed during the flush.
+    //
+    // If positive, this is equal to the difference between the amount of "spooled" memory
+    // registered in dirty_memory_manager with account_potentially_cleaned_up_memory
+    // and unregistered with revert_potentially_cleaned_up_memory.
+    // If negative, the above difference is 0.
+    int64_t _flushed_memory = 0;
+    // For most of the time, this is equal to occupancy().total_memory.
+    // But we want to know the current memory usage in our logalloc::region_listener
+    // handlers, and at that point in time occupancy() is undefined. (LSA can choose to
+    // update it before or after the handler). So we track it ourselves, based on the deltas
+    // passed to the handlers.
+    uint64_t _total_memory = 0;
+    // During LSA compaction, _total_memory can fluctuate up and down.
+    // But we are only interested in the maximal total decrease since the beginning of flush.
+    // This tracks the lowest value of _total_memory seen during the flush.
+    uint64_t _total_memory_low_watermark_during_flush = 0;
     bool _merged_into_cache = false;
     replica::table_stats& _table_stats;
 
@@ -194,7 +211,6 @@ private:
     void add_flushed_memory(uint64_t);
     void remove_flushed_memory(uint64_t);
     void clear() noexcept;
-    uint64_t dirty_size() const;
 public:
     explicit memtable(schema_ptr schema, dirty_memory_manager&,
             memtable_table_shared_data& shared_data,

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2133,7 +2133,7 @@ private:
         _non_lsa_occupancy -= occupancy_stats(0, allocated_size);
         if (_listener) {
             _evictable_space -= allocated_size;
-            _listener->decrease_usage(_region, allocated_size);
+            _listener->decrease_usage(_region, -allocated_size);
         }
         segment_pool().subtract_non_lsa_memory_in_use(allocated_size);
     }


### PR DESCRIPTION
`dirty_memory_manager` tracks two quantities about memtable memory usage:
"real" and "unspooled" memory usage.

"real" is the total memory usage (sum of `occupancy().total_space()`)
by all memtable LSA regions, plus a upper-bound estimate of the size of
memtable data which has already moved to the cache region but isn't
evictable (merged into the cache) yet.

"unspooled" is the difference between total memory usage by all memtable
LSA regions, and the total flushed memory (sum of `_flushed_memory`)
of memtables.

`dirty_memory_manager` controls the shares of compaction and/or blocks
writes when these quantities cross various thresholds.

"Total flushed memory" isn't a well defined notion,
since the actual consumption of memory by the same data can vary over
time due to LSA compactions, and even the data present in memtable can
change over the course of the flush due to removals of outdated MVCC versions.
So `_flushed_memory` is merely an approximation computed by `flush_reader`
based on the data passing through it.

This approximation is supposed to be a conservative lower bound.
In particular, `_flushed_memory` should be not greater than
`occupancy().total_space()`. Otherwise, for example, "unspooled" memory
could become negative (and/or wrap around) and weird things could happen.
There is an assertion in `~flush_memory_accounter` which checks that
`_flushed_memory < occupancy().total_space()` at the end of flush.

But it can fail. Without additional treatment, the memtable reader sometimes emits
data which is already deleted. (In particular, it emites rows covered by
a partition tombstone in a newer MVCC version.)
This data is seen by `flush_reader` and accounted in `_flushed_memory`.
But this data can be garbage-collected by the `mutation_cleaner` later during the
flush and decrease `total_memory` below `_flushed_memory`.

There is a piece of code in `mutation_cleaner` intended to prevent that.
If `total_memory` decreases during a `mutation_cleaner` run,
`_flushed_memory` is lowered by the same amount, just to preserve the
asserted property. (This could also make `_flushed_memory` quite inaccurate,
but that's considered acceptable).

But that only works if `total_memory` is decreased during that run. It doesn't
work if the `total_memory` decrease (enabled by the new allocator holes made
by `mutation_cleaner`'s garbage collection work) happens asynchronously
(due to memory reclaim for whatever reason) after the run.

This patch fixes that by tracking the decreases of `total_memory` closer to the
source. Instead of relying on `mutation_cleaner` to notify the memtable if it
lowers `total_memory`, the memtable itself listens for notifications about
LSA segment deallocations. It keeps `_flushed_memory` equal to the reader's
estimate of flushed memory decreased by the change in `total_memory` since the
beginning of flush (if it was positive), and it keeps the amount of "spooled"
memory reported to the `dirty_memory_manager` at `max(0, _flushed_memory)`.

Fixes scylladb/scylladb#21413