### PR TITLE
Update mig-tool-review.rst

### DIFF
--- a/docs/using-scylla/mig-tool-review.rst
+++ b/docs/using-scylla/mig-tool-review.rst
@@ -8,10 +8,9 @@ such as Apache Cassandra, or from other ScyllaDB clusters (ScyllaDB Open Source 
 * From SSTable to SSTable
     - Using nodetool refresh, :ref:`Load and Stream <nodetool-refresh-load-and-stream>` option.
     - On a large scale, it requires tooling to upload / transfer files from location to location.
-* From SSTable to CQL.
-    - :doc:`sstableloader</operating-scylla/admin-tools/sstableloader/>`
+
 * From CQL to CQL
-    - `Spark Migrator <https://github.com/scylladb/scylla-migrator>`_.  The Spark migrator allows you to easily transform the data before pushing it to the destination DB.
+    - `Spark Migrator <https://https://migrator.docs.scylladb.com>`_.  The Spark migrator allows you to easily transform the data before pushing it to the destination DB.
 
 * From DynamoDB to ScyllaDB Alternator
-    - `Spark Migrator <https://github.com/scylladb/scylla-migrator>`_.  The Spark migrator allows you to easily transform the data before pushing it to the destination DB.
+    - `Spark Migrator <https://https://migrator.docs.scylladb.com>`_.  The Spark migrator allows you to easily transform the data before pushing it to the destination DB.

--- a/docs/using-scylla/mig-tool-review.rst
+++ b/docs/using-scylla/mig-tool-review.rst
@@ -13,4 +13,4 @@ such as Apache Cassandra, or from other ScyllaDB clusters (ScyllaDB Open Source 
     - `Spark Migrator <https://https://migrator.docs.scylladb.com>`_.  The Spark migrator allows you to easily transform the data before pushing it to the destination DB.
 
 * From DynamoDB to ScyllaDB Alternator
-    - `Spark Migrator <https://https://migrator.docs.scylladb.com>`_.  The Spark migrator allows you to easily transform the data before pushing it to the destination DB.
+    - `Spark Migrator <https://migrator.docs.scylladb.com>`_.  The Spark migrator allows you to easily transform the data before pushing it to the destination DB.


### PR DESCRIPTION
sstable to CQL is no longer supported
changed url for scylla-migratior from github to documentation

**Please replace this line with justification for the backport/\* labels added to this PR**