### PR TITLE
table: make update_effective_replication_map sync again

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -352,7 +352,7 @@ public:
     // refresh_mutation_source must be called when there are changes to data source
     // structures but logical state of data is not changed (e.g. when state for a
     // new tablet replica is allocated).
-    virtual future<> update_effective_replication_map(const locator::effective_replication_map& erm, noncopyable_function<void()> refresh_mutation_source) = 0;
+    virtual void update_effective_replication_map(const locator::effective_replication_map& erm, noncopyable_function<void()> refresh_mutation_source) = 0;
 
     virtual compaction_group& compaction_group_for_token(dht::token token) const noexcept = 0;
     virtual utils::chunked_vector<compaction_group*> compaction_groups_for_token_range(dht::token_range tr) const = 0;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -863,7 +863,7 @@ public:
     void set_schema(schema_ptr);
     db::commitlog* commitlog() const;
     const locator::effective_replication_map_ptr& get_effective_replication_map() const { return _erm; }
-    future<> update_effective_replication_map(locator::effective_replication_map_ptr);
+    void update_effective_replication_map(locator::effective_replication_map_ptr);
     [[gnu::always_inline]] bool uses_tablets() const;
 private:
     future<> clear_inactive_reads_for_tablet(database& db, storage_group& sg);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -693,7 +693,7 @@ public:
         return make_ready_future<>();
     }
 
