### PR TITLE
Update config.cc - fix a typo in Repair_multishard_reader_enable_read…

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -984,7 +984,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "The buffer size to use for the buffer-hint feature of the multishard reader when running repair in mixed-shard clusters. This can help the performance of mixed-shard repair (including RBNO). Set to 0 to disable the hint feature altogether.")
     , repair_multishard_reader_enable_read_ahead(this, "repair_multishard_reader_enable_read_ahead", liveness::LiveUpdate, value_status::Used, false,
         "The multishard reader has a read-ahead feature to improve latencies of range-scans. This feature can be detrimental when the multishard reader is used under repair, as is the case in repair in mixed-shard clusters."
-        " This know allows disabling this read-ahead (default), this can help the performance of mixed-shard repair (including RBNO).")
+        " This now allows disabling this read-ahead (default), this can help the performance of mixed-shard repair (including RBNO).")
     , enable_small_table_optimization_for_rbno(this, "enable_small_table_optimization_for_rbno", liveness::LiveUpdate, value_status::Used, false, "Set true to enable small table optimization for repair based node operations")
     , ring_delay_ms(this, "ring_delay_ms", value_status::Used, 30 * 1000, "Time a node waits to hear from other nodes before joining the ring in milliseconds. Same as -Dcassandra.ring_delay_ms in cassandra.")
     , shadow_round_ms(this, "shadow_round_ms", value_status::Used, 300 * 1000, "The maximum gossip shadow round time. Can be used to reduce the gossip feature check time during node boot up.")


### PR DESCRIPTION
…_ahead description

Intreduced in https://github.com/scylladb/scylladb/pull/20815

The typo popogate to the docs
https://enterprise.docs.scylladb.com/stable/reference/configuration-parameters.html#confval-repair_multishard_reader_enable_read_ahead