### PR TITLE
abstract_replication_strategy.hh: apply pimpl to boost::icl::interval_map

### DIFF
--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -18,7 +18,43 @@
 #include "replica/database.hh"
 #include "utils/stall_free.hh"
 
+#include <boost/icl/interval.hpp>
+#include <boost/icl/interval_map.hpp>
+
 namespace locator {
+
+using ring_mapping_underlying_type = boost::icl::interval_map<token, std::unordered_set<locator::host_id>>;
+
+struct ring_mapping_impl {
+     ring_mapping_underlying_type map;
+};
+
+ring_mapping::ring_mapping()
+    : _impl(std::make_unique<ring_mapping_impl>()) {
+}
+
+ring_mapping::ring_mapping(ring_mapping&&) noexcept = default;
+
+ring_mapping&
+ring_mapping::operator=(ring_mapping&&) noexcept = default;
+
+ring_mapping::~ring_mapping() = default;
+
+auto* ring_mapping::operator->() {
+    return &_impl->map;
+}
+
+auto* ring_mapping::operator->() const {
+    return &std::as_const(_impl->map);
+}
+
+auto& ring_mapping::operator*() {
+    return _impl->map;
+}
+
+auto& ring_mapping::operator*() const {
+    return std::as_const(_impl->map);
+}
 
 template <typename ResultSet, typename SourceSet>
 static ResultSet resolve_endpoints(const SourceSet& host_ids, const token_metadata& tm) {
@@ -116,12 +152,12 @@ void maybe_remove_node_being_replaced(const token_metadata& tm,
 }
 
 static const std::unordered_set<locator::host_id>* find_token(const ring_mapping& ring_mapping, const token& token) {
-    if (ring_mapping.empty()) {
+    if (ring_mapping->empty()) {
         return nullptr;
     }
     const auto interval = token_metadata::range_to_interval(wrapping_interval<dht::token>(token));
-    const auto it = ring_mapping.find(interval);
-    return it != ring_mapping.end() ? &it->second : nullptr;
+    const auto it = ring_mapping->find(interval);
+    return it != ring_mapping->end() ? &it->second : nullptr;
 }
 
 inet_address_vector_topology_change vnode_effective_replication_map::get_pending_endpoints(const token& search_token) const {
@@ -147,7 +183,7 @@ std::optional<tablet_routing_info> vnode_effective_replication_map::check_locali
 }
 
 bool vnode_effective_replication_map::has_pending_ranges(locator::host_id endpoint) const {
-    for (const auto& item : _pending_endpoints) {
+    for (const auto& item : *_pending_endpoints) {
         const auto& nodes = item.second;
         if (nodes.contains(endpoint)) {
             return true;
@@ -158,7 +194,7 @@ bool vnode_effective_replication_map::has_pending_ranges(locator::host_id endpoi
 
 std::unordered_set<locator::host_id> vnode_effective_replication_map::get_all_pending_nodes() const {
     std::unordered_set<locator::host_id> endpoints;
-    for (const auto& item : _pending_endpoints) {
+    for (const auto& item : *_pending_endpoints) {
         endpoints.insert(item.second.begin(), item.second.end());
     }
 
@@ -407,20 +443,20 @@ future<mutable_vnode_effective_replication_map_ptr> calculate_effective_replicat
             auto target_endpoints = co_await rs->calculate_natural_endpoints(token, *topology_changes->target_token_metadata);
 
             auto add_mapping = [&](ring_mapping& target, std::unordered_set<locator::host_id>&& endpoints) {
-                using interval = ring_mapping::interval_type;
+                using interval = ring_mapping_underlying_type::interval_type;
                 if (!depend_on_token) {
-                    target += std::make_pair(
+                    *target += std::make_pair(
                         interval::open(dht::minimum_token(), dht::maximum_token()),
                         std::move(endpoints));
                 } else if (i == 0) {
-                    target += std::make_pair(
+                    *target += std::make_pair(
                         interval::open(all_tokens.back(), dht::maximum_token()),
                         endpoints);
-                    target += std::make_pair(
+                    *target += std::make_pair(
                         interval::left_open(dht::minimum_token(), token),
                         std::move(endpoints));
                 } else {
-                    target += std::make_pair(
+                    *target += std::make_pair(
                         interval::left_open(all_tokens[i - 1], token),
                         std::move(endpoints));
                 }
@@ -482,13 +518,13 @@ auto vnode_effective_replication_map::clone_data_gently() const -> future<std::u
         co_await coroutine::maybe_yield();
     }
 
-    for (const auto& i : _pending_endpoints) {
-        result->pending_endpoints += i;
+    for (const auto& i : *_pending_endpoints) {
+        *result->pending_endpoints += i;
         co_await coroutine::maybe_yield();
     }
 
-    for (const auto& i : _read_endpoints) {
-        result->read_endpoints += i;
+    for (const auto& i : *_read_endpoints) {
+        *result->read_endpoints += i;
         co_await coroutine::maybe_yield();
     }
 
@@ -536,8 +572,8 @@ vnode_effective_replication_map::~vnode_effective_replication_map() {
         _factory->erase_effective_replication_map(this);
         try {
             _factory->submit_background_work(clear_gently(std::move(_replication_map),
-                std::move(_pending_endpoints),
-                std::move(_read_endpoints),
+                std::move(*_pending_endpoints),
+                std::move(*_read_endpoints),
                 std::move(_tmptr)));
         } catch (...) {
             // ignore

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -11,8 +11,6 @@
 #include <memory>
 #include <functional>
 #include <unordered_map>
-#include <boost/icl/interval.hpp>
-#include <boost/icl/interval_map.hpp>
 #include "gms/inet_address.hh"
 #include "locator/snitch_base.hh"
 #include "locator/token_range_splitter.hh"
@@ -170,7 +168,22 @@ public:
     future<dht::token_range_vector> get_pending_address_ranges(const token_metadata_ptr tmptr, std::unordered_set<token> pending_tokens, locator::host_id pending_address, locator::endpoint_dc_rack dr) const;
 };
 
-using ring_mapping = boost::icl::interval_map<token, std::unordered_set<locator::host_id>>;
+struct ring_mapping_impl;
+
+class ring_mapping {
+    std::unique_ptr<ring_mapping_impl> _impl;
+public:
+    ring_mapping();
+    ring_mapping(ring_mapping&&) noexcept;
+    ring_mapping& operator=(ring_mapping&&) noexcept;
+    ~ring_mapping();
+    // Return auto since we don't want to expose the wrapped type, it's a complicated boost type
+    auto* operator->() const;
+    auto* operator->();
+    auto& operator*() const;
+    auto& operator*();
+};
+
 using replication_strategy_ptr = seastar::shared_ptr<const abstract_replication_strategy>;
 using mutable_replication_strategy_ptr = seastar::shared_ptr<abstract_replication_strategy>;
 


### PR DESCRIPTION
interval_map is a heavyweight header, hide it behind the pimpl idiom to reduce #include load.

Ref #1

Build time improvement, no need to backport.