### PR TITLE
test.py: deselect random failures which can cause #21534

### DIFF
--- a/test/topology_random_failures/cluster_events.py
+++ b/test/topology_random_failures/cluster_events.py
@@ -558,6 +558,13 @@ async def stop_non_coordinator_node_gracefully(manager: ManagerClient,
     yield
 
 
+@deselect_for(
+    # TODO: remove this skip when #21534 will be resolved.
+    error_injections=[
+        "stop_after_setting_mode_to_normal_raft_topology",
+    ],
+    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
+)
 async def stop_coordinator_node_gracefully(manager: ManagerClient,
                                            random_tables: RandomTables,
                                            error_injection: str) -> AsyncIterator[None]:
@@ -583,6 +590,13 @@ async def kill_non_coordinator_node(manager: ManagerClient,
     yield
 
 
+@deselect_for(
+    # TODO: remove this skip when #21534 will be resolved.
+    error_injections=[
+        "stop_after_setting_mode_to_normal_raft_topology",
+    ],
+    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
+)
 async def kill_coordinator_node(manager: ManagerClient,
                                 random_tables: RandomTables,
                                 error_injection: str) -> AsyncIterator[None]:


### PR DESCRIPTION
Following combinations of error injections and cluster events can cause #21534.  Disable them for now because they break CI.
