### PR TITLE
repair: correct misspelling of "corespondent"

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -293,7 +293,7 @@ static std::vector<locator::host_id> get_neighbors(
                     // If same host is listed twice, don't add it again later
                     neighbor_set.erase(*endpoint);
                 } else {
-                    rlogger.warn("Provided host ip {} has no corespondent host id", ip);
+                    rlogger.warn("Provided host ip {} has no corresponding host id", ip);
                 }
             }
             // Nodes which aren't neighbors for this range are ignored.


### PR DESCRIPTION
replace "corespondent" with "corresponding" in a logging message.

---

it's a cleanup, hence no need to backport.