### PR TITLE
mv: handle mismatched base/view replica count caused by RF change

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -677,6 +677,10 @@ database::setup_metrics() {
 
         sm::make_total_operations("total_view_updates_on_wrong_node", _cf_stats.total_view_updates_on_wrong_node,
                 sm::description("Total number of view updates which are computed on the wrong node.")).set_skip_when_empty(),
+
+        sm::make_total_operations("total_base_view_replicas_mismatch", _cf_stats.total_base_view_replicas_mismatch,
+                sm::description("Total number of view updates for which the base had a different replica count than the view. "
+                    "Should only increase during RF change. Should stop increasing shortly after finishing the RF change.")).set_skip_when_empty(),
     });
     if (this_shard_id() == 0) {
         _metrics.add_group("database", {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -332,6 +332,8 @@ struct cf_stats {
 
     // How many times we build view updates only to realize it's the wrong node and drop the update
     uint64_t total_view_updates_on_wrong_node = 0;
+    // How many times we had a different count of base and view replicas.
+    uint64_t total_base_view_replicas_mismatch = 0;
 };
 
 class table;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6045,6 +6045,17 @@ future<> storage_service::clone_locally_tablet_storage(locator::global_tablet_id
 // Streams data to the pending tablet replica of a given tablet on this node.
 // The source tablet replica is determined from the current transition info of the tablet.
 future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
+    co_await utils::get_local_injector().inject("block_tablet_streaming", [this, &tablet] (auto& handler) -> future<> {
+        const auto keyspace = handler.get("keyspace");
+        const auto table = handler.get("table");
+        SCYLLA_ASSERT(keyspace);
+        SCYLLA_ASSERT(table);
+        auto s = _db.local().find_column_family(tablet.table).schema();
+        bool should_block = s->ks_name() == *keyspace && s->cf_name() == *table;
+        while (should_block && !handler.poll_for_message() && !_async_gate.is_closed()) {
+            co_await sleep(std::chrono::milliseconds(100));
+        }
+    });
     co_await do_tablet_operation(tablet, "Streaming", [this, tablet] (locator::tablet_metadata_guard& guard) -> future<tablet_operation_result> {
         auto tm = guard.get_token_metadata();
         auto& tmap = guard.get_tablet_map();


### PR DESCRIPTION
During a ALTER KEYSPACE statement execution where a table with a view is present, we need to perform tablet migrations for both tables. These migrations are not synchronized, so at some point the base may have a different number of replicas than the view. Because of that, we can't pair them correctly, which can cause a crash.

This patch adds a workaround for this scenario. If after one migration we have too many base tablets, we simply do not generate updates from it, and the new view replica (in case of RF increase) is pending and will get updates from all other base replicas.
If after one migration we have too many view replicas, no base replica will be paired with it, so we add it to the pending replica list so that it gets an update anyway.
Replication changes only modify the last replica in the list, so we identify the last entry in the list as the new replica

This patch will also take effect if the base and view replica counts differ due to some other bug. To track that, a new metric is added to count such occurrences.

This patch also includes a test for this exact scenario, which is enforced by an injection.

Fixes https://github.com/scylladb/scylladb/issues/21492

This patch can prevent a crash, so we should probably backport this