### PR TITLE
Update ScyllaDB version to: 2025.1.0-dev

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -78,7 +78,7 @@ fi
 
 # Default scylla product/version tags
 PRODUCT=scylla
-VERSION=6.3.0-dev
+VERSION=2025.1.0-dev
 
 if test -f version
 then


### PR DESCRIPTION
Following the license changes in f3eade2f6249ef4a964f34da76ec75aaacec26ff

**No backport is needed, change in dev version**