### PR TITLE
[RFC] Implement crc_check_chance

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1179,7 +1179,7 @@ public:
                 unwrap_monitor_generator(),
                 default_sstable_predicate(),
                 &_reader_statistics,
-                integrity_check::yes);
+                integrity_check::checksums_and_digest);
     }
 
     std::string_view report_start_desc() const override {
@@ -1329,7 +1329,7 @@ public:
                 unwrap_monitor_generator(),
                 default_sstable_predicate(),
                 nullptr,
-                integrity_check::yes);
+                integrity_check::checksums_and_digest);
     }
 
     std::string_view report_start_desc() const override {
@@ -1671,7 +1671,7 @@ public:
         if (!range.is_full()) {
             on_internal_error(clogger, fmt::format("Scrub compaction in mode {} expected full partition range, but got {} instead", _options.operation_mode, range));
         }
-        auto full_scan_reader = _compacting->make_full_scan_reader(std::move(s), std::move(permit), nullptr, unwrap_monitor_generator(), integrity_check::yes);
+        auto full_scan_reader = _compacting->make_full_scan_reader(std::move(s), std::move(permit), nullptr, unwrap_monitor_generator(), integrity_check::checksums_and_digest);
         return make_mutation_reader<reader>(std::move(full_scan_reader), _options.operation_mode, _validation_errors);
     }
 
@@ -1777,7 +1777,7 @@ public:
                 sm_fwd,
                 mr_fwd,
                 unwrap_monitor_generator(),
-                integrity_check::yes);
+                integrity_check::checksums_and_digest);
 
     }
 

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -412,7 +412,12 @@ alter_table_statement::prepare_schema_mutations(query_processor& qp, const query
             keyspace(),
             column_family());
 
-  co_return std::make_tuple(std::move(ret), std::move(m), std::vector<sstring>());
+    cql3::cql_warnings_vec warnings;
+    if (_properties) {
+        _properties->maybe_add_warning_for_deprecated_crc_check_chance_in_compression(warnings);
+    }
+
+  co_return std::make_tuple(std::move(ret), std::move(m), std::move(warnings));
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -358,7 +358,7 @@ std::pair<schema_builder, std::vector<view_ptr>> alter_table_statement::prepare_
                 throw exceptions::invalid_request_exception(format("The synchronous_updates option is only applicable to materialized views, not to base tables"));
             }
 
