### PR TITLE
./github/workflow/add-label-when-promoted: fix indentation which preventing the workflow to be triggered when label was added

### DIFF
--- a/.github/workflows/add-label-when-promoted.yaml
+++ b/.github/workflows/add-label-when-promoted.yaml
@@ -6,9 +6,9 @@ on:
       - master
       - branch-*.*
       - enterprise
-    pull_request_target:
-      types: [labeled]
-      branches: [master, next, enterprise]
+  pull_request_target:
+    types: [labeled]
+    branches: [master, next, enterprise]
 
 jobs:
   check-commit:


### PR DESCRIPTION
this workflow should be triggered either if a push event occurred or pull_request_target (which means someone added a backport label)

It seems that due to wrong indentation, the workflow wasn't triggered during label add

Fixing it

**This is only relevant for master, there is no need for a backport**