### PR TITLE
[Backport 6.1] service_levels: increase timeout of internal queries and update cache on startup

### DIFF
--- a/cql3/statements/list_service_level_statement.cc
+++ b/cql3/statements/list_service_level_statement.cc
@@ -54,7 +54,7 @@ list_service_level_statement::execute(query_processor& qp,
 
     return make_ready_future().then([this, &state] () {
                                   if (_describe_all) {
-                                      return state.get_service_level_controller().get_distributed_service_levels();
+                                      return state.get_service_level_controller().get_distributed_service_levels(qos::query_context::user);
                                   } else {
                                       return state.get_service_level_controller().get_distributed_service_level(_service_level);
                                   }

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -756,8 +756,8 @@ system_distributed_keyspace::get_cdc_desc_v1_timestamps(context ctx) {
     co_return res;
 }
 
-future<qos::service_levels_info> system_distributed_keyspace::get_service_levels() const {
-    return qos::get_service_levels(_qp, NAME, SERVICE_LEVELS, db::consistency_level::ONE);
+future<qos::service_levels_info> system_distributed_keyspace::get_service_levels(qos::query_context ctx) const {
+    return qos::get_service_levels(_qp, NAME, SERVICE_LEVELS, db::consistency_level::ONE, ctx);
 }
 
 future<qos::service_levels_info> system_distributed_keyspace::get_service_level(sstring service_level_name) const {

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -112,7 +112,7 @@ public:
 
     future<db_clock::time_point> cdc_current_generation_timestamp(context);
 
-    future<qos::service_levels_info> get_service_levels() const;
+    future<qos::service_levels_info> get_service_levels(qos::query_context ctx) const;
     future<qos::service_levels_info> get_service_level(sstring service_level_name) const;
     future<> set_service_level(sstring service_level_name, qos::service_level_options slo) const;
     future<> drop_service_level(sstring service_level_name) const;

--- a/main.cc
+++ b/main.cc
@@ -1948,6 +1948,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 api::unset_server_authorization_cache(ctx).get();
             });
 
+            // update the service level cache after the SL data accessor and auth service are initialized.
+            if (sl_controller.local().is_v2()) {
+                sl_controller.local().update_service_levels_from_distributed_data().get();
+            }
+
             sl_controller.invoke_on_all([&lifecycle_notifier] (qos::service_level_controller& controller) {
                 lifecycle_notifier.local().register_subscriber(&controller);
             }).get();

--- a/service/qos/qos_common.cc
+++ b/service/qos/qos_common.cc
@@ -125,13 +125,14 @@ void service_level_options::init_effective_names(sstring& service_level_name) {
     };
 }
 
-service::query_state& qos_query_state() {
+service::query_state& qos_query_state(qos::query_context ctx) {
     using namespace std::chrono_literals;
     const auto t = 10s;
     static timeout_config tc{ t, t, t, t, t, t, t };
     static thread_local service::client_state cs(service::client_state::internal_tag{}, tc);
-    static thread_local service::query_state qs(cs, empty_service_permit());
-    return qs;
+    static thread_local service::query_state qs_default(cs, empty_service_permit());
+    static thread_local service::query_state qs_internal(service::client_state::for_internal_calls(), empty_service_permit());
+    return ctx == qos::query_context::group0 ? qs_internal : qs_default;
 };
 
 static service_level_options::timeout_type get_duration(const cql3::untyped_result_set_row&row, std::string_view col_name) {
@@ -142,9 +143,9 @@ static service_level_options::timeout_type get_duration(const cql3::untyped_resu
     return std::chrono::duration_cast<lowres_clock::duration>(std::chrono::nanoseconds(dur_opt->nanoseconds));
 };
 
-future<qos::service_levels_info> get_service_levels(cql3::query_processor& qp, std::string_view ks_name, std::string_view cf_name, db::consistency_level cl) {
+future<qos::service_levels_info> get_service_levels(cql3::query_processor& qp, std::string_view ks_name, std::string_view cf_name, db::consistency_level cl, qos::query_context ctx) {
     sstring prepared_query = format("SELECT * FROM {}.{};", ks_name, cf_name);
-    auto result_set = co_await qp.execute_internal(prepared_query, cl, qos_query_state(), cql3::query_processor::cache_internal::yes);
+    auto result_set = co_await qp.execute_internal(prepared_query, cl, qos_query_state(ctx), cql3::query_processor::cache_internal::yes);
  
     qos::service_levels_info service_levels;
     for (auto &&row : *result_set) {

--- a/service/qos/qos_common.hh
+++ b/service/qos/qos_common.hh
@@ -29,6 +29,17 @@ namespace qos {
 
 enum class include_effective_names { yes, no };
 
+/*
+ * for functions that execute queries, this is used to determine whether to execute
+ * the query with internal client_state with an 'infinite' timeout, or a default
+ * state with short timeout.
+ * for queries that are executed in context of group0 operations it is important to have
+ * a long timeout so the query doesn't fail the group0 client spuriously. in the context
+ * of user commands, however, a shorter timeout is preferred. in other cases, the default
+ * unspecified behavior may be sufficient.
+ */
+enum class query_context { group0, user, unspecified };
+
 /**
  *  a structure that holds the configuration for
  *  a service level.
@@ -93,9 +104,9 @@ public:
     }
 };
 
-service::query_state& qos_query_state();
+service::query_state& qos_query_state(qos::query_context ctx = qos::query_context::unspecified);
 
-future<service_levels_info> get_service_levels(cql3::query_processor& qp, std::string_view ks_name, std::string_view cf_name, db::consistency_level cl);
+future<service_levels_info> get_service_levels(cql3::query_processor& qp, std::string_view ks_name, std::string_view cf_name, db::consistency_level cl, qos::query_context ctx);
 future<service_levels_info> get_service_level(cql3::query_processor& qp, std::string_view ks_name, std::string_view cf_name, sstring service_level_name, db::consistency_level cl);
 
 }

--- a/service/qos/raft_service_level_distributed_data_accessor.cc
+++ b/service/qos/raft_service_level_distributed_data_accessor.cc
@@ -39,8 +39,8 @@ raft_service_level_distributed_data_accessor::raft_service_level_distributed_dat
     : _qp(qp)
     , _group0_client(group0_client) {}
 
-future<qos::service_levels_info> raft_service_level_distributed_data_accessor::get_service_levels() const {
-    return qos::get_service_levels(_qp, db::system_keyspace::NAME, db::system_keyspace::SERVICE_LEVELS_V2, db::consistency_level::LOCAL_ONE);
+future<qos::service_levels_info> raft_service_level_distributed_data_accessor::get_service_levels(qos::query_context ctx) const {
+    return qos::get_service_levels(_qp, db::system_keyspace::NAME, db::system_keyspace::SERVICE_LEVELS_V2, db::consistency_level::LOCAL_ONE, ctx);
 }
 
 future<qos::service_levels_info> raft_service_level_distributed_data_accessor::get_service_level(sstring service_level_name) const {

--- a/service/qos/raft_service_level_distributed_data_accessor.hh
+++ b/service/qos/raft_service_level_distributed_data_accessor.hh
@@ -33,7 +33,7 @@ private:
 public:
     raft_service_level_distributed_data_accessor(cql3::query_processor& qp, service::raft_group0_client& group0_client);
 
-    virtual future<qos::service_levels_info> get_service_levels() const override;
+    virtual future<qos::service_levels_info> get_service_levels(qos::query_context ctx) const override;
     virtual future<qos::service_levels_info> get_service_level(sstring service_level_name) const override;
     virtual future<> set_service_level(sstring service_level_name, qos::service_level_options slo, service::group0_batch& mc) const override;
     virtual future<> drop_service_level(sstring service_level_name, service::group0_batch& mc) const override;

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -141,7 +141,7 @@ void service_level_controller::abort_group0_operations() {
     }
 }
 
-future<> service_level_controller::update_service_levels_from_distributed_data() {
+future<> service_level_controller::update_service_levels_from_distributed_data(qos::query_context ctx) {
 
     if (!_sl_data_accessor) {
         return make_ready_future();
@@ -151,14 +151,14 @@ future<> service_level_controller::update_service_levels_from_distributed_data()
         return make_ready_future();
     }
 
-    return with_semaphore(_global_controller_db->notifications_serializer, 1, [this] () {
-        return async([this] () {
+    return with_semaphore(_global_controller_db->notifications_serializer, 1, [this, ctx] () {
+        return async([this, ctx] () {
             service_levels_info service_levels;
             // The next statement can throw, but that's fine since we would like the caller
             // to be able to agreggate those failures and only report when it is critical or noteworthy.
             // one common reason for failure is because one of the nodes comes down and before this node
             // detects it the scan query done inside this call is failing.
-            service_levels = _sl_data_accessor->get_service_levels().get();
+            service_levels = _sl_data_accessor->get_service_levels(ctx).get();
 
             service_levels_info service_levels_for_add_or_update;
             service_levels_info service_levels_for_delete;
@@ -417,8 +417,8 @@ future<> service_level_controller::drop_distributed_service_level(sstring name, 
     co_return co_await _sl_data_accessor->drop_service_level(name, mc);
 }
 
-future<service_levels_info> service_level_controller::get_distributed_service_levels() {
-    return _sl_data_accessor ? _sl_data_accessor->get_service_levels() : make_ready_future<service_levels_info>();
+future<service_levels_info> service_level_controller::get_distributed_service_levels(qos::query_context ctx) {
+    return _sl_data_accessor ? _sl_data_accessor->get_service_levels(ctx) : make_ready_future<service_levels_info>();
 }
 
 future<service_levels_info> service_level_controller::get_distributed_service_level(sstring service_level_name) {

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -58,7 +58,7 @@ class service_level_controller : public peering_sharded_service<service_level_co
 public:
     class service_level_distributed_data_accessor {
     public:
-        virtual future<qos::service_levels_info> get_service_levels() const = 0;
+        virtual future<qos::service_levels_info> get_service_levels(qos::query_context ctx = qos::query_context::unspecified) const = 0;
         virtual future<qos::service_levels_info> get_service_level(sstring service_level_name) const = 0;
         virtual future<> set_service_level(sstring service_level_name, qos::service_level_options slo, service::group0_batch& mc) const = 0;
         virtual future<> drop_service_level(sstring service_level_name, service::group0_batch& mc) const = 0;
@@ -171,13 +171,13 @@ public:
      * Updates the service level data from the distributed data store.
      * @return a future that is resolved when the update is done
      */
-    future<> update_service_levels_from_distributed_data();
+    future<> update_service_levels_from_distributed_data(qos::query_context ctx = qos::query_context::unspecified);
 
 
     future<> add_distributed_service_level(sstring name, service_level_options slo, bool if_not_exsists, service::group0_batch& mc);
     future<> alter_distributed_service_level(sstring name, service_level_options slo, service::group0_batch& mc);
     future<> drop_distributed_service_level(sstring name, bool if_exists, service::group0_batch& mc);
-    future<service_levels_info> get_distributed_service_levels();
+    future<service_levels_info> get_distributed_service_levels(qos::query_context ctx);
     future<service_levels_info> get_distributed_service_level(sstring service_level_name);
 
     /**

--- a/service/qos/standard_service_level_distributed_data_accessor.cc
+++ b/service/qos/standard_service_level_distributed_data_accessor.cc
@@ -17,8 +17,8 @@ standard_service_level_distributed_data_accessor::standard_service_level_distrib
 _sys_dist_ks(sys_dist_ks) {
 }
 
-future<qos::service_levels_info> standard_service_level_distributed_data_accessor::get_service_levels() const {
-    return _sys_dist_ks.get_service_levels();
+future<qos::service_levels_info> standard_service_level_distributed_data_accessor::get_service_levels(qos::query_context ctx) const {
+    return _sys_dist_ks.get_service_levels(ctx);
 }
 
 future<qos::service_levels_info> standard_service_level_distributed_data_accessor::get_service_level(sstring service_level_name) const {

--- a/service/qos/standard_service_level_distributed_data_accessor.hh
+++ b/service/qos/standard_service_level_distributed_data_accessor.hh
@@ -25,7 +25,7 @@ private:
     db::system_distributed_keyspace& _sys_dist_ks;
 public:
     standard_service_level_distributed_data_accessor(db::system_distributed_keyspace &sys_dist_ks);
-    virtual future<qos::service_levels_info> get_service_levels() const override;
+    virtual future<qos::service_levels_info> get_service_levels(qos::query_context ctx) const override;
     virtual future<qos::service_levels_info> get_service_level(sstring service_level_name) const override;
     virtual future<> set_service_level(sstring service_level_name, qos::service_level_options slo, service::group0_batch&) const override;
     virtual future<> drop_service_level(sstring service_level_name, service::group0_batch&) const override;

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -154,7 +154,7 @@ group0_state_machine::modules_to_reload group0_state_machine::get_modules_to_rel
 
 future<> group0_state_machine::reload_modules(modules_to_reload modules) {
     if (modules.service_levels_cache) {
-        co_await _ss.update_service_levels_cache();
+        co_await _ss.update_service_levels_cache(qos::query_context::group0);
     }
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -673,7 +673,7 @@ future<> storage_service::topology_state_load() {
     co_await _sl_controller.invoke_on_all([this] (qos::service_level_controller& sl_controller) {
         sl_controller.upgrade_to_v2(_qp, _group0->client());
     });
-    co_await update_service_levels_cache();
+    co_await update_service_levels_cache(qos::query_context::group0);
 
     co_await _feature_service.container().invoke_on_all([&] (gms::feature_service& fs) {
         return fs.enable(boost::copy_range<std::set<std::string_view>>(_topology_state_machine._topology.enabled_features));
@@ -861,9 +861,9 @@ future<> storage_service::merge_topology_snapshot(raft_snapshot snp) {
     co_await _db.local().apply(freeze(muts), db::no_timeout);
 }
 
-future<> storage_service::update_service_levels_cache() {
+future<> storage_service::update_service_levels_cache(qos::query_context ctx) {
     assert(this_shard_id() == 0);
-    co_await _sl_controller.local().update_service_levels_from_distributed_data();
+    co_await _sl_controller.local().update_service_levels_from_distributed_data(ctx);
 }
 
 // Moves the coroutine lambda onto the heap and extends its

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -875,7 +875,7 @@ public:
 
     // Reload service levels in-memory configuration once.
     // Must be called on shard 0.
-    future<> update_service_levels_cache();
+    future<> update_service_levels_cache(qos::query_context ctx = qos::query_context::unspecified);
 
     future<> do_cluster_cleanup();
 

--- a/test/auth_cluster/test_raft_service_levels.py
+++ b/test/auth_cluster/test_raft_service_levels.py
@@ -169,3 +169,30 @@ async def test_service_levels_work_during_recovery(manager: ManagerClient):
     sls_list = await cql.run_async("LIST ALL SERVICE LEVELS")
     assert sl_v1 not in [sl.service_level for sl in sls_list]
     assert set([sl.service_level for sl in sls_list]) == set(sls + [new_sl])
+
+@pytest.mark.asyncio
+async def test_service_level_cache_after_restart(manager: ManagerClient):
+    servers = await manager.servers_add(1)
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    await cql.run_async(f"CREATE SERVICE LEVEL sl1 WITH timeout=500ms AND workload_type='batch'")
+
+    sls_list_before = await cql.run_async("LIST ALL SERVICE LEVELS")
+    assert len(sls_list_before) == 1
+
+    await manager.rolling_restart(servers)
+    cql = await reconnect_driver(manager)
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    # after restart the service level cache is repopulated.
+    # we want to verify it's populated, and that operations that use
+    # the cache behave as expected.
+
+    sls_list_after = await cql.run_async("LIST ALL SERVICE LEVELS")
+    assert sls_list_after == sls_list_before
+
+    await cql.run_async(f"ALTER SERVICE LEVEL sl1 WITH timeout = 400ms")
+
+    result = await cql.run_async("SELECT workload_type FROM system.service_levels_v2")
+    assert len(result) == 1 and result[0].workload_type == 'batch'


### PR DESCRIPTION
Backport of two service level related fixes:

service/qos/service_level_controller: update cache on startup
Fixes https://github.com/scylladb/scylladb/issues/21763
Parent PR: https://github.com/scylladb/scylladb/pull/21773

service/qos: increase timeout of internal get_service_levels queries
Fixes https://github.com/scylladb/scylladb/issues/20483
Parent PR: https://github.com/scylladb/scylladb/pull/21748