### PR TITLE
test: topology_custom: ensure node visibility before keyspace creation

### DIFF
--- a/test/topology_custom/test_raft_recovery_stuck.py
+++ b/test/topology_custom/test_raft_recovery_stuck.py
@@ -79,9 +79,9 @@ async def test_recover_stuck_raft_recovery(request, manager: ManagerClient):
     logging.info(f"Restarting {others}")
     await manager.rolling_restart(others)
 
-    # Prevent scylladb/scylladb#20791
-    logging.info(f"Wait until {srv1} sees {others} as alive")
-    await manager.server_sees_others(srv1.server_id, len(others))
+    # Prevent scylladb/scylladb#21724
+    logging.info("Wait until everyone sees everyone as alive")
+    await manager.servers_see_each_other(servers)
 
     logging.info(f"{others} restarted, waiting until driver reconnects to them")
     hosts = await wait_for_cql_and_get_hosts(cql, others, time.time() + 60)


### PR DESCRIPTION
Building upon commit 69b47694, this change addresses a subtle synchronization weakness in node visibility checks during recovery mode testing.

Previous Approach:
- Waited only for the first node to see its peers
- Insufficient to guarantee full cluster consistency

Current Solution:
1. Implement comprehensive node visibility verification
2. Ensure all nodes mutually recognize each other
3. Prevent potential schema propagation race conditions

Key Improvements:
- Robust cluster state validation before keyspace creation
- Eliminate partial visibility scenarios

Fixes scylladb/scylladb#21724

---

this change fixes a flaky test, hence should be backported to all LTS branches containing this test.