### PR TITLE
treewide: migrate from boost::copy_range to std::ranges::to

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -16,10 +16,7 @@
 #include <assert.h>
 #include <algorithm>
 
-#include <boost/range/algorithm.hpp>
 #include <boost/range/join.hpp>
-#include <boost/range/numeric.hpp>
-#include <boost/algorithm/string/join.hpp>
 
 #include <seastar/core/future-util.hh>
 #include <seastar/core/scheduling.hh>
@@ -227,7 +224,7 @@ static api::timestamp_type get_max_purgeable_timestamp(const table_state& table_
 
 static std::vector<shared_sstable> get_uncompacting_sstables(const table_state& table_s, std::vector<shared_sstable> sstables) {
     auto sstable_set = table_s.sstable_set_for_tombstone_gc();
-    auto all_sstables = boost::copy_range<std::vector<shared_sstable>>(*sstable_set->all());
+    auto all_sstables = *sstable_set->all() | std::ranges::to<std::vector>();
     auto& compacted_undeleted = table_s.compacted_undeleted_sstables();
     all_sstables.insert(all_sstables.end(), compacted_undeleted.begin(), compacted_undeleted.end());
     std::ranges::sort(all_sstables, std::ranges::less(), std::mem_fn(&sstable::generation));

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -21,8 +21,6 @@
 #include "compaction_strategy_state.hh"
 #include "cql3/statements/property_definitions.hh"
 #include "schema/schema.hh"
-#include <boost/range/algorithm/find.hpp>
-#include <boost/range/numeric.hpp>
 #include "size_tiered_compaction_strategy.hh"
 #include "leveled_compaction_strategy.hh"
 #include "time_window_compaction_strategy.hh"
@@ -303,7 +301,7 @@ void size_tiered_backlog_tracker::replace_sstables(const std::vector<sstables::s
             }
         }
     }
