### PR TITLE
Fix edge case issues related to tablet draining 

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -2443,14 +2443,25 @@ public:
                     lblogger.info("Will drain node {} ({}) from DC {}", node.host_id(), node.get_state(), dc);
                     nodes_to_drain.emplace(node.host_id());
                     nodes[node.host_id()].drained = true;
-                } else if (node.is_excluded() || _skiplist.contains(node.host_id())) {
+                } else if (node.is_excluded()) {
                     // Excluded nodes should not be chosen as targets for migration.
-                    lblogger.debug("Ignoring excluded or dead node {}: state={}", node.host_id(), node.get_state());
+                    lblogger.debug("Ignoring excluded node {}: state={}", node.host_id(), node.get_state());
                 } else {
                     ensure_node(node.host_id());
                 }
             }
         });
+
+        // Apply skiplist only when not draining.
+        // It's unsafe to move tablets to non-skip nodes as this can lead to node overload.
+        if (nodes_to_drain.empty()) {
+            for (auto host_to_skip : _skiplist) {
+                if (auto handle = nodes.extract(host_to_skip)) {
+                    auto& node = handle.mapped();
+                    lblogger.debug("Ignoring dead node {}: state={}", node.id, node.node->get_state());
+                }
+            }
+        }
 
         // Compute tablet load on nodes.
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -2559,6 +2559,10 @@ public:
         }
 
         if (!min_load_node) {
+            if (!nodes_to_drain.empty()) {
+                throw std::runtime_error(format("There are nodes with tablets to drain but no candidate nodes in DC {}."
+                                                " Consider adding new nodes or reducing replication factor.", dc));
+            }
             lblogger.debug("No candidate nodes");
             _stats.for_dc(dc).stop_no_candidates++;
             co_return plan;

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2512,6 +2512,48 @@ SEASTAR_THREAD_TEST_CASE(test_drained_node_is_not_balanced_internally) {
   }).get();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_plan_fails_when_removing_last_replica) {
+    do_with_cql_env_thread([] (auto& e) {
+        inet_address ip1("192.168.0.1");
+        inet_address ip2("192.168.0.2");
+
+        auto host1 = host_id(next_uuid());
+
+        auto table1 = table_id(next_uuid());
+
+        unsigned shard_count = 1;
+
+        semaphore sem(1);
+        shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
+            locator::topology::config{
+                .this_endpoint = ip1,
+                .this_host_id = host1,
+                .local_dc_rack = locator::endpoint_dc_rack::default_location
+            }
+        });
+
+        stm.mutate_token_metadata([&] (locator::token_metadata& tm) -> future<> {
+            tm.update_host_id(host1, ip1);
+            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, locator::node::state::being_removed, shard_count);
+            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 2))}, host1);
+
+            tablet_map tmap(1);
+            for (auto tid : tmap.tablet_ids()) {
+                tmap.set_tablet(tid, tablet_info {
+                    tablet_replica_set{tablet_replica{host1, 0}}
+                });
+            }
+            tablet_metadata tmeta;
+            tmeta.set_tablet_map(table1, std::move(tmap));
+            tm.set_tablets(std::move(tmeta));
+            co_return;
+        }).get();
+
+        std::unordered_set<host_id> skiplist = {host1};
+        BOOST_REQUIRE_THROW(rebalance_tablets(e.get_tablet_allocator().local(), stm, {}, skiplist), std::runtime_error);
+    }).get();
+}
+
 SEASTAR_THREAD_TEST_CASE(test_skiplist_is_ignored_when_draining) {
     // When doing normal load balancing, we can ignore DOWN nodes in the node set
     // and just balance the UP nodes among themselves because it's ok to equalize

--- a/test/topology_custom/test_tablets.py
+++ b/test/topology_custom/test_tablets.py
@@ -631,7 +631,6 @@ async def test_orphaned_sstables_on_startup(manager: ManagerClient):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("with_zero_token_node", [False, True])
-@pytest.mark.xfail(reason="https://github.com/scylladb/scylladb/issues/21826")
 async def test_remove_failure_with_no_normal_token_owners_in_dc(manager: ManagerClient, with_zero_token_node: bool):
     """
     Reproducer for #21826
@@ -664,7 +663,7 @@ async def test_remove_failure_with_no_normal_token_owners_in_dc(manager: Manager
 
     logger.info("Attempting removenode - expected to fail")
     await manager.remove_node(initiator_node.server_id, server_id=node_to_remove.server_id, ignore_dead=[replaced_host_id],
-                              expected_error="Removenode failed. See earlier errors (Rolled back: Failed to drain tablets: std::runtime_error (Unable to find new replica for tablet")
+                              expected_error="Removenode failed. See earlier errors (Rolled back: Failed to drain tablets: std::runtime_error (There are nodes with tablets to drain")
 
     logger.info(f"Replacing {node_to_replace} with a new node")
     replace_cfg = ReplaceConfig(replaced_id=node_to_remove.server_id, reuse_ip_addr = False, use_host_id=True, wait_replaced_dead=True)


### PR DESCRIPTION
Main problem:

If we're draining the last node in a DC, we won't have a chance to
evaluate candidates and notice that constraints cannot be satisfied (N
< RF). Draining will succeed and node will be removed with replicas
still present on that node. This will cause later draining in the same
DC to fail when we will have 2 replicas which need relocaiton for a
given tablet.

The expected behvior is for draining to fail, because we cannot keep
the RF in the DC. This is consistent, for example, with what happens
when removing a node in a 2-node cluster with RF=2.

Fixes #21826

Secondary problem:

We allowed tablet_draining transition to be exited with undrained nodes, leaving replicas on nodes in the "left" state.

Third problem: 

We removed DOWN nodes from the candidate node set, even when draining. This is not safe because it may lead to overload. This also makes the "main problem" more likely by extending it to the scenario when the DC is DOWN. 

The overload part in not a problem in practice currently, since migrations will block on global topology barrier if there are DOWN nodes. 
