### PR TITLE
main, view: Pair view builder drain with its start

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1787,18 +1787,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 sys_dist_ks.invoke_on_all(&db::system_distributed_keyspace::stop).get();
             });
 
-            group0_service.start().get();
-            auto stop_group0_service = defer_verbose_shutdown("group 0 service", [&group0_service] {
-                sl_controller.local().abort_group0_operations();
-                group0_service.abort().get();
-            });
-
-            utils::get_local_injector().inject("stop_after_starting_group0_service",
-                [] { std::raise(SIGSTOP); });
-
-            // Set up group0 service earlier since it is needed by group0 setup just below
-            ss.local().set_group0(group0_service);
-
             supervisor::notify("starting view update generator");
             view_update_generator.start(std::ref(db), std::ref(proxy), std::ref(stop_signal.as_sharded_abort_source())).get();
             auto stop_view_update_generator = defer_verbose_shutdown("view update generator", [] {
@@ -2069,6 +2057,18 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
              * the system keyspace started and nobody seemed to have any troubles.
              */
             db.local().enable_autocompaction_toggle();
+
+            group0_service.start().get();
+            auto stop_group0_service = defer_verbose_shutdown("group 0 service", [&group0_service] {
+                sl_controller.local().abort_group0_operations();
+                group0_service.abort().get();
+            });
+
+            utils::get_local_injector().inject("stop_after_starting_group0_service",
+                [] { std::raise(SIGSTOP); });
+
+            // Set up group0 service earlier since it is needed by group0 setup just below
+            ss.local().set_group0(group0_service);
 
             // Load address_map from system.peers and subscribe to gossiper events to keep it updated.
             ss.local().init_address_map(gossip_address_map.local()).get();

--- a/main.cc
+++ b/main.cc
@@ -2249,6 +2249,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             if (cfg->view_building()) {
                 view_builder.invoke_on_all(&db::view::view_builder::start, std::ref(mm), utils::cross_shard_barrier()).get();
             }
+            auto drain_view_builder = defer_verbose_shutdown("draining view builders", [&] {
+                view_builder.invoke_on_all(&db::view::view_builder::drain).get();
+            });
 
             api::set_server_view_builder(ctx, view_builder).get();
             auto stop_vb_api = defer_verbose_shutdown("view builder API", [&ctx] {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -926,13 +926,6 @@ private:
                 _group0_registry.invoke_on_all(&service::raft_group_registry::drain_on_shutdown).get();
             });
 
-            group0_service.start().get();
-            auto stop_group0_service = defer([&group0_service] {
-                group0_service.abort().get();
-            });
-
-            _ss.local().set_group0(group0_service);
-
             _view_update_generator.start(std::ref(_db), std::ref(_proxy), std::ref(abort_sources)).get();
             _view_update_generator.invoke_on_all(&db::view::view_update_generator::start).get();
             auto stop_view_update_generator = defer([this] {
@@ -981,6 +974,13 @@ private:
             auto stop_cdc_service = defer([this] {
                 _cdc.stop().get();
             });
+
+            group0_service.start().get();
+            auto stop_group0_service = defer([&group0_service] {
+                group0_service.abort().get();
+            });
+
+            _ss.local().set_group0(group0_service);
 
             // Load address_map from system.peers and subscribe to gossiper events to keep it updated.
             _ss.local().init_address_map(_gossip_address_map.local()).get();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -1045,6 +1045,9 @@ private:
             _view_builder.invoke_on_all([this] (db::view::view_builder& vb) {
                 return vb.start(_mm.local());
             }).get();
+            auto drain_view_builder = defer([this] {
+                _view_builder.invoke_on_all(&db::view::view_builder::drain).get();
+            });
 
             // Create the testing user.
             try {

--- a/test/topology_custom/test_mv_building.py
+++ b/test/topology_custom/test_mv_building.py
@@ -42,3 +42,15 @@ async def test_view_building_scheduling_group(manager: ManagerClient):
     ratio = ms_statement / ms_streaming
     print(f"ms_streaming: {ms_streaming}, ms_statement: {ms_statement}, ratio: {ratio}")
     assert ratio < 0.1
+
+# A sanity check test ensures that starting and shutting down Scylla when view building is
+# disabled is conducted properly and we don't run into any issues.
+@pytest.mark.asyncio
+async def test_start_scylla_with_view_building_disabled(manager: ManagerClient):
+    server = await manager.server_add(config={"view_building": "false"})
+    await manager.server_stop_gracefully(server_id=server.server_id)
+
+    # Make sure there have been no errors.
+    log = await manager.server_open_log(server.server_id)
+    res = await log.grep(r"ERROR.*\[shard [0-9]+:[a-z]+\]")
+    assert len(res) == 0


### PR DESCRIPTION
In this PR, we pair draining the view builder with its start.
To better understand what was done and why, let's first look at the
situation before this commit and the context of it:

(a) The following things happened in order:

    1. The view builder would be constructed.
    2. Right after that, a deferred lambda would be created to stop the
       view builder during shutdown.
    3. group0_service would be started.
    4. A deferred lambda stopping group0_service would be created right
       after that.
    5. The view builder would be started.

(b) Because the view builder depends on group0_client, it couldn't be
    started before starting group0_service. On the other hand, other
    services depend on the view builder, e.g. the stream manager. That
    makes changing the order of initialization a difficult problem,
    so we want to avoid doing that unless we're sure it's the right
    choice.

(c) Since the view builder uses group0_client, there was a possibility
    of running into a segmentation fault issue in the following
    scenario:

    1. A call to `view_builder::mark_view_build_success()` is issued.
    2. We stop group0_service.
    3. `view_builder::mark_view_build_success()` calls
       `announce_with_raft()`, which leads to a use-after-free because
       group0_service has already been destroyed.

      This very scenario took place in scylladb/scylladb#20772.

Initially, we decided to solve the issue by initializing
group0_service a bit earlier (scylladb/scylladb@7bad8378c723a700e531aa55dae87db035f5b64d).
Unfortunately, it led to other issues described in scylladb/scylladb#21534,
so we revert that patch. These changes are the second attempt
to the problem where we want to solve it in a safer manner.

The solution we came up with is to pair the start of the view builder
with a deferred lambda that deinitializes it by calling
`view_builder::drain()`. No other component of the system should be
able to use the view builder anymore, so it's safe to do that.
Furthermore, that pairing makes the analysis of
initialization/deinitialization order much easier. We also solve the
aformentioned use-after-free issue because the view builder itself
will no longer attempt to use group0_client.

Note that we still pair a deferred lambda calling `view_builder::stop()`
with the construction of the view builder; that function will also call
`view_builder::drain()`. Another notable thing is `view_builder::drain()`
may be called earlier by `storage_service::do_drain()`. In other words,
these changes cover the situation when Scylla runs into a problem when
starting up.

Backport: The patch I'm reverting made it to 6.2, so we want to backport this one there too.

Fixes scylladb/scylladb#20772
Fixes scylladb/scylladb#21534