### PR TITLE
readers: migrate to std::ranges

### DIFF
--- a/readers/combined.cc
+++ b/readers/combined.cc
@@ -31,7 +31,7 @@ struct mutation_fragment_and_stream_id {
     { }
 };
 
-using mutation_fragment_batch = boost::iterator_range<merger_vector<mutation_fragment_and_stream_id>::iterator>;
+using mutation_fragment_batch = std::ranges::subrange<merger_vector<mutation_fragment_and_stream_id>::iterator>;
 using mutation_fragment_batch_opt = std::optional<mutation_fragment_batch>;
 
 template<typename Producer>
@@ -493,7 +493,7 @@ future<mutation_fragment_batch_opt> mutation_reader_merger::maybe_produce_batch(
         if (_single_reader.reader->is_buffer_empty()) {
             if (_single_reader.reader->is_end_of_stream()) {
                 _current.clear();
-                return make_ready_future<mutation_fragment_batch_opt>(mutation_fragment_batch(_current, &_single_reader));
+                return make_ready_future<mutation_fragment_batch_opt>(_current);
             }
             return _single_reader.reader->fill_buffer().then([] {
                 return make_ready_future<mutation_fragment_batch_opt>();

--- a/readers/mutation_reader.cc
+++ b/readers/mutation_reader.cc
@@ -8,8 +8,6 @@
 
 #include <seastar/util/lazy.hh>
 
-#include <boost/range/adaptor/transformed.hpp>
-
 #include "readers/mutation_reader.hh"
 #include "mutation/mutation_rebuilder.hh"
 #include "schema_upgrader.hh"
@@ -18,11 +16,11 @@ logging::logger mrlog("mutation_reader");
 
 static size_t compute_buffer_size(const schema& s, const mutation_reader::tracked_buffer& buffer)
 {
-    return boost::accumulate(
+    return std::ranges::fold_left(
         buffer
-        | boost::adaptors::transformed([] (const mutation_fragment_v2& mf) {
+        | std::views::transform([] (const mutation_fragment_v2& mf) {
             return mf.memory_usage();
-        }), size_t(0)
+        }), size_t(0), std::plus<size_t>()
     );
 }
 


### PR DESCRIPTION
With C++23, we have ranges available. Migrate the code in `readers/` to use ranges, to reduce our dependency on boost (and modernize the code a bit).

Improvement, no backport required