### PR TITLE
test/pylib: do not check for self.cmd when tearing down ScyllaServer

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -714,8 +714,7 @@ class ScyllaServer:
         else:
             await self.cmd.wait()
         finally:
-            if self.cmd:
-                self.logger.info("stopped %s in %s", self, self.workdir.name)
+            self.logger.info("stopped %s in %s", self, self.workdir.name)
             self.cmd = None
 
     @stop_event


### PR DESCRIPTION
we already check `self.cmd` for null at the very beginning of the `ScyllaServer.stop()`, and in the `try` block, we don't reset `self.cmd`, hence there is no need to check it again.

---

it's a cleanup, hence no need to backport.