### PR TITLE
build: cmake: Propagate target architecture to CMake build system

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -86,8 +86,10 @@ endfunction()
 add_compile_options("-ffile-prefix-map=${CMAKE_BINARY_DIR}=.")
 
 default_target_arch(target_arch)
+set(Scylla_TARGET_ARCH "${target_arch}" CACHE STRING
+  "Target architecture (-march)")
 if(target_arch)
-  add_compile_options("-march=${target_arch}")
+  add_compile_options("-march=${Scylla_TARGET_ARCH}")
 endif()
 
 add_compile_options("SHELL:-Xclang -fexperimental-assignment-tracking=disabled")

--- a/configure.py
+++ b/configure.py
@@ -2555,6 +2555,8 @@ def configure_using_cmake(args):
         settings['Boost_USE_STATIC_LIBS'] = 'ON'
     if args.clang_inline_threshold != -1:
         settings['Scylla_CLANG_INLINE_THRESHOLD'] = args.clang_inline_threshold
+    if args.target:
+        settings['Scylla_TARGET_ARCH'] = args.target
 
     source_dir = os.path.realpath(os.path.dirname(__file__))
     if os.path.isabs(args.build_dir):


### PR DESCRIPTION
Previously, the `--target` command-line option from `configure.py` was not passed to the CMake build system, despite preserving existing default settings. This meant that when no target was specified, CMake would still use the default target architecture.

To align the build process with `configure.py`, we introduce a new CMake option `Scylla_TARGET_ARCH` that captures the target architecture specified through the command-line interface. This ensures consistent target architecture selection across the configuration and build processes.

Key changes:
- Added `Scylla_TARGET_ARCH` option to CMake configuration
- Propagate `args.target` value from `configure.py` to CMake
- Maintain default behavior when no target is explicitly specified

---

this is an improvement in the cmake-based building system, hence no need to backport.