### PR TITLE
counters.hh: drop unused boost includes

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -25,6 +25,7 @@
 #include "unimplemented.hh"
 
 #include <boost/range/algorithm/copy.hpp>
+#include <boost/range/numeric.hpp>
 
 extern logging::logger apilog;
 

--- a/collection_mutation.cc
+++ b/collection_mutation.cc
@@ -16,6 +16,8 @@
 
 #include "collection_mutation.hh"
 
+#include <boost/range/numeric.hpp>
+
 bytes_view collection_mutation_input_stream::read_linearized(size_t n) {
     managed_bytes_view mbv = ::read_simple_bytes(_src, n);
     if (mbv.is_linearized()) {

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -18,6 +18,7 @@
 
 #include <boost/range/algorithm.hpp>
 #include <boost/range/join.hpp>
+#include <boost/range/numeric.hpp>
 #include <boost/algorithm/string/join.hpp>
 
 #include <seastar/core/future-util.hh>

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -22,6 +22,7 @@
 #include "cql3/statements/property_definitions.hh"
 #include "schema/schema.hh"
 #include <boost/range/algorithm/find.hpp>
+#include <boost/range/numeric.hpp>
 #include "size_tiered_compaction_strategy.hh"
 #include "leveled_compaction_strategy.hh"
 #include "time_window_compaction_strategy.hh"

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -7,6 +7,7 @@
  */
 
 #include <boost/range/algorithm/min_element.hpp>
+#include <boost/range/numeric.hpp>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -16,6 +16,7 @@
 #include <boost/range/algorithm/find.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/algorithm/min_element.hpp>
+#include <boost/range/numeric.hpp>
 
 #include <ranges>
 

--- a/counters.hh
+++ b/counters.hh
@@ -9,8 +9,6 @@
 #pragma once
 
 #include "utils/assert.hh"
-#include <boost/range/iterator_range.hpp>
-#include <boost/range/numeric.hpp>
 
 #include "mutation/atomic_cell.hh"
 #include "types/types.hh"

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -13,6 +13,7 @@
 #include "utils/log.hh"
 #include <boost/range/algorithm/for_each.hpp>
 #include <boost/range/adaptor/map.hpp>
+#include <boost/range/numeric.hpp>
 #include "utils/disk-error-handler.hh"
 #include "seastarx.hh"
 #include <seastar/core/sleep.hh>

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 
 #include <boost/algorithm/string/join.hpp>
+#include <boost/range/numeric.hpp>
 
 #include <fmt/ranges.h>
 

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -11,6 +11,7 @@
 #include "gms/inet_address.hh"
 #include <seastar/util/defer.hh>
 #include <boost/range/adaptor/map.hpp>
+#include <boost/range/numeric.hpp>
 #include "replica/database.hh"
 #include "view_update_generator.hh"
 #include "utils/error_injection.hh"

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -30,6 +30,7 @@
 #include <boost/range/algorithm.hpp>
 #include <boost/range/algorithm_ext.hpp>
 #include <boost/range/adaptor/map.hpp>
+#include <boost/range/numeric.hpp>
 
 #include <fmt/ranges.h>
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -53,6 +53,7 @@
 
 #include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/algorithm.hpp>
+#include <boost/range/numeric.hpp>
 #include "utils/error_injection.hh"
 #include "readers/reversing_v2.hh"
 #include "readers/empty_v2.hh"

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -15,6 +15,7 @@
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/algorithm/copy.hpp>
+#include <boost/range/numeric.hpp>
 
 #include "sstables.hh"
 

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -10,6 +10,7 @@
 
 #include <seastar/core/iostream.hh>
 #include <seastar/core/fstream.hh>
+#include <boost/range/numeric.hpp>
 #include "sstables/types.hh"
 #include "checksum_utils.hh"
 #include "vint-serialization.hh"

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -9,6 +9,7 @@
 #include <set>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/adaptor/sliced.hpp>
+#include <boost/range/numeric.hpp>
 #include <boost/test/unit_test.hpp>
 #include <fmt/ranges.h>
 #include "partition_slice_builder.hh"

--- a/test/lib/sstable_run_based_compaction_strategy_for_tests.cc
+++ b/test/lib/sstable_run_based_compaction_strategy_for_tests.cc
@@ -8,6 +8,7 @@
 
 
 #include "test/lib/sstable_run_based_compaction_strategy_for_tests.hh"
+#include <boost/range/numeric.hpp>
 
 namespace sstables {
 

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -15,6 +15,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/range/irange.hpp>
 #include <boost/range/algorithm_ext.hpp>
+#include <boost/range/numeric.hpp>
 #include <json/json.h>
 #include <fmt/ranges.h>
 #include "test/lib/cql_test_env.hh"


### PR DESCRIPTION
Re-add them to source files that need them.

Code cleanup; no need to backport.