### PR TITLE
Complete implementation of configuring IO bandwidth limits

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -80,7 +80,7 @@ future<> set_server_init(http_context& ctx) {
     });
 }
 
-future<> set_server_config(http_context& ctx, const db::config& cfg) {
+future<> set_server_config(http_context& ctx, db::config& cfg) {
     auto rb02 = std::make_shared < api_registry_builder20 > (ctx.api_doc, "/v2");
     return ctx.http_server.set_routes([&ctx, &cfg, rb02](routes& r) {
         set_config(rb02, ctx, r, cfg, false);

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -88,7 +88,7 @@ struct http_context {
 };
 
 future<> set_server_init(http_context& ctx);
-future<> set_server_config(http_context& ctx, const db::config& cfg);
+future<> set_server_config(http_context& ctx, db::config& cfg);
 future<> unset_server_config(http_context& ctx);
 future<> set_server_snitch(http_context& ctx, sharded<locator::snitch_ptr>& snitch);
 future<> unset_server_snitch(http_context& ctx);

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -204,14 +204,6 @@ void set_compaction_manager(http_context& ctx, routes& r, sharded<compaction_man
         int value = cm.local().throughput_mbs();
         return make_ready_future<json::json_return_type>(value);
     });
-
-    ss::set_compaction_throughput_mb_per_sec.set(r, [](std::unique_ptr<http::request> req) {
-        //TBD
-        unimplemented();
-        auto value = req->get_query_param("value");
-        return make_ready_future<json::json_return_type>(json_void());
-    });
-
 }
 
 void unset_compaction_manager(http_context& ctx, routes& r) {
@@ -227,7 +219,6 @@ void unset_compaction_manager(http_context& ctx, routes& r) {
     cm::get_compaction_history.unset(r);
     cm::get_compaction_info.unset(r);
     ss::get_compaction_throughput_mb_per_sec.unset(r);
-    ss::set_compaction_throughput_mb_per_sec.unset(r);
 }
 
 }

--- a/api/config.cc
+++ b/api/config.cc
@@ -193,6 +193,12 @@ void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx
         return cfg.saved_caches_directory();
     });
 
+    ss::set_compaction_throughput_mb_per_sec.set(r, [](std::unique_ptr<http::request> req) {
+        //TBD
+        unimplemented();
+        auto value = req->get_query_param("value");
+        return make_ready_future<json::json_return_type>(json::json_void());
+    });
 }
 
 void unset_config(http_context& ctx, routes& r) {
@@ -213,6 +219,7 @@ void unset_config(http_context& ctx, routes& r) {
     sp::set_truncate_rpc_timeout.unset(r);
     ss::get_all_data_file_locations.unset(r);
     ss::get_saved_caches_location.unset(r);
+    ss::set_compaction_throughput_mb_per_sec.unset(r);
 }
 
 }

