### PR TITLE
sstables_loader: report progress with the unit of batch

### DIFF
--- a/test/object_store/test_backup.py
+++ b/test/object_store/test_backup.py
@@ -285,9 +285,9 @@ async def do_test_simple_backup_and_restore(manager: ManagerClient, s3_server, d
     if not do_abort:
         assert status is not None
         assert status['state'] == 'done'
-        assert status['progress_units'] == "sstables"
-        assert status['progress_completed'] == len(toc_names)
-        assert status['progress_total'] == len(toc_names)
+        assert status['progress_units'] == 'batches'
+        assert status['progress_completed'] == status['progress_total']
+        assert status['progress_completed'] > 0
 
     print('Check that sstables came back')
     files = list_sstables()


### PR DESCRIPTION
Previously, restore progress was tracked using individual sstables as the unit of measurement. This approach introduced inaccuracies for tables distributed with tablets, where:
- An sstable spanning multiple tablets could be counted multiple times
- Progress reporting could become misleading (e.g., showing "40" progress for a table with 10 sstables)

This change introduces a more robust progress tracking method:
- Use "batch" as the unit of progress instead of individual sstables
- Stream sstables for each tablet separately, handling both partially and fully contained sstables
- Calculate progress based on the total number of sstables being streamed
- Skip tablet IDs with no owned tokens

For vnode-distributed tables, the number of "batches" directly corresponds to the number of sstables, ensuring:
- Consistent progress reporting across different table distribution models
- Simplified implementation
- Accurate representation of restore progress

The new approach provides a more reliable and uniform method of tracking restoration progress across different table distribution strategies.

Fixes scylladb/scylladb#21816

---

the feature being addressed by this fix is still experimental, hence no need to backport.