### PR TITLE
locator: remove unused "#include"s

### DIFF
--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -11,7 +11,6 @@
 #include <memory>
 #include <functional>
 #include <unordered_map>
-#include <boost/icl/interval.hpp>
 #include <boost/icl/interval_map.hpp>
 #include "gms/inet_address.hh"
 #include "locator/snitch_base.hh"
@@ -19,7 +18,6 @@
 #include "dht/token-sharding.hh"
 #include "token_metadata.hh"
 #include "snitch_base.hh"
-#include <seastar/util/bool_class.hh>
 #include "utils/maybe_yield.hh"
 #include "utils/sequenced_set.hh"
 #include "utils/simple_hashers.hh"

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -10,6 +10,7 @@
 
 #include "locator/gossiping_property_file_snitch.hh"
 
+#include <seastar/core/file.hh>
 #include <seastar/core/seastar.hh>
 #include "gms/versioned_value.hh"
 #include "gms/gossiper.hh"

--- a/locator/gossiping_property_file_snitch.hh
+++ b/locator/gossiping_property_file_snitch.hh
@@ -14,7 +14,6 @@
 #include <chrono>
 #include <optional>
 #include "production_snitch_base.hh"
-#include <seastar/core/file.hh>
 
 namespace locator {
 

--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -15,8 +15,6 @@
 #include "utils/extremum_tracking.hh"
 #include "utils/div_ceil.hh"
 
-#include <seastar/core/smp.hh>
-#include <seastar/coroutine/maybe_yield.hh>
 #include <absl/container/btree_set.h>
 
 #include <optional>

--- a/locator/snitch_base.hh
+++ b/locator/snitch_base.hh
@@ -11,13 +11,12 @@
 #pragma once
 
 #include "utils/assert.hh"
-#include <boost/signals2.hpp>
+#include <boost/signals2/signal_type.hpp>
 #include <boost/signals2/dummy_mutex.hpp>
 
 #include "gms/endpoint_state.hh"
 #include "locator/types.hh"
 #include "gms/inet_address.hh"
-#include <seastar/core/shared_ptr.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/distributed.hh>
 #include "utils/log.hh"

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -23,10 +23,8 @@
 #include <ranges>
 #include <seastar/core/reactor.hh>
 #include <seastar/util/log.hh>
-#include <seastar/core/coroutine.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/util/noncopyable_function.hh>
-#include <seastar/coroutine/maybe_yield.hh>
 
 namespace locator {
 

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -17,7 +17,6 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/core/smp.hh>
 #include <seastar/util/bool_class.hh>
 
 #include "locator/types.hh"

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -12,6 +12,7 @@
 #include "service/task_manager_module.hh"
 #include "tasks/task_handler.hh"
 #include "tasks/virtual_task_hint.hh"
+#include <seastar/coroutine/maybe_yield.hh>
 
 namespace service {
 


### PR DESCRIPTION
these unused includes are identified by clang-include-cleaner. after auditing the source files, all of the reports have been confirmed.

---

it's a cleanup, hence no need to backport.