### PR TITLE
mutation: remove unused "#include"s

### DIFF
--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -11,7 +11,7 @@ env:
   CLEANER_OUTPUT_PATH: build/clang-include-cleaner.log
   # the "idl" subdirectory does not contain C++ source code. the .hh files in it are
   # supposed to be processed by idl-compiler.py, so we don't check them using the cleaner
-  CLEANER_DIRS: test/unit exceptions alternator api auth cdc compaction db dht gms index lang message
+  CLEANER_DIRS: test/unit exceptions alternator api auth cdc compaction db dht gms index lang message mutation
 
 permissions: {}
 

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -7,7 +7,6 @@
  */
 
 #include <fmt/ranges.h>
-#include <seastar/core/sleep.hh>
 #include "alternator/executor.hh"
 #include "auth/permission.hh"
 #include "auth/resource.hh"
@@ -44,6 +43,8 @@
 #include "replica/database.hh"
 #include "alternator/rmw_operation.hh"
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <boost/range/algorithm/find_end.hpp>
 #include <unordered_set>
 #include "service/storage_proxy.hh"

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -36,6 +36,7 @@
 #include "utils/log.hh"
 #include "schema/schema_fwd.hh"
 #include <seastar/core/future.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <variant>
 #include "service/migration_manager.hh"

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 
 #include "gms/endpoint_state.hh"
 #include "gms/versioned_value.hh"

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -27,6 +27,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/shard_id.hh>
 #include <seastar/core/on_internal_error.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 
 #include "compaction/compaction_garbage_collector.hh"
 #include "dht/i_partitioner.hh"

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -7,6 +7,7 @@
  */
 
 #include <boost/range/algorithm/min_element.hpp>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 
 #include "compaction/task_manager_module.hh"

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -17,6 +17,7 @@
 #include "seastarx.hh"
 #include <seastar/core/sleep.hh>
 #include <seastar/core/seastar.hh>
+#include <seastar/core/when_all.hh>
 #include "utils/div_ceil.hh"
 #include "utils/lister.hh"
 

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -9,6 +9,7 @@
 #include "utils/assert.hh"
 #include <seastar/core/format.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/when_all.hh>
 #include "db/system_keyspace.hh"
 #include "db/large_data_handler.hh"
 #include "sstables/sstables.hh"

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -13,6 +13,7 @@
 #include <seastar/rpc/rpc_types.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/on_internal_error.hh>

--- a/db/snapshot/backup_task.cc
+++ b/db/snapshot/backup_task.cc
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <seastar/coroutine/maybe_yield.hh>
+
 #include "utils/lister.hh"
 #include "utils/s3/client.hh"
 #include "replica/database.hh"

--- a/locator/util.cc
+++ b/locator/util.cc
@@ -8,6 +8,7 @@
 #include "locator/util.hh"
 #include "replica/database.hh"
 #include "gms/gossiper.hh"
