### PR TITLE
replica: not not include unused headers

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -17,7 +17,6 @@
 #include "locator/tablets.hh"
 #include "sstables/sstable_set.hh"
 #include "utils/chunked_vector.hh"
-#include <boost/intrusive/list.hpp>
 #include <absl/container/flat_hash_map.h>
 
 #pragma once

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -13,7 +13,6 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
-#include <seastar/core/shared_mutex.hh>
 #include <seastar/core/execution_stage.hh>
 #include "utils/assert.hh"
 #include "utils/hash.hh"


### PR DESCRIPTION
these unused includes are identified by clang-include-cleaner. after auditing the source files, all of the reports have been confirmed.

---

it's a cleanup, hence no need to backport.