### PR TITLE
test.py: topology_random_failures: increase timeout for Scylla startup

### DIFF
--- a/test/topology_random_failures/test_random_failures.py
+++ b/test/topology_random_failures/test_random_failures.py
@@ -135,6 +135,7 @@ async def test_random_failures(manager: ManagerClient,
         expected_statuses=[
             psutil.STATUS_STOPPED,
         ],
+        deadline=time.time() + 180,
     )
 
     LOGGER.info("Run the cluster event main step.")


### PR DESCRIPTION
We run topology_random_failures in debug mode only and sometimes Scylla is too slow in this mode.  Increase timeout for Scylla startup from 30s to 180s to reduce flakiness.

Fixes #21101
