### PR TITLE
Materialized view name length should be limited

### DIFF
--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -87,6 +87,10 @@ std::vector<::shared_ptr<index_target>> create_index_statement::validate_while_e
                 "Secondary indexes are not supported on COMPACT STORAGE tables that have clustering columns");
     }
 
+    if (_index_name.size() > size_t(schema::NAME_LENGTH)) {
+        throw exceptions::invalid_request_exception(format("index names shouldn't be more than {:d} characters long (got \"{}\")", schema::NAME_LENGTH, _index_name.c_str()));
+    }
+
     if (!db.features().views_with_tablets && db.find_keyspace(keyspace()).get_replication_strategy().uses_tablets()) {
         throw exceptions::invalid_request_exception(format("Secondary indexes are not supported on base tables with tablets (keyspace '{}')", keyspace()));
     }

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -193,6 +193,14 @@ def test_create_index_if_not_exists2(cql, test_keyspace, cassandra_bug):
         with pytest.raises(InvalidRequest, match="already exists"):
             cql.execute(f"CREATE INDEX IF NOT EXISTS {index_name} ON {table}(v2)")
 
+# Verify that oversized index names are cleanly rejected  as InvalidRequest
+# Reproduces issue #20755
+def test_create_index_oversized_name(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, 'p int primary key, v int') as table:
+        index_name = 'x'*500
+        with pytest.raises((InvalidRequest, ConfigurationException)):
+            cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+
 # Test that the paging state works properly for indexes on tables
 # with descending clustering order. There was a problem with indexes
 # created on clustering keys with DESC clustering order - they are represented


### PR DESCRIPTION
Oversized materialized view and index names are rejected; Materialized view names with invalid symbols are rejected.

fixes: #20755

backport/none