### PR TITLE
Revert "test.py: Make it test/cqlpy python module"

### DIFF
--- a/test/cqlpy/cassandra_tests/batch_test.py
+++ b/test/cqlpy/cassandra_tests/batch_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .porting import *
+from cassandra_tests.porting import *
 
 from cassandra.query import BatchStatement, BatchType
 from cassandra.protocol import InvalidRequest

--- a/test/cqlpy/cassandra_tests/distinct_query_paging_test.py
+++ b/test/cqlpy/cassandra_tests/distinct_query_paging_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .porting import *
+from cassandra_tests.porting import *
 
 from cassandra.query import BatchStatement, BatchType
 from cassandra.protocol import InvalidRequest

--- a/test/cqlpy/cassandra_tests/functions/cast_fcts_test.py
+++ b/test/cqlpy/cassandra_tests/functions/cast_fcts_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...cassandra_tests.porting import *
+from cassandra_tests.porting import *
 from decimal import Decimal
 from ctypes import c_float
 from datetime import datetime, timezone

--- a/test/cqlpy/cassandra_tests/functions/operation_fcts_test.py
+++ b/test/cqlpy/cassandra_tests/functions/operation_fcts_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...cassandra_tests.porting import *
+from cassandra_tests.porting import *
 
 from decimal import Decimal
 from ctypes import c_float

--- a/test/cqlpy/cassandra_tests/porting.py
+++ b/test/cqlpy/cassandra_tests/porting.py
@@ -13,14 +13,14 @@ import re
 import collections
 import struct
 import time
-from ..util import unique_name
+from util import unique_name
 from contextlib import contextmanager
 from cassandra.protocol import SyntaxException, InvalidRequest
 from cassandra.protocol import ConfigurationException
 from cassandra.util import SortedSet, OrderedMapSerializedKey
 from cassandra.query import UNSET_VALUE
 
-from .. import nodetool
+import nodetool
 
 # A utility function for creating a new temporary table with a given schema.
 # Because Scylla becomes slower when a huge number of uniquely-named tables

--- a/test/cqlpy/cassandra_tests/validation/entities/collections_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/collections_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import  *
+from cassandra_tests.porting import *
 from cassandra.query import UNSET_VALUE
 
 from uuid import UUID

--- a/test/cqlpy/cassandra_tests/validation/entities/counters_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/counters_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import  *
+from cassandra_tests.porting import *
 
 from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException
 from cassandra.query import UNSET_VALUE

--- a/test/cqlpy/cassandra_tests/validation/entities/date_type_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/date_type_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import create_table, execute, assert_invalid
+from cassandra_tests.porting import create_table, execute, assert_invalid
 
 # Check dates are correctly recognized and validated,
 # migrated from cql_tests.py:TestCQL.date_test()

--- a/test/cqlpy/cassandra_tests/validation/entities/frozen_collections_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/frozen_collections_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException
 from cassandra.util import OrderedMap

--- a/test/cqlpy/cassandra_tests/validation/entities/json_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/json_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 from cassandra.protocol import FunctionFailure
 from cassandra.util import Date, Time, Duration

--- a/test/cqlpy/cassandra_tests/validation/entities/secondary_index_on_map_entries_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/secondary_index_on_map_entries_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 def assertIndexInvalidForColumn(cql, table, colname):
     assert_invalid(cql, table, f"CREATE INDEX ON %s(ENTRIES({colname}))")

--- a/test/cqlpy/cassandra_tests/validation/entities/secondary_index_on_static_column_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/secondary_index_on_static_column_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 
 def testSimpleStaticColumn(cql, test_keyspace):

--- a/test/cqlpy/cassandra_tests/validation/entities/secondary_index_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/secondary_index_test.py
@@ -40,7 +40,7 @@
 # * testCanQuerySecondaryIndex
 # * testDroppingIndexInvalidatesPreparedStatements
 
-from ...porting import *
+from cassandra_tests.porting import *
 from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException
 from uuid import UUID
 

--- a/test/cqlpy/cassandra_tests/validation/entities/static_columns_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/static_columns_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 #Migrated from cql_tests.py:TestCQL.static_columns_test()
 def testStaticColumns(cql, test_keyspace):

--- a/test/cqlpy/cassandra_tests/validation/entities/timestamp_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/timestamp_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 import time
 from cassandra.query import UNSET_VALUE

--- a/test/cqlpy/cassandra_tests/validation/entities/timeuuid_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/timeuuid_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 from cassandra.protocol import SyntaxException
 from cassandra.util import datetime_from_uuid1

--- a/test/cqlpy/cassandra_tests/validation/entities/tuple_type_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/tuple_type_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 from cassandra.query import UNSET_VALUE
 from datetime import datetime
 

--- a/test/cqlpy/cassandra_tests/validation/entities/type_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/type_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 def testNonExistingOnes(cql, test_keyspace):
     # The Scylla and Cassandra error messages are slightly different, but both

--- a/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
@@ -7,10 +7,10 @@
 
 import datetime
 import uuid
-from ...porting import *
+from cassandra_tests.porting import *
 
 from cassandra.util import Date
-from ....util import new_function, unique_name, new_secondary_index
+from util import new_function, unique_name, new_secondary_index
 import os
 
 def is_scylla(cql, test_keyspace):

--- a/test/cqlpy/cassandra_tests/validation/entities/user_types_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/user_types_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 from cassandra.query import UNSET_VALUE
 from uuid import UUID
 