--- a/api/config.cc
+++ b/api/config.cc
@@ -83,7 +83,7 @@ future<> get_config_swagger_entry(std::string_view name, const std::string& desc
 
 namespace cs = httpd::config_json;
 
-void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx, routes& r, const db::config& cfg, bool first) {
+void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx, routes& r, db::config& cfg, bool first) {
     rb->register_function(r, [&cfg, first] (output_stream<char>& os) {
         return do_with(first, [&os, &cfg] (bool& first) {
             auto f = make_ready_future();

--- a/api/config.cc
+++ b/api/config.cc
@@ -193,17 +193,15 @@ void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx
         return cfg.saved_caches_directory();
     });
 
-    ss::set_compaction_throughput_mb_per_sec.set(r, [](std::unique_ptr<http::request> req) {
-        //TBD
-        unimplemented();
-        auto value = req->get_query_param("value");
+    ss::set_compaction_throughput_mb_per_sec.set(r, [&cfg](std::unique_ptr<http::request> req) mutable {
+        api::req_param<uint32_t> value(*req, "value", 0);
+        cfg.compaction_throughput_mb_per_sec(value.value, utils::config_file::config_source::API);
         return make_ready_future<json::json_return_type>(json::json_void());
     });
 
-    ss::set_stream_throughput_mb_per_sec.set(r, [](std::unique_ptr<http::request> req) {
-        //TBD
-        unimplemented();
-        auto value = req->get_query_param("value");
+    ss::set_stream_throughput_mb_per_sec.set(r, [&cfg](std::unique_ptr<http::request> req) mutable {
+        api::req_param<uint32_t> value(*req, "value", 0);
+        cfg.stream_io_throughput_mb_per_sec(value.value, utils::config_file::config_source::API);
         return make_ready_future<json::json_return_type>(json::json_void());
     });
 }

--- a/api/config.cc
+++ b/api/config.cc
@@ -199,6 +199,13 @@ void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx
         auto value = req->get_query_param("value");
         return make_ready_future<json::json_return_type>(json::json_void());
     });
+
+    ss::set_stream_throughput_mb_per_sec.set(r, [](std::unique_ptr<http::request> req) {
+        //TBD
+        unimplemented();
+        auto value = req->get_query_param("value");
+        return make_ready_future<json::json_return_type>(json::json_void());
+    });
 }
 
 void unset_config(http_context& ctx, routes& r) {
@@ -220,6 +227,7 @@ void unset_config(http_context& ctx, routes& r) {
     ss::get_all_data_file_locations.unset(r);
     ss::get_saved_caches_location.unset(r);
     ss::set_compaction_throughput_mb_per_sec.unset(r);
+    ss::set_stream_throughput_mb_per_sec.unset(r);
 }
 
 }

--- a/api/config.hh
+++ b/api/config.hh
@@ -13,6 +13,6 @@
 
 namespace api {
 
-void set_config(std::shared_ptr<httpd::api_registry_builder20> rb, http_context& ctx, httpd::routes& r, const db::config& cfg, bool first = false);
+void set_config(std::shared_ptr<httpd::api_registry_builder20> rb, http_context& ctx, httpd::routes& r, db::config& cfg, bool first = false);
 void unset_config(http_context& ctx, httpd::routes& r);
 }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1048,19 +1048,6 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         });
     });
 
-    ss::set_stream_throughput_mb_per_sec.set(r, [](std::unique_ptr<http::request> req) {
-        //TBD
-        unimplemented();
-        auto value = req->get_query_param("value");
-        return make_ready_future<json::json_return_type>(json_void());
-    });
-
-    ss::get_stream_throughput_mb_per_sec.set(r, [](std::unique_ptr<http::request> req) {
-        //TBD
-        unimplemented();
-        return make_ready_future<json::json_return_type>(0);
-    });
-
     ss::is_incremental_backups_enabled.set(r, [&ctx](std::unique_ptr<http::request> req) {
         // If this is issued in parallel with an ongoing change, we may see values not agreeing.
         // Reissuing is asking for trouble, so we will just return true upon seeing any true value.
@@ -1625,8 +1612,6 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::is_initialized.unset(r);
     ss::join_ring.unset(r);
     ss::is_joined.unset(r);
-    ss::set_stream_throughput_mb_per_sec.unset(r);
-    ss::get_stream_throughput_mb_per_sec.unset(r);
     ss::is_incremental_backups_enabled.unset(r);
     ss::set_incremental_backups_enabled.unset(r);
     ss::rebuild.unset(r);

--- a/api/stream_manager.cc
+++ b/api/stream_manager.cc
@@ -11,6 +11,7 @@
 #include "streaming/stream_result_future.hh"
 #include "api/api.hh"
 #include "api/api-doc/stream_manager.json.hh"
+#include "api/api-doc/storage_service.json.hh"
 #include <vector>
 #include <rapidjson/document.h>
 #include "gms/gossiper.hh"
@@ -18,6 +19,7 @@
 namespace api {
 using namespace seastar::httpd;
 
+namespace ss = httpd::storage_service_json;
 namespace hs = httpd::stream_manager_json;
 
 static void set_summaries(const std::vector<streaming::stream_summary>& from,
@@ -148,6 +150,12 @@ void set_stream_manager(http_context& ctx, routes& r, sharded<streaming::stream_
             return make_ready_future<json::json_return_type>(res);
         });
     });
+
+    ss::get_stream_throughput_mb_per_sec.set(r, [](std::unique_ptr<http::request> req) {
+        //TBD
+        unimplemented();
+        return make_ready_future<json::json_return_type>(0);
+    });
 }
 
 void unset_stream_manager(http_context& ctx, routes& r) {
@@ -157,6 +165,7 @@ void unset_stream_manager(http_context& ctx, routes& r) {
     hs::get_all_total_incoming_bytes.unset(r);
     hs::get_total_outgoing_bytes.unset(r);
     hs::get_all_total_outgoing_bytes.unset(r);
+    ss::get_stream_throughput_mb_per_sec.unset(r);
 }
 
 }

