### PR TITLE
build_docker: add option for building container based on Ubuntu Pro

### DIFF
--- a/dist/docker/pro-attach-config.yaml
+++ b/dist/docker/pro-attach-config.yaml
@@ -1,0 +1,4 @@
+token: <token>
+enable_services:
+- fips
+- fips-updates


### PR DESCRIPTION
Today our container is based on ubuntu:22.04, we need to build another container based on Ubuntu Pro for FIPS support (currently the latest one is 20.04)

The default Docker build process doesn't change. If FIPS is required, I have added `--type pro` to build a supported container.

To enable FIPS there is a need to attach an Ubuntu Pro subscription (it will be done as part of https://github.com/scylladb/scylla-pkg/issues/4186)

**applying changes due to license change, no backport  is needed**