### PR TITLE
schema: fix issue 21825: add validation for PERCENTILE values in speculative_retry configuration. 

### DIFF
--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -82,6 +82,10 @@ speculative_retry::from_sstring(sstring str) {
     } else if (str.compare(str.size() - percentile.size(), percentile.size(), percentile) == 0) {
         t = type::PERCENTILE;
         v = convert(percentile) / 100;
+        if  (v <= 0.0 || v >= 1.0) {
+            throw exceptions::configuration_exception(
+                format("Invalid value {} for PERCENTILE option 'speculative_retry': must be between (0.0 and 100.0)", str));
+        }
     } else {
         throw std::invalid_argument(format("cannot convert {} to speculative_retry\n", str));
     }


### PR DESCRIPTION
[Issue 21825](https://github.com/scylladb/scylladb/issues/21825) has been resolved.

Validation for the PERCENTILE value in `speculative_retry` have been added:
- In the static method `speculative_retry::from_sstring`, as the PERCENTILE value passed as a string can [range from 0 to 100](https://enterprise.docs.scylladb.com/stable/cql/ddl.html#speculative-retry-options).