### PR TITLE
transport/server: revert using async function in `for_each_gently()`

### DIFF
--- a/generic_server.hh
+++ b/generic_server.hh
@@ -118,7 +118,7 @@ protected:
 
     virtual future<> unadvertise_connection(shared_ptr<connection> conn);
 
-    future<> for_each_gently(noncopyable_function<future<>(connection&)>);
+    future<> for_each_gently(noncopyable_function<void(connection&)>);
 };
 
 }

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -346,6 +346,7 @@ public:
     future<bool> check_has_permission(auth::command_desc) const;
     future<> ensure_has_permission(auth::command_desc) const;
     future<> maybe_update_per_service_level_params();
+    void update_per_service_level_params(qos::service_level_options& slo);
 
     /**
      * Returns an exceptional future with \ref exceptions::invalid_request_exception if the resource does not exist.

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -348,6 +348,17 @@ future<std::optional<service_level_options>> service_level_controller::find_effe
     }
 }
 
+std::optional<service_level_options> service_level_controller::find_cached_effective_service_level(const sstring& role_name) {
+    if (!_sl_data_accessor->is_v2()) {
+        return std::nullopt;
+    }
+
+    auto effective_sl_it = _effective_service_levels_db.find(role_name);
+    return effective_sl_it != _effective_service_levels_db.end() 
+        ? std::optional<service_level_options>(effective_sl_it->second)
+        : std::nullopt;
+}
+
 future<>  service_level_controller::notify_service_level_added(sstring name, service_level sl_data) {
     return seastar::async( [this, name, sl_data] {
         _subscribers.thread_for_each([name, sl_data] (qos_configuration_change_subscriber* subscriber) {

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -252,6 +252,10 @@ public:
      */
     future<std::optional<service_level_options>> find_effective_service_level(const sstring& role_name);
 
+    // Synchronous equivalent of `find_effective_service_level`. 
+    // The method uses only effective service level cache, so it requires service levels in v2.
+    std::optional<service_level_options> find_cached_effective_service_level(const sstring& role_name);
+
     /**
      * Gets the service level data by name.
      * @param service_level_name - the name of the requested service level

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -2044,10 +2044,9 @@ void cql_server::response::write(const cql3::prepared_metadata& m, uint8_t versi
 
 future<utils::chunked_vector<client_data>> cql_server::get_client_data() {
     utils::chunked_vector<client_data> ret;
-    co_await for_each_gently([&ret] (const generic_server::connection& c) -> future<> {
+    co_await for_each_gently([&ret] (const generic_server::connection& c) {
         const connection& conn = dynamic_cast<const connection&>(c);
         ret.emplace_back(conn.make_client_data());
-        return make_ready_future<>();
     });
     co_return ret;
 }
@@ -2059,7 +2058,7 @@ future<> cql_server::update_connections_service_level_params() {
         return make_ready_future<>();
     }
 
-    return for_each_gently([this] (generic_server::connection& conn) -> future<> {
+    return for_each_gently([this] (generic_server::connection& conn) {
         connection& cql_conn = dynamic_cast<connection&>(conn);
         auto& cs = cql_conn.get_client_state();
         auto& user = cs.user();
@@ -2070,13 +2069,12 @@ future<> cql_server::update_connections_service_level_params() {
                 cs.update_per_service_level_params(*slo);
             }
         }
-        co_return;
     });
 }
 
 future<std::vector<connection_service_level_params>> cql_server::get_connections_service_level_params() {
     std::vector<connection_service_level_params> sl_params;
-    co_await for_each_gently([&sl_params] (const generic_server::connection& conn) -> future<> {
+    co_await for_each_gently([&sl_params] (const generic_server::connection& conn) {
         auto& cql_conn = dynamic_cast<const connection&>(conn);
         auto& client_state = cql_conn.get_client_state();
         auto& user = client_state.user();
@@ -2085,7 +2083,6 @@ future<std::vector<connection_service_level_params>> cql_server::get_connections
                 : "UNAUTHENTICATED";
 
         sl_params.emplace_back(std::move(role_name), client_state.get_timeout_config(), client_state.get_workload_type());
-        co_return;
     });
     co_return sl_params;
 }


### PR DESCRIPTION
This patch reverts 324b3c43c017b9d7b6f38088f74c55eb58d02c93 and adds synchronous versions of `service_level_controller::find_effective_service_level()` and `client_state::maybe_update_per_service_level_params()`.

It isn't safe to do asynchronous calls in `for_each_gently`, as the
connection may be disconnected while a call in callback preempts.

Fixes https://github.com/scylladb/scylladb/issues/21801