### PR TITLE
mutation: cut mutation-query pages after tombstone-limit tombstones

### DIFF
--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -876,8 +876,8 @@ private:
     schema_ptr _s;
 
 public:
-    mutation_query_result_builder(const schema& s, const query::partition_slice& slice, query::result_memory_accounter&& accounter)
-        : _builder(s, slice, std::move(accounter))
+    mutation_query_result_builder(const schema& s, const query::partition_slice& slice, query::result_memory_accounter&& accounter, uint64_t tombstone_limit)
+        : _builder(s, slice, std::move(accounter), tombstone_limit)
         , _s(s.shared_from_this())
      { }
 
@@ -993,7 +993,7 @@ future<std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_tempera
         db::timeout_clock::time_point timeout) {
     return do_query_on_all_shards<mutation_query_result_builder>(db, query_schema, cmd, ranges, std::move(trace_state), timeout,
             [query_schema, &cmd] (query::result_memory_accounter&& accounter) {
-        return mutation_query_result_builder(*query_schema, cmd.slice, std::move(accounter));
+        return mutation_query_result_builder(*query_schema, cmd.slice, std::move(accounter), cmd.tombstone_limit);
     });
 }
 

--- a/mutation_query.hh
+++ b/mutation_query.hh
@@ -149,13 +149,17 @@ class reconcilable_result_builder {
     utils::chunked_vector<partition> _result;
     size_t _used_at_entry;
 
+    const uint64_t _tombstone_limit = query::max_tombstones;
+    uint64_t _tombstones = 0;
+
 private:
     stop_iteration consume(range_tombstone&& rt);
+    stop_iteration bump_and_check_tombstone_limit();
 
 public:
     // Expects reversed schema and reversed slice when building results for reverse query.
     reconcilable_result_builder(const schema& query_schema, const query::partition_slice& slice,
-                                query::result_memory_accounter&& accounter) noexcept
+                                query::result_memory_accounter&& accounter, uint64_t tombstone_limit) noexcept
         : _query_schema(query_schema.shared_from_this()), _slice(slice)
         , _memory_accounter(std::move(accounter))
     { }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3378,7 +3378,7 @@ table::mutation_query(schema_ptr query_schema,
 
     std::exception_ptr ex;
   try {
-    auto rrb = reconcilable_result_builder(*query_schema, cmd.slice, std::move(accounter));
+    auto rrb = reconcilable_result_builder(*query_schema, cmd.slice, std::move(accounter), cmd.tombstone_limit);
     auto r = co_await q.consume_page(std::move(rrb), cmd.get_row_limit(), cmd.partition_limit, cmd.timestamp, trace_state);
 
     if (!saved_querier || (!q.are_limits_reached() && !r.is_short_read())) {

--- a/test/boost/mutation_query_test.cc
+++ b/test/boost/mutation_query_test.cc
@@ -86,7 +86,7 @@ static reconcilable_result mutation_query(schema_ptr s, reader_permit permit, co
 
     auto querier = query::querier(source, s, std::move(permit), range, slice, {});
     auto close_querier = deferred_close(querier);
-    auto rrb = reconcilable_result_builder(*s, slice, make_accounter());
+    auto rrb = reconcilable_result_builder(*s, slice, make_accounter(), query::max_tombstones);
     return querier.consume_page(std::move(rrb), row_limit, partition_limit, query_time).get();
 }
 


### PR DESCRIPTION
Data queries (user queries) have their pages cut after processing tombstone-limit tombstones for a while now. The same mechanism was not used for mutation queries (read-repair reads), instead mutation-query pages are cut based on the memory limit only. This can still allow the mutations returned by mutation-query to have enough tombstone to cause stalls on the coordinator, as it tries to reconcile them. To avoid this, use the already existing and propagated tombstone-limit, to cut mutation-query pages after having processed this many tombstones, avoding the above mentioned stalls.

Fixes: #21818

Problem is present in all versions, should be backported to 6.1 and 6.2

TODO: testing, I should write a test for this, but I don't know how to test "shouldn't cause stalls".