-    future<> update_effective_replication_map(const locator::effective_replication_map& erm, noncopyable_function<void()> refresh_mutation_source) override { return make_ready_future(); }
+    void update_effective_replication_map(const locator::effective_replication_map& erm, noncopyable_function<void()> refresh_mutation_source) override {}
 
     compaction_group& compaction_group_for_token(dht::token token) const noexcept override {
         return get_compaction_group();
@@ -739,6 +739,7 @@ class tablet_storage_group_manager final : public storage_group_manager {
     replica::table& _t;
     locator::host_id _my_host_id;
     const locator::tablet_map* _tablet_map;
+    future<> _stop_fut = make_ready_future();
     // Every table replica that completes split work will load the seq number from tablet metadata into its local
     // state. So when coordinator pull the local state of a table, it will know whether the table is ready for the
     // current split, and not a previously revoked (stale) decision.
@@ -764,12 +765,12 @@ private:
     // Called when coordinator executes tablet splitting, i.e. commit the new tablet map with
     // each tablet split into two, so this replica will remap all of its compaction groups
     // that were previously split.
-    future<> handle_tablet_split_completion(const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap);
+    void handle_tablet_split_completion(const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap);
 
     // Called when coordinator executes tablet merge. Tablet ids X and X+1 are merged into
     // the new tablet id (X >> 1). In practice, that means storage groups for X and X+1
     // are merged into a new storage group with id (X >> 1).
-    future<> handle_tablet_merge_completion(const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap);
+    void handle_tablet_merge_completion(const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap);
 
     // When merge completes, compaction groups of sibling tablets are added to same storage
     // group, but they're not merged yet into one, since the merge completion handler happens
@@ -835,10 +836,11 @@ public:
 
     future<> stop() override {
         _merge_completion_event.signal();
-        return std::exchange(_merge_completion_fiber, make_ready_future<>());
+        return when_all(std::exchange(_merge_completion_fiber, make_ready_future<>()),
+                std::exchange(_stop_fut, make_ready_future())).discard_result();
     }
 
-    future<> update_effective_replication_map(const locator::effective_replication_map& erm, noncopyable_function<void()> refresh_mutation_source) override;
+    void update_effective_replication_map(const locator::effective_replication_map& erm, noncopyable_function<void()> refresh_mutation_source) override;
 
     compaction_group& compaction_group_for_token(dht::token token) const noexcept override;
     utils::chunked_vector<compaction_group*> compaction_groups_for_token_range(dht::token_range tr) const override;
@@ -2469,7 +2471,7 @@ locator::table_load_stats table::table_load_stats(std::function<bool(const locat
     return _sg_manager->table_load_stats(std::move(tablet_filter));
 }
 
-future<> tablet_storage_group_manager::handle_tablet_split_completion(const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap) {
+void tablet_storage_group_manager::handle_tablet_split_completion(const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap) {
     auto table_id = schema()->id();
     size_t old_tablet_count = old_tmap.tablet_count();
     size_t new_tablet_count = new_tmap.tablet_count();
@@ -2492,7 +2494,6 @@ future<> tablet_storage_group_manager::handle_tablet_split_completion(const loca
     }
 
     // Stop the released main compaction groups asynchronously
-    future<> stop_fut = make_ready_future<>();
     for (auto& [id, sg] : _storage_groups) {
         if (!sg->split_unready_groups_are_empty()) {
             on_internal_error(tlogger, format("Found that storage of group {} for table {} wasn't split correctly, " \
@@ -2503,7 +2504,7 @@ future<> tablet_storage_group_manager::handle_tablet_split_completion(const loca
         auto cg_ptr = sg->main_compaction_group();
         auto f = cg_ptr->stop("tablet split");
         if (!f.available() || f.failed()) [[unlikely]] {
-            stop_fut = stop_fut.then([f = std::move(f), cg_ptr = std::move(cg_ptr)] () mutable {
+            _stop_fut = _stop_fut.then([f = std::move(f), cg_ptr = std::move(cg_ptr)] () mutable {
                 return std::move(f).handle_exception([cg_ptr = std::move(cg_ptr)] (std::exception_ptr ex) {
                     tlogger.warn("Failed to stop compaction group: {}.  Ignored", std::move(ex));
                 });
@@ -2525,8 +2526,6 @@ future<> tablet_storage_group_manager::handle_tablet_split_completion(const loca
     }
 
     _storage_groups = std::move(new_storage_groups);
-
-    return stop_fut;
 }
 
 future<> tablet_storage_group_manager::merge_completion_fiber() {
@@ -2557,7 +2556,7 @@ future<> tablet_storage_group_manager::merge_completion_fiber() {
     }
 }
 
-future<> tablet_storage_group_manager::handle_tablet_merge_completion(const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap) {
+void tablet_storage_group_manager::handle_tablet_merge_completion(const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap) {
     auto table_id = schema()->id();
     size_t old_tablet_count = old_tmap.tablet_count();
     size_t new_tablet_count = new_tmap.tablet_count();
@@ -2599,10 +2598,9 @@ future<> tablet_storage_group_manager::handle_tablet_merge_completion(const loca
     }
     _storage_groups = std::move(new_storage_groups);
     _merge_completion_event.signal();
-    return make_ready_future<>();
 }
 
-future<> tablet_storage_group_manager::update_effective_replication_map(const locator::effective_replication_map& erm, noncopyable_function<void()> refresh_mutation_source) {
+void tablet_storage_group_manager::update_effective_replication_map(const locator::effective_replication_map& erm, noncopyable_function<void()> refresh_mutation_source) {
     auto* new_tablet_map = &erm.get_token_metadata().tablets().get_tablet_map(schema()->id());
     auto* old_tablet_map = std::exchange(_tablet_map, new_tablet_map);
 
@@ -2611,13 +2609,11 @@ future<> tablet_storage_group_manager::update_effective_replication_map(const lo
     if (new_tablet_count > old_tablet_count) {
         tlogger.info0("Detected tablet split for table {}.{}, increasing from {} to {} tablets",
                         schema()->ks_name(), schema()->cf_name(), old_tablet_count, new_tablet_count);
-        co_await handle_tablet_split_completion(*old_tablet_map, *new_tablet_map);
-        co_return;
+        handle_tablet_split_completion(*old_tablet_map, *new_tablet_map);
     } else if (new_tablet_count < old_tablet_count) {
         tlogger.info0("Detected tablet merge for table {}.{}, decreasing from {} to {} tablets",
                       schema()->ks_name(), schema()->cf_name(), old_tablet_count, new_tablet_count);
-        co_await handle_tablet_merge_completion(*old_tablet_map, *new_tablet_map);
-        co_return;
+        handle_tablet_merge_completion(*old_tablet_map, *new_tablet_map);
     }
 
     // Allocate storage group if tablet is migrating in.
@@ -2658,10 +2654,9 @@ future<> tablet_storage_group_manager::update_effective_replication_map(const lo
     if (tablet_migrating_in) {
         refresh_mutation_source();
     }
-    co_return;
 }
 
-future<> table::update_effective_replication_map(locator::effective_replication_map_ptr erm) {
+void table::update_effective_replication_map(locator::effective_replication_map_ptr erm) {
     auto old_erm = std::exchange(_erm, std::move(erm));
 
     auto refresh_mutation_source = [this] {
@@ -2670,7 +2665,7 @@ future<> table::update_effective_replication_map(locator::effective_replication_
     };
 
     if (uses_tablets()) {
-        co_await _sg_manager->update_effective_replication_map(*_erm, refresh_mutation_source);
+        _sg_manager->update_effective_replication_map(*_erm, refresh_mutation_source);
     }
     if (old_erm) {
         old_erm->invalidate();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3143,6 +3143,8 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
 
                 co_await utils::clear_gently(erms);
                 co_await utils::clear_gently(tmptr);
+                co_await utils::clear_gently(table_erms);
+                co_await utils::clear_gently(view_erms);
             });
         } catch (...) {
             slogger.warn("Failure to reset pending token_metadata in cleanup path: {}. Ignored.", std::current_exception());

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3167,6 +3167,7 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
             auto& table_erms = pending_table_erms[this_shard_id()];
             auto& view_erms = pending_view_erms[this_shard_id()];
             for (auto it = table_erms.begin(); it != table_erms.end(); ) {
+                co_await coroutine::maybe_yield();
                 // Update base/views effective_replication_maps atomically.
                 auto& cf = db.find_column_family(it->first);
                 cf.update_effective_replication_map(std::move(it->second));
@@ -3180,18 +3181,6 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
                     view.update_effective_replication_map(std::move(view_it->second));
                     view_erms.erase(view_it);
                 }
-                co_await utils::get_local_injector().inject("delay_after_erm_update", [&cf, &ss] (auto& handler) -> future<> {
-                    auto& ss_ = ss;
-                    const auto ks_name = handler.get("ks_name");
-                    const auto cf_name = handler.get("cf_name");
-                    SCYLLA_ASSERT(ks_name);
-                    SCYLLA_ASSERT(cf_name);
-                    if (cf.schema()->ks_name() != *ks_name || cf.schema()->cf_name() != *cf_name) {
-                        co_return;
-                    }
-
-                    co_await sleep_abortable(std::chrono::seconds{5}, ss_._abort_source);
-                });
                 if (cf.uses_tablets()) {
                     register_tablet_split_candidate(it->first);
                 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3160,7 +3160,7 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
             auto& table_erms = pending_table_erms[this_shard_id()];
             for (auto it = table_erms.begin(); it != table_erms.end(); ) {
                 auto& cf = db.find_column_family(it->first);
-                co_await cf.update_effective_replication_map(std::move(it->second));
+                cf.update_effective_replication_map(std::move(it->second));
                 co_await utils::get_local_injector().inject("delay_after_erm_update", [&cf, &ss] (auto& handler) -> future<> {
                     auto& ss_ = ss;
                     const auto ks_name = handler.get("ks_name");

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3050,7 +3050,9 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
     std::vector<std::unordered_map<sstring, locator::vnode_effective_replication_map_ptr>> pending_effective_replication_maps;
     pending_effective_replication_maps.resize(smp::count);
     std::vector<std::unordered_map<table_id, locator::effective_replication_map_ptr>> pending_table_erms;
+    std::vector<std::unordered_map<table_id, locator::effective_replication_map_ptr>> pending_view_erms;
     pending_table_erms.resize(smp::count);
+    pending_view_erms.resize(smp::count);
 
     std::unordered_set<session_id> open_sessions;
 
@@ -3119,7 +3121,11 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
                 } else {
                     erm = pending_effective_replication_maps[this_shard_id()][table->schema()->ks_name()];
                 }
-                pending_table_erms[this_shard_id()].emplace(id, std::move(erm));
+                if (table->schema()->is_view()) {
+                    pending_view_erms[this_shard_id()].emplace(id, std::move(erm));
+                } else {
+                    pending_table_erms[this_shard_id()].emplace(id, std::move(erm));
+                }
             });
         });
     } catch (...) {
@@ -3133,6 +3139,7 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
                 auto tmptr = std::move(pending_token_metadata_ptr[this_shard_id()]);
                 auto erms = std::move(pending_effective_replication_maps[this_shard_id()]);
                 auto table_erms = std::move(pending_table_erms[this_shard_id()]);
+                auto view_erms = std::move(pending_view_erms[this_shard_id()]);
 
                 co_await utils::clear_gently(erms);
                 co_await utils::clear_gently(tmptr);
@@ -3158,9 +3165,21 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
             }
 
             auto& table_erms = pending_table_erms[this_shard_id()];
+            auto& view_erms = pending_view_erms[this_shard_id()];
             for (auto it = table_erms.begin(); it != table_erms.end(); ) {
+                // Update base/views effective_replication_maps atomically.
                 auto& cf = db.find_column_family(it->first);
                 cf.update_effective_replication_map(std::move(it->second));
+                for (const auto& view_ptr : cf.views()) {
+                    const auto& view_id = view_ptr->id();
+                    auto view_it = view_erms.find(view_id);
+                    if (view_it == view_erms.end()) {
+                        throw std::runtime_error(format("Could not find pending effective_replication_map for view {}.{} id={}", view_ptr->ks_name(), view_ptr->cf_name(), view_id));
+                    }
+                    auto& view = db.find_column_family(view_id);
+                    view.update_effective_replication_map(std::move(view_it->second));
+                    view_erms.erase(view_it);
+                }
                 co_await utils::get_local_injector().inject("delay_after_erm_update", [&cf, &ss] (auto& handler) -> future<> {
                     auto& ss_ = ss;
                     const auto ks_name = handler.get("ks_name");
@@ -3177,6 +3196,10 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
                     register_tablet_split_candidate(it->first);
                 }
                 it = table_erms.erase(it);
+            }
+
+            if (!view_erms.empty()) {
+                throw std::runtime_error(fmt::format("Found orphaned pending effective_replication_maps for the following views: {}", std::views::keys(view_erms)));
             }
 
             auto& session_mgr = get_topology_session_manager();

--- a/test/topology_custom/test_mv_topology_change.py
+++ b/test/topology_custom/test_mv_topology_change.py
@@ -71,7 +71,6 @@ async def test_mv_topology_change(manager: ManagerClient):
     await asyncio.gather(*tasks)
 
     [await manager.api.disable_injection(s.ip_addr, "delay_before_get_view_natural_endpoint") for s in servers]
-    [await manager.api.enable_injection(s.ip_addr, "delay_after_erm_update", False, parameters={'ks_name': 'ks', 'cf_name': 't'}) for s in servers]
 
     # to hit the issue #17786 we need to run multiple batches of writes, so that some write is processed while the 
     # effective replication maps for base and view are different


### PR DESCRIPTION
Commit f2ff701489995fdc84ea7ca0addbec2918c35be4 introduced
a yield in update_effective_replication_map that might
cause the storage_group manager to be inconsistent with the
new effective_replication_map (e.g. if yielding right
before calling `handle_tablet_split_completion`.

Also, yielding inside storage_service::replicate_to_all_cores
update loop means that base tables and their views
aren't updated atomically, that caused scylladb/scylladb#17786

This change essentially reverts f2ff701489995fdc84ea7ca0addbec2918c35be4
and makes handle_tablet_split_completion synchronous too.
The stopped compaction groups future is kept as a member and
storage_group_manager::stop() consumes this future during table::stop().

- storage_service: replicate_to_all_cores: update base and view tables atomically
    
Currently, the loop updating all tables (including views) with the
new effective_replication_map may yield, and therefore expose
a state where the base and view tables effective_replication_map
and topology are out of sync (as seen in scylladb/scylladb#17786)

To prevent that, loop over all base tables and for each table
update the base table and all views atomically, without yielding,
and so allow yielding only between base tables.

* Regression was introduced in f2ff701489995fdc84ea7ca0addbec2918c35be4, so backport is required to 6.x, 2024.2