### PR TITLE
scylla-server.service: drop scylla-jmx.service

### DIFF
--- a/dist/common/systemd/scylla-server.service
+++ b/dist/common/systemd/scylla-server.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Scylla Server
-Wants=scylla-jmx.service
 Wants=scylla-housekeeping-restart.timer
 Wants=scylla-housekeeping-daily.timer
 # This will only requires for abrt < 2.14


### PR DESCRIPTION
Since we dropped scylla-jmx at 3cd2a61, Wants=scylla-jmx.service is not needed anymore.

Also we have issue on nonroot mode installation with this line (#21720), we need to drop this now.

Fixes #21720