### PR TITLE
api: move histogram data into future to avoid deep copying

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -202,7 +202,7 @@ static future<json::json_return_type> get_cf_histogram(http_context& ctx, utils:
     return ctx.db.map(fun).then([](const std::vector<utils::ihistogram> &res) {
         std::vector<httpd::utils_json::histogram> r;
         std::ranges::copy(res | std::views::transform(to_json), std::back_inserter(r));
-        return make_ready_future<json::json_return_type>(r);
+        return make_ready_future<json::json_return_type>(std::move(r));
     });
 }
 


### PR DESCRIPTION
Previously, we created a vector<utils_json::histogram> and returned it by copying into a future. Since histogram is a JSON representation of ihistogram, it can be heavyweight, making the vector copy overhead significant.

Now we move the vector into the returned future instead of copying it, eliminating the deep copy overhead. The APIs backed by this function are marked deprecated, so this performance improvement is not that important.

---

it's a cleanup, hence no need to backport.