### PR TITLE
replica: do not set tablet_task_info if it isn't valid

### DIFF
--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -135,11 +135,13 @@ tablet_map_to_mutation(const tablet_map& tablets, table_id id, const sstring& ke
         auto last_token = tablets.get_last_token(tid);
         auto ck = clustering_key::from_single_value(*s, data_value(dht::token::to_int64(last_token)).serialize_nonnull());
         m.set_clustered_cell(ck, "replicas", make_list_value(replica_set_type, replicas_to_data_value(tablet.replicas)), ts);
-        if (features.tablet_migration_virtual_task) {
+        if (features.tablet_migration_virtual_task && tablet.migration_task_info.is_valid()) {
             m.set_clustered_cell(ck, "migration_task_info", tablet_task_info_to_data_value(tablet.migration_task_info), ts);
         }
         if (features.tablet_repair_scheduler) {
-            m.set_clustered_cell(ck, "repair_task_info", tablet_task_info_to_data_value(tablet.repair_task_info), ts);
+            if (tablet.repair_task_info.is_valid()) {
+                m.set_clustered_cell(ck, "repair_task_info", tablet_task_info_to_data_value(tablet.repair_task_info), ts);
+            }
             if (tablet.repair_time != db_clock::time_point{}) {
                 m.set_clustered_cell(ck, "repair_time", data_value(tablet.repair_time), ts);
             }

--- a/test/pylib/repair.py
+++ b/test/pylib/repair.py
@@ -44,3 +44,13 @@ async def create_table_insert_data_for_repair(manager, rf = 3 , tablets = 8, fas
     logging.info(f'Got hosts={hosts}');
     table_id = await manager.get_table_id("test", "test")
     return (servers, cql, hosts, table_id)
+
+async def get_tablet_task_id(cql, host, table_id, token):
+    rows = await cql.run_async(f"SELECT last_token, repair_task_info from system.tablets where table_id = {table_id}", host=host)
+    for row in rows:
+        if row.last_token == token:
+            if row.repair_task_info == None:
+                return None
+            else:
+                return str(row.repair_task_info.tablet_task_id)
+    return None


### PR DESCRIPTION
Currently, in tablet_map_to_mutation, repair's and migration's tablet_task_info is always set.

Do not set the tablet_task_info if there is no running operation.

No backport needed, 6.2 does not contain the bug