### PR TITLE
configure.py: honor "--build-dir" when using CMake

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2556,7 +2556,10 @@ def configure_using_cmake(args):
         settings['Scylla_CLANG_INLINE_THRESHOLD'] = args.clang_inline_threshold
 
     source_dir = os.path.realpath(os.path.dirname(__file__))
-    build_dir = os.path.join(source_dir, 'build')
+    if os.path.isabs(args.build_dir):
+        build_dir = args.build_dir
+    else:
+        build_dir = os.path.join(source_dir, args.build_dir)
 
     if not args.dist_only:
         for mode in selected_modes:


### PR DESCRIPTION
The "--use-cmake" option currently hardwires the build directory as "$source_dir/build". Adhere to the "--build-dir" option's argument instead:

- If the option is not specified, its argument defaults to "build"; thus, there is no change in behavior.

- If the option specifies a relative pathname, append it to $source_dir.

- If the option specifies an absolute pathname, use it as-is.

This is especially useful for keeping the build directory on a filesystem separate from the source directory (without resorting to creating "build" as a symlink, before running "configure.py"). For example, the source tree can be accessed remotely over sshfs, from a build host, while keeping the build artifacts (and hence the link stage) local to the build host.

Small improvement for the cmake-based build; no need to backport.