### PR TITLE
server: set connection_stage to READY when authenticated

### DIFF
--- a/transport/server.cc
+++ b/transport/server.cc
@@ -946,6 +946,8 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_au
                 return client_state.maybe_update_per_service_level_params();
             });
             return f.then([this, stream, challenge = std::move(challenge), trace_state]() mutable {
+                _authenticating = false;
+                _ready = true;
                 return make_ready_future<std::unique_ptr<cql_server::response>>(make_auth_success(stream, std::move(challenge), trace_state));
             });
         });


### PR DESCRIPTION
If authentication is enabled, but STARTUP isn't followed by REGISTER (which is optional, and in practice only happens on only one of a driver's connections — because there's no point listening for the same events on multiple connections), connections are wrongly displayed in the system.clients as AUTHENTICATING instead of READY, even when they are ready.
This commit fixes this problem.

Fixes: scylladb/scylladb#12640

No backport needed, it's cosmetic change relating only to how we're displaying the connection status.