### PR TITLE
storage_service: preserve state of busy topology when transiting tablet

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6549,8 +6549,9 @@ future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables(
 future<> storage_service::transit_tablet(table_id table, dht::token token, noncopyable_function<std::tuple<std::vector<canonical_mutation>, sstring>(const locator::tablet_map&, api::timestamp_type)> prepare_mutations) {
     while (true) {
         auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
+        bool topology_busy;
 
-        while (_topology_state_machine._topology.is_busy()) {
+        while ((topology_busy = _topology_state_machine._topology.is_busy())) {
             const auto tstate = *_topology_state_machine._topology.tstate;
             if (tstate == topology::transition_state::tablet_draining ||
                 tstate == topology::transition_state::tablet_migration) {
@@ -6573,10 +6574,15 @@ future<> storage_service::transit_tablet(table_id table, dht::token token, nonco
         rtlogger.info("{}", reason);
         rtlogger.trace("do update {} reason {}", updates, reason);
 
-        updates.emplace_back(topology_mutation_builder(guard.write_timestamp())
-            .set_transition_state(topology::transition_state::tablet_migration)
-            .set_version(_topology_state_machine._topology.version + 1)
-            .build());
+        {
+            topology_mutation_builder builder(guard.write_timestamp());
+
+            if (!topology_busy) {
+                builder.set_transition_state(topology::transition_state::tablet_migration);
+            }
+            builder.set_version(_topology_state_machine._topology.version + 1);
+            updates.push_back(builder.build());
+        }
 
         topology_change change{std::move(updates)};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, reason);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6577,7 +6577,9 @@ future<> storage_service::transit_tablet(table_id table, dht::token token, nonco
         {
             topology_mutation_builder builder(guard.write_timestamp());
 
-            if (!topology_busy) {
+            if (topology_busy) {
+                rtlogger.debug("transit_tablet({}): topology busy, keeping transition state", locator::global_tablet_id{table, tid});
+            } else {
                 builder.set_transition_state(topology::transition_state::tablet_migration);
             }
             builder.set_version(_topology_state_machine._topology.version + 1);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2092,6 +2092,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             }
                 break;
             case topology::transition_state::tablet_draining:
+                co_await utils::get_local_injector().inject("suspend_decommission", utils::wait_for_message(1min));
                 try {
                     co_await handle_tablet_migration(std::move(guard), true);
                 } catch (term_changed_error&) {

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -75,6 +75,7 @@ async def test_tablet_cannot_decommision_below_replication_factor(manager: Manag
     for r in rows:
         assert r.c == r.pk
 
+
 async def test_reshape_with_tablets(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cfg = {'enable_user_defined_functions': False, 'enable_tablets': True}
@@ -310,6 +311,7 @@ async def test_saved_readers_tablet_migration(manager: ManagerClient, build_mode
     # The tablet move should have evicted the cached reader.
     assert all(map(lambda x: x == 0, [get_querier_cache_population(server) for server in servers]))
 
+
 # Reproducer for https://github.com/scylladb/scylladb/issues/19052
 #   1) table A has N tablets and views
 #   2) migration starts for a tablet of A from node 1 to 2.
@@ -424,11 +426,13 @@ async def test_keyspace_creation_cql_vs_config_sanity(manager: ManagerClient, wi
     res = cql.execute(f"SELECT initial_tablets FROM system_schema.scylla_keyspaces WHERE keyspace_name = 'test_n'").one()
     assert res is None
 
+
 @pytest.mark.asyncio
 async def test_tablets_and_gossip_topology_changes_are_incompatible(manager: ManagerClient):
     cfg = {"enable_tablets": True, "force_gossip_topology_changes": True}
     with pytest.raises(Exception, match="Failed to add server"):
         await manager.server_add(config=cfg)
+
 
 @pytest.mark.asyncio
 async def test_tablets_disabled_with_gossip_topology_changes(manager: ManagerClient):
@@ -446,6 +450,7 @@ async def test_tablets_disabled_with_gossip_topology_changes(manager: ManagerCli
         with pytest.raises(SyntaxException, match=expected):
             ks_name = unique_name()
             await cql.run_async(f"CREATE KEYSPACE {ks_name} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets {{'enabled': {enabled}}};")
+
 
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
@@ -500,6 +505,7 @@ async def test_tablet_streaming_with_unbuilt_view(manager: ManagerClient):
     # Verify that the view has the expected number of rows
     rows = await cql.run_async("SELECT c from test.mv1")
     assert len(list(rows)) == num_of_rows
+
 
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
@@ -575,6 +581,7 @@ async def test_tablet_streaming_with_staged_sstables(manager: ManagerClient):
     rows = await cql.run_async("SELECT c from test.mv1")
     assert len(list(rows)) == expected_num_of_rows
 
+
 @pytest.mark.asyncio
 async def test_orphaned_sstables_on_startup(manager: ManagerClient):
     """
@@ -629,6 +636,7 @@ async def test_orphaned_sstables_on_startup(manager: ManagerClient):
     # Error thrown is of format : "Unable to load SSTable {sstable_name} : Storage wasn't found for tablet {tablet_id} of table test.test"
     await manager.server_start(servers[0].server_id, expected_error="Storage wasn't found for tablet")
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("with_zero_token_node", [False, True])
 @pytest.mark.xfail(reason="https://github.com/scylladb/scylladb/issues/21826")
@@ -670,6 +678,7 @@ async def test_remove_failure_with_no_normal_token_owners_in_dc(manager: Manager
     replace_cfg = ReplaceConfig(replaced_id=node_to_remove.server_id, reuse_ip_addr = False, use_host_id=True, wait_replaced_dead=True)
     await manager.server_add(replace_cfg=replace_cfg, property_file={'dc': 'dc1', 'rack': f'rack1'})
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("with_zero_token_node", [False, True])
 async def test_remove_failure_then_replace(manager: ManagerClient, with_zero_token_node: bool):
@@ -702,6 +711,7 @@ async def test_remove_failure_then_replace(manager: ManagerClient, with_zero_tok
     logger.info(f"Replacing {node_to_remove} with a new node")
     replace_cfg = ReplaceConfig(replaced_id=node_to_remove.server_id, reuse_ip_addr = False, use_host_id=True, wait_replaced_dead=True)
     await manager.server_add(replace_cfg=replace_cfg, property_file={'dc': 'dc1', 'rack': f'rack1'})
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("with_zero_token_node", [False, True])

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -12,7 +12,7 @@ from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
 from test.pylib.util import unique_name
 from test.topology.conftest import skip_mode
-from test.topology.util import wait_for_cql_and_get_hosts
+from test.topology.util import wait_for_cql_and_get_hosts, get_topology_coordinator
 from contextlib import nullcontext as does_not_raise
 import time
 import pytest
@@ -383,6 +383,108 @@ async def test_read_of_pending_replica_during_migration(manager: ManagerClient, 
 
     rows = await cql.run_async("SELECT pk from test.test")
     assert len(list(rows)) == 1
+
+
+# Reproducer for https://github.com/scylladb/scylladb/issues/20073
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_explicit_tablet_movement_during_decommission(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    cfg = {'enable_user_defined_functions': False, 'enable_tablets': True}
+    cmdline = [
+        '--logger-log-level', 'storage_service=debug',
+        '--logger-log-level', 'raft_topology=debug',
+    ]
+
+    # Launch the cluster with two nodes.
+    server_tasks = [asyncio.create_task(manager.server_add(cmdline=cmdline, config=cfg)) for _ in range(2)]
+    servers = [await task for task in server_tasks]
+
+    # Disable the load balancer so that it does not move tablets behind our back mid-test. This does not disable automatic tablet movement in response to
+    # decommission, but we'll block the latter by injecting a wait-for-message.
+    #
+    # Load balancing being enabled or disabled is a cluster-global property; we can use any node to toggle it.
+    logger.info("Disabling load balancing")
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    logger.info("Populating tablet")
+    # Create a table with just one partition and RF=1, so we have exactly one tablet.
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
+    await cql.run_async("CREATE TABLE test.tabmv_decomm (pk int PRIMARY KEY);")
+    await cql.run_async("INSERT INTO test.tabmv_decomm (pk) VALUES (0)")
+    rows = await cql.run_async("SELECT pk FROM test.tabmv_decomm")
+    assert len(list(rows)) == 1
+
+    logger.info("Identifying source, destination, coordinator and non-coordinator nodes")
+    # Get the sole replica (see RF=1 above) for the sole tablet. (The token value is irrelevant due to there being only one tablet.) We can ask either one of
+    # the nodes.
+    token = 0
+    source_task = asyncio.create_task(get_tablet_replica(manager, servers[0], 'test', 'tabmv_decomm', token))
+
+    # Get the IDs of both nodes.
+    node_id_tasks = [asyncio.create_task(manager.get_host_id(srv.server_id)) for srv in servers]
+
+    # Get the ID of the topology coordinator.
+    crd_task = asyncio.create_task(get_topology_coordinator(manager))
+
+    # Open the logs of both servers.
+    log_tasks = [asyncio.create_task(manager.server_open_log(srv.server_id)) for srv in servers]
+
+    # Collect results (completion order doesn't matter).
+    src_node_id, src_shard = await source_task
+    node_ids = [await task for task in node_id_tasks]
+    crd_id = await crd_task
+    logs = [await task for task in log_tasks]
+
+    # The destination node is the node that is not the source node. We always use shard#0 on the destination.
+    src = node_ids.index(src_node_id)
+    dst = 1 - src
+    dst_shard = 0
+
+    # The coordinator node is one of the two nodes. The non-coordinator node is the other node.
+    crd = node_ids.index(crd_id)
+    ncr = 1 - crd
+
+    # Four variations are possible:
+    #
+    # source  destination  coordinator  non-coordinator
+    # ------  -----------  -----------  ---------------
+    # node#0       node#1       node#0           node#1
+    # node#0       node#1       node#1           node#0
+    # node#1       node#0       node#0           node#1
+    # node#1       node#0       node#1           node#0
+    logger.info(f"src id={servers[src].server_id} ip={servers[src].ip_addr} node={node_ids[src]} shard={src_shard}")
+    logger.info(f"dst id={servers[dst].server_id} ip={servers[dst].ip_addr} node={node_ids[dst]} shard={dst_shard}")
+    logger.info(f"crd id={servers[crd].server_id} ip={servers[crd].ip_addr} node={node_ids[crd]}")
+    logger.info(f"ncr id={servers[ncr].server_id} ip={servers[ncr].ip_addr} node={node_ids[ncr]}")
+
+    logger.info("Decommissioning src")
+    # Inject a wait-for-message into the topology coordinator. We're going to block decommission right after entering the "tablet draining" transition state.
+    await manager.api.enable_injection(servers[crd].ip_addr, "suspend_decommission", one_shot=True)
+
+    # Initiate decommissioning the source node, and wait until the coordinator reaches "tablet draining".
+    crd_log_mark = await logs[crd].mark()
+    decomm_task = asyncio.create_task(manager.decommission_node(servers[src].server_id))
+    await logs[crd].wait_for('entered `tablet draining` transition state', from_mark=crd_log_mark)
+
+    logger.info("Moving tablet from src to dst")
+    # Move the tablet from the source node to the destination node. Ask the non-coordinator node to do it, as the coordinator node is suspended. Wait until the
+    # storage service on the non-coordinator node confirms it has seen the topology state machine as busy, and that it has kept the transition state intact.
+    ncr_log_mark = await logs[ncr].mark()
+    move_task = asyncio.create_task(manager.api.move_tablet(servers[ncr].ip_addr, "test", "tabmv_decomm",
+                                                            node_ids[src], src_shard, node_ids[dst], dst_shard, token))
+    await logs[ncr].wait_for(r'transit_tablet\([^)]+\): topology busy, keeping transition state', from_mark=ncr_log_mark)
+
+    logger.info("Completing decommissioning and tablet movement")
+    # Resume decommissioning.
+    await manager.api.message_injection(servers[crd].ip_addr, "suspend_decommission")
+
+    # Complete both the decommissioning and the explicit tablet movement (completion order does not matter).
+    #
+    # Completion of "decomm_task" shows that the decommission flow doesn't get stuck.
+    await decomm_task
+    await move_task
 
 
 # This test checks that --enable-tablets option and the TABLETS parameters of the CQL CREATE KEYSPACE


### PR DESCRIPTION
Commit 876478b84fd0 ("storage_service: allow concurrent tablet migration in tablets/move API", 2024-02-08) introduced a code path on which the topology state machine would be busy -- in "tablet_draining" or "tablet_migration" state -- at the time of starting tablet migration. The pre-commit code would unconditionally transition the topology to "tablet_migration" state, assuming the topology had been idle previously. On the new code path, this state change would be idempotent if the topology state machine had been busy in "tablet_migration", but the state change would incorrectly overwrite the "tablet_draining" state otherwise.

Restrict the state change to when the topology state machine is idle.

In addition, add the topology update to the "updates" vector with plain push_back(). emplace_back() is not helpful here, as topology_mutation_builder::build() cannot construct in-place, and so we invoke the "canonical_mutation" move constructor once, either way.

Unit test:

Start a two node cluster. Create a single tablet on one of the nodes. Start decommissioning that node, but block decommissioning at once. In that state (i.e., in "tablet_draining"), move the tablet manually to the other node. Check that transit_tablet() leaves the topology transition state alone.

Fixes #20073.

Commit 876478b was first released in scylla-6.0.0, so we might want to backport this patch accordingly.