### PR TITLE
topology_custom/test_tablets: add remove/replace tests for edge cases

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1605,14 +1605,12 @@ class ScyllaClusterManager:
                     f" ignore_dead: {ignore_dead}), check log file at {initiator.log_filename},"
                     f" error: \"{exc}\"")
         else:
+            self.cluster.server_mark_removed(server_id)
             if expected_error:
-                self.cluster.server_mark_removed(server_id)
                 raise RuntimeError(
                     f"removenode succeeded when it should have failed (initiator: {initiator},"
                     f"to_remove: {to_remove}, ignore_dead: {ignore_dead}, expected error: \"{expected_error}\"),"
                     f" check log file at {initiator.log_filename}")
-
-        self.cluster.server_mark_removed(server_id)
 
     async def _cluster_decommission_node(self, request) -> None:
         """Run decommission node on Scylla REST API for a specified server"""

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1599,6 +1599,9 @@ class ScyllaClusterManager:
                         f"removenode failed (initiator: {initiator}, to_remove: {to_remove},"
                         f" ignore_dead: {ignore_dead}) but did not contain expected error (\"{expected_error}\"),"
                         f"check log file at {initiator.log_filename}, error: \"{exc}\"")
+                else:
+                    self.logger.info(f"removenode (initiator: {initiator}, to_remove: {to_remove}, ignore_dead: {ignore_dead})"
+                                     f" failed as expected: {exc}")
             else:
                 raise RuntimeError(
                     f"removenode failed (initiator: {initiator}, to_remove: {to_remove},"
@@ -1611,6 +1614,7 @@ class ScyllaClusterManager:
                     f"removenode succeeded when it should have failed (initiator: {initiator},"
                     f"to_remove: {to_remove}, ignore_dead: {ignore_dead}, expected error: \"{expected_error}\"),"
                     f" check log file at {initiator.log_filename}")
+            self.logger.info(f"removenode (initiator: {initiator}, to_remove: {to_remove}, ignore_dead: {ignore_dead}) succeeded")
 
     async def _cluster_decommission_node(self, request) -> None:
         """Run decommission node on Scylla REST API for a specified server"""


### PR DESCRIPTION
Test cases related to #21826:

1. test_remove_failure_with_no_normal_token_owners_in_dc: attempts to
    remove a node with another node down in the datacenter, leaving
    no normal token owners in that dc (reproducing #21826).
    Removenode is expected to fail in this case since it
    should have no place to rebuild the removed node replicas,
    yet it currently succeeds unexpectedly.

2. test_remove_failure_then_replace: verify that removenode
    fails as expected when there are not enough nodes to
    rebuild its replicas on, with and without additional zero-token nodes.

3. test_replace_with_no_normal_token_owners_in_dc: verify that
    nodes can be replaced in a datacenter that has no live
    token owners, with and without additional zero-token nodes.
    Tablet replace uses all replicas to rebuild the lost replicas
    and therefore should succeed in the edge case.
    The restored data is verified as well.

Refs #21826

* New tests, no backport needed