### PR TITLE
repair: Enable small table optimization for RBNO rebuild

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1523,6 +1523,7 @@ future<> repair::data_sync_repair_task_impl::run() {
             "system_traces"
         };
         if (_reason == streaming::stream_reason::bootstrap ||
+            _reason == streaming::stream_reason::rebuild ||
             _reason == streaming::stream_reason::decommission) {
             small_table_optimization = small_table_optimization_enabled_ks.contains(keyspace);
         }


### PR DESCRIPTION
Similar to 9ace1916163b6d59aa5d05ece52384c12be191bd (repair: Enable small table optimization for RBNO bootstrap and decommission), this patch enables small table optimization for RBNO rebuild.

This is useful for rebuild ops which is used for building an empty DC.

Fixes: #21951

New feature. No backport. 