### PR TITLE
dist: scylla_io_setup: use raw string to avoid invalid escape sequence

### DIFF
--- a/dist/common/scripts/scylla_io_setup
+++ b/dist/common/scripts/scylla_io_setup
@@ -38,7 +38,7 @@ class scylla_cpuinfo:
 
     def __parse_cpuset(self):
         f = open(etcdir() + "/scylla.d/cpuset.conf", "r")
-        pattern = re.compile(_nocomment + r"CPUSET=\s*\"" + _reopt(_cpuset) + _reopt(_smp) + "\s*\"")
+        pattern = re.compile(_nocomment + r"CPUSET=\s*\"" + _reopt(_cpuset) + _reopt(_smp) + r"\s*\"")
         grp = [pattern.match(x) for x in f.readlines() if pattern.match(x)]
         if not grp:
             d = {"cpuset": None, "smp": None}


### PR DESCRIPTION
Use raw string literals to prevent syntax warnings when using regular expressions with backslash-based patterns.

The original code triggered a SyntaxWarning in developer mode (`python3 -Xdev`) due to unescaped backslash characters in regex patterns like '\s'. While CPython typically interprets these silently, strict Python parsing modes raise warnings about potentially unintended escape sequences.

This change adds the `r` prefix to string literals containing regex patterns, ensuring consistent behavior across different Python runtime configurations and eliminating unnecessary syntax warning like:

```
/opt/scylladb/scripts/libexec/scylla_io_setup:41: SyntaxWarning: invalid escape sequence '\s'
  pattern = re.compile(_nocomment + r"CPUSET=\s*\"" + _reopt(_cpuset) + _reopt(_smp) + "\s*\"")
```

---

it's a cleanup, hence no need to backport.