### PR TITLE
replica: Fix use-after-free due to a race between split and cleanup

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -227,6 +227,11 @@ public:
         return _async_gate;
     }
 
+    // Closes storage group without stopping its compaction groups that might be referenced elsewhere.
+    future<> close() noexcept {
+        return _async_gate.close();
+    }
+
     const dht::token_range& token_range() const noexcept;
 
     size_t memtable_count() const noexcept;

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3015,6 +3015,7 @@ static mutation_reader compacted_sstable_reader(test_env& env, schema_ptr s,
                      sstring table_name, std::vector<sstables::generation_type::int_t> gen_values) {
     env.maybe_start_compaction_manager(false);
     auto cf = env.make_table_for_tests(s);
+    auto close_cf = deferred_stop(cf);
     auto generations = generations_from_values(gen_values);
     lw_shared_ptr<replica::memtable> mt = make_lw_shared<replica::memtable>(s);
 


### PR DESCRIPTION
There is an assumption that every destroyed compaction_group will be stopped first. Otherwise, the group is still referenced by compaction manager and can use it after freed. That's what happened in issue #21867 in the context of merge.

The issue is pre-existing but was made more likely with merge.

One problem is a race between split and cleanup, where if split is emitted while cleanup is stopping groups, it can happen split preparation adds new groups that will never be closed, since cleanup is already past the group stopping step.

Another problem found is that split completion handler is not accounting for possible existence of merging groups, if split happens right after merge. Split completion handler should stop all empty groups that previously had data split from them.

The problems will be fixed by guaranteeing that new groups will not be added for a tablet being migrated away, and that empty groups are properly closed when handling split completion.

A reproducer was added.

Fixes #21867.

**Please replace this line with justification for the backport/\* labels added to this PR**
Not backporting since merge is still fresh and not present in any release