### PR TITLE
test: enable test_truncate_with_coordinator_crash

### DIFF
--- a/test/topology_custom/test_truncate_with_tablets.py
+++ b/test/topology_custom/test_truncate_with_tablets.py
@@ -168,7 +168,6 @@ async def test_truncate_while_node_restart(manager: ManagerClient):
     assert row[0].count == 0
 
 
-@pytest.mark.xfail(reason="issue #21719")
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_truncate_with_coordinator_crash(manager: ManagerClient):


### PR DESCRIPTION
The test `topology_custom/test_truncate_with_tablets::test_truncate_with_coordinator_crash` was added in PR #19789 but was disabled with xfail because of a bug with the way truncate saved the commit log replay positions. More specifically, the replay positions for shards that had no mutations were saved to system.truncated with shard_id == 0, regardless for which shard it was actually saved for (see #21719).

The bug was fixed in #21722, so this change removes the xfail tag, enabling the test.

No backport is necessary.