### PR TITLE
[Backport 6.1] compaction: update maintenance sstable set on scrub compaction completion

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -139,15 +139,10 @@ public:
     void add_maintenance_sstable(sstables::shared_sstable sst);
     api::timestamp_type max_seen_timestamp() const { return _max_seen_timestamp; }
 
-    // Update main sstable set based on info in completion descriptor, where input sstables
-    // will be replaced by output ones, row cache ranges are possibly invalidated and
-    // statistics are updated.
-    future<> update_main_sstable_list_on_compaction_completion(sstables::compaction_completion_desc desc);
-
-    // This will update sstable lists on behalf of off-strategy compaction, where
-    // input files will be removed from the maintenance set and output files will
-    // be inserted into the main set.
-    future<> update_sstable_lists_on_off_strategy_completion(sstables::compaction_completion_desc desc);
+    // Update main and/or maintenance sstable sets based in info in completion descriptor,
+    // where input sstables will be replaced by output ones, row cache ranges are possibly
+    // invalidated and statistics are updated.
+    future<> update_sstable_sets_on_compaction_completion(sstables::compaction_completion_desc desc);
 
     const lw_shared_ptr<sstables::sstable_set>& main_sstables() const noexcept;
     void set_main_sstables(lw_shared_ptr<sstables::sstable_set> new_main_sstables);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -565,8 +565,15 @@ public:
         sstable_list_builder& operator=(const sstable_list_builder&) = delete;
         sstable_list_builder(const sstable_list_builder&) = delete;
 
+        // Struct to return the newly built sstable set and the removed sstables
+        struct result {
+            lw_shared_ptr<sstables::sstable_set> new_sstable_set;
+            std::vector<sstables::shared_sstable> removed_sstables;
+        };
+
         // Builds new sstable set from existing one, with new sstables added to it and old sstables removed from it.
-        future<lw_shared_ptr<sstables::sstable_set>>
+        // Returns the updated sstable set and a list of removed sstables.
+        future<result>
         build_new_list(const sstables::sstable_set& current_sstables,
                        sstables::sstable_set new_sstable_list,
                        const std::vector<sstables::shared_sstable>& new_sstables,


### PR DESCRIPTION
Scrub compaction can pick up input sstables from maintenance sstable set
but on compaction completion, it doesn't update the maintenance set
leaving the original sstable in set after it has been scrubbed. To fix
this, on compaction completion has to update the maintenance sstable if
the input originated from there. This PR solves the issue by updating the
correct sstable_sets on compaction completion.

Fixes #20030

This issue has existed since the introduction of main and maintenance sstable sets into scrub compaction. It would be good to have the fix backported to versions 6.1 and 6.2.

- (cherry picked from commit 58baeac0ad01d7c09bc14329d0ea09f31f122cf9)

Parent PR: #21582