### PR TITLE
materialized view: make flow-control maximum delay configurable

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1179,6 +1179,11 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , error_injections_at_startup(this, "error_injections_at_startup", error_injection_value_status, {}, "List of error injections that should be enabled on startup.")
     , topology_barrier_stall_detector_threshold_seconds(this, "topology_barrier_stall_detector_threshold_seconds", value_status::Used, 2, "Report sites blocking topology barrier if it takes longer than this.")
     , enable_tablets(this, "enable_tablets", value_status::Used, false, "Enable tablets for newly created keyspaces.")
+    , view_flow_control_delay_limit_in_ms(this, "view_flow_control_delay_limit_in_ms", liveness::LiveUpdate, value_status::Used, 1000,
+        "The maximal amount of time that materialized-view update flow control may delay responses "
+        "to try to slow down the client and prevent buildup of unfinished view updates. "
+        "To be effective, this maximal delay should be larger than the typical latencies. "
+        "Setting view_flow_control_delay_limit_in_ms to 0 disables view-update flow control.")
     , default_log_level(this, "default_log_level", value_status::Used, seastar::log_level::info, "Default log level for log messages")
     , logger_log_level(this, "logger_log_level", value_status::Used, {}, "Map of logger name to log level. Valid log levels are 'error', 'warn', 'info', 'debug' and 'trace'")
     , log_to_stdout(this, "log_to_stdout", value_status::Used, true, "Send log output to stdout")

--- a/db/config.hh
+++ b/db/config.hh
@@ -496,6 +496,7 @@ public:
     named_value<std::vector<error_injection_at_startup>> error_injections_at_startup;
     named_value<double> topology_barrier_stall_detector_threshold_seconds;
     named_value<bool> enable_tablets;
+    named_value<uint32_t> view_flow_control_delay_limit_in_ms;
 
     static const sstring default_tls_priority;
 private:

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -3283,12 +3283,12 @@ void delete_ghost_rows_visitor::accept_new_row(const clustering_key& ck, const q
 }
 
 std::chrono::microseconds calculate_view_update_throttling_delay(db::view::update_backlog backlog,
-                                                                 db::timeout_clock::time_point timeout) {
-    constexpr auto delay_limit_us = 1000000;
+                                                                 db::timeout_clock::time_point timeout,
+                                                                 uint32_t view_flow_control_delay_limit_in_ms) {
     auto adjust = [] (float x) { return x * x * x; };
     auto budget = std::max(service::storage_proxy::clock_type::duration(0),
         timeout - service::storage_proxy::clock_type::now());
-    std::chrono::microseconds ret(uint32_t(adjust(backlog.relative_size()) * delay_limit_us));
+    std::chrono::microseconds ret(uint32_t(adjust(backlog.relative_size()) * view_flow_control_delay_limit_in_ms * 1000));
     // "budget" has millisecond resolution and can potentially be long
     // in the future so converting it to microseconds may overflow.
     // So to compare buget and ret we need to convert both to the lower

--- a/db/view/view_update_backlog.hh
+++ b/db/view/view_update_backlog.hh
@@ -82,5 +82,6 @@ public:
 // See: https://www.scylladb.com/2018/12/04/worry-free-ingestion-flow-control/
 std::chrono::microseconds calculate_view_update_throttling_delay(
     update_backlog backlog,
-    db::timeout_clock::time_point timeout);
+    db::timeout_clock::time_point timeout,
+    uint32_t view_flow_control_delay_limit_in_ms);
 }

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -22,6 +22,7 @@
 #include "utils/pretty_printers.hh"
 #include "readers/from_mutations_v2.hh"
 #include "service/storage_proxy.hh"
+#include "db/config.hh"
 
 static logging::logger vug_logger("view_update_generator");
 
