### PR TITLE
utils/big_decimal: add fast paths to operator <=>

### DIFF
--- a/test/cqlpy/test_type_decimal.py
+++ b/test/cqlpy/test_type_decimal.py
@@ -1,0 +1,46 @@
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+#############################################################################
+# Test involving the "decimal" column type.
+# There are additional tests involving decimals in specific contexts in other
+# files - e.g., aggregating decimals in test_aggregate.py, casting decimals
+# in test_cast_data.py, and decimals in JSON in test_json.py
+#############################################################################
+
+from decimal import Decimal
+import pytest
+
+from . import nodetool
+from .util import new_test_table, unique_key_int
+
+@pytest.fixture(scope="module")
+def table1(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c decimal, PRIMARY KEY (p, c)") as table:
+        yield table
+
+# Test that if we have clustering keys of wildly different scales, sorting
+# them works. Reproduces issue #21716 where comparing two decimals of
+# very different scales needed to expand the digits of one of them and
+# would take huge amounts of CPU and also run out of memory.
+# See also test_json.py::test_json_decimal_high_mantissa where printing
+# a decimal runs into a similar problem.
+def test_decimal_clustering_key_high_exponent(cql, table1):
+    # The two numbers "low" and "high" have wildly different exponents.
+    # Any algorithm that attempts to expand the digits of one to have the
+    # same exponent as the other will run out of memory (#21716).
+    low = Decimal('19866597869857659876855e-1000000000')
+    high = Decimal('19866597869857659876855e1000000000')
+    minuslow = Decimal('-19866597869857659876855e-1000000000')
+    minushigh = Decimal('-19866597869857659876855e1000000000')
+    p = unique_key_int()
+    stmt = cql.prepare(f"INSERT INTO {table1} (p, c) VALUES ({p}, ?)")
+    cql.execute(stmt, [high])
+    cql.execute(stmt, [low])
+    cql.execute(stmt, [minushigh])
+    cql.execute(stmt, [minuslow])
+    assert list(cql.execute(f"SELECT c from {table1} where p = {p}")) == [(minushigh,),(minuslow,),(low,),(high,)]
+    # Do a memtable flush, just to make sure the memtable-flushing or sstable
+    # writing code also doesn't use problematic decimal-handling algorithms.
+    nodetool.flush(cql, table1)

--- a/utils/big_decimal.hh
+++ b/utils/big_decimal.hh
@@ -21,6 +21,11 @@ class big_decimal {
 private:
     int32_t _scale;
     boost::multiprecision::cpp_int _unscaled_value;
+
+private:
+    std::strong_ordering tri_cmp_slow(const big_decimal& other) const;
+    std::strong_ordering tri_cmp_positive_nonzero_different_scale(const big_decimal& other) const;
+
 public:
     enum class rounding_mode {
         HALF_EVEN,
@@ -43,6 +48,7 @@ public:
     big_decimal& operator-=(const big_decimal& other);
     big_decimal operator+(const big_decimal& other) const;
     big_decimal operator-(const big_decimal& other) const;
+    big_decimal operator-() const;
     big_decimal div(const ::uint64_t y, const rounding_mode mode) const;
 };
 


### PR DESCRIPTION
Currently, the tri-compare operator for big_decimal (operator <=>), uses a precise but potentially very expensive algorithm for comparing the numbers: it first brings them to the same scale, then compares the normalized unscaled values. big_decimal has abritrary precisions, therefore the stored numbers can be arbitrarily large. In extreme cases, comparing two numbers can result in huge amount of memory allocated and stalls. If this type is used int he primary key of a table, these comparisons can make the node completely unresponsive. 

This patch adds the following fast-paths to operator <=>:
* An early return for the case of equal scales.
* An early return for different signs.
* An early return for the case where one or both of the numbers are 0.
* A fast algorithm for detecting the case where the there is a big difference between the two numbers. This algorithm works only with the scales and is able to compare the two numbers by using only one division and some additions and substractions. This algorithm is imprecise and when the numbers are closer than its confidence window, it will fall-back to the current slow but precise tri-compare.

All but the last case should have been fast before as well, but the scale-compare algorithm makes a huge difference. Numbers, which would previously make the node unresponsive, now compare in constant-time.

Fixes: https://github.com/scylladb/scylladb/issues/21716