--- a/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
@@ -19,7 +19,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 def testDropColumnAsPreparedStatement(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(key int PRIMARY KEY, value int)") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/batch_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/batch_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 from cassandra.query import UNSET_VALUE
 
 # Test batch statements

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 from uuid import UUID
 from cassandra.query import UNSET_VALUE
 from cassandra.util import Duration

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_table_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_table_test.py
@@ -19,7 +19,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 # ALTER ... DROP COMPACT STORAGE was recently dropped (unless a special
 # flag is used) by Cassandra, and it was never implemented in Scylla, so

--- a/test/cqlpy/cassandra_tests/validation/operations/create_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/create_test.py
@@ -19,7 +19,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...porting import *
+from cassandra_tests.porting import *
 from cassandra.util import Duration
 from cassandra.protocol import SyntaxException, InvalidRequest, ConfigurationException
 from uuid import UUID

--- a/test/cqlpy/cassandra_tests/validation/operations/delete_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/delete_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 import random
 
 # Test for cassandra 8558

--- a/test/cqlpy/cassandra_tests/validation/operations/drop_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/drop_test.py
@@ -19,7 +19,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 def testNonExistingOnes(cql, test_keyspace):
     # The specific error message that Scylla and Cassandra print in these

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_test.py
@@ -19,7 +19,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 def testInsertWithUnset(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, s text, i int)") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_collections_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_collections_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 import random
 
 # InsertUpdateIfConditionCollectionsTest class has been split into multiple ones because of timeout issues (CASSANDRA-16670)

--- a/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_statics_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/insert_update_if_condition_statics_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 # InsertUpdateIfConditionCollectionsTest class has been split into multiple ones because of timeout issues (CASSANDRA-16670)
 # Any changes here check if they apply to the other classes

--- a/test/cqlpy/cassandra_tests/validation/operations/select_group_by_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_group_by_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 @pytest.mark.xfail(reason="Issue #2060, #13109")
 def testGroupByWithoutPaging(cql, test_keyspace):

--- a/test/cqlpy/cassandra_tests/validation/operations/select_limit_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_limit_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 # Test limit queries on a sparse table,
 # migrated from cql_tests.py:TestCQL.limit_sparse_test()

--- a/test/cqlpy/cassandra_tests/validation/operations/select_multi_column_relation_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_multi_column_relation_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 TOO_BIG = bytearray([1])*1024*65
 REQUIRES_ALLOW_FILTERING_MESSAGE = "Cannot execute this query as it might involve data filtering and thus may have unpredictable performance. If you want to execute this query despite the performance unpredictability, use ALLOW FILTERING"

--- a/test/cqlpy/cassandra_tests/validation/operations/select_order_by_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_order_by_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 def testSelectOrderBy(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, PRIMARY KEY (a, b))") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/select_single_column_relation_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_single_column_relation_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 from cassandra.query import UNSET_VALUE
 
 def testInvalidCollectionEqualityRelation(cql, test_keyspace):

--- a/test/cqlpy/cassandra_tests/validation/operations/select_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 from uuid import UUID
 from cassandra.query import UNSET_VALUE
 from cassandra.util import Duration

--- a/test/cqlpy/cassandra_tests/validation/operations/truncate_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/truncate_test.py
@@ -19,7 +19,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 def testTruncate(cql, test_keyspace):
     for arg in ["", "TABLE"]:

--- a/test/cqlpy/cassandra_tests/validation/operations/tuples_with_nulls_comparison_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/tuples_with_nulls_comparison_test.py
@@ -19,7 +19,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 def testAddUDTField(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(foo text)") as typename:

--- a/test/cqlpy/cassandra_tests/validation/operations/update_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/update_test.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ...porting import *
+from cassandra_tests.porting import *
 import re
 
 def testTypeCasts(cql, test_keyspace):

--- a/test/cqlpy/cassandra_tests/validation/operations/use_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/use_test.py
@@ -19,7 +19,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...porting import *
+from cassandra_tests.porting import *
 
 def testUseStatementWithBindVariable(cql, test_keyspace):
     assert_invalid_syntax_message(cql, test_keyspace, "Bind variables cannot be used for keyspace names", "USE ?")

--- a/test/cqlpy/conftest.py
+++ b/test/cqlpy/conftest.py
@@ -21,7 +21,9 @@ import tempfile
 import time
 import random
 
-from .util import unique_name, new_test_keyspace, keyspace_has_tablets, cql_session, local_process_id, is_scylla
+import sys
+sys.path.insert(1, sys.path[0] + '/../..')
+from util import unique_name, new_test_keyspace, keyspace_has_tablets, cql_session, local_process_id, is_scylla
 
 
 print(f"Driver name {DRIVER_NAME}, version {DRIVER_VERSION}")

--- a/test/cqlpy/rest_api.py
+++ b/test/cqlpy/rest_api.py
@@ -7,7 +7,7 @@
 # Some metrics cannot be obtained by nodetool, but they are available by API.
 
 import requests
-from . import nodetool
+import nodetool
 import pytest
 from contextlib import contextmanager
 

--- a/test/cqlpy/test_aggregate.py
+++ b/test/cqlpy/test_aggregate.py
@@ -9,10 +9,10 @@
 import pytest
 import math
 from decimal import Decimal
-from .util import new_test_table, unique_key_int, project, new_type
+from util import new_test_table, unique_key_int, project, new_type
 from cassandra.util import Date
 from cassandra.protocol import SyntaxException
-from .cassandra_tests.porting import assert_invalid_message
+from cassandra_tests.porting import assert_invalid_message
 
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):

--- a/test/cqlpy/test_allow_filtering.py
+++ b/test/cqlpy/test_allow_filtering.py
@@ -30,7 +30,7 @@ import time
 
 from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException, ReadFailure
 
-from .util import unique_name, new_test_table
+from util import unique_name, new_test_table
 
 # check_af_optional() and check_af_mandatory() are utility functions for
 # checking that ALLOW FILTERING is optional or mandatory on a SELECT on a

--- a/test/cqlpy/test_alter_table.py
+++ b/test/cqlpy/test_alter_table.py
@@ -7,8 +7,8 @@
 import time
 import pytest
 
-from .util import new_test_table, unique_name
-from .nodetool import flush
+from util import new_test_table, unique_name
+from nodetool import flush
 
 # Test checks only case of preparing `ALTER TABLE ... DROP ... USING TIMESTAMP ?` statement.
 # It is `scylla_only` because Cassandra doesn't allow to prepare the statement with ? as the timestamp.

--- a/test/cqlpy/test_bad_grammar.py
+++ b/test/cqlpy/test_bad_grammar.py
@@ -6,7 +6,7 @@
 # some point in the past.
 
 import pytest
-from .util import new_test_table
+from util import new_test_table
 from cassandra.protocol import InvalidRequest, SyntaxException
 
 

--- a/test/cqlpy/test_batch.py
+++ b/test/cqlpy/test_batch.py
@@ -2,13 +2,14 @@
 # Copyright 2022-present ScyllaDB
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
+
 #############################################################################
 # Tests for batch operations
 #############################################################################
 from cassandra import InvalidRequest
 from cassandra.cluster import NoHostAvailable
-from .util import new_test_table
-from .rest_api import scylla_inject_error
+from util import new_test_table
+from rest_api import scylla_inject_error
 
 
 import pytest

--- a/test/cqlpy/test_bloom_filter.py
+++ b/test/cqlpy/test_bloom_filter.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import pytest
-from . import nodetool
-from . import rest_api
-from .util import new_test_table, config_value_context
+import rest_api
+import nodetool
+from util import new_test_table, config_value_context
 from cassandra.protocol import ConfigurationException
 
 # Disable component memory reclamation by setting the threshold to max value

--- a/test/cqlpy/test_cast.py
+++ b/test/cqlpy/test_cast.py
@@ -32,7 +32,7 @@
 
 import pytest
 from cassandra.protocol import InvalidRequest
-from .util import unique_name, unique_key_int
+from util import unique_name, unique_key_int
 import uuid
 
 @pytest.fixture(scope="module")

--- a/test/cqlpy/test_cast_data.py
+++ b/test/cqlpy/test_cast_data.py
@@ -20,7 +20,7 @@
 
 import pytest
 import math
-from .util import new_test_table, unique_key_int
+from util import new_test_table, unique_key_int
 from cassandra.protocol import InvalidRequest
 from ctypes import c_float
 

--- a/test/cqlpy/test_cdc.py
+++ b/test/cqlpy/test_cdc.py
@@ -6,8 +6,8 @@ from cassandra.cluster import ConsistencyLevel
 from cassandra.query import SimpleStatement
 from cassandra.protocol import InvalidRequest
 
-from .util import new_test_table, unique_name
-from .nodetool import flush
+from util import new_test_table, unique_name
+from nodetool import flush
 import pytest
 import time
 

--- a/test/cqlpy/test_clustering_order.py
+++ b/test/cqlpy/test_clustering_order.py
@@ -12,7 +12,7 @@
 
 import pytest
 
-from .util import new_test_table, unique_key_int
+from util import new_test_table, unique_key_int
 
 @pytest.fixture(scope="module")
 def table_int_desc(cql, test_keyspace):

--- a/test/cqlpy/test_compaction.py
+++ b/test/cqlpy/test_compaction.py
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+from util import new_materialized_view, new_test_table
+import nodetool
 import pytest
 import requests
-from .util import new_materialized_view, new_test_table
-from . import nodetool
 import time
 
 # sleep to let a ttl (of `seconds`) expire and

--- a/test/cqlpy/test_compaction_strategy_validation.py
+++ b/test/cqlpy/test_compaction_strategy_validation.py
@@ -7,7 +7,7 @@
 #############################################################################
 
 import pytest
-from .util import new_test_table
+from util import new_test_table
 from cassandra.protocol import ConfigurationException
 
 @pytest.fixture(scope="module")

--- a/test/cqlpy/test_counter.py
+++ b/test/cqlpy/test_counter.py
@@ -8,9 +8,9 @@
 ###############################################################################
 
 import pytest
-from .util import new_test_table, unique_key_int
+from util import new_test_table, unique_key_int
 from cassandra.protocol import InvalidRequest
-from .rest_api import scylla_inject_error
+from rest_api import scylla_inject_error
 
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):

