### PR TITLE
treewide: switch from boost::range::join() to utils::views::concat()

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -17,7 +17,6 @@
 #include <algorithm>
 
 #include <boost/range/algorithm.hpp>
-#include <boost/range/join.hpp>
 #include <boost/algorithm/string/join.hpp>
 
 #include <seastar/core/future-util.hh>
@@ -49,6 +48,7 @@
 #include "mutation/mutation_fragment_stream_validator.hh"
 #include "utils/assert.hh"
 #include "utils/error_injection.hh"
+#include "utils/ranges_concat.hh"
 #include "utils/pretty_printers.hh"
 #include "readers/multi_range.hh"
 #include "readers/compacting.hh"
@@ -178,7 +178,7 @@ static api::timestamp_type get_max_purgeable_timestamp(const table_state& table_
         timestamp = memtable_min_timestamp;
     }
     std::optional<utils::hashed_key> hk;
-    for (auto&& sst : boost::range::join(selector.select(dk).sstables, table_s.compacted_undeleted_sstables())) {
+    for (auto&& sst : utils::views::concat(selector.select(dk).sstables, table_s.compacted_undeleted_sstables())) {
         if (compacting_set.contains(sst)) {
             continue;
         }
@@ -980,7 +980,7 @@ private:
         // Delete either partially or fully written sstables of a compaction that
         // was either stopped abruptly (e.g. out of disk space) or deliberately
         // (e.g. nodetool stop COMPACTION).
-        for (auto& sst : boost::range::join(_new_partial_sstables, _new_unused_sstables)) {
+        for (auto& sst : utils::views::concat(_new_partial_sstables, _new_unused_sstables)) {
             log_debug("Deleting sstable {} of interrupted compaction for {}.{}", sst->get_filename(), _schema->ks_name(), _schema->cf_name());
             sst->mark_for_deletion();
         }

--- a/configure.py
+++ b/configure.py
@@ -544,6 +544,7 @@ scylla_tests = set([
     'test/boost/query_processor_test',
     'test/boost/radix_tree_test',
     'test/boost/range_tombstone_list_test',
+    'test/boost/ranges_concat_test',
     'test/boost/rate_limiter_test',
     'test/boost/reader_concurrency_semaphore_test',
     'test/boost/recent_entries_map_test',

--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -17,6 +17,7 @@
 
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
+#include <boost/range/join.hpp>
 
 using namespace std::chrono_literals;
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -91,6 +91,7 @@
 #include <seastar/coroutine/exception.hh>
 #include "utils/stall_free.hh"
 #include "utils/error_injection.hh"
+#include "utils/ranges_concat.hh"
 #include "locator/util.hh"
 #include "idl/storage_service.dist.hh"
 #include "service/storage_proxy.hh"
@@ -108,7 +109,6 @@
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/join.hpp>
 
 using token = dht::token;
 using UUID = utils::UUID;
@@ -424,7 +424,7 @@ future<storage_service::nodes_to_notify_after_sync> storage_service::sync_raft_t
     {
         if (!used_ips) {
             used_ips.emplace();
-            for (const auto& [sid, rs]: boost::range::join(t.normal_nodes, t.transition_nodes)) {
+            for (const auto& [sid, rs]: utils::views::concat(t.normal_nodes, t.transition_nodes)) {
                 if (const auto used_ip = am.find(locator::host_id{sid.uuid()})) {
                     used_ips->insert(*used_ip);
                 }
@@ -6992,7 +6992,7 @@ void storage_service::init_messaging_service() {
                 }
             }
 
-            for (const auto& table : boost::join(params.tables, additional_tables)) {
+            for (const auto& table : utils::views::concat(params.tables, additional_tables)) {
                 auto schema = ss._db.local().find_schema(table);
                 auto muts = co_await ss.get_system_mutations(schema);
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -8,6 +8,8 @@
 
 #include <fmt/ranges.h>
 
+#include <boost/range/join.hpp>
+
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/as_future.hh>

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -11,7 +11,6 @@
 #include <list>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/transform.hpp>
-#include <boost/range/join.hpp>
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/rwlock.hh>
@@ -24,6 +23,7 @@
 #include "schema/schema_fwd.hh"
 #include "tasks/types.hh"
 #include "utils/chunked_vector.hh"
+#include "utils/ranges_concat.hh"
 #include "utils/serialized_action.hh"
 #include "utils/updateable_value.hh"
 
@@ -172,7 +172,7 @@ public:
                     std::function<std::optional<Res>(const task_essentials&)> map_finished_children) const {
                 auto shared_holder = co_await _lock.hold_read_lock();
 
-                co_return boost::join(
+                co_return utils::views::concat(
                             _children | boost::adaptors::map_values | boost::adaptors::transformed(map_children),
                             _finished_children | boost::adaptors::transformed(map_finished_children)
                         )

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -243,6 +243,8 @@ add_scylla_test(radix_tree_test
   KIND SEASTAR)
 add_scylla_test(range_tombstone_list_test
   KIND BOOST)
+add_scylla_test(ranges_concat_test
+  KIND BOOST)
 add_scylla_test(rate_limiter_test
   KIND SEASTAR)
 add_scylla_test(reader_concurrency_semaphore_test

--- a/test/boost/ranges_concat_test.cc
+++ b/test/boost/ranges_concat_test.cc
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#define BOOST_TEST_MODULE utils
+
+#include <boost/test/unit_test.hpp>
+
+#include <vector>
+#include <list>
+#include <string>
+#include <ranges>
+
+#include "utils/ranges_concat.hh"
+
+BOOST_AUTO_TEST_CASE(test_join_two_integer_vectors) {
+    std::vector<int> v1 = {1, 2, 3};
+    std::vector<int> v2 = {4, 5, 6};
+
+    auto joined = utils::concat_view(v1, v2);
+
+    auto result = joined | std::ranges::to<std::vector>();
+
+    std::vector<int> expected = {1, 2, 3, 4, 5, 6};
+    BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(),
+                                  expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(test_join_empty_rcanges) {
+    std::vector<int> v1;
+    std::vector<int> v2;
+
+    auto joined = utils::concat_view(v1, v2);
+
+    auto result = joined | std::ranges::to<std::vector>();
+
+    BOOST_CHECK(result.empty());
+}
+
+
+BOOST_AUTO_TEST_CASE(test_join_one_empty_range) {
+    std::vector<int> v1 = {1, 2, 3};
+    std::vector<int> v2;
+
+    auto joined = utils::views::concat(v1, v2);
+
+    auto result = joined | std::ranges::to<std::vector>();
+
+    std::vector<int> expected = {1, 2, 3};
+    BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(),
+                                  expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(test_join_different_container_types) {
+    std::vector<std::string> v1 = {"Hello", "World"};
+    std::list<std::string> v2 = {"Boost", "Test"};
+
+    auto joined = utils::views::concat(v1, v2);
+
+    auto result = joined | std::ranges::to<std::vector>();
+
+    std::vector<std::string> expected = {"Hello", "World", "Boost", "Test"};
+    BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(),
+                                  expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(test_iterator_comparison) {
+    std::vector<int> v1 = {1, 2, 3};
+    std::vector<int> v2 = {4, 5, 6};
+
+    auto joined = utils::views::concat(v1, v2);
+
+    auto it1 = joined.begin();
+    auto it2 = joined.begin();
+
+    BOOST_CHECK(it1 == it2);
+
+    ++it1;
+    BOOST_CHECK(it1 != it2);
+}
+
+BOOST_AUTO_TEST_CASE(test_range_based_for_loop) {
+    std::vector<int> v1 = {1, 2, 3};
+    std::vector<int> v2 = {4, 5, 6};
+
+    auto joined = utils::views::concat(v1, v2);
+
+    int expected[] = {1, 2, 3, 4, 5, 6};
+    int index = 0;
+
+    for (int x : joined) {
+        BOOST_CHECK_EQUAL(x, expected[index++]);
+    }
+
+    BOOST_CHECK_EQUAL(index, 6);
+}

--- a/utils/ranges_concat.hh
+++ b/utils/ranges_concat.hh
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <iterator>
+#include <ranges>
+#include <utility>
+
+#ifdef __cpp_lib_ranges_concat
+#warning "use std::views::concat instead"
+#endif
+
+namespace utils {
+
+// A custom implementation of the missing std::views::concat in C++23.
+//
+// Unlike std::views::concat (which would join multiple ranges), this implementation
+// is specifically designed to join exactly two ranges of the same value type.
+template<std::ranges::input_range V1, std::ranges::input_range V2>
+class concat_view : public std::ranges::view_interface<concat_view<V1, V2>> {
+private:
+    V1 _first;
+    V2 _second;
+
+public:
+    concat_view(V1 first, V2 second)
+    : _first(std::move(first))
+    , _second(std::move(second)) {}
+
+    class iterator {
+    private:
+        enum class State { First, Second, End };
+
+        std::ranges::iterator_t<V1> _first_iter;
+        std::ranges::iterator_t<V2> _second_iter;
+        concat_view* _parent = nullptr;
+        State _current_state = State::First;
+
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using iterator_concept = std::forward_iterator_tag;
+        using value_type = std::common_type_t<
+            std::iter_value_t<std::ranges::iterator_t<V1>>,
+            std::iter_value_t<std::ranges::iterator_t<V2>>>;
+        using difference_type = std::ptrdiff_t;
+        using pointer = void;
+
+        iterator() = default;
+
+        iterator(std::ranges::iterator_t<V1> first_begin,
+                 std::ranges::iterator_t<V2> second_begin,
+                 concat_view* parent,
+                 bool is_end)
+            : _first_iter(first_begin)
+            , _second_iter(second_begin)
+            , _parent(parent)
+            , _current_state(is_end ? State::End : State::First)
+        {
+            if (!is_end && _first_iter == std::ranges::end(_parent->_first)) {
+                _current_state = State::Second;
+            }
+        }
+
+        decltype(auto) operator*() const {
+            return _current_state == State::First
+                ? *_first_iter
+                : *_second_iter;
+        }
+
+        iterator& operator++() {
+            if (_current_state == State::First) {
+                ++_first_iter;
+                if (_first_iter == std::ranges::end(_parent->_first)) {
+                    _current_state = State::Second;
+                }
+            } else {
+                ++_second_iter;
+                if (_second_iter == std::ranges::end(_parent->_second)) {
+                    _current_state = State::End;
+                }
+            }
+            return *this;
+        }
+
+        iterator operator++(int) {
+            auto tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        friend bool operator==(const iterator& x, const iterator& y) {
+            if (x._current_state != y._current_state) {
+                return false;
+            }
+            switch (x._current_state) {
+            case State::First:
+                return x._first_iter == y._first_iter;
+            case State::Second:
+                return x._second_iter == y._second_iter;
+            case State::End:
+                return true;
+            }
+        }
+
+        friend bool operator==(const iterator& x, std::default_sentinel_t) {
+            switch (x._current_state) {
+            case State::First:
+                return false;
+            case State::Second:
+                return x._second_iter == std::ranges::end(x._parent->_second);
+            case State::End:
+                return true;
+            }
+        }
+    };
+
+    auto begin() {
+        bool is_end = std::ranges::empty(_first) && std::ranges::empty(_second);
+        return iterator(
+            std::ranges::begin(_first),
+            std::ranges::begin(_second),
+            this,
+            is_end
+        );
+    }
+
+    auto end() {
+        return std::default_sentinel;
+    }
+};
+
+namespace views {
+
+struct concat_fn {
+    template<std::ranges::input_range V1, std::ranges::input_range V2>
+    constexpr auto operator() (V1&& first, V2&& second) const {
+        return concat_view(std::forward<V1>(first), std::forward<V2>(second));
+    }
+};
+
+inline constexpr concat_fn concat;
+}
+
+} // namespace utils


### PR DESCRIPTION
In order to reduce the dependency on external libraries, and for better integration with ranges in C++ standard library. let's use the homebrew `utils::views::concat()` before switching to C++26.

---

it's a cleanup, hence no need to backport.