### PR TITLE
service: use read barrier in tablet_virtual_task::contains

### DIFF
--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -8,6 +8,7 @@
 
 #include "locator/tablets.hh"
 #include "replica/database.hh"
+#include "service/migration_manager.hh"
 #include "service/storage_service.hh"
 #include "service/task_manager_module.hh"
 #include "tasks/task_handler.hh"
@@ -78,6 +79,8 @@ static bool tablet_id_provided(const locator::tablet_task_type& task_type) {
 }
 
 future<std::optional<tasks::virtual_task_hint>> tablet_virtual_task::contains(tasks::task_id task_id) const {
+    co_await _ss._migration_manager.local().get_group0_barrier().trigger();
+
     auto tables = get_table_ids();
     for (auto table : tables) {
         auto& tmap = _ss.get_token_metadata().tablets().get_tablet_map(table);

--- a/test/topology_tasks/test_tablet_tasks.py
+++ b/test/topology_tasks/test_tablet_tasks.py
@@ -493,3 +493,23 @@ async def test_tablet_resize_revoked(manager: ManagerClient):
         check_task_status(status, ["suspended"], "split", "table", False, keyspace, table1, [0, 1, 2])
 
     await asyncio.gather(revoke_resize(log, mark), wait_for_task(task0.task_id))
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_tablet_task_sees_latest_state(manager: ManagerClient):
+    servers, cql, hosts, table_id = await create_table_insert_data_for_repair(manager)
+
+    token = -1
+    async def repair_task():
+        await inject_error_on(manager, "repair_tablet_fail_on_rpc_call", servers)
+        # Check failed repair request can be deleted
+        await manager.api.tablet_repair(servers[0].ip_addr, "test", "test", token)
+
+    async def del_repair_task():
+        tablet_task_id = None
+        while tablet_task_id is None:
+            tablet_task_id = await get_tablet_task_id(cql, hosts[0], table_id, token)
+
+        await manager.api.abort_task(servers[0].ip_addr, tablet_task_id)
+
+    await asyncio.gather(repair_task(), del_repair_task())


### PR DESCRIPTION
Currently, when the tablet repair is started, info regarding the operation is kept in the system.tablets. The new tablet states are reflected in memory after load_topology_state is called. Before that, the data in the table and the memory aren't consistent.

To check the supported operations, tablet_virtual_task uses in-memory tablet_metadata. Hence, it may not see the operation, even though its info is already kept in system.tablets table.

Run read barrier in tablet_virtual_task::contains to ensure it will see the latest data. Add a test to check it.

Fixes: #21975.

Needs backport to 2025.1 as it contains tablet_virtual_task