### PR TITLE
tablets: scheduler: Fix temporary imbalance in a mixed-capacity cluster on decommission

### DIFF
--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1417,7 +1417,11 @@ static
 void check_tablet_invariants(const tablet_metadata& tmeta);
 
 static
-void rebalance_tablets(tablet_allocator& talloc, shared_token_metadata& stm, locator::load_stats_ptr load_stats = {}, std::unordered_set<host_id> skiplist = {}) {
+void rebalance_tablets(tablet_allocator& talloc,
+                       shared_token_metadata& stm,
+                       locator::load_stats_ptr load_stats = {},
+                       std::unordered_set<host_id> skiplist = {},
+                       std::function<bool(const migration_plan&)> stop = nullptr) {
     // Sanity limit to avoid infinite loops.
     // The x10 factor is arbitrary, it's there to account for more complex schedules than direct migration.
     auto max_iterations = 1 + get_tablet_count(stm.get()->tablets()) * 10;
@@ -1425,6 +1429,9 @@ void rebalance_tablets(tablet_allocator& talloc, shared_token_metadata& stm, loc
     for (size_t i = 0; i < max_iterations; ++i) {
         auto plan = talloc.balance_tablets(stm.get(), load_stats, skiplist).get();
         if (plan.empty()) {
+            return;
+        }
+        if (stop && stop(plan)) {
             return;
         }
         stm.mutate_token_metadata([&] (token_metadata& tm) {
@@ -2284,6 +2291,71 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_two_empty_nodes) {
         }
     }
   }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_asymmetric_node_capacity) {
+    do_with_cql_env_thread([](auto& e) {
+        inet_address ip1("192.168.0.1");
+        inet_address ip2("192.168.0.2");
+        inet_address ip3("192.168.0.3");
+
+        auto host1 = host_id(next_uuid());
+        auto host2 = host_id(next_uuid());
+        auto host3 = host_id(next_uuid());
+
+        auto table1 = table_id(next_uuid());
+
+        semaphore sem(1);
+        shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
+            locator::topology::config {
+                .this_endpoint = ip1,
+                .this_host_id = host1,
+                .local_dc_rack = locator::endpoint_dc_rack::default_location
+            }
+        });
+
+        stm.mutate_token_metadata([&](token_metadata& tm) -> future<> {
+            tm.update_host_id(host1, ip1);
+            tm.update_host_id(host2, ip2);
+            tm.update_host_id(host3, ip3);
+            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::being_decommissioned, 8);
+            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, 1);
+            tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::normal, 7);
+            co_await tm.update_normal_tokens(std::unordered_set {token(tests::d2t(1. / 4))}, host1);
+            co_await tm.update_normal_tokens(std::unordered_set {token(tests::d2t(2. / 4))}, host2);
+            co_await tm.update_normal_tokens(std::unordered_set {token(tests::d2t(3. / 4))}, host3);
+
+            tablet_map tmap(16);
+            for (auto tid: tmap.tablet_ids()) {
+                tmap.set_tablet(tid, tablet_info {
+                    tablet_replica_set {
+                        tablet_replica {host1, 0},
+                    }
+              });
+            }
+            tablet_metadata tmeta;
+            tmeta.set_tablet_map(table1, std::move(tmap));
+            tm.set_tablets(std::move(tmeta));
+            co_return;
+        }).get();
+
+        auto until_nodes_drained = [] (const migration_plan& plan) {
+            return !plan.has_nodes_to_drain();
+        };
+
+        rebalance_tablets(e.get_tablet_allocator().local(), stm, {}, {}, until_nodes_drained);
+
+        {
+          load_sketch load(stm.get());
+          load.populate().get();
+
+          for (auto h: {host2, host3}) {
+              testlog.debug("Checking host {}", h);
+              BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(h), 2); // 16 tablets / 8 shards = 2 tablets / shard
+              BOOST_REQUIRE_EQUAL(load.get_shard_imbalance(h), 0);
+          }
+        }
+    }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_load_balancer_disabling) {


### PR DESCRIPTION
When tablet scheduler drains nodes, it chooses target location based
on "badness" metric. Nodes with lowest score are preferred. Before the
patch, the score which was used was the number of tablets on that node
post-movement. This way we populate least-loaded node first. But this
works only if nodes have equal number of shards. If nodes have different
capacity, then number of tablets is not a good metric, because we don't
aim to equalize per-node count, but per-shard count. We assume that each
shard has equal capacity.

Because of this bug, during decommission, the nodes with fewer shards
would be preferred to receive replicas, which may lead to overloading
of those nodes. This imbalance would be later fixed by the normal load
balancing logic, but it's still problematic.

Fixes #21783
