### PR TITLE
repair: Remove repair_task_info only when repair is finished

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1579,6 +1579,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::end_repair);
                         auto update = get_mutation_builder()
                                         .set_stage(last_token, locator::tablet_transition_stage::end_repair)
+                                        .del_repair_task_info(last_token)
                                         .del_session(last_token);
                         if (valid) {
                             auto time = tinfo.repair_task_info.sched_time;
@@ -1593,7 +1594,6 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         _tablets.erase(gid);
                         updates.emplace_back(get_mutation_builder()
                             .del_transition(last_token)
-                            .del_repair_task_info(last_token)
                             .build());
                     }
                 }

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -273,8 +273,8 @@ class ScyllaRESTAPIClient():
             "token": str(token)
         })
 
-    async def tablet_repair(self, node_ip: str, ks: str, table: str, token : int) -> None:
-        await self.client.post(f"/storage_service/tablets/repair", host=node_ip, params={
+    async def tablet_repair(self, node_ip: str, ks: str, table: str, token : int, timeout: Optional[float] = None) -> None:
+        await self.client.post(f"/storage_service/tablets/repair", host=node_ip, timeout=timeout, params={
             "ks": ks,
             "table": table,
             "tokens": str(token)


### PR DESCRIPTION
In case of error, repair will be moved into the end_repair stage. We should not remove repair_task_info in this case because the repair task requested by the user is not finished yet.

To fix, we should remove repair_task_info at the end of repair stage.

Tests are added to ensure failed repair is not reported as finished.

No backport. The code in question  is not released in any releases yet. 