-            _properties->apply_to_builder(cfm, std::move(schema_extensions), db, keyspace());
+            _properties->apply_to_builder(cfm, std::move(schema_extensions), db, keyspace(), cf_prop_defs::is_create_statement::no);
         }
         break;
 

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -401,12 +401,12 @@ std::pair<schema_builder, std::vector<view_ptr>> alter_table_statement::prepare_
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
 alter_table_statement::prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type ts) const {
-  data_dictionary::database db = qp.db();
-  auto [cfm, view_updates] = prepare_schema_update(db, options);
-  auto m = co_await service::prepare_column_family_update_announcement(qp.proxy(), cfm.build(), std::move(view_updates), ts);
+    data_dictionary::database db = qp.db();
+    auto [cfm, view_updates] = prepare_schema_update(db, options);
+    auto m = co_await service::prepare_column_family_update_announcement(qp.proxy(), cfm.build(), std::move(view_updates), ts);
 
-  using namespace cql_transport;
-  auto ret = ::make_shared<event::schema_change>(
+    using namespace cql_transport;
+    auto ret = ::make_shared<event::schema_change>(
             event::schema_change::change_type::UPDATED,
             event::schema_change::target_type::TABLE,
             keyspace(),
@@ -417,7 +417,7 @@ alter_table_statement::prepare_schema_mutations(query_processor& qp, const query
         _properties->maybe_add_warning_for_deprecated_crc_check_chance_in_compression(warnings);
     }
 
-  co_return std::make_tuple(std::move(ret), std::move(m), std::move(warnings));
+    co_return std::make_tuple(std::move(ret), std::move(m), std::move(warnings));
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>

--- a/cql3/statements/alter_view_statement.cc
+++ b/cql3/statements/alter_view_statement.cc
@@ -56,7 +56,7 @@ view_ptr alter_view_statement::prepare_view(data_dictionary::database db) const 
     _properties->validate(db, keyspace(), schema_extensions);
 
     auto builder = schema_builder(schema);
-    _properties->apply_to_builder(builder, std::move(schema_extensions), db, keyspace());
+    _properties->apply_to_builder(builder, std::move(schema_extensions), db, keyspace(), cf_prop_defs::is_create_statement::no);
 
     if (builder.get_gc_grace_seconds() == 0) {
         throw exceptions::invalid_request_exception(

--- a/cql3/statements/alter_view_statement.cc
+++ b/cql3/statements/alter_view_statement.cc
@@ -85,7 +85,12 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector
             keyspace(),
             column_family());
 
-    co_return std::make_tuple(std::move(ret), std::move(m), std::vector<sstring>());
+    cql3::cql_warnings_vec warnings;
+    if (_properties) {
+        _properties->maybe_add_warning_for_deprecated_crc_check_chance_in_compression(warnings);
+    }
+
+    co_return std::make_tuple(std::move(ret), std::move(m), std::move(warnings));
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>

--- a/cql3/statements/cf_prop_defs.cc
+++ b/cql3/statements/cf_prop_defs.cc
@@ -154,6 +154,13 @@ void cf_prop_defs::validate(const data_dictionary::database db, sstring ks_name,
         }
     }
 
+    if (get_simple(KW_CRC_CHECK_CHANCE)) {
+        const double crc_check_chance = get_double(KW_CRC_CHECK_CHANCE, 0.0/*not used*/);
+        if (crc_check_chance < 0.0 || crc_check_chance > 1.0) {
+            throw exceptions::configuration_exception(format("{} must be between 0.0 and 1.0.", KW_CRC_CHECK_CHANCE));
+        }
+    }
+
     auto memtable_flush_period = get_int(KW_MEMTABLE_FLUSH_PERIOD, DEFAULT_MEMTABLE_FLUSH_PERIOD);
     if (memtable_flush_period != 0 && memtable_flush_period < DEFAULT_MEMTABLE_FLUSH_PERIOD_MIN_VALUE) {
         throw exceptions::configuration_exception(format(

--- a/cql3/statements/cf_prop_defs.cc
+++ b/cql3/statements/cf_prop_defs.cc
@@ -399,6 +399,12 @@ std::optional<sstables::compaction_strategy_type> cf_prop_defs::get_compaction_s
     return std::nullopt;
 }
 
+void cf_prop_defs::maybe_add_warning_for_deprecated_crc_check_chance_in_compression(std::vector<sstring>& warnings) const {
+    if (const auto co = get_compression_options(); co && co->contains(compression_parameters::CRC_CHECK_CHANCE)) {
+        warnings.push_back(fmt::format("{} is now a table-level option, it is deprecated as a compression option", compression_parameters::CRC_CHECK_CHANCE));
+    }
+}
+
 }
 
 }

--- a/cql3/statements/cf_prop_defs.hh
+++ b/cql3/statements/cf_prop_defs.hh
@@ -108,6 +108,8 @@ public:
     void apply_to_builder(schema_builder& builder, schema::extensions_map schema_extensions, const data_dictionary::database& db, sstring ks_name,
             is_create_statement is_create) const;
     void validate_minimum_int(const sstring& field, int32_t minimum_value, int32_t default_value) const;
+
+    void maybe_add_warning_for_deprecated_crc_check_chance_in_compression(std::vector<sstring>& warnings) const;
 };
 
 }

--- a/cql3/statements/cf_prop_defs.hh
+++ b/cql3/statements/cf_prop_defs.hh
@@ -104,7 +104,9 @@ public:
     std::optional<table_id> get_id() const;
     bool get_synchronous_updates_flag() const;
 
-    void apply_to_builder(schema_builder& builder, schema::extensions_map schema_extensions, const data_dictionary::database& db, sstring ks_name) const;
+    using is_create_statement = bool_class<struct is_create_statement_tag>;
+    void apply_to_builder(schema_builder& builder, schema::extensions_map schema_extensions, const data_dictionary::database& db, sstring ks_name,
+            is_create_statement is_create) const;
     void validate_minimum_int(const sstring& field, int32_t minimum_value, int32_t default_value) const;
 };
 

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -124,7 +124,7 @@ void create_table_statement::apply_properties_to(schema_builder& builder, const 
         addColumnMetadataFromAliases(cfmd, Collections.singletonList(valueAlias), defaultValidator, ColumnDefinition.Kind.COMPACT_VALUE);
 #endif
 
-    _properties->apply_to_builder(builder, _properties->make_schema_extensions(db.extensions()), db, keyspace());
+    _properties->apply_to_builder(builder, _properties->make_schema_extensions(db.extensions()), db, keyspace(), cf_prop_defs::is_create_statement::yes);
 }
 
 void create_table_statement::add_column_metadata_from_aliases(schema_builder& builder, std::vector<bytes> aliases, const std::vector<data_type>& types, column_kind kind) const

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -353,7 +353,7 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
             db::view::create_virtual_column(builder, def->name(), def->type);
         }
     }
