### PR TITLE
build: cmake: Improve function return mechanism with `return(PROPAGATE)`

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -21,7 +21,8 @@ function(generate_swagger)
       ${header_out}
       ${source_out})
 
-  set(${args_VAR} ${header_out} ${source_out} PARENT_SCOPE)
+  set(${args_VAR} ${header_out} ${source_out})
+  return(PROPAGATE ${args_VAR})
 endfunction()
 
 set(swagger_files

--- a/cmake/generate_cql_grammar.cmake
+++ b/cmake/generate_cql_grammar.cmake
@@ -43,5 +43,6 @@ function(generate_cql_grammar)
     COMMENT "Generating sources from ${grammar}"
     VERBATIM)
 
-  set(${parsed_args_SOURCES} ${outputs} PARENT_SCOPE)
+  set(${parsed_args_SOURCES} ${outputs})
+  return(PROPAGATE ${parsed_args_SOURCES})
 endfunction(generate_cql_grammar)

--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -26,17 +26,18 @@ add_compile_options(
 function(default_target_arch arch)
   set(x86_instruction_sets i386 i686 x86_64)
   if(CMAKE_SYSTEM_PROCESSOR IN_LIST x86_instruction_sets)
-    set(${arch} "westmere" PARENT_SCOPE)
+    set(${arch} "westmere")
   elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
     # we always use intrinsics like vmull.p64 for speeding up crc32 calculations
     # on the aarch64 architectures, and they require the crypto extension, so
     # we have to add "+crypto" in the architecture flags passed to -march. the
     # same applies to crc32 instructions, which need the ARMv8-A CRC32 extension
     # please note, Seastar also sets -march when compiled with DPDK enabled.
-    set(${arch} "armv8-a+crc+crypto" PARENT_SCOPE)
+    set(${arch} "armv8-a+crc+crypto")
   else()
-    set(${arch} "" PARENT_SCOPE)
+    set(${arch} "")
   endif()
+  return(PROPAGATE ${arch})
 endfunction()
 
 function(pad_at_begin output fill str length)
@@ -49,7 +50,8 @@ function(pad_at_begin output fill str length)
   if(padding_len GREATER 0)
     string(REPEAT ${fill} ${padding_len} padding)
   endif()
-  set(${output} "${padding}${str}" PARENT_SCOPE)
+  set(${output} "${padding}${str}")
+  return(PROPAGATE ${output})
 endfunction()
 
 # The relocatable package includes its own dynamic linker. We don't
@@ -80,7 +82,8 @@ function(get_padded_dynamic_linker_option output length)
   endif()
   # prefixing a path with "/"s does not actually change it means
   pad_at_begin(padded_dynamic_linker "/" "${dynamic_linker}" ${length})
-  set(${output} "${dynamic_linker_option}=${padded_dynamic_linker}" PARENT_SCOPE)
+  set(${output} "${dynamic_linker_option}=${padded_dynamic_linker}")
+  return(PROPAGATE ${output})
 endfunction()
 
 add_compile_options("-ffile-prefix-map=${CMAKE_BINARY_DIR}=.")

--- a/idl/CMakeLists.txt
+++ b/idl/CMakeLists.txt
@@ -18,7 +18,8 @@ function(compile_idl input)
     OUTPUT ${output}
     COMMAND ${Python3_EXECUTABLE} ${idl_compiler} --ns ser -f ${input} -o ${output}
     DEPENDS ${idl_compiler} ${input})
-  set(${parsed_args_SOURCES} ${output} PARENT_SCOPE)
+  set(${parsed_args_SOURCES} ${output})
+  return(PROPAGATE ${parsed_args_SOURCES})
 endfunction(compile_idl)
 
 set(idl_headers

--- a/redis/CMakeLists.txt
+++ b/redis/CMakeLists.txt
@@ -17,7 +17,8 @@ function(generate_ragel)
   add_custom_target(${args_TARGET}
     DEPENDS ${args_OUT_FILE})
 
-  set(${args_VAR} ${args_OUT_FILE} PARENT_SCOPE)
+  set(${args_VAR} ${args_OUT_FILE})
+  return(PROPAGATE ${args_VAR})
 endfunction()
 
 generate_ragel(

--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -48,7 +48,8 @@ function(generate_cxxbridge name)
     COMMAND ${command} --header --output ${header}
     COMMAND ${command} --output ${source})
 
-  set(${parsed_args_SOURCES} ${outputs} PARENT_SCOPE)
+  set(${parsed_args_SOURCES} ${outputs})
+  return(PROPAGATE ${parsed_args_SOURCES})
 endfunction(generate_cxxbridge)
 
 

--- a/test/resource/wasm/CMakeLists.txt
+++ b/test/resource/wasm/CMakeLists.txt
@@ -11,7 +11,8 @@ function(wasm2wat input)
     COMMAND ${WASM2WAT} ${input} --output=${output}
     DEPENDS ${input}
     COMMENT "Generating WebAssembly Text ${output}")
-  set(${parsed_args_WAT} ${output} PARENT_SCOPE)
+  set(${parsed_args_WAT} ${output})
+  return(PROPAGATE ${parsed_args_WAT})
 endfunction()
 
 add_custom_target(wasm ALL)

--- a/test/resource/wasm/c/CMakeLists.txt
+++ b/test/resource/wasm/c/CMakeLists.txt
@@ -17,7 +17,8 @@ function(compile_c_to_wasm input)
       -o ${output}
     DEPENDS ${input}
     COMMENT "Building WASM ${output}")
-  set(${parsed_args_WASM} ${output} PARENT_SCOPE)
+  set(${parsed_args_WASM} ${output})
+  return(PROPAGATE ${parsed_args_WASM})
 endfunction(compile_c_to_wasm)
 
 set(c_srcs

--- a/test/resource/wasm/rust/CMakeLists.txt
+++ b/test/resource/wasm/rust/CMakeLists.txt
@@ -29,7 +29,8 @@ function(compile_rust_to_wasm input)
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Building WASM ${output}"
     VERBATIM)
-  set(${parsed_args_WASM} ${output} PARENT_SCOPE)
+  set(${parsed_args_WASM} ${output})
+  return(PROPAGATE ${parsed_args_WASM})
 endfunction(compile_rust_to_wasm)
 
 set(rust_srcs


### PR DESCRIPTION
Replace `set(... PARENT_SCOPE)` with `return(PROPAGATE)` to enhance code readability and intent communication. This change provides clearer semantics by:

- Signaling the end of the function
- Explicitly indicating the return value's purpose
- Making the code's intent more transparent to readers

The `return(PROPAGATE)` approach more directly communicates the function's behavior compared to the previous `set()` method, improving overall code comprehension.

---

this is an improvement in the cmake-based building system, hence no need to backport.