### PR TITLE
.github/scripts/auto-backport.py: Add comment to PR when conflicts apply

### DIFF
--- a/.github/scripts/auto-backport.py
+++ b/.github/scripts/auto-backport.py
@@ -47,6 +47,11 @@ def create_pull_request(repo, new_branch_name, base_branch_name, pr, backport_pr
         )
         logging.info(f"Pull request created: {backport_pr.html_url}")
         backport_pr.add_to_assignees(pr.user)
+        if is_draft:
+            backport_pr.add_to_labels("conflicts")
+            pr_comment = f"@{pr.user} - This PR was marked as draft because it has conflicts\n"
+            pr_comment += "Please resolve them and mark this PR as ready for review"
+            backport_pr.create_issue_comment(pr_comment)
         logging.info(f"Assigned PR to original author: {pr.user}")
         return backport_pr
     except GithubException as e:


### PR DESCRIPTION
When we open a PR with conflicts, the PR owner gets a notification about the assignment but has no idea if this PR is with conflicts or not (in Scylla it's important since CI will not start on draft PR)

Let's add a comment to notify the user we have conflicts

**Auto backport improvement, no need for backporting**