### PR TITLE
test/topology_experimental_raft: Prevent keyspace creation conflicts with IF NOT EXISTS

### DIFF
--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -1546,8 +1546,8 @@ async def create_and_populate_table(manager: ManagerClient, rf: int = 3, initial
 
     cql = manager.get_cql()
     try:
-        await cql.run_async(f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} AND tablets = {{'initial': {initial_tablets}}}")
-        await cql.run_async(f"CREATE TABLE {ks}.{table} (pk int PRIMARY KEY, c int)")
+        await cql.run_async(f"CREATE KEYSPACE IF NOT EXISTS {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} AND tablets = {{'initial': {initial_tablets}}}")
+        await cql.run_async(f"CREATE TABLE IF NOT EXISTS {ks}.{table} (pk int PRIMARY KEY, c int)")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.{table} (pk, c) VALUES ({k}, 1);") for k in range(num_keys)])
         yield TestContext(ks, table, rf, initial_tablets, num_keys)
     finally:


### PR DESCRIPTION
Background:

- Python driver exhibits unexpected behavior causing duplicate keyspace creation attempts (scylladb/python-driver#317)

- Existing test cases can fail with cassandra.AlreadyExists exception:

  ``` cassandra.AlreadyExists: Keyspace 'test_1732631552019_lxagp' already exists ```

Resolution:

- Added `IF NOT EXISTS` clause to keyspace and table creation statements
- Mitigates potential race conditions during test setup
- Aligns with previous mitigation approach in commit 8876b9b0ef

Specific Changes:

- Ensures safe keyspace creation in concurrent test scenarios
- Prevents test failures due to duplicate keyspace generation

Fixes scylladb/scylladb#21701

---

the test was introduced by d8be1cafb51e67067f5d83607af1c8c899d3bd0f, which has not been included by any LTS branches. hence no need to backport.