### PR TITLE
message: do not include unused header

### DIFF
--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -16,7 +16,6 @@
 #include "gms/inet_address.hh"
 #include <seastar/rpc/rpc_types.hh>
 #include <unordered_map>
-#include "gc_clock.hh"
 #include "interval.hh"
 #include "schema/schema_fwd.hh"
 #include "streaming/stream_fwd.hh"


### PR DESCRIPTION
In commit bfee93c7, repair verbs were moved to IDL. During this refactoring, the `gc_clock.hh` header became unused as its references were relocated. `clang-include-cleaner` helped identify this unnecessary include, which is now removed to clean up the codebase.

---

it's a cleanup, hence no need to backport.