### PR TITLE
docs/cql/ddl: Clarify crc_check_chance option behavior

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -767,14 +767,10 @@ available:
                                            defines the size (in KB) of the block. Bigger values may improve the
                                            compression rate, but increases the minimum size of data to be read from disk
                                            for a read. Allowed values are powers of two between 1 and 128.
+ ``crc_check_chance``      1.0             Not implemented (option value is ignored).
 ========================= =============== =============================================================================
 
-.. ``crc_check_chance``      1.0             When compression is enabled, each compressed block includes a checksum of
-..                                           that block for the purpose of detecting disk bitrot and avoiding the
-..                                           propagation of corruption to other replicas. This option defines the
-..                                           probability with which those checksums are checked during read. By default
-..                                           they are always checked. Set to 0 to disable checksum checking and to 0.5 for
-..                                           instance to check them every other read   |
+.. crc_check_chance was promoted to a top-level table option since Cassandra 3.0, but we didn't do this.
 
 For example, to enable compression:
 


### PR DESCRIPTION
Although `crc_check_chance` is accepted as a configuration option in ScyllaDB,
the value is currently ignored during runtime. This change makes this behavior
explicit in the documentation to prevent potential user misunderstandings.

Changes:
- Explicitly document that the option is currently a no-op
- Provide clear guidance on the current implementation
- Prevent confusion about the option's actual functionality

Refs scylladb/scylladb#21792
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

it's a cleanup, hence no need to backport.