### PR TITLE
repair: do not include unused headers

### DIFF
--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -8,19 +8,13 @@
 
 #pragma once
 
-#include <boost/range/adaptor/map.hpp>
-
 #include <unordered_map>
 #include <exception>
-#include <absl/container/btree_set.h>
 #include <fmt/core.h>
 
-#include <seastar/core/abort_source.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/future.hh>
-#include <seastar/core/condition-variable.hh>
-#include <seastar/core/gate.hh>
 
 #include "locator/abstract_replication_strategy.hh"
 #include "replica/database_fwd.hh"
@@ -30,7 +24,6 @@
 #include "utils/stall_free.hh"
 #include "repair/sync_boundary.hh"
 #include "tasks/types.hh"
-#include "schema/schema.hh"
 #include "gms/gossip_address_map.hh"
 
 namespace tasks {

--- a/repair/row.hh
+++ b/repair/row.hh
@@ -10,7 +10,6 @@
 #include <optional>
 #include "mutation/frozen_mutation.hh"
 #include <seastar/core/shared_ptr.hh>
-#include <seastar/core/coroutine.hh>
 #include "repair/decorated_key_with_hash.hh"
 #include "repair/hash.hh"
 #include "repair/sync_boundary.hh"

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <fmt/format.h>
-
 #include <vector>
 #include "gms/gossip_address_map.hh"
 #include "gms/inet_address.hh"

--- a/repair/writer.hh
+++ b/repair/writer.hh
@@ -7,7 +7,6 @@
 #include "streaming/stream_reason.hh"
 #include "repair/decorated_key_with_hash.hh"
 #include "readers/upgrading_consumer.hh"
-#include <seastar/core/coroutine.hh>
 
 using namespace seastar;
 


### PR DESCRIPTION
these unused includes are identified by clang-include-cleaner. after auditing the source files, all of the reports have been confirmed.

---

it's a cleanup, hence no need to backport.