-    auto tmp_contrib = calculate_sstables_backlog_contribution(boost::copy_range<std::vector<shared_sstable>>(tmp_all), _stcs_options);
+    auto tmp_contrib = calculate_sstables_backlog_contribution(tmp_all | std::ranges::to<std::vector>(), _stcs_options);
 
     std::invoke([&] () noexcept {
         _all = std::move(tmp_all);

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -16,7 +16,6 @@
 #include <boost/range/algorithm/find.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/algorithm/min_element.hpp>
-#include <boost/range/numeric.hpp>
 
 #include <ranges>
 
@@ -525,7 +524,7 @@ int64_t time_window_compaction_strategy::estimated_pending_compactions(table_sta
     auto& state = get_state(table_s);
     auto min_threshold = table_s.min_compaction_threshold();
     auto max_threshold = table_s.schema()->max_compaction_threshold();
-    auto candidate_sstables = boost::copy_range<std::vector<sstables::shared_sstable>>(*table_s.main_sstable_set().all());
+    auto candidate_sstables = *table_s.main_sstable_set().all() | std::ranges::to<std::vector>();
     auto [buckets, max_timestamp] = get_buckets(std::move(candidate_sstables), _options);
 
     int64_t n = 0;

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -11,8 +11,6 @@
 #include "db/consistency_level.hh"
 #include "db/consistency_level_validations.hh"
 
-#include <boost/range/algorithm/find.hpp>
-#include <boost/range/algorithm/transform.hpp>
 #include "exceptions/exceptions.hh"
 #include <fmt/ranges.h>
 #include <seastar/core/sstring.hh>
@@ -336,7 +334,7 @@ filter_for_query(consistency_level cl,
         if (!old_node && ht_max - ht_min > 0.01) { // if there is old node or hit rates are close skip calculations
             // local node is always first if present (see storage_proxy::get_endpoints_for_reading)
             unsigned local_idx = erm.get_topology().is_me(epi[0].first) ? 0 : epi.size() + 1;
-            auto weighted = boost::copy_range<host_id_vector_replica_set>(miss_equalizing_combination(epi, local_idx, remaining_bf, bool(extra)));
+            auto weighted = miss_equalizing_combination(epi, local_idx, remaining_bf, bool(extra)) | std::ranges::to<host_id_vector_replica_set>();
             // Workaround for https://github.com/scylladb/scylladb/issues/9285
             auto last = std::adjacent_find(weighted.begin(), weighted.end());
             if (last == weighted.end()) {

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -14,7 +14,6 @@
 #include "db/system_keyspace.hh"
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/range/adaptor/map.hpp>
 #include "gms/gossiper.hh"
 #include "gms/i_endpoint_state_change_subscriber.hh"
 #include "utils/assert.hh"
@@ -308,7 +307,7 @@ future<> feature_service::enable_features_on_startup(db::system_keyspace& sys_ks
     }
 
     co_await container().invoke_on_all([&features_to_enable] (auto& srv) -> future<> {
-        std::set<std::string_view> feat = boost::copy_range<std::set<std::string_view>>(features_to_enable);
+        auto feat = features_to_enable | std::ranges::to<std::set<std::string_view>>();
         co_await srv.enable(std::move(feat));
     });
 }
@@ -380,7 +379,7 @@ future<> persistent_feature_enabler::enable_features() {
     co_await _sys_ks.save_local_enabled_features(std::move(feats_set), true);
 
     co_await _feat.container().invoke_on_all([&features] (feature_service& fs) -> future<> {
-        std::set<std::string_view> features_v = boost::copy_range<std::set<std::string_view>>(features);
+        auto features_v = features | std::ranges::to<std::set<std::string_view>>();
         co_await fs.enable(std::move(features_v));
     });
 }

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -35,11 +35,7 @@
 #include <chrono>
 #include "locator/host_id.hh"
 #include <boost/range/algorithm/set_algorithm.hpp>
-#include <boost/range/algorithm/count_if.hpp>
 #include <boost/range/algorithm/partition.hpp>
-#include <boost/range/adaptor/map.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/classification.hpp>
 #include <utility>
 #include "gms/generation-number.hh"
 #include "locator/token_metadata.hh"
@@ -998,7 +994,7 @@ future<> gossiper::failure_detector_loop() {
                 co_await sleep_abortable(std::chrono::seconds(1), _abort_source);
                 continue;
             }
-            auto nodes = boost::copy_range<std::vector<inet_address>>(_live_endpoints);
+            auto nodes = _live_endpoints | std::ranges::to<std::vector<inet_address>>();
             auto live_endpoints_version = _live_endpoints_version;
             auto generation_number = my_endpoint_state().get_heart_beat_state().get_generation();
             co_await coroutine::parallel_for_each(std::views::iota(0u, nodes.size()), [this, generation_number, live_endpoints_version, &nodes] (size_t idx) {
@@ -1089,7 +1085,7 @@ void gossiper::run() {
                 gossip_digest_syn message(get_cluster_name(), get_partitioner_name(), g_digests, get_group0_id());
 
                 if (_endpoints_to_talk_with.empty()) {
-                    auto live_endpoints = boost::copy_range<std::vector<inet_address>>(_live_endpoints);
+                    auto live_endpoints = _live_endpoints | std::ranges::to<std::vector<inet_address>>();
                     std::shuffle(live_endpoints.begin(), live_endpoints.end(), _random_engine);
                     // This guarantees the local node will talk with all nodes
                     // in live_endpoints at least once within nr_rounds gossip rounds.

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -399,8 +399,8 @@ future<tablet_replica_set> network_topology_strategy::add_tablets_in_dc(schema_p
 
     auto replicas = cur_replicas;
     // all_dc_racks is ordered lexicographically on purpose
-    auto all_dc_racks = boost::copy_range<std::map<sstring, std::unordered_set<std::reference_wrapper<const node>>>>(
-            tm->get_datacenter_racks_token_owners_nodes().at(dc));
+    auto all_dc_racks = tm->get_datacenter_racks_token_owners_nodes().at(dc)
+        | std::ranges::to<std::map>();
 
     // Track all nodes with no replicas on them for this tablet, per rack.
     struct node_load {

--- a/locator/util.cc
+++ b/locator/util.cc
@@ -140,8 +140,8 @@ describe_ring(const replica::database& db, const gms::gossiper& gossiper, const 
     if (left_inf != right_inf
             && left_inf != ranges.end()
             && right_inf != ranges.end()
-            && (boost::copy_range<set>(left_inf->_endpoints)
-                 == boost::copy_range<set>(right_inf->_endpoints))) {
+            && ((left_inf->_endpoints | std::ranges::to<set>()) ==
+                (right_inf->_endpoints | std::ranges::to<set>()))) {
         left_inf->_start_token = std::move(right_inf->_start_token);
         ranges.erase(right_inf);
     }

--- a/partition_range_compat.hh
+++ b/partition_range_compat.hh
@@ -67,7 +67,7 @@ wrap(const std::vector<interval<T>>& v) {
         ret.emplace_back(v.back().start(), v.front().end());
         return ret;
     }
-    return boost::copy_range<std::vector<wrapping_interval<T>>>(v);
+    return v | std::ranges::to<std::vector<wrapping_interval<T>>>();
 }
 
 template <typename T>
@@ -81,8 +81,7 @@ wrap(std::vector<interval<T>>&& v) {
         ret.emplace_back(std::move(v.back()).start(), std::move(v.front()).end());
         return ret;
     }
-    // want boost::adaptor::moved ...
-    return boost::copy_range<std::vector<wrapping_interval<T>>>(v);
+    return std::ranges::owning_view(std::move(v)) | std::ranges::to<std::vector>();
 }
 
 inline

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -28,9 +28,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/range/algorithm_ext.hpp>
-#include <boost/range/adaptor/map.hpp>
 #include <boost/range/numeric.hpp>
 
 #include <fmt/ranges.h>
@@ -1902,7 +1900,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
                         // Choose the decommission node n3 to run repair to
                         // sync with one of the replica nodes, e.g., n1, in the
                         // local DC.
-                        neighbors_set = get_neighbors_set(boost::copy_range<std::vector<locator::host_id>>(new_eps));
+                        neighbors_set = get_neighbors_set(new_eps | std::ranges::to<std::vector<locator::host_id>>());
                     }
                 } else {
                     throw std::runtime_error(fmt::format("{}: keyspace={}, range={}, current_replica_endpoints={}, new_replica_endpoints={}, wrong number of new owner node={}",

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2898,7 +2898,7 @@ future<table::snapshot_file_set> table::take_snapshot(sstring jsondir) {
 
     auto sstable_deletion_guard = co_await get_units(_sstable_deletion_sem, 1);
 
-    auto tables = boost::copy_range<std::vector<sstables::shared_sstable>>(*_sstables->all());
+    auto tables = *_sstables->all() | std::ranges::to<std::vector<sstables::shared_sstable>>();
     auto table_names = std::make_unique<std::unordered_set<sstring>>();
 
     co_await io_check([&jsondir] { return recursive_touch_directory(jsondir); });

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -165,7 +165,7 @@ future<std::vector<tasks::task_stats>> tablet_virtual_task::get_stats() {
 }
 
 std::vector<table_id> tablet_virtual_task::get_table_ids() const {
-    return boost::copy_range<std::vector<table_id>>(_ss.get_token_metadata().tablets().all_tables() | boost::adaptors::transformed([] (const auto& table_to_tablets) { return table_to_tablets.first; }));
+    return _ss.get_token_metadata().tablets().all_tables() | std::views::transform([] (const auto& table_to_tablets) { return table_to_tablets.first; }) | std::ranges::to<std::vector<table_id>>();
 }
 
 static void update_status(const locator::tablet_task_info& task_info, tasks::task_status& status, size_t& sched_nr) {

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -113,7 +113,7 @@ std::ostream& operator<<(std::ostream& os, const sstables::sstable_run& run) {
         os << format("  Identifier: {}\n", (*run.all().begin())->run_identifier());
     }
 
-    auto frags = boost::copy_range<std::vector<shared_sstable>>(run.all());
+    auto frags = run.all() | std::ranges::to<std::vector<shared_sstable>>();
     std::ranges::sort(frags, std::ranges::less(), [] (const shared_sstable& x) {
         return x->get_first_decorated_key().token();
     });

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3020,7 +3020,7 @@ sstable::compute_shards_for_this_sstable(const dht::sharder& sharder_) const {
         shards.insert(rpras->shard);
         rpras = sharder.next(*_schema);
     }
-    return boost::copy_range<std::vector<unsigned>>(shards);
+    return shards | std::ranges::to<std::vector>();
 }
 
 future<bool> sstable::has_partition_key(const utils::hashed_key& hk, const dht::decorated_key& dk) {

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -191,9 +191,9 @@ SEASTAR_THREAD_TEST_CASE(test_ring_position_ordering) {
 
     testlog.info("Keys: {}", keys);
 
-    auto positions = boost::copy_range<std::vector<dht::ring_position>>(keys);
-    auto ext_positions = boost::copy_range<std::vector<dht::ring_position_ext>>(keys);
-    auto views = boost::copy_range<std::vector<dht::ring_position_view>>(positions);
+    auto positions = keys | std::ranges::to<std::vector<dht::ring_position>>();
+    auto ext_positions = keys | std::ranges::to<std::vector<dht::ring_position_ext>>();
+    auto views = positions | std::ranges::to<std::vector<dht::ring_position_view>>();
 
     total_order_check<dht::ring_position_comparator, dht::ring_position, dht::ring_position_view, dht::decorated_key>(cmp)
       .next(dht::ring_position_view::min())

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -121,7 +121,7 @@ public:
     }
 
     std::vector<sstables::shared_sstable> candidates(table_state& t) const override {
-        return _candidates_opt.value_or(boost::copy_range<std::vector<sstables::shared_sstable>>(*t.main_sstable_set().all()));
+        return _candidates_opt.value_or(*t.main_sstable_set().all() | std::ranges::to<std::vector>());
     }
 
     std::vector<sstables::frozen_sstable_run> candidates_as_runs(table_state& t) const override {

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2055,7 +2055,7 @@ SEASTAR_TEST_CASE(sstable_owner_shards) {
         auto assert_sstable_owners = [&] (std::unordered_set<unsigned> expected_owners, unsigned ignore_msb, unsigned smp_count) {
             SCYLLA_ASSERT(expected_owners.size() <= smp_count);
             auto sst = make_shared_sstable(expected_owners, ignore_msb, smp_count);
-            auto owners = boost::copy_range<std::unordered_set<unsigned>>(sst->get_shards_for_this_sstable());
+            auto owners = sst->get_shards_for_this_sstable() | std::ranges::to<std::unordered_set<unsigned>>();
             BOOST_REQUIRE(std::ranges::all_of(expected_owners, [&] (unsigned expected_owner) {
                 return owners.contains(expected_owner);
             }));

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -7,9 +7,6 @@
  */
 
 #include <set>
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/adaptor/sliced.hpp>
-#include <boost/range/numeric.hpp>
 #include <boost/test/unit_test.hpp>
 #include <fmt/ranges.h>
 #include "partition_slice_builder.hh"
@@ -323,9 +320,7 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
 
     for (auto prange_size = 1u; prange_size < mutations.size(); prange_size += 2) {
         for (auto pstart = 0u; pstart + prange_size <= mutations.size(); pstart++) {
-            auto ms = boost::copy_range<std::vector<mutation>>(
-                mutations | boost::adaptors::sliced(pstart, pstart + prange_size)
-            );
+            auto ms = mutations | std::views::drop(pstart) | std::views::take(prange_size) | std::ranges::to<std::vector>();
             if (prange_size == 1) {
                 test_ckey({dht::partition_range::make_singular(mutations[pstart].decorated_key())}, ms, mutation_reader::forwarding::yes);
                 test_ckey({dht::partition_range::make_singular(mutations[pstart].decorated_key())}, ms, mutation_reader::forwarding::no);

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -2106,9 +2106,7 @@ int scylla_fast_forward_main(int argc, char** argv) {
                         return make_ready_future();
                     });
 
-                    auto requested_test_groups = boost::copy_range<std::unordered_set<std::string>>(
-                            app.configuration()["run-tests"].as<std::vector<std::string>>()
-                    );
+                    auto requested_test_groups = app.configuration()["run-tests"].as<std::vector<std::string>>() | std::ranges::to<std::unordered_set>();
                     auto enabled_test_groups = test_groups | std::views::filter([&] (auto&& tc) {
                         return requested_test_groups.contains(tc.name);
                     });


### PR DESCRIPTION
now that we are allowed to use C++23. we now have the luxury of using `std::ranges::to`.

in this change, we:

- replace `boost::copy_range` to `std::ranges::to`
- remove unused `#include` of boost headers

---

it's a cleanup, hence no need to backport.