### PR TITLE
raft: do not include unused headers

### DIFF
--- a/raft/logical_clock.hh
+++ b/raft/logical_clock.hh
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <chrono>
-#include <fmt/chrono.h>
+#include <fmt/core.h>
 
 namespace raft {
 

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -8,15 +8,12 @@
 #pragma once
 
 #include "utils/assert.hh"
-#include <concepts>
 #include <vector>
 #include <unordered_set>
 #include <functional>
 #include <boost/container/deque.hpp>
-#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/future.hh>
 #include <seastar/util/log.hh>
-#include <seastar/util/source_location-compat.hh>
 #include <seastar/core/abort_source.hh>
 #include "bytes_ostream.hh"
 #include "internal.hh"

--- a/raft/tracker.hh
+++ b/raft/tracker.hh
@@ -8,7 +8,6 @@
 #pragma once
 
 #include "utils/assert.hh"
-#include <seastar/core/condition-variable.hh>
 #include <fmt/core.h>
 #include "raft.hh"
 


### PR DESCRIPTION
these unused includes are identified by clang-include-cleaner. after auditing the source files, all of the reports have been confirmed.

---

it's a cleanup, hence no need to backport.