### PR TITLE
task_manager.hh: replace boost ranges with std ranges

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -64,6 +64,7 @@
 #include "version.hh"
 #include "dht/range_streamer.hh"
 #include <boost/range/algorithm.hpp>
+#include <boost/range/join.hpp>
 #include "transport/server.hh"
 #include <seastar/core/rwlock.hh>
 #include "db/batchlog_manager.hh"

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -13,6 +13,7 @@
 #include "tasks/task_handler.hh"
 #include "tasks/virtual_task_hint.hh"
 #include <seastar/coroutine/maybe_yield.hh>
+#include <boost/range/adaptor/transformed.hpp>
 
 namespace service {
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -57,6 +57,8 @@
 
 #include "service/topology_coordinator.hh"
 
+#include <boost/range/join.hpp>
+
 using token = dht::token;
 using inet_address = gms::inet_address;
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -27,6 +27,8 @@
 #include <cfloat>
 #include <algorithm>
 
+#include <boost/range/adaptor/transformed.hpp>
+
 static logging::logger llog("sstables_loader");
 
 namespace {


### PR DESCRIPTION
Standardize on one range library to reduce dependency load.

Unfortunately, std::views::concat (the replacement for boost::join), is C++26 only. We use two separate inserts to the result vector to compensate, and rationalize it by saying that boost::join() is likely slow due to the need for type-erasure.

Code cleanup; no backport.