--- a/test/cqlpy/test_describe.py
+++ b/test/cqlpy/test_describe.py
@@ -12,8 +12,7 @@ import random
 import re
 import textwrap
 from contextlib import contextmanager, ExitStack
-from .util import new_type, unique_name, new_test_table, new_test_keyspace, new_function, new_aggregate, \
-    new_cql, keyspace_has_tablets, unique_name_prefix, new_session, new_user
+from util import is_scylla, new_type, unique_name, new_test_table, new_test_keyspace, new_function, new_aggregate, new_cql, keyspace_has_tablets, unique_name_prefix, new_user, new_session
 from cassandra.protocol import InvalidRequest, Unauthorized
 from collections.abc import Iterable
 from typing import Any

--- a/test/cqlpy/test_distinct.py
+++ b/test/cqlpy/test_distinct.py
@@ -7,7 +7,7 @@
 #############################################################################
 
 import pytest
-from .util import new_test_table, unique_key_int, random_string
+from util import new_test_table, unique_key_int, random_string
 from cassandra.protocol import InvalidRequest
 
 @pytest.fixture(scope="module")

--- a/test/cqlpy/test_empty.py
+++ b/test/cqlpy/test_empty.py
@@ -8,9 +8,9 @@
 
 import pytest
 from cassandra.protocol import InvalidRequest
