### PR TITLE
db,auth,locator: Remove unused member variables

### DIFF
--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -53,7 +53,6 @@ static const class_registrator<
 
 default_authorizer::default_authorizer(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm)
         : _qp(qp)
-        , _group0_client(g0)
         , _migration_manager(mm) {
 }
 

--- a/auth/default_authorizer.hh
+++ b/auth/default_authorizer.hh
@@ -26,7 +26,6 @@ namespace auth {
 
 class default_authorizer : public authorizer {
     cql3::query_processor& _qp;
-    ::service::raft_group0_client& _group0_client;
 
     ::service::migration_manager& _migration_manager;
 

--- a/db/hints/resource_manager.hh
+++ b/db/hints/resource_manager.hh
@@ -127,7 +127,6 @@ class resource_manager {
     space_watchdog::per_device_limits_map _per_device_limits_map;
     space_watchdog _space_watchdog;
 
-    service::storage_proxy& _proxy;
     shared_ptr<const gms::gossiper> _gossiper_ptr;
 
     enum class state {
@@ -175,7 +174,6 @@ public:
         , _send_limiter(_max_send_in_flight_memory, named_semaphore_exception_factory{"send limiter"})
         , _operation_lock(1, named_semaphore_exception_factory{"operation lock"})
         , _space_watchdog(_shard_managers, _per_device_limits_map)
-        , _proxy(proxy)
     {}
 
     resource_manager(resource_manager&&) = delete;

--- a/locator/ec2_multi_region_snitch.hh
+++ b/locator/ec2_multi_region_snitch.hh
@@ -28,6 +28,5 @@ public:
 private:
     inet_address _local_public_address;
     sstring _local_private_address;
-    bool _broadcast_rpc_address_specified_by_user;
 };
 } // namespace locator


### PR DESCRIPTION
this issue was identified by clang-20.

---

it's a cleanup, hence no need to backport.
