### PR TITLE
tasks: add tablet migration virtual task

### DIFF
--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -148,6 +148,8 @@ public:
     gms::feature tablet_repair_scheduler { *this, "TABLET_REPAIR_SCHEDULER"sv };
     gms::feature tablet_merge { *this, "TABLET_MERGE"sv };
 
+    gms::feature tablet_migration_virtual_task { *this, "TABLET_MIGRATION_VIRTUAL_TASK"sv };
+
     // A feature just for use in tests. It must not be advertised unless
     // the "features_enable_test_feature" injection is enabled.
     // This feature MUST NOT be advertised in release mode!

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -160,14 +160,15 @@ bool tablet_has_excluded_node(const locator::topology& topo, const tablet_info& 
     return false;
 }
 
-tablet_info::tablet_info(tablet_replica_set replicas, db_clock::time_point repair_time, tablet_task_info repair_task_info)
+tablet_info::tablet_info(tablet_replica_set replicas, db_clock::time_point repair_time, tablet_task_info repair_task_info, tablet_task_info migration_task_info)
     : replicas(std::move(replicas))
     , repair_time(repair_time)
     , repair_task_info(std::move(repair_task_info))
+    , migration_task_info(std::move(migration_task_info))
 {}
 
 tablet_info::tablet_info(tablet_replica_set replicas)
