### PR TITLE
auth/passwords: Clean up prefix_for_scheme()

### DIFF
--- a/auth/passwords.cc
+++ b/auth/passwords.cc
@@ -53,7 +53,6 @@ const char* prefix_for_scheme(scheme c) noexcept {
     case scheme::sha_512: return "$6$";
     case scheme::sha_256: return "$5$";
     case scheme::md5: return "$1$";
-    default: return nullptr;
     }
 }
 

--- a/auth/passwords.cc
+++ b/auth/passwords.cc
@@ -46,7 +46,7 @@ sstring hash_with_salt(const sstring& pass, const sstring& salt) {
     return res;
 }
 
-const char* prefix_for_scheme(scheme c) noexcept {
+std::string_view prefix_for_scheme(scheme c) noexcept {
     switch (c) {
     case scheme::bcrypt_y: return "$2y$";
     case scheme::bcrypt_a: return "$2a$";

--- a/auth/passwords.hh
+++ b/auth/passwords.hh
@@ -57,7 +57,7 @@ sstring generate_random_salt_bytes(RandomNumberEngine& g) {
 ///
 scheme identify_best_supported_scheme();
 
-const char* prefix_for_scheme(scheme) noexcept;
+std::string_view prefix_for_scheme(scheme) noexcept;
 
 ///
 /// Generate a implementation-specific salt string for hashing passwords.


### PR DESCRIPTION
In this PR, we get rid of the unnecessary default switch case in `prefix_for_scheme()`. We also change the return type of the function to `std::string_view` as it's easier to operate on.

Backport: not needed; this is a code cleanup.