### PR TITLE
config: Enable enable_small_table_optimization_for_rbno by default

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1060,7 +1060,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , repair_multishard_reader_enable_read_ahead(this, "repair_multishard_reader_enable_read_ahead", liveness::LiveUpdate, value_status::Used, false,
         "The multishard reader has a read-ahead feature to improve latencies of range-scans. This feature can be detrimental when the multishard reader is used under repair, as is the case in repair in mixed-shard clusters."
         " This know allows disabling this read-ahead (default), this can help the performance of mixed-shard repair (including RBNO).")
-    , enable_small_table_optimization_for_rbno(this, "enable_small_table_optimization_for_rbno", liveness::LiveUpdate, value_status::Used, false, "Set true to enable small table optimization for repair based node operations")
+    , enable_small_table_optimization_for_rbno(this, "enable_small_table_optimization_for_rbno", liveness::LiveUpdate, value_status::Used, true, "Set true to enable small table optimization for repair based node operations")
     , ring_delay_ms(this, "ring_delay_ms", value_status::Used, 30 * 1000, "Time a node waits to hear from other nodes before joining the ring in milliseconds. Same as -Dcassandra.ring_delay_ms in cassandra.")
     , shadow_round_ms(this, "shadow_round_ms", value_status::Used, 300 * 1000, "The maximum gossip shadow round time. Can be used to reduce the gossip feature check time during node boot up.")
     , fd_max_interval_ms(this, "fd_max_interval_ms", value_status::Used, 2 * 1000, "The maximum failure_detector interval time in milliseconds. Interval larger than the maximum will be ignored. Larger cluster may need to increase the default.")


### PR DESCRIPTION
Since the problematic dtests are with the
enable_small_table_optimization_for_rbno turn off now, we can enable the flag by default.

https://github.com/scylladb/scylla-dtest/pull/5383

Refs: #19131

New feature. No backport.