### PR TITLE
build: cmake: Enforce explicit library linkage visibility

### DIFF
--- a/alternator/CMakeLists.txt
+++ b/alternator/CMakeLists.txt
@@ -25,11 +25,13 @@ target_include_directories(alternator
   PRIVATE
     ${RAPIDJSON_INCLUDE_DIRS})
 target_link_libraries(alternator
-  cql3
-  idl
-  Seastar::seastar
-  xxHash::xxhash
-  absl::headers)
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    cql3
+    idl
+    absl::headers)
 
 check_headers(check-headers alternator
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -96,11 +96,13 @@ target_include_directories(api
     ${CMAKE_SOURCE_DIR}
     ${scylla_gen_build_dir})
 target_link_libraries(api
-  idl
-  wasmtime_bindings
-  Seastar::seastar
-  xxHash::xxhash
-  absl::headers)
+  PUBLIC
+    Seastar::seastar
+    xxHash::xxhash
+  PRIVATE
+    idl
+    wasmtime_bindings
+    absl::headers)
 
 check_headers(check-headers api
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/types/CMakeLists.txt
+++ b/types/CMakeLists.txt
@@ -6,10 +6,12 @@ target_include_directories(types
   PUBLIC
     ${CMAKE_SOURCE_DIR})
 target_link_libraries(types
-    cql3
-    idl
+  PUBLIC
     Seastar::seastar
-    xxHash::xxhash)
+    xxHash::xxhash
+  PRIVATE
+    cql3
+    idl)
 
 check_headers(check-headers types
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)


### PR DESCRIPTION
This change improves dependency management by explicitly specifying library linkage visibility in CMake targets.

Previously, some ScyllaDB targets used `target_link_libraries()` without `PUBLIC` or `PRIVATE` keywords, which resulted in transitive library dependencies by default. This unintentionally exposed non-public dependencies to downstream targets.

Changes:
- Always use explicit `PRIVATE` or `PUBLIC` keywords with `target_link_libraries()`
- Tighten build dependency tree
- Enforce a more modular linkage model

See: [CMake documentation on library dependencies](https://cmake.org/cmake/help/latest/command/target_link_libraries.html)

---

this is a cmake-related change, hence no need to backport.