### PR TITLE
tasks: add tablet resize virtual task

### DIFF
--- a/api/api-doc/task_manager.json
+++ b/api/api-doc/task_manager.json
@@ -284,7 +284,8 @@
                   "created",
                   "running",
                   "done",
-                  "failed"
+                  "failed",
+                  "suspended"
                ],
                "description":"The state of a task"
             },
@@ -352,7 +353,8 @@
                   "created",
                   "running",
                   "done",
-                  "failed"
+                  "failed",
+                  "suspended"
                ],
                "description":"The state of the task"
             },

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -150,6 +150,7 @@ public:
     gms::feature tablet_merge { *this, "TABLET_MERGE"sv };
 
     gms::feature tablet_migration_virtual_task { *this, "TABLET_MIGRATION_VIRTUAL_TASK"sv };
+    gms::feature tablet_resize_virtual_task { *this, "TABLET_RESIZE_VIRTUAL_TASK"sv };
 
     // A feature just for use in tests. It must not be advertised unless
     // the "features_enable_test_feature" injection is enabled.

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -558,6 +558,8 @@ static const std::unordered_map<tablet_task_type, sstring> tablet_task_type_to_n
     {locator::tablet_task_type::auto_repair, "auto_repair"},
     {locator::tablet_task_type::migration, "migration"},
     {locator::tablet_task_type::intranode_migration, "intranode_migration"},