+#include <seastar/coroutine/maybe_yield.hh>
 
 namespace locator {
 

--- a/mutation/atomic_cell.hh
+++ b/mutation/atomic_cell.hh
@@ -10,16 +10,13 @@
 
 #include <seastar/util/bool_class.hh>
 
-#include "bytes.hh"
 #include "timestamp.hh"
 #include "mutation/tombstone.hh"
 #include "gc_clock.hh"
 #include "utils/assert.hh"
 #include "utils/managed_bytes.hh"
-#include <seastar/net//byteorder.hh>
 #include <seastar/util/bool_class.hh>
 #include <cstdint>
-#include <iosfwd>
 #include "utils/fragmented_temporary_buffer.hh"
 
 #include "serializer.hh"

--- a/mutation/mutation.hh
+++ b/mutation/mutation.hh
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <iosfwd>
-
 #include "mutation_partition.hh"
 #include "keys.hh"
 #include "schema/schema_fwd.hh"
@@ -21,9 +19,8 @@
 #include "mutation/mutation_consumer_concepts.hh"
 #include "utils/preempt.hh"
 
+#include <seastar/util/later.hh>
 #include <seastar/util/optimized_optional.hh>
-#include <seastar/core/coroutine.hh>
-#include <seastar/coroutine/maybe_yield.hh>
 
 struct mutation_consume_cookie {
     using crs_iterator_type = mutation_partition::rows_type::iterator;

--- a/mutation/mutation_fragment.hh
+++ b/mutation/mutation_fragment.hh
@@ -14,8 +14,6 @@
 #include <optional>
 #include <seastar/util/optimized_optional.hh>
 
-#include <seastar/core/future-util.hh>
-
 #include "reader_permit.hh"
 #include "mutation_fragment_fwd.hh"
 #include "mutation/mutation_partition.hh"

--- a/mutation/mutation_fragment_fwd.hh
+++ b/mutation/mutation_fragment_fwd.hh
@@ -7,7 +7,6 @@
  */
 
 #pragma once
-#include <seastar/util/bool_class.hh>
 #include <seastar/util/optimized_optional.hh>
 
 using namespace seastar;

--- a/mutation/mutation_fragment_stream_validator.cc
+++ b/mutation/mutation_fragment_stream_validator.cc
@@ -7,7 +7,7 @@
  */
 
 #include "mutation/mutation_fragment_stream_validator.hh"
-#include "utils/to_string.hh"
+#include <fmt/std.h>
 #include "seastarx.hh"
 
 logging::logger validator_log("mutation_fragment_stream_validator");

--- a/mutation/mutation_fragment_v2.hh
+++ b/mutation/mutation_fragment_v2.hh
@@ -15,8 +15,6 @@
 #include <optional>
 #include <seastar/util/optimized_optional.hh>
 
-#include <seastar/core/future-util.hh>
-
 #include "reader_permit.hh"
 
 // Mutation fragment which represents a range tombstone boundary.

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -9,10 +9,8 @@
 #pragma once
 
 #include <iosfwd>
-#include <boost/intrusive/set.hpp>
 #include <boost/intrusive/parent_from_member.hpp>
 
-#include <seastar/core/bitset-iter.hh>
 #include <seastar/util/optimized_optional.hh>
 
 #include <ranges>

--- a/mutation/mutation_partition_serializer.cc
+++ b/mutation/mutation_partition_serializer.cc
@@ -11,7 +11,6 @@
 #include "mutation_partition.hh"
 
 #include "counters.hh"
-#include "idl/mutation.dist.hh"
 #include "idl/mutation.dist.impl.hh"
 #include "frozen_mutation.hh"
 #include <seastar/coroutine/maybe_yield.hh>

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -9,12 +9,7 @@
 #pragma once
 
 #include "utils/assert.hh"
-#include <iosfwd>
-#include <boost/intrusive/set.hpp>
 #include <boost/intrusive/parent_from_member.hpp>
-
-#include <seastar/core/bitset-iter.hh>
-#include <seastar/util/optimized_optional.hh>
 
 #include "mutation_partition.hh"
 

--- a/mutation/mutation_partition_view.hh
+++ b/mutation/mutation_partition_view.hh
@@ -12,7 +12,6 @@
 #include "mutation_partition_visitor.hh"
 #include "utils/input_stream.hh"
 #include "atomic_cell.hh"
-#include "idl/mutation.dist.hh"
 #include "idl/mutation.dist.impl.hh"
 
 namespace ser {

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -17,7 +17,6 @@
 #include "utils/chunked_vector.hh"
 
 #include <boost/intrusive/parent_from_member.hpp>
-#include <boost/intrusive/slist.hpp>
 
 class static_row;
 

--- a/mutation/range_tombstone.hh
+++ b/mutation/range_tombstone.hh
@@ -8,15 +8,12 @@
 
 #pragma once
 
-#include <boost/intrusive/set.hpp>
 #include <optional>
 #include "utils/hashing.hh"
 #include "keys.hh"
 #include "mutation/tombstone.hh"
 #include "clustering_bounds_comparator.hh"
 #include "mutation/position_in_partition.hh"
-
-namespace bi = boost::intrusive;
 
 /**
  * Represents a ranged deletion operation. Can be empty.

--- a/mutation/range_tombstone_assembler.hh
+++ b/mutation/range_tombstone_assembler.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <exception>
 #include <seastar/core/format.hh>
 
 #include "mutation/mutation_fragment_v2.hh"

--- a/mutation/range_tombstone_list.hh
+++ b/mutation/range_tombstone_list.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <seastar/util/defer.hh>
+#include <boost/intrusive/set.hpp>
 #include "range_tombstone.hh"
 #include "query-request.hh"
 #include "utils/assert.hh"

--- a/mutation/tombstone.hh
+++ b/mutation/tombstone.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <functional>
 #include <compare>
 
 #include "timestamp.hh"

--- a/mutation_writer/timestamp_based_splitting_writer.cc
+++ b/mutation_writer/timestamp_based_splitting_writer.cc
@@ -12,6 +12,7 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm/min_element.hpp>
 #include <seastar/core/shared_mutex.hh>
+#include <seastar/core/when_all.hh>
 
 #include "mutation_writer/feed_writers.hh"
 

--- a/readers/combined.cc
+++ b/readers/combined.cc
@@ -7,6 +7,7 @@
  */
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/when_all.hh>
 
 #include "readers/empty_v2.hh"
 #include "readers/clustering_combined.hh"

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -37,10 +37,11 @@
 #include <seastar/util/defer.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/coroutine.hh>
-#include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/sleep.hh>
-#include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
+#include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 
 #include <exception>
 #include <cfloat>

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -7,6 +7,7 @@
  */
 
 #include <fmt/ranges.h>
+#include <seastar/coroutine/maybe_yield.hh>
 
 #include "types/types.hh"
 #include "types/tuple.hh"

--- a/service/mapreduce_service.cc
+++ b/service/mapreduce_service.cc
@@ -10,6 +10,7 @@
 
 #include <boost/range/algorithm/remove_if.hpp>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/smp.hh>

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -21,6 +21,7 @@
 #include "gms/feature_service.hh"
 #include <utility>
 #include <fmt/ranges.h>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <absl/container/flat_hash_map.h>
 
 using namespace locator;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -11,6 +11,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -8,6 +8,7 @@
 
 #include <fmt/ranges.h>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/switch_to.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/rpc/rpc.hh>

--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -11,6 +11,8 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/algorithm/unique.hpp>
 
+#include <seastar/coroutine/maybe_yield.hh>
+
 #include "cql3/cql3_type.hh"
 #include "cql3/description.hh"
 #include "mutation/mutation.hh"


### PR DESCRIPTION
these unused includes are identified by clang-include-cleaner. after auditing the source files, all of the reports have been confirmed.

please note, because `mutation/mutation.hh` does not include `seastar/coroutine/maybe_yield.hh` anymore, and quite a few source files were relying on this header to bring in the declaration of `maybe_yield()`, we have to include this header in the places where this symbol is used. the same applies to `seastar/core/when_all.hh`.

---

it's a cleanup, hence no need to backport.