### PR TITLE
pytest: don't override default live-logging setting

### DIFF
--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
 asyncio_mode = auto
 
-log_cli = true
 log_format = %(asctime)s.%(msecs)03d %(levelname)s>  %(message)s
 log_date_format = %H:%M:%S
 


### PR DESCRIPTION
In commit 8bf62a0 we introduced a test/pytest.ini which affects every run of pytest in the project. One specific line in that file

    log_cli = true

Overrides pytest's standard CLI output, which is traditionally short unless the "-v" (verbose) option is used, to be always long and spammy. There is absolutely no reason to do that - if the user wants to run "pytest -v", they can do that - it doesn't need to be the default.

Moreover, as https://docs.pytest.org/en/stable/how-to/logging.html explains, the "log_cli = true" was added in pytest 3.4 to revert to pytest 3.3 behavior that "community feedback" showed was NOT LIKED. Why would we want to revert to behavior that wasn't liked?

After this patch, which removes that line, the output of commands like
    cd test/cqlpy; pytest

return to what they used to be before commit 8bf62a0 and what the pytest developers intended. Users who like verbose output can use "pytest -v".

Fixes #21712

Patch for interactive test use only,  and fixes a very recent regression, no need to backport.