### PR TITLE
treewide: fix typos and includes reported by GH checks

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -8,6 +8,7 @@
 
 #include <fmt/ranges.h>
 #include "alternator/executor.hh"
+#include "alternator/consumed_capacity.hh"
 #include "auth/permission.hh"
 #include "auth/resource.hh"
 #include "cdc/log.hh"

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -22,7 +22,6 @@
 #include "stats.hh"
 #include "utils/rjson.hh"
 #include "utils/updateable_value.hh"
-#include "alternator/consumed_capacity.hh"
 
 #include "tracing/trace_state.hh"
 

--- a/alternator/rmw_operation.hh
+++ b/alternator/rmw_operation.hh
@@ -11,6 +11,7 @@
 #include "seastarx.hh"
 #include "service/paxos/cas_request.hh"
 #include "utils/rjson.hh"
+#include "consumed_capacity.hh"
 #include "executor.hh"
 #include "tracing/trace_state.hh"
 #include "keys.hh"

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -22,7 +22,6 @@
 #include "atomic_cell_or_collection.hh"
 #include "hashing_partition_visitor.hh"
 #include "range_tombstone_list.hh"
-#include "utils/assert.hh"
 #include "utils/intrusive_btree.hh"
 #include "utils/preempt.hh"
 #include "utils/lru.hh"
@@ -31,6 +30,10 @@
 #include "utils/immutable-collection.hh"
 #include "tombstone_gc.hh"
 #include "mutation/compact_and_expire_result.hh"
+
+#ifdef SEASTAR_DEBUG
+#include "utils/assert.hh"
+#endif
 
 class mutation_fragment;
 class mutation_partition_view;

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -8,12 +8,15 @@
 
 #pragma once
 
-#include "utils/assert.hh"
 #include <boost/intrusive/parent_from_member.hpp>
 
 #include "mutation_partition.hh"
 
 #include <ranges>
+
+#ifdef SEASTAR_DEBUG
+#include "utils/assert.hh"
+#endif
 
 // is_evictable::yes means that the object is part of an evictable snapshots in MVCC,
 // and non-evictable one otherwise.

--- a/mutation/partition_version_list.hh
+++ b/mutation/partition_version_list.hh
@@ -8,8 +8,11 @@
 
 #pragma once
 
-#include "utils/assert.hh"
 #include "partition_version.hh"
+
+#ifdef SEASTAR_DEBUG
+#include "utils/assert.hh"
+#endif
 
 // Double-ended chained list of partition_version objects
 // utilizing partition_version's intrinsic anchorless_list_base_hook.


### PR DESCRIPTION
Clean up some items reported by the GitHub checks that are polluting the PR diffs:
- typos
- unnecessary includes

No backport: clean up of current master code, no functional changes.