### PR TITLE
Cache base info for view schemas in the schema registry

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -914,6 +914,14 @@ db::commitlog* database::commitlog_for(const schema_ptr& schema) {
 }
 
 future<> database::add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new) {
+    if (schema->is_view()) {
+        try {
+            auto base_schema = find_schema(schema->view_info()->base_id());
+            schema->view_info()->set_base_info(schema->view_info()->make_base_dependent_view_info(*base_schema));
+        } catch (no_such_column_family&) {
+            throw std::invalid_argument("The base table " + schema->view_info()->base_name() + " was already dropped");
+        }
+    }
     schema = local_schema_registry().learn(schema);
     schema->registry_entry()->mark_synced();
     auto&& rs = ks.get_replication_strategy();
@@ -958,6 +966,14 @@ future<> database::add_column_family_and_make_directory(schema_ptr schema, is_ne
 }
 
 bool database::update_column_family(schema_ptr new_schema) {
+    if (new_schema->is_view()) {
+        try {
+            auto base_schema = find_schema(new_schema->view_info()->base_id());
+            new_schema->view_info()->set_base_info(new_schema->view_info()->make_base_dependent_view_info(*base_schema));
+        } catch (no_such_column_family&) {
+            throw std::invalid_argument("The base table " + new_schema->view_info()->base_name() + " was already dropped");
+        }
+    }
     column_family& cfm = find_column_family(new_schema->id());
     bool columns_changed = !cfm.schema()->equal_columns(*new_schema);
     auto s = local_schema_registry().learn(new_schema);
@@ -965,11 +981,8 @@ bool database::update_column_family(schema_ptr new_schema) {
     cfm.set_schema(s);
     find_keyspace(s->ks_name()).metadata()->add_or_update_column_family(s);
     if (s->is_view()) {
-        try {
-            find_column_family(s->view_info()->base_id()).add_or_update_view(view_ptr(s));
-        } catch (no_such_column_family&) {
-            // Update view mutations received after base table drop.
-        }
+        // We already tested that the base table exists
+        find_column_family(s->view_info()->base_id()).add_or_update_view(view_ptr(s));
     }
     cfm.get_index_manager().reload();
     return columns_changed;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3223,8 +3223,6 @@ static std::vector<view_ptr>::iterator find_view(std::vector<view_ptr>& views, c
 }
 
 void table::add_or_update_view(view_ptr v) {
-    v->view_info()->set_base_info(
-        v->view_info()->make_base_dependent_view_info(*_schema));
     auto existing = find_view(_views, v);
     if (existing != _views.end()) {
         *existing = std::move(v);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3204,8 +3204,15 @@ void table::set_schema(schema_ptr s) {
     _schema = std::move(s);
 
     for (auto&& v : _views) {
-        v->view_info()->set_base_info(
-            v->view_info()->make_base_dependent_view_info(*_schema));
+        auto base_info = v->view_info()->make_base_dependent_view_info(*_schema);
+        v->view_info()->set_base_info(base_info);
+        if (v->registry_entry()) {
+            v->registry_entry()->update_base_schema(_schema);
+        }
+        if (auto reverse_schema = local_schema_registry().get_or_null(reversed(v->version()))) {
+            reverse_schema->view_info()->set_base_info(base_info);
+            reverse_schema->registry_entry()->update_base_schema(_schema);
+        }
     }
 
     set_compaction_strategy(_schema->compaction_strategy());

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -1940,8 +1940,16 @@ schema_ptr schema::make_reversed() const {
 }
 
 schema_ptr schema::get_reversed() const {
-    return local_schema_registry().get_or_load(reversed(_raw._version), [this] (table_schema_version) {
-        return frozen_schema(make_reversed());
+    return local_schema_registry().get_or_load(reversed(_raw._version), [this] (table_schema_version) -> base_and_view_schemas {
+        auto s = make_reversed();
+
+        if (s->is_view()) {
+            if (!s->view_info()->base_info()) {
+                on_internal_error(dblog, format("Tried to make a reverse schema for view {}.{} with an uninitialized base info", s->ks_name(), s->cf_name()));
+            }
+            return {frozen_schema(s), s->view_info()->base_info()->base_schema()};
+        }
+        return {frozen_schema(s)};
     });
 }
 

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -262,6 +262,10 @@ frozen_schema schema_registry_entry::frozen() const {
     return *_frozen_schema;
 }
 
+void schema_registry_entry::update_base_schema(schema_ptr s) {
+    _base_schema = s;
+}
+
 future<> schema_registry_entry::maybe_sync(std::function<future<>()> syncer) {
     switch (_sync_state) {
         case schema_registry_entry::sync_state::SYNCED:

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -393,17 +393,7 @@ global_schema_ptr::global_schema_ptr(const schema_ptr& ptr)
 
     schema_ptr s = ensure_registry_entry(ptr);
     if (s->is_view()) {
-        if (s->view_info()->base_info()) {
-            _base_schema = ensure_registry_entry(s->view_info()->base_info()->base_schema());
-        } else if (ptr->view_info()->base_info()) {
-            _base_schema = ensure_registry_entry(ptr->view_info()->base_info()->base_schema());
-        } else {
-            on_internal_error(slogger, format("Tried to build a global schema for view {}.{} with an uninitialized base info", s->ks_name(), s->cf_name()));
-        }
-
-        if (!s->view_info()->base_info() || !s->view_info()->base_info()->base_schema()->registry_entry()) {
-            s->view_info()->set_base_info(s->view_info()->make_base_dependent_view_info(*_base_schema));
-        }
+        _base_schema = ensure_registry_entry(s->view_info()->base_info()->base_schema());
     }
     _ptr = s;
 }

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -170,8 +170,11 @@ void schema_registry::clear() {
     _entries.clear();
 }
 
-schema_ptr schema_registry_entry::load(frozen_schema fs) {
-    _frozen_schema = std::move(fs);
+schema_ptr schema_registry_entry::load(base_and_view_schemas fs) {
+    _frozen_schema = std::move(fs.schema);
+    if (fs.base_schema) {
+        _base_schema = std::move(fs.base_schema);
+    }
     auto s = get_schema();
     if (_state == state::LOADING) {
         _schema_promise.set_value(s);
@@ -184,6 +187,9 @@ schema_ptr schema_registry_entry::load(frozen_schema fs) {
 
 schema_ptr schema_registry_entry::load(schema_ptr s) {
     _frozen_schema = frozen_schema(s);
+    if (s->is_view()) {
+        _base_schema = s->view_info()->base_info()->base_schema();
+    }
     _schema = &*s;
     _schema->_registry_entry = this;
     _erase_timer.cancel();
@@ -203,7 +209,7 @@ future<schema_ptr> schema_registry_entry::start_loading(async_schema_loader load
     _state = state::LOADING;
     slogger.trace("Loading {}", _version);
     // Move to background.
-    (void)f.then_wrapped([self = shared_from_this(), this] (future<frozen_schema>&& f) {
+    (void)f.then_wrapped([self = shared_from_this(), this] (future<base_and_view_schemas>&& f) {
         _loader = {};
         if (_state != state::LOADING) {
             slogger.trace("Loading of {} aborted", _version);
@@ -231,6 +237,10 @@ schema_ptr schema_registry_entry::get_schema() {
         auto s = _frozen_schema->unfreeze(*_registry._ctxt);
         if (s->version() != _version) {
             throw std::runtime_error(format("Unfrozen schema version doesn't match entry version ({}): {}", _version, *s));
+        }
+        if (s->is_view()) {
+            // We may encounter a no_such_column_family here, which means that the base table was deleted and we should fail the request
+            s->view_info()->set_base_info(s->view_info()->make_base_dependent_view_info(**_base_schema));
         }
         _erase_timer.cancel();
         s->_registry_entry = this;
@@ -325,17 +335,17 @@ schema_ptr global_schema_ptr::get() const {
     if (this_shard_id() == _cpu_of_origin) {
         return _ptr;
     } else {
-        auto registered_schema = [](const schema_registry_entry& e) {
+        auto registered_schema = [](const schema_registry_entry& e, std::optional<schema_ptr> base_schema = std::nullopt) -> schema_ptr {
             schema_ptr ret = local_schema_registry().get_or_null(e.version());
             if (!ret) {
-                ret = local_schema_registry().get_or_load(e.version(), [&e](table_schema_version) {
-                    return e.frozen();
+                ret = local_schema_registry().get_or_load(e.version(), [&e, &base_schema](table_schema_version) -> base_and_view_schemas {
+                    return {e.frozen(), base_schema};
                 });
             }
             return ret;
         };
 
-        schema_ptr registered_bs;
+        std::optional<schema_ptr> registered_bs;
         // the following code contains registry entry dereference of a foreign shard
         // however, it is guaranteed to succeed since we made sure in the constructor
         // that _bs_schema and _ptr will have a registry on the foreign shard where this
@@ -344,16 +354,10 @@ schema_ptr global_schema_ptr::get() const {
         if (_base_schema) {
             registered_bs = registered_schema(*_base_schema->registry_entry());
             if (_base_schema->registry_entry()->is_synced()) {
-                registered_bs->registry_entry()->mark_synced();
+                registered_bs.value()->registry_entry()->mark_synced();
             }
         }
-        schema_ptr s = registered_schema(*_ptr->registry_entry());
-        if (s->is_view()) {
-            if (!s->view_info()->base_info()) {
-                // we know that registered_bs is valid here because we make sure of it in the constructors.
-                s->view_info()->set_base_info(s->view_info()->make_base_dependent_view_info(*registered_bs));
-            }
-        }
+        schema_ptr s = registered_schema(*_ptr->registry_entry(), registered_bs);
         if (_ptr->registry_entry()->is_synced()) {
             s->registry_entry()->mark_synced();
         }
@@ -370,8 +374,15 @@ global_schema_ptr::global_schema_ptr(const schema_ptr& ptr)
         if (e) {
             return s;
         } else {
-            return local_schema_registry().get_or_load(s->version(), [&s] (table_schema_version) {
-                return frozen_schema(s);
+            return local_schema_registry().get_or_load(s->version(), [&s] (table_schema_version) -> base_and_view_schemas {
+                if (s->is_view()) {
+                    if (!s->view_info()->base_info()) {
+                        on_internal_error(slogger, format("Tried to build a global schema for view {}.{} with an uninitialized base info", s->ks_name(), s->cf_name()));
+                    }
+                    return {frozen_schema(s), s->view_info()->base_info()->base_schema()};
+                } else {
+                    return {frozen_schema(s)};
+                }
             });
         }
     };

--- a/schema/schema_registry.hh
+++ b/schema/schema_registry.hh
@@ -94,6 +94,9 @@ public:
     future<> maybe_sync(std::function<future<>()> sync);
     // Marks this schema version as synced. Syncing cannot be in progress.
     void mark_synced();
+    // Updates the frozen base schema for a view, should be called when updating the base info
+    // Is not needed when we set the base info for the first time - that means this schema is not in the registry
+    void update_base_schema(schema_ptr);
     // Can be called from other shards
     frozen_schema frozen() const;
     // Can be called from other shards

--- a/schema/schema_registry.hh
+++ b/schema/schema_registry.hh
@@ -22,8 +22,13 @@ class schema_ctxt;
 
 class schema_registry;
 
-using async_schema_loader = std::function<future<frozen_schema>(table_schema_version)>;
-using schema_loader = std::function<frozen_schema(table_schema_version)>;
+struct base_and_view_schemas {
+    frozen_schema schema;
+    std::optional<schema_ptr> base_schema;
+};
+
+using async_schema_loader = std::function<future<base_and_view_schemas>(table_schema_version)>;
+using schema_loader = std::function<base_and_view_schemas(table_schema_version)>;
 
 class schema_version_not_found : public std::runtime_error {
 public:
@@ -61,6 +66,8 @@ class schema_registry_entry : public enable_lw_shared_from_this<schema_registry_
     shared_promise<schema_ptr> _schema_promise; // valid when state == LOADING
 
     std::optional<frozen_schema> _frozen_schema; // engaged when state == LOADED
+    std::optional<schema_ptr> _base_schema;// engaged when state == LOADED for view schemas
+
     // valid when state == LOADED
     // This is != nullptr when there is an alive schema_ptr associated with this entry.
     const ::schema* _schema = nullptr;
@@ -77,7 +84,7 @@ public:
     schema_registry_entry(schema_registry_entry&&) = delete;
     schema_registry_entry(const schema_registry_entry&) = delete;
     ~schema_registry_entry();
-    schema_ptr load(frozen_schema);
+    schema_ptr load(base_and_view_schemas);
     schema_ptr load(schema_ptr);
     future<schema_ptr> start_loading(async_schema_loader);
     schema_ptr get_schema(); // call only when state >= LOADED
@@ -108,6 +115,7 @@ public:
 // alive the registry will keep its entry. To ensure remote nodes can query current node
 // for schema version, make sure that schema_ptr for the request is alive around the call.
 //
+// Schemas of views returned by this registry always have base_info set.
 class schema_registry {
     std::unordered_map<table_schema_version, lw_shared_ptr<schema_registry_entry>> _entries;
     std::unique_ptr<db::schema_ctxt> _ctxt;
@@ -125,6 +133,7 @@ public:
     void init(const db::schema_ctxt&);
 
     // Looks up schema by version or loads it using supplied loader.
+    // If the schema refers to a view, the loader must return both view and base schemas.
     schema_ptr get_or_load(table_schema_version, const schema_loader&);
 
     // Looks up schema by version or returns an empty pointer if not available.
@@ -134,6 +143,7 @@ public:
     // deferring. The loader is copied must be alive only until this method
     // returns. If the loader fails, the future resolves with
     // schema_version_loading_failed.
+    // If the schema refers to a view, the loader must return both view and base schemas.
     future<schema_ptr> get_or_load(table_schema_version, const async_schema_loader&);
 
     // Looks up schema version. Throws schema_version_not_found when not found
@@ -149,6 +159,7 @@ public:
     // the schema which was passed as argument.
     // The schema instance pointed to by the argument will be attached to the registry
     // entry and will keep it alive.
+    // If the schema refers to a view, it must have base_info set.
     schema_ptr learn(const schema_ptr&);
 
     // Removes all entries from the registry. This in turn removes all dependencies

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -1072,20 +1072,6 @@ static future<schema_ptr> get_schema_definition(table_schema_version v, locator:
                 }
             });
         });
-    }).then([&storage_proxy] (schema_ptr s) {
-        // If this is a view so this schema also needs a reference to the base
-        // table.
-        if (s->is_view()) {
-            if (!s->view_info()->base_info()) {
-                auto& db = storage_proxy.local_db();
-                // This line might throw a no_such_column_family
-                // It should be fine since if we tried to register a view for which
-                // we don't know the base table, our registry is broken.
-                schema_ptr base_schema = db.find_schema(s->view_info()->base_id());
-                s->view_info()->set_base_info(s->view_info()->make_base_dependent_view_info(*base_schema));
-            }
-        }
-        return s;
     });
 }
 
@@ -1109,6 +1095,8 @@ future<schema_ptr> migration_manager::get_schema_for_write(table_schema_version 
     }
 
     if (!s) {
+        // The schema returned by get_schema_definition comes (eventually) from the schema registry,
+        // so if it is a view, it already has base info and we don't need to set it later
         s = co_await get_schema_definition(v, dst, shard, ms, _storage_proxy);
     }
 
@@ -1121,23 +1109,6 @@ future<schema_ptr> migration_manager::get_schema_for_write(table_schema_version 
             co_await maybe_sync(s, dst);
         }
     }
-    // here s is guaranteed to be valid and synced
-    if (s->is_view() && !s->view_info()->base_info()) {
-        // The way to get here is if the view schema was deactivated
-        // and reactivated again, or if we loaded it from the schema
-        // history.
-        auto& db = _storage_proxy.local_db();
-        // This line might throw a no_such_column_family but
-        // that is fine, if the schema is synced, it means that if
-        // we failed to get the base table, we learned about the base
-        // table not existing (which means that the view also doesn't exist
-        // any more), which means that this schema is actually useless for either
-        // read or write so we better throw than return an incomplete useless
-        // schema
-        schema_ptr base_schema = db.find_schema(s->view_info()->base_id());
-        s->view_info()->set_base_info(s->view_info()->make_base_dependent_view_info(*base_schema));
-    }
-
     co_return s;
 }
 

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -1058,13 +1058,18 @@ static future<schema_ptr> get_schema_definition(table_schema_version v, locator:
             // with TTL (refresh TTL in case column mapping already existed prior to that).
             auto us = s.unfreeze(db::schema_ctxt(proxy));
             // if this is a view - sanity check that its schema doesn't need fixing.
+            schema_ptr base_schema;
             if (us->is_view()) {
                 auto& db = proxy.local().local_db();
-                schema_ptr base_schema = db.find_schema(us->view_info()->base_id());
+                base_schema = db.find_schema(us->view_info()->base_id());
                 db::schema_tables::check_no_legacy_secondary_index_mv_schema(db, view_ptr(us), base_schema);
             }
-            return db::schema_tables::store_column_mapping(proxy, us, true).then([us] {
-                return frozen_schema{us};
+            return db::schema_tables::store_column_mapping(proxy, us, true).then([us, base_schema] -> base_and_view_schemas {
+                if (us->is_view()) {
+                    return {frozen_schema(us), base_schema};
+                } else {
+                    return {frozen_schema(us)};
+                }
             });
         });
     }).then([&storage_proxy] (schema_ptr s) {

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -58,7 +58,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_with_non_nantive_type) {
            .build();
 
     local_schema_registry().get_or_load(s->version(), [s] (table_schema_version) {
-        return make_ready_future<frozen_schema>(frozen_schema(s));
+        return make_ready_future<base_and_view_schemas>(frozen_schema(s));
     }).get();
 }
 
@@ -69,7 +69,7 @@ SEASTAR_TEST_CASE(test_async_loading) {
         auto s2 = random_schema();
 
         auto s1_loaded = local_schema_registry().get_or_load(s1->version(), [s1] (table_schema_version) {
-            return make_ready_future<frozen_schema>(frozen_schema(s1));
+            return make_ready_future<base_and_view_schemas>(frozen_schema(s1));
         }).get();
 
         BOOST_REQUIRE(s1_loaded);
@@ -78,7 +78,7 @@ SEASTAR_TEST_CASE(test_async_loading) {
         BOOST_REQUIRE(s1_later);
 
         auto s2_loaded = local_schema_registry().get_or_load(s2->version(), [s2] (table_schema_version) {
-            return yield().then([s2] { return frozen_schema(s2); });
+            return yield().then([s2] -> base_and_view_schemas { return {frozen_schema(s2)}; });
         }).get();
 
         BOOST_REQUIRE(s2_loaded);
@@ -92,7 +92,7 @@ SEASTAR_TEST_CASE(test_schema_is_synced_when_syncer_doesnt_defer) {
     return seastar::async([] {
         dummy_init dummy;
         auto s = random_schema();
-        s = local_schema_registry().get_or_load(s->version(), [s] (table_schema_version) { return frozen_schema(s); });
+        s = local_schema_registry().get_or_load(s->version(), [s] (table_schema_version) -> base_and_view_schemas { return {frozen_schema(s)}; });
         BOOST_REQUIRE(!s->is_synced());
         s->registry_entry()->maybe_sync([] { return make_ready_future<>(); }).get();
         BOOST_REQUIRE(s->is_synced());
@@ -103,7 +103,7 @@ SEASTAR_TEST_CASE(test_schema_is_synced_when_syncer_defers) {
     return seastar::async([] {
         dummy_init dummy;
         auto s = random_schema();
-        s = local_schema_registry().get_or_load(s->version(), [s] (table_schema_version) { return frozen_schema(s); });
+        s = local_schema_registry().get_or_load(s->version(), [s] (table_schema_version) -> base_and_view_schemas { return {frozen_schema(s)}; });
         BOOST_REQUIRE(!s->is_synced());
         s->registry_entry()->maybe_sync([] { return yield(); }).get();
         BOOST_REQUIRE(s->is_synced());
@@ -114,7 +114,7 @@ SEASTAR_TEST_CASE(test_failed_sync_can_be_retried) {
     return seastar::async([] {
         dummy_init dummy;
         auto s = random_schema();
-        s = local_schema_registry().get_or_load(s->version(), [s] (table_schema_version) { return frozen_schema(s); });
+        s = local_schema_registry().get_or_load(s->version(), [s] (table_schema_version) -> base_and_view_schemas { return {frozen_schema(s)}; });
         BOOST_REQUIRE(!s->is_synced());
 
         promise<> fail_sync;
@@ -202,8 +202,8 @@ SEASTAR_THREAD_TEST_CASE(test_table_is_attached) {
                 .with_column(random_column_name(), bytes_type)
                 .build();
 
-        auto learned_s2 = local_schema_registry().get_or_load(s2->version(), [&] (table_schema_version) {
-            return frozen_schema(s2);
+        auto learned_s2 = local_schema_registry().get_or_load(s2->version(), [&] (table_schema_version) -> base_and_view_schemas {
+            return {frozen_schema(s2)};
         });
         BOOST_REQUIRE(learned_s2->maybe_table() == s0->maybe_table());
 
@@ -221,9 +221,9 @@ SEASTAR_THREAD_TEST_CASE(test_table_is_attached) {
                 .build();
         utils::throttle s3_thr;
         auto s3_entered = s3_thr.block();
-        auto learned_s3 = local_schema_registry().get_or_load(s3->version(), [&, fs = frozen_schema(s3)] (table_schema_version) -> future<frozen_schema> {
+        auto learned_s3 = local_schema_registry().get_or_load(s3->version(), [&, fs = frozen_schema(s3)] (table_schema_version) -> future<base_and_view_schemas> {
             co_await s3_thr.enter();
-            co_return fs;
+            co_return base_and_view_schemas{fs};
         });
         s3_entered.get();
         local_schema_registry().learn(s3);
@@ -238,12 +238,12 @@ SEASTAR_THREAD_TEST_CASE(test_table_is_attached) {
                 .build();
         utils::throttle s4_thr;
         auto s4_entered = s4_thr.block();
-        auto learned_s4 = local_schema_registry().get_or_load(s4->version(), [&, fs = frozen_schema(s4)] (table_schema_version) -> future<frozen_schema> {
+        auto learned_s4 = local_schema_registry().get_or_load(s4->version(), [&, fs = frozen_schema(s4)] (table_schema_version) -> future<base_and_view_schemas> {
             co_await s4_thr.enter();
-            co_return fs;
+            co_return base_and_view_schemas(fs);
         });
         s4_entered.get();
-        s4 = local_schema_registry().get_or_load(s4->version(), [&, fs = frozen_schema(s4)] (table_schema_version) { return fs; });
+        s4 = local_schema_registry().get_or_load(s4->version(), [&, fs = frozen_schema(s4)] (table_schema_version) -> base_and_view_schemas { return {fs}; });
         s4_thr.unblock();
         auto s4_s = learned_s4.get();
         BOOST_REQUIRE(s4_s->maybe_table() == s0->maybe_table());

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -12,6 +12,8 @@
 #undef SEASTAR_TESTING_MAIN
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/lowres_clock.hh>
 #include "data_dictionary/user_types_metadata.hh"
 #include "schema/schema_registry.hh"
 #include "schema/schema_builder.hh"
@@ -23,6 +25,7 @@
 #include "utils/throttle.hh"
 #include "test/lib/cql_test_env.hh"
 #include "gms/feature_service.hh"
+#include "view_info.hh"
 
 BOOST_AUTO_TEST_SUITE(schema_registry_test)
 
@@ -40,10 +43,11 @@ static schema_ptr random_schema() {
 struct dummy_init {
     std::unique_ptr<db::config> config;
     gms::feature_service fs;
-
+    seastar::lowres_clock::duration grace_period;
     dummy_init()
             : config(std::make_unique<db::config>())
-            , fs(gms::feature_config_from_db_config(*config)) {
+            , fs(gms::feature_config_from_db_config(*config))
+            , grace_period(std::chrono::seconds(config->schema_registry_grace_period())) {
         local_schema_registry().init(db::schema_ctxt(*config, std::make_shared<data_dictionary::dummy_user_types_storage>(), fs));
     }
 };
@@ -256,6 +260,42 @@ SEASTAR_THREAD_TEST_CASE(test_table_is_attached) {
         BOOST_REQUIRE(!learned_s2->maybe_table());
         BOOST_REQUIRE_THROW(learned_s1->table(), replica::no_such_column_family);
     }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_schema_is_recovered_after_dying) {
+    dummy_init dummy;
+    auto base_schema = schema_builder("ks", "cf")
+        .with_column("pk", int32_type, column_kind::partition_key)
+        .with_column("v", int32_type)
+        .build();
+    auto base_registry_schema = local_schema_registry().get_or_load(base_schema->version(),
+        [base_schema] (table_schema_version) -> base_and_view_schemas { return {frozen_schema(base_schema)}; });
+    base_registry_schema = nullptr;
+    auto recovered_registry_schema = local_schema_registry().get_or_null(base_schema->version());
+    BOOST_REQUIRE(recovered_registry_schema);
+    recovered_registry_schema = nullptr;
+    seastar::sleep(dummy.grace_period).get();
+    BOOST_REQUIRE(!local_schema_registry().get_or_null(base_schema->version()));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_view_info_is_recovered_after_dying) {
+    dummy_init dummy;
+    auto base_schema = schema_builder("ks", "cf")
+        .with_column("pk", int32_type, column_kind::partition_key)
+        .with_column("v", int32_type)
+        .build();
+    schema_builder view_builder("ks", "cf_view");
+    auto view_schema = schema_builder("ks", "cf_view")
+            .with_column("v", int32_type, column_kind::partition_key)
+            .with_column("pk", int32_type)
+            .with_view_info(*base_schema, false, "pk IS NOT NULL AND v IS NOT NULL")
+            .build();
+    view_schema->view_info()->set_base_info(view_schema->view_info()->make_base_dependent_view_info(*base_schema));
+    local_schema_registry().get_or_load(view_schema->version(),
+        [view_schema, base_schema] (table_schema_version) -> base_and_view_schemas { return {frozen_schema(view_schema), base_schema}; });
+    auto view_registry_schema = local_schema_registry().get_or_null(view_schema->version());
+    BOOST_REQUIRE(view_registry_schema);
+    BOOST_REQUIRE(view_registry_schema->view_info()->base_info());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -1687,3 +1687,14 @@ def test_view_in_API(cql, test_keyspace):
             wait_for_view_built(cql, view)
             res = rest_api.get_request(cql, f"column_family/built_indexes/{base.replace('.',':')}")
             assert view_name not in res
+
+# Test that we can perform reads from the view in reverse order without crashing.
+# Reproduces issue https://github.com/scylladb/scylladb/issues/21354
+def test_reverse_read_from_view(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, 'a int PRIMARY KEY, b int') as table:
+        with new_materialized_view(cql, table, '*', 'b, a', 'a is not null and b is not null') as mv:
+            cql.execute(f'insert into {table} (a, b) values (1, 1)')
+            cql.execute(f'insert into {table} (a, b) values (2, 1)')
+            assert {(1,),(2,)} == set(cql.execute(f'select a from {mv} where b=1'))
+            assert [(1,),(2,)] == list(cql.execute(f'select a from {mv} where b=1 order by a asc'))
+            assert [(2,),(1,)] == list(cql.execute(f'select a from {mv} where b=1 order by a desc'))


### PR DESCRIPTION
Currently, when we load a frozen schema into the registry, we lose
the base info if the schema was of a view. Because of that, in various
places we need to set the base info again, and in some codepaths we
may miss it completely, which may make us unable to process some
requests (for example, when executing reverse queries on views).
Even after setting the base info, we may still lose it if the schema
entry gets deactivated due to all `schema_ptr`s temporarily dying.

To fix this, this patch adds the base schema to the registry, alongside
the view schema. We store just the frozen base schema, so that we can
transfer it across shards. With the base schema, we can now set the base
info when returning the schema from the registry. As a result, we can now
assume that all view schemas returned by the registry have base_info set.

In this series we also make sure that the view schemas in the registry are
kept up-to-date in regards to base schema changes.

Fixes https://github.com/scylladb/scylladb/issues/21354

This issue is a bug, so adding backport labels 6.1 and 6.2