### PR TITLE
locator: topology: use const node& instead of const node*

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2438,10 +2438,10 @@ view_builder::view_build_statuses(sstring keyspace, sstring view_name) const {
     std::unordered_map<locator::host_id, sstring> status = co_await view_status(std::move(keyspace), std::move(view_name));
     std::unordered_map<sstring, sstring> status_map;
     const auto& topo = _db.get_token_metadata().get_topology();
-    topo.for_each_node([&] (const locator::node *node) {
-        auto it = status.find(node->host_id());
+    topo.for_each_node([&] (const locator::node& node) {
+        auto it = status.find(node.host_id());
         auto s = it != status.end() ? std::move(it->second) : "UNKNOWN";
-        status_map.emplace(fmt::to_string(node->endpoint()), std::move(s));
+        status_map.emplace(fmt::to_string(node.endpoint()), std::move(s));
     });
     co_return status_map;
 }

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -399,7 +399,7 @@ future<tablet_replica_set> network_topology_strategy::add_tablets_in_dc(schema_p
 
     auto replicas = cur_replicas;
     // all_dc_racks is ordered lexicographically on purpose
-    auto all_dc_racks = boost::copy_range<std::map<sstring, std::unordered_set<const node*>>>(
+    auto all_dc_racks = boost::copy_range<std::map<sstring, std::unordered_set<std::reference_wrapper<const node>>>>(
             tm->get_datacenter_racks_token_owners_nodes().at(dc));
 
     // Track all nodes with no replicas on them for this tablet, per rack.
@@ -433,10 +433,10 @@ future<tablet_replica_set> network_topology_strategy::add_tablets_in_dc(schema_p
         auto& candidate = existing.empty() ?
                 new_racks.emplace_back(rack) : existing_racks.emplace_back(rack);
         for (const auto& node : nodes) {
-            if (!node->is_normal()) {
+            if (!node.get().is_normal()) {
                 continue;
             }
-            const auto& host_id = node->host_id();
+            const auto& host_id = node.get().host_id();
             if (!existing.contains(host_id)) {
                 candidate.nodes.emplace_back(host_id, load.get_load(host_id));
             }

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <functional>
 #include <unordered_set>
 #include <unordered_map>
 #include "gms/inet_address.hh"
@@ -343,11 +344,11 @@ public:
 
     // Returns the map: DC -> token owners in that DC.
     // If there are no token owners in a DC, it is not present in the result.
-    std::unordered_map<sstring, std::unordered_set<const node*>> get_datacenter_token_owners_nodes() const;
+    std::unordered_map<sstring, std::unordered_set<std::reference_wrapper<const node>>> get_datacenter_token_owners_nodes() const;
 
     // Returns the map: DC -> (map: rack -> token owners in that rack).
     // If there are no token owners in a DC/rack, it is not present in the result.
-    std::unordered_map<sstring, std::unordered_map<sstring, std::unordered_set<const node*>>>
+    std::unordered_map<sstring, std::unordered_map<sstring, std::unordered_set<std::reference_wrapper<const node>>>>
     get_datacenter_racks_token_owners_nodes() const;
 
     // Updates the read_new flag, switching read requests from

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -2038,10 +2038,10 @@ future<> repair_service::do_rebuild_replace_with_repair(std::unordered_map<sstri
         std::unordered_set<locator::host_id> all_live_nodes;
         std::unordered_map<sstring, std::unordered_set<locator::host_id>> live_nodes_per_dc;
         std::unordered_map<sstring, size_t> lost_nodes_per_dc;
-        topology.for_each_node([&] (const locator::node* node) {
-            const auto& host_id = node->host_id();
-            const auto& dc = node->dc_rack().dc;
-            if (node->is_this_node()) {
+        topology.for_each_node([&] (const locator::node& node) {
+            const auto& host_id = node.host_id();
+            const auto& dc = node.dc_rack().dc;
+            if (node.is_this_node()) {
                 // Count the rebuilt node as lost.
                 // For replace, we count the replaced_node below.
                 if (reason == streaming::stream_reason::rebuild) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3929,7 +3929,7 @@ storage_proxy::mutate_atomically_result(std::vector<mutation> mutations, db::con
                             auto local_token_nodes  = _ermp->get_token_metadata().get_datacenter_racks_token_owners_nodes().at(local_dc);
                             for (const auto& e : local_token_nodes) {
                                 local_token_owners.emplace(e.first, e.second |
-                                    std::views::transform([] (const locator::node* n) { return n->host_id(); }) |
+                                    std::views::transform([] (const locator::node& n) { return n.host_id(); }) |
                                     std::ranges::to<std::unordered_set<locator::host_id>>());
                             }
                             auto local_rack = topology.get_rack();

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -771,11 +771,11 @@ public:
             }
         };
         // TODO: share code with make_plan()
-        topo.for_each_node([&] (const locator::node* node_ptr) {
-            bool is_drained = node_ptr->get_state() == locator::node::state::being_decommissioned
-                              || node_ptr->get_state() == locator::node::state::being_removed;
-            if (node_ptr->get_state() == locator::node::state::normal || is_drained) {
-                ensure_node(node_ptr->host_id());
+        topo.for_each_node([&] (const locator::node& node) {
+            bool is_drained = node.get_state() == locator::node::state::being_decommissioned
+                              || node.get_state() == locator::node::state::being_removed;
+            if (node.get_state() == locator::node::state::normal || is_drained) {
+                ensure_node(node.host_id());
             }
         });
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2765,7 +2765,7 @@ future<locator::load_stats> topology_coordinator::refresh_tablet_load_stats() {
         locator::load_stats dc_stats;
         rtlogger.info("raft topology: Refreshing table load stats for DC {} that has {} token owners", dc, nodes.size());
         co_await coroutine::parallel_for_each(nodes, [&] (const auto& node) -> future<> {
-            auto dst = node->host_id();
+            auto dst = node.get().host_id();
 
             _as.check();
 
@@ -2931,13 +2931,13 @@ future<> topology_coordinator::build_coordinator_state(group0_guard guard) {
     std::set<sstring> enabled_features;
 
     // Build per-node state
-    for (const auto* node: tmptr->get_topology().get_nodes()) {
-        if (!node->is_member()) {
+    for (const auto& node: tmptr->get_topology().get_nodes()) {
+        if (!node.get().is_member()) {
             continue;
         }
 
-        const auto& host_id = node->host_id();
-        const auto& ep = node->endpoint();
+        const auto& host_id = node.get().host_id();
+        const auto& ep = node.get().endpoint();
         const auto eptr = _gossiper.get_endpoint_state_ptr(ep);
         if (!eptr) {
             throw std::runtime_error(format("failed to build initial raft topology state from gossip for node {}/{} as gossip contains no data for it", host_id, ep));


### PR DESCRIPTION
locator: topology: use node& instead of node*
This change goes thru locator:topology to use node& instead of node* where nullptr is not possible. There are place where the node object is used in unordered_set, in those cases the node is wrapped in std::reference_wrapper.

Fixes https://github.com/scylladb/scylladb/issues/20357

cleanup,
`backport/none`