### PR TITLE
locator,service: correct the misspellings

### DIFF
--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -359,7 +359,7 @@ void topology::index_node(const node* node) {
         auto eit = _nodes_by_endpoint.find(node->endpoint());
         if (eit != _nodes_by_endpoint.end()) {
             if (eit->second->get_state() == node::state::none && eit->second->is_this_node()) {
-                // eit->second is default entry created for local node and it is replaced by existing node withe the same ip
+                // eit->second is default entry created for local node and it is replaced by existing node with the same ip
                 // it means this node is going to replace the existing node with the same ip, but it does not know it yet
                 // map ip to the old node
                 _nodes_by_endpoint.erase(node->endpoint());

--- a/service/address_map.hh
+++ b/service/address_map.hh
@@ -35,7 +35,7 @@ namespace service {
 extern seastar::logger rslog;
 
 // This class provides an abstraction of expirable server address mappings
-// used by the messaging service and raft rpc module to store host id to ip maping
+// used by the messaging service and raft rpc module to store host id to ip mapping
 template <typename Clock>
 class address_map_t : public peering_sharded_service<address_map_t<Clock>> {
     // Expiring mappings stay in the cache for 1 hour (if not accessed during this time period)


### PR DESCRIPTION
these misspellings were identified by codespell. in this change, they are corrected.

---

it's a cleanup, hence no need to backport.