### PR TITLE
treewide: migrate from boost::adaptors::transformed to std::views::transform

### DIFF
--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -11,7 +11,6 @@
 #include "size_tiered_compaction_strategy.hh"
 #include "cql3/statements/property_definitions.hh"
 
-#include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/adaptor/reversed.hpp>
 #include <boost/range/algorithm.hpp>
 

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -722,7 +722,7 @@ future<> table_resharding_compaction_task_impl::run() {
     auto all_jobs = co_await collect_all_shared_sstables(_dir, _db, _status.keyspace, _status.table, _owned_ranges_ptr);
     auto destinations = co_await distribute_reshard_jobs(std::move(all_jobs));
 
-    uint64_t total_size = boost::accumulate(destinations | boost::adaptors::transformed(std::mem_fn(&replica::reshard_shard_descriptor::size)), uint64_t(0));
+    uint64_t total_size = std::ranges::fold_left(destinations | std::views::transform(std::mem_fn(&replica::reshard_shard_descriptor::size)), uint64_t(0), std::plus{});
     if (total_size == 0) {
         co_return;
     }

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -16,7 +16,6 @@
 #include <boost/range/algorithm/find.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/algorithm/min_element.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 
 #include <ranges>
 
@@ -267,7 +266,7 @@ time_window_compaction_strategy::get_reshaping_job(std::vector<shared_sstable> i
             single_window.size(), !single_window.empty() && sstable_set_overlapping_count(schema, single_window) == 0);
 
     auto get_job_size = [] (const std::vector<shared_sstable>& ssts) {
-        return boost::accumulate(ssts | boost::adaptors::transformed(std::mem_fn(&sstable::bytes_on_disk)), uint64_t(0));
+        return std::ranges::fold_left(ssts | std::views::transform(std::mem_fn(&sstable::bytes_on_disk)), uint64_t(0), std::plus{});
     };
 
     // Targets a space overhead of 10%. All disjoint sstables can be compacted together as long as they won't

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <boost/range/algorithm.hpp>
+#include <boost/range/numeric.hpp>
 #include <functional>
 #include <ranges>
 #include <stdexcept>

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -21,7 +21,6 @@
 #include "timestamp.hh"
 #include "validation.hh"
 #include "db/extensions.hh"
-#include <boost/range/adaptor/transformed.hpp>
 #include "cql3/util.hh"
 #include "view_info.hh"
 #include "data_dictionary/data_dictionary.hh"
@@ -141,7 +140,7 @@ static void validate_column_rename(data_dictionary::database db, const schema& s
             throw exceptions::invalid_request_exception(
                     seastar::format("Cannot rename column {} because it has dependent secondary indexes ({})",
                                     from,
-                                    fmt::join(dependent_indices | boost::adaptors::transformed([](const index_metadata& im) {
+                                    fmt::join(dependent_indices | std::views::transform([](const index_metadata& im) {
                                         return im.name();
                                     }), ", ")));
         }

--- a/cql3/statements/authorization_statement.cc
+++ b/cql3/statements/authorization_statement.cc
@@ -65,12 +65,11 @@ void cql3::statements::authorization_statement::maybe_correct_resource(auth::res
         auto function_args = functions_view.function_args();
         std::vector<data_type> parsed_types;
         if (function_args) {
-            parsed_types = boost::copy_range<std::vector<data_type>>(
-                *function_args | boost::adaptors::transformed([&] (std::string_view raw_type) {
+            parsed_types =
+                *function_args | std::views::transform([&] (std::string_view raw_type) {
                     auto parsed = db::cql_type_parser::parse(sstring(keyspace->data(), keyspace->size()), sstring(raw_type.data(), raw_type.size()), utm);
                     return parsed->is_user_type() ? parsed->freeze() : parsed;
-                })
-            );
+                }) | std::ranges::to<std::vector>();
         }
         resource = auth::make_functions_resource(*keyspace, auth::encode_signature(function_name, parsed_types));
     }

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -19,6 +19,7 @@
 #include "service/storage_proxy.hh"
 #include "tracing/trace_state.hh"
 
+#include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/adaptor/uniqued.hpp>
 
 template<typename T = void>

--- a/cql3/statements/create_aggregate_statement.cc
+++ b/cql3/statements/create_aggregate_statement.cc
@@ -19,7 +19,6 @@
 #include "mutation/mutation.hh"
 #include "cql3/query_processor.hh"
 #include "gms/feature_service.hh"
-#include <boost/range/adaptor/transformed.hpp>
 
 
 namespace cql3 {
@@ -40,7 +39,7 @@ seastar::future<shared_ptr<db::functions::function>> create_aggregate_statement:
     acc_types.insert(acc_types.end(), _arg_types.begin(), _arg_types.end());
     auto state_func = dynamic_pointer_cast<functions::scalar_function>(functions::instance().find(functions::function_name{_name.keyspace, _sfunc}, acc_types));
     if (!state_func) {
-        auto acc_type_names = acc_types | boost::adaptors::transformed([] (auto&& t) { return t->cql3_type_name(); });
+        auto acc_type_names = acc_types | std::views::transform([] (auto&& t) { return t->cql3_type_name(); });
         throw exceptions::invalid_request_exception(seastar::format("State function {}({}) not found", _sfunc, fmt::join(acc_type_names, ", ")));
     }
     if (state_func->return_type() != state_type) {

--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -27,8 +27,6 @@
 #include "index/secondary_index_manager.hh"
 #include "mutation/mutation.hh"
 
-#include <boost/range/adaptor/transformed.hpp>
-#include <boost/algorithm/string/join.hpp>
 #include <stdexcept>
 
 namespace cql3 {
@@ -179,7 +177,7 @@ std::vector<::shared_ptr<index_target>> create_index_statement::validate_while_e
 void create_index_statement::validate_for_local_index(const schema& schema) const {
     if (!_raw_targets.empty()) {
             if (const auto* index_pk = std::get_if<std::vector<::shared_ptr<column_identifier::raw>>>(&_raw_targets.front()->value)) {
-                auto base_pk_identifiers = *index_pk | boost::adaptors::transformed([&schema] (const ::shared_ptr<column_identifier::raw>& raw_ident) {
+                auto base_pk_identifiers = *index_pk | std::views::transform([&schema] (const ::shared_ptr<column_identifier::raw>& raw_ident) {
                     return raw_ident->prepare_column_identifier(schema);
                 });
                 auto remaining_base_pk_columns = schema.partition_key_columns();

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -21,9 +21,6 @@
 #include "db/consistency_level_validations.hh"
 #include <optional>
 #include <seastar/core/shared_ptr.hh>
-#include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/adaptor/indirected.hpp>
 #include "transport/messages/result_message.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include "replica/database.hh"

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2035,7 +2035,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
 
     auto all_aggregates = [] (const std::vector<selection::prepared_selector>& prepared_selectors) {
         return std::ranges::all_of(
-            prepared_selectors | boost::adaptors::transformed(std::mem_fn(&selection::prepared_selector::expr)),
+            prepared_selectors | std::views::transform(std::mem_fn(&selection::prepared_selector::expr)),
             [] (const expr::expression& e) {
                 auto fn_expr = expr::as_if<expr::function_call>(&e);
                 if (!fn_expr) {
@@ -2587,8 +2587,9 @@ std::unique_ptr<cql3::statements::raw::select_statement> build_select_statement(
         // If the column name is not entirely lowercase (or digits or _),
         // when output to CQL it must be quoted to preserve case as well
         // as non alphanumeric characters.
-        auto cols = boost::copy_range<std::vector<sstring>>(selected_columns
-                | boost::adaptors::transformed(std::mem_fn(&column_definition::name_as_cql_string)));
+        auto cols = selected_columns
+                | std::views::transform(std::mem_fn(&column_definition::name_as_cql_string))
+                | std::ranges::to<std::vector>();
         fmt::print(out, "{}", fmt::join(cols, ", "));
     }
     // Note that cf_name may need to be quoted, just like column names above.

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -14,8 +14,6 @@
 #include "cql3/expr/evaluate.hh"
 #include "cql3/expr/expr-utils.hh"
 
-#include <boost/range/adaptor/transformed.hpp>
-
 #include "mutation/mutation.hh"
 #include "types/user.hh"
 

--- a/cql3/util.cc
+++ b/cql3/util.cc
@@ -138,8 +138,8 @@ sstring relations_to_where_clause(const expr::expression& e) {
         return fmt::format("{:user}", e);
     };
     auto relations = expr::boolean_factors(e);
-    auto expressions = relations | boost::adaptors::transformed(expr_to_pretty_string);
-    return boost::algorithm::join(expressions, " AND ");
+    auto expressions = relations | std::views::transform(expr_to_pretty_string);
+    return fmt::to_string(fmt::join(expressions, " AND "));
 }
 
 expr::expression where_clause_to_relations(const std::string_view& where_clause, dialect d) {

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -55,9 +55,6 @@
 #include "commitlog_entry.hh"
 #include "commitlog_extensions.hh"
 
-#include <boost/range/numeric.hpp>
-#include <boost/range/adaptor/transformed.hpp>
-
 #include "checked-file-impl.hh"
 #include "utils/disk-error-handler.hh"
 

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -323,13 +323,13 @@ filter_for_query(consistency_level cl,
         float ht_min = 1;
         bool old_node = false;
 
-        auto epi = boost::copy_range<std::vector<std::pair<gms::inet_address, float>>>(live_endpoints | boost::adaptors::transformed([&] (gms::inet_address ep) {
+        auto epi = live_endpoints | std::views::transform([&] (gms::inet_address ep) {
             auto ht = get_hit_rate(ep);
             old_node = old_node || ht < 0;
             ht_max = std::max(ht_max, ht);
             ht_min = std::min(ht_min, ht);
             return std::make_pair(ep, ht);
-        }));
+        }) | std::ranges::to<std::vector<std::pair<gms::inet_address, float>>>();
 
         if (!old_node && ht_max - ht_min > 0.01) { // if there is old node or hit rates are close skip calculations
             // local node is always first if present (see storage_proxy::get_endpoints_for_reading)

--- a/db/extensions.cc
+++ b/db/extensions.cc
@@ -11,8 +11,6 @@
 #include "sstables/sstables.hh"
 #include "commitlog/commitlog_extensions.hh"
 #include "schema/schema.hh"
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 
 db::extensions::extensions()
 {}

--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -11,9 +11,6 @@
 #include <algorithm>
 
 #include "utils/assert.hh"
-#include <boost/range/adaptor/indirected.hpp>
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 
 #include "clustering_bounds_comparator.hh"
 #include "replica/database_fwd.hh"
@@ -311,9 +308,9 @@ size_estimates_mutation_reader::estimates_for_current_keyspace(std::vector<token
     // For each specified range, estimate (crudely) mean partition size and partitions count.
     auto pkey = partition_key::from_single_value(*_schema, utf8_type->decompose(*_current_partition));
     auto cfs = _db.find_keyspace(*_current_partition).metadata()->cf_meta_data();
-    auto cf_names = boost::copy_range<std::vector<bytes>>(cfs | boost::adaptors::transformed([] (auto&& cf) {
+    auto cf_names = cfs | std::views::transform([] (auto&& cf) {
         return utf8_type->decompose(cf.first);
-    }));
+    }) | std::ranges::to<std::vector<bytes>>();
     std::ranges::sort(cf_names, [] (auto&& n1, auto&& n2) {
         return utf8_type->less(n1, n2);
     });

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -31,8 +31,6 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 
-#include <boost/range/adaptor/transformed.hpp>
-
 #include <optional>
 #include <vector>
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -8,7 +8,6 @@
  */
 
 #include <boost/range/algorithm.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/icl/interval_map.hpp>
 #include <fmt/ranges.h>
@@ -2526,12 +2525,12 @@ future<> system_keyspace::remove_built_view(sstring ks_name, sstring view_name) 
 
 future<std::vector<system_keyspace::view_name>> system_keyspace::load_built_views() {
     return execute_cql(format("SELECT * FROM system.{}", v3::BUILT_VIEWS)).then([] (::shared_ptr<cql3::untyped_result_set> cql_result) {
-        return boost::copy_range<std::vector<view_name>>(*cql_result
-                | boost::adaptors::transformed([] (const cql3::untyped_result_set::row& row) {
+        return *cql_result
+                | std::views::transform([] (const cql3::untyped_result_set::row& row) {
             auto ks_name = row.get_as<sstring>("keyspace_name");
             auto cf_name = row.get_as<sstring>("view_name");
             return std::pair(std::move(ks_name), std::move(cf_name));
-        }));
+        }) | std::ranges::to<std::vector<view_name>>();
     });
 }
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -8,7 +8,6 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 
-#include <boost/range/adaptor/transformed.hpp>
 #include <chrono>
 #include <deque>
 #include <functional>
@@ -17,9 +16,6 @@
 #include <vector>
 #include <algorithm>
 
-#include <boost/range/algorithm/remove_if.hpp>
-#include <boost/range/algorithm/transform.hpp>
-#include <boost/range/algorithm/copy.hpp>
 #include <boost/algorithm/string/join.hpp>
 
 #include <fmt/ranges.h>
@@ -720,8 +716,8 @@ view_updates::get_view_rows(const partition_key& base_key, const clustering_or_s
 
     std::vector<view_updates::view_row_entry> ret;
     auto compute_row = [&]<typename Range>(Range&& pk, Range&& ck) {
-        partition_key pkey = partition_key::from_range(boost::adaptors::transform(pk, view_managed_key_view_and_action::get_key_view));
-        clustering_key ckey = clustering_key::from_range(boost::adaptors::transform(ck, view_managed_key_view_and_action::get_key_view));
+        partition_key pkey = partition_key::from_range(std::views::transform(pk, view_managed_key_view_and_action::get_key_view));
+        clustering_key ckey = clustering_key::from_range(std::views::transform(ck, view_managed_key_view_and_action::get_key_view));
         auto action = (action_column < pk.size() ? pk[action_column] : ck[action_column - pk.size()])._action;
         mutation_partition& partition = partition_for(std::move(pkey));
 
@@ -738,11 +734,11 @@ view_updates::get_view_rows(const partition_key& base_key, const clustering_or_s
     if (had_multiple_values_in_pk) {
         // cartesian_product expects std::vector<std::vector<>>, while we have std::vector<small_vector>.
         std::vector<std::vector<view_managed_key_view_and_action>> pk_elems_, ck_elems_;
-        auto std_vector_from_small_vector = boost::adaptors::transformed([](const auto& vector) {
+        auto std_vector_from_small_vector = std::views::transform([](const auto& vector) {
             return std::vector<view_managed_key_view_and_action>{vector.begin(), vector.end()};
         });
-        boost::copy(pk_elems | std_vector_from_small_vector, std::back_inserter(pk_elems_));
-        boost::copy(ck_elems | std_vector_from_small_vector, std::back_inserter(ck_elems_));
+        std::ranges::copy(pk_elems | std_vector_from_small_vector, std::back_inserter(pk_elems_));
+        std::ranges::copy(ck_elems | std_vector_from_small_vector, std::back_inserter(ck_elems_));
 
         auto cartesian_product_pk = cartesian_product(pk_elems_),
              cartesian_product_ck = cartesian_product(ck_elems_);
@@ -776,7 +772,7 @@ view_updates::get_view_rows(const partition_key& base_key, const clustering_or_s
         }
     } else {
         // Here it's the old regular index over regular values. Each vector has just one element.
-        auto get_front = boost::adaptors::transformed([](const auto& v) { return v.front(); });
+        auto get_front = std::views::transform([](const auto& v) { return v.front(); });
         compute_row(pk_elems | get_front, ck_elems | get_front);
     }
 
@@ -1613,14 +1609,14 @@ view_update_builder make_view_update_builder(
         mutation_reader&& updates,
         mutation_reader_opt&& existings,
         gc_clock::time_point now) {
-    auto vs = boost::copy_range<std::vector<view_updates>>(views_to_update | boost::adaptors::transformed([&] (view_and_base v) {
+    auto vs = views_to_update | std::views::transform([&] (view_and_base v) {
         if (base->version() != v.base->base_schema()->version()) {
             on_internal_error(vlogger, format("Schema version used for view updates ({}) does not match the current"
                                               " base schema version of the view ({}) for view {}.{} of {}.{}",
                 base->version(), v.base->base_schema()->version(), v.view->ks_name(), v.view->cf_name(), base->ks_name(), base->cf_name()));
         }
         return view_updates(std::move(v));
-    }));
+    }) | std::ranges::to<std::vector<view_updates>>();
     return view_update_builder(std::move(db), base_table, base, std::move(vs), std::move(updates), std::move(existings), now);
 }
 
@@ -1678,11 +1674,11 @@ future<query::clustering_row_ranges> calculate_affected_clustering_ranges(data_d
     // this mutation.
 
     //FIXME: Unfortunate copy.
-    co_return boost::copy_range<query::clustering_row_ranges>(
-            interval<clustering_key_prefix_view>::deoverlap(std::move(row_ranges), cmp)
-            | boost::adaptors::transformed([] (auto&& v) {
+    co_return interval<clustering_key_prefix_view>::deoverlap(std::move(row_ranges), cmp)
+            | std::views::transform([] (auto&& v) {
                 return std::move(v).transform([] (auto&& ckv) { return clustering_key_prefix(ckv); });
-            }));
+            })
+            | std::ranges::to<query::clustering_row_ranges>();
 
 }
 
@@ -2419,12 +2415,13 @@ view_status_common(cql3::query_processor& qp, sstring ks_name, sstring cf_name, 
             view_builder_query_state(),
             { std::move(view_ks_name), std::move(view_name) },
             cql3::query_processor::cache_internal::no).then([] (::shared_ptr<cql3::untyped_result_set> cql_result) {
-        return boost::copy_range<std::unordered_map<locator::host_id, sstring>>(*cql_result
-                | boost::adaptors::transformed([] (const cql3::untyped_result_set::row& row) {
+        return *cql_result
+                | std::views::transform([] (const cql3::untyped_result_set::row& row) {
                     auto host_id = locator::host_id(row.get_as<utils::UUID>("host_id"));
                     auto status = row.get_as<sstring>("status");
                     return std::pair(std::move(host_id), std::move(status));
-                }));
+                })
+                | std::ranges::to<std::unordered_map<locator::host_id, sstring>>();
     });
 }
 
@@ -2659,7 +2656,7 @@ future<> view_builder::migrate_to_v2(locator::token_metadata_ptr tmptr, db::syst
 
     co_await utils::get_local_injector().inject("view_builder_pause_in_migrate_v2", utils::wait_for_message(5min));
 
-    auto col_names = boost::copy_range<std::vector<sstring>>(schema->all_columns() | boost::adaptors::transformed([] (const auto& col) {return col.name_as_cql_string(); }));
+    auto col_names = schema->all_columns() | std::views::transform([] (const auto& col) {return col.name_as_cql_string(); }) | std::ranges::to<std::vector<sstring>>();
     auto col_names_str = boost::algorithm::join(col_names, ", ");
     sstring val_binders_str = "?";
     for (size_t i = 1; i < col_names.size(); ++i) {
@@ -2986,10 +2983,9 @@ public:
     built_views consume_end_of_stream() {
         inject_failure("view_builder_consume_end_of_stream");
         if (vlogger.is_enabled(log_level::debug)) {
-            auto view_names = boost::copy_range<std::vector<sstring>>(
-                    _views_to_build | boost::adaptors::transformed([](auto v) {
+            auto view_names = _views_to_build | std::views::transform([](auto v) {
                         return v->cf_name();
-                    }));
+                    }) | std::ranges::to<std::vector<sstring>>();
             vlogger.debug("Completed build step for base {}.{}, at token {}; views={}", _step.base->schema()->ks_name(),
                           _step.base->schema()->cf_name(), _step.current_token(), view_names);
         }
@@ -3231,9 +3227,9 @@ view_updating_consumer::view_updating_consumer(view_update_generator& gen, schem
 { }
 
 std::vector<db::view::view_and_base> with_base_info_snapshot(std::vector<view_ptr> vs) {
-    return boost::copy_range<std::vector<db::view::view_and_base>>(vs | boost::adaptors::transformed([] (const view_ptr& v) {
+    return vs | std::views::transform([] (const view_ptr& v) {
         return db::view::view_and_base{v, v->view_info()->base_info()};
-    }));
+    }) | std::ranges::to<std::vector>();
 }
 
 delete_ghost_rows_visitor::delete_ghost_rows_visitor(service::storage_proxy& proxy, service::query_state& state, view_ptr view, db::timeout_clock::duration timeout_duration)

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -312,9 +312,9 @@ void view_update_generator::discover_staging_sstables() {
 }
 
 static size_t memory_usage_of(const utils::chunked_vector<frozen_mutation_and_schema>& ms) {
-    return boost::accumulate(ms | boost::adaptors::transformed([] (const frozen_mutation_and_schema& m) {
+    return std::ranges::fold_left(ms | std::views::transform([] (const frozen_mutation_and_schema& m) {
         return memory_usage_of(m);
-    }), 0);
+    }), 0, std::plus{});
 }
 
 /**

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -14,9 +14,6 @@
 #include "dht/token-sharding.hh"
 #include "utils/assert.hh"
 #include "utils/class_registrator.hh"
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/irange.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 #include "sstables/key.hh"
 #include <seastar/core/thread.hh>
 #include <seastar/core/on_internal_error.hh>

--- a/gms/versioned_value.cc
+++ b/gms/versioned_value.cc
@@ -12,7 +12,6 @@
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 #include <charconv>
 
 namespace gms {
@@ -25,7 +24,7 @@ versioned_value versioned_value::network_version() {
 }
 
 sstring versioned_value::make_full_token_string(const std::unordered_set<dht::token>& tokens) {
-    return fmt::to_string(fmt::join(tokens | boost::adaptors::transformed([] (const dht::token& t) {
+    return fmt::to_string(fmt::join(tokens | std::views::transform([] (const dht::token& t) {
         return t.to_sstring(); }), ";"));
 }
 

--- a/keys.cc
+++ b/keys.cc
@@ -12,7 +12,6 @@
 #include "dht/i_partitioner.hh"
 #include "clustering_bounds_comparator.hh"
 #include <boost/algorithm/string.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 
 logging::logger klog("keys");
 
@@ -111,8 +110,8 @@ const thread_local clustering_key_prefix bound_view::_empty_prefix = clustering_
 
 std::ostream&
 operator<<(std::ostream& os, const exploded_clustering_prefix& ecp) {
-    // Can't pass to_hex() to transformed(), since it is overloaded, so wrap:
+    // Can't pass to_hex() to transform(), since it is overloaded, so wrap:
     auto enhex = [] (auto&& x) { return fmt_hex(x); };
-    fmt::print(os, "prefix{{{}}}", fmt::join(ecp._v | boost::adaptors::transformed(enhex), ":"));
+    fmt::print(os, "prefix{{{}}}", fmt::join(ecp._v | std::views::transform(enhex), ":"));
     return os;
 }

--- a/main.cc
+++ b/main.cc
@@ -470,7 +470,7 @@ public:
 // "[key1: value1_1 value1_2 ..., key2: value2_1 value 2_2 ..., (positional) value3, ...]"
 std::string format_parsed_options(const std::vector<bpo::option>& opts) {
     return fmt::format("[{}]",
-        boost::algorithm::join(opts | boost::adaptors::transformed([] (const bpo::option& opt) {
+        fmt::join(opts | std::views::transform([] (const bpo::option& opt) {
             if (opt.value.empty()) {
                 return opt.string_key;
             }

--- a/mutation/frozen_mutation.cc
+++ b/mutation/frozen_mutation.cc
@@ -7,7 +7,6 @@
  */
 
 #include <seastar/core/coroutine.hh>
-#include <boost/range/adaptor/transformed.hpp>
 #include "frozen_mutation.hh"
 #include "schema/schema_registry.hh"
 #include "mutation_partition.hh"
@@ -119,15 +118,15 @@ frozen_mutation freeze(const mutation& m) {
 }
 
 std::vector<frozen_mutation> freeze(const std::vector<mutation>& muts) {
-    return boost::copy_range<std::vector<frozen_mutation>>(muts | boost::adaptors::transformed([] (const mutation& m) {
+    return muts | std::views::transform([] (const mutation& m) {
         return freeze(m);
-    }));
+    }) | std::ranges::to<std::vector<frozen_mutation>>();
 }
 
 std::vector<mutation> unfreeze(const std::vector<frozen_mutation>& muts) {
-    return boost::copy_range<std::vector<mutation>>(muts | boost::adaptors::transformed([] (const frozen_mutation& fm) {
+    return muts | std::views::transform([] (const frozen_mutation& fm) {
         return fm.unfreeze(local_schema_registry().get(fm.schema_version()));
-    }));
+    }) | std::ranges::to<std::vector<mutation>>();
 }
 
 

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -9,8 +9,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
-#include <boost/range/adaptor/transformed.hpp>
-
 #include "mutation_partition.hh"
 #include "clustering_interval_set.hh"
 #include "converting_mutation_partition_applier.hh"
@@ -838,7 +836,7 @@ operator<<(std::ostream& os, const std::pair<column_id, const atomic_cell_or_col
 // in the original range is prefxied with given string.
 template<typename RangeOfPrintable>
 static auto prefixed(const sstring& prefix, const RangeOfPrintable& r) {
-    return r | boost::adaptors::transformed([&] (auto&& e) { return format("{}{}", prefix, e); });
+    return r | std::views::transform([&] (auto&& e) { return format("{}{}", prefix, e); });
 }
 
 std::ostream&

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -9,8 +9,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
-#include <boost/range/adaptor/transformed.hpp>
-
 #include "mutation_partition_v2.hh"
 #include "clustering_interval_set.hh"
 #include "converting_mutation_partition_applier.hh"
@@ -761,7 +759,7 @@ void mutation_partition_v2::for_each_row(const schema& schema, const query::clus
 // in the original range is prefxied with given string.
 template<typename RangeOfPrintable>
 static auto prefixed(const sstring& prefix, const RangeOfPrintable& r) {
-    return r | boost::adaptors::transformed([&] (auto&& e) { return format("{}{}", prefix, e); });
+    return r | std::views::transform([&] (auto&& e) { return format("{}{}", prefix, e); });
 }
 
 auto fmt::formatter<mutation_partition_v2::printer>::format(const mutation_partition_v2::printer& p, fmt::format_context& ctx) const

--- a/mutation_writer/shard_based_splitting_writer.cc
+++ b/mutation_writer/shard_based_splitting_writer.cc
@@ -8,8 +8,6 @@
 
 #include "mutation_writer/shard_based_splitting_writer.hh"
 
-#include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/algorithm/min_element.hpp>
 #include <seastar/core/shared_mutex.hh>
 #include "dht/i_partitioner.hh"
 #include "mutation_writer/feed_writers.hh"

--- a/mutation_writer/timestamp_based_splitting_writer.cc
+++ b/mutation_writer/timestamp_based_splitting_writer.cc
@@ -9,8 +9,6 @@
 #include "mutation_writer/timestamp_based_splitting_writer.hh"
 
 #include <optional>
-#include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/algorithm/min_element.hpp>
 #include <seastar/core/shared_mutex.hh>
 
 #include "mutation_writer/feed_writers.hh"

--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -143,8 +143,8 @@ future<> node_ops_virtual_task::abort(tasks::task_id id) noexcept {
 future<std::vector<tasks::task_stats>> node_ops_virtual_task::get_stats() {
     db::system_keyspace& sys_ks = _ss._sys_ks.local();
     service::topology& topology = _ss._topology_state_machine._topology;
-    co_return boost::copy_range<std::vector<tasks::task_stats>>(co_await get_entries(sys_ks, topology, get_task_manager().get_user_task_ttl())
-            | boost::adaptors::transformed([] (const auto& e) {
+    co_return std::ranges::to<std::vector<tasks::task_stats>>(co_await get_entries(sys_ks, topology, get_task_manager().get_user_task_ttl())
+            | std::views::transform([] (const auto& e) {
         auto id = e.first;
         auto& entry = e.second;
         return tasks::task_stats {

--- a/query-result-reader.hh
+++ b/query-result-reader.hh
@@ -9,8 +9,6 @@
 #pragma once
 
 #include "utils/assert.hh"
-#include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/numeric.hpp>
 
 #include "query-result.hh"
 #include "full_position.hh"

--- a/query-result-set.cc
+++ b/query-result-set.cc
@@ -160,7 +160,7 @@ result_set_builder::deserialize(const result_row_view& row, bool is_static)
     std::unordered_map<sstring, non_null_data_value> cells;
     auto i = row.iterator();
     auto column_ids = is_static ? _slice.static_columns : _slice.regular_columns;
-    auto columns = column_ids | boost::adaptors::transformed([this, is_static] (column_id id) -> const column_definition& {
+    auto columns = column_ids | std::views::transform([this, is_static] (column_id id) -> const column_definition& {
         if (is_static) {
             return _schema->static_column_at(id);
         } else {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1327,8 +1327,9 @@ private:
             }
         }
         if (update_hash_set) {
-            _peer_row_hash_sets[node_idx] = boost::copy_range<repair_hash_set>(row_diff |
-                    boost::adaptors::transformed([] (repair_row& r) { thread::maybe_yield(); return r.hash(); }));
+            _peer_row_hash_sets[node_idx] = row_diff
+                   | std::views::transform([] (repair_row& r) { thread::maybe_yield(); return r.hash(); })
+                   | std::ranges::to<repair_hash_set>();
         }
         // Repair rows in row_diff will be flushed to disk by flush_rows_in_working_row_buf,
         // so we skip calling do_apply_rows here.

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -38,8 +38,6 @@
 #include "db/extensions.hh"
 #include "query-result-writer.hh"
 #include "db/view/view_update_generator.hh"
-#include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/adaptor/map.hpp>
 #include "utils/error_injection.hh"
 #include "utils/histogram_metrics_helper.hh"
 #include "mutation/mutation_source_metadata.hh"
@@ -202,7 +200,7 @@ table::add_memtables_to_reader_list(std::vector<mutation_reader>& readers,
     }
     auto token_range = range.transform(std::mem_fn(&dht::ring_position::token));
     auto cgs = compaction_groups_for_token_range(token_range);
-    reserve_fn(boost::accumulate(cgs | boost::adaptors::transformed(std::mem_fn(&compaction_group::memtable_count)), uint64_t(0)));
+    reserve_fn(std::ranges::fold_left(cgs | std::views::transform(std::mem_fn(&compaction_group::memtable_count)), uint64_t(0), std::plus{}));
     for (auto& cg : cgs) {
         add_memtables_from_cg(*cg);
     }
@@ -372,12 +370,11 @@ api::timestamp_type compaction_group::min_memtable_timestamp() const {
         return api::max_timestamp;
     }
 
-    return *boost::range::min_element(
+    return std::ranges::min(
         *_memtables
-        | boost::adaptors::transformed(
+        | std::views::transform(
             [](const shared_memtable& m) { return m->get_min_timestamp(); }
-        )
-    );
+        ));
 }
 
 api::timestamp_type compaction_group::min_memtable_live_timestamp() const {
@@ -385,12 +382,11 @@ api::timestamp_type compaction_group::min_memtable_live_timestamp() const {
         return api::max_timestamp;
     }
 
-    return *boost::range::min_element(
+    return std::ranges::min(
         *_memtables
-        | boost::adaptors::transformed(
+        | std::views::transform(
             [](const shared_memtable& m) { return m->get_min_live_timestamp(); }
-        )
-    );
+        ));
 }
 
 api::timestamp_type compaction_group::min_memtable_live_row_marker_timestamp() const {
@@ -398,12 +394,11 @@ api::timestamp_type compaction_group::min_memtable_live_row_marker_timestamp() c
         return api::max_timestamp;
     }
 
-    return *boost::range::min_element(
+    return std::ranges::min(
         *_memtables
-        | boost::adaptors::transformed(
+        | std::views::transform(
             [](const shared_memtable& m) { return m->get_min_live_row_marker_timestamp(); }
-        )
-    );
+        ));
 }
 
 bool compaction_group::memtable_has_key(const dht::decorated_key& key) const {
@@ -1732,11 +1727,11 @@ uint64_t compaction_group::live_disk_space_used() const noexcept {
 
 uint64_t storage_group::live_disk_space_used() const noexcept {
     auto cgs = const_cast<storage_group&>(*this).compaction_groups();
-    return boost::accumulate(cgs | boost::adaptors::transformed(std::mem_fn(&compaction_group::live_disk_space_used)), uint64_t(0));
+    return std::ranges::fold_left(cgs | std::views::transform(std::mem_fn(&compaction_group::live_disk_space_used)), uint64_t(0), std::plus{});
 }
 
 uint64_t compaction_group::total_disk_space_used() const noexcept {
-    return live_disk_space_used() + boost::accumulate(_sstables_compacted_but_not_deleted | boost::adaptors::transformed(std::mem_fn(&sstables::sstable::bytes_on_disk)), uint64_t(0));
+    return live_disk_space_used() + std::ranges::fold_left(_sstables_compacted_but_not_deleted | std::views::transform(std::mem_fn(&sstables::sstable::bytes_on_disk)), uint64_t(0), std::plus{});
 }
 
 void table::rebuild_statistics() {
@@ -2877,7 +2872,7 @@ size_t compaction_group::memtable_count() const noexcept {
 size_t storage_group::memtable_count() const noexcept {
     auto memtable_count = [] (const compaction_group_ptr& cg) { return cg ? cg->memtable_count() : 0; };
     return memtable_count(_main_cg) +
-            boost::accumulate(_split_ready_groups | boost::adaptors::transformed(std::mem_fn(&compaction_group::memtable_count)), size_t(0));
+            std::ranges::fold_left(_split_ready_groups | std::views::transform(std::mem_fn(&compaction_group::memtable_count)), size_t(0), std::plus{});
 }
 
 future<> table::flush(std::optional<db::replay_position> pos) {

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -598,7 +598,7 @@ future<> service_level_controller::migrate_to_v2(size_t nodes_count, db::system_
     }
     
 
-    auto col_names = boost::copy_range<std::vector<sstring>>(schema->all_columns() | boost::adaptors::transformed([] (const auto& col) {return col.name_as_cql_string(); }));
+    auto col_names = schema->all_columns() | std::views::transform([] (const auto& col) {return col.name_as_cql_string(); }) | std::ranges::to<std::vector<sstring>>();
     auto col_names_str = boost::algorithm::join(col_names, ", ");
     sstring val_binders_str = "?";
     for (size_t i = 1; i < col_names.size(); ++i) {

--- a/service/raft/group0_state_machine_merger.cc
+++ b/service/raft/group0_state_machine_merger.cc
@@ -9,8 +9,6 @@
 #include "db/system_keyspace.hh"
 #include "service/raft/group0_state_machine_merger.hh"
 
-#include <boost/range/adaptor/transformed.hpp>
-
 namespace service {
 
 static logging::logger slogger("group0_raft_sm_merger");
@@ -29,7 +27,7 @@ size_t group0_state_machine_merger::cmd_size(group0_command& cmd) {
     if (holds_alternative<broadcast_table_query>(cmd.change)) {
         return 0;
     }
-    auto r = get_command_mutations(cmd) | boost::adaptors::transformed([] (const canonical_mutation& m) { return m.representation().size(); });
+    auto r = get_command_mutations(cmd) | std::views::transform([] (const canonical_mutation& m) { return m.representation().size(); });
     return std::accumulate(std::begin(r), std::end(r), size_t(0));
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3000,9 +3000,9 @@ future<> storage_service::join_cluster(sharded<db::system_distributed_keyspace>&
     auto seeds = _gossiper.get_seeds();
     auto initial_contact_nodes = loaded_endpoints.empty() ?
         std::unordered_set<gms::inet_address>(seeds.begin(), seeds.end()) :
-        boost::copy_range<std::unordered_set<gms::inet_address>>(loaded_endpoints | boost::adaptors::transformed([] (const auto& x) {
+        loaded_endpoints | std::views::transform([] (const auto& x) {
             return x.second.endpoint;
-        }));
+        }) | std::ranges::to<std::unordered_set<gms::inet_address>>();
     auto loaded_peer_features = co_await _sys_ks.local().load_peer_features();
     slogger.info("initial_contact_nodes={}, loaded_endpoints={}, loaded_peer_features={}",
             initial_contact_nodes, loaded_endpoints | std::views::keys, loaded_peer_features.size());
@@ -3427,7 +3427,7 @@ storage_service::prepare_replacement_info(std::unordered_set<gms::inet_address> 
     }
 
     slogger.info("Host {}/{} is replacing {}/{} ignore_nodes={}", get_token_metadata().get_my_id(), get_broadcast_address(), replace_host_id, replace_address,
-            fmt::join(ri.ignore_nodes | boost::adaptors::transformed ([] (const auto& x) {
+            fmt::join(ri.ignore_nodes | std::views::transform ([] (const auto& x) {
                 return fmt::format("{}/{}", x.first, x.second.endpoint);
             }), ","));
     co_await _gossiper.reset_endpoint_state_map();
@@ -3955,9 +3955,9 @@ void storage_service::run_replace_ops(std::unordered_set<token>& bootstrap_token
     auto stop_ctl = deferred_stop(ctl);
     const auto& uuid = ctl.uuid();
     gms::inet_address replace_address = replace_info.address;
-    ctl.ignore_nodes = boost::copy_range<std::unordered_set<gms::inet_address>>(replace_info.ignore_nodes | boost::adaptors::transformed([] (const auto& x) {
+    ctl.ignore_nodes = replace_info.ignore_nodes | std::views::transform([] (const auto& x) {
         return x.second.endpoint;
-    }));
+    }) | std::ranges::to<std::unordered_set<gms::inet_address>>();
     // Step 1: Decide who needs to sync data for replace operation
     // The replacing node is not a normal token owner yet
     // Add it back explicitly after checking all other nodes.
@@ -3993,9 +3993,9 @@ void storage_service::run_replace_ops(std::unordered_set<token>& bootstrap_token
             slogger.info("replace[{}]: Using repair based node ops to sync data", uuid);
             auto ks_erms = _db.local().get_non_local_strategy_keyspaces_erms();
             auto tmptr = get_token_metadata_ptr();
-            auto ignore_nodes = boost::copy_range<std::unordered_set<locator::host_id>>(replace_info.ignore_nodes | boost::adaptors::transformed([] (const auto& x) {
+            auto ignore_nodes = replace_info.ignore_nodes | std::views::transform([] (const auto& x) {
                 return x.first;
-            }));
+            }) | std::ranges::to<std::unordered_set<locator::host_id>>();
             _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), bootstrap_tokens, std::move(ignore_nodes), replace_info.host_id).get();
         } else {
             slogger.info("replace[{}]: Using streaming based node ops to sync data", uuid);
@@ -5678,9 +5678,9 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                     on_internal_error(rtlogger, ::format("Cannot find request_param for node id {}", id));
                                 }
                                 if (is_repair_based_node_ops_enabled(streaming::stream_reason::replace)) {
-                                    auto ignored_nodes = boost::copy_range<std::unordered_set<locator::host_id>>(_topology_state_machine._topology.ignored_nodes | boost::adaptors::transformed([] (const auto& id) {
+                                    auto ignored_nodes = _topology_state_machine._topology.ignored_nodes | std::views::transform([] (const auto& id) {
                                         return locator::host_id(id.uuid());
-                                    }));
+                                    }) | std::ranges::to<std::unordered_set<locator::host_id>>();
                                     auto ks_erms = _db.local().get_non_local_strategy_keyspaces_erms();
                                     auto tmptr = get_token_metadata_ptr();
                                     auto replaced_node = locator::host_id(replaced_id.uuid());
@@ -7465,10 +7465,9 @@ bool storage_service::is_normal_state_handled_on_boot(gms::inet_address node) {
 future<> storage_service::wait_for_normal_state_handled_on_boot() {
     static logger::rate_limit rate_limit{std::chrono::seconds{5}};
     static auto fmt_nodes_with_statuses = [this] (const auto& eps) {
-        return boost::algorithm::join(
-                eps | boost::adaptors::transformed([this] (const auto& ep) {
+        return eps | std::views::transform([this] (const auto& ep) {
                     return ::format("({}, status={})", ep, _gossiper.get_gossip_status(ep));
-                }), ", ");
+                }) | std::views::join_with(',');
     };
 
     slogger.info("Started waiting for normal state handlers to finish");
@@ -7487,13 +7486,13 @@ future<> storage_service::wait_for_normal_state_handled_on_boot() {
 
         if (std::chrono::steady_clock::now() > start_time + std::chrono::seconds(60)) {
             auto err = ::format("Timed out waiting for normal state handlers to finish for nodes {}",
-                    fmt_nodes_with_statuses(boost::make_iterator_range(it, eps.end())));
+                    fmt_nodes_with_statuses(std::ranges::subrange(it, eps.end())));
             slogger.error("{}", err);
             throw std::runtime_error{std::move(err)};
         }
 
         slogger.log(log_level::info, rate_limit, "Normal state handlers not yet finished for nodes {}",
-                    fmt_nodes_with_statuses(boost::make_iterator_range(it, eps.end())));
+                    fmt_nodes_with_statuses(std::ranges::subrange(it, eps.end())));
 
         co_await sleep_abortable(std::chrono::milliseconds{100}, _abort_source);
     }

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -14,8 +14,6 @@
 #include "types/set.hh"
 #include "types/map.hh"
 
-#include <boost/range/adaptor/transformed.hpp>
-
 namespace db {
     extern thread_local data_type cdc_generation_ts_id_type;
 }
@@ -146,15 +144,15 @@ const schema& topology_node_mutation_builder::schema() const {
 }
 
 topology_node_mutation_builder& topology_node_mutation_builder::set(const char* cell, const std::unordered_set<raft::server_id>& nodes_ids) {
-    return apply_set(cell, collection_apply_mode::overwrite, nodes_ids | boost::adaptors::transformed([] (const auto& node_id) { return node_id.id; }));
+    return apply_set(cell, collection_apply_mode::overwrite, nodes_ids | std::views::transform([] (const auto& node_id) { return node_id.id; }));
 }
 
 topology_node_mutation_builder& topology_node_mutation_builder::set(const char* cell, const std::unordered_set<dht::token>& tokens) {
-    return apply_set(cell, collection_apply_mode::overwrite, tokens | boost::adaptors::transformed([] (const auto& t) { return t.to_sstring(); }));
+    return apply_set(cell, collection_apply_mode::overwrite, tokens | std::views::transform([] (const auto& t) { return t.to_sstring(); }));
 }
 
 topology_node_mutation_builder& topology_node_mutation_builder::set(const char* cell, const std::set<sstring>& features) {
-    return apply_set(cell, collection_apply_mode::overwrite, features | boost::adaptors::transformed([] (const auto& f) { return sstring(f); }));
+    return apply_set(cell, collection_apply_mode::overwrite, features | std::views::transform([] (const auto& f) { return sstring(f); }));
 }
 
 canonical_mutation topology_node_mutation_builder::build() {
@@ -211,7 +209,7 @@ topology_mutation_builder& topology_mutation_builder::set_new_cdc_generation_dat
 }
 
 topology_mutation_builder& topology_mutation_builder::set_committed_cdc_generations(const std::vector<cdc::generation_id_v2>& values) {
-    auto dv = values | boost::adaptors::transformed([&] (const auto& v) {
+    auto dv = values | std::views::transform([&] (const auto& v) {
         return make_tuple_value(db::cdc_generation_ts_id_type, tuple_type_impl::native_type({v.ts, timeuuid_native_type{v.id}}));
     });
     return apply_set("committed_cdc_generations", collection_apply_mode::overwrite, std::move(dv));
@@ -227,7 +225,7 @@ topology_mutation_builder& topology_mutation_builder::set_new_keyspace_rf_change
 }
 
 topology_mutation_builder& topology_mutation_builder::set_unpublished_cdc_generations(const std::vector<cdc::generation_id_v2>& values) {
-    auto dv = values | boost::adaptors::transformed([&] (const auto& v) {
+    auto dv = values | std::views::transform([&] (const auto& v) {
         return make_tuple_value(db::cdc_generation_ts_id_type, tuple_type_impl::native_type({v.ts, timeuuid_native_type{v.id}}));
     });
     return apply_set("unpublished_cdc_generations", collection_apply_mode::overwrite, std::move(dv));
@@ -246,7 +244,7 @@ topology_mutation_builder& topology_mutation_builder::set_upgrade_state(topology
 }
 
 topology_mutation_builder& topology_mutation_builder::add_enabled_features(const std::set<sstring>& features) {
-    return apply_set("enabled_features", collection_apply_mode::update, features | boost::adaptors::transformed([] (const auto& f) { return sstring(f); }));
+    return apply_set("enabled_features", collection_apply_mode::update, features | std::views::transform([] (const auto& f) { return sstring(f); }));
 }
 
 topology_mutation_builder& topology_mutation_builder::add_new_committed_cdc_generation(const cdc::generation_id_v2& value) {
@@ -257,11 +255,11 @@ topology_mutation_builder& topology_mutation_builder::add_new_committed_cdc_gene
 }
 
 topology_mutation_builder& topology_mutation_builder::add_ignored_nodes(const std::unordered_set<raft::server_id>& value) {
-    return apply_set("ignore_nodes", collection_apply_mode::update, value | boost::adaptors::transformed([] (const auto& id) { return id.uuid(); }));
+    return apply_set("ignore_nodes", collection_apply_mode::update, value | std::views::transform([] (const auto& id) { return id.uuid(); }));
 }
 
 topology_mutation_builder& topology_mutation_builder::set_ignored_nodes(const std::unordered_set<raft::server_id>& value) {
-    return apply_set("ignore_nodes", collection_apply_mode::overwrite, value | boost::adaptors::transformed([] (const auto& id) { return id.uuid(); }));
+    return apply_set("ignore_nodes", collection_apply_mode::overwrite, value | std::views::transform([] (const auto& id) { return id.uuid(); }));
 }
 
 topology_mutation_builder& topology_mutation_builder::del_global_topology_request() {

--- a/sstables/mx/parsers.hh
+++ b/sstables/mx/parsers.hh
@@ -15,8 +15,6 @@
 #include "sstables/mx/types.hh"
 #include "mutation/position_in_partition.hh"
 
-#include <boost/range/adaptor/transformed.hpp>
-
 namespace sstables {
 namespace mc {
 
@@ -82,7 +80,7 @@ class clustering_parser {
     }
 
     position_in_partition make_position() {
-        auto key = clustering_key_prefix::from_range(clustering_key_values | boost::adaptors::transformed(
+        auto key = clustering_key_prefix::from_range(clustering_key_values | std::views::transform(
             [] (const FragmentedBuffer & b) { return typename FragmentedBuffer::view(b); }));
 
         if (kind == bound_kind_m::clustering) {

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -304,7 +304,7 @@ public:
     }
 
     row_processing_result consume_row_start(const std::vector<fragmented_temporary_buffer>& ecp) {
-        auto key = clustering_key_prefix::from_range(ecp | boost::adaptors::transformed(
+        auto key = clustering_key_prefix::from_range(ecp | std::views::transform(
             [] (const fragmented_temporary_buffer& b) { return fragmented_temporary_buffer::view(b); }));
 
         _sst->get_stats().on_row_read();
@@ -477,7 +477,7 @@ public:
     data_consumer::proceed consume_range_tombstone(const std::vector<fragmented_temporary_buffer>& ecp,
                                             bound_kind kind,
                                             tombstone tomb) {
-        auto ck = clustering_key_prefix::from_range(ecp | boost::adaptors::transformed(
+        auto ck = clustering_key_prefix::from_range(ecp | std::views::transform(
             [] (const fragmented_temporary_buffer& b) { return fragmented_temporary_buffer::view(b); }));
         if (kind == bound_kind::incl_start || kind == bound_kind::excl_start) {
             return consume_range_tombstone_start(std::move(ck), kind, std::move(tomb));
@@ -490,7 +490,7 @@ public:
                                             sstables::bound_kind_m kind,
                                             tombstone end_tombstone,
                                             tombstone start_tombstone) {
-        auto ck = clustering_key_prefix::from_range(ecp | boost::adaptors::transformed(
+        auto ck = clustering_key_prefix::from_range(ecp | std::views::transform(
             [] (const fragmented_temporary_buffer& b) { return fragmented_temporary_buffer::view(b); }));
         switch (kind) {
         case bound_kind_m::incl_end_excl_start: {
@@ -1913,7 +1913,7 @@ private:
 
 private:
     clustering_key from_fragmented_buffer(const std::vector<fragmented_temporary_buffer>& ecp) {
-        return clustering_key_prefix::from_range(ecp | boost::adaptors::transformed(
+        return clustering_key_prefix::from_range(ecp | std::views::transform(
                 [] (const fragmented_temporary_buffer& b) { return fragmented_temporary_buffer::view(b); }));
     }
     void validate_fragment_order(mutation_fragment_v2::kind kind, std::optional<tombstone> new_current_tombstone) {

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -92,11 +92,11 @@ void sstable_run::erase(shared_sstable sst) {
 }
 
 uint64_t sstable_run::data_size() const {
-    return boost::accumulate(_all | boost::adaptors::transformed(std::mem_fn(&sstable::data_size)), uint64_t(0));
+    return std::ranges::fold_left(_all | std::views::transform(std::mem_fn(&sstable::data_size)), uint64_t(0), std::plus{});
 }
 
 double sstable_run::estimate_droppable_tombstone_ratio(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state, const schema_ptr& s) const {
-    auto estimate_sum = boost::accumulate(_all | boost::adaptors::transformed(std::bind(&sstable::estimate_droppable_tombstone_ratio, std::placeholders::_1, compaction_time, gc_state, s)), double(0));
+    auto estimate_sum = std::ranges::fold_left(_all | std::views::transform(std::bind(&sstable::estimate_droppable_tombstone_ratio, std::placeholders::_1, compaction_time, gc_state, s)), double(0), std::plus{});
     return _all.size() ? estimate_sum / _all.size() : double(0);
 }
 
@@ -303,9 +303,9 @@ partitioned_sstable_set::partitioned_sstable_set(schema_ptr schema, bool use_lev
 }
 
 static std::unordered_map<run_id, shared_sstable_run> clone_runs(const std::unordered_map<run_id, shared_sstable_run>& runs) {
-    return boost::copy_range<std::unordered_map<run_id, shared_sstable_run>>(runs | boost::adaptors::transformed([] (auto& p) {
+    return runs | std::views::transform([] (auto& p) {
         return std::make_pair(p.first, make_lw_shared<sstable_run>(*p.second));
-    }));
+    }) | std::ranges::to<std::unordered_map<run_id, shared_sstable_run>>();
 }
 
 partitioned_sstable_set::partitioned_sstable_set(schema_ptr schema, const std::vector<shared_sstable>& unleveled_sstables, const interval_map_type& leveled_sstables,
@@ -951,13 +951,12 @@ sstable_set_impl::create_single_key_sstable_reader(
     if (!num_sstables) {
         return make_empty_flat_reader_v2(schema, permit);
     }
-    auto readers = boost::copy_range<std::vector<mutation_reader>>(
-        filter_sstable_for_reader_by_ck(std::move(selected_sstables), *cf, schema, slice)
-        | boost::adaptors::transformed([&] (const shared_sstable& sstable) {
+    auto readers = filter_sstable_for_reader_by_ck(std::move(selected_sstables), *cf, schema, slice)
+        | std::views::transform([&] (const shared_sstable& sstable) {
             tracing::trace(trace_state, "Reading key {} from sstable {}", pos, seastar::value_of([&sstable] { return sstable->get_filename(); }));
             return sstable->make_reader(schema, permit, pr, slice, trace_state, fwd);
-        })
-    );
+          })
+        | std::ranges::to<std::vector<mutation_reader>>();
 
     // If filter_sstable_for_reader_by_ck filtered any sstable that contains the partition
     // we want to emit partition_start/end if no rows were found,
@@ -1150,12 +1149,12 @@ bool compound_sstable_set::erase(shared_sstable sst) {
 
 size_t
 compound_sstable_set::size() const noexcept {
-    return boost::accumulate(_sets | boost::adaptors::transformed(std::mem_fn(&sstable_set::size)), size_t(0));
+    return std::ranges::fold_left(_sets | std::views::transform(std::mem_fn(&sstable_set::size)), size_t(0), std::plus{});
 }
 
 uint64_t
 compound_sstable_set::bytes_on_disk() const noexcept {
-    return boost::accumulate(_sets | boost::adaptors::transformed(std::mem_fn(&sstable_set::bytes_on_disk)), uint64_t(0));
+    return std::ranges::fold_left(_sets | std::views::transform(std::mem_fn(&sstable_set::bytes_on_disk)), uint64_t(0), std::plus{});
 }
 
 class compound_sstable_set::incremental_selector : public incremental_selector_impl {
@@ -1164,9 +1163,9 @@ class compound_sstable_set::incremental_selector : public incremental_selector_i
     std::vector<sstable_set::incremental_selector> _selectors;
 private:
     std::vector<sstable_set::incremental_selector> make_selectors(const std::vector<lw_shared_ptr<sstable_set>>& sets) {
-        return boost::copy_range<std::vector<sstable_set::incremental_selector>>(_sets | boost::adaptors::transformed([] (const auto& set) {
+        return _sets | std::views::transform([] (const auto& set) {
             return set->make_incremental_selector();
-        }));
+        }) | std::ranges::to<std::vector<sstable_set::incremental_selector>>();
     }
 public:
     incremental_selector(const schema& schema, const std::vector<lw_shared_ptr<sstable_set>>& sets)
@@ -1246,12 +1245,11 @@ compound_sstable_set::create_single_key_sstable_reader(
         return non_empty_set->create_single_key_sstable_reader(cf, std::move(schema), std::move(permit), sstable_histogram, pr, slice, trace_state, fwd, fwd_mr, predicate);
     }
 
-    auto readers = boost::copy_range<std::vector<mutation_reader>>(
-        boost::make_iterator_range(sets.begin(), it)
-        | boost::adaptors::transformed([&] (const lw_shared_ptr<sstable_set>& non_empty_set) {
+    auto readers = std::ranges::subrange(sets.begin(), it)
+        | std::views::transform([&] (const lw_shared_ptr<sstable_set>& non_empty_set) {
             return non_empty_set->create_single_key_sstable_reader(cf, schema, permit, sstable_histogram, pr, slice, trace_state, fwd, fwd_mr, predicate);
-        })
-    );
+          })
+        | std::ranges::to<std::vector<mutation_reader>>();
     return make_combined_reader(std::move(schema), std::move(permit), std::move(readers), fwd, fwd_mr);
 }
 

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -10,7 +10,6 @@
 
 #include <seastar/core/iostream.hh>
 #include <seastar/core/fstream.hh>
-#include <boost/range/adaptor/transformed.hpp>
 #include "sstables/types.hh"
 #include "checksum_utils.hh"
 #include "vint-serialization.hh"
@@ -46,7 +45,7 @@ public:
         return make_ready_future<>();
     }
     virtual future<> put(std::vector<temporary_buffer<char>> data) override {
-        _size += boost::accumulate(data | boost::adaptors::transformed(std::mem_fn(&temporary_buffer<char>::size)), 0);
+        _size += std::ranges::fold_left(data | std::views::transform(std::mem_fn(&temporary_buffer<char>::size)), 0, std::plus{});
         return make_ready_future<>();
     }
     virtual future<> put(temporary_buffer<char> buf) override {

--- a/tasks/task_handler.cc
+++ b/tasks/task_handler.cc
@@ -186,12 +186,12 @@ future<utils::chunked_vector<task_status>> task_handler::get_status_recursively(
                     .entity = task.task_status.entity,
                     .progress_units = task.task_status.progress_units,
                     .progress = task.task_progress,
-                    .children = boost::copy_range<std::vector<task_identity>>(task.failed_children | boost::adaptors::transformed([&tm = _tm] (auto& child) {
+                    .children = task.failed_children | std::views::transform([&tm = _tm] (auto& child) {
                         return task_identity{
                             .node = tm.get_broadcast_address(),
                             .task_id = child.task_status.id
                         };
-                    }))
+                    }) | std::ranges::to<std::vector<task_identity>>()
                 };
                 res.push_back(status);
 

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -391,7 +391,7 @@ static std::vector<std::vector<bytes_opt>> to_bytes(const cql_transport::message
     auto rs = rows.rs().result_set().rows();
     std::vector<std::vector<bytes_opt>> results;
     for (auto it = rs.begin(); it != rs.end(); ++it) {
-        results.push_back(boost::copy_range<std::vector<bytes_opt>>(*it | boost::adaptors::transformed([] (const managed_bytes_opt& x) { return to_bytes_opt(x); })));
+        results.push_back(*it | std::views::transform([] (const managed_bytes_opt& x) { return to_bytes_opt(x); }) | std::ranges::to<std::vector<bytes_opt>>());
     }
     return results;
 }

--- a/test/boost/compaction_group_test.cc
+++ b/test/boost/compaction_group_test.cc
@@ -155,10 +155,10 @@ SEASTAR_TEST_CASE(basic_compaction_group_splitting_test) {
             compaction_group->rebuild_main_set(ssts, {});
 
             auto& cm = t->get_compaction_manager();
-            auto expected_compaction_size = boost::accumulate(ssts | boost::adaptors::transformed([&] (auto& sst) {
+            auto expected_compaction_size = std::ranges::fold_left(ssts | std::views::transform([&] (auto& sst) {
                 // sstables that doesn't need split will have compaction bypassed.
                 return sstable_needs_split(sst) ? sst->bytes_on_disk() : size_t(0);
-            }), int64_t(0));
+            }), int64_t(0), std::plus{});
 
             auto ret = cm.perform_split_compaction(*compaction_group, sstables::compaction_type_options::split{classifier}, tasks::task_info{}).get();
             BOOST_REQUIRE_EQUAL(ret->start_size, expected_compaction_size);

--- a/test/boost/compound_test.cc
+++ b/test/boost/compound_test.cc
@@ -18,8 +18,6 @@
 #include "schema/schema_builder.hh"
 #include "dht/murmur3_partitioner.hh"
 
-#include <boost/range/adaptor/transformed.hpp>
-
 static std::vector<managed_bytes> to_bytes_vec(std::vector<sstring> values) {
     std::vector<managed_bytes> result;
     for (auto&& v : values) {
@@ -328,9 +326,9 @@ SEASTAR_THREAD_TEST_CASE(test_composite_from_exploded) {
 
 SEASTAR_THREAD_TEST_CASE(test_composite_view_explode) {
     auto to_owning_vector = [] (std::vector<bytes_view> bvs) {
-        return boost::copy_range<std::vector<bytes>>(bvs | boost::adaptors::transformed([] (auto bv) {
+        return bvs | std::views::transform([] (auto bv) {
             return bytes(bv.begin(), bv.end());
-        }));
+        }) | std::ranges::to<std::vector<bytes>>();
     };
     {
         BOOST_REQUIRE_EQUAL(to_owning_vector(composite_view(composite(bytes({'\x00', '\x03', 'e', 'l', '1', '\x00'}))).explode()),

--- a/test/boost/counter_test.cc
+++ b/test/boost/counter_test.cc
@@ -14,8 +14,6 @@
 #include <seastar/core/thread.hh>
 #include <seastar/testing/random.hh>
 
-#include <boost/range/adaptor/transformed.hpp>
-
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/test_utils.hh"
 #include "schema/schema_builder.hh"
@@ -545,11 +543,9 @@ SEASTAR_TEST_CASE(test_counter_id_ordering) {
                 "ffeeddcc-aa99-8878-6655-443322110000",
         };
 
-        auto counter_ids = boost::copy_range<std::vector<counter_id>>(
-            ids | boost::adaptors::transformed([] (auto id) {
+        auto counter_ids = ids | std::views::transform([] (auto id) {
                 return counter_id(utils::UUID(id));
-            })
-        );
+            }) | std::ranges::to<std::vector<counter_id>>();
 
         for (auto it = counter_ids.begin(); it != counter_ids.end(); ++it) {
             BOOST_REQUIRE_EQUAL(*it, *it);

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -2965,16 +2965,16 @@ SEASTAR_TEST_CASE(test_reversed_slice_with_many_clustering_ranges) {
         // Many singular ranges - to check that the right range is used for
         // determining the disk read-range upper bound.
         {
-            const auto select_query = format(
+            const auto select_query = fmt::format(
                     "SELECT * FROM test WHERE pk = {} and ck IN ({}) ORDER BY ck DESC BYPASS CACHE;",
                     pk,
-                    boost::algorithm::join(selected_cks | boost::adaptors::transformed([] (int ck) { return format("{}", ck); }), ", "));
+                    fmt::join(selected_cks | std::views::transform([] (int ck) { return format("{}", ck); }), ", "));
             assert_that(e.execute_cql(select_query).get())
                     .is_rows()
-                    .with_rows(boost::copy_range<std::vector<std::vector<bytes_opt>>>(
-                                selected_cks
-                                | boost::adaptors::reversed
-                                | boost::adaptors::transformed(make_expected_row)));
+                    .with_rows(selected_cks
+                                | std::views::reverse
+                                | std::views::transform(make_expected_row)
+                                | std::ranges::to<std::vector<std::vector<bytes_opt>>>());
         }
 
         // A single wide range - to check that the right range bound is used for

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -10,10 +10,6 @@
 #include "utils/assert.hh"
 #include <fmt/ranges.h>
 
-#include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/algorithm/copy.hpp>
-#include <boost/range/algorithm_ext/push_back.hpp>
-
 #include <boost/test/unit_test.hpp>
 #include "query-result-set.hh"
 #include "query-result-writer.hh"

--- a/test/boost/mutation_reader_another_test.cc
+++ b/test/boost/mutation_reader_another_test.cc
@@ -667,7 +667,7 @@ SEASTAR_THREAD_TEST_CASE(test_make_forwardable) {
                    return s.make_row(permit, s.make_ckey(n), "value");
                }) | std::ranges::to<std::vector<mutation_fragment>>();
 
-    auto ms = keys | boost::adaptors::transformed([&](auto &key) {
+    auto ms = keys | std::views::transform([&](auto &key) {
         auto m = mutation(s.schema(), key);
         for (auto &mf : crs) {
             m.apply(mf);

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -8,8 +8,6 @@
 
 
 #include <random>
-#include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/algorithm/copy.hpp>
 #include <boost/range/algorithm_ext/push_back.hpp>
 #include <boost/range/combine.hpp>
 #include "compaction/compaction_garbage_collector.hh"
@@ -3761,7 +3759,7 @@ SEASTAR_THREAD_TEST_CASE(test_compactor_validator) {
             auto msg = fmt::format("expected_is_valid ({}) != is_valid ({}), fragments:\n{}",
                     expected_is_valid,
                     is_valid,
-                    fmt::join(frag_refs | boost::adaptors::transformed([&] (std::reference_wrapper<const mutation_fragment_v2> mf) {
+                    fmt::join(frag_refs | std::views::transform([&] (std::reference_wrapper<const mutation_fragment_v2> mf) {
                         return fmt::format("{}", mutation_fragment_v2::printer(*s, mf.get()));
                     }), "\n"));
             BOOST_FAIL(msg);

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -8,8 +8,6 @@
 
 
 #include "utils/assert.hh"
-#include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/algorithm/copy.hpp>
 #include <boost/range/algorithm_ext/push_back.hpp>
 #include <boost/range/size.hpp>
 #include <seastar/core/thread.hh>

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -559,7 +559,7 @@ static void test_random_balancing(sharded<snitch_ptr>& snitch, gms::inet_address
     }
 
     testlog.debug("num_dcs={} num_racks={} nodes_per_rack={} shards_per_node={} ring_points=[{}]", num_dcs, num_racks, nodes_per_rack, shard_count,
-            fmt::join(ring_points | boost::adaptors::transformed([] (const ring_point& rp) {
+            fmt::join(ring_points | std::views::transform([] (const ring_point& rp) {
                 return fmt::format("({}, {})", rp.id, rp.host);
             }), ", "));
 
@@ -815,12 +815,12 @@ static void test_equivalence(const shared_token_metadata& stm, const locator::to
     };
 
     my_network_topology_strategy nts(replication_strategy_params(
-                    boost::copy_range<std::map<sstring, sstring>>(
-                                    datacenters
-                                                    | boost::adaptors::transformed(
+                                    datacenters | std::views::transform(
                                                                     [](const std::pair<sstring, size_t>& p) {
                                                                         return std::make_pair(p.first, to_sstring(p.second));
-                                                                    })), std::nullopt));
+                                                                    })
+                                                | std::ranges::to<std::map<sstring, sstring>>(),
+                                    std::nullopt));
 
     const token_metadata& tm = *stm.get();
     for (size_t i = 0; i < 1000; ++i) {

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -307,8 +307,7 @@ void test_sharding(const dht::sharder& sharder, unsigned shards, std::vector<dht
 
 SEASTAR_THREAD_TEST_CASE(test_murmur3_sharding) {
     auto make_token_vector = [] (std::vector<int64_t> v) {
-        return boost::copy_range<std::vector<dht::token>>(
-                v | boost::adaptors::transformed(token_from_long));
+        return v | std::views::transform(token_from_long) | std::ranges::to<std::vector<dht::token>>();
     };
     dht::static_sharder mm3p7s(7);
     auto mm3p7s_shard_limits = make_token_vector({
@@ -331,8 +330,7 @@ SEASTAR_THREAD_TEST_CASE(test_murmur3_sharding) {
 
 SEASTAR_THREAD_TEST_CASE(test_murmur3_sharding_with_ignorebits) {
     auto make_token_vector = [] (std::vector<int64_t> v) {
-        return boost::copy_range<std::vector<dht::token>>(
-                v | boost::adaptors::transformed(token_from_long));
+        return v | std::views::transform(token_from_long) | std::ranges::to<std::vector<dht::token>>();
     };
     dht::static_sharder mm3p7s2i(7, 2);
     auto mm3p7s2i_shard_limits = make_token_vector({

--- a/test/boost/restrictions_test.cc
+++ b/test/boost/restrictions_test.cc
@@ -24,7 +24,6 @@
 namespace {
 
 using seastar::compat::source_location;
-using boost::adaptors::transformed;
 
 std::unique_ptr<cql3::query_options> to_options(
         const cql3::cql_config& cfg,
@@ -45,7 +44,7 @@ void require_rows(cql_test_env& e,
                   const std::vector<std::vector<bytes_opt>>& expected,
                   const seastar::compat::source_location& loc = source_location::current()) {
     // This helps compiler pick the right overload for make_value:
-    const auto rvals = values | transformed([] (const bytes_opt& v) { return cql3::raw_value::make_value(v); });
+    const auto rvals = values | std::views::transform([] (const bytes_opt& v) { return cql3::raw_value::make_value(v); });
     cql3::cql_config cfg(cql3::cql_config::default_tag{});
     auto opts = to_options(cfg, std::move(names), std::vector(rvals.begin(), rvals.end()));
     try {
@@ -746,7 +745,7 @@ SEASTAR_THREAD_TEST_CASE(multi_col_in) {
         auto bound_tuples = [] (std::vector<std::tuple<int32_t, float>> tuples) {
             const auto tuple_type = tuple_type_impl::get_instance({int32_type, float_type});
             const auto list_type = list_type_impl::get_instance(tuple_type, true);
-            const auto tvals = tuples | transformed([&] (const std::tuple<int32_t, float>& t) {
+            const auto tvals = tuples | std::views::transform([&] (const std::tuple<int32_t, float>& t) {
                 return make_tuple_value(tuple_type, tuple_type_impl::native_type({std::get<0>(t), std::get<1>(t)}));
             });
             return list_type->decompose(

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -77,8 +77,7 @@ test_using_reusable_sst(schema_ptr s, sstring dir, sstables::generation_type::in
 future<std::vector<partition_key>> index_read(schema_ptr schema, sstring path) {
     return test_using_reusable_sst(std::move(schema), std::move(path), 1, [] (test_env& env, sstable_ptr ptr) {
         auto indexes = sstables::test(ptr).read_indexes(env.make_reader_permit()).get();
-        return boost::copy_range<std::vector<partition_key>>(
-                indexes | boost::adaptors::transformed([] (const sstables::test::index_entry& e) { return e.key; }));
+        return indexes | std::views::transform([] (const sstables::test::index_entry& e) { return e.key; }) | std::ranges::to<std::vector<partition_key>>();
     });
 }
 

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2824,7 +2824,7 @@ SEASTAR_THREAD_TEST_CASE(test_tablet_range_splitter) {
     };
 
     check_single(dht::partition_range::make_open_ended_both_sides(), included_ranges);
-    check(boost::copy_range<dht::partition_range_vector>(included_ranges | boost::adaptors::transformed([&] (auto& r) { return r.range; })), included_ranges);
+    check(included_ranges | std::views::transform([&] (auto& r) { return r.range; }) | std::ranges::to<dht::partition_range_vector>(), included_ranges);
     check(excluded_ranges, {});
 
     check_intersection_single({bound{dks[0], true}, bound{dks[1], false}});

--- a/test/lib/data_model.cc
+++ b/test/lib/data_model.cc
@@ -12,7 +12,6 @@
 #include "test/lib/data_model.hh"
 
 #include <boost/algorithm/string/join.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 
 #include "schema/schema_builder.hh"
 #include "concrete_types.hh"
@@ -276,11 +275,9 @@ schema_ptr table_description::build_schema() const {
 }
 
 std::vector<mutation> table_description::build_mutations(schema_ptr s) const {
-    auto ms = boost::copy_range<std::vector<mutation>>(
-        _mutations | boost::adaptors::transformed([&] (const mutation_description& md) {
+    auto ms = _mutations | std::views::transform([&] (const mutation_description& md) {
             return md.build(s);
-        })
-    );
+        }) | std::ranges::to<std::vector<mutation>>();
     std::ranges::sort(ms, mutation_decorated_key_less_comparator());
     return ms;
 }

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -2100,7 +2100,7 @@ public:
         // The pre-existing assumption here is that the type of all the primary key components is blob.
         // So we generate partition keys and take the single blob component and save it as a random blob value.
         auto keys = tests::generate_partition_keys(n_blobs, _schema, _local_shard_only, tests::key_size{_external_blob_size, _external_blob_size});
-        _blobs =  boost::copy_range<std::vector<bytes>>(keys | boost::adaptors::transformed([] (const dht::decorated_key& dk) { return dk.key().explode().front(); }));
+        _blobs =  keys | std::views::transform([] (const dht::decorated_key& dk) { return dk.key().explode().front(); }) | std::ranges::to<std::vector<bytes>>();
     }
 
     void set_key_cardinality(size_t n_keys) {
@@ -2558,12 +2558,10 @@ void for_each_schema_change(std::function<void(schema_ptr, const std::vector<mut
     }
 
     auto max_generator_count = std::max(
-        // boost::max_elements wants the iterators to be copy-assignable. The ones we get
-        // from boost::adaptors::transformed aren't.
-        boost::accumulate(static_columns | boost::adaptors::transformed([] (const column_description& c) {
+        std::ranges::fold_left(static_columns | std::views::transform([] (const column_description& c) {
             return c.data_generators.size();
         }), 0u, [] (size_t a, size_t b) { return std::max(a, b); }),
-        boost::accumulate(regular_columns | boost::adaptors::transformed([] (const column_description& c) {
+        std::ranges::fold_left(regular_columns | std::views::transform([] (const column_description& c) {
             return c.data_generators.size();
         }), 0u, [] (size_t a, size_t b) { return std::max(a, b); })
     );

--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -1004,8 +1004,8 @@ sstring random_schema::cql() const {
 
     sstring udts_str;
     if (!udts.empty()) {
-        udts_str = boost::algorithm::join(udts |
-                boost::adaptors::transformed([] (const user_type_impl* const udt) { return udt_to_str(*udt); }), "\n");
+        udts_str = seastar::format("{}", fmt::join(udts |
+                std::views::transform([] (const user_type_impl* const udt) { return udt_to_str(*udt); }), "\n"));
     }
 
     std::vector<sstring> col_specs;
@@ -1048,8 +1048,9 @@ std::vector<data_model::mutation_description::key> random_schema::make_pkeys(siz
         ++i;
     }
 
-    return boost::copy_range<std::vector<data_model::mutation_description::key>>(keys |
-            boost::adaptors::transformed([] (const dht::decorated_key& dkey) { return dkey.key().explode(); }));
+    return keys
+        | std::views::transform([] (const dht::decorated_key& dkey) { return dkey.key().explode(); })
+        | std::ranges::to<std::vector<data_model::mutation_description::key>>();
 }
 
 data_model::mutation_description::key random_schema::make_ckey(uint32_t n) {
@@ -1065,8 +1066,9 @@ std::vector<data_model::mutation_description::key> random_schema::make_ckeys(siz
         keys.emplace(clustering_key::from_exploded(make_clustering_key(i, val_gen)));
     }
 
-    return boost::copy_range<std::vector<data_model::mutation_description::key>>(keys |
-            boost::adaptors::transformed([] (const clustering_key& ckey) { return ckey.explode(); }));
+    return keys
+        | std::views::transform([] (const clustering_key& ckey) { return ckey.explode(); })
+        | std::ranges::to<std::vector<data_model::mutation_description::key>>();
 }
 
 data_model::mutation_description random_schema::new_mutation(data_model::mutation_description::key pkey) {

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -23,8 +23,6 @@
 #include "test/lib/key_utils.hh"
 #include "mutation/atomic_cell_or_collection.hh"
 
-#include <boost/range/adaptor/transformed.hpp>
-
 // Helper for working with the following table:
 //
 //   CREATE TABLE ks.cf (pk text, ck text, v text, s1 text static, PRIMARY KEY (pk, ck));
@@ -273,9 +271,9 @@ public:
     }
 
     static std::vector<dht::ring_position> to_ring_positions(const std::vector<dht::decorated_key>& keys) {
-        return boost::copy_range<std::vector<dht::ring_position>>(keys | boost::adaptors::transformed([] (const dht::decorated_key& key) {
+        return keys | std::views::transform([] (const dht::decorated_key& key) {
             return dht::ring_position(key);
-        }));
+        }) | std::ranges::to<std::vector>();
     }
 
     // Returns n clustering keys in their natural order

--- a/test/manual/enormous_table_scan_test.cc
+++ b/test/manual/enormous_table_scan_test.cc
@@ -16,10 +16,6 @@
 #include "test/lib/cql_assertions.hh"
 #include "transport/messages/result_message.hh"
 
-#include <boost/range/adaptor/indirected.hpp>
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/adaptor/transformed.hpp>
-
 #include "dht/i_partitioner.hh"
 #include "mutation/mutation_fragment.hh"
 #include "schema/schema_builder.hh"

--- a/test/perf/perf_commitlog.cc
+++ b/test/perf/perf_commitlog.cc
@@ -9,10 +9,8 @@
 #include <fstream>
 
 #include <fmt/ranges.h>
-#include <boost/range/irange.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 #include <json/json.h>
 
 #include <seastar/core/app-template.hh>
@@ -258,10 +256,10 @@ int main(int argc, char** argv) {
             auto median = median_result.throughput;
             auto min = results[0].throughput;
             auto max = results[results.size() - 1].throughput;
-            auto absolute_deviations = boost::copy_range<std::vector<double>>(
-                    results
-                    | boost::adaptors::transformed(std::mem_fn(&perf_result::throughput))
-                    | boost::adaptors::transformed([&] (double r) { return abs(r - median); }));
+            auto absolute_deviations = results
+                    | std::views::transform(std::mem_fn(&perf_result::throughput))
+                    | std::views::transform([&] (double r) { return abs(r - median); })
+                    | std::ranges::to<std::vector<double>>();
             std::sort(absolute_deviations.begin(), absolute_deviations.end());
             auto mad = absolute_deviations[results.size() / 2];
             std::cout << format("\nmedian {}\nmedian absolute deviation: {:.2f}\nmaximum: {:.2f}\nminimum: {:.2f}\n", median_result, mad, max, min);

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -1284,12 +1284,12 @@ void print_all(const test_result_vector& results) {
     if (!dump_all_results || results.empty()) {
         return;
     }
-    output_mgr->add_all_test_values(results.back().get_params(), boost::copy_range<std::vector<stats_values>>(
-        results
-        | boost::adaptors::transformed([] (const test_result& tr) {
+    output_mgr->add_all_test_values(results.back().get_params(), results
+        | std::views::transform([] (const test_result& tr) {
             return tr.get_stats_values();
         })
-    ));
+        | std::ranges::to<std::vector<stats_values>>()
+    );
 }
 
 class result_collector {
@@ -1965,9 +1965,9 @@ int scylla_fast_forward_main(int argc, char** argv) {
     app.add_options()
         ("random-seed", boost::program_options::value<unsigned>(), "Random number generator seed")
         ("run-tests", bpo::value<std::vector<std::string>>()->default_value(
-                boost::copy_range<std::vector<std::string>>(
-                    test_groups | boost::adaptors::transformed([] (auto&& tc) { return tc.name; }))
-                ),
+                test_groups
+                    | std::views::transform([] (auto&& tc) { return tc.name; })
+                    | std::ranges::to<std::vector<std::string>>()),
             "Test groups to run")
         ("datasets", bpo::value<std::vector<std::string>>()->default_value(
                 datasets
@@ -2069,13 +2069,13 @@ int scylla_fast_forward_main(int argc, char** argv) {
                 output_mgr = std::make_unique<output_manager>(app.configuration()["output-format"].as<sstring>());
 
                 auto enabled_dataset_names = app.configuration()["datasets"].as<std::vector<std::string>>();
-                auto enabled_datasets = boost::copy_range<std::vector<dataset*>>(enabled_dataset_names
-                                        | boost::adaptors::transformed([&](auto&& name) {
+                auto enabled_datasets = enabled_dataset_names
+                                        | std::views::transform([&](auto&& name) {
                     if (!datasets.contains(name)) {
                         throw std::runtime_error(seastar::format("No such dataset: {}", name));
                     }
                     return datasets[name].get();
-                }));
+                }) | std::ranges::to<std::vector<dataset*>>();
 
                 if (app.configuration().contains("populate")) {
                     int n_rows = app.configuration()["rows"].as<int>();
@@ -2112,10 +2112,11 @@ int scylla_fast_forward_main(int argc, char** argv) {
                         return requested_test_groups.contains(tc.name);
                     });
 
-                    auto compaction_guard = make_compaction_disabling_guard(db, boost::copy_range<std::vector<replica::table*>>(
-                        enabled_datasets | boost::adaptors::transformed([&] (auto&& ds) {
+                    auto compaction_guard = make_compaction_disabling_guard(db, enabled_datasets
+                        | std::views::transform([&] (auto&& ds) {
                             return &find_table(db, *ds);
-                        })));
+                          })
+                        | std::ranges::to<std::vector<replica::table*>>());
 
                     auto run_tests = [&] (test_group::type type) {
                                 std::ranges::for_each(

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -118,7 +118,7 @@ private:
         return wrap(*it);
     }
     virtual std::vector<data_dictionary::keyspace> get_keyspaces(data_dictionary::database db) const override {
-        return boost::copy_range<std::vector<data_dictionary::keyspace>>(unwrap(db).keyspaces | boost::adaptors::transformed([this] (const keyspace& ks) { return wrap(ks); }));
+        return unwrap(db).keyspaces | std::views::transform([this] (const keyspace& ks) { return wrap(ks); }) | std::ranges::to<std::vector<data_dictionary::keyspace>>();
     }
     virtual std::vector<sstring> get_user_keyspaces(data_dictionary::database db) const override {
         return std::ranges::to<std::vector<sstring>>(
@@ -128,10 +128,10 @@ private:
         );
     }
     virtual std::vector<sstring> get_all_keyspaces(data_dictionary::database db) const override {
-        return boost::copy_range<std::vector<sstring>>(unwrap(db).keyspaces | boost::adaptors::transformed([] (const keyspace& ks) { return ks.metadata->name(); }));
+        return unwrap(db).keyspaces | std::views::transform([] (const keyspace& ks) { return ks.metadata->name(); }) | std::ranges::to<std::vector<sstring>>();
     }
     virtual std::vector<data_dictionary::table> get_tables(data_dictionary::database db) const override {
-        return boost::copy_range<std::vector<data_dictionary::table>>(unwrap(db).tables | boost::adaptors::transformed([this] (const table& ks) { return wrap(ks); }));
+        return unwrap(db).tables | std::views::transform([this] (const table& ks) { return wrap(ks); }) | std::ranges::to<std::vector<data_dictionary::table>>();
     }
     virtual std::optional<data_dictionary::table> try_find_table(data_dictionary::database db, std::string_view ks, std::string_view tab) const override {
         auto& tables = unwrap(db).tables;
@@ -445,9 +445,9 @@ schema_ptr do_load_schema_from_schema_tables(const db::config& dbcfg, std::files
         db::cql_type_parser::raw_builder ut_builder(*ks);
 
         auto get_list = [] (const query::result_set_row& row, const char* name) {
-            return boost::copy_range<std::vector<sstring>>(
-                    row.get_nonnull<const list_type_impl::native_type&>(name)
-                    | boost::adaptors::transformed([] (const data_value& v) { return value_cast<sstring>(v); }));
+            return row.get_nonnull<const list_type_impl::native_type&>(name)
+                    | std::views::transform([] (const data_value& v) { return value_cast<sstring>(v); })
+                    | std::ranges::to<std::vector<sstring>>();
         };
 
         for (const auto& row : result.rows()) {

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -4559,7 +4559,7 @@ For more information, see: {})";
     const auto operations = get_operations_with_func() | std::views::keys | std::ranges::to<std::vector>();
     tool_app_template::config app_cfg{
             .name = app_name,
-            .description = seastar::format(description_template, app_name, nlog.name(), boost::algorithm::join(operations | boost::adaptors::transformed([] (const auto& op) {
+            .description = seastar::format(description_template, app_name, nlog.name(), fmt::join(operations | std::views::transform([] (const auto& op) {
                 return seastar::format("* {}: {}", op.name(), op.summary());
             }), "\n"), doc_link("operating-scylla/nodetool.html")),
             .logger_name = nlog.name(),

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1818,7 +1818,7 @@ class json_mutation_stream_parser {
         }
 
         std::string stack_to_string() const {
-            return boost::algorithm::join(_state_stack | boost::adaptors::transformed([] (state s) { return std::string(to_string(s)); }), "|");
+            return fmt::to_string(fmt::join(_state_stack | std::views::transform([] (state s) { return to_string(s); }), "|"));
         }
 
         template<typename... Args>
@@ -3098,7 +3098,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
     const auto operations = operations_with_func | std::views::keys | std::ranges::to<std::vector>();
     tool_app_template::config app_cfg{
             .name = app_name,
-            .description = seastar::format(description_template, app_name, sst_log.name(), boost::algorithm::join(operations | boost::adaptors::transformed([] (const auto& op) {
+            .description = seastar::format(description_template, app_name, sst_log.name(), fmt::join(operations | std::views::transform([] (const auto& op) {
                 return seastar::format("* {}: {}", op.name(), op.summary());
             }), "\n")),
             .logger_name = sst_log.name(),

--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -8,9 +8,7 @@
 
 #include <seastar/core/thread.hh>
 #include <fmt/ranges.h>
-#include <boost/algorithm/string/join.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 
 #include "db/config.hh"
 #include "db/extensions.hh"

--- a/tracing/trace_state.cc
+++ b/tracing/trace_state.cc
@@ -8,7 +8,6 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 #include <chrono>
-#include <boost/range/adaptor/transformed.hpp>
 #include "cql3/statements/prepared_statement.hh"
 #include "tracing/trace_state.hh"
 #include "timestamp.hh"
@@ -113,7 +112,7 @@ void trace_state::build_parameters_map() {
     params_values& vals = *_params_ptr;
 
     if (vals.batchlog_endpoints) {
-        auto batch_endpoints = fmt::format("{}", fmt::join(*vals.batchlog_endpoints | boost::adaptors::transformed([](gms::inet_address ep) {return seastar::format("/{}", ep);}), ","));
+        auto batch_endpoints = fmt::format("{}", fmt::join(*vals.batchlog_endpoints | std::views::transform([](gms::inet_address ep) {return seastar::format("/{}", ep);}), ","));
         params_map.emplace("batch_endpoints", std::move(batch_endpoints));
     }
 


### PR DESCRIPTION
now that we are allowed to use C++23. we now have the luxury of using `std::views::transform`.

in this change, we:

- replace `boost::adaptors::transformed` with `std::views::transform`
- use `fmt::join()` when appropriate where `boost::algorithm::join()` is not applicable to a range view returned by `std::view::transform`.
- use `std::ranges::fold_left()` to accumulate the range returned by `std::view::transform`
- use `std::ranges::fold_left()` to get the maximum element in the range returned by `std::view::transform`
- use `std::ranges::min()` to get the minimal element in the range returned by `std::view::transform`
- use `std::ranges::equal()` to compare the range views returned by `std::view::transform`
- remove unused `#include <boost/range/adaptor/transformed.hpp>`

to reduce the dependency to boost for better maintainability, and leverage standard library features for better long-term support.

this change is part of our ongoing effort to modernize our codebase and reduce external dependencies where possible.

limitations:

there are still a couple places where we are still using `boost::adaptors::transformed` due to the lack of a C++23 alternative for `boost::join()` and `boost::adaptors::uniqued`.

---

it's a cleanup, hence no need to backport.