### PR TITLE
cql3: implement NOT IN

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -1785,6 +1785,13 @@ columnCondition returns [uexpression e]
                             oper_t::IN,
                             std::move(values));
                 }
+        | K_NOT K_IN
+            values=singleColumnInValuesOrMarkerExpr {
+                    e = binary_operator(
+                            std::move(key),
+                            oper_t::NOT_IN,
+                            std::move(values));
+                }
         )
     ;
 
@@ -1835,6 +1842,14 @@ relation returns [uexpression e]
         { $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::IN, std::move(marker1)); }
     | name=cident K_IN in_values=singleColumnInValues
         { $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::IN,
+        collection_constructor {
+            .style = collection_constructor::style_type::list,
+            .elements = std::move(in_values)
+        }); }
+    | name=cident K_NOT K_IN marker1=marker
+        { $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::NOT_IN, std::move(marker1)); }
+    | name=cident K_NOT K_IN in_values=singleColumnInValues
+        { $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::NOT_IN,
         collection_constructor {
             .style = collection_constructor::style_type::list,
             .elements = std::move(in_values)

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -329,6 +329,8 @@ bool_or_null limits(const expression& lhs, oper_t op, null_handling_style null_h
                 } else {
                     return list_contains_null(*sides_bytes.second);
                 }
+            case oper_t::NOT_IN:
+                on_internal_error(expr_logger, "NOT IN operator on limits(), despite being rejected via !is_slice()");
             }
         }
     }
@@ -492,6 +494,48 @@ bool_or_null is_one_of(const expression& lhs, const expression& rhs, const evalu
     return false;
 }
 
