### PR TITLE
mv: add an experimental feature for creating views using tablets

### DIFF
--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -29,6 +29,7 @@
 #include "gms/feature_service.hh"
 #include "db/view/view.hh"
 #include "service/migration_manager.hh"
+#include "replica/database.hh"
 
 namespace cql3 {
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -1367,6 +1367,7 @@ std::map<sstring, db::experimental_features_t::feature> db::experimental_feature
         {"broadcast-tables", feature::BROADCAST_TABLES},
         {"keyspace-storage-options", feature::KEYSPACE_STORAGE_OPTIONS},
         {"tablets", feature::UNUSED},
+        {"views-with-tablets", feature::VIEWS_WITH_TABLETS}
     };
 }
 

--- a/db/config.hh
+++ b/db/config.hh
@@ -107,6 +107,7 @@ struct experimental_features_t {
         ALTERNATOR_STREAMS,
         BROADCAST_TABLES,
         KEYSPACE_STORAGE_OPTIONS,
+        VIEWS_WITH_TABLETS
     };
     static std::map<sstring, feature> map(); // See enum_option.
     static std::vector<enum_option<experimental_features_t>> all();

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -83,6 +83,9 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
     if (!cfg.check_experimental(db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS)) {
         fcfg._disabled_features.insert("KEYSPACE_STORAGE_OPTIONS"s);
     }
+    if (!cfg.check_experimental(db::experimental_features_t::feature::VIEWS_WITH_TABLETS)) {
+        fcfg._disabled_features.insert("VIEWS_WITH_TABLETS"s);
+    }
     if (cfg.force_gossip_topology_changes()) {
         if (cfg.enable_tablets()) {
             throw std::runtime_error("Tablets cannot be enabled with gossip topology changes.  Use either --enable-tablets or --force-gossip-topology-changes, not both.");

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -134,6 +134,7 @@ public:
     gms::feature native_reverse_queries { *this, "NATIVE_REVERSE_QUERIES"sv };
     gms::feature zero_token_nodes { *this, "ZERO_TOKEN_NODES"sv };
     gms::feature view_build_status_on_group0 { *this, "VIEW_BUILD_STATUS_ON_GROUP0"sv };
+    gms::feature views_with_tablets { *this, "VIEWS_WITH_TABLETS"sv };
 
     // Whether to allow fragmented commitlog entries. While this is a node-local feature as such, hide
     // behind a feature to ensure an upgrading cluster appears to be at least functional before using,

--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -312,6 +312,7 @@ def run_scylla_cmd(pid, dir):
         # test/alternator/run.
         '--experimental-features=udf',
         '--experimental-features=keyspace-storage-options',
+        '--experimental-features=views-with-tablets',
         '--enable-tablets=true',
         '--enable-user-defined-functions', '1',
         # Set up authentication in order to allow testing this module

--- a/test/cqlpy/suite.yaml
+++ b/test/cqlpy/suite.yaml
@@ -5,4 +5,5 @@ dirties_cluster:
 extra_scylla_cmdline_options:
   - '--experimental-features=udf'
   - '--experimental-features=keyspace-storage-options'
+  - '--experimental-features=views-with-tablets'
   - '--enable-tablets=true'

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -100,7 +100,8 @@ def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addr
         'experimental_features': ['udf',
                                   'alternator-streams',
                                   'broadcast-tables',
-                                  'keyspace-storage-options'],
+                                  'keyspace-storage-options',
+                                  'views-with-tablets'],
 
         'skip_wait_for_gossip_to_settle': 0,
         'ring_delay_ms': 0,

--- a/test/rest_api/suite.yaml
+++ b/test/rest_api/suite.yaml
@@ -8,3 +8,4 @@ skip_in_release:
 extra_scylla_cmdline_options:
   - '--experimental-features=udf'
   - '--enable-tablets=true'
+  - '--experimental-features=views-with-tablets'

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -238,6 +238,8 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
 
     gms::feature_service feature_service(gms::feature_config_from_db_config(cfg));
     feature_service.enable(feature_service.supported_feature_set()).get();
+    feature_service.views_with_tablets.enable();
+
     sharded<locator::shared_token_metadata> token_metadata;
 
     auto my_address = gms::inet_address("localhost");


### PR DESCRIPTION
We still have a number of issues to be solved for views with tablets.
Until they are fixed, we should prevent users from creating them,
and use the vnode-based views instead.

This patch prepares the feature for enabling views with tablets. The
feature is disabled by default, but currently it has no effect.
After all tests are adjusted to use the feature, we should depend
on the feature for deciding whether we can create materialized views
in tablet-enabled keyspaces.

The unit tests are adjusted to enable this feature explicitly, and it's
also added to the scylla sstable tool config - this tool treats all
tables as if they were tablet-based (surprisingly, with SimpleStrategy),
so for it to work on views, the new feature must be enabled.

Refs https://github.com/scylladb/scylladb/issues/21832