### PR TITLE
raft: refactor the voters api to allow enabling voters

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1811,7 +1811,7 @@ future<> storage_service::join_topology(sharded<db::system_distributed_keyspace>
     // if the node is bootstrapped the function will do nothing since we already created group0 in main.cc
     ::shared_ptr<group0_handshaker> handshaker = raft_topology_change_enabled()
             ? ::make_shared<join_node_rpc_handshaker>(*this, join_params)
-            : _group0->make_legacy_handshaker(false);
+            : _group0->make_legacy_handshaker(can_vote::no);
     co_await _group0->setup_group0(_sys_ks.local(), initial_contact_nodes, std::move(handshaker),
             raft_replace_info, *this, _qp, _migration_manager.local(), raft_topology_change_enabled());
 
@@ -4085,7 +4085,7 @@ future<> storage_service::raft_removenode(locator::host_id host_id, locator::hos
         }
         try {
             // Make non voter during request submission for better HA
-            co_await _group0->make_nonvoters(ignored_ids, _group0_as, raft_timeout{});
+            co_await _group0->set_voters_status(ignored_ids, can_vote::no, _group0_as, raft_timeout{});
             co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
         } catch (group0_concurrent_modification&) {
             rtlogger.info("removenode: concurrent operation is detected, retrying.");
@@ -4168,7 +4168,7 @@ future<> storage_service::removenode(locator::host_id host_id, locator::host_id_
                 // but before removing it group 0, group 0's availability won't be reduced.
                 if (is_group0_member && ss._group0->is_member(raft_id, true)) {
                     slogger.info("removenode[{}]: making node {} a non-voter in group 0", uuid, raft_id);
-                    ss._group0->make_nonvoter(raft_id, ss._group0_as).get();
+                    ss._group0->set_voter_status(raft_id, can_vote::no, ss._group0_as).get();
                     slogger.info("removenode[{}]: made node {} a non-voter in group 0", uuid, raft_id);
                 }
 
@@ -6827,7 +6827,7 @@ future<join_node_request_result> storage_service::join_node_request_handler(join
 
         try {
             // Make replaced node and ignored nodes non voters earlier for better HA
-            co_await _group0->make_nonvoters(ignored_nodes_from_join_params(params), _group0_as, raft_timeout{});
+            co_await _group0->set_voters_status(ignored_nodes_from_join_params(params), can_vote::no, _group0_as, raft_timeout{});
             co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
             break;
         } catch (group0_concurrent_modification&) {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2128,7 +2128,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     // FIXME: removenode may be aborted and the already dead node can be resurrected. We should consider
                     // restoring its voter state on the recovery path.
                     if (node.rs->state == node_state::removing) {
-                        co_await _group0.make_nonvoter(node.id, _as);
+                        co_await _group0.set_voter_status(node.id, can_vote::no, _as);
                     }
 
                     // If we decommission a node when the number of nodes is even, we make it a non-voter early.
@@ -2145,7 +2145,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                                          "giving up leadership");
                             co_await step_down_as_nonvoter();
                         } else {
-                            co_await _group0.make_nonvoter(node.id, _as);
+                            co_await _group0.set_voter_status(node.id, can_vote::no, _as);
                         }
                     }
                 }
@@ -2153,7 +2153,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     // We make a replaced node a non-voter early, just like a removed node.
                     auto replaced_node_id = parse_replaced_node(node.req_param);
                     if (_group0.is_member(replaced_node_id, true)) {
-                        co_await _group0.make_nonvoter(replaced_node_id, _as);
+                        co_await _group0.set_voter_status(replaced_node_id, can_vote::no, _as);
                     }
                 }
                 utils::get_local_injector().inject("crash_coordinator_before_stream", [] { abort(); });


### PR DESCRIPTION
The raft voters api implementation only allowed to make a node to be a non-voter, but for the "limited voters" feature we need to also have the option to make the node a voter (from within the topology coordinator).

Modifying the api to allow both adding and removing voters.

This in particular tries to simplify the API by not having to add another set of new functions to make a voter, but having a single setter that allows to modify the node configuration to either become a voter or a non-voter.

Fixes: scylladb/scylladb#21914

Refs: scylladb/scylladb#18793

No backport: Only needed for a new feature (that will not be backported)