### PR TITLE
service/storage_proxy: data_read_resolver::resolve(): remove unneded maybe_yield()

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5035,7 +5035,6 @@ public:
                 if (ver.par) {
                     mutation_application_stats app_stats;
                     co_await apply_gently(m.partition(), *schema, ver.par->mut().partition(), *schema, app_stats);
-                    co_await coroutine::maybe_yield();
                 }
             }
             auto live_row_count = m.live_row_count();


### PR DESCRIPTION
We already have a yield in the loop via apply_gently(), the maybe_yield is superfluous so remove it.

Follow-up to https://github.com/scylladb/scylladb/pull/21884

The change making the yield superfluous (https://github.com/scylladb/scylladb/commit/1a717f3014bcb0b45c664c93a3f2ef7310b251fe) is not in any release yet, no backport needed.