-    : tablet_info(std::move(replicas), db_clock::time_point{}, tablet_task_info{})
+    : tablet_info(std::move(replicas), db_clock::time_point{}, tablet_task_info{}, tablet_task_info{})
 {}
 
 std::optional<tablet_info> merge_tablet_info(tablet_info a, tablet_info b) {
@@ -184,7 +185,7 @@ std::optional<tablet_info> merge_tablet_info(tablet_info a, tablet_info b) {
     }
 
     auto repair_time = std::max(a.repair_time, b.repair_time);
-    return tablet_info(std::move(a.replicas), repair_time, a.repair_task_info);
+    return tablet_info(std::move(a.replicas), repair_time, a.repair_task_info, a.migration_task_info);
 }
 
 std::optional<tablet_replica> get_leaving_replica(const tablet_info& tinfo, const tablet_transition_info& trinfo) {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1171,17 +1171,17 @@ bool locator::tablet_task_info::is_valid() const {
     return request_type != locator::tablet_task_type::none;
 }
 
-bool locator::tablet_task_info::is_user_request() const {
+bool locator::tablet_task_info::is_user_repair_request() const {
     return request_type == locator::tablet_task_type::user_repair;
 }
 
-locator::tablet_task_info locator::tablet_task_info::make_auto_request() {
+locator::tablet_task_info locator::tablet_task_info::make_auto_repair_request() {
     long sched_nr = 0;
     auto tablet_task_id = locator::tablet_task_id(utils::UUID_gen::get_time_UUID());
     return locator::tablet_task_info{locator::tablet_task_type::auto_repair, tablet_task_id, db_clock::now(), sched_nr, db_clock::time_point()};
 }
 
-locator::tablet_task_info locator::tablet_task_info::make_user_request() {
+locator::tablet_task_info locator::tablet_task_info::make_user_repair_request() {
     long sched_nr = 0;
     auto tablet_task_id = locator::tablet_task_id(utils::UUID_gen::get_time_UUID());
     return locator::tablet_task_info{locator::tablet_task_type::user_repair, tablet_task_id, db_clock::now(), sched_nr, db_clock::time_point()};

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -555,6 +555,8 @@ static const std::unordered_map<tablet_task_type, sstring> tablet_task_type_to_n
     {locator::tablet_task_type::none, "none"},
     {locator::tablet_task_type::user_repair, "user_repair"},
     {locator::tablet_task_type::auto_repair, "auto_repair"},
+    {locator::tablet_task_type::migration, "migration"},
+    {locator::tablet_task_type::intranode_migration, "intranode_migration"},
 };
 
 static const std::unordered_map<sstring, tablet_task_type> tablet_task_type_from_name = std::invoke([] {
@@ -568,7 +570,7 @@ static const std::unordered_map<sstring, tablet_task_type> tablet_task_type_from
 sstring tablet_task_type_to_string(tablet_task_type kind) {
     auto i = tablet_task_type_to_name.find(kind);
     if (i == tablet_task_type_to_name.end()) {
-        on_internal_error(tablet_logger, format("Invalid repair task type: {}", static_cast<int>(kind)));
+        on_internal_error(tablet_logger, format("Invalid tablet task type: {}", static_cast<int>(kind)));
     }
     return i->second;
 }
@@ -1185,4 +1187,16 @@ locator::tablet_task_info locator::tablet_task_info::make_user_repair_request() 
     long sched_nr = 0;
     auto tablet_task_id = locator::tablet_task_id(utils::UUID_gen::get_time_UUID());
     return locator::tablet_task_info{locator::tablet_task_type::user_repair, tablet_task_id, db_clock::now(), sched_nr, db_clock::time_point()};
+}
+
+locator::tablet_task_info locator::tablet_task_info::make_migration_request() {
+    long sched_nr = 0;
+    auto tablet_task_id = locator::tablet_task_id(utils::UUID_gen::get_time_UUID());
+    return locator::tablet_task_info{locator::tablet_task_type::migration, tablet_task_id, db_clock::now(), sched_nr, db_clock::time_point()};
+}
+
+locator::tablet_task_info locator::tablet_task_info::make_intranode_migration_request() {
+    long sched_nr = 0;
+    auto tablet_task_id = locator::tablet_task_id(utils::UUID_gen::get_time_UUID());
+    return locator::tablet_task_info{locator::tablet_task_type::intranode_migration, tablet_task_id, db_clock::now(), sched_nr, db_clock::time_point()};
 }

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -160,9 +160,9 @@ struct tablet_task_info {
     db_clock::time_point sched_time;
     bool operator==(const tablet_task_info&) const = default;
     bool is_valid() const;
-    bool is_user_request() const;
-    static tablet_task_info make_user_request();
-    static tablet_task_info make_auto_request();
+    bool is_user_repair_request() const;
+    static tablet_task_info make_user_repair_request();
+    static tablet_task_info make_auto_repair_request();
 };
 
 /// Stores information about a single tablet.

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -174,9 +174,10 @@ struct tablet_info {
     tablet_replica_set replicas;
     db_clock::time_point repair_time;
     locator::tablet_task_info repair_task_info;
+    locator::tablet_task_info migration_task_info;
 
     tablet_info() = default;
-    tablet_info(tablet_replica_set, db_clock::time_point, tablet_task_info);
+    tablet_info(tablet_replica_set, db_clock::time_point, tablet_task_info, tablet_task_info);
     tablet_info(tablet_replica_set);
 
     bool operator==(const tablet_info&) const = default;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -147,6 +147,8 @@ enum class tablet_task_type {
     none,
     user_repair,
     auto_repair,
+    migration,
+    intranode_migration
 };
 
 sstring tablet_task_type_to_string(tablet_task_type);
@@ -163,6 +165,8 @@ struct tablet_task_info {
     bool is_user_repair_request() const;
     static tablet_task_info make_user_repair_request();
     static tablet_task_info make_auto_repair_request();
+    static tablet_task_info make_migration_request();
+    static tablet_task_info make_intranode_migration_request();
 };
 
 /// Stores information about a single tablet.

--- a/replica/tablet_mutation_builder.hh
+++ b/replica/tablet_mutation_builder.hh
@@ -44,6 +44,8 @@ public:
     tablet_mutation_builder& set_repair_time(dht::token last_token, db_clock::time_point repair_time);
     tablet_mutation_builder& set_repair_task_info(dht::token last_token, locator::tablet_task_info info);
     tablet_mutation_builder& del_repair_task_info(dht::token last_token);
+    tablet_mutation_builder& set_migration_task_info(dht::token last_token, locator::tablet_task_info info, const gms::feature_service& features);
+    tablet_mutation_builder& del_migration_task_info(dht::token last_token, const gms::feature_service& features);
 
     mutation build() {
         return std::move(_m);

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -17,6 +17,7 @@
 #include "cql3/query_processor.hh"
 #include "cql3/untyped_result_set.hh"
 #include "cql3/stats.hh"
+#include "gms/feature_service.hh"
 #include "replica/database.hh"
 #include "replica/tablets.hh"
 #include "replica/tablet_mutation_builder.hh"
@@ -73,6 +74,7 @@ schema_ptr make_tablets_schema() {
             .with_column("repair_time", timestamp_type)
             .with_column("repair_task_info", tablet_task_info_type)
             .with_column("repair_scheduler_config", repair_scheduler_config_type, column_kind::static_column)
+            .with_column("migration_task_info", tablet_task_info_type)
             .with_hash_version()
             .build();
 }
@@ -131,6 +133,7 @@ tablet_map_to_mutation(const tablet_map& tablets, table_id id, const sstring& ke
         auto last_token = tablets.get_last_token(tid);
         auto ck = clustering_key::from_single_value(*s, data_value(dht::token::to_int64(last_token)).serialize_nonnull());
         m.set_clustered_cell(ck, "replicas", make_list_value(replica_set_type, replicas_to_data_value(tablet.replicas)), ts);
+        m.set_clustered_cell(ck, "migration_task_info", tablet_task_info_to_data_value(tablet.migration_task_info), ts);
         if (auto tr_info = tablets.get_tablet_transition_info(tid)) {
             m.set_clustered_cell(ck, "stage", tablet_transition_stage_to_string(tr_info->stage), ts);
             m.set_clustered_cell(ck, "transition", tablet_transition_kind_to_string(tr_info->transition), ts);
@@ -225,6 +228,23 @@ tablet_mutation_builder&
 tablet_mutation_builder::del_repair_task_info(dht::token last_token) {
     auto col = _s->get_column_definition("repair_task_info");
     _m.set_clustered_cell(get_ck(last_token), *col, atomic_cell::make_dead(_ts, gc_clock::now()));
+    return *this;
+}
+
+tablet_mutation_builder&
+tablet_mutation_builder::set_migration_task_info(dht::token last_token, locator::tablet_task_info migration_task_info, const gms::feature_service& features) {
+    if (features.tablet_migration_virtual_task) {
+        _m.set_clustered_cell(get_ck(last_token), "migration_task_info", tablet_task_info_to_data_value(migration_task_info), _ts);
+    }
+    return *this;
+}
+
+tablet_mutation_builder&
+tablet_mutation_builder::del_migration_task_info(dht::token last_token, const gms::feature_service& features) {
+    if (features.tablet_migration_virtual_task) {
+        auto col = _s->get_column_definition("migration_task_info");
+        _m.set_clustered_cell(get_ck(last_token), *col, atomic_cell::make_dead(_ts, gc_clock::now()));
+    }
     return *this;
 }
 
@@ -447,6 +467,11 @@ tablet_id process_one_row(table_id table, tablet_map& map, tablet_id tid, const 
         repair_task_info = deserialize_tablet_task_info(row.get_view("repair_task_info"));
     }
 
+    locator::tablet_task_info migration_task_info;
+    if (row.has("migration_task_info")) {
+        migration_task_info = deserialize_tablet_task_info(row.get_view("migration_task_info"));
+    }
+
     if (row.has("stage")) {
         auto stage = tablet_transition_stage_from_string(row.get_as<sstring>("stage"));
         auto transition = tablet_transition_kind_from_string(row.get_as<sstring>("transition"));
@@ -468,7 +493,7 @@ tablet_id process_one_row(table_id table, tablet_map& map, tablet_id tid, const 
                 std::move(new_tablet_replicas), pending_replica, session_id});
     }
 
-    map.set_tablet(tid, tablet_info{std::move(tablet_replicas), repair_time, repair_task_info});
+    map.set_tablet(tid, tablet_info{std::move(tablet_replicas), repair_time, repair_task_info, migration_task_info});
 
     auto persisted_last_token = dht::token::from_int64(row.get_as<int64_t>("last_token"));
     auto current_last_token = map.get_last_token(tid);

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -134,6 +134,10 @@ tablet_map_to_mutation(const tablet_map& tablets, table_id id, const sstring& ke
         auto ck = clustering_key::from_single_value(*s, data_value(dht::token::to_int64(last_token)).serialize_nonnull());
         m.set_clustered_cell(ck, "replicas", make_list_value(replica_set_type, replicas_to_data_value(tablet.replicas)), ts);
         m.set_clustered_cell(ck, "migration_task_info", tablet_task_info_to_data_value(tablet.migration_task_info), ts);
+        m.set_clustered_cell(ck, "repair_task_info", tablet_task_info_to_data_value(tablet.repair_task_info), ts);
+        if (tablet.repair_time != db_clock::time_point{}) {
+            m.set_clustered_cell(ck, "repair_time", data_value(tablet.repair_time), ts);
+        }
         if (auto tr_info = tablets.get_tablet_transition_info(tid)) {
             m.set_clustered_cell(ck, "stage", tablet_transition_stage_to_string(tr_info->stage), ts);
             m.set_clustered_cell(ck, "transition", tablet_transition_kind_to_string(tr_info->transition), ts);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6188,7 +6188,7 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
         throw std::runtime_error("The TABLET_REPAIR_SCHEDULER feature is not enabled on the cluster yet");
     }
 
-    auto repair_task_info = locator::tablet_task_info::make_user_request();
+    auto repair_task_info = locator::tablet_task_info::make_user_repair_request();
     auto res = std::unordered_map<sstring, sstring>{{sstring("tablet_task_id"), repair_task_info.tablet_task_id.to_sstring()}};
 
     auto start = std::chrono::steady_clock::now();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6345,11 +6345,16 @@ future<> storage_service::move_tablet(table_id table, dht::token token, locator:
             }
         }
 
+        auto migration_task_info = src.host == dst.host ? locator::tablet_task_info::make_intranode_migration_request()
+            : locator::tablet_task_info::make_migration_request();
+        migration_task_info.sched_nr++;
+        migration_task_info.sched_time = db_clock::now();
         updates.emplace_back(replica::tablet_mutation_builder(write_timestamp, table)
             .set_new_replicas(last_token, locator::replace_replica(tinfo.replicas, src, dst))
             .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
             .set_transition(last_token, src.host == dst.host ? locator::tablet_transition_kind::intranode_migration
                                                              : locator::tablet_transition_kind::migration)
+            .set_migration_task_info(last_token, std::move(migration_task_info), _db.local().features())
             .build());
 
         sstring reason = format("Moving tablet {} from {} to {}", gid, src, dst);

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -845,7 +845,7 @@ public:
                 }
 
                 db_clock::duration diff;
-                auto is_user_reuqest = info.repair_task_info.is_user_request();
+                auto is_user_reuqest = info.repair_task_info.is_user_repair_request();
                 if (is_user_reuqest) {
                     // This means the user has issued a repair request manually. Select it for repair scheduling.
                 } else {

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -89,12 +89,12 @@ future<std::vector<tasks::task_stats>> tablet_virtual_task::get_stats() {
                 .task_id = task_id,
                 .type = locator::tablet_task_type_to_string(info.repair_task_info.request_type),
                 .kind = tasks::task_kind::cluster,
-                .scope = info.repair_task_info.is_user_request() ? "table" : "tablet",
+                .scope = info.repair_task_info.is_user_repair_request() ? "table" : "tablet",
                 .state = tasks::task_manager::task_state::running,
                 .keyspace = schema->ks_name(),
                 .table = schema->cf_name()
             };
-            if (info.repair_task_info.is_user_request()) {
+            if (info.repair_task_info.is_user_repair_request()) {
                 // User requested repair may encompass more that one tablet.
                 user_requests[task_id] = std::move(stats);
                 sched_num_sum[task_id] += info.repair_task_info.sched_nr;
@@ -133,7 +133,7 @@ future<std::optional<tasks::task_status>> tablet_virtual_task::get_status_helper
         if (info.repair_task_info.tablet_task_id.uuid() == id.uuid()) {
             sched_nr += info.repair_task_info.sched_nr;
             res.type = locator::tablet_task_type_to_string(info.repair_task_info.request_type);
-            res.scope = info.repair_task_info.is_user_request() ? "table" : "tablet";
+            res.scope = info.repair_task_info.is_user_repair_request() ? "table" : "tablet";
             res.start_time = info.repair_task_info.request_time;
             tablets.push_back(tid);
         }

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -81,30 +81,38 @@ future<tasks::is_abortable> tablet_virtual_task::is_abortable(tasks::virtual_tas
 
 future<std::optional<tasks::task_status>> tablet_virtual_task::get_status(tasks::task_id id, tasks::virtual_task_hint hint) {
     utils::chunked_vector<locator::tablet_id> tablets;
-    co_return co_await get_status_helper(id, tablets, std::move(hint));
+    std::optional<locator::tablet_replica> pending_replica;
+    co_return co_await get_status_helper(id, tablets, std::move(hint), pending_replica);
 }
 
 future<std::optional<tasks::task_status>> tablet_virtual_task::wait(tasks::task_id id, tasks::virtual_task_hint hint) {
     auto table = hint.get_table_id();
     auto task_type = hint.get_task_type();
-    if (!is_repair_task(task_type)) {
-        co_return std::nullopt;
-    }
+    auto tablet_id_opt = tablet_id_provided(task_type) ? std::make_optional(hint.get_tablet_id()) : std::nullopt;
 
     utils::chunked_vector<locator::tablet_id> tablets;
-    auto status = co_await get_status_helper(id, tablets, std::move(hint));
+    std::optional<locator::tablet_replica> pending_replica;
+    auto status = co_await get_status_helper(id, tablets, std::move(hint), pending_replica);
     if (!status) {
         co_return std::nullopt;
     }
 
     co_await _ss._topology_state_machine.event.wait([&] {
         auto& tmap = _ss.get_token_metadata().tablets().get_tablet_map(table);
+        if (tablet_id_opt.has_value()) {
+            return tmap.get_tablet_info(tablet_id_opt.value()).migration_task_info.tablet_task_id.uuid() != id.uuid();
+        }
         return std::all_of(tablets.begin(), tablets.end(), [&] (const locator::tablet_id& tablet) {
             return tmap.get_tablet_info(tablet).repair_task_info.tablet_task_id.uuid() != id.uuid();
         });
     });
 
     status->state = tasks::task_manager::task_state::done; // Failed repair task is retried.
+    if (!is_repair_task(task_type)) {
+        auto& replicas = _ss.get_token_metadata().tablets().get_tablet_map(table).get_tablet_info(tablet_id_opt.value()).replicas;
+        auto migration_failed = std::all_of(replicas.begin(), replicas.end(), [&] (const auto& replica) { return pending_replica.has_value() && replica != pending_replica.value(); });
+        status->state = migration_failed ? tasks::task_manager::task_state::failed : tasks::task_manager::task_state::done;
+    }
     status->end_time = db_clock::now(); // FIXME: Get precise end time.
     co_return status;
 }
@@ -167,7 +175,7 @@ static void update_status(const locator::tablet_task_info& task_info, tasks::tas
     status.start_time = task_info.request_time;
 }
 
-future<std::optional<tasks::task_status>> tablet_virtual_task::get_status_helper(tasks::task_id id, utils::chunked_vector<locator::tablet_id>& tablets, tasks::virtual_task_hint hint) {
+future<std::optional<tasks::task_status>> tablet_virtual_task::get_status_helper(tasks::task_id id, utils::chunked_vector<locator::tablet_id>& tablets, tasks::virtual_task_hint hint, std::optional<locator::tablet_replica>& pending_replica) {
     auto table = hint.get_table_id();
     auto task_type = hint.get_task_type();
     auto schema = _ss._db.local().get_tables_metadata().get_table(table).schema();
@@ -191,6 +199,7 @@ future<std::optional<tasks::task_status>> tablet_virtual_task::get_status_helper
         });
     } else {    // Migration task.
         auto tablet_id = hint.get_tablet_id();
+        pending_replica = tmap.get_tablet_transition_info(tablet_id)->pending_replica;
         auto& task_info = tmap.get_tablet_info(tablet_id).migration_task_info;
         if (task_info.tablet_task_id.uuid() == id.uuid()) {
             update_status(task_info, res, sched_nr);

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -94,6 +94,7 @@ future<std::optional<tasks::task_status>> tablet_virtual_task::wait(tasks::task_
         co_return std::nullopt;
     }
 
+    tasks::tmlogger.info("tablet_virtual_task: wait until tablet operation is finished");
     co_await _ss._topology_state_machine.event.wait([&] {
         auto& tmap = _ss.get_token_metadata().tablets().get_tablet_map(table);
         if (tablet_id_opt.has_value()) {

--- a/service/task_manager_module.hh
+++ b/service/task_manager_module.hh
@@ -14,6 +14,7 @@
 namespace locator {
 class tablet_id;
 enum class tablet_task_type;
+class tablet_replica;
 }
 
 namespace service {
@@ -41,7 +42,7 @@ public:
     virtual future<std::vector<tasks::task_stats>> get_stats() override;
 private:
     std::vector<table_id> get_table_ids() const;
-    future<std::optional<tasks::task_status>> get_status_helper(tasks::task_id id, utils::chunked_vector<locator::tablet_id>& tablets, tasks::virtual_task_hint hint);
+    future<std::optional<tasks::task_status>> get_status_helper(tasks::task_id id, utils::chunked_vector<locator::tablet_id>& tablets, tasks::virtual_task_hint hint, std::optional<locator::tablet_replica>& pending_replica);
 };
 
 class task_manager_module : public tasks::task_manager::module {

--- a/service/task_manager_module.hh
+++ b/service/task_manager_module.hh
@@ -13,6 +13,7 @@
 
 namespace locator {
 class tablet_id;
+enum class tablet_task_type;
 }
 
 namespace service {

--- a/service/task_manager_module.hh
+++ b/service/task_manager_module.hh
@@ -42,7 +42,6 @@ public:
 private:
     std::vector<table_id> get_table_ids() const;
     future<std::optional<tasks::task_status>> get_status_helper(tasks::task_id id, utils::chunked_vector<locator::tablet_id>& tablets, tasks::virtual_task_hint hint);
-    table_id get_table_id(const tasks::virtual_task_hint& hint) const;
 };
 
 class task_manager_module : public tasks::task_manager::module {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1249,8 +1249,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
         }
         auto& info = tmap.get_tablet_info(gid.tablet);
         auto repair_task_info = info.repair_task_info;
-        if (!repair_task_info.is_user_request()) {
-            repair_task_info = locator::tablet_task_info::make_auto_request();
+        if (!repair_task_info.is_user_repair_request()) {
+            repair_task_info = locator::tablet_task_info::make_auto_repair_request();
         }
         repair_task_info.sched_nr++;
         repair_task_info.sched_time = db_clock::now();

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -809,4 +809,11 @@ locator::tablet_id virtual_task_hint::get_tablet_id() const {
     return tablet_id.value();
 }
 
+::table_id virtual_task_hint::get_table_id() const {
+    if (!table_id.has_value()) {
+        on_internal_error(tasks::tmlogger, "tablet_virtual_task hint does not contain table_id");
+    }
+    return table_id.value();
+}
+
 }

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -795,4 +795,18 @@ future<> task_manager::uninit_ms_handlers() {
     return make_ready_future();
 }
 
+locator::tablet_task_type virtual_task_hint::get_task_type() const {
+    if (!task_type.has_value()) {
+        on_internal_error(tmlogger, "tablet_virtual_task hint does not contain task type");
+    }
+    return task_type.value();
+}
+
+locator::tablet_id virtual_task_hint::get_tablet_id() const {
+    if (!tablet_id.has_value()) {
+        on_internal_error(tmlogger, "tablet_virtual_task hint does not contain tablet_id");
+    }
+    return tablet_id.value();
+}
+
 }

--- a/tasks/virtual_task_hint.hh
+++ b/tasks/virtual_task_hint.hh
@@ -8,12 +8,18 @@
 
 #pragma once
 
+#include "locator/tablets.hh"
 #include "schema/schema_fwd.hh"
 namespace tasks {
 
 struct virtual_task_hint {
     // Contains hints for all virtual tasks types.
     std::optional<table_id> table_id;
+    std::optional<locator::tablet_task_type> task_type;
+    std::optional<locator::tablet_id> tablet_id;
+
+    locator::tablet_task_type get_task_type() const;
+    locator::tablet_id get_tablet_id() const;
 };
 
 }

--- a/tasks/virtual_task_hint.hh
+++ b/tasks/virtual_task_hint.hh
@@ -20,6 +20,7 @@ struct virtual_task_hint {
 
     locator::tablet_task_type get_task_type() const;
     locator::tablet_id get_tablet_id() const;
+    ::table_id get_table_id() const;
 };
 
 }

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -126,7 +126,10 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                         tablet_replica {h1, 0},
                         tablet_replica {h2, 3},
                         tablet_replica {h3, 1},
-                    }
+                    },
+                    db_clock::now(),
+                    locator::tablet_task_info::make_auto_repair_request(),
+                    locator::tablet_task_info::make_intranode_migration_request()
                 });
                 tm.set_tablet_map(table1, std::move(tmap));
             }
@@ -140,7 +143,10 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                 tmap.set_tablet(tb, tablet_info {
                     tablet_replica_set {
                         tablet_replica {h1, 0},
-                    }
+                    },
+                    {},
+                    {},
+                    locator::tablet_task_info::make_migration_request()
                 });
                 tb = *tmap.next_tablet(tb);
                 tmap.set_tablet(tb, tablet_info {
@@ -152,7 +158,10 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                 tmap.set_tablet(tb, tablet_info {
                     tablet_replica_set {
                         tablet_replica {h2, 2},
-                    }
+                    },
+                    {},
+                    {},
+                    locator::tablet_task_info::make_migration_request()
                 });
                 tb = *tmap.next_tablet(tb);
                 tmap.set_tablet(tb, tablet_info {


### PR DESCRIPTION
In this change, tablet_virtual_task starts supporting tablet
migration, in addition to tablet repair. Both tablet operations 
reuse the same virtual_task because their task data is retrieved
similarly. However, it changes nothing from the task manager 
API users' perspective. They can list running migrations or check 
their statuses all the same as if migration had its own virtual_task. 

Users can see running migration tasks - finished tasks are not 
presented with the task manager API. However, the result 
of the migration (whether it succeeded or failed) would be
presented to users, if they use wait API.

If a migration was reverted, it will appear to users as failed.
We assume that the migration was reverted, when its destination
does not contain a tablet replica.

Fixes: https://github.com/scylladb/scylladb/issues/21365.

No backport, new feature