-from .util import unique_name, unique_key_string, unique_key_int, new_test_table
+from util import unique_name, unique_key_string, unique_key_int, new_test_table
 
-from . import nodetool
+import nodetool
 
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):

--- a/test/cqlpy/test_filtering.py
+++ b/test/cqlpy/test_filtering.py
@@ -12,7 +12,7 @@
 
 import pytest
 import re
-from .util import new_test_table, new_type, user_type
+from util import new_test_table, new_type, user_type
 from cassandra.protocol import InvalidRequest
 from cassandra.query import UNSET_VALUE
 

--- a/test/cqlpy/test_frozen_collection.py
+++ b/test/cqlpy/test_frozen_collection.py
@@ -12,7 +12,7 @@
 
 import pytest
 from cassandra.util import SortedSet, OrderedMapSerializedKey
-from .util import unique_name, new_test_table, unique_key_int
+from util import unique_name, new_test_table, unique_key_int
 
 
 # A test table with a (frozen) nested collection as its primary key.

--- a/test/cqlpy/test_group_by.py
+++ b/test/cqlpy/test_group_by.py
@@ -7,7 +7,7 @@
 #############################################################################
 
 import pytest
-from .util import new_test_table
+from util import new_test_table
 from cassandra.protocol import InvalidRequest
 
 # table1 has some pre-set data which the tests below SELECT on (the tests

--- a/test/cqlpy/test_guardrail_replication_strategy.py
+++ b/test/cqlpy/test_guardrail_replication_strategy.py
@@ -1,6 +1,6 @@
 import pytest
 from contextlib import ExitStack
-from .util import unique_name, config_value_context, new_test_keyspace
+from util import unique_name, config_value_context, new_test_keyspace
 from cassandra.protocol import ConfigurationException
 
 # Tests for the replication_strategy_{warn,fail}_list guardrail. Because

--- a/test/cqlpy/test_json.py
+++ b/test/cqlpy/test_json.py
@@ -11,7 +11,7 @@
 # to reproduce bugs discovered by bigger Cassandra tests.
 #############################################################################
 
-from .util import unique_name, new_test_table, unique_key_int
+from util import unique_name, new_test_table, unique_key_int
 
 from cassandra.protocol import FunctionFailure, InvalidRequest
 from cassandra.util import Date, Time

--- a/test/cqlpy/test_key_length.py
+++ b/test/cqlpy/test_key_length.py
@@ -19,8 +19,8 @@
 #############################################################################
 
 import pytest
-from .util import new_test_table, random_string, unique_key_string, unique_key_int
-from . import nodetool
+from util import new_test_table, random_string, unique_key_string, unique_key_int
+import nodetool
 from cassandra.protocol import InvalidRequest
 from cassandra.util import SortedSet
 

--- a/test/cqlpy/test_keyspace.py
+++ b/test/cqlpy/test_keyspace.py
@@ -5,7 +5,7 @@
 # Tests for basic keyspace operations: CREATE KEYSPACE, DROP KEYSPACE,
 # ALTER KEYSPACE
 
-from .util import new_test_keyspace, unique_name
+from util import new_test_keyspace, unique_name
 import pytest
 from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException
 from threading import Thread

--- a/test/cqlpy/test_large_cells_rows.py
+++ b/test/cqlpy/test_large_cells_rows.py
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from .util import new_test_table
+from util import new_test_table
 
 import requests
