### PR TITLE
[Backport 6.2] topology_coordinator: introduce reload_count in topology state and use it to prevent race

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -686,6 +686,7 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
 
     // read topology state from disk and recreate token_metadata from it
     _topology_state_machine._topology = co_await _sys_ks.local().load_topology_state(tablet_hosts);
+    _topology_state_machine.reload_count++;
 
     if (_manage_topology_change_kind_from_group0) {
         set_topology_change_kind(upgrade_state_to_topology_op_kind(_topology_state_machine._topology.upgrade_state));
@@ -1531,7 +1532,7 @@ future<> storage_service::await_tablets_rebuilt(raft::server_id replaced_id) {
     };
     if (!is_drained()) {
         slogger.info("Waiting for tablet replicas from the replaced node to be rebuilt");
-        co_await _topology_state_machine.event.wait([&] {
+        co_await _topology_state_machine.event.when([&] {
             return is_drained();
         });
     }
@@ -4726,12 +4727,19 @@ future<> storage_service::do_cluster_cleanup() {
 }
 
 future<sstring> storage_service::wait_for_topology_request_completion(utils::UUID id, bool require_entry) {
+    rtlogger.debug("Start waiting for topology request completion (request id {})", id);
     while (true) {
+        auto c = _topology_state_machine.reload_count;
         auto [done, error] = co_await  _sys_ks.local().get_topology_request_state(id, require_entry);
         if (done) {
+            rtlogger.debug("Request with id {} is completed with status: {}", id, error.empty() ? sstring("success") : error);
             co_return error;
         }
-        co_await _topology_state_machine.event.when();
+        if (c == _topology_state_machine.reload_count) {
+            // wait only if the state was not reloaded while we were preempted
+            rtlogger.debug("Waiting for a topology event while waiting for topology request completion (request id {})", id);
+            co_await _topology_state_machine.event.when();
+        }
     }
 
     co_return sstring();
@@ -4741,7 +4749,7 @@ future<> storage_service::wait_for_topology_not_busy() {
     auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
     while (_topology_state_machine._topology.is_busy()) {
         release_guard(std::move(guard));
-        co_await _topology_state_machine.event.wait();
+        co_await _topology_state_machine.event.when();
         guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
     }
 }
@@ -6403,7 +6411,7 @@ future<> storage_service::transit_tablet(table_id table, dht::token token, nonco
             }
             rtlogger.debug("transit_tablet(): topology state machine is busy: {}", tstate);
             release_guard(std::move(guard));
-            co_await _topology_state_machine.event.wait();
+            co_await _topology_state_machine.event.when();
             guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
         }
 
@@ -6434,7 +6442,7 @@ future<> storage_service::transit_tablet(table_id table, dht::token token, nonco
     }
 
     // Wait for transition to finish.
-    co_await _topology_state_machine.event.wait([&] {
+    co_await _topology_state_machine.event.when([&] {
         auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
         return !tmap.get_tablet_transition_info(tmap.get_tablet_id(token));
     });
@@ -6472,7 +6480,7 @@ future<> storage_service::set_tablet_balancing_enabled(bool enabled) {
 
     while (_topology_state_machine._topology.is_busy()) {
         rtlogger.debug("set_tablet_balancing_enabled(): topology is busy");
-        co_await _topology_state_machine.event.wait();
+        co_await _topology_state_machine.event.when();
     }
 }
 

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -229,6 +229,7 @@ struct topology_state_machine {
     using topology_type = topology;
     topology_type _topology;
     condition_variable event;
+    size_t reload_count = 0;
 
     future<> await_not_busy();
 };


### PR DESCRIPTION
Topology request table may change between the code reading it and
calling to cv::when() since reading is a preemption point. In this
case cv:signal can be missed. Detect that there was no signal in between
reading and waiting by introducing reload_count which is increased each
time the state is reloaded and signaled. If the counter is different
before and after reading the state may have change so re-check it again
instead of sleeping.

Fixes: https://github.com/scylladb/scylladb/issues/19994



- (cherry picked from commit 8f858325b6134809d6556a945f5d403a895cc1d1)

Parent PR: #21713