### PR TITLE
tombstone_gc.hh: remove include of boost/icl/interval_map.hh

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -26,6 +26,7 @@
 #include "utils/error_injection.hh"
 #include "utils/UUID_gen.hh"
 #include "db/system_keyspace.hh"
+#include "tombstone_gc-internals.hh"
 #include <cmath>
 #include <boost/range/algorithm/remove_if.hpp>
 

--- a/tombstone_gc-internals.hh
+++ b/tombstone_gc-internals.hh
@@ -1,0 +1,19 @@
+// Copyright (C) 2024-present ScyllaDB
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#include "tombstone_gc.hh"
+#include <boost/icl/interval_map.hpp>
+
+using repair_history_map = boost::icl::interval_map<dht::token, gc_clock::time_point, boost::icl::partial_absorber, std::less, boost::icl::inplace_max>;
+
+class repair_history_map_ptr {
+    lw_shared_ptr<repair_history_map> _ptr;
+public:
+    repair_history_map_ptr() = default;
+    repair_history_map_ptr(lw_shared_ptr<repair_history_map> ptr) : _ptr(std::move(ptr)) {}
+    repair_history_map& operator*() const { return _ptr.operator*(); }
+    repair_history_map* operator->() const { return _ptr.operator->(); }
+    explicit operator bool() const { return _ptr.operator bool(); }
+};
+
+

--- a/tombstone_gc.cc
+++ b/tombstone_gc.cc
@@ -11,6 +11,7 @@
 #include "schema/schema.hh"
 #include "gc_clock.hh"
 #include "tombstone_gc.hh"
+#include "tombstone_gc-internals.hh"
 #include "locator/token_metadata.hh"
 #include "exceptions/exceptions.hh"
 #include "locator/abstract_replication_strategy.hh"
@@ -20,7 +21,7 @@
 
 extern logging::logger dblog;
 
-seastar::lw_shared_ptr<repair_history_map> tombstone_gc_state::get_or_create_repair_history_for_table(const table_id& id) {
+repair_history_map_ptr tombstone_gc_state::get_or_create_repair_history_for_table(const table_id& id) {
     if (!_reconcile_history_maps) {
         return {};
     }
@@ -33,7 +34,7 @@ seastar::lw_shared_ptr<repair_history_map> tombstone_gc_state::get_or_create_rep
     return reconcile_history_maps[id];
 }
 
-seastar::lw_shared_ptr<repair_history_map> tombstone_gc_state::get_repair_history_for_table(const table_id& id) const {
+repair_history_map_ptr tombstone_gc_state::get_repair_history_for_table(const table_id& id) const {
     if (!_reconcile_history_maps) {
         return {};
     }

--- a/tombstone_gc.hh
+++ b/tombstone_gc.hh
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <boost/icl/interval_map.hpp>
-
 #include <seastar/core/shared_ptr.hh>
 #include "gc_clock.hh"
 #include "dht/token.hh"
@@ -35,11 +33,11 @@ class database;
 //
 // The map is used to determine the time when the tombstones can be safely removed from the table (for the tables with
 // the "repair" tombstone GC mode).
-using repair_history_map = boost::icl::interval_map<dht::token, gc_clock::time_point, boost::icl::partial_absorber, std::less, boost::icl::inplace_max>;
+class repair_history_map_ptr;
 
 class per_table_history_maps {
 public:
-    std::unordered_map<table_id, seastar::lw_shared_ptr<repair_history_map>> _repair_maps;
+    std::unordered_map<table_id, repair_history_map_ptr> _repair_maps;
 
     // Separating the group0 GC time - it is not kept per table, but for the whole group0:
     // - the state_id of the last mutation applies to all group0 tables wrt. the tombstone GC
@@ -56,8 +54,8 @@ class tombstone_gc_state {
     per_table_history_maps* _reconcile_history_maps;
     [[nodiscard]] gc_clock::time_point check_min(schema_ptr, gc_clock::time_point) const;
 
-    [[nodiscard]] seastar::lw_shared_ptr<repair_history_map> get_repair_history_for_table(const table_id& id) const;
-    [[nodiscard]] seastar::lw_shared_ptr<repair_history_map> get_or_create_repair_history_for_table(const table_id& id);
+    [[nodiscard]] repair_history_map_ptr get_repair_history_for_table(const table_id& id) const;
+    [[nodiscard]] repair_history_map_ptr get_or_create_repair_history_for_table(const table_id& id);
 
     [[nodiscard]] seastar::lw_shared_ptr<gc_clock::time_point> get_group0_gc_time() const;
     [[nodiscard]] seastar::lw_shared_ptr<gc_clock::time_point> get_or_create_group0_gc_time();


### PR DESCRIPTION
tombstone_gc.hh is relatively lightweight and is used in many places, but it includes the heavyweight boost/icl/interval_map.hh. Lighten the load for its users by wrapping lw_shared_ptr<some icl map type> in a forward-declared class. Define the class in a new header tombstone_gc-internals.hh, to be used by the two translation units that need it.

Ref #1.

Compile time reduction, no need to backport.