### PR TITLE
docs: Update documentation on CREATE ROLE WITH HASHED PASSWORD

### DIFF
--- a/docs/cql/describe-schema.rst
+++ b/docs/cql/describe-schema.rst
@@ -107,5 +107,5 @@ following form:
     CREATE ROLE [IF NOT EXISTS] <role_name> WITH HASHED PASSWORD = '<hashed_password>' AND LOGIN = <boolean> AND SUPERUSER = <boolean>
 
 The semantics of this statement is analogous to the regular ``CREATE ROLE`` statement except that it circumvents
-the encryption phase of the execution and inserts the hashed password directly into ``system.roles``. You should not use
-this statement unless it was returned by ``DESCRIBE SCHEMA``.
+the encryption phase of the execution and inserts the hashed password directly into the database.
+See :doc:`the article on authorization in ScyllaDB </operating-scylla/security/authorization>` to learn more about it.


### PR DESCRIPTION
As part of #18750, we added a CQL statement CREATE ROLE WITH SALTED HASH that prevented hashing a password when creating a role, effectively leading to inserting a hash given by the user directly into the database. In #21350, we noticed that Cassandra had implemented a CQL statement of similar semantics but different syntax. We decided to rename Scylla's statement to be compatible with Cassandra. Unfortunately, we didn't notice one more difference between what we had in Scylla and what was part of Cassandra.

Scylla's statement was originally supposed to only be used when restoring the schema and the user needn't have to be aware of its existence at all: the database produced a sequence of CQL statements that the user saved to a file and when a need to restore the schema arose, they would execute the contents of the file. That's why that although we documented the feature, it was only done in the necessary places. Those that weren't related to the backup & restore procedure were deliberately skipped.

Cassandra, on the other hand, added the statement for a different purpose (for details, see the relevant issue) and it was supposed to be used by the user by design. The statement is also documented as such.

Since we want to preserve compatibility with Cassandra, we document the statement and its semantics in the user documentation, explicitly implying that it can be used by the user.

We also add a test verifying that logging in works correctly.

Fixes scylladb/scylladb#21691

Backport: not needed. The relevant code didn't make it to 6.2 or any previous version of OSS.