### PR TITLE
service/storage_proxy: data_resolver::resolve(): apply mutations gently

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4951,7 +4951,7 @@ public:
             for (const version& ver : v) {
                 if (ver.par) {
                     mutation_application_stats app_stats;
-                    m.partition().apply(*schema, ver.par->mut().partition(), *schema, app_stats);
+                    co_await apply_gently(m.partition(), *schema, ver.par->mut().partition(), *schema, app_stats);
                     co_await coroutine::maybe_yield();
                 }
             }


### PR DESCRIPTION
The data resolved has to apply all mutations from all replica to a single mutation. In the extreme case, when all rows are dead, the mutations can have around 10K rows in them. This is not a huge amount, but it is enough to cause moderate stalls of <20ms. To avoid this, use the gentle variant of apply(), which can yield in the middle.

Fixes: scylladb/scylladb#21818

Not a regression, no backport needed.