### PR TITLE
test: Move test_query_built_indexes_virtual_table from boost to cqlpy

### DIFF
--- a/test/boost/virtual_reader_test.cc
+++ b/test/boost/virtual_reader_test.cc
@@ -212,31 +212,3 @@ SEASTAR_TEST_CASE(test_query_view_built_progress_virtual_table) {
         assert_that(rs).is_rows().with_size(0);
     });
 }
-
-SEASTAR_TEST_CASE(test_query_built_indexes_virtual_table) {
-    return do_with_cql_env_thread([] (cql_test_env& e) {
-        auto idx = secondary_index::index_table_name("idx");
-        e.execute_cql("create table cf(p int PRIMARY KEY, v int);").get();
-        auto f1 = e.local_view_builder().wait_until_built("ks", "vcf");
-        auto f2 = e.local_view_builder().wait_until_built("ks", idx);
-        e.execute_cql("create materialized view vcf as select * from cf "
-                      "where v is not null and p is not null "
-                      "primary key (v, p)").get();
-        e.execute_cql("create index idx on cf (v)").get();
-        f1.get();
-        f2.get();
-        auto rs = e.execute_cql("select * from system.built_views").get();
-        assert_that(rs).is_rows().with_rows_ignore_order({
-                { {utf8_type->decompose(sstring("ks"))}, {utf8_type->decompose(idx)} },
-                { {utf8_type->decompose(sstring("ks"))}, {"vcf"} },
-        });
-        rs = e.execute_cql("select * from system.\"IndexInfo\"").get();
-        assert_that(rs).is_rows().with_rows_ignore_order({
-                { {utf8_type->decompose(sstring("ks"))}, {utf8_type->decompose(sstring("idx"))} },
-        });
-        rs = e.execute_cql("select * from system.\"IndexInfo\" where table_name = 'ks' and index_name = 'idx'").get();
-        assert_that(rs).is_rows().with_size(1);
-        rs = e.execute_cql("select * from system.\"IndexInfo\" where table_name = 'ks' and index_name = 'vcf'").get();
-        assert_that(rs).is_rows().with_size(0);
-    });
-}

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -14,7 +14,7 @@ from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, C
 from cassandra.query import SimpleStatement
 from .cassandra_tests.porting import assert_rows, assert_row_count, assert_rows_ignoring_order, assert_empty
 
-from .util import new_test_table, unique_name, unique_key_int
+from .util import new_test_table, unique_name, unique_key_int, is_scylla
 
 # A reproducer for issue #7443: Normally, when the entire table is SELECTed,
 # the partitions are returned sorted by the partitions' token. When there
@@ -1956,3 +1956,18 @@ def test_paging_and_drop_index_no_allow_filtering(cql, test_keyspace):
                 assert len(r.current_rows) <= page_size
                 got.extend(r.current_rows)
             assert expected == got
+
+
+# Test index representation in system.* tables
+def test_index_in_system_tables(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v int") as table:
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+        wait_for_index(cql, test_keyspace, index_name)
+        if is_scylla(cql):
+            res = [ f'{r.keyspace_name}.{r.view_name}' for r in cql.execute('select * from system.built_views')]
+            assert f'{test_keyspace}.{index_name}_index' in res
+        res = [ f'{r.table_name}::{r.index_name}' for r in cql.execute('select * from system."IndexInfo"')]
+        assert f'{test_keyspace}::{index_name}' in res
+        res = cql.execute(f'select * from system."IndexInfo" where table_name = \'{test_keyspace}\' AND index_name = \'{index_name}\'').one()
+        assert (test_keyspace, index_name) == (res.table_name, res.index_name)


### PR DESCRIPTION
And split it into two -- one for materialized view, another for secondary index. This is to fit current cqlpy layout that has different files for views and indexes.

refs: #21552
refs: #21551 (detached this patch from there, as that PR needs fix in the core code)