--- a/api/stream_manager.cc
+++ b/api/stream_manager.cc
@@ -151,10 +151,9 @@ void set_stream_manager(http_context& ctx, routes& r, sharded<streaming::stream_
         });
     });
 
-    ss::get_stream_throughput_mb_per_sec.set(r, [](std::unique_ptr<http::request> req) {
-        //TBD
-        unimplemented();
-        return make_ready_future<json::json_return_type>(0);
+    ss::get_stream_throughput_mb_per_sec.set(r, [&sm](std::unique_ptr<http::request> req) {
+        auto value = sm.local().throughput_mbs();
+        return make_ready_future<json::json_return_type>(value);
     });
 }
 

--- a/docs/operating-scylla/nodetool-commands/getcompactionthroughput.rst
+++ b/docs/operating-scylla/nodetool-commands/getcompactionthroughput.rst
@@ -1,0 +1,19 @@
+================================
+Nodetool getcompactionthroughput
+================================
+**getcompactionthroughput** - Print the throughput cap for compaction in the system
+
+If zero is printed, it means throughput is uncapped
+
+Syntax
+-------
+.. code-block:: console
+
+   nodetool [options] getcompactionthroughput
+
+See also
+
+* :doc:`setcompactionthroughput <setcompactionthroughput>`
+
+.. include:: nodetool-index.rst
+

--- a/docs/operating-scylla/nodetool-commands/getstreamthroughput.rst
+++ b/docs/operating-scylla/nodetool-commands/getstreamthroughput.rst
@@ -1,0 +1,24 @@
+============================
+Nodetool getstreamthroughput
+============================
+**getstreamthroughput** - Print the throughput cap for SSTables streaming in the system
+
+If zero is printed, it means throughput is uncapped
+
+Syntax
+-------
+.. code-block:: console
+
+   nodetool [options] getstreamthroughput [--mib]
+
+Options
+--------
+
+* ``--mib`` - Print the value in MiB rather than megabits per second
+
+See also
+
+* :doc:`setstreamthroughput <setstreamthroughput>`
+
+.. include:: nodetool-index.rst
+

--- a/docs/operating-scylla/nodetool-commands/setcompactionthroughput.rst
+++ b/docs/operating-scylla/nodetool-commands/setcompactionthroughput.rst
@@ -1,0 +1,19 @@
+================================
+Nodetool setcompactionthroughput
+================================
+**setcompactionthroughput** - Print the throughput cap for compaction in the system
+
+Setting zero throughput disables capping
+
+Syntax
+-------
+.. code-block:: console
+
+   nodetool [options] setcompactionthroughput <value_in_mib>
+
+See also
+
+* :doc:`getcompactionthroughput <getcompactionthroughput>`
+
+.. include:: nodetool-index.rst
+

--- a/docs/operating-scylla/nodetool-commands/setstreamthroughput.rst
+++ b/docs/operating-scylla/nodetool-commands/setstreamthroughput.rst
@@ -1,0 +1,19 @@
+============================
+Nodetool setstreamthroughput
+============================
+**setstreamthroughput** - Print the throughput cap for SSTables streaming in the system
+
+Setting zero throughput disables capping
+
+Syntax
+-------
+.. code-block:: console
+
+   nodetool [options] setstreamthroughput <value_in_mb>
+
+See also
+
+* :doc:`getstreamthroughput <getstreamthroughput>`
+
+.. include:: nodetool-index.rst
+

--- a/docs/operating-scylla/nodetool.rst
+++ b/docs/operating-scylla/nodetool.rst
@@ -60,6 +60,8 @@ Nodetool
    nodetool-commands/upgradesstables
    nodetool-commands/viewbuildstatus
    nodetool-commands/version
+   nodetool-commands/getcompactionthroughput
+   nodetool-commands/setcompactionthroughput
 
 The ``nodetool`` utility provides a simple command-line interface to the following exposed operations and attributes.
 
@@ -132,5 +134,7 @@ Operations that are not listed below are currently not available.
 * :doc:`upgradesstables </operating-scylla/nodetool-commands/upgradesstables>` - Upgrades each table that is not running the latest ScyllaDB version, by rewriting SSTables.
 * :doc:`viewbuildstatus </operating-scylla/nodetool-commands/viewbuildstatus/>` - Shows the progress of a materialized view build.
 * :doc:`version </operating-scylla/nodetool-commands/version>` - Print the DB version.
+* :doc:`getcompactionthroughput </operating-scylla/nodetool-commands/getcompactionthroughput>` - Print the throughput cap for compaction in the system
+* :doc:`setcompactionthroughput </operating-scylla/nodetool-commands/setcompactionthroughput>` - Set the throughput cap for compaction in the system
 
 

--- a/docs/operating-scylla/nodetool.rst
+++ b/docs/operating-scylla/nodetool.rst
@@ -62,6 +62,8 @@ Nodetool
    nodetool-commands/version
    nodetool-commands/getcompactionthroughput
    nodetool-commands/setcompactionthroughput
+   nodetool-commands/getstreamthroughput
+   nodetool-commands/setstreamthroughput
 
 The ``nodetool`` utility provides a simple command-line interface to the following exposed operations and attributes.
 
@@ -136,5 +138,6 @@ Operations that are not listed below are currently not available.
 * :doc:`version </operating-scylla/nodetool-commands/version>` - Print the DB version.
 * :doc:`getcompactionthroughput </operating-scylla/nodetool-commands/getcompactionthroughput>` - Print the throughput cap for compaction in the system
 * :doc:`setcompactionthroughput </operating-scylla/nodetool-commands/setcompactionthroughput>` - Set the throughput cap for compaction in the system
-
+* :doc:`getstreamthroughput </operating-scylla/nodetool-commands/getstreamthroughput>` - Print the throughput cap for SSTables streaming in the system
+* :doc:`setstreamthroughput </operating-scylla/nodetool-commands/setstreamthroughput>` - Set the throughput cap for SSTables streaming in the system
 

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -189,6 +189,10 @@ private:
 
 public:
     void update_finished_percentage(streaming::stream_reason reason, float percentage);
+
+    uint32_t throughput_mbs() const noexcept {
+        return _io_throughput_mbs.get();
+    }
 };
 
 } // namespace streaming

