### PR TITLE
service/qos: increase timeout of internal get_service_levels queries

### DIFF
--- a/cql3/statements/list_service_level_statement.cc
+++ b/cql3/statements/list_service_level_statement.cc
@@ -54,7 +54,7 @@ list_service_level_statement::execute(query_processor& qp,
 
     return make_ready_future().then([this, &state] () {
                                   if (_describe_all) {
-                                      return state.get_service_level_controller().get_distributed_service_levels();
+                                      return state.get_service_level_controller().get_distributed_service_levels(qos::query_context::user);
                                   } else {
                                       return state.get_service_level_controller().get_distributed_service_level(_service_level);
                                   }

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -742,8 +742,8 @@ system_distributed_keyspace::get_cdc_desc_v1_timestamps(context ctx) {
     co_return res;
 }
 
-future<qos::service_levels_info> system_distributed_keyspace::get_service_levels() const {
-    return qos::get_service_levels(_qp, NAME, SERVICE_LEVELS, db::consistency_level::ONE);
+future<qos::service_levels_info> system_distributed_keyspace::get_service_levels(qos::query_context ctx) const {
+    return qos::get_service_levels(_qp, NAME, SERVICE_LEVELS, db::consistency_level::ONE, ctx);
 }
 
 future<qos::service_levels_info> system_distributed_keyspace::get_service_level(sstring service_level_name) const {

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -112,7 +112,7 @@ public:
 
     future<db_clock::time_point> cdc_current_generation_timestamp(context);
 
-    future<qos::service_levels_info> get_service_levels() const;
+    future<qos::service_levels_info> get_service_levels(qos::query_context ctx) const;
     future<qos::service_levels_info> get_service_level(sstring service_level_name) const;
     future<> set_service_level(sstring service_level_name, qos::service_level_options slo) const;
     future<> drop_service_level(sstring service_level_name) const;

--- a/service/qos/qos_common.hh
+++ b/service/qos/qos_common.hh
@@ -30,6 +30,17 @@ namespace qos {
 
 enum class include_effective_names { yes, no };
 
+/*
+ * for functions that execute queries, this is used to determine whether to execute
+ * the query with internal client_state with an 'infinite' timeout, or a default
+ * state with short timeout.
+ * for queries that are executed in context of group0 operations it is important to have
+ * a long timeout so the query doesn't fail the group0 client spuriously. in the context
+ * of user commands, however, a shorter timeout is preferred. in other cases, the default
+ * unspecified behavior may be sufficient.
+ */
+enum class query_context { group0, user, unspecified };
+
 /**
  *  a structure that holds the configuration for
  *  a service level.
@@ -94,9 +105,9 @@ public:
     }
 };
 
-service::query_state& qos_query_state();
+service::query_state& qos_query_state(qos::query_context ctx = qos::query_context::unspecified);
 
-future<service_levels_info> get_service_levels(cql3::query_processor& qp, std::string_view ks_name, std::string_view cf_name, db::consistency_level cl);
+future<service_levels_info> get_service_levels(cql3::query_processor& qp, std::string_view ks_name, std::string_view cf_name, db::consistency_level cl, qos::query_context ctx);
 future<service_levels_info> get_service_level(cql3::query_processor& qp, std::string_view ks_name, std::string_view cf_name, sstring service_level_name, db::consistency_level cl);
 
 }

--- a/service/qos/raft_service_level_distributed_data_accessor.cc
+++ b/service/qos/raft_service_level_distributed_data_accessor.cc
@@ -39,8 +39,8 @@ raft_service_level_distributed_data_accessor::raft_service_level_distributed_dat
     : _qp(qp)
     , _group0_client(group0_client) {}
 
-future<qos::service_levels_info> raft_service_level_distributed_data_accessor::get_service_levels() const {
-    return qos::get_service_levels(_qp, db::system_keyspace::NAME, db::system_keyspace::SERVICE_LEVELS_V2, db::consistency_level::LOCAL_ONE);
+future<qos::service_levels_info> raft_service_level_distributed_data_accessor::get_service_levels(qos::query_context ctx) const {
+    return qos::get_service_levels(_qp, db::system_keyspace::NAME, db::system_keyspace::SERVICE_LEVELS_V2, db::consistency_level::LOCAL_ONE, ctx);
 }
 
 future<qos::service_levels_info> raft_service_level_distributed_data_accessor::get_service_level(sstring service_level_name) const {

--- a/service/qos/raft_service_level_distributed_data_accessor.hh
+++ b/service/qos/raft_service_level_distributed_data_accessor.hh
@@ -33,7 +33,7 @@ private:
 public:
     raft_service_level_distributed_data_accessor(cql3::query_processor& qp, service::raft_group0_client& group0_client);
 
-    virtual future<qos::service_levels_info> get_service_levels() const override;
+    virtual future<qos::service_levels_info> get_service_levels(qos::query_context ctx) const override;
     virtual future<qos::service_levels_info> get_service_level(sstring service_level_name) const override;
     virtual future<> set_service_level(sstring service_level_name, qos::service_level_options slo, service::group0_batch& mc) const override;
     virtual future<> drop_service_level(sstring service_level_name, service::group0_batch& mc) const override;

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -101,7 +101,7 @@ class service_level_controller : public peering_sharded_service<service_level_co
 public:
     class service_level_distributed_data_accessor {
     public:
-        virtual future<qos::service_levels_info> get_service_levels() const = 0;
+        virtual future<qos::service_levels_info> get_service_levels(qos::query_context ctx = qos::query_context::unspecified) const = 0;
         virtual future<qos::service_levels_info> get_service_level(sstring service_level_name) const = 0;
         virtual future<> set_service_level(sstring service_level_name, qos::service_level_options slo, service::group0_batch& mc) const = 0;
         virtual future<> drop_service_level(sstring service_level_name, service::group0_batch& mc) const = 0;
@@ -217,7 +217,7 @@ public:
      * Must be executed on shard 0.
      * @return a future that is resolved when the update is done
      */
-    future<> update_service_levels_cache();
+    future<> update_service_levels_cache(qos::query_context ctx = qos::query_context::unspecified);
 
     /**
      * Updates effective service levels cache.
@@ -235,12 +235,12 @@ public:
      * update_both_cache_levels::yes - updates both levels of the cache
      * update_both_cache_levels::no  - update only effective service levels cache
      */
-    future<> update_cache(update_both_cache_levels update_both_cache_levels = update_both_cache_levels::yes);
+    future<> update_cache(update_both_cache_levels update_both_cache_levels = update_both_cache_levels::yes, qos::query_context ctx = qos::query_context::unspecified);
 
     future<> add_distributed_service_level(sstring name, service_level_options slo, bool if_not_exsists, service::group0_batch& mc);
     future<> alter_distributed_service_level(sstring name, service_level_options slo, service::group0_batch& mc);
     future<> drop_distributed_service_level(sstring name, bool if_exists, service::group0_batch& mc);
-    future<service_levels_info> get_distributed_service_levels();
+    future<service_levels_info> get_distributed_service_levels(qos::query_context ctx);
     future<service_levels_info> get_distributed_service_level(sstring service_level_name);
 
     /**

--- a/service/qos/standard_service_level_distributed_data_accessor.cc
+++ b/service/qos/standard_service_level_distributed_data_accessor.cc
@@ -17,8 +17,8 @@ standard_service_level_distributed_data_accessor::standard_service_level_distrib
 _sys_dist_ks(sys_dist_ks) {
 }
 
-future<qos::service_levels_info> standard_service_level_distributed_data_accessor::get_service_levels() const {
-    return _sys_dist_ks.get_service_levels();
+future<qos::service_levels_info> standard_service_level_distributed_data_accessor::get_service_levels(qos::query_context ctx) const {
+    return _sys_dist_ks.get_service_levels(ctx);
 }
 
 future<qos::service_levels_info> standard_service_level_distributed_data_accessor::get_service_level(sstring service_level_name) const {

--- a/service/qos/standard_service_level_distributed_data_accessor.hh
+++ b/service/qos/standard_service_level_distributed_data_accessor.hh
@@ -25,7 +25,7 @@ private:
     db::system_distributed_keyspace& _sys_dist_ks;
 public:
     standard_service_level_distributed_data_accessor(db::system_distributed_keyspace &sys_dist_ks);
-    virtual future<qos::service_levels_info> get_service_levels() const override;
+    virtual future<qos::service_levels_info> get_service_levels(qos::query_context ctx) const override;
     virtual future<qos::service_levels_info> get_service_level(sstring service_level_name) const override;
     virtual future<> set_service_level(sstring service_level_name, qos::service_level_options slo, service::group0_batch&) const override;
     virtual future<> drop_service_level(sstring service_level_name, service::group0_batch&) const override;

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -164,7 +164,7 @@ group0_state_machine::modules_to_reload group0_state_machine::get_modules_to_rel
 
 future<> group0_state_machine::reload_modules(modules_to_reload modules) {
     if (modules.service_levels_cache || modules.service_levels_effective_cache) { // this also updates SL effective cache
-        co_await _ss.update_service_levels_cache(qos::update_both_cache_levels(modules.service_levels_cache));
+        co_await _ss.update_service_levels_cache(qos::update_both_cache_levels(modules.service_levels_cache), qos::query_context::group0);
     }
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -701,7 +701,7 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
     co_await _sl_controller.invoke_on_all([this] (qos::service_level_controller& sl_controller) {
         sl_controller.upgrade_to_v2(_qp, _group0->client());
     });
-    co_await update_service_levels_cache(qos::update_both_cache_levels::yes);
+    co_await update_service_levels_cache(qos::update_both_cache_levels::yes, qos::query_context::group0);
 
     // the view_builder is migrated to v2 in view_builder::migrate_to_v2.
     // it writes a v2 version mutation as topology_change, then we get here
@@ -919,9 +919,9 @@ future<> storage_service::merge_topology_snapshot(raft_snapshot snp) {
     co_await _db.local().apply(freeze(muts), db::no_timeout);
 }
 
-future<> storage_service::update_service_levels_cache(qos::update_both_cache_levels update_only_effective_cache) {
+future<> storage_service::update_service_levels_cache(qos::update_both_cache_levels update_only_effective_cache, qos::query_context ctx) {
     SCYLLA_ASSERT(this_shard_id() == 0);
-    co_await _sl_controller.local().update_cache(update_only_effective_cache);
+    co_await _sl_controller.local().update_cache(update_only_effective_cache, ctx);
 }
 
 // Moves the coroutine lambda onto the heap and extends its

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -900,7 +900,7 @@ public:
     //    
     // update_both_cache_levels::yes - updates both levels of the cache
     // update_both_cache_levels::no  - update only effective service levels cache
-    future<> update_service_levels_cache(qos::update_both_cache_levels update_only_effective_cache = qos::update_both_cache_levels::yes);
+    future<> update_service_levels_cache(qos::update_both_cache_levels update_only_effective_cache = qos::update_both_cache_levels::yes, qos::query_context ctx = qos::query_context::unspecified);
 
     future<> do_cluster_cleanup();
 


### PR DESCRIPTION
The function get_service_levels is used to retrieve all service levels and it is called from multiple different contexts. Importantly, it is called internally from the context of group0 state reload, where it should be executed with a long timeout, similarly to other internal queries, because a failure of this function affects the entire group0 client, and a longer timeout can be tolerated. The function is also called in the context of the user command LIST SERVICE LEVELS, and perhaps other contexts, where a shorter timeout is preferred.

The commit introduces a function parameter to indicate whether the context is internal or not. For internal context, a long timeout is chosen for the query. Otherwise, the timeout is shorter, the same as before. When the distinction is not important, a default value is chosen which maintains the same behavior.

The main purpose is to fix the case where the timeout is too short and causes a failure that propagates and fails the group0 client.

Fixes scylladb/scylladb#20483

backport is needed because it's a bug fix.