### PR TITLE
replica: correct indentation after coroutinizing make_sstables_available

### DIFF
--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -133,9 +133,9 @@ distributed_loader::make_sstables_available(sstables::sstable_directory& dir, sh
         auto gen = table.calculate_generation_for_new_table();
         dblog.trace("Loading {} into {}, new generation {}", sst->get_filename(), needs_view_update ? "staging" : "base", gen);
         co_await sst->pick_up_from_upload(!needs_view_update ? sstables::sstable_state::normal : sstables::sstable_state::staging, gen);
-            // When loading an imported sst, set level to 0 because it may overlap with existing ssts on higher levels.
-            sst->set_sstable_level(0);
-            new_sstables.push_back(std::move(sst));
+        // When loading an imported sst, set level to 0 because it may overlap with existing ssts on higher levels.
+        sst->set_sstable_level(0);
+        new_sstables.push_back(std::move(sst));
     });
 
     // nothing loaded


### PR DESCRIPTION
The previous commit (b3ebbf35e2) transformed `make_sstables_available()` into a coroutine but left behind incorrectly indented statements from a nested lambda. This commit restores proper indentation.

---

it's a cleanup, hence no need to backport.