### PR TITLE
sstables: parse(summary): reserve positions vector

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -507,7 +507,7 @@ future<> parse(const schema& schema, sstable_version_types v, random_access_read
 
     // Positions are encoded in little-endian.
     auto b = buf.get();
-    s.positions = utils::chunked_vector<pos_type>();
+    s.positions.reserve(s.header.size + 1);
     while (s.positions.size() != s.header.size) {
         s.positions.push_back(seastar::read_le<pos_type>(b));
         b += sizeof(pos_type);


### PR DESCRIPTION
We know the number of positions in advance
so reserve the chunked_vector capacity for that.

* Small optimization, no backport needed