### PR TITLE
dht: include a smaller header file

### DIFF
--- a/dht/auto_refreshing_sharder.hh
+++ b/dht/auto_refreshing_sharder.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "dht/sharder.hh"
+#include "dht/token-sharding.hh"
 #include "locator/abstract_replication_strategy.hh"
 
 #include <seastar/core/abort_source.hh>


### PR DESCRIPTION
Replace `dht/sharder.hh` with a "smaller" header, which provides just the enough dependencies.

in f744007e, we traded `database.hh` with a smaller set of headers. but it turns out `dht/sharder.hh` can be replaced with a even smaller one. because `dht::sharder` is defined by `dht/token-sharding.hh`, and what we need from `dht/sharder.hh` is this class's declaration. `clang-include-cleaner` identified this issue.

---

it's a cleanup, hence no need to backport.