-from . import nodetool
+import nodetool
 
 def test_create_large_static_cells_and_rows(cql, test_keyspace):
     '''Test that `large_data_handler` successfully reports large static cells

--- a/test/cqlpy/test_limit.py
+++ b/test/cqlpy/test_limit.py
@@ -28,7 +28,7 @@
 #############################################################################
 
 import pytest
-from .util import unique_key_int, new_test_table
+from util import unique_key_int, new_test_table
 
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):

--- a/test/cqlpy/test_logs.py
+++ b/test/cqlpy/test_logs.py
@@ -32,8 +32,8 @@ import re
 
 from cassandra import InvalidRequest
 
-from .util import new_test_table, local_process_id
-from .test_batch import generate_big_batch
+from util import new_test_table, local_process_id
+from test_batch import generate_big_batch
 
 # A fixture to find the Scylla log file, returning the log file's path.
 # If the log file cannot be found, or it's not Scylla, the fixture calls

--- a/test/cqlpy/test_lwt.py
+++ b/test/cqlpy/test_lwt.py
@@ -12,7 +12,7 @@ import re
 import pytest
 from cassandra.protocol import InvalidRequest
 
-from .util import new_test_table, unique_key_int
+from util import new_test_table, unique_key_int
 
 @pytest.fixture(scope="module")
 # FIXME: LWT is not supported with tablets yet. See #18066

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -8,12 +8,12 @@ import time
 import re
 import pytest
 
-from .util import new_test_table, unique_name, new_materialized_view, ScyllaMetrics, new_secondary_index
+from util import new_test_table, unique_name, new_materialized_view, ScyllaMetrics, new_secondary_index
 from cassandra.protocol import ConfigurationException, InvalidRequest, SyntaxException
 from cassandra.cluster import ConsistencyLevel
 from cassandra.query import SimpleStatement
 
-from . import nodetool
+import nodetool
 
 def get_id_of_cf(cql, cf_name):
     ks, cf = cf_name.split(".")

--- a/test/cqlpy/test_native_functions.py
+++ b/test/cqlpy/test_native_functions.py
@@ -10,7 +10,7 @@
 ###############################################################################
 
 import pytest
-from .util import new_test_table, unique_key_int
+from util import new_test_table, unique_key_int
 from datetime import datetime
 from cassandra.protocol import InvalidRequest
 

--- a/test/cqlpy/test_native_transport.py
+++ b/test/cqlpy/test_native_transport.py
@@ -4,8 +4,8 @@
 
 import pytest
 import time
-from . import nodetool
-from .util import new_test_table
+import nodetool
+from util import new_test_table
 from cassandra.cluster import NoHostAvailable
 
 def test_enable_disable_binary(cql, test_keyspace):

--- a/test/cqlpy/test_non_deterministic_functions.py
+++ b/test/cqlpy/test_non_deterministic_functions.py
@@ -14,7 +14,7 @@
 import pytest
 
 from time import sleep
-from .util import new_test_table
+from util import new_test_table
 
 def lwt_nondeterm_fn_repeated_execute(cql, test_keyspace, pk_type, fn):
     with new_test_table(cql, test_keyspace, f"pk {pk_type} PRIMARY KEY") as table:

--- a/test/cqlpy/test_null.py
+++ b/test/cqlpy/test_null.py
@@ -9,7 +9,7 @@
 import pytest
 import re
 from cassandra.protocol import InvalidRequest
-from .util import unique_name, unique_key_string
+from util import unique_name, unique_key_string
 
 
 @pytest.fixture(scope="module")

--- a/test/cqlpy/test_paging.py
+++ b/test/cqlpy/test_paging.py
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from .util import new_test_table
+from util import new_test_table
 from cassandra.query import SimpleStatement
 import pytest
-from . import nodetool
+import nodetool
 
 # Test that the _stop flag set in the compactor at the end of a page is not
 # sticky and doesn't remain set on the following page. If it does it can cause

--- a/test/cqlpy/test_permissions.py
+++ b/test/cqlpy/test_permissions.py
@@ -8,9 +8,9 @@
 
 import pytest
 import time
-from . import rest_api
+import rest_api
 from cassandra.protocol import SyntaxException, InvalidRequest, Unauthorized, ConfigurationException
-from .util import new_test_table, new_function, new_user, new_session, new_test_keyspace, unique_name, new_type
+from util import new_test_table, new_function, new_user, new_session, new_test_keyspace, unique_name, new_type
 from contextlib import contextmanager
 
 # Test that granting permissions to various resources works for the default user.

--- a/test/cqlpy/test_prepare.py
+++ b/test/cqlpy/test_prepare.py
@@ -11,7 +11,7 @@
 # https://github.com/apache/cassandra/blob/1959502d8b16212479eecb076c89945c3f0f180c/doc/native_protocol_v4.spec#L675
 
 import pytest
-from .util import new_test_table, unique_key_int, config_value_context
+from util import new_test_table, unique_key_int, config_value_context
 from cassandra.protocol import InvalidRequest
 
 @pytest.fixture(scope="module")

--- a/test/cqlpy/test_range_and_slice.py
+++ b/test/cqlpy/test_range_and_slice.py
@@ -6,7 +6,7 @@
 # Tests the calculation of partition range and slice.
 
 import pytest
-from .util import new_test_table
+from util import new_test_table
 
 def test_delete_where_empty_IN(cql, test_keyspace):
     """Tests that DELETE FROM t WHERE p IN () is allowed.  See #9311."""

--- a/test/cqlpy/test_restrictions.py
+++ b/test/cqlpy/test_restrictions.py
@@ -11,7 +11,7 @@
 # we should just merge these two test files.
 
 import pytest
-from .util import new_test_table, unique_key_int
+from util import new_test_table, unique_key_int
 from cassandra.protocol import InvalidRequest
 
 @pytest.fixture(scope="module")

--- a/test/cqlpy/test_scan.py
+++ b/test/cqlpy/test_scan.py
@@ -12,7 +12,7 @@
 #############################################################################
 
 import pytest
-from .util import new_test_table, new_type, user_type
+from util import new_test_table, new_type, user_type
 from cassandra.protocol import InvalidRequest
 from cassandra.query import SimpleStatement
 

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -12,9 +12,9 @@ import pytest
 import os
 from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException, ReadFailure, WriteFailure
 from cassandra.query import SimpleStatement
-from .cassandra_tests.porting import assert_rows, assert_row_count, assert_rows_ignoring_order, assert_empty
+from cassandra_tests.porting import assert_rows, assert_row_count, assert_rows_ignoring_order, assert_empty
 
-from .util import new_test_table, unique_name, unique_key_int
+from util import new_test_table, unique_name, unique_key_int
 
 # A reproducer for issue #7443: Normally, when the entire table is SELECTed,
 # the partitions are returned sorted by the partitions' token. When there

--- a/test/cqlpy/test_select_from_mutation_fragments.py
+++ b/test/cqlpy/test_select_from_mutation_fragments.py
@@ -12,11 +12,11 @@ import cassandra.query
 import glob
 import json
 import os
-from . import nodetool
-from . import util
+import nodetool
 import pytest
 import requests
 import subprocess
+import util
 
 
 @pytest.fixture(scope="module")

--- a/test/cqlpy/test_service_levels.py
+++ b/test/cqlpy/test_service_levels.py
@@ -9,7 +9,7 @@
 #############################################################################
 
 from contextlib import contextmanager
-from .util import unique_name, new_test_table, new_user
+from util import unique_name, new_test_table, new_user
 
 from cassandra.protocol import InvalidRequest, ReadTimeout
 from cassandra.util import Duration

--- a/test/cqlpy/test_shedding.py
+++ b/test/cqlpy/test_shedding.py
@@ -9,7 +9,7 @@
 import pytest
 from cassandra.cluster import NoHostAvailable
 from cassandra.protocol import InvalidRequest
-from .util import unique_name, new_cql, ScyllaMetrics
+from util import unique_name, new_cql, ScyllaMetrics
 from contextlib import contextmanager
 
 

--- a/test/cqlpy/test_sstable.py
+++ b/test/cqlpy/test_sstable.py
@@ -11,8 +11,8 @@
 # the disk.
 #############################################################################
 
-from .util import new_test_table
-from . import nodetool
+from util import new_test_table
+import nodetool
 import random
 
 # Reproduces issue #8138, where the sstable reader in a TWCS sstable set

--- a/test/cqlpy/test_sstable_compression.py
+++ b/test/cqlpy/test_sstable_compression.py
@@ -8,8 +8,8 @@
 #############################################################################
 
 import pytest
-from . import nodetool
-from .util import new_test_table
+import nodetool
+from util import new_test_table
 from cassandra.protocol import ConfigurationException, SyntaxException
 
 # In older Cassandra and Scylla, the name of the compression algorithm was

--- a/test/cqlpy/test_static.py
+++ b/test/cqlpy/test_static.py
@@ -11,7 +11,7 @@
 
 import pytest
 
-from .util import new_test_table, unique_key_int
+from util import new_test_table, unique_key_int
 
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):

--- a/test/cqlpy/test_system_tables.py
+++ b/test/cqlpy/test_system_tables.py
@@ -8,9 +8,9 @@
 # or may assume, that Scylla provides similar content.
 #############################################################################
 
-from .util import new_test_table
+from util import new_test_table
 import pytest
-from . import nodetool
+import nodetool
 
 #############################################################################
 # system.size_estimates.partitions_count

--- a/test/cqlpy/test_tablets.py
+++ b/test/cqlpy/test_tablets.py
@@ -13,7 +13,7 @@
 #############################################################################
 
 import pytest
-from .util import new_test_keyspace, new_test_table, unique_name, index_table_name
+from util import new_test_keyspace, new_test_table, unique_name, index_table_name
 from cassandra.protocol import ConfigurationException, InvalidRequest
 
 # A fixture similar to "test_keyspace", just creates a keyspace that enables

--- a/test/cqlpy/test_tombstone_limit.py
+++ b/test/cqlpy/test_tombstone_limit.py
@@ -12,8 +12,8 @@
 # for all supported tombstones.
 #############################################################################
 
-from .util import new_test_table, config_value_context, unique_key_int
-from .conftest import driver_bug_1
+from util import new_test_table, config_value_context, unique_key_int
+from conftest import driver_bug_1
 from cassandra.query import SimpleStatement
 import pytest
 

--- a/test/cqlpy/test_tools.py
+++ b/test/cqlpy/test_tools.py
@@ -11,6 +11,7 @@ import glob
 import itertools
 import functools
 import json
+import nodetool
 import os
 import pathlib
 import pytest
@@ -19,8 +20,7 @@ import tempfile
 import random
 import re
 import shutil
-from . import nodetool
-from . import util
+import util
 from typing import Iterable, Type, Union
 
 

--- a/test/cqlpy/test_ttl.py
+++ b/test/cqlpy/test_ttl.py
@@ -6,7 +6,7 @@
 # Various tests for Scylla's ttl feature - USING TTL and DEFAULT_TIME_TO_LIVE
 #############################################################################
 
-from .util import new_test_table, unique_key_int
+from util import new_test_table, unique_key_int
 from cassandra.query import UNSET_VALUE
 import pytest
 import time

--- a/test/cqlpy/test_type_date.py
+++ b/test/cqlpy/test_type_date.py
@@ -6,7 +6,7 @@
 # Test involving the "date" column type.
 #############################################################################
 
-from .util import unique_name, unique_key_int
+from util import unique_name, unique_key_int
 from cassandra.util import Date
 from cassandra.protocol import InvalidRequest
 

--- a/test/cqlpy/test_type_duration.py
+++ b/test/cqlpy/test_type_duration.py
@@ -7,7 +7,7 @@
 # Test involving the "duration" column type.
 #############################################################################
 
-from .util import unique_name, unique_key_int
+from util import unique_name, unique_key_int
 
 import pytest
 

--- a/test/cqlpy/test_type_string.py
+++ b/test/cqlpy/test_type_string.py
@@ -9,7 +9,7 @@
 #############################################################################
 
 import pytest
-from .util import unique_name, unique_key_string, random_string, random_bytes
+from util import unique_name, unique_key_string, random_string, random_bytes
 
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):

--- a/test/cqlpy/test_type_time.py
+++ b/test/cqlpy/test_type_time.py
@@ -6,7 +6,7 @@
 # Test involving the "time" column type.
 #############################################################################
 
-from .util import unique_name, unique_key_int
+from util import unique_name, unique_key_int
 
 import pytest
 

--- a/test/cqlpy/test_type_timestamp.py
+++ b/test/cqlpy/test_type_timestamp.py
@@ -10,7 +10,7 @@
 # That latter concept is tested in test_timestamp.py, not here.
 #############################################################################
 
-from .util import new_test_table, unique_key_int
+from util import new_test_table, unique_key_int
 from datetime import datetime
 from cassandra.protocol import SyntaxException, InvalidRequest
 import pytest

--- a/test/cqlpy/test_type_uuid.py
+++ b/test/cqlpy/test_type_uuid.py
@@ -11,7 +11,7 @@
 # timeuuid is a separate type and may
 #############################################################################
 
-from .util import new_test_table, unique_key_int
+from util import new_test_table, unique_key_int
 
 import pytest
 import uuid

--- a/test/cqlpy/test_uda.py
+++ b/test/cqlpy/test_uda.py
@@ -9,7 +9,7 @@
 
 import pytest
 from cassandra.protocol import InvalidRequest, ConfigurationException
-from .util import unique_name, new_test_table, new_function, new_aggregate, new_type
+from util import unique_name, new_test_table, new_function, new_aggregate, new_type
 
 # Test that computing an average by hand works the same as
 # the built-in function

--- a/test/cqlpy/test_udf.py
+++ b/test/cqlpy/test_udf.py
@@ -8,7 +8,7 @@
 #############################################################################
 
 import pytest
-from .util import unique_name, new_function
+from util import unique_name, new_function
 from cassandra.protocol import InvalidRequest
 
 # Unfortunately, while ScyllaDB and Cassandra support the same UDF

--- a/test/cqlpy/test_unset.py
+++ b/test/cqlpy/test_unset.py
@@ -10,7 +10,7 @@
 #############################################################################
 
 import pytest
-from .util import new_test_table, unique_key_int
+from util import new_test_table, unique_key_int
 from cassandra.query import UNSET_VALUE
 from cassandra.cluster import NoHostAvailable
 from cassandra.protocol import InvalidRequest

--- a/test/cqlpy/test_use.py
+++ b/test/cqlpy/test_use.py
@@ -15,7 +15,7 @@
 
 import pytest
 from cassandra.protocol import InvalidRequest
-from .util import unique_name, new_cql
+from util import unique_name, new_cql
 
 # Check that CREATE TABLE and DROP TABLE work without an explicit keyspace
 # name if a default keyspace name is specified with "USE".

--- a/test/cqlpy/test_using_service_level.py
+++ b/test/cqlpy/test_using_service_level.py
@@ -4,7 +4,7 @@
 
 # Tests for USING SERVICE LEVEL extension
 
-from .util import new_test_keyspace, unique_name, unique_key_int
+from util import new_test_keyspace, unique_name, unique_key_int
 import pytest
 from cassandra.protocol import InvalidRequest, ReadTimeout, WriteTimeout, SyntaxException
 from cassandra.cluster import NoHostAvailable

--- a/test/cqlpy/test_using_timeout.py
+++ b/test/cqlpy/test_using_timeout.py
@@ -4,7 +4,7 @@
 
 # Tests for USING TIMEOUT extension
 
-from .util import new_test_keyspace, unique_name, unique_key_int
+from util import new_test_keyspace, unique_name, unique_key_int
 import pytest
 from cassandra.protocol import InvalidRequest, ReadTimeout, WriteTimeout, SyntaxException
 from cassandra.cluster import NoHostAvailable

--- a/test/cqlpy/test_using_timestamp.py
+++ b/test/cqlpy/test_using_timestamp.py
@@ -10,7 +10,7 @@
 # aiming to reproduce bugs discovered by bigger Cassandra tests.
 #############################################################################
 
-from .util import unique_name, new_test_table, unique_key_int
+from util import unique_name, new_test_table, unique_key_int
 from cassandra.protocol import FunctionFailure, InvalidRequest
 import pytest
 import time

--- a/test/cqlpy/test_utf8.py
+++ b/test/cqlpy/test_utf8.py
@@ -12,7 +12,7 @@
 import pytest
 import unicodedata
 from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException, ReadFailure
-from .util import unique_name, unique_key_string
+from util import unique_name, unique_key_string
 
 
 @pytest.fixture(scope="module")

--- a/test/cqlpy/test_validation.py
+++ b/test/cqlpy/test_validation.py
@@ -13,7 +13,7 @@ import pytest
 import re
 import random
 from cassandra.protocol import SyntaxException, AlreadyExists, InvalidRequest, ConfigurationException, ReadFailure
-from .util import unique_name, unique_key_int, new_test_table
+from util import unique_name, unique_key_int, new_test_table
 
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):

--- a/test/cqlpy/test_virtual_tables.py
+++ b/test/cqlpy/test_virtual_tables.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import pytest
-from . import nodetool
-from . import util
+import util
+import nodetool
 import json
 
 from collections import defaultdict

--- a/test/cqlpy/test_wasm.py
+++ b/test/cqlpy/test_wasm.py
@@ -9,7 +9,7 @@
 
 from cassandra.protocol import InvalidRequest
 from cassandra.cluster import NoHostAvailable
-from .util import new_test_table, unique_name, new_function, new_aggregate
+from util import new_test_table, unique_name, new_function, new_aggregate
 
 import pytest
 import requests

--- a/test/rest_api/conftest.py
+++ b/test/rest_api/conftest.py
@@ -19,7 +19,9 @@ from cassandra.cluster import Cluster, ConsistencyLevel, ExecutionProfile, EXEC_
 from cassandra.policies import RoundRobinPolicy
 
 
-from ..cqlpy.util import unique_name, new_test_keyspace, keyspace_has_tablets, is_scylla
+# Use the util.py library from ../cqlpy:
+sys.path.insert(1, sys.path[0] + '/test/cqlpy')
+from util import unique_name, new_test_keyspace, keyspace_has_tablets, is_scylla
 
 # By default, tests run against a Scylla server listening
 # on localhost:9042 for CQL and localhost:10000 for the REST API.

--- a/test/rest_api/test_column_family.py
+++ b/test/rest_api/test_column_family.py
@@ -8,7 +8,9 @@ import requests
 import threading
 import time
 
-from ..cqlpy.util import new_test_table, new_test_keyspace
+# Use the util.py library from ../cqlpy:
+sys.path.insert(1, sys.path[0] + '/test/cqlpy')
+from util import new_test_table, new_test_keyspace
 from test.rest_api.rest_util import scylla_inject_error
 
 def do_test_column_family_attribute_api_table(cql, this_dc, rest_api, api_name):

--- a/test/rest_api/test_compaction_manager.py
+++ b/test/rest_api/test_compaction_manager.py
@@ -6,7 +6,9 @@ import pytest
 import sys
 import requests
 
-from ..cqlpy.util import new_test_table, unique_name
+# Use the util.py library from ../cqlpy:
+sys.path.insert(1, sys.path[0] + '/test/cqlpy')
+from util import new_test_table, unique_name
 
 # "keyspace" function: Creates and returns a temporary keyspace to be
 # used in tests that need a keyspace. The keyspace is created with RF=1,

--- a/test/rest_api/test_compaction_task.py
+++ b/test/rest_api/test_compaction_task.py
@@ -2,7 +2,9 @@ import requests
 import sys
 import threading
 
-from ..cqlpy.util import new_test_table, new_test_keyspace
+# Use the util.py library from ../cqlpy:
+sys.path.insert(1, sys.path[0] + '/test/cqlpy')
+from util import new_test_table, new_test_keyspace
 from test.rest_api.rest_util import set_tmp_task_ttl, scylla_inject_error
 from test.rest_api.task_manager_utils import wait_for_task, list_tasks, check_child_parent_relationship, drain_module_tasks, abort_task, get_task_status, get_task_status_recursively, get_children
 

--- a/test/rest_api/test_compactionhistory.py
+++ b/test/rest_api/test_compactionhistory.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 
 # Use the util.py library from ../cqlpy:
 sys.path.insert(1, sys.path[0] + '/test/cqlpy')
-from ..cqlpy.util import new_test_table, new_test_keyspace
+from util import new_test_table, new_test_keyspace
 
 
 def extractRowsMergedAsSortedList(response, ks):

--- a/test/rest_api/test_gossiper.py
+++ b/test/rest_api/test_gossiper.py
@@ -8,6 +8,8 @@ import requests
 import threading
 import time
 
+# Use the util.py library from ../cqlpy:
+sys.path.insert(1, sys.path[0] + '/test/cqlpy')
 
 def test_gossiper_live_endpoints(cql, rest_api):
     resp = rest_api.send("GET", f"gossiper/endpoint/live")

--- a/test/rest_api/test_repair_task.py
+++ b/test/rest_api/test_repair_task.py
@@ -1,4 +1,8 @@
-from ..cqlpy.util import new_test_table, new_test_keyspace
+import sys
+
+# Use the util.py library from ../cqlpy:
+sys.path.insert(1, sys.path[0] + '/test/cqlpy')
+from util import new_test_table, new_test_keyspace
 from test.rest_api.rest_util import set_tmp_task_ttl, scylla_inject_error
 from test.rest_api.task_manager_utils import list_tasks, drain_module_tasks, get_task_status, get_task_status_recursively, wait_for_task, check_child_parent_relationship, get_children
 

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -8,7 +8,8 @@ import requests
 import time
 
 # Use the util.py library from ../cqlpy:
-from ..cqlpy.util import unique_name, new_test_table, new_test_keyspace, new_materialized_view, new_secondary_index
+sys.path.insert(1, sys.path[0] + '/test/cqlpy')
+from util import unique_name, new_test_table, new_test_keyspace, new_materialized_view, new_secondary_index
 from test.rest_api.rest_util import new_test_snapshot, scylla_inject_error, ThreadWrapper
 
 # "keyspace" function: Creates and returns a temporary keyspace to be

--- a/test/rest_api/test_task_manager.py
+++ b/test/rest_api/test_task_manager.py
@@ -1,8 +1,11 @@
 from enum import Enum
 import requests
+import sys
 import time
 
-from ..cqlpy.util import new_test_table, new_test_keyspace
+# Use the util.py library from ../cqlpy:
+sys.path.insert(1, sys.path[0] + '/test/cqlpy')
+from util import new_test_table, new_test_keyspace
 from test.rest_api.rest_util import new_test_module, new_test_task, set_tmp_task_ttl, ThreadWrapper, scylla_inject_error, set_tmp_user_task_ttl
 from test.rest_api.task_manager_utils import check_field_correctness, check_status_correctness, assert_task_does_not_exist, list_modules, get_task_status, list_tasks, get_task_status_recursively, wait_for_task, drain_module_tasks, abort_task
 

--- a/test/topology_custom/test_multidc.py
+++ b/test/topology_custom/test_multidc.py
@@ -9,7 +9,9 @@ import sys
 import pytest
 from cassandra.policies import WhiteListRoundRobinPolicy
 
-from test.cqlpy import nodetool
+
+sys.path.insert(0, sys.path[0] + "/test/cqlpy")
+import nodetool
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
 from test.pylib.manager_client import ManagerClient


### PR DESCRIPTION
This reverts commit 6c267bbc7056a20de119f22ec748c30b6b6f1612.

Seems this change breaks the dtest test somehow.