### PR TITLE
mutation: remove unused "#include"s

### DIFF
--- a/mutation/frozen_mutation.hh
+++ b/mutation/frozen_mutation.hh
@@ -17,8 +17,6 @@
 #include "range_tombstone_change_generator.hh"
 #include "schema/schema.hh"
 
-#include <span>
-
 class mutation;
 class mutation_reader;
 


### PR DESCRIPTION
This commit follows up on commit f436edfa22, which initially cleaned up unused #include directives in the "mutation" subdirectory. This change removes additional unused header files that were missed in the previous cleanup.

---

it's a cleanup, hence no need to backport.