### PR TITLE
test/pytest.ini: put `repair` marker declaration back

### DIFF
--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -9,6 +9,7 @@ markers =
     replication_factor: replication factor for RandomTables
     without_scylla: run without attaching to a scylla process
     enable_tablets: create keyspace with tablets enabled or disabled
+    repair: tests for repair
 norecursedirs = manual perf lib
 # Ignore warnings about HTTPS requests without certificate verification
 # (see issue #15287). Pytest breaks urllib3.disable_warnings() in conftest.py,


### PR DESCRIPTION
During the consolidation of per-suite pytest.ini files (commit 8bf62a086f), the 'repair' marker was inadvertently dropped. This led to pytest warnings for tests using the @pytest.mark.repair decorator.

This patch restores the marker declaration to eliminate the distracting PytestUnknownMarkWarning:

```
test/topology_experimental_raft/test_tablets.py:396
  /home/kefu/dev/scylladb/test/topology_experimental_raft/test_tablets.py:396: PytestUnknownMarkWarning: Unknown pytest.mark.repair - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.repair

```

Restoring the marker allows tests to use the 'repair' mark without generating warnings.

---

this improves the developer's experience of testing, hence no need to backport.