### PR TITLE
db/commitlog: make the commit log hard limit mandatory

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -106,7 +106,7 @@ db::commitlog::config db::commitlog::config::from_db_config(const db::config& cf
     c.mode = cfg.commitlog_sync() == "batch" ? sync_mode::BATCH : sync_mode::PERIODIC;
     c.extensions = &cfg.extensions();
     c.use_o_dsync = cfg.commitlog_use_o_dsync();
-    c.allow_going_over_size_limit = !cfg.commitlog_use_hard_size_limit();
+    c.allow_going_over_size_limit = false;
 
     if (cfg.commitlog_flush_threshold_in_mb() >= 0) {
         c.commitlog_flush_threshold_in_mb = cfg.commitlog_flush_threshold_in_mb();

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -108,7 +108,7 @@ public:
 
         bool use_o_dsync = false;
         bool warn_about_segments_left_on_disk_after_shutdown = true;
-        bool allow_going_over_size_limit = true;
+        bool allow_going_over_size_limit = false;
         bool allow_fragmented_entries = false;
 
         // The base segment ID to use.

--- a/db/config.cc
+++ b/db/config.cc
@@ -574,8 +574,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Threshold for commitlog disk usage. When used disk space goes above this value, Scylla initiates flushes of memtables to disk for the oldest commitlog segments, removing those log segments. Adjusting this affects disk usage vs. write latency. Default is (approximately) commitlog_total_space_in_mb - <num shards>*commitlog_segment_size_in_mb.")
     , commitlog_use_o_dsync(this, "commitlog_use_o_dsync", value_status::Used, true,
         "Whether or not to use O_DSYNC mode for commitlog segments IO. Can improve commitlog latency on some file systems.\n")
-    , commitlog_use_hard_size_limit(this, "commitlog_use_hard_size_limit", value_status::Used, true,
-        "Whether or not to use a hard size limit for commitlog disk usage. Default is true. Enabling this can cause latency spikes, whereas the default can lead to occasional disk usage peaks.\n")
+    , commitlog_use_hard_size_limit(this, "commitlog_use_hard_size_limit", value_status::Deprecated, true,
+        "Whether or not to use a hard size limit for commitlog disk usage. Default is true. Enabling this can cause latency spikes, whereas disabling this can lead to occasional disk usage peaks.\n")
     , commitlog_use_fragmented_entries(this, "commitlog_use_fragmented_entries", value_status::Used, true,
         "Whether or not to allow commitlog entries to fragment across segments, allowing for larger entry sizes.\n")
     /**

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -309,6 +309,7 @@ SEASTAR_TEST_CASE(test_commitlog_delete_when_over_disk_limit) {
     cfg.commitlog_segment_size_in_mb = max_size_mb;
     cfg.commitlog_total_space_in_mb = 1;
     cfg.commitlog_sync_period_in_ms = 1;
+    cfg.allow_going_over_size_limit = true;
     return cl_test(cfg, [](commitlog& log) {
             auto sem = make_lw_shared<semaphore>(0);
             auto segments = make_lw_shared<std::set<sstring>>();


### PR DESCRIPTION
mark the config parameter `--commitlog-use-hard-size-limit` as deprecated so the default 'true' is always used, making the hard limit mandatory.

Fixes scylladb/scylladb#16471