### PR TITLE
treewide: use angle brackets when including seastar headers

### DIFF
--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -30,8 +30,8 @@
 #include "db/consistency_level_type.hh"
 #include "exceptions/exceptions.hh"
 #include "utils/log.hh"
-#include "seastar/core/loop.hh"
-#include "seastar/coroutine/maybe_yield.hh"
+#include <seastar/core/loop.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include "service/raft/raft_group0_client.hh"
 #include "utils/class_registrator.hh"
 #include "service/migration_manager.hh"

--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -18,7 +18,7 @@
 #include "exceptions/exceptions.hh"
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/coroutine/maybe_yield.hh>
-#include "seastar/coroutine/exception.hh"
+#include <seastar/coroutine/exception.hh>
 #include "service/client_state.hh"
 #include "types/types.hh"
 #include "cql3/query_processor.hh"

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "mutation/mutation.hh"
-#include "seastar/core/future.hh"
+#include <seastar/core/future.hh>
 #include "service/storage_proxy.hh"
 #include "query-result-set.hh"
 

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -43,8 +43,8 @@
 #include <utility>
 #include "gms/generation-number.hh"
 #include "locator/token_metadata.hh"
-#include "seastar/core/shard_id.hh"
-#include "seastar/rpc/rpc_types.hh"
+#include <seastar/core/shard_id.hh>
+#include <seastar/rpc/rpc_types.hh>
 #include "utils/assert.hh"
 #include "utils/exceptions.hh"
 #include "utils/error_injection.hh"

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -12,7 +12,7 @@
 #include <seastar/util/lazy.hh>
 #include <utility>
 
-#include "seastar/core/shard_id.hh"
+#include <seastar/core/shard_id.hh>
 #include "utils/log.hh"
 #include "locator/topology.hh"
 #include "locator/production_snitch_base.hh"

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -10,7 +10,7 @@
 #include <exception>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/all.hh>
-#include "seastar/coroutine/exception.hh"
+#include <seastar/coroutine/exception.hh>
 #include "service/storage_proxy.hh"
 #include "service/paxos/proposal.hh"
 #include "service/paxos/paxos_state.hh"

--- a/service/paxos/paxos_state.hh
+++ b/service/paxos/paxos_state.hh
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: (AGPL-3.0-or-later and Apache-2.0)
  */
 #pragma once
-#include "seastar/core/semaphore.hh"
+#include <seastar/core/semaphore.hh>
 #include "service/paxos/proposal.hh"
 #include "utils/log.hh"
 #include "utils/digest_algorithm.hh"

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -21,10 +21,10 @@
 #include "db/system_keyspace.hh"
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/core/timer.hh>
-#include "seastar/core/future.hh"
-#include "seastar/core/semaphore.hh"
-#include "seastar/core/shard_id.hh"
-#include "seastar/coroutine/maybe_yield.hh"
+#include <seastar/core/future.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/shard_id.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include "service/qos/raft_service_level_distributed_data_accessor.hh"
 #include "service/qos/standard_service_level_distributed_data_accessor.hh"
 #include "service_level_controller.hh"

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <seastar/core/timer.hh>
-#include "seastar/util/bool_class.hh"
+#include <seastar/util/bool_class.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/distributed.hh>

--- a/test/boost/service_level_controller_test.cc
+++ b/test/boost/service_level_controller_test.cc
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <fmt/std.h>
 
-#include "seastar/core/future.hh"
+#include <seastar/core/future.hh>
 #include "seastarx.hh"
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/test_utils.hh"

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -8,7 +8,7 @@
 
 
 
-#include "seastar/core/shard_id.hh"
+#include <seastar/core/shard_id.hh>
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/random_utils.hh"
 #include <fmt/ranges.h>


### PR DESCRIPTION
We treat Seastar as a "system" library, and those are included with angle brackets.

Code cleanup; no backport.