### PR TITLE
install.sh: fix incorrect variable name

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -624,7 +624,7 @@ if $nonroot; then
     chmod 644 $rprefix/SCYLLA-OFFLINE-FILE
     touch $rprefix/SCYLLA-NONROOT-FILE
     chmod 644 $rprefix/SCYLLA-NONROOT-FILE
-    if ! $without_systemd_check && check_usermode_support; then
+    if ! $skip_systemd_check && check_usermode_support; then
         systemctl --user daemon-reload
     fi
     echo "Scylla non-root install completed."


### PR DESCRIPTION
$without_systemd_check is incorrect variable name, it should be $skip_systemd_check.

The bug skips to run "systemctl --user daemon-reload" unexpectedly on nonroot mode installation.

This is likely root cause of the issue #21720.

Fixes #21720