--- a/test/nodetool/test_compaction_throughput.py
+++ b/test/nodetool/test_compaction_throughput.py
@@ -1,0 +1,19 @@
+#
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from test.nodetool.rest_api_mock import expected_request
+import pytest
+
+def test_get_compaction_throughput(nodetool, scylla_only):
+    res = nodetool("getcompactionthroughput", expected_requests = [
+            expected_request("GET", "/storage_service/compaction_throughput", response=0)
+        ])
+    assert res.stdout == '0\n'
+
+def test_set_compaction_throughput(nodetool, scylla_only):
+    nodetool("setcompactionthroughput", "100", expected_requests = [
+            expected_request("POST", "/storage_service/compaction_throughput", params={"value": "100"})
+        ])

--- a/test/nodetool/test_stream_throughput.py
+++ b/test/nodetool/test_stream_throughput.py
@@ -1,0 +1,25 @@
+#
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+from test.nodetool.rest_api_mock import expected_request
+import pytest
+
+def test_get_stream_throughput(nodetool, scylla_only):
+    res = nodetool("getstreamthroughput", "--mib", expected_requests = [
+            expected_request("GET", "/storage_service/stream_throughput", response=100)
+        ])
+    assert res.stdout == "100\n"
+
+def test_get_stream_throughput_mbits(nodetool, scylla_only):
+    res = nodetool("getstreamthroughput", expected_requests = [
+            expected_request("GET", "/storage_service/stream_throughput", response=100)
+        ])
+    assert res.stdout == f"{int(100*1024*1024*8/1000000)}\n"
+
+def test_set_stream_throughput(nodetool, scylla_only):
+    nodetool("setstreamthroughput", "100", expected_requests = [
+            expected_request("POST", "/storage_service/stream_throughput", params={"value": "100"})
+        ])