-    _properties.properties()->apply_to_builder(builder, std::move(schema_extensions), db, keyspace());
+    _properties.properties()->apply_to_builder(builder, std::move(schema_extensions), db, keyspace(), cf_prop_defs::is_create_statement::yes);
 
     if (builder.default_time_to_live().count() > 0) {
         throw exceptions::invalid_request_exception(

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -380,6 +380,8 @@ create_view_statement::prepare_schema_mutations(query_processor& qp, const query
         }
     }
 
+    _properties.properties()->maybe_add_warning_for_deprecated_crc_check_chance_in_compression(warnings);
+
     // If an IF NOT EXISTS clause was used and resource was already created
     // we shouldn't emit created event. However it interacts badly with
     // concurrent clients creating resources. The client seeing no create event

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -730,7 +730,8 @@ public:
     // When created with `raw_stream::yes`, the sstable data file will be
     // streamed as-is, without decompressing (if compressed).
     //
-    // When created with `integrity_check::yes`, the integrity mechanisms
+    // When created with integrity_check::checksum_only` or
+    // `integrity_check::checksums_and_digest`, the integrity mechanisms
     // of the underlying data streams will be enabled.
     //
     // The `error_handler` parameter allows to customize the error handling

--- a/sstables/types_fwd.hh
+++ b/sstables/types_fwd.hh
@@ -15,6 +15,11 @@
 namespace sstables {
 
 using run_id = utils::tagged_uuid<struct run_id_tag>;
-using integrity_check = bool_class<class integrity_check_tag>;
+
+enum class integrity_check {
+    no = 0,
+    checksums_only,
+    checksums_and_digest,
+};
 
 } // namespace sstables


### PR DESCRIPTION
`crc_check_chance` is the probability of ScyllaDB checking the checksums on an SSTable read. The option should have a value in the interval [0.0, 1.0] and interpreted as the probability of checking the checksum.
This options was originally part of the compression options map, then [CASSANDRA-9839](https://issues.apache.org/jira/browse/CASSANDRA-9839) promoted it to table-level option.
ScyllaDB accepts this option in both the compression options map (where its value is validated to be between 0.0 and 1.0) and as a table-level option (unvalidated). In both plaes, the value of the option is completely ignored, instead ScyllaDB always check checksums on tables which use compression, and never checks them on tables which don't use compression.
This PR implements this option (with some changes), so that control is given back to the user, while trying to keep the old semantics as default.
The value is still not treated as a probability, instead 0.0 is used to disable checksum checks and any value larger than 0.0 enables it for all reads.
When creating table or view, the default value of this option is chosen to match the previous semantics: if the table/view uses compression, the option defaults to 1.0, otherwise it defaults to 0.0 (for uncompressed tables). Alters do not change the value, so when adding compression, users can end up with disabled checksums unless they also change the option value manually.

Providing this option as part of the compression options map is now deprecated and doing so will raise a CQL warning. The option is not yet removed from `compression_options`, and the value is still validated if provided.

Fixes: https://github.com/scylladb/scylladb/issues/2431

TODO: testing

New feature, no backport required.