### PR TITLE
test/pylib: Catch and log all exceptions in ScyllaServer.install()

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -33,6 +33,7 @@ import aiohttp
 import aiohttp.web
 import yaml
 import signal
+import sys
 import glob
 import errno
 import re
@@ -987,6 +988,15 @@ class ScyllaCluster:
             workdir = '<unknown>' if server is None else server.workdir.name
             self.logger.error("Failed to start Scylla server at host %s in %s: %s",
                           ip_addr, workdir, str(exc))
+            await handle_join_failure()
+            raise
+        except:
+            # catches everything
+            workdir = '<unknown>' if server is None else server.workdir.name
+            exc_type, exc_value, _ = sys.exc_info()
+            self.logger.error("Failed to start Scylla server at host %s in %s: %s(%s)",
+                              ip_addr, workdir, exc_type.__name__, exc_value)
+            self.logger.error("Traceback: ", exc_info=sys.exc_info())
             await handle_join_failure()
             raise
 


### PR DESCRIPTION
Previously, the error handling in `ScyllaServer.install_and_start()` only captured exceptions derived from the base `Exception` class. This meant that any unexpected or lower-level exceptions raised during server installation would go unlogged and unhandled.

This change modifies the exception handling to catch all possible exceptions in the caller of `ScyllaCluster.add_server()`. By using a broader exception catching mechanism, we ensure that any type of exception raised during the server installation process is captured and logged, improving error visibility and debugging capabilities.

Refs scylladb/scylladb#21912

---

this change improves the debugging experience, hence no need to backport.