### PR TITLE
[Backport 6.2] test: Parametrize 'replacement with inter-dc encryption' test to confirm behavior in zero token node cases

### DIFF
--- a/test/topology_custom/test_replace_with_encryption.py
+++ b/test/topology_custom/test_replace_with_encryption.py
@@ -7,42 +7,54 @@ import pytest
 from test.pylib.manager_client import ManagerClient
 from test.pylib.scylla_cluster import ReplaceConfig
 
+
 @pytest.mark.asyncio
-async def test_replace_with_encryption(manager: ManagerClient):
+@pytest.mark.parametrize("join_ring", [True, False])
+async def test_replace_with_encryption(manager: ManagerClient, join_ring):
     """Test that a node can be replaced if inter-dc encryption is enabled.
        The test creates 6 node cluster with two DCs and replaces one node in
-       each DC"""
+       each DC. The test is parametrized to confirm behavior in zero token node cases as well."""
     config = {"endpoint_snitch": "GossipingPropertyFileSnitch"}
+    config_maybe_zero_token = {"endpoint_snitch": "GossipingPropertyFileSnitch", "join_ring": join_ring}
     property_file_dc1 = {"dc": "dc1", "rack": "myrack"}
     property_file_dc2 = {"dc": "dc2", "rack": "myrack"}
 
-    s1 = await manager.servers_add(3,
+    await manager.servers_add(2,
             config=config,
             property_file=property_file_dc1,
             server_encryption="dc"
           )
-    s2 = await manager.servers_add(3,
+    await manager.servers_add(2,
             config=config,
             property_file=property_file_dc2,
             server_encryption="dc"
           )
 
-    await manager.server_stop_gracefully(s1[1].server_id)
+    s1 = await manager.server_add(config=config_maybe_zero_token,
+                                  property_file=property_file_dc1,
+                                  server_encryption="dc"
+                                  )
+    s2 = await manager.server_add(config=config_maybe_zero_token,
+                                  property_file=property_file_dc2,
+                                  server_encryption="dc"
+                                  )
 
-    replace_cfg = ReplaceConfig(replaced_id = s1[1].server_id, reuse_ip_addr = False,
+    await manager.server_stop_gracefully(s1.server_id)
+
+    replace_cfg = ReplaceConfig(replaced_id = s1.server_id, reuse_ip_addr = False,
                                 use_host_id = True)
 
-    await manager.server_add(replace_cfg=replace_cfg, config=config,
+    await manager.server_add(replace_cfg=replace_cfg, config=config_maybe_zero_token,
                              property_file=property_file_dc1,
                              server_encryption="dc"
                             )
 
-    await manager.server_stop_gracefully(s2[0].server_id)
+    await manager.server_stop_gracefully(s2.server_id)
 
-    replace_cfg = ReplaceConfig(replaced_id = s2[0].server_id, reuse_ip_addr = False,
+    replace_cfg = ReplaceConfig(replaced_id = s2.server_id, reuse_ip_addr = False,
                                 use_host_id = True)
 
-    await manager.server_add(replace_cfg=replace_cfg, config=config,
+    await manager.server_add(replace_cfg=replace_cfg, config=config_maybe_zero_token,
                              property_file=property_file_dc2,
                              server_encryption="dc"
                             )


### PR DESCRIPTION
In the current scenario, 'test_replace_with_encryption' only confirms the replacement with inter-dc encryption for normal nodes. This commit increases the coverage of test by parametrizing the test to confirm behavior for zero token node replacement as well.

This PR increases coverage for existing code. Hence we need to backport it. Since only 6.2 version has zero token node support, hence we only backport it to 6.2

Fixes: scylladb/scylladb#21096


- (cherry picked from commit acd643bd75468703150b2e23b1bbf05a3e95e42d)

Parent PR: #21609