### PR TITLE
gossiper: fix the backward incompatible change

### DIFF
--- a/gms/application_state.cc
+++ b/gms/application_state.cc
@@ -54,9 +54,9 @@ static constexpr std::string_view application_state_name(application_state state
     case application_state::SHARD_COUNT:
         return "SHARD_COUNT";
     case application_state::IGNORE_MSB_BITS:
-        return "IGNORE_MSB_BITS";
+        return "IGNOR_MSB_BITS"; /* keeping the typo in "IGNOR_MSB_BITS" (missing "E") for backward compatibility */
     case application_state::CDC_GENERATION_ID:
-        return "CDC_GENERATION_ID";
+        return "CDC_STREAMS_TIMESTAMP"; /* not named "CDC_GENERATION_ID" for backward compatibility */
     case application_state::SNITCH_NAME:
         return "SNITCH_NAME";
     case application_state::GROUP0_STATE_ID:


### PR DESCRIPTION
In the cleanup commit a840949ea04abf1696a0cc0fe5837762f16b06cf a regression was introduced that caused backward incompatible changes in the gossiper application state name strings.

In the e486e0f7593e6071d4bf0bb6915fffbd5fc57602 the value `application_state::CDC_STREAMS_TIMESTAMP` was changed to `application_state::CDC_GENERATION_ID`, but the name string "CDC_STREAMS_TIMESTAMP" was kept for backward compatibility.

The cleanup commit a840949ea04abf1696a0cc0fe5837762f16b06cf however changed the name string to "CDC_GENERATION_ID" by ommission (not noticing the difference) which caused backward incompatible change.

There is also another case found of "IGNOR_MSB_BITS" (that has a typo - missing the "E" in "IGNORE") to "IGNORE_MSB_BITS", which also needs to be reverted back to keep the backward compatibility.

The application state apply failure message was also changed from "warn" to "error" to better catch similar cases in the future in our upgrade tests.

Fixes: scylladb/scylladb#21811

No backport: The issue is only present in the current master (not part of 6.2 or older branches)