### PR TITLE
test: s3_proxy: bring back InjectingHandler.log_message

### DIFF
--- a/test/pylib/s3_proxy.py
+++ b/test/pylib/s3_proxy.py
@@ -7,6 +7,7 @@
 
 # S3 proxy server to inject retryable errors for fuzzy testing.
 
+import logging
 import os
 import random
 import sys
@@ -91,6 +92,15 @@ class InjectingHandler(BaseHTTPRequestHandler):
         self.max_retries = max_retries
         super().__init__(*args, **kwargs)
         self.close_connection = False
+
+    def log_message(self, format, *args):
+        if not self.logger.isEnabledFor(logging.INFO):
+            return
+        self.logger.info("%s - - [%s] %s",
+                         self.client_address[0],
+                         self.log_date_time_string(),
+                         format % args)
+
 
     def parsed_qs(self):
         parsed_url = urlparse(self.path)


### PR DESCRIPTION
in 0dff187b7a, we dropped `InjectingHandler.log_message()`, but this method was defined to override the default implementation provided by `BaseHTTPRequestHandler.log_message()`. this change flooded the standard output when testing `aws_error_injection_test` with `test.py` with logging messages like:
```
127.0.0.1 - - [26/Nov/2024 17:27:34] "PUT /?Policy=0&Key=%2Ftest%2Ftestobject-large-817295 HTTP/1.1" 200
127.0.0.1 - - [26/Nov/2024 17:27:34] "PUT /?Policy=1&Key=%2Ftest%2Ftestobject-large-817306 HTTP/1.1" 200
```

this is unexpected.

in this change, we bring this method back, and additionally, we format the logging message lazily.

---

this is a change which intend to improve the developer's experience, hence no need to backport.