### PR TITLE
scylla-sstable: dump-summary: print also first and last tokens

### DIFF
--- a/mutation/json.hh
+++ b/mutation/json.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "dht/decorated_key.hh"
 #include "dht/token.hh"
 #include "schema/schema.hh"
 #include "utils/rjson.hh"
@@ -48,6 +49,9 @@ public:
         Key("value");
         AsString(key.with_schema(schema));
         EndObject();
+    }
+    void DataKey(const schema& schema, const dht::decorated_key& dk) {
+        DataKey(schema, dk.key(), dk.token());
     }
     void StartStream() {
         StartObject();

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1170,11 +1170,11 @@ void dump_summary_operation(schema_ptr schema, reader_permit permit, const std::
         }
         writer.EndArray();
 
-        auto first_key = sstables::key_view(summary.first_key.value).to_partition_key(*schema);
+        auto first_key = dht::decorate_key(*schema, sstables::key_view(summary.first_key.value).to_partition_key(*schema));
         writer.Key("first_key");
         writer.DataKey(*schema, first_key);
 
-        auto last_key = sstables::key_view(summary.last_key.value).to_partition_key(*schema);
+        auto last_key = dht::decorate_key(*schema, sstables::key_view(summary.last_key.value).to_partition_key(*schema));
         writer.Key("last_key");
         writer.DataKey(*schema, last_key);
 


### PR DESCRIPTION
To help scylla-manager restore to map sstables to
nodes or tablets, print also the tokens of the
sstable first and last keys.

For example, the json output will now look like this:
```
$ build/dev/scylla sstable dump-summary /tmp/scylla-344593/data/ks/t-52a92590afd011ef9b68ba86378ed63b/me-3glp_0tm9_00uv52doobo0bvk2t7-big-Data.db | jq
{
  "sstables": {
    "/tmp/scylla-344593/data/ks/t-52a92590afd011ef9b68ba86378ed63b/me-3glp_0tm9_00uv52doobo0bvk2t7-big-Data.db": {
      "header": {
        "min_index_interval": 128,
        "size": 1,
        "memory_size": 16,
        "sampling_level": 128,
        "size_at_full_sampling": 0
      },
      "positions": [
        4
      ],
      "entries": [
        {
          "key": {
            "token": "2008715943680221220",
            "raw": "000400000064",
            "value": "100"
          },
          "position": 0
        }
      ],
      "first_key": {
        "token": "2008715943680221220",
        "raw": "000400000064",
        "value": "100"
      },
      "last_key": {
        "token": "9010454139840013625",
        "raw": "000400000003",
        "value": "3"
      }
    }
  }
}
```

* New feature.  No backport required