+/// True iff the column value is NOT in the set defined by rhs. Differs from !is_one_of() in handling NULLs.
+bool_or_null is_none_of(const expression& lhs, const expression& rhs, const evaluation_inputs& inputs, null_handling_style null_handling) {
+    auto [lhs_bytes, rhs_bytes] = evaluate_binop_sides(lhs, rhs, oper_t::IN, inputs);
+
+    if (!lhs_bytes || !rhs_bytes) {
+        switch (null_handling) {
+        case null_handling_style::sql:
+            return bool_or_null::null();
+        case null_handling_style::lwt_nulls:
+            if (!rhs_bytes) {
+                return true;
+            } else {
+                return !list_contains_null(*rhs_bytes);
+            }
+        }
+    }
+
+    expression lhs_constant = constant(raw_value::make_value(std::move(*lhs_bytes)), type_of(lhs));
+    utils::chunked_vector<managed_bytes_opt> list_elems = get_list_elements(raw_value::make_value(std::move(*rhs_bytes)));
+    bool saw_null = false;
+    for (const managed_bytes_opt& elem : list_elems) {
+        auto cmp_result = equal(lhs_constant, elem, inputs);
+        if (cmp_result.is_null()) {
+            // If we match another element in the list, we can return `false` with
+            // confidence. If we don't, we return NULL to indicate we don't know.
+            saw_null = true;
+        } else if (cmp_result.is_true()) {
+            return false;
+        }
+    }
+    if (saw_null) {
+            switch (null_handling) {
+            case null_handling_style::sql:
+                return bool_or_null::null();
+            case null_handling_style::lwt_nulls:
+                // In LWT, `3 NOT IN (NULL, 5)` counts as true
+                return true;
+            }
+    }
+    return true;
+}
+
 bool is_not_null(const expression& lhs, const expression& rhs, const evaluation_inputs& inputs) {
     cql3::raw_value lhs_val = evaluate(lhs, inputs);
     cql3::raw_value rhs_val = evaluate(rhs, inputs);
@@ -609,12 +653,12 @@ auto fmt::formatter<cql3::expr::expression::printer>::format(const cql3::expr::e
                         out = fmt::format_to(out, " [[lwt_nulls]]");
                     }
                 } else {
-                    if (opr.op == oper_t::IN && is<collection_constructor>(opr.rhs)) {
+                    if ((opr.op == oper_t::IN || opr.op == oper_t::NOT_IN) && is<collection_constructor>(opr.rhs)) {
                         tuple_constructor rhs_tuple {
                             .elements = as<collection_constructor>(opr.rhs).elements
                         };
                         out = fmt::format_to(out, "{} {} {}", to_printer(opr.lhs), opr.op, to_printer(rhs_tuple));
-                    } else if (opr.op == oper_t::IN && is<constant>(opr.rhs) && as<constant>(opr.rhs).type->without_reversed().is_list()) {
+                    } else if ((opr.op == oper_t::IN || opr.op == oper_t::NOT_IN) && is<constant>(opr.rhs) && as<constant>(opr.rhs).type->without_reversed().is_list()) {
                         tuple_constructor rhs_tuple;
                         const list_type_impl* list_typ = dynamic_cast<const list_type_impl*>(&as<constant>(opr.rhs).type->without_reversed());
                         for (const managed_bytes_opt& elem : get_list_elements(as<constant>(opr.rhs).value)) {
@@ -1064,6 +1108,9 @@ cql3::raw_value do_evaluate(const binary_operator& binop, const evaluation_input
             break;
         case oper_t::IN:
             binop_result = is_one_of(binop.lhs, binop.rhs, inputs, binop.null_handling);
+            break;
+        case oper_t::NOT_IN:
+            binop_result = is_none_of(binop.lhs, binop.rhs, inputs, binop.null_handling);
             break;
         case oper_t::IS_NOT:
             binop_result = is_not_null(binop.lhs, binop.rhs, inputs);
@@ -2305,6 +2352,8 @@ std::string_view fmt::formatter<cql3::expr::oper_t>::to_string(const cql3::expr:
         return ">=";
     case oper_t::IN:
         return "IN";
+    case oper_t::NOT_IN:
+        return "NOT IN";
     case oper_t::CONTAINS:
         return "CONTAINS";
     case oper_t::CONTAINS_KEY:

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -221,7 +221,7 @@ const column_value& get_subscripted_column(const subscript&);
 /// Only columns can be subscripted in CQL, so we can expect that the subscripted expression is a column_value.
 const column_value& get_subscripted_column(const expression&);
 
-enum class oper_t { EQ, NEQ, LT, LTE, GTE, GT, IN, CONTAINS, CONTAINS_KEY, IS_NOT, LIKE };
+enum class oper_t { EQ, NEQ, LT, LTE, GTE, GT, IN, NOT_IN, CONTAINS, CONTAINS_KEY, IS_NOT, LIKE };
 
 /// Describes the nature of clustering-key comparisons.  Useful for implementing SCYLLA_CLUSTERING_BOUND.
 enum class comparison_order : char {

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1450,9 +1450,9 @@ static lw_shared_ptr<column_specification> get_lhs_receiver(const expression& pr
 static lw_shared_ptr<column_specification> get_rhs_receiver(lw_shared_ptr<column_specification>& lhs_receiver, oper_t oper) {
     const data_type lhs_type = lhs_receiver->type->underlying_type();
 
-    if (oper == oper_t::IN) {
+    if (oper == oper_t::IN || oper == oper_t::NOT_IN) {
         data_type rhs_receiver_type = list_type_impl::get_instance(std::move(lhs_type), false);
-        auto in_name = ::make_shared<column_identifier>(format("in({})", lhs_receiver->name->text()), true);
+        auto in_name = ::make_shared<column_identifier>(format("{}({})", oper, lhs_receiver->name->text()), true);
         return make_lw_shared<column_specification>(lhs_receiver->ks_name,
                                                     lhs_receiver->cf_name,
                                                     in_name,

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -99,7 +99,7 @@ extern bool index_supports_some_column(
 
 inline bool needs_filtering(oper_t op) {
     return (op == oper_t::CONTAINS) || (op == oper_t::CONTAINS_KEY) || (op == oper_t::LIKE) ||
-           (op == oper_t::IS_NOT) || (op == oper_t::NEQ) ;
+           (op == oper_t::IS_NOT) || (op == oper_t::NEQ) || (op == oper_t::NOT_IN);
 }
 
 inline auto find_needs_filtering(const expression& e) {

--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -29,7 +29,7 @@ Querying data from data is done using a ``SELECT`` statement:
    relation: `column_name` `operator` `term`
            : '(' `column_name` ( ',' `column_name` )* ')' `operator` `tuple_literal`
            : TOKEN '(' `column_name` ( ',' `column_name` )* ')' `operator` `term`
-   operator: '=' | '<' | '>' | '<=' | '>=' | IN | CONTAINS | CONTAINS KEY
+   operator: '=' | '<' | '>' | '<=' | '>=' | IN | NOT IN | CONTAINS | CONTAINS KEY
    ordering_clause: `column_name` [ ASC | DESC ] ( ',' `column_name` [ ASC | DESC ] )*
    timeout: `duration`
 

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -2822,6 +2822,33 @@ BOOST_AUTO_TEST_CASE(evaluate_binary_operator_in) {
     test_evaluate_binop_null(oper_t::IN, make_int_const(5), in_list);
 }
 
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_not_in) {
+    // IN expects a list as its rhs, sets are not allowed
+    expression in_list = make_int_list_const({1, 3, 5});
+
+    expression false_not_in_binop = binary_operator(make_int_const(3), oper_t::NOT_IN, in_list);
+    BOOST_REQUIRE_EQUAL(evaluate(false_not_in_binop, evaluation_inputs{}), make_bool_raw(false));
+
+    expression true_not_in_binop = binary_operator(make_int_const(2), oper_t::NOT_IN, in_list);
+    BOOST_REQUIRE_EQUAL(evaluate(true_not_in_binop, evaluation_inputs{}), make_bool_raw(true));
+
+    expression empty_not_in_list = binary_operator(make_empty_const(int32_type), oper_t::NOT_IN, in_list);
+    BOOST_REQUIRE_EQUAL(evaluate(empty_not_in_list, evaluation_inputs{}), make_bool_raw(true));
+
+    expression list_with_empty =
+        make_list_const({make_int_const(1), make_empty_const(int32_type), make_int_const(3)}, int32_type);
+    expression empty_not_in_list_with_empty = binary_operator(make_empty_const(int32_type), oper_t::NOT_IN, list_with_empty);
+    BOOST_REQUIRE_EQUAL(evaluate(empty_not_in_list_with_empty, evaluation_inputs{}), make_bool_raw(false));
+
+    expression existing_int_not_in_list_with_empty = binary_operator(make_int_const(3), oper_t::NOT_IN, list_with_empty);
+    BOOST_REQUIRE_EQUAL(evaluate(existing_int_not_in_list_with_empty, evaluation_inputs{}), make_bool_raw(false));
+
+    expression nonexisting_not_int_in_list_with_empty = binary_operator(make_int_const(321), oper_t::NOT_IN, list_with_empty);
+    BOOST_REQUIRE_EQUAL(evaluate(nonexisting_not_int_in_list_with_empty, evaluation_inputs{}), make_bool_raw(true));
+
+    test_evaluate_binop_null(oper_t::NOT_IN, make_int_const(5), in_list);
+}
+
 // Tests `<int_value> IN (123, ?, 789)` where the bind variable has value 456
 BOOST_AUTO_TEST_CASE(evaluate_binary_operator_in_list_with_bind_variable) {
     schema_ptr table_schema =
@@ -2843,6 +2870,29 @@ BOOST_AUTO_TEST_CASE(evaluate_binary_operator_in_list_with_bind_variable) {
 
     expression empty_in_list = binary_operator(make_empty_const(int32_type), oper_t::IN, in_list);
     BOOST_REQUIRE_EQUAL(evaluate(empty_in_list, inputs), make_bool_raw(false));
+}
+
+// Tests `<int_value> IN (123, ?, 789)` where the bind variable has value 456
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_not_in_list_with_bind_variable) {
+    schema_ptr table_schema =
+        schema_builder("test_ks", "test_cf").with_column("pk", int32_type, column_kind::partition_key).build();
+
+    expression in_list = collection_constructor{
+        .style = collection_constructor::style_type::list,
+        .elements = {make_int_const(123), bind_variable{.bind_index = 0, .receiver = make_receiver(int32_type)},
+                     make_int_const(789)},
+        .type = list_type_impl::get_instance(int32_type, true)};
+
+    auto [inputs, inputs_data] = make_evaluation_inputs(table_schema, {{"pk", make_int_raw(111)}}, {make_int_raw(456)});
+
+    expression false_not_in_binop = binary_operator(make_int_const(456), oper_t::NOT_IN, in_list);
+    BOOST_REQUIRE_EQUAL(evaluate(false_not_in_binop, inputs), make_bool_raw(false));
+
+    expression true_not_in_binop = binary_operator(make_int_const(-100), oper_t::NOT_IN, in_list);
+    BOOST_REQUIRE_EQUAL(evaluate(true_not_in_binop, inputs), make_bool_raw(true));
+
+    expression empty_not_in_list = binary_operator(make_empty_const(int32_type), oper_t::NOT_IN, in_list);
+    BOOST_REQUIRE_EQUAL(evaluate(empty_not_in_list, inputs), make_bool_raw(true));
 }
 
 BOOST_AUTO_TEST_CASE(evaluate_binary_operator_list_contains) {

--- a/test/cqlpy/test_filtering.py
+++ b/test/cqlpy/test_filtering.py
@@ -152,6 +152,45 @@ def test_filtering_with_in_relation(cql, test_keyspace, cassandra_bug):
         res = cql.execute(f"select * from {table} where v in (5,7) ALLOW FILTERING")
         assert set(res) == set([(2,3,4,5), (4,5,6,7)])
 
+# Test that NOT IN restrictions are supported with filtering and return the
+# correct results.
+def test_filtering_with_not_in_relation(cql, test_keyspace):
+    schema = 'p1 int, p2 int, c int, v int, primary key ((p1, p2),c)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (1, 2, 3, 4)")
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (2, 3, 4, 5)")
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (3, 4, 5, 6)")
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (4, 5, 6, 7)")
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (5, 6, 7, NULL)")
+        res = cql.execute(f"select * from {table} where p1 NOT IN (2,4) ALLOW FILTERING")
+        assert set(res) == set([(1,2,3,4), (3,4,5,6), (5,6,7,None)])
+        res = cql.execute(f"select * from {table} where p2 NOT IN (2,4) ALLOW FILTERING")
+        assert set(res) == set([(2,3,4,5), (4,5,6,7), (5,6,7,None)])
+        res = cql.execute(f"select * from {table} where c NOT IN (3,5) ALLOW FILTERING")
+        assert set(res) == set([(2,3,4,5), (4,5,6,7), (5,6,7,None)])
+        res = cql.execute(f"select * from {table} where v NOT IN (5,7) ALLOW FILTERING")
+        assert set(res) == set([(1,2,3,4), (3,4,5,6)])
+        with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+            cql.execute(f"select * from {table} where p1 NOT IN (2,4)")
+
+# Test that NOT IN restrictions are supported with filtering and return the
+# correct results, when the right-hand side of the NOT IN contains a NULL.
+#
+# Cassandra reports 'cassandra.InvalidRequest: Error from server: code=2200
+# [Invalid query] message="Invalid null value for column v"'
+def test_filtering_with_not_in_relation_when_list_contains_null(cql, test_keyspace, cassandra_bug):
+    schema = 'p1 int, p2 int, c int, v int, primary key ((p1, p2),c)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (1, 2, 3, 4)")
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (2, 3, 4, 5)")
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (3, 4, 5, 6)")
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (4, 5, 6, 7)")
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (5, 6, 7, NULL)")
+        # Since NULL is unknown, it could have matched p1, so NOT IN returns NULL too.
+        res = cql.execute(f"select * from {table} where v NOT IN (5,NULL) ALLOW FILTERING")
+        assert set(res) == set()
+
+
 # Test that subscripts in expressions work as expected. They should only work
 # on map columns, and must have the correct type. Test that they also work
 # as expected for null or unset subscripts.
@@ -445,13 +484,13 @@ def test_multi_column_relation_tuples_null_check(cql, test_keyspace):
 #This test shows how Scylla handles invalid number of items in one of the tuples of multi-column relation.
 #If the number of items is lesser than required, Scylla throws "Expected {} elements in value tuple, but got {}"
 #But if the number of items is greater than required, Scylla throws different error: 
-#"Invalid list literal for in((b,c,d)): value (1, 2, 3, 4) is not of type frozen<tuple<int, int, int>>"
+#"Invalid list literal for IN((b,c,d)): value (1, 2, 3, 4) is not of type frozen<tuple<int, int, int>>"
 # Reproduces #13217
 def test_multi_column_relation_wrong_number_of_items_in_tuple(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'a int, b int, c int, d int, primary key (a, b, c, d)') as table:
         with pytest.raises(InvalidRequest, match='elements in value tuple, but got'):
             cql.execute(f'SELECT * FROM {table} WHERE a = 0 AND (b, c, d) IN ((1, 2), (2, 1, 4))')
-        with pytest.raises(InvalidRequest, match='Invalid list literal for in'):
+        with pytest.raises(InvalidRequest, match='Invalid list literal for IN'):
             cql.execute(f'SELECT * FROM {table} WHERE a = 0 AND (b, c, d) IN ((1, 2, 3, 4, 5), (2, 1, 4))')
 
 # Test for a bug found while developing the fix for #10357. The bug was that if a regular column was selected

--- a/test/cqlpy/test_lwt.py
+++ b/test/cqlpy/test_lwt.py
@@ -102,3 +102,29 @@ def test_lwt_with_batch_conflict_2(cql, table1):
     # Scylla returns a separate row for each of the two conditions.
     for r in rs:
         assert r.applied == False
+
+# Test NOT IN condition in LWT IF clause
+#
+# Cassandra rejects this with "line 1:84 no viable alternative at input 'NOT' (...AND c=1 IF r [NOT]...)"",
+# indicating its grammar only supports this for WHERE, not IF.
+def test_lwt_not_in(cql, table1, cassandra_bug):
+    p = unique_key_int()
+    cql.execute(f'INSERT INTO {table1}(p, c, r) values ({p}, 1, 1)')
+    rs = list(cql.execute(f'UPDATE {table1} SET r=2 WHERE p={p} AND c=1 IF r NOT IN (1, 2)'))
+    for r in rs:
+        assert r.applied == False
+    # Check that we look at the entire list, not just the first element
+    rs = list(cql.execute(f'UPDATE {table1} SET r=2 WHERE p={p} AND c=1 IF r NOT IN (2, 1)'))
+    for r in rs:
+        assert r.applied == False
+    rs = list(cql.execute(f'UPDATE {table1} SET r=2 WHERE p={p} AND c=1 IF r NOT IN (7, 8)'))
+    for r in rs:
+        assert r.applied == True
+    # LWT IF conditions don't treat NULL as a special value
+    rs = list(cql.execute(f'UPDATE {table1} SET r=NULL WHERE p={p} AND c=1 IF r NOT IN (NULL, 7, 8)'))
+    for r in rs:
+        assert r.applied == True
+    # Similar, but now show that NULL input fails the condition
+    rs = list(cql.execute(f'UPDATE {table1} SET r=NULL WHERE p={p} AND c=1 IF r NOT IN (NULL, 7, 8)'))
+    for r in rs:
+        assert r.applied == False


### PR DESCRIPTION
Where the grammar supports IN, we add NOT IN. This includes the WHERE clause and LWT IF clause.

Evaluation of NOT IN follows from IN.

In statement_restrictions analysis, they are different, as NOT IN doesn't enable any clever query plan and must filter.

Some tests are added. An error message was changed ('in' changed to 'IN'), so some tests are adjusted.

CQL grammar enhancement, not bug fix, so backport not indicated.