### PR TITLE
Refactor reader parameters into a single struct

### DIFF
--- a/readers/compacting.hh
+++ b/readers/compacting.hh
@@ -36,4 +36,4 @@ class tombstone_gc_state;
 mutation_reader make_compacting_reader(mutation_reader source, gc_clock::time_point compaction_time,
         max_purgeable_fn get_max_purgeable,
         const tombstone_gc_state& gc_state,
-        streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no);
+        mutation_reader::reader_params params);

--- a/readers/from_fragments_v2.hh
+++ b/readers/from_fragments_v2.hh
@@ -10,22 +10,20 @@
 #include "schema/schema_fwd.hh"
 #include <deque>
 #include "dht/i_partitioner_fwd.hh"
+#include "readers/mutation_reader.hh"
 
 class mutation_reader;
-class reader_permit;
 class mutation_fragment_v2;
-class ring_position;
 
 namespace query {
     class partition_slice;
 }
 
 mutation_reader
-make_mutation_reader_from_fragments(schema_ptr, reader_permit, std::deque<mutation_fragment_v2>);
+make_mutation_reader_from_fragments(schema_ptr, mutation_reader::reader_params, std::deque<mutation_fragment_v2>);
 
 mutation_reader
-make_mutation_reader_from_fragments(schema_ptr, reader_permit, std::deque<mutation_fragment_v2>, const dht::partition_range& pr);
+make_mutation_reader_from_fragments(schema_ptr, mutation_reader::reader_params, std::deque<mutation_fragment_v2>, const dht::partition_range& pr);
 
 mutation_reader
-make_mutation_reader_from_fragments(schema_ptr, reader_permit, std::deque<mutation_fragment_v2>, const dht::partition_range& pr, const query::partition_slice& slice);
-
+make_mutation_reader_from_fragments(schema_ptr, mutation_reader::reader_params, std::deque<mutation_fragment_v2>, const dht::partition_range& pr, const query::partition_slice& slice);

--- a/readers/mutation_reader.hh
+++ b/readers/mutation_reader.hh
@@ -124,6 +124,13 @@ public:
     using forwarding = bool_class<partition_range_forwarding_tag>;
     using tracked_buffer = circular_buffer<mutation_fragment_v2, tracking_allocator<mutation_fragment_v2>>;
 
+    struct reader_params {
+        const dht::partition_range& partition_range;
+        const query::partition_slice& partition_slice;
+        reader_permit permit;
+        tracing::trace_state_ptr trace_state;
+    };
+
     class impl {
     private:
         tracked_buffer _buffer;


### PR DESCRIPTION
Related to #2764

Refactor reader parameters into a single struct `reader_params` and update relevant functions to use it.

* **Introduce `reader_params` struct:**
  - Add `reader_params` struct in `readers/mutation_reader.hh` to encapsulate parameters like `partition_range`, `partition_slice`, `reader_permit`, and `trace_state`.

* **Update function signatures:**
  - Modify `make_mutation_reader_from_fragments` function in `readers/from_fragments_v2.hh` to accept `reader_params` struct instead of individual parameters.
  - Update `make_compacting_reader` function in `readers/compacting.hh` to use `reader_params` struct.
  - Refactor `make_delegating_reader` function in `readers/mutation_readers.cc` to accept `reader_params` struct.

* **Refactor `mutation_reader` class:**
  - Update `mutation_reader` class in `readers/mutation_reader.hh` to use `reader_params` struct for passing parameters.
  - Modify `consume` method to accept `reader_params` instead of individual parameters.

* **Remove individual parameters:**
  - Remove individual parameters from function signatures and replace them with `reader_params` struct in `readers/from_fragments_v2.hh`, `readers/compacting.hh`, and `readers/mutation_readers.cc`.

