### PR TITLE
db/view: stop view building before removing the table from db

### DIFF
--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -336,7 +336,7 @@ future<> view_update_generator::populate_views(const replica::table& table,
         gc_clock::time_point now) {
     auto schema = reader.schema();
     view_update_builder builder = make_view_update_builder(
-            get_db().as_data_dictionary(),
+            get_db(),
             table,
             schema,
             std::move(views),
@@ -412,7 +412,7 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
     auto base_token = m.token();
     auto m_schema = m.schema();
     view_update_builder builder = make_view_update_builder(
-            get_db().as_data_dictionary(),
+            get_db(),
             table,
             base,
             std::move(views),

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -982,6 +982,7 @@ future<> database::remove(table& cf) noexcept {
 
 future<> database::detach_column_family(table& cf) {
     auto uuid = cf.schema()->id();
+    co_await cf.await_view_building();
     co_await remove(cf);
     cf.clear_views();
     co_await cf.await_pending_ops();

--- a/test/topology_custom/test_mv_building.py
+++ b/test/topology_custom/test_mv_building.py
@@ -42,3 +42,26 @@ async def test_view_building_scheduling_group(manager: ManagerClient):
     ratio = ms_statement / ms_streaming
     print(f"ms_streaming: {ms_streaming}, ms_statement: {ms_statement}, ratio: {ratio}")
     assert ratio < 0.1
+
+# While view building is in progress, drop the view and change the schema
+# of the base table. The view table's state may become inconsistent with
+# the base table because they are detached.
+@pytest.mark.asyncio
+async def test_view_building_during_drop_view(manager: ManagerClient):
+    server = await manager.server_add()
+    cql = manager.get_cql()
+    await manager.api.enable_injection(server.ip_addr, "view_builder_consume_end_of_partition_delay_3s", one_shot=True)
+
+    await cql.run_async(f"CREATE KEYSPACE ks WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}")
+    await cql.run_async(f"CREATE TABLE ks.tab (p int, c int, PRIMARY KEY (p, c))")
+    await cql.run_async("INSERT INTO ks.tab (p,c) VALUES (123, 1000)")
+
+    await cql.run_async("CREATE INDEX idx1 ON ks.tab (c)")
+    # wait for view building to start
+    await asyncio.sleep(1)
+
+    # while view building is delayed, we drop the view and change the schema of the base table
+    await cql.run_async("DROP INDEX ks.idx1")
+    await asyncio.sleep(5)
+
+    await cql.run_async("DROP TABLE ks.tab")


### PR DESCRIPTION
When a view is dropped, it is detached and removed from the database's data structures, and its links with the base table are removed. If the view building is in progress, it is stopped in the background when receiving a notification, so it may continue after the view is removed from the database.

The problem is that when we remove the link between the view and the base table, the view building state may become inconsistent. For example, when a base table schema changes it sets the base_info for every one of its views. But if the view was removed and the base table schema changes, its base_info becomes out of sync and causes unexpected errors in view building.

To solve this, in the commit we introduce a gate for view tables that we hold in view building steps while populating the view, and it is closed before the view table is removed. This ensures that we stop all view building operations on a view before it is removed.

Fixes scylladb/scylladb#21292

backport is not required because it seems to be an old issue without much impact except occasional CI failures