+    {locator::tablet_task_type::split, "split"},
+    {locator::tablet_task_type::merge, "merge"},
 };
 
 static const std::unordered_map<sstring, tablet_task_type> tablet_task_type_from_name = std::invoke([] {
@@ -1174,4 +1176,16 @@ locator::tablet_task_info locator::tablet_task_info::make_intranode_migration_re
     long sched_nr = 0;
     auto tablet_task_id = locator::tablet_task_id(utils::UUID_gen::get_time_UUID());
     return locator::tablet_task_info{locator::tablet_task_type::intranode_migration, tablet_task_id, db_clock::now(), sched_nr, db_clock::time_point()};
+}
+
+locator::tablet_task_info locator::tablet_task_info::make_split_request() {
+    long sched_nr = 0;
+    auto tablet_task_id = locator::tablet_task_id(utils::UUID_gen::get_time_UUID());
+    return locator::tablet_task_info{locator::tablet_task_type::split, tablet_task_id, db_clock::now(), sched_nr, db_clock::time_point()};
+}
+
+locator::tablet_task_info locator::tablet_task_info::make_merge_request() {
+    long sched_nr = 0;
+    auto tablet_task_id = locator::tablet_task_id(utils::UUID_gen::get_time_UUID());
+    return locator::tablet_task_info{locator::tablet_task_type::merge, tablet_task_id, db_clock::now(), sched_nr, db_clock::time_point()};
 }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -425,6 +425,10 @@ void tablet_map::set_resize_decision(locator::resize_decision decision) {
     _resize_decision = std::move(decision);
 }
 
+void tablet_map::set_resize_task_info(tablet_task_info task_info) {
+    _resize_task_info = std::move(task_info);
+}
+
 void tablet_map::set_repair_scheduler_config(locator::repair_scheduler_config config) {
     _repair_scheduler_config = std::move(config);
 }
@@ -604,6 +608,10 @@ bool tablet_map::needs_merge() const {
 
 const locator::resize_decision& tablet_map::resize_decision() const {
     return _resize_decision;
+}
+
+const tablet_task_info& tablet_map::resize_task_info() const {
+    return _resize_task_info;
 }
 
 const locator::repair_scheduler_config& tablet_map::repair_scheduler_config() const {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -148,7 +148,9 @@ enum class tablet_task_type {
     user_repair,
     auto_repair,
     migration,
-    intranode_migration
+    intranode_migration,
+    split,
+    merge
 };
 
 sstring tablet_task_type_to_string(tablet_task_type);
@@ -167,6 +169,8 @@ struct tablet_task_info {
     static tablet_task_info make_auto_repair_request();
     static tablet_task_info make_migration_request();
     static tablet_task_info make_intranode_migration_request();
+    static tablet_task_info make_split_request();
+    static tablet_task_info make_merge_request();
 };
 
 /// Stores information about a single tablet.

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -400,6 +400,7 @@ private:
     size_t _log2_tablets; // log_2(_tablets.size())
     std::unordered_map<tablet_id, tablet_transition_info> _transitions;
     resize_decision _resize_decision;
+    tablet_task_info _resize_task_info;
     repair_scheduler_config _repair_scheduler_config;
 
     /// Returns the largest token owned by tablet_id when the tablet_count is `1 << log2_tablets`.
@@ -522,11 +523,13 @@ public:
     dht::token_range get_token_range_after_split(const token& t) const noexcept;
 
     const locator::resize_decision& resize_decision() const;
+    const tablet_task_info& resize_task_info() const;
     const locator::repair_scheduler_config& repair_scheduler_config() const;
 public:
     void set_tablet(tablet_id, tablet_info);
     void set_tablet_transition_info(tablet_id, tablet_transition_info);
     void set_resize_decision(locator::resize_decision);
+    void set_resize_task_info(tablet_task_info);
     void set_repair_scheduler_config(locator::repair_scheduler_config config);
     void clear_tablet_transition_info(tablet_id);
     void clear_transitions();

--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -203,7 +203,7 @@ task_manager_module::task_manager_module(tasks::task_manager& tm, service::stora
     , _ss(ss)
 {}
 
-std::set<gms::inet_address> task_manager_module::get_nodes() const noexcept {
+std::set<gms::inet_address> task_manager_module::get_nodes() const {
     return std::ranges::join_view(std::to_array({
             std::views::all(_ss._topology_state_machine._topology.normal_nodes),
             std::views::all(_ss._topology_state_machine._topology.transition_nodes)})

--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -204,14 +204,7 @@ task_manager_module::task_manager_module(tasks::task_manager& tm, service::stora
 {}
 
 std::set<gms::inet_address> task_manager_module::get_nodes() const {
-    return std::ranges::join_view(std::to_array({
-            std::views::all(_ss._topology_state_machine._topology.normal_nodes),
-            std::views::all(_ss._topology_state_machine._topology.transition_nodes)})
-        ) | std::views::transform([&ss = _ss] (auto& node) {
-            return ss.host2ip(locator::host_id{node.first.uuid()});
-        }) | std::views::filter([&ss = _ss] (gms::inet_address ip) {
-            return ss._gossiper.is_alive(ip);
-        }) | std::ranges::to<std::set<gms::inet_address>>();
+    return get_task_manager().get_nodes(_ss);
 }
 
 }

--- a/node_ops/task_manager_module.hh
+++ b/node_ops/task_manager_module.hh
@@ -67,7 +67,7 @@ private:
 public:
     task_manager_module(tasks::task_manager& tm, service::storage_service& ss) noexcept;
 
-    virtual std::set<gms::inet_address> get_nodes() const noexcept override;
+    virtual std::set<gms::inet_address> get_nodes() const override;
 };
 
 }

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -264,7 +264,7 @@ public:
     //  1) Flushes all memtables which were created in non-split mode, and waits for that to complete.
     //  2) Compacts all sstables which overlap with the split point
     // Returns a future which resolves when this process is complete.
-    future<> split(sstables::compaction_type_options::split opt);
+    future<> split(sstables::compaction_type_options::split opt, tasks::task_info tablet_split_task_info);
 
     // Make an sstable set spanning all sstables in the storage_group
     lw_shared_ptr<const sstables::sstable_set> make_sstable_set() const;
@@ -368,7 +368,7 @@ public:
 
     virtual locator::table_load_stats table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept = 0;
     virtual bool all_storage_groups_split() = 0;
-    virtual future<> split_all_storage_groups() = 0;
+    virtual future<> split_all_storage_groups(tasks::task_info tablet_split_task_info) = 0;
     virtual future<> maybe_split_compaction_group_of(size_t idx) = 0;
     virtual future<std::vector<sstables::shared_sstable>> maybe_split_sstable(const sstables::shared_sstable& sst) = 0;
     virtual dht::token_range get_token_range_after_split(const dht::token&) const noexcept = 0;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -586,7 +586,7 @@ public:
     // Precondition: table needs tablet splitting.
     // Returns true if all storage of table is ready for splitting.
     bool all_storage_groups_split();
-    future<> split_all_storage_groups();
+    future<> split_all_storage_groups(tasks::task_info tablet_split_task_info);
 
     // Splits compaction group of a single tablet, if and only if the underlying table has
     // split request emitted by coordinator (found in tablet metadata).

--- a/replica/tablet_mutation_builder.hh
+++ b/replica/tablet_mutation_builder.hh
@@ -39,13 +39,15 @@ public:
     tablet_mutation_builder& set_session(dht::token last_token, service::session_id);
     tablet_mutation_builder& del_session(dht::token last_token);
     tablet_mutation_builder& del_transition(dht::token last_token);
-    tablet_mutation_builder& set_resize_decision(locator::resize_decision);
+    tablet_mutation_builder& set_resize_decision(locator::resize_decision, const gms::feature_service&);
     tablet_mutation_builder& set_repair_scheduler_config(locator::repair_scheduler_config);
     tablet_mutation_builder& set_repair_time(dht::token last_token, db_clock::time_point repair_time);
     tablet_mutation_builder& set_repair_task_info(dht::token last_token, locator::tablet_task_info info);
     tablet_mutation_builder& del_repair_task_info(dht::token last_token);
     tablet_mutation_builder& set_migration_task_info(dht::token last_token, locator::tablet_task_info info, const gms::feature_service& features);
     tablet_mutation_builder& del_migration_task_info(dht::token last_token, const gms::feature_service& features);
+    tablet_mutation_builder& set_resize_task_info(locator::tablet_task_info info, const gms::feature_service& features);
+    tablet_mutation_builder& del_resize_task_info(const gms::feature_service& features);
 
     mutation build() {
         return std::move(_m);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -193,7 +193,7 @@ storage_service::storage_service(abort_source& abort_source,
         , _group0(nullptr)
         , _node_ops_abort_thread(node_ops_abort_thread())
         , _node_ops_module(make_shared<node_ops::task_manager_module>(tm, *this))
-        , _tablets_module(make_shared<service::task_manager_module>(tm))
+        , _tablets_module(make_shared<service::task_manager_module>(tm, *this))
         , _address_map(address_map)
         , _shared_token_metadata(stm)
         , _erm_factory(erm_factory)

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5418,7 +5418,7 @@ future<> storage_service::process_tablet_split_candidate(table_id table) noexcep
 
     auto split_all_compaction_groups = [&] () -> future<> {
         return _db.invoke_on_all([table] (replica::database& db) -> future<> {
-            return db.find_column_family(table).split_all_storage_groups();
+            return db.find_column_family(table).split_all_storage_groups(tasks::task_info{});
         });
     };
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -1006,7 +1006,7 @@ private:
 
     friend class join_node_rpc_handshaker;
     friend class node_ops::node_ops_virtual_task;
-    friend class node_ops::task_manager_module;
+    friend class tasks::task_manager;
     friend class tablet_virtual_task;
 };
 

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -215,8 +215,13 @@ future<std::optional<tasks::task_status>> tablet_virtual_task::get_status_helper
     co_return std::nullopt;
 }
 
-task_manager_module::task_manager_module(tasks::task_manager& tm) noexcept
+task_manager_module::task_manager_module(tasks::task_manager& tm, service::storage_service& ss) noexcept
     : tasks::task_manager::module(tm, "tablets")
+    , _ss(ss)
 {}
+
+std::set<gms::inet_address> task_manager_module::get_nodes() const {
+    return get_task_manager().get_nodes(_ss);
+}
 
 }

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -110,9 +110,6 @@ future<std::optional<tasks::virtual_task_hint>> tablet_virtual_task::contains(ta
 
 future<tasks::is_abortable> tablet_virtual_task::is_abortable(tasks::virtual_task_hint hint) const {
     auto task_type = hint.get_task_type();
-    if (is_resize_task(task_type)) {
-        return make_ready_future<tasks::is_abortable>(tasks::is_abortable::no);
-    }
     return make_ready_future<tasks::is_abortable>(is_repair_task(task_type));
 }
 
@@ -165,10 +162,6 @@ future<std::optional<tasks::task_status>> tablet_virtual_task::wait(tasks::task_
 future<> tablet_virtual_task::abort(tasks::task_id id, tasks::virtual_task_hint hint) noexcept {
     auto table = hint.get_table_id();
     auto task_type = hint.get_task_type();
-    if (is_resize_task(task_type)) {
-        co_return;
-    }
-
     if (!is_repair_task(task_type)) {
         on_internal_error(tasks::tmlogger, format("non-abortable task {} of type {} cannot be aborted", id, task_type));
     }

--- a/service/task_manager_module.hh
+++ b/service/task_manager_module.hh
@@ -46,7 +46,11 @@ private:
 };
 
 class task_manager_module : public tasks::task_manager::module {
+private:
+    service::storage_service& _ss;
 public:
-    task_manager_module(tasks::task_manager& tm) noexcept;
+    task_manager_module(tasks::task_manager& tm, service::storage_service& ss) noexcept;
+
+    std::set<gms::inet_address> get_nodes() const override;
 };
 }

--- a/service/task_manager_module.hh
+++ b/service/task_manager_module.hh
@@ -42,7 +42,7 @@ public:
     virtual future<std::vector<tasks::task_stats>> get_stats() override;
 private:
     std::vector<table_id> get_table_ids() const;
-    future<std::optional<tasks::task_status>> get_status_helper(tasks::task_id id, utils::chunked_vector<locator::tablet_id>& tablets, tasks::virtual_task_hint hint, std::optional<locator::tablet_replica>& pending_replica);
+    future<std::optional<tasks::task_status>> get_status_helper(tasks::task_id id, utils::chunked_vector<locator::tablet_id>& tablets, tasks::virtual_task_hint hint, std::optional<locator::tablet_replica>& pending_replica, size_t& tablet_count);
 };
 
 class task_manager_module : public tasks::task_manager::module {

--- a/service/task_manager_module.hh
+++ b/service/task_manager_module.hh
@@ -19,6 +19,7 @@ class tablet_replica;
 
 namespace service {
 
+class status_helper;
 class storage_service;
 
 class tablet_virtual_task : public tasks::task_manager::virtual_task::impl {
@@ -42,7 +43,7 @@ public:
     virtual future<std::vector<tasks::task_stats>> get_stats() override;
 private:
     std::vector<table_id> get_table_ids() const;
-    future<std::optional<tasks::task_status>> get_status_helper(tasks::task_id id, utils::chunked_vector<locator::tablet_id>& tablets, tasks::virtual_task_hint hint, std::optional<locator::tablet_replica>& pending_replica, size_t& tablet_count);
+    future<std::optional<status_helper>> get_status_helper(tasks::task_id id, tasks::virtual_task_hint hint);
 };
 
 class task_manager_module : public tasks::task_manager::module {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1281,7 +1281,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                            table_id, resize_decision.type_name(), resize_decision.sequence_number);
             out.emplace_back(
                 replica::tablet_mutation_builder(guard.write_timestamp(), table_id)
-                    .set_resize_decision(std::move(resize_decision))
+                    .set_resize_decision(std::move(resize_decision), _db.features())
                     .build());
     }
 

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -527,7 +527,7 @@ const task_manager::tasks_collection& task_manager::module::get_tasks_collection
     return _tasks;
 }
 
-std::set<gms::inet_address> task_manager::module::get_nodes() const noexcept {
+std::set<gms::inet_address> task_manager::module::get_nodes() const {
     return {_tm.get_broadcast_address()};
 }
 

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -156,7 +156,7 @@ is_abortable task_manager::task::impl::is_abortable() const noexcept {
 }
 
 is_internal task_manager::task::impl::is_internal() const noexcept {
-    return tasks::is_internal(bool(_parent_id));
+    return tasks::is_internal(_parent_id && _parent_kind != task_kind::cluster);
 }
 
 tasks::is_user_task task_manager::task::impl::is_user_task() const noexcept {

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -332,7 +332,7 @@ public:
         tasks_collection& get_tasks_collection() noexcept;
         const tasks_collection& get_tasks_collection() const noexcept;
         // Returns a set of nodes on which some of virtual tasks on this module can have their children.
-        virtual std::set<gms::inet_address> get_nodes() const noexcept;
+        virtual std::set<gms::inet_address> get_nodes() const;
         future<utils::chunked_vector<task_stats>> get_stats(is_internal internal, std::function<bool(std::string&, std::string&)> filter) const;
 
         void register_task(task_ptr task);

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -29,6 +29,10 @@ namespace repair {
 class task_manager_module;
 }
 
+namespace service {
+class storage_service;
+}
+
 namespace netw {
 class messaging_service;
 }
@@ -322,6 +326,7 @@ public:
 
         uint64_t new_sequence_number() noexcept;
         task_manager& get_task_manager() noexcept;
+        const task_manager& get_task_manager() const noexcept;
         seastar::abort_source& abort_source() noexcept;
         gate& async_gate() noexcept;
         const std::string& get_name() const noexcept;
@@ -384,6 +389,8 @@ public:
     tasks_collection& get_tasks_collection() noexcept;
     const tasks_collection& get_tasks_collection() const noexcept;
     future<std::vector<task_id>> get_virtual_task_children(task_id parent_id);
+
+    std::set<gms::inet_address> get_nodes(service::storage_service& ss) const;
 
     module_ptr make_module(std::string name);
     void register_module(std::string name, module_ptr module);

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -104,7 +104,8 @@ public:
         created,
         running,
         done,
-        failed
+        failed,
+        suspended
     };
 
     enum class task_group {

--- a/tasks/types.hh
+++ b/tasks/types.hh
@@ -18,7 +18,7 @@ struct task_info {
     task_id id;
     unsigned shard;
 
-    task_info() noexcept : id(task_id::create_null_id()) {}
+    task_info() noexcept : id(task_id::create_null_id()), shard(0) {}
     task_info(task_id id, unsigned parent_shard) noexcept : id(id), shard(parent_shard) {}
 
     operator bool() const noexcept {

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -190,7 +190,7 @@ SEASTAR_TEST_CASE(test_tablet_sstable_set_copy_ctor) {
         }
         auto& cf = env.local_db().find_column_family("test_tablet_sstable_set_copy_ctor", "test");
         auto& sgm = column_family_test::get_storage_group_manager(cf);
-        sgm->split_all_storage_groups().get();
+        sgm->split_all_storage_groups(tasks::task_info{}).get();
 
         auto tablet_sstable_set = replica::make_tablet_sstable_set(cf.schema(), *sgm.get(), locator::tablet_map(8));
         auto tablet_sstable_set_copy = *tablet_sstable_set.get();

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -283,6 +283,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                 decision.way = locator::resize_decision::split{},
                 decision.sequence_number = 1;
                 tmap.set_resize_decision(decision);
+                tmap.set_resize_task_info(locator::tablet_task_info::make_split_request());
                 tm.set_tablet_map(table1, std::move(tmap));
             }
 

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -983,7 +983,7 @@ SEASTAR_TEST_CASE(test_mutation_builder) {
                     tablet_replica {h2, 3},
             });
             b.del_transition(last_token);
-            b.set_resize_decision(resize_decision);
+            b.set_resize_decision(resize_decision, e.local_db().features());
             e.local_db().apply({freeze(b.build())}, db::no_timeout).get();
         }
 
@@ -1006,6 +1006,7 @@ SEASTAR_TEST_CASE(test_mutation_builder) {
             expected_tmap.set_resize_decision(resize_decision);
 
             auto tm_from_disk = read_tablet_metadata(e.local_qp()).get();
+            expected_tmap.set_resize_task_info(tm_from_disk.get_tablet_map(table1).resize_task_info());
             BOOST_REQUIRE_EQUAL(expected_tmap, tm_from_disk.get_tablet_map(table1));
         }
     }, tablet_cql_test_config());

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2825,7 +2825,7 @@ SEASTAR_THREAD_TEST_CASE(basic_tablet_storage_splitting_test) {
         e.db().invoke_on_all([] (replica::database& db) {
             auto& table = db.find_column_family("ks", "cf");
             testlog.info("sstable count: {}", table.sstables_count());
-            return table.split_all_storage_groups();
+            return table.split_all_storage_groups(tasks::task_info{});
         }).get();
 
         testlog.info("Verifying sstables are split...");

--- a/test/topology_tasks/task_manager_types.py
+++ b/test/topology_tasks/task_manager_types.py
@@ -23,6 +23,7 @@ class State(StrEnum):
     running = "running"
     done = "done"
     failed = "failed"
+    suspended = "suspended"
 
 
 class TaskStats(NamedTuple):

--- a/test/topology_tasks/test_tablet_tasks.py
+++ b/test/topology_tasks/test_tablet_tasks.py
@@ -5,6 +5,7 @@
 #
 
 import asyncio
+import random
 from typing import Optional
 import pytest
 
@@ -310,3 +311,74 @@ async def test_repair_task_info_is_none_when_no_running_repair(manager: ManagerC
         await check_none()
 
     await asyncio.gather(repair_task(), wait_and_check_none())
+
+async def prepare_split(manager: ManagerClient, server: ServerInfo, keyspace: str, table: str, keys: list[int]):
+    await manager.api.disable_tablet_balancing(server.ip_addr)
+
+    cql = manager.get_cql()
+    insert = cql.prepare(f"INSERT INTO {keyspace}.{table}(pk, c) VALUES(?, ?)")
+    for pk in keys:
+        value = random.randbytes(1000)
+        cql.execute(insert, [pk, value])
+
+    await manager.api.flush_keyspace(server.ip_addr, keyspace)
+
+async def prepare_merge(manager: ManagerClient, server: ServerInfo, keyspace: str, table: str, keys: list[int]):
+    await manager.api.disable_tablet_balancing(server.ip_addr)
+
+    cql = manager.get_cql()
+    await asyncio.gather(*[cql.run_async(f"DELETE FROM {keyspace}.{table} WHERE pk={k};") for k in keys])
+
+    await manager.api.flush_keyspace(server.ip_addr, keyspace)
+
+async def enable_tablet_balancing_and_wait(manager: ManagerClient, server: ServerInfo, message: str):
+    s1_log = await manager.server_open_log(server.server_id)
+    s1_mark = await s1_log.mark()
+
+    await manager.api.enable_tablet_balancing(server.ip_addr)
+
+    await s1_log.wait_for(message, from_mark=s1_mark)
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_tablet_resize_task(manager: ManagerClient):
+    module_name = "tablets"
+    tm = TaskManagerClient(manager.api)
+    cmdline = [
+        '--target-tablet-size-in-bytes', '30000',
+    ]
+    servers = [await manager.server_add(cmdline=cmdline, config={
+        'error_injections_at_startup': ['short_tablet_stats_refresh_interval']
+    })]
+
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    cql = manager.get_cql()
+    keyspace = "test"
+    table1 = "test1"
+    table2 = "test2"
+    await cql.run_async(f"CREATE KEYSPACE {keyspace} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': 1}};")
+    await cql.run_async(f"CREATE TABLE {keyspace}.{table1} (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1;")
+    await cql.run_async(f"CREATE TABLE {keyspace}.{table2} (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1;")
+
+    total_keys = 60
+    keys = range(total_keys)
+    await prepare_split(manager, servers[0], keyspace, table1, keys)
+    await enable_tablet_balancing_and_wait(manager, servers[0], "Detected tablet split for table")
+    await wait_tasks_created(tm, servers[0], module_name, 0, "split", table1)
+
+    await prepare_split(manager, servers[0], keyspace, table2, keys)
+    await prepare_merge(manager, servers[0], keyspace, table1, keys[:-1])
+    await manager.api.keyspace_compaction(servers[0].ip_addr, "test")
+
+    injection = "tablet_split_finalization_postpone"
+    await enable_injection(manager, servers, injection)
+    await manager.api.enable_tablet_balancing(servers[0].ip_addr)
+
+    async def wait_and_check_status(server, type, keyspace, table):
+        task = (await wait_tasks_created(tm, server, module_name, 1, type, table))[0]
+        status = await tm.get_task_status(server.ip_addr, task.task_id)
+        check_task_status(status, ["running"], type, "table", False, keyspace, table, [0, 1, 2])
+
+    await wait_and_check_status(servers[0], "split", keyspace, table2)
+    await wait_and_check_status(servers[0], "merge", keyspace, table1)


### PR DESCRIPTION
In this change, tablet_virtual_task starts supporting tablet
resize (i.e. split and merge).

Users can see running resize tasks - finished tasks are not
presented with the task manager API.

A new task state "suspended" is added. If a resize was revoked, 
it will appear to users as suspended. We assume that the resize was revoked
when the tablet number didn't change.

Fixes: #21366.
Fixes: #21367.

No backport, new feature