@@ -450,7 +451,7 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
         // the one which limits the number of incoming client requests by delaying the response to the client.
         if (batch_num > 0) {
             update_backlog local_backlog = _db.get_view_update_backlog();
-            std::chrono::microseconds throttle_delay =  calculate_view_update_throttling_delay(local_backlog, timeout);
+            std::chrono::microseconds throttle_delay =  calculate_view_update_throttling_delay(local_backlog, timeout, _db.get_config().view_flow_control_delay_limit_in_ms());
 
             co_await seastar::sleep(throttle_delay);
 

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -268,6 +268,10 @@ future<> view_update_backlog_broker::stop() {
 
 future<> view_update_backlog_broker::on_change(gms::inet_address endpoint, const gms::application_state_map& states, gms::permit_id pid) {
     return on_application_state_change(endpoint, states, gms::application_state::VIEW_BACKLOG, pid, [this] (gms::inet_address endpoint, const gms::versioned_value& value, gms::permit_id) {
+        if (utils::get_local_injector().enter("skip_updating_local_backlog_via_view_update_backlog_broker")) {
+            return make_ready_future<>();
+        }
+
         size_t current;
         size_t max;
         api::timestamp_type ticks;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1599,7 +1599,7 @@ public:
     template<typename Func>
     void delay(tracing::trace_state_ptr trace, Func&& on_resume) {
         auto backlog = max_backlog();
-        auto delay = db::view::calculate_view_update_throttling_delay(backlog, _expire_timer.get_timeout());
+        auto delay = db::view::calculate_view_update_throttling_delay(backlog, _expire_timer.get_timeout(), _proxy->data_dictionary().get_config().view_flow_control_delay_limit_in_ms());
         stats().last_mv_flow_control_delay = delay;
         stats().mv_flow_control_delay += delay.count();
         if (delay.count() == 0) {

--- a/test/topology_custom/test_mv_backlog.py
+++ b/test/topology_custom/test_mv_backlog.py
@@ -5,12 +5,17 @@
 #
 from test.pylib.manager_client import ManagerClient
 
+import logging
+import time
 import asyncio
 import pytest
 from test.topology.conftest import skip_mode
-from test.pylib.util import wait_for_view
+from test.pylib.util import wait_for_view, wait_for
 from test.topology_experimental_raft.test_mv_tablets import pin_the_only_tablet
 from test.pylib.tablets import get_tablet_replica
+
+logger = logging.getLogger(__name__)
+
 
 # This test reproduces issue #18542
 # In the test, we create a table and perform a write to it a couple of times
@@ -76,3 +81,117 @@ async def test_gossip_same_backlog(manager: ManagerClient) -> None:
     await cql.run_async(stmt, [0, 0, 'a'], host=hosts[0])
 
     await cql.run_async(f"DROP KEYSPACE ks")
+
+# A test for the view_flow_control_delay_limit_in_ms parameter.
+#
+# The test creates a table with a materialized view and pins all tablets
+# of the base on one node, and all tablets of the view to another node.
+#
+# Then, for a bunch of some possible values of the parameter, do the following:
+#
+# - Perform a live update of the parameter on both nodes.
+# - Do a large write to the base table while using the `never_finish_remote_view_updates`
+#   error injection to keep the remote view update resident and occupying
+#   memory, influencing the view update backlog as a result.
+#   Follow it with one more small write to make sure that it is delayed
+#   by the first write's backlog.
+# - Read the `scylla_storage_proxy_coordinator_mv_flow_control_delay_total` metric,
+#   before and after the second write, in order to measure the calculated delay
+#   of last view update.
+#
+# Finally, calculate ratios between the measured delays - the ratios should be
+# the same as ratios of the view_flow_control_delay_limit_in_ms parameter
+# that was set during the measurement.
+@pytest.mark.asyncio
+@skip_mode('release', "error injections aren't enabled in release mode")
+async def test_configurable_mv_control_flow_delay(manager: ManagerClient) -> None:
+    node_count = 2
+    servers = await manager.servers_add(node_count,
+                                        config={'error_injections_at_startup': ['update_backlog_immediately', 'view_update_limit', 'skip_updating_local_backlog_via_view_update_backlog_broker'], 'enable_tablets': True},
+                                        cmdline=['--smp=1'])
+    cql, hosts = await manager.get_ready_cql(servers)
+    await cql.run_async(f"CREATE KEYSPACE ks WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}"
+                         "AND tablets = {'initial': 1}")
+    await cql.run_async(f"CREATE TABLE ks.tab (key int, c int, v text, PRIMARY KEY (key, c))")
+    await cql.run_async(f"CREATE MATERIALIZED VIEW ks.mv_cf_view AS SELECT * FROM ks.tab "
+                    "WHERE c IS NOT NULL and key IS NOT NULL PRIMARY KEY (c, key) ")
+    await wait_for_view(cql, 'mv_cf_view', node_count)
+
+    # Only remote updates hold on to memory, so make the update remote
+    srv_base = servers[0]
+    srv_view = servers[1]
+    host_base = next(h for h in hosts if h.address == srv_base.ip_addr)
+    await pin_the_only_tablet(manager, "ks", "tab", srv_base)
+    await pin_the_only_tablet(manager, "ks", "mv_cf_view", srv_view)
+
+    # All nodes in the cluster run with --smp=1, so there is only shard 0
+    shard = 0
+
+    delay_metric_name = 'scylla_storage_proxy_coordinator_mv_flow_control_delay_total'
+    throttled_writes_metric_name = 'scylla_storage_proxy_coordinator_throttled_base_writes_total'
+
+    delay_limits = [0, 500, 1000, 2000, 10000]
+    computed_delays = []
+
+    stmt = cql.prepare(f"INSERT INTO ks.tab (key, c, v) VALUES (?, ?, ?)")
+
+    for delay_limit in delay_limits:
+        logger.info(f"delay_limit = {delay_limit}")
+
+        # Update the delay
+        await asyncio.gather(*(cql.run_async(f"UPDATE system.config SET value = '{delay_limit}' WHERE name = 'view_flow_control_delay_limit_in_ms'", host=h) for h in hosts))
+
+        # Make sure that view updates will hang
+        await asyncio.gather(*(manager.api.enable_injection(s.ip_addr, "never_finish_remote_view_updates", one_shot=False) for s in servers))
+
+        # Generate a large view update and then a small one.
+        # The reason why we do two writes is as follows: view backlog is propagated
+        # in responses from base writes and the coordinator caches it but it will
+        # not necessarily use it when calculating the delay of the same write.
+        # The second small write will use the value of the backlog from the previous write.
+        await cql.run_async(stmt, [0, 0, 100000*'a'], host=host_base)
+
+        # Measure the total delay before the second write, and the number of delayed writes
+        local_metrics = await manager.metrics.query(srv_base.ip_addr)
+        before_computed_delay = local_metrics.get(delay_metric_name, shard=str(shard)) or 0.0
+        before_total_throttled_writes = local_metrics.get(throttled_writes_metric_name, shard=str(shard)) or 0.0
+
+        # Do the second write, as mentioned previously
+        await cql.run_async(stmt, [0, 0, ''], host=host_base)
+
+        # Make sure that there is exactly one throttled write and calculate a delay for it.
+        # If we're testing the 0ms delay, instead make sure that there were no delayed writes.
+        local_metrics = await manager.metrics.query(srv_base.ip_addr)
+        after_computed_delay = local_metrics.get(delay_metric_name, shard=str(shard)) or 0.0
+        after_total_throttled_writes = local_metrics.get(throttled_writes_metric_name, shard=str(shard)) or 0.0
+
+        if delay_limit == 0:
+            assert after_total_throttled_writes == before_total_throttled_writes
+        else:
+            assert after_total_throttled_writes == before_total_throttled_writes + 1
+
+        computed_delay = after_computed_delay - before_computed_delay
+        computed_delays.append(computed_delay)
+
+        # Unpause the view update and wait until it is drained in order to prepare for the next pass
+        await asyncio.gather(*(manager.api.disable_injection(s.ip_addr, "never_finish_remote_view_updates") for s in servers))
+        async def view_updates_drained():
+            local_metrics = await manager.metrics.query(srv_base.ip_addr)
+            backlog = local_metrics.get('scylla_storage_proxy_replica_view_update_backlog', shard=str(shard))
+            if backlog == 0:
+                return True
+        await wait_for(view_updates_drained, deadline=time.time() + 30.0)
+
+    ratios = [delay / limit for delay, limit in zip(computed_delays, delay_limits) if limit != 0]
+
+    logger.info(f"delay_limits: {delay_limits}")
+    logger.info(f"computed_delays: {computed_delays}")
+    logger.info(f"ratios (for non-zero limits): {ratios}")
+
+    # Check that the ratios are relatively stable, i.e. there is not much
+    # relative difference between minimum and maximum
+    assert min(ratios) / max(ratios) > 0.9
+
+    # Additionally, check that the delay is zero for a zero value
+    # of the view_flow_control_delay_limit_in_ms parameter
+    assert computed_delays[0] == 0.0


### PR DESCRIPTION
This pull request is continuation of scylladb/scylladb#20688 - contents of the main commit are the same, the only change is the additional commit with a test.

Until this patch, the materialized view flow-control algorithm (https://www.scylladb.com/2018/12/04/worry-free-ingestion-flow-control/) used a constant delay_limit_us hard-coded to one second, which means that when the size of view-update backlog reached the maximum (10% of memory), we delay every request by an additional second - while smaller amounts of backlog will result in smaller delays.

This hard-coded one maximum second delay was considered *huge* - it will slow down a client with concurrency 1000 to just 1000 requests per second - but we already saw some workloads where it was not enough - such as a test workload running very slow reads at high concurrency on a slow machine, where a latency of over one second was expected for each read, so adding a one second latecy for writes wasn't having any noticable affect on slowing down the client.

So this patch replaces the hard-coded default with a live-updateable configuration parameter, `view_flow_control_delay_limit_in_ms`, which defaults to 1000ms as before.

Another useful way in which the new `view_flow_control_delay_limit_in_ms` can be used is to set it to 0. In that case, the view-update flow control always adds zero delay, and in effect - does absolutely nothing. This setting can be used in emergency situations where it is suspected that the MV flow control is not behaving properly, and the user wants to disable it.

The new parameter's help string mentions both these use cases of the parameter.

Fixes #18187

This is new functionality, no need to backport to any open source release.