### PR TITLE
db,sstables: migate boost::range::stable_partition to std library

### DIFF
--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -24,7 +24,6 @@
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/container/static_vector.hpp>
 #include <boost/range/adaptor/indexed.hpp>
-#include <boost/range/algorithm/stable_partition.hpp>
 
 logging::logger slogger("mc_writer");
 
@@ -419,8 +418,8 @@ sstable_schema make_sstable_schema(const schema& s, const encoding_stats& enc_st
     // For static and regular columns, we write all simple columns first followed by collections
     // These containers have columns partitioned by atomicity
     auto pred = [] (const std::reference_wrapper<const column_definition>& column) { return column.get().is_atomic(); };
-    boost::range::stable_partition(sst_sch.regular_columns, pred);
-    boost::range::stable_partition(sst_sch.static_columns, pred);
+    std::ranges::stable_partition(sst_sch.regular_columns, pred);
+    std::ranges::stable_partition(sst_sch.static_columns, pred);
 
     return sst_sch;
 }

--- a/sstables/sstable_mutation_reader.cc
+++ b/sstables/sstable_mutation_reader.cc
@@ -13,7 +13,6 @@
 #include "utils/fragment_range.hh"
 #include "utils/to_string.hh"
 
-#include <boost/range/algorithm/stable_partition.hpp>
 #include <boost/intrusive/list.hpp>
 
 namespace sstables {
@@ -155,7 +154,7 @@ std::vector<column_translation::column_info> column_translation::state::build(
                 schema_mismatch
             });
         }
-        boost::range::stable_partition(cols, [](const column_info& column) { return !column.is_collection; });
+        std::ranges::stable_partition(cols, [](const column_info& column) { return !column.is_collection; });
     }
     return cols;
 }


### PR DESCRIPTION
now that we are allowed to use C++23. we now have the luxury of using `std::ranges::stable_partition`.

in this change, we:

- replace `boost::range::stable_parition()` to `std::ranges::stable_parition()`
- since `std::ranges::stable_parition()` returns a subrange instead of an iterator, change the names of variables which were previously used for holding the return value of `boost::range::stable_partition()` accordingly for better readability.
- remove unused `#include` of boost headers

---

it's a cleanup, hence no need to backport.