### PR TITLE
replica: check enabled features in tablet_map_to_mutation

### DIFF
--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -29,6 +29,12 @@ class query_processor;
 
 }
 
+namespace gms {
+
+class feature_service;
+
+}
+
 namespace replica {
 
 data_type get_replica_set_type();
@@ -50,7 +56,8 @@ future<mutation> tablet_map_to_mutation(const locator::tablet_map&,
                                         table_id,
                                         const sstring& keyspace_name,
                                         const sstring& table_name,
-                                        api::timestamp_type);
+                                        api::timestamp_type,
+                                        const gms::feature_service& features);
 
 mutation make_drop_tablet_map_mutation(table_id, api::timestamp_type);
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -2710,7 +2710,7 @@ public:
             auto tm = _db.get_shared_token_metadata().get();
             lblogger.debug("Creating tablets for {}.{} id={}", s.ks_name(), s.cf_name(), s.id());
             auto map = tablet_rs->allocate_tablets_for_new_table(s.shared_from_this(), tm, _config.initial_tablets_scale).get();
-            muts.emplace_back(tablet_map_to_mutation(map, s.id(), s.ks_name(), s.cf_name(), ts).get());
+            muts.emplace_back(tablet_map_to_mutation(map, s.id(), s.ks_name(), s.cf_name(), ts, _db.features()).get());
         }
     }
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1699,7 +1699,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 table_id,
                 s->ks_name(),
                 s->cf_name(),
-                guard.write_timestamp()));
+                guard.write_timestamp(),
+                _db.features()));
 
             // Clears the resize decision for a table.
             generate_resize_update(updates, guard, table_id, locator::resize_decision{});

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -387,7 +387,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_update) {
             });
 
             verify_tablet_metadata_update(e, tm, {
-                    tablet_map_to_mutation(tmap, table1, table1_schema->ks_name(), table1_schema->cf_name(), ++ts).get(),
+                    tablet_map_to_mutation(tmap, table1, table1_schema->ks_name(), table1_schema->cf_name(), ++ts, db.features()).get(),
             });
         }
 
@@ -422,7 +422,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_update) {
             });
 
             verify_tablet_metadata_update(e, tm, {
-                    tablet_map_to_mutation(tmap, table2, table2_schema->ks_name(), table2_schema->cf_name(), ++ts).get(),
+                    tablet_map_to_mutation(tmap, table2, table2_schema->ks_name(), table2_schema->cf_name(), ++ts, db.features()).get(),
             });
         }
 
@@ -477,7 +477,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_update) {
             });
 
             verify_tablet_metadata_update(e, tm, {
-                    tablet_map_to_mutation(tmap, table1, table1_schema->ks_name(), table1_schema->cf_name(), ++ts).get(),
+                    tablet_map_to_mutation(tmap, table1, table1_schema->ks_name(), table1_schema->cf_name(), ++ts, db.features()).get(),
             });
         }
 
@@ -495,7 +495,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_update) {
             });
 
             verify_tablet_metadata_update(e, tm, {
-                    tablet_map_to_mutation(tmap, table1, table1_schema->ks_name(), table1_schema->cf_name(), ++ts).get(),
+                    tablet_map_to_mutation(tmap, table1, table1_schema->ks_name(), table1_schema->cf_name(), ++ts, db.features()).get(),
             });
         }
 


### PR DESCRIPTION
Before adding a value to a new column in tablet_map_to_mutation check 
if the column is supported by the whole cluster.

No backport needed, 6.2 does not contain the new columns