### PR TITLE
docs/cql/ddl: uncomment crc_check_chance 

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -767,14 +767,13 @@ available:
                                            defines the size (in KB) of the block. Bigger values may improve the
                                            compression rate, but increases the minimum size of data to be read from disk
                                            for a read. Allowed values are powers of two between 1 and 128.
+ ``crc_check_chance``      1.0             When compression is enabled, each compressed block includes a checksum of
+                                           that block for the purpose of detecting disk bitrot and avoiding the
+                                           propagation of corruption to other replicas. This option defines the
+                                           probability with which those checksums are checked during read. By default
+                                           they are always checked. Set to 0 to disable checksum checking and to 0.5 for
+                                           instance to check them every other read
 ========================= =============== =============================================================================
-
-.. ``crc_check_chance``      1.0             When compression is enabled, each compressed block includes a checksum of
-..                                           that block for the purpose of detecting disk bitrot and avoiding the
-..                                           propagation of corruption to other replicas. This option defines the
-..                                           probability with which those checksums are checked during read. By default
-..                                           they are always checked. Set to 0 to disable checksum checking and to 0.5 for
-..                                           instance to check them every other read   |
 
 For example, to enable compression:
 

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -771,8 +771,8 @@ available:
                                            that block for the purpose of detecting disk bitrot and avoiding the
                                            propagation of corruption to other replicas. This option defines the
                                            probability with which those checksums are checked during read. By default
-                                           they are always checked. Set to 0 to disable checksum checking and to 0.5 for
-                                           instance to check them every other read
+                                           they are always checked. Set to 0 to disable checksum checking and to 0.5, for
+                                           instance, to check them every other read.
 ========================= =============== =============================================================================
 
 For example, to enable compression:


### PR DESCRIPTION
we do support crc_check_chance as a suboption of compression.
so let's make its document visible to users.

Fixes scylladb/scylladb#21792

---

this is a user-facing document. so we should backport this change to all LTS branches.