### PR TITLE
.github: Ensure header generation before include analysis 

### DIFF
--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -45,6 +45,10 @@ jobs:
             -G Ninja                                    \
             -B $BUILD_DIR                               \
             -S .
+      - run: |
+          cmake                       \
+          --build $BUILD_DIR          \
+          --target wasmtime_bindings
       - name: Build headers
         run: |
           swagger_targets=''


### PR DESCRIPTION
When running clang-include-cleaner, the tool performs static analysis by
"compiling" specified source files. Previously, non-existent included headers
caused the tool to skip source files, reducing the effectiveness of unused
include detection.

Problem:
- Header files like 'rust/wasmtime_bindings.hh' were not pre-generated
- Compilation errors led to skipping source file analysis

  ```
  /__w/scylladb/scylladb/lang/wasm.hh:15:10: fatal error: 'rust/wasmtime_bindings.hh' file not found
     15 | #include "rust/wasmtime_bindings.hh"
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
  Skipping file /__w/scylladb/scylladb/lang/wasm.hh due to compiler errors. clang-include-cleaner expects to work on compilable source code.
  1 error generated.
```

- This significantly reduced clang-include-cleaner's coverage

Solution:
- Build the `wasmtime_bindings` target to generate required header files
- Ensure all necessary headers are created before running static analysis
- Enable full source file checking for unused includes

By generating headers before analysis, we prevent skipping of source files
and improve the comprehensiveness of our include cleaner workflow.

---

this is a improvement in the workflow running a static analysis, hence no need to backport.