### PR TITLE
dirty-memory-manager: Brush up "blocked" state check

### DIFF
--- a/replica/dirty_memory_manager.cc
+++ b/replica/dirty_memory_manager.cc
@@ -96,11 +96,6 @@ region_group::moved(logalloc::region* old_address, logalloc::region* new_address
     region_group_binomial_group_sanity_check(_regions);
 }
 
-bool
-region_group::execution_permitted() noexcept {
-    return !under_unspooled_pressure() && !_under_real_pressure;
-}
-
 void
 region_group::execute_one() {
     auto req = std::move(_blocked_requests.front());


### PR DESCRIPTION
One of run_when_memory_available() checks mirrors the one done by the execution_permitted() helper, so its worth re-using it. Since the former helper is header template, the latter is worth moving to header too. And, once re-used, the `bool blocking` variable becomes excessive, and the `if (blocking)` check can also be expressed with fewer LOCs.
