### PR TITLE
storage_service: replicate_to_all_cores: prevent stalls when preparing per-table erms

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3108,10 +3108,10 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
             }
         });
         // Prepare per-table erms.
-        co_await container().invoke_on_all([&] (storage_service& ss) {
+        co_await container().invoke_on_all([&] (storage_service& ss) -> future<> {
             auto& db = ss._db.local();
             auto tmptr = pending_token_metadata_ptr[this_shard_id()];
-            db.get_tables_metadata().for_each_table([&] (table_id id, lw_shared_ptr<replica::table> table) {
+            co_await db.get_tables_metadata().for_each_table_gently([&] (table_id id, lw_shared_ptr<replica::table> table) {
                 auto rs = db.find_keyspace(table->schema()->ks_name()).get_replication_strategy_ptr();
                 locator::effective_replication_map_ptr erm;
                 if (auto pt_rs = rs->maybe_as_per_table()) {
@@ -3120,6 +3120,7 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
                     erm = pending_effective_replication_maps[this_shard_id()][table->schema()->ks_name()];
                 }
                 pending_table_erms[this_shard_id()].emplace(id, std::move(erm));
+                return make_ready_future();
             });
         });
     } catch (...) {


### PR DESCRIPTION
Although the `network_topology_stratergy::make_replication_map` -> `tablet_aware_replication_strategy::do_make_replication_map` is not cpu intensive it still allocates and constructs a shared `tablet_effective_replication_map`, and that might stall with thousands of tablet-based tables.

Therefore coroutinize the preparation loop to allow yielding.

* Backport not strictly required since we haven't seen such an extreme case in practice yet