### PR TITLE
schema: deinline some speculative_retry methods

### DIFF
--- a/clustering_ranges_walker.hh
+++ b/clustering_ranges_walker.hh
@@ -16,6 +16,8 @@
 #include "mutation/mutation_fragment.hh"
 #include "mutation/mutation_fragment_v2.hh"
 
+#include <boost/range/iterator_range.hpp>
+
 // Utility for in-order checking of overlap with position ranges.
 class clustering_ranges_walker {
     const schema& _schema;

--- a/mutation_query.cc
+++ b/mutation_query.cc
@@ -11,6 +11,8 @@
 #include "mutation_query.hh"
 #include "schema/schema_registry.hh"
 
+#include <boost/range/algorithm/equal.hpp>
+
 reconcilable_result::~reconcilable_result() {}
 
 reconcilable_result::reconcilable_result()

--- a/partition_range_compat.hh
+++ b/partition_range_compat.hh
@@ -12,6 +12,7 @@
 #include <vector>
 #include "interval.hh"
 #include "dht/ring_position.hh"
+#include <boost/range/iterator_range_core.hpp>
 
 namespace compat {
 

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -14,7 +14,6 @@
 #include <optional>
 #include <unordered_map>
 #include <ranges>
-#include <boost/lexical_cast.hpp>
 #include <boost/dynamic_bitset.hpp>
 
 #include "cql3/column_specification.hh"
@@ -163,50 +162,8 @@ private:
 public:
     speculative_retry(type t, double v) : _t(t), _v(v) {}
 
-    sstring to_sstring() const {
-        if (_t == type::NONE) {
-            return "NONE";
-        } else if (_t == type::ALWAYS) {
-            return "ALWAYS";
-        } else if (_t == type::CUSTOM) {
-            return format("{:.2f}ms", _v);
-        } else if (_t == type::PERCENTILE) {
-            return format("{:.1f}PERCENTILE", 100 * _v);
-        } else {
-            throw std::invalid_argument(format("unknown type: {:d}\n", uint8_t(_t)));
-        }
-    }
-    static speculative_retry from_sstring(sstring str) {
-        std::transform(str.begin(), str.end(), str.begin(), ::toupper);
-
-        sstring ms("MS");
-        sstring percentile("PERCENTILE");
-
-        auto convert = [&str] (sstring& t) {
-            try {
-                return boost::lexical_cast<double>(str.substr(0, str.size() - t.size()));
-            } catch (boost::bad_lexical_cast& e) {
-                throw std::invalid_argument(format("cannot convert {} to speculative_retry\n", str));
-            }
-        };
-
-        type t;
-        double v = 0;
-        if (str == "NONE") {
-            t = type::NONE;
-        } else if (str == "ALWAYS") {
-            t = type::ALWAYS;
-        } else if (str.compare(str.size() - ms.size(), ms.size(), ms) == 0) {
-            t = type::CUSTOM;
-            v = convert(ms);
-        } else if (str.compare(str.size() - percentile.size(), percentile.size(), percentile) == 0) {
-            t = type::PERCENTILE;
-            v = convert(percentile) / 100;
-        } else {
-            throw std::invalid_argument(format("cannot convert {} to speculative_retry\n", str));
-        }
-        return speculative_retry(t, v);
-    }
+    sstring to_sstring() const;
+    static speculative_retry from_sstring(sstring str);
     type get_type() const {
         return _t;
     }


### PR DESCRIPTION
This string conversion functions are not in any fast path. Deinlining them moves a <boost/lexical_cast.hpp> include out of a common header file.

Some files accessed on boost::iterator_range via lexical_cast.hpp, so they gain a new dependency.

Code cleanup, no backport needed.