### PR TITLE
sstables_manager: do not reclaim unlinked sstables

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1553,6 +1553,15 @@ future<> sstable::reload_reclaimed_components() {
     sstlog.info("Reloaded bloom filter of {}", get_filename());
 }
 
+void sstable::disable_component_memory_reload() {
+    if (total_reclaimable_memory_size() > 0) {
+        // should be called only when the components have been dropped already
+        on_internal_error(sstlog, "disable_component_memory_reload() called with reclaimable memory");
+    }
+
+    _total_memory_reclaimed = 0;
+}
+
 future<> sstable::load_metadata(sstable_open_config cfg, bool validate) noexcept {
     co_await read_toc();
     // read scylla-meta after toc. Might need it to parse

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -710,6 +710,8 @@ private:
     size_t total_memory_reclaimed() const;
     // Reload components from which memory was previously reclaimed
     future<> reload_reclaimed_components();
+    // Disable reload of components for this sstable
+    void disable_component_memory_reload();
 
 public:
     // Finds first position_in_partition in a given partition.

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -342,8 +342,7 @@ std::vector<std::filesystem::path> sstables_manager::get_local_directories(const
 }
 
 void sstables_manager::on_unlink(sstable* sst) {
-    // Remove the sst from manager's reclaimed list to prevent any attempts to reload its components.
-    _reclaimed.erase(*sst);
+    reclaim_memory_and_stop_tracking_sstable(sst);
 }
 
 sstables_registry::~sstables_registry() = default;

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -171,7 +171,9 @@ void sstables_manager::increment_total_reclaimable_memory_and_maybe_reclaim(ssta
     _total_memory_reclaimed += memory_reclaimed;
     _total_reclaimable_memory -= memory_reclaimed;
     _reclaimed.insert(*sst_with_max_memory);
-    smlogger.info("Reclaimed {} bytes of memory from SSTable components. Total memory reclaimed so far is {} bytes", memory_reclaimed, _total_memory_reclaimed);
+    // TODO: As of now only bloom filter is reclaimed. Print actual component names when adding support for more components.
+    smlogger.info("Reclaimed {} bytes of memory from components of {}. Total memory reclaimed so far is {} bytes",
+            memory_reclaimed, sst_with_max_memory->get_filename(), _total_memory_reclaimed);
 }
 
 size_t sstables_manager::get_memory_available_for_reclaimable_components() {

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -219,6 +219,10 @@ private:
     // Fiber to reload reclaimed components back into memory when memory becomes available.
     future<> components_reloader_fiber();
     size_t get_memory_available_for_reclaimable_components();
+    // Reclaim memory from the SSTable and remove it from the memory tracking metrics.
+    // The method is idempotent and for an sstable that is deleted, it is called both
+    // during unlink and during deactivation.
+    void reclaim_memory_and_stop_tracking_sstable(sstable* sst);
 private:
     db::large_data_handler& get_large_data_handler() const {
         return _large_data_handler;

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -68,6 +68,10 @@ public:
         _reclaimed.erase(*sst);
     }
 
+    auto& get_active_list() {
+        return _active;
+    }
+
     auto& get_reclaimed_set() {
         return _reclaimed;
     }


### PR DESCRIPTION
When an sstable is unlinked, it remains in the _active list of the
sstable manager. Its memory might be reclaimed and later reloaded,
causing issues since the sstable is already unlinked. This patch updates
the on_unlink method to reclaim memory from the sstable upon unlinking,
remove it from memory tracking, and thereby prevent the issues described
above.

Added a testcase to verify the fix.

Fixes #21887

This is a bug fix in the bloom filter reload/reclaim mechanism and should be backported to older versions.