### PR TITLE
docs/ddl: document memtable_flush_period_in_ms

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -684,6 +684,10 @@ A table supports the following options:
      - simple
      - 0
      - The default expiration time (“TTL”) in seconds for a table.
+   * - ``memtable_flush_period_in_ms``
+     - simple
+     - 0
+     - Flush the memtables associated with this table every ``memtable_flush_period_in_ms`` milliseconds. When set to ``0``, periodic flush is disabled. Cannot set to values lower than ``60000`` (1 minute). Default: ``0``.
    * - ``compaction``
      - map
      - see below


### PR DESCRIPTION
This option was implemented by scylladb/scylladb#20999 but it wasn't documented. Add a description of this option to the create table page. Note that the option was accepted already before
scylladb/scylladb#20999, but it's value was ignored.

Fixes: scylladb/scylladb#21671

This PR documents an option implemented in https://github.com/scylladb/scylladb/commit/b965729f0a9784f43e673d50c4db0c20ca0c2b48, which is not yet part of any release, so no backport is necessary.