--- a/test/rest_api/test_system.py
+++ b/test/rest_api/test_system.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import pytest
+import requests
+
 def test_system_uptime_ms(rest_api):
     resp = rest_api.send('GET', "system/uptime_ms")
     resp.raise_for_status()
@@ -11,3 +14,21 @@ def test_system_highest_sstable_format(rest_api):
     resp = rest_api.send('GET', "system/highest_supported_sstable_version")
     resp.raise_for_status()
     assert resp.json() == "me"
+
+@pytest.mark.parametrize("params", [
+    ("storage_service/compaction_throughput", "value"),
+    ("storage_service/stream_throughput", "value")
+])
+def test_io_throughput(rest_api, params):
+    resp = rest_api.send("POST", params[0], params={ params[1]: 100 })
+    resp.raise_for_status()
+    resp = rest_api.send("GET", params[0])
+    resp.raise_for_status()
+    assert resp.json() == 100
+    resp = rest_api.send("POST", params[0], params={ params[1]: 0 })
+    resp.raise_for_status()
+    resp = rest_api.send("GET", params[0])
+    resp.raise_for_status()
+    assert resp.json() == 0
+    resp = rest_api.send("POST", params[0])
+    assert resp.status_code == requests.codes.bad_request

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -3249,6 +3249,22 @@ void version_operation(scylla_rest_client& client, const bpo::variables_map& vm)
     fmt::print(std::cout, "ReleaseVersion: {}\n", rjson::to_string_view(version_json));
 }
 
+void getcompactionthroughput_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    auto res = client.get("/storage_service/compaction_throughput");
+    uint32_t compaction_throughput_mb_per_sec = res.GetInt();
+    fmt::print("{}\n", compaction_throughput_mb_per_sec);
+}
+
+void setcompactionthroughput_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    std::unordered_map<sstring, sstring> params;
+    if (vm.contains("mbs")) {
+        params["value"] = fmt::to_string(vm["mbs"].as<uint32_t>());
+    } else {
+        throw std::invalid_argument(fmt::format("The throughput value must be specified"));
+    }
+    client.post("/storage_service/compaction_throughput", std::move(params));
+}
+
 const std::vector<operation_option> global_options{
     typed_option<sstring>("host,h", "localhost", "the hostname or ip address of the ScyllaDB node"),
     typed_option<uint16_t>("port,p", 10000, "the port of the REST API of the ScyllaDB node"),
@@ -4449,6 +4465,34 @@ For more information, see: {}"
             },
             {
                 version_operation
+            }
+        },
+        {
+            {
+                "getcompactionthroughput",
+                "Get compaction IO throughput",
+R"(
+Print the MiB/s throughput cap for compaction in the system
+)",
+            },
+            {
+                getcompactionthroughput_operation
+            }
+        },
+        {
+            {
+                "setcompactionthroughput",
+                "Set compaction IO throughput",
+R"(
+Set the MiB/s throughput for compaction, or 0 to disable throttling
+)",
+                {},
+                {
+                    typed_option<uint32_t>("mbs", "Value in MiB, 0 to disable throttling ", 1),
+                },
+            },
+            {
+                setcompactionthroughput_operation
             }
         },
     };

--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -11,6 +11,8 @@
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
+
 #include <unordered_map>
 #include <iosfwd>
 #include <string_view>


### PR DESCRIPTION
In Scylla there are two options that control IO bandwidth limit -- the /storage_service/(compaction|stream)_throughput REST API endpoints. The endpoints are partially implemented and have no counterparts in the nodetool.

This set implements the missing bits and adds tests for new functionality.