### PR TITLE
scylla-sstable: revamp schema sources

### DIFF
--- a/test/cqlpy/test_tools.py
+++ b/test/cqlpy/test_tools.py
@@ -651,14 +651,14 @@ class TestScyllaSsstableSchemaLoading(TestScyllaSsstableSchemaLoadingBase):
     def test_table_dir_data_dir(self, scylla_path, system_scylla_local_sstable_prepared, system_scylla_local_reference_dump, scylla_data_dir):
         self.check(
                 scylla_path,
-                ["--scylla-data-dir", scylla_data_dir, "--keyspace", self.keyspace, "--table", self.table],
+                ["--schema-tables", "--scylla-data-dir", scylla_data_dir, "--keyspace", self.keyspace, "--table", self.table],
                 system_scylla_local_sstable_prepared,
                 system_scylla_local_reference_dump)
 
     def test_table_dir_data_dir_deduced_keyspace_table(self, scylla_path, system_scylla_local_sstable_prepared, system_scylla_local_reference_dump, scylla_data_dir):
         self.check(
                 scylla_path,
-                ["--scylla-data-dir", scylla_data_dir],
+                ["--schema-tables", "--scylla-data-dir", scylla_data_dir],
                 system_scylla_local_sstable_prepared,
                 system_scylla_local_reference_dump)
 
@@ -666,7 +666,7 @@ class TestScyllaSsstableSchemaLoading(TestScyllaSsstableSchemaLoadingBase):
         scylla_yaml_file = os.path.join(scylla_home_dir, "conf", "scylla.yaml")
         self.check(
                 scylla_path,
-                ["--scylla-yaml-file", scylla_yaml_file, "--keyspace", self.keyspace, "--table", self.table],
+                ["--schema-tables", "--scylla-yaml-file", scylla_yaml_file, "--keyspace", self.keyspace, "--table", self.table],
                 system_scylla_local_sstable_prepared,
                 system_scylla_local_reference_dump)
 
@@ -674,7 +674,7 @@ class TestScyllaSsstableSchemaLoading(TestScyllaSsstableSchemaLoadingBase):
         scylla_yaml_file = os.path.join(scylla_home_dir, "conf", "scylla.yaml")
         self.check(
                 scylla_path,
-                ["--scylla-yaml-file", scylla_yaml_file],
+                ["--schema-tables", "--scylla-yaml-file", scylla_yaml_file],
                 system_scylla_local_sstable_prepared,
                 system_scylla_local_reference_dump)
 
@@ -699,7 +699,7 @@ class TestScyllaSsstableSchemaLoading(TestScyllaSsstableSchemaLoadingBase):
         ext_sstable = self.copy_sstable_to_external_dir(system_scylla_local_sstable_prepared, temp_workdir)
         self.check(
                 scylla_path,
-                ["--scylla-data-dir", scylla_data_dir, "--keyspace", self.keyspace, "--table", self.table],
+                ["--schema-tables", "--scylla-data-dir", scylla_data_dir, "--keyspace", self.keyspace, "--table", self.table],
                 ext_sstable,
                 system_scylla_local_reference_dump)
 
@@ -708,9 +708,19 @@ class TestScyllaSsstableSchemaLoading(TestScyllaSsstableSchemaLoadingBase):
         scylla_yaml_file = os.path.join(scylla_home_dir, "conf", "scylla.yaml")
         self.check(
                 scylla_path,
-                ["--scylla-yaml-file", scylla_yaml_file, "--keyspace", self.keyspace, "--table", self.table],
+                ["--schema-tables", "--scylla-yaml-file", scylla_yaml_file, "--keyspace", self.keyspace, "--table", self.table],
                 ext_sstable,
                 system_scylla_local_reference_dump)
+
+    def test_external_dir_sstable_serialization_header_keyspace_table(self, scylla_path, system_scylla_local_sstable_prepared, system_scylla_local_reference_dump, temp_workdir):
+        ext_sstable = self.copy_sstable_to_external_dir(system_scylla_local_sstable_prepared, temp_workdir)
+        # It is important to use a controlled workdir, so scylla-sstable doesn't accidentally pick up a scylla.yaml.
+        self.check(
+                scylla_path,
+                ["--sstable-schema", "--keyspace", self.keyspace, "--table", self.table],
+                ext_sstable,
+                system_scylla_local_reference_dump,
+                cwd=temp_workdir)
 
     def test_external_dir_autodetect_schema_file(self, scylla_path, system_scylla_local_sstable_prepared, system_scylla_local_reference_dump, temp_workdir, system_scylla_local_schema_file):
         ext_sstable = self.copy_sstable_to_external_dir(system_scylla_local_sstable_prepared, temp_workdir)
@@ -775,7 +785,7 @@ class TestScyllaSsstableSchemaLoading(TestScyllaSsstableSchemaLoadingBase):
         scylla_yaml_file = os.path.join(scylla_home_dir, "conf", "scylla.yaml")
         self.check_fail(
                 scylla_path,
-                ["--scylla-yaml-file", scylla_yaml_file, "--keyspace", "non-existent-keyspace", "--table", self.table],
+                ["--schema-tables", "--scylla-yaml-file", scylla_yaml_file, "--keyspace", "non-existent-keyspace", "--table", self.table],
                 ext_sstable,
                 error_msg="error processing arguments: could not load schema via schema-tables: std::runtime_error (Failed to find non-existent-keyspace.scylla_local in schema tables)")
 
@@ -784,7 +794,7 @@ class TestScyllaSsstableSchemaLoading(TestScyllaSsstableSchemaLoadingBase):
         scylla_yaml_file = os.path.join(scylla_home_dir, "conf", "scylla.yaml")
         self.check_fail(
                 scylla_path,
-                ["--scylla-yaml-file", scylla_yaml_file, "--keyspace", self.keyspace, "--table", "non-existent-table"],
+                ["--schema-tables", "--scylla-yaml-file", scylla_yaml_file, "--keyspace", self.keyspace, "--table", "non-existent-table"],
                 ext_sstable,
                 error_msg="error processing arguments: could not load schema via schema-tables: std::runtime_error (Failed to find system.non-existent-table in schema tables)")
 


### PR DESCRIPTION
Demote --scylla-data-dir and --scylla-yaml-file to schema source helpers, rather than schema source in themselves. This practically means that when these options are used, they won't define where the tool will attempt to load the schema from, they will just be helpers to help locate the schema, for whichever schema source the tool was instructed to use (or left to choose).
--scylla-data-dir and --scylla-yaml-file being schema sources were problematic with encryption at rest and for S3 support (not yet implemented). With encryption, the tool needs access to the configuration, so --scylla-yaml-file is often used to provide the path to the configuration file, which contains encryption configuration, needed for the tool to decrypt the sstable. Currently, using this option implies forcing the tool to read the schema from the schema tables, which is a problematic option for tests -- Scylla might be compacting a schema sstable and this will make the tool fail to load the schema. Demoting these options the schema helpers, allows providing them, while at the same time having the option to use a different schema-source.

To allow the user to force the tool to load the schema from the schema tables, a new --schema-tables option is added. Similarly, a --sstable-schema option is introduced to force the tool to load the schema from the sstable itself.

With this, each 4 schema source now has an option to force the use of said schema source. There are various helper options to be used along with these.

The documentation as well as the tests are updated with the changes. The schema related documentation gets an rather extensive facelift because it was a bit out-of-date and incomplete.

Fixes: scylladb/scylladb#20534

Improvement, no backport needed.