### PR TITLE
install-dependencies.sh: cleanups to silence shellcheck

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -185,7 +185,7 @@ arch_packages=(
 )
 
 go_arch() {
-    declare -A local GO_ARCH=(
+    local -A GO_ARCH=(
         ["x86_64"]=amd64
         ["aarch64"]=arm64
         ["s390x"]=s390x

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -327,7 +327,7 @@ elif [ "$ID" = "fedora" ]; then
     dnf install -y "${fedora_packages[@]}" "${fedora_python3_packages[@]}"
     PIP_DEFAULT_ARGS="--only-binary=:all: -v"
     pip_constrained_packages=""
-    for package in ${!pip_packages[@]}
+    for package in "${!pip_packages[@]}"
     do
         pip_constrained_packages="${pip_constrained_packages} ${package}${pip_packages[$package]}"
     done


### PR DESCRIPTION
this changeset includes two changes to silence the warnings reported by shellcheck. This changeset has no functional impact and serves as a proactive code improvement.

---

it's a cleanup, hence no need to backport.