### PR TITLE
Delete the maintenance socket on a clean shutdown

### DIFF
--- a/auth/maintenance_socket_role_manager.cc
+++ b/auth/maintenance_socket_role_manager.cc
@@ -11,6 +11,7 @@
 #include <seastar/core/future.hh>
 #include <stdexcept>
 #include <string_view>
+#include <filesystem>
 #include "cql3/description.hh"
 #include "utils/class_registrator.hh"
 
@@ -41,7 +42,7 @@ future<> maintenance_socket_role_manager::start() {
 }
 
 future<> maintenance_socket_role_manager::stop() {
-    return make_ready_future<>();
+    return delete_maintenance_socket();
 }
 
 future<> maintenance_socket_role_manager::ensure_superuser_is_created() {
@@ -116,6 +117,15 @@ future<> maintenance_socket_role_manager::remove_attribute(std::string_view role
 
 future<std::vector<cql3::description>> maintenance_socket_role_manager::describe_role_grants() {
     return operation_not_supported_exception<std::vector<cql3::description>>("DESCRIBE SCHEMA WITH INTERNALS");
+}
+
+future<> maintenance_socket_role_manager::delete_maintenance_socket() {
+    std::error_code ec;
+    std::filesystem::remove("maintenance_socket", ec);
+    if (ec) {
+        return make_exception_future<>(std::runtime_error(fmt::format("Failed to delete maintenance socket: {}", ec.message())));
+    }
+    return make_ready_future<>();
 }
 
 } // namespace auth

--- a/auth/maintenance_socket_role_manager.hh
+++ b/auth/maintenance_socket_role_manager.hh
@@ -72,6 +72,9 @@ public:
     virtual future<> remove_attribute(std::string_view role_name, std::string_view attribute_name, ::service::group0_batch& mc) override;
 
     virtual future<std::vector<cql3::description>> describe_role_grants() override;
+
+private:
+    future<> delete_maintenance_socket();
 };
 
 }

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -260,6 +260,11 @@ future<> service::stop() {
         return make_ready_future<>();
     }).then([this] {
         return when_all_succeed(_role_manager->stop(), _authorizer->stop(), _authenticator->stop()).discard_result();
+    }).then([this] {
+        if (_used_by_maintenance_socket) {
+            return _role_manager->stop();
+        }
+        return make_ready_future<>();
     });
 }
 


### PR DESCRIPTION
Related to #17065

Implement logic to delete the maintenance socket on a clean shutdown.

* **auth/maintenance_socket_role_manager.cc**
  - Include `<filesystem>` header.
  - Implement `delete_maintenance_socket` method to delete the maintenance socket file.
  - Call `delete_maintenance_socket` method in the `stop` method.

* **auth/maintenance_socket_role_manager.hh**
  - Add a private method declaration for `delete_maintenance_socket`.

* **auth/service.cc**
  - Call the `stop` method of `maintenance_socket_role